### PR TITLE
Revert AirTunes service name change

### DIFF
--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -627,8 +627,7 @@ bool CAirTunesServer::StartServer(int port, bool nonlocal, bool usePassword, con
     txt.emplace_back("am", "Kodi,1");
     txt.emplace_back("vs", "130.14");
 
-    CZeroconf::GetInstance()->PublishService("servers.airtunes", "_raop._tcp",
-                                             CSysInfo::GetDeviceName() + " airtunes", port, txt);
+    CZeroconf::GetInstance()->PublishService("servers.airtunes", "_raop._tcp", appName, port, txt);
   }
 
   return success;


### PR DESCRIPTION
## Description
Partial revert of #24890

The AirTunes service name must be in a specific format to be recognised by Apple devices. Keep the previous service name used.

Related to issue #25555

## How has this been tested?
I've verified that Kodi running on Android TV is once again recognised by Apple devices.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
