### PR TITLE
Add a setting to make subtitles line spacing configurable

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24169,7 +24169,19 @@ msgctxt "#39201"
 msgid "HDR10+"
 msgstr ""
 
-#empty strings from id 39202 to 39999
+#. Subtitle line spacing setting
+#: system/settings/settings.xml
+msgctxt "#39202"
+msgid "Line spacing"
+msgstr ""
+
+#. Subtitle line spacing setting help
+#: system/settings/settings.xml
+msgctxt "#39203"
+msgid "Adjust the space between lines of text. Setting a value too low may cause boxes to overlap when the \"Background type\" setting is used."
+msgstr ""
+
+#empty strings from id 39204 to 39999
 
 # 40000 to 40800 are reserved for Video Versions feature
 

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -605,7 +605,7 @@
           <control type="list" format="string" />
         </setting>
         <setting id="subtitles.fontsize" type="integer" label="289" help="36186">
-          <level>3</level>
+          <level>2</level>
           <default>42</default> <!-- in pixels -->
           <constraints>
             <minimum>12</minimum>
@@ -618,7 +618,7 @@
           <control type="list" format="string" />
         </setting>
         <setting id="subtitles.style" type="integer" label="736" help="36187">
-          <level>3</level>
+          <level>2</level>
           <default>0</default> <!-- FontStyle::NORMAL -->
           <constraints>
             <options>
@@ -631,17 +631,17 @@
           <control type="list" format="string" />
         </setting>
         <setting id="subtitles.colorpick" type="string" label="737" help="36188">
-          <level>3</level>
+          <level>2</level>
           <default>FFFFFFFF</default> <!-- White -->
           <control type="colorbutton" />
         </setting>
         <setting id="subtitles.opacity" type="integer" label="752" help="36295">
-          <level>3</level>
+          <level>2</level>
           <default>100</default>
           <control type="slider" format="percentage" range="0,100" />
         </setting>
         <setting id="subtitles.bordersize" type="integer" label="39159" help="688">
-          <level>3</level>
+          <level>2</level>
           <default>25</default>
           <dependencies>
             <dependency type="enable" setting="subtitles.backgroundtype" operator="!is">2</dependency>
@@ -649,7 +649,7 @@
           <control type="slider" format="percentage" range="0,100" />
         </setting>
         <setting id="subtitles.bordercolorpick" type="string" label="39160" help="689">
-          <level>3</level>
+          <level>2</level>
           <default>FF000000</default> <!-- Black -->
           <dependencies>
             <dependency type="enable" setting="subtitles.backgroundtype" operator="!is">2</dependency>
@@ -659,6 +659,11 @@
         <setting id="subtitles.blur" type="integer" label="39173" help="690">
           <level>3</level>
           <default>0</default>
+          <control type="slider" format="percentage" range="0,100" />
+        </setting>
+        <setting id="subtitles.linespacing" type="integer" label="39202" help="39203">
+          <level>3</level>
+          <default>12</default>
           <control type="slider" format="percentage" range="0,100" />
         </setting>
         <setting id="subtitles.backgroundtype" type="integer" label="39165" help="39169">

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -420,7 +420,6 @@ void CDVDSubtitlesLibass::ApplyStyle(const std::shared_ptr<struct style>& subSty
     style->SecondaryColour = ConvColor(COLOR::BLACK);
 
     // Configure the effects
-    double lineSpacing = 0.0;
     if (subStyle->borderStyle == BorderType::OUTLINE ||
         subStyle->borderStyle == BorderType::OUTLINE_NO_SHADOW)
     {
@@ -450,8 +449,6 @@ void CDVDSubtitlesLibass::ApplyStyle(const std::shared_ptr<struct style>& subSty
       style->BackColour =
           ConvColor(subStyle->shadowColor, subStyle->shadowOpacity); // Set the box shadow color
       style->Shadow = (10.00 / 100 * subStyle->shadowSize) * scale; // Set the box shadow size
-      // By default a box overlaps the other, then we increase a bit the line spacing
-      lineSpacing = 8.0 * scaleDefault;
     }
     else if (subStyle->borderStyle == BorderType::SQUARE_BOX)
     {
@@ -463,9 +460,14 @@ void CDVDSubtitlesLibass::ApplyStyle(const std::shared_ptr<struct style>& subSty
       style->Shadow = 4 * scale; // Space between the text and the box edges
     }
 
+    double lineSpacing = (static_cast<double>(subStyle->lineSpacing) * (playResY / 4)) / 100;
+    if (subStyle->assOverrideFont)
+      lineSpacing *= scaleDefault;
+    else
+      lineSpacing *= scale;
     // ass_set_line_spacing do not scale, so we have to scale to frame size
     ass_set_line_spacing(m_renderer,
-                         lineSpacing / playResY * static_cast<double>(opts.frameHeight));
+                         lineSpacing / playResY * static_cast<double>(opts.frameHeight / 4));
 
     style->Blur = (10.00 / 100 * subStyle->blur);
 

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h
@@ -101,6 +101,7 @@ struct style
   // Vertical margin value in pixels scaled for VIEWPORT_HEIGHT
   int marginVertical = MARGIN_VERTICAL;
   int blur = 0; // In %
+  int lineSpacing = 0;
 };
 
 struct subtitleOpts

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -398,6 +398,7 @@ void CRenderer::CreateSubtitlesStyle()
                        static_cast<double>(settings->GetVerticalMarginPerc()));
 
   m_overlayStyle->blur = settings->GetBlurSize();
+  m_overlayStyle->lineSpacing = settings->GetLineSpacing();
 }
 
 std::shared_ptr<COverlay> CRenderer::ConvertLibass(

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -160,6 +160,7 @@ public:
   static constexpr auto SETTING_SUBTITLES_BORDERCOLOR = "subtitles.bordercolorpick";
   static constexpr auto SETTING_SUBTITLES_OPACITY = "subtitles.opacity";
   static constexpr auto SETTING_SUBTITLES_BLUR = "subtitles.blur";
+  static constexpr auto SETTING_SUBTITLES_LINE_SPACING = "subtitles.linespacing";
   static constexpr auto SETTING_SUBTITLES_BACKGROUNDTYPE = "subtitles.backgroundtype";
   static constexpr auto SETTING_SUBTITLES_SHADOWCOLOR = "subtitles.shadowcolor";
   static constexpr auto SETTING_SUBTITLES_SHADOWOPACITY = "subtitles.shadowopacity";

--- a/xbmc/settings/SubtitlesSettings.cpp
+++ b/xbmc/settings/SubtitlesSettings.cpp
@@ -38,7 +38,7 @@ CSubtitlesSettings::CSubtitlesSettings(const std::shared_ptr<CSettings>& setting
        CSettings::SETTING_SUBTITLES_LANGUAGES,      CSettings::SETTING_SUBTITLES_STORAGEMODE,
        CSettings::SETTING_SUBTITLES_CUSTOMPATH,     CSettings::SETTING_SUBTITLES_PAUSEONSEARCH,
        CSettings::SETTING_SUBTITLES_DOWNLOADFIRST,  CSettings::SETTING_SUBTITLES_TV,
-       CSettings::SETTING_SUBTITLES_MOVIE});
+       CSettings::SETTING_SUBTITLES_MOVIE,          CSettings::SETTING_SUBTITLES_LINE_SPACING});
 }
 
 CSubtitlesSettings::~CSubtitlesSettings()
@@ -131,6 +131,11 @@ int CSubtitlesSettings::GetShadowOpacity()
 int CSubtitlesSettings::GetBlurSize()
 {
   return m_settings->GetInt(CSettings::SETTING_SUBTITLES_BLUR);
+}
+
+int CSubtitlesSettings::GetLineSpacing()
+{
+  return m_settings->GetInt(CSettings::SETTING_SUBTITLES_LINE_SPACING);
 }
 
 BackgroundType CSubtitlesSettings::GetBackgroundType()

--- a/xbmc/settings/SubtitlesSettings.h
+++ b/xbmc/settings/SubtitlesSettings.h
@@ -161,6 +161,12 @@ public:
   int GetBlurSize();
 
   /*!
+   * \brief Get line spacing
+   * \return The line spacing
+   */
+  int GetLineSpacing();
+
+  /*!
    * \brief Get background type
    * \return The background type
    */


### PR DESCRIPTION
## Description
Make subtitles line spacing configurable

## Motivation and context
Coming from a different player, the default line spacing seemed off to me, so I decided to make it configurable.

## How has this been tested?
Ran locally, made sure that the setting indeed adjusts the line spacing.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
