### PR TITLE
changed: move CFileItem::FillInDefaultIcon to ArtUtils

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -116,7 +116,7 @@ CFileItem::CFileItem(const CMusicInfoTag& music)
   m_strPath = music.GetURL();
   m_bIsFolder = URIUtils::HasSlashAtEnd(m_strPath);
   *GetMusicInfoTag() = music;
-  FillInDefaultIcon();
+  ART::FillInDefaultIcon(*this);
   FillInMimeType(false);
 }
 
@@ -1220,130 +1220,6 @@ bool CFileItem::IsReadOnly() const
   return !CUtil::SupportsWriteFileOperations(m_strPath);
 }
 
-void CFileItem::FillInDefaultIcon()
-{
-  if (URIUtils::IsPVRGuideItem(m_strPath))
-  {
-    // epg items never have a default icon. no need to execute this expensive method.
-    // when filling epg grid window, easily tens of thousands of epg items are processed.
-    return;
-  }
-
-  //CLog::Log(LOGINFO, "FillInDefaultIcon({})", pItem->GetLabel());
-  // find the default icon for a file or folder item
-  // for files this can be the (depending on the file type)
-  //   default picture for photo's
-  //   default picture for songs
-  //   default picture for videos
-  //   default picture for shortcuts
-  //   default picture for playlists
-  //
-  // for folders
-  //   for .. folders the default picture for parent folder
-  //   for other folders the defaultFolder.png
-
-  if (GetArt("icon").empty())
-  {
-    if (!m_bIsFolder)
-    {
-      /* To reduce the average runtime of this code, this list should
-       * be ordered with most frequently seen types first.  Also bear
-       * in mind the complexity of the code behind the check in the
-       * case of IsWhatever() returns false.
-       */
-      if (IsPVRChannel())
-      {
-        if (GetPVRChannelInfoTag()->IsRadio())
-          SetArt("icon", "DefaultMusicSongs.png");
-        else
-          SetArt("icon", "DefaultTVShows.png");
-      }
-      else if ( IsLiveTV() )
-      {
-        // Live TV Channel
-        SetArt("icon", "DefaultTVShows.png");
-      }
-      else if ( URIUtils::IsArchive(m_strPath) )
-      { // archive
-        SetArt("icon", "DefaultFile.png");
-      }
-      else if ( IsUsablePVRRecording() )
-      {
-        // PVR recording
-        SetArt("icon", "DefaultVideo.png");
-      }
-      else if ( IsDeletedPVRRecording() )
-      {
-        // PVR deleted recording
-        SetArt("icon", "DefaultVideoDeleted.png");
-      }
-      else if (IsPVRProvider())
-      {
-        SetArt("icon", "DefaultPVRProvider.png");
-      }
-      else if (PLAYLIST::IsPlayList(*this) || PLAYLIST::IsSmartPlayList(*this))
-      {
-        SetArt("icon", "DefaultPlaylist.png");
-      }
-      else if (MUSIC::IsAudio(*this))
-      {
-        // audio
-        SetArt("icon", "DefaultAudio.png");
-      }
-      else if (VIDEO::IsVideo(*this))
-      {
-        // video
-        SetArt("icon", "DefaultVideo.png");
-      }
-      else if (IsPVRTimer())
-      {
-        SetArt("icon", "DefaultVideo.png");
-      }
-      else if ( IsPicture() )
-      {
-        // picture
-        SetArt("icon", "DefaultPicture.png");
-      }
-      else if ( IsPythonScript() )
-      {
-        SetArt("icon", "DefaultScript.png");
-      }
-      else if (IsFavourite())
-      {
-        SetArt("icon", "DefaultFavourites.png");
-      }
-      else
-      {
-        // default icon for unknown file type
-        SetArt("icon", "DefaultFile.png");
-      }
-    }
-    else
-    {
-      if (PLAYLIST::IsPlayList(*this) || PLAYLIST::IsSmartPlayList(*this))
-      {
-        SetArt("icon", "DefaultPlaylist.png");
-      }
-      else if (IsParentFolder())
-      {
-        SetArt("icon", "DefaultFolderBack.png");
-      }
-      else
-      {
-        SetArt("icon", "DefaultFolder.png");
-      }
-    }
-  }
-  // Set the icon overlays (if applicable)
-  if (!HasOverlay() && !HasProperty("icon_never_overlay"))
-  {
-    if (URIUtils::IsInRAR(m_strPath))
-      SetOverlayImage(CGUIListItem::ICON_OVERLAY_RAR);
-    else if (URIUtils::IsInZIP(m_strPath))
-      SetOverlayImage(CGUIListItem::ICON_OVERLAY_ZIP);
-  }
-}
-
 void CFileItem::RemoveExtension()
 {
   if (m_bIsFolder)
@@ -1726,7 +1602,7 @@ void CFileItem::SetFromVideoInfoTag(const CVideoInfoTag &video)
 
   if (video.m_iSeason == 0)
     SetProperty("isspecial", "true");
-  FillInDefaultIcon();
+  ART::FillInDefaultIcon(*this);
   FillInMimeType(false);
 }
 
@@ -1794,7 +1670,7 @@ void CFileItem::SetFromMusicInfoTag(const MUSIC_INFO::CMusicInfoTag& music)
     SetArt("thumb", thumb.GetValueToSave(GetArt("thumb")));
 
   *GetMusicInfoTag() = music;
-  FillInDefaultIcon();
+  ART::FillInDefaultIcon(*this);
   FillInMimeType(false);
 }
 

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -226,7 +226,6 @@ public:
 
   void RemoveExtension();
   void CleanString();
-  void FillInDefaultIcon();
   void SetFileSizeLabel();
   void SetLabel(const std::string &strLabel) override;
   VideoDbContentType GetVideoContentType() const;

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -23,6 +23,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Archive.h"
+#include "utils/ArtUtils.h"
 #include "utils/Crc32.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/Random.h"
@@ -545,7 +546,7 @@ void CFileItemList::FillInDefaultIcons()
   for (int i = 0; i < (int)m_items.size(); ++i)
   {
     CFileItemPtr pItem = m_items[i];
-    pItem->FillInDefaultIcon();
+    ART::FillInDefaultIcon(*pItem);
   }
 }
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -26,6 +26,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "playlists/PlayListTypes.h"
 #include "settings/SkinSettings.h"
+#include "utils/ArtUtils.h"
 #include "utils/CharsetConverter.h"
 #include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
@@ -11313,7 +11314,7 @@ void CGUIInfoManager::UpdateCurrentItem(const CFileItem &item)
 void CGUIInfoManager::SetCurrentItem(const CFileItem &item)
 {
   *m_currentFile = item;
-  m_currentFile->FillInDefaultIcon();
+  ART::FillInDefaultIcon(*m_currentFile);
 
   m_infoProviders.InitCurrentItem(m_currentFile);
 
@@ -11327,7 +11328,7 @@ void CGUIInfoManager::SetCurrentAlbumThumb(const std::string &thumbFileName)
   else
   {
     m_currentFile->SetArt("thumb", "");
-    m_currentFile->FillInDefaultIcon();
+    ART::FillInDefaultIcon(*m_currentFile);
   }
 }
 

--- a/xbmc/filesystem/ZeroconfDirectory.cpp
+++ b/xbmc/filesystem/ZeroconfDirectory.cpp
@@ -13,12 +13,14 @@
 #include "FileItemList.h"
 #include "URL.h"
 #include "network/ZeroconfBrowser.h"
+#include "utils/ArtUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
 #include <cassert>
 #include <stdexcept>
 
+using namespace KODI;
 using namespace XFILE;
 
 CZeroconfDirectory::CZeroconfDirectory()
@@ -137,7 +139,7 @@ bool GetDirectoryFromTxtRecords(const CZeroconfBrowser::ZeroconfService& zerocon
 
       item->SetLabelPreformatted(true);
       //just set the default folder icon
-      item->FillInDefaultIcon();
+      ART::FillInDefaultIcon(*item);
       item->m_bIsShareOrDrive=true;
       items.Add(item);
       ret = true;
@@ -173,7 +175,7 @@ bool CZeroconfDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         item->SetLabel(it.GetName() + " (" + protocol + ")");
         item->SetLabelPreformatted(true);
         //just set the default folder icon
-        item->FillInDefaultIcon();
+        ART::FillInDefaultIcon(*item);
         items.Add(item);
       }
     }

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -23,6 +23,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/ArtUtils.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
@@ -100,7 +101,7 @@ bool CPictureThumbLoader::LoadItemCached(CFileItem* pItem)
     CServiceBroker::GetTextureCache()->BackgroundCacheImage(thumb);
     pItem->SetArt("thumb", thumb);
   }
-  pItem->FillInDefaultIcon();
+  ART::FillInDefaultIcon(*pItem);
   return true;
 }
 
@@ -215,6 +216,6 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
       }
     }
     // refill in the icon to get it to update
-    pItem->FillInDefaultIcon();
+    ART::FillInDefaultIcon(*pItem);
   }
 }

--- a/xbmc/utils/ArtUtils.h
+++ b/xbmc/utils/ArtUtils.h
@@ -15,6 +15,9 @@ class CFileItem;
 namespace KODI::ART
 {
 
+//! \brief Set default icon for item.
+void FillInDefaultIcon(CFileItem& item);
+
 /*!
  \brief Get the local fanart for item if it exists
  \return path to the local fanart for this item, or empty if none exists


### PR DESCRIPTION
## Description
Move another function from CFileItem to ArtUtils

## Motivation and context
Less code in CFileItem

## How has this been tested?
It builds + added tests passes.

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
