### PR TITLE
[PVR] When hiding a member of the all channels group we must not dele…

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -562,7 +562,7 @@ void CPVRChannelGroup::DeleteGroupMembersFromDb(
 
     for (const auto& member : membersToDelete)
     {
-      commitPending |= member->QueueDelete();
+      commitPending |= database->QueueDeleteQuery(*member);
 
       size_t queryCount = database->GetDeleteQueriesCount();
       if (queryCount > CHANNEL_COMMIT_QUERY_COUNT_LIMIT)

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -783,9 +783,12 @@ bool CPVRChannelGroup::RemoveFromGroup(
     }
   }
 
-  // no need to renumber if nothing was removed
+  // no need to delete and renumber if nothing was removed
   if (bReturn)
+  {
+    DeleteGroupMembersFromDb({std::make_shared<CPVRChannelGroupMember>(*groupMember)});
     Renumber();
+  }
 
   return bReturn;
 }
@@ -876,11 +879,6 @@ void CPVRChannelGroup::Delete()
     if (database->Delete(*this))
       m_bDeleted = true;
   }
-}
-
-void CPVRChannelGroup::DeleteGroupMember(const std::shared_ptr<CPVRChannelGroupMember>& member)
-{
-  DeleteGroupMembersFromDb({member});
 }
 
 bool CPVRChannelGroup::Renumber(RenumberMode mode /* = NORMAL */)

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -442,12 +442,6 @@ public:
   void Delete();
 
   /*!
-   * @brief Remove the given group member from the database.
-   * @param member The member to remove from the database.
-   */
-  void DeleteGroupMember(const std::shared_ptr<CPVRChannelGroupMember>& member);
-
-  /*!
    * @brief Whether this group is deleted.
    * @return True, if deleted, false otherwise.
    */

--- a/xbmc/pvr/channels/PVRChannelGroupMember.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupMember.cpp
@@ -9,7 +9,6 @@
 #include "PVRChannelGroupMember.h"
 
 #include "ServiceBroker.h"
-#include "pvr/PVRDatabase.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClient.h"
 #include "pvr/channels/PVRChannel.h"
@@ -131,13 +130,4 @@ void CPVRChannelGroupMember::SetOrder(int iOrder)
     m_iOrder = iOrder;
     m_bNeedsSave = true;
   }
-}
-
-bool CPVRChannelGroupMember::QueueDelete()
-{
-  const std::shared_ptr<CPVRDatabase> database = CServiceBroker::GetPVRManager().GetTVDatabase();
-  if (!database)
-    return false;
-
-  return database->QueueDeleteQuery(*this);
 }

--- a/xbmc/pvr/channels/PVRChannelGroupMember.h
+++ b/xbmc/pvr/channels/PVRChannelGroupMember.h
@@ -77,12 +77,6 @@ public:
 
   bool IsRadio() const { return m_bIsRadio; }
 
-  /*!
-   * @brief Delete this group member from the database.
-   * @return True if it was deleted successfully, false otherwise.
-   */
-  bool QueueDelete();
-
 private:
   int m_iGroupID = -1;
   int m_iGroupClientID = -1;

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -764,8 +764,6 @@ bool CPVRChannelGroups::RemoveFromGroup(const std::shared_ptr<CPVRChannelGroup>&
 
     if (group->RemoveFromGroup(groupMember))
     {
-      group->DeleteGroupMember(groupMember);
-
       // Changes in the all channels group may require resorting/renumbering of other groups.
       if (group->IsChannelsOwner())
         UpdateChannelNumbersFromAllChannelsGroup();


### PR DESCRIPTION
…te the respective database record.

Although I cannot reproduce myself, according to the logs and db dumps we have, this should fix #25571.

It was definitely wrong to delete the channel group member from the database when it only gets hidden. Not doing this anymore, should fix above mentioned issue, as problem there was that recreation of the channel group member in the db right after removing it from the db failed.

Second commit is just some small optimization I did while debugging the problem.

@phunkyfish code change is minimal. Please review.