### PR TITLE
[video] Do not show video info dialog if item has an empty video info tag

### DIFF
--- a/xbmc/filesystem/VideoDatabaseDirectory.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -106,7 +106,7 @@ bool CVideoDatabaseDirectory::GetDirectory(const CURL& url, CFileItemList &items
       if (!strImage.empty() && CServiceBroker::GetGUI()->GetTextureManager().HasTexture(strImage))
         item->SetArt("icon", strImage);
     }
-    if (item->GetVideoInfoTag())
+    if (item->HasVideoInfoTag())
     {
       item->SetDynPath(item->GetVideoInfoTag()->GetPath());
     }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -416,7 +416,7 @@ bool CGUIWindowVideoBase::ShowInfo(const CFileItemPtr& item2, const ScraperPtr& 
     }
     m_database.Close();
   }
-  else if(item->HasVideoInfoTag())
+  else if (item->HasVideoInfoTag() && !item->GetVideoInfoTag()->IsEmpty())
   {
     bHasInfo = true;
     movieDetails = *item->GetVideoInfoTag();


### PR DESCRIPTION
Fixes the problems reported in the forum: https://forum.kodi.tv/showthread.php?tid=378073

Runtume-tested on macOS, latest Kodi master.

@enen92 can you please review? Idea for the fix is that empty video info tags might be present at the items passed around and we must only show the dialog for items with non-empty video info tags. The second commit is a logical error which leads to unneeded creation of an empty video info tag.