### PR TITLE
[PVR] Add 2 new types of system generated channel groups

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -3996,7 +3996,13 @@ msgctxt "#858"
 msgid "User"
 msgstr ""
 
-#empty strings from id 859 to 996
+#. Label postfix for channel groups containing content from all channels (e.g. "PVR Client 1 [All channels]")
+#: xbmc/pvr/channels/PVRChannelGroupAllChannelsSingleClient.cpp
+msgctxt "#859"
+msgid "{0:s} [All channels]"
+msgstr ""
+
+#empty strings from id 860 to 996
 
 #: xbmc/windows/GUIMediaWindow.cpp
 msgctxt "#997"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -3998,6 +3998,7 @@ msgstr ""
 
 #. Label postfix for channel groups containing content from all channels (e.g. "PVR Client 1 [All channels]")
 #: xbmc/pvr/channels/PVRChannelGroupAllChannelsSingleClient.cpp
+#: xbmc/pvr/channels/PVRChannelGroupMergedByName.cpp
 msgctxt "#859"
 msgid "{0:s} [All channels]"
 msgstr ""

--- a/xbmc/pvr/channels/CMakeLists.txt
+++ b/xbmc/pvr/channels/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES PVRChannel.cpp
             PVRChannelGroupAllChannelsSingleClient.cpp
             PVRChannelGroupFromClient.cpp
             PVRChannelGroupMember.cpp
+            PVRChannelGroupMergedByName.cpp
             PVRChannelGroupSettings.cpp
             PVRChannelGroups.cpp
             PVRChannelGroupsContainer.cpp
@@ -20,6 +21,7 @@ set(HEADERS PVRChannel.h
             PVRChannelGroupFromClient.h
             PVRChannelGroupFromUser.h
             PVRChannelGroupMember.h
+            PVRChannelGroupMergedByName.h
             PVRChannelGroupSettings.h
             PVRChannelGroups.h
             PVRChannelGroupsContainer.h

--- a/xbmc/pvr/channels/CMakeLists.txt
+++ b/xbmc/pvr/channels/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES PVRChannel.cpp
             PVRChannelGroup.cpp
             PVRChannelGroupAllChannels.cpp
             PVRChannelGroupFactory.cpp
+            PVRChannelGroupAllChannelsSingleClient.cpp
             PVRChannelGroupFromClient.cpp
             PVRChannelGroupMember.cpp
             PVRChannelGroupSettings.cpp
@@ -15,6 +16,7 @@ set(HEADERS PVRChannel.h
             PVRChannelGroup.h
             PVRChannelGroupAllChannels.h
             PVRChannelGroupFactory.h
+            PVRChannelGroupAllChannelsSingleClient.h
             PVRChannelGroupFromClient.h
             PVRChannelGroupFromUser.h
             PVRChannelGroupMember.h

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -25,8 +25,9 @@ struct PVR_CHANNEL_GROUP;
 namespace PVR
 {
 static constexpr int PVR_GROUP_TYPE_CLIENT = 0;
-static constexpr int PVR_GROUP_TYPE_SYSTEM_ALL_CHANNELS = 1;
+static constexpr int PVR_GROUP_TYPE_SYSTEM_ALL_CHANNELS_ALL_CLIENTS = 1;
 static constexpr int PVR_GROUP_TYPE_USER = 2;
+static constexpr int PVR_GROUP_TYPE_SYSTEM_ALL_CHANNELS_SINGLE_CLIENT = 3;
 
 static constexpr int PVR_GROUP_CLIENT_ID_UNKNOWN = -2;
 static constexpr int PVR_GROUP_CLIENT_ID_LOCAL = -1;
@@ -525,6 +526,19 @@ public:
    */
   virtual bool ShouldBeIgnored(
       const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups) const;
+
+  /*!
+   * @brief Update all group members.
+   * @param allChannelsGroup The all channels group.
+   * @param allChannelGroups All available channel groups.
+   * @return True on success, false otherwise.
+   */
+  virtual bool UpdateGroupMembers(
+      const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup,
+      const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups)
+  {
+    return true;
+  }
 
 protected:
   /*!

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -28,6 +28,7 @@ static constexpr int PVR_GROUP_TYPE_CLIENT = 0;
 static constexpr int PVR_GROUP_TYPE_SYSTEM_ALL_CHANNELS_ALL_CLIENTS = 1;
 static constexpr int PVR_GROUP_TYPE_USER = 2;
 static constexpr int PVR_GROUP_TYPE_SYSTEM_ALL_CHANNELS_SINGLE_CLIENT = 3;
+static constexpr int PVR_GROUP_TYPE_SYSTEM_MERGED_BY_NAME = 4;
 
 static constexpr int PVR_GROUP_CLIENT_ID_UNKNOWN = -2;
 static constexpr int PVR_GROUP_CLIENT_ID_LOCAL = -1;

--- a/xbmc/pvr/channels/PVRChannelGroupAllChannels.h
+++ b/xbmc/pvr/channels/PVRChannelGroupAllChannels.h
@@ -62,7 +62,7 @@ public:
   /*!
    * @brief Return the type of this group.
    */
-  int GroupType() const override { return PVR_GROUP_TYPE_SYSTEM_ALL_CHANNELS; }
+  int GroupType() const override { return PVR_GROUP_TYPE_SYSTEM_ALL_CHANNELS_ALL_CLIENTS; }
 
   /*!
    * @brief Check whether this group could be deleted by the user.

--- a/xbmc/pvr/channels/PVRChannelGroupAllChannelsSingleClient.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupAllChannelsSingleClient.cpp
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRChannelGroupAllChannelsSingleClient.h"
+
+#include "ServiceBroker.h"
+#include "guilib/LocalizeStrings.h"
+#include "pvr/PVRManager.h"
+#include "pvr/addons/PVRClient.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
+#include "pvr/channels/PVRChannelsPath.h"
+#include "utils/StringUtils.h"
+#include "utils/log.h"
+
+#include <algorithm>
+#include <unordered_set>
+
+using namespace PVR;
+
+std::vector<std::shared_ptr<CPVRChannelGroup>> CPVRChannelGroupAllChannelsSingleClient::
+    CreateMissingGroups(const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup,
+                        const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups)
+{
+  const std::vector<std::shared_ptr<CPVRChannelGroupMember>> allGroupMembers{
+      allChannelsGroup->GetMembers()};
+
+  // Create a unique list of active client ids from current members of the all channels list.
+  std::unordered_set<int> clientIds;
+  for (const auto& member : allGroupMembers)
+  {
+    clientIds.insert(member->ChannelClientID());
+  }
+
+  // If only one client is active, global all channels group would be identical to the all
+  // channels group for the client. No need to create it.
+  if (clientIds.size() <= 1)
+    return {};
+
+  std::vector<std::shared_ptr<CPVRChannelGroup>> addedGroups;
+
+  for (int clientId : clientIds)
+  {
+    const std::shared_ptr<const CPVRClient> client{
+        CServiceBroker().GetPVRManager().GetClient(clientId)};
+    if (!client)
+    {
+      CLog::LogFC(LOGERROR, LOGPVR, "Failed to get client instance for client id {}", clientId);
+      continue;
+    }
+
+    // Create a group containg all channels for this client, if not yet existing.
+    const auto it = std::find_if(allChannelGroups.cbegin(), allChannelGroups.cend(),
+                                 [&client](const auto& group)
+                                 {
+                                   return (group->GroupType() ==
+                                           PVR_GROUP_TYPE_SYSTEM_ALL_CHANNELS_SINGLE_CLIENT) &&
+                                          (group->GetClientID() == client->GetID());
+                                 });
+    if (it == allChannelGroups.cend())
+    {
+      const std::string name{
+          StringUtils::Format(g_localizeStrings.Get(859), client->GetFullClientName())};
+      const CPVRChannelsPath path{allChannelsGroup->IsRadio(), name, client->GetID()};
+      addedGroups.emplace_back(
+          std::make_shared<CPVRChannelGroupAllChannelsSingleClient>(path, allChannelsGroup));
+    }
+  }
+
+  return addedGroups;
+}
+
+bool CPVRChannelGroupAllChannelsSingleClient::UpdateGroupMembers(
+    const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup,
+    const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups)
+{
+  std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers;
+
+  // Collect and populate matching members.
+  const auto allChannelsGroupMembers{allChannelsGroup->GetMembers()};
+  for (const auto& member : allChannelsGroupMembers)
+  {
+    if (member->ChannelClientID() != GetClientID())
+      continue;
+
+    groupMembers.emplace_back(std::make_shared<CPVRChannelGroupMember>(
+        GroupID(), GroupName(), GetClientID(), member->Channel()));
+  }
+
+  return UpdateGroupEntries(groupMembers);
+}

--- a/xbmc/pvr/channels/PVRChannelGroupAllChannelsSingleClient.h
+++ b/xbmc/pvr/channels/PVRChannelGroupAllChannelsSingleClient.h
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "pvr/channels/PVRChannelGroup.h"
+
+namespace PVR
+{
+
+class CPVRChannelGroupAllChannelsSingleClient : public CPVRChannelGroup
+{
+public:
+  /*!
+   * @brief Create a new channel group instance.
+   * @param path The channel group path.
+   * @param allChannelsGroup The channel group containing all TV or radio channels.
+   */
+  CPVRChannelGroupAllChannelsSingleClient(
+      const CPVRChannelsPath& path, const std::shared_ptr<const CPVRChannelGroup>& allChannelsGroup)
+    : CPVRChannelGroup(path, allChannelsGroup)
+  {
+  }
+
+  /*!
+   * @brief Get the group's origin.
+   * @return The origin.
+   */
+  Origin GetOrigin() const override { return Origin::SYSTEM; }
+
+  /*!
+   * @brief Return the type of this group.
+   */
+  int GroupType() const override { return PVR_GROUP_TYPE_SYSTEM_ALL_CHANNELS_SINGLE_CLIENT; }
+
+  /*!
+   * @brief Check whether this group could be deleted by the user.
+   * @return True if the group could be deleted, false otherwise.
+   */
+  bool SupportsDelete() const override { return false; }
+
+  /*!
+   * @brief Check whether members could be added to this group by the user.
+   * @return True if members could be added, false otherwise.
+   */
+  bool SupportsMemberAdd() const override { return false; }
+
+  /*!
+   * @brief Check whether members could be removed from this group by the user.
+   * @return True if members could be removed, false otherwise.
+   */
+  bool SupportsMemberRemove() const override { return false; }
+
+  /*!
+   * @brief Check whether this group is owner of the channel instances it contains.
+   * @return True if owner, false otherwise.
+   */
+  bool IsChannelsOwner() const override { return false; }
+
+  /*!
+   * @brief Update data with channel group members from the given clients, sync with local data.
+   * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
+   * @return True on success, false otherwise.
+   */
+  bool UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients) override
+  {
+    return true; // Nothing to update from any client for locally managed groups.
+  }
+
+  /*!
+   * @brief Create any missing channel groups (e.g. after an update of groups/members/clients).
+   * @param allChannelsGroup The all channels group.
+   * @param allChannelGroups All channel groups.
+   * @return The newly created groups, if any.
+   */
+  static std::vector<std::shared_ptr<CPVRChannelGroup>> CreateMissingGroups(
+      const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup,
+      const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups);
+
+  /*!
+   * @brief Update all group members.
+   * @param allChannelsGroup The all channels group.
+   * @param allChannelGroups All available channel groups.
+   * @return True on success, false otherwise.
+   */
+  bool UpdateGroupMembers(
+      const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup,
+      const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups) override;
+};
+} // namespace PVR

--- a/xbmc/pvr/channels/PVRChannelGroupFactory.h
+++ b/xbmc/pvr/channels/PVRChannelGroupFactory.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 struct PVR_CHANNEL_GROUP;
 
@@ -73,5 +74,15 @@ public:
    * @return The group's type priority.
    */
   int GetGroupTypePriority(const std::shared_ptr<const CPVRChannelGroup>& group) const;
+
+  /*!
+   * @brief Create any missing channel groups (e.g. after an update of groups/members/clients).
+   * @param allChannelsGroup The all channels group.
+   * @param allChannelGroups All channel groups.
+   * @return The newly created groups, if any.
+   */
+  std::vector<std::shared_ptr<CPVRChannelGroup>> CreateMissingGroups(
+      const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup,
+      const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups);
 };
 } // namespace PVR

--- a/xbmc/pvr/channels/PVRChannelGroupMergedByName.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupMergedByName.cpp
@@ -1,0 +1,164 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRChannelGroupMergedByName.h"
+
+#include "guilib/LocalizeStrings.h"
+#include "pvr/channels/PVRChannelGroupMember.h"
+#include "utils/StringUtils.h"
+
+#include <unordered_map>
+#include <utility>
+
+using namespace PVR;
+
+bool CPVRChannelGroupMergedByName::ShouldBeIgnored(
+    const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups) const
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+
+  // Ignore the group if it is empty or only members from one group are present.
+
+  if (m_members.empty())
+    return true;
+
+  const std::string mergedGroupName{!ClientGroupName().empty() ? ClientGroupName() : GroupName()};
+  static constexpr int NO_GROUP_FOUND{-1};
+  int matchingGroup{NO_GROUP_FOUND};
+
+  for (const auto& member : m_members)
+  {
+    for (const auto& group : allChannelGroups)
+    {
+      if (group->GetOrigin() != Origin::USER && group->GetOrigin() != Origin::CLIENT)
+        continue;
+
+      if (group->GroupName() != mergedGroupName && group->ClientGroupName() != mergedGroupName)
+        continue;
+
+      if (group->IsGroupMember(member.second))
+      {
+        if (matchingGroup != NO_GROUP_FOUND && matchingGroup != group->GroupID())
+        {
+          // Found a second group containing a member of this group. This group must not be ignored.
+          return false;
+        }
+        // First match or no new group. Continue with next group.
+        matchingGroup = group->GroupID();
+      }
+    }
+  }
+  return true;
+}
+
+namespace
+{
+std::vector<std::string> GetGroupNames(const std::vector<std::shared_ptr<CPVRChannelGroup>>& groups)
+{
+  std::unordered_map<std::string, unsigned int> knownNamesCountMap;
+
+  // Structure group data for easy further processing.
+  for (const auto& group : groups)
+  {
+    const std::string groupName{!group->ClientGroupName().empty() ? group->ClientGroupName()
+                                                                  : group->GroupName()};
+    switch (group->GetOrigin())
+    {
+      case CPVRChannelGroup::Origin::SYSTEM:
+      {
+        // Ignore system-created groups, except merged by name groups
+        if (group->GroupType() == PVR_GROUP_TYPE_SYSTEM_MERGED_BY_NAME)
+        {
+          const auto it = knownNamesCountMap.find(groupName);
+          if (it == knownNamesCountMap.end())
+            knownNamesCountMap.insert({groupName, 0}); // remember we found a merged group
+          else
+            (*it).second = 0; // reset groups counter. we do not need a new merged group
+        }
+        break;
+      }
+
+      case CPVRChannelGroup::Origin::USER:
+      case CPVRChannelGroup::Origin::CLIENT:
+      {
+        const auto it = knownNamesCountMap.find(groupName);
+        if (it == knownNamesCountMap.end())
+          knownNamesCountMap.insert({groupName, 1}); // first occurance
+        else if ((*it).second > 0)
+          (*it).second++; // second+ occurance
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  std::vector<std::string> names;
+  for (const auto& name : knownNamesCountMap)
+  {
+    if (name.second > 1)
+      names.emplace_back(name.first);
+  }
+  return names;
+}
+} // namespace
+
+std::vector<std::shared_ptr<CPVRChannelGroup>> CPVRChannelGroupMergedByName::CreateMissingGroups(
+    const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup,
+    const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups)
+{
+  std::vector<std::shared_ptr<CPVRChannelGroup>> addedGroups;
+
+  const std::vector<std::string> names{GetGroupNames(allChannelGroups)};
+  for (const auto& name : names)
+  {
+    const std::string groupName{StringUtils::Format(g_localizeStrings.Get(859), name)};
+    const CPVRChannelsPath path{allChannelsGroup->IsRadio(), groupName, PVR_GROUP_CLIENT_ID_LOCAL};
+    const std::shared_ptr<CPVRChannelGroup> mergedByNameGroup{
+        std::make_shared<CPVRChannelGroupMergedByName>(path, allChannelsGroup)};
+    mergedByNameGroup->SetClientGroupName(name);
+    addedGroups.emplace_back(mergedByNameGroup);
+  }
+
+  return addedGroups;
+}
+
+bool CPVRChannelGroupMergedByName::UpdateGroupMembers(
+    const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup,
+    const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups)
+{
+  std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers;
+
+  // Collect and populate matching members.
+  for (const auto& group : allChannelGroups)
+  {
+    const std::string groupName{!group->ClientGroupName().empty() ? group->ClientGroupName()
+                                                                  : group->GroupName()};
+    if (groupName != ClientGroupName())
+      continue;
+
+    switch (group->GetOrigin())
+    {
+      case CPVRChannelGroup::Origin::USER:
+      case CPVRChannelGroup::Origin::CLIENT:
+      {
+        const auto members{group->GetMembers()};
+        for (const auto& member : members)
+        {
+          groupMembers.emplace_back(std::make_shared<CPVRChannelGroupMember>(
+              GroupID(), GroupName(), GetClientID(), member->Channel()));
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return UpdateGroupEntries(groupMembers);
+}

--- a/xbmc/pvr/channels/PVRChannelGroupMergedByName.h
+++ b/xbmc/pvr/channels/PVRChannelGroupMergedByName.h
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "pvr/channels/PVRChannelGroup.h"
+
+namespace PVR
+{
+
+class CPVRChannelGroupMergedByName : public CPVRChannelGroup
+{
+public:
+  /*!
+   * @brief Create a new channel group instance.
+   * @param path The channel group path.
+   * @param allChannelsGroup The channel group containing all TV or radio channels.
+   */
+  CPVRChannelGroupMergedByName(const CPVRChannelsPath& path,
+                               const std::shared_ptr<const CPVRChannelGroup>& allChannelsGroup)
+    : CPVRChannelGroup(path, allChannelsGroup)
+  {
+  }
+
+  /*!
+   * @brief Get the group's origin.
+   * @return The origin.
+   */
+  Origin GetOrigin() const override { return Origin::SYSTEM; }
+
+  /*!
+   * @brief Return the type of this group.
+   */
+  int GroupType() const override { return PVR_GROUP_TYPE_SYSTEM_MERGED_BY_NAME; }
+
+  /*!
+   * @brief Check whether this group could be deleted by the user.
+   * @return True if the group could be deleted, false otherwise.
+   */
+  bool SupportsDelete() const override { return false; }
+
+  /*!
+   * @brief Check whether members could be added to this group by the user.
+   * @return True if members could be added, false otherwise.
+   */
+  bool SupportsMemberAdd() const override { return false; }
+
+  /*!
+   * @brief Check whether members could be removed from this group by the user.
+   * @return True if members could be removed, false otherwise.
+   */
+  bool SupportsMemberRemove() const override { return false; }
+
+  /*!
+   * @brief Check whether this group is owner of the channel instances it contains.
+   * @return True if owner, false otherwise.
+   */
+  bool IsChannelsOwner() const override { return false; }
+
+  /*!
+   * @brief Update data with channel group members from the given clients, sync with local data.
+   * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
+   * @return True on success, false otherwise.
+   */
+  bool UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients) override
+  {
+    return true; // Nothing to update from any client for locally managed groups.
+  }
+
+  /*!
+   * @brief Check whether this group should be ignored, e.g. not presented to the user and API.
+   * @param allChannelGroups All available channel groups.
+   * @return True if to be ignored, false otherwise.
+   */
+  bool ShouldBeIgnored(
+      const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups) const override;
+
+  /*!
+   * @brief Create any missing channel groups (e.g. after an update of groups/members/clients).
+   * @param allChannelsGroup The all channels group.
+   * @param allChannelGroups All channel groups.
+   * @return The newly created groups, if any.
+   */
+  static std::vector<std::shared_ptr<CPVRChannelGroup>> CreateMissingGroups(
+      const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup,
+      const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups);
+
+  /*!
+   * @brief Update all group members.
+   * @param allChannelsGroup The all channels group.
+   * @param allChannelGroups All available channel groups.
+   * @return True on success, false otherwise.
+   */
+  bool UpdateGroupMembers(
+      const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup,
+      const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups) override;
+};
+} // namespace PVR

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -294,6 +294,8 @@ private:
   void GroupStateChanged(const std::shared_ptr<CPVRChannelGroup>& group,
                          GroupState state = GroupState::CHANGED);
 
+  void UpdateSystemChannelGroups();
+
   bool m_bRadio{false};
   std::vector<std::shared_ptr<CPVRChannelGroup>> m_groups;
   mutable CCriticalSection m_critSection;


### PR DESCRIPTION
Currently we have already one channel group which is automatically created and maintained by PVR core: The "All channels" group which contains all channels from all active PVR clients/instances.

This PR adds two new types of these groups, which are especially useful for multi-client-/instance setups:

1) An "All channels" group per client/instance containing all channels of the client/instance. Example: 2 clients enabled, create two groups 'Client 1 [All channels]' containing all channels from client 1 and 'Client 2 [All channels]' containing all channels from client 2.

2) A "Merged by name" group per duplicate group name across clients/instances. Example: A group with name 'A' is provided by two different client addons, create a group 'A [All channels]' containing all channels from both 'A' groups. This restores the pre-Omega functionality to automatically merge groups with same names, as requested by some users in the forum, btw.

In case users do not want the new groups, they can be disabled in the channel group manager, exactly like possible today with the global "All channels" group (and every other group).

Carefully runtime-tested for some weeks on macOS and Android, latest Kodi master.

@phunkyfish something to review for you I guess. Best reviewed commit-by-commit. Start with "per client all channels group" commit.