### PR TITLE
[Audio] PackerMAT: simplify code - remove non-essential code

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/PackerMAT.h
+++ b/xbmc/cores/AudioEngine/Utils/PackerMAT.h
@@ -12,14 +12,6 @@
 #include <stdint.h>
 #include <vector>
 
-struct TrueHDMajorSyncInfo
-{
-  int ratebits{0};
-  uint16_t outputTiming{0};
-  bool outputTimingPresent{false};
-  bool valid{false};
-};
-
 enum class Type
 {
   PADDING,
@@ -49,13 +41,7 @@ private:
     // 10 -> 176.4 kHz
     int ratebits;
 
-    // Output timing obtained parsing TrueHD major sync headers (when available) or
-    // inferred increasing a counter the rest of the time.
-    uint16_t outputTiming;
-    bool outputTimingValid;
-
-    // Input timing of audio unit (obtained of each audio unit) and used to calculate padding
-    // bytes. On the contrary of outputTiming, frametime is present in all audio units.
+    // input timing of previous audio unit used to calculate padding bytes
     uint16_t prevFrametime;
     bool prevFrametimeValid;
 
@@ -63,8 +49,6 @@ private:
     uint32_t prevMatFramesize; // size in bytes of previous MAT frame
 
     uint32_t padding; // padding bytes pending to write
-    uint32_t samples; // number of samples accumulated in current MAT frame
-    int numberOfSamplesOffset; // offset respect number of samples in a standard MAT frame (40 * 24)
   };
 
   void WriteHeader();
@@ -73,44 +57,10 @@ private:
   uint32_t GetCount() const { return m_bufferCount; }
   int FillDataBuffer(const uint8_t* data, int size, Type type);
   void FlushPacket();
-  TrueHDMajorSyncInfo ParseTrueHDMajorSyncHeaders(const uint8_t* p, int buffsize) const;
 
   MATState m_state{};
 
   uint32_t m_bufferCount{0};
   std::vector<uint8_t> m_buffer;
   std::deque<std::vector<uint8_t>> m_outputQueue;
-};
-
-class CBitStream
-{
-public:
-  // opens an existing byte array as bitstream
-  CBitStream(const uint8_t* bytes, int _size)
-  {
-    data = bytes;
-    size = _size;
-  }
-
-  // reads bits from bitstream
-  int ReadBits(int bits)
-  {
-    int dat = 0;
-    for (int i = index; i < index + bits; i++)
-    {
-      dat = dat * 2 + getbit(data[i / 8], i % 8);
-    }
-    index += bits;
-    return dat;
-  }
-
-  // skip bits from bitstream
-  void SkipBits(int bits) { index += bits; }
-
-private:
-  uint8_t getbit(uint8_t x, int y) { return (x >> (7 - y)) & 1; }
-
-  const uint8_t* data{nullptr};
-  int size{0};
-  int index{0};
 };


### PR DESCRIPTION
## Description
PackerMAT: simplify code - remove non-essential code:
- Remove parsing code to obtain output timing.
- Remove log of stream discontinuities.
- Simplify parse of ratebits.
- Remove track of MAT samples and samples offset.

## Motivation and context
Output timing is used to detect stream discontinuities related to seamless branching Blu-Ray but is not used inside MAT packer algorithm. In initially versions was used to partial reset packer state (similar to seek) but later found that is not necessary (and is bad). Currently only used to log these discontinuities but this only means that stream has been edited/touched by the rip tool. Not means that stream is "bad".  In fact rip tools needs touch the stream to remove overlapped frames. See: https://github.com/domyd/mlp?tab=readme-ov-file#faq

My explanation (partly assumptions) is that the rip tools should correct the Output timing field but this is too expensive because it is in very deep layers of the headers and cannot be touched without recalculating the checksums, etc. and they do not do it because it is not necessary since this field is not used: neither in the MAT packaging nor in the subsequent decoding in the AVR.

For all this not makes sense parse all TrueHD headers only for log "possible bad stream" and not use this information for nothing more.   

This PR removes all not necessary parsing code without change bitstream at all.

## How has this been tested?
Runtime Windows and Shield.

Tested 20 minutes of Cars and no dropouts same as before. Tested also intensive seek and chapter skip on Free Guy.


## What is the effect on users?
Nothing apart from eliminate "stream discontinuities warning" in logs.


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
