### PR TITLE
[cmake][addons] Dont quote variable passed to externalproject_add

### DIFF
--- a/cmake/scripts/common/HandleDepends.cmake
+++ b/cmake/scripts/common/HandleDepends.cmake
@@ -271,7 +271,7 @@ function(add_addon_depends addon searchpath)
 
             externalproject_add(${id}
                                 URL ${url}
-                                "${URL_HASH_COMMAND}"
+                                ${URL_HASH_COMMAND}
                                 DOWNLOAD_DIR ${DOWNLOAD_DIR}
                                 CONFIGURE_COMMAND ${CONFIGURE_COMMAND}
                                 ${EXTERNALPROJECT_SETUP})


### PR DESCRIPTION
## Description
Fixes #25619 

## Motivation and context
Alwin partially fixed this in https://github.com/xbmc/xbmc/commit/2c1ef3dce244e4918b07f452d1c28a3b3b6d71a3 
Reason he probably didnt see this was most of our addons use a sha256 file. game.libretro.mrboom and game.libretro.2048 do not, and therefore fail to build with errors such as:

```
CMake Error at /usr/share/cmake-3.30/Modules/ExternalProject/shared_internal_commands.cmake:1127 (message): At least one entry of URL is a path (invalid in a list) 
Call Stack (most recent call first):
/usr/share/cmake-3.30/Modules/ExternalProject.cmake:3035 (_ep_add_download_command)
/home/xxx/repos/xbmc/cmake/scripts/common/HandleDepends.cmake:272 (externalproject_add) 
CMakeLists.txt:455 (add_addon_depends)

-- Configuring incomplete, errors occurred!
```

## How has this been tested?
Build game.libretro.mrboom (without sha255 file), build pvr.hdhomerun (with sha256 file)

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
