### PR TITLE
xbmc/addons: cppcheck performance fixes

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -625,8 +625,7 @@ int64_t CAddonInstaller::EnumeratePackageFolder(
     size += items[i]->m_dwSize;
     std::string pack,dummy;
     CAddonVersion::SplitFileName(pack, dummy, items[i]->GetLabel());
-    if (result.find(pack) == result.end())
-      result[pack] = std::make_unique<CFileItemList>();
+    result.try_emplace(pack, std::make_unique<CFileItemList>());
     result[pack]->Add(std::make_shared<CFileItem>(*items[i]));
   }
 

--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -175,7 +175,7 @@ bool CAddonVersion::SplitFileName(std::string& ID,
     return false;
   ID = filename.substr(0, dpos);
   version = filename.substr(dpos + 1);
-  version = version.substr(0, version.size() - 4);
+  version.resize(version.size() - 4);
 
   return true;
 }

--- a/xbmc/addons/ImageResource.cpp
+++ b/xbmc/addons/ImageResource.cpp
@@ -18,9 +18,9 @@ namespace ADDON
 {
 
 CImageResource::CImageResource(const AddonInfoPtr& addonInfo)
-  : CResource(addonInfo, AddonType::RESOURCE_IMAGES)
+  : CResource(addonInfo, AddonType::RESOURCE_IMAGES),
+    m_type(Type(AddonType::RESOURCE_IMAGES)->GetValue("@type").asString())
 {
-  m_type = Type(AddonType::RESOURCE_IMAGES)->GetValue("@type").asString();
 }
 
 void CImageResource::OnPreUnInstall()

--- a/xbmc/addons/LanguageResource.cpp
+++ b/xbmc/addons/LanguageResource.cpp
@@ -29,12 +29,11 @@ namespace ADDON
 {
 
 CLanguageResource::CLanguageResource(const AddonInfoPtr& addonInfo)
-  : CResource(addonInfo, AddonType::RESOURCE_LANGUAGE)
+  : CResource(addonInfo, AddonType::RESOURCE_LANGUAGE),
+    // parse <extension> attributes
+    m_locale(
+        CLocale::FromString(Type(AddonType::RESOURCE_LANGUAGE)->GetValue("@locale").asString()))
 {
-  // parse <extension> attributes
-  m_locale =
-      CLocale::FromString(Type(AddonType::RESOURCE_LANGUAGE)->GetValue("@locale").asString());
-
   // parse <charsets>
   const CAddonExtensions* charsetsElement =
       Type(AddonType::RESOURCE_LANGUAGE)->GetElement("charsets");

--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -772,7 +772,7 @@ bool CAddonInfoBuilder::GetTextList(const tinyxml2::XMLElement* element,
 
 const char* CAddonInfoBuilder::GetPlatformLibraryName(const tinyxml2::XMLElement* element)
 {
-  const char* libraryName;
+  const char* libraryName = nullptr;
 #if defined(TARGET_ANDROID)
   libraryName = element->Attribute("library_android");
 #elif defined(TARGET_LINUX) || defined(TARGET_FREEBSD)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

This fixes a few performance issues found with 
```
% cppcheck --enable=performance xbmc/addons --check-level=exhaustive --force
```

There's one more issue that I wasn't sure about (which seems a false positive):
```
xbmc/addons/addoninfo/AddonInfo.cpp:303:32: performance: Constructing a std::string_view from the result of c_str() is slow and redundant. [stlcstrConstructor]
        const std::string_view uid(filename.data() + startName.length());
```

## Motivation and context
This fixes issues reported by cppcheck.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
I compiled the code to see if I made mistakes while fixing cppcheck issues. The changes themselves should be pretty self-explanatory.

## What is the effect on users?
Eh, changes should be barely noticeable. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
