### PR TITLE
[Omega] Python: Restore close of WindowXML when application exits

### DIFF
--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -668,16 +668,6 @@ namespace XBMCAddon
 
         while (bModal && !g_application.m_bStop)
         {
-//! @todo garbear added this code to the python window.cpp class and
-//!  commented in XBPyThread.cpp. I'm not sure how to handle this
-//! in this native implementation.
-//          // Check if XBPyThread::stop() raised a SystemExit exception
-//          if (PyThreadState_Get()->async_exc == PyExc_SystemExit)
-//          {
-//            CLog::Log(LOGDEBUG, "PYTHON: doModal() encountered a SystemExit exception, closing window and returning");
-//            Window_Close(self, NULL);
-//            break;
-//          }
           languageHook->MakePendingCalls(); // MakePendingCalls
 
           bool stillWaiting;
@@ -687,6 +677,14 @@ namespace XBMCAddon
               DelayedCallGuard dcguard(languageHook);
               stillWaiting = WaitForActionEvent(100) ? false : true;
             }
+
+            // If application has quit, close the window
+            if (bModal && g_application.m_bStop)
+            {
+              CLog::Log(LOGDEBUG, "PYTHON: Application quit inside doModal(), closing window");
+              close();
+            }
+
             languageHook->MakePendingCalls();
           } while (stillWaiting);
         }


### PR DESCRIPTION
## Description

Backport of https://github.com/xbmc/xbmc/pull/25380

## How has this been tested?

Tested on my OASIS development branch based on Omega.

## What is the effect on users?

* Fixed active Python window not closing on application exit

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
