### PR TITLE
fixed: need to check for playlists before music/video/pictures files

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1253,6 +1253,10 @@ void CFileItem::FillInDefaultIcon()
         // PVR deleted recording
         SetArt("icon", "DefaultVideoDeleted.png");
       }
+      else if (PLAYLIST::IsPlayList(*this) || PLAYLIST::IsSmartPlayList(*this))
+      {
+        SetArt("icon", "DefaultPlaylist.png");
+      }
       else if (MUSIC::IsAudio(*this))
       {
         // audio
@@ -1271,10 +1275,6 @@ void CFileItem::FillInDefaultIcon()
       {
         // picture
         SetArt("icon", "DefaultPicture.png");
-      }
-      else if (PLAYLIST::IsPlayList(*this) || PLAYLIST::IsSmartPlayList(*this))
-      {
-        SetArt("icon", "DefaultPlaylist.png");
       }
       else if ( IsPythonScript() )
       {


### PR DESCRIPTION
## Description
We never get the playlist icon as the playlist extensions are in the music/video/pictures extension list 

## Motivation and context
We want correct icons

## How has this been tested?
Noticed while writing tests..

## What is the effect on users?
Old shiny playlist icon will be used

## Screenshots (if appropriate):
![wrong](https://github.com/xbmc/xbmc/assets/5844320/f0b4740b-f161-4671-8132-eaeddb7c27a6)
![correct](https://github.com/xbmc/xbmc/assets/5844320/dfdcba9b-357b-4065-a533-1c97ddd493af)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
