### PR TITLE
Optional better UI scaling

### DIFF
--- a/xbmc/guilib/GUIShaderDX.cpp
+++ b/xbmc/guilib/GUIShaderDX.cpp
@@ -10,6 +10,8 @@
 #include "windowing/GraphicContext.h"
 #include "rendering/dx/DeviceResources.h"
 #include "rendering/dx/RenderContext.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/log.h"
 
 // shaders bytecode includes
@@ -155,8 +157,9 @@ bool CGUIShaderDX::CreateSamplers()
   sampDesc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
   sampDesc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
   sampDesc.ComparisonFunc = D3D11_COMPARISON_NEVER;
-  sampDesc.MinLOD = 0;
+  sampDesc.MinLOD = -D3D11_FLOAT32_MAX;
   sampDesc.MaxLOD = D3D11_FLOAT32_MAX;
+  sampDesc.MipLODBias = -CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiMipMappingSharpen;
 
   if (FAILED(DX::DeviceResources::Get()->GetD3DDevice()->CreateSamplerState(&sampDesc, m_pSampLinear.ReleaseAndGetAddressOf())))
     return false;

--- a/xbmc/guilib/TextureDX.cpp
+++ b/xbmc/guilib/TextureDX.cpp
@@ -8,6 +8,9 @@
 
 #include "TextureDX.h"
 
+#include "ServiceBroker.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/MemUtils.h"
 #include "utils/log.h"
 
@@ -87,12 +90,12 @@ void CDXTexture::LoadToGPU()
     if (m_format != XB_FMT_RGB8)
     {
       // this is faster way to create texture with initial data instead of create empty and then copy to it
-      m_texture.Create(m_textureWidth, m_textureHeight, IsMipmapped() ? 0 : 1, usage, GetFormat(), m_pixels, GetPitch());
+      m_texture.Create(m_textureWidth, m_textureHeight, IsMipmapped() || CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiMipMapping ? 0 : 1, usage, GetFormat(), m_pixels, GetPitch());
       if (m_texture.Get() != nullptr)
         needUpdate = false;
     }
     else
-      m_texture.Create(m_textureWidth, m_textureHeight, IsMipmapped() ? 0 : 1, usage, GetFormat());
+      m_texture.Create(m_textureWidth, m_textureHeight, IsMipmapped() || CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiMipMapping ? 0 : 1, usage, GetFormat());
 
     if (m_texture.Get() == nullptr)
     {
@@ -114,7 +117,7 @@ void CDXTexture::LoadToGPU()
       m_texture.Release();
       usage = D3D11_USAGE_DYNAMIC;
 
-      m_texture.Create(m_textureWidth, m_textureHeight, IsMipmapped() ? 0 : 1, usage, GetFormat(), m_pixels, GetPitch());
+      m_texture.Create(m_textureWidth, m_textureHeight, IsMipmapped() || CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiMipMapping ? 0 : 1, usage, GetFormat(), m_pixels, GetPitch());
       if (m_texture.Get() == nullptr)
       {
         CLog::Log(LOGDEBUG, "CDXTexture::CDXTexture: Error creating new texture for size {} x {}.",
@@ -175,7 +178,7 @@ void CDXTexture::LoadToGPU()
       CLog::LogF(LOGERROR, "failed to lock texture.");
     }
     m_texture.UnlockRect(0);
-    if (usage != D3D11_USAGE_STAGING && IsMipmapped())
+    if (usage != D3D11_USAGE_STAGING && (IsMipmapped() || CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiMipMapping))
       m_texture.GenerateMipmaps();
   }
 

--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -71,13 +71,13 @@ void CGLTexture::LoadToGPU()
   GLenum filter = (m_scalingMethod == TEXTURE_SCALING::NEAREST ? GL_NEAREST : GL_LINEAR);
 
   // Set the texture's stretching properties
-  if (IsMipmapped())
+  if (IsMipmapped() || CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiMipMapping)
   {
     GLenum mipmapFilter = (m_scalingMethod == TEXTURE_SCALING::NEAREST ? GL_LINEAR_MIPMAP_NEAREST : GL_LINEAR_MIPMAP_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipmapFilter);
 
     // Lower LOD bias equals more sharpness, but less smooth animation
-    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_LOD_BIAS, -0.5f);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_LOD_BIAS, -CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiMipMappingSharpen);
     if (!m_isOglVersion3orNewer)
       glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE);
   }
@@ -156,7 +156,7 @@ void CGLTexture::LoadToGPU()
                            GetPitch() * GetRows(), m_pixels);
   }
 
-  if (IsMipmapped() && m_isOglVersion3orNewer)
+  if ((IsMipmapped() || CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiMipMapping) && m_isOglVersion3orNewer)
   {
     glGenerateMipmap(GL_TEXTURE_2D);
   }

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -415,6 +415,8 @@ void CAdvancedSettings::Initialize()
   m_guiVisualizeDirtyRegions = false;
   m_guiAlgorithmDirtyRegions = 3;
   m_guiSmartRedraw = false;
+  m_guiMipMapping = false;
+  m_guiMipMappingSharpen = 0.65f;
   m_airTunesPort = 36666;
   m_airPlayPort = 36667;
 
@@ -1228,6 +1230,8 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetBoolean(pElement, "geometryclear", m_guiGeometryClear);
     XMLUtils::GetBoolean(pElement, "asynctextureupload", m_guiAsyncTextureUpload);
     XMLUtils::GetBoolean(pElement, "transparentvideolayout", m_guiVideoLayoutTransparent);
+    XMLUtils::GetBoolean(pElement, "mipmapping", m_guiMipMapping);
+    XMLUtils::GetFloat(pElement, "mipmappingsharpen", m_guiMipMappingSharpen, 0.0f, 3.0f);
   }
 
   std::string seekSteps;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -338,6 +338,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_guiGeometryClear{true};
     bool m_guiAsyncTextureUpload{false};
     bool m_guiVideoLayoutTransparent{false};
+    bool m_guiMipMapping;
+    float m_guiMipMappingSharpen;
 
     unsigned int m_addonPackageFolderSize;
 


### PR DESCRIPTION
Ref.: https://github.com/xbmc/xbmc/pull/18780


Hi fellow Kodi supporters, 

i hope you are all well. After another 4 years flying by and still repeatedly being asked by different ppl and project contributors that i please should try again to get the UI scaling improvements updated and merged, this PR is now a follow-up on https://github.com/xbmc/xbmc/pull/18780

Seeing the recently introduced new gui-advancedsettings.xml entries, i simplified and updated the implementation for latest git master, minimized the number of settings after further evaluation and moved them to the gui-section. 

While i fully understand the teased theoretical reservations about memory and performance of mipmaps in general, i can say that i already extensively tested this implementation since 8 years ago on as low as one of my very old, outdated low powered 2-core Intel NUC with merely 2GB of RAM with great results while using edge-case test-libraries with 2500+ entries of lanczos-scaled, full quality imageres-1080 posters/artwork - even in the initial phase when starting with an empty userdata/Thumbnails folder - and all this while using wall views with high amounts of items displayed at once. 


To lower any hurdles, i left the implementation _fully_ _optional_ by default. 


Bottom line key facts:

- It's only a few lines of code in very few files without any complex changes to the source

- It's extremely easily reversible _if_ one day someone writes a completely different and new implementation
(which even seems unlikely for now considering that 16(!) years have gone by since discussions about ui scaling started)

- Potential risks: Near zero to none

- Proven benefit for a cleanly scaled UI: Huge

&nbsp;
Cheers