### PR TITLE
[GUI][X11] Fix deadlock on dialog renderloop

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1475,7 +1475,10 @@ bool CGUIWindowManager::ProcessRenderLoop(bool renderOnly)
     m_iNested++;
     if (!renderOnly)
       m_pCallback->Process();
-    m_pCallback->FrameMove(!renderOnly);
+    {
+      CSingleExit leaveIt(CServiceBroker::GetWinSystem()->GetGfxContext());
+      m_pCallback->FrameMove(!renderOnly);
+    }
     m_pCallback->Render();
     m_iNested--;
   }


### PR DESCRIPTION
## Description
Found while working on a new feature. Regardless of the design choices, currently in Kodi the renderloop can basically be driven by two different elements:
 - The CApp itself https://github.com/xbmc/xbmc/blob/fb90b04e8d65c929499157cc99ec23351db7c6ff/xbmc/application/Application.cpp#L1827
 - The window manager called by the current active dialog https://github.com/xbmc/xbmc/blob/fb90b04e8d65c929499157cc99ec23351db7c6ff/xbmc/guilib/GUIWindowManager.cpp#L1468

The last one happens right after opening a new modal dialog (as the result of a visibility change). You can follow the flow here:
- UpdateVisibility is called by the Dialog `DoProcess` (which is itself started by `WindowManager::Process` and holds the graphics lock https://github.com/xbmc/xbmc/blob/fb90b04e8d65c929499157cc99ec23351db7c6ff/xbmc/guilib/GUIWindowManager.cpp#L1211
- `UpdateVisibility` call in `DoProcess` https://github.com/xbmc/xbmc/blob/fb90b04e8d65c929499157cc99ec23351db7c6ff/xbmc/guilib/GUIDialog.cpp#L114 may trigger `Open` https://github.com/xbmc/xbmc/blob/fb90b04e8d65c929499157cc99ec23351db7c6ff/xbmc/guilib/GUIDialog.cpp#L131
- `Open` may trigger open internal https://github.com/xbmc/xbmc/blob/fb90b04e8d65c929499157cc99ec23351db7c6ff/xbmc/guilib/GUIDialog.cpp#L202 see how the graphics lock is unlocked if we delegate this back to the application via messaging (a few lines above)
- `Open_Internal`, drives the render loop https://github.com/xbmc/xbmc/blob/fb90b04e8d65c929499157cc99ec23351db7c6ff/xbmc/guilib/GUIDialog.cpp#L180
- The render loop invokes the `FrameMove` https://github.com/xbmc/xbmc/blob/fb90b04e8d65c929499157cc99ec23351db7c6ff/xbmc/guilib/GUIWindowManager.cpp#L1478

While for CApp `FrameMove` the graphics lock is not held (the method already locks it in the places it actually needs to lock it), for the window manager cal it locks the graphic context right from the beginning until it goes out of scope. This leads to all input events to be executed while the lock is held.
Some of the resulting operations from an input request (e.g. a key press) may actually need to lock the graphics lock.
This is the case on X11, where to Stop the Player (as the result of a `X` key press during playback) the `VideoReference` clock is destructed and the videosyncGLX also locks the graphic context:
https://github.com/xbmc/xbmc/blob/fb90b04e8d65c929499157cc99ec23351db7c6ff/xbmc/windowing/X11/VideoSyncGLX.cpp#L249

Kodi ends up on a deadlock situation because the `VideoReferenceclock` process thread is waiting to hold the graphics context lock (held by the main thread) while the mainthread is waiting for the `VideoReference` clock to exit/join.

This change makes sure we leave the lock before actually calling `FrameMove` when the Windowmanager is responsible for driving the renderloop.

## Motivation and context
I am trying to extend EDL to support intro/outro since it has been requested for a long time. Hence I added this modal dialog to estuary:

```
<?xml version="1.0" encoding="utf-8"?>
<window type="dialog" id="1111" modality="modal">
	<visible>Player.Playing</visible>
	<onload>Notification(started, started!)</onload>
	<onunload>Notification(stop, stop!)</onunload>
	<!--<include>Animation_BottomSlide</include>-->
	<depth>DepthOSD</depth>
	<zorder>0</zorder>
	<defaultcontrol always="true">1</defaultcontrol>
	<controls>
		<control type="group">
			<!--<animation effect="fade" start="0" end="100" time="300">VisibleChange</animation>-->
			 <control type="button" id="1">
				<description>Hit me if you can!</description>
				<width>auto</width>
				<bottom>150</bottom>
				<left>200</left>
				<height>110</height>
				<label>Hit me if you can!</label>
				<textoffsetx>40</textoffsetx>
				<onclick>Notification(Ouch, Ouch!)</onclick>
				<onclick>SetProperty(hitclicked,1,home)</onclick>
				<align>center</align>
				<texturefocus border="23" colordiffuse="button_focus">buttons/dialogbutton-fo.png</texturefocus>
				<texturenofocus border="40">buttons/dialogbutton-nofo.png</texturenofocus>
			</control>
		</control>
	</controls>
</window>
```
![image](https://github.com/xbmc/xbmc/assets/7375276/4fb0037b-3b71-47fb-9e4d-c7e40b54c626)

I've found that if you stop playback using the keyboard while the dialog is active (it is driving the loop), Kodi deadlocks.

## How has this been tested?
Runtime tested on X11, dialog closes successfully without deadlocks

## What is the effect on users?
Deadlock in this specific (or similar conditions) should now be avoided.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

