### PR TITLE
[addons][PVR] PVR Addon API 9.0.0

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
@@ -284,7 +284,10 @@ template<class CPP_CLASS, typename C_STRUCT>
 class DynamicCStructHdl
 {
 public:
-  DynamicCStructHdl() : m_cStructure(new C_STRUCT()), m_owner(true) {}
+  DynamicCStructHdl() : m_cStructure(new C_STRUCT()), m_owner(true)
+  {
+    memset(m_cStructure, 0, sizeof(C_STRUCT));
+  }
 
   DynamicCStructHdl(const CPP_CLASS& cppClass)
     : m_cStructure(new C_STRUCT(*cppClass.m_cStructure)), m_owner(true)

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/ChannelGroups.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/ChannelGroups.h
@@ -40,7 +40,7 @@ class PVRChannelGroup : public DynamicCStructHdl<PVRChannelGroup, PVR_CHANNEL_GR
 
 public:
   /*! \cond PRIVATE */
-  PVRChannelGroup() { memset(m_cStructure, 0, sizeof(PVR_CHANNEL_GROUP)); }
+  PVRChannelGroup() = default;
   PVRChannelGroup(const PVRChannelGroup& group) : DynamicCStructHdl(group) {}
   /*! \endcond */
 
@@ -66,7 +66,10 @@ public:
   }
 
   /// @brief To get with @ref SetGroupName changed values.
-  std::string GetGroupName() const { return m_cStructure->strGroupName; }
+  std::string GetGroupName() const
+  {
+    return m_cStructure->strGroupName ? m_cStructure->strGroupName : "";
+  }
 
   /// @brief **required**\n
   /// **true** If this is a radio channel group, **false** otherwise.
@@ -158,7 +161,7 @@ class PVRChannelGroupMember
 
 public:
   /*! \cond PRIVATE */
-  PVRChannelGroupMember() { memset(m_cStructure, 0, sizeof(PVR_CHANNEL_GROUP_MEMBER)); }
+  PVRChannelGroupMember() = default;
   PVRChannelGroupMember(const PVRChannelGroupMember& member) : DynamicCStructHdl(member) {}
   /*! \endcond */
 
@@ -186,7 +189,10 @@ public:
   }
 
   /// @brief To get with @ref SetGroupName changed values.
-  std::string GetGroupName() const { return m_cStructure->strGroupName; }
+  std::string GetGroupName() const
+  {
+    return m_cStructure->strGroupName ? m_cStructure->strGroupName : "";
+  }
 
   /// @brief **required**\n
   /// Unique id of the member.

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Channels.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Channels.h
@@ -41,11 +41,7 @@ class PVRChannel : public DynamicCStructHdl<PVRChannel, PVR_CHANNEL>
 
 public:
   /*! \cond PRIVATE */
-  PVRChannel()
-  {
-    memset(m_cStructure, 0, sizeof(PVR_CHANNEL));
-    m_cStructure->iClientProviderUid = PVR_PROVIDER_INVALID_UID;
-  }
+  PVRChannel() { m_cStructure->iClientProviderUid = PVR_PROVIDER_INVALID_UID; }
   PVRChannel(const PVRChannel& channel) : DynamicCStructHdl(channel) {}
   /*! \endcond */
 
@@ -114,7 +110,10 @@ public:
   }
 
   /// @brief To get with @ref SetChannelName changed values.
-  std::string GetChannelName() const { return m_cStructure->strChannelName; }
+  std::string GetChannelName() const
+  {
+    return m_cStructure->strChannelName ? m_cStructure->strChannelName : "";
+  }
 
   /// @brief **optional**\n
   /// Input format mime type.
@@ -128,7 +127,10 @@ public:
   }
 
   /// @brief To get with @ref SetMimeType changed values.
-  std::string GetMimeType() const { return m_cStructure->strMimeType; }
+  std::string GetMimeType() const
+  {
+    return m_cStructure->strMimeType ? m_cStructure->strMimeType : "";
+  }
 
   /// @brief **optional**\n
   /// The encryption ID or CaID of this channel (Conditional access systems).
@@ -153,7 +155,10 @@ public:
   }
 
   /// @brief To get with @ref SetIconPath changed values.
-  std::string GetIconPath() const { return m_cStructure->strIconPath; }
+  std::string GetIconPath() const
+  {
+    return m_cStructure->strIconPath ? m_cStructure->strIconPath : "";
+  }
 
   /// @brief **optional**\n
   /// **true** if this channel is marked as hidden.
@@ -300,7 +305,10 @@ public:
   }
 
   /// @brief To get with @ref SetAdapterName changed values.
-  std::string GetAdapterName() const { return m_cStructure->strAdapterName; }
+  std::string GetAdapterName() const
+  {
+    return m_cStructure->strAdapterName ? m_cStructure->strAdapterName : "";
+  }
 
   /// @brief **optional**\n
   /// Status of the adapter that's being used.
@@ -310,7 +318,10 @@ public:
   }
 
   /// @brief To get with @ref SetAdapterStatus changed values.
-  std::string GetAdapterStatus() const { return m_cStructure->strAdapterStatus; }
+  std::string GetAdapterStatus() const
+  {
+    return m_cStructure->strAdapterStatus ? m_cStructure->strAdapterStatus : "";
+  }
 
   /// @brief **optional**\n
   /// Name of the current service.
@@ -320,7 +331,10 @@ public:
   }
 
   /// @brief To get with @ref SetServiceName changed values.
-  std::string GetServiceName() const { return m_cStructure->strServiceName; }
+  std::string GetServiceName() const
+  {
+    return m_cStructure->strServiceName ? m_cStructure->strServiceName : "";
+  }
 
   /// @brief **optional**\n
   /// Name of the current service's provider.
@@ -330,7 +344,10 @@ public:
   }
 
   /// @brief To get with @ref SetProviderName changed values.
-  std::string GetProviderName() const { return m_cStructure->strProviderName; }
+  std::string GetProviderName() const
+  {
+    return m_cStructure->strProviderName ? m_cStructure->strProviderName : "";
+  }
 
   /// @brief **optional**\n
   /// Name of the current mux.
@@ -340,7 +357,10 @@ public:
   }
 
   /// @brief To get with @ref SetMuxName changed values.
-  std::string GetMuxName() const { return m_cStructure->strMuxName; }
+  std::string GetMuxName() const
+  {
+    return m_cStructure->strMuxName ? m_cStructure->strMuxName : "";
+  }
 
   /// @brief **optional**\n
   /// Signal/noise ratio.
@@ -514,7 +534,10 @@ public:
   }
 
   /// @brief To get with @ref SetCardSystem changed values.
-  std::string GetCardSystem() const { return m_cStructure->strCardSystem; }
+  std::string GetCardSystem() const
+  {
+    return m_cStructure->strCardSystem ? m_cStructure->strCardSystem : "";
+  }
 
   /// @brief **optional**\n
   /// Empty string if not available.
@@ -524,7 +547,7 @@ public:
   }
 
   /// @brief To get with @ref SetReader changed values.
-  std::string GetReader() const { return m_cStructure->strReader; }
+  std::string GetReader() const { return m_cStructure->strReader ? m_cStructure->strReader : ""; }
 
   /// @brief **optional**\n
   /// Empty string if not available.
@@ -534,7 +557,7 @@ public:
   }
 
   /// @brief To get with @ref SetFrom changed values.
-  std::string GetFrom() const { return m_cStructure->strFrom; }
+  std::string GetFrom() const { return m_cStructure->strFrom ? m_cStructure->strFrom : ""; }
 
   /// @brief **optional**\n
   /// Empty string if not available.
@@ -544,7 +567,10 @@ public:
   }
 
   /// @brief To get with @ref SetProtocol changed values.
-  std::string GetProtocol() const { return m_cStructure->strProtocol; }
+  std::string GetProtocol() const
+  {
+    return m_cStructure->strProtocol ? m_cStructure->strProtocol : "";
+  }
   ///@}
 
   static void AllocResources(const PVR_DESCRAMBLE_INFO* source, PVR_DESCRAMBLE_INFO* target)

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/EPG.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/EPG.h
@@ -75,8 +75,10 @@ public:
   /// | **Genre sub type** | `int` | @ref PVREPGTag::SetGenreSubType "SetGenreSubType" | @ref PVREPGTag::GetGenreSubType "GetGenreSubType" | *optional*
   /// | **Genre description** | `std::string` | @ref PVREPGTag::SetGenreDescription "SetGenreDescription" | @ref PVREPGTag::GetGenreDescription "GetGenreDescription" | *optional*
   /// | **First aired** | `time_t` | @ref PVREPGTag::SetFirstAired "SetFirstAired" | @ref PVREPGTag::GetFirstAired "GetFirstAired" | *optional*
-  /// | **Parental rating** | `int` | @ref PVREPGTag::SetParentalRating "SetParentalRating" | @ref PVREPGTag::GetParentalRating "GetParentalRating" | *optional*
-  /// | **Parental rating code** | `int` | @ref PVREPGTag::SetParentalRatingCode "SetParentalRatingCode" | @ref PVREPGTag::GetParentalRatingCode "GetParentalRatingCode" | *optional*
+  /// | **Parental rating** | `unsigned int` | @ref PVREPGTag::SetParentalRating "SetParentalRating" | @ref PVREPGTag::GetParentalRating "GetParentalRating" | *optional*
+  /// | **Parental rating code** | `std::string` | @ref PVREPGTag::SetParentalRatingCode "SetParentalRatingCode" | @ref PVREPGTag::GetParentalRatingCode "GetParentalRatingCode" | *optional*
+  /// | **Parental rating icon** | `std::string` | @ref PVREPGTag::SetParentalRatingIcon "SetParentalRatingIcon" | @ref PVREPGTag::GetParentalRatingIcon "GetParentalRatingIcon" | *optional*
+  /// | **Parental rating source** | `std::string` | @ref PVREPGTag::SetParentalRatingSource "SetParentalRatingSource" | @ref PVREPGTag::GetParentalRatingSource "GetParentalRatingSource" | *optional*
   /// | **Star rating** | `int` | @ref PVREPGTag::SetStarRating "SetStarRating" | @ref PVREPGTag::GetStarRating "GetStarRating" | *optional*
   /// | **Series number** | `int` | @ref PVREPGTag::SetSeriesNumber "SetSeriesNumber" | @ref PVREPGTag::GetSeriesNumber "GetSeriesNumber" | *optional*
   /// | **Episode number** | `int` | @ref PVREPGTag::SetEpisodeNumber "SetEpisodeNumber" | @ref PVREPGTag::GetEpisodeNumber "GetEpisodeNumber" | *optional*
@@ -361,12 +363,15 @@ public:
 
   /// @brief **optional**\n
   /// Parental rating.
-  void SetParentalRating(int parentalRating) { m_cStructure->iParentalRating = parentalRating; }
+  void SetParentalRating(unsigned int parentalRating)
+  {
+    m_cStructure->iParentalRating = parentalRating;
+  }
 
   /// @brief To get with @ref SetParentalRatinge changed values.
-  int GetParentalRating() const { return m_cStructure->iParentalRating; }
+  unsigned int GetParentalRating() const { return m_cStructure->iParentalRating; }
 
-  /// @brief **required**\n
+  /// @brief **optional**\n
   /// This event's parental rating code.
   void SetParentalRatingCode(const std::string& parentalRatingCode)
   {
@@ -377,6 +382,33 @@ public:
   std::string GetParentalRatingCode() const
   {
     return m_cStructure->strParentalRatingCode ? m_cStructure->strParentalRatingCode : "";
+  }
+
+  /// @brief **optional**\n
+  /// This event's parental rating icon.
+  void SetParentalRatingIcon(const std::string& parentalRatingIcon)
+  {
+    ReallocAndCopyString(&m_cStructure->strParentalRatingIcon, parentalRatingIcon.c_str());
+  }
+
+  /// @brief To get with @ref SetParentalRatingIcon changed values.
+  std::string GetParentalRatingIcon() const
+  {
+    return m_cStructure->strParentalRatingIcon ? m_cStructure->strParentalRatingIcon : "";
+  }
+
+  /// @brief **optional**\n
+  /// The event's parental rating source.
+  void SetParentalRatingSource(const std::string& parentalRatingSource)
+  {
+    //m_parentalRatingSource = parentalRatingSource;
+    ReallocAndCopyString(&m_cStructure->strParentalRatingSource, parentalRatingSource.c_str());
+  }
+
+  /// @brief To get with @ref SetParentalRatingSource changed values.
+  std::string GetParentalRatingSource() const
+  {
+    return m_cStructure->strParentalRatingSource ? m_cStructure->strParentalRatingSource : "";
   }
 
   /// @brief **optional**\n
@@ -465,6 +497,8 @@ public:
     target->strIconPath = AllocAndCopyString(source->strIconPath);
     target->strGenreDescription = AllocAndCopyString(source->strGenreDescription);
     target->strParentalRatingCode = AllocAndCopyString(source->strParentalRatingCode);
+    target->strParentalRatingIcon = AllocAndCopyString(source->strParentalRatingIcon);
+    target->strParentalRatingSource = AllocAndCopyString(source->strParentalRatingSource);
     target->strEpisodeName = AllocAndCopyString(source->strEpisodeName);
     target->strSeriesLink = AllocAndCopyString(source->strSeriesLink);
     target->strFirstAired = AllocAndCopyString(source->strFirstAired);
@@ -483,6 +517,8 @@ public:
     FreeString(target->strIconPath);
     FreeString(target->strGenreDescription);
     FreeString(target->strParentalRatingCode);
+    FreeString(target->strParentalRatingIcon);
+    FreeString(target->strParentalRatingSource);
     FreeString(target->strEpisodeName);
     FreeString(target->strSeriesLink);
     FreeString(target->strFirstAired);

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/EPG.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/EPG.h
@@ -44,7 +44,6 @@ public:
   /*! \cond PRIVATE */
   PVREPGTag()
   {
-    memset(m_cStructure, 0, sizeof(EPG_TAG));
     m_cStructure->iSeriesNumber = EPG_TAG_INVALID_SERIES_EPISODE;
     m_cStructure->iEpisodeNumber = EPG_TAG_INVALID_SERIES_EPISODE;
     m_cStructure->iEpisodePartNumber = EPG_TAG_INVALID_SERIES_EPISODE;
@@ -118,7 +117,7 @@ public:
   }
 
   /// @brief To get with @ref SetTitle changed values.
-  std::string GetTitle() const { return m_cStructure->strTitle; }
+  std::string GetTitle() const { return m_cStructure->strTitle ? m_cStructure->strTitle : ""; }
 
   /// @brief **required**\n
   /// Start time in UTC.
@@ -146,7 +145,10 @@ public:
   }
 
   /// @brief To get with @ref SetPlotOutline changed values.
-  std::string GetPlotOutline() const { return m_cStructure->strPlotOutline; }
+  std::string GetPlotOutline() const
+  {
+    return m_cStructure->strPlotOutline ? m_cStructure->strPlotOutline : "";
+  }
 
   /// @brief **optional**\n
   /// Plot name.
@@ -156,7 +158,7 @@ public:
   }
 
   /// @brief To get with @ref GetPlot changed values.
-  std::string GetPlot() const { return m_cStructure->strPlot; }
+  std::string GetPlot() const { return m_cStructure->strPlot ? m_cStructure->strPlot : ""; }
 
   /// @brief **optional**\n
   /// Original title.
@@ -166,7 +168,10 @@ public:
   }
 
   /// @brief To get with @ref SetOriginalTitle changed values
-  std::string GetOriginalTitle() const { return m_cStructure->strOriginalTitle; }
+  std::string GetOriginalTitle() const
+  {
+    return m_cStructure->strOriginalTitle ? m_cStructure->strOriginalTitle : "";
+  }
 
   /// @brief **optional**\n
   /// Cast name(s).
@@ -178,7 +183,7 @@ public:
   }
 
   /// @brief To get with @ref SetCast changed values
-  std::string GetCast() const { return m_cStructure->strCast; }
+  std::string GetCast() const { return m_cStructure->strCast ? m_cStructure->strCast : ""; }
 
   /// @brief **optional**\n
   /// Director name(s).
@@ -190,7 +195,10 @@ public:
   }
 
   /// @brief To get with @ref SetDirector changed values.
-  std::string GetDirector() const { return m_cStructure->strDirector; }
+  std::string GetDirector() const
+  {
+    return m_cStructure->strDirector ? m_cStructure->strDirector : "";
+  }
 
   /// @brief **optional**\n
   /// Writer name(s).
@@ -202,7 +210,7 @@ public:
   }
 
   /// @brief To get with @ref SetDirector changed values
-  std::string GetWriter() const { return m_cStructure->strWriter; }
+  std::string GetWriter() const { return m_cStructure->strWriter ? m_cStructure->strWriter : ""; }
 
   /// @brief **optional**\n
   /// Year.
@@ -219,7 +227,10 @@ public:
   }
 
   /// @brief To get with @ref SetIMDBNumber changed values.
-  std::string GetIMDBNumber() const { return m_cStructure->strIMDBNumber; }
+  std::string GetIMDBNumber() const
+  {
+    return m_cStructure->strIMDBNumber ? m_cStructure->strIMDBNumber : "";
+  }
 
   /// @brief **optional**\n
   /// Icon path.
@@ -229,7 +240,10 @@ public:
   }
 
   /// @brief To get with @ref SetIconPath changed values.
-  std::string GetIconPath() const { return m_cStructure->strIconPath; }
+  std::string GetIconPath() const
+  {
+    return m_cStructure->strIconPath ? m_cStructure->strIconPath : "";
+  }
 
   /// @brief **optional**\n
   /// Genre type.
@@ -327,7 +341,10 @@ public:
   }
 
   /// @brief To get with @ref SetGenreDescription changed values.
-  std::string GetGenreDescription() const { return m_cStructure->strGenreDescription; }
+  std::string GetGenreDescription() const
+  {
+    return m_cStructure->strGenreDescription ? m_cStructure->strGenreDescription : "";
+  }
 
   /// @brief **optional**\n
   /// First aired in UTC.
@@ -337,7 +354,10 @@ public:
   }
 
   /// @brief To get with @ref SetFirstAired changed values.
-  std::string GetFirstAired() const { return m_cStructure->strFirstAired; }
+  std::string GetFirstAired() const
+  {
+    return m_cStructure->strFirstAired ? m_cStructure->strFirstAired : "";
+  }
 
   /// @brief **optional**\n
   /// Parental rating.
@@ -354,7 +374,10 @@ public:
   }
 
   /// @brief To get with @ref SetParentalRatingCode changed values.
-  std::string GetParentalRatingCode() const { return m_cStructure->strParentalRatingCode; }
+  std::string GetParentalRatingCode() const
+  {
+    return m_cStructure->strParentalRatingCode ? m_cStructure->strParentalRatingCode : "";
+  }
 
   /// @brief **optional**\n
   /// Star rating.
@@ -395,7 +418,10 @@ public:
   }
 
   /// @brief To get with @ref SetEpisodeName changed values.
-  std::string GetEpisodeName() const { return m_cStructure->strEpisodeName; }
+  std::string GetEpisodeName() const
+  {
+    return m_cStructure->strEpisodeName ? m_cStructure->strEpisodeName : "";
+  }
 
   /// @brief **optional**\n
   /// Bit field of independent flags associated with the EPG entry.
@@ -419,7 +445,10 @@ public:
   }
 
   /// @brief To get with @ref SetSeriesLink changed values.
-  std::string GetSeriesLink() const { return m_cStructure->strSeriesLink; }
+  std::string GetSeriesLink() const
+  {
+    return m_cStructure->strSeriesLink ? m_cStructure->strSeriesLink : "";
+  }
 
   ///@}
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/General.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/General.h
@@ -55,8 +55,6 @@ public:
   ///@{
 
   /// @brief Default class constructor.
-  ///
-  /// @note Values must be set afterwards.
   PVRTypeIntValue() = default;
 
   /// @brief Class constructor with integrated value set.
@@ -82,7 +80,10 @@ public:
   }
 
   /// @brief To get with the description text of the value.
-  std::string GetDescription() const { return m_cStructure->strDescription; }
+  std::string GetDescription() const
+  {
+    return m_cStructure->strDescription ? m_cStructure->strDescription : "";
+  }
   ///@}
 
   static PVR_ATTRIBUTE_INT_VALUE* AllocAndCopyData(const std::vector<PVRTypeIntValue>& source)
@@ -171,7 +172,7 @@ class PVRCapabilities : public DynamicCStructHdl<PVRCapabilities, PVR_ADDON_CAPA
 
 public:
   /*! \cond PRIVATE */
-  PVRCapabilities() { memset(m_cStructure, 0, sizeof(PVR_ADDON_CAPABILITIES)); }
+  PVRCapabilities() = default;
   PVRCapabilities(const PVRCapabilities& capabilities) : DynamicCStructHdl(capabilities) {}
   /*! \endcond */
 
@@ -550,8 +551,6 @@ public:
   ///@{
 
   /// @brief Default class constructor.
-  ///
-  /// @note Values must be set afterwards.
   PVRStreamProperty() = default;
 
   /// @brief Class constructor with integrated value set.
@@ -571,7 +570,7 @@ public:
   }
 
   /// @brief To get with the identification name.
-  std::string GetName() const { return m_cStructure->strName; }
+  std::string GetName() const { return m_cStructure->strName ? m_cStructure->strName : ""; }
 
   /// @brief To set with the used property value.
   void SetValue(const std::string& value)
@@ -580,7 +579,7 @@ public:
   }
 
   /// @brief To get with the used property value.
-  std::string GetValue() const { return m_cStructure->strValue; }
+  std::string GetValue() const { return m_cStructure->strValue ? m_cStructure->strValue : ""; }
   ///@}
 
   static void AllocResources(const PVR_NAMED_VALUE* source, PVR_NAMED_VALUE* target)

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/General.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/General.h
@@ -497,6 +497,7 @@ private:
 /// ...
 ///
 /// PVR_ERROR CMyPVRInstance::GetChannelStreamProperties(const kodi::addon::PVRChannel& channel,
+///                                                      PVR_SOURCE source,
 ///                                                      std::vector<kodi::addon::PVRStreamProperty>& properties)
 /// {
 ///   ...
@@ -513,6 +514,7 @@ private:
 /// ...
 ///
 /// PVR_ERROR CMyPVRInstance::GetChannelStreamProperties(const kodi::addon::PVRChannel& channel,
+///                                                      PVR_SOURCE source,
 ///                                                      std::vector<kodi::addon::PVRStreamProperty>& properties)
 /// {
 ///   ...

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Providers.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Providers.h
@@ -42,7 +42,7 @@ class PVRProvider : public DynamicCStructHdl<PVRProvider, PVR_PROVIDER>
 
 public:
   /*! \cond PRIVATE */
-  PVRProvider() { memset(m_cStructure, 0, sizeof(PVR_PROVIDER)); }
+  PVRProvider() = default;
   PVRProvider(const PVRProvider& provider) : DynamicCStructHdl(provider) {}
   /*! \endcond */
 
@@ -78,7 +78,7 @@ public:
   }
 
   /// @brief To get with @ref SetName changed values.
-  std::string GetName() const { return m_cStructure->strName; }
+  std::string GetName() const { return m_cStructure->strName ? m_cStructure->strName : ""; }
 
   /// @brief **optional**\n
   /// Provider type.
@@ -107,7 +107,10 @@ public:
   }
 
   /// @brief To get with @ref SetIconPath changed values.
-  std::string GetIconPath() const { return m_cStructure->strIconPath; }
+  std::string GetIconPath() const
+  {
+    return m_cStructure->strIconPath ? m_cStructure->strIconPath : "";
+  }
   ///@}
 
   /// @brief **optional**\n
@@ -124,7 +127,10 @@ public:
   /// @brief To get with @ref SetCountries changed values.
   std::vector<std::string> GetCountries() const
   {
-    return tools::StringUtils::Split(m_cStructure->strCountries, PROVIDER_STRING_TOKEN_SEPARATOR);
+    if (m_cStructure->strCountries)
+      return tools::StringUtils::Split(m_cStructure->strCountries, PROVIDER_STRING_TOKEN_SEPARATOR);
+    else
+      return {};
   }
   ///@}
 
@@ -142,7 +148,10 @@ public:
   /// @brief To get with @ref SetLanguages changed values.
   std::vector<std::string> GetLanguages() const
   {
-    return tools::StringUtils::Split(m_cStructure->strLanguages, PROVIDER_STRING_TOKEN_SEPARATOR);
+    if (m_cStructure->strLanguages)
+      return tools::StringUtils::Split(m_cStructure->strLanguages, PROVIDER_STRING_TOKEN_SEPARATOR);
+    else
+      return {};
   }
   ///@}
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Recordings.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Recordings.h
@@ -45,7 +45,6 @@ public:
   {
     m_cStructure->iSeriesNumber = PVR_RECORDING_INVALID_SERIES_EPISODE;
     m_cStructure->iEpisodeNumber = PVR_RECORDING_INVALID_SERIES_EPISODE;
-    m_cStructure->recordingTime = 0;
     m_cStructure->iDuration = PVR_RECORDING_VALUE_NOT_AVAILABLE;
     m_cStructure->iPriority = PVR_RECORDING_VALUE_NOT_AVAILABLE;
     m_cStructure->iLifetime = PVR_RECORDING_VALUE_NOT_AVAILABLE;
@@ -53,11 +52,8 @@ public:
     m_cStructure->iGenreSubType = PVR_RECORDING_VALUE_NOT_AVAILABLE;
     m_cStructure->iPlayCount = PVR_RECORDING_VALUE_NOT_AVAILABLE;
     m_cStructure->iLastPlayedPosition = PVR_RECORDING_VALUE_NOT_AVAILABLE;
-    m_cStructure->bIsDeleted = false;
-    m_cStructure->iEpgEventId = 0;
     m_cStructure->iChannelUid = PVR_RECORDING_VALUE_NOT_AVAILABLE;
     m_cStructure->channelType = PVR_RECORDING_CHANNEL_TYPE_UNKNOWN;
-    m_cStructure->iFlags = 0;
     m_cStructure->sizeInBytes = PVR_RECORDING_VALUE_NOT_AVAILABLE;
   }
   PVRRecording(const PVRRecording& recording) : DynamicCStructHdl(recording) {}
@@ -112,7 +108,10 @@ public:
   }
 
   /// @brief To get with @ref SetRecordingId changed values.
-  std::string GetRecordingId() const { return m_cStructure->strRecordingId; }
+  std::string GetRecordingId() const
+  {
+    return m_cStructure->strRecordingId ? m_cStructure->strRecordingId : "";
+  }
 
   /// @brief **required**\n
   /// The title of this recording.
@@ -122,7 +121,7 @@ public:
   }
 
   /// @brief To get with @ref SetTitle changed values.
-  std::string GetTitle() const { return m_cStructure->strTitle; }
+  std::string GetTitle() const { return m_cStructure->strTitle ? m_cStructure->strTitle : ""; }
 
   /// @brief **optional**\n
   /// Episode name (also known as subtitle).
@@ -132,7 +131,10 @@ public:
   }
 
   /// @brief To get with @ref SetEpisodeName changed values.
-  std::string GetEpisodeName() const { return m_cStructure->strEpisodeName; }
+  std::string GetEpisodeName() const
+  {
+    return m_cStructure->strEpisodeName ? m_cStructure->strEpisodeName : "";
+  }
 
   /// @brief **optional**\n
   /// Series number (usually called season).
@@ -171,7 +173,10 @@ public:
   }
 
   /// @brief To get with @ref SetDirectory changed values.
-  std::string GetDirectory() const { return m_cStructure->strDirectory; }
+  std::string GetDirectory() const
+  {
+    return m_cStructure->strDirectory ? m_cStructure->strDirectory : "";
+  }
 
   /// @brief **optional**\n
   /// Plot outline name.
@@ -181,7 +186,10 @@ public:
   }
 
   /// @brief To get with @ref SetPlotOutline changed values.
-  std::string GetPlotOutline() const { return m_cStructure->strPlotOutline; }
+  std::string GetPlotOutline() const
+  {
+    return m_cStructure->strPlotOutline ? m_cStructure->strPlotOutline : "";
+  }
 
   /// @brief **optional**\n
   /// Plot name.
@@ -191,7 +199,7 @@ public:
   }
 
   /// @brief To get with @ref SetPlot changed values.
-  std::string GetPlot() const { return m_cStructure->strPlot; }
+  std::string GetPlot() const { return m_cStructure->strPlot ? m_cStructure->strPlot : ""; }
 
   /// @brief **optional**\n
   /// Channel name.
@@ -201,7 +209,10 @@ public:
   }
 
   /// @brief To get with @ref SetChannelName changed values.
-  std::string GetChannelName() const { return m_cStructure->strChannelName; }
+  std::string GetChannelName() const
+  {
+    return m_cStructure->strChannelName ? m_cStructure->strChannelName : "";
+  }
 
   /// @brief **optional**\n
   /// Channel logo (icon) path.
@@ -211,7 +222,10 @@ public:
   }
 
   /// @brief To get with @ref SetIconPath changed values.
-  std::string GetIconPath() const { return m_cStructure->strIconPath; }
+  std::string GetIconPath() const
+  {
+    return m_cStructure->strIconPath ? m_cStructure->strIconPath : "";
+  }
 
   /// @brief **optional**\n
   /// Thumbnail path.
@@ -221,7 +235,10 @@ public:
   }
 
   /// @brief To get with @ref SetThumbnailPath changed values.
-  std::string GetThumbnailPath() const { return m_cStructure->strThumbnailPath; }
+  std::string GetThumbnailPath() const
+  {
+    return m_cStructure->strThumbnailPath ? m_cStructure->strThumbnailPath : "";
+  }
 
   /// @brief **optional**\n
   /// Fanart path.
@@ -231,7 +248,10 @@ public:
   }
 
   /// @brief To get with @ref SetFanartPath changed values.
-  std::string GetFanartPath() const { return m_cStructure->strFanartPath; }
+  std::string GetFanartPath() const
+  {
+    return m_cStructure->strFanartPath ? m_cStructure->strFanartPath : "";
+  }
 
   /// @brief **optional**\n
   /// Start time of the recording.
@@ -354,7 +374,10 @@ public:
   }
 
   /// @brief To get with @ref SetGenreDescription changed values.
-  std::string GetGenreDescription() const { return m_cStructure->strGenreDescription; }
+  std::string GetGenreDescription() const
+  {
+    return m_cStructure->strGenreDescription ? m_cStructure->strGenreDescription : "";
+  }
 
   /// @brief **optional**\n
   /// Play count of this recording on the client.
@@ -436,7 +459,10 @@ public:
   }
 
   /// @brief To get with @ref SetFirstAired changed values
-  std::string GetFirstAired() const { return m_cStructure->strFirstAired; }
+  std::string GetFirstAired() const
+  {
+    return m_cStructure->strFirstAired ? m_cStructure->strFirstAired : "";
+  }
 
   /// @brief **optional**\n
   /// Bit field of independent flags associated with the recording.
@@ -481,7 +507,10 @@ public:
   }
 
   /// @brief To get with @ref SetProviderName changed values.
-  std::string GetProviderName() const { return m_cStructure->strProviderName; }
+  std::string GetProviderName() const
+  {
+    return m_cStructure->strProviderName ? m_cStructure->strProviderName : "";
+  }
 
   static void AllocResources(const PVR_RECORDING* source, PVR_RECORDING* target)
   {

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Recordings.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Recordings.h
@@ -45,6 +45,7 @@ public:
   {
     m_cStructure->iSeriesNumber = PVR_RECORDING_INVALID_SERIES_EPISODE;
     m_cStructure->iEpisodeNumber = PVR_RECORDING_INVALID_SERIES_EPISODE;
+    m_cStructure->iEpisodePartNumber = PVR_RECORDING_INVALID_SERIES_EPISODE;
     m_cStructure->iDuration = PVR_RECORDING_VALUE_NOT_AVAILABLE;
     m_cStructure->iPriority = PVR_RECORDING_VALUE_NOT_AVAILABLE;
     m_cStructure->iLifetime = PVR_RECORDING_VALUE_NOT_AVAILABLE;
@@ -70,6 +71,7 @@ public:
   /// | **Episode name** | `std::string` | @ref PVRRecording::SetEpisodeName "SetEpisodeName" | @ref PVRRecording::GetEpisodeName "GetEpisodeName" | *optional*
   /// | **Series number** | `int` | @ref PVRRecording::SetSeriesNumber "SetSeriesNumber" | @ref PVRRecording::GetSeriesNumber "GetSeriesNumber" | *optional*
   /// | **Episode number** | `int` | @ref PVRRecording::SetEpisodeNumber "SetEpisodeNumber" | @ref PVRRecording::GetEpisodeNumber "GetEpisodeNumber" | *optional*
+  /// | **Episode part number** | `int` | @ref PVRRecording::SetEpisodePartNumber "SetEpisodePartNumber" | @ref PVRRecording::GetEpisodePartNumber "GetEpisodePartNumber" | *optional*
   /// | **Year** | `int` | @ref PVRRecording::SetYear "SetYear" | @ref PVRRecording::GetYear "GetYear" | *optional*
   /// | **Directory** | `std::string` | @ref PVRRecording::SetDirectory "SetDirectory" | @ref PVRRecording::GetDirectory "GetDirectory" | *optional*
   /// | **Plot outline** | `std::string` | @ref PVRRecording::SetPlotOutline "SetPlotOutline" | @ref PVRRecording::GetPlotOutline "GetPlotOutline" | *optional*
@@ -157,6 +159,16 @@ public:
 
   /// @brief To get with @ref SetEpisodeNumber changed values.
   int GetEpisodeNumber() const { return m_cStructure->iEpisodeNumber; }
+
+  /// @brief **optional**\n
+  /// Episode part number.
+  void SetEpisodePartNumber(int episodePartNumber)
+  {
+    m_cStructure->iEpisodePartNumber = episodePartNumber;
+  }
+
+  /// @brief To get with @ref SetEpisodePartNumber changed values.
+  int GetEpisodePartNumber() const { return m_cStructure->iEpisodePartNumber; }
 
   /// @brief **optional**\n
   /// Year of first release (use to identify a specific movie re-make) / first

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Recordings.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Recordings.h
@@ -96,6 +96,10 @@ public:
   /// | **Size in bytes** | `std::string` | @ref PVRRecording::SetSizeInBytes "SetSizeInBytes" | @ref PVRRecording::GetSizeInBytes "GetSizeInBytes" | *optional*
   /// | **Client provider unique identifier** | `int` | @ref PVRChannel::SetClientProviderUid "SetClientProviderUid" | @ref PVRTimer::GetClientProviderUid "GetClientProviderUid" | *optional*
   /// | **Provider name** | `std::string` | @ref PVRChannel::SetProviderName "SetProviderlName" | @ref PVRChannel::GetProviderName "GetProviderName" | *optional*
+  /// | **Parental rating age** | `unsigned int` | @ref PVRRecording::SetParentalRating "SetParentalRating" | @ref PVRRecording::GetParentalRating "GetParentalRating" | *optional*
+  /// | **Parental rating code** | `std::string` | @ref PVRRecording::SetParentalRatingCode "SetParentalRatingCode" | @ref PVRRecording::GetParentalRatingCode "GetParentalRatingCode" | *optional*
+  /// | **Parental rating icon** | `std::string` | @ref PVRRecording::SetParentalRatingIcon "SetParentalRatingIcon" | @ref PVRRecording::GetParentalRatingIcon "GetParentalRatingIcon" | *optional*
+  /// | **Parental rating source** | `std::string` | @ref PVRRecording::SetParentalRatingSource "SetParentalRatingSource" | @ref PVRRecording::GetParentalRatingSource "GetParentalRatingSource" | *optional*
 
   /// @addtogroup cpp_kodi_addon_pvr_Defs_Recording_PVRRecording
   ///@{
@@ -512,6 +516,55 @@ public:
     return m_cStructure->strProviderName ? m_cStructure->strProviderName : "";
   }
 
+  /// @brief **optional**\n
+  /// Age rating for the recording.
+  void SetParentalRating(unsigned int iParentalRating)
+  {
+    m_cStructure->iParentalRating = iParentalRating;
+  }
+
+  /// @brief To get with @ref SetParentalRating changed values
+  unsigned int GetParentalRating() const { return m_cStructure->iParentalRating; }
+
+  /// @brief **optional**\n
+  /// Parental rating code for this recording.
+  void SetParentalRatingCode(const std::string& ratingCode)
+  {
+    ReallocAndCopyString(&m_cStructure->strParentalRatingCode, ratingCode.c_str());
+  }
+
+  /// @brief To get with @ref SetParentalRatingCode changed values.
+  std::string GetParentalRatingCode() const
+  {
+    return m_cStructure->strParentalRatingCode ? m_cStructure->strParentalRatingCode : "";
+  }
+
+  /// @brief **optional**\n
+  /// Parental rating icon for this recording.
+  void SetParentalRatingIcon(const std::string& ratingIcon)
+  {
+    ReallocAndCopyString(&m_cStructure->strParentalRatingIcon, ratingIcon.c_str());
+  }
+
+  /// @brief To get with @ref SetParentalRatingIcon changed values.
+  std::string GetParentalRatingIcon() const
+  {
+    return m_cStructure->strParentalRatingIcon ? m_cStructure->strParentalRatingIcon : "";
+  }
+
+  /// @brief **optional**\n
+  /// Parental rating source for this recording.
+  void SetParentalRatingSource(const std::string& ratingSource)
+  {
+    ReallocAndCopyString(&m_cStructure->strParentalRatingSource, ratingSource.c_str());
+  }
+
+  /// @brief To get with @ref SetParentalRatingSource changed values.
+  std::string GetParentalRatingSource() const
+  {
+    return m_cStructure->strParentalRatingSource ? m_cStructure->strParentalRatingSource : "";
+  }
+
   static void AllocResources(const PVR_RECORDING* source, PVR_RECORDING* target)
   {
     target->strRecordingId = AllocAndCopyString(source->strRecordingId);
@@ -527,6 +580,9 @@ public:
     target->strFanartPath = AllocAndCopyString(source->strFanartPath);
     target->strFirstAired = AllocAndCopyString(source->strFirstAired);
     target->strProviderName = AllocAndCopyString(source->strProviderName);
+    target->strParentalRatingCode = AllocAndCopyString(source->strParentalRatingCode);
+    target->strParentalRatingIcon = AllocAndCopyString(source->strParentalRatingIcon);
+    target->strParentalRatingSource = AllocAndCopyString(source->strParentalRatingSource);
   }
 
   static void FreeResources(PVR_RECORDING* target)
@@ -544,6 +600,9 @@ public:
     FreeString(target->strFanartPath);
     FreeString(target->strFirstAired);
     FreeString(target->strProviderName);
+    FreeString(target->strParentalRatingCode);
+    FreeString(target->strParentalRatingIcon);
+    FreeString(target->strParentalRatingSource);
   }
 
 private:

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Timers.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Timers.h
@@ -43,26 +43,13 @@ public:
   /*! \cond PRIVATE */
   PVRTimer()
   {
-    m_cStructure->iClientIndex = 0;
     m_cStructure->state = PVR_TIMER_STATE_NEW;
     m_cStructure->iTimerType = PVR_TIMER_TYPE_NONE;
-    m_cStructure->iParentClientIndex = 0;
     m_cStructure->iClientChannelUid = PVR_TIMER_VALUE_NOT_AVAILABLE;
-    m_cStructure->startTime = 0;
-    m_cStructure->endTime = 0;
-    m_cStructure->bStartAnyTime = false;
-    m_cStructure->bEndAnyTime = false;
-    m_cStructure->bFullTextEpgSearch = false;
     m_cStructure->iPriority = PVR_TIMER_VALUE_NOT_AVAILABLE;
     m_cStructure->iLifetime = PVR_TIMER_VALUE_NOT_AVAILABLE;
     m_cStructure->iMaxRecordings = PVR_TIMER_VALUE_NOT_AVAILABLE;
-    m_cStructure->iRecordingGroup = 0;
-    m_cStructure->firstDay = 0;
     m_cStructure->iWeekdays = PVR_WEEKDAY_NONE;
-    m_cStructure->iPreventDuplicateEpisodes = 0;
-    m_cStructure->iEpgUid = 0;
-    m_cStructure->iMarginStart = 0;
-    m_cStructure->iMarginEnd = 0;
     m_cStructure->iGenreType = PVR_TIMER_VALUE_NOT_AVAILABLE;
     m_cStructure->iGenreSubType = PVR_TIMER_VALUE_NOT_AVAILABLE;
   }
@@ -171,7 +158,7 @@ public:
   }
 
   /// @brief To get with @ref SetTitle changed values.
-  std::string GetTitle() const { return m_cStructure->strTitle; }
+  std::string GetTitle() const { return m_cStructure->strTitle ? m_cStructure->strTitle : ""; }
 
   /// @brief **optional**\n
   /// For timers scheduled by a repeating timer.
@@ -245,7 +232,10 @@ public:
   }
 
   /// @brief To get with @ref SetEPGSearchString changed values
-  std::string GetEPGSearchString() const { return m_cStructure->strEpgSearchString; }
+  std::string GetEPGSearchString() const
+  {
+    return m_cStructure->strEpgSearchString ? m_cStructure->strEpgSearchString : "";
+  }
 
   /// @brief **optional**\n
   /// Indicates, whether @ref SetEPGSearchString() is to match against the epg
@@ -266,7 +256,10 @@ public:
   }
 
   /// @brief To get with @ref SetDirectory changed values.
-  std::string GetDirectory() const { return m_cStructure->strDirectory; }
+  std::string GetDirectory() const
+  {
+    return m_cStructure->strDirectory ? m_cStructure->strDirectory : "";
+  }
 
   /// @brief **optional**\n
   /// The summary for this timer.
@@ -276,7 +269,10 @@ public:
   }
 
   /// @brief To get with @ref SetDirectory changed values.
-  std::string GetSummary() const { return m_cStructure->strSummary; }
+  std::string GetSummary() const
+  {
+    return m_cStructure->strSummary ? m_cStructure->strSummary : "";
+  }
 
   /// @brief **optional**\n
   /// The priority of this timer.
@@ -461,7 +457,10 @@ public:
   }
 
   /// @brief To get with @ref SetSeriesLink changed values.
-  std::string GetSeriesLink() const { return m_cStructure->strSeriesLink; }
+  std::string GetSeriesLink() const
+  {
+    return m_cStructure->strSeriesLink ? m_cStructure->strSeriesLink : "";
+  }
   ///@}
 
   static void AllocResources(const PVR_TIMER* source, PVR_TIMER* target)
@@ -550,7 +549,6 @@ public:
   /*! \cond PRIVATE */
   PVRTimerType()
   {
-    memset(m_cStructure, 0, sizeof(PVR_TIMER_TYPE));
     m_cStructure->iPrioritiesDefault = -1;
     m_cStructure->iLifetimesDefault = -1;
     m_cStructure->iPreventDuplicateEpisodesDefault = -1;
@@ -628,7 +626,10 @@ public:
   }
 
   /// @brief To get with @ref SetDescription changed values.
-  std::string GetDescription() const { return m_cStructure->strDescription; }
+  std::string GetDescription() const
+  {
+    return m_cStructure->strDescription ? m_cStructure->strDescription : "";
+  }
 
   //----------------------------------------------------------------------------
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr.h
@@ -163,6 +163,7 @@ extern "C"
     enum PVR_ERROR(__cdecl* GetChannels)(const struct AddonInstance_PVR*, PVR_HANDLE, bool);
     enum PVR_ERROR(__cdecl* GetChannelStreamProperties)(const struct AddonInstance_PVR*,
                                                         const struct PVR_CHANNEL*,
+                                                        enum PVR_SOURCE,
                                                         struct PVR_NAMED_VALUE***,
                                                         unsigned int*);
     enum PVR_ERROR(__cdecl* GetSignalStatus)(const struct AddonInstance_PVR*,
@@ -305,6 +306,7 @@ extern "C"
     // Stream demux interface functions
     enum PVR_ERROR(__cdecl* GetStreamProperties)(const struct AddonInstance_PVR*,
                                                  struct PVR_STREAM_PROPERTIES*);
+    enum PVR_ERROR(__cdecl* StreamClosed)(const struct AddonInstance_PVR*);
     struct DEMUX_PACKET*(__cdecl* DemuxRead)(const struct AddonInstance_PVR*);
     void(__cdecl* DemuxReset)(const struct AddonInstance_PVR*);
     void(__cdecl* DemuxAbort)(const struct AddonInstance_PVR*);

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_epg.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_epg.h
@@ -639,8 +639,10 @@ extern "C"
     int iGenreSubType;
     const char* strGenreDescription;
     const char* strFirstAired;
-    int iParentalRating;
+    unsigned int iParentalRating;
     const char* strParentalRatingCode;
+    const char* strParentalRatingIcon;
+    const char* strParentalRatingSource;
     int iStarRating;
     int iSeriesNumber;
     int iEpisodeNumber;

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h
@@ -113,6 +113,27 @@ extern "C"
   //----------------------------------------------------------------------------
 
   //============================================================================
+  /// @defgroup cpp_kodi_addon_pvr_Defs_General_PVR_SOURCE enum PVR_SOURCE
+  /// @ingroup cpp_kodi_addon_pvr_Defs_General
+  /// @brief **PVR add-on playback source**\n
+  /// Used in call to GetChannelStreamProperties() to indicate where the playback
+  /// call initiated.
+  ///
+  /// - @ref kodi::addon::CInstancePVRClient::GetChannelStreamProperties()
+  ///
+  ///@{
+  typedef enum PVR_SOURCE
+  {
+    /// @brief __0__ : Regular live playback
+    DEFAULT = 0,
+
+    /// @brief __1__ : From EPG, but playing back as live
+    PVR_SOURCE_EPG_AS_LIVE = 1,
+  } PVR_SOURCE;
+  ///@}
+  //----------------------------------------------------------------------------
+
+  //============================================================================
   /// @defgroup cpp_kodi_addon_pvr_Defs_General_PVR_STREAM_PROPERTY definition PVR_STREAM_PROPERTY
   /// @ingroup cpp_kodi_addon_pvr_Defs_General_Inputstream
   /// @brief **PVR related stream property values**\n
@@ -134,6 +155,7 @@ extern "C"
   /// ...
   ///
   /// PVR_ERROR CMyPVRInstance::GetChannelStreamProperties(const kodi::addon::PVRChannel& channel,
+  ///                                                      PVR_SOURCE source,
   ///                                                      std::vector<PVRStreamProperty>& properties)
   /// {
   ///   ...
@@ -249,6 +271,14 @@ extern "C"
   /// play as normal video.
   ///
 #define PVR_STREAM_PROPERTY_EPGPLAYBACKASLIVE "epgplaybackaslive"
+
+  /// @brief <b>"true"</b> to denote that if the stream is from a channel but should
+  /// be played as an EPG tag.
+  ///
+  /// It should be played as an epg/catchup stream. Otherwise if it's a channel it will
+  /// played as live stream.
+  ///
+#define PVR_STREAM_PROPERTY_LIVEPLAYBACKASEPG "liveplaybackasepg"
 
   /// @brief Special value for @ref PVR_STREAM_PROPERTY_INPUTSTREAM to use
   /// ffmpeg to directly play a stream URL.

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_recordings.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_recordings.h
@@ -139,6 +139,10 @@ extern "C"
     int64_t sizeInBytes;
     int iClientProviderUid;
     const char* strProviderName;
+    unsigned int iParentalRating;
+    const char* strParentalRatingCode;
+    const char* strParentalRatingIcon;
+    const char* strParentalRatingSource;
   } PVR_RECORDING;
 
 #ifdef __cplusplus

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_recordings.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_recordings.h
@@ -113,6 +113,7 @@ extern "C"
     const char* strEpisodeName;
     int iSeriesNumber;
     int iEpisodeNumber;
+    int iEpisodePartNumber;
     int iYear;
     const char* strDirectory;
     const char* strPlotOutline;

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -130,8 +130,8 @@
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"
 
-#define ADDON_INSTANCE_VERSION_PVR                    "8.4.0"
-#define ADDON_INSTANCE_VERSION_PVR_MIN                "8.4.0"
+#define ADDON_INSTANCE_VERSION_PVR                    "9.0.0"
+#define ADDON_INSTANCE_VERSION_PVR_MIN                "9.0.0"
 #define ADDON_INSTANCE_VERSION_PVR_XML_ID             "kodi.binary.instance.pvr"
 #define ADDON_INSTANCE_VERSION_PVR_DEPENDS            "c-api/addon-instance/pvr.h" \
                                                       "c-api/addon-instance/pvr/pvr_channel_groups.h" \

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -1530,8 +1530,8 @@ PVR_ERROR CPVRClient::GetChannelStreamProperties(const std::shared_ptr<const CPV
 
     PVR_NAMED_VALUE** property_array{nullptr};
     unsigned int size{0};
-    const PVR_ERROR error{
-        addon->toAddon->GetChannelStreamProperties(addon, &addonChannel, &property_array, &size)};
+    const PVR_ERROR error{addon->toAddon->GetChannelStreamProperties(
+        addon, &addonChannel, PVR_SOURCE::DEFAULT, &property_array, &size)};
     if (error == PVR_ERROR_NO_ERROR)
       WriteStreamProperties(property_array, size, props);
 

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -812,7 +812,9 @@ public:
       m_strIconPath(kodiTag->ClientIconPath()),
       m_strSeriesLink(kodiTag->SeriesLink()),
       m_strGenreDescription(kodiTag->GenreDescription()),
-      m_strParentalRatingCode(kodiTag->ParentalRatingCode())
+      m_strParentalRatingCode(kodiTag->ParentalRatingCode()),
+      m_strParentalRatingIcon(""), //! @todo
+      m_strParentalRatingSource("") //! @todo
   {
     time_t t;
     kodiTag->StartAsUTC().GetAsTime(t);
@@ -849,6 +851,8 @@ public:
     strGenreDescription = m_strGenreDescription.c_str();
     strFirstAired = m_strFirstAired.c_str();
     strParentalRatingCode = m_strParentalRatingCode.c_str();
+    strParentalRatingIcon = m_strParentalRatingIcon.c_str();
+    strParentalRatingSource = m_strParentalRatingSource.c_str();
   }
 
   virtual ~CAddonEpgTag() = default;
@@ -868,6 +872,8 @@ private:
   std::string m_strGenreDescription;
   std::string m_strFirstAired;
   std::string m_strParentalRatingCode;
+  std::string m_strParentalRatingIcon;
+  std::string m_strParentalRatingSource;
 };
 
 PVR_ERROR CPVRClient::IsRecordable(const std::shared_ptr<const CPVREpgInfoTag>& tag,

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -122,7 +122,10 @@ public:
       m_thumbnailPath(recording.ClientThumbnailPath()),
       m_fanartPath(recording.ClientFanartPath()),
       m_firstAired(recording.FirstAired().IsValid() ? recording.FirstAired().GetAsW3CDate() : ""),
-      m_providerName(recording.ProviderName())
+      m_providerName(recording.ProviderName()),
+      m_parentalRatingCode(""), //! @todo
+      m_parentalRatingIcon(""), //! @todo
+      m_parentalRatingSource("") //! @todo
   {
     time_t recTime;
     recording.RecordingTimeAsUTC().GetAsTime(recTime);
@@ -161,6 +164,9 @@ public:
     sizeInBytes = recording.GetSizeInBytes();
     strProviderName = m_providerName.c_str();
     iClientProviderUid = recording.ClientProviderUniqueId();
+    strParentalRatingCode = m_parentalRatingCode.c_str();
+    strParentalRatingIcon = m_parentalRatingIcon.c_str();
+    strParentalRatingSource = m_parentalRatingSource.c_str();
   }
   virtual ~CAddonRecording() = default;
 
@@ -178,6 +184,9 @@ private:
   const std::string m_fanartPath;
   const std::string m_firstAired;
   const std::string m_providerName;
+  const std::string m_parentalRatingCode;
+  const std::string m_parentalRatingIcon;
+  const std::string m_parentalRatingSource;
 };
 
 class CAddonTimer : public PVR_TIMER

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -135,6 +135,7 @@ public:
     strEpisodeName = m_episodeName.c_str();
     iSeriesNumber = recording.m_iSeason;
     iEpisodeNumber = recording.m_iEpisode;
+    iEpisodePartNumber = PVR_RECORDING_INVALID_SERIES_EPISODE; //! @todo
     iYear = recording.GetYear();
     strDirectory = m_directory.c_str();
     strPlotOutline = m_plotOutline.c_str();


### PR DESCRIPTION
This is an incompatible PVR Addon API change. All PVR client addons must be recompiled and re-released! I will take care of that for all the addons in kodi-pvr repo.

* Fixes crashes introduced with API 8.4.0 #25552
* Cherry picked the API changes from #24096 
* Cherry picked the API changes from #24622
* Added PVR_RECORDING::iEpisodePartNumber

Runtime-tested on macOS, latest xbmc master, with adapted local versions of pvr.hts and pvr.plutotv
 
@phunkyfish As @AlwinEsch is not around currently, I would like to ask you to review.

@DeltaMikeCharlie, @emveepee f.y.i.