### PR TITLE
[Cmake] silence policy warning and OCD reordering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,13 @@ if(POLICY CMP0069)
   cmake_policy(SET CMP0069 NEW)
 endif()
 
+# https://cmake.org/cmake/help/latest/policy/CMP0074.html
+# find_package() uses <PackageName>_ROOT variables
+if(POLICY CMP0074)
+  set(CMAKE_POLICY_DEFAULT_CMP0074 NEW)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
 if(POLICY CMP0079)
   set(CMAKE_POLICY_DEFAULT_CMP0079 NEW)
   cmake_policy(SET CMP0079 NEW)

--- a/cmake/modules/FindCurl.cmake
+++ b/cmake/modules/FindCurl.cmake
@@ -11,10 +11,9 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
   include(cmake/scripts/common/ModuleHelpers.cmake)
 
   macro(buildCurl)
-
+    find_package(Brotli REQUIRED QUIET)
     find_package(NGHttp2 REQUIRED QUIET)
     find_package(OpenSSL REQUIRED QUIET)
-    find_package(Brotli REQUIRED QUIET)
 
     # Darwin platforms link against toolchain provided zlib regardless
     # They will fail when searching for static. All other platforms, prefer static
@@ -23,7 +22,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin" AND NOT (WIN32 OR WINDOWS_STORE))
       set(ZLIB_USE_STATIC_LIBS ON)
     endif()
-    find_package(ZLIB REQUIRED)
+    find_package(Zlib REQUIRED)
     unset(ZLIB_USE_STATIC_LIBS)
 
     set(CURL_VERSION ${${MODULE}_VER})
@@ -61,14 +60,14 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     BUILD_DEP_TARGET()
 
     # Link libraries for target interface
-    set(PC_CURL_LINK_LIBRARIES Brotli::Brotli OpenSSL::Crypto OpenSSL::SSL NGHttp2::NGHttp2 ZLIB::ZLIB ${PLATFORM_LINK_LIBS})
+    set(PC_CURL_LINK_LIBRARIES Brotli::Brotli NGHttp2::NGHttp2 OpenSSL::Crypto OpenSSL::SSL ZLIB::ZLIB ${PLATFORM_LINK_LIBS})
 
     # Add dependencies to build target
+    add_dependencies(${MODULE_LC} Brotli::Brotli)
     add_dependencies(${MODULE_LC} NGHttp2::NGHttp2)
     add_dependencies(${MODULE_LC} OpenSSL::SSL)
     add_dependencies(${MODULE_LC} OpenSSL::Crypto)
     add_dependencies(${MODULE_LC} ZLIB::ZLIB)
-    add_dependencies(${MODULE_LC} Brotli::Brotli)
   endmacro()
 
   set(MODULE_LC curl)


### PR DESCRIPTION
## Description
Silence a warning for a policy

## Motivation and context
less warn

## How has this been tested?


## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
