### PR TITLE
Egl async rendering fixes

### DIFF
--- a/xbmc/utils/EGLFence.cpp
+++ b/xbmc/utils/EGLFence.cpp
@@ -133,11 +133,7 @@ void CEGLFence::WaitSyncCPU()
   if (!m_kmsFence)
     return;
 
-  EGLint status{EGL_FALSE};
-
-  while (status != EGL_CONDITION_SATISFIED_KHR)
-    status = m_eglClientWaitSyncKHR(m_display, m_kmsFence, 0, EGL_FOREVER_KHR);
-
-  m_eglDestroySyncKHR(m_display, m_kmsFence);
+  if (m_eglClientWaitSyncKHR(m_display, m_kmsFence, 0, EGL_FOREVER_KHR) != EGL_FALSE)
+    m_eglDestroySyncKHR(m_display, m_kmsFence);
 }
 #endif

--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
@@ -149,6 +149,11 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
   {
     CLog::Log(LOGERROR, "CDRMAtomic::{} - atomic commit failed: {}", __FUNCTION__,
               strerror(errno));
+    m_atomicRequestQueue.pop_back();
+  }
+  else if (m_atomicRequestQueue.size() > 1)
+  {
+    m_atomicRequestQueue.pop_front();
   }
 
   if (m_inFenceFd != -1)
@@ -163,9 +168,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
       CLog::Log(LOGERROR, "CDRMAtomic::{} - failed to destroy property blob: {}", __FUNCTION__,
                 strerror(errno));
   }
-
-  if (m_atomicRequestQueue.size() > 1)
-    m_atomicRequestQueue.pop_back();
 
   m_atomicRequestQueue.emplace_back(std::make_unique<CDRMAtomicRequest>());
   m_req = m_atomicRequestQueue.back().get();


### PR DESCRIPTION
## Description
This fixes the infinite loop issue, when an invalid drm atomic request is commit which the drm planes can not satisfy in gbm mode.

## Motivation and context
In the code flow a drm request is tested against validity first and then commit if drivers validates it. However due to the reasons unknown (could either be kodi or mesa/egl or even kernel driver issue) sometimes such a request is commit and reported several times in https://github.com/xbmc/xbmc/issues/24760, https://github.com/xbmc/xbmc/issues/25222, https://github.com/LibreELEC/LibreELEC.tv/issues/8488

And in this case async EGL renderer tries to wait to sync infinitely for the same request. This causes infinite loop waiting a positive result for the same impossible request.

To reproduce:
1. Start kodi in GBM mode
2. check your drm capabilities with tool `drm_info`
3. create a test file which exceeds the capabilities of your drm plane, ie if the max width is 4096, try something ridicilous like 16K
4. try to play the video, and drm planes will complain and kodi will go infinite loop.
5. log will be spammed with
```
2024-08-07 22:30:18.486 T:9437    debug <general>: EGL Debugging:
                                                   Error: EGL_BAD_PARAMETER
                                                   Command: eglClientWaitSyncKHR
                                                   Type: EGL_DEBUG_MSG_ERROR_KHR
                                                   Message: _eglClientWaitSyncCommon
```

## How has this been tested?
Latest kodi from master branch with Rk3588 rockchip bsp kernel.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
