### PR TITLE
Exiv2 support old API

### DIFF
--- a/cmake/modules/FindExiv2.cmake
+++ b/cmake/modules/FindExiv2.cmake
@@ -10,8 +10,6 @@
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
   macro(buildexiv2)
-
-    find_package(Patch MODULE REQUIRED)
     find_package(Iconv REQUIRED)
 
     # Note: Please drop once a release based on master is made. First 2 are already upstream.
@@ -20,6 +18,17 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     "${CMAKE_SOURCE_DIR}/tools/depends/target/${MODULE_LC}/0003-UWP-Disable-getLoadedLibraries.patch")
 
     generate_patchcommand("${patches}")
+
+    if(WIN32 OR WINDOWS_STORE)
+      # Exiv2 cant be built using /RTC1, so we alter and disable the auto addition of flags
+      # using WIN_DISABLE_PROJECT_FLAGS
+      string(REPLACE "/RTC1" "" EXIV2_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG} )
+
+      set(EXTRA_ARGS "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}$<$<CONFIG:Debug>: ${EXIV2_CXX_FLAGS_DEBUG}>$<$<CONFIG:Release>: ${CMAKE_CXX_FLAGS_RELEASE}>"
+                     "-DCMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS}$<$<CONFIG:Debug>: ${CMAKE_EXE_LINKER_FLAGS_DEBUG}>$<$<CONFIG:Release>: ${CMAKE_EXE_LINKER_FLAGS_RELEASE}>")
+
+      set(WIN_DISABLE_PROJECT_FLAGS ON)
+    endif()
 
     set(CMAKE_ARGS -DBUILD_SHARED_LIBS=OFF
                    -DEXIV2_ENABLE_WEBREADY=OFF
@@ -33,7 +42,8 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
                    -DEXIV2_ENABLE_BROTLI=OFF
                    -DEXIV2_ENABLE_INIH=OFF
                    -DEXIV2_ENABLE_FILESYSTEM_ACCESS=OFF
-                   -DEXIV2_BUILD_EXIV2_COMMAND=OFF)
+                   -DEXIV2_BUILD_EXIV2_COMMAND=OFF
+                   ${EXTRA_ARGS})
 
     if(NOT CMAKE_CXX_COMPILER_LAUNCHER STREQUAL "")
       list(APPEND CMAKE_ARGS -DBUILD_WITH_CCACHE=ON)
@@ -58,7 +68,36 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
     buildexiv2()
   else()
-    if(NOT TARGET Exiv2::exiv2lib)
+    if(TARGET Exiv2::exiv2lib OR TARGET exiv2lib)
+      # We create variables based off TARGET data for use with FPHSA
+      # exiv2 < 0.28 uses a non namespaced target, but also has an alias. Prioritise
+      # namespaced target, and fallback to old target for < 0.28
+      if(TARGET Exiv2::exiv2lib)
+        set(_exiv_target_name Exiv2::exiv2lib)
+      else()
+        set(_exiv_target_name exiv2lib)
+      endif()
+
+      # This is for the case where a distro provides a non standard (Debug/Release) config type
+      # eg Debian's config file is exiv2Config-none.cmake
+      # convert this back to either DEBUG/RELEASE or just RELEASE
+      # we only do this because we use find_package_handle_standard_args for config time output
+      # and it isnt capable of handling TARGETS, so we have to extract the info
+      get_target_property(_EXIV2_CONFIGURATIONS ${_exiv_target_name} IMPORTED_CONFIGURATIONS)
+      foreach(_exiv2_config IN LISTS _EXIV2_CONFIGURATIONS)
+        # Some non standard config (eg None on Debian)
+        # Just set to RELEASE var so select_library_configurations can continue to work its magic
+        string(TOUPPER ${_exiv2_config} _exiv2_config_UPPER)
+        if((NOT ${_exiv2_config_UPPER} STREQUAL "RELEASE") AND
+          (NOT ${_exiv2_config_UPPER} STREQUAL "DEBUG"))
+          get_target_property(EXIV2_LIBRARY_RELEASE ${_exiv_target_name} IMPORTED_LOCATION_${_exiv2_config_UPPER})
+        else()
+          get_target_property(EXIV2_LIBRARY_${_exiv2_config_UPPER} ${_exiv_target_name} IMPORTED_LOCATION_${_exiv2_config_UPPER})
+        endif()
+      endforeach()
+
+      get_target_property(EXIV2_INCLUDE_DIR ${_exiv_target_name} INTERFACE_INCLUDE_DIRECTORIES)
+    else()
       find_package(PkgConfig)
       # Fallback to pkg-config and individual lib/include file search
       if(PKG_CONFIG_FOUND)
@@ -67,33 +106,10 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
       endif()
 
       find_path(EXIV2_INCLUDE_DIR NAMES exiv2/exiv2.hpp
-                                  HINTS ${PC_EXIV2_INCLUDEDIR} NO_CACHE)
-      find_library(EXIV2_LIBRARY NAMES exiv2
-                                 HINTS ${PC_EXIV2_LIBDIR} NO_CACHE)
+                                  HINTS ${PC_EXIV2_INCLUDEDIR})
+      find_library(EXIV2_LIBRARY_RELEASE NAMES exiv2
+                                        HINTS ${PC_EXIV2_LIBDIR})
     endif()
-  endif()
-
-  # We create variables based off TARGET data for use with FPHSA
-  if(TARGET Exiv2::exiv2lib AND NOT TARGET exiv2)
-    # This is for the case where a distro provides a non standard (Debug/Release) config type
-    # eg Debian's config file is exiv2Config-none.cmake
-    # convert this back to either DEBUG/RELEASE or just RELEASE
-    # we only do this because we use find_package_handle_standard_args for config time output
-    # and it isnt capable of handling TARGETS, so we have to extract the info
-    get_target_property(_FMT_CONFIGURATIONS Exiv2::exiv2lib IMPORTED_CONFIGURATIONS)
-    foreach(_exiv2_config IN LISTS _FMT_CONFIGURATIONS)
-      # Some non standard config (eg None on Debian)
-      # Just set to RELEASE var so select_library_configurations can continue to work its magic
-      string(TOUPPER ${_exiv2_config} _exiv2_config_UPPER)
-      if((NOT ${_exiv2_config_UPPER} STREQUAL "RELEASE") AND
-         (NOT ${_exiv2_config_UPPER} STREQUAL "DEBUG"))
-        get_target_property(EXIV2_LIBRARY_RELEASE Exiv2::exiv2lib IMPORTED_LOCATION_${_exiv2_config_UPPER})
-      else()
-        get_target_property(EXIV2_LIBRARY_${_exiv2_config_UPPER} Exiv2::exiv2lib IMPORTED_LOCATION_${_exiv2_config_UPPER})
-      endif()
-    endforeach()
-
-    get_target_property(EXIV2_INCLUDE_DIR Exiv2::exiv2lib INTERFACE_INCLUDE_DIRECTORIES)
   endif()
 
   include(SelectLibraryConfigurations)
@@ -106,14 +122,31 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
                                     VERSION_VAR EXIV2_VER)
 
   if(EXIV2_FOUND)
-    if(TARGET Exiv2::exiv2lib AND NOT TARGET exiv2)
-      # Exiv2 config found. Use it
-      add_library(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} ALIAS Exiv2::exiv2lib)
+    if((TARGET Exiv2::exiv2lib OR TARGET exiv2lib) AND NOT TARGET exiv2)
+      # Exiv alias exiv2lib in their latest cmake config. We test for the alias
+      # to workout what we need to point OUR alias at.
+      get_target_property(_EXIV2_ALIASTARGET exiv2lib ALIASED_TARGET)
+      if(_EXIV2_ALIASTARGET)
+        set(_exiv_target_name ${_EXIV2_ALIASTARGET})
+      endif()
+      add_library(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} ALIAS ${_exiv_target_name})
     else()
       add_library(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} UNKNOWN IMPORTED)
       set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
-                                                                       IMPORTED_LOCATION "${EXIV2_LIBRARY}"
                                                                        INTERFACE_INCLUDE_DIRECTORIES "${EXIV2_INCLUDE_DIR}")
+
+      if(EXIV2_LIBRARY_RELEASE)
+        set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
+                                                                         IMPORTED_CONFIGURATIONS RELEASE
+                                                                         IMPORTED_LOCATION_RELEASE "${EXIV2_LIBRARY_RELEASE}")
+      endif()
+      if(EXIV2_LIBRARY_DEBUG)
+        set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
+                                                                         IMPORTED_LOCATION_DEBUG "${EXIV2_LIBRARY_DEBUG}")
+        set_property(TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} APPEND PROPERTY
+                                                                              IMPORTED_CONFIGURATIONS DEBUG)
+      endif()
+
       if(CORE_SYSTEM_NAME STREQUAL "freebsd")
         set_property(TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} APPEND PROPERTY
                                                                               INTERFACE_LINK_LIBRARIES procstat)

--- a/cmake/modules/FindExiv2.cmake
+++ b/cmake/modules/FindExiv2.cmake
@@ -14,12 +14,15 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
     # Note: Please drop once a release based on master is made. First 2 are already upstream.
     set(patches "${CMAKE_SOURCE_DIR}/tools/depends/target/${MODULE_LC}/0001-Add-EXIV2_ENABLE_FILESYSTEM_ACCESS-option.patch"
-    "${CMAKE_SOURCE_DIR}/tools/depends/target/${MODULE_LC}/0002-Set-conditional-HTTP-depending-on-EXIV2_ENABLE_WEBRE.patch"
-    "${CMAKE_SOURCE_DIR}/tools/depends/target/${MODULE_LC}/0003-UWP-Disable-getLoadedLibraries.patch")
+                "${CMAKE_SOURCE_DIR}/tools/depends/target/${MODULE_LC}/0002-Set-conditional-HTTP-depending-on-EXIV2_ENABLE_WEBRE.patch"
+                "${CMAKE_SOURCE_DIR}/tools/depends/target/${MODULE_LC}/0003-UWP-Disable-getLoadedLibraries.patch"
+                "${CMAKE_SOURCE_DIR}/tools/depends/target/${MODULE_LC}/0004-WIN-lib-postfix.patch")
 
     generate_patchcommand("${patches}")
 
     if(WIN32 OR WINDOWS_STORE)
+      set(EXIV2_DEBUG_POSTFIX d)
+
       # Exiv2 cant be built using /RTC1, so we alter and disable the auto addition of flags
       # using WIN_DISABLE_PROJECT_FLAGS
       string(REPLACE "/RTC1" "" EXIV2_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG} )

--- a/tools/depends/target/exiv2/0004-WIN-lib-postfix.patch
+++ b/tools/depends/target/exiv2/0004-WIN-lib-postfix.patch
@@ -1,0 +1,10 @@
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -215,6 +215,7 @@
+     target_compile_definitions(exiv2lib PRIVATE PSAPI_VERSION=1)    # to be compatible with <= WinVista (#905)
+     # Since windows.h is included in some headers, we need to propagate this definition
+     target_compile_definitions(exiv2lib PUBLIC WIN32_LEAN_AND_MEAN)
++    set_target_properties(exiv2lib PROPERTIES DEBUG_POSTFIX d)
+ endif()
+ 
+ if (NOT MSVC)

--- a/xbmc/pictures/metadata/ImageMetadataParser.h
+++ b/xbmc/pictures/metadata/ImageMetadataParser.h
@@ -24,7 +24,7 @@ public:
 
 private:
   CImageMetadataParser();
-  void ExtractCommonMetadata(std::unique_ptr<Exiv2::Image>& image);
+  void ExtractCommonMetadata(Exiv2::Image& image);
   void ExtractExif(Exiv2::ExifData& exifData);
   void ExtractIPTC(Exiv2::IptcData& iptcData);
 

--- a/xbmc/pictures/metadata/test/TestMetadataExtraction.cpp
+++ b/xbmc/pictures/metadata/test/TestMetadataExtraction.cpp
@@ -46,9 +46,11 @@ TEST_F(TestMetadataExtraction, TestGPSImage)
   EXPECT_EQ(metadata->width, 1);
   EXPECT_EQ(metadata->height, 1);
   EXPECT_TRUE(metadata->fileComment.empty());
+#if (EXIV2_MAJOR_VERSION >= 0) && (EXIV2_MINOR_VERSION >= 28) && (EXIV2_PATCH_VERSION >= 2)
   // format specific (but common) metadata
   EXPECT_TRUE(metadata->isColor);
   EXPECT_EQ(metadata->encodingProcess, "Baseline DCT, Huffman coding");
+#endif
 }
 
 TEST_F(TestMetadataExtraction, TestIPTC)
@@ -74,7 +76,9 @@ TEST_F(TestMetadataExtraction, TestIPTC)
   EXPECT_EQ(metadata->width, 1);
   EXPECT_EQ(metadata->height, 1);
   EXPECT_TRUE(metadata->fileComment.empty());
+#if (EXIV2_MAJOR_VERSION >= 0) && (EXIV2_MINOR_VERSION >= 28) && (EXIV2_PATCH_VERSION >= 2)
   // format specific (but common) metadata
   EXPECT_TRUE(metadata->isColor);
   EXPECT_EQ(metadata->encodingProcess, "Baseline DCT, Huffman coding");
+#endif
 }


### PR DESCRIPTION
## Description
Cleanup/fix cmake mistakes.
Add support for old (<0.28) cmake config for exiv2
Add support for old (<0.27) libexiv2 API

PRing this so those that care can bikeshed how to deal with the old API. This is no doubt a nasty way to deal with this, but its a start at least i guess.
More than happy for someone else to take this on and make cleaner.

## Motivation and context
Ubuntu users whinging.

## How has this been tested?
Tests pass on Ubuntu 22.04

## What is the effect on users?
Less ubuntu users whinging

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
