### PR TITLE
[Settings] Show "Maximum rewind time" on basic level

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2667,7 +2667,7 @@
           <control type="toggle" />
         </setting>
         <setting id="gamesgeneral.rewindtime" type="integer" label="35205" help="35206">
-          <level>2</level>
+          <level>0</level>
           <default>60</default>
           <constraints>
             <minimum>10</minimum>


### PR DESCRIPTION
## Description

As PR title says, this change adds the "Maximum rewind time" setting in the games category from advanced to basic so that it will be shown by default.

## Motivation and context

I noticed the skin Confluence ZEITGEIST is adding games support, so I'm including its repo in my test builds now. I noticed the Games Settings page was sad and empty:

![Screenshot from 2024-07-29 15-29-14](https://github.com/user-attachments/assets/1c72c800-3b06-48cf-9aa5-1145eedc5098)

I originally chose Advanced in to manage complexity in the Game Settings page. However, we've done such a good job of defaulting settings to appropriate values that none have been added to this page. And rewind time is clearly a simple concept so "basic" is most appropriate.

## How has this been tested?

Tested in Confluence ZEITGEIST in my latest round of test builds: https://github.com/garbear/xbmc/releases/tag/retroplayer-21-20240729

## What is the effect on users?

* Added "Maximum rewind time" setting to Basic settings level

## Screenshots (if appropriate):

After:

![Screenshot from 2024-07-29 15-28-47](https://github.com/user-attachments/assets/9616e968-b6db-45e2-827c-6760de9fc3c4)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
