### PR TITLE
Python: Fix hang at application shutdown

### DIFF
--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -57,7 +57,13 @@ XBPython::~XBPython()
 #if PY_VERSION_HEX >= 0x03070000
   if (Py_IsInitialized())
   {
+    // Switch to the main interpreter thread before finalizing
     PyThreadState_Swap(PyInterpreterState_ThreadHead(PyInterpreterState_Main()));
+
+    // Clear all loaded modules to prevent circular references
+    PyObject* modules = PyImport_GetModuleDict();
+    PyDict_Clear(modules);
+
     Py_Finalize();
   }
 #endif


### PR DESCRIPTION
## Description

After rebasing on Omega, I noticed that Kodi hung on shutdown when running my smarthome add-on. I traced this down to PyFinalize() never returning due to circular references. By clearing the modules explicitly, we avoid the hang.

## Motivation and context

I'm actually not 100% sure that a circularity is the problem. I tried a bunch of things, and explicitly clearing modules was the only thing that fixed the hang at exit. But ChatGPT's analysis pointed to circular references being the root cause.

## How has this been tested?

Before:

```
2024-06-25 23:26:52.349 T:88587   debug <general>: Thread Timer 136904888551104 terminating
2024-06-25 23:26:52.350 T:88541   debug <general>: object 0 --> 0 instances
2024-06-25 23:26:52.350 T:88541   debug <general>: object 1 --> 0 instances
2024-06-25 23:26:52.350 T:88541   debug <general>: object 2 --> 0 instances
2024-06-25 23:26:52.350 T:88541   debug <general>: object 3 --> 0 instances
2024-06-25 23:26:52.350 T:88541   debug <general>: object 4 --> 0 instances
2024-06-25 23:26:52.350 T:88541   debug <general>: object 5 --> 0 instances
2024-06-25 23:26:52.350 T:88541   debug <general>: object 6 --> 0 instances
2024-06-25 23:26:52.350 T:88541   debug <general>: object 7 --> 0 instances
2024-06-25 23:26:52.350 T:88541   debug <general>: object 8 --> 0 instances
2024-06-25 23:26:52.350 T:88541   debug <general>: object 9 --> 0 instances
```


After:

```
2024-06-25 23:25:33.826 T:86757   debug <general>: Thread Timer 137915950696128 terminating
2024-06-25 23:25:33.827 T:86711   debug <general>: object 0 --> 0 instances
2024-06-25 23:25:33.827 T:86711   debug <general>: object 1 --> 0 instances
2024-06-25 23:25:33.827 T:86711   debug <general>: object 2 --> 0 instances
2024-06-25 23:25:33.827 T:86711   debug <general>: object 3 --> 0 instances
2024-06-25 23:25:33.827 T:86711   debug <general>: object 4 --> 0 instances
2024-06-25 23:25:33.827 T:86711   debug <general>: object 5 --> 0 instances
2024-06-25 23:25:33.827 T:86711   debug <general>: object 6 --> 0 instances
2024-06-25 23:25:33.827 T:86711   debug <general>: object 7 --> 0 instances
2024-06-25 23:25:33.827 T:86711   debug <general>: object 8 --> 0 instances
2024-06-25 23:25:33.827 T:86711   debug <general>: object 9 --> 0 instances
2024-06-25 23:25:33.839 T:86714   debug <general>: Thread Announce 137917737469632 terminating
2024-06-25 23:25:33.839 T:86711    info <general>: Exiting the application...
```

## What is the effect on users?

* Fixed hang on shutdown with circular references in Python

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
