### PR TITLE
changed: move CFileItem::GetTBNFile to ArtUtils

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -52,6 +52,7 @@
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
 #include "utils/Archive.h"
+#include "utils/ArtUtils.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/Mime.h"
 #include "utils/RegExp.h"
@@ -1926,7 +1927,7 @@ std::string CFileItem::GetUserMusicThumb(bool alwaysCheckRemote /* = false */, b
     return "";
 
   // we first check for <filename>.tbn or <foldername>.tbn
-  std::string fileThumb(GetTBNFile());
+  std::string fileThumb(ART::GetTBNFile(*this));
   if (CFile::Exists(fileThumb))
     return fileThumb;
 
@@ -1982,53 +1983,6 @@ std::string CFileItem::GetUserMusicThumb(bool alwaysCheckRemote /* = false */, b
   }
   // No thumb found
   return "";
-}
-
-// Gets the .tbn filename from a file or folder name.
-// <filename>.ext -> <filename>.tbn
-// <foldername>/ -> <foldername>.tbn
-std::string CFileItem::GetTBNFile() const
-{
-  std::string thumbFile;
-  std::string strFile = m_strPath;
-
-  if (IsStack())
-  {
-    std::string strPath, strReturn;
-    URIUtils::GetParentPath(m_strPath,strPath);
-    CFileItem item(CStackDirectory::GetFirstStackedFile(strFile),false);
-    std::string strTBNFile = item.GetTBNFile();
-    strReturn = URIUtils::AddFileToFolder(strPath, URIUtils::GetFileName(strTBNFile));
-    if (CFile::Exists(strReturn))
-      return strReturn;
-
-    strFile = URIUtils::AddFileToFolder(strPath,URIUtils::GetFileName(CStackDirectory::GetStackedTitlePath(strFile)));
-  }
-
-  if (URIUtils::IsInRAR(strFile) || URIUtils::IsInZIP(strFile))
-  {
-    std::string strPath = URIUtils::GetDirectory(strFile);
-    std::string strParent;
-    URIUtils::GetParentPath(strPath,strParent);
-    strFile = URIUtils::AddFileToFolder(strParent, URIUtils::GetFileName(m_strPath));
-  }
-
-  CURL url(strFile);
-  strFile = url.GetFileName();
-
-  if (m_bIsFolder && !IsFileFolder())
-    URIUtils::RemoveSlashAtEnd(strFile);
-
-  if (!strFile.empty())
-  {
-    if (m_bIsFolder && !IsFileFolder())
-      thumbFile = strFile + ".tbn"; // folder, so just add ".tbn"
-    else
-      thumbFile = URIUtils::ReplaceExtension(strFile, ".tbn");
-    url.SetFileName(thumbFile);
-    thumbFile = url.Get();
-  }
-  return thumbFile;
 }
 
 bool CFileItem::SkipLocalArt() const
@@ -2257,7 +2211,7 @@ std::string CFileItem::GetLocalFanart() const
     strPath2 = dir.GetStackedTitlePath(strFile);
     strFile = URIUtils::AddFileToFolder(strPath, URIUtils::GetFileName(strPath2));
     CFileItem item(dir.GetFirstStackedFile(m_strPath),false);
-    std::string strTBNFile(URIUtils::ReplaceExtension(item.GetTBNFile(), "-fanart"));
+    std::string strTBNFile(URIUtils::ReplaceExtension(ART::GetTBNFile(item), "-fanart"));
     strFile2 = URIUtils::AddFileToFolder(strPath, URIUtils::GetFileName(strTBNFile));
   }
   if (URIUtils::IsInRAR(strFile) || URIUtils::IsInZIP(strFile))
@@ -2663,7 +2617,7 @@ std::string CFileItem::FindTrailer() const
     strPath2 = dir.GetStackedTitlePath(strFile);
     strFile = URIUtils::AddFileToFolder(strPath,URIUtils::GetFileName(strPath2));
     CFileItem item(dir.GetFirstStackedFile(m_strPath),false);
-    std::string strTBNFile(URIUtils::ReplaceExtension(item.GetTBNFile(), "-trailer"));
+    std::string strTBNFile(URIUtils::ReplaceExtension(ART::GetTBNFile(item), "-trailer"));
     strFile2 = URIUtils::AddFileToFolder(strPath,URIUtils::GetFileName(strTBNFile));
   }
   if (URIUtils::IsInRAR(strFile) || URIUtils::IsInZIP(strFile))

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -443,8 +443,6 @@ public:
    */
   std::string GetThumbHideIfUnwatched(const CFileItem* item) const;
 
-  // Gets the .tbn file associated with this item
-  std::string GetTBNFile() const;
   // Gets the folder image associated with this item (defaults to folder.jpg)
   std::string GetFolderThumb(const std::string &folderJPG = "folder.jpg") const;
   // Gets the correct movie title

--- a/xbmc/ThumbLoader.cpp
+++ b/xbmc/ThumbLoader.cpp
@@ -11,7 +11,10 @@
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "TextureCache.h"
+#include "utils/ArtUtils.h"
 #include "utils/FileUtils.h"
+
+using namespace KODI;
 
 CThumbLoader::CThumbLoader() :
   CBackgroundInfoLoader()
@@ -117,7 +120,7 @@ std::string CProgramThumbLoader::GetLocalThumb(const CFileItem &item)
   }
   else
   {
-    std::string fileThumb(item.GetTBNFile());
+    std::string fileThumb(ART::GetTBNFile(item));
     if (CFileUtils::Exists(fileThumb))
       return fileThumb;
   }

--- a/xbmc/utils/ArtUtils.cpp
+++ b/xbmc/utils/ArtUtils.cpp
@@ -24,42 +24,42 @@ namespace KODI::ART
 std::string GetTBNFile(const CFileItem& item)
 {
   std::string thumbFile;
-  std::string strFile = item.GetPath();
+  std::string file = item.GetPath();
 
   if (item.IsStack())
   {
-    std::string strPath, strReturn;
-    URIUtils::GetParentPath(item.GetPath(), strPath);
-    CFileItem item(CStackDirectory::GetFirstStackedFile(strFile), false);
-    std::string strTBNFile = GetTBNFile(item);
-    strReturn = URIUtils::AddFileToFolder(strPath, URIUtils::GetFileName(strTBNFile));
-    if (CFile::Exists(strReturn))
-      return strReturn;
+    std::string path, returnPath;
+    URIUtils::GetParentPath(item.GetPath(), path);
+    CFileItem item(CStackDirectory::GetFirstStackedFile(file), false);
+    const std::string TBNFile = GetTBNFile(item);
+    returnPath = URIUtils::AddFileToFolder(path, URIUtils::GetFileName(TBNFile));
+    if (CFile::Exists(returnPath))
+      return returnPath;
 
-    strFile = URIUtils::AddFileToFolder(
-        strPath, URIUtils::GetFileName(CStackDirectory::GetStackedTitlePath(strFile)));
+    const std::string& stackPath = CStackDirectory::GetStackedTitlePath(file);
+    file = URIUtils::AddFileToFolder(path, URIUtils::GetFileName(stackPath));
   }
 
-  if (URIUtils::IsInRAR(strFile) || URIUtils::IsInZIP(strFile))
+  if (URIUtils::IsInRAR(file) || URIUtils::IsInZIP(file))
   {
-    std::string strPath = URIUtils::GetDirectory(strFile);
-    std::string strParent;
-    URIUtils::GetParentPath(strPath, strParent);
-    strFile = URIUtils::AddFileToFolder(strParent, URIUtils::GetFileName(item.GetPath()));
+    const std::string path = URIUtils::GetDirectory(file);
+    std::string parent;
+    URIUtils::GetParentPath(path, parent);
+    file = URIUtils::AddFileToFolder(parent, URIUtils::GetFileName(item.GetPath()));
   }
 
-  CURL url(strFile);
-  strFile = url.GetFileName();
+  CURL url(file);
+  file = url.GetFileName();
 
   if (item.m_bIsFolder && !item.IsFileFolder())
-    URIUtils::RemoveSlashAtEnd(strFile);
+    URIUtils::RemoveSlashAtEnd(file);
 
-  if (!strFile.empty())
+  if (!file.empty())
   {
     if (item.m_bIsFolder && !item.IsFileFolder())
-      thumbFile = strFile + ".tbn"; // folder, so just add ".tbn"
+      thumbFile = file + ".tbn"; // folder, so just add ".tbn"
     else
-      thumbFile = URIUtils::ReplaceExtension(strFile, ".tbn");
+      thumbFile = URIUtils::ReplaceExtension(file, ".tbn");
     url.SetFileName(thumbFile);
     thumbFile = url.Get();
   }

--- a/xbmc/utils/ArtUtils.cpp
+++ b/xbmc/utils/ArtUtils.cpp
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ArtUtils.h"
+
+#include "FileItem.h"
+#include "filesystem/File.h"
+#include "filesystem/StackDirectory.h"
+#include "utils/URIUtils.h"
+
+using namespace XFILE;
+
+namespace KODI::ART
+{
+
+// Gets the .tbn filename from a file or folder name.
+// <filename>.ext -> <filename>.tbn
+// <foldername>/ -> <foldername>.tbn
+std::string GetTBNFile(const CFileItem& item)
+{
+  std::string thumbFile;
+  std::string strFile = item.GetPath();
+
+  if (item.IsStack())
+  {
+    std::string strPath, strReturn;
+    URIUtils::GetParentPath(item.GetPath(), strPath);
+    CFileItem item(CStackDirectory::GetFirstStackedFile(strFile), false);
+    std::string strTBNFile = GetTBNFile(item);
+    strReturn = URIUtils::AddFileToFolder(strPath, URIUtils::GetFileName(strTBNFile));
+    if (CFile::Exists(strReturn))
+      return strReturn;
+
+    strFile = URIUtils::AddFileToFolder(
+        strPath, URIUtils::GetFileName(CStackDirectory::GetStackedTitlePath(strFile)));
+  }
+
+  if (URIUtils::IsInRAR(strFile) || URIUtils::IsInZIP(strFile))
+  {
+    std::string strPath = URIUtils::GetDirectory(strFile);
+    std::string strParent;
+    URIUtils::GetParentPath(strPath, strParent);
+    strFile = URIUtils::AddFileToFolder(strParent, URIUtils::GetFileName(item.GetPath()));
+  }
+
+  CURL url(strFile);
+  strFile = url.GetFileName();
+
+  if (item.m_bIsFolder && !item.IsFileFolder())
+    URIUtils::RemoveSlashAtEnd(strFile);
+
+  if (!strFile.empty())
+  {
+    if (item.m_bIsFolder && !item.IsFileFolder())
+      thumbFile = strFile + ".tbn"; // folder, so just add ".tbn"
+    else
+      thumbFile = URIUtils::ReplaceExtension(strFile, ".tbn");
+    url.SetFileName(thumbFile);
+    thumbFile = url.Get();
+  }
+  return thumbFile;
+}
+
+} // namespace KODI::ART

--- a/xbmc/utils/ArtUtils.h
+++ b/xbmc/utils/ArtUtils.h
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+class CFileItem;
+
+namespace KODI::ART
+{
+
+// Gets the .tbn file associated with an item
+std::string GetTBNFile(const CFileItem& item);
+
+} // namespace KODI::ART

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES ActorProtocol.cpp
             AlarmClock.cpp
             AliasShortcutUtils.cpp
             Archive.cpp
+            ArtUtils.cpp
             Base64.cpp
             BitstreamConverter.cpp
             BitstreamReader.cpp
@@ -82,6 +83,7 @@ set(HEADERS ActorProtocol.h
             AlarmClock.h
             AliasShortcutUtils.h
             Archive.h
+            ArtUtils.h
             Base64.h
             BitstreamConverter.h
             BitstreamReader.h

--- a/xbmc/utils/test/CMakeLists.txt
+++ b/xbmc/utils/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES TestAlarmClock.cpp
             TestAliasShortcutUtils.cpp
             TestArchive.cpp
+            TestArtUtils.cpp
             TestBase64.cpp
             TestBitstreamStats.cpp
             TestCharsetConverter.cpp

--- a/xbmc/utils/test/TestArtUtils.cpp
+++ b/xbmc/utils/test/TestArtUtils.cpp
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "FileItem.h"
+#include "platform/Filesystem.h"
+#include "utils/ArtUtils.h"
+#include "utils/FileUtils.h"
+#include "utils/URIUtils.h"
+
+#include <array>
+#include <fstream>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+using namespace KODI;
+
+struct TbnTest
+{
+  std::string path;
+  std::string result;
+  bool isFolder = false;
+};
+
+class GetTbnTest : public testing::WithParamInterface<TbnTest>, public testing::Test
+{
+};
+
+TEST_P(GetTbnTest, TbnTest)
+{
+  EXPECT_EQ(ART::GetTBNFile(CFileItem(GetParam().path, GetParam().isFolder)), GetParam().result);
+}
+
+const auto tbn_tests = std::array{
+    TbnTest{"/home/user/video.avi", "/home/user/video.tbn"},
+    TbnTest{"/home/user/video/", "/home/user/video.tbn", true},
+    TbnTest{"/home/user/bar.xbt", "/home/user/bar.tbn", true},
+    TbnTest{"zip://%2fhome%2fuser%2fbar.zip/foo.avi", "/home/user/foo.tbn"},
+    TbnTest{"stack:///home/user/foo-cd1.avi , /home/user/foo-cd2.avi", "/home/user/foo.tbn"}};
+
+INSTANTIATE_TEST_SUITE_P(TestArtUtils, GetTbnTest, testing::ValuesIn(tbn_tests));
+
+TEST(TestArtUtils, GetTbnStack)
+{
+  std::error_code ec;
+  auto path = KODI::PLATFORM::FILESYSTEM::temp_directory_path(ec);
+  ASSERT_TRUE(!ec);
+  const auto file_path = URIUtils::AddFileToFolder(path, "foo-cd1.tbn");
+  {
+    std::ofstream of(file_path, std::ios::out);
+  }
+  const std::string stackPath =
+      fmt::format("stack://{} , {}", URIUtils::AddFileToFolder(path, "foo-cd1.avi"),
+                  URIUtils::AddFileToFolder(path, "foo-cd2.avi"));
+  CFileItem item(stackPath, false);
+  EXPECT_EQ(ART::GetTBNFile(item), file_path);
+  CFileUtils::DeleteItem(file_path);
+}

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -44,6 +44,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
+#include "utils/ArtUtils.h"
 #include "utils/FileUtils.h"
 #include "utils/GroupUtils.h"
 #include "utils/LabelFormatter.h"
@@ -10710,7 +10711,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
         }
         else
         {
-          std::string nfoFile(URIUtils::ReplaceExtension(item.GetTBNFile(), ".nfo"));
+          std::string nfoFile(URIUtils::ReplaceExtension(ART::GetTBNFile(item), ".nfo"));
 
           if (item.IsOpticalMediaFile())
           {
@@ -10863,7 +10864,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
         }
         else
         {
-          std::string nfoFile(URIUtils::ReplaceExtension(item.GetTBNFile(), ".nfo"));
+          std::string nfoFile(URIUtils::ReplaceExtension(ART::GetTBNFile(item), ".nfo"));
 
           if (overwrite || !CFile::Exists(nfoFile, false))
           {
@@ -11064,7 +11065,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
           }
           else
           {
-            std::string nfoFile(URIUtils::ReplaceExtension(item.GetTBNFile(), ".nfo"));
+            std::string nfoFile(URIUtils::ReplaceExtension(ART::GetTBNFile(item), ".nfo"));
 
             if (overwrite || !CFile::Exists(nfoFile, false))
             {


### PR DESCRIPTION
## Description
Introduce a new compile unit ArtUtils and move CFileItem::GetTBNFile into it.

## Motivation and context
Move more code out of CFileItem.

## How has this been tested?
It builds + I have added a test

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
