### PR TITLE
[PVR] Group Manager: Fix group thumbnail update.

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.h
@@ -39,7 +39,7 @@ protected:
 
 private:
   void Clear();
-  void ClearSelectedGroupsThumbnail();
+  void ClearGroupThumbnails(const CFileItem& changedItem);
   void Update();
   bool ActionButtonOk(const CGUIMessage& message);
   bool ActionButtonNewGroup(const CGUIMessage& message);


### PR DESCRIPTION
For certain group manager usage scenarios, like adding or removing channels from the "all channels" group, which effectively hides the channel system-wide, it is not enough to update the group thumbnail of the directly effected group, but also the thumbnail of other groups (namely those containing the just hidden channel) must be refreshed. This is what this PR changes, determining all effected groups and updating also their thumbnail, along with the directly changed group's thumbnail.

Runtime-tested on Android and macOS, latest Kodi master.

@phunkyfish please review.