### PR TITLE
[video] Change select action choose implementation to open the full context menu of the item…

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15675,7 +15675,6 @@ msgstr ""
 #. Label to denote that there is something 'more'
 #. xbmc/favourites/ContextMenus.h
 #: xbmc/guilib/listproviders/DirectoryProvider.cpp
-#: xbmc/video/guilib/VideoSelectActionProcessor.cpp
 #: system/settings/settings.xml
 msgctxt "#22082"
 msgid "More..."

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1081,14 +1081,14 @@
       <group id="1" label="593">
         <setting id="myvideos.selectaction" type="integer" label="22079" help="36177">
           <level>0</level>
-          <default>1</default> <!-- SELECT_ACTION_PLAY_OR_RESUME -->
+          <default>1</default> <!-- ACTION_PLAY_OR_RESUME -->
           <constraints>
             <options>
-              <option label="22080">0</option> <!-- SELECT_ACTION_CHOOSE -->
-              <option label="208">1</option> <!-- SELECT_ACTION_PLAY_OR_RESUME -->
-              <option label="13404">2</option> <!-- SELECT_ACTION_RESUME -->
-              <option label="22081">3</option> <!-- SELECT_ACTION_INFO -->
-              <option label="13347">7</option> <!-- SELECT_ACTION_QUEUE -->
+              <option label="22080">0</option> <!-- ACTION_CHOOSE -->
+              <option label="208">1</option> <!-- ACTION_PLAY_OR_RESUME -->
+              <option label="13404">2</option> <!-- ACTION_RESUME -->
+              <option label="22081">3</option> <!-- ACTION_INFO -->
+              <option label="13347">7</option> <!-- ACTION_QUEUE -->
             </options>
           </constraints>
           <control type="list" format="string" />
@@ -1100,11 +1100,11 @@
         </setting>
         <setting id="myvideos.playaction" type="integer" label="22076" help="36204">
           <level>0</level>
-          <default>1</default> <!-- PLAY_ACTION_PLAY_OR_RESUME -->
+          <default>1</default> <!-- ACTION_PLAY_OR_RESUME -->
           <constraints>
             <options>
-              <option label="22077">1</option> <!-- PLAY_ACTION_PLAY_OR_RESUME -->
-              <option label="22078">2</option> <!-- PLAY_ACTION_RESUME -->
+              <option label="22077">1</option> <!-- ACTION_PLAY_OR_RESUME -->
+              <option label="22078">2</option> <!-- ACTION_RESUME -->
             </options>
           </constraints>
           <control type="list" format="string" />

--- a/xbmc/favourites/GUIWindowFavourites.cpp
+++ b/xbmc/favourites/GUIWindowFavourites.cpp
@@ -90,7 +90,7 @@ protected:
     return UTILS::GUILIB::CGUIContentUtils::ShowInfoForItem(*m_item);
   }
 
-  bool OnMoreSelected() override
+  bool OnChooseSelected() override
   {
     CONTEXTMENU::ShowFor(m_item, CContextMenuManager::MAIN);
     return true;

--- a/xbmc/guilib/listproviders/DirectoryProvider.cpp
+++ b/xbmc/guilib/listproviders/DirectoryProvider.cpp
@@ -516,7 +516,7 @@ protected:
     return true;
   }
 
-  bool OnMoreSelected() override
+  bool OnChooseSelected() override
   {
     m_provider.OnContextMenu(m_item);
     return true;

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -268,7 +268,7 @@ protected:
     return true;
   }
 
-  bool OnMoreSelected() override
+  bool OnChooseSelected() override
   {
     m_window.OnPopupMenu(m_itemIndex);
     return true;

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -228,7 +228,7 @@ protected:
     return true;
   }
 
-  bool OnMoreSelected() override
+  bool OnChooseSelected() override
   {
     CONTEXTMENU::ShowFor(m_item, CContextMenuManager::MAIN);
     return true;

--- a/xbmc/video/guilib/VideoAction.h
+++ b/xbmc/video/guilib/VideoAction.h
@@ -18,7 +18,7 @@ enum Action
   ACTION_PLAY_OR_RESUME = 1, // if resume is possible, ask user. play from beginning otherwise
   ACTION_RESUME = 2, // resume if possibly, play from beginning otherwise
   ACTION_INFO = 3,
-  ACTION_MORE = 4,
+  // 4 unused
   ACTION_PLAY_FROM_BEGINNING = 5, // play from beginning, also if resume would be possible
   ACTION_PLAYPART = 6,
   ACTION_QUEUE = 7,

--- a/xbmc/video/guilib/VideoSelectActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoSelectActionProcessor.cpp
@@ -11,7 +11,6 @@
 #include "FileItem.h"
 #include "FileItemList.h"
 #include "ServiceBroker.h"
-#include "dialogs/GUIDialogContextMenu.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "filesystem/Directory.h"
 #include "guilib/GUIComponent.h"
@@ -22,7 +21,6 @@
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "video/VideoFileItemClassify.h"
-#include "video/VideoInfoTag.h"
 #include "video/guilib/VideoGUIUtils.h"
 
 namespace KODI::VIDEO::GUILIB
@@ -47,16 +45,7 @@ bool CVideoSelectActionProcessorBase::Process(Action action)
   switch (action)
   {
     case ACTION_CHOOSE:
-    {
-      const Action selectedAction = ChooseVideoItemSelectAction();
-      if (selectedAction < 0)
-      {
-        m_userCancelled = true;
-        return true; // User cancelled the select menu. We're done.
-      }
-
-      return Process(selectedAction);
-    }
+      return OnChooseSelected();
 
     case ACTION_PLAYPART:
     {
@@ -82,9 +71,6 @@ bool CVideoSelectActionProcessorBase::Process(Action action)
 
       return OnInfoSelected();
     }
-
-    case ACTION_MORE:
-      return OnMoreSelected();
 
     default:
       break;
@@ -113,28 +99,6 @@ unsigned int CVideoSelectActionProcessorBase::ChooseStackItemPartNumber() const
     return 0; // User cancelled the dialog.
 
   return dialog->GetSelectedItem() + 1; // part numbers are 1-based
-}
-
-Action CVideoSelectActionProcessorBase::ChooseVideoItemSelectAction() const
-{
-  CContextButtons choices;
-
-  const std::string resumeString = UTILS::GetResumeString(*m_item);
-  if (!resumeString.empty())
-  {
-    choices.Add(ACTION_RESUME, resumeString);
-    choices.Add(ACTION_PLAY_FROM_BEGINNING, 12021); // Play from beginning
-  }
-  else
-  {
-    choices.Add(ACTION_PLAY_FROM_BEGINNING, 208); // Play
-  }
-
-  choices.Add(ACTION_INFO, 22081); // Show information
-  choices.Add(ACTION_QUEUE, 13347); // Queue item
-  choices.Add(ACTION_MORE, 22082); // More
-
-  return static_cast<Action>(CGUIDialogContextMenu::ShowAndGetChoice(choices));
 }
 
 } // namespace KODI::VIDEO::GUILIB

--- a/xbmc/video/guilib/VideoSelectActionProcessor.h
+++ b/xbmc/video/guilib/VideoSelectActionProcessor.h
@@ -35,11 +35,10 @@ protected:
   virtual bool OnPlayPartSelected(unsigned int part) = 0;
   virtual bool OnQueueSelected() = 0;
   virtual bool OnInfoSelected() = 0;
-  virtual bool OnMoreSelected() = 0;
+  virtual bool OnChooseSelected() = 0;
 
 private:
   CVideoSelectActionProcessorBase() = delete;
-  Action ChooseVideoItemSelectAction() const;
   unsigned int ChooseStackItemPartNumber() const;
 };
 } // namespace KODI::VIDEO::GUILIB

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -605,7 +605,7 @@ protected:
 
   bool OnInfoSelected() override { return m_window.OnItemInfo(*m_item); }
 
-  bool OnMoreSelected() override
+  bool OnChooseSelected() override
   {
     // window only shows the default version, so no window specific context menu items available
     if (m_item->HasVideoVersions() && !m_item->GetVideoInfoTag()->IsDefaultVideoVersion())


### PR DESCRIPTION
…, not a special short context menu. Brings back old (pre-Omega) behavior for PVR recordings, adds more flexibility to other video items.

Requested in the forum: https://forum.kodi.tv/showthread.php?tid=377142

Runtime-tested on macOS, latest Kodi master.

@enen92 could you have  a look at the code changes?

Needs backport.