### PR TITLE
[PVR] CPVRGUIDirectory: Add support for saved search results.

### DIFF
--- a/xbmc/pvr/epg/CMakeLists.txt
+++ b/xbmc/pvr/epg/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES EpgContainer.cpp
             Epg.cpp
             EpgDatabase.cpp
             EpgInfoTag.cpp
+            EpgSearch.cpp
             EpgSearchFilter.cpp
             EpgSearchPath.cpp
             EpgChannelData.cpp
@@ -12,6 +13,7 @@ set(HEADERS Epg.h
             EpgContainer.h
             EpgDatabase.h
             EpgInfoTag.h
+            EpgSearch.h
             EpgSearchData.h
             EpgSearchFilter.h
             EpgSearchPath.h

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -953,7 +953,8 @@ int CPVREpgContainer::CleanupCachedImages()
                          });
 }
 
-std::vector<std::shared_ptr<CPVREpgSearchFilter>> CPVREpgContainer::GetSavedSearches(bool bRadio)
+std::vector<std::shared_ptr<CPVREpgSearchFilter>> CPVREpgContainer::GetSavedSearches(
+    bool bRadio) const
 {
   const std::shared_ptr<const CPVREpgDatabase> database = GetEpgDatabase();
   if (!database)
@@ -965,7 +966,8 @@ std::vector<std::shared_ptr<CPVREpgSearchFilter>> CPVREpgContainer::GetSavedSear
   return database->GetSavedSearches(bRadio);
 }
 
-std::shared_ptr<CPVREpgSearchFilter> CPVREpgContainer::GetSavedSearchById(bool bRadio, int iId)
+std::shared_ptr<CPVREpgSearchFilter> CPVREpgContainer::GetSavedSearchById(bool bRadio,
+                                                                          int iId) const
 {
   const std::shared_ptr<const CPVREpgDatabase> database = GetEpgDatabase();
   if (!database)

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -224,7 +224,7 @@ namespace PVR
      * @param bRadio Whether to fetch saved searches for radio or TV.
      * @return The searches.
      */
-    std::vector<std::shared_ptr<CPVREpgSearchFilter>> GetSavedSearches(bool bRadio);
+    std::vector<std::shared_ptr<CPVREpgSearchFilter>> GetSavedSearches(bool bRadio) const;
 
     /*!
      * @brief Get the saved search matching the given id.
@@ -232,7 +232,7 @@ namespace PVR
      * @param iId The id.
      * @return The saved search or nullptr if not found.
      */
-    std::shared_ptr<CPVREpgSearchFilter> GetSavedSearchById(bool bRadio, int iId);
+    std::shared_ptr<CPVREpgSearchFilter> GetSavedSearchById(bool bRadio, int iId) const;
 
     /*!
      * @brief Persist a saved search in the database.

--- a/xbmc/pvr/epg/EpgSearch.cpp
+++ b/xbmc/pvr/epg/EpgSearch.cpp
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "EpgSearch.h"
+
+#include "ServiceBroker.h"
+#include "pvr/PVRManager.h"
+#include "pvr/epg/EpgContainer.h"
+#include "pvr/epg/EpgSearchFilter.h"
+
+#include <algorithm>
+#include <mutex>
+
+using namespace PVR;
+
+void CPVREpgSearch::Execute()
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+
+  std::vector<std::shared_ptr<CPVREpgInfoTag>> tags{
+      CServiceBroker::GetPVRManager().EpgContainer().GetTags(m_filter.GetEpgSearchData())};
+  m_filter.SetEpgSearchDataFiltered();
+
+  // Tags can still contain false positives, for search criteria that cannot be handled via
+  // database. So, run extended search filters on what we got from the database.
+  for (auto it = tags.cbegin(); it != tags.cend();)
+  {
+    it = tags.erase(std::remove_if(tags.begin(), tags.end(),
+                                   [this](const std::shared_ptr<const CPVREpgInfoTag>& entry)
+                                   { return !m_filter.FilterEntry(entry); }),
+                    tags.cend());
+  }
+
+  if (m_filter.ShouldRemoveDuplicates())
+    m_filter.RemoveDuplicates(tags);
+
+  m_filter.SetLastExecutedDateTime(CDateTime::GetUTCDateTime());
+
+  m_results = tags;
+}
+
+const std::vector<std::shared_ptr<CPVREpgInfoTag>>& CPVREpgSearch::GetResults() const
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+  return m_results;
+}

--- a/xbmc/pvr/epg/EpgSearch.h
+++ b/xbmc/pvr/epg/EpgSearch.h
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "threads/CriticalSection.h"
+
+#include <memory>
+#include <vector>
+
+namespace PVR
+{
+class CPVREpgInfoTag;
+class CPVREpgSearchFilter;
+
+class CPVREpgSearch
+{
+public:
+  CPVREpgSearch() = delete;
+
+  /*!
+   * @brief ctor.
+   * @param filter The filter defining the search criteria.
+   */
+  explicit CPVREpgSearch(CPVREpgSearchFilter& filter) : m_filter(filter) {}
+
+  /*!
+   * @brief Execute the search.
+   */
+  void Execute();
+
+  /*!
+   * @brief Get the last search results.
+   * @return the results.
+   */
+  const std::vector<std::shared_ptr<CPVREpgInfoTag>>& GetResults() const;
+
+private:
+  mutable CCriticalSection m_critSection;
+  CPVREpgSearchFilter& m_filter;
+  std::vector<std::shared_ptr<CPVREpgInfoTag>> m_results;
+};
+} // namespace PVR

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.h
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.h
@@ -100,6 +100,7 @@ private:
   bool GetTimersDirectory(CFileItemList& results) const;
   bool GetRecordingsDirectory(CFileItemList& results) const;
   bool GetSavedSearchesDirectory(bool bRadio, CFileItemList& results) const;
+  bool GetSavedSearchResults(bool isRadio, int id, CFileItemList& results) const;
 
   const CURL m_url;
 };


### PR DESCRIPTION
Adds vfs support for listing the content of a saved search, means, the search results. Can be seen in action in the search window, info panel, which now shows the search results as a preview as soon as a saved search entry gets selected.

![screenshot00003](https://github.com/user-attachments/assets/af1ac54c-ae36-4373-bce6-960dea9397e0)

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish please review, thanks. Most of the code was already there and needed only to be moved. 