### PR TITLE
Enable file:// protocol in CURL and CCurlFile

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -131,13 +131,16 @@ void CURL::Parse(std::string strURL1)
   // ones that come to mind are iso9660, cdda, musicdb, etc.
   // they are all local protocols and have no server part, port number, special options, etc.
   // this removes the need for special handling below.
+  // clang-format off
   if (
     IsProtocol("stack") ||
     IsProtocol("virtualpath") ||
     IsProtocol("multipath") ||
     IsProtocol("special") ||
-    IsProtocol("resource")
+    IsProtocol("resource") ||
+    IsProtocol("file")
     )
+  // clang-format on
   {
     SetFileName(std::move(strURL).substr(iPos));
     return;

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1097,7 +1097,15 @@ bool CCurlFile::Open(const CURL& url)
 
   m_httpresponse = m_state->Connect(m_bufferSize);
 
-  if (m_httpresponse <= 0 || (m_failOnError && m_httpresponse >= 400))
+  long hte = 0;
+
+  // Allow HTTP response code 0 for file:// protocol
+  if (url2.IsProtocol("file"))
+  {
+    hte = -1;
+  }
+
+  if (m_httpresponse <= hte || (m_failOnError && m_httpresponse >= 400))
   {
     std::string error;
     if (m_httpresponse >= 400 && CServiceBroker::GetLogging().CanLogComponent(LOGCURL))


### PR DESCRIPTION
## Description

This PR allows distro package builders to add local addon repositories and use them as a fallback if no mirror repository is available or enabled.
Adding the local repo list to official origins allows automatic updates of addons from the local repo by versions from mirrors.kodi.tv repo once it becomes enabled / available.

## Motivation and context

I crafted this change to provide a local repository for language addons on Debian (#25631)

The original problem arose from the following chain of events:

* In 2017, kodi addon repository was made optional to install in Debian [bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=877767)
* In 2020, user with intranet-only Kodi setup revealed one can not install any language addon [bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1009278)
* In 2023, user complained that 77 language addons I made preinstalled with kodi clutter UX and waste space [bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1042996)
* In 2024, I attempted to split language packs into separate Debian packages like firefox or libreoffice do in Debian, but got a REJECT from FTP Masters (#25631)
* To fix this once and for all, I made language packs in a local repo within `/usr/share/kodi/language-repo` and added the local repo to Kodi official repo list to be able to update language packs if mirrors.kodi.tv repo is installed and enabled.

Usage example: https://salsa.debian.org/multimedia-team/kodi-media-center/kodi/-/commit/cc8dcea2ab3d9d375fde8ce0165ccd174bfc46f2  + https://salsa.debian.org/multimedia-team/kodi-media-center/kodi/-/commit/d063166a3e227cd1e2d0e101cbb206cf3c722ba4

## How has this been tested?

1. Install Kodi from Debian 21.1 from unstable
2. Remove kodi-repository-kodi package before first Kodi start
3. Try to set primary UI language different from English
4. See language add-on has been installed and language has been changed

## What is the effect on users?

Users on selected distributions can use repositories bundled inside Kodi distribution package

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
