### PR TITLE
[PVR] Fix CAddonRecording member init.

### DIFF
--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -121,7 +121,7 @@ public:
       m_iconPath(recording.ClientIconPath()),
       m_thumbnailPath(recording.ClientThumbnailPath()),
       m_fanartPath(recording.ClientFanartPath()),
-      m_firstAired(recording.FirstAired().GetAsW3CDate()),
+      m_firstAired(recording.FirstAired().IsValid() ? recording.FirstAired().GetAsW3CDate() : ""),
       m_providerName(recording.ProviderName())
   {
     time_t recTime;
@@ -156,8 +156,7 @@ public:
     iChannelUid = recording.ChannelUid();
     channelType =
         recording.IsRadio() ? PVR_RECORDING_CHANNEL_TYPE_RADIO : PVR_RECORDING_CHANNEL_TYPE_TV;
-    if (recording.FirstAired().IsValid())
-      strFirstAired = m_firstAired.c_str();
+    strFirstAired = m_firstAired.c_str();
     iFlags = recording.Flags();
     sizeInBytes = recording.GetSizeInBytes();
     strProviderName = m_providerName.c_str();


### PR DESCRIPTION
Fixes a crash introduced by 4a445ac0802de54ebf26625ef8d4d5a1dd7526bc

Runtime-tested on macOS and Android, latest xbmc master.

Will merge without review, because the fix is straight forward and the crash makes using PVR impossible as it crashes when entering the TV home screen section, so makes PVR almost unusable.