### PR TITLE
GUILIB: Only fade between two textures

### DIFF
--- a/xbmc/guilib/GUIBorderedImage.cpp
+++ b/xbmc/guilib/GUIBorderedImage.cpp
@@ -39,12 +39,12 @@ CGUIBorderedImage::CGUIBorderedImage(const CGUIBorderedImage& right)
 void CGUIBorderedImage::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   CGUIImage::Process(currentTime, dirtyregions);
-  if (!m_borderImage->GetFileName().empty() && m_texture->ReadyToRender())
+  if (!m_borderImage->GetFileName().empty() && m_textureCurrent->ReadyToRender())
   {
-    CRect rect = CRect(m_texture->GetXPosition(), m_texture->GetYPosition(),
-                       m_texture->GetXPosition() + m_texture->GetWidth(),
-                       m_texture->GetYPosition() + m_texture->GetHeight());
-    rect.Intersect(m_texture->GetRenderRect());
+    CRect rect = CRect(m_textureCurrent->GetXPosition(), m_textureCurrent->GetYPosition(),
+                       m_textureCurrent->GetXPosition() + m_textureCurrent->GetWidth(),
+                       m_textureCurrent->GetYPosition() + m_textureCurrent->GetHeight());
+    rect.Intersect(m_textureCurrent->GetRenderRect());
     m_borderImage->SetPosition(rect.x1 - m_borderSize.x1, rect.y1 - m_borderSize.y1);
     m_borderImage->SetWidth(rect.Width() + m_borderSize.x1 + m_borderSize.x2);
     m_borderImage->SetHeight(rect.Height() + m_borderSize.y1 + m_borderSize.y2);
@@ -62,7 +62,7 @@ void CGUIBorderedImage::Render()
   if (renderFrontToBack)
     CGUIImage::Render();
 
-  if (!m_borderImage->GetFileName().empty() && m_texture->ReadyToRender())
+  if (!m_borderImage->GetFileName().empty() && m_textureCurrent->ReadyToRender())
     m_borderImage->Render(-1);
 
   if (!renderFrontToBack)

--- a/xbmc/guilib/GUIImage.h
+++ b/xbmc/guilib/GUIImage.h
@@ -93,7 +93,12 @@ protected:
   virtual void FreeTextures(bool immediately = false);
   void FreeResourcesButNotAnims();
   unsigned char GetFadeLevel(unsigned int time) const;
-  bool ProcessFading(CFadingTexture *texture, unsigned int frameTime, unsigned int currentTime);
+  std::string GetFallback(const std::string& currentName);
+  void ProcessState();
+  void ProcessAllocation();
+  void ProcessNoTransition(unsigned int currentTime);
+  void ProcessInstantTransition(unsigned int currentTime);
+  void ProcessFadingTransition(unsigned int currentTime);
 
   /*!
    * \brief Update the diffuse color based on the current item infos
@@ -107,9 +112,16 @@ protected:
   CTextureInfo m_image;
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_info;
 
-  std::unique_ptr<CGUITexture> m_texture;
-  std::vector<CFadingTexture *> m_fadingTextures;
-  std::string m_currentTexture;
+  bool m_isTransitioning{false};
+  bool m_hasNewStagingTexture{false};
+
+  std::unique_ptr<CGUITexture> m_textureCurrent;
+  std::unique_ptr<CGUITexture> m_textureNext;
+
+  std::string m_nameCurrent{};
+  std::string m_nameNext{};
+  std::string m_nameStaging{};
+
   std::string m_currentFallback;
 
   unsigned int m_crossFadeTime;


### PR DESCRIPTION
## Description
With this PR, most of our texture fading implementation has been replaced. Instead of fading an arbitrary number of textures, at maximum only two textures are active at any given time.

## Motivation and context
The previous implementation would regularly fade between three or more fanart textures when scrolling through a typical movie view, while additional textures were being loaded from disk. This could choke even fairly potent systems.

The new implementation has only two texture slots, one for holding and fading out the current texture, the other one for loading and fading in a new texture. The animation cycle has to conclude before a new texture can be processed. Especially since there can only be a texture fading in or a texture loading in, I would guesstimate that this change reduces the peak GPU/CPU memory bandwidth load of the element by up to 50%. Because the fade effect is often used on fanart, the savings are substantial. 

It also allows for more optimized blending and texture processing in the future.

## How has this been tested?
Runs fine on my desktop. I have yet to test it on an embedded system.

Estuary might load the wrong fanart when switching through panels. But this is a bug in Estuary, as it missuses the "onfocus" action.

## What is the effect on users?
Better performance, less jank.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
