### PR TITLE
Improve threaded texture upload

### DIFF
--- a/xbmc/CMakeLists.txt
+++ b/xbmc/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SOURCES AutoSwitch.cpp
             GUIInfoManager.cpp
             GUILargeTextureManager.cpp
             GUIPassword.cpp
+            GUITextureJobManager.cpp
             InfoScanner.cpp
             LangInfo.cpp
             MediaSource.cpp
@@ -51,6 +52,7 @@ set(HEADERS AutoSwitch.h
             GUIInfoManager.h
             GUILargeTextureManager.h
             GUIPassword.h
+            GUITextureJobManager.h
             GUIUserMessages.h
             HDRStatus.h
             IFileItemListModifier.h

--- a/xbmc/GUILargeTextureManager.cpp
+++ b/xbmc/GUILargeTextureManager.cpp
@@ -25,14 +25,12 @@
 #include <mutex>
 
 CImageLoader::CImageLoader(const std::string& path,
-                           const bool useCache,
+                           bool useCache,
                            CGUILargeTextureManager* callback)
   : m_path(path), m_texture(nullptr), m_callback(callback)
 {
   m_use_cache = useCache;
 }
-
-CImageLoader::~CImageLoader() = default;
 
 bool CImageLoader::DoWork(bool immediatelyUpload)
 {
@@ -151,10 +149,6 @@ void CGUILargeTextureManager::CLargeTexture::SetTexture(std::unique_ptr<CTexture
     m_texture.Set(std::move(texture), width, height);
   }
 }
-
-CGUILargeTextureManager::CGUILargeTextureManager() = default;
-
-CGUILargeTextureManager::~CGUILargeTextureManager() = default;
 
 void CGUILargeTextureManager::CleanupUnusedImages(bool immediately)
 {

--- a/xbmc/GUILargeTextureManager.h
+++ b/xbmc/GUILargeTextureManager.h
@@ -29,8 +29,8 @@ class CTexture;
 class CImageLoader
 {
 public:
-  CImageLoader(const std::string& path, const bool useCache, CGUILargeTextureManager* callback);
-  ~CImageLoader();
+  CImageLoader(const std::string& path, bool useCache, CGUILargeTextureManager* callback);
+  virtual ~CImageLoader() = default;
 
   /*!
    \brief Work function that loads in a particular image.
@@ -58,8 +58,8 @@ public:
 class CGUILargeTextureManager
 {
 public:
-  CGUILargeTextureManager();
-  ~CGUILargeTextureManager();
+  CGUILargeTextureManager() = default;
+  virtual ~CGUILargeTextureManager() = default;
 
   /*!
    \brief Callback from CImageLoader on completion of a loaded image
@@ -143,4 +143,3 @@ private:
 
   CCriticalSection m_listSection;
 };
-

--- a/xbmc/GUITextureJobManager.cpp
+++ b/xbmc/GUITextureJobManager.cpp
@@ -1,0 +1,109 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GUITextureJobManager.h"
+
+#include "ServiceBroker.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
+#include "windowing/WinSystem.h"
+
+using namespace std::chrono_literals;
+
+using namespace KODI::GUILIB;
+
+CGUITextureLoaderThread::CGUITextureLoaderThread(CGUITextureJobManager* manager,
+                                                 unsigned int threadID)
+  : CThread("TextureLoader")
+{
+  m_manager = manager;
+  m_threadID = threadID;
+  Create();
+  SetPriority(ThreadPriority::LOWEST);
+}
+
+void CGUITextureLoaderThread::Process()
+{
+  bool hasContext = false;
+
+  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiAsyncTextureUpload)
+    hasContext = CServiceBroker::GetWinSystem()->BindSecondaryGPUContext(m_threadID);
+
+  while (!m_bStop)
+  {
+    CImageLoader* image = m_manager->GetNextImage();
+    if (image)
+    {
+      image->DoWork(hasContext);
+      image->m_callback->OnLoadComplete(image);
+    }
+    else
+    {
+      CThread::Sleep(THREAD_SLEEP_DURATION);
+    }
+  }
+}
+
+CGUITextureJobManager::CGUITextureJobManager()
+{
+  std::unique_lock<CCriticalSection> lock(m_section);
+
+  uint32_t maxThreads =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiTextureThreads;
+  for (uint32_t i = 0; i < maxThreads; i++)
+    m_textureThread.push_back(new CGUITextureLoaderThread(this, i));
+}
+
+CGUITextureJobManager::~CGUITextureJobManager()
+{
+  std::unique_lock<CCriticalSection> lock(m_section);
+  for (const auto& thread : m_textureThread)
+    delete thread;
+}
+
+unsigned int CGUITextureJobManager::AddImageToQueue(CImageLoader* image)
+{
+  std::unique_lock<CCriticalSection> lock(m_section);
+
+  image->m_imageID = m_imageIDCounter;
+
+  m_imageQueue.push_back(image);
+
+  return m_imageIDCounter++;
+}
+
+void CGUITextureJobManager::CancelImageLoad(const unsigned int& imageID)
+{
+  std::unique_lock<CCriticalSection> lock(m_section);
+
+  for (size_t i = 0; i < m_imageQueue.size(); i++)
+  {
+    if (m_imageQueue[i] && m_imageQueue[i]->m_imageID == imageID)
+    {
+      delete m_imageQueue[i];
+      m_imageQueue[i] = nullptr;
+      return;
+    }
+  }
+}
+
+CImageLoader* CGUITextureJobManager::GetNextImage()
+{
+  std::unique_lock<CCriticalSection> lock(m_section);
+
+  while (!m_imageQueue.empty())
+  {
+    CImageLoader* image = m_imageQueue.front();
+    m_imageQueue.pop_front();
+
+    if (image)
+      return image;
+  }
+
+  return nullptr;
+}

--- a/xbmc/GUITextureJobManager.h
+++ b/xbmc/GUITextureJobManager.h
@@ -14,31 +14,30 @@
 
 #include <deque>
 
-using namespace std::chrono_literals;
-
 namespace KODI::GUILIB
 {
 
 class CGUITextureJobManager;
-class CGUITextureLoaderThread : protected CThread
+class CGUITextureLoaderThread : CThread
 {
 public:
   CGUITextureLoaderThread(CGUITextureJobManager* manager, unsigned int threadID);
 
 protected:
+  void OnStartup() override;
   void Process() override;
 
 private:
-  static constexpr auto THREAD_SLEEP_DURATION{16ms};
-  unsigned int m_threadID;
+  unsigned int m_threadID{0};
   CGUITextureJobManager* m_manager{nullptr};
+  bool m_hasContext{false};
 };
 
 class CGUITextureJobManager
 {
 public:
   CGUITextureJobManager();
-  ~CGUITextureJobManager();
+  virtual ~CGUITextureJobManager();
 
   /*!
    \brief Adds a image to the processing queue.
@@ -52,7 +51,7 @@ public:
 
    \param imageID image to cancel
    */
-  void CancelImageLoad(const unsigned int& imageID);
+  void CancelImageLoad(unsigned int imageID);
   /*!
    \brief Gets a image next in queue.
 
@@ -62,8 +61,8 @@ public:
 
 private:
   mutable CCriticalSection m_section;
-  unsigned int m_imageIDCounter;
-  std::vector<CGUITextureLoaderThread*> m_textureThread;
+  unsigned int m_imageIDCounter{0};
+  std::vector<std::unique_ptr<CGUITextureLoaderThread>> m_textureThread;
   std::deque<CImageLoader*> m_imageQueue{};
 };
 

--- a/xbmc/GUITextureJobManager.h
+++ b/xbmc/GUITextureJobManager.h
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "GUILargeTextureManager.h"
+#include "threads/CriticalSection.h"
+#include "threads/Thread.h"
+
+#include <deque>
+
+using namespace std::chrono_literals;
+
+namespace KODI::GUILIB
+{
+
+class CGUITextureJobManager;
+class CGUITextureLoaderThread : protected CThread
+{
+public:
+  CGUITextureLoaderThread(CGUITextureJobManager* manager, unsigned int threadID);
+
+protected:
+  void Process() override;
+
+private:
+  static constexpr auto THREAD_SLEEP_DURATION{16ms};
+  unsigned int m_threadID;
+  CGUITextureJobManager* m_manager{nullptr};
+};
+
+class CGUITextureJobManager
+{
+public:
+  CGUITextureJobManager();
+  ~CGUITextureJobManager();
+
+  /*!
+   \brief Adds a image to the processing queue.
+
+   \param image CImageLoader object which should be processed
+   \return the ID of the added image
+   */
+  unsigned int AddImageToQueue(CImageLoader* image);
+  /*!
+   \brief Cancels a queued image. Images in flight can't be canceled.
+
+   \param imageID image to cancel
+   */
+  void CancelImageLoad(const unsigned int& imageID);
+  /*!
+   \brief Gets a image next in queue.
+
+   \return CImageLoader object 
+   */
+  CImageLoader* GetNextImage();
+
+private:
+  mutable CCriticalSection m_section;
+  unsigned int m_imageIDCounter;
+  std::vector<CGUITextureLoaderThread*> m_textureThread;
+  std::deque<CImageLoader*> m_imageQueue{};
+};
+
+} // namespace KODI::GUILIB

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -394,6 +394,11 @@ void CServiceBroker::UnregisterJobManager()
 std::shared_ptr<CJobManager> CServiceBroker::GetJobManager()
 {
   return g_serviceBroker.m_jobManager;
+}
+
+KODI::GUILIB::CGUITextureJobManager& CServiceBroker::GetTextureJobManager()
+{
+  return g_application.m_ServiceManager->GetTextureJobManager();
 }
 
 void CServiceBroker::RegisterAppMessenger(

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -108,6 +108,11 @@ namespace RETRO
 {
 class CGUIGameRenderManager;
 }
+
+namespace GUILIB
+{
+class CGUITextureJobManager;
+}
 } // namespace KODI
 
 namespace PERIPHERALS
@@ -149,6 +154,7 @@ public:
   static WSDiscovery::IWSDiscovery& GetWSDiscovery();
   static MEDIA_DETECT::CDetectDVDMedia& GetDetectDVDMedia();
   static PVR::CPVRManager& GetPVRManager();
+  static KODI::GUILIB::CGUITextureJobManager& GetTextureJobManager();
   static CContextMenuManager& GetContextMenuManager();
   static CDataCacheCore& GetDataCacheCore();
   static CPlatform& GetPlatform();

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -10,6 +10,7 @@
 
 #include "ContextMenuManager.h"
 #include "DatabaseManager.h"
+#include "GUITextureJobManager.h"
 #include "PlayListPlayer.h"
 #include "addons/AddonManager.h"
 #include "addons/BinaryAddonCache.h"
@@ -212,6 +213,8 @@ bool CServiceManager::InitStageThree(const std::shared_ptr<CProfileManager>& pro
 
   m_playerCoreFactory = std::make_unique<CPlayerCoreFactory>(*profileManager);
 
+  m_textureJobManager = std::make_unique<KODI::GUILIB::CGUITextureJobManager>();
+
   if (!m_Platform->InitStageThree())
     return false;
 
@@ -344,6 +347,11 @@ MEDIA_DETECT::CDetectDVDMedia& CServiceManager::GetDetectDVDMedia()
 PVR::CPVRManager& CServiceManager::GetPVRManager()
 {
   return *m_PVRManager;
+}
+
+KODI::GUILIB::CGUITextureJobManager& CServiceManager::GetTextureJobManager()
+{
+  return *m_textureJobManager;
 }
 
 CContextMenuManager& CServiceManager::GetContextMenuManager()

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -67,6 +67,11 @@ namespace RETRO
 {
 class CGUIGameRenderManager;
 }
+
+namespace GUILIB
+{
+class CGUITextureJobManager;
+}
 } // namespace KODI
 
 namespace MEDIA_DETECT
@@ -117,6 +122,7 @@ public:
   WSDiscovery::IWSDiscovery& GetWSDiscovery();
 #endif
   PVR::CPVRManager& GetPVRManager();
+  KODI::GUILIB::CGUITextureJobManager& GetTextureJobManager();
   CContextMenuManager& GetContextMenuManager();
   CDataCacheCore& GetDataCacheCore();
   /**\brief Get the platform object. This is save to be called after Init1() was called
@@ -164,6 +170,7 @@ protected:
   std::unique_ptr<XBPython> m_XBPython;
 #endif
   std::unique_ptr<PVR::CPVRManager> m_PVRManager;
+  std::unique_ptr<KODI::GUILIB::CGUITextureJobManager> m_textureJobManager;
   std::unique_ptr<CContextMenuManager> m_contextMenuManager;
   std::unique_ptr<CDataCacheCore> m_dataCacheCore;
   std::unique_ptr<CPlatform> m_Platform;

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -266,22 +266,6 @@ bool CTexture::LoadIImage(IImage* pImage,
   ClampToEdge();
 
   return true;
-}
-
-void CTexture::LoadToGPUAsync()
-{
-  // Already in main context?
-  if (CServiceBroker::GetWinSystem()->HasContext())
-    return;
-
-  if (!CServiceBroker::GetWinSystem()->BindTextureUploadContext())
-    return;
-
-  LoadToGPU();
-
-  SyncGPU();
-
-  CServiceBroker::GetWinSystem()->UnbindTextureUploadContext();
 }
 
 bool CTexture::LoadFromMemory(unsigned int width,

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -87,11 +87,6 @@ public:
               XB_FMT format,
               const unsigned char* pixels,
               bool loadToGPU);
-
-  /*! 
-   * \brief Uploads the texture to the GPU. 
-   */
-  void LoadToGPUAsync();
 
   virtual void CreateTextureObject() = 0;
   virtual void DestroyTextureObject() = 0;

--- a/xbmc/guilib/TextureGLES.cpp
+++ b/xbmc/guilib/TextureGLES.cpp
@@ -191,6 +191,11 @@ void CGLESTexture::LoadToGPU()
   m_loadedToGPU = true;
 }
 
+void CGLESTexture::SyncGPU()
+{
+  glFinish();
+}
+
 void CGLESTexture::BindToUnit(unsigned int unit)
 {
   glActiveTexture(GL_TEXTURE0 + unit);

--- a/xbmc/guilib/TextureGLES.h
+++ b/xbmc/guilib/TextureGLES.h
@@ -21,6 +21,7 @@ public:
   void CreateTextureObject() override;
   void DestroyTextureObject() override;
   void LoadToGPU() override;
+  void SyncGPU() override;
   void BindToUnit(unsigned int unit) override;
 
 protected:

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -1227,6 +1227,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetBoolean(pElement, "fronttobackrendering", m_guiFrontToBackRendering);
     XMLUtils::GetBoolean(pElement, "geometryclear", m_guiGeometryClear);
     XMLUtils::GetBoolean(pElement, "asynctextureupload", m_guiAsyncTextureUpload);
+    XMLUtils::GetUInt(pElement, "texturethreads", m_guiTextureThreads, 1, 4);
     XMLUtils::GetBoolean(pElement, "transparentvideolayout", m_guiVideoLayoutTransparent);
   }
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -337,6 +337,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_guiFrontToBackRendering{false};
     bool m_guiGeometryClear{true};
     bool m_guiAsyncTextureUpload{false};
+    uint32_t m_guiTextureThreads{1};
     bool m_guiVideoLayoutTransparent{false};
 
     unsigned int m_addonPackageFolderSize;

--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -611,7 +611,7 @@ bool CEGLContextUtils::TrySwapBuffers()
   return (eglSwapBuffers(m_eglDisplay, m_eglSurface) == EGL_TRUE);
 }
 
-bool CEGLContextUtils::BindSecondaryGPUContext(const unsigned int& id)
+bool CEGLContextUtils::BindSecondaryGPUContext(unsigned int id)
 {
   if (id > m_eglSecondaryContexts.size())
   {

--- a/xbmc/utils/EGLUtils.h
+++ b/xbmc/utils/EGLUtils.h
@@ -221,7 +221,7 @@ public:
     return m_eglConfig;
   }
 
-  bool BindSecondaryGPUContext(const unsigned int& id);
+  bool BindSecondaryGPUContext(unsigned int id);
 
 private:
   void SurfaceAttrib();

--- a/xbmc/utils/EGLUtils.h
+++ b/xbmc/utils/EGLUtils.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017-2018 Team Kodi
+ *  Copyright (C) 2017-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -221,9 +221,7 @@ public:
     return m_eglConfig;
   }
 
-  bool BindTextureUploadContext();
-  bool UnbindTextureUploadContext();
-  bool HasContext();
+  bool BindSecondaryGPUContext(const unsigned int& id);
 
 private:
   void SurfaceAttrib();
@@ -235,6 +233,5 @@ private:
   EGLSurface m_eglSurface{EGL_NO_SURFACE};
   EGLContext m_eglContext{EGL_NO_CONTEXT};
   EGLConfig m_eglConfig{}, m_eglHDRConfig{};
-  EGLContext m_eglUploadContext{EGL_NO_CONTEXT};
-  mutable CCriticalSection m_textureUploadLock;
+  std::vector<EGLContext> m_eglSecondaryContexts;
 };

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -266,7 +266,7 @@ public:
    * \param id id of the requesting context
    * \return Return true if a texture upload context exists and the binding succeeds
    */
-  virtual bool BindSecondaryGPUContext(const unsigned int& id) { return false; }
+  virtual bool BindSecondaryGPUContext(unsigned int id) { return false; }
 
 protected:
   void UpdateDesktopResolution(RESOLUTION_INFO& newRes, const std::string &output, int width, int height, float refreshRate, uint32_t dwFlags);

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -261,22 +261,12 @@ public:
   std::pair<bool, int> GetDitherSettings();
 
   /*!
-   * \brief Binds a shared context to the current thread, in order to upload textures asynchronously.
-   * \return Return true if a texture upload context exists and the binding succeeds.
+   * \brief Binds an at startup allocated shared context to the current thread, in order to upload textures asynchronously
+   *
+   * \param id id of the requesting context
+   * \return Return true if a texture upload context exists and the binding succeeds
    */
-  virtual bool BindTextureUploadContext() { return false; }
-
-  /*!
-   * \brief Unbinds the shared context.
-   * \return Return true if the texture upload context has been unbound.
-   */
-  virtual bool UnbindTextureUploadContext() { return false; }
-
-  /*!
-   * \brief Checks if a graphics context is already bound to the current thread.
-   * \return Return true if so.
-   */
-  virtual bool HasContext() { return false; }
+  virtual bool BindSecondaryGPUContext(const unsigned int& id) { return false; }
 
 protected:
   void UpdateDesktopResolution(RESOLUTION_INFO& newRes, const std::string &output, int width, int height, float refreshRate, uint32_t dwFlags);

--- a/xbmc/windowing/X11/GLContextEGL.cpp
+++ b/xbmc/windowing/X11/GLContextEGL.cpp
@@ -559,7 +559,7 @@ uint64_t CGLContextEGL::GetVblankTiming(uint64_t &msc, uint64_t &interval)
   return ret;
 }
 
-bool CGLContextEGL::BindSecondaryGPUContext(const unsigned int& id)
+bool CGLContextEGL::BindSecondaryGPUContext(unsigned int id)
 {
   if (id > m_eglSecondaryContexts.size())
   {

--- a/xbmc/windowing/X11/GLContextEGL.cpp
+++ b/xbmc/windowing/X11/GLContextEGL.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -162,9 +162,12 @@ bool CGLContextEGL::Refresh(bool force, int screen, Window glWindow, bool &newCo
       EGL_NONE
   };
   m_eglContext = eglCreateContext(m_eglDisplay, m_eglConfig, EGL_NO_CONTEXT, contextAttributes);
-  m_eglUploadContext = eglCreateContext(m_eglDisplay, m_eglConfig, m_eglContext, contextAttributes);
 
-  if (m_eglContext == EGL_NO_CONTEXT)
+  if (m_eglContext)
+  {
+    CreateSecondaryContexts(contextAttributes);
+  }
+  else
   {
     EGLint contextAttributes[] =
     {
@@ -172,8 +175,6 @@ bool CGLContextEGL::Refresh(bool force, int screen, Window glWindow, bool &newCo
       EGL_NONE
     };
     m_eglContext = eglCreateContext(m_eglDisplay, m_eglConfig, EGL_NO_CONTEXT, contextAttributes);
-    m_eglUploadContext =
-        eglCreateContext(m_eglDisplay, m_eglConfig, m_eglContext, contextAttributes);
 
     if (m_eglContext == EGL_NO_CONTEXT)
     {
@@ -181,6 +182,8 @@ bool CGLContextEGL::Refresh(bool force, int screen, Window glWindow, bool &newCo
       Destroy();
       return false;
     }
+
+    CreateSecondaryContexts(contextAttributes);
 
     CLog::Log(LOGWARNING, "Failed to get an OpenGL context supporting core profile 3.2, "
                           "using legacy mode with reduced feature set");
@@ -196,11 +199,20 @@ bool CGLContextEGL::Refresh(bool force, int screen, Window glWindow, bool &newCo
 
   m_eglGetSyncValuesCHROMIUM = (PFNEGLGETSYNCVALUESCHROMIUMPROC)eglGetProcAddress("eglGetSyncValuesCHROMIUM");
 
-  if (m_eglUploadContext == EGL_NO_CONTEXT)
-    CLog::Log(LOGWARNING, "failed to create EGL upload context");
-
   m_usePB = false;
   return true;
+}
+
+void CGLContextEGL::CreateSecondaryContexts(const EGLint* contextAttributes)
+{
+  if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiAsyncTextureUpload)
+    return;
+
+  uint32_t maxThreads =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiTextureThreads;
+  for (uint32_t i = 0; i < maxThreads; i++)
+    m_eglSecondaryContexts.push_back(
+        eglCreateContext(m_eglDisplay, m_eglConfig, m_eglContext, contextAttributes));
 }
 
 bool CGLContextEGL::CreatePB()
@@ -295,11 +307,6 @@ bool CGLContextEGL::CreatePB()
     return false;
   }
 
-  m_eglUploadContext = eglCreateContext(m_eglDisplay, m_eglConfig, m_eglContext, contextAttributes);
-
-  if (m_eglUploadContext == EGL_NO_CONTEXT)
-    CLog::Log(LOGWARNING, "Failed to create EGL upload context");
-
   m_usePB = true;
   return true;
 }
@@ -314,11 +321,9 @@ void CGLContextEGL::Destroy()
     m_eglContext = EGL_NO_CONTEXT;
   }
 
-  if (m_eglUploadContext)
-  {
-    eglDestroyContext(m_eglDisplay, m_eglUploadContext);
-    m_eglUploadContext = EGL_NO_CONTEXT;
-  }
+  for (const auto& context : m_eglSecondaryContexts)
+    eglDestroyContext(m_eglDisplay, context);
+  m_eglSecondaryContexts.clear();
 
   if (m_eglSurface)
   {
@@ -554,50 +559,21 @@ uint64_t CGLContextEGL::GetVblankTiming(uint64_t &msc, uint64_t &interval)
   return ret;
 }
 
-bool CGLContextEGL::BindTextureUploadContext()
+bool CGLContextEGL::BindSecondaryGPUContext(const unsigned int& id)
 {
-  if (m_eglDisplay == EGL_NO_DISPLAY || m_eglUploadContext == EGL_NO_CONTEXT)
+  if (id > m_eglSecondaryContexts.size())
   {
-    CLog::LogF(LOGERROR, "No texture upload context found.");
+    CLog::LogF(LOGERROR, "Not enough secondary EGL contexts.");
     return false;
   }
 
-  m_textureUploadLock.lock();
-
-  if (!eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, m_eglUploadContext))
+  if (!eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, m_eglSecondaryContexts[id]))
   {
-    m_textureUploadLock.unlock();
-    CLog::LogF(LOGERROR, "Couldn't bind texture upload context.");
+    CLog::LogF(LOGERROR, "Couldn't bind secondary GPU context.");
     return false;
   }
 
   return true;
-}
-
-bool CGLContextEGL::UnbindTextureUploadContext()
-{
-  if (m_eglDisplay == EGL_NO_DISPLAY || m_eglUploadContext == EGL_NO_CONTEXT)
-  {
-    CLog::LogF(LOGERROR, "No texture upload context found.");
-    m_textureUploadLock.unlock();
-    return false;
-  }
-
-  if (!eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT))
-  {
-    CLog::LogF(LOGERROR, "Couldn't release texture upload context");
-    m_textureUploadLock.unlock();
-    return false;
-  }
-
-  m_textureUploadLock.unlock();
-
-  return true;
-}
-
-bool CGLContextEGL::HasContext()
-{
-  return eglGetCurrentContext() != EGL_NO_CONTEXT;
 }
 
 void CGLContextEGL::QueryExtensions()

--- a/xbmc/windowing/X11/GLContextEGL.h
+++ b/xbmc/windowing/X11/GLContextEGL.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -12,6 +12,7 @@
 #include "threads/CriticalSection.h"
 
 #include <cstdint>
+#include <vector>
 
 #include "system_egl.h"
 
@@ -37,9 +38,7 @@ public:
   void QueryExtensions() override;
   uint64_t GetVblankTiming(uint64_t &msc, uint64_t &interval) override;
 
-  bool BindTextureUploadContext();
-  bool UnbindTextureUploadContext();
-  bool HasContext();
+  bool BindSecondaryGPUContext(const unsigned int& id);
 
   EGLint m_renderingApi;
   EGLDisplay m_eglDisplay = EGL_NO_DISPLAY;
@@ -49,6 +48,7 @@ public:
 protected:
   bool SuitableCheck(EGLDisplay eglDisplay, EGLConfig config);
   EGLConfig GetEGLConfig(EGLDisplay eglDisplay, XVisualInfo *vInfo);
+  void CreateSecondaryContexts(const EGLint* list);
   PFNEGLGETSYNCVALUESCHROMIUMPROC m_eglGetSyncValuesCHROMIUM = nullptr;
   PFNEGLGETPLATFORMDISPLAYEXTPROC m_eglGetPlatformDisplayEXT = nullptr;
 
@@ -66,6 +66,5 @@ protected:
 
   bool m_usePB = false;
 
-  EGLContext m_eglUploadContext = EGL_NO_CONTEXT;
-  mutable CCriticalSection m_textureUploadLock;
+  std::vector<EGLContext> m_eglSecondaryContexts;
 };

--- a/xbmc/windowing/X11/GLContextEGL.h
+++ b/xbmc/windowing/X11/GLContextEGL.h
@@ -38,7 +38,7 @@ public:
   void QueryExtensions() override;
   uint64_t GetVblankTiming(uint64_t &msc, uint64_t &interval) override;
 
-  bool BindSecondaryGPUContext(const unsigned int& id);
+  bool BindSecondaryGPUContext(unsigned int id);
 
   EGLint m_renderingApi;
   EGLDisplay m_eglDisplay = EGL_NO_DISPLAY;

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -112,26 +112,10 @@ EGLConfig CWinSystemX11GLContext::GetEGLConfig() const
   return static_cast<CGLContextEGL*>(m_pGLContext)->m_eglConfig;
 }
 
-bool CWinSystemX11GLContext::BindTextureUploadContext()
+bool CWinSystemX11GLContext::BindSecondaryGPUContext(const unsigned int& id)
 {
   if (m_pGLContext)
-    return static_cast<CGLContextEGL*>(m_pGLContext)->BindTextureUploadContext();
-  else
-    return false;
-}
-
-bool CWinSystemX11GLContext::UnbindTextureUploadContext()
-{
-  if (m_pGLContext)
-    return static_cast<CGLContextEGL*>(m_pGLContext)->UnbindTextureUploadContext();
-  else
-    return false;
-}
-
-bool CWinSystemX11GLContext::HasContext()
-{
-  if (m_pGLContext)
-    return static_cast<CGLContextEGL*>(m_pGLContext)->HasContext();
+    return static_cast<CGLContextEGL*>(m_pGLContext)->BindSecondaryGPUContext(id);
   else
     return false;
 }

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -112,7 +112,7 @@ EGLConfig CWinSystemX11GLContext::GetEGLConfig() const
   return static_cast<CGLContextEGL*>(m_pGLContext)->m_eglConfig;
 }
 
-bool CWinSystemX11GLContext::BindSecondaryGPUContext(const unsigned int& id)
+bool CWinSystemX11GLContext::BindSecondaryGPUContext(unsigned int id)
 {
   if (m_pGLContext)
     return static_cast<CGLContextEGL*>(m_pGLContext)->BindSecondaryGPUContext(id);

--- a/xbmc/windowing/X11/WinSystemX11GLContext.h
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -58,9 +58,7 @@ public:
   EGLContext GetEGLContext() const;
   EGLConfig GetEGLConfig() const;
 
-  bool BindTextureUploadContext() override;
-  bool UnbindTextureUploadContext() override;
-  bool HasContext() override;
+  bool BindSecondaryGPUContext(const unsigned int& id) override;
 
 protected:
   bool SetWindow(int width, int height, bool fullscreen, const std::string &output, int *winstate = NULL) override;

--- a/xbmc/windowing/X11/WinSystemX11GLContext.h
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.h
@@ -58,7 +58,7 @@ public:
   EGLContext GetEGLContext() const;
   EGLConfig GetEGLConfig() const;
 
-  bool BindSecondaryGPUContext(const unsigned int& id) override;
+  bool BindSecondaryGPUContext(unsigned int id) override;
 
 protected:
   bool SetWindow(int width, int height, bool fullscreen, const std::string &output, int *winstate = NULL) override;

--- a/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -92,26 +92,10 @@ EGLConfig CWinSystemX11GLESContext::GetEGLConfig() const
   return m_pGLContext->m_eglConfig;
 }
 
-bool CWinSystemX11GLESContext::BindTextureUploadContext()
+bool CWinSystemX11GLESContext::BindSecondaryGPUContext(const unsigned int& id)
 {
   if (m_pGLContext)
-    return static_cast<CGLContextEGL*>(m_pGLContext)->BindTextureUploadContext();
-  else
-    return false;
-}
-
-bool CWinSystemX11GLESContext::UnbindTextureUploadContext()
-{
-  if (m_pGLContext)
-    return static_cast<CGLContextEGL*>(m_pGLContext)->UnbindTextureUploadContext();
-  else
-    return false;
-}
-
-bool CWinSystemX11GLESContext::HasContext()
-{
-  if (m_pGLContext)
-    return static_cast<CGLContextEGL*>(m_pGLContext)->HasContext();
+    return static_cast<CGLContextEGL*>(m_pGLContext)->BindSecondaryGPUContext(id);
   else
     return false;
 }

--- a/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
@@ -92,7 +92,7 @@ EGLConfig CWinSystemX11GLESContext::GetEGLConfig() const
   return m_pGLContext->m_eglConfig;
 }
 
-bool CWinSystemX11GLESContext::BindSecondaryGPUContext(const unsigned int& id)
+bool CWinSystemX11GLESContext::BindSecondaryGPUContext(unsigned int id)
 {
   if (m_pGLContext)
     return static_cast<CGLContextEGL*>(m_pGLContext)->BindSecondaryGPUContext(id);

--- a/xbmc/windowing/X11/WinSystemX11GLESContext.h
+++ b/xbmc/windowing/X11/WinSystemX11GLESContext.h
@@ -46,7 +46,7 @@ public:
   EGLContext GetEGLContext() const;
   EGLConfig GetEGLConfig() const;
 
-  bool BindSecondaryGPUContext(const unsigned int& id) override;
+  bool BindSecondaryGPUContext(unsigned int id) override;
 
 protected:
   bool SetWindow(int width, int height, bool fullscreen, const std::string& output, int* winstate = nullptr) override;

--- a/xbmc/windowing/X11/WinSystemX11GLESContext.h
+++ b/xbmc/windowing/X11/WinSystemX11GLESContext.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -46,9 +46,7 @@ public:
   EGLContext GetEGLContext() const;
   EGLConfig GetEGLConfig() const;
 
-  bool BindTextureUploadContext() override;
-  bool UnbindTextureUploadContext() override;
-  bool HasContext() override;
+  bool BindSecondaryGPUContext(const unsigned int& id) override;
 
 protected:
   bool SetWindow(int width, int height, bool fullscreen, const std::string& output, int* winstate = nullptr) override;

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -151,7 +151,7 @@ void CWinSystemGbmEGLContext::delete_CVaapiProxy::operator()(CVaapiProxy *p) con
   VaapiProxyDelete(p);
 }
 
-bool CWinSystemGbmEGLContext::BindSecondaryGPUContext(const unsigned int& id)
+bool CWinSystemGbmEGLContext::BindSecondaryGPUContext(unsigned int id)
 {
   return m_eglContext.BindSecondaryGPUContext(id);
 }

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -151,17 +151,7 @@ void CWinSystemGbmEGLContext::delete_CVaapiProxy::operator()(CVaapiProxy *p) con
   VaapiProxyDelete(p);
 }
 
-bool CWinSystemGbmEGLContext::BindTextureUploadContext()
+bool CWinSystemGbmEGLContext::BindSecondaryGPUContext(const unsigned int& id)
 {
-  return m_eglContext.BindTextureUploadContext();
-}
-
-bool CWinSystemGbmEGLContext::UnbindTextureUploadContext()
-{
-  return m_eglContext.UnbindTextureUploadContext();
-}
-
-bool CWinSystemGbmEGLContext::HasContext()
-{
-  return m_eglContext.HasContext();
+  return m_eglContext.BindSecondaryGPUContext(id);
 }

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
@@ -35,7 +35,7 @@ public:
                        RESOLUTION_INFO& res) override;
   bool DestroyWindow() override;
 
-  bool BindSecondaryGPUContext(const unsigned int& id) override;
+  bool BindSecondaryGPUContext(unsigned int id) override;
 
 protected:
   CWinSystemGbmEGLContext(EGLenum platform, std::string const& platformExtension)

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -35,9 +35,7 @@ public:
                        RESOLUTION_INFO& res) override;
   bool DestroyWindow() override;
 
-  bool BindTextureUploadContext() override;
-  bool UnbindTextureUploadContext() override;
-  bool HasContext() override;
+  bool BindSecondaryGPUContext(const unsigned int& id) override;
 
 protected:
   CWinSystemGbmEGLContext(EGLenum platform, std::string const& platformExtension)

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContext.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContext.cpp
@@ -102,7 +102,7 @@ bool CWinSystemWaylandEGLContext::DestroyWindowSystem()
   return CWinSystemWaylandImpl::DestroyWindowSystem();
 }
 
-bool CWinSystemWaylandEGLContext::BindSecondaryGPUContext(const unsigned int& id)
+bool CWinSystemWaylandEGLContext::BindSecondaryGPUContext(unsigned int id)
 {
   return m_eglContext.BindSecondaryGPUContext(id);
 }

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContext.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContext.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017-2018 Team Kodi
+ *  Copyright (C) 2017-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -102,19 +102,9 @@ bool CWinSystemWaylandEGLContext::DestroyWindowSystem()
   return CWinSystemWaylandImpl::DestroyWindowSystem();
 }
 
-bool CWinSystemWaylandEGLContext::BindTextureUploadContext()
+bool CWinSystemWaylandEGLContext::BindSecondaryGPUContext(const unsigned int& id)
 {
-  return m_eglContext.BindTextureUploadContext();
-}
-
-bool CWinSystemWaylandEGLContext::UnbindTextureUploadContext()
-{
-  return m_eglContext.UnbindTextureUploadContext();
-}
-
-bool CWinSystemWaylandEGLContext::HasContext()
-{
-  return m_eglContext.HasContext();
+  return m_eglContext.BindSecondaryGPUContext(id);
 }
 
 CSizeInt CWinSystemWaylandEGLContext::GetNativeWindowAttachedSize()

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContext.h
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContext.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017-2018 Team Kodi
+ *  Copyright (C) 2017-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -43,9 +43,7 @@ public:
   bool DestroyWindow() override;
   bool DestroyWindowSystem() override;
 
-  bool BindTextureUploadContext() override;
-  bool UnbindTextureUploadContext() override;
-  bool HasContext() override;
+  bool BindSecondaryGPUContext(const unsigned int& id) override;
 
 protected:
   /**

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContext.h
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContext.h
@@ -43,7 +43,7 @@ public:
   bool DestroyWindow() override;
   bool DestroyWindowSystem() override;
 
-  bool BindSecondaryGPUContext(const unsigned int& id) override;
+  bool BindSecondaryGPUContext(unsigned int id) override;
 
 protected:
   /**


### PR DESCRIPTION
## Description
This PR re-implements async texture uploads in a different way. See https://github.com/xbmc/xbmc/pull/25139.

There are two related advanced settings now. `asynctextureupload` enables threaded texture uploads on systems which support it. `texturethreads` manages the number of texture processing threads to be spawned (default is 1, up to 4 possible).

```
<advancedsettings>
  <gui>
    <asynctextureupload>true</asynctextureupload>
    <texturethreads>4</texturethreads>
  </gui>
</advancedsettings>
```

## Motivation and context
The previous PR had some shortcomings, which are largely addressed.

There are dedicated texture threads now, which stay active during the whole lifetime of the GUI. There is no more need for EGL context switching, as each thread has its own context, if supplied by the windowing system (X11, Wayland, GBM).



## How has this been tested?
Compiles and runs fine on X11 with GL and GLES. Wayland and GBM is untested.

## What is the effect on users?
Possibly less jank if `asynctextureupload` is enabled. Less OOM situations on systems with a low amount of RAM (<=1GB), when a single texture thread is configured

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
