### PR TITLE
[MUSIC] Fix ambiguous field in SQL if sorting by artist sortname

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -13234,6 +13234,13 @@ int CMusicDatabase::GetOrderFilter(const std::string& type,
     }
   }
 
+  // Get the right tableview as if we are using strArtistSort the column name is ambiguous
+  std::string table;
+  if (StringUtils::StartsWithNoCase(type, "album"))
+    table = "albumview.";
+  else if (StringUtils::StartsWithNoCase(type, "song"))
+    table = "songview.";
+
   // Convert field names into order by statement elements
   for (auto& name : orderfields)
   {
@@ -13242,7 +13249,8 @@ int CMusicDatabase::GetOrderFilter(const std::string& type,
     if (StringUtils::EndsWith(name, "strArtists") || StringUtils::EndsWith(name, "strArtist"))
     {
       if (StringUtils::EndsWith(name, "strArtists"))
-        sortSQL = SortnameBuildSQL("artistsortname", sorting.sortAttributes, name, "strArtistSort");
+        sortSQL = SortnameBuildSQL("artistsortname", sorting.sortAttributes, name,
+                                   table + "strArtistSort");
       else
         sortSQL = SortnameBuildSQL("artistsortname", sorting.sortAttributes, name, "strSortName");
       if (!sortSQL.empty())


### PR DESCRIPTION
## Description
In some circumstances, when using smartplaylists, its possible for the code to generate SQL with an ambiguous column name.  This happens with both MySQL/MariaDB & SQlite, but only if using "sort artists using artist sort".

This PR fixes the issue by pre-pending the correct view to the strArtistSort field.

This issue only occurs with the following circumstances (never-the-less, it still requires fixing).

- The xsp must be of type "songs"
- Grouping must be by "albums"
- Sort artists using artist sortname must be enabled in the music settings

I only noticed this when demonstrating some library features to a visitor and noticed that some of my smart playlists from years ago now no longer work!

Not sure who can review this with Dave being MIA.  Perhaps @CrystalP ?

## Motivation and context
It's possible to write some valid xsp such as 

```
<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
<smartplaylist type="songs">
    <name>quad</name>
    <match>all</match>
    <rule field="channels" operator="greaterthan">
        <value>3</value>
    </rule>
    <group>albums</group>
    <order direction="ascending">album</order>
</smartplaylist>
```
That will show all albums that are in a surround format, so 4.0, 5.1 etc.  It doesn't work though if you have **Sort artists using sortname enabled**.  This is because the field `strArtistSort` is in the albumview as well as the songview and we need to JOIN the songview to the albumview.

My solution, (although @DaveTBlake would likely have a more elegant solution), is to check whether we are dealing with albums or songs and pre-pend the appropriate view to the field when building the SQL. 

## How has this been tested?
Tested against Mariadb and sqlite with several different xsp's, with sort artists using sortnames both enabled and disabled.  In all cases, without this change, when sortnames are enabled, the xsp produces no results other than an error in the log.  EG
```
error <general>: SQL: [MyMusic83.db] SQLite error SQLITE_ERROR (ambiguous column name: strArtistSort)
SQL: [MyMusic83] Undefined MySQL error: Code (1052)

```

With the proposed change, no such error occurs and the query completes correctly.

## What is the effect on users?
Fixes an issue with some smartplaylists when sort artist by artist sortname is enabled.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
