### PR TITLE
SMBWSDiscoveryListener: Fix clang warning

### DIFF
--- a/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.h
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.h
@@ -111,16 +111,16 @@ private:
   const std::string wsd_instance_address;
 
   // Number of sends for UDP messages
-  const int retries = 4;
+  static constexpr int retries{4};
 
   // Max udp packet size (+ UDP header + IP header overhead = 65535)
-  const int UDPBUFFSIZE = 65507;
+  static constexpr int UDPBUFFSIZE{65507};
 
   // Port for unicast/multicast WSD traffic
-  const int wsdUDP = 3702;
+  static constexpr int wsdUDP{3702};
 
   // ipv4 multicast group WSD - https://specs.xmlsoap.org/ws/2005/04/discovery/ws-discovery.pdf
-  const char* WDSIPv4MultiGroup = "239.255.255.250";
+  static constexpr char WDSIPv4MultiGroup[]{"239.255.255.250"};
 
   // ToDo: ipv6 broadcast address
   // const char* WDSIPv6MultiGroup = "FF02::C"


### PR DESCRIPTION
## Description

Fixes this clang (18.1.8) warning:

```
SMBWSDiscoveryListener.cpp:275:19: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
  275 |       char msgbuf[UDPBUFFSIZE];
      |                   ^~~~~~~~~~~
SMBWSDiscoveryListener.cpp:275:19: note: implicit use of 'this' pointer is only allowed within the evaluation of a call to a 'constexpr' member function
```

Also makes the instantiated class a little smaller. 

## Motivation and context

Fewer distracting warnings when building.

## How has this been tested?

Builds and launches.

## What is the effect on users?

None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
