### PR TITLE
[Android] Move GetStorageUsage function to CAndroidStorageProvider

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -92,7 +92,6 @@
 #include <androidjni/NetworkInfo.h>
 #include <androidjni/PackageManager.h>
 #include <androidjni/Resources.h>
-#include <androidjni/StatFs.h>
 #include <androidjni/System.h>
 #include <androidjni/SystemClock.h>
 #include <androidjni/SystemProperties.h>
@@ -105,8 +104,6 @@
 #include <jni.h>
 #include <rapidjson/document.h>
 #include <unistd.h>
-
-#define GIGABYTES       1073741824
 
 #define ACTION_XBMC_RESUME "android.intent.XBMC_RESUME"
 
@@ -1131,72 +1128,6 @@ bool CXBMCApp::GetExternalStorage(std::string &path, const std::string &type /* 
   mountedState = CJNIEnvironment::getExternalStorageState();
   mounted = (mountedState == "mounted" || mountedState == "mounted_ro");
   return mounted && !path.empty();
-}
-
-bool CXBMCApp::GetStorageUsage(const std::string &path, std::string &usage)
-{
-#define PATH_MAXLEN 38
-
-  if (path.empty())
-  {
-    std::ostringstream fmt;
-
-    fmt.width(PATH_MAXLEN);
-    fmt << std::left << "Filesystem";
-
-    fmt.width(12);
-    fmt << std::right << "Size";
-
-    fmt.width(12);
-    fmt << "Used";
-
-    fmt.width(12);
-    fmt << "Avail";
-
-    fmt.width(12);
-    fmt << "Use %";
-
-    usage = fmt.str();
-    return false;
-  }
-
-  CJNIStatFs fileStat(path);
-  int blockSize = fileStat.getBlockSize();
-  int blockCount = fileStat.getBlockCount();
-  int freeBlocks = fileStat.getFreeBlocks();
-
-  if (blockSize <= 0 || blockCount <= 0 || freeBlocks < 0)
-    return false;
-
-  float totalSize = (float)blockSize * blockCount / GIGABYTES;
-  float freeSize = (float)blockSize * freeBlocks / GIGABYTES;
-  float usedSize = totalSize - freeSize;
-  float usedPercentage = usedSize / totalSize * 100;
-
-  std::ostringstream fmt;
-
-  fmt << std::fixed;
-  fmt.precision(1);
-
-  fmt.width(PATH_MAXLEN);
-  fmt << std::left
-      << (path.size() < PATH_MAXLEN - 1 ? path : StringUtils::Left(path, PATH_MAXLEN - 4) + "...");
-
-  fmt.width(11);
-  fmt << std::right << totalSize << "G";
-
-  fmt.width(11);
-  fmt << usedSize << "G";
-
-  fmt.width(11);
-  fmt << freeSize << "G";
-
-  fmt.precision(0);
-  fmt.width(11);
-  fmt << usedPercentage << "%";
-
-  usage = fmt.str();
-  return true;
 }
 
 // Used in Application.cpp to figure out volume steps

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -173,8 +173,7 @@ public:
    * \param type optional type. Possible values are "", "files", "music", "videos", "pictures", "photos, "downloads"
    * \return true if external storage is available and a valid path has been stored in the path parameter
    */
-  static bool GetExternalStorage(std::string &path, const std::string &type = "");
-  static bool GetStorageUsage(const std::string &path, std::string &usage);
+  static bool GetExternalStorage(std::string& path, const std::string& type = "");
   static int GetMaxSystemVolume();
   static float GetSystemVolume();
   static void SetSystemVolume(float percent);

--- a/xbmc/platform/android/storage/AndroidStorageProvider.h
+++ b/xbmc/platform/android/storage/AndroidStorageProvider.h
@@ -37,4 +37,6 @@ private:
 
   static std::set<std::string> GetRemovableDrives();
   static std::set<std::string> GetRemovableDrivesLinux();
+
+  bool GetStorageUsage(const std::string& path, std::string& usage);
 };


### PR DESCRIPTION
## Description
Small code improvement consisting in moving the `GetStorageUsage()` function to the `CAndroidStorageProvider` class.

This function is only used by this class, so it becomes a private function of this class.

## Motivation and context
Clean code and simplify the main class `CXBMCApp`

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
