### PR TITLE
[DVDFactorySubtitle] Improved ASS format detection

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDFactorySubtitle.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDFactorySubtitle.cpp
@@ -20,6 +20,12 @@
 
 #include <cstring>
 #include <memory>
+#include <regex>
+
+namespace
+{
+constexpr const char* ASS_SCRIPT_TYPE_RE = "^ScriptType:\\s*v4\\.00\\+?";
+}
 
 CDVDSubtitleParser* CDVDFactorySubtitle::CreateParser(std::string& strFile)
 {
@@ -31,6 +37,8 @@ CDVDSubtitleParser* CDVDFactorySubtitle::CreateParser(std::string& strFile)
   {
     return nullptr;
   }
+
+  const std::regex reAssScriptType{ASS_SCRIPT_TYPE_RE};
 
   for (int t = 0; t < 256; t++)
   {
@@ -55,10 +63,9 @@ CDVDSubtitleParser* CDVDFactorySubtitle::CreateParser(std::string& strFile)
         return new CDVDSubtitleParserVplayer(std::move(pStream), strFile);
       }
       else if (!StringUtils::CompareNoCase(line, "!: This is a Sub Station Alpha v", 32) ||
-               !StringUtils::CompareNoCase(line, "ScriptType: v4.00", 17) ||
-               !StringUtils::CompareNoCase(line, "Dialogue: Marked", 16) ||
-               !StringUtils::CompareNoCase(line, "Dialogue: ", 10) ||
-               !StringUtils::CompareNoCase(line, "[Events]", 8))
+               std::regex_match(line, reAssScriptType) ||
+               !StringUtils::CompareNoCase(line, "[Events]", 8) ||
+               !StringUtils::CompareNoCase(line, "Dialogue:", 9))
       {
         return new CDVDSubtitleParserSSA(std::move(pStream), strFile);
       }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
1) use regex to check `ScriptType:` content with or without spaces
2) removed `Dialogue: Marked` since the "dialogue" field data depends on "Format:" line placed on top, so check for `Marked` text its not so useful, the generic `Dialogue:` check is enough
3) moved `[Events]` condition before `Dialogue:`, since the header appears first than "Dialogue" data

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #25440
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
following user file
[CANAAN - S01E01.ass.txt](https://github.com/user-attachments/files/16115414/CANAAN.-.S01E01.ass.txt)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
subs detected correctly
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
