### PR TITLE
[VideoPlayer] Add GUI settings for audio/video playback queues

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -8398,7 +8398,19 @@ msgctxt "#14128"
 msgid "Allow double refresh rates"
 msgstr ""
 
-#empty strings from id 14129 to 14199
+#empty strings from id 14129 to 14186
+
+#: system/settings/settings.xml
+msgctxt "#14187"
+msgid "Advanced"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#14188"
+msgid "Player audio/video queues"
+msgstr ""
+
+#empty strings from id 14189 to 14199
 
 #: system/settings/settings.xml
 msgctxt "#14200"
@@ -22496,17 +22508,57 @@ msgstr ""
 
 #. Value of setting - MByte
 #: xbmc/settings/SevicesSettings.cpp
+#: xbmc/settings/PlayerSettings.cpp
 msgctxt "#37122"
 msgid "{0:d} MB"
 msgstr ""
 
 #. Value of setting - GByte
 #: xbmc/settings/SevicesSettings.cpp
+#: xbmc/settings/PlayerSettings.cpp
 msgctxt "#37123"
 msgid "{0:d} GB"
 msgstr ""
 
-#empty strings from id 37124 to 38010
+#empty strings from id 37124 to 37127
+
+#. Value of setting - second
+#: xbmc/settings/PlayerSettings.cpp
+msgctxt "#37128"
+msgid "{0:d} second"
+msgstr ""
+
+#. Value of setting - seconds
+#: xbmc/settings/PlayerSettings.cpp
+msgctxt "#37129"
+msgid "{0:d} seconds"
+msgstr ""
+
+#. Setting "Audio/video queue time"
+#: system/settings/settings.xml
+msgctxt "#37130"
+msgid "Audio/video queue time"
+msgstr ""
+
+#. Description of setting with label #37130 "Audio/video queue time"
+#: system/settings/settings.xml
+msgctxt "#37131"
+msgid "Duration in seconds of audio/video queues. The duration determines the amount of data stored in memory."
+msgstr ""
+
+#. Setting "Video queue maximum size"
+#: system/settings/settings.xml
+msgctxt "#37132"
+msgid "Video queue maximum size"
+msgstr ""
+
+#. Description of setting with label #37132 "Video queue maximum size"
+#: system/settings/settings.xml
+msgctxt "#37133"
+msgid "Limits the maximum memory usage for the video queue. The amount of memory used depends on the video bitrate and the length of the queue. If the memory limit is reached, the queue time is reduced as necessary."
+msgstr ""
+
+#empty strings from id 37134 to 38010
 
 #. Setting #38011 "Show All Items entry"
 #: system/settings/settings.xml
@@ -22918,7 +22970,13 @@ msgctxt "#38112"
 msgid "Automatically go to the visualisation window when audio playback starts"
 msgstr ""
 
-#empty strings from id 38113 to 38189
+#. Description of category #14187 "Advanced"
+#: system/settings/settings.xml
+msgctxt "#38113"
+msgid "This category contains the advanced settings for video playback"
+msgstr ""
+
+#empty strings from id 38114 to 38189
 
 msgctxt "#38190"
 msgid "Extract thumbnails from video files"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -891,6 +891,26 @@
         </setting>
       </group>
     </category>
+    <category id="advanced" label="14187" help="38113">
+      <group id="1" label="14188">
+        <setting id="videoplayer.queuetimesize" type="integer" label="37130" help="37131">
+          <level>2</level>
+          <default>40</default> <!-- 4.0 s -->
+          <constraints>
+            <options>playerqueuetimesizes</options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
+        <setting id="videoplayer.queuedatasize" type="integer" label="37132" help="37133">
+          <level>2</level>
+          <default>256</default> <!-- 256 MB -->
+          <constraints>
+            <options>playerqueuedatasizes</options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
+      </group>
+    </category>
   </section>
   <section id="media" label="14211" help="38101">
     <category id="library" label="14202" help="39004">

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
@@ -333,14 +333,14 @@ int CDVDMessageQueue::GetLevel() const
   return level;
 }
 
-int CDVDMessageQueue::GetTimeSize() const
+double CDVDMessageQueue::GetTimeSize() const
 {
   std::unique_lock<CCriticalSection> lock(m_section);
 
   if (IsDataBased())
-    return 0;
+    return 0.0;
   else
-    return (int)((m_TimeFront - m_TimeBack) / DVD_TIME_BASE);
+    return (m_TimeFront - m_TimeBack) / DVD_TIME_BASE;
 }
 
 bool CDVDMessageQueue::IsDataBased() const

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.h
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.h
@@ -74,7 +74,7 @@ public:
   }
 
   int GetDataSize() const { return m_iDataSize; }
-  int GetTimeSize() const;
+  double GetTimeSize() const;
   unsigned GetPacketCount(CDVDMsg::Message type);
   bool ReceivedAbortRequest() { return m_bAbortRequest; }
   void WaitUntilEmpty();

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -73,11 +73,6 @@
 using namespace KODI;
 using namespace std::chrono_literals;
 
-namespace
-{
-constexpr double VP_MESSAGE_QUEUE_TIME_SIZE = 8.0;
-}
-
 //------------------------------------------------------------------------------
 // selection streams
 //------------------------------------------------------------------------------
@@ -644,7 +639,11 @@ CVideoPlayer::CVideoPlayer(IPlayerCallback& callback)
   m_HasVideo = false;
   m_HasAudio = false;
   m_UpdateStreamDetails = false;
-  m_messageQueueTimeSize = VP_MESSAGE_QUEUE_TIME_SIZE;
+
+  const int tenthsSeconds = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+      CSettings::SETTING_VIDEOPLAYER_QUEUETIMESIZE);
+
+  m_messageQueueTimeSize = static_cast<double>(tenthsSeconds) / 10.0;
 
   m_SkipCommercials = true;
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -51,8 +51,7 @@ CVideoPlayerAudio::CVideoPlayerAudio(CDVDClock* pClock,
     IDVDStreamPlayerAudio(processInfo),
     m_messageQueue("audio"),
     m_messageParent(parent),
-    m_audioSink(pClock),
-    m_messageQueueTimeSize(messageQueueTimeSize)
+    m_audioSink(pClock)
 {
   m_pClock = pClock;
   m_audioClock = 0;
@@ -66,8 +65,8 @@ CVideoPlayerAudio::CVideoPlayerAudio(CDVDClock* pClock,
   m_maxspeedadjust = 0.0;
 
   // allows max bitrate of 18 Mbit/s (TrueHD max peak) during m_messageQueueTimeSize seconds
-  m_messageQueue.SetMaxDataSize(18 * m_messageQueueTimeSize / 8 * 1024 * 1024);
-  m_messageQueue.SetMaxTimeSize(m_messageQueueTimeSize);
+  m_messageQueue.SetMaxDataSize(18 * messageQueueTimeSize / 8 * 1024 * 1024);
+  m_messageQueue.SetMaxTimeSize(messageQueueTimeSize);
 
   m_disconAdjustTimeMs = processInfo.GetMaxPassthroughOffSyncDuration();
 }
@@ -201,10 +200,9 @@ void CVideoPlayerAudio::OnStartup()
 
 void CVideoPlayerAudio::UpdatePlayerInfo()
 {
-  const int level = m_messageQueue.GetLevel();
   std::ostringstream s;
-  s << "aq:" << std::setw(2) << std::min(99, level);
-  s << "% " << std::fixed << std::setprecision(3) << m_messageQueueTimeSize * level / 100.0;
+  s << "aq:" << std::setw(2) << std::min(99, m_messageQueue.GetLevel());
+  s << "% " << std::fixed << std::setprecision(3) << m_messageQueue.GetTimeSize();
   s << "s, Kb/s:" << std::fixed << std::setprecision(2) << m_audioStats.GetBitrate() / 1024.0;
 
   // print a/v discontinuity adjustments counter when audio is not resampled (passthrough mode)

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -120,6 +120,5 @@ protected:
   bool m_displayReset = false;
   unsigned int m_disconAdjustTimeMs = 50; // maximum sync-off before adjusting
   int m_disconAdjustCounter = 0;
-  double m_messageQueueTimeSize{0.0};
 };
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -16,6 +16,7 @@
 #include "cores/VideoPlayer/Interface/DemuxPacket.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/MathUtils.h"
 #include "utils/log.h"
@@ -68,8 +69,10 @@ CVideoPlayerVideo::CVideoPlayerVideo(CDVDClock* pClock,
   m_iDroppedRequest = 0;
   m_fForcedAspectRatio = 0;
 
-  // allows max bitrate of 128 Mbit/s (e.g. UHD Blu-Ray) during m_messageQueueTimeSize seconds
-  m_messageQueue.SetMaxDataSize(128 * m_messageQueueTimeSize / 8 * 1024 * 1024);
+  const int sizeMB = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+      CSettings::SETTING_VIDEOPLAYER_QUEUEDATASIZE);
+
+  m_messageQueue.SetMaxDataSize(sizeMB * 1024 * 1024);
   m_messageQueue.SetMaxTimeSize(m_messageQueueTimeSize);
 
   m_iDroppedFrames = 0;

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -54,8 +54,7 @@ CVideoPlayerVideo::CVideoPlayerVideo(CDVDClock* pClock,
     IDVDStreamPlayerVideo(processInfo),
     m_messageQueue("video"),
     m_messageParent(parent),
-    m_renderManager(renderManager),
-    m_messageQueueTimeSize(messageQueueTimeSize)
+    m_renderManager(renderManager)
 {
   m_pClock = pClock;
   m_pOverlayContainer = pOverlayContainer;
@@ -73,7 +72,7 @@ CVideoPlayerVideo::CVideoPlayerVideo(CDVDClock* pClock,
       CSettings::SETTING_VIDEOPLAYER_QUEUEDATASIZE);
 
   m_messageQueue.SetMaxDataSize(sizeMB * 1024 * 1024);
-  m_messageQueue.SetMaxTimeSize(m_messageQueueTimeSize);
+  m_messageQueue.SetMaxTimeSize(messageQueueTimeSize);
 
   m_iDroppedFrames = 0;
   m_fFrameRate = 25;
@@ -956,10 +955,9 @@ CVideoPlayerVideo::EOutputState CVideoPlayerVideo::OutputPicture(const VideoPict
 
 std::string CVideoPlayerVideo::GetPlayerInfo()
 {
-  const int level = m_processInfo.GetLevelVQ();
   std::ostringstream s;
-  s << "vq:" << std::setw(2) << std::min(99, level);
-  s << "% " << std::fixed << std::setprecision(3) << m_messageQueueTimeSize * level / 100.0;
+  s << "vq:" << std::setw(2) << std::min(99, m_processInfo.GetLevelVQ());
+  s << "% " << std::fixed << std::setprecision(3) << m_messageQueue.GetTimeSize();
   s << "s, Mb/s:" << std::fixed << std::setprecision(2)
     << static_cast<double>(GetVideoBitrate()) / (1024.0 * 1024.0);
   s << ", fr:" << std::fixed << std::setprecision(3) << m_fFrameRate;

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -142,6 +142,4 @@ protected:
   VideoPicture m_picture;
 
   EOutputState m_outputSate{OUTPUT_NORMAL};
-
-  double m_messageQueueTimeSize{0.0};
 };

--- a/xbmc/settings/CMakeLists.txt
+++ b/xbmc/settings/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES AdvancedSettings.cpp
             LibExportSettings.cpp
             MediaSettings.cpp
             MediaSourceSettings.cpp
+            PlayerSettings.cpp
             ServicesSettings.cpp
             SettingAddon.cpp
             SettingConditions.cpp
@@ -28,6 +29,7 @@ set(HEADERS AdvancedSettings.h
             LibExportSettings.h
             MediaSettings.h
             MediaSourceSettings.h
+            PlayerSettings.h
             ServicesSettings.h
             SettingAddon.h
             SettingConditions.h

--- a/xbmc/settings/PlayerSettings.cpp
+++ b/xbmc/settings/PlayerSettings.cpp
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PlayerSettings.h"
+
+#include "guilib/LocalizeStrings.h"
+#include "utils/StringUtils.h"
+
+void CPlayerSettings::SettingOptionsQueueTimeSizesFiller(const SettingConstPtr& setting,
+                                                         std::vector<IntegerSettingOption>& list,
+                                                         int& current,
+                                                         void* data)
+{
+  const auto& secFloat = g_localizeStrings.Get(13553);
+  const auto& seconds = g_localizeStrings.Get(37129);
+  const auto& second = g_localizeStrings.Get(37128);
+
+  list.emplace_back(StringUtils::Format(secFloat, 0.5), 5);
+  list.emplace_back(StringUtils::Format(second, 1), 10);
+  list.emplace_back(StringUtils::Format(seconds, 2), 20);
+  list.emplace_back(StringUtils::Format(seconds, 4), 40);
+  list.emplace_back(StringUtils::Format(seconds, 8), 80);
+  list.emplace_back(StringUtils::Format(seconds, 16), 160);
+}
+
+void CPlayerSettings::SettingOptionsQueueDataSizesFiller(const SettingConstPtr& setting,
+                                                         std::vector<IntegerSettingOption>& list,
+                                                         int& current,
+                                                         void* data)
+{
+  const auto& mb = g_localizeStrings.Get(37122);
+  const auto& gb = g_localizeStrings.Get(37123);
+
+  list.emplace_back(StringUtils::Format(mb, 16), 16);
+  list.emplace_back(StringUtils::Format(mb, 32), 32);
+  list.emplace_back(StringUtils::Format(mb, 64), 64);
+  list.emplace_back(StringUtils::Format(mb, 128), 128);
+  list.emplace_back(StringUtils::Format(mb, 256), 256);
+  list.emplace_back(StringUtils::Format(mb, 512), 512);
+  list.emplace_back(StringUtils::Format(gb, 1), 1024);
+}

--- a/xbmc/settings/PlayerSettings.h
+++ b/xbmc/settings/PlayerSettings.h
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "settings/ISubSettings.h"
+#include "settings/lib/Setting.h"
+
+#include <vector>
+
+class CPlayerSettings : public ISubSettings
+{
+public:
+  static void SettingOptionsQueueTimeSizesFiller(const SettingConstPtr& setting,
+                                                 std::vector<IntegerSettingOption>& list,
+                                                 int& current,
+                                                 void* data);
+  static void SettingOptionsQueueDataSizesFiller(const SettingConstPtr& setting,
+                                                 std::vector<IntegerSettingOption>& list,
+                                                 int& current,
+                                                 void* data);
+};

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -40,6 +40,7 @@
 #include "settings/DisplaySettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/MediaSourceSettings.h"
+#include "settings/PlayerSettings.h"
 #include "settings/ServicesSettings.h"
 #include "settings/SettingConditions.h"
 #include "settings/SettingsComponent.h"
@@ -419,6 +420,10 @@ void CSettings::InitializeOptionFillers()
       "filecachereadfactors", CServicesSettings::SettingOptionsReadFactorsFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller(
       "filecachechunksizes", CServicesSettings::SettingOptionsCacheChunkSizesFiller);
+  GetSettingsManager()->RegisterSettingOptionsFiller(
+      "playerqueuetimesizes", CPlayerSettings::SettingOptionsQueueTimeSizesFiller);
+  GetSettingsManager()->RegisterSettingOptionsFiller(
+      "playerqueuedatasizes", CPlayerSettings::SettingOptionsQueueDataSizesFiller);
 }
 
 void CSettings::UninitializeOptionFillers()
@@ -470,6 +475,8 @@ void CSettings::UninitializeOptionFillers()
   GetSettingsManager()->UnregisterSettingOptionsFiller("filecachememorysizes");
   GetSettingsManager()->UnregisterSettingOptionsFiller("filecachereadfactors");
   GetSettingsManager()->UnregisterSettingOptionsFiller("filecachechunksizes");
+  GetSettingsManager()->UnregisterSettingOptionsFiller("playerqueuetimesizes");
+  GetSettingsManager()->UnregisterSettingOptionsFiller("playerqueuedatasizes");
 }
 
 void CSettings::InitializeConditions()

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -136,6 +136,8 @@ public:
   static constexpr auto SETTING_VIDEOPLAYER_SUPPORTMVC = "videoplayer.supportmvc";
   static constexpr auto SETTING_VIDEOPLAYER_CONVERTDOVI = "videoplayer.convertdovi";
   static constexpr auto SETTING_VIDEOPLAYER_ALLOWEDHDRFORMATS = "videoplayer.allowedhdrformats";
+  static constexpr auto SETTING_VIDEOPLAYER_QUEUETIMESIZE = "videoplayer.queuetimesize";
+  static constexpr auto SETTING_VIDEOPLAYER_QUEUEDATASIZE = "videoplayer.queuedatasize";
   static constexpr auto SETTING_MYVIDEOS_SELECTACTION = "myvideos.selectaction";
   static constexpr auto SETTING_MYVIDEOS_SELECTDEFAULTVERSION = "myvideos.selectdefaultversion";
   static constexpr auto SETTING_MYVIDEOS_PLAYACTION = "myvideos.playaction";


### PR DESCRIPTION
## Description
- Add GUI settings for audio/video playback queues.
- Improves audio/video queues time calculation.

## Motivation and context
Follow-up of https://github.com/xbmc/xbmc/pull/25334

Initially only wanted reduce queue size to 4.0 to reduce memory usage but after comment https://github.com/xbmc/xbmc/pull/25334#issuecomment-2173517743 thinking on a more flexible way advancesettings... I end up creating full GUI settings.

I'm not sure if the place chosen for the settings is the most correct but I have created a new category because it does not fit video or audio. Also I think that in the future more adjustments can be added here. e.g. these related with low latency if https://github.com/xbmc/xbmc/pull/25330 progress.

The second commit fixes the debug OSD a/v queues time calculation: the reason is in the commit description.

## How has this been tested?
Runtime Windows x64 and Shield

## What is the effect on users?
With default settings (4s, 256 MB) less memory usage for regular up to 128 Mbit/s UHD streams due reduced queue time from 8s to 4s (maximum expected memory usage is reduced from 128 MB to 64 MB). 

At same time improves the playback of exceptionally high birtate streams as Jellyfish 400 Mbit/s (https://repo.jellyfin.org/jellyfish/) because default memory limit is 256 MB (128 MB before) and for this stream is required ~200 MB  --->  400Mbps * 4.0s / 8 = 200

As high memory usage only occurs in very high bitrate streams for most users 256 MB limit is fine. Only those with really memory limited device (or if you want to use 16s queue) make sense limit more the memory.

There are many possible adjusts: for example someone with a very limited device but who at the same time wants to use a 16 second queue could choose 16s / 64MB. Memory usage will be almost constant and the queue time will vary depending on the bitrate but ensuring 16s for low bitrates.

**Jellyfish 400 Mbps - before --> Observe progress bar oscillates**

https://github.com/xbmc/xbmc/assets/58434170/85a7aa3e-f385-4f43-852f-efe1e29b805e


**Jellyfish 400 Mbps - after**

https://github.com/xbmc/xbmc/assets/58434170/f3e7e08c-34ab-437f-a912-a21ee6687d60




## Screenshots (if appropriate):

![screenshot00000](https://github.com/xbmc/xbmc/assets/58434170/cdec6c4f-ccc4-4a08-93fc-3bc048971461)

![screenshot00001](https://github.com/xbmc/xbmc/assets/58434170/ac9f9623-e237-4647-9f9e-5f81043511a8)

![screenshot00002](https://github.com/xbmc/xbmc/assets/58434170/d2d9597d-4032-453f-a72f-7e35453d7e0b)

![screenshot00003](https://github.com/xbmc/xbmc/assets/58434170/5c7b0d91-e0c1-4f00-828b-c5dcc34083dd)

![screenshot00004](https://github.com/xbmc/xbmc/assets/58434170/a56bda47-0402-45e5-bf14-049214aa0663)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
