### PR TITLE
Scale large texture to the actual display size

### DIFF
--- a/xbmc/GUILargeTextureManager.h
+++ b/xbmc/GUILargeTextureManager.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "guilib/AspectRatio.h"
 #include "guilib/TextureManager.h"
 #include "threads/CriticalSection.h"
 #include "utils/Job.h"
@@ -30,7 +31,11 @@ class CTexture;
 class CImageLoader : public CJob
 {
 public:
-  CImageLoader(const std::string &path, const bool useCache);
+  CImageLoader(const std::string& path,
+               unsigned int targetWidth,
+               unsigned int targetHeight,
+               CAspectRatio::AspectRatio aspectRatio,
+               const bool useCache);
   ~CImageLoader() override;
 
   /*!
@@ -41,6 +46,11 @@ public:
   bool          m_use_cache; ///< Whether or not to use any caching with this image
   std::string    m_path; ///< path of image to load
   std::unique_ptr<CTexture> m_texture; ///< Texture object to load the image into \sa CTexture.
+
+private:
+  unsigned int m_targetWidth; ///< target width of the image
+  unsigned int m_targetHeight; ///< target height of the image
+  CAspectRatio::AspectRatio m_aspectRatio; ///< aspect ratio mode of the image
 };
 
 /*!
@@ -76,12 +86,20 @@ public:
 
    \param path path of the image to load.
    \param texture texture object to hold the resulting texture
-   \param orientation orientation of resulting texture
+   \param width target width of the image. 0 means original width.
+   \param height target height of the image. 0 means original height.
    \param firstRequest true if this is the first time we are requesting this texture
+   \param useCache whether to load from image cache.
    \return true if the image exists, else false.
    \sa CGUITextureArray and CGUITexture
    */
-  bool GetImage(const std::string &path, CTextureArray &texture, bool firstRequest, bool useCache = true);
+  bool GetImage(const std::string& path,
+                CTextureArray& texture,
+                unsigned int width,
+                unsigned int height,
+                CAspectRatio::AspectRatio aspectRatio,
+                bool firstRequest,
+                bool useCache = true);
 
   /*!
    \brief Request a texture to be unloaded.
@@ -91,10 +109,16 @@ public:
    texture is still queued for loading, or is in the process of loading, the image load is cancelled.
 
    \param path path of the image to release.
+   \param width target width of the image to release.
+   \param height target height of the image to release.
    \param immediately if set true the image is immediately unloaded once its reference count reaches zero
                       rather than being unloaded after a delay.
    */
-  void ReleaseImage(const std::string &path, bool immediately = false);
+  void ReleaseImage(const std::string& path,
+                    unsigned int width,
+                    unsigned int height,
+                    CAspectRatio::AspectRatio aspectRatio,
+                    bool immediately = false);
 
   /*!
    \brief Cleanup images that are no longer in use.
@@ -111,7 +135,10 @@ private:
   class CLargeTexture
   {
   public:
-    explicit CLargeTexture(const std::string &path);
+    explicit CLargeTexture(const std::string& path,
+                           unsigned int targetWidth,
+                           unsigned int targetHeight,
+                           CAspectRatio::AspectRatio aspectRatio);
     virtual ~CLargeTexture();
 
     void AddRef();
@@ -121,6 +148,9 @@ private:
 
     const std::string& GetPath() const { return m_path; }
     const CTextureArray& GetTexture() const { return m_texture; }
+    unsigned int GetTargetWidth() const { return m_targetWidth; }
+    unsigned int GetTargetHeight() const { return m_targetHeight; }
+    CAspectRatio::AspectRatio GetAspectRatio() const { return m_aspectRatio; }
 
   private:
     static const unsigned int TIME_TO_DELETE = 2000;
@@ -128,10 +158,17 @@ private:
     unsigned int m_refCount;
     std::string m_path;
     CTextureArray m_texture;
+    unsigned int m_targetWidth;
+    unsigned int m_targetHeight;
+    CAspectRatio::AspectRatio m_aspectRatio;
     unsigned int m_timeToDelete;
   };
 
-  void QueueImage(const std::string &path, bool useCache = true);
+  void QueueImage(const std::string& path,
+                  unsigned int width,
+                  unsigned int height,
+                  CAspectRatio::AspectRatio aspectRatio,
+                  bool useCache = true);
 
   std::vector< std::pair<unsigned int, CLargeTexture *> > m_queued;
   std::vector<CLargeTexture *> m_allocated;

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -146,9 +146,13 @@ bool CTextureCache::StartCacheImage(const std::string& image)
   return false;
 }
 
-std::string CTextureCache::CacheImage(const std::string& image,
-                                      std::unique_ptr<CTexture>* texture /*= nullptr*/,
-                                      CTextureDetails* details /*= nullptr*/)
+std::string CTextureCache::CacheImage(
+    const std::string& image,
+    std::unique_ptr<CTexture>* texture /*= nullptr*/,
+    CTextureDetails* details /*= nullptr*/,
+    unsigned int idealWidth /*= 0*/,
+    unsigned int idealHeight /*= 0*/,
+    CAspectRatio::AspectRatio aspectRatio /*= CAspectRatio::CENTER*/)
 {
   std::string url = IMAGE_FILES::ToCacheKey(image);
   if (url.empty())
@@ -187,7 +191,7 @@ std::string CTextureCache::CacheImage(const std::string& image,
   if (!cachedpath.empty())
   {
     if (texture)
-      *texture = CTexture::LoadFromFile(cachedpath, 0, 0);
+      *texture = CTexture::LoadFromFile(cachedpath, idealWidth, idealHeight, aspectRatio);
   }
   else
   {

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -10,6 +10,7 @@
 
 #include "TextureCacheJob.h"
 #include "TextureDatabase.h"
+#include "guilib/AspectRatio.h"
 #include "threads/CriticalSection.h"
 #include "threads/Event.h"
 #include "threads/Timer.h"
@@ -92,12 +93,18 @@ public:
    \param image url of the image to cache
    \param texture [out] the loaded image
    \param details [out] details of the cached image
+   \param idealWidth the ideal width of the returned texture (defaults to 0, no ideal width). Only matters if texture is not null.
+   \param idealHeight the ideal height of the returned texture (defaults to 0, no ideal height). Only matters if texture is not null.
+   \param aspectRatio the aspect ratio mode of the texture (defaults to "center"). Only matters if texture is not null.
    \return cached url of this image
    \sa CTextureCacheJob::CacheTexture
    */
   std::string CacheImage(const std::string& image,
                          std::unique_ptr<CTexture>* texture = nullptr,
-                         CTextureDetails* details = nullptr);
+                         CTextureDetails* details = nullptr,
+                         unsigned int idealWidth = 0,
+                         unsigned int idealHeight = 0,
+                         CAspectRatio::AspectRatio aspectRatio = CAspectRatio::CENTER);
 
   /*! \brief Cache an image to image cache if not already cached, returning the image details.
    \param image url of the image to cache.

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -186,7 +186,8 @@ std::unique_ptr<CTexture> CTextureCacheJob::LoadImage(const IMAGE_FILES::CImageF
     return {};
   }
 
-  auto texture = CTexture::LoadFromFile(imageURL.GetTargetFile(), 0, 0, true, file.GetMimeType());
+  auto texture = CTexture::LoadFromFile(imageURL.GetTargetFile(), 0, 0, CAspectRatio::CENTER,
+                                        file.GetMimeType());
   if (!texture)
     return {};
 

--- a/xbmc/application/ApplicationSkinHandling.cpp
+++ b/xbmc/application/ApplicationSkinHandling.cpp
@@ -31,6 +31,7 @@
 #include "guilib/GUIColorManager.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIFontManager.h"
+#include "guilib/GUITextureCallbackManager.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/StereoscopicsManager.h"
@@ -163,6 +164,8 @@ bool CApplicationSkinHandling::LoadSkin(const std::string& skinID)
   CServiceBroker::GetGUI()->GetWindowManager().AddMsgTarget(m_msgCb);
   CServiceBroker::GetGUI()->GetWindowManager().AddMsgTarget(&CServiceBroker::GetPlaylistPlayer());
   CServiceBroker::GetGUI()->GetWindowManager().AddMsgTarget(&g_fontManager);
+  CServiceBroker::GetGUI()->GetWindowManager().AddMsgTarget(
+      &CServiceBroker::GetGUI()->GetTextureCallbackManager());
   CServiceBroker::GetGUI()->GetWindowManager().AddMsgTarget(
       &CServiceBroker::GetGUI()->GetStereoscopicsManager());
   CServiceBroker::GetGUI()->GetWindowManager().SetCallback(*m_wCb);

--- a/xbmc/guilib/AspectRatio.h
+++ b/xbmc/guilib/AspectRatio.h
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (C) 2005-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+// image alignment for <aspect>keep</aspect>, <aspect>scale</aspect> or <aspect>center</aspect>
+inline constexpr unsigned int ASPECT_ALIGN_CENTER = 0;
+inline constexpr unsigned int ASPECT_ALIGN_LEFT = 1;
+inline constexpr unsigned int ASPECT_ALIGN_RIGHT = 2;
+inline constexpr unsigned int ASPECT_ALIGNY_CENTER = 0;
+inline constexpr unsigned int ASPECT_ALIGNY_TOP = 4;
+inline constexpr unsigned int ASPECT_ALIGNY_BOTTOM = 8;
+inline constexpr unsigned int ASPECT_ALIGN_MASK = 3;
+inline constexpr unsigned int ASPECT_ALIGNY_MASK = ~3;
+
+class CAspectRatio
+{
+public:
+  enum class AspectRatio
+  {
+    // Do not keep aspect ratio. Image size = box size.
+    STRETCH = 0,
+    // Keep aspect ratio. Image size >= box size.
+    SCALE,
+    // Keep aspect ratio. Image size <= box size.
+    KEEP,
+    // Do not scale image.
+    CENTER
+  };
+  using enum AspectRatio;
+
+  CAspectRatio(AspectRatio aspect = STRETCH)
+  {
+    ratio = aspect;
+    align = ASPECT_ALIGN_CENTER | ASPECT_ALIGNY_CENTER;
+    scaleDiffuse = true;
+  }
+
+  CAspectRatio(AspectRatio aspect, uint32_t al, bool scaleD)
+    : ratio(aspect), align(al), scaleDiffuse(scaleD)
+  {
+  }
+
+  bool operator!=(const CAspectRatio& right) const
+  {
+    if (ratio != right.ratio)
+      return true;
+    if (align != right.align)
+      return true;
+    if (scaleDiffuse != right.scaleDiffuse)
+      return true;
+    return false;
+  };
+
+  AspectRatio ratio;
+  uint32_t align;
+  bool scaleDiffuse;
+};

--- a/xbmc/guilib/CMakeLists.txt
+++ b/xbmc/guilib/CMakeLists.txt
@@ -72,7 +72,8 @@ set(SOURCES DDSImage.cpp
             XBTF.cpp
             XBTFReader.cpp)
 
-set(HEADERS DDSImage.h
+set(HEADERS AspectRatio.h
+            DDSImage.h
             DirtyRegion.h
             DirtyRegionSolvers.h
             DirtyRegionTracker.h

--- a/xbmc/guilib/CMakeLists.txt
+++ b/xbmc/guilib/CMakeLists.txt
@@ -53,6 +53,7 @@ set(SOURCES DDSImage.cpp
             GUITextBox.cpp
             GUITextLayout.cpp
             GUITexture.cpp
+            GUITextureCallbackManager.cpp
             GUIToggleButtonControl.cpp
             GUIVideoControl.cpp
             GUIVisualisationControl.cpp
@@ -132,6 +133,7 @@ set(HEADERS AspectRatio.h
             GUITextBox.h
             GUITextLayout.h
             GUITexture.h
+            GUITextureCallbackManager.h
             GUIToggleButtonControl.h
             GUIVideoControl.h
             GUIVisualisationControl.h

--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -487,23 +487,8 @@ bool CFFmpegImage::DecodeFrame(AVFrame* frame, unsigned int width, unsigned int 
   AVColorRange range = frame->color_range;
   AVPixelFormat pixFormat = ConvertFormats(frame);
 
-  // assumption quadratic maximums e.g. 2048x2048
-  float ratio = m_width / (float)m_height;
-  unsigned int nHeight = m_originalHeight;
-  unsigned int nWidth = m_originalWidth;
-  if (nHeight > height)
-  {
-    nHeight = height;
-    nWidth = (unsigned int)(nHeight * ratio + 0.5f);
-  }
-  if (nWidth > width)
-  {
-    nWidth = width;
-    nHeight = (unsigned int)(nWidth / ratio + 0.5f);
-  }
-
-  struct SwsContext* context = sws_getContext(m_originalWidth, m_originalHeight, pixFormat,
-    nWidth, nHeight, AV_PIX_FMT_RGB32, SWS_BICUBIC, NULL, NULL, NULL);
+  SwsContext* context = sws_getContext(m_originalWidth, m_originalHeight, pixFormat, width, height,
+                                       AV_PIX_FMT_RGB32, SWS_BICUBIC, NULL, NULL, NULL);
 
   if (range == AVCOL_RANGE_JPEG)
   {
@@ -531,7 +516,7 @@ bool CFFmpegImage::DecodeFrame(AVFrame* frame, unsigned int width, unsigned int 
     const unsigned char *src = pictureRGB->data[0];
     unsigned char* dst = pixels;
 
-    for (unsigned int y = 0; y < nHeight; y++)
+    for (unsigned int y = 0; y < height; y++)
     {
       memcpy(dst, src, minPitch);
       src += pictureRGB->linesize[0];
@@ -546,9 +531,9 @@ bool CFFmpegImage::DecodeFrame(AVFrame* frame, unsigned int width, unsigned int 
     av_frame_free(&pictureRGB);
   }
 
-  // update width and height original dimensions are kept
-  m_height = nHeight;
-  m_width = nWidth;
+  // update width and height
+  m_height = height;
+  m_width = width;
 
   return true;
 }

--- a/xbmc/guilib/GUIColorButtonControl.cpp
+++ b/xbmc/guilib/GUIColorButtonControl.cpp
@@ -36,8 +36,8 @@ CGUIColorButtonControl::CGUIColorButtonControl(int parentID,
 {
   m_colorPosX = 0;
   m_colorPosY = 0;
-  m_imgColorMask->SetAspectRatio(CAspectRatio::AR_KEEP);
-  m_imgColorDisabledMask->SetAspectRatio(CAspectRatio::AR_KEEP);
+  m_imgColorMask->SetAspectRatio(CAspectRatio::KEEP);
+  m_imgColorDisabledMask->SetAspectRatio(CAspectRatio::KEEP);
   m_imgBoxColor = GUIINFO::CGUIInfoColor(KODI::UTILS::COLOR::NONE);
   ControlType = GUICONTROL_COLORBUTTON;
   // offsetX is like a left/right padding, "hex" label does not require high values

--- a/xbmc/guilib/GUIComponent.cpp
+++ b/xbmc/guilib/GUIComponent.cpp
@@ -12,6 +12,7 @@
 #include "GUIColorManager.h"
 #include "GUIInfoManager.h"
 #include "GUILargeTextureManager.h"
+#include "GUITextureCallbackManager.h"
 #include "GUIWindowManager.h"
 #include "ServiceBroker.h"
 #include "StereoscopicsManager.h"
@@ -26,6 +27,7 @@ CGUIComponent::CGUIComponent()
   : m_pWindowManager(std::make_unique<CGUIWindowManager>()),
     m_pTextureManager(std::make_unique<CGUITextureManager>()),
     m_pLargeTextureManager(std::make_unique<CGUILargeTextureManager>()),
+    m_pTextureCallbackManager(std::make_unique<CGUITextureCallbackManager>()),
     m_stereoscopicsManager(std::make_unique<CStereoscopicsManager>()),
     m_guiInfoManager(std::make_unique<CGUIInfoManager>()),
     m_guiColorManager(std::make_unique<CGUIColorManager>()),
@@ -73,6 +75,11 @@ CGUITextureManager& CGUIComponent::GetTextureManager()
 CGUILargeTextureManager& CGUIComponent::GetLargeTextureManager()
 {
   return *m_pLargeTextureManager;
+}
+
+CGUITextureCallbackManager& CGUIComponent::GetTextureCallbackManager()
+{
+  return *m_pTextureCallbackManager;
 }
 
 CStereoscopicsManager &CGUIComponent::GetStereoscopicsManager()

--- a/xbmc/guilib/GUIComponent.h
+++ b/xbmc/guilib/GUIComponent.h
@@ -14,6 +14,7 @@
 class CGUIWindowManager;
 class CGUITextureManager;
 class CGUILargeTextureManager;
+class CGUITextureCallbackManager;
 class CStereoscopicsManager;
 class CGUIInfoManager;
 class CGUIColorManager;
@@ -32,6 +33,7 @@ public:
   CGUIWindowManager& GetWindowManager();
   CGUITextureManager& GetTextureManager();
   CGUILargeTextureManager& GetLargeTextureManager();
+  CGUITextureCallbackManager& GetTextureCallbackManager();
   CStereoscopicsManager &GetStereoscopicsManager();
   CGUIInfoManager &GetInfoManager();
   CGUIColorManager &GetColorManager();
@@ -44,6 +46,7 @@ protected:
   std::unique_ptr<CGUIWindowManager> m_pWindowManager;
   std::unique_ptr<CGUITextureManager> m_pTextureManager;
   std::unique_ptr<CGUILargeTextureManager> m_pLargeTextureManager;
+  std::unique_ptr<CGUITextureCallbackManager> m_pTextureCallbackManager;
   std::unique_ptr<CStereoscopicsManager> m_stereoscopicsManager;
   std::unique_ptr<CGUIInfoManager> m_guiInfoManager;
   std::unique_ptr<CGUIColorManager> m_guiColorManager;

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -328,13 +328,13 @@ bool CGUIControlFactory::GetAspectRatio(const TiXmlNode* pRootNode,
 
   ratio = node->FirstChild()->Value();
   if (StringUtils::EqualsNoCase(ratio, "keep"))
-    aspect.ratio = CAspectRatio::AR_KEEP;
+    aspect.ratio = CAspectRatio::KEEP;
   else if (StringUtils::EqualsNoCase(ratio, "scale"))
-    aspect.ratio = CAspectRatio::AR_SCALE;
+    aspect.ratio = CAspectRatio::SCALE;
   else if (StringUtils::EqualsNoCase(ratio, "center"))
-    aspect.ratio = CAspectRatio::AR_CENTER;
+    aspect.ratio = CAspectRatio::CENTER;
   else if (StringUtils::EqualsNoCase(ratio, "stretch"))
-    aspect.ratio = CAspectRatio::AR_STRETCH;
+    aspect.ratio = CAspectRatio::STRETCH;
 
   const char* attribute = node->Attribute("align");
   if (attribute)

--- a/xbmc/guilib/GUIListItemLayout.cpp
+++ b/xbmc/guilib/GUIListItemLayout.cpp
@@ -221,7 +221,7 @@ void CGUIListItemLayout::CreateListControlLayouts(float width, float height, boo
   }
   CGUIImage *image = new CGUIImage(0, 0, 8, 0, iconWidth, texHeight, CTextureInfo(""));
   image->SetInfo(GUIINFO::CGUIInfoLabel("$INFO[ListItem.Icon]", "", m_group.GetParentID()));
-  image->SetAspectRatio(CAspectRatio::AR_KEEP);
+  image->SetAspectRatio(CAspectRatio::KEEP);
   m_group.AddControl(image);
   float x = iconWidth + labelInfo.offsetX + 10;
   CGUIListLabel *label = new CGUIListLabel(0, 0, x, labelInfo.offsetY, width - x - 18, height, labelInfo, GUIINFO::CGUIInfoLabel("$INFO[ListItem.Label]", "", m_group.GetParentID()), CGUIControl::FOCUS);

--- a/xbmc/guilib/GUIRadioButtonControl.cpp
+++ b/xbmc/guilib/GUIRadioButtonControl.cpp
@@ -39,12 +39,12 @@ CGUIRadioButtonControl::CGUIRadioButtonControl(int parentID,
 {
   m_radioPosX = 0;
   m_radioPosY = 0;
-  m_imgRadioOnFocus->SetAspectRatio(CAspectRatio::AR_KEEP);
-  m_imgRadioOnNoFocus->SetAspectRatio(CAspectRatio::AR_KEEP);
-  m_imgRadioOffFocus->SetAspectRatio(CAspectRatio::AR_KEEP);
-  m_imgRadioOffNoFocus->SetAspectRatio(CAspectRatio::AR_KEEP);
-  m_imgRadioOnDisabled->SetAspectRatio(CAspectRatio::AR_KEEP);
-  m_imgRadioOffDisabled->SetAspectRatio(CAspectRatio::AR_KEEP);
+  m_imgRadioOnFocus->SetAspectRatio(CAspectRatio::KEEP);
+  m_imgRadioOnNoFocus->SetAspectRatio(CAspectRatio::KEEP);
+  m_imgRadioOffFocus->SetAspectRatio(CAspectRatio::KEEP);
+  m_imgRadioOffNoFocus->SetAspectRatio(CAspectRatio::KEEP);
+  m_imgRadioOnDisabled->SetAspectRatio(CAspectRatio::KEEP);
+  m_imgRadioOffDisabled->SetAspectRatio(CAspectRatio::KEEP);
   ControlType = GUICONTROL_RADIO;
   m_useLabel2 = false;
 }

--- a/xbmc/guilib/GUIScrollBarControl.cpp
+++ b/xbmc/guilib/GUIScrollBarControl.cpp
@@ -39,8 +39,8 @@ GUIScrollBarControl::GUIScrollBarControl(int parentID,
     m_guiNibNoFocus(CGUITexture::CreateTexture(posX, posY, width, height, nibTexture)),
     m_guiNibFocus(CGUITexture::CreateTexture(posX, posY, width, height, nibTextureFocus))
 {
-  m_guiNibNoFocus->SetAspectRatio(CAspectRatio::AR_CENTER);
-  m_guiNibFocus->SetAspectRatio(CAspectRatio::AR_CENTER);
+  m_guiNibNoFocus->SetAspectRatio(CAspectRatio::CENTER);
+  m_guiNibFocus->SetAspectRatio(CAspectRatio::CENTER);
   m_numItems = 100;
   m_offset = 0;
   m_pageSize = 10;

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -184,7 +184,7 @@ bool CGUISliderControl::ProcessSelector(CGUITexture* background,
     dirty |= nib->SetWidth(nib->GetTextureWidth() * fScale);
     dirty |= nib->SetHeight(nib->GetWidth() * 2);
   }
-  CAspectRatio ratio(CAspectRatio::AR_KEEP);
+  CAspectRatio ratio(CAspectRatio::KEEP);
   ratio.align = ASPECT_ALIGN_LEFT | ASPECT_ALIGNY_CENTER;
   dirty |= nib->SetAspectRatio(ratio);
   dirty |= nib->Process(currentTime);

--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -427,7 +427,7 @@ bool CGUITexture::CalculateSize()
   float newWidth = m_width;
   float newHeight = m_height;
 
-  if (m_aspect.ratio != CAspectRatio::AR_STRETCH && m_frameWidth && m_frameHeight)
+  if (m_aspect.ratio != CAspectRatio::STRETCH && m_frameWidth && m_frameHeight)
   {
     // to get the pixel ratio, we must use the SCALED output sizes
     float pixelRatio = CServiceBroker::GetWinSystem()->GetGfxContext().GetScalingPixelRatio();
@@ -440,13 +440,13 @@ bool CGUITexture::CalculateSize()
     // maximize the width
     newHeight = m_width / fOutputFrameRatio;
 
-    if ((m_aspect.ratio == CAspectRatio::AR_SCALE && newHeight < m_height) ||
-        (m_aspect.ratio == CAspectRatio::AR_KEEP && newHeight > m_height))
+    if ((m_aspect.ratio == CAspectRatio::SCALE && newHeight < m_height) ||
+        (m_aspect.ratio == CAspectRatio::KEEP && newHeight > m_height))
     {
       newHeight = m_height;
       newWidth = newHeight * fOutputFrameRatio;
     }
-    if (m_aspect.ratio == CAspectRatio::AR_CENTER)
+    if (m_aspect.ratio == CAspectRatio::CENTER)
     { // keep original size + center
       newWidth = m_frameWidth / sqrt(pixelRatio);
       newHeight = m_frameHeight * sqrt(pixelRatio);

--- a/xbmc/guilib/GUITexture.h
+++ b/xbmc/guilib/GUITexture.h
@@ -85,6 +85,7 @@ public:
   bool AllocResources();
   void FreeResources(bool immediately = false);
   void SetInvalid();
+  void OnWindowResize();
 
   bool SetVisible(bool visible);
   bool SetAlpha(unsigned char alpha);

--- a/xbmc/guilib/GUITexture.h
+++ b/xbmc/guilib/GUITexture.h
@@ -10,49 +10,11 @@
 
 #include "TextureManager.h"
 #include "guiinfo/GUIInfoColor.h"
+#include "guilib/AspectRatio.h"
 #include "utils/ColorUtils.h"
 #include "utils/Geometry.h"
 
 #include <functional>
-
-// image alignment for <aspect>keep</aspect>, <aspect>scale</aspect> or <aspect>center</aspect>
-#define ASPECT_ALIGN_CENTER  0
-#define ASPECT_ALIGN_LEFT    1
-#define ASPECT_ALIGN_RIGHT   2
-#define ASPECT_ALIGNY_CENTER 0
-#define ASPECT_ALIGNY_TOP    4
-#define ASPECT_ALIGNY_BOTTOM 8
-#define ASPECT_ALIGN_MASK    3
-#define ASPECT_ALIGNY_MASK  ~3
-
-class CAspectRatio
-{
-public:
-  enum ASPECT_RATIO { AR_STRETCH = 0, AR_SCALE, AR_KEEP, AR_CENTER };
-  CAspectRatio(ASPECT_RATIO aspect = AR_STRETCH)
-  {
-    ratio = aspect;
-    align = ASPECT_ALIGN_CENTER | ASPECT_ALIGNY_CENTER;
-    scaleDiffuse = true;
-  }
-
-  CAspectRatio(ASPECT_RATIO aspect, uint32_t al, bool scaleD)
-    : ratio(aspect), align(al), scaleDiffuse(scaleD)
-  {
-  }
-
-  bool operator!=(const CAspectRatio &right) const
-  {
-    if (ratio != right.ratio) return true;
-    if (align != right.align) return true;
-    if (scaleDiffuse != right.scaleDiffuse) return true;
-    return false;
-  };
-
-  ASPECT_RATIO ratio;
-  uint32_t     align;
-  bool         scaleDiffuse;
-};
 
 class CTextureInfo
 {

--- a/xbmc/guilib/GUITexture.h
+++ b/xbmc/guilib/GUITexture.h
@@ -165,6 +165,11 @@ protected:
   float m_height;
   float m_depth{0};
 
+  // size used to get and release image from LargeTextureManager
+  int m_requestWidth = REQUEST_SIZE_UNSET;
+  int m_requestHeight = REQUEST_SIZE_UNSET;
+  static constexpr int REQUEST_SIZE_UNSET = -1;
+
   CRect m_vertex;       // vertex coords to render
   bool m_invalid;       // if true, we need to recalculate
   bool m_use_cache;

--- a/xbmc/guilib/GUITextureCallbackManager.cpp
+++ b/xbmc/guilib/GUITextureCallbackManager.cpp
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GUITextureCallbackManager.h"
+
+#include "guilib/GUITexture.h"
+
+#include <vector>
+
+CGUITextureCallbackManager::CGUITextureCallbackManager() = default;
+
+CGUITextureCallbackManager::~CGUITextureCallbackManager() = default;
+
+bool CGUITextureCallbackManager::OnMessage(CGUIMessage& message)
+{
+  if (message.GetMessage() != GUI_MSG_NOTIFY_ALL)
+    return false;
+
+  if (message.GetParam1() != GUI_MSG_WINDOW_RESIZE)
+    return false;
+
+  // Create a temporary copy because textures can be removed during the iteration
+  const std::vector<CGUITexture*> currentTextures{m_textures.begin(), m_textures.end()};
+  std::for_each(currentTextures.cbegin(), currentTextures.cend(),
+                [](CGUITexture* texture) { texture->OnWindowResize(); });
+
+  return true;
+}
+
+void CGUITextureCallbackManager::RegisterOnWindowResizeCallback(CGUITexture& texture)
+{
+  m_textures.insert(&texture);
+}
+
+void CGUITextureCallbackManager::UnregisterOnWindowResizeCallback(CGUITexture& texture)
+{
+  m_textures.erase(&texture);
+}

--- a/xbmc/guilib/GUITextureCallbackManager.h
+++ b/xbmc/guilib/GUITextureCallbackManager.h
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+/*!
+\file GUITextureCallbackManager.h
+\brief
+*/
+
+#include "IMsgTargetCallback.h"
+#include "utils/GlobalsHandling.h"
+
+#include <unordered_set>
+
+class CGUITexture;
+
+/*!
+ \ingroup textures
+ \brief
+ */
+class CGUITextureCallbackManager : public IMsgTargetCallback
+{
+public:
+  CGUITextureCallbackManager();
+  ~CGUITextureCallbackManager() override;
+
+  bool OnMessage(CGUIMessage& message) override;
+
+  void RegisterOnWindowResizeCallback(CGUITexture& texture);
+  void UnregisterOnWindowResizeCallback(CGUITexture& texture);
+
+private:
+  std::unordered_set<CGUITexture*> m_textures;
+};

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "guilib/AspectRatio.h"
 #include "guilib/TextureBase.h"
 #include "guilib/TextureFormats.h"
 
@@ -43,14 +44,16 @@ public:
    \param texturePath the path of the texture to load.
    \param idealWidth the ideal width of the texture (defaults to 0, no ideal width).
    \param idealHeight the ideal height of the texture (defaults to 0, no ideal height).
+   \param aspectRatio the aspect ratio mode of the texture (defaults to "center").
    \param strMimeType mimetype of the given texture if available (defaults to empty)
    \return a CTexture std::unique_ptr to the created texture - nullptr if the texture failed to load.
    */
-  static std::unique_ptr<CTexture> LoadFromFile(const std::string& texturePath,
-                                                unsigned int idealWidth = 0,
-                                                unsigned int idealHeight = 0,
-                                                bool requirePixels = false,
-                                                const std::string& strMimeType = "");
+  static std::unique_ptr<CTexture> LoadFromFile(
+      const std::string& texturePath,
+      unsigned int idealWidth = 0,
+      unsigned int idealHeight = 0,
+      CAspectRatio::AspectRatio aspectRatio = CAspectRatio::CENTER,
+      const std::string& strMimeType = "");
 
   /*! \brief Load a texture from a file in memory
    Loads a texture from a file in memory, restricting in size if needed based on maxHeight and maxWidth.
@@ -60,13 +63,16 @@ public:
    \param mimeType the mime type of the file in buffer.
    \param idealWidth the ideal width of the texture (defaults to 0, no ideal width).
    \param idealHeight the ideal height of the texture (defaults to 0, no ideal height).
+   \param aspectRatio the aspect ratio mode of the texture (defaults to "center").
    \return a CTexture std::unique_ptr to the created texture - nullptr if the texture failed to load.
    */
-  static std::unique_ptr<CTexture> LoadFromFileInMemory(unsigned char* buffer,
-                                                        size_t bufferSize,
-                                                        const std::string& mimeType,
-                                                        unsigned int idealWidth = 0,
-                                                        unsigned int idealHeight = 0);
+  static std::unique_ptr<CTexture> LoadFromFileInMemory(
+      unsigned char* buffer,
+      size_t bufferSize,
+      const std::string& mimeType,
+      unsigned int idealWidth = 0,
+      unsigned int idealHeight = 0,
+      CAspectRatio::AspectRatio aspectRatio = CAspectRatio::CENTER);
 
   bool LoadFromMemory(unsigned int width,
                       unsigned int height,
@@ -135,12 +141,21 @@ private:
   CTexture(const CTexture& copy) = delete;
 
 protected:
-  bool LoadFromFileInMem(unsigned char* buffer, size_t size, const std::string& mimeType,
-                         unsigned int maxWidth, unsigned int maxHeight);
-  bool LoadFromFileInternal(const std::string& texturePath, unsigned int maxWidth, unsigned int maxHeight, bool requirePixels, const std::string& strMimeType = "");
+  bool LoadFromFileInMem(unsigned char* buffer,
+                         size_t size,
+                         const std::string& mimeType,
+                         unsigned int idealWidth,
+                         unsigned int idealHeight,
+                         CAspectRatio::AspectRatio aspectRatio);
+  bool LoadFromFileInternal(const std::string& texturePath,
+                            unsigned int idealWidth,
+                            unsigned int idealHeight,
+                            CAspectRatio::AspectRatio aspectRatio,
+                            const std::string& strMimeType = "");
   bool LoadIImage(IImage* pImage,
                   unsigned char* buffer,
                   unsigned int bufSize,
-                  unsigned int width,
-                  unsigned int height);
+                  unsigned int idealWidth,
+                  unsigned int idealHeight,
+                  CAspectRatio::AspectRatio aspectRatio);
 };

--- a/xbmc/guilib/test/TestGUIControlFactory.cpp
+++ b/xbmc/guilib/test/TestGUIControlFactory.cpp
@@ -201,25 +201,25 @@ class TestAspectRatio : public testing::WithParamInterface<AspectRatioTest>, pub
 
 const auto AspectRatioTests = std::array{
     AspectRatioTest{R"(<root><test align="center">keep</test></root>)"s,
-                    {CAspectRatio::AR_KEEP, ASPECT_ALIGN_CENTER, true}},
+                    {CAspectRatio::KEEP, ASPECT_ALIGN_CENTER, true}},
     AspectRatioTest{R"(<root><test align="right">scale</test></root>)"s,
-                    {CAspectRatio::AR_SCALE, ASPECT_ALIGN_RIGHT, true}},
+                    {CAspectRatio::SCALE, ASPECT_ALIGN_RIGHT, true}},
     AspectRatioTest{R"(<root><test align="left">center</test></root>)"s,
-                    {CAspectRatio::AR_CENTER, ASPECT_ALIGN_LEFT, true}},
+                    {CAspectRatio::CENTER, ASPECT_ALIGN_LEFT, true}},
     AspectRatioTest{R"(<root><test align="center">stretch</test></root>)"s,
-                    {CAspectRatio::AR_STRETCH, ASPECT_ALIGN_CENTER, true}},
+                    {CAspectRatio::STRETCH, ASPECT_ALIGN_CENTER, true}},
     AspectRatioTest{R"(<root><test aligny="center" scalediffuse="true">keep</test></root>)"s,
-                    {CAspectRatio::AR_KEEP, ASPECT_ALIGNY_CENTER, true}},
+                    {CAspectRatio::KEEP, ASPECT_ALIGNY_CENTER, true}},
     AspectRatioTest{R"(<root><test aligny="bottom" scalediffuse="yes">keep</test></root>)"s,
-                    {CAspectRatio::AR_KEEP, ASPECT_ALIGNY_BOTTOM, true}},
+                    {CAspectRatio::KEEP, ASPECT_ALIGNY_BOTTOM, true}},
     AspectRatioTest{
         R"(<root><test align="right" aligny="top" scalediffuse="no">keep</test></root>)"s,
-        {CAspectRatio::AR_KEEP, ASPECT_ALIGN_RIGHT | ASPECT_ALIGNY_TOP, false}},
+        {CAspectRatio::KEEP, ASPECT_ALIGN_RIGHT | ASPECT_ALIGNY_TOP, false}},
     AspectRatioTest{R"(<root><test scalediffuse="false">keep</test></root>)"s,
-                    {CAspectRatio::AR_KEEP, ASPECT_ALIGN_CENTER, false}},
+                    {CAspectRatio::KEEP, ASPECT_ALIGN_CENTER, false}},
     AspectRatioTest{
-        R"(<root><test/></root>)"s, {CAspectRatio::AR_STRETCH, ASPECT_ALIGN_CENTER, true}, false},
-    AspectRatioTest{R"(<root/>)"s, {CAspectRatio::AR_STRETCH, ASPECT_ALIGN_CENTER, true}, false},
+        R"(<root><test/></root>)"s, {CAspectRatio::STRETCH, ASPECT_ALIGN_CENTER, true}, false},
+    AspectRatioTest{R"(<root/>)"s, {CAspectRatio::STRETCH, ASPECT_ALIGN_CENTER, true}, false},
 };
 
 struct ColorTest

--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -379,8 +379,9 @@ namespace XBMCAddon
             CTextureInfo(strFileName));
       pGUIControl->SetVisible(m_visible);
 
-      if (pGUIControl && aspectRatio <= CAspectRatio::AR_KEEP)
-        static_cast<CGUIImage*>(pGUIControl)->SetAspectRatio((CAspectRatio::ASPECT_RATIO)aspectRatio);
+      if (pGUIControl && (CAspectRatio::AspectRatio)aspectRatio <= CAspectRatio::KEEP)
+        static_cast<CGUIImage*>(pGUIControl)
+            ->SetAspectRatio((CAspectRatio::AspectRatio)aspectRatio);
 
       if (pGUIControl && colorDiffuse)
         static_cast<CGUIImage*>(pGUIControl)->SetColorDiffuse(GUILIB::GUIINFO::CGUIInfoColor(colorDiffuse));

--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -293,7 +293,7 @@ std::unique_ptr<CTexture> CPicture::CreateTiledThumb(const std::vector<std::stri
     int y = i / num_across;
     // load in the image
     unsigned int width = tile_width - 2 * tile_gap, height = tile_height - 2 * tile_gap;
-    std::unique_ptr<CTexture> texture = CTexture::LoadFromFile(files[i], width, height, true);
+    std::unique_ptr<CTexture> texture = CTexture::LoadFromFile(files[i], width, height);
     if (texture && texture->GetWidth() && texture->GetHeight())
     {
       GetScale(texture->GetWidth(), texture->GetHeight(), width, height);

--- a/xbmc/rendering/RenderSystem.cpp
+++ b/xbmc/rendering/RenderSystem.cpp
@@ -69,7 +69,7 @@ void CRenderSystemBase::ShowSplash(const std::string& message)
         static_cast<float>(CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth()),
         static_cast<float>(CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight()),
         CTextureInfo(CUtil::GetSplashPath()));
-    m_splashImage->SetAspectRatio(CAspectRatio::AR_SCALE);
+    m_splashImage->SetAspectRatio(CAspectRatio::SCALE);
   }
 
   CServiceBroker::GetWinSystem()->GetGfxContext().lock();

--- a/xbmc/windows/GUIWindowSplash.cpp
+++ b/xbmc/windows/GUIWindowSplash.cpp
@@ -33,7 +33,7 @@ void CGUIWindowSplash::OnInitWindow()
       static_cast<float>(CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth()),
       static_cast<float>(CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight()),
       CTextureInfo(CUtil::GetSplashPath()));
-  m_image->SetAspectRatio(CAspectRatio::AR_SCALE);
+  m_image->SetAspectRatio(CAspectRatio::SCALE);
 }
 
 void CGUIWindowSplash::Render()


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

After this PR, `CGUILargeTextureManager` will load the scaled version of the texture with the actual display size. The scaled version will be kept in memory until released. When a new size of a texture is requested, the texture will be loaded and scaled again. When the window size changes, the textures will be reloaded with their new sizes.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To address the long-standing GUI image quality problem: https://forum.kodi.tv/showthread.php?tid=200401
This greatly improves the display quality of artwork.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on a MacBook Pro (M1 Pro, macOS 14.5), a 3rd gen Fire TV Cube (Fire OS 7/Android 9) and a Chromecast with Google TV (4K) (Android 12).

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

### Performance

On all the devices I've tested on, this didn't cause any noticeable delay on image loading.
This might need to be tested on some lower end devices, though.

### Memory usage

This saves a lot of memory both on macOS (checked the memory usage of Kodi with Activity Monitor) and on Android TV (checked the memory usage of Kodi with `adb shell dumpsys meminfo`).

## Screenshots (if appropriate):

Before:
![screenshot00000](https://github.com/user-attachments/assets/4d8320b3-0ecd-46aa-a7a2-96ad8ada22f1)

After:
![screenshot00001](https://github.com/user-attachments/assets/33d9ebdf-b541-4226-bdab-011027a50efd)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
