### PR TITLE
KeyboardTranslator: Fix call to `StringUtils::ToLower`

### DIFF
--- a/xbmc/input/keymaps/keyboard/KeyboardTranslator.cpp
+++ b/xbmc/input/keymaps/keyboard/KeyboardTranslator.cpp
@@ -51,10 +51,10 @@ uint32_t CKeyboardTranslator::TranslateButton(const tinyxml2::XMLElement* pButto
     button_id = TranslateString(szButton);
 
   // Process the ctrl/shift/alt modifiers
-  const char* strMod;
-  if (pButton->QueryStringAttribute("mod", &strMod) == tinyxml2::XML_SUCCESS)
+  const char* cstrMod;
+  if (pButton->QueryStringAttribute("mod", &cstrMod) == tinyxml2::XML_SUCCESS)
   {
-    StringUtils::ToLower(strMod);
+    const std::string strMod = StringUtils::ToLower(cstrMod);
 
     std::vector<std::string> modArray = StringUtils::Split(strMod, ",");
     for (auto substr : modArray)


### PR DESCRIPTION
## Description

567960ee8e2ea5d0d0b4c3e442a0cf3de7b036ea changed `strMod` from `std::string` to `const char*` resulting in the call to `StringUtils::ToLower` to not modify `strMod` inplace anymore.

## Motivation and context

I'm currently in the progress of modernizing `StringUtils` and adding `[[nodiscard]]` to the `StringUtils::ToLower` overload that's returning a `std::string` brought this unwanted change to my attention.

## How has this been tested?
 
Not tested, but I'm fairly certain this restores the old behavior.

## What is the effect on users?

Not sure :sweat_smile: 

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
