### PR TITLE
[Windows] Modernize code to obtain system AppData folder

### DIFF
--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -349,27 +349,6 @@ size_t CWIN32Util::GetSystemMemorySize()
 #endif
 }
 
-#ifdef TARGET_WINDOWS_DESKTOP
-std::string CWIN32Util::GetSpecialFolder(int csidl)
-{
-  std::string strProfilePath;
-  static const int bufSize = MAX_PATH;
-  WCHAR* buf = new WCHAR[bufSize];
-
-  if(SUCCEEDED(SHGetFolderPathW(NULL, csidl, NULL, SHGFP_TYPE_CURRENT, buf)))
-  {
-    buf[bufSize-1] = 0;
-    g_charsetConverter.wToUTF8(buf, strProfilePath);
-    strProfilePath = UncToSmb(strProfilePath);
-  }
-  else
-    strProfilePath = "";
-
-  delete[] buf;
-  return strProfilePath;
-}
-#endif
-
 std::string CWIN32Util::GetProfilePath(const bool platformDirectories)
 {
   std::string strProfilePath;
@@ -380,7 +359,7 @@ std::string CWIN32Util::GetProfilePath(const bool platformDirectories)
   std::string strHomePath = CUtil::GetHomePath();
 
   if (platformDirectories)
-    strProfilePath = URIUtils::AddFileToFolder(GetSpecialFolder(CSIDL_APPDATA|CSIDL_FLAG_CREATE), CCompileInfo::GetAppName());
+    strProfilePath = URIUtils::AddFileToFolder(GetAppDataFolder(), CCompileInfo::GetAppName());
   else
     strProfilePath = URIUtils::AddFileToFolder(strHomePath , "portable_data");
 
@@ -391,6 +370,39 @@ std::string CWIN32Util::GetProfilePath(const bool platformDirectories)
 #endif
   return strProfilePath;
 }
+
+#ifdef TARGET_WINDOWS_DESKTOP
+std::string CWIN32Util::GetAppDataFolder()
+{
+  std::string profilePath;
+  WCHAR* path = nullptr;
+
+  // First get the roaming appdata location.
+  // All current users use this folder, must not break their setup.
+  if (SUCCEEDED(SHGetKnownFolderPath(FOLDERID_RoamingAppData, KF_FLAG_CREATE, NULL, &path)))
+  {
+    g_charsetConverter.wToUTF8(path, profilePath);
+    // We do not support appdata on a UNC path.
+    if (profilePath.starts_with("\\\\"))
+      profilePath.clear();
+  }
+
+  // Must always free, even if failed. This handles NULL, no need to check.
+  CoTaskMemFree(path);
+  path = nullptr;
+
+  // If we still do not have the data folder, get the local appdata path.
+  // This will only happen for new users with redirected roaming appdata.
+  if (profilePath.empty())
+  {
+    if (SUCCEEDED(SHGetKnownFolderPath(FOLDERID_LocalAppData, KF_FLAG_CREATE, NULL, &path)))
+      g_charsetConverter.wToUTF8(path, profilePath);
+    CoTaskMemFree(path);
+  }
+
+  return profilePath;
+}
+#endif
 
 std::string CWIN32Util::UncToSmb(const std::string &strPath)
 {

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -370,16 +370,6 @@ std::string CWIN32Util::GetSpecialFolder(int csidl)
 }
 #endif
 
-std::string CWIN32Util::GetSystemPath()
-{
-#ifdef TARGET_WINDOWS_STORE
-  // access to system folder is not allowed in a UWP app
-  return "";
-#else
-  return GetSpecialFolder(CSIDL_SYSTEM);
-#endif
-}
-
 std::string CWIN32Util::GetProfilePath(const bool platformDirectories)
 {
   std::string strProfilePath;

--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -67,7 +67,7 @@ public:
   static BOOL IsCurrentUserLocalAdministrator();
 
 #ifdef TARGET_WINDOWS_DESKTOP
-  static std::string GetSpecialFolder(int csidl);
+  static std::string GetAppDataFolder();
   static LONG UtilRegGetValue( const HKEY hKey, const char *const pcKey, DWORD *const pdwType, char **const ppcBuffer, DWORD *const pdwSizeBuff, const DWORD dwSizeAdd );
   static bool UtilRegOpenKeyEx( const HKEY hKeyParent, const char *const pcKey, const REGSAM rsAccessRights, HKEY *hKey, const bool bReadX64= false );
   static bool GetFocussedProcess(std::string &strProcessFile);

--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -46,7 +46,6 @@ public:
   static int GetDesktopColorDepth();
   static size_t GetSystemMemorySize();
 
-  static std::string GetSystemPath();
   static std::string GetProfilePath(const bool platformDirectories);
   static std::string UncToSmb(const std::string &strPath);
   static std::string SmbToUnc(const std::string &strPath);


### PR DESCRIPTION
## Description
- Remove `CWIN32Util::GetSystemPath()` as is dead code.
- Windows API call `SHGetFolderPathW` is deprecated, updated to `SHGetKnownFolderPath`.
- Allows use LocalAppData when RoamingAppData is in UNC path.
- Fixes https://github.com/xbmc/xbmc/issues/25483

## Motivation and context
When RoamingAppData folder is in UNC location causes a lot of issues: see  https://github.com/xbmc/xbmc/issues/25483 

Even if all issues were patched, use a network folder as Kodi data folder is not suitable for performance reasons. e.g. in some cases this folder is used by FileCache and is expected to be fast storage with low latency, etc.

In a new designed application (and Windows only) probably the best approach is use RoamingAppData for small data that needs persistence (guisettings, advancedsettings, etc.) and use LocalAppData for more big data but that can be recreated (cache, temp files, thumbnails, etc.).

This is not the case here because RoamingAppData is already being used and should remain that way. The only improvement is that now LocalAppData also can be used when RoamingAppData is not available or is on a UNC path. That's only expected to happen when installing Kodi for the first time on a system configured this way.

## How has this been tested?
Windows x64

## What is the effect on users?
Kodi not crash when system RoamingAppData in on a UNC path.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
