### PR TITLE
RetroPlayer: Show emulator name and icon in Advanced Settings dialog

### DIFF
--- a/addons/skin.estuary/xml/DialogAddonSettings.xml
+++ b/addons/skin.estuary/xml/DialogAddonSettings.xml
@@ -123,6 +123,44 @@
 					<param name="label" value="" />
 				</include>
 			</control>
+			<control type="group">
+				<description>Currently-playing emulator name and icon</description>
+				<visible>Player.HasGame + String.IsEqual(Window(addonsettings).Property(Addon.Type),kodi.gameclient)</visible>
+				<left>1510</left>
+				<width>300</width>
+				<top>528</top>
+				<height>260</height>
+				<control type="label">
+					<description>Emulator name</description>
+					<height>30</height>
+					<font>font23_narrow</font>
+					<textoffsetx>20</textoffsetx>
+					<textcolor>button_focus</textcolor>
+					<shadowcolor>text_shadow</shadowcolor>
+					<align>center</align>
+					<label>$INFO[Window(addonsettings).Property(GameClient.Name)]</label>
+				</control>
+				<control type="label">
+					<description>Emulator version</description>
+					<top>30</top>
+					<height>30</height>
+					<font>font23_narrow</font>
+					<textoffsetx>20</textoffsetx>
+					<textcolor>button_focus</textcolor>
+					<shadowcolor>text_shadow</shadowcolor>
+					<align>center</align>
+					<label>$INFO[Window(addonsettings).Property(Addon.Version)]</label>
+				</control>
+				<control type="image">
+					<description>Emulator icon</description>
+					<left>50</left>
+					<top>70</top>
+					<height>200</height>
+					<width>200</width>
+					<aspectratio>keep</aspectratio>
+					<texture>$INFO[Window(addonsettings).Property(Addon.Icon)]</texture>
+				</control>
+			</control>
 			<control type="radiobutton" id="20">
 				<left>29</left>
 				<top>700</top>


### PR DESCRIPTION
## Description

As title says, this PR adds the emulator name and icon to the Advanced Settings dialog in the in-game OSD.

## Motivation and context

It's helpful to see which emulator the advanced settings on the screen belong to. The emulator is currently buried in the dialog title, but this change makes it much more evident.

## How has this been tested?

Tested on my latest v21 test branch.

TODO: Include in test builds.

## What is the effect on users?

* Improved Advanced Settings dialog in the in-game OSD

## Screenshots (if appropriate):

Playing Mr.Boom:

![screenshot00004](https://github.com/user-attachments/assets/996f2d9f-86ac-4983-9e58-8bdd261ba828)

Testing with a really long emulator name:

![screenshot00005](https://github.com/user-attachments/assets/2747d8c7-6ece-4cd5-99f8-565023777738)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
