### PR TITLE
[cmake] Change binary addon repo branch to Piers.

### DIFF
--- a/cmake/addons/bootstrap/repositories/binary-addons.txt
+++ b/cmake/addons/bootstrap/repositories/binary-addons.txt
@@ -1,1 +1,1 @@
-binary-addons https://github.com/xbmc/repo-binary-addons.git Omega
+binary-addons https://github.com/xbmc/repo-binary-addons.git Piers


### PR DESCRIPTION
We need to switch to Piers repo for binay addons (once that repo is online; other PRs pending currently)