### PR TITLE
[PVR] Group Manager: Fix channel numbers in other groups not updated …

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -739,6 +739,10 @@ bool CPVRChannelGroups::AppendToGroup(
 
     if (group->AppendToGroup(groupMember))
     {
+      // Changes in the all channels group may require resorting/renumbering of other groups.
+      if (group->IsChannelsOwner())
+        UpdateChannelNumbersFromAllChannelsGroup();
+
       GroupStateChanged(group);
       return true;
     }
@@ -761,6 +765,11 @@ bool CPVRChannelGroups::RemoveFromGroup(const std::shared_ptr<CPVRChannelGroup>&
     if (group->RemoveFromGroup(groupMember))
     {
       group->DeleteGroupMember(groupMember);
+
+      // Changes in the all channels group may require resorting/renumbering of other groups.
+      if (group->IsChannelsOwner())
+        UpdateChannelNumbersFromAllChannelsGroup();
+
       GroupStateChanged(group);
       return true;
     }

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -1046,10 +1046,9 @@ void CGUIDialogPVRChannelManager::SaveList()
   pDlgProgress->SetPercentage(0);
 
   /* persist all channels */
-  std::shared_ptr<CPVRChannelGroup> group =
-      CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(m_bIsRadio);
-  if (!group)
-    return;
+  const std::shared_ptr<const CPVRChannelGroupsContainer> groupsContainer{
+      CServiceBroker::GetPVRManager().ChannelGroups()};
+  const std::shared_ptr<CPVRChannelGroup> group{groupsContainer->GetGroupAll(m_bIsRadio)};
 
   for (int iListPtr = 0; iListPtr < m_channelItems->Size(); ++iListPtr)
   {
@@ -1080,11 +1079,7 @@ void CGUIDialogPVRChannelManager::SaveList()
   }
 
   group->SortAndRenumber();
-
-  const std::shared_ptr<CPVRChannelGroups> channelGroups{
-      CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio)};
-  channelGroups->UpdateChannelNumbersFromAllChannelsGroup();
-  channelGroups->PersistAll();
+  groupsContainer->Get(m_bIsRadio)->PersistAll();
   pDlgProgress->Close();
 
   CONTROL_DISABLE(BUTTON_APPLY);


### PR DESCRIPTION
…after adding/removing channels to/from 'All channels' group.

When adding/removing channels from the "All channels" group in the Group Manager, the numbers of the affected channels contained in other  other groups were not updated until next Kodi restart.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish something best to be reviewed by you  I guess.