### PR TITLE
[Android][Network] Use CJNIContext and remove friend class

### DIFF
--- a/xbmc/platform/android/network/NetworkAndroid.cpp
+++ b/xbmc/platform/android/network/NetworkAndroid.cpp
@@ -6,17 +6,15 @@
  *  See LICENSES/README.md for more information.
  */
 
-
 #include "NetworkAndroid.h"
 
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
-#include "platform/android/activity/XBMCApp.h"
-
 #include <mutex>
 
 #include <androidjni/ConnectivityManager.h>
+#include <androidjni/Context.h>
 #include <androidjni/InetAddress.h>
 #include <androidjni/LinkAddress.h>
 #include <androidjni/NetworkInfo.h>
@@ -50,7 +48,7 @@ std::vector<std::string> CNetworkInterfaceAndroid::GetNameServers()
 
 bool CNetworkInterfaceAndroid::IsEnabled() const
 {
-  CJNIConnectivityManager connman(CXBMCApp::getSystemService(CJNIContext::CONNECTIVITY_SERVICE));
+  CJNIConnectivityManager connman(CJNIContext::getSystemService(CJNIContext::CONNECTIVITY_SERVICE));
   CJNINetworkInfo ni = connman.getNetworkInfo(m_network);
   if (!ni)
     return false;
@@ -60,7 +58,7 @@ bool CNetworkInterfaceAndroid::IsEnabled() const
 
 bool CNetworkInterfaceAndroid::IsConnected() const
 {
-  CJNIConnectivityManager connman(CXBMCApp::getSystemService(CJNIContext::CONNECTIVITY_SERVICE));
+  CJNIConnectivityManager connman(CJNIContext::getSystemService(CJNIContext::CONNECTIVITY_SERVICE));
   CJNINetworkInfo ni = connman.getNetworkInfo(m_network);
   if (!ni)
     return false;
@@ -237,7 +235,7 @@ CNetworkAndroid::CNetworkAndroid() : CNetworkBase(), CJNIXBMCConnectivityManager
 {
   RetrieveInterfaces();
 
-  CJNIConnectivityManager connman{CXBMCApp::getSystemService(CJNIContext::CONNECTIVITY_SERVICE)};
+  CJNIConnectivityManager connman{CJNIContext::getSystemService(CJNIContext::CONNECTIVITY_SERVICE)};
   connman.registerDefaultNetworkCallback(this->get_raw());
 }
 
@@ -248,7 +246,7 @@ CNetworkAndroid::~CNetworkAndroid()
   for (auto intf : m_oldInterfaces)
     delete intf;
 
-  CJNIConnectivityManager connman{CXBMCApp::getSystemService(CJNIContext::CONNECTIVITY_SERVICE)};
+  CJNIConnectivityManager connman{CJNIContext::getSystemService(CJNIContext::CONNECTIVITY_SERVICE)};
   connman.unregisterNetworkCallback(this->get_raw());
 }
 
@@ -331,7 +329,7 @@ void CNetworkAndroid::RetrieveInterfaces()
   m_oldInterfaces = m_interfaces;
   m_interfaces.clear();
 
-  CJNIConnectivityManager connman(CXBMCApp::getSystemService(CJNIContext::CONNECTIVITY_SERVICE));
+  CJNIConnectivityManager connman(CJNIContext::getSystemService(CJNIContext::CONNECTIVITY_SERVICE));
   std::vector<CJNINetwork> networks = connman.getAllNetworks();
 
   for (const auto& n : networks)
@@ -364,7 +362,7 @@ void CNetworkAndroid::onAvailable(const CJNINetwork n)
 {
   CLog::Log(LOGDEBUG, "CNetworkAndroid::onAvailable The default network is now: {}", n.toString());
 
-  CJNIConnectivityManager connman{CXBMCApp::getSystemService(CJNIContext::CONNECTIVITY_SERVICE)};
+  CJNIConnectivityManager connman{CJNIContext::getSystemService(CJNIContext::CONNECTIVITY_SERVICE)};
   CJNILinkProperties lp = connman.getLinkProperties(n);
 
   if (lp)

--- a/xbmc/platform/android/network/NetworkAndroid.h
+++ b/xbmc/platform/android/network/NetworkAndroid.h
@@ -47,7 +47,6 @@ protected:
 
 class CNetworkAndroid : public CNetworkBase, public jni::CJNIXBMCConnectivityManagerNetworkCallback
 {
-  friend class CXBMCApp;
 
 public:
   CNetworkAndroid();


### PR DESCRIPTION
## Description
Use `CJNIContext` class to call [getSystemService()](https://developer.android.com/reference/android/content/Context#getSystemService(java.lang.String)) function instead of doing via `CXBMCApp` class.

Remove unnecessary declaration of `CXBMCApp` as a friend class in `CNetworkAndroid` class.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
