### PR TITLE
[CMap] Reduce complexity of find to log(N) and general C++20 improvements

### DIFF
--- a/xbmc/utils/Map.h
+++ b/xbmc/utils/Map.h
@@ -36,26 +36,7 @@ public:
   template<typename Iterable>
   constexpr CMap(Iterable begin, Iterable end)
   {
-    size_t index = 0;
-    while (begin != end)
-    {
-      // c++17 doesn't have constexpr assignment operator for std::pair
-      auto& first = m_map[index].first;
-      auto& second = m_map[index].second;
-      ++index;
-
-      first = std::move(begin->first);
-      second = std::move(begin->second);
-      ++begin;
-
-      //! @todo: c++20 can use constexpr assignment operator instead
-      // auto& p = data[index];
-      // ++index;
-
-      // p = std::move(*begin);
-      // ++begin;
-      //
-    }
+    std::move(begin, end, m_map.begin());
 
     if constexpr (requires(Key k) { std::less<>{}(k, k); })
     {

--- a/xbmc/utils/Map.h
+++ b/xbmc/utils/Map.h
@@ -34,7 +34,7 @@ class CMap
 {
 public:
   template<typename Iterable>
-  constexpr CMap(Iterable begin, Iterable end)
+  consteval CMap(Iterable begin, Iterable end)
   {
     std::move(begin, end, m_map.begin());
 
@@ -97,7 +97,7 @@ private:
  *
  */
 template<typename Key, typename Value, std::size_t Size>
-constexpr auto make_map(std::pair<Key, Value>(&&m)[Size]) -> CMap<Key, Value, Size>
+consteval auto make_map(std::pair<Key, Value> (&&m)[Size]) -> CMap<Key, Value, Size>
 {
   return CMap<Key, Value, Size>(std::begin(m), std::end(m));
 }

--- a/xbmc/utils/test/CMakeLists.txt
+++ b/xbmc/utils/test/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOURCES TestAlarmClock.cpp
             TestLangCodeExpander.cpp
             TestLocale.cpp
             Testlog.cpp
+            TestMap.cpp
             TestMathUtils.cpp
             TestMime.cpp
             TestPOUtils.cpp

--- a/xbmc/utils/test/TestMap.cpp
+++ b/xbmc/utils/test/TestMap.cpp
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "utils/Map.h"
+
+#include <algorithm>
+
+#include <gtest/gtest.h>
+
+// CMap with sortable keys. Keys are sorted at compile time and find uses binary search
+TEST(TestMap, SortableKey)
+{
+  constexpr auto map = make_map<int, std::string_view>({{3, "three"}, {1, "one"}, {2, "two"}});
+  EXPECT_EQ(map.find(1)->second, "one");
+  EXPECT_EQ(map.find(2)->second, "two");
+  EXPECT_EQ(map.find(3)->second, "three");
+  EXPECT_EQ(map.find(0), map.cend());
+  EXPECT_EQ(map.find(4), map.cend());
+  // Ensure content is sorted
+  EXPECT_TRUE(
+      std::is_sorted(map.cbegin(), map.cend(), [](auto& a, auto& b) { return a.first < b.first; }));
+}
+
+// CMap with non sortable keys. Performs linear search in find
+TEST(TestMap, NonSortableKey)
+{
+  struct Dummy
+  {
+    int i;
+    bool operator==(const Dummy& other) const { return i == other.i; }
+  };
+
+  constexpr auto map = make_map<Dummy, std::string_view>(
+      {{Dummy{3}, "three"}, {Dummy{1}, "one"}, {Dummy{2}, "two"}});
+  EXPECT_EQ(map.find(Dummy{1})->second, "one");
+  EXPECT_EQ(map.find(Dummy{2})->second, "two");
+  EXPECT_EQ(map.find(Dummy{3})->second, "three");
+  EXPECT_EQ(map.find(Dummy{0}), map.cend());
+  EXPECT_EQ(map.find(Dummy{4}), map.cend());
+}
+
+// CMap compile time tests (not really a unit test...)
+TEST(TestMap, EnumConstexpr)
+{
+  enum class ENUM
+  {
+    ONE,
+    TWO,
+    THREE,
+    ENUM_MAX,
+  };
+
+  constexpr auto map = make_map<ENUM, std::string_view>(
+      {{ENUM::ONE, "ONE"}, {ENUM::TWO, "TWO"}, {ENUM::THREE, "THREE"}});
+  static_assert(map.find(ENUM::ONE)->second == "ONE");
+  static_assert(map.find(ENUM::TWO)->second == "TWO");
+  static_assert(map.find(ENUM::THREE)->second == "THREE");
+  static_assert(map.find(ENUM::ENUM_MAX) == map.cend());
+  static_assert(map.size() == size_t(ENUM::ENUM_MAX));
+}


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Make the algorithmic complexity of `CMap` log(n) instead of linear. It doesn't makes much off a difference for the map sizes we are currently using but who knows about the future. For keys that can't be sorted, the complexity remains linear.

Also some general C++20 simplifications, nothing major.

Last but not least, I added a small unit test, hoping I didn't break anything.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Make lookups faster.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added simple unit tests + runtime testing.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
