### PR TITLE
Upload XBT textures with right dimensions

### DIFF
--- a/xbmc/guilib/TextureBase.cpp
+++ b/xbmc/guilib/TextureBase.cpp
@@ -45,20 +45,6 @@ void CTextureBase::Allocate(uint32_t width, uint32_t height, XB_FMT format)
     m_textureWidth = ((m_textureWidth + 3) / 4) * 4;
     m_textureHeight = ((m_textureHeight + 3) / 4) * 4;
   }
-  else
-  {
-    // align all textures so that they have an even width
-    // in some circumstances when we downsize a thumbnail
-    // which has an uneven number of pixels in width
-    // we crash in CPicture::ScaleImage in ffmpegs swscale
-    // because it tries to access beyond the source memory
-    // (happens on osx and ios)
-    // UPDATE: don't just update to be on an even width;
-    // ffmpegs swscale relies on a 16-byte stride on some systems
-    // so the textureWidth needs to be a multiple of 16. see ffmpeg
-    // swscale headers for more info.
-    m_textureWidth = ((m_textureWidth + 15) / 16) * 16;
-  }
 
   // check for max texture size
   m_textureWidth = std::min(m_textureWidth, CServiceBroker::GetRenderSystem()->GetMaxTextureSize());


### PR DESCRIPTION
## Description
Currently, staging texture allocation is done in widths with a multiple of 16 in all cases. This PR lets textures allocate an appropriate size.

## Motivation and context
The "multiple of 16 width" requirement stems from the need of having such a buffer size for swscale's memory alignment needs. But swscale is only used in one texture loading path. In other paths (like XBT loading), the content of the added width is undefined, leading to rendering artifacts.

## How has this been tested?
Runs and looks fine on GL.

## What is the effect on users?
Correct visuals for XBT textures with a width which is not a multiple of 16. Also, faster processing due to one continuous memcpy (not for every line individually). Slightly less memory consumption.

## Screenshots (if appropriate):
https://forum.kodi.tv/showthread.php?tid=376706&pid=3199821#pid3199821

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
