### PR TITLE
Added: Mark issues and PR's older then 365 days as `stale`.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: 'Close stale issues and PRs'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */2 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 365
+          stale-issue-message: 'This issue is stale because it has been open over a year without activity. Remove stale label or comment on it to reset the stale state.'
+          stale-issue-label: Stale
+          stale-pr-message: 'This PR is stale because it has been open for over a year without activity. Remove stale label or comment on it to reset the stale state.'
+          stale-pr-label: Stale
+          operations-per-run: 100
+          debug-only: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,9 +15,9 @@ jobs:
       - uses: actions/stale@v9
         with:
           days-before-stale: 365
-          stale-issue-message: 'This issue is stale because it has been open over a year without activity. Remove stale label or comment on it to reset the stale state.'
+          stale-issue-message: 'This issue is now marked stale because it has been open over a year without activity. Remove the stale label or add a comment to reset the stale state.'
           stale-issue-label: Stale
-          stale-pr-message: 'This PR is stale because it has been open for over a year without activity. Remove stale label or comment on it to reset the stale state.'
+          stale-pr-message: 'This pull request is now marked stale because it has been open over a year without activity. Remove the stale label or add a comment to reset the stale state.'
           stale-pr-label: Stale
           operations-per-run: 100
           debug-only: true


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
As discussed in the team meeting: This PR adds a GitHub action that marks old PR's and Issues as `stale`. 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Currently the `debug-only` is enabled to debug during runs.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
PR owners and Issue openers will get a notification if their PR/Issue is older than 365 days.

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
