### PR TITLE
[PVR] Strings cleanup

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1046,7 +1046,9 @@ msgstr ""
 #: xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
 #: xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
 #: xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+#: xbmc/pvr/dialogs/GUIDialogPVRClientPriorities.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
 #: xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -1214,7 +1216,10 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogFileBrowser.cpp
 #: xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
 #: xbmc/network/NetworkServices.cpp
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+#. xbmc/pvr/timers/PVRTimerInfoTag.cpp
 #: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
 #: xbmc/music/windows/GUIWindowMusicBase.cpp
 #: xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1250,7 +1255,7 @@ msgstr ""
 
 #. Label for a context menu entry / button to start/schedule a recording
 #: xbmc/music/windows/GUIWindowMusicBase.cpp
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
 #: xbmc/pvr/windows/GUIWIndowPVRGuide.cpp
 #: xbmc/pvr/PVRContextMenus.cpp
@@ -1504,7 +1509,7 @@ msgstr ""
 
 #. generic "cleaning database" label used in different places
 #: xbmc/music/MusicDatabase.cpp
-#: xbmc/pvr/guilib/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
 #: xbmc/settings/MediaSettings.cpp
 #: xbmc/video/VideoDatabase.cpp
 msgctxt "#313"
@@ -2822,7 +2827,9 @@ msgstr ""
 #: xbmc/filesystem/AddonsDirectory.cpp
 #: xbmc/PlayListPlayer.cpp
 #: xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+#: xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
 msgctxt "#593"
 msgid "All"
 msgstr ""
@@ -3611,7 +3618,7 @@ msgstr ""
 #empty strings from id 800 to 801
 
 #. Label of progress bar which shows the available/total space of pvr backend
-#: xbmc/pvr/PVRGUIInfo.cpp
+#: xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
 msgctxt "#802"
 msgid "{0:s} of {1:s} available"
 msgstr ""
@@ -3846,13 +3853,13 @@ msgid "Live"
 msgstr ""
 
 #. Message in a dialog when a user wants to delete a timer that was scheduled by a timer rule
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#840"
 msgid "Do you only want to delete this timer or also the timer rule that has scheduled it?"
 msgstr ""
 
 #. Label for No button in a dialog when a user wants to delete a timer that was scheduled by a timer rule
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#841"
 msgid "Only this"
 msgstr ""
@@ -3876,25 +3883,25 @@ msgid "Deactivate"
 msgstr ""
 
 #. Message in a dialog when a user wants to delete a timer rule
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#845"
 msgid "Are you sure you want to delete this timer rule and all timers it has scheduled?"
 msgstr ""
 
 #. Message in a dialog when a user wants to delete a timer
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#846"
 msgid "Are you sure you want to delete this timer?"
 msgstr ""
 
 #. Heading for a dialog for confirming to stop an active recording
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#847"
 msgid "Confirm stop recording"
 msgstr ""
 
 #. Message in a dialog when a user wants to stop an active recording
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#848"
 msgid "Are you sure you want to stop this recording?"
 msgstr ""
@@ -5802,7 +5809,7 @@ msgstr ""
 #: addons/skin.estuary/xml/Variables.xml
 #: xbmc/Autorun.cpp
 #: xbmc/favourites/ContextMenus.cpp
-#: xbmc/pvr/PVRGUIActionsPlayback.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
 #: xbmc/video/ContextMenus.cpp
 #: xbmc/video/guilib/VideoSelectActionProcessor.cpp
 #: xbmc/video/guilib/VideoPlayActionProcessor.cpp
@@ -5811,7 +5818,7 @@ msgid "Play from beginning"
 msgstr ""
 
 #. Label of various controls for resuming playback from a certain point in time
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/video/VideoUtils.cpp
 #: xbmc/video/windows/GUIWindowVideoBase.cpp
 msgctxt "#12022"
 msgid "Resume from {0:s}"
@@ -6614,7 +6621,7 @@ msgstr ""
 #: xbmc/pvr/addons/PVRClients.cpp
 #: xbmc/pvr/channels/PVRChannel.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRClientPriorities.cpp
-#: xbmc/pvr/PVRGUIInfo.cpp
+#: xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
 #: xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
 #: xbmc/video/PlayerController.cpp
 #: xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -7992,6 +7999,7 @@ msgid "- Shutdown while playing"
 msgstr ""
 
 #: system/settings/settings.xml
+#: xbmc/pvr/settings/PVRSettings.cpp
 msgctxt "#14044"
 msgid "{0:d} min"
 msgstr ""
@@ -9139,7 +9147,6 @@ msgid "Enter value"
 msgstr ""
 
 #. PVR error messages dialog text.
-#: xbmc/addons/PVRClients.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
 msgctxt "#16029"
 msgid "Check the log for more information about this message."
@@ -9625,8 +9632,8 @@ msgstr ""
 #: addons/skin.estuary/xml/Home.xml
 #: addons/skin.estuary/xml/Variables.xml
 #: xbmc/dialogs/GUIDialogMediaSource.cpp
-#: xbmc/pvr/PVRGUIDirectory.cpp
-#: xbmc/pvr/guilib/PVRGUIActions.cpp
+#: xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
 msgctxt "#19017"
 msgid "Recordings"
 msgstr ""
@@ -9643,8 +9650,8 @@ msgstr ""
 #: addons/skin.estuary/xml/DialogPVRChannelsOSD.xml
 #: addons/skin.estuary/xml/Variables.xml
 #: addons/skin.estuary/xml/Home.xml
-#: xbmc/pvr/PVRGUIDirectory.cpp
-#: xbmc/pvr/guilib/PVRGUIActions.cpp
+#: xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
 #: xbmc/windows/GUIWindowSystemInfo.cpp
 msgctxt "#19019"
 msgid "Channels"
@@ -9654,8 +9661,8 @@ msgstr ""
 #: addons/skin.estuary/xml/Home.xml
 #: addons/skin.estuary/xml/SkinSettings.xml:
 #: addons/skin.estuary/xml/Variables.xml
-#: xbmc/pvr/PVRGUIActions.cpp
-#: xbmc/pvr/PVRGUIDirectory.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+#: xbmc/pvr/filesystem/PVRGUIDirectory.cpp
 msgctxt "#19020"
 msgid "TV"
 msgstr ""
@@ -9664,8 +9671,8 @@ msgstr ""
 #: addons/skin.estuary/xml/Home.xml
 #: addons/skin.estuary/xml/SkinSettings.xml
 #: addons/skin.estuary/xml/Variables.xml
-#: xbmc/pvr/PVRGUIActions.cpp
-#: xbmc/pvr/PVRGUIDirectory.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+#: xbmc/pvr/filesystem/PVRGUIDirectory.cpp
 msgctxt "#19021"
 msgid "Radio"
 msgstr ""
@@ -9698,7 +9705,7 @@ msgstr ""
 
 #. label for "add timer..." list item used in pvr timers / timer rules window
 #: xbmc/pvr/timers/PVRTimerInfoTag.cpp
-#: xbmc/pvr/PVRGUIDirectory.cpp
+#: xbmc/pvr/filesystem/PVRGUIDirectory.cpp
 msgctxt "#19026"
 msgid "Add timer..."
 msgstr ""
@@ -9718,7 +9725,7 @@ msgstr ""
 #: addons/skin.estuary/xml/DialogFullScreenInfo.xml
 #: xbmc/filesystem/PluginDirectory.cpp
 #: xbmc/pvr/channels/PVRChannel.cpp
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
 #: xbmc/utils/SortUtils.cpp
 msgctxt "#19029"
 msgid "Channel"
@@ -9749,10 +9756,8 @@ msgstr ""
 #: xbmc/favourites/ContextMenus.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
-#: xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
-#: xbmc/pvr/timers/PVRTimerInfoTag.cpp
-#: xbmc/pvr/PVRGUIActions.cpp
-#: xbmc/pvr/PVRManager.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 #: xbmc/video/windows/GUIWindowVideoBase.cpp
 #: addons/skin.estuary/xml/MusicOSD.xml
 #: addons/skin.estuary/xml/VideoOSD.xml
@@ -9761,21 +9766,18 @@ msgid "Information"
 msgstr ""
 
 #. message box text stating that a timer is already set for a given epg event.
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19034"
 msgid "There is already a timer set for this event"
 msgstr ""
 
 #. message box text stating that a pvr channel could not be played.
-#: xbmc/pvr/PVRGUIActions.cpp
-#: xbmc/pvr/PVRManager.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
 msgctxt "#19035"
 msgid "{0:s} can't be played. Check the log for more information about this message."
 msgstr ""
 
-#. message box text stating that a recording could not be played.
-#: xbmc/pvr/PVRGUIActions.cpp
-#: xbmc/video/windows/GUIWindowVideoBase.cpp
+#: @@@ unused?
 msgctxt "#19036"
 msgid "This recording can't be played. Check the log for more information about this message."
 msgstr ""
@@ -9793,7 +9795,7 @@ msgid "Not supported by the PVR backend."
 msgstr ""
 
 #. message box text asking for confirmation to hide a channel.
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
 msgctxt "#19039"
 msgid "Are you sure you want to hide this channel?"
 msgstr ""
@@ -9877,7 +9879,7 @@ msgid "Recording information"
 msgstr ""
 
 #. header label for hide channel confirmation message box
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
 msgctxt "#19054"
 msgid "Hide channel"
 msgstr ""
@@ -9892,9 +9894,9 @@ msgstr ""
 #: addons/skin.estuary/xml/MyVideoNav.xml
 #: addons/skin.estuary/xml/View_50_List.xml
 #: xbmc/pvr/epg/EpgInfoTag.cpp
+#: xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
 #: xbmc/FileItem.cpp
 #: xbmc/GUIInfoManager.cpp
-#: xbmc/pvr/PVRManager.cpp
 #: xbmc/video/windows/GUIWindowVideoBase.cpp
 #: xbmc/utils/SystemInfo.cpp
 msgctxt "#19055"
@@ -9986,7 +9988,8 @@ msgstr ""
 
 #. generic label for the electronic program guide (EPG) used in different places
 #: addons/skin.estuary/xml/Variables.xml
-#: xbmc/pvr/guilib/PVRGUIActions.cpp
+#: xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
 msgctxt "#19069"
 msgid "Guide"
 msgstr ""
@@ -10089,7 +10092,7 @@ msgstr ""
 
 #. Label for "Instant recording action" setting
 #: system/settings/settings.xml
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19086"
 msgid "Instant recording action"
 msgstr ""
@@ -10113,37 +10116,37 @@ msgid "Ask what to do"
 msgstr ""
 
 #. Label for "Instant recording action" dialog settings value
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19090"
 msgid "Record the next {0:d} minutes"
 msgstr ""
 
 #. Label for "Instant recording action" dialog settings value
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19091"
 msgid "Record current show ({0:s})"
 msgstr ""
 
 #. Label for "Instant recording action" dialog settings value
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19092"
 msgid "Record next show ({0:s})"
 msgstr ""
 
 #. Instant recording summary. Expands to "Instant recording: <recording start and end times>", for example "Instant recording: 31/05/2016 from 9:00 to 11:00"
-#: xbmc/pvr/PVRTimerInfoTag.cpp
+#: xbmc/pvr/timers/PVRTimerInfoTag.cpp
 msgctxt "#19093"
 msgid "Instant recording: {0:s}"
 msgstr ""
 
 #. error message displayed in case adding a timer failed because no suitable epg-based timer type could be found.
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19094"
 msgid "Timer creation failed. Unsupported timer type."
 msgstr ""
 
 #. error message displayed in case adding a timer rule failed because no suitable epg-based timer rule type could be found.
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19095"
 msgid "Timer rule creation failed. Unsupported timer type."
 msgstr ""
@@ -10165,8 +10168,7 @@ msgstr ""
 #: xbmc/addons/AddonSystemSettings.cpp
 #: xbmc/addons/gui/GUIDialogAddonSettings.cpp
 #: xbmc/network/NetworkServices.cpp
-#: xbmc/pvr/channels/PVRChannelGroupInternal.cpp
-#: xbmc/pvr/PVRManager.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
 msgctxt "#19098"
 msgid "Warning!"
 msgstr ""
@@ -10189,8 +10191,7 @@ msgctxt "#19101"
 msgid "Provider"
 msgstr ""
 
-#. message box text prompting user to switch to another channel
-#: xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+#: @@@ unused?
 msgctxt "#19102"
 msgid "Please switch to another channel."
 msgstr ""
@@ -10214,13 +10215,13 @@ msgid "Please select a channel"
 msgstr ""
 
 #. part of timer information text (e.g. "Next recording on 10/10/2016 at 9:00 AM")
-#: xbmc/pvr/PVRGUITimerInfo.cpp
+#: xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.cpp
 msgctxt "#19106"
 msgid "Next recording on"
 msgstr ""
 
 #. part of timer information text (e.g. "Next recording on 10/10/2016 at 9:00 AM")
-#: xbmc/pvr/PVRGUITimerInfo.cpp
+#: xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.cpp
 #: xbmc/pvr/timers/PVRTimerInfoTag.cpp
 msgctxt "#19107"
 msgid "at"
@@ -10233,31 +10234,31 @@ msgid "Fallback framerate"
 msgstr ""
 
 #. message box text stating that a timer could not be saved
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19109"
 msgid "Could not save the timer. Check the log for more information about this message."
 msgstr ""
 
 #. message box text stating that a timer could not be deleted
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19110"
 msgid "Could not delete the timer. Check the log for more information about this message."
 msgstr ""
 
 #. message box text stating that a PVR backend error occurred
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
 msgctxt "#19111"
 msgid "PVR backend error. Check the log for more information about this message."
 msgstr ""
 
 #. delete recordings confirmation message box text
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
 msgctxt "#19112"
 msgid "Delete this recording?"
 msgstr ""
 
 #. delete multiple recordings confirmation message box text
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
 msgctxt "#19113"
 msgid "Delete all recordings in this folder?"
 msgstr ""
@@ -10292,7 +10293,7 @@ msgid "Can't use PVR functions while searching."
 msgstr ""
 
 #. channel scan backend selection dialog text
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
 msgctxt "#19119"
 msgid "On which backend do you want to search?"
 msgstr ""
@@ -10447,7 +10448,8 @@ msgstr ""
 
 #. generic label for pvr channel groups used in different places
 #: addons/skin.estuary/xml/DialogPVRChannelsOSD.xml
-#: xbmc/pvr/guilib/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
+#: xbmc/pvr/windows/GUIWindowPVRBase.cpp
 msgctxt "#19146"
 msgid "Groups"
 msgstr ""
@@ -10554,14 +10556,14 @@ msgid "Recordings"
 msgstr ""
 
 #. error box text stating that recording could not be started
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19164"
 msgid "Could not start recording. Check the log for more information about this message."
 msgstr ""
 
 #. Label for "switch to channel" button""
 #: addons/skin.estuary/xml/DialogPVRInfo.xml
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 #: xbmc/pvr/windows/GUIWIndowPVRGuide.cpp
 msgctxt "#19165"
 msgid "Switch"
@@ -10569,8 +10571,8 @@ msgstr ""
 
 #. label for header of misc PVR GUI elements
 #: xbmc/windows/GUIWindowSystemInfo.cpp
-#: xbmc/pvr/PVRManager.cpp
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+#: xbmc/pvr/windows/GUIWIndowPVRChannels.cpp
 msgctxt "#19166"
 msgid "PVR information"
 msgstr ""
@@ -10593,7 +10595,7 @@ msgid "Hide video information box"
 msgstr ""
 
 #. error box text stating that recording could not be stopped
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19170"
 msgid "Could not stop recording. Check the log for more information about this message."
 msgstr ""
@@ -10683,7 +10685,7 @@ msgstr ""
 #. label for "deleted recordings" data source in media source window
 #: addons/skin.estuary/xml/Includes_MediaMenu.xml
 #: xbmc/dialogs/GUIDialogMediaSource.cpp
-#: xbmc/pvr/PVRGUIDirectory.cpp
+#: xbmc/pvr/filesystem/PVRGUIDirectory.cpp
 msgctxt "#19184"
 msgid "Deleted recordings"
 msgstr ""
@@ -10695,25 +10697,25 @@ msgid "Clear data"
 msgstr ""
 
 #. message box text for pvr data reset confirmation
-#: xbmc/pvr/guilib/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
 msgctxt "#19186"
 msgid "All selected data will be cleared. Some information cannot be restored from the clients afterwards. Proceed anyway?"
 msgstr ""
 
 #. progress dialog text shown while purging pvr data
-#: xbmc/pvr/guilib/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
 msgctxt "#19187"
 msgid "Clearing data."
 msgstr ""
 
 #. message box text for epg data reset confirmation
-#: xbmc/pvr/guilib/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
 msgctxt "#19188"
 msgid "All guide data will be cleared. Are you sure?"
 msgstr ""
 
 #. message box text stating that the PVR backend forbids to record a given epg event.
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19189"
 msgid "The PVR backend does not allow to record this event."
 msgstr ""
@@ -10731,13 +10733,13 @@ msgid "PVR service"
 msgstr ""
 
 #. info message box text stating that none of the available pvr clients does support channel scanning
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
 msgctxt "#19192"
 msgid "None of the connected PVR backends supports scanning for channels."
 msgstr ""
 
 #. error message box text stating that a given pvr channel could not be played
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
 msgctxt "#19193"
 msgid "The channel scan can't be started. Check the log for more information about this message."
 msgstr ""
@@ -10754,19 +10756,19 @@ msgid "Delay mark last watched"
 msgstr ""
 
 #. value for "pvr client specific actions" dialog headers
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsClients.cpp
 msgctxt "#19196"
 msgid "PVR client specific actions"
 msgstr ""
 
 #. text for "recording started on <pvr client name>" pvr client addon callback notification
-#: xbmc/addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.cpp
+#: xbmc/pvr/addons/PVRClient.cpp
 msgctxt "#19197"
 msgid "Recording started on: {0:s}"
 msgstr ""
 
 #. text for "recording finished on <pvr client name>" pvr client addon callback notification
-#: xbmc/addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.cpp
+#: xbmc/pvr/addons/PVRClient.cpp
 msgctxt "#19198"
 msgid "Recording finished on: {0:s}"
 msgstr ""
@@ -10864,7 +10866,7 @@ msgstr ""
 
 #. generic label for PVR reminders used in different places
 #: system/settings/settings.xml
-#: xbmc/pvr/guilib/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
 msgctxt "#19215"
 msgid "Reminders"
 msgstr ""
@@ -11139,31 +11141,34 @@ msgid "Change PIN"
 msgstr ""
 
 #. generic 'parental control enter pin' label
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsParentalControl.cpp
 msgctxt "#19262"
 msgid "Parental control. Enter PIN:"
 msgstr ""
 
 #. message box text stating that a timer could not be updated
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19263"
 msgid "Could not update the timer. Check the log for more information about this message."
 msgstr ""
 
 #. label for 'incorrect pin' error dialog header
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsParentalControl.cpp
 msgctxt "#19264"
 msgid "Incorrect PIN"
 msgstr ""
 
 #. label for 'incorrect pin' error dialog text
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsParentalControlTimers.cpp
+#: xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
 msgctxt "#19265"
 msgid "The entered PIN was incorrect."
 msgstr ""
 
 #. label to use for epg tag title instead of actual event title if the respective channel is parental locked
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/FileItem.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+#: xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
 msgctxt "#19266"
 msgid "Parental locked"
 msgstr ""
@@ -11279,13 +11284,13 @@ msgid "Browse for icon"
 msgstr ""
 
 #. Label for channel icon search progress dialog
-#: xbmc/pvr/channels/PVRChannelGroup.cpp
+#: xbmc/pvr/guilib/PVRGUIChannelIconUpdater.cpp
 msgctxt "#19286"
 msgid "Searching for channel icons"
 msgstr ""
 
-#. Label for the default pvr channel group
-#: xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+#. Label for the pvr 'all chnanels' 'channel group
+#: xbmc/pvr/channels/PVRChannelGroupAllChannels.cpp
 msgctxt "#19287"
 msgid "All channels"
 msgstr ""
@@ -11316,19 +11321,20 @@ msgid "Delete permanently"
 msgstr ""
 
 #. "remove deleted recordings from trash" dialog header
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
+#: xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
 msgctxt "#19292"
 msgid "Delete all permanently"
 msgstr ""
 
 #. "remove deleted recordings from trash" dialog text
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
 msgctxt "#19293"
 msgid "Remove all deleted recordings from trash? This operation cannot be reverted."
 msgstr ""
 
 #. "remove deleted recording from trash" dialog text
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
 msgctxt "#19294"
 msgid "Remove this deleted recording from trash? This operation cannot be reverted."
 msgstr ""
@@ -11407,37 +11413,37 @@ msgid "Deleted missed PVR reminder for channel '{0:s}' at '{1:s}'"
 msgstr ""
 
 #. text for reminder announcement dialog
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19307"
 msgid "Reminder for [B]{0:s}[/B] on channel [B]{1:s}[/B] at [B]{2:s}[/B]."
 msgstr ""
 
 #. text for reminder announcement dialog
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19308"
 msgid "Reminder for channel [B]{0:s}[/B] at [B]{1:s}[/B]."
 msgstr ""
 
 #. additional text for reminder announcement dialog, used if a recording can be scheduled
-#: xbmc/pvr/timers/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19309"
 msgid "(Auto-close of this reminder will schedule a recording...)"
 msgstr ""
 
 #. text for event log entry for logging auto scheduled recordings for auto-closed reminders
-#: xbmc/pvr/timers/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19310"
 msgid "Scheduled recording for auto-closed PVR reminder for '{0:s}' on channel '{1:s}' at '{2:s}'"
 msgstr ""
 
 #. text for event log entry for logging auto scheduled recordings for auto-closed reminders
-#: xbmc/pvr/timers/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19311"
 msgid "Scheduled recording for auto-closed PVR reminder for channel '{0:s}' at '{1:s}'"
 msgstr ""
 
 #. heading for pvr reminder notification dialog
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19312"
 msgid "PVR reminder"
 msgstr ""
@@ -11455,7 +11461,7 @@ msgid "Schedule recording when auto-closing the reminder popup"
 msgstr ""
 
 #. generic 'backend order' label
-#: xbmc/pvr/channels/PVRChannel.cpp
+#: xbmc/pvr/windows/GUIViewStatePVR.cpp
 #: xbmc/utils/SortUtils.cpp
 msgctxt "#19315"
 msgid "Backend order"
@@ -11542,7 +11548,7 @@ msgid "Delete watched"
 msgstr ""
 
 #. delete multiple recordings confirmation message box text
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
 msgctxt "#19328"
 msgid "Delete all watched recordings in this folder?"
 msgstr ""
@@ -11560,25 +11566,25 @@ msgid "Switch to channel when auto-closing the reminder popup"
 msgstr ""
 
 #. additional text for reminder announcement dialog, used if a recording can be scheduled
-#: xbmc/pvr/timers/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19331"
 msgid "(Auto-close of this reminder will switch to channel...)"
 msgstr ""
 
 #. text for event log entry for logging auto channel switch for auto-closed reminders
-#: xbmc/pvr/timers/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19332"
 msgid "Switched to channel for auto-closed PVR reminder for '{0:s}' on channel '{1:s}' at '{2:s}'"
 msgstr ""
 
 #. text for event log entry for logging auto scheduled recordings for auto-closed reminders
-#: xbmc/pvr/timers/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19333"
 msgid "Switched to channel for auto-closed PVR reminder for channel '{0:s}' at '{1:s}'"
 msgstr ""
 
 #. label for PVR backend number of channel providers in system information's PVR section
-#: xbmc/pvr/timers/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
 #: xbmc/windows/GUIWindowSystemInfo.cpp
 msgctxt "#19334"
 msgid "Providers"
@@ -11603,7 +11609,7 @@ msgid "Saved searches"
 msgstr ""
 
 #. delete saved search confirmation message box text
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsEPG.cpp
 msgctxt "#19338"
 msgid "Delete this saved search?"
 msgstr ""
@@ -11657,12 +11663,13 @@ msgid "Display and manage available PVR client add-ons."
 msgstr ""
 
 #. info message box text stating that none of the available pvr clients does provide client-specific settings
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsClients.cpp
 msgctxt "#19347"
 msgid "None of the active PVR clients provide client-specific settings."
 msgstr ""
 
 #. label for 'by provider' sort method
+#: xbmc/pvr/windows/GUIViewStatePVR.cpp
 #: xbmc/utils/SortUtils.cpp
 msgctxt "#19348"
 msgid "Provider"
@@ -11699,7 +11706,7 @@ msgid "Play programmes from here"
 msgstr ""
 
 #. Label of a context menu entry to kick catchup / VOD playback of only the selected item, not auto playing any following programmes
-#: xbmc/pvr/PVRContextMenuItem.cpp
+#: xbmc/pvr/PVRContextMenus.cpp
 msgctxt "#19354"
 msgid "Play only this programme"
 msgstr ""
@@ -12281,20 +12288,20 @@ msgid "Adult"
 msgstr ""
 
 #. Title for shutdown confirmation dialog
-#: xbmc/pvr/PVRManager.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
 msgctxt "#19685"
 msgid "Confirm shutdown"
 msgstr ""
 
-#: Label for buttons to open channel guide dialog
+#. Label for buttons to open channel guide dialog
 #: addons/skin.estuary/xml/DialogPVRInfo.xml
 msgctxt "#19686"
 msgid "Channel guide"
 msgstr ""
 
-#: Label for context menu entries, dialog heading, button to start playing a recording
+#. Label for context menu entries, dialog heading, button to start playing a recording
 #: xbmc/pvr/PVRContextMenus.cpp
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
 msgctxt "#19687"
 msgid "Play recording"
 msgstr ""
@@ -12302,43 +12309,43 @@ msgstr ""
 #empty strings from id 19688 to 19689
 
 #. Text for shutdown confirmation dialog
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
 msgctxt "#19690"
 msgid "PVR has scheduled a reminder for '{0:s}' on channel '{1:s}' in {2:s}."
 msgstr ""
 
 #. Text for shutdown confirmation dialog.
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
 msgctxt "#19691"
 msgid "PVR is currently recording '{0:s}' on channel '{1:s}'."
 msgstr ""
 
 #. Text for shutdown confirmation dialog
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
 msgctxt "#19692"
 msgid "PVR will start recording '{0:s}' on channel '{1:s}' in {2:s}."
 msgstr ""
 
 #. Text for shutdown confirmation dialog
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
 msgctxt "#19693"
 msgid "Daily wakeup is due in {0:s}."
 msgstr ""
 
 #. Text for shutdown confirmation dialog
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
 msgctxt "#19694"
 msgid "{0:d} minutes"
 msgstr ""
 
 #. Text for shutdown confirmation dialog
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
 msgctxt "#19695"
 msgid "about a minute"
 msgstr ""
 
 #. Yes button label for shutdown confirmation dialog
-#: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
 msgctxt "#19696"
 msgid "Shutdown anyway"
 msgstr ""
@@ -13632,6 +13639,7 @@ msgstr ""
 
 #: xbmc/media/MediaTypes.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
+#: xbmc/pvr/windows/GUIViewStatePVR.cppp
 #: addons/skin.estuary/xml/DialogFullScreenInfo.xml
 #: addons/skin.estuary/xml/Variables.xml
 msgctxt "#20359"
@@ -13664,6 +13672,7 @@ msgid "Remove TV show from library"
 msgstr ""
 
 #: xbmc/playlists/SmartPlaylist.cpp
+#: xbmc/pvr/recordings/PVRRecording.cpp
 msgctxt "#20364"
 msgid "TV show"
 msgstr ""
@@ -15744,7 +15753,7 @@ msgstr ""
 
 #. generic label to denote the addon type pvr clients, used in different places
 #: xbmc/addons/Addon.cpp
-#: xbmc/pvr/guilib/PVRGUIActions.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
 msgctxt "#24019"
 msgid "PVR clients"
 msgstr ""

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9146,8 +9146,8 @@ msgctxt "#16028"
 msgid "Enter value"
 msgstr ""
 
-#. PVR error messages dialog text.
-#: xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+#. General error messages dialog text.
+#: xbmc/cores/VideoPlayer/VideoPlayer.cpp
 msgctxt "#16029"
 msgid "Check the log for more information about this message."
 msgstr ""
@@ -9774,12 +9774,12 @@ msgstr ""
 #. message box text stating that a pvr channel could not be played.
 #: xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
 msgctxt "#19035"
-msgid "{0:s} can't be played. Check the log for more information about this message."
+msgid "{0:s} can't be played."
 msgstr ""
 
 #: @@@ unused?
 msgctxt "#19036"
-msgid "This recording can't be played. Check the log for more information about this message."
+msgid "This recording can't be played."
 msgstr ""
 
 #. pvr settings "show signal quality" label
@@ -9825,12 +9825,12 @@ msgstr ""
 
 #: @@@ unused?
 msgctxt "#19044"
-msgid "Please check your configuration. Check the log for more information about this message."
+msgid "Please check your configuration."
 msgstr ""
 
 #: @@@ unused?
 msgctxt "#19045"
-msgid "No PVR clients have been started yet. Wait for the PVR clients to start up. Check the log for more information about this message."
+msgid "No PVR clients have been started yet. Wait for the PVR clients to start up."
 msgstr ""
 
 #: @@@ unused?
@@ -10236,19 +10236,19 @@ msgstr ""
 #. message box text stating that a timer could not be saved
 #: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19109"
-msgid "Could not save the timer. Check the log for more information about this message."
+msgid "Could not save the timer."
 msgstr ""
 
 #. message box text stating that a timer could not be deleted
 #: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19110"
-msgid "Could not delete the timer. Check the log for more information about this message."
+msgid "Could not delete the timer."
 msgstr ""
 
 #. message box text stating that a PVR backend error occurred
 #: xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
 msgctxt "#19111"
-msgid "PVR backend error. Check the log for more information about this message."
+msgid "PVR backend error."
 msgstr ""
 
 #. delete recordings confirmation message box text
@@ -10558,7 +10558,7 @@ msgstr ""
 #. error box text stating that recording could not be started
 #: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19164"
-msgid "Could not start recording. Check the log for more information about this message."
+msgid "Could not start recording."
 msgstr ""
 
 #. Label for "switch to channel" button""
@@ -10597,7 +10597,7 @@ msgstr ""
 #. error box text stating that recording could not be stopped
 #: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19170"
-msgid "Could not stop recording. Check the log for more information about this message."
+msgid "Could not stop recording."
 msgstr ""
 
 #. pvr settings "start playback full screen" setting label
@@ -10741,7 +10741,7 @@ msgstr ""
 #. error message box text stating that a given pvr channel could not be played
 #: xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
 msgctxt "#19193"
-msgid "The channel scan can't be started. Check the log for more information about this message."
+msgid "The channel scan can't be started."
 msgstr ""
 
 #. unused?
@@ -11149,7 +11149,7 @@ msgstr ""
 #. message box text stating that a timer could not be updated
 #: xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
 msgctxt "#19263"
-msgid "Could not update the timer. Check the log for more information about this message."
+msgid "Could not update the timer."
 msgstr ""
 
 #. label for 'incorrect pin' error dialog header

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -577,10 +577,8 @@ bool CGUIDialogPVRChannelManager::OnClickButtonNewChannel()
       HELPERS::ShowOKDialogText(
           CVariant{19033}, CVariant{19038}); // "Information", "Not supported by the PVR backend."
     else
-      HELPERS::ShowOKDialogText(
-          CVariant{2103},
-          CVariant{
-              16029}); // "Add-on error", "Check the log for more information about this message."
+      HELPERS::ShowOKDialogText(CVariant{2103},
+                                CVariant{19111}); // "Add-on error", "PVR backend error."
   }
   return true;
 }
@@ -749,10 +747,8 @@ bool CGUIDialogPVRChannelManager::OnContextButton(int itemNumber, CONTEXT_BUTTON
       HELPERS::ShowOKDialogText(
           CVariant{19033}, CVariant{19038}); // "Information", "Not supported by the PVR backend."
     else
-      HELPERS::ShowOKDialogText(
-          CVariant{2103},
-          CVariant{
-              16029}); // "Add-on error", "Check the log for more information about this message."
+      HELPERS::ShowOKDialogText(CVariant{2103},
+                                CVariant{19111}); // "Add-on error", "PVR backend error."
   }
   else if (button == CONTEXT_BUTTON_DELETE)
   {
@@ -788,10 +784,8 @@ bool CGUIDialogPVRChannelManager::OnContextButton(int itemNumber, CONTEXT_BUTTON
               CVariant{19033},
               CVariant{19038}); // "Information", "Not supported by the PVR backend."
         else
-          HELPERS::ShowOKDialogText(
-              CVariant{2103},
-              CVariant{
-                  16029}); // "Add-on error", "Check the log for more information about this message."
+          HELPERS::ShowOKDialogText(CVariant{2103},
+                                    CVariant{19111}); // "Add-on error", "PVR backend error."
       }
     }
   }
@@ -958,7 +952,7 @@ void CGUIDialogPVRChannelManager::RenameChannel(const CFileItemPtr& pItem)
     const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(*pItem);
     if (!client || (client->RenameChannel(channel) != PVR_ERROR_NO_ERROR))
       HELPERS::ShowOKDialogText(CVariant{2103},
-                                CVariant{16029}); // Add-on error;Check the log file for details.
+                                CVariant{19111}); // "Add-on error", "PVR backend error."
   }
 }
 

--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
@@ -311,10 +311,8 @@ bool CPVRGUIActionsChannels::StartChannelScan(int clientId)
 
   /* do the scan */
   if (scanClient->StartChannelScan() != PVR_ERROR_NO_ERROR)
-    HELPERS::ShowOKDialogText(
-        CVariant{257}, // "Error"
-        CVariant{
-            19193}); // "The channel scan can't be started. Check the log for more information about this message."
+    HELPERS::ShowOKDialogText(CVariant{257}, // "Error"
+                              CVariant{19193}); // "The channel scan can't be started."
 
   auto end = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
@@ -321,9 +321,8 @@ bool CPVRGUIActionsPlayback::SwitchToChannel(const CFileItem& item, bool bCheckR
   {
     const std::string channelName =
         channel ? channel->ChannelName() : g_localizeStrings.Get(19029); // Channel
-    const std::string msg = StringUtils::Format(
-        g_localizeStrings.Get(19035),
-        channelName); // CHANNELNAME could not be played. Check the log for details.
+    const std::string msg = StringUtils::Format(g_localizeStrings.Get(19035),
+                                                channelName); // CHANNELNAME could not be played.
 
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(19166),
                                           msg); // PVR information
@@ -407,9 +406,7 @@ bool CPVRGUIActionsPlayback::SwitchToChannel(PlaybackType type) const
       g_localizeStrings.Get(19166), // PVR information
       StringUtils::Format(
           g_localizeStrings.Get(19035),
-          g_localizeStrings.Get(
-              bIsRadio ? 19021
-                       : 19020))); // Radio/TV could not be played. Check the log for details.
+          g_localizeStrings.Get(bIsRadio ? 19021 : 19020))); // Radio/TV could not be played.
   return false;
 }
 

--- a/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
@@ -256,10 +256,7 @@ bool CPVRGUIActionsRecordings::DeleteRecording(const CFileItem& item) const
 
   if (!AsyncDeleteRecording().Execute(item))
   {
-    HELPERS::ShowOKDialogText(
-        CVariant{257},
-        CVariant{
-            19111}); // "Error", "PVR backend error. Check the log for more information about this message."
+    HELPERS::ShowOKDialogText(CVariant{257}, CVariant{19111}); // "Error", "PVR backend error."
     return false;
   }
 
@@ -289,10 +286,7 @@ bool CPVRGUIActionsRecordings::DeleteWatchedRecordings(const CFileItem& item) co
 
   if (!AsyncDeleteRecording(true).Execute(item))
   {
-    HELPERS::ShowOKDialogText(
-        CVariant{257},
-        CVariant{
-            19111}); // "Error", "PVR backend error. Check the log for more information about this message."
+    HELPERS::ShowOKDialogText(CVariant{257}, CVariant{19111}); // "Error", "PVR backend error."
     return false;
   }
 
@@ -333,10 +327,7 @@ bool CPVRGUIActionsRecordings::UndeleteRecording(const CFileItem& item) const
 
   if (!AsyncUndeleteRecording().Execute(item))
   {
-    HELPERS::ShowOKDialogText(
-        CVariant{257},
-        CVariant{
-            19111}); // "Error", "PVR backend error. Check the log for more information about this message."
+    HELPERS::ShowOKDialogText(CVariant{257}, CVariant{19111}); // "Error", "PVR backend error."
     return false;
   }
 

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
@@ -82,10 +82,8 @@ private:
       if (CServiceBroker::GetPVRManager().Timers()->UpdateTimer(m_newTimer))
         return;
 
-      HELPERS::ShowOKDialogText(
-          CVariant{257},
-          CVariant{
-              19263}); // "Error", "Could not update the timer. Check the log for more information about this message."
+      HELPERS::ShowOKDialogText(CVariant{257},
+                                CVariant{19263}); // "Error", "Could not update the timer."
       m_success = false;
       return;
     }
@@ -266,10 +264,8 @@ bool CPVRGUIActionsTimers::AddTimer(const std::shared_ptr<CPVRTimerInfoTag>& ite
   if (!item->Channel() && !item->GetTimerType()->IsEpgBasedTimerRule())
   {
     CLog::LogF(LOGERROR, "No channel given");
-    HELPERS::ShowOKDialogText(
-        CVariant{257},
-        CVariant{
-            19109}); // "Error", "Could not save the timer. Check the log for more information about this message."
+    HELPERS::ShowOKDialogText(CVariant{257},
+                              CVariant{19109}); // "Error", "Could not save the timer."
     return false;
   }
 
@@ -287,10 +283,8 @@ bool CPVRGUIActionsTimers::AddTimer(const std::shared_ptr<CPVRTimerInfoTag>& ite
 
   if (!CServiceBroker::GetPVRManager().Timers()->AddTimer(item))
   {
-    HELPERS::ShowOKDialogText(
-        CVariant{257},
-        CVariant{
-            19109}); // "Error", "Could not save the timer. Check the log for more information about this message."
+    HELPERS::ShowOKDialogText(CVariant{257},
+                              CVariant{19109}); // "Error", "Could not save the timer"
     return false;
   }
 
@@ -574,10 +568,8 @@ bool CPVRGUIActionsTimers::SetRecordingOnChannel(const std::shared_ptr<CPVRChann
         bReturn = CServiceBroker::GetPVRManager().Timers()->AddTimer(newTimer);
 
       if (!bReturn)
-        HELPERS::ShowOKDialogText(
-            CVariant{257},
-            CVariant{
-                19164}); // "Error", "Could not start recording. Check the log for more information about this message."
+        HELPERS::ShowOKDialogText(CVariant{257},
+                                  CVariant{19164}); // "Error", "Could not start recording."
     }
     else if (!bOnOff && CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*channel))
     {
@@ -586,10 +578,8 @@ bool CPVRGUIActionsTimers::SetRecordingOnChannel(const std::shared_ptr<CPVRChann
           CServiceBroker::GetPVRManager().Timers()->DeleteTimersOnChannel(channel, true, true);
 
       if (!bReturn)
-        HELPERS::ShowOKDialogText(
-            CVariant{257},
-            CVariant{
-                19170}); // "Error", "Could not stop recording. Check the log for more information about this message."
+        HELPERS::ShowOKDialogText(CVariant{257},
+                                  CVariant{19170}); // "Error", "Could not stop recording."
     }
   }
 
@@ -627,10 +617,8 @@ bool CPVRGUIActionsTimers::ToggleTimerState(const CFileItem& item) const
   if (CServiceBroker::GetPVRManager().Timers()->UpdateTimer(timer))
     return true;
 
-  HELPERS::ShowOKDialogText(
-      CVariant{257},
-      CVariant{
-          19263}); // "Error", "Could not update the timer. Check the log for more information about this message."
+  HELPERS::ShowOKDialogText(CVariant{257},
+                            CVariant{19263}); // "Error", "Could not update the timer."
   return false;
 }
 
@@ -727,10 +715,8 @@ bool CPVRGUIActionsTimers::DeleteTimer(const CFileItem& item,
           TimerOperationResult::OK)
         return true;
 
-      HELPERS::ShowOKDialogText(
-          CVariant{257},
-          CVariant{
-              19170}); // "Error", "Could not stop recording. Check the log for more information about this message."
+      HELPERS::ShowOKDialogText(CVariant{257},
+                                CVariant{19170}); // "Error", "Could not stop recording."
       return false;
     }
   }
@@ -773,10 +759,8 @@ bool CPVRGUIActionsTimers::DeleteTimer(const std::shared_ptr<CPVRTimerInfoTag>& 
     }
     case TimerOperationResult::FAILED:
     {
-      HELPERS::ShowOKDialogText(
-          CVariant{257},
-          CVariant{
-              19110}); // "Error", "Could not delete the timer. Check the log for more information about this message."
+      HELPERS::ShowOKDialogText(CVariant{257},
+                                CVariant{19110}); // "Error", "Could not delete the timer."
       return false;
     }
     default:


### PR DESCRIPTION
Commit 1: Sync PVR source file references with reality.

Commit 2. Remove "Check the log for more information about this message." from PVR error messages. As I said on Slack, a log file is nothing an average user should ever have to deal with on their own (except sending it to devs and leave interpretation up to them). Normal users don't even know what a log is and where to find it. Even worse, often actually nothing useful related to the error messsage can be found in the log.

Note: This kind of error messages is also used in other Kodi components, but to fix this is not part of this PR.

Not much to runtime-test here, but it builds.

@emveepee fyi

@phunkyfish can you have a look at the string and related small code changes?