### PR TITLE
CDVDVideoCodecDRMPRIME: Fix use of v4l2request hwdevice

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -172,11 +172,8 @@ static const AVCodecHWConfig* FindHWConfig(const AVCodec* codec)
     if (!IsSupportedHwFormat(config->pix_fmt))
       continue;
 
-    if ((config->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX) &&
-        config->device_type == AV_HWDEVICE_TYPE_DRM)
-      return config;
-
-    if ((config->methods & AV_CODEC_HW_CONFIG_METHOD_INTERNAL))
+    if ((config->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX) ||
+        (config->methods & AV_CODEC_HW_CONFIG_METHOD_INTERNAL))
       return config;
   }
 
@@ -299,41 +296,48 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
   m_hints = hints;
 
   const AVCodecHWConfig* pConfig = FindHWConfig(pCodec);
-  if (pConfig && (pConfig->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX) &&
-      pConfig->device_type == AV_HWDEVICE_TYPE_DRM)
+  if (pConfig && (pConfig->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX))
   {
+    const char* type = av_hwdevice_get_type_name(pConfig->device_type);
     const char* device = nullptr;
 
-    if (getenv("KODI_RENDER_NODE"))
-      device = getenv("KODI_RENDER_NODE");
+    if (pConfig->device_type == AV_HWDEVICE_TYPE_DRM)
+    {
+      if (getenv("KODI_RENDER_NODE"))
+        device = getenv("KODI_RENDER_NODE");
 
 #if defined(HAVE_GBM)
-    auto winSystem = dynamic_cast<KODI::WINDOWING::GBM::CWinSystemGbm*>(CServiceBroker::GetWinSystem());
+      auto winSystem =
+          dynamic_cast<KODI::WINDOWING::GBM::CWinSystemGbm*>(CServiceBroker::GetWinSystem());
 
-    if (winSystem)
-    {
-      auto drm = winSystem->GetDrm();
+      if (winSystem)
+      {
+        auto drm = winSystem->GetDrm();
 
-      if (!drm)
-        return false;
+        if (!drm)
+          return false;
 
-      if (!device)
-        device = drm->GetRenderDevicePath();
-    }
+        if (!device)
+          device = drm->GetRenderDevicePath();
+      }
 #endif
 
-    //! @todo: fix with proper device when dma-hints wayland protocol works
-    if (!device)
-      device = "/dev/dri/renderD128";
+      //! @todo: fix with proper device when dma-hints wayland protocol works
+      if (!device)
+        device = "/dev/dri/renderD128";
+    }
 
-    CLog::Log(LOGDEBUG, "CDVDVideoCodecDRMPRIME::{} - using drm device for av_hwdevice_ctx: {}", __FUNCTION__, device);
+    CLog::Log(LOGDEBUG,
+              "CDVDVideoCodecDRMPRIME::{} - creating {} hwdevice context using device: {}",
+              __FUNCTION__, type ? type : "unknown", device ? device : "(null)");
 
     if (av_hwdevice_ctx_create(&m_pCodecContext->hw_device_ctx, pConfig->device_type,
                                device, nullptr, 0) < 0)
     {
-      CLog::Log(LOGERROR,
-                "CDVDVideoCodecDRMPRIME::{} - unable to create hwdevice context using device: {}",
-                __FUNCTION__, device);
+      CLog::Log(
+          LOGERROR,
+          "CDVDVideoCodecDRMPRIME::{} - unable to create {} hwdevice context using device: {}",
+          __FUNCTION__, type ? type : "unknown", device ? device : "(null)");
       avcodec_free_context(&m_pCodecContext);
       return false;
     }


### PR DESCRIPTION
## Description

This PR extend `CDVDVideoCodecDRMPRIME` to support using any `AVCodecHWConfig` that support `drm_prime` output.

~Created as a draft PR because [work-in-progress FFmpeg patches](https://github.com/FFmpeg/FFmpeg/compare/master...Kwiboo:FFmpeg:v4l2request-2024-v2) are still being worked on.~

The reworked v2 patches was [posted](https://ffmpeg.org/pipermail/ffmpeg-devel/2024-August/332034.html) in early August, a v3 series with minimal changes should reach ffmpeg-devel next few days.

## Motivation and context

Current out-of-tree FFmpeg V4L2 Request API hwaccel patches abuse the drm hwdevice type.

Revised v2 patches posted for upstream FFmpeg changed this to use a new dedicated v4l2request hwdevice type.

Use of `device ? device : "(null)"` to work around `string pointer is null` exception from `libfmt` when a `nullptr` device was being logged.

## How has this been tested?

Using [work-in-progress FFmpeg patches](https://github.com/FFmpeg/FFmpeg/compare/master...Kwiboo:FFmpeg:v4l2request-2024-v2) on a LibreELEC based image.

## What is the effect on users?

None, users can use both old out-of-tree FFmpeg V4L2 Request API hwaccel patches or newer reworked patches for upstream FFmpeg.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
