### PR TITLE
[PVR] Feature: "Delete after watching" for recordings

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -4004,7 +4004,50 @@ msgctxt "#859"
 msgid "{0:s} [All channels]"
 msgstr ""
 
-#empty strings from id 860 to 996
+#. Label for setting 'Delete after watching' and delete confirmation dialog box.
+#: system/settings/settings.xml
+#: xbmc/pvr/guilib/PVRGUIActionsRecordings..cpp
+msgctxt "#860"
+msgid "Delete after watching"
+msgstr ""
+
+#. Help text for setting 'Delete after watching'.
+#: system/settings/settings.xml
+msgctxt "#861"
+msgid "Configure whether recordings should be deleted after watching."
+msgstr ""
+
+#. Value for setting 'Delete after watching'. Keep after watching.
+#: system/settings/settings.xml
+msgctxt "#862"
+msgid "No"
+msgstr ""
+
+#. Value for setting 'Delete after watching'. Confirm delete.
+#: system/settings/settings.xml
+msgctxt "#863"
+msgid "Ask"
+msgstr ""
+
+#. Value for setting 'Delete after watching'. Delete after watching.
+#: system/settings/settings.xml
+msgctxt "#864"
+msgid "Yes"
+msgstr ""
+
+#. Text for delete after watch confirmation dialog box.
+#: xbmc/pvr/guilib/PVRGUIActionsRecordings..cpp
+msgctxt "#865"
+msgid "Do you want to delete this recording?"
+msgstr ""
+
+#. Text for auto delete after watch toast message.
+#: xbmc/pvr/guilib/PVRGUIActionsRecordings..cpp
+msgctxt "#866"
+msgid "Recording deleted: '{0:s}'"
+msgstr ""
+
+#empty strings from id 867 to 996
 
 #: xbmc/windows/GUIMediaWindow.cpp
 msgctxt "#997"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2015,6 +2015,18 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
+        <setting id="pvrrecord.deleteafterwatch" type="integer" label="860" help="861">
+          <level>2</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="862">0</option>   <!-- No delete -->
+              <option label="863">1</option>   <!-- Ask to delete -->
+              <option label="864">2</option>   <!-- Delete -->
+            </options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
         <setting id="pvrrecord.grouprecordings" type="boolean" label="" help="">
           <default>true</default>
           <level>4</level>

--- a/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
@@ -26,6 +26,7 @@
 #include "pvr/dialogs/GUIDialogPVRRecordingInfo.h"
 #include "pvr/dialogs/GUIDialogPVRRecordingSettings.h"
 #include "pvr/recordings/PVRRecording.h"
+#include "pvr/recordings/PVRRecordings.h"
 #include "settings/Settings.h"
 #include "threads/IRunnable.h"
 #include "utils/Variant.h"
@@ -350,4 +351,21 @@ bool CPVRGUIActionsRecordings::ShowRecordingSettings(
   pDlgInfo->Open();
 
   return pDlgInfo->IsConfirmed();
+}
+
+bool CPVRGUIActionsRecordings::IncrementPlayCount(const CFileItem& item) const
+{
+  if (!item.IsPVRRecording())
+    return false;
+
+  return item.GetPVRRecordingInfoTag()->IncrementPlayCount();
+}
+
+bool CPVRGUIActionsRecordings::MarkWatched(const CFileItem& item, bool watched) const
+{
+  if (!item.IsPVRRecording())
+    return false;
+
+  return CServiceBroker::GetPVRManager().Recordings()->MarkWatched(item.GetPVRRecordingInfoTag(),
+                                                                   watched);
 }

--- a/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
@@ -17,8 +17,11 @@
 #include "filesystem/IDirectory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "pvr/PVREventLogJob.h"
 #include "pvr/PVRItem.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClient.h"
@@ -29,6 +32,7 @@
 #include "pvr/recordings/PVRRecordings.h"
 #include "settings/Settings.h"
 #include "threads/IRunnable.h"
+#include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
 
@@ -41,6 +45,14 @@ using namespace KODI::MESSAGING;
 
 namespace
 {
+enum PVRRECORD_DELETE_AFTER_WATCH
+{
+  // Values must match those defined in settings.xml -> pvrrecord.deleteafterwatch
+  NO = 0,
+  ASK = 1,
+  YES = 2,
+};
+
 class AsyncRecordingAction : private IRunnable
 {
 public:
@@ -182,6 +194,11 @@ private:
 };
 
 } // unnamed namespace
+
+CPVRGUIActionsRecordings::CPVRGUIActionsRecordings()
+  : m_settings({CSettings::SETTING_PVRRECORD_DELETEAFTERWATCH})
+{
+}
 
 bool CPVRGUIActionsRecordings::ShowRecordingInfo(const CFileItem& item) const
 {
@@ -353,12 +370,69 @@ bool CPVRGUIActionsRecordings::ShowRecordingSettings(
   return pDlgInfo->IsConfirmed();
 }
 
+bool CPVRGUIActionsRecordings::ProcessDeleteAfterWatch(const CFileItem& item) const
+{
+  bool deleteRecording{false};
+
+  const int action{m_settings.GetIntValue(CSettings::SETTING_PVRRECORD_DELETEAFTERWATCH)};
+  switch (action)
+  {
+    case PVRRECORD_DELETE_AFTER_WATCH::NO:
+      deleteRecording = false;
+      break;
+
+    case PVRRECORD_DELETE_AFTER_WATCH::ASK:
+      deleteRecording = (HELPERS::ShowYesNoDialogLines(
+                             CVariant{860}, // "Delete after watching"
+                             CVariant{865}, // "Do you want to delete this recording?"
+                             CVariant{""}, CVariant{item.GetPVRRecordingInfoTag()->GetTitle()}) ==
+                         HELPERS::DialogResponse::CHOICE_YES);
+      break;
+
+    case PVRRECORD_DELETE_AFTER_WATCH::YES:
+      deleteRecording = true;
+      break;
+
+    default:
+      CLog::LogF(LOGERROR, "Unhandled delete after watch action! Defaulting to 'no delete'.");
+      deleteRecording = false;
+      break;
+  }
+
+  if (deleteRecording)
+  {
+    if (AsyncDeleteRecording().Execute(item))
+    {
+      CPVREventLogJob* job = new CPVREventLogJob;
+      job->AddEvent(true, // display a toast, and log event
+                    EventLevel::Information, // info, no error
+                    g_localizeStrings.Get(860), // "Delete after watching"
+                    StringUtils::Format(g_localizeStrings.Get(866), // Recording deleted: <title>
+                                        item.GetPVRRecordingInfoTag()->GetTitle()),
+                    item.GetPVRRecordingInfoTag()->IconPath());
+      CServiceBroker::GetJobManager()->AddJob(job, nullptr);
+    }
+    else
+    {
+      HELPERS::ShowOKDialogText(CVariant{257}, // "Error"
+                                CVariant{19111}); // "PVR backend error."
+      return false;
+    }
+  }
+  return true;
+}
+
 bool CPVRGUIActionsRecordings::IncrementPlayCount(const CFileItem& item) const
 {
   if (!item.IsPVRRecording())
     return false;
 
-  return item.GetPVRRecordingInfoTag()->IncrementPlayCount();
+  if (item.GetPVRRecordingInfoTag()->IncrementPlayCount())
+  {
+    // Item must now be watched (because play count > 0).
+    return ProcessDeleteAfterWatch(item);
+  }
+  return false;
 }
 
 bool CPVRGUIActionsRecordings::MarkWatched(const CFileItem& item, bool watched) const
@@ -366,6 +440,13 @@ bool CPVRGUIActionsRecordings::MarkWatched(const CFileItem& item, bool watched) 
   if (!item.IsPVRRecording())
     return false;
 
-  return CServiceBroker::GetPVRManager().Recordings()->MarkWatched(item.GetPVRRecordingInfoTag(),
-                                                                   watched);
+  if (CServiceBroker::GetPVRManager().Recordings()->MarkWatched(item.GetPVRRecordingInfoTag(),
+                                                                watched))
+  {
+    if (watched)
+      return ProcessDeleteAfterWatch(item);
+
+    return true;
+  }
+  return false;
 }

--- a/xbmc/pvr/guilib/PVRGUIActionsRecordings.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsRecordings.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "pvr/IPVRComponent.h"
+#include "pvr/settings/PVRSettings.h"
 
 #include <memory>
 
@@ -21,7 +22,7 @@ class CPVRRecording;
 class CPVRGUIActionsRecordings : public IPVRComponent
 {
 public:
-  CPVRGUIActionsRecordings() = default;
+  CPVRGUIActionsRecordings();
   ~CPVRGUIActionsRecordings() override = default;
 
   /*!
@@ -74,14 +75,14 @@ public:
   bool UndeleteRecording(const CFileItem& item) const;
 
   /*!
-   * @brief Increment the play count of a recording.
+   * @brief Increment the play count of a recording. Process "Delete after watching" action.
    * @param item containing a recording for which the play count shall be incremented.
    * @return true, if the recording's play count was incremented successfully, false otherwise.
    */
   bool IncrementPlayCount(const CFileItem& item) const;
 
   /*!
-   * @brief Mark a recording watched or unwatched.
+   * @brief Mark a recording watched or unwatched. Process "Delete after watching" action.
    * @param item containing a recording to be marked watched or unwatched.
    * @param watched Whether to mark the recording watched or unwatched.
    * @return true, if the recording's watched state was changed successfully, false otherwise.
@@ -118,6 +119,15 @@ private:
    * @return true, if the dialog was ended successfully, false otherwise.
    */
   bool ShowRecordingSettings(const std::shared_ptr<CPVRRecording>& recording) const;
+
+  /*!
+   * @brief Process action according to "Delete after watching" setting value.
+   * @param item The watched recording.
+   * @return true on success, false otherwise.
+   */
+  bool ProcessDeleteAfterWatch(const CFileItem& item) const;
+
+  CPVRSettings m_settings;
 };
 
 namespace GUI

--- a/xbmc/pvr/guilib/PVRGUIActionsRecordings.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsRecordings.h
@@ -73,6 +73,21 @@ public:
    */
   bool UndeleteRecording(const CFileItem& item) const;
 
+  /*!
+   * @brief Increment the play count of a recording.
+   * @param item containing a recording for which the play count shall be incremented.
+   * @return true, if the recording's play count was incremented successfully, false otherwise.
+   */
+  bool IncrementPlayCount(const CFileItem& item) const;
+
+  /*!
+   * @brief Mark a recording watched or unwatched.
+   * @param item containing a recording to be marked watched or unwatched.
+   * @param watched Whether to mark the recording watched or unwatched.
+   * @return true, if the recording's watched state was changed successfully, false otherwise.
+   */
+  bool MarkWatched(const CFileItem& item, bool watched) const;
+
 private:
   CPVRGUIActionsRecordings(const CPVRGUIActionsRecordings&) = delete;
   CPVRGUIActionsRecordings const& operator=(CPVRGUIActionsRecordings const&) = delete;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -233,6 +233,7 @@ public:
   static constexpr auto SETTING_PVRRECORD_MARGINSTART = "pvrrecord.marginstart";
   static constexpr auto SETTING_PVRRECORD_MARGINEND = "pvrrecord.marginend";
   static constexpr auto SETTING_PVRRECORD_TIMERNOTIFICATIONS = "pvrrecord.timernotifications";
+  static constexpr auto SETTING_PVRRECORD_DELETEAFTERWATCH = "pvrrecord.deleteafterwatch";
   static constexpr auto SETTING_PVRRECORD_GROUPRECORDINGS = "pvrrecord.grouprecordings";
   static constexpr auto SETTING_PVRREMINDERS_AUTOCLOSEDELAY = "pvrreminders.autoclosedelay";
   static constexpr auto SETTING_PVRREMINDERS_AUTORECORD = "pvrreminders.autorecord";

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -26,6 +26,8 @@
 #include "music/MusicFileItemClassify.h"
 #include "music/tags/MusicInfoTag.h"
 #include "network/upnp/UPnP.h"
+#include "pvr/PVRManager.h"
+#include "pvr/guilib/PVRGUIActionsRecordings.h"
 #include "utils/Variant.h"
 #include "video/Bookmark.h"
 #include "video/VideoDatabase.h"
@@ -119,7 +121,11 @@ void CSaveFileState::DoWork(CFileItem& item,
 
               if (item.HasVideoInfoTag())
               {
-                item.GetVideoInfoTag()->IncrementPlayCount();
+                if (item.IsPVRRecording())
+                  CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().IncrementPlayCount(
+                      item);
+                else
+                  item.GetVideoInfoTag()->IncrementPlayCount();
 
                 if (newLastPlayed.IsValid())
                   item.GetVideoInfoTag()->m_lastPlayed = newLastPlayed;

--- a/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
@@ -18,7 +18,7 @@
 #endif
 #include "profiles/ProfileManager.h"
 #include "pvr/PVRManager.h"
-#include "pvr/recordings/PVRRecordings.h"
+#include "pvr/guilib/PVRGUIActionsRecordings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/URIUtils.h"
 #include "video/VideoDatabase.h"
@@ -70,8 +70,8 @@ bool CVideoLibraryMarkWatchedJob::Work(CVideoDatabase &db)
       continue;
 #endif
 
-    if (item->HasPVRRecordingInfoTag() &&
-        CServiceBroker::GetPVRManager().Recordings()->MarkWatched(item->GetPVRRecordingInfoTag(), m_mark))
+    if (item->IsPVRRecording() &&
+        CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().MarkWatched(*item, m_mark))
     {
       CDateTime newLastPlayed;
       if (m_mark)


### PR DESCRIPTION
Adds a feature that was requested in the forum: https://forum.kodi.tv/showthread.php?tid=378399&pid=3206293#pid3206293

Introduces a setting to control whether recordings are deleted after watching (technically, play count jumps from zero to 1). Screenshots should be pretty self-explaining:

![screenshot00003](https://github.com/user-attachments/assets/c384cab3-35e3-4297-a1a0-beeb1bbbdc60)

![screenshot00004](https://github.com/user-attachments/assets/cb4dbb34-45d0-4111-8488-679acd8b202e)

<img width="1710" alt="Screenshot 2024-08-17 at 11 20 11" src="https://github.com/user-attachments/assets/427b3d30-b2dc-4dd1-815d-23ae14122762">

Default is not to delete and not to ask.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish please review, thanks.
