### PR TITLE
GUILIB: remove unnecessary threading for focus actions

### DIFF
--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1005,8 +1005,6 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
   GetActions(pControlNode, "ontextchange", textChangeActions);
   GetActions(pControlNode, "onfocus", focusActions);
   GetActions(pControlNode, "onunfocus", unfocusActions);
-  focusActions.EnableSendThreadMessageMode();
-  unfocusActions.EnableSendThreadMessageMode();
   GetActions(pControlNode, "altclick", altclickActions);
 
   std::string infoString;


### PR DESCRIPTION
## Description
The PR changes the message behavior of focus actions. It uses the faster, non-threaded codepath.

## Motivation and context
Previously, focus/unfocus actions would use the threaded message queue. The way it is set up, it would introduce a one frame delay for those messages. But skins like Estuary require those messages to reach its consumer in the same processing cycle.

Possibly fixes https://forum.kodi.tv/showthread.php?pid=2726367#pid2726367.

## How has this been tested?
Compiles and runs fine on my Linux system

## What is the effect on users?
Less resources wasted, depending on the scene. Possibly less jank.

## Screenshots (if appropriate):
Previously, selecting the Caminandes movie by pressing down would result in loading the Tears of Steel fanart for one frame. Only in the next frame, the appropriate fanart would load.
![image](https://github.com/user-attachments/assets/57f1f5d9-cb97-43a6-b8a5-52b07bbc8e63)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
