### PR TITLE
[PVR| Fix Group manager persistence problems

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -886,6 +886,11 @@ void CPVRChannelGroup::Delete()
   }
 }
 
+void CPVRChannelGroup::DeleteGroupMember(const std::shared_ptr<CPVRChannelGroupMember>& member)
+{
+  DeleteGroupMembersFromDb({member});
+}
+
 bool CPVRChannelGroup::Renumber(RenumberMode mode /* = NORMAL */)
 {
   bool bReturn(false);
@@ -1022,7 +1027,7 @@ std::string CPVRChannelGroup::GroupName() const
   return m_path.GetGroupName();
 }
 
-void CPVRChannelGroup::SetGroupName(const std::string& strGroupName,
+bool CPVRChannelGroup::SetGroupName(const std::string& strGroupName,
                                     bool isUserSetName /* = false */)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
@@ -1038,11 +1043,10 @@ void CPVRChannelGroup::SetGroupName(const std::string& strGroupName,
     }
 
     if (m_bLoaded)
-    {
       m_bChanged = true;
-      Persist(); //! @todo why must we persist immediately?
-    }
+    return true;
   }
+  return false;
 }
 
 std::string CPVRChannelGroup::ClientGroupName() const
@@ -1140,9 +1144,9 @@ bool CPVRChannelGroup::SetHidden(bool bHidden)
     m_bHidden = bHidden;
     if (m_bLoaded)
       m_bChanged = true;
+    return true;
   }
-
-  return m_bChanged;
+  return false;
 }
 
 bool CPVRChannelGroup::IsHidden() const
@@ -1157,7 +1161,7 @@ int CPVRChannelGroup::GetPosition() const
   return m_iPosition;
 }
 
-void CPVRChannelGroup::SetPosition(int iPosition)
+bool CPVRChannelGroup::SetPosition(int iPosition)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
 
@@ -1166,7 +1170,9 @@ void CPVRChannelGroup::SetPosition(int iPosition)
     m_iPosition = iPosition;
     if (m_bLoaded)
       m_bChanged = true;
+    return true;
   }
+  return false;
 }
 
 int CPVRChannelGroup::GetClientPosition() const

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -156,8 +156,9 @@ public:
    * @brief Change the name of this group.
    * @param strGroupName The new group name.
    * @param isUserSetName Whether the name was set by the user.
+   * @return True if the group name was changed, false otherwise.
    */
-  void SetGroupName(const std::string& strGroupName, bool isUserSetName = false);
+  bool SetGroupName(const std::string& strGroupName, bool isUserSetName = false);
 
   /*!
    * @brief Set the name this group has on the client.
@@ -381,7 +382,17 @@ public:
    */
   std::shared_ptr<CPVRChannelGroupMember> GetByUniqueID(const std::pair<int, int>& id) const;
 
+  /*!
+   * @brief Set the hidden state of this group.
+   * @param bHidden True to set hidden state, false to unhide the group.
+   * @return True if hidden state was changed, false otherwise.
+   */
   bool SetHidden(bool bHidden);
+
+  /*!
+   * @brief Check whether this group is hidden.
+   * @return True if group is hidden, false otherwise.
+   */
   bool IsHidden() const;
 
   /*!
@@ -393,8 +404,9 @@ public:
   /*!
    * @brief Set the local position of this group.
    * @param iPosition The new local group position.
+   * @return True if position has changed, false otherwise.
    */
-  void SetPosition(int iPosition);
+  bool SetPosition(int iPosition);
 
   /*!
    * @brief Get the position of this group as supplied by the PVR client.
@@ -434,6 +446,12 @@ public:
    * @brief Remove this group from database.
    */
   void Delete();
+
+  /*!
+   * @brief Remove the given group member from the database.
+   * @param member The member to remove from the database.
+   */
+  void DeleteGroupMember(const std::shared_ptr<CPVRChannelGroupMember>& member);
 
   /*!
    * @brief Whether this group is deleted.

--- a/xbmc/pvr/channels/PVRChannelGroupAllChannels.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupAllChannels.cpp
@@ -49,7 +49,10 @@ void CPVRChannelGroupAllChannels::CheckGroupName()
 
   // Ensure the group name is still correct, or channels may fail to load after a locale change
   if (!IsUserSetName())
-    SetGroupName(g_localizeStrings.Get(19287));
+  {
+    if (SetGroupName(g_localizeStrings.Get(19287)))
+      Persist();
+  }
 }
 
 bool CPVRChannelGroupAllChannels::UpdateFromClients(

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -192,6 +192,42 @@ public:
   bool HideGroup(const std::shared_ptr<CPVRChannelGroup>& group, bool bHide);
 
   /*!
+   * @brief Change the name of the given group.
+   * @param group The group.
+   * @param newGroupName The new group name.
+   * @param isUserSetName Whether the name was set by the user.
+   * @return True if the group name was changed, false otherwise.
+   */
+  bool SetGroupName(const std::shared_ptr<CPVRChannelGroup>& group,
+                    const std::string& newGroupName,
+                    bool isUserSetName);
+
+  /*!
+   * @brief Append a channel group member to the given group.
+   * @param group The group.
+   * @param groupMember The channel group member to append.
+   * @return True if the channel group member was appended, false otherwise.
+   */
+  bool AppendToGroup(const std::shared_ptr<CPVRChannelGroup>& group,
+                     const std::shared_ptr<const CPVRChannelGroupMember>& groupMember);
+
+  /*!
+   * @brief Remove a channel group member from the given group.
+   * @param group The group.
+   * @param groupMember The channel group member to remove.
+   * @return @return True if the channel group member was removed, false otherwise.
+   */
+  bool RemoveFromGroup(const std::shared_ptr<CPVRChannelGroup>& group,
+                       const std::shared_ptr<CPVRChannelGroupMember>& groupMember);
+
+  /*!
+   * @brief Reset the position of the given groups, then resort groups.
+   * @param sortedGroupPaths The paths of the groups to re-position.
+   * @return True if any group position was changed, false otherwise.
+   */
+  bool ResetGroupPositions(const std::vector<std::string>& sortedGroupPaths);
+
+  /*!
    * @brief Persist all changes in channel groups.
    * @return True if everything was persisted, false otherwise.
    */
@@ -223,12 +259,8 @@ public:
    */
   int CleanupCachedImages();
 
-  /*!
-   * @brief Sort the groups.
-   */
-  void SortGroups();
-
 private:
+  void SortGroups();
   void SortGroupsByBackendOrder();
   void SortGroupsByLocalOrder();
 
@@ -253,6 +285,14 @@ private:
                                                    int clientID,
                                                    Exclude exclude) const;
   std::shared_ptr<CPVRChannelGroup> GetGroupById(int groupId, Exclude exclude) const;
+
+  enum class GroupState
+  {
+    DELETED,
+    CHANGED,
+  };
+  void GroupStateChanged(const std::shared_ptr<CPVRChannelGroup>& group,
+                         GroupState state = GroupState::CHANGED);
 
   bool m_bRadio{false};
   std::vector<std::shared_ptr<CPVRChannelGroup>> m_groups;

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -979,12 +979,18 @@ bool CGUIDialogPVRChannelManager::UpdateChannelData(const std::shared_ptr<CFileI
     }
 
     // make sure the channel is part of the group
-    group->AppendToGroup(groupMember);
+    CServiceBroker::GetPVRManager()
+        .ChannelGroups()
+        ->Get(m_bIsRadio)
+        ->AppendToGroup(group, groupMember);
   }
   else
   {
     // remove the hidden channel from the group
-    group->RemoveFromGroup(groupMember);
+    CServiceBroker::GetPVRManager()
+        .ChannelGroups()
+        ->Get(m_bIsRadio)
+        ->RemoveFromGroup(group, groupMember);
   }
 
   const auto channel = groupMember->Channel();

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -48,20 +48,20 @@
 #include <utility>
 #include <vector>
 
-#define BUTTON_OK                 4
-#define BUTTON_APPLY              5
-#define BUTTON_CANCEL             6
-#define RADIOBUTTON_ACTIVE        7
-#define EDIT_NAME                 8
-#define BUTTON_CHANNEL_LOGO       9
-#define IMAGE_CHANNEL_LOGO        10
-#define RADIOBUTTON_USEEPG        12
-#define SPIN_EPGSOURCE_SELECTION  13
+#define BUTTON_OK 4
+#define BUTTON_APPLY 5
+#define BUTTON_CANCEL 6
+#define RADIOBUTTON_ACTIVE 7
+#define EDIT_NAME 8
+#define BUTTON_CHANNEL_LOGO 9
+#define IMAGE_CHANNEL_LOGO 10
+#define RADIOBUTTON_USEEPG 12
+#define SPIN_EPGSOURCE_SELECTION 13
 #define RADIOBUTTON_PARENTAL_LOCK 14
-#define CONTROL_LIST_CHANNELS     20
-#define BUTTON_GROUP_MANAGER      30
-#define BUTTON_NEW_CHANNEL        31
-#define BUTTON_RADIO_TV           34
+#define CONTROL_LIST_CHANNELS 20
+#define BUTTON_GROUP_MANAGER 30
+#define BUTTON_NEW_CHANNEL 31
+#define BUTTON_RADIO_TV 34
 #define BUTTON_REFRESH_LOGOS 35
 
 namespace
@@ -88,8 +88,8 @@ constexpr const char* PROPERTY_ITEM_CHANGED = "Changed";
 using namespace PVR;
 using namespace KODI::MESSAGING;
 
-CGUIDialogPVRChannelManager::CGUIDialogPVRChannelManager() :
-    CGUIDialog(WINDOW_DIALOG_PVR_CHANNEL_MANAGER, "DialogPVRChannelManager.xml"),
+CGUIDialogPVRChannelManager::CGUIDialogPVRChannelManager()
+  : CGUIDialog(WINDOW_DIALOG_PVR_CHANNEL_MANAGER, "DialogPVRChannelManager.xml"),
     m_channelItems(new CFileItemList)
 {
   SetRadio(false);
@@ -142,9 +142,10 @@ bool CGUIDialogPVRChannelManager::OnActionMove(const CAction& action)
       }
       else
       {
-        bool bMoveUp = iActionId == ACTION_PAGE_UP || iActionId == ACTION_MOVE_UP || iActionId == ACTION_FIRST_PAGE;
+        bool bMoveUp = iActionId == ACTION_PAGE_UP || iActionId == ACTION_MOVE_UP ||
+                       iActionId == ACTION_FIRST_PAGE;
         unsigned int iLines = bMoveUp ? abs(m_iSelected - iSelected) : 1;
-        bool bOutOfBounds = bMoveUp ? m_iSelected <= 0  : m_iSelected >= m_channelItems->Size() - 1;
+        bool bOutOfBounds = bMoveUp ? m_iSelected <= 0 : m_iSelected >= m_channelItems->Size() - 1;
         if (bOutOfBounds)
         {
           bMoveUp = !bMoveUp;
@@ -183,8 +184,7 @@ bool CGUIDialogPVRChannelManager::OnActionMove(const CAction& action)
 
 bool CGUIDialogPVRChannelManager::OnAction(const CAction& action)
 {
-  return OnActionMove(action) ||
-         CGUIDialog::OnAction(action);
+  return OnActionMove(action) || CGUIDialog::OnAction(action);
 }
 
 void CGUIDialogPVRChannelManager::OnInitWindow()
@@ -251,10 +251,12 @@ bool CGUIDialogPVRChannelManager::OnClickListChannels(const CGUIMessage& message
     int iItem = m_viewControl.GetSelectedItem();
 
     /* Check file item is in list range and get his pointer */
-    if (iItem < 0 || iItem >= m_channelItems->Size()) return true;
+    if (iItem < 0 || iItem >= m_channelItems->Size())
+      return true;
 
     /* Process actions */
-    if (iAction == ACTION_SELECT_ITEM || iAction == ACTION_CONTEXT_MENU || iAction == ACTION_MOUSE_RIGHT_CLICK)
+    if (iAction == ACTION_SELECT_ITEM || iAction == ACTION_CONTEXT_MENU ||
+        iAction == ACTION_MOUSE_RIGHT_CLICK)
     {
       /* Show Contextmenu */
       OnPopupMenu(iItem);
@@ -391,9 +393,11 @@ bool CGUIDialogPVRChannelManager::OnClickButtonChannelLogo()
   if (!pItem)
     return false;
 
-  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
+  const std::shared_ptr<CProfileManager> profileManager =
+      CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  if (profileManager->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
+  if (profileManager->GetCurrentProfile().canWriteSources() &&
+      !g_passwordManager.IsProfileLockUnlocked())
     return false;
 
   // setup our thumb list
@@ -432,7 +436,8 @@ bool CGUIDialogPVRChannelManager::OnClickButtonChannelLogo()
     shares.push_back(share1);
   }
   CServiceBroker::GetMediaManager().GetLocalDrives(shares);
-  if (!CGUIDialogFileBrowser::ShowAndGetImage(items, shares, g_localizeStrings.Get(19285), strThumb, NULL, 19285))
+  if (!CGUIDialogFileBrowser::ShowAndGetImage(items, shares, g_localizeStrings.Get(19285), strThumb,
+                                              NULL, 19285))
     return false;
 
   if (strThumb == "thumb://Current")
@@ -497,7 +502,9 @@ bool CGUIDialogPVRChannelManager::OnClickButtonGroupManager()
   PromptAndSaveList();
 
   /* Load group manager dialog */
-  CGUIDialogPVRGroupManager* pDlgInfo = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogPVRGroupManager>(WINDOW_DIALOG_PVR_GROUP_MANAGER);
+  CGUIDialogPVRGroupManager* pDlgInfo =
+      CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogPVRGroupManager>(
+          WINDOW_DIALOG_PVR_GROUP_MANAGER);
   if (!pDlgInfo)
     return false;
 
@@ -517,7 +524,9 @@ bool CGUIDialogPVRChannelManager::OnClickButtonNewChannel()
   int iSelection = 0;
   if (m_clientsWithSettingsList.size() > 1)
   {
-    CGUIDialogSelect* pDlgSelect = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
+    CGUIDialogSelect* pDlgSelect =
+        CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(
+            WINDOW_DIALOG_SELECT);
     if (!pDlgSelect)
       return false;
 
@@ -565,9 +574,13 @@ bool CGUIDialogPVRChannelManager::OnClickButtonNewChannel()
       }
     }
     else if (ret == PVR_ERROR_NOT_IMPLEMENTED)
-      HELPERS::ShowOKDialogText(CVariant{19033}, CVariant{19038}); // "Information", "Not supported by the PVR backend."
+      HELPERS::ShowOKDialogText(
+          CVariant{19033}, CVariant{19038}); // "Information", "Not supported by the PVR backend."
     else
-      HELPERS::ShowOKDialogText(CVariant{2103}, CVariant{16029}); // "Add-on error", "Check the log for more information about this message."
+      HELPERS::ShowOKDialogText(
+          CVariant{2103},
+          CVariant{
+              16029}); // "Add-on error", "Check the log for more information about this message."
   }
   return true;
 }
@@ -597,38 +610,38 @@ bool CGUIDialogPVRChannelManager::OnClickButtonRefreshChannelLogos()
 bool CGUIDialogPVRChannelManager::OnMessageClick(const CGUIMessage& message)
 {
   int iControl = message.GetSenderId();
-  switch(iControl)
+  switch (iControl)
   {
-  case CONTROL_LIST_CHANNELS:
-    return OnClickListChannels(message);
-  case BUTTON_OK:
-    return OnClickButtonOK();
-  case BUTTON_APPLY:
-    return OnClickButtonApply();
-  case BUTTON_CANCEL:
-    return OnClickButtonCancel();
-  case BUTTON_RADIO_TV:
-    return OnClickButtonRadioTV();
-  case RADIOBUTTON_ACTIVE:
-    return OnClickButtonRadioActive();
-  case RADIOBUTTON_PARENTAL_LOCK:
-    return OnClickButtonRadioParentalLocked();
-  case EDIT_NAME:
-    return OnClickButtonEditName();
-  case BUTTON_CHANNEL_LOGO:
-    return OnClickButtonChannelLogo();
-  case RADIOBUTTON_USEEPG:
-    return OnClickButtonUseEPG();
-  case SPIN_EPGSOURCE_SELECTION:
-    return OnClickEPGSourceSpin();
-  case BUTTON_GROUP_MANAGER:
-    return OnClickButtonGroupManager();
-  case BUTTON_NEW_CHANNEL:
-    return OnClickButtonNewChannel();
-  case BUTTON_REFRESH_LOGOS:
-    return OnClickButtonRefreshChannelLogos();
-  default:
-    return false;
+    case CONTROL_LIST_CHANNELS:
+      return OnClickListChannels(message);
+    case BUTTON_OK:
+      return OnClickButtonOK();
+    case BUTTON_APPLY:
+      return OnClickButtonApply();
+    case BUTTON_CANCEL:
+      return OnClickButtonCancel();
+    case BUTTON_RADIO_TV:
+      return OnClickButtonRadioTV();
+    case RADIOBUTTON_ACTIVE:
+      return OnClickButtonRadioActive();
+    case RADIOBUTTON_PARENTAL_LOCK:
+      return OnClickButtonRadioParentalLocked();
+    case EDIT_NAME:
+      return OnClickButtonEditName();
+    case BUTTON_CHANNEL_LOGO:
+      return OnClickButtonChannelLogo();
+    case RADIOBUTTON_USEEPG:
+      return OnClickButtonUseEPG();
+    case SPIN_EPGSOURCE_SELECTION:
+      return OnClickEPGSourceSpin();
+    case BUTTON_GROUP_MANAGER:
+      return OnClickButtonGroupManager();
+    case BUTTON_NEW_CHANNEL:
+      return OnClickButtonNewChannel();
+    case BUTTON_REFRESH_LOGOS:
+      return OnClickButtonRefreshChannelLogos();
+    default:
+      return false;
   }
 }
 
@@ -706,7 +719,8 @@ bool CGUIDialogPVRChannelManager::OnPopupMenu(int iItem)
 bool CGUIDialogPVRChannelManager::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 {
   /* Check file item is in list range and get his pointer */
-  if (itemNumber < 0 || itemNumber >= m_channelItems->Size()) return false;
+  if (itemNumber < 0 || itemNumber >= m_channelItems->Size())
+    return false;
 
   CFileItemPtr pItem = m_channelItems->Get(itemNumber);
   if (!pItem)
@@ -732,13 +746,19 @@ bool CGUIDialogPVRChannelManager::OnContextButton(int itemNumber, CONTEXT_BUTTON
       SetData(m_iSelected);
     }
     else if (ret == PVR_ERROR_NOT_IMPLEMENTED)
-      HELPERS::ShowOKDialogText(CVariant{19033}, CVariant{19038}); // "Information", "Not supported by the PVR backend."
+      HELPERS::ShowOKDialogText(
+          CVariant{19033}, CVariant{19038}); // "Information", "Not supported by the PVR backend."
     else
-      HELPERS::ShowOKDialogText(CVariant{2103}, CVariant{16029}); // "Add-on error", "Check the log for more information about this message."
+      HELPERS::ShowOKDialogText(
+          CVariant{2103},
+          CVariant{
+              16029}); // "Add-on error", "Check the log for more information about this message."
   }
   else if (button == CONTEXT_BUTTON_DELETE)
   {
-    CGUIDialogYesNo* pDialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogYesNo>(WINDOW_DIALOG_YES_NO);
+    CGUIDialogYesNo* pDialog =
+        CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogYesNo>(
+            WINDOW_DIALOG_YES_NO);
     if (!pDialog)
       return true;
 
@@ -764,9 +784,14 @@ bool CGUIDialogPVRChannelManager::OnContextButton(int itemNumber, CONTEXT_BUTTON
           }
         }
         else if (ret == PVR_ERROR_NOT_IMPLEMENTED)
-          HELPERS::ShowOKDialogText(CVariant{19033}, CVariant{19038}); // "Information", "Not supported by the PVR backend."
+          HELPERS::ShowOKDialogText(
+              CVariant{19033},
+              CVariant{19038}); // "Information", "Not supported by the PVR backend."
         else
-          HELPERS::ShowOKDialogText(CVariant{2103}, CVariant{16029}); // "Add-on error", "Check the log for more information about this message."
+          HELPERS::ShowOKDialogText(
+              CVariant{2103},
+              CVariant{
+                  16029}); // "Add-on error", "Check the log for more information about this message."
       }
     }
   }
@@ -807,7 +832,8 @@ void CGUIDialogPVRChannelManager::Update()
   // empty the lists ready for population
   Clear();
 
-  std::shared_ptr<CPVRChannelGroup> channels = CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(m_bIsRadio);
+  std::shared_ptr<CPVRChannelGroup> channels =
+      CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(m_bIsRadio);
 
   // No channels available, nothing to do.
   if (!channels)
@@ -849,13 +875,14 @@ void CGUIDialogPVRChannelManager::Update()
   }
 
   {
-    std::vector< std::pair<std::string, int> > labels;
+    std::vector<std::pair<std::string, int>> labels;
     labels.emplace_back(g_localizeStrings.Get(19210), 0);
     //! @todo Add Labels for EPG scrapers here
     SET_CONTROL_LABELS(SPIN_EPGSOURCE_SELECTION, 0, &labels);
   }
 
-  m_clientsWithSettingsList = CServiceBroker::GetPVRManager().Clients()->GetClientsSupportingChannelSettings(m_bIsRadio);
+  m_clientsWithSettingsList =
+      CServiceBroker::GetPVRManager().Clients()->GetClientsSupportingChannelSettings(m_bIsRadio);
   if (!m_clientsWithSettingsList.empty())
     m_bAllowNewChannel = true;
 
@@ -930,7 +957,8 @@ void CGUIDialogPVRChannelManager::RenameChannel(const CFileItemPtr& pItem)
 
     const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(*pItem);
     if (!client || (client->RenameChannel(channel) != PVR_ERROR_NO_ERROR))
-      HELPERS::ShowOKDialogText(CVariant{2103}, CVariant{16029}); // Add-on error;Check the log file for details.
+      HELPERS::ShowOKDialogText(CVariant{2103},
+                                CVariant{16029}); // Add-on error;Check the log file for details.
   }
 }
 
@@ -1006,7 +1034,9 @@ void CGUIDialogPVRChannelManager::SaveList()
     return;
 
   /* display the progress dialog */
-  CGUIDialogProgress* pDlgProgress = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
+  CGUIDialogProgress* pDlgProgress =
+      CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogProgress>(
+          WINDOW_DIALOG_PROGRESS);
   pDlgProgress->SetHeading(CVariant{190});
   pDlgProgress->SetLine(0, CVariant{""});
   pDlgProgress->SetLine(1, CVariant{328});
@@ -1016,7 +1046,8 @@ void CGUIDialogPVRChannelManager::SaveList()
   pDlgProgress->SetPercentage(0);
 
   /* persist all channels */
-  std::shared_ptr<CPVRChannelGroup> group = CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(m_bIsRadio);
+  std::shared_ptr<CPVRChannelGroup> group =
+      CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(m_bIsRadio);
   if (!group)
     return;
 
@@ -1060,9 +1091,9 @@ void CGUIDialogPVRChannelManager::SaveList()
 
 bool CGUIDialogPVRChannelManager::HasChangedItems() const
 {
-  return std::any_of(m_channelItems->cbegin(), m_channelItems->cend(), [](const auto& item) {
-    return item && item->GetProperty(PROPERTY_ITEM_CHANGED).asBoolean();
-  });
+  return std::any_of(m_channelItems->cbegin(), m_channelItems->cend(),
+                     [](const auto& item)
+                     { return item && item->GetProperty(PROPERTY_ITEM_CHANGED).asBoolean(); });
 }
 
 namespace

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
@@ -21,76 +21,76 @@ class CGUIMessage;
 
 namespace PVR
 {
-  class CPVRChannelGroup;
-  class CPVRClient;
+class CPVRChannelGroup;
+class CPVRClient;
 
-  class CGUIDialogPVRChannelManager : public CGUIDialog
-  {
-  public:
-    CGUIDialogPVRChannelManager();
-    ~CGUIDialogPVRChannelManager() override;
-    bool OnMessage(CGUIMessage& message) override;
-    bool OnAction(const CAction& action) override;
-    void OnWindowLoaded() override;
-    void OnWindowUnload() override;
-    bool HasListItems() const override{ return true; }
-    CFileItemPtr GetCurrentListItem(int offset = 0) override;
+class CGUIDialogPVRChannelManager : public CGUIDialog
+{
+public:
+  CGUIDialogPVRChannelManager();
+  ~CGUIDialogPVRChannelManager() override;
+  bool OnMessage(CGUIMessage& message) override;
+  bool OnAction(const CAction& action) override;
+  void OnWindowLoaded() override;
+  void OnWindowUnload() override;
+  bool HasListItems() const override { return true; }
+  CFileItemPtr GetCurrentListItem(int offset = 0) override;
 
-    void Open(const std::shared_ptr<CFileItem>& initialSelection);
-    void SetRadio(bool bIsRadio);
+  void Open(const std::shared_ptr<CFileItem>& initialSelection);
+  void SetRadio(bool bIsRadio);
 
-  protected:
-    void OnInitWindow() override;
-    void OnDeinitWindow(int nextWindowID) override;
+protected:
+  void OnInitWindow() override;
+  void OnDeinitWindow(int nextWindowID) override;
 
-  private:
-    void Clear();
-    void Update();
-    void PromptAndSaveList();
-    void SaveList();
-    void Renumber();
-    void SetData(int iItem);
-    void RenameChannel(const CFileItemPtr& pItem);
+private:
+  void Clear();
+  void Update();
+  void PromptAndSaveList();
+  void SaveList();
+  void Renumber();
+  void SetData(int iItem);
+  void RenameChannel(const CFileItemPtr& pItem);
 
-    void ClearChannelOptions();
-    void EnableChannelOptions(bool bEnable);
+  void ClearChannelOptions();
+  void EnableChannelOptions(bool bEnable);
 
-    bool OnPopupMenu(int iItem);
-    bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
-    bool OnActionMove(const CAction& action);
-    bool OnMessageClick(const CGUIMessage& message);
-    bool OnClickListChannels(const CGUIMessage& message);
-    bool OnClickButtonOK();
-    bool OnClickButtonApply();
-    bool OnClickButtonCancel();
-    bool OnClickButtonRadioTV();
-    bool OnClickButtonRadioActive();
-    bool OnClickButtonRadioParentalLocked();
-    bool OnClickButtonEditName();
-    bool OnClickButtonChannelLogo();
-    bool OnClickButtonUseEPG();
-    bool OnClickEPGSourceSpin();
-    bool OnClickButtonGroupManager();
-    bool OnClickButtonNewChannel();
-    bool OnClickButtonRefreshChannelLogos();
+  bool OnPopupMenu(int iItem);
+  bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
+  bool OnActionMove(const CAction& action);
+  bool OnMessageClick(const CGUIMessage& message);
+  bool OnClickListChannels(const CGUIMessage& message);
+  bool OnClickButtonOK();
+  bool OnClickButtonApply();
+  bool OnClickButtonCancel();
+  bool OnClickButtonRadioTV();
+  bool OnClickButtonRadioActive();
+  bool OnClickButtonRadioParentalLocked();
+  bool OnClickButtonEditName();
+  bool OnClickButtonChannelLogo();
+  bool OnClickButtonUseEPG();
+  bool OnClickEPGSourceSpin();
+  bool OnClickButtonGroupManager();
+  bool OnClickButtonNewChannel();
+  bool OnClickButtonRefreshChannelLogos();
 
-    bool UpdateChannelData(const std::shared_ptr<CFileItem>& pItem,
-                           const std::shared_ptr<CPVRChannelGroup>& group);
+  bool UpdateChannelData(const std::shared_ptr<CFileItem>& pItem,
+                         const std::shared_ptr<CPVRChannelGroup>& group);
 
-    bool HasChangedItems() const;
-    void SetItemChanged(const CFileItemPtr& pItem);
+  bool HasChangedItems() const;
+  void SetItemChanged(const CFileItemPtr& pItem);
 
-    bool m_bIsRadio = false;
-    bool m_bMovingMode = false;
-    bool m_bAllowNewChannel = false;
-    bool m_bAllowRenumber = false;
-    bool m_bAllowReorder = false;
+  bool m_bIsRadio = false;
+  bool m_bMovingMode = false;
+  bool m_bAllowNewChannel = false;
+  bool m_bAllowRenumber = false;
+  bool m_bAllowReorder = false;
 
-    std::shared_ptr<CFileItem> m_initialSelection;
-    int m_iSelected = 0;
-    CFileItemList* m_channelItems;
-    CGUIViewControl m_viewControl;
+  std::shared_ptr<CFileItem> m_initialSelection;
+  int m_iSelected = 0;
+  CFileItemList* m_channelItems;
+  CGUIViewControl m_viewControl;
 
-    std::vector<std::shared_ptr<CPVRClient>> m_clientsWithSettingsList;
-  };
-}
+  std::vector<std::shared_ptr<CPVRClient>> m_clientsWithSettingsList;
+};
+} // namespace PVR

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -85,11 +85,6 @@ void CGUIDialogPVRGroupManager::SetRadio(bool bIsRadio)
   SetProperty("IsRadio", m_bIsRadio ? "true" : "");
 }
 
-bool CGUIDialogPVRGroupManager::PersistChanges()
-{
-  return CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio)->PersistAll();
-}
-
 bool CGUIDialogPVRGroupManager::OnPopupMenu(int itemNumber)
 {
   // Currently, the only context menu item is "move".
@@ -144,7 +139,6 @@ bool CGUIDialogPVRGroupManager::ActionButtonOk(const CGUIMessage& message)
 
   if (iControl == BUTTON_OK)
   {
-    PersistChanges();
     Close();
     bReturn = true;
   }
@@ -211,7 +205,9 @@ bool CGUIDialogPVRGroupManager::ActionButtonDeleteGroup(const CGUIMessage& messa
               .ChannelGroups()
               ->Get(m_bIsRadio)
               ->DeleteGroup(m_selectedGroup))
+      {
         Update();
+      }
     }
 
     bReturn = true;
@@ -242,8 +238,14 @@ bool CGUIDialogPVRGroupManager::ActionButtonRenameGroup(const CGUIMessage& messa
       if (!strGroupName.empty())
       {
         ClearSelectedGroupsThumbnail();
-        m_selectedGroup->SetGroupName(strGroupName, !resetName);
-        Update();
+        if (CServiceBroker::GetPVRManager()
+                .ChannelGroups()
+                ->Get(m_bIsRadio)
+                ->SetGroupName(m_selectedGroup, strGroupName, !resetName))
+        {
+          m_iSelectedChannelGroup = -1; // recalc index in Update()
+          Update();
+        }
       }
     }
 
@@ -275,9 +277,13 @@ bool CGUIDialogPVRGroupManager::ActionButtonUngroupedChannels(const CGUIMessage&
         {
           const auto itemChannel = m_ungroupedChannels->Get(m_iSelectedUngroupedChannel);
 
-          if (m_selectedGroup->AppendToGroup(itemChannel->GetPVRChannelGroupMemberInfoTag()))
+          if (CServiceBroker::GetPVRManager()
+                  .ChannelGroups()
+                  ->Get(m_bIsRadio)
+                  ->AppendToGroup(m_selectedGroup, itemChannel->GetPVRChannelGroupMemberInfoTag()))
           {
             ClearSelectedGroupsThumbnail();
+            m_iSelectedChannelGroup = -1; // recalc index in Update()
             Update();
           }
         }
@@ -306,9 +312,16 @@ bool CGUIDialogPVRGroupManager::ActionButtonGroupMembers(const CGUIMessage& mess
         if (m_selectedGroup && m_groupMembers->GetFileCount() > 0)
         {
           const auto itemChannel = m_groupMembers->Get(m_iSelectedGroupMember);
-          m_selectedGroup->RemoveFromGroup(itemChannel->GetPVRChannelGroupMemberInfoTag());
           ClearSelectedGroupsThumbnail();
-          Update();
+          if (CServiceBroker::GetPVRManager()
+                  .ChannelGroups()
+                  ->Get(m_bIsRadio)
+                  ->RemoveFromGroup(m_selectedGroup,
+                                    itemChannel->GetPVRChannelGroupMemberInfoTag()))
+          {
+            m_iSelectedChannelGroup = -1; // recalc index in Update()
+            Update();
+          }
         }
       }
     }
@@ -351,15 +364,20 @@ bool CGUIDialogPVRGroupManager::ActionButtonChannelGroups(const CGUIMessage& mes
         m_movingItem = false;
 
         // reset group positions
-        auto* groups = CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio);
-        int pos = 1;
-        for (auto& groupItem : *m_channelGroups)
+        std::vector<std::string> paths;
+        for (const auto& groupItem : *m_channelGroups)
         {
-          const auto group = groups->GetGroupByPath(groupItem->GetPath());
-          if (group)
-            group->SetPosition(pos++);
+          paths.emplace_back(groupItem->GetPath());
         }
-        groups->SortGroups();
+
+        if (CServiceBroker::GetPVRManager()
+                .ChannelGroups()
+                ->Get(m_bIsRadio)
+                ->ResetGroupPositions(paths))
+        {
+          Update();
+        }
+
         bReturn = true;
       }
     }
@@ -378,11 +396,13 @@ bool CGUIDialogPVRGroupManager::ActionButtonHideGroup(const CGUIMessage& message
         static_cast<CGUIRadioButtonControl*>(GetControl(message.GetSenderId()));
     if (button)
     {
-      CServiceBroker::GetPVRManager()
-          .ChannelGroups()
-          ->Get(m_bIsRadio)
-          ->HideGroup(m_selectedGroup, button->IsSelected());
-      Update();
+      if (CServiceBroker::GetPVRManager()
+              .ChannelGroups()
+              ->Get(m_bIsRadio)
+              ->HideGroup(m_selectedGroup, button->IsSelected()))
+      {
+        Update();
+      }
     }
 
     bReturn = true;
@@ -397,7 +417,6 @@ bool CGUIDialogPVRGroupManager::ActionButtonToggleRadioTV(const CGUIMessage& mes
 
   if (message.GetSenderId() == BUTTON_TOGGLE_RADIO_TV)
   {
-    PersistChanges();
     SetRadio(!m_bIsRadio);
     Update();
     bReturn = true;

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -42,19 +42,19 @@
 using namespace KODI::MESSAGING;
 using namespace PVR;
 
-#define CONTROL_LIST_CHANNELS_LEFT    11
-#define CONTROL_LIST_CHANNELS_RIGHT   12
-#define CONTROL_LIST_CHANNEL_GROUPS   13
-#define CONTROL_CURRENT_GROUP_LABEL   20
-#define CONTROL_UNGROUPED_LABEL       21
-#define CONTROL_IN_GROUP_LABEL        22
-#define BUTTON_HIDE_GROUP             25
-#define BUTTON_NEWGROUP               26
-#define BUTTON_RENAMEGROUP            27
-#define BUTTON_DELGROUP               28
-#define BUTTON_OK                     29
-#define BUTTON_TOGGLE_RADIO_TV        34
-#define BUTTON_RECREATE_GROUP_THUMB   35
+#define CONTROL_LIST_CHANNELS_LEFT 11
+#define CONTROL_LIST_CHANNELS_RIGHT 12
+#define CONTROL_LIST_CHANNEL_GROUPS 13
+#define CONTROL_CURRENT_GROUP_LABEL 20
+#define CONTROL_UNGROUPED_LABEL 21
+#define CONTROL_IN_GROUP_LABEL 22
+#define BUTTON_HIDE_GROUP 25
+#define BUTTON_NEWGROUP 26
+#define BUTTON_RENAMEGROUP 27
+#define BUTTON_DELGROUP 28
+#define BUTTON_OK 29
+#define BUTTON_TOGGLE_RADIO_TV 34
+#define BUTTON_RECREATE_GROUP_THUMB 35
 
 namespace
 {
@@ -62,8 +62,8 @@ constexpr const char* PROPERTY_CLIENT_NAME = "ClientName";
 
 } // namespace
 
-CGUIDialogPVRGroupManager::CGUIDialogPVRGroupManager() :
-    CGUIDialog(WINDOW_DIALOG_PVR_GROUP_MANAGER, "DialogPVRGroupManager.xml")
+CGUIDialogPVRGroupManager::CGUIDialogPVRGroupManager()
+  : CGUIDialog(WINDOW_DIALOG_PVR_GROUP_MANAGER, "DialogPVRGroupManager.xml")
 {
   m_ungroupedChannels = new CFileItemList;
   m_groupMembers = new CFileItemList;
@@ -160,7 +160,8 @@ bool CGUIDialogPVRGroupManager::ActionButtonNewGroup(const CGUIMessage& message)
   if (iControl == BUTTON_NEWGROUP)
   {
     std::string strGroupName;
-    if (CGUIKeyboardFactory::ShowAndGetInput(strGroupName, CVariant{g_localizeStrings.Get(19139)}, false))
+    if (CGUIKeyboardFactory::ShowAndGetInput(strGroupName, CVariant{g_localizeStrings.Get(19139)},
+                                             false))
     {
       if (!strGroupName.empty())
       {
@@ -191,7 +192,9 @@ bool CGUIDialogPVRGroupManager::ActionButtonDeleteGroup(const CGUIMessage& messa
     if (!m_selectedGroup)
       return bReturn;
 
-    CGUIDialogYesNo* pDialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogYesNo>(WINDOW_DIALOG_YES_NO);
+    CGUIDialogYesNo* pDialog =
+        CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogYesNo>(
+            WINDOW_DIALOG_YES_NO);
     if (!pDialog)
       return bReturn;
 
@@ -371,7 +374,8 @@ bool CGUIDialogPVRGroupManager::ActionButtonHideGroup(const CGUIMessage& message
 
   if (message.GetSenderId() == BUTTON_HIDE_GROUP && m_selectedGroup)
   {
-    CGUIRadioButtonControl* button = static_cast<CGUIRadioButtonControl*>(GetControl(message.GetSenderId()));
+    CGUIRadioButtonControl* button =
+        static_cast<CGUIRadioButtonControl*>(GetControl(message.GetSenderId()));
     if (button)
     {
       CServiceBroker::GetPVRManager()
@@ -418,16 +422,11 @@ bool CGUIDialogPVRGroupManager::ActionButtonRecreateThumbnail(const CGUIMessage&
 
 bool CGUIDialogPVRGroupManager::OnMessageClick(const CGUIMessage& message)
 {
-  return ActionButtonOk(message) ||
-      ActionButtonNewGroup(message) ||
-      ActionButtonDeleteGroup(message) ||
-      ActionButtonRenameGroup(message) ||
-      ActionButtonUngroupedChannels(message) ||
-      ActionButtonGroupMembers(message) ||
-      ActionButtonChannelGroups(message) ||
-      ActionButtonHideGroup(message) ||
-      ActionButtonToggleRadioTV(message) ||
-      ActionButtonRecreateThumbnail(message);
+  return ActionButtonOk(message) || ActionButtonNewGroup(message) ||
+         ActionButtonDeleteGroup(message) || ActionButtonRenameGroup(message) ||
+         ActionButtonUngroupedChannels(message) || ActionButtonGroupMembers(message) ||
+         ActionButtonChannelGroups(message) || ActionButtonHideGroup(message) ||
+         ActionButtonToggleRadioTV(message) || ActionButtonRecreateThumbnail(message);
 }
 
 bool CGUIDialogPVRGroupManager::OnMessage(CGUIMessage& message)
@@ -519,8 +518,7 @@ bool CGUIDialogPVRGroupManager::OnActionMove(const CAction& action)
 
 bool CGUIDialogPVRGroupManager::OnAction(const CAction& action)
 {
-  return OnActionMove(action) ||
-         CGUIDialog::OnAction(action);
+  return OnActionMove(action) || CGUIDialog::OnAction(action);
 }
 
 void CGUIDialogPVRGroupManager::OnInitWindow()

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.h
@@ -19,61 +19,61 @@ class CGUIMessage;
 
 namespace PVR
 {
-  class CPVRChannelGroup;
+class CPVRChannelGroup;
 
-  class CGUIDialogPVRGroupManager : public CGUIDialog
-  {
-  public:
-    CGUIDialogPVRGroupManager();
-    ~CGUIDialogPVRGroupManager() override;
-    bool OnMessage(CGUIMessage& message) override;
-    bool OnAction(const CAction& action) override;
-    void OnWindowLoaded() override;
-    void OnWindowUnload() override;
+class CGUIDialogPVRGroupManager : public CGUIDialog
+{
+public:
+  CGUIDialogPVRGroupManager();
+  ~CGUIDialogPVRGroupManager() override;
+  bool OnMessage(CGUIMessage& message) override;
+  bool OnAction(const CAction& action) override;
+  void OnWindowLoaded() override;
+  void OnWindowUnload() override;
 
-    void SetRadio(bool bIsRadio);
+  void SetRadio(bool bIsRadio);
 
-  protected:
-    void OnInitWindow() override;
-    void OnDeinitWindow(int nextWindowID) override;
+protected:
+  void OnInitWindow() override;
+  void OnDeinitWindow(int nextWindowID) override;
 
-  private:
-    void Clear();
-    void ClearSelectedGroupsThumbnail();
-    void Update();
-    bool PersistChanges();
-    bool ActionButtonOk(const CGUIMessage& message);
-    bool ActionButtonNewGroup(const CGUIMessage& message);
-    bool ActionButtonDeleteGroup(const CGUIMessage& message);
-    bool ActionButtonRenameGroup(const CGUIMessage& message);
-    bool ActionButtonUngroupedChannels(const CGUIMessage& message);
-    bool ActionButtonGroupMembers(const CGUIMessage& message);
-    bool ActionButtonChannelGroups(const CGUIMessage& message);
-    bool ActionButtonHideGroup(const CGUIMessage& message);
-    bool ActionButtonToggleRadioTV(const CGUIMessage& message);
-    bool ActionButtonRecreateThumbnail(const CGUIMessage& message);
-    bool OnMessageClick(const CGUIMessage& message);
-    bool OnPopupMenu(int itemNumber);
-    bool OnContextButton(int itemNumber, int button);
-    bool OnActionMove(const CAction& action);
+private:
+  void Clear();
+  void ClearSelectedGroupsThumbnail();
+  void Update();
+  bool PersistChanges();
+  bool ActionButtonOk(const CGUIMessage& message);
+  bool ActionButtonNewGroup(const CGUIMessage& message);
+  bool ActionButtonDeleteGroup(const CGUIMessage& message);
+  bool ActionButtonRenameGroup(const CGUIMessage& message);
+  bool ActionButtonUngroupedChannels(const CGUIMessage& message);
+  bool ActionButtonGroupMembers(const CGUIMessage& message);
+  bool ActionButtonChannelGroups(const CGUIMessage& message);
+  bool ActionButtonHideGroup(const CGUIMessage& message);
+  bool ActionButtonToggleRadioTV(const CGUIMessage& message);
+  bool ActionButtonRecreateThumbnail(const CGUIMessage& message);
+  bool OnMessageClick(const CGUIMessage& message);
+  bool OnPopupMenu(int itemNumber);
+  bool OnContextButton(int itemNumber, int button);
+  bool OnActionMove(const CAction& action);
 
-    std::shared_ptr<CPVRChannelGroup> m_selectedGroup;
-    bool m_bIsRadio;
-    bool m_movingItem{false};
-    bool m_allowReorder{false};
+  std::shared_ptr<CPVRChannelGroup> m_selectedGroup;
+  bool m_bIsRadio;
+  bool m_movingItem{false};
+  bool m_allowReorder{false};
 
-    int m_iSelectedUngroupedChannel = 0;
-    int m_iSelectedGroupMember = 0;
-    int m_iSelectedChannelGroup = 0;
+  int m_iSelectedUngroupedChannel = 0;
+  int m_iSelectedGroupMember = 0;
+  int m_iSelectedChannelGroup = 0;
 
-    CFileItemList *   m_ungroupedChannels;
-    CFileItemList *   m_groupMembers;
-    CFileItemList *   m_channelGroups;
+  CFileItemList* m_ungroupedChannels;
+  CFileItemList* m_groupMembers;
+  CFileItemList* m_channelGroups;
 
-    CGUIViewControl m_viewUngroupedChannels;
-    CGUIViewControl m_viewGroupMembers;
-    CGUIViewControl m_viewChannelGroups;
+  CGUIViewControl m_viewUngroupedChannels;
+  CGUIViewControl m_viewGroupMembers;
+  CGUIViewControl m_viewChannelGroups;
 
-    CPVRThumbLoader m_thumbLoader;
-  };
-}
+  CPVRThumbLoader m_thumbLoader;
+};
+} // namespace PVR

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.h
@@ -41,7 +41,6 @@ private:
   void Clear();
   void ClearSelectedGroupsThumbnail();
   void Update();
-  bool PersistChanges();
   bool ActionButtonOk(const CGUIMessage& message);
   bool ActionButtonNewGroup(const CGUIMessage& message);
   bool ActionButtonDeleteGroup(const CGUIMessage& message);

--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
@@ -215,10 +215,9 @@ bool CPVRGUIActionsChannels::HideChannel(const CFileItem& item) const
           CVariant{""}, CVariant{channel->ChannelName()}))
     return false;
 
-  if (!CServiceBroker::GetPVRManager()
-           .ChannelGroups()
-           ->GetGroupAll(channel->IsRadio())
-           ->RemoveFromGroup(groupMember))
+  const auto groups{CServiceBroker::GetPVRManager().ChannelGroups()};
+  if (!groups->Get(channel->IsRadio())
+           ->RemoveFromGroup(groups->GetGroupAll(channel->IsRadio()), groupMember))
     return false;
 
   CGUIWindowPVRBase* pvrWindow =


### PR DESCRIPTION
Before this PR, PVR Group manager's implementation for persisting the changes made via the manager was inconsistent, leading to some problems. 

Idea of the implementation was, that all changes are written directly to the respective PVR core data structures, and on exit from the dialog, these changes were persisted to the PVR database all at once.

Following problems were identified with the existing implementation:

1) Some of the changes were actually persisted on exit like intended, others (like creation of new groups) were directly persisted to the database.
2) If the dialog was cancelled (not ended with OK), the in-memory changes done with the manager were not rolled back (which would be difficult to implement anyway), but the changes (except some, see 1) were not be written to the db, which leads to a) inconsistent maor vs. db sate and b) other actions done later could lead to the changes being written to db anyway. Depending on a) and b) it could that after Kodi restart some changes done with the manager in the previous Kodi session were still present, or not. Nobody could say for sure. 

This PR changes persistence strategy of the Group manager to persist every change instantly to the database along with the in-memory changes, to avoid above described inconsistencies and unpredictable results.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish something for you to review I guess.