### PR TITLE
RegExp: Fix heap-use-after-free

### DIFF
--- a/xbmc/utils/RegExp.h
+++ b/xbmc/utils/RegExp.h
@@ -134,6 +134,7 @@ private:
   pcre2_match_context* m_ctxt;
   static const int OVECCOUNT=(m_MaxNumOfBackrefrences + 1) * 3;
   unsigned int m_offset;
+  pcre2_match_data* m_matchData;
   PCRE2_SIZE* m_iOvector;
   utf8Mode    m_utf8Mode;
   int         m_iMatchCount;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

`m_iOvector` is a pointer array into the match data, so the match data must be kept as long as `m_iOvector` is used.

<details>
<summary>Address Sanitizer output</summary>

```
==28015==ERROR: AddressSanitizer: heap-use-after-free on address 0x5190000406e8 at pc 0x59cf02e5ad9e bp 0x7ffdcd8a1a10 sp 0x7ffdcd8a1a08 READ of size 8 at 0x5190000406e8 thread T0
    #0 0x59cf02e5ad9d in CRegExp::PrivateRegFind(unsigned long, char const*, unsigned int, int) xbmc/utils/RegExp.cpp:425:10
    #1 0x59cf013cb942 in CRegExp::RegFind(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int, int) xbmc/utils/RegExp.h:95:12
    #2 0x59cf0316a9ef in CXBMCTinyXML2::ParseHelper(unsigned long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>&&) xbmc/utils/XBMCTinyXML2.cpp:106:12
    #3 0x59cf0316965b in CXBMCTinyXML2::Parse(std::basic_string_view<char, std::char_traits<char>>) xbmc/utils/XBMCTinyXML2.cpp:82:10
    #4 0x59cf03168fac in CXBMCTinyXML2::LoadFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) xbmc/utils/XBMCTinyXML2.cpp:36:3
    #5 0x59cf0563fe1b in CMediaSourceSettings::Load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) xbmc/settings/MediaSourceSettings.cpp:85:15
    #6 0x59cf0563f590 in CMediaSourceSettings::Load() xbmc/settings/MediaSourceSettings.cpp:71:10
    #7 0x59cf0563f3d0 in CMediaSourceSettings::OnSettingsLoaded() xbmc/settings/MediaSourceSettings.cpp:61:3
    #8 0x59cf053c86c4 in CSettingsManager::OnSettingsLoaded() xbmc/settings/lib/SettingsManager.cpp:1022:22
    #9 0x59cf053969dc in CSettingsManager::Load(TiXmlElement const*, bool&, bool, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::shared_ptr<CSetting>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, std::shared_ptr<CSetting>>>>*) xbmc/settings/lib/SettingsManager.cpp:173:5
    #10 0x59cf056ed775 in CSettingsBase::LoadValuesFromXml(TiXmlElement const*, bool&) xbmc/settings/SettingsBase.cpp:86:29
    #11 0x59cf056b96b0 in CSettings::Load(TiXmlElement const*, bool&) xbmc/settings/Settings.cpp:217:23
    #12 0x59cf056b8f00 in CSettings::Load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) xbmc/settings/Settings.cpp:125:8
    #13 0x59cf056b87e5 in CSettings::Load() xbmc/settings/Settings.cpp:117:10
    #14 0x59cf05715a60 in CSettingsComponent::Load() xbmc/settings/SettingsComponent.cpp:83:22
    #15 0x59cf041da912 in CApplication::Create() xbmc/application/Application.cpp:320:27
    #16 0x59cf033b4eed in XBMC_Run xbmc/platform/xbmc.cpp:26:22
    #17 0x59cf00752b7f in main xbmc/platform/posix/main.cpp:70:16
    #18 0x74a07d239c87  (/usr/lib/libc.so.6+0x25c87) (BuildId: 32a656aa5562eece8c59a585f5eacd6cf5e2307b)
    #19 0x74a07d239d4b in __libc_start_main (/usr/lib/libc.so.6+0x25d4b) (BuildId: 32a656aa5562eece8c59a585f5eacd6cf5e2307b)
    #20 0x59cf00618804 in _start (/home/mark/Coding/Repos/kodi-git/build_clang_debug_sanitizer/kodi.bin+0x9f91804) (BuildId: fa447ae84e6fbfe91e7ec718a600116496d7607e)

0x5190000406e8 is located 104 bytes inside of 1112-byte region [0x519000040680,0x519000040ad8) freed by thread T0 here:
    #0 0x59cf007069b2 in free.part.0 (/home/mark/Coding/Repos/kodi-git/build_clang_debug_sanitizer/kodi.bin+0xa07f9b2) (BuildId: fa447ae84e6fbfe91e7ec718a600116496d7607e)
    #1 0x59cf02e59ed8 in CRegExp::PrivateRegFind(unsigned long, char const*, unsigned int, int) xbmc/utils/RegExp.cpp:352:3
    #2 0x59cf013cb942 in CRegExp::RegFind(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int, int) xbmc/utils/RegExp.h:95:12
    #3 0x59cf0316a9ef in CXBMCTinyXML2::ParseHelper(unsigned long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>&&) xbmc/utils/XBMCTinyXML2.cpp:106:12
    #4 0x59cf0316965b in CXBMCTinyXML2::Parse(std::basic_string_view<char, std::char_traits<char>>) xbmc/utils/XBMCTinyXML2.cpp:82:10
    #5 0x59cf03168fac in CXBMCTinyXML2::LoadFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) xbmc/utils/XBMCTinyXML2.cpp:36:3
    #6 0x59cf0563fe1b in CMediaSourceSettings::Load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) xbmc/settings/MediaSourceSettings.cpp:85:15
    #7 0x59cf0563f590 in CMediaSourceSettings::Load() xbmc/settings/MediaSourceSettings.cpp:71:10
    #8 0x59cf0563f3d0 in CMediaSourceSettings::OnSettingsLoaded() xbmc/settings/MediaSourceSettings.cpp:61:3
    #9 0x59cf053c86c4 in CSettingsManager::OnSettingsLoaded() xbmc/settings/lib/SettingsManager.cpp:1022:22
    #10 0x59cf053969dc in CSettingsManager::Load(TiXmlElement const*, bool&, bool, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::shared_ptr<CSetting>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, std::shared_ptr<CSetting>>>>*) xbmc/settings/lib/SettingsManager.cpp:173:5
    #11 0x59cf056ed775 in CSettingsBase::LoadValuesFromXml(TiXmlElement const*, bool&) xbmc/settings/SettingsBase.cpp:86:29
    #12 0x59cf056b96b0 in CSettings::Load(TiXmlElement const*, bool&) xbmc/settings/Settings.cpp:217:23
    #13 0x59cf056b8f00 in CSettings::Load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) xbmc/settings/Settings.cpp:125:8
    #14 0x59cf056b87e5 in CSettings::Load() xbmc/settings/Settings.cpp:117:10
    #15 0x59cf05715a60 in CSettingsComponent::Load() xbmc/settings/SettingsComponent.cpp:83:22
    #16 0x59cf041da912 in CApplication::Create() xbmc/application/Application.cpp:320:27
    #17 0x59cf033b4eed in XBMC_Run xbmc/platform/xbmc.cpp:26:22
    #18 0x59cf00752b7f in main xbmc/platform/posix/main.cpp:70:16
    #19 0x74a07d239c87  (/usr/lib/libc.so.6+0x25c87) (BuildId: 32a656aa5562eece8c59a585f5eacd6cf5e2307b)
    #20 0x74a07d239d4b in __libc_start_main (/usr/lib/libc.so.6+0x25d4b) (BuildId: 32a656aa5562eece8c59a585f5eacd6cf5e2307b)
    #21 0x59cf00618804 in _start (/home/mark/Coding/Repos/kodi-git/build_clang_debug_sanitizer/kodi.bin+0x9f91804) (BuildId: fa447ae84e6fbfe91e7ec718a600116496d7607e)

previously allocated by thread T0 here:
    #0 0x59cf007079e9 in malloc (/home/mark/Coding/Repos/kodi-git/build_clang_debug_sanitizer/kodi.bin+0xa0809e9) (BuildId: fa447ae84e6fbfe91e7ec718a600116496d7607e)
    #1 0x74a07fb7faed  (/usr/lib/libpcre2-8.so.0+0x12aed) (BuildId: d6a22ace8f92ae592b620499fc467ef7899f99a0)
    #2 0x74a07fbbf29f in pcre2_match_data_create_8 (/usr/lib/libpcre2-8.so.0+0x5229f) (BuildId: d6a22ace8f92ae592b620499fc467ef7899f99a0)
    #3 0x59cf02e59c65 in CRegExp::PrivateRegFind(unsigned long, char const*, unsigned int, int) xbmc/utils/RegExp.cpp:347:8
    #4 0x59cf013cb942 in CRegExp::RegFind(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int, int) xbmc/utils/RegExp.h:95:12
    #5 0x59cf0316a9ef in CXBMCTinyXML2::ParseHelper(unsigned long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>&&) xbmc/utils/XBMCTinyXML2.cpp:106:12
    #6 0x59cf0316965b in CXBMCTinyXML2::Parse(std::basic_string_view<char, std::char_traits<char>>) xbmc/utils/XBMCTinyXML2.cpp:82:10
    #7 0x59cf03168fac in CXBMCTinyXML2::LoadFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) xbmc/utils/XBMCTinyXML2.cpp:36:3
    #8 0x59cf0563fe1b in CMediaSourceSettings::Load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) xbmc/settings/MediaSourceSettings.cpp:85:15
    #9 0x59cf0563f590 in CMediaSourceSettings::Load() xbmc/settings/MediaSourceSettings.cpp:71:10
    #10 0x59cf0563f3d0 in CMediaSourceSettings::OnSettingsLoaded() xbmc/settings/MediaSourceSettings.cpp:61:3
    #11 0x59cf053c86c4 in CSettingsManager::OnSettingsLoaded() xbmc/settings/lib/SettingsManager.cpp:1022:22
    #12 0x59cf053969dc in CSettingsManager::Load(TiXmlElement const*, bool&, bool, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::shared_ptr<CSetting>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, std::shared_ptr<CSetting>>>>*) xbmc/settings/lib/SettingsManager.cpp:173:5
    #13 0x59cf056ed775 in CSettingsBase::LoadValuesFromXml(TiXmlElement const*, bool&) xbmc/settings/SettingsBase.cpp:86:29
    #14 0x59cf056b96b0 in CSettings::Load(TiXmlElement const*, bool&) xbmc/settings/Settings.cpp:217:23
    #15 0x59cf056b8f00 in CSettings::Load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) xbmc/settings/Settings.cpp:125:8
    #16 0x59cf056b87e5 in CSettings::Load() xbmc/settings/Settings.cpp:117:10
    #17 0x59cf05715a60 in CSettingsComponent::Load() xbmc/settings/SettingsComponent.cpp:83:22
    #18 0x59cf041da912 in CApplication::Create() xbmc/application/Application.cpp:320:27
    #19 0x59cf033b4eed in XBMC_Run xbmc/platform/xbmc.cpp:26:22
    #20 0x59cf00752b7f in main xbmc/platform/posix/main.cpp:70:16
    #21 0x74a07d239c87  (/usr/lib/libc.so.6+0x25c87) (BuildId: 32a656aa5562eece8c59a585f5eacd6cf5e2307b)
    #22 0x74a07d239d4b in __libc_start_main (/usr/lib/libc.so.6+0x25d4b) (BuildId: 32a656aa5562eece8c59a585f5eacd6cf5e2307b)
    #23 0x59cf00618804 in _start (/home/mark/Coding/Repos/kodi-git/build_clang_debug_sanitizer/kodi.bin+0x9f91804) (BuildId: fa447ae84e6fbfe91e7ec718a600116496d7607e)

SUMMARY: AddressSanitizer: heap-use-after-free xbmc/utils/RegExp.cpp:425:10 in CRegExp::PrivateRegFind(unsigned long, char const*, unsigned int, int) Shadow bytes around the buggy address:
  0x519000040400: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x519000040480: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x519000040500: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x519000040580: fd fd fd fd fd fd fa fa fa fa fa fa fa fa fa fa
  0x519000040600: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x519000040680: fd fd fd fd fd fd fd fd fd fd fd fd fd[fd]fd fd
  0x519000040700: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x519000040780: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x519000040800: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x519000040880: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x519000040900: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==28015==ABORTING
```
</details>

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See above.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Address sanitizer is happy and no leaks are reported.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Kodi not crashing.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
