### PR TITLE
[PVR] Saved searches: Add possibility to set a user defined icon for a search

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -11354,23 +11354,27 @@ msgstr ""
 
 #. Label for a select option or list item, representing an icon graphic (like a TV channel icon)
 #: xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsEPG.cpp
 msgctxt "#19282"
 msgid "Current icon"
 msgstr ""
 
 #. Label for a select option or list item, representing an icon graphic (like a TV channel icon)
 #: xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsEPG.cpp
 msgctxt "#19283"
 msgid "No icon"
 msgstr ""
 
-#. used by several skins
+#. used by several skins and PVR
+#: xbmc/pvr/PVRContextMenus.cpp
 msgctxt "#19284"
 msgid "Choose icon"
 msgstr ""
 
 #. Label for a select/menu option to select an icon graphic
 #: xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+#: xbmc/pvr/guilib/PVRGUIActionsEPG.cpp
 msgctxt "#19285"
 msgid "Browse for icon"
 msgstr ""

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -190,7 +190,11 @@ CFileItem::CFileItem(const std::shared_ptr<PVR::CPVREpgSearchFilter>& filter)
   if (lastExec.IsValid())
     m_dateTime.SetFromUTCDateTime(lastExec);
 
-  SetArt("icon", "DefaultPVRSearch.png");
+  const std::string iconPath = filter->GetIconPath();
+  if (!iconPath.empty())
+    SetArt("icon", iconPath);
+  else
+    SetArt("icon", "DefaultPVRSearch.png");
 
   // Speedup FillInDefaultIcon()
   SetProperty("icon_never_overlay", true);

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -80,6 +80,7 @@ DECL_STATICCONTEXTMENUITEM(AddReminder);
 DECL_STATICCONTEXTMENUITEM(ExecuteSearch);
 DECL_STATICCONTEXTMENUITEM(EditSearch);
 DECL_STATICCONTEXTMENUITEM(RenameSearch);
+DECL_STATICCONTEXTMENUITEM(ChooseIconForSearch);
 DECL_STATICCONTEXTMENUITEM(DeleteSearch);
 
 class PVRClientMenuHook : public IContextMenuItem
@@ -735,6 +736,19 @@ bool RenameSearch::Execute(const std::shared_ptr<CFileItem>& item) const
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// Choose icon for saved search
+
+bool ChooseIconForSearch::IsVisible(const CFileItem& item) const
+{
+  return item.HasEPGSearchFilter();
+}
+
+bool ChooseIconForSearch::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ChooseIconForSavedSearch(*item);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // Delete saved search
 
 bool DeleteSearch::IsVisible(const CFileItem& item) const
@@ -779,6 +793,7 @@ CPVRContextMenuManager::CPVRContextMenuManager()
         std::make_shared<CONTEXTMENUITEM::ExecuteSearch>(137), /* Search */
         std::make_shared<CONTEXTMENUITEM::EditSearch>(21450), /* Edit */
         std::make_shared<CONTEXTMENUITEM::RenameSearch>(118), /* Rename */
+        std::make_shared<CONTEXTMENUITEM::ChooseIconForSearch>(19284), /* Choose icon */
         std::make_shared<CONTEXTMENUITEM::DeleteSearch>(117), /* Delete */
     })
 {

--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -128,8 +128,9 @@ void CPVREpgDatabase::CreateTables()
               "bIgnoreFutureBroadcasts   bool, "
               "bFreeToAirOnly            bool, "
               "bIgnorePresentTimers      bool, "
-              "bIgnorePresentRecordings  bool,"
-              "iChannelGroup             integer"
+              "bIgnorePresentRecordings  bool, "
+              "iChannelGroup             integer, "
+              "sIconPath                 varchar(255)"
               ")");
 }
 
@@ -323,6 +324,12 @@ void CPVREpgDatabase::UpdateTables(int iVersion)
   {
     m_pDS->exec("ALTER TABLE savedsearches ADD iChannelGroup integer;");
     m_pDS->exec("UPDATE savedsearches SET iChannelGroup = -1");
+  }
+
+  if (iVersion < 17)
+  {
+    m_pDS->exec("ALTER TABLE savedsearches ADD sIconPath varchar(255);");
+    m_pDS->exec("UPDATE savedsearches SET sIconPath = ''");
   }
 }
 
@@ -1321,6 +1328,7 @@ std::shared_ptr<CPVREpgSearchFilter> CPVREpgDatabase::CreateEpgSearchFilter(
     newSearch->SetIgnorePresentTimers(m_pDS->fv("bIgnorePresentTimers").get_asBool());
     newSearch->SetIgnorePresentRecordings(m_pDS->fv("bIgnorePresentRecordings").get_asBool());
     newSearch->SetChannelGroupID(m_pDS->fv("iChannelGroup").get_asInt());
+    newSearch->SetIconPath(m_pDS->fv("sIconPath").get_asString());
 
     newSearch->SetChanged(false);
 
@@ -1392,9 +1400,9 @@ bool CPVREpgDatabase::Persist(CPVREpgSearchFilter& epgSearch)
         "iGenreType, bIncludeUnknownGenres, sStartDateTime, sEndDateTime, iMinimumDuration, "
         "iMaximumDuration, bIsRadio, iClientId, iChannelUid, bRemoveDuplicates, "
         "bIgnoreFinishedBroadcasts, bIgnoreFutureBroadcasts, bFreeToAirOnly, bIgnorePresentTimers, "
-        "bIgnorePresentRecordings, iChannelGroup) "
+        "bIgnorePresentRecordings, iChannelGroup, sIconPath) "
         "VALUES ('%s', '%s', '%s', %i, %i, %i, %i, '%s', '%s', %i, %i, %i, %i, %i, %i, %i, %i, "
-        "%i, %i, %i, %i);",
+        "%i, %i, %i, %i, '%s');",
         epgSearch.GetTitle().c_str(),
         epgSearch.GetLastExecutedDateTime().IsValid()
             ? epgSearch.GetLastExecutedDateTime().GetAsDBDateTime().c_str()
@@ -1413,7 +1421,8 @@ bool CPVREpgDatabase::Persist(CPVREpgSearchFilter& epgSearch)
         epgSearch.ShouldIgnoreFinishedBroadcasts() ? 1 : 0,
         epgSearch.ShouldIgnoreFutureBroadcasts() ? 1 : 0, epgSearch.IsFreeToAirOnly() ? 1 : 0,
         epgSearch.ShouldIgnorePresentTimers() ? 1 : 0,
-        epgSearch.ShouldIgnorePresentRecordings() ? 1 : 0, epgSearch.GetChannelGroupID());
+        epgSearch.ShouldIgnorePresentRecordings() ? 1 : 0, epgSearch.GetChannelGroupID(),
+        epgSearch.GetIconPath().c_str());
   else
     strQuery = PrepareSQL(
         "REPLACE INTO savedsearches "
@@ -1421,9 +1430,9 @@ bool CPVREpgDatabase::Persist(CPVREpgSearchFilter& epgSearch)
         "bIsCaseSensitive, iGenreType, bIncludeUnknownGenres, sStartDateTime, sEndDateTime, "
         "iMinimumDuration, iMaximumDuration, bIsRadio, iClientId, iChannelUid, bRemoveDuplicates, "
         "bIgnoreFinishedBroadcasts, bIgnoreFutureBroadcasts, bFreeToAirOnly, bIgnorePresentTimers, "
-        "bIgnorePresentRecordings, iChannelGroup) "
+        "bIgnorePresentRecordings, iChannelGroup, sIconPath) "
         "VALUES (%i, '%s', '%s', '%s', %i, %i, %i, %i, '%s', '%s', %i, %i, %i, %i, %i, %i, %i, %i, "
-        "%i, %i, %i, %i);",
+        "%i, %i, %i, %i, '%s');",
         epgSearch.GetDatabaseId(), epgSearch.GetTitle().c_str(),
         epgSearch.GetLastExecutedDateTime().IsValid()
             ? epgSearch.GetLastExecutedDateTime().GetAsDBDateTime().c_str()
@@ -1442,7 +1451,8 @@ bool CPVREpgDatabase::Persist(CPVREpgSearchFilter& epgSearch)
         epgSearch.ShouldIgnoreFinishedBroadcasts() ? 1 : 0,
         epgSearch.ShouldIgnoreFutureBroadcasts() ? 1 : 0, epgSearch.IsFreeToAirOnly() ? 1 : 0,
         epgSearch.ShouldIgnorePresentTimers() ? 1 : 0,
-        epgSearch.ShouldIgnorePresentRecordings() ? 1 : 0, epgSearch.GetChannelGroupID());
+        epgSearch.ShouldIgnorePresentRecordings() ? 1 : 0, epgSearch.GetChannelGroupID(),
+        epgSearch.GetIconPath().c_str());
 
   bool bReturn = ExecuteQuery(strQuery);
 

--- a/xbmc/pvr/epg/EpgDatabase.h
+++ b/xbmc/pvr/epg/EpgDatabase.h
@@ -66,7 +66,7 @@ namespace PVR
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    int GetSchemaVersion() const override { return 16; }
+    int GetSchemaVersion() const override { return 17; }
 
     /*!
      * @brief Get the default sqlite database filename.

--- a/xbmc/pvr/epg/EpgSearchFilter.cpp
+++ b/xbmc/pvr/epg/EpgSearchFilter.cpp
@@ -251,6 +251,15 @@ void CPVREpgSearchFilter::SetTitle(const std::string& title)
   }
 }
 
+void CPVREpgSearchFilter::SetIconPath(const std::string& iconPath)
+{
+  if (m_iconPath != iconPath)
+  {
+    m_iconPath = iconPath;
+    m_bChanged = true;
+  }
+}
+
 void CPVREpgSearchFilter::SetLastExecutedDateTime(const CDateTime& lastExecutedDateTime)
 {
   // Note: No need to set m_bChanged here

--- a/xbmc/pvr/epg/EpgSearchFilter.h
+++ b/xbmc/pvr/epg/EpgSearchFilter.h
@@ -123,6 +123,9 @@ namespace PVR
     const std::string& GetTitle() const { return m_title; }
     void SetTitle(const std::string& title);
 
+    const std::string& GetIconPath() const { return m_iconPath; }
+    void SetIconPath(const std::string& iconPath);
+
     const CDateTime& GetLastExecutedDateTime() const { return m_lastExecutedDateTime; }
     void SetLastExecutedDateTime(const CDateTime& lastExecutedDateTime);
 
@@ -166,6 +169,7 @@ namespace PVR
 
     int m_iDatabaseId = -1;
     std::string m_title;
+    std::string m_iconPath;
     CDateTime m_lastExecutedDateTime;
   };
 }

--- a/xbmc/pvr/guilib/PVRGUIActionsEPG.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsEPG.h
@@ -69,6 +69,13 @@ public:
   bool RenameSavedSearch(const CFileItem& item);
 
   /*!
+   * @brief Choose an icon for a saved search. Opens an art chooser dialog.
+   * @param item The item containing a search filter.
+   * @return True on success, false otherwise.
+   */
+  bool ChooseIconForSavedSearch(const CFileItem& item);
+
+  /*!
    * @brief Delete a saved search. Opens confirmation dialog before deleting.
    * @param item The item containing a search filter.
    * @return True on success, false otherwise.


### PR DESCRIPTION
Adds a feature that was requested in the forum: https://forum.kodi.tv/showthread.php?tid=378289

<img width="941" alt="Screenshot 2024-08-14 at 22 10 23" src="https://github.com/user-attachments/assets/0d20955d-7bcb-44a5-9ce4-745a66771fc7">
<img width="1186" alt="Screenshot 2024-08-14 at 22 09 43" src="https://github.com/user-attachments/assets/1f44321b-631d-4d98-a120-4de43add17c6">
<img width="883" alt="Screenshot 2024-08-14 at 22 09 00" src="https://github.com/user-attachments/assets/261221b5-6a31-4f90-8ee7-b65456ac83fe">

Runtime-tested on macOS, latest Kodi master.

@phunkyfish should not be to difficult to review I hope.