### PR TITLE
[PVR] Misc cppcheck warning fixes.

### DIFF
--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -114,11 +114,6 @@ void CPVRClients::UpdateClients(
           else
           {
             client = std::make_shared<CPVRClient>(addon, instanceId, clientId);
-            if (!client)
-            {
-              CLog::LogF(LOGERROR, "Severe error, incorrect add-on type");
-              continue;
-            }
           }
 
           // determine actual enabled state of instance

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -840,8 +840,6 @@ void CGUIDialogPVRChannelManager::Update()
   for (const auto& member : groupMembers)
   {
     channelFile = std::make_shared<CFileItem>(member);
-    if (!channelFile)
-      continue;
     const std::shared_ptr<const CPVRChannel> channel(channelFile->GetPVRChannelInfoTag());
 
     channelFile->SetProperty(PROPERTY_CHANNEL_ENABLED, !channel->IsHidden());

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -264,6 +264,9 @@ bool CGUIDialogPVRGroupManager::ActionButtonUngroupedChannels(const CGUIMessage&
 
   if (m_viewUngroupedChannels.HasControl(iControl)) // list/thumb control
   {
+    if (!m_selectedGroup)
+      return bReturn;
+
     m_iSelectedUngroupedChannel = m_viewUngroupedChannels.GetSelectedItem();
     if (m_selectedGroup->SupportsMemberAdd())
     {
@@ -304,6 +307,9 @@ bool CGUIDialogPVRGroupManager::ActionButtonGroupMembers(const CGUIMessage& mess
 
   if (m_viewGroupMembers.HasControl(iControl)) // list/thumb control
   {
+    if (!m_selectedGroup)
+      return bReturn;
+
     m_iSelectedGroupMember = m_viewGroupMembers.GetSelectedItem();
     if (m_selectedGroup->SupportsMemberRemove())
     {
@@ -311,7 +317,7 @@ bool CGUIDialogPVRGroupManager::ActionButtonGroupMembers(const CGUIMessage& mess
 
       if (actionID == ACTION_SELECT_ITEM || actionID == ACTION_MOUSE_LEFT_CLICK)
       {
-        if (m_selectedGroup && m_groupMembers->GetFileCount() > 0)
+        if (m_groupMembers->GetFileCount() > 0)
         {
           const auto itemChannel = m_groupMembers->Get(m_iSelectedGroupMember);
           ClearGroupThumbnails(*itemChannel);

--- a/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
@@ -246,8 +246,7 @@ void CPVRGUIChannelNavigator::SwitchToCurrentChannel()
     item = std::make_unique<CFileItem>(m_currentChannel);
   }
 
-  if (item)
-    CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(*item, false);
+  CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(*item, false);
 }
 
 bool CPVRGUIChannelNavigator::IsPreview() const


### PR DESCRIPTION
Fixes cppcheck warnings:
Null checks for std::make_shared and std::make_unique are pointless.
One potential nullptr deref in CGUIDialogPVRGroupManager.

@phunkyfish  should be easy to review.