### PR TITLE
Python: Restore close of WindowXML when application exits

### DIFF
--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -668,16 +668,6 @@ namespace XBMCAddon
 
         while (bModal && !g_application.m_bStop)
         {
-//! @todo garbear added this code to the python window.cpp class and
-//!  commented in XBPyThread.cpp. I'm not sure how to handle this
-//! in this native implementation.
-//          // Check if XBPyThread::stop() raised a SystemExit exception
-//          if (PyThreadState_Get()->async_exc == PyExc_SystemExit)
-//          {
-//            CLog::Log(LOGDEBUG, "PYTHON: doModal() encountered a SystemExit exception, closing window and returning");
-//            Window_Close(self, NULL);
-//            break;
-//          }
           languageHook->MakePendingCalls(); // MakePendingCalls
 
           bool stillWaiting;
@@ -687,6 +677,14 @@ namespace XBMCAddon
               DelayedCallGuard dcguard(languageHook);
               stillWaiting = WaitForActionEvent(100) ? false : true;
             }
+
+            // If application has quit, close the window
+            if (bModal && g_application.m_bStop)
+            {
+              CLog::Log(LOGDEBUG, "PYTHON: Application quit inside doModal(), closing window");
+              close();
+            }
+
             languageHook->MakePendingCalls();
           } while (stillWaiting);
         }


### PR DESCRIPTION
## Description

The check to close windows at system exit, added in https://github.com/xbmc/xbmc/pull/1224, was commented out in https://github.com/xbmc/xbmc/pull/901.

This PR restores the check in a slightly different place, ensuring that the WindowXML is closed on application exit.

## Motivation and context

When testing my OASIS service, I noticed it now hangs at exit. Here is how the service looks:

```python
class OasisService:
    @staticmethod
    def run(hostname: str) -> None:
        window: xbmcgui.WindowXML

        ...

        window.doModal()
        xbmc.sleep(100)
        del window

        xbmc.log("Exiting OASIS service", level=xbmc.LOGDEBUG)
```

## How has this been tested?

Before:

```
2024-06-25 21:45:23.435 T:42421   debug <general>: CPythonInvoker(0, service.oasis/resources/lib/main.py): trigger Monitor abort request
2024-06-25 21:45:28.435 T:42421   error <general>: CPythonInvoker(0, service.oasis/resources/lib/main.py): script didn't stop in 5 seconds - let's kill it
2024-06-25 21:45:28.435 T:42468   debug <general>: CPythonInvoker(0, service.oasis/resources/lib/main.py): script aborted
2024-06-25 21:45:28.450 T:42468   debug <general>: onExecutionDone(0, service.oasis/resources/lib/main.py)
2024-06-25 21:45:28.461 T:42468   debug <general>: Python interpreter interrupted by user
```

After:

```
2024-06-25 21:47:01.833 T:44160   debug <general>: PYTHON: Application quit inside doModal(), closing window
2024-06-25 21:47:01.933 T:44160   debug <general>: Exiting OASIS service
2024-06-25 21:47:01.933 T:44160   debug <general>: CPythonInvoker(0, service.oasis/resources/lib/main.py): script successfully run
2024-06-25 21:47:01.933 T:44160   debug <general>: onExecutionDone(0, service.oasis/resources/lib/main.py)
2024-06-25 21:47:01.939 T:44160   debug <general>: Python interpreter stopped
```

"Exiting OASIS service" is now printed.

## What is the effect on users?

* Fixed Python windows not closing on application exit

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
