### PR TITLE
Tuple: fix warning maybe-uninitialized

### DIFF
--- a/xbmc/interfaces/legacy/Tuple.h
+++ b/xbmc/interfaces/legacy/Tuple.h
@@ -35,7 +35,8 @@ namespace XBMCAddon
   template<typename T1> class Tuple<T1, tuple_null_type, tuple_null_type, tuple_null_type, tuple_null_type> : public TupleBase
   {
   private:
-    T1 v1;
+    T1 v1{};
+
   public:
     explicit inline Tuple(T1 p1) : TupleBase(1), v1(p1) {}
     inline Tuple() : TupleBase(0) {}
@@ -49,8 +50,8 @@ namespace XBMCAddon
   // Tuple that holds two values
   template<typename T1, typename T2> class Tuple<T1, T2, tuple_null_type, tuple_null_type, tuple_null_type> : public Tuple<T1>
   {
-  protected:
-    T2 v2;
+  private:
+    T2 v2{};
 
   public:
     inline Tuple(T1 p1, T2 p2) : Tuple<T1>(p1), v2(p2) { TupleBase::nvs(2); }
@@ -67,7 +68,8 @@ namespace XBMCAddon
   template<typename T1, typename T2, typename T3> class Tuple<T1, T2, T3, tuple_null_type, tuple_null_type> : public Tuple<T1,T2>
   {
   private:
-    T3 v3;
+    T3 v3{};
+
   public:
     inline Tuple(T1 p1, T2 p2, T3 p3) : Tuple<T1,T2>(p1,p2), v3(p3) { TupleBase::nvs(3); }
     inline Tuple(T1 p1, T2 p2) : Tuple<T1,T2>(p1,p2) {}
@@ -83,7 +85,8 @@ namespace XBMCAddon
   template<typename T1, typename T2, typename T3, typename T4> class Tuple<T1, T2, T3, T4, tuple_null_type> : public Tuple<T1,T2,T3>
   {
   private:
-    T4 v4;
+    T4 v4{};
+
   public:
     inline Tuple(T1 p1, T2 p2, T3 p3, T4 p4) : Tuple<T1,T2,T3>(p1,p2,p3), v4(p4) { TupleBase::nvs(4); }
     inline Tuple(T1 p1, T2 p2, T3 p3) : Tuple<T1,T2,T3>(p1,p2,p3) {}


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
fix warning maybe-uninitialized

```
In member function '__ct ',
    inlined from '__ct ' at ../xbmc/interfaces/legacy/Tuple.h:60:64,
    inlined from '__ct ' at /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/14.1.0/bits/stl_pair.h:882:35,
    inlined from 'construct' at /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/14.1.0/bits/new_allocator.h:191:4,
    inlined from 'construct' at /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/14.1.0/bits/alloc_traits.h:534:17,
    inlined from '_M_construct_node' at /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/14.1.0/bits/stl_tree.h:593:32,
    inlined from '_M_create_node' at /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/14.1.0/bits/stl_tree.h:610:21,
    inlined from '__ct ' at /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/14.1.0/bits/stl_tree.h:1633:32,
    inlined from '_M_emplace_hint_unique' at /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/14.1.0/bits/stl_tree.h:2458:13,
    inlined from 'emplace_hint' at /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/14.1.0/bits/stl_map.h:640:38,
    inlined from 'emplace' at /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/14.1.0/bits/stl_map.h:601:22,
    inlined from 'xbmc_XBMCAddon_xbmc_InfoTagVideo_setRatings' at build/swig/AddonModuleXbmc.i.cpp:13516:24:
../xbmc/interfaces/legacy/Tuple.h:42:54: warning: 'MEM[(float &)&value + 4]' may be used uninitialized [-Wmaybe-uninitialized]
   42 |     inline Tuple(const Tuple<T1>& o) : TupleBase(o), v1(o.v1) {}
      |                                                      ^
build/swig/AddonModuleXbmc.i.cpp: In function 'xbmc_XBMCAddon_xbmc_InfoTagVideo_setRatings':
build/swig/AddonModuleXbmc.i.cpp:13486:27: note: 'MEM[(float &)&value + 4]' was declared here
13486 |         Tuple<float, int> value;
      |                           ^
In member function '__ct ',
    inlined from '__ct ' at /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/14.1.0/bits/stl_pair.h:882:35,
    inlined from 'construct' at /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/14.1.0/bits/new_allocator.h:191:4,
    inlined from 'construct' at /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/14.1.0/bits/alloc_traits.h:534:17,
    inlined from '_M_construct_node' at /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/14.1.0/bits/stl_tree.h:593:32,
    inlined from '_M_create_node' at /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/14.1.0/bits/stl_tree.h:610:21,
    inlined from '__ct ' at /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/14.1.0/bits/stl_tree.h:1633:32,
    inlined from '_M_emplace_hint_unique' at /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/14.1.0/bits/stl_tree.h:2458:13,
    inlined from 'emplace_hint' at /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/14.1.0/bits/stl_map.h:640:38,
    inlined from 'emplace' at /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/14.1.0/bits/stl_map.h:601:22,
    inlined from 'xbmc_XBMCAddon_xbmc_InfoTagVideo_setRatings' at build/swig/AddonModuleXbmc.i.cpp:13516:24:
../xbmc/interfaces/legacy/Tuple.h:60:57: warning: 'MEM[(int &)&value + 8]' may be used uninitialized [-Wmaybe-uninitialized]
   60 |     inline Tuple(const Tuple<T1,T2>& o) : Tuple<T1>(o), v2(o.v2) {}
      |                                                         ^
build/swig/AddonModuleXbmc.i.cpp: In function 'xbmc_XBMCAddon_xbmc_InfoTagVideo_setRatings':
build/swig/AddonModuleXbmc.i.cpp:13486:27: note: 'MEM[(int &)&value + 8]' was declared here
13486 |         Tuple<float, int> value;
      |                    
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
cleaner compile output to easily spot other real warnings and errors

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Compile and runtime on LibreELEC and CoreELEC.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
