### PR TITLE
TextureBase: Fix pitches computation

### DIFF
--- a/xbmc/guilib/TextureBase.cpp
+++ b/xbmc/guilib/TextureBase.cpp
@@ -127,7 +127,7 @@ void CTextureBase::ClampToEdge()
       for (uint32_t x = imagePitch; x < texturePitch; x += blockSize)
         memcpy(dst + x, src, blockSize);
       dst += texturePitch;
-      src += texturePitch;
+      src += imagePitch;
     }
   }
 


### PR DESCRIPTION
In 7572e2764cbdd5f686bb96fad06789e92958ae3e it was wrongly assumed that texturePitch and imagePitch are the same, which is not the case. So to end up at the same offset input wise and output wise, both have to be incremented with their specific pitch sizes.