### PR TITLE
[Android] Set a default path to the NDK

### DIFF
--- a/docs/README.Android.md
+++ b/docs/README.Android.md
@@ -73,7 +73,7 @@ sudo apt install autoconf bison build-essential curl default-jdk flex gawk git g
 **[back to top](#table-of-contents)**
 
 ## 3. Prerequisites
-Building Kodi for Android requires Android NDK revision 27c. For the SDK just use the latest available.
+Building Kodi for Android requires Android NDK revision 27c (27.2.12479018). For the SDK just use the latest available.
 Kodi CI/CD platforms currently use r27c for build testing and releases, so we recommend using r27c for the most tested build experience
 
 * **[Android SDK](https://developer.android.com/studio/index.html)** (Look for `Get just the command line tools`)
@@ -135,22 +135,22 @@ cd $HOME/kodi/tools/depends
 
 Configure build for aarch64:
 ```
-./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=aarch64-linux-android --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-sdk-linux/ndk/27.2.12479018 --prefix=$HOME/android-tools/xbmc-depends
+./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=aarch64-linux-android --with-sdk-path=$HOME/android-tools/android-sdk-linux --prefix=$HOME/android-tools/xbmc-depends
 ```
 
 Or configure build for arm:
 ```
-./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=arm-linux-androideabi --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-sdk-linux/ndk/27.2.12479018 --prefix=$HOME/android-tools/xbmc-depends
+./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=arm-linux-androideabi --with-sdk-path=$HOME/android-tools/android-sdk-linux --prefix=$HOME/android-tools/xbmc-depends
 ```
 
 Or configure build for x86:
 ```
-./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=i686-linux-android --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-sdk-linux/ndk/27.2.12479018 --prefix=$HOME/android-tools/xbmc-depends
+./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=i686-linux-android --with-sdk-path=$HOME/android-tools/android-sdk-linux --prefix=$HOME/android-tools/xbmc-depends
 ```
 
 Or configure build for x86_64:
 ```
-./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=x86_64-linux-android --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-sdk-linux/ndk/27.2.12479018 --prefix=$HOME/android-tools/xbmc-depends
+./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=x86_64-linux-android --with-sdk-path=$HOME/android-tools/android-sdk-linux --prefix=$HOME/android-tools/xbmc-depends
 ```
 
 > [!NOTE]  
@@ -238,12 +238,12 @@ make -j$(getconf _NPROCESSORS_ONLN)
 ```
 --with-ndk-api=<ndk number>
 ```
-  specify ndk level (optional for android), default is 24.]
+  specify ndk level (optional for android), default is 24.
 
 ```
 --with-ndk-path=<path>
 ```
-  specify path to ndk (required for android only)
+  specify path to ndk (optional for android), default is sdk_path/ndk/27.2.12479018
 
 ```
 --with-sdk-path=<path>

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -70,15 +70,16 @@ AC_ARG_WITH([cpu],
   [use_cpu=$withval],
   [use_cpu=auto])
 
-AC_ARG_WITH([ndk-path],
-  [AS_HELP_STRING([--with-ndk-path],
-  [specify path to ndk (required for android only)])],
-  [use_ndk_path=$withval])
-
 AC_ARG_WITH([sdk-path],
   [AS_HELP_STRING([--with-sdk-path],
   [specify path to sdk (required for android only)])],
   [use_sdk_path=$withval])
+
+AC_ARG_WITH([ndk-path],
+  [AS_HELP_STRING([--with-ndk-path],
+  [specify path to ndk (optional for android), default is sdk_path/ndk/27.2.12479018])],
+  [use_ndk_path=$withval],
+  [use_ndk_path=$use_sdk_path/ndk/27.2.12479018])
 
 AC_ARG_WITH([sdk],
   [AS_HELP_STRING([--with-sdk],


### PR DESCRIPTION
## Description
Currently it's required to set the path to the ndk via the configure option `--with-ndk-path`.

I propose to make this optional. If not specified during configure, set the default path to `$sdk_path/ndk/version`

`version` is the recommended and tested ndk version 26.2.11394342

## Motivation and context
Reduce the number of options required and simplify the process.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
