### PR TITLE
[DirectSound] Fix buffer underrun for Bluetooth audio devices

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -124,6 +124,7 @@ bool CAESinkDirectSound::Initialize(AEAudioFormat &format, std::string &device)
   if (m_initialized)
     return false;
 
+  bool deviceIsBluetooth = false;
   LPGUID deviceGUID = nullptr;
   RPC_WSTR wszUuid  = nullptr;
   HRESULT hr = E_FAIL;
@@ -150,6 +151,21 @@ bool CAESinkDirectSound::Initialize(AEAudioFormat &format, std::string &device)
       }
     }
     if (hr == RPC_S_OK) RpcStringFree(&wszUuid);
+  }
+
+  // Detect a Bluetooth device
+  for (const auto& device : CAESinkFactoryWin::GetRendererDetails())
+  {
+    if (StringUtils::CompareNoCase(device.strDeviceId, strDeviceGUID) != 0)
+      continue;
+
+    if (device.strDeviceEnumerator == "BTHENUM")
+    {
+      deviceIsBluetooth = true;
+      CLog::LogF(LOGDEBUG, "Audio device '{}' is detected as Bluetooth device", deviceFriendlyName);
+    }
+
+    break;
   }
 
   hr = DirectSoundCreate(deviceGUID, m_pDSound.ReleaseAndGetAddressOf(), nullptr);
@@ -218,10 +234,13 @@ bool CAESinkDirectSound::Initialize(AEAudioFormat &format, std::string &device)
 
   m_AvgBytesPerSec = wfxex.Format.nAvgBytesPerSec;
 
-  const unsigned int uiFrameCount = static_cast<int>(format.m_sampleRate * 0.050); // 50ms chunks
+  const unsigned int chunkDurationMs = deviceIsBluetooth ? 50 : 20;
+  const unsigned int uiFrameCount = format.m_sampleRate * chunkDurationMs / 1000U;
   m_dwFrameSize = wfxex.Format.nBlockAlign;
   m_dwChunkSize = m_dwFrameSize * uiFrameCount;
-  m_dwBufferLen = m_dwChunkSize * 8; // 400ms total buffer
+
+  // BT: 500ms total buffer (50 * 10); non-BT: 200ms total buffer (20 * 10)
+  m_dwBufferLen = m_dwChunkSize * 10;
 
   // fill in the secondary sound buffer descriptor
   DSBUFFERDESC dsbdesc = {};

--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin.h
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin.h
@@ -178,6 +178,7 @@ struct RendererDetail
   std::string strDeviceId;
   std::string strDescription;
   std::string strWinDevType;
+  std::string strDeviceEnumerator;
   AEDeviceType eDeviceType;
   unsigned int nChannels;
   unsigned int uiChannelMask;

--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp
@@ -129,6 +129,17 @@ std::vector<RendererDetail> CAESinkFactoryWin::GetRendererDetails()
     details.uiChannelMask = std::max(varName.uintVal, (unsigned int)KSAUDIO_SPEAKER_STEREO);
     PropVariantClear(&varName);
 
+    hr = pProperty->GetValue(PKEY_Device_EnumeratorName, &varName);
+    if (FAILED(hr))
+    {
+      CLog::LogF(LOGERROR, "Retrieval of endpoint enumerator name failed.");
+      goto failed;
+    }
+
+    details.strDeviceEnumerator = KODI::PLATFORM::WINDOWS::FromW(varName.pwszVal);
+    StringUtils::ToUpper(details.strDeviceEnumerator);
+    PropVariantClear(&varName);
+
     if (pDevice->GetId(&pwszID) == S_OK)
     {
       if (wstrDDID.compare(pwszID) == 0)


### PR DESCRIPTION
## Description
[DirectSound] Fix buffer underrun for Bluetooth audio devices

Fix https://github.com/xbmc/xbmc/issues/25379

## Motivation and context
Follow-up of https://github.com/xbmc/xbmc/pull/25046

The current fix has two important drawbacks:

- Not fixes the issue in all systems (probably only 80%).
- Changes the buffer length for all DirectSound devices, then is a high risk of create side effects on others systems and is not valid for Omega backport.

This PR increases the buffer to 500 ms (400 ms before) but only for Bluetooth audio devices. For others devices only increases buffer length a bit from 180 ms to 200 ms. This is because chunk size is has been adjusted from 15 ms to 20 ms due is a multiple of 10 ms and fits better on how works Windows audio drivers currently:

> Duration of audio processing quantum
> On most PCs, XAudio 2.9 processes audio in 10 millisecond chunks. This is called the processing quantum. However, the duration of this quantum may be different than 10 milliseconds on some hardware. Apps that need to know the exact quantum can invoke the IXAudio2Extension::GetProcessingQuantum method to retrieve the value.

https://learn.microsoft.com/en-us/windows/win32/xaudio2/xaudio2-redistributable#duration-of-audio-processing-quantum

This only applies to XAudio API but on modern Windows 11 systems DirectSound API is deprecated and is only emulated for backward compatibility, then probably internally is used same 10 ms value.

Other reason to prefer 20 ms is that 15 ms is not exact number of samples at 44100 Hz:

44100 * 0.015 = 661.5 samples
44100 * 0.020 = 882 samples

NOTE: due DirectSound uses a circular buffer, never is filled completely (to avoid read pointer = write pointer), then max effective buffer duration values are:

BT --> 50 ms * 9 chunks = 450 ms
non-BT --> 20 ms * 9 chunks = 180 ms

## How has this been tested?
Tested with Bluetooth earphones "ASUS CETRA TRUE WIRELESS" on Windows 11 23H2. 

This device has two modes: normal and gaming (less latency). With previous fix only works in game mode while in this PR works  fine also in default mode. Without fix (current Omega state) not works game mode nor default mode. 

Also two users has confirmed is working:
- https://github.com/xbmc/xbmc/issues/20567#issuecomment-2241457818
- https://github.com/xbmc/xbmc/issues/25379#issuecomment-2241285328
- Forum testing is ongoing: https://forum.kodi.tv/showthread.php?tid=376406&pid=3204473#pid3204473

Also tested with non-Bluetooth devices to make sure that the new 20 ms chunk not causes regressions and GUI sounds seem to behave even better.

## What is the effect on users?
Fixes buffer underrun in Bluetooth audio devices when using DirectSound in Windows 11.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
