### PR TITLE
[video| Fix bookmarks db persistence

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2430,12 +2430,12 @@ bool CFileItem::LoadDetails()
     bool ret{false};
     auto tag{std::make_unique<CVideoInfoTag>()};
     if (params.GetMovieId() >= 0)
-      ret = db.GetMovieInfo(GetPath(), *tag, static_cast<int>(params.GetMovieId()),
+      ret = db.GetMovieInfo({}, *tag, static_cast<int>(params.GetMovieId()),
                             static_cast<int>(params.GetVideoVersionId()));
     else if (params.GetMVideoId() >= 0)
-      ret = db.GetMusicVideoInfo(GetPath(), *tag, static_cast<int>(params.GetMVideoId()));
+      ret = db.GetMusicVideoInfo({}, *tag, static_cast<int>(params.GetMVideoId()));
     else if (params.GetEpisodeId() >= 0)
-      ret = db.GetEpisodeInfo(GetPath(), *tag, static_cast<int>(params.GetEpisodeId()));
+      ret = db.GetEpisodeInfo({}, *tag, static_cast<int>(params.GetEpisodeId()));
     else if (params.GetSetId() >= 0) // movie set
       ret = db.GetSetInfo(static_cast<int>(params.GetSetId()), *tag, this);
     else if (params.GetTvShowId() >= 0)
@@ -2448,7 +2448,7 @@ bool CFileItem::LoadDetails()
           ret = db.GetSeasonInfo(idSeason, *tag, this);
       }
       else
-        ret = db.GetTvShowInfo(GetPath(), *tag, static_cast<int>(params.GetTvShowId()), this);
+        ret = db.GetTvShowInfo({}, *tag, static_cast<int>(params.GetTvShowId()), this);
     }
 
     if (ret)

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -188,10 +188,7 @@ void CGUIDialogVideoBookmarks::Delete(int item)
   {
     CVideoDatabase videoDatabase;
     videoDatabase.Open();
-    std::string path(g_application.CurrentFile());
-    if (g_application.CurrentFileItem().HasProperty("original_listitem_url") &&
-       !URIUtils::IsVideoDb(g_application.CurrentFileItem().GetProperty("original_listitem_url").asString()))
-      path = g_application.CurrentFileItem().GetProperty("original_listitem_url").asString();
+    const std::string path{g_application.CurrentFileItem().GetDynPath()};
     videoDatabase.ClearBookMarkOfFile(path, m_bookmarks[item], m_bookmarks[item].type);
     videoDatabase.Close();
     CUtil::DeleteVideoDatabaseDirectoryCache();
@@ -205,10 +202,7 @@ void CGUIDialogVideoBookmarks::OnRefreshList()
   std::vector<CFileItemPtr> items;
 
   // open the d/b and retrieve the bookmarks for the current movie
-  m_filePath = g_application.CurrentFile();
-  if (g_application.CurrentFileItem().HasProperty("original_listitem_url") &&
-     !URIUtils::IsVideoDb(g_application.CurrentFileItem().GetProperty("original_listitem_url").asString()))
-     m_filePath = g_application.CurrentFileItem().GetProperty("original_listitem_url").asString();
+  m_filePath = g_application.CurrentFileItem().GetDynPath();
 
   CVideoDatabase videoDatabase;
   videoDatabase.Open();
@@ -355,10 +349,7 @@ void CGUIDialogVideoBookmarks::ClearBookmarks()
 {
   CVideoDatabase videoDatabase;
   videoDatabase.Open();
-  std::string path = g_application.CurrentFile();
-  if (g_application.CurrentFileItem().HasProperty("original_listitem_url") &&
-     !URIUtils::IsVideoDb(g_application.CurrentFileItem().GetProperty("original_listitem_url").asString()))
-    path = g_application.CurrentFileItem().GetProperty("original_listitem_url").asString();
+  const std::string path{g_application.CurrentFileItem().GetDynPath()};
   videoDatabase.ClearBookMarksOfFile(path, CBookmark::STANDARD);
   videoDatabase.ClearBookMarksOfFile(path, CBookmark::RESUME);
   videoDatabase.ClearBookMarksOfFile(path, CBookmark::EPISODE);
@@ -471,10 +462,7 @@ bool CGUIDialogVideoBookmarks::AddBookmark(CVideoInfoTag* tag)
     videoDatabase.AddBookMarkForEpisode(*tag, bookmark);
   else
   {
-    std::string path = g_application.CurrentFile();
-    if (g_application.CurrentFileItem().HasProperty("original_listitem_url") &&
-       !URIUtils::IsVideoDb(g_application.CurrentFileItem().GetProperty("original_listitem_url").asString()))
-      path = g_application.CurrentFileItem().GetProperty("original_listitem_url").asString();
+    const std::string path{g_application.CurrentFileItem().GetDynPath()};
     videoDatabase.AddBookMarkToFile(path, bookmark, CBookmark::STANDARD);
   }
   videoDatabase.Close();


### PR DESCRIPTION
Fixes #25301

Omega introduced a regression which leads to writing wrong entries to the 'path' and 'files' tables of the video database when creating a new bookmark for a movie. Instead of reusing the existing ids for the movie file, by mistake videodb URLs were handed over to the respective `CVideoDatabase` methods, which are not able to process these kind of URLs correctly (and never shall be able to, btw). This mistake (writing wrong database entries) leads to strange follow-up behavior, like described in above mentioned issue.

When trying to resume/play/show info/... for an effected movie presented by a Home screen widget, loading of the respective video info from the video db failed and resume was not possible / media info not displayed / ...

First commit of this PR fixes the root cause of the problem. It corrects the `CGUIDialogVideoBookamarks` code to pass the right URLs to the database (DynPath instead of Path), so that now the correct bookmark information for the existing file/path db entries is written on bookmark creation, deleted on bookmark delete, ...

Second commit corrects the code reading the video information upon access from home screen widget to ignore the wrong file information that might be there due to the root cause of this problem. This was possible without further hacks, because the path leading to the problem was actually not needed (but used if present as optimization). So, wrong entries remain in the db, but should no longer have any bad effects.

Runtime.tested on macOS and Android, latest Kodi master.

@enen92 something for you to review? 