### PR TITLE
[windows][buildsteps] run-tests.bat fail if test executable outputs no test data

### DIFF
--- a/tools/buildsteps/windows/run-tests.bat
+++ b/tools/buildsteps/windows/run-tests.bat
@@ -43,6 +43,11 @@ ECHO ------------------------------------------------------------
 ECHO Running testsuite...
   "%buildconfig%\%APP_NAME%-test.exe" --gtest_output=xml:%WORKSPACE%\gtestresults.xml
 
+  IF NOT EXIST %WORKSPACE%\gtestresults.xml (
+    set DIETEXT="%APP_NAME%-test.exe failed to execute or output test results!"
+    goto DIE
+  )
+
   rem Adapt gtest xml output to be conform with junit xml
   rem this basically looks for lines which have "notrun" in the <testcase /> tag
   rem and adds a <skipped/> subtag into it. For example:


### PR DESCRIPTION
## Description
Fail run-tests.bat if the test executable doesnt output any test data

## Motivation and context
Windows tests are currently broke. Jenkins didnt pick it up, whoops.

## How has this been tested?
Script outputs DIE when tests dont output (ie current master)

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
