### PR TITLE
[FileItem][PVR] Remove duplicate code to calculate the title for an E…

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -43,6 +43,7 @@
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/epg/EpgSearchFilter.h"
 #include "pvr/guilib/PVRGUIActionsChannels.h"
+#include "pvr/guilib/PVRGUIActionsEPG.h"
 #include "pvr/guilib/PVRGUIActionsUtils.h"
 #include "pvr/recordings/PVRRecording.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
@@ -124,36 +125,17 @@ CFileItem::CFileItem(const CVideoInfoTag& movie)
   SetFromVideoInfoTag(movie);
 }
 
-namespace
-{
-std::string GetEpgTagTitle(const std::shared_ptr<const CPVREpgInfoTag>& epgTag)
-{
-  if (CServiceBroker::GetPVRManager().IsParentalLocked(epgTag))
-    return g_localizeStrings.Get(19266); // Parental locked
-  else if (epgTag->Title().empty() &&
-           !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-               CSettings::SETTING_EPG_HIDENOINFOAVAILABLE))
-    return g_localizeStrings.Get(19055); // no information available
-  else
-    return epgTag->Title();
-}
-} // unnamed namespace
-
 void CFileItem::FillMusicInfoTag(const std::shared_ptr<const CPVREpgInfoTag>& tag)
 {
   CMusicInfoTag* musictag = GetMusicInfoTag(); // create (!) the music tag.
 
+  musictag->SetTitle(CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().GetTitleForEpgTag(tag));
+
   if (tag)
   {
-    musictag->SetTitle(GetEpgTagTitle(tag));
     musictag->SetGenre(tag->Genre());
     musictag->SetDuration(tag->GetDuration());
     musictag->SetURL(tag->Path());
-  }
-  else if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-               CSettings::SETTING_EPG_HIDENOINFOAVAILABLE))
-  {
-    musictag->SetTitle(g_localizeStrings.Get(19055)); // no information available
   }
 
   musictag->SetLoaded(true);
@@ -167,7 +149,7 @@ CFileItem::CFileItem(const std::shared_ptr<CPVREpgInfoTag>& tag)
   m_epgInfoTag = tag;
   m_strPath = tag->Path();
   m_bCanQueue = false;
-  SetLabel(GetEpgTagTitle(tag));
+  SetLabel(CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().GetTitleForEpgTag(tag));
   m_dateTime = tag->StartAsLocalTime();
 
   if (!tag->IconPath().empty())

--- a/xbmc/pvr/guilib/PVRGUIActionsEPG.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsEPG.cpp
@@ -21,9 +21,12 @@
 #include "pvr/dialogs/GUIDialogPVRChannelGuide.h"
 #include "pvr/dialogs/GUIDialogPVRGuideInfo.h"
 #include "pvr/epg/EpgContainer.h"
+#include "pvr/epg/EpgInfoTag.h"
 #include "pvr/epg/EpgSearchFilter.h"
 #include "pvr/guilib/PVRGUIActionsParentalControl.h"
 #include "pvr/windows/GUIWindowPVRSearch.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
 
@@ -214,4 +217,21 @@ bool CPVRGUIActionsEPG::DeleteSavedSearch(const CFileItem& item)
     return CServiceBroker::GetPVRManager().EpgContainer().DeleteSavedSearch(*searchFilter);
   }
   return false;
+}
+
+std::string CPVRGUIActionsEPG::GetTitleForEpgTag(const std::shared_ptr<const CPVREpgInfoTag>& tag)
+{
+  if (tag)
+  {
+    if (CServiceBroker::GetPVRManager().IsParentalLocked(tag))
+      return g_localizeStrings.Get(19266); // Parental locked
+    else if (!tag->Title().empty())
+      return tag->Title();
+  }
+
+  if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          CSettings::SETTING_EPG_HIDENOINFOAVAILABLE))
+    return g_localizeStrings.Get(19055); // no information available
+
+  return {};
 }

--- a/xbmc/pvr/guilib/PVRGUIActionsEPG.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsEPG.h
@@ -10,10 +10,15 @@
 
 #include "pvr/IPVRComponent.h"
 
+#include <memory>
+#include <string>
+
 class CFileItem;
 
 namespace PVR
 {
+class CPVREpgInfoTag;
+
 class CPVRGUIActionsEPG : public IPVRComponent
 {
 public:
@@ -69,6 +74,16 @@ public:
    * @return True on success, false otherwise.
    */
   bool DeleteSavedSearch(const CFileItem& item);
+
+  /*!
+   * @brief Get the title for the given EPG tag, taking settings and parental controls into account.
+   * @param item The EPG tag.
+   * @return "Parental locked" in case the access to the information is restricted by parental
+   * controls, "No information avilable" if the real EPG event title is empty and
+   * SETTING_EPG_HIDENOINFOAVAILABLE is false or tag is nullptr, the real EPG event title as given
+   * by the EPG data provider otherwise.
+   */
+  std::string GetTitleForEpgTag(const std::shared_ptr<const CPVREpgInfoTag>& tag);
 
 private:
   CPVRGUIActionsEPG(const CPVRGUIActionsEPG&) = delete;


### PR DESCRIPTION
…PG tag, taking settings and parental controls into account.

Only code cleanup, no functional changes.

Runtime-tested on macOS, latest Kodi master.

@phunkyfish should be easy to review.