### PR TITLE
[GUIDialogSubtitleSettings] Fix browse local files regression

### DIFF
--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -147,34 +147,34 @@ bool CPlayListM3U::Load(const std::string& strFileName)
              !StringUtils::StartsWith(strLine, ArtistMarker) &&
              !StringUtils::StartsWith(strLine, AlbumMarker))
     {
-      std::string strFileName = strLine;
+      std::string filePath = strLine;
 
-      if (!strFileName.empty() && strFileName[0] == '#')
+      if (!filePath.empty() && filePath[0] == '#')
         continue; // assume a comment or something else we don't support
 
       // Skip self - do not load playlist recursively
       // We compare case-less in case user has input incorrect case of the current playlist
-      if (StringUtils::EqualsNoCase(URIUtils::GetFileName(strFileName), m_strPlayListName))
+      if (StringUtils::EqualsNoCase(URIUtils::GetFileName(filePath), m_strPlayListName))
         continue;
 
-      if (strFileName.length() > 0)
+      if (filePath.length() > 0)
       {
         if (!utf8)
-          g_charsetConverter.unknownToUTF8(strFileName);
+          g_charsetConverter.unknownToUTF8(filePath);
 
         // If no info was read from from the extended tag information, use the file name
         if (strInfo.length() == 0)
         {
-          strInfo = URIUtils::GetFileName(strFileName);
+          strInfo = URIUtils::GetFileName(filePath);
         }
 
         // should substitution occur before or after charset conversion??
-        strFileName = URIUtils::SubstitutePath(strFileName);
+        filePath = URIUtils::SubstitutePath(filePath);
 
         // Get the full path file name and add it to the the play list
-        CUtil::GetQualifiedFilename(m_strBasePath, strFileName);
+        CUtil::GetQualifiedFilename(m_strBasePath, filePath);
         CFileItemPtr newItem(new CFileItem(strInfo));
-        newItem->SetPath(strFileName);
+        newItem->SetPath(filePath);
         if (iStartOffset != 0 || iEndOffset != 0)
         {
           newItem->SetStartOffset(iStartOffset);
@@ -192,6 +192,9 @@ bool CPlayListM3U::Load(const std::string& strFileName)
           newItem->GetVideoInfoTag()->Reset(); // Force VideoInfoTag creation
         if (lDuration && MUSIC::IsAudio(*newItem))
           newItem->GetMusicInfoTag()->SetDuration(lDuration);
+
+        newItem->SetProperty("original_playlist_filepath", strFileName);
+
         for (auto &prop : properties)
         {
           newItem->SetProperty(prop.first, prop.second);

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -737,6 +737,11 @@ bool URIUtils::IsMultiPath(const std::string& strPath)
   return IsProtocol(strPath, "multipath");
 }
 
+bool URIUtils::IsDatabase(const std::string& strFile)
+{
+  return IsVideoDb(strFile) || IsMusicDb(strFile);
+}
+
 bool URIUtils::IsHD(const std::string& strFileName)
 {
   CURL url(strFileName);

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -155,6 +155,7 @@ public:
   static bool IsPVRTVRecordingFileOrFolder(const std::string& strFile);
   static bool IsPVRRadioRecordingFileOrFolder(const std::string& strFile);
   static bool IsMultiPath(const std::string& strPath);
+  static bool IsDatabase(const std::string& strFile);
   static bool IsMusicDb(const std::string& strFile);
   static bool IsNfs(const std::string& strFile);
   static bool IsOnDVD(const std::string& strFile);

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -128,14 +128,23 @@ std::string CGUIDialogSubtitleSettings::BrowseForSubtitle()
   }
 
   std::string strPath;
-  const std::string dynPath{g_application.CurrentFileItem().GetDynPath()};
-  if (URIUtils::IsInRAR(dynPath) || URIUtils::IsInZIP(dynPath))
+  const CFileItem& fileItem = g_application.CurrentFileItem();
+  const std::string path{fileItem.GetPath()};
+
+  // NOTE: On playlists (e.g. STRM) that contains a single non-media file (e.g. streaming manifest)
+  // the GetPath return the playlist file, instead the DynPath can contains a web address
+  // but is not browsable, so allow get subtitles from local storage by using playlist path.
+  if (URIUtils::IsDatabase(path))
   {
-    strPath = CURL(dynPath).GetHostName();
+    strPath = fileItem.GetDynPath();
   }
-  else if (!URIUtils::IsPlugin(dynPath))
+  else if (URIUtils::IsInRAR(path) || URIUtils::IsInZIP(path))
   {
-    strPath = dynPath;
+    strPath = CURL(path).GetHostName();
+  }
+  else if (!URIUtils::IsPlugin(path))
+  {
+    strPath = path;
   }
 
   std::string strMask =


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
When PR #24303 has been merged has broken "Browse for subtitles" menu on OSD settings
for cases of playlists like STRM

the problem is that has been replaced all conditions with dynPath
but this cant works with playlists that have a single media item
and that _media item is not a media file_

this can happens by using InputStream addons, example
```
#KODIPROP:inputstream=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=mpd
https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd
```
kodi see a manifest url but cannot be handled as a media file, its a server address
in this case the GetPath return the playlist file (STRM)
instead the DynPath contains the web address that isnt browsable

the PR #24303 was trying just to fix a use case for databases
as you can seen on https://github.com/xbmc/xbmc/issues/24219

so i have reverted all changes and add database condition
this restore the original situation and should not cause problems with database paths

i need someone that can test database use case because im not sure how test it

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #24779
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
play the strm above and browse subs by using OSD

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
can browse local subtitles as happens on Kodi <=20

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
