### PR TITLE
Fix texture edge clamping

### DIFF
--- a/xbmc/guilib/TextureBase.cpp
+++ b/xbmc/guilib/TextureBase.cpp
@@ -127,6 +127,7 @@ void CTextureBase::ClampToEdge()
       for (uint32_t x = imagePitch; x < texturePitch; x += blockSize)
         memcpy(dst + x, src, blockSize);
       dst += texturePitch;
+      src += texturePitch;
     }
   }
 


### PR DESCRIPTION
## Description
Fix edge clamping of our texture loader.

## Motivation and context
The edge clamping function was never working correctly. It would just take the color value of the upper right pixel, which it would replicate across the undefined texture area.

## How has this been tested?
Seems fine in Renderdoc.

## What is the effect on users?
Improved image quality in some situations.

## Screenshots (if appropriate):
Before:
![image](https://github.com/xbmc/xbmc/assets/30039775/d8abffb0-9c90-4261-aebb-062152c483ca)

After:
![image](https://github.com/xbmc/xbmc/assets/30039775/febc895e-496e-448d-a9ec-b6e6ac26442f)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
