### PR TITLE
Android: Improve default button maps slightly

### DIFF
--- a/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
+++ b/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
@@ -469,6 +469,10 @@ bool CAndroidJoystickState::MapButton(JOYSTICK::IButtonMap& buttonMap, int butto
   if (controllerButton.empty())
     return false;
 
+  // Check if feature is already mapped
+  if (buttonMap.GetFeatureType(controllerButton) != JOYSTICK::FEATURE_TYPE::UNKNOWN)
+    return false;
+
   // Map the button
   CLog::Log(LOGDEBUG, "Automatically mapping {} to {}", controllerButton,
             buttonPrimitive.ToString());

--- a/xbmc/platform/android/peripherals/PeripheralBusAndroid.cpp
+++ b/xbmc/platform/android/peripherals/PeripheralBusAndroid.cpp
@@ -112,6 +112,8 @@ bool CPeripheralBusAndroid::InitializeProperties(CPeripheral& peripheral)
   joystick.SetButtonCount(state.GetButtonCount());
   joystick.SetAxisCount(state.GetAxisCount());
 
+  std::unique_lock<CCriticalSection> lock(m_critSectionStates);
+
   // remember the joystick state
   m_joystickStates.insert(std::make_pair(deviceId, std::move(state)));
 
@@ -133,6 +135,8 @@ bool CPeripheralBusAndroid::InitializeButtonMap(const CPeripheral& peripheral,
               peripheral.Location());
     return false;
   }
+
+  std::unique_lock<CCriticalSection> lock(m_critSectionStates);
 
   // get the joystick state
   auto it = m_joystickStates.find(deviceId);
@@ -325,7 +329,10 @@ void CPeripheralBusAndroid::OnInputDeviceRemoved(int deviceId)
 
   if (removed)
   {
-    m_joystickStates.erase(deviceId);
+    {
+      std::unique_lock<CCriticalSection> lock(m_critSectionStates);
+      m_joystickStates.erase(deviceId);
+    }
 
     OnDeviceRemoved(deviceLocation);
   }

--- a/xbmc/platform/android/peripherals/PeripheralBusAndroid.h
+++ b/xbmc/platform/android/peripherals/PeripheralBusAndroid.h
@@ -66,7 +66,7 @@ private:
 
   mutable std::map<int, CAndroidJoystickState> m_joystickStates;
   PeripheralScanResults m_scanResults;
-  CCriticalSection m_critSectionStates;
+  mutable CCriticalSection m_critSectionStates;
   CCriticalSection m_critSectionResults;
 };
 using PeripheralBusAndroidPtr = std::shared_ptr<CPeripheralBusAndroid>;


### PR DESCRIPTION
## Description

This PR makes two small improvements.

First, a mutex is added in a few missing spots. Nothing where a missing mutex would likely cause problems, but good for correctness.

Second, I added a check for surjective Android keys, where two keys map to the same controller button, such as the A key and the D-pad Center key. You can see the surjective map here: https://github.com/xbmc/xbmc/blob/85dcca1fd4932c104ebba40f91756ab66895ef55/xbmc/platform/android/peripherals/AndroidJoystickTranslator.cpp#L737-L774

## Motivation and context

Revealed in testing after merging https://github.com/xbmc/xbmc/pull/25176. Doesn't fix any major issues but is good for correctness.

## How has this been tested?

Tried pressing A on a default-mapped controller (Xbox One):

```
debug <general>: Android Key AKEYCODE_BUTTON_A (96) pressed
debug <general>: BUTTON [ 0 ] on "Microsoft X-Box One S pad" pressed
debug <general>: FEATURE [ a ] on game.controller.default pressed (ignored)
debug <general>: FEATURE [ a ] on game.controller.default pressed (handled)
debug <general>: Android Key AKEYCODE_BUTTON_A (96) released
debug <general>: BUTTON [ 0 ] on "Microsoft X-Box One S pad" released
debug <general>: FEATURE [ a ] on game.controller.default released
debug <general>: FEATURE [ a ] on game.controller.default released
```

## What is the effect on users?

* Fixes default button maps for some controllers

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
