### PR TITLE
[clang-tidy] fix modernize-* and performance-* warnings

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -468,7 +468,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetLastGroup() const
   std::unique_lock<CCriticalSection> lock(m_critSection);
   for (auto it = m_groups.crbegin(); it != m_groups.crend(); ++it)
   {
-    const auto group{*it};
+    const auto& group{*it};
     if (!group->ShouldBeIgnored(m_groups))
       return group;
   }
@@ -548,7 +548,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetPreviousGroup(
     std::unique_lock<CCriticalSection> lock(m_critSection);
     for (auto it = m_groups.crbegin(); it != m_groups.crend(); ++it)
     {
-      const auto currentGroup{*it};
+      const auto& currentGroup{*it};
 
       // return this entry
       if (bReturnNext && !currentGroup->IsHidden() && !currentGroup->ShouldBeIgnored(m_groups))
@@ -562,7 +562,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetPreviousGroup(
     // no match return last visible group
     for (auto it = m_groups.crbegin(); it != m_groups.crend(); ++it)
     {
-      const auto currentGroup{*it};
+      const auto& currentGroup{*it};
       if (!currentGroup->IsHidden() && !currentGroup->ShouldBeIgnored(m_groups))
         return currentGroup;
     }
@@ -581,7 +581,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetNextGroup(
     std::unique_lock<CCriticalSection> lock(m_critSection);
     for (auto it = m_groups.cbegin(); it != m_groups.cend(); ++it)
     {
-      const auto currentGroup{*it};
+      const auto& currentGroup{*it};
 
       // return this entry
       if (bReturnNext && !currentGroup->IsHidden() && !currentGroup->ShouldBeIgnored(m_groups))
@@ -595,7 +595,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetNextGroup(
     // no match return first visible group
     for (auto it = m_groups.cbegin(); it != m_groups.cend(); ++it)
     {
-      const auto currentGroup{*it};
+      const auto& currentGroup{*it};
       if (!currentGroup->IsHidden() && !currentGroup->ShouldBeIgnored(m_groups))
         return currentGroup;
     }

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -79,7 +79,7 @@ void CPVRChannelGroups::Unload()
 
   m_groups.clear();
   m_allChannelsGroup.reset();
-  m_channelGroupFactory.reset(new CPVRChannelGroupFactory);
+  m_channelGroupFactory = std::make_shared<CPVRChannelGroupFactory>();
   m_failedClientsForChannelGroups.clear();
 }
 


### PR DESCRIPTION
## Description
[clang-tidy] fix modernize-* and performance-* warnings

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
