### PR TITLE
RetroPlayer: fix warning 'violates the C++ One Definition Rule'

### DIFF
--- a/xbmc/cores/RetroPlayer/messages/savestate.fbs
+++ b/xbmc/cores/RetroPlayer/messages/savestate.fbs
@@ -55,7 +55,7 @@ table Savestate {
   video_data:[uint8] (id: 18);
   video_width:uint16 (id: 19);
   video_height:uint16 (id: 20);
-  rotation_ccw:VideoRotation (id: 21);
+  rotation_ccw:VideoRotationSaveState (id: 21);
 
   // Memory properties
   memory_data:[uint8] (id: 10);

--- a/xbmc/cores/RetroPlayer/messages/video.fbs
+++ b/xbmc/cores/RetroPlayer/messages/video.fbs
@@ -35,7 +35,7 @@ enum PixelFormat : uint8 {
   RGB_555_LE,
 }
 
-enum VideoRotation : uint8 {
+enum VideoRotationSaveState : uint8 {
   CCW_0,
   CCW_90,
   CCW_180,

--- a/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
@@ -143,39 +143,39 @@ AVPixelFormat TranslatePixelFormat(PixelFormat pixelFormat)
 /*!
  * \brief Translate the video rotation (RetroPlayer to FlatBuffers)
  */
-VideoRotation TranslateRotation(unsigned int rotationCCW)
+VideoRotationSaveState TranslateRotation(unsigned int rotationCCW)
 {
   switch (rotationCCW)
   {
     case 0:
-      return VideoRotation_CCW_0;
+      return VideoRotationSaveState_CCW_0;
     case 90:
-      return VideoRotation_CCW_90;
+      return VideoRotationSaveState_CCW_90;
     case 180:
-      return VideoRotation_CCW_180;
+      return VideoRotationSaveState_CCW_180;
     case 270:
-      return VideoRotation_CCW_270;
+      return VideoRotationSaveState_CCW_270;
     default:
       break;
   }
 
-  return VideoRotation_CCW_0;
+  return VideoRotationSaveState_CCW_0;
 }
 
 /*!
  * \brief Translate the video rotation (RetroPlayer to FlatBuffers)
  */
-unsigned int TranslateRotation(VideoRotation rotationCCW)
+unsigned int TranslateRotation(VideoRotationSaveState rotationCCW)
 {
   switch (rotationCCW)
   {
-    case VideoRotation_CCW_0:
+    case VideoRotationSaveState_CCW_0:
       return 0;
-    case VideoRotation_CCW_90:
+    case VideoRotationSaveState_CCW_90:
       return 90;
-    case VideoRotation_CCW_180:
+    case VideoRotationSaveState_CCW_180:
       return 180;
-    case VideoRotation_CCW_270:
+    case VideoRotationSaveState_CCW_270:
       return 270;
     default:
       break;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
fix warning
type 'VideoRotation' violates the C++ One Definition Rule [-Wodr]
type 'KODI::RETRO::VideoRotation' violates the C++ One Definition Rule [-Wodr]

```
../../kodi-e495e26f477d4de8a7e6c2fac4acbe1a15e22242/.aarch64-libreelec-linux-gnu/../xbmc/cores/RetroPlayer/streams/RetroPlayerStreamTypes.h:77: warning: type 'VideoRotation' violates the C++ One Definition Rule [-Wodr]
../../kodi-e495e26f477d4de8a7e6c2fac4acbe1a15e22242/.aarch64-libreelec-linux-gnu/build/cores/RetroPlayer/messages/video_generated.h:76: note: a type with different precision is defined in another translation unit
../../kodi-e495e26f477d4de8a7e6c2fac4acbe1a15e22242/.aarch64-libreelec-linux-gnu/../xbmc/cores/RetroPlayer/streams/RetroPlayerStreamTypes.h:77: warning: type 'KODI::RETRO::VideoRotation' violates the C++ One Definition Rule [-Wodr]
../../kodi-e495e26f477d4de8a7e6c2fac4acbe1a15e22242/.aarch64-libreelec-linux-gnu/build/cores/RetroPlayer/messages/video_generated.h:76: note: an enum with different value name is defined in another translation unit
../../kodi-e495e26f477d4de8a7e6c2fac4acbe1a15e22242/.aarch64-libreelec-linux-gnu/../xbmc/cores/RetroPlayer/streams/RetroPlayerStreamTypes.h:79: note: name 'ROTATION_0' differs from name 'VideoRotation_CCW_0' defined in another translation unit
../../kodi-e495e26f477d4de8a7e6c2fac4acbe1a15e22242/.aarch64-libreelec-linux-gnu/build/cores/RetroPlayer/messages/video_generated.h:77: note: mismatching definition
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
cleaner compile output to easily spot other real warnings and errors

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
untested

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
