### PR TITLE
[cmake][macros] Enable buildtools to function after target migration of core/optional deps

### DIFF
--- a/cmake/scripts/common/Macros.cmake
+++ b/cmake/scripts/common/Macros.cmake
@@ -429,7 +429,7 @@ function(core_optional_dep)
       set(_required True)
     endif()
 
-    if(TARGET kodi::${dep} OR (${depup}_FOUND AND ${depspec} IN_LIST optional_buildtools))
+    if(TARGET ${APP_NAME_LC}::${dep} OR (${depup}_FOUND AND ${depspec} IN_LIST optional_buildtools))
       set(final_message ${final_message} "${depup} enabled: Yes")
 
       # We dont want to add a build tool

--- a/cmake/scripts/common/Macros.cmake
+++ b/cmake/scripts/common/Macros.cmake
@@ -433,7 +433,7 @@ function(core_optional_dep)
       set(final_message ${final_message} "${depup} enabled: Yes")
 
       # We dont want to add a build tool
-      if (NOT ${depspec} IN_LIST optional_buildtools AND NOT ${depspec} IN_LIST required_buildtools)
+      if (NOT ${depspec} IN_LIST optional_buildtools)
         # If dependency is found and is not in the list (eg mariadb/mysql) add to list
         if (NOT ${depspec} IN_LIST optional_deps)
           set(optional_deps  ${optional_deps} ${depspec} PARENT_SCOPE)

--- a/cmake/scripts/common/Macros.cmake
+++ b/cmake/scripts/common/Macros.cmake
@@ -429,7 +429,7 @@ function(core_optional_dep)
       set(_required True)
     endif()
 
-    if(TARGET kodi::${dep})
+    if(TARGET kodi::${dep} OR (${depup}_FOUND AND ${depspec} IN_LIST optional_buildtools))
       set(final_message ${final_message} "${depup} enabled: Yes")
 
       # We dont want to add a build tool


### PR DESCRIPTION
## Description
Look to fix issue mentioned https://github.com/xbmc/xbmc/pull/25228#issuecomment-2188272686 regarding build tools after core required/optional dep target migration

## Motivation and context
Fix issue reported.

## How has this been tested?
```
make -C tools/depends/target/cmakebuildsys CMAKE_EXTRA_ARGUMENTS="-DENABLE_CLANGTIDY=ON -DENABLE_INCLUDEWHATYOUUSE=ON -DENABLE_CPPCHECK=OFF -DENABLE_CCACHE=ON"
```

And some OFF/ON usage.

@Rechi is there anything further missing after this?

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
