### PR TITLE
TestConversionMatrix: Add missing `<iomanip>` include

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/test/TestConversionMatrix.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/test/TestConversionMatrix.cpp
@@ -10,6 +10,7 @@
 #include "cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.h"
 #include "xbmc/utils/MathUtils.h"
 
+#include <iomanip>
 #include <iostream>
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
## Description

Add missing `<iomanip>` include in TestConversionMatrix.cpp.

## Motivation and context

Recently something broke building of the unit test on Linux:

```
xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/test/TestConversionMatrix.cpp:35:23: error: no member named 'setprecision' in namespace 'std'
   35 |     std::cout << std::setprecision(10)
      |                  ~~~~~^
xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/test/TestConversionMatrix.cpp:55:23: error: no member named 'setprecision' in namespace 'std'
   55 |     std::cout << std::setprecision(10)
      |                  ~~~~~^
2 errors generated.
```

## How has this been tested?

Builds and unit tests are running fine.

## What is the effect on users?

None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
