### PR TITLE
[Video][Stacks] Fix folder stacks.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16912,7 +16912,31 @@ msgctxt "#25014"
 msgid "Manual"
 msgstr ""
 
-#empty strings from id 25015 to 29800
+#: application/ApplicationPlayerCallback.cpp
+#. Dialog box title
+msgctxt "#25015"
+msgid "Stacks"
+msgstr ""
+
+#: application/ApplicationPlayerCallback.cpp
+#. Dialog displayed after a Bluray/DVD item in a stack is played
+msgctxt "#25016"
+msgid "Continue to play next item in stack?"
+msgstr ""
+
+#: application/ApplicationPlayerCallback.cpp
+#. Option for #25016
+msgctxt "#25017"
+msgid "Continue"
+msgstr ""
+
+#: application/ApplicationPlayerCallback.cpp
+#. Option for #25016
+msgctxt "#25018"
+msgid "Stop"
+msgstr ""
+
+#empty strings from id 25019 to 29800
 
 #: unused
 msgctxt "#29801"

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1773,22 +1773,6 @@ void CFileItem::SetDynPath(const std::string &path)
   m_strDynPath = path;
 }
 
-std::string CFileItem::GetBlurayPath() const
-{
-  if (VIDEO::IsBlurayPlaylist(*this))
-  {
-    CURL url(GetDynPath());
-    CURL url2(url.GetHostName()); // strip bluray://
-    if (url2.IsProtocol("udf"))
-      // ISO
-      return url2.GetHostName(); // strip udf://
-    else if (url.IsProtocol("bluray"))
-      // BDMV
-      return url2.Get() + "BDMV/index.bdmv";
-  }
-  return GetDynPath();
-}
-
 void CFileItem::SetCueDocument(const CCueDocumentPtr& cuePtr)
 {
   m_cueDocument = cuePtr;
@@ -1996,11 +1980,12 @@ std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
     return GetLocalMetadataPath();
 
   if (bUseFolderNames &&
-     (!m_bIsFolder || URIUtils::IsInArchive(m_strPath) ||
-     (HasVideoInfoTag() && GetVideoInfoTag()->m_iDbId > 0 && !CMediaTypes::IsContainer(GetVideoInfoTag()->m_type))))
+      (!m_bIsFolder || URIUtils::IsInArchive(m_strPath) || URIUtils::IsStack(m_strPath) ||
+       (HasVideoInfoTag() && GetVideoInfoTag()->m_iDbId > 0 &&
+        !CMediaTypes::IsContainer(GetVideoInfoTag()->m_type))))
   {
     std::string name2(strMovieName);
-    URIUtils::GetParentPath(name2,strMovieName);
+    URIUtils::GetParentPath(name2, strMovieName);
     if (URIUtils::IsInArchive(m_strPath))
     {
       // Try to get archive itself, if empty take path before
@@ -2025,7 +2010,7 @@ std::string CFileItem::GetLocalMetadataPath() const
 
   std::string parent{};
   if (VIDEO::IsBlurayPlaylist(*this))
-    parent = URIUtils::GetParentPath(GetBlurayPath());
+    parent = URIUtils::GetParentPath(URIUtils::GetBlurayPath(GetDynPath()));
   else
     parent = URIUtils::GetParentPath(m_strPath);
   std::string parentFolder(parent);

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -144,8 +144,6 @@ public:
   const std::string &GetDynPath() const;
   void SetDynPath(const std::string &path);
 
-  std::string GetBlurayPath() const;
-
   /*! \brief reset class to it's default values as per construction.
    Free's all allocated memory.
    \sa Initialize

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -706,7 +706,31 @@ void CFileItemList::RemoveExtensions()
     m_items[i]->RemoveExtension();
 }
 
-void CFileItemList::Stack(bool stackFiles /* = true */)
+void CFileItemList::ConvertDiscFoldersToFiles()
+{
+  for (auto& item : m_items)
+  {
+    const std::string playPath = VIDEO::UTILS::GetOpticalMediaPath(*item);
+    if (!playPath.empty())
+      item = CreateDiscFolderFileItem(item, playPath);
+  }
+}
+
+std::shared_ptr<CFileItem> CFileItemList::CreateDiscFolderFileItem(
+    const std::shared_ptr<CFileItem>& item, const std::string& playPath)
+{
+  std::shared_ptr<CFileItem> fileItem{item};
+  fileItem->SetPath(playPath); // updated path (for DVD/Bluray files)
+  fileItem->m_bIsFolder = false;
+  fileItem->SetLabelPreformatted(true);
+  m_sortDescription.sortBy = SortByNone; // sorting is now broken
+  return fileItem;
+}
+
+static constexpr int FOLDER_CANDIDATE = 1;
+static constexpr int FILE_CANDIDATE = 2;
+
+void CFileItemList::Stack()
 {
   std::unique_lock<CCriticalSection> lock(m_lock);
 
@@ -719,279 +743,173 @@ void CFileItemList::Stack(bool stackFiles /* = true */)
   // items needs to be sorted for stuff below to work properly
   Sort(SortByLabel, SortOrderAscending);
 
-  StackFolders();
+  // Convert folder paths containing disc images to files (INDEX.BDMV or VIDEO_TS.IFO)
+  ConvertDiscFoldersToFiles();
 
-  if (stackFiles)
-    StackFiles();
-}
-
-void CFileItemList::StackFolders()
-{
-  // Precompile our REs
+  // Get REs
   VECCREGEXP folderRegExps;
-  CRegExp folderRegExp(true, CRegExp::autoUtf8);
-  const std::vector<std::string>& strFolderRegExps =
-      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_folderStackRegExps;
+  VECCREGEXP fileRegExps;
+  CStackDirectory::LoadRegExps(fileRegExps, folderRegExps);
 
-  std::vector<std::string>::const_iterator strExpression = strFolderRegExps.begin();
-  while (strExpression != strFolderRegExps.end())
+  if (fileRegExps.empty() || folderRegExps.empty())
+    CLog::LogF(LOGDEBUG, "No stack expressions available. Skipping stacking");
+  else
   {
-    if (!folderRegExp.RegComp(*strExpression))
-      CLog::Log(LOGERROR, "{}: Invalid folder stack RegExp:'{}'", __FUNCTION__,
-                strExpression->c_str());
-    else
-      folderRegExps.push_back(folderRegExp);
+    // Find stack candidates (ie. any file or directory that matches a RegEx)
+    // stackCandidates - vector of <a,b,c,d>
+    //                     a - type of item (file or folder)
+    //                     b - title (eg. name of movie)
+    //                     c - volume/part
+    //                     d - offset in m_items
+    std::vector<std::tuple<int, std::string, std::string, int, int64_t>> stackCandidates;
 
-    ++strExpression;
-  }
-
-  if (!folderRegExp.IsCompiled())
-  {
-    CLog::Log(LOGDEBUG, "{}: No stack expressions available. Skipping folder stacking",
-              __FUNCTION__);
-    return;
-  }
-
-  // stack folders
-  for (int i = 0; i < Size(); i++)
-  {
-    CFileItemPtr item = Get(i);
-    // combined the folder checks
-    if (item->m_bIsFolder)
+    for (auto& item : m_items)
     {
-      // only check known fast sources?
-      // NOTES:
-      // 1. rars and zips may be on slow sources? is this supposed to be allowed?
-      if (!NETWORK::IsRemote(*item) || item->IsSmb() || item->IsNfs() ||
-          URIUtils::IsInRAR(item->GetPath()) || URIUtils::IsInZIP(item->GetPath()) ||
-          URIUtils::IsOnLAN(item->GetPath()))
+      // Fast sources
+      // RARs and ZIPs may be on slow sources? is this supposed to be allowed?
+      if ((item->m_bIsFolder || VIDEO::IsDVDFile(*item) || VIDEO::IsBDFile(*item)) &&
+          (!NETWORK::IsRemote(*item) || item->IsSmb() || item->IsNfs() ||
+           URIUtils::IsInRAR(item->GetPath()) || URIUtils::IsInZIP(item->GetPath()) ||
+           URIUtils::IsOnLAN(item->GetPath())))
       {
-        // stack cd# folders if contains only a single video file
+        // Folder stacking (for BD/DVD files/images)
+        std::string folder{StringUtils::ToLower(item->GetLabel())};
+        URIUtils::RemoveSlashAtEnd(folder);
 
-        bool bMatch(false);
-
-        VECCREGEXP::iterator expr = folderRegExps.begin();
-        while (!bMatch && expr != folderRegExps.end())
+        // Test each item against each RegExp
+        for (auto& regExp : folderRegExps)
         {
-          //CLog::Log(LOGDEBUG,"{}: Running expression {} on {}", __FUNCTION__, expr->GetPattern(), item->GetLabel());
-          bMatch = (expr->RegFind(item->GetLabel().c_str()) != -1);
-          if (bMatch)
+          if (regExp.RegFind(folder) != -1)
           {
-            CFileItemList items;
-            CDirectory::GetDirectory(
-                item->GetPath(), items,
-                CServiceBroker::GetFileExtensionProvider().GetVideoExtensions(), DIR_FLAG_DEFAULTS);
-            // optimized to only traverse listing once by checking for filecount
-            // and recording last file item for later use
-            int nFiles = 0;
-            int index = -1;
-            for (int j = 0; j < items.Size(); j++)
+            // Directory matches RegEx so get image files
+            // BD/DVD files (not ISOs) are dealt with in ConvertDiscFoldersToFiles()
+            bool fileFound{true};
+            if (item->m_bIsFolder)
             {
-              if (!items[j]->m_bIsFolder)
-              {
-                nFiles++;
-                index = j;
-              }
+              // Look for disc images here (by extension)
+              CFileItemList items;
+              CDirectory::GetDirectory(
+                  item->GetPath(), items,
+                  CServiceBroker::GetFileExtensionProvider().GetVideoExtensions(),
+                  DIR_FLAG_DEFAULTS);
 
-              if (nFiles > 1)
-                break;
+              // Only expect one disc image per folder (if >1 should be a file stack)
+              if (items.GetFileCount() == 1)
+                item = CreateDiscFolderFileItem(item, items[0]->GetPath());
+              else
+                fileFound = false;
             }
-
-            if (nFiles == 1)
-              *item = *items[index];
-          }
-          ++expr;
-        }
-
-        // check for dvd folders
-        if (!bMatch)
-        {
-          std::string dvdPath = VIDEO::UTILS::GetOpticalMediaPath(*item);
-
-          if (!dvdPath.empty())
-          {
-            // NOTE: should this be done for the CD# folders too?
-            item->m_bIsFolder = false;
-            item->SetPath(dvdPath);
-            item->SetLabel2("");
-            item->SetLabelPreformatted(true);
-            m_sortDescription.sortBy = SortByNone; /* sorting is now broken */
-          }
-        }
-      }
-    }
-  }
-}
-
-void CFileItemList::StackFiles()
-{
-  // Precompile our REs
-  VECCREGEXP stackRegExps;
-  CRegExp tmpRegExp(true, CRegExp::autoUtf8);
-  const std::vector<std::string>& strStackRegExps =
-      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoStackRegExps;
-  std::vector<std::string>::const_iterator strRegExp = strStackRegExps.begin();
-  while (strRegExp != strStackRegExps.end())
-  {
-    if (tmpRegExp.RegComp(*strRegExp))
-    {
-      if (tmpRegExp.GetCaptureTotal() == 4)
-        stackRegExps.push_back(tmpRegExp);
-      else
-        CLog::Log(LOGERROR, "Invalid video stack RE ({}). Must have 4 captures.", *strRegExp);
-    }
-    ++strRegExp;
-  }
-
-  // now stack the files, some of which may be from the previous stack iteration
-  int i = 0;
-  while (i < Size())
-  {
-    CFileItemPtr item1 = Get(i);
-
-    // skip folders, nfo files, playlists
-    if (item1->m_bIsFolder || item1->IsParentFolder() || item1->IsNFO() ||
-        PLAYLIST::IsPlayList(*item1))
-    {
-      // increment index
-      i++;
-      continue;
-    }
-
-    int64_t size = 0;
-    size_t offset = 0;
-    std::string stackName;
-    std::string file1;
-    std::string filePath;
-    std::vector<int> stack;
-    VECCREGEXP::iterator expr = stackRegExps.begin();
-
-    URIUtils::Split(item1->GetPath(), filePath, file1);
-    if (URIUtils::HasEncodedFilename(CURL(filePath)))
-      file1 = CURL::Decode(file1);
-
-    int j;
-    while (expr != stackRegExps.end())
-    {
-      if (expr->RegFind(file1, offset) != -1)
-      {
-        std::string Title1 = expr->GetMatch(1), Volume1 = expr->GetMatch(2),
-                    Ignore1 = expr->GetMatch(3), Extension1 = expr->GetMatch(4);
-        if (offset)
-          Title1 = file1.substr(0, expr->GetSubStart(2));
-        j = i + 1;
-        while (j < Size())
-        {
-          CFileItemPtr item2 = Get(j);
-
-          // skip folders, nfo files, playlists
-          if (item2->m_bIsFolder || item2->IsParentFolder() || item2->IsNFO() ||
-              PLAYLIST::IsPlayList(*item2))
-          {
-            // increment index
-            j++;
-            continue;
-          }
-
-          std::string file2, filePath2;
-          URIUtils::Split(item2->GetPath(), filePath2, file2);
-          if (URIUtils::HasEncodedFilename(CURL(filePath2)))
-            file2 = CURL::Decode(file2);
-
-          if (expr->RegFind(file2, offset) != -1)
-          {
-            std::string Title2 = expr->GetMatch(1), Volume2 = expr->GetMatch(2),
-                        Ignore2 = expr->GetMatch(3), Extension2 = expr->GetMatch(4);
-            if (offset)
-              Title2 = file2.substr(0, expr->GetSubStart(2));
-            if (StringUtils::EqualsNoCase(Title1, Title2))
+            if (fileFound)
             {
-              if (!StringUtils::EqualsNoCase(Volume1, Volume2))
-              {
-                if (StringUtils::EqualsNoCase(Ignore1, Ignore2) &&
-                    StringUtils::EqualsNoCase(Extension1, Extension2))
-                {
-                  if (stack.empty())
-                  {
-                    stackName = Title1 + Ignore1 + Extension1;
-                    stack.push_back(i);
-                    size += item1->m_dwSize;
-                  }
-                  stack.push_back(j);
-                  size += item2->m_dwSize;
-                }
-                else // Sequel
-                {
-                  offset = 0;
-                  ++expr;
-                  break;
-                }
-              }
-              else if (!StringUtils::EqualsNoCase(Ignore1,
-                                                  Ignore2)) // False positive, try again with offset
-              {
-                offset = expr->GetSubStart(3);
-                break;
-              }
-              else // Extension mismatch
-              {
-                offset = 0;
-                ++expr;
-                break;
-              }
-            }
-            else // Title mismatch
-            {
-              offset = 0;
-              ++expr;
+              // Add to stack vector
+              stackCandidates.emplace_back(FOLDER_CANDIDATE, regExp.GetMatch(1) /* title */,
+                                           regExp.GetMatch(2) /* volume */,
+                                           static_cast<int>(&item - &m_items[0]), item->m_dwSize);
               break;
             }
           }
-          else // No match 2, next expression
+        }
+      }
+      else if (!(item->m_bIsFolder || item->IsParentFolder() || item->IsNFO() ||
+                 PLAYLIST::IsPlayList(*item)))
+      {
+        // File stacking
+        std::string file{};
+        std::string filePath{};
+        URIUtils::Split(StringUtils::ToLower(item->GetPath()), filePath, file);
+        if (URIUtils::HasEncodedFilename(CURL(filePath)))
+          file = CURL::Decode(file);
+
+        // Test each item against each RegExp
+        for (auto& regExp : fileRegExps)
+        {
+          if (regExp.RegFind(file) != -1)
           {
-            offset = 0;
-            ++expr;
+            // Get components of file name
+            stackCandidates.emplace_back(FILE_CANDIDATE, regExp.GetMatch(1) /* Title */,
+                                         regExp.GetMatch(2) /* Volume */,
+                                         static_cast<int>(&item - &m_items[0]), item->m_dwSize);
             break;
           }
-          j++;
         }
-        if (j == Size())
-          expr = stackRegExps.end();
       }
-      else // No match 1
+    }
+
+    // Sort stack candidates
+    std::sort(stackCandidates.begin(), stackCandidates.end(),
+              [](const auto& s, const auto& t)
+              {
+                if (std::get<0>(s) == std::get<0>(t)) // type (file/folder)
+                {
+                  if (std::get<1>(s) == std::get<1>(t)) // title
+                    return std::get<2>(s) < std::get<2>(t); // volume
+                  else
+                    return std::get<1>(s) < std::get<1>(t);
+                }
+                else
+                  return std::get<0>(s) < std::get<0>(t);
+              });
+
+    // Count stack candidates
+    // countCandidates - <a,b>
+    //                    a - type (file/folder)
+    //                    b - title (eg. movie name)
+    std::map<std::pair<int, std::string>, int> countCandidates;
+    for (const auto& s : stackCandidates)
+      ++countCandidates[std::make_pair(std::get<0>(s), std::get<1>(s))];
+
+    // Find stacks (and collect items for deletion)
+    std::vector<int> deleteItems;
+    for (const auto& stackBase : countCandidates)
+    {
+      const auto& stackBaseItem = stackBase.first;
+      if (stackBase.second > 1) // more than one item to stack
       {
-        offset = 0;
-        ++expr;
-      }
-      if (stack.size() > 1)
-      {
-        // have a stack, remove the items and add the stacked item
-        // dont actually stack a multipart rar set, just remove all items but the first
-        std::string stackPath;
+        // Find all items in stack
+        std::vector<int> stack;
+        int64_t size{0};
+
+        for (const auto& stackItem : stackCandidates)
+        {
+          if (stackBaseItem.first == std::get<0>(stackItem) && // type
+              stackBaseItem.second == std::get<1>(stackItem)) // title
+          {
+            const int index{std::get<3>(stackItem)}; // index
+            stack.emplace_back(index);
+            size += std::get<4>(stackItem); // size
+            if (stack.size() > 1)
+              deleteItems.emplace_back(index); // delete all but first
+          }
+        }
+
+        // Create stack
+        // Generate combined stack path
+        std::string stackPath{};
         if (Get(stack[0])->IsRAR())
           stackPath = Get(stack[0])->GetPath();
         else
-        {
-          CStackDirectory dir;
-          stackPath = dir.ConstructStackPath(*this, stack);
-        }
-        item1->SetPath(stackPath);
-        // clean up list
-        for (unsigned k = 1; k < stack.size(); k++)
-          Remove(i + 1);
-        // item->m_bIsFolder = true;  // don't treat stacked files as folders
-        // the label may be in a different char set from the filename (eg over smb
-        // the label is converted from utf8, but the filename is not)
+          stackPath = CStackDirectory::ConstructStackPath(*this, stack);
+
+        // First item in stack becomes the stack
+        std::string stackName = std::get<1>(stackBaseItem); // title
         if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
                 CSettings::SETTING_FILELISTS_SHOWEXTENSIONS))
           URIUtils::RemoveExtension(stackName);
 
-        item1->SetLabel(stackName);
-        item1->m_dwSize = size;
-        break;
+        // Update item
+        const std::shared_ptr<CFileItem> stackItem{Get(stack[0])};
+        stackItem->SetPath(stackPath);
+        stackItem->SetLabel(stackName);
+        stackItem->m_dwSize = size;
       }
     }
-    i++;
+
+    // Delete unneeded items
+    // Sort and delete from last to first (otherwise index is no longer correct)
+    std::sort(deleteItems.begin(), deleteItems.end(),
+              [](const int i, const int j) { return i > j; });
+    for (int i : deleteItems)
+      Remove(i);
   }
 }
 

--- a/xbmc/FileItemList.h
+++ b/xbmc/FileItemList.h
@@ -80,7 +80,7 @@ public:
    \param stackFiles whether to stack all items or just collapse folders (defaults to true)
    \sa StackFiles,StackFolders
    */
-  void Stack(bool stackFiles = true);
+  void Stack();
 
   SortOrder GetSortOrder() const { return m_sortDescription.sortOrder; }
   SortBy GetSortMethod() const { return m_sortDescription.sortBy; }
@@ -178,17 +178,9 @@ private:
   void FillSortFields(FILEITEMFILLFUNC func);
   std::string GetDiscFileCache(int windowID) const;
 
-  /*!
-   \brief stack files in a CFileItemList
-   \sa Stack
-   */
-  void StackFiles();
-
-  /*!
-   \brief stack folders in a CFileItemList
-   \sa Stack
-   */
-  void StackFolders();
+  void ConvertDiscFoldersToFiles();
+  std::shared_ptr<CFileItem> CreateDiscFolderFileItem(const std::shared_ptr<CFileItem>& item,
+                                                      const std::string& playPath);
 
   VECFILEITEMS m_items;
   MAPFILEITEMS m_map;

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -53,6 +53,7 @@
 #include "dialogs/GUIDialogCache.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogSimpleMenu.h"
+#include "dialogs/GUIDialogYesNo.h"
 #include "events/EventLog.h"
 #include "events/NotificationEvent.h"
 #include "filesystem/Directory.h"
@@ -143,6 +144,7 @@
 #include "utils/TimeUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
+#include "utils/XBMCTinyXML2.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 #include "video/Bookmark.h"
@@ -177,6 +179,7 @@
 #include "platform/win32/threads/Win32Exception.h"
 #endif
 
+#include <charconv>
 #include <cmath>
 #include <memory>
 #include <mutex>
@@ -2257,39 +2260,6 @@ bool CApplication::PlayMedia(CFileItem& item, const std::string& player, PLAYLIS
   return PlayFile(item, player, false);
 }
 
-// PlayStack()
-// For playing a multi-file video.  Particularly inefficient
-// on startup, as we are required to calculate the length
-// of each video, so we open + close each one in turn.
-// A faster calculation of video time would improve this
-// substantially.
-// return value: same with PlayFile()
-bool CApplication::PlayStack(CFileItem& item, bool bRestart)
-{
-  const auto stackHelper = GetComponent<CApplicationStackHelper>();
-  if (!stackHelper->InitializeStack(item))
-    return false;
-
-  std::optional<int64_t> startoffset = stackHelper->InitializeStackStartPartAndOffset(item);
-  if (!startoffset)
-  {
-    CLog::LogF(LOGERROR, "Failed to obtain start offset for stack {}. Aborting playback.",
-               item.GetDynPath());
-    return false;
-  }
-
-  CFileItem selectedStackPart = stackHelper->GetCurrentStackPartFileItem();
-  selectedStackPart.SetStartOffset(startoffset.value());
-
-  if (item.HasProperty("savedplayerstate"))
-  {
-    selectedStackPart.SetProperty("savedplayerstate", item.GetProperty("savedplayerstate")); // pass on to part
-    item.ClearProperty("savedplayerstate");
-  }
-
-  return PlayFile(selectedStackPart, "", true);
-}
-
 bool CApplication::PlayFile(CFileItem item,
                             const std::string& player,
                             bool bRestart /* = false */,
@@ -2329,12 +2299,27 @@ bool CApplication::PlayFile(CFileItem item,
     return false;
   }
 
-  // if we have a stacked set of files, we need to setup our stack routines for
-  // "seamless" seeking and total time of the movie etc.
-  // will recall with restart set to true
-  if (item.IsStack())
-    return PlayStack(item, bRestart);
+  // Deal with stacks here
+  // Need to reference both the stacked FileItem and the individual FileItem later
+  // Along with the starting offset
+  CFileItem stack;
+  bool isStack{false};
+  double stackOffset{0.0};
+  if (stackHelper->InitializeStack(item))
+  {
+    std::optional<int64_t> startoffset = stackHelper->InitializeStackStartPartAndOffset(item);
+    if (!startoffset)
+    {
+      CLog::LogF(LOGERROR, "Failed to obtain start offset for stack {}. Aborting playback.",
+                 item.GetDynPath());
+      return false;
+    }
+    stackOffset = static_cast<double>(*startoffset / 1000);
+    isStack = true;
+  }
 
+  // Set player options
+  // This is saved under the stack filename for stacks so leave item = stacked item
   CPlayerOptions options;
 
   if (item.HasProperty("StartPercent"))
@@ -2343,15 +2328,10 @@ bool CApplication::PlayFile(CFileItem item,
     item.SetStartOffset(0);
   }
 
+  // For items in file stacks
   options.starttime = CUtil::ConvertMilliSecsToSecs(item.GetStartOffset());
 
-  if (bRestart)
-  {
-    // have to be set here due to playstack using this for starting the file
-    if (item.HasVideoInfoTag())
-      options.state = item.GetVideoInfoTag()->GetResumePoint().playerState;
-  }
-  if (!bRestart || stackHelper->IsPlayingISOStack())
+  if (!bRestart || isStack)
   {
     // the following code block is only applicable when bRestart is false OR to ISO stacks
 
@@ -2361,8 +2341,8 @@ bool CApplication::PlayFile(CFileItem item,
       CVideoDatabase dbs;
       dbs.Open();
 
-      std::string path = item.GetPath();
-      std::string videoInfoTagPath(item.GetVideoInfoTag()->m_strFileNameAndPath);
+      std::string path{item.GetPath()};
+      std::string videoInfoTagPath{item.GetVideoInfoTag()->m_strFileNameAndPath};
       if (videoInfoTagPath.starts_with("removable://") || VIDEO::IsVideoDb(item))
         path = videoInfoTagPath;
 
@@ -2389,9 +2369,11 @@ bool CApplication::PlayFile(CFileItem item,
         {
           CBookmark bookmark;
           std::string path = item.GetPath();
-          if (item.HasVideoInfoTag() && StringUtils::StartsWith(item.GetVideoInfoTag()->m_strFileNameAndPath, "removable://"))
+          if (item.HasVideoInfoTag() &&
+              StringUtils::StartsWith(item.GetVideoInfoTag()->m_strFileNameAndPath, "removable://"))
             path = item.GetVideoInfoTag()->m_strFileNameAndPath;
-          else if (item.HasProperty("original_listitem_url") && URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
+          else if (item.HasProperty("original_listitem_url") &&
+                   URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
             path = item.GetProperty("original_listitem_url").asString();
           if (dbs.GetResumeBookMark(path, bookmark))
           {
@@ -2403,7 +2385,7 @@ bool CApplication::PlayFile(CFileItem item,
         if (options.starttime == 0.0 && item.HasVideoInfoTag())
         {
           // No resume point is set, but check if this item is part of a multi-episode file
-          const CVideoInfoTag *tag = item.GetVideoInfoTag();
+          const CVideoInfoTag* tag = item.GetVideoInfoTag();
 
           if (tag->m_iBookmarkId > 0)
           {
@@ -2416,7 +2398,7 @@ bool CApplication::PlayFile(CFileItem item,
       }
       else if (item.HasVideoInfoTag())
       {
-        const CVideoInfoTag *tag = item.GetVideoInfoTag();
+        const CVideoInfoTag* tag = item.GetVideoInfoTag();
 
         if (tag->m_iBookmarkId > 0)
         {
@@ -2429,6 +2411,51 @@ bool CApplication::PlayFile(CFileItem item,
 
       dbs.Close();
     }
+  }
+
+  // Now item needs to point to the item we are playing (ie. the part of the stack)
+  if (isStack)
+  {
+    // Save info needed from stack item
+    bool resume{item.GetStartOffset() == STARTOFFSET_RESUME};
+    const CVideoInfoTag tag{*item.GetVideoInfoTag()};
+
+    // Get individual stack part as item
+    bool stackSet{false};
+    if (!options.state.empty())
+    {
+      CXBMCTinyXML2 xmlDoc;
+      if (xmlDoc.Parse(options.state))
+      {
+        tinyxml2::XMLHandle hRoot(xmlDoc.RootElement());
+        if (hRoot.ToElement() && StringUtils::EqualsNoCase(hRoot.ToElement()->Value(), "nextpart"))
+        {
+          int nextItem;
+          std::from_chars(hRoot.ToElement()->GetText(),
+                          hRoot.ToElement()->GetText() + std::strlen(hRoot.ToElement()->GetText()),
+                          nextItem);
+          item = stackHelper->SetStackPartCurrentFileItem(nextItem);
+          stackSet = true;
+          options.startpercent = options.starttime = 0;
+        }
+      }
+    }
+    if (!stackSet)
+    {
+      item = stackHelper->GetCurrentStackPartFileItem();
+
+      // Save resume state (needed for correct bluray playback)
+      if (resume)
+        item.SetStartOffset(STARTOFFSET_RESUME);
+
+      // Adjust bookmark start
+      options.starttime = stackOffset;
+    }
+
+    // Keep VideoInfoTag
+    const std::string path = item.GetPath();
+    item.SetFromVideoInfoTag(tag);
+    item.SetPath(path);
   }
 
   // a disc image might be Blu-Ray disc
@@ -2452,8 +2479,10 @@ bool CApplication::PlayFile(CFileItem item,
     if (isSimpleMenuAllowed)
     {
       // Check if we must show the simplified bd menu.
+      m_cancelPlayback = true;
       if (!CGUIDialogSimpleMenu::ShowPlaySelection(item, forceSelection))
         return true;
+      m_cancelPlayback = false;
     }
   }
 
@@ -2464,35 +2493,39 @@ bool CApplication::PlayFile(CFileItem item,
   { // playing from a playlist by the looks
     // don't switch to fullscreen if we are not playing the first item...
     options.fullscreen = !CServiceBroker::GetPlaylistPlayer().HasPlayedFirstFile() &&
-        CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-        CSettings::SETTING_MUSICFILES_SELECTACTION) &&
-        !CMediaSettings::GetInstance().DoesMediaStartWindowed();
+                         CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                             CSettings::SETTING_MUSICFILES_SELECTACTION) &&
+                         !CMediaSettings::GetInstance().DoesMediaStartWindowed();
   }
   else if (VIDEO::IsVideo(item) && playlistId == PLAYLIST::Id::TYPE_VIDEO &&
            CServiceBroker::GetPlaylistPlayer().GetPlaylist(playlistId).size() > 1)
   { // playing from a playlist by the looks
     // don't switch to fullscreen if we are not playing the first item...
-    options.fullscreen = !CServiceBroker::GetPlaylistPlayer().HasPlayedFirstFile() &&
+    options.fullscreen =
+        !CServiceBroker::GetPlaylistPlayer().HasPlayedFirstFile() &&
         CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_fullScreenOnMovieStart &&
         !CMediaSettings::GetInstance().DoesMediaStartWindowed();
   }
-  else if (stackHelper->IsPlayingRegularStack())
+  else if (isStack)
   {
     //! @todo - this will fail if user seeks back to first file in stack
     if (stackHelper->GetCurrentPartNumber() == 0 ||
         stackHelper->GetRegisteredStack(item)->GetStartOffset() != 0)
-      options.fullscreen = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->
-          m_fullScreenOnMovieStart && !CMediaSettings::GetInstance().DoesMediaStartWindowed();
+      options.fullscreen =
+          CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_fullScreenOnMovieStart &&
+          !CMediaSettings::GetInstance().DoesMediaStartWindowed();
     else
       options.fullscreen = false;
   }
   else
-    options.fullscreen = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->
-        m_fullScreenOnMovieStart && !CMediaSettings::GetInstance().DoesMediaStartWindowed();
+    options.fullscreen =
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_fullScreenOnMovieStart &&
+        !CMediaSettings::GetInstance().DoesMediaStartWindowed();
 
   // stereo streams may have lower quality, i.e. 32bit vs 16 bit
-  options.preferStereo = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoPreferStereoStream &&
-                         CServiceBroker::GetActiveAE()->HasStereoAudioChannelCount();
+  options.preferStereo =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoPreferStereoStream &&
+      CServiceBroker::GetActiveAE()->HasStereoAudioChannelCount();
 
   // reset VideoStartWindowed as it's a temp setting
   CMediaSettings::GetInstance().SetMediaStartWindowed(false);
@@ -2502,18 +2535,17 @@ bool CApplication::PlayFile(CFileItem item,
     // pushed some delay message into the threadmessage list, they are not
     // expected be processed after or during the new item playback starting.
     // so we clean up previous playing item's playback callback delay messages here.
-    int previousMsgsIgnoredByNewPlaying[] = {
-      GUI_MSG_PLAYBACK_STARTED,
-      GUI_MSG_PLAYBACK_ENDED,
-      GUI_MSG_PLAYBACK_STOPPED,
-      GUI_MSG_PLAYLIST_CHANGED,
-      GUI_MSG_PLAYLISTPLAYER_STOPPED,
-      GUI_MSG_PLAYLISTPLAYER_STARTED,
-      GUI_MSG_PLAYLISTPLAYER_CHANGED,
-      GUI_MSG_QUEUE_NEXT_ITEM,
-      0
-    };
-    int dMsgCount = CServiceBroker::GetGUI()->GetWindowManager().RemoveThreadMessageByMessageIds(&previousMsgsIgnoredByNewPlaying[0]);
+    int previousMsgsIgnoredByNewPlaying[] = {GUI_MSG_PLAYBACK_STARTED,
+                                             GUI_MSG_PLAYBACK_ENDED,
+                                             GUI_MSG_PLAYBACK_STOPPED,
+                                             GUI_MSG_PLAYLIST_CHANGED,
+                                             GUI_MSG_PLAYLISTPLAYER_STOPPED,
+                                             GUI_MSG_PLAYLISTPLAYER_STARTED,
+                                             GUI_MSG_PLAYLISTPLAYER_CHANGED,
+                                             GUI_MSG_QUEUE_NEXT_ITEM,
+                                             0};
+    int dMsgCount = CServiceBroker::GetGUI()->GetWindowManager().RemoveThreadMessageByMessageIds(
+        &previousMsgsIgnoredByNewPlaying[0]);
     if (dMsgCount > 0)
       CLog::LogF(LOGDEBUG, "Ignored {} playback thread messages", dMsgCount);
   }
@@ -2524,7 +2556,7 @@ bool CApplication::PlayFile(CFileItem item,
   appPlayer->SetMute(appVolume->IsMuted());
 
 #if !defined(TARGET_POSIX)
-  CGUIComponent *gui = CServiceBroker::GetGUI();
+  CGUIComponent* gui = CServiceBroker::GetGUI();
   if (gui)
     gui->GetAudioManager().Enable(false);
 #endif
@@ -2887,21 +2919,46 @@ bool CApplication::OnMessage(CGUIMessage& message)
                                                        m_itemCurrentFile, data);
 
     m_playerEvent.Set();
-    const auto stackHelper = GetComponent<CApplicationStackHelper>();
-    if (stackHelper->IsPlayingRegularStack() && stackHelper->HasNextStackPartFileItem())
-    { // just play the next item in the stack
-      PlayFile(stackHelper->SetNextStackPartCurrentFileItem(), "", true);
-      return true;
-    }
 
     // For EPG playlist items we keep the player open to ensure continuous viewing experience.
     const bool isEpgPlaylistItem{
         m_itemCurrentFile->GetProperty("epg_playlist_item").asBoolean(false)};
 
+    const std::string path{m_itemCurrentFile->GetDynPath()};
     ResetCurrentItem();
 
     if (!isEpgPlaylistItem)
     {
+      const auto stackHelper = GetComponent<CApplicationStackHelper>();
+      if ((stackHelper->IsPlayingRegularStack() || stackHelper->IsPlayingDiscStack()) &&
+          stackHelper->HasNextStackPartFileItem())
+      {
+        // If stack was stopped (eg. DVD at menu after main feature finished) then ask if continue or stop
+        if (!stackHelper->GetStackPartStopped() ||
+            CGUIDialogYesNo::ShowAndGetInput(CVariant{25015}, CVariant{25016}, "", "",
+                                             CVariant{25018}, CVariant{25017}))
+        {
+          PlayFile(stackHelper->SetNextStackPartCurrentFileItem(), "", true);
+          if (!m_cancelPlayback)
+            return true;
+
+          // Selection of next part cancelled so
+          // create bookmark for next part
+          CBookmark bookmark;
+          bookmark.timeInSeconds = stackHelper->GetCurrentStackPartStartTimeMs() / 1000.0;
+          bookmark.totalTimeInSeconds = stackHelper->GetStackTotalTimeMs() / 1000.0;
+          bookmark.playerState =
+              StringUtils::Format("<nextpart>{}</nextpart>", stackHelper->GetCurrentPartNumber());
+
+          CVideoDatabase db;
+          if (db.Open())
+          {
+            db.AddBookMarkToFile(path, bookmark, CBookmark::RESUME);
+            db.Close();
+          }
+        }
+      }
+
       if (!CServiceBroker::GetPlaylistPlayer().PlayNext(1, true))
         GetComponent<CApplicationPlayer>()->ClosePlayer();
 
@@ -3348,7 +3405,7 @@ const CFileItem& CApplication::CurrentUnstackedItem()
 {
   const auto stackHelper = GetComponent<CApplicationStackHelper>();
 
-  if (stackHelper->IsPlayingISOStack() || stackHelper->IsPlayingRegularStack())
+  if (stackHelper->IsPlayingDiscStack() || stackHelper->IsPlayingRegularStack())
     return stackHelper->GetCurrentStackPartFileItem();
   else
     return *m_itemCurrentFile;

--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -216,6 +216,8 @@ protected:
 
   int m_nextPlaylistItem = -1;
 
+  bool m_cancelPlayback{false};
+
   std::chrono::time_point<std::chrono::steady_clock> m_lastRenderTime;
   bool m_skipGuiRender = false;
 

--- a/xbmc/application/ApplicationStackHelper.cpp
+++ b/xbmc/application/ApplicationStackHelper.cpp
@@ -77,7 +77,6 @@ bool CApplicationStackHelper::InitializeStack(const CFileItem & item)
     SetRegisteredStack(GetStackPartFileItem(i), stack);
     SetRegisteredStackPartNumber(GetStackPartFileItem(i), i);
   }
-  m_currentStackIsDiscImageStack = URIUtils::IsDiscImageStack(item.GetDynPath());
 
   return true;
 }
@@ -85,141 +84,120 @@ bool CApplicationStackHelper::InitializeStack(const CFileItem & item)
 std::optional<int64_t> CApplicationStackHelper::InitializeStackStartPartAndOffset(
     const CFileItem& item)
 {
+  // see if we have the info in the database
+  //! @todo If user changes the time speed (FPS via framerate conversion stuff)
+  //!       then these times will be wrong.
+  //!       Also, this is really just a hack for the slow load up times we have
+  //!       A much better solution is a fast reader of FPS and fileLength
+  //!       that we can use on a file to get it's time.
   CVideoDatabase dbs;
-  int64_t startoffset = 0;
 
-  // case 1: stacked ISOs
-  if (m_currentStackIsDiscImageStack)
+  std::vector<uint64_t> times;
+  uint64_t totalTimeMs{0};
+  bool haveTimes{false};
+
+  if (dbs.Open())
+    haveTimes = dbs.GetStackTimes(item.GetDynPath(), times);
+
+  // If not times and is a regular (file) stack then get times from files
+  // Not possible for BD/DVD (folder) stacks due to playlist/title not known
+  if (!haveTimes && !IsPlayingDiscStack())
   {
-    // first assume values passed to the stack
-    int selectedFile = item.m_lStartPartNumber;
-    startoffset = item.GetStartOffset();
-
-    // check if we instructed the stack to resume from default
-    if (startoffset == STARTOFFSET_RESUME) // selected file is not specified, pick the 'last' resume point
+    for (int i = 0; i < m_currentStack->Size(); ++i)
     {
-      if (dbs.Open())
+      int duration;
+      if (!CDVDFileInfo::GetFileDuration(GetStackPartFileItem(i).GetDynPath(), duration))
       {
-        CBookmark bookmark;
-        std::string path = item.GetDynPath();
-        if (item.HasProperty("original_listitem_url") && URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
-          path = item.GetProperty("original_listitem_url").asString();
-        if (dbs.GetResumeBookMark(path, bookmark))
-        {
-          startoffset = CUtil::ConvertSecsToMilliSecs(bookmark.timeInSeconds);
-          selectedFile = bookmark.partNumber;
-        }
-        dbs.Close();
+        m_currentStack->Clear();
+        return std::nullopt;
       }
-      else
-        CLog::LogF(LOGERROR, "Cannot open VideoDatabase");
+      totalTimeMs += duration;
+      times.emplace_back(totalTimeMs);
     }
-
-    // make sure that the selected part is within the boundaries
-    if (selectedFile <= 0)
-    {
-      CLog::LogF(LOGWARNING, "Selected part {} out of range, playing part 1", selectedFile);
-      selectedFile = 1;
-    }
-    else if (selectedFile > m_currentStack->Size())
-    {
-      CLog::LogF(LOGWARNING, "Selected part {} out of range, playing part {}", selectedFile,
-                 m_currentStack->Size());
-      selectedFile = m_currentStack->Size();
-    }
-
-    // set startoffset in selected item, track stack item for updating purposes, and finally play disc part
-    m_currentStackPosition = selectedFile - 1;
-    startoffset = startoffset > 0 ? STARTOFFSET_RESUME : 0;
+    dbs.SetStackTimes(item.GetDynPath(), times);
+    haveTimes = true;
   }
-  // case 2: all other stacks
-  else
+
+  // If have times (saved or found above) then update stack
+  if (haveTimes)
   {
-    // see if we have the info in the database
-    //! @todo If user changes the time speed (FPS via framerate conversion stuff)
-    //!       then these times will be wrong.
-    //!       Also, this is really just a hack for the slow load up times we have
-    //!       A much better solution is a fast reader of FPS and fileLength
-    //!       that we can use on a file to get it's time.
-    std::vector<uint64_t> times;
-    bool haveTimes(false);
-
-    if (dbs.Open())
+    totalTimeMs = times.back();
+    int i;
+    for (i = 0; i < static_cast<int>(times.size()); ++i)
     {
-      haveTimes = dbs.GetStackTimes(item.GetDynPath(), times);
-      dbs.Close();
+      CFileItem& part{GetStackPartFileItem(i)};
+      // set end time in known parts
+      part.SetEndOffset(times[i]);
+      // set start time in known parts
+      SetRegisteredStackPartStartTimeMs(part, i == 0 ? 0 : times[i - 1]);
+      // set total time in known parts
+      SetRegisteredStackTotalTimeMs(part, totalTimeMs);
     }
-
-    // calculate the total time of the stack
-    uint64_t totalTimeMs = 0;
-    for (int i = 0; i < m_currentStack->Size(); i++)
-    {
-      if (haveTimes)
-      {
-        // set end time in every part
-        GetStackPartFileItem(i).SetEndOffset(times[i]);
-      }
-      else
-      {
-        int duration;
-        if (!CDVDFileInfo::GetFileDuration(GetStackPartFileItem(i).GetDynPath(), duration))
-        {
-          m_currentStack->Clear();
-          return std::nullopt;
-        }
-        totalTimeMs += duration;
-        // set end time in every part
-        GetStackPartFileItem(i).SetEndOffset(totalTimeMs);
-        times.push_back(totalTimeMs);
-      }
-      // set start time in every part
-      SetRegisteredStackPartStartTimeMs(GetStackPartFileItem(i), GetStackPartStartTimeMs(i));
-    }
-    // set total time in every part
-    totalTimeMs = GetStackTotalTimeMs();
-    for (int i = 0; i < m_currentStack->Size(); i++)
-      SetRegisteredStackTotalTimeMs(GetStackPartFileItem(i), totalTimeMs);
-
-    uint64_t msecs = item.GetStartOffset();
-
-    if (!haveTimes || item.GetStartOffset() == STARTOFFSET_RESUME)
-    {
-      if (dbs.Open())
-      {
-        // have our times now, so update the dB
-        if (!haveTimes && !times.empty())
-          dbs.SetStackTimes(item.GetDynPath(), times);
-
-        if (item.GetStartOffset() == STARTOFFSET_RESUME)
-        {
-          // can only resume seek here, not dvdstate
-          CBookmark bookmark;
-          std::string path = item.GetDynPath();
-          if (item.HasProperty("original_listitem_url") && URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
-            path = item.GetProperty("original_listitem_url").asString();
-          if (dbs.GetResumeBookMark(path, bookmark))
-            msecs = static_cast<uint64_t>(bookmark.timeInSeconds * 1000);
-          else
-            msecs = 0;
-        }
-        dbs.Close();
-      }
-    }
-
-    m_currentStackPosition = GetStackPartNumberAtTimeMs(msecs);
-    startoffset = msecs - GetStackPartStartTimeMs(m_currentStackPosition);
+    m_knownStackParts = times.size();
   }
-  return startoffset;
+
+  int64_t msecs = item.GetStartOffset();
+
+  if (msecs == STARTOFFSET_RESUME)
+  {
+    CBookmark bookmark;
+    std::string path = item.GetDynPath();
+    if (item.HasProperty("original_listitem_url") &&
+        URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
+      path = item.GetProperty("original_listitem_url").asString();
+    if (dbs.GetResumeBookMark(path, bookmark))
+      msecs = static_cast<int64_t>(bookmark.timeInSeconds * 1000);
+    else
+      msecs = 0;
+  }
+
+  dbs.Close();
+
+  // Adjust absolute position to stack
+  m_currentStackPosition = GetStackPartNumberAtTimeMs(msecs);
+
+  // Remember if this was a disc stack
+  m_wasDiscStack = HasDiscParts();
+
+  return msecs - static_cast<int64_t>(GetStackPartStartTimeMs(m_currentStackPosition));
 }
 
-bool CApplicationStackHelper::IsPlayingISOStack() const
+// IsPlayingDiscStack - means we can't move back and forth between items
+
+bool CApplicationStackHelper::IsPlayingDiscStack() const
 {
-  return m_currentStack->Size() > 0 && m_currentStackIsDiscImageStack;
+  return m_currentStack->Size() > 0 && !IsPlayingRegularStack();
 }
+
+// Is PlayingRegularStack - means we can move back and forth between items
 
 bool CApplicationStackHelper::IsPlayingRegularStack() const
 {
-  return m_currentStack->Size() > 0 && !m_currentStackIsDiscImageStack;
+  if (m_currentStack->Size() > 0)
+  {
+    const int currentPart = GetCurrentPartNumber() < 1 ? 1 : GetCurrentPartNumber();
+    for (int i = 0; i < currentPart; ++i)
+    {
+      const std::string path = GetStackPartFileItem(i).GetDynPath();
+      if (URIUtils::IsDiscImage(path) || URIUtils::IsDVDFile(path) || URIUtils::IsBDFile(path))
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+bool CApplicationStackHelper::HasDiscParts() const
+{
+  for (int i = 0; i < m_currentStack->Size(); ++i)
+  {
+    const std::string path = GetStackPartFileItem(i).GetDynPath();
+    if (URIUtils::IsDiscImage(path) || URIUtils::IsDVDFile(path) || URIUtils::IsBDFile(path))
+      return true;
+  }
+  return false;
 }
 
 bool CApplicationStackHelper::HasNextStackPartFileItem() const
@@ -234,10 +212,16 @@ uint64_t CApplicationStackHelper::GetStackPartEndTimeMs(int partNumber) const
 
 uint64_t CApplicationStackHelper::GetStackTotalTimeMs() const
 {
-  return GetStackPartEndTimeMs(m_currentStack->Size() - 1);
+  for (int i = m_currentStack->Size() - 1; i >= 0; --i)
+  {
+    const uint64_t endTime = GetStackPartEndTimeMs(i);
+    if (endTime > 0)
+      return endTime;
+  }
+  return 0;
 }
 
-int CApplicationStackHelper::GetStackPartNumberAtTimeMs(uint64_t msecs)
+int CApplicationStackHelper::GetStackPartNumberAtTimeMs(uint64_t msecs) const
 {
   if (msecs > 0)
   {
@@ -259,12 +243,12 @@ void CApplicationStackHelper::ClearAllRegisteredStackInformation()
 std::shared_ptr<const CFileItem> CApplicationStackHelper::GetRegisteredStack(
     const CFileItem& item) const
 {
-  return GetStackPartInformation(item.GetDynPath())->m_pStack;
+  return GetStackPartInformation(item.GetPath())->m_pStack;
 }
 
 bool CApplicationStackHelper::HasRegisteredStack(const CFileItem& item) const
 {
-  const auto it = m_stackmap.find(item.GetDynPath());
+  const auto it = m_stackmap.find(item.GetPath());
   return it != m_stackmap.end() && it->second != nullptr;
 }
 
@@ -286,32 +270,60 @@ const CFileItem& CApplicationStackHelper::GetStackPartFileItem(int partNumber) c
 
 int CApplicationStackHelper::GetRegisteredStackPartNumber(const CFileItem& item)
 {
-  return GetStackPartInformation(item.GetDynPath())->m_lStackPartNumber;
+  return GetStackPartInformation(item.GetPath())->m_lStackPartNumber;
 }
 
 void CApplicationStackHelper::SetRegisteredStackPartNumber(const CFileItem& item, int partNumber)
 {
-  GetStackPartInformation(item.GetDynPath())->m_lStackPartNumber = partNumber;
+  GetStackPartInformation(item.GetPath())->m_lStackPartNumber = partNumber;
 }
 
 uint64_t CApplicationStackHelper::GetRegisteredStackPartStartTimeMs(const CFileItem& item) const
 {
-  return GetStackPartInformation(item.GetDynPath())->m_lStackPartStartTimeMs;
+  return GetStackPartInformation(item.GetPath())->m_lStackPartStartTimeMs;
 }
 
 void CApplicationStackHelper::SetRegisteredStackPartStartTimeMs(const CFileItem& item, uint64_t startTime)
 {
-  GetStackPartInformation(item.GetDynPath())->m_lStackPartStartTimeMs = startTime;
+  GetStackPartInformation(item.GetPath())->m_lStackPartStartTimeMs = startTime;
 }
 
 uint64_t CApplicationStackHelper::GetRegisteredStackTotalTimeMs(const CFileItem& item) const
 {
-  return GetStackPartInformation(item.GetDynPath())->m_lStackTotalTimeMs;
+  return GetStackPartInformation(item.GetPath())->m_lStackTotalTimeMs;
 }
 
 void CApplicationStackHelper::SetRegisteredStackTotalTimeMs(const CFileItem& item, uint64_t totalTime)
 {
-  GetStackPartInformation(item.GetDynPath())->m_lStackTotalTimeMs = totalTime;
+  GetStackPartInformation(item.GetPath())->m_lStackTotalTimeMs = totalTime;
+}
+
+void CApplicationStackHelper::SetRegisteredStackDynPaths(const std::string& newPath) const
+{
+  for (const auto& stackmapitem : m_stackmap)
+    stackmapitem.second->m_pStack->SetDynPath(newPath);
+}
+
+void CApplicationStackHelper::SetRegisteredStackPartDynPath(const CFileItem& item,
+                                                            const std::string& newPath)
+{
+  CFileItem& stackItem(GetStackPartFileItem(GetRegisteredStackPartNumber(item)));
+  stackItem.SetDynPath(newPath);
+}
+
+void CApplicationStackHelper::SetStackEndTimeMs(const uint64_t totalTimeMs)
+{
+  for (int i = 0; i < m_currentStack->Size(); i++)
+    SetRegisteredStackTotalTimeMs(GetStackPartFileItem(i), totalTimeMs);
+}
+
+void CApplicationStackHelper::SetStackPartOffsets(const CFileItem& item,
+                                                  const int64_t startOffset,
+                                                  const int64_t endOffset)
+{
+  CFileItem& stackItem(GetStackPartFileItem(GetRegisteredStackPartNumber(item)));
+  stackItem.SetStartOffset(startOffset);
+  stackItem.SetEndOffset(endOffset);
 }
 
 CApplicationStackHelper::StackPartInformationPtr CApplicationStackHelper::GetStackPartInformation(

--- a/xbmc/application/ApplicationStackHelper.h
+++ b/xbmc/application/ApplicationStackHelper.h
@@ -81,7 +81,8 @@ public:
   */
   const CFileItem& SetStackPartCurrentFileItem(int partNumber)
   {
-    return GetStackPartFileItem(m_currentStackPosition = partNumber);
+    m_currentStackPosition = partNumber;
+    return GetStackPartFileItem(m_currentStackPosition);
   }
 
   /*!

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -166,6 +166,7 @@ public:
   virtual int Read(uint8_t* buf, int buf_size) = 0;
   virtual int64_t Seek(int64_t offset, int whence) = 0;
   virtual int64_t GetLength() = 0;
+  virtual int64_t GetDuration() = 0;
   virtual std::string& GetContent() { return m_content; }
   virtual std::string GetFileName();
   virtual CURL GetURL();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -324,12 +324,7 @@ bool CDVDInputStreamBluray::Open()
 
   int mode = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_DISC_PLAYBACK);
 
-  if (URIUtils::HasExtension(filename, ".mpls"))
-  {
-    m_navmode = false;
-    m_titleInfo = GetTitleFile(filename);
-  }
-  else if (mode == BD_PLAYBACK_MAIN_TITLE)
+  if (mode == BD_PLAYBACK_MAIN_TITLE)
   {
     m_navmode = false;
     m_titleInfo = GetTitleLongest();
@@ -339,6 +334,11 @@ bool CDVDInputStreamBluray::Open()
     // resuming a bluray for which we have a saved state - the playlist will be open later on SetState
     m_navmode = false;
     return true;
+  }
+  else if (URIUtils::HasExtension(filename, ".mpls"))
+  {
+    m_navmode = false;
+    m_titleInfo = GetTitleFile(filename);
   }
   else
   {
@@ -1012,6 +1012,13 @@ int64_t CDVDInputStreamBluray::Seek(int64_t offset, int whence)
 int64_t CDVDInputStreamBluray::GetLength()
 {
   return static_cast<int64_t>(bd_get_title_size(m_bd));
+}
+
+int64_t CDVDInputStreamBluray::GetDuration()
+{
+  if (m_titleInfo)
+    return static_cast<int64_t>(m_titleInfo->duration / 90);
+  return 0;
 }
 
 static bool find_stream(int pid, BLURAY_STREAM_INFO *info, int count, std::string &language)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -61,6 +61,7 @@ public:
   void Abort() override;
   bool IsEOF() override;
   int64_t GetLength() override;
+  int64_t GetDuration() override;
   int GetBlockSize() override { return 6144; }
   ENextStream NextStream() override;
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.h
@@ -22,6 +22,7 @@ public:
   int64_t Seek(int64_t offset, int whence) override;
   bool IsEOF() override;
   int64_t GetLength() override;
+  int64_t GetDuration() override { return 0; }
   std::string GetFileName() override;
 
   void  Abort() override { m_aborted = true;  }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.h
@@ -21,6 +21,7 @@ public:
   int64_t Seek(int64_t offset, int whence) override;
   bool IsEOF() override;
   int64_t GetLength() override;
+  int64_t GetDuration() override { return 0; }
   BitstreamStats GetBitstreamStats() const override ;
   int GetBlockSize() override;
   void SetReadRate(uint32_t rate) override;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -56,6 +56,7 @@ public:
   int GetBlockSize() override { return DVDSTREAM_BLOCK_SIZE_DVD; }
   bool IsEOF() override { return m_bEOF; }
   int64_t GetLength() override { return 0; }
+  int64_t GetDuration() override { return 0; }
   ENextStream NextStream() override ;
 
   void ActivateButton() override;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamStack.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamStack.h
@@ -25,6 +25,7 @@ public:
   int64_t Seek(int64_t offset, int whence) override;
   bool IsEOF() override;
   int64_t GetLength() override;
+  int64_t GetDuration() override { return 0; }
 
 protected:
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
@@ -57,6 +57,7 @@ public:
   int Read(uint8_t* buf, int buf_size) override;
   int64_t Seek(int64_t offset, int whence) override;
   int64_t GetLength() override;
+  int64_t GetDuration() override { return 0; }
   int GetBlockSize() override;
   bool IsEOF() override;
   bool CanSeek() override; //! @todo drop this

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamMultiSource.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamMultiSource.h
@@ -29,6 +29,7 @@ public:
   int GetBlockSize() override;
   bool GetCacheStatus(XFILE::SCacheStatus *status) override;
   int64_t GetLength() override;
+  int64_t GetDuration() override { return 0; }
   bool IsEOF() override;
   CDVDInputStream::ENextStream NextStream() override;
   bool Open() override;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.h
@@ -38,6 +38,7 @@ public:
   int64_t Seek(int64_t offset, int whence) override;
   bool IsEOF() override;
   int64_t GetLength() override;
+  int64_t GetDuration() override { return 0; }
   int GetBlockSize() override;
 
   ENextStream NextStream() override;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -33,6 +33,7 @@
 #include "VideoPlayerRadioRDS.h"
 #include "VideoPlayerVideo.h"
 #include "application/Application.h"
+#include "application/ApplicationStackHelper.h"
 #include "cores/DataCacheCore.h"
 #include "cores/EdlEdit.h"
 #include "cores/FFmpeg.h"
@@ -45,7 +46,6 @@
 #include "input/actions/ActionIDs.h"
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
-#include "network/NetworkFileItemClassify.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -716,6 +716,7 @@ bool CVideoPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options
   m_error = false;
   m_bCloseRequest = false;
   m_renderManager.PreInit();
+  m_longestTime = 0;
 
   Create();
   m_messenger.Init();
@@ -1294,6 +1295,29 @@ void CVideoPlayer::Prepare()
 
   if (!discStateRestored)
     OpenDefaultStreams();
+
+  auto& components{CServiceBroker::GetAppComponents()};
+  const auto& stackHelper{components.GetComponent<CApplicationStackHelper>()};
+  if (stackHelper->GetRegisteredStack(fileItem) != nullptr)
+  {
+    if (stackHelper->GetRegisteredStackPartNumber(fileItem) >= stackHelper->GetKnownStackParts())
+    {
+      stackHelper->IncreaseKnownStackParts();
+
+      // Dynamically update stack for bluray://
+      if (URIUtils::IsProtocol(fileItem.GetDynPath(), "bluray"))
+      {
+        int64_t length{m_pInputStream->GetDuration()};
+        uint64_t time{stackHelper->GetStackTotalTimeMs()};
+        stackHelper->SetStackEndTimeMs(time + length);
+        stackHelper->SetRegisteredStackPartStartTimeMs(fileItem, time);
+        stackHelper->SetStackPartOffsets(fileItem, time, time + length);
+        stackHelper->SetRegisteredStackPartDynPath(fileItem, fileItem.GetDynPath());
+        fileItem.SetStartOffset(time);
+        fileItem.SetEndOffset(time + length);
+      }
+    }
+  }
 
   /*
    * Check to see if the demuxer should start at something other than time 0. This will be the case
@@ -2561,7 +2585,6 @@ void CVideoPlayer::OnExit()
     CLog::Log(LOGINFO, "VideoPlayer: eof, waiting for queues to empty");
 
   CFileItem fileItem(m_item);
-  UpdateFileItemStreamDetails(fileItem);
 
   CloseStream(m_CurrentAudio, !m_bAbortRequest);
   CloseStream(m_CurrentVideo, !m_bAbortRequest);
@@ -5016,6 +5039,33 @@ void CVideoPlayer::UpdatePlayState(double timeout)
 
   m_processInfo->SetPlayTimes(state.startTime, state.time, state.timeMin, state.timeMax);
 
+  // Save longest stream (for DVDs and Blurays played through menu)
+  if (state.timeMax > m_longestTime && m_content.m_videoIndex >= 0 && !IsInMenuInternal())
+  {
+    m_longestTime = state.timeMax;
+
+    // Use longest stream in case of Bluray menus
+    // (used to call UpdateFileItemStreamDetails here)
+    m_item.GetVideoInfoTag()->m_streamDetails.Reset();
+    UpdateFileItemStreamDetails(m_item, true);
+    m_item.SetProperty("longest_stream_duration", m_longestTime);
+
+    // Also generate bluray:// path for longest stream (in case playing from menu)
+    CURL url{m_item.GetDynPath()};
+    if (URIUtils::IsProtocol(m_item.GetDynPath(), "bluray"))
+    {
+      BlurayState blurayState;
+      CBlurayStateSerializer serializer;
+      if (serializer.XMLToBlurayState(blurayState, state.player_state))
+        url.SetFileName(StringUtils::Format("BDMV/PLAYLIST/{:05}.mpls", blurayState.playlistId));
+    }
+    m_item.SetProperty("longest_stream_path", url.Get());
+  }
+  if (IsInMenuInternal())
+    m_item.SetProperty("stopped_in_menu", true);
+  else
+    m_item.SetProperty("stopped_in_menu", false);
+
   std::unique_lock<CCriticalSection> lock(m_StateSection);
   m_State = state;
 }
@@ -5203,9 +5253,10 @@ void CVideoPlayer::OnResetDisplay()
   m_VideoPlayerAudio->SendMessage(std::make_shared<CDVDMsg>(CDVDMsg::PLAYER_DISPLAY_RESET), 1);
 }
 
-void CVideoPlayer::UpdateFileItemStreamDetails(CFileItem& item)
+void CVideoPlayer::UpdateFileItemStreamDetails(CFileItem& item,
+                                               const bool alwaysUpdate /* = false */)
 {
-  if (!m_UpdateStreamDetails)
+  if (!m_UpdateStreamDetails && !alwaysUpdate)
     return;
   m_UpdateStreamDetails = false;
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -24,6 +24,7 @@
 #include "guilib/DispResource.h"
 #include "threads/SystemClock.h"
 #include "threads/Thread.h"
+#include "utils/StreamDetails.h"
 
 #include <atomic>
 #include <chrono>
@@ -478,7 +479,7 @@ protected:
   void UpdateContent();
   void UpdateContentState();
 
-  void UpdateFileItemStreamDetails(CFileItem& item);
+  void UpdateFileItemStreamDetails(CFileItem& item, const bool alwaysUpdate = false);
   int GetPreviousChapter();
 
   bool m_players_created;
@@ -493,6 +494,7 @@ protected:
   XbmcThreads::EndTime<> m_cachingTimer;
 
   std::unique_ptr<CProcessInfo> m_processInfo;
+  uint64_t m_longestTime{0};
 
   CCurrentStream m_CurrentAudio;
   CCurrentStream m_CurrentVideo;

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -60,7 +60,7 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item, bool forceSelectio
   if (forceSelection && VIDEO::IsBlurayPlaylist(item))
   {
     item.SetProperty("save_dyn_path", item.GetDynPath()); // save for screen refresh later
-    item.SetDynPath(item.GetBlurayPath());
+    item.SetDynPath(URIUtils::GetBlurayPath(item.GetDynPath()));
   }
 
   if (VIDEO::IsBDFile(item))

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -31,7 +31,6 @@
 
 #include <libbluray/bluray-version.h>
 #include <libbluray/bluray.h>
-#include <libbluray/filesystem.h>
 #include <libbluray/log_control.h>
 
 namespace XFILE

--- a/xbmc/filesystem/StackDirectory.cpp
+++ b/xbmc/filesystem/StackDirectory.cpp
@@ -18,8 +18,6 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
-#include <stdlib.h>
-
 namespace XFILE
 {
   CStackDirectory::CStackDirectory() = default;
@@ -44,105 +42,103 @@ namespace XFILE
     return true;
   }
 
-  std::string CStackDirectory::GetStackedTitlePath(const std::string &strPath)
+  // Used to derive a filename/path to look for NFO files and art for stacks
+  // For file stacks - movie part 1.mp4, movie part 2.mp4 -> movie.mp4
+  // For folder stacks - movie part 1/..., movie part 2/... -> movie/
+  std::string CStackDirectory::GetStackedTitlePath(const std::string& strPath)
   {
-    // Load up our REs
-    VECCREGEXP  RegExps;
-    CRegExp     tempRE(true, CRegExp::autoUtf8);
-    const std::vector<std::string>& strRegExps = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoStackRegExps;
-    std::vector<std::string>::const_iterator itRegExp = strRegExps.begin();
-    while (itRegExp != strRegExps.end())
+    // Get our REs
+    VECCREGEXP folderRegExps;
+    VECCREGEXP fileRegExps;
+    LoadRegExps(fileRegExps, folderRegExps);
+
+    std::string stackPath{};
+    if (fileRegExps.empty() || folderRegExps.empty())
+      CLog::LogF(LOGDEBUG, "No stack expressions available. Skipping stack title path creation");
+    else
     {
-      (void)tempRE.RegComp(*itRegExp);
-      if (tempRE.GetCaptureTotal() == 4)
-        RegExps.push_back(tempRE);
-      else
-        CLog::Log(LOGERROR, "Invalid video stack RE ({}). Must have exactly 4 captures.",
-                  *itRegExp);
-      ++itRegExp;
-    }
-    return GetStackedTitlePath(strPath, RegExps);
-  }
+      CStackDirectory stack;
+      std::string stackTitle{};
+      CFileItemList parts;
+      const CURL pathToUrl(strPath);
+      const std::string commonPath{URIUtils::GetParentPath(strPath)};
 
-  std::string CStackDirectory::GetStackedTitlePath(const std::string &strPath, VECCREGEXP& RegExps)
-  {
-    CStackDirectory stack;
-    CFileItemList   files;
-    std::string      strStackTitlePath,
-                    strCommonDir        = URIUtils::GetParentPath(strPath);
+      stack.GetDirectory(pathToUrl, parts);
 
-    const CURL pathToUrl(strPath);
-    stack.GetDirectory(pathToUrl, files);
-
-    if (files.Size() > 1)
-    {
-      std::string strStackTitle;
-
-      std::string File1 = URIUtils::GetFileName(files[0]->GetPath());
-      std::string File2 = URIUtils::GetFileName(files[1]->GetPath());
-      // Check if source path uses URL encoding
-      if (URIUtils::HasEncodedFilename(CURL(strCommonDir)))
+      if (parts.Size() > 1)
       {
-        File1 = CURL::Decode(File1);
-        File2 = CURL::Decode(File2);
-      }
-
-      std::vector<CRegExp>::iterator itRegExp = RegExps.begin();
-      int offset = 0;
-
-      while (itRegExp != RegExps.end())
-      {
-        if (itRegExp->RegFind(File1, offset) != -1)
+        const bool isFolderStack = [&]
         {
-          std::string Title1     = itRegExp->GetMatch(1),
-                     Volume1    = itRegExp->GetMatch(2),
-                     Ignore1    = itRegExp->GetMatch(3),
-                     Extension1 = itRegExp->GetMatch(4);
-          if (offset)
-            Title1 = File1.substr(0, itRegExp->GetSubStart(2));
-          if (itRegExp->RegFind(File2, offset) != -1)
-          {
-            std::string Title2     = itRegExp->GetMatch(1),
-                       Volume2    = itRegExp->GetMatch(2),
-                       Ignore2    = itRegExp->GetMatch(3),
-                       Extension2 = itRegExp->GetMatch(4);
-            if (offset)
-              Title2 = File2.substr(0, itRegExp->GetSubStart(2));
-            if (StringUtils::EqualsNoCase(Title1, Title2))
-            {
-              if (!StringUtils::EqualsNoCase(Volume1, Volume2))
-              {
-                if (StringUtils::EqualsNoCase(Ignore1, Ignore2) &&
-                    StringUtils::EqualsNoCase(Extension1, Extension2))
-                {
-                  // got it
-                  strStackTitle = Title1 + Ignore1 + Extension1;
-                  // Check if source path uses URL encoding
-                  if (URIUtils::HasEncodedFilename(CURL(strCommonDir)))
-                    strStackTitle = CURL::Encode(strStackTitle);
+          std::string path{StringUtils::ToLower(parts[0]->GetBaseMoviePath(true))};
+          URIUtils::RemoveSlashAtEnd(path);
+          for (auto& regExp : folderRegExps)
+            if (regExp.RegFind(path) != -1)
+              return true;
+          return false;
+        }();
 
-                  itRegExp = RegExps.end();
-                  break;
-                }
-                else // Invalid stack
-                  break;
-              }
-              else // Early match, retry with offset
-              {
-                offset = itRegExp->GetSubStart(3);
-                continue;
-              }
+        std::vector<std::tuple<std::string, std::string>> stackParts;
+        for (const auto& part : parts)
+        {
+          if (isFolderStack)
+          {
+            // Folder stack
+            std::string path = URIUtils::GetBasePath(part->GetPath());
+            URIUtils::RemoveSlashAtEnd(path);
+            std::string last = URIUtils::GetFileName(path);
+            if (last == "BDMV" || last == "VIDEO_TS")
+            {
+              path = URIUtils::GetParentPath(path);
+              URIUtils::RemoveSlashAtEnd(path);
             }
+            path = URIUtils::GetFileName(path);
+
+            // Test each item against each RegExp and save parts
+            for (auto& regExp : folderRegExps)
+              if (regExp.RegFind(path) != -1)
+              {
+                stackParts.emplace_back(regExp.GetMatch(1), "");
+                break;
+              }
+          }
+          else
+          {
+            // File stack
+            std::string fileName{URIUtils::GetFileName(part->GetPath())};
+
+            // Check if source path uses URL encoding
+            if (URIUtils::HasEncodedFilename(CURL(commonPath)))
+              fileName = CURL::Decode(fileName);
+
+            // Test each item against each RegExp and save parts
+            for (auto& regExp : fileRegExps)
+              if (regExp.RegFind(fileName) != -1)
+              {
+                stackParts.emplace_back(regExp.GetMatch(1) /* Title */,
+                                        regExp.GetMatch(3) /* Ignore */);
+                break;
+              }
           }
         }
-        offset = 0;
-        ++itRegExp;
-      }
-      if (!strCommonDir.empty() && !strStackTitle.empty())
-        strStackTitlePath = strCommonDir + strStackTitle;
-    }
 
-    return strStackTitlePath;
+        // Check all equal
+        if (!stackParts.empty() && std::adjacent_find(stackParts.begin(), stackParts.end(),
+                                                      std::not_equal_to<>()) == stackParts.end())
+        {
+          // Create stacked title
+          stackTitle = std::get<0>(stackParts[0]) + std::get<1>(stackParts[0]) +
+                       (isFolderStack ? "/" : URIUtils::GetExtension(parts[0]->GetPath()));
+
+          // Check if source path uses URL encoding
+          if (!isFolderStack && URIUtils::HasEncodedFilename(CURL(commonPath)))
+            stackTitle = CURL::Encode(stackTitle);
+
+          if (!commonPath.empty() && !stackTitle.empty())
+            stackPath = commonPath + stackTitle;
+        }
+      }
+    }
+    return stackPath;
   }
 
   std::string CStackDirectory::GetFirstStackedFile(const std::string &strPath)
@@ -229,5 +225,61 @@ namespace XFILE
     }
     return true;
   }
-}
 
+  std::string CStackDirectory::GetParentPath(const std::string& stackPath)
+  {
+    std::vector<std::string> paths;
+    if (GetPaths(stackPath, paths))
+    {
+      bool first = true;
+      do
+      {
+        for (auto& path : paths)
+        {
+          URIUtils::RemoveSlashAtEnd(path);
+          if (first)
+            path = URIUtils::GetBaseMoviePath(path);
+          else
+            path = URIUtils::GetParentPath(path);
+        }
+        first = false;
+      } while (std::adjacent_find(paths.begin(), paths.end(), std::not_equal_to<>()) !=
+               paths.end());
+    }
+    return paths[0];
+  }
+
+  void CStackDirectory::LoadRegExps(VECCREGEXP& fileRegExps, VECCREGEXP& folderRegExps)
+  {
+    // Folder RegExps
+    CRegExp folderRegExp(true, CRegExp::autoUtf8);
+    const std::vector<std::string>& folderStackRegExps =
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_folderStackRegExps;
+    for (const auto& regExp : folderStackRegExps)
+    {
+      if (!folderRegExp.RegComp(regExp))
+        CLog::LogF(LOGERROR, "Invalid folder stack RegExp:'{}'", regExp);
+      else if (folderRegExp.GetCaptureTotal() != 2)
+        CLog::LogF(LOGERROR, "Invalid folder stack RE ({}). Must have 2 captures.",
+                   folderRegExp.GetPattern());
+      else
+        folderRegExps.emplace_back(folderRegExp);
+    }
+
+    // File RegExps
+    CRegExp fileRegExp(true, CRegExp::autoUtf8);
+    const std::vector<std::string>& fileStackRegExps =
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoStackRegExps;
+
+    for (const auto& regExp : fileStackRegExps)
+    {
+      if (!fileRegExp.RegComp(regExp))
+        CLog::LogF(LOGERROR, "Invalid folder stack RegExp:'{}'", regExp);
+      else if (fileRegExp.GetCaptureTotal() != 4)
+        CLog::LogF(LOGERROR, "Invalid video stack RE ({}). Must have 4 captures.",
+                   fileRegExp.GetPattern());
+      else
+        fileRegExps.emplace_back(fileRegExp);
+    }
+  }
+  } // namespace XFILE

--- a/xbmc/filesystem/StackDirectory.h
+++ b/xbmc/filesystem/StackDirectory.h
@@ -23,11 +23,12 @@ namespace XFILE
     ~CStackDirectory() override;
     bool GetDirectory(const CURL& url, CFileItemList& items) override;
     bool AllowAll() const override { return true; }
-    static std::string GetStackedTitlePath(const std::string &strPath);
-    static std::string GetStackedTitlePath(const std::string &strPath, VECCREGEXP& RegExps);
+    static std::string GetStackedTitlePath(const std::string& strPath);
     static std::string GetFirstStackedFile(const std::string &strPath);
     static bool GetPaths(const std::string& strPath, std::vector<std::string>& vecPaths);
     static std::string ConstructStackPath(const CFileItemList& items, const std::vector<int> &stack);
     static bool ConstructStackPath(const std::vector<std::string> &paths, std::string &stackedPath);
+    static std::string GetParentPath(const std::string& path);
+    static void LoadRegExps(VECCREGEXP& fileRegExps, VECCREGEXP& folderRegExps);
   };
 }

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -269,7 +269,7 @@ void CPowerManager::StorePlayerState()
                                            stackHelper->GetCurrentStackPartStartTimeMs());
     // in case of iso stack, keep track of part number
     m_lastPlayedFileItem->m_lStartPartNumber =
-        stackHelper->IsPlayingISOStack() ? stackHelper->GetCurrentPartNumber() + 1 : 1;
+        stackHelper->IsPlayingDiscStack() ? stackHelper->GetCurrentPartNumber() + 1 : 1;
     // for iso and iso stacks, keep track of playerstate
     m_lastPlayedFileItem->SetProperty("savedplayerstate", appPlayer->GetPlayerState());
     CLog::Log(LOGDEBUG,

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -244,12 +244,16 @@ void CAdvancedSettings::Initialize()
                                         m_allExcludeFromScanRegExps.end());
 
   m_folderStackRegExps.clear();
-  m_folderStackRegExps.emplace_back("((cd|dvd|dis[ck])[0-9]+)$");
+  //m_folderStackRegExps.emplace_back("((cd|dvd|dis[ck])[0-9]+)$");
+  m_folderStackRegExps.emplace_back(
+      "(.*?)(?:[^\\/])((?:cd|dvd|p(?:(?:ar)?t)|dis[ck])[ _.-]*[0-9])$");
 
   m_videoStackRegExps.clear();
-  m_videoStackRegExps.emplace_back("(.*?)([ _.-]*(?:cd|dvd|p(?:(?:ar)?t)|dis[ck])[ _.-]*[0-9]+)(.*?)(\\.[^.]+)$");
-  m_videoStackRegExps.emplace_back("(.*?)([ _.-]*(?:cd|dvd|p(?:(?:ar)?t)|dis[ck])[ _.-]*[a-d])(.*?)(\\.[^.]+)$");
-  m_videoStackRegExps.emplace_back("(.*?)([ ._-]*[a-d])(.*?)(\\.[^.]+)$");
+  m_videoStackRegExps.emplace_back(
+      "(.*?)([ _.-]*(?:cd|dvd|p(?:(?:ar)?t)|dis[ck]|file)[ _.-]*[0-9]+)(.*?)(\\.[^.]+)$");
+  m_videoStackRegExps.emplace_back(
+      "(.*?)([ _.-]*(?:cd|dvd|p(?:(?:ar)?t)|dis[ck])[ _.-]*[a-z])(.*?)(\\.[^.]+)$");
+  m_videoStackRegExps.emplace_back("^(.+)((?:[ ._-]|(?<=\\)))[a-z])()(\\.[^.]+)$");
   // This one is a bit too greedy to enable by default.  It will stack sequels
   // in a flat dir structure, but is perfectly safe in a dir-per-vid one.
   //m_videoStackRegExps.push_back("(.*?)([ ._-]*[0-9])(.*?)(\\.[^.]+)$");
@@ -430,6 +434,7 @@ void CAdvancedSettings::Initialize()
   m_subtitlesExtensions = ".utf|.utf8|.utf-8|.sub|.srt|.smi|.rt|.txt|.ssa|.text|.ssa|.aqt|.jss|"
                           ".ass|.vtt|.idx|.ifo|.zip|.sup";
   m_discStubExtensions = ".disc";
+  m_discImageExtensions = ".img|.iso|.nrg|.udf";
   // internal music extensions
   m_musicExtensions += "|.cdda";
   // internal video extensions

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -364,6 +364,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     // runtime settings which cannot be set from advancedsettings.xml
     std::string m_videoExtensions;
     std::string m_discStubExtensions;
+    std::string m_discImageExtensions;
     std::string m_subtitlesExtensions;
     std::string m_musicExtensions;
     std::string m_pictureExtensions;

--- a/xbmc/utils/ArtUtils.cpp
+++ b/xbmc/utils/ArtUtils.cpp
@@ -208,10 +208,7 @@ std::string GetLocalArtBaseFilename(const CFileItem& item, bool& useFolder)
   std::string strFile;
   if (item.IsStack())
   {
-    std::string strPath;
-    URIUtils::GetParentPath(item.GetPath(), strPath);
-    strFile = URIUtils::AddFileToFolder(
-        strPath, URIUtils::GetFileName(CStackDirectory::GetStackedTitlePath(item.GetPath())));
+    strFile = CStackDirectory::GetStackedTitlePath(item.GetPath());
   }
 
   std::string file = strFile.empty() ? item.GetPath() : strFile;

--- a/xbmc/utils/FileExtensionProvider.cpp
+++ b/xbmc/utils/FileExtensionProvider.cpp
@@ -51,6 +51,11 @@ std::string CFileExtensionProvider::GetDiscStubExtensions() const
   return m_advancedSettings->m_discStubExtensions;
 }
 
+std::string CFileExtensionProvider::GetDiscImageExtensions() const
+{
+  return m_advancedSettings->m_discImageExtensions;
+}
+
 std::string CFileExtensionProvider::GetMusicExtensions() const
 {
   std::string extensions(m_advancedSettings->m_musicExtensions);

--- a/xbmc/utils/FileExtensionProvider.h
+++ b/xbmc/utils/FileExtensionProvider.h
@@ -54,6 +54,11 @@ public:
   std::string GetDiscStubExtensions() const;
 
   /*!
+   * @brief Returns a list of disc image extensions
+   */
+  std::string GetDiscImageExtensions() const;
+
+  /*!
    * @brief Returns a file folder extensions
    */
   std::string GetFileFolderExtensions() const;

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -9,7 +9,6 @@
 #include "URIUtils.h"
 
 #include "FileItem.h"
-#include "FileItemList.h"
 #include "ServiceBroker.h"
 #include "StringUtils.h"
 #include "URL.h"
@@ -325,32 +324,14 @@ bool URIUtils::GetParentPath(const std::string& strPath, std::string& strParent)
 
   CURL url(strPath);
   std::string strFile = url.GetFileName();
-  if ( URIUtils::HasParentInHostname(url) && strFile.empty())
+  if (HasParentInHostname(url) && strFile.empty())
   {
     strFile = url.GetHostName();
     return GetParentPath(strFile, strParent);
   }
   else if (url.IsProtocol("stack"))
   {
-    CStackDirectory dir;
-    CFileItemList items;
-    if (!dir.GetDirectory(url, items))
-      return false;
-    CURL url2(GetDirectory(items[0]->GetPath()));
-    if (HasParentInHostname(url2))
-      GetParentPath(url2.Get(), strParent);
-    else
-      strParent = url2.Get();
-    for( int i=1;i<items.Size();++i)
-    {
-      items[i]->m_strDVDLabel = GetDirectory(items[i]->GetPath());
-      if (HasParentInHostname(url2))
-        items[i]->SetPath(GetParentPath(items[i]->m_strDVDLabel));
-      else
-        items[i]->SetPath(items[i]->m_strDVDLabel);
-
-      GetCommonPath(strParent,items[i]->GetPath());
-    }
+    strParent = CStackDirectory::GetParentPath(url.Get());
     return true;
   }
   else if (url.IsProtocol("multipath"))
@@ -453,6 +434,57 @@ std::string URIUtils::GetBasePath(const std::string& strPath)
       strDirectory = GetDirectory(strCheck);
   }
   return strDirectory;
+}
+
+std::string URIUtils::GetBaseMoviePath(const std::string& path)
+{
+  std::string root{path};
+
+  // Deal with dvd:// or bluray:// and any embedded udf://
+  CURL url{root};
+  while (HasParentInHostname(url))
+  {
+    root = url.GetHostName();
+    url.Parse(root);
+  }
+
+  // Deal with any BD/DVD directories
+  if (IsBDFile(root))
+  {
+    root = GetParentPath(root);
+    RemoveSlashAtEnd(root);
+    if (GetFileName(root) == "BDMV")
+      root = GetParentPath(root);
+  }
+  else if (IsDVDFile(root))
+  {
+    root = GetParentPath(root);
+    RemoveSlashAtEnd(root);
+    if (GetFileName(root) == "VIDEO_TS")
+      root = GetParentPath(root);
+  }
+
+  // If simply file then get path
+  if (!GetFileName(root).empty())
+    root = GetDirectory(root);
+
+  return root;
+}
+
+std::string URIUtils::GetBlurayPath(const std::string& path)
+{
+  if (IsBlurayPlaylist(path))
+  {
+    CURL url(path);
+    CURL url2(url.GetHostName()); // strip bluray://
+    if (url2.IsProtocol("udf"))
+      // ISO
+      return url2.GetHostName(); // strip udf://
+    if (url.IsProtocol("bluray"))
+      // BDMV
+      return url2.Get() + "BDMV/index.bdmv";
+  }
+  return path;
 }
 
 std::string URLEncodePath(const std::string& strPath)
@@ -779,6 +811,22 @@ bool URIUtils::IsDVD(const std::string& strFile)
   return false;
 }
 
+bool URIUtils::IsDVDFile(const std::string& file)
+{
+  return StringUtils::EndsWith(StringUtils::ToLower(file), "video_ts.ifo");
+}
+
+bool URIUtils::IsBDFile(const std::string& file)
+{
+  return StringUtils::EndsWith(StringUtils::ToLower(file), "index.bdmv");
+}
+
+bool URIUtils::IsBlurayPlaylist(const std::string& file)
+{
+  return IsProtocol(file, "bluray") &&
+         StringUtils::EqualsNoCase(GetExtension(StringUtils::ToLower(file)), ".mpls");
+}
+
 bool URIUtils::IsStack(const std::string& strFile)
 {
   return IsProtocol(strFile, "stack");
@@ -866,9 +914,19 @@ bool URIUtils::IsDiscImage(const std::string& file)
   return HasExtension(file, ".img|.iso|.nrg|.udf");
 }
 
+// Consider a disc image stack if ANY of the items is a disc image
+
 bool URIUtils::IsDiscImageStack(const std::string& file)
 {
-  return IsStack(file) && IsDiscImage(CStackDirectory::GetFirstStackedFile(file));
+  if (IsStack(file))
+  {
+    std::vector<std::string> paths;
+    CStackDirectory::GetPaths(file, paths);
+    for (const std::string& path : paths)
+      if (IsDiscImage(path) || IsDVDFile(path) || IsBDFile(path))
+        return true;
+  }
+  return false;
 }
 
 bool URIUtils::IsSpecial(const std::string& strFile)

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -87,6 +87,9 @@ public:
    */
   static std::string GetBasePath(const std::string& strPath);
 
+  static std::string GetBaseMoviePath(const std::string& path);
+  static std::string GetBlurayPath(const std::string& path);
+
   /* \brief Change the base path of a URL: fromPath/fromFile -> toPath/toFile
     Handles changes in path separator and filename URL encoding if necessary to derive toFile.
     \param fromPath the base path of the original URL
@@ -135,6 +138,9 @@ public:
   static bool IsDAV(const std::string& strFile);
   static bool IsDOSPath(const std::string &path);
   static bool IsDVD(const std::string& strFile);
+  static bool IsDVDFile(const std::string& file);
+  static bool IsBDFile(const std::string& file);
+  static bool IsBlurayPlaylist(const std::string& file);
   static bool IsFTP(const std::string& strFile);
   static bool IsHTTP(const std::string& strFile, bool bTranslate = false);
   static bool IsUDP(const std::string& strFile);
@@ -178,6 +184,7 @@ public:
   static bool IsArchive(const std::string& strFile);
   static bool IsDiscImage(const std::string& file);
   static bool IsDiscImageStack(const std::string& file);
+  static bool IsDiscStack(const std::string& file);
   static bool IsBluray(const std::string& strFile);
   static bool IsAndroidApp(const std::string& strFile);
   static bool IsLibraryFolder(const std::string& strFile);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1319,6 +1319,31 @@ int CVideoDatabase::GetMovieId(const std::string& strFilenameAndPath)
   return -1;
 }
 
+int CVideoDatabase::GetMovieId(const int fileId) const
+{
+  try
+  {
+    if (nullptr == m_pDB)
+      return -1;
+    if (nullptr == m_pDS)
+      return -1;
+    if (fileId == -1)
+      return -1;
+
+    const std::string strSQL = PrepareSQL("SELECT idMovie FROM movie WHERE idFile=%i", fileId);
+    m_pDS->query(strSQL);
+
+    if (m_pDS->num_rows() > 0)
+      return m_pDS->fv(0).get_asInt();
+    return -1;
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, fileId);
+  }
+  return -1;
+}
+
 int CVideoDatabase::GetTvShowId(const std::string& strPath)
 {
   try
@@ -1992,8 +2017,15 @@ bool CVideoDatabase::HasMovieInfo(const std::string& strFilenameAndPath)
       return false;
     if (nullptr == m_pDS)
       return false;
+
     int idMovie = GetMovieId(strFilenameAndPath);
-    return (idMovie > 0); // index of zero is also invalid
+    if (idMovie > 0) // index of zero is also invalid
+      return true;
+
+    // Check to see if filename has been updated with bluray:// or dvd://
+    const int idFile = GetFileId(strFilenameAndPath);
+    idMovie = GetMovieId(idFile);
+    return (idMovie > 0);
   }
   catch (...)
   {
@@ -3017,13 +3049,20 @@ int CVideoDatabase::SetDetailsForSeason(const CVideoInfoTag& details, const std:
   return -1;
 }
 
-bool CVideoDatabase::SetFileForEpisode(const std::string& fileAndPath, int idEpisode, int idFile)
+bool CVideoDatabase::SetFileForEpisode(const std::string& fileAndPath,
+                                       const int idEpisode,
+                                       const int oldIdFile)
 {
+  const int idFile = AddFile(fileAndPath);
+  if (idFile < 0)
+    return false;
+
   try
   {
-    std::string sql = PrepareSQL("UPDATE episode SET c18='%s', idFile=%i WHERE idEpisode=%i",
-                                 fileAndPath.c_str(), idFile, idEpisode);
+    std::string sql =
+        PrepareSQL("UPDATE episode SET idFile=%i WHERE idEpisode=%i", idFile, idEpisode);
     m_pDS->exec(sql);
+    DeleteFile(oldIdFile);
 
     return true;
   }
@@ -3034,26 +3073,77 @@ bool CVideoDatabase::SetFileForEpisode(const std::string& fileAndPath, int idEpi
   return false;
 }
 
-bool CVideoDatabase::SetFileForMovie(const std::string& fileAndPath, int idMovie, int idFile)
+bool CVideoDatabase::SetFileForMovie(const std::string& fileAndPath, const int oldIdFile)
 {
+  const int idFile = AddFile(fileAndPath);
+  if (idFile < 0)
+    return false;
+
   try
   {
     assert(m_pDB->in_transaction());
+    std::string sql = PrepareSQL("UPDATE movie SET idFile=%i WHERE idFile=%i", idFile, oldIdFile);
+    m_pDS->exec(sql);
 
-    std::string sql = PrepareSQL("UPDATE movie SET c22='%s', idFile=%i WHERE idMovie=%i",
-                                 fileAndPath.c_str(), idFile, idMovie);
+    sql = PrepareSQL("UPDATE videoversion SET idFile=%i WHERE idFile=%i AND media_type='movie'",
+                     idFile, oldIdFile);
     m_pDS->exec(sql);
-    sql = PrepareSQL("UPDATE videoversion SET idFile=%i WHERE idMedia=%i AND media_type='movie'",
-                     idFile, idMovie);
+
+    sql = PrepareSQL("UPDATE art SET media_id=%i WHERE media_id=%i AND media_type='videoversion'",
+                     idFile, oldIdFile);
     m_pDS->exec(sql);
+    DeleteFile(oldIdFile);
 
     return true;
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idMovie);
+    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idFile);
   }
   return false;
+}
+
+void CVideoDatabase::DeleteFile(int idFile)
+{
+  // First check not multiple references to file (eg. episodes)
+  std::string sql{PrepareSQL("SELECT idFile FROM movie WHERE idFile = %i UNION SELECT idFile FROM "
+                             "episode WHERE idFile = %i",
+                             idFile, idFile)};
+  m_pDS->query(sql);
+  if (m_pDS->eof())
+  {
+    // Get idPath
+    sql = PrepareSQL(
+        "SELECT path.idPath FROM path JOIN files ON path.idPath = files.idPath WHERE idFile = %i",
+        idFile);
+    m_pDS->query(sql);
+    int path{-1};
+    if (!m_pDS->eof())
+    {
+      path = m_pDS->fv("idPath").get_asInt();
+    }
+
+    // Remove file and any associated bookmarks and streamdetails
+    sql = PrepareSQL("DELETE FROM files WHERE idFile = %i", idFile);
+    m_pDS->exec(sql);
+    sql = PrepareSQL("DELETE FROM bookmark WHERE idFile = %i", idFile);
+    m_pDS->exec(sql);
+    DeleteStreamDetails(idFile);
+
+    // Delete path if orphan
+    if (path >= 0)
+    {
+      sql = PrepareSQL("SELECT idFile FROM files JOIN path ON files.idPath = path.idPath WHERE "
+                       "files.idPath = %i",
+                       path);
+      m_pDS->query(sql);
+      if (m_pDS->eof())
+      {
+        sql = PrepareSQL("DELETE FROM path WHERE idPath = %i", path);
+        m_pDS->exec(sql);
+      }
+    }
+  }
 }
 
 int CVideoDatabase::SetDetailsForEpisode(CVideoInfoTag& details,
@@ -3245,19 +3335,14 @@ int CVideoDatabase::SetDetailsForMusicVideo(CVideoInfoTag& details,
   return -1;
 }
 
-int CVideoDatabase::SetStreamDetailsForFile(const CStreamDetails& details,
-                                            const std::string& strFileNameAndPath)
+void CVideoDatabase::SetStreamDetailsForFile(const CStreamDetails& details,
+                                             const std::string& strFileNameAndPath)
 {
   // AddFile checks to make sure the file isn't already in the DB first
   int idFile = AddFile(strFileNameAndPath);
   if (idFile < 0)
-    return -1;
-
-  //! @todo ugly error return mechanism, fixme
-  if (SetStreamDetailsForFileId(details, idFile))
-    return idFile;
-  else
-    return -2;
+    return;
+  SetStreamDetailsForFileId(details, idFile);
 }
 
 bool CVideoDatabase::SetStreamDetailsForFileId(const CStreamDetails& details, int idFile)
@@ -3368,54 +3453,47 @@ void CVideoDatabase::GetBookMarksForFile(const std::string& strFilenameAndPath, 
 {
   try
   {
-    if (URIUtils::IsDiscImageStack(strFilenameAndPath))
-    {
-      CStackDirectory dir;
-      CFileItemList fileList;
-      const CURL pathToUrl(strFilenameAndPath);
-      dir.GetDirectory(pathToUrl, fileList);
-      if (!bAppend)
-        bookmarks.clear();
-      for (int i = fileList.Size() - 1; i >= 0; i--) // put the bookmarks of the highest part first in the list
-        GetBookMarksForFile(fileList[i]->GetPath(), bookmarks, type, true, (i+1));
-    }
-    else
-    {
-      int idFile = GetFileId(strFilenameAndPath);
-      if (idFile < 0) return ;
-      if (!bAppend)
-        bookmarks.erase(bookmarks.begin(), bookmarks.end());
-      if (nullptr == m_pDB)
-        return;
-      if (nullptr == m_pDS)
-        return;
+    int idFile = GetFileId(strFilenameAndPath);
+    if (idFile < 0)
+      return;
+    if (!bAppend)
+      bookmarks.erase(bookmarks.begin(), bookmarks.end());
+    if (nullptr == m_pDB)
+      return;
+    if (nullptr == m_pDS)
+      return;
 
-      std::string strSQL=PrepareSQL("select * from bookmark where idFile=%i and type=%i order by timeInSeconds", idFile, (int)type);
-      m_pDS->query( strSQL );
-      while (!m_pDS->eof())
+    std::string strSQL =
+        PrepareSQL("select * from bookmark where idFile=%i and type=%i order by timeInSeconds",
+                   idFile, (int)type);
+    m_pDS->query(strSQL);
+    while (!m_pDS->eof())
+    {
+      CBookmark bookmark;
+      bookmark.timeInSeconds = m_pDS->fv("timeInSeconds").get_asDouble();
+      bookmark.partNumber = partNumber;
+      bookmark.totalTimeInSeconds = m_pDS->fv("totalTimeInSeconds").get_asDouble();
+      bookmark.thumbNailImage = m_pDS->fv("thumbNailImage").get_asString();
+      bookmark.playerState = m_pDS->fv("playerState").get_asString();
+      bookmark.player = m_pDS->fv("player").get_asString();
+      bookmark.type = type;
+      if (type == CBookmark::EPISODE)
       {
-        CBookmark bookmark;
-        bookmark.timeInSeconds = m_pDS->fv("timeInSeconds").get_asDouble();
-        bookmark.partNumber = partNumber;
-        bookmark.totalTimeInSeconds = m_pDS->fv("totalTimeInSeconds").get_asDouble();
-        bookmark.thumbNailImage = m_pDS->fv("thumbNailImage").get_asString();
-        bookmark.playerState = m_pDS->fv("playerState").get_asString();
-        bookmark.player = m_pDS->fv("player").get_asString();
-        bookmark.type = type;
-        if (type == CBookmark::EPISODE)
-        {
-          std::string strSQL2=PrepareSQL("select c%02d, c%02d from episode where c%02d=%i order by c%02d, c%02d", VIDEODB_ID_EPISODE_EPISODE, VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_EPISODE_BOOKMARK, m_pDS->fv("idBookmark").get_asInt(), VIDEODB_ID_EPISODE_SORTSEASON, VIDEODB_ID_EPISODE_SORTEPISODE);
-          m_pDS2->query(strSQL2);
-          bookmark.episodeNumber = m_pDS2->fv(0).get_asInt();
-          bookmark.seasonNumber = m_pDS2->fv(1).get_asInt();
-          m_pDS2->close();
-        }
-        bookmarks.push_back(bookmark);
-        m_pDS->next();
+        std::string strSQL2 =
+            PrepareSQL("select c%02d, c%02d from episode where c%02d=%i order by c%02d, c%02d",
+                       VIDEODB_ID_EPISODE_EPISODE, VIDEODB_ID_EPISODE_SEASON,
+                       VIDEODB_ID_EPISODE_BOOKMARK, m_pDS->fv("idBookmark").get_asInt(),
+                       VIDEODB_ID_EPISODE_SORTSEASON, VIDEODB_ID_EPISODE_SORTEPISODE);
+        m_pDS2->query(strSQL2);
+        bookmark.episodeNumber = m_pDS2->fv(0).get_asInt();
+        bookmark.seasonNumber = m_pDS2->fv(1).get_asInt();
+        m_pDS2->close();
       }
-      //sort(bookmarks.begin(), bookmarks.end(), SortBookmarks);
-      m_pDS->close();
+      bookmarks.push_back(bookmark);
+      m_pDS->next();
     }
+    //sort(bookmarks.begin(), bookmarks.end(), SortBookmarks);
+    m_pDS->close();
   }
   catch (...)
   {
@@ -4024,7 +4102,7 @@ std::string CVideoDatabase::GetFileBasePathById(int idFile)
   return "";
 }
 
-int CVideoDatabase::GetFileIdByMovie(int idMovie)
+int CVideoDatabase::GetFileIdByMovie(int idMovie) const
 {
   if (!m_pDB || !m_pDS)
     return -1;
@@ -4045,6 +4123,32 @@ int CVideoDatabase::GetFileIdByMovie(int idMovie)
   catch (...)
   {
     CLog::Log(LOGERROR, "{} failed for movie {}", __FUNCTION__, idMovie);
+  }
+
+  return idFile;
+}
+
+int CVideoDatabase::GetFileIdByEpisode(int idEpisode) const
+{
+  if (!m_pDB || !m_pDS)
+    return -1;
+
+  int idFile = -1;
+
+  try
+  {
+    m_pDS->query(PrepareSQL("SELECT idFile FROM episode WHERE idEpisode = %i", idEpisode));
+
+    if (!m_pDS->eof())
+    {
+      idFile = m_pDS->fv("idFile").get_asInt();
+    }
+
+    m_pDS->close();
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "{} failed for episode {}", __FUNCTION__, idEpisode);
   }
 
   return idFile;
@@ -6712,7 +6816,9 @@ void CVideoDatabase::UpdateFanart(const CFileItem& item, VideoDbContentType type
 CDateTime CVideoDatabase::SetPlayCount(const CFileItem& item, int count, const CDateTime& date)
 {
   int id{-1};
-  if (IsBlurayPlaylist(item))
+  if (item.HasProperty("new_stack_path"))
+    id = AddFile(item.GetProperty("new_stack_path").asString());
+  else if (IsBlurayPlaylist(item))
     id = AddFile(item.GetDynPath());
   else if (item.HasProperty("original_listitem_url") &&
            URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
@@ -10118,6 +10224,10 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
         if (URIUtils::IsInArchive(fullPath))
           fullPath = CURL(fullPath).GetHostName();
 
+        // if bluray:// get actual path
+        if (URIUtils::IsProtocol(fullPath, "bluray"))
+          fullPath = URIUtils::GetBlurayPath(fullPath);
+
         bool del = true;
         if (URIUtils::IsPlugin(fullPath))
         {
@@ -11437,10 +11547,12 @@ bool CVideoDatabase::ImportArtFromXML(const TiXmlNode *node, std::map<std::strin
   return !artwork.empty();
 }
 
-void CVideoDatabase::ConstructPath(std::string& strDest, const std::string& strPath, const std::string& strFileName)
+void CVideoDatabase::ConstructPath(std::string& strDest,
+                                   const std::string& strPath,
+                                   const std::string& strFileName)
 {
-  if (URIUtils::IsStack(strFileName) ||
-      URIUtils::IsInArchive(strFileName) || URIUtils::IsPlugin(strPath))
+  if (URIUtils::IsStack(strFileName) || URIUtils::IsInArchive(strFileName) ||
+      URIUtils::IsPlugin(strPath) || URIUtils::IsProtocol(strFileName, "bluray"))
     strDest = strFileName;
   else
     strDest = URIUtils::AddFileToFolder(strPath, strFileName);
@@ -11452,6 +11564,19 @@ void CVideoDatabase::SplitPath(const std::string& strFileNameAndPath, std::strin
   {
     URIUtils::GetParentPath(strFileNameAndPath,strPath);
     strFileName = strFileNameAndPath;
+  }
+  else if (URIUtils::IsProtocol(strFileNameAndPath, "bluray"))
+  {
+    CURL url(strFileNameAndPath);
+    std::string root = url.GetHostName();
+    if (URIUtils::IsProtocol(root, "udf"))
+    {
+      CURL url(root);
+      root = url.GetHostName();
+    }
+    strFileName = strFileNameAndPath;
+    std::string temp;
+    URIUtils::Split(root, strPath, temp);
   }
   else if (URIUtils::IsPlugin(strFileNameAndPath))
   {

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3059,6 +3059,7 @@ bool CVideoDatabase::SetFileForEpisode(const std::string& fileAndPath,
 
   try
   {
+    assert(m_pDB->in_transaction());
     std::string sql =
         PrepareSQL("UPDATE episode SET idFile=%i WHERE idEpisode=%i", idFile, idEpisode);
     m_pDS->exec(sql);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -592,12 +592,13 @@ public:
                            const std::map<std::string, std::string>& artwork,
                            int idShow,
                            int idEpisode = -1);
-  bool SetFileForEpisode(const std::string& fileAndPath, int idEpisode, int idFile);
-  bool SetFileForMovie(const std::string& fileAndPath, int idMovie, int idFile);
+  bool SetFileForEpisode(const std::string& fileAndPath, const int idEpisode, const int oldIdFile);
+  bool SetFileForMovie(const std::string& fileAndPath, const int oldIdFile);
   int SetDetailsForMusicVideo(CVideoInfoTag& details,
                               const std::map<std::string, std::string>& artwork,
                               int idMVideo = -1);
-  int SetStreamDetailsForFile(const CStreamDetails& details, const std::string& strFileNameAndPath);
+  void SetStreamDetailsForFile(const CStreamDetails& details,
+                               const std::string& strFileNameAndPath);
   /*!
    * \brief Clear any existing stream details and add the new provided details to a file.
    * \param[in] details New stream details
@@ -637,6 +638,7 @@ public:
   void UpdateFanart(const CFileItem& item, VideoDbContentType type);
   void DeleteSet(int idSet);
   void DeleteTag(int idTag, VideoDbContentType mediaType);
+  void DeleteFile(int idFile);
 
   /*! \brief Get video settings for the specified file id
    \param idFile file id to get the settings for
@@ -1143,9 +1145,11 @@ public:
   bool UpdateAssetsOwner(const std::string& mediaType, int dbIdSource, int dbIdTarget);
 
   int GetMovieId(const std::string& strFilenameAndPath);
+  int GetMovieId(const int fileId) const;
   std::string GetMovieTitle(int idMovie);
   void GetSameVideoItems(const CFileItem& item, CFileItemList& items);
-  int GetFileIdByMovie(int idMovie);
+  int GetFileIdByMovie(int idMovie) const;
+  int GetFileIdByEpisode(int idEpisode) const;
   std::string GetFileBasePathById(int idFile);
 
   /*!

--- a/xbmc/video/VideoFileItemClassify.cpp
+++ b/xbmc/video/VideoFileItemClassify.cpp
@@ -66,6 +66,19 @@ bool IsDVDFile(const CFileItem& item, bool bVobs /*= true*/, bool bIfos /*= true
   return false;
 }
 
+bool IsDVDImageFile(const CFileItem& item)
+{
+  if (URIUtils::IsDiscImage(item.GetDynPath()))
+  {
+    CURL url;
+    url.SetProtocol("udf");
+    url.SetHostName(item.GetPath());
+    url.SetFileName("VIDEO_TS/VIDEO_TS.IFO");
+    return CFileUtils::Exists(url.Get());
+  }
+  return false;
+}
+
 bool IsProtectedBlurayDisc(const CFileItem& item)
 {
   const std::string path = URIUtils::AddFileToFolder(item.GetPath(), "AACS", "Unit_Key_RO.inf");

--- a/xbmc/video/VideoFileItemClassify.h
+++ b/xbmc/video/VideoFileItemClassify.h
@@ -22,6 +22,9 @@ bool IsDiscStub(const CFileItem& item);
 //! \brief Check whether an item is a DVD file.
 bool IsDVDFile(const CFileItem& item, bool bVobs = true, bool bIfos = true);
 
+//! \brief Check whether an item is a DVD image file.
+bool IsDVDImageFile(const CFileItem& item);
+
 //! \brief Checks whether item points to a protected blu-ray disc.
 bool IsProtectedBlurayDisc(const CFileItem& item);
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1486,7 +1486,8 @@ namespace KODI::VIDEO
 
     CVideoInfoTag &movieDetails = *pItem->GetVideoInfoTag();
     if (movieDetails.m_basePath.empty())
-      movieDetails.m_basePath = pItem->GetBaseMoviePath(videoFolder);
+      movieDetails.m_basePath =
+          pItem->GetBaseMoviePath(videoFolder || URIUtils::IsStack(pItem->GetDynPath()));
     movieDetails.m_parentPathID = m_database.AddPath(URIUtils::GetParentPath(movieDetails.m_basePath));
 
     movieDetails.m_strFileNameAndPath = pItem->GetPath();


### PR DESCRIPTION
## Description

Reopened as discussed in #25433.

Folder stacks are useful for those who have ISOs or DVD/Bluray folders.
They are currently broken.

There were several issues:
- the code to generate folder stacks (`stack://`) was incomplete.
- folder stacks were then not recognised at various points in the play pathway (initially, transitioning from one item to another etc..)
- playing a stack from the main menu (not movie menu) was also broken (fixed in #24820)
- correct length of combined folder stack and streamdetails not saved correctly and not shown in bottom right
- routine to determine potential NFO/art path was broken

Also fixes:
- if you stop a DVD/Bluray on a menu after watching the film the menu length and not the film length is recoded (and shown in bottom right).
- one of the regexs for file stacks was to relaxed (see discussion in comments of #24794)

There a few differences now between file and folder stacks.
- For DVDs - each item is played in isolation, sequentially - you cannot move back and forth like you can with a file stack.
- For Blurays, now #24720 is in, bluray stacks will be built dynamically the first time they are played - and you will be able to move backwards. Once every item is played (and converted to bluray://) then a stack will behave exactly like a file stack.

## Motivation and context

Fixes #16109.

## How has this been tested?

Only locally currently.
With DVD/ISO/Bluray folders.
Also checked file stacks and individual DVD/Bluray/ISOs still play.

## What is the effect on users?

As above.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed