### PR TITLE
Savestate Manager: Show emulator version that savestate was created with

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -19005,11 +19005,7 @@ msgctxt "#35254"
 msgid "Save the game automatically during game play, if supported. Resume playing where you left off."
 msgstr ""
 
-#. Label for showing which emulator the game was saved with
-#: system/settings/settings.xml
-msgctxt "#35255"
-msgid "Saved with:"
-msgstr ""
+#empty string with id 35255
 
 #. Error message when a game client fails to install when a game is being launched
 #: xbmc/games/dialogs/GUIDialogSelectGameClient.cpp

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -323,46 +323,42 @@
 					</include>
 				</control>
 				<control type="group">
-					<description>Emulator name and icon</description>
-					<right>0</right>
-					<width>310</width>
-					<top>162</top>
-					<height>330</height>
-					<bottom>50</bottom>
-					<control type="group">
-						<left>52</left>
-						<control type="image">
-							<left>-20</left>
-							<right>-20</right>
-							<top>-20</top>
-							<bottom>-20</bottom>
-							<texture border="40">buttons/dialogbutton-nofo.png</texture>
-						</control>
-						<control type="label">
-							<description>Label for Saved with: text</description>
-							<top>14</top>
-							<height>20</height>
-							<shadowcolor>text_shadow</shadowcolor>
-							<label>35255</label>
-							<align>center</align>
-						</control>
-						<control type="label" id="10823">
-							<description>Emulator name</description>
-							<top>60</top>
-							<height>20</height>
-							<font>font23_narrow</font>
-							<textcolor>button_focus</textcolor>
-							<shadowcolor>text_shadow</shadowcolor>
-							<align>center</align>
-						</control>
-						<control type="image" id="10824">
-							<description>Emulator icon</description>
-							<top>108</top>
-							<height>192</height>
-							<right>33</right>
-							<width>192</width>
-							<aspectratio>keep</aspectratio>
-						</control>
+					<description>Saved-with emulator name, version and icon</description>
+					<left>1302</left>
+					<top>420</top>
+					<control type="label">
+						<description>Label for "Saved with:" text</description>
+						<height>20</height>
+						<font>font16</font>
+						<shadowcolor>text_shadow</shadowcolor>
+						<label>35255</label>
+						<align>center</align>
+					</control>
+					<control type="label" id="10823">
+						<description>Emulator name</description>
+						<top>48</top>
+						<height>30</height>
+						<font>font23_narrow</font>
+						<textoffsetx>20</textoffsetx>
+						<textcolor>button_focus</textcolor>
+						<shadowcolor>text_shadow</shadowcolor>
+						<align>center</align>
+					</control>
+					<control type="label" id="10828">
+						<description>Emulator version</description>
+						<top>78</top>
+						<height>30</height>
+						<font>font23_narrow</font>
+						<textoffsetx>20</textoffsetx>
+						<textcolor>button_focus</textcolor>
+						<shadowcolor>text_shadow</shadowcolor>
+						<align>center</align>
+					</control>
+					<control type="image" id="10824">
+						<description>Emulator icon</description>
+						<top>128</top>
+						<height>200</height>
+						<aspectratio>keep</aspectratio>
 					</control>
 				</control>
 				<control type="group">

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -326,14 +326,6 @@
 					<description>Saved-with emulator name, version and icon</description>
 					<left>1302</left>
 					<top>420</top>
-					<control type="label">
-						<description>Label for "Saved with:" text</description>
-						<height>20</height>
-						<font>font16</font>
-						<shadowcolor>text_shadow</shadowcolor>
-						<label>35255</label>
-						<align>center</align>
-					</control>
 					<control type="label" id="10823">
 						<description>Emulator name</description>
 						<top>48</top>

--- a/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
@@ -181,6 +181,7 @@ void CSavestateDatabase::GetSavestateItem(const ISavestate& savestate,
   item.SetProperty(SAVESTATE_LABEL, savestate.Label());
   item.SetProperty(SAVESTATE_CAPTION, savestate.Caption());
   item.SetProperty(SAVESTATE_GAME_CLIENT, savestate.GameClientID());
+  item.SetProperty(SAVESTATE_GAME_CLIENT_VERSION, savestate.GameClientVersion());
   item.m_dateTime = dateUTC;
 }
 

--- a/xbmc/games/dialogs/DialogGameDefines.h
+++ b/xbmc/games/dialogs/DialogGameDefines.h
@@ -12,6 +12,7 @@
 constexpr auto SAVESTATE_LABEL = "savestate.label";
 constexpr auto SAVESTATE_CAPTION = "savestate.caption";
 constexpr auto SAVESTATE_GAME_CLIENT = "savestate.gameclient";
+constexpr auto SAVESTATE_GAME_CLIENT_VERSION = "savestate.gameclientversion";
 
 // Control IDs for game dialogs
 constexpr unsigned int CONTROL_VIDEO_HEADING = 10810;
@@ -25,3 +26,4 @@ constexpr unsigned int CONTROL_SAVES_EMULATOR_ICON = 10824;
 constexpr unsigned int CONTROL_SAVES_NEW_BUTTON = 10825;
 constexpr unsigned int CONTROL_SAVES_CANCEL_BUTTON = 10826;
 constexpr unsigned int CONTROL_NUMBER_OF_ITEMS = 10827;
+constexpr unsigned int CONTROL_SAVES_EMULATOR_VERSION = 10828;

--- a/xbmc/games/dialogs/osd/DialogGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameSaves.cpp
@@ -225,6 +225,7 @@ void CDialogGameSaves::OnInitWindow()
       if (!gameClientId.empty())
       {
         std::string emulatorName;
+        std::string emulatorVersion;
         std::string emulatorIcon;
 
         using namespace ADDON;
@@ -239,6 +240,7 @@ void CDialogGameSaves::OnInitWindow()
             m_currentGameClient = gameClient->ID();
 
             emulatorName = gameClient->GetEmulatorName();
+            emulatorVersion = item->GetProperty(SAVESTATE_GAME_CLIENT_VERSION).asString();
             emulatorIcon = gameClient->Icon();
           }
         }
@@ -247,6 +249,12 @@ void CDialogGameSaves::OnInitWindow()
         {
           CGUIMessage message(GUI_MSG_LABEL_SET, GetID(), CONTROL_SAVES_EMULATOR_NAME);
           message.SetLabel(emulatorName);
+          OnMessage(message);
+        }
+        if (!emulatorVersion.empty())
+        {
+          CGUIMessage message(GUI_MSG_LABEL_SET, GetID(), CONTROL_SAVES_EMULATOR_VERSION);
+          message.SetLabel(emulatorVersion);
           OnMessage(message);
         }
         if (!emulatorIcon.empty())
@@ -362,15 +370,18 @@ void CDialogGameSaves::OnFocus(const CFileItem& item)
 {
   const std::string caption = item.GetProperty(SAVESTATE_CAPTION).asString();
   const std::string gameClientId = item.GetProperty(SAVESTATE_GAME_CLIENT).asString();
+  const std::string gameClientVersion = item.GetProperty(SAVESTATE_GAME_CLIENT_VERSION).asString();
 
   HandleCaption(caption);
   HandleGameClient(gameClientId);
+  HandleGameClientVersion(gameClientVersion);
 }
 
 void CDialogGameSaves::OnFocusLost()
 {
   HandleCaption("");
   HandleGameClient("");
+  HandleGameClientVersion("");
 }
 
 void CDialogGameSaves::OnContextMenu(CFileItem& item)
@@ -498,4 +509,19 @@ void CDialogGameSaves::HandleGameClient(const std::string& gameClientId)
     message.SetLabel(iconPath);
     CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(message, GetID());
   }
+}
+
+void CDialogGameSaves::HandleGameClientVersion(const std::string& gameClientVersion)
+{
+  if (gameClientVersion == m_currentGameClientVersion)
+    return;
+
+  m_currentGameClientVersion = gameClientVersion;
+  if (m_currentGameClientVersion.empty())
+    return;
+
+  // Update the GUI elements
+  CGUIMessage message(GUI_MSG_LABEL_SET, GetID(), CONTROL_SAVES_EMULATOR_VERSION);
+  message.SetLabel(gameClientVersion);
+  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(message, GetID());
 }

--- a/xbmc/games/dialogs/osd/DialogGameSaves.h
+++ b/xbmc/games/dialogs/osd/DialogGameSaves.h
@@ -99,6 +99,11 @@ private:
   */
   void HandleGameClient(const std::string& gameClientId);
 
+  /*!
+  * \brief Called every frame with the game client version to set
+  */
+  void HandleGameClientVersion(const std::string& gameClientVersion);
+
   // Dialog parameters
   std::unique_ptr<CGUIViewControl> m_viewControl;
   std::unique_ptr<CFileItemList> m_vecList;
@@ -111,6 +116,7 @@ private:
   // State parameters
   std::string m_currentCaption;
   std::string m_currentGameClient;
+  std::string m_currentGameClientVersion;
 };
 } // namespace GAME
 } // namespace KODI


### PR DESCRIPTION
## Description

As title says, this PR adds the version of the emulator that the savestate was created with to the emulator info box in the Savestate Manager.

It also scrolls long emulator names, a suggestion from https://github.com/xbmc/xbmc/pull/25598.

## Motivation and context

While working on https://github.com/xbmc/xbmc/pull/25598 I realized the changes would improve the savestate manager too.

## How has this been tested?

Included in upcoming round of test builds.

## What is the effect on users?

* Improved Savestate Manager

## Screenshots (if appropriate):

![screenshot00002](https://github.com/user-attachments/assets/cc3777c4-c363-4e54-ab56-adf9a3842c10)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
