### PR TITLE
[Backport][DirectSound] Fix buffer underrun for Bluetooth audio devices

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin.h
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin.h
@@ -178,6 +178,7 @@ struct RendererDetail
   std::string strDeviceId;
   std::string strDescription;
   std::string strWinDevType;
+  std::string strDeviceEnumerator;
   AEDeviceType eDeviceType;
   unsigned int nChannels;
   unsigned int uiChannelMask;

--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp
@@ -129,6 +129,17 @@ std::vector<RendererDetail> CAESinkFactoryWin::GetRendererDetails()
     details.uiChannelMask = std::max(varName.uintVal, (unsigned int)KSAUDIO_SPEAKER_STEREO);
     PropVariantClear(&varName);
 
+    hr = pProperty->GetValue(PKEY_Device_EnumeratorName, &varName);
+    if (FAILED(hr))
+    {
+      CLog::LogF(LOGERROR, "Retrieval of endpoint enumerator name failed.");
+      goto failed;
+    }
+
+    details.strDeviceEnumerator = KODI::PLATFORM::WINDOWS::FromW(varName.pwszVal);
+    StringUtils::ToUpper(details.strDeviceEnumerator);
+    PropVariantClear(&varName);
+
     if (pDevice->GetId(&pwszID) == S_OK)
     {
       if (wstrDDID.compare(pwszID) == 0)


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/25510


## What is the effect on users?
Fixes buffer underrun in Bluetooth audio devices when using DirectSound in Windows 11.


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
