### PR TITLE
[buildsteps] android update to jenkins docker info

### DIFF
--- a/tools/buildsteps/android-arm64-v8a/configure-depends
+++ b/tools/buildsteps/android-arm64-v8a/configure-depends
@@ -3,7 +3,7 @@ XBMC_PLATFORM_DIR=android
 . $WORKSPACE/tools/buildsteps/defaultenv
 
 #the following path must exist on the slave and use the defined scheme here!
-NDK_PATH=$ANDROID_DEV_ROOT/android-ndk-r$NDK_VERSION
+NDK_PATH=$SDK_PATH/ndk/$NDK_VERSION
 
 if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
 then

--- a/tools/buildsteps/android-x86_64/configure-depends
+++ b/tools/buildsteps/android-x86_64/configure-depends
@@ -3,7 +3,7 @@ XBMC_PLATFORM_DIR=android
 . $WORKSPACE/tools/buildsteps/defaultenv
 
 #the following path must exist on the slave and use the defined scheme here!
-NDK_PATH=$ANDROID_DEV_ROOT/android-ndk-r$NDK_VERSION
+NDK_PATH=$SDK_PATH/ndk/$NDK_VERSION
 
 if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
 then

--- a/tools/buildsteps/android/configure-depends
+++ b/tools/buildsteps/android/configure-depends
@@ -3,7 +3,7 @@ XBMC_PLATFORM_DIR=android
 . $WORKSPACE/tools/buildsteps/defaultenv
 
 #the following path must exist on the slave and use the defined scheme here!
-NDK_PATH=$ANDROID_DEV_ROOT/android-ndk-r$NDK_VERSION
+NDK_PATH=$SDK_PATH/ndk/$NDK_VERSION
 
 if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
 then

--- a/tools/buildsteps/androidx86/configure-depends
+++ b/tools/buildsteps/androidx86/configure-depends
@@ -3,7 +3,7 @@ XBMC_PLATFORM_DIR=android
 . $WORKSPACE/tools/buildsteps/defaultenv
 
 #the following path must exist on the slave and use the defined scheme here!
-NDK_PATH=$ANDROID_DEV_ROOT/android-ndk-r$NDK_VERSION
+NDK_PATH=$SDK_PATH/ndk/$NDK_VERSION
 
 if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
 then

--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -56,7 +56,7 @@ case $XBMC_PLATFORM_DIR in
     ;;
 
   android)
-    DEFAULT_NDK_VERSION="26c" # NDK package version (newer API can be inside)
+    DEFAULT_NDK_VERSION="26.2.11394342" # NDK package version (newer API can be inside)
     DEFAULT_NDK_API="24" # Nougat API level (24) defined in package ./sysroot/usr/include/android/api-level.h
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="RelWithDebInfo"


### PR DESCRIPTION
## Description
Buildsteps are still used for addon CI jobs. we need this data to match the pipeline CI (and therefore the actual docker path structure) to succed

## Motivation and context
Addons fail for Piers.

```
configure: error: "/home/jenkins/android-tools//android-ndk-r26c is not an NDK directory"
script returned exit code 1
```

Old path structure isnt used with new docker CI. Update to match following path structure

```
-- Found assembler: /home/jenkins/android-tools/android-sdk-linux/ndk/26.2.11394342/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang
```

## How has this been tested?
N/A

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
