### PR TITLE
[Android] Replace ALooper_pollAll with ALooper_pollOnce

### DIFF
--- a/xbmc/platform/android/activity/EventLoop.cpp
+++ b/xbmc/platform/android/activity/EventLoop.cpp
@@ -23,33 +23,30 @@ CEventLoop::CEventLoop(android_app* application)
   m_application->onInputEvent = inputCallback;
 }
 
-void CEventLoop::run(IActivityHandler &activityHandler, IInputHandler &inputHandler)
+void CEventLoop::run(IActivityHandler& activityHandler, IInputHandler& inputHandler)
 {
-  int ident;
-  int events;
-  struct android_poll_source* source;
-
   m_activityHandler = &activityHandler;
   m_inputHandler = &inputHandler;
 
   CXBMCApp::android_printf("CEventLoop: starting event loop");
-  while (true)
-  {
-    // We will block forever waiting for events.
-    while ((ident = ALooper_pollAll(-1, NULL, &events, (void**)&source)) >= 0)
-    {
-      // Process this event.
-      if (source != NULL)
-        source->process(m_application, source);
 
-      // Check if we are exiting.
-      if (m_application->destroyRequested)
-      {
-        CXBMCApp::android_printf("CEventLoop: we are being destroyed");
-        return;
-      }
+  while (!m_application->destroyRequested)
+  {
+    android_poll_source* source = nullptr;
+    int result = ALooper_pollOnce(-1, nullptr, nullptr, reinterpret_cast<void**>(&source));
+
+    if (result == ALOOPER_POLL_ERROR)
+    {
+      CXBMCApp::android_printf("CEventLoop: ALooper_pollOnce returned an error");
+      break;
     }
+
+    // Process this event.
+    if (source != nullptr)
+      source->process(m_application, source);
   }
+
+  CXBMCApp::android_printf("CEventLoop: we are being destroyed");
 }
 
 void CEventLoop::processActivity(int32_t command)


### PR DESCRIPTION
## Description
`ALooper_pollAll` must be replaced because the implementation has a race (may ignore wakes) so it can't be used safely. `ALooper_pollOnce` should be used instead.

`ALooper_pollAll` has marked as removed. Existing apps will continue to function (though probably with the bug), but apps building with NDK 27 or newer will not be able to call that function.

## How has this been tested?
Several tests with events and playbacks and it works as usual.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
