### PR TITLE
[GUIWindowSlideShow] Close dialog if a video starts playing

### DIFF
--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -152,12 +152,30 @@ CGUIWindowSlideShow::CGUIWindowSlideShow(void)
   m_loadType = KEEP_IN_MEMORY;
   m_bLoadNextPic = false;
   CServiceBroker::GetSlideShowDelegator().SetDelegate(this);
+  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
   Reset();
 }
 
 CGUIWindowSlideShow::~CGUIWindowSlideShow()
 {
   CServiceBroker::GetSlideShowDelegator().ResetDelegate();
+  CServiceBroker::GetAnnouncementManager()->RemoveAnnouncer(this);
+}
+
+void CGUIWindowSlideShow::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                                   const std::string& sender,
+                                   const std::string& message,
+                                   const CVariant& data)
+{
+  if (flag & ANNOUNCEMENT::Player)
+  {
+    if (message == "OnPlay" || message == "OnResume")
+    {
+      if (data.isMember("player") && data["player"].isMember("playerid") &&
+          data["player"]["playerid"] == static_cast<int>(PLAYLIST::Id::TYPE_VIDEO))
+        Close();
+    }
+  }
 }
 
 void CGUIWindowSlideShow::AnnouncePlayerPlay(const CFileItemPtr& item)

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -10,6 +10,7 @@
 
 #include "SlideShowPicture.h"
 #include "guilib/GUIDialog.h"
+#include "interfaces/IAnnouncer.h"
 #include "interfaces/ISlideShowDelegate.h"
 #include "threads/Event.h"
 #include "threads/Thread.h"
@@ -48,7 +49,9 @@ private:
   CGUIWindowSlideShow* m_pCallback = nullptr;
 };
 
-class CGUIWindowSlideShow : public CGUIDialog, public ISlideShowDelegate
+class CGUIWindowSlideShow : public CGUIDialog,
+                            public ISlideShowDelegate,
+                            public ANNOUNCEMENT::IAnnouncer
 {
 public:
   CGUIWindowSlideShow(void);
@@ -86,6 +89,12 @@ public:
                    const std::string& strExtensions = "") override;
   void Shuffle() override;
   int GetDirection() const override { return m_iDirection; }
+
+  // implementation of IAnnouncer
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                const std::string& sender,
+                const std::string& message,
+                const CVariant& data) override;
 
   bool OnMessage(CGUIMessage& message) override;
   EVENT_RESULT OnMouseEvent(const CPoint& point, const KODI::MOUSE::CMouseEvent& event) override;


### PR DESCRIPTION
## Description
When a video is requested for playback the slideshowdelegator (in this case the GUI window slideshow) should be closed so that the current picture does not overlay the video playing in the background. The same should not happen to music as we can have a slideshow playing with music on the background.
Implementation is done using the `IAnnouncer` interface so that components are not coupled.

Fixes https://github.com/xbmc/xbmc/issues/25443