### PR TITLE
[PVR] CPVRChannelGroupsContainer: Replace raw pointers with std::shared_ptr

### DIFF
--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -65,8 +65,9 @@ JSONRPC_STATUS CPVROperations::GetChannelGroups(const std::string &method, ITran
   if (!channelGroupContainer)
     return FailedToExecute;
 
-  CPVRChannelGroups *channelGroups = channelGroupContainer->Get(parameterObject["channeltype"].asString().compare("radio") == 0);
-  if (channelGroups == NULL)
+  const std::shared_ptr<const CPVRChannelGroups> channelGroups{
+      channelGroupContainer->Get(parameterObject["channeltype"].asString().compare("radio") == 0)};
+  if (!channelGroups)
     return FailedToExecute;
 
   int start, end;

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -97,8 +97,8 @@ void CPVRPlaybackState::ReInit()
 
   const std::shared_ptr<const CPVRChannelGroupsContainer> groups =
       CServiceBroker::GetPVRManager().ChannelGroups();
-  const CPVRChannelGroups* groupsTV = groups->GetTV();
-  const CPVRChannelGroups* groupsRadio = groups->GetRadio();
+  const std::shared_ptr<const CPVRChannelGroups> groupsTV{groups->GetTV()};
+  const std::shared_ptr<const CPVRChannelGroups> groupsRadio{groups->GetRadio()};
 
   m_activeGroupTV = groupsTV->GetLastOpenedGroup();
   m_activeGroupRadio = groupsRadio->GetLastOpenedGroup();
@@ -555,7 +555,7 @@ namespace
 std::shared_ptr<CPVRChannelGroup> GetFirstNonDeletedAndNonHiddenChannelGroup(
     const std::shared_ptr<CPVRChannelGroupMember>& groupMember)
 {
-  CPVRChannelGroups* groups{
+  const std::shared_ptr<const CPVRChannelGroups> groups{
       CServiceBroker::GetPVRManager().ChannelGroups()->Get(groupMember->IsRadio())};
   if (groups)
   {

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -239,7 +239,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroups::GetChannelGroupMember
 }
 
 std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRChannelGroups::GetMembersAvailableForGroup(
-    const std::shared_ptr<const CPVRChannelGroup>& group)
+    const std::shared_ptr<const CPVRChannelGroup>& group) const
 {
   std::vector<std::shared_ptr<CPVRChannelGroupMember>> result;
 

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -97,7 +97,7 @@ public:
    * @return The channel group members that could be added to the group
    */
   std::vector<std::shared_ptr<CPVRChannelGroupMember>> GetMembersAvailableForGroup(
-      const std::shared_ptr<const CPVRChannelGroup>& group);
+      const std::shared_ptr<const CPVRChannelGroup>& group) const;
 
   /*!
    * @brief Get a pointer to a channel group given its ID.

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -27,8 +27,6 @@ CPVRChannelGroupsContainer::CPVRChannelGroupsContainer()
 CPVRChannelGroupsContainer::~CPVRChannelGroupsContainer()
 {
   Unload();
-  delete m_groupsRadio;
-  delete m_groupsTV;
 }
 
 bool CPVRChannelGroupsContainer::Update(const std::vector<std::shared_ptr<CPVRClient>>& clients)
@@ -68,7 +66,7 @@ void CPVRChannelGroupsContainer::Unload()
   m_groupsTV->Unload();
 }
 
-CPVRChannelGroups* CPVRChannelGroupsContainer::Get(bool bRadio) const
+std::shared_ptr<CPVRChannelGroups> CPVRChannelGroupsContainer::Get(bool bRadio) const
 {
   return bRadio ? m_groupsRadio : m_groupsTV;
 }

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.h
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.h
@@ -60,20 +60,20 @@ public:
    * @brief Get the TV channel groups.
    * @return The TV channel groups.
    */
-  CPVRChannelGroups* GetTV() const { return Get(false); }
+  std::shared_ptr<CPVRChannelGroups> GetTV() const { return Get(false); }
 
   /*!
    * @brief Get the radio channel groups.
    * @return The radio channel groups.
    */
-  CPVRChannelGroups* GetRadio() const { return Get(true); }
+  std::shared_ptr<CPVRChannelGroups> GetRadio() const { return Get(true); }
 
   /*!
    * @brief Get the radio or TV channel groups.
    * @param bRadio If true, get the radio channel groups. Get the TV channel groups otherwise.
    * @return The requested groups.
    */
-  CPVRChannelGroups* Get(bool bRadio) const;
+  std::shared_ptr<CPVRChannelGroups> Get(bool bRadio) const;
 
   /*!
    * @brief Get the group containing all TV channels.
@@ -169,8 +169,8 @@ private:
    */
   bool LoadFromDatabase(const std::vector<std::shared_ptr<CPVRClient>>& clients);
 
-  CPVRChannelGroups* m_groupsRadio; /*!< all radio channel groups */
-  CPVRChannelGroups* m_groupsTV; /*!< all TV channel groups */
+  std::shared_ptr<CPVRChannelGroups> m_groupsRadio; /*!< all radio channel groups */
+  std::shared_ptr<CPVRChannelGroups> m_groupsTV; /*!< all TV channel groups */
   CCriticalSection m_critSection;
   bool m_bIsUpdating = false;
 };

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -771,8 +771,8 @@ bool CGUIDialogPVRChannelManager::OnContextButton(int itemNumber, CONTEXT_BUTTON
         PVR_ERROR ret = client->DeleteChannel(channel);
         if (ret == PVR_ERROR_NO_ERROR)
         {
-          CPVRChannelGroups* groups =
-              CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio);
+          const std::shared_ptr<CPVRChannelGroups> groups{
+              CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio)};
           if (groups)
           {
             groups->UpdateFromClients({});
@@ -1081,7 +1081,8 @@ void CGUIDialogPVRChannelManager::SaveList()
 
   group->SortAndRenumber();
 
-  auto channelGroups = CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio);
+  const std::shared_ptr<CPVRChannelGroups> channelGroups{
+      CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio)};
   channelGroups->UpdateChannelNumbersFromAllChannelsGroup();
   channelGroups->PersistAll();
   pDlgProgress->Close();

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -133,8 +133,8 @@ bool CGUIDialogPVRChannelsOSD::OnAction(const CAction& action)
       SaveControlStates();
 
       // switch to next or previous group
-      const CPVRChannelGroups* groups =
-          CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_group->IsRadio());
+      const std::shared_ptr<const CPVRChannelGroups> groups{
+          CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_group->IsRadio())};
       const std::shared_ptr<CPVRChannelGroup> nextGroup = action.GetID() == ACTION_NEXT_CHANNELGROUP
                                                               ? groups->GetNextGroup(*m_group)
                                                               : groups->GetPreviousGroup(*m_group);

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -161,7 +161,8 @@ bool CGUIDialogPVRGroupManager::ActionButtonNewGroup(const CGUIMessage& message)
       if (!strGroupName.empty())
       {
         // add the group if it doesn't already exist
-        CPVRChannelGroups* groups{CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio)};
+        const std::shared_ptr<CPVRChannelGroups> groups{
+            CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio)};
         const auto group = groups->AddGroup(strGroupName);
         if (group)
         {
@@ -653,7 +654,8 @@ void CGUIDialogPVRGroupManager::Update()
       m_groupMembers->Add(std::make_shared<CFileItem>(groupMember));
     }
 
-    CPVRChannelGroups* groups{CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio)};
+    const std::shared_ptr<const CPVRChannelGroups> groups{
+        CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio)};
     const auto availableMembers = groups->GetMembersAvailableForGroup(m_selectedGroup);
 
     for (const auto& groupMember : availableMembers)
@@ -685,8 +687,8 @@ void CGUIDialogPVRGroupManager::Clear()
 
 void CGUIDialogPVRGroupManager::ClearGroupThumbnails(const CFileItem& changedItem)
 {
-  const CPVRChannelGroups* groups{CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio)};
-
+  const std::shared_ptr<const CPVRChannelGroups> groups{
+      CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio)};
   const std::shared_ptr<const CPVRChannelGroupMember> changedMember{
       changedItem.GetPVRChannelGroupMemberInfoTag()};
   if (changedMember)

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -439,8 +439,8 @@ bool CPVRGUIDirectory::GetChannelGroupsDirectory(bool bRadio,
                                                  bool bExcludeHidden,
                                                  CFileItemList& results)
 {
-  const CPVRChannelGroups* channelGroups =
-      CServiceBroker::GetPVRManager().ChannelGroups()->Get(bRadio);
+  const std::shared_ptr<const CPVRChannelGroups> channelGroups{
+      CServiceBroker::GetPVRManager().ChannelGroups()->Get(bRadio)};
   if (channelGroups)
   {
     std::shared_ptr<CFileItem> item;
@@ -477,7 +477,7 @@ std::shared_ptr<CPVRChannelGroupMember> GetLastWatchedChannelGroupMember(
 std::shared_ptr<CPVRChannelGroupMember> GetFirstMatchingGroupMember(
     const std::shared_ptr<CPVRChannel>& channel)
 {
-  CPVRChannelGroups* groups{
+  const std::shared_ptr<const CPVRChannelGroups> groups{
       CServiceBroker::GetPVRManager().ChannelGroups()->Get(channel->IsRadio())};
   if (groups)
   {

--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
@@ -125,8 +125,8 @@ void CPVRChannelSwitchingInputHandler::SwitchToChannel(const CPVRChannelNumber& 
         if (!groupMember)
         {
           // channel number present in any group?
-          const CPVRChannelGroups* groupAccess =
-              CServiceBroker::GetPVRManager().ChannelGroups()->Get(bRadio);
+          const std::shared_ptr<const CPVRChannelGroups> groupAccess{
+              CServiceBroker::GetPVRManager().ChannelGroups()->Get(bRadio)};
           const std::vector<std::shared_ptr<CPVRChannelGroup>> groups =
               groupAccess->GetMembers(true);
           for (const auto& currentGroup : groups)

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -218,7 +218,8 @@ bool CGUIWindowPVRBase::ActivatePreviousChannelGroup()
   const std::shared_ptr<const CPVRChannelGroup> channelGroup = GetChannelGroup();
   if (channelGroup)
   {
-    const CPVRChannelGroups* groups = CServiceBroker::GetPVRManager().ChannelGroups()->Get(channelGroup->IsRadio());
+    const std::shared_ptr<const CPVRChannelGroups> groups{
+        CServiceBroker::GetPVRManager().ChannelGroups()->Get(channelGroup->IsRadio())};
     if (groups)
     {
       SetChannelGroup(groups->GetPreviousGroup(*channelGroup));
@@ -233,7 +234,8 @@ bool CGUIWindowPVRBase::ActivateNextChannelGroup()
   const std::shared_ptr<const CPVRChannelGroup> channelGroup = GetChannelGroup();
   if (channelGroup)
   {
-    const CPVRChannelGroups* groups = CServiceBroker::GetPVRManager().ChannelGroups()->Get(channelGroup->IsRadio());
+    const std::shared_ptr<const CPVRChannelGroups> groups{
+        CServiceBroker::GetPVRManager().ChannelGroups()->Get(channelGroup->IsRadio())};
     if (groups)
     {
       SetChannelGroup(groups->GetNextGroup(*channelGroup));


### PR DESCRIPTION
Not much to say: Get rid of raw pointer usage in class `CPVRChannelGroupsContainer`.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish should be an easy one to review.