### PR TITLE
[Texture] Fix NPOT condition

### DIFF
--- a/xbmc/guilib/TextureBase.cpp
+++ b/xbmc/guilib/TextureBase.cpp
@@ -32,7 +32,7 @@ void CTextureBase::Allocate(uint32_t width, uint32_t height, XB_FMT format)
   m_textureWidth = m_imageWidth;
   m_textureHeight = m_imageHeight;
 
-  if (!CServiceBroker::GetRenderSystem()->SupportsNPOT((m_textureFormat & KD_TEX_FMT_TYPE_MASK) !=
+  if (!CServiceBroker::GetRenderSystem()->SupportsNPOT((m_textureFormat & KD_TEX_FMT_TYPE_MASK) ==
                                                        KD_TEX_FMT_S3TC))
   {
     m_textureWidth = PadPow2(m_textureWidth);


### PR DESCRIPTION
## Description

https://github.com/xbmc/xbmc/pull/24508 caused a regression and changed behaviour. `SupportsNPOT()` expects to check against dxt (the bool is even called dxt): https://github.com/xbmc/xbmc/blob/93d54c26968c42418f59b79129d209fffaf68c3c/xbmc/rendering/RenderSystem.cpp#L38-L44.

It was previously written as `(m_format & XB_FMT_DXT_MASK) != 0)` - which is pretty much the same as checking for dxt. The way it was written in the aforementioned PR is exactly the opposite, so the affected block of code runs for any texture format. 

## Motivation and context
Found teletext was broken in android:

![image](https://github.com/user-attachments/assets/18d001c0-e5d8-4fab-acee-5b92ec3c2cc6)

## How has this been tested?
Runtime tested on android

## What is the effect on users?
Teletext should run again in all its glory. Probably other issues can potentially be fixed since this is a logic error.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
