### PR TITLE
[video][windows] Fix videos provided by plugins not played from info …

### DIFF
--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -141,12 +141,15 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
 
   if (item->m_bIsFolder)
   {
-    // check if it's a folder with dvd or bluray files, then just add the relevant file
-    const std::string mediapath = VIDEO::UTILS::GetOpticalMediaPath(*item);
-    if (!mediapath.empty())
+    if (!item->IsPlugin())
     {
-      m_queuedItems.Add(std::make_shared<CFileItem>(mediapath, false));
-      return;
+      // check if it's a folder with dvd or bluray files, then just add the relevant file
+      const std::string mediapath = VIDEO::UTILS::GetOpticalMediaPath(*item);
+      if (!mediapath.empty())
+      {
+        m_queuedItems.Add(std::make_shared<CFileItem>(mediapath, false));
+        return;
+      }
     }
 
     // Check if we add a locked share

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -769,6 +769,12 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
       m_history.RemoveParentPath();
   }
 
+  // Store parent path along with item as parent path cannot safely be calculated from item's path.
+  for (const auto& item : items)
+  {
+    item->SetProperty("ParentPath", m_vecItems->GetPath());
+  }
+
   // update the view state's reference to the current items
   m_guiState.reset(CGUIViewState::GetViewState(GetID(), items));
 
@@ -1742,8 +1748,6 @@ bool CGUIMediaWindow::OnPopupMenu(int itemIdx)
   auto item = m_vecItems->Get(itemIdx);
   if (!item)
     return false;
-
-  item->SetProperty("ParentPath", m_vecItems->GetPath());
 
   CContextButtons buttons;
 


### PR DESCRIPTION
…dialog for certain settings combination.

I was able to reproduce #25603 and this PR should fix the issue reported there.

Two things went wrong:
1) `VIDEO::UTILS::GetOpticalMediaPath` must only be called for items with a working `CFile::Exists` implementation. `CPluginFile::Exists` for example returns always `true` making the code below thinking the plugin item resides on an optical media.
2) To make "Auto play next item" work the proper parent path of the first item to play must be available. For some items like plugin-provided items the parent path cannot safely calculated be just removing the last URL segment.

Runtime-tested on macOS, latest Kodi master.

@enen92 I hope this is something you can review. Not sure whether the !plugin check better should be done somewhere else, maybe inside `VIDEO::UTILS::GetOpticalMediaPath` implememtation.