### PR TITLE
Improve default TLS config to TLS 1.2 + PFS ciphers, per current RFC's

### DIFF
--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -1192,7 +1192,7 @@ bool CWebServer::LoadCert(std::string& skey, std::string& scert)
 struct MHD_Daemon* CWebServer::StartMHD(unsigned int flags, int port)
 {
   unsigned int timeout = 60 * 60 * 24;
-  const char* ciphers = "NORMAL:-VERS-TLS1.0:-VERS-TLS1.1";
+  const char* ciphers = "PFS:-VERS-TLS1.0:-VERS-TLS1.1";
 
   MHD_set_panic_func(&panicHandlerForMHD, nullptr);
 

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -1192,7 +1192,7 @@ bool CWebServer::LoadCert(std::string& skey, std::string& scert)
 struct MHD_Daemon* CWebServer::StartMHD(unsigned int flags, int port)
 {
   unsigned int timeout = 60 * 60 * 24;
-  const char* ciphers = "NORMAL:-VERS-TLS1.0";
+  const char* ciphers = "NORMAL:-VERS-TLS1.0:-VERS-TLS1.1";
 
   MHD_set_panic_func(&panicHandlerForMHD, nullptr);
 


### PR DESCRIPTION
## Description
Improve default TLS config to TLS 1.2+ and PFS ciphers, per current RFC's:

- TLS 1.1 has been formally deprecated in [RFC 8996](https://www.rfc-editor.org/rfc/rfc8996.html)
- non-PFS ciphers are strongly discouraged by BCP RFC's [7525](https://www.rfc-editor.org/rfc/rfc7525) and [9325](https://www.rfc-editor.org/rfc/rfc9325), 
and will be formally deprecated as well by [draft-ietf-tls-deprecate-obsolete-kex](https://datatracker.ietf.org/doc/html/draft-ietf-tls-deprecate-obsolete-kex-04)

as proposed and discussed in https://github.com/xbmc/xbmc/issues/19735.

## Motivation and context
This updates the default Kodi TLS profile to conform to current RFC's, and should not cause incompatibility with existing clients, as the minimum was already TLS 1.1 (no real-world clients have TLS 1.1 as highest supported protocol).
See eg. https://www.ssllabs.com/ssltest/clients.html

I added PFS in a separate commit so you can cherry-pick if wanted.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Making the gnutls default profile configurable as advanced config was considered, but may be overkill.
Advanced users can still customize their configuration via gnutls priority file, see #19735.

## How has this been tested?
I'm running Kodi for a long time with such config via `GNUTLS_SYSTEM_PRIORITY_FILE`, as described in #19735.
This is compatible with old Android clients down to 4.4.2 (as the old default config was).

## What is the effect on users?
See above, no impact expected as we already required TLS 1.1
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
