### PR TITLE
[MUSIC] Fix separators so that artist sortnames split correctly

### DIFF
--- a/xbmc/music/Song.cpp
+++ b/xbmc/music/Song.cpp
@@ -89,13 +89,16 @@ void CSong::SetArtistCredits(const std::vector<std::string>& names, const std::v
   artistCredits.clear();
   std::vector<std::string> artistHints = hints;
   //Split the artist sort string to try and get sort names for individual artists
-  std::vector<std::string> artistSort = StringUtils::Split(strArtistSort, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);
+  std::vector<std::string> artistSort = StringUtils::Split(
+      strArtistSort,
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);
+
+  // Vector of possible separators in the order least likely to be part of artist name
+  static const std::vector<std::string> separators{
+      " feat. ", " ft. ", " Feat. ", " Ft. ", ";", ":", "|", "#", "/", " with ", "&"};
 
   if (!mbids.empty())
   { // Have musicbrainz artist info, so use it
-
-    // Vector of possible separators in the order least likely to be part of artist name
-    const std::vector<std::string> separators{ " feat. ", " ft. ", " Feat. "," Ft. ", ";", ":", "|", "#", "/", " with ", ",", "&" };
 
     // Establish tag consistency - do the number of musicbrainz ids and number of names in hints or artist match
     if (mbids.size() != artistHints.size() && mbids.size() != names.size())
@@ -147,7 +150,7 @@ void CSong::SetArtistCredits(const std::vector<std::string>& names, const std::v
     // Try to get number of artist sort names and musicbrainz ids to match. Split sort names
     // further using multiple possible delimiters, over single separator applied in Tag loader
     if (artistSort.size() != mbids.size())
-      artistSort = StringUtils::SplitMulti(artistSort, { ";", ":", "|", "#" });
+      artistSort = StringUtils::SplitMulti(artistSort, separators);
 
     for (size_t i = 0; i < mbids.size(); i++)
     {
@@ -185,7 +188,7 @@ void CSong::SetArtistCredits(const std::vector<std::string>& names, const std::v
 
     if (artistSort.size() != artists.size())
       // Split artist sort names further using multiple possible delimiters, over single separator applied in Tag loader
-      artistSort = StringUtils::SplitMulti(artistSort, { ";", ":", "|", "#" });
+      artistSort = StringUtils::SplitMulti(artistSort, separators);
 
     for (size_t i = 0; i < artists.size(); i++)
     {


### PR DESCRIPTION
## Description
Artist sort names are currently split on several delimiters including ",".  This causes an issue however as at least musicbrainz picard will set a sortname of "surname, first name".  When dealing with sort strings such as `surname, first name Feat surname, first name & surname` this gets split too much and doesn't match the number of mbids.  Therefore, these strings are never properly processed and inserted into the db.

Tidied the code a little.

This should be quite safe to backport, although users would need to re-scan their music for it to take effect.

## Motivation and context
Reported in the forum here -> https://forum.kodi.tv/showthread.php?tid=378299

Using the test data provided it became apparent that a string of  `Emery, Gareth & STANDERWICK feat. HALIENE` was being split into 4 values.  Removing the "," splits the string correctly into the 3 values required.  Note that this does not affect single artists with a string of eg `Buuren, van, Armin`, just multiple artist strings.

## How has this been tested?
Runtime tested with latest master.  Contents of db checked after scanning test files.
## What is the effect on users?
Sort orders for song artists will work correctly going forwards.
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
