### PR TITLE
RecursiveMutex: Prevent initialization-order-fiasco of mutex attribute

### DIFF
--- a/xbmc/platform/posix/threads/RecursiveMutex.cpp
+++ b/xbmc/platform/posix/threads/RecursiveMutex.cpp
@@ -11,31 +11,18 @@
 namespace XbmcThreads
 {
 
-static pthread_mutexattr_t recursiveAttr;
-
-static bool SetRecursiveAttr()
+pthread_mutexattr_t& CRecursiveMutex::getRecursiveAttr()
 {
-  static bool alreadyCalled = false;
-
-  if (!alreadyCalled)
+  static pthread_mutexattr_t recursiveAttr = []()
   {
+    pthread_mutexattr_t recursiveAttr;
     pthread_mutexattr_init(&recursiveAttr);
     pthread_mutexattr_settype(&recursiveAttr, PTHREAD_MUTEX_RECURSIVE);
 #if !defined(TARGET_ANDROID)
     pthread_mutexattr_setprotocol(&recursiveAttr, PTHREAD_PRIO_INHERIT);
 #endif
-    alreadyCalled = true;
-  }
-
-  return true; // note, we never call destroy.
-}
-
-static bool recursiveAttrSet = SetRecursiveAttr();
-
-pthread_mutexattr_t& CRecursiveMutex::getRecursiveAttr()
-{
-  if (!recursiveAttrSet) // this is only possible in the single threaded startup code
-    recursiveAttrSet = SetRecursiveAttr();
+    return recursiveAttr;
+  }();
 
   return recursiveAttr;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

After the initialization problem observed in #25396 I also checked the regular Kodi executable and Address Sanitizer came up with this problem:

<details>
<summary>ASAN error</summary>

```
==226990==ERROR: AddressSanitizer: initialization-order-fiasco on address 0x5a8f25b81ce0 at pc 0x5a8f17dd10ae bp 0x7ffe5391ce50 sp 0x7ffe5391ce48 READ of size 1 at 0x5a8f25b81ce0 thread T0
    #0 0x5a8f17dd10ad in XbmcThreads::CRecursiveMutex::getRecursiveAttr() xbmc/platform/posix/threads/RecursiveMutex.cpp:37:8
    #1 0x5a8f17817a4e in XbmcThreads::CRecursiveMutex::CRecursiveMutex() xbmc/platform/posix/threads/RecursiveMutex.h:35:60
    #2 0x5a8f17817998 in XbmcThreads::CountingLockable<XbmcThreads::CRecursiveMutex>::CountingLockable() xbmc/threads/Lockables.h:47:12
    #3 0x5a8f1780dae8 in CCriticalSection::CCriticalSection() xbmc/threads/CriticalSection.h:16:7
    #4 0x5a8f1b27fd98 in CComponentContainer<IApplicationComponent>::CComponentContainer() xbmc/utils/ComponentContainer.h:26:7
    #5 0x5a8f1b1f3273 in CApplication::CApplication() xbmc/application/Application.cpp:217:15
    #6 0x5a8f17918fe0 in xbmcutil::GlobalsSingleton<CApplication>::getInstance() xbmc/utils/GlobalsHandling.h:147:23
    #7 0x5a8f17918f0f in __cxx_global_var_init.1 xbmc/application/Application.h:250:1
    #8 0x5a8f17918f49 in _GLOBAL__sub_I_UPnPRenderer.cpp xbmc/network/upnp/UPnPRenderer.cpp
    #9 0x7c5016639dc3 in __libc_start_main (/usr/lib/libc.so.6+0x25dc3) (BuildId: 32a656aa5562eece8c59a585f5eacd6cf5e2307b)
    #10 0x5a8f17636814 in _start (/home/mark/Coding/Repos/kodi-git/build_clang_debug_sanitizer/kodi.bin+0x9fa3814) (BuildId: 6cfd7dacce8a4a587ad47d2f082a4e50dad4c176)

0x5a8f25b81ce0 is located 32 bytes before global variable 'XbmcThreads::recursiveAttr' defined in 'xbmc/platform/posix/threads/RecursiveMutex.cpp' (0x5a8f25b81d00) of size 4
  registered at:
    #0 0x5a8f17651629 in __asan_register_globals.part.0 (/home/mark/Coding/Repos/kodi-git/build_clang_debug_sanitizer/kodi.bin+0x9fbe629) (BuildId: 6cfd7dacce8a4a587ad47d2f082a4e50dad4c176)
    #1 0x5a8f17651cce in __asan_register_elf_globals (/home/mark/Coding/Repos/kodi-git/build_clang_debug_sanitizer/kodi.bin+0x9fbecce) (BuildId: 6cfd7dacce8a4a587ad47d2f082a4e50dad4c176)
    #2 0x7c5016639dc3 in __libc_start_main (/usr/lib/libc.so.6+0x25dc3) (BuildId: 32a656aa5562eece8c59a585f5eacd6cf5e2307b)
    #3 0x5a8f17636814 in _start (/home/mark/Coding/Repos/kodi-git/build_clang_debug_sanitizer/kodi.bin+0x9fa3814) (BuildId: 6cfd7dacce8a4a587ad47d2f082a4e50dad4c176)

0x5a8f25b81ce0 is located 0 bytes inside of global variable 'XbmcThreads::recursiveAttrSet' defined in 'xbmc/platform/posix/threads/RecursiveMutex.cpp' (0x5a8f25b81ce0) of size 1
  'XbmcThreads::recursiveAttrSet' is ascii string ''
  registered at:
    #0 0x5a8f17651629 in __asan_register_globals.part.0 (/home/mark/Coding/Repos/kodi-git/build_clang_debug_sanitizer/kodi.bin+0x9fbe629) (BuildId: 6cfd7dacce8a4a587ad47d2f082a4e50dad4c176)
    #1 0x5a8f17651cce in __asan_register_elf_globals (/home/mark/Coding/Repos/kodi-git/build_clang_debug_sanitizer/kodi.bin+0x9fbecce) (BuildId: 6cfd7dacce8a4a587ad47d2f082a4e50dad4c176)
    #2 0x7c5016639dc3 in __libc_start_main (/usr/lib/libc.so.6+0x25dc3) (BuildId: 32a656aa5562eece8c59a585f5eacd6cf5e2307b)
    #3 0x5a8f17636814 in _start (/home/mark/Coding/Repos/kodi-git/build_clang_debug_sanitizer/kodi.bin+0x9fa3814) (BuildId: 6cfd7dacce8a4a587ad47d2f082a4e50dad4c176)

SUMMARY: AddressSanitizer: initialization-order-fiasco xbmc/platform/posix/threads/RecursiveMutex.cpp:37:8 in XbmcThreads::CRecursiveMutex::getRecursiveAttr() Shadow bytes around the buggy address:
  0x5a8f25b81a00: f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 00 00 00 00
  0x5a8f25b81a80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x5a8f25b81b00: 00 00 f9 f9 f9 f9 f9 f9 00 f9 f9 f9 00 00 00 00
  0x5a8f25b81b80: f6 f6 f6 f6 00 00 00 00 f6 f6 f6 f6 f6 f6 f6 f6
  0x5a8f25b81c00: f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6
=>0x5a8f25b81c80: 00 00 00 00 f6 f6 f6 f6 00 00 00 00[f6]f6 f6 f6
  0x5a8f25b81d00: 04 f9 f9 f9 01 f9 f9 f9 00 00 00 00 f6 f6 f6 f6
  0x5a8f25b81d80: 00 00 00 00 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6
  0x5a8f25b81e00: 00 00 00 00 f6 f6 f6 f6 00 00 00 00 f9 f9 f9 f9
  0x5a8f25b81e80: 00 f9 f9 f9 00 f9 f9 f9 f6 f6 f6 f6 f6 f6 f6 f6
  0x5a8f25b81f00: f6 f6 f6 f6 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
```
</details>

This PR address this by relying on the thread save initialization of local static variables.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The original code was relying on the value of the static global `recursiveAttrSet` which has not been initialized yet. This may results in undesired behavior.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

ASAN is happy and Kodi is starting fine.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Probably none.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
