### PR TITLE
[PVR][Estuary] PVR list sublabel change

### DIFF
--- a/addons/skin.estuary/xml/DialogPVRChannelsOSD.xml
+++ b/addons/skin.estuary/xml/DialogPVRChannelsOSD.xml
@@ -26,6 +26,8 @@
 					<include content="PVRListItemLayouts">
 						<param name="list_id" value="11" />
 						<param name="label1" value="$INFO[ListItem.Label]" />
+						<param name="label3" value="$VAR[PVRListItemSubLabel]" />
+						<param name="label3_focused" value="$VAR[PVRListItemSubLabelFocused]" />
 						<param name="has_status_icon" value="true" />
 						<param name="info_update" value="5000" />
 					</include>

--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -120,7 +120,7 @@
 					<param name="label0" value="[COLOR grey]$INFO[ListItem.ChannelNumberLabel][/COLOR]" />
 					<param name="label1" value="$PARAM[label1]" />
 					<param name="label2" value="$PARAM[label2]" />
-					<param name="label3" value="$VAR[PVRListItemSubLabel]" />
+					<param name="label3" value="$PARAM[label3]" />
 					<param name="label4" value="[COLOR grey]$INFO[ListItem.Comment][/COLOR]" />
 				</include>
 			</itemlayout>
@@ -150,7 +150,7 @@
 					<param name="label0" value="$INFO[ListItem.ChannelNumberLabel]" />
 					<param name="label1" value="$PARAM[label1]" />
 					<param name="label2" value="$PARAM[label2]" />
-					<param name="label3" value="$VAR[PVRListItemSubLabelFocused]" />
+					<param name="label3" value="$PARAM[label3_focused]" />
 					<param name="label4" value="$INFO[ListItem.Comment]" />
 				</include>
 			</focusedlayout>

--- a/addons/skin.estuary/xml/MyPVRChannels.xml
+++ b/addons/skin.estuary/xml/MyPVRChannels.xml
@@ -27,6 +27,8 @@
 					<include content="PVRListItemLayouts">
 						<param name="list_id" value="50" />
 						<param name="label1" value="$INFO[ListItem.Label]" />
+						<param name="label3" value="$VAR[PVRListItemSubLabel]" />
+						<param name="label3_focused" value="$VAR[PVRListItemSubLabelFocused]" />
 						<param name="has_status_icon" value="true" />
 						<param name="info_update" value="5000" />
 					</include>

--- a/addons/skin.estuary/xml/MyPVRRecordings.xml
+++ b/addons/skin.estuary/xml/MyPVRRecordings.xml
@@ -29,6 +29,8 @@
 						<param name="has_info_icon" value="true" />
 						<param name="label1" value="$INFO[ListItem.Label]" />
 						<param name="label2" value="$VAR[ListLabel2Var]" />
+						<param name="label3" value="$VAR[PVRListItemSubLabel]" />
+						<param name="label3_focused" value="$VAR[PVRListItemSubLabelFocused]" />
 					</include>
 				</control>
 			</control>

--- a/addons/skin.estuary/xml/MyPVRSearch.xml
+++ b/addons/skin.estuary/xml/MyPVRSearch.xml
@@ -30,6 +30,8 @@
 						<param name="only_label_condition" value="String.IsEmpty(ListItem.Date)" />
 						<param name="label1" value="$VAR[PVRMySearchLabel1Var]" />
 						<param name="label2" value="$INFO[ListItem.Date]" />
+						<param name="label3" value="$VAR[PVRListItemSubLabel]" />
+						<param name="label3_focused" value="$VAR[PVRListItemSubLabelFocused]" />
 					</include>
 				</control>
 			</control>

--- a/addons/skin.estuary/xml/MyPVRTimers.xml
+++ b/addons/skin.estuary/xml/MyPVRTimers.xml
@@ -29,6 +29,8 @@
 						<param name="has_info_icon" value="true" />
 						<param name="label1" value="$INFO[ListItem.Label]" />
 						<param name="label2" value="$INFO[ListItem.Date]" />
+						<param name="label3" value="$VAR[PVRTimerListItemSubLabel]" />
+						<param name="label3_focused" value="$VAR[PVRTimerListItemSubLabelFocused]" />
 					</include>
 				</control>
 			</control>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -657,16 +657,26 @@
 		<value condition="!String.IsEmpty(ListItem.NextTitle)">[COLOR grey]$LOCALIZE[19031]:[/COLOR] $INFO[ListItem.NextTitle]</value>
 	</variable>
 	<variable name="PVRListItemSubLabel">
-		<value condition="ListItem.IsFolder">[COLOR grey]$INFO[ListItem.Timertype][/COLOR]</value>
 		<value condition="$EXP[listitem_has_episode_info] + !String.IsEmpty(ListItem.EpgEventTitle) + !String.StartsWith(ListItem.EpisodeName,ListItem.EpgEventTitle)">$INFO[ListItem.EpgEventTitle] | [COLOR grey]$VAR[SeasonEpisodeLabel]$INFO[ListItem.EpisodeName][/COLOR]</value>
 		<value condition="$EXP[listitem_has_episode_info]">[COLOR grey]$VAR[SeasonEpisodeLabel]$INFO[ListItem.EpisodeName][/COLOR]</value>
 		<value>$INFO[ListItem.EpgEventTitle]</value>
 	</variable>
 	<variable name="PVRListItemSubLabelFocused">
-		<value condition="ListItem.IsFolder">$INFO[ListItem.Timertype]</value>
-		<value condition="$EXP[listitem_has_episode_info] + !String.IsEmpty(ListItem.EpgEventTitle) + !String.StartsWith(ListItem.EpisodeName,ListItem.EpgEventTitle)">$INFO[ListItem.EpgEventTitle] | [COLOR grey]$VAR[SeasonEpisodeLabel]$INFO[ListItem.EpisodeName][/COLOR]</value>
+		<value condition="$EXP[listitem_has_episode_info] + !String.IsEmpty(ListItem.EpgEventTitle) + !String.StartsWith(ListItem.EpisodeName,ListItem.EpgEventTitle)">$INFO[ListItem.EpgEventTitle] | $VAR[SeasonEpisodeLabel]$INFO[ListItem.EpisodeName]</value>
 		<value condition="$EXP[listitem_has_episode_info]">$VAR[SeasonEpisodeLabel]$INFO[ListItem.EpisodeName]</value>
 		<value>$INFO[ListItem.EpgEventTitle]</value>
+	</variable>
+	<variable name="PVRTimerListItemSubLabel">
+		<value condition="ListItem.IsFolder">[COLOR grey]$INFO[ListItem.Timertype][/COLOR]</value>
+		<value condition="$EXP[listitem_has_episode_info] + !String.IsEmpty(ListItem.EpgEventTitle) + !String.StartsWith(ListItem.EpisodeName,ListItem.EpgEventTitle) + !String.IsEqual(ListItem.EpgEventTitle,ListItem.Label)">$INFO[ListItem.EpgEventTitle] | [COLOR grey]$VAR[SeasonEpisodeLabel]$INFO[ListItem.EpisodeName][/COLOR]</value>
+		<value condition="$EXP[listitem_has_episode_info]">[COLOR grey]$VAR[SeasonEpisodeLabel]$INFO[ListItem.EpisodeName][/COLOR]</value>
+		<value condition="!String.IsEqual(ListItem.EpgEventTitle,ListItem.Label)">$INFO[ListItem.EpgEventTitle]</value>
+	</variable>
+	<variable name="PVRTimerListItemSubLabelFocused">
+		<value condition="ListItem.IsFolder">$INFO[ListItem.Timertype]</value>
+		<value condition="$EXP[listitem_has_episode_info] + !String.IsEmpty(ListItem.EpgEventTitle) + !String.StartsWith(ListItem.EpisodeName,ListItem.EpgEventTitle) + !String.IsEqual(ListItem.EpgEventTitle,ListItem.Label)">$INFO[ListItem.EpgEventTitle] | $VAR[SeasonEpisodeLabel]$INFO[ListItem.EpisodeName]</value>
+		<value condition="$EXP[listitem_has_episode_info]">$VAR[SeasonEpisodeLabel]$INFO[ListItem.EpisodeName]</value>
+		<value condition="!String.IsEqual(ListItem.EpgEventTitle,ListItem.Label)">$INFO[ListItem.EpgEventTitle]</value>
 	</variable>
 	<variable name="PVRInfoPanelDateDurationLabel">
 		<value condition="!String.IsEmpty(ListItem.StartDate) + !String.IsEmpty(ListItem.StartTime)">$INFO[ListItem.StartDate,[COLOR grey]$LOCALIZE[552]:[/COLOR] ,[CR]]$INFO[ListItem.StartTime,[COLOR grey]$LOCALIZE[555]:[/COLOR] ,[CR]]$INFO[ListItem.Duration,[COLOR grey]$LOCALIZE[180]:[/COLOR] ]</value>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
Fix missing episode title in PVR search results.  Revert the change for all lists and introduces timer-based list processing

<!--- Describe your change in detail here. -->
PR 25447 https://github.com/xbmc/xbmc/pull/25447 introduced a bug incorrectly assuming generic PVR lists all used a standard Label  This PR addresses the issue by decoupling the sub label from the label allowing custom sub labels based on the list type.  The primary label is already not fixed so there should be no requirement that the sub label is fixed.

By creating a timer specific format, a timer condition could be removed from the generic processing.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Rather than reverting PR 25447 and living with the issue that it was designed to fix I felt a more generic solution would help fix the original problem and allow more flexibility in PVR list handling in the future

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Because each list owner needed to be modified it was easier to see how lists are impacted by changes to generic lists.  All lists were viewed 

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Fixes the problem introduced in PR 25447 as well as the problem it was designed to fix.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
