### PR TITLE
[Android][gnutls] Retain the warning behaviour when building with the next ndk

### DIFF
--- a/tools/depends/target/gnutls/Makefile
+++ b/tools/depends/target/gnutls/Makefile
@@ -35,7 +35,7 @@ CONFIGURE=./configure --prefix=$(PREFIX) \
                       $(CONFIGURE_OPTIONS)
 
 # LLVM 15 has raised this to error by default. drop back to warning
-CFLAGS+= -Wno-error=implicit-int
+CFLAGS+= -Wno-error=implicit-int -Wno-error=implicit-function-declaration -Wno-error=int-conversion 
 export CFLAGS
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/lib$(LIBNAME).a


### PR DESCRIPTION
## Description
~~Update ndk to the latest stable release available, see the [changelog](https://github.com/android/ndk/wiki/Changelog-r27).~~

It's necessary to retain the warning behaviour in two rules added in C99 in order to build the gnutls dependency.

~~Also update the build guide.~~

~~**Docker builders**: need to manually install the ndk and update the pipeline.~~

## How has this been tested?
Tested on Android TV 11


## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
