### PR TITLE
[PVR] Fix Reminders update special cases

### DIFF
--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -551,6 +551,12 @@ bool CPVRTimers::UpdateEntries(int iMaxNotificationDelay)
                 }
               }
             }
+            else if (!timer->IsTimerRule())
+            {
+              // epg event no longer present. delete the timer
+              bDeleteTimer = true;
+              timer->DeleteFromDatabase();
+            }
           }
         }
 

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -550,6 +550,23 @@ bool CPVRTimers::UpdateEntries(int iMaxNotificationDelay)
                   timer->Persist();
                 }
               }
+
+              // check for epg tag uids that were re-used for a different event (which is actually
+              // an add-on/a backend bug)
+              if (!timer->IsTimerRule() && (epgTag->Title() != timer->Title()))
+              {
+                const std::shared_ptr<CPVRTimerInfoTag> parent{GetTimerRule(timer)};
+                if (parent)
+                {
+                  const CPVRTimerRuleMatcher matcher{parent, now};
+                  if (!matcher.Matches(epgTag))
+                  {
+                    // epg event no longer matches the rule. delete the timer
+                    bDeleteTimer = true;
+                    timer->DeleteFromDatabase();
+                  }
+                }
+              }
             }
             else if (!timer->IsTimerRule())
             {

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -668,6 +668,13 @@ bool CPVRTimers::UpdateEntries(int iMaxNotificationDelay)
       ++it;
   }
 
+  // reinsert timers with changed timer start
+  for (const auto& timer : timersToReinsert)
+  {
+    InsertEntry(timer);
+    timer->Persist();
+  }
+
   // create new children of local epg-based reminder timer rules
   for (const auto& epgMapEntry : epgMap)
   {
@@ -694,14 +701,7 @@ bool CPVRTimers::UpdateEntries(int iMaxNotificationDelay)
     }
   }
 
-  // reinsert timers with changed timer start
-  for (const auto& timer : timersToReinsert)
-  {
-    InsertEntry(timer);
-    timer->Persist();
-  }
-
-  // insert new children of time-based local timer rules
+  // persist and insert/update new children of local time-based and epg-based reminder timer rules
   for (const auto& timerPair : childTimersToInsert)
   {
     PersistAndUpdateLocalTimer(timerPair.second, timerPair.first);


### PR DESCRIPTION
Three fixes for a problem with reminders I encountered recently. I suddenly was confronted with a number of duplicate reminders, two of them even for not existing EPG events. Now I was luckily able to reproduce able to fix the problems.

The code periodically updating the reminders based on latest EPG data was not handling correct:

1) EPG events that existed when the reminder was created and later disappeared. => The reminder was not deleted in that case.
2) EPG events for which the start time changed after the reminder was created. => Every time this happened another "new" reminder was created instead of updating the existing reminder.
3) EPG events for which the actual content changed after reminder creation to something completely different, so that the reminder rule no longer matches, but the backend/client reused the original EPG event UID. => The reminder was not deleted in that case.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish please review.

