### PR TITLE
libUPnP: Fix memory allocation of size 0

### DIFF
--- a/lib/libUPnP/Neptune/Source/Core/NptDataBuffer.cpp
+++ b/lib/libUPnP/Neptune/Source/Core/NptDataBuffer.cpp
@@ -237,7 +237,9 @@ NPT_DataBuffer::ReallocateBuffer(NPT_Size size)
     // check that the existing data fits
     if (m_DataSize > size) return NPT_ERROR_INVALID_PARAMETERS;
 
-    // allocate a new buffer
+    // allocate a new buffer only if size is not zero
+    if (!size) return NPT_ERROR_INVALID_PARAMETERS;
+
     NPT_Byte* newBuffer = new NPT_Byte[size];
 
     // copy the contents of the previous buffer, if any

--- a/lib/libUPnP/patches/0054-libUPnP-Fix-memory-allocation-of-size-0.patch
+++ b/lib/libUPnP/patches/0054-libUPnP-Fix-memory-allocation-of-size-0.patch
@@ -1,0 +1,33 @@
+From 667922032fa22607697ca4b5eb81c1f8c96e2161 Mon Sep 17 00:00:00 2001
+From: Peter <peter.vicman@gmail.com>
+Date: Tue, 25 Jun 2024 10:57:31 +0200
+Subject: [PATCH] libUPnP: Fix memory allocation of size 0
+
+In member function 'ReallocateBuffer',
+    inlined from 'SetBufferSize' at ../../kodi-e495e26f477d4de8a7e6c2fac4acbe1a15e22242/.aarch64-libreelec-linux-gnu/../lib/libUPnP/Neptune/Source/Core/NptDataBuffer.cpp:172:32,
+    inlined from 'Load' at ../../kodi-e495e26f477d4de8a7e6c2fac4acbe1a15e22242/.aarch64-libreelec-linux-gnu/../lib/libUPnP/Neptune/Source/Core/NptStreams.cpp:106:33:
+../../kodi-e495e26f477d4de8a7e6c2fac4acbe1a15e22242/.aarch64-libreelec-linux-gnu/../lib/libUPnP/Neptune/Source/Core/NptDataBuffer.cpp:245:23: warning: '__builtin_memcpy' writing between 1 and 4294967295 bytes into a region of size 0 [-Wstringop-overflow=]
+../../kodi-e495e26f477d4de8a7e6c2fac4acbe1a15e22242/.aarch64-libreelec-linux-gnu/../lib/libUPnP/Neptune/Source/Core/NptDataBuffer.cpp:241:44: note: destination object of size 0 allocated by 'operator new []'
+
+---
+ lib/libUPnP/Neptune/Source/Core/NptDataBuffer.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/lib/libUPnP/Neptune/Source/Core/NptDataBuffer.cpp b/lib/libUPnP/Neptune/Source/Core/NptDataBuffer.cpp
+index f5ab03c..c0b1c80 100644
+--- a/lib/libUPnP/Neptune/Source/Core/NptDataBuffer.cpp
++++ b/lib/libUPnP/Neptune/Source/Core/NptDataBuffer.cpp
+@@ -237,7 +237,9 @@ NPT_DataBuffer::ReallocateBuffer(NPT_Size size)
+     // check that the existing data fits
+     if (m_DataSize > size) return NPT_ERROR_INVALID_PARAMETERS;
+ 
+-    // allocate a new buffer
++    // allocate a new buffer only if size is not zero
++    if (!size) return NPT_ERROR_INVALID_PARAMETERS;
++
+     NPT_Byte* newBuffer = new NPT_Byte[size];
+ 
+     // copy the contents of the previous buffer, if any
+-- 
+2.41.0.dirty
+


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
fix warning `destination object of size 0 allocated by 'operator new []'`

```
In member function 'ReallocateBuffer',
    inlined from 'SetBufferSize' at ../../kodi-e495e26f477d4de8a7e6c2fac4acbe1a15e22242/.aarch64-libreelec-linux-gnu/../lib/libUPnP/Neptune/Source/Core/NptDataBuffer.cpp:172:32,
    inlined from 'Load' at ../../kodi-e495e26f477d4de8a7e6c2fac4acbe1a15e22242/.aarch64-libreelec-linux-gnu/../lib/libUPnP/Neptune/Source/Core/NptStreams.cpp:106:33:
../../kodi-e495e26f477d4de8a7e6c2fac4acbe1a15e22242/.aarch64-libreelec-linux-gnu/../lib/libUPnP/Neptune/Source/Core/NptDataBuffer.cpp:245:23: warning: '__builtin_memcpy' writing between 1 and 4294967295 bytes into a region of size 0 [-Wstringop-overflow=] ../../kodi-e495e26f477d4de8a7e6c2fac4acbe1a15e22242/.aarch64-libreelec-linux-gnu/../lib/libUPnP/Neptune/Source/Core/NptDataBuffer.cpp:241:44: note: destination object of size 0 allocated by 'operator new []'
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
cleaner compile output and possible fix application crash if size passed to method is 0

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Compile and runtime on LibreELEC and CoreELEC.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
