### PR TITLE
[PVR] Group Manager: Do not show hidden channels in list of ungrouped channels…

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -250,7 +250,8 @@ std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRChannelGroups::GetMembe
     const auto allGroupMembers = GetGroupAll()->GetMembers();
     for (const auto& groupMember : allGroupMembers)
     {
-      if (!group->IsGroupMember(groupMember))
+      if (!group->IsGroupMember(groupMember) &&
+          (group->IsChannelsOwner() || !groupMember->Channel()->IsHidden()))
         result.emplace_back(groupMember);
     }
   }


### PR DESCRIPTION
… , except for the 'All channels' group.

Fixes a bug reported in the forum: https://forum.kodi.tv/showthread.php?tid=375691&pid=3204857#pid3204857 ff.

Runtime-tested on macOS, latest Kodi master.

@phunkyfish should be easy to review.