### PR TITLE
Modernize `StringUtils`

### DIFF
--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <memory>
 #include <regex>
+#include <string_view>
 
 namespace
 {
@@ -462,8 +463,8 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon,
       element = child->FirstChildElement("platform");
       if (element && element->GetText() != nullptr)
       {
-        auto platforms = StringUtils::Split(element->GetText(),
-                                            {" ", "\t", "\n", "\r"});
+        using namespace std::literals;
+        auto platforms = StringUtils::Split(element->GetText(), {{" "sv, "\t"sv, "\n"sv, "\r"sv}});
         platforms.erase(std::remove_if(platforms.begin(), platforms.end(),
                         [](const std::string& platform) { return platform.empty(); }),
                         platforms.cend());

--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -19,6 +19,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <string_view>
 
 using namespace MUSIC_INFO;
 
@@ -66,6 +67,7 @@ void CAlbum::SetArtistCredits(const std::vector<std::string>& names, const std::
                               const std::vector<std::string>& artistnames, const std::vector<std::string>& artisthints,
                               const std::vector<std::string>& artistmbids)
 {
+  using namespace std::literals;
   std::vector<std::string> albumartistHints = hints;
   //Split the artist sort string to try and get sort names for individual artists
   auto artistSort = StringUtils::Split(strArtistSort, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);
@@ -150,7 +152,9 @@ void CAlbum::SetArtistCredits(const std::vector<std::string>& names, const std::
     // Try to get number of artist sort names and musicbrainz ids to match. Split sort names
     // further using multiple possible delimiters, over single separator applied in Tag loader
     if (artistSort.size() != mbids.size())
-      artistSort = StringUtils::SplitMulti(artistSort, { ";", ":", "|", "#" });
+    {
+      artistSort = StringUtils::SplitMulti(artistSort, {{";"sv, ":"sv, "|"sv, "#"sv}});
+    }
 
     for (size_t i = 0; i < mbids.size(); i++)
     {
@@ -192,8 +196,10 @@ void CAlbum::SetArtistCredits(const std::vector<std::string>& names, const std::
       albumArtists = StringUtils::SplitMulti(albumArtists, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicArtistSeparators);
 
     if (artistSort.size() != albumArtists.size())
+    {
       // Split artist sort names further using multiple possible delimiters, over single separator applied in Tag loader
-      artistSort = StringUtils::SplitMulti(artistSort, { ";", ":", "|", "#" });
+      artistSort = StringUtils::SplitMulti(artistSort, {{";"sv, ":"sv, "|"sv, "#"sv}});
+    }
 
     for (size_t i = 0; i < albumArtists.size(); i++)
     {

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -58,6 +58,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <string_view>
 #include <utility>
 
 using namespace KODI;
@@ -847,8 +848,11 @@ void CMusicInfoScanner::FileItemsToAlbums(CFileItemList& items, VECALBUMS& album
       //Split the albumartist sort string to try and get sort names for individual artists
       std::vector<std::string> sortnames = StringUtils::Split(albumartistsort, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);
       if (sortnames.size() != common.size())
-          // Split artist sort names further using multiple possible delimiters, over single separator applied in Tag loader
-        sortnames = StringUtils::SplitMulti(sortnames, { ";", ":", "|", "#" });
+      {
+        // Split artist sort names further using multiple possible delimiters, over single separator applied in Tag loader
+        using namespace std::literals;
+        sortnames = StringUtils::SplitMulti(sortnames, {{";"sv, ":"sv, "|"sv, "#"sv}});
+      }
 
       for (size_t i = 0; i < common.size(); i++)
       {

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -730,7 +730,7 @@ PLT_MediaObject* BuildObject(CFileItem& item,
     if (with_count && upnp_server)
     {
       const NPT_String decodedObjectId = DecodeObjectId(object->m_ObjectID.GetChars());
-      if (StringUtils::StartsWithNoCase(decodedObjectId, "virtualpath://"))
+      if (StringUtils::StartsWithNoCase(decodedObjectId.GetChars(), "virtualpath://"))
       {
         NPT_LargeSize count = 0;
         NPT_CHECK_LABEL(NPT_File::GetSize(file_path, count), failure);
@@ -1362,7 +1362,7 @@ bool GetResource(const PLT_MediaObject* entry, CFileItem& item)
     }
 
     // if this is an image fill the thumb of the item
-    if (StringUtils::StartsWithNoCase(resource.m_ProtocolInfo.GetContentType(), "image"))
+    if (StringUtils::StartsWithNoCase(resource.m_ProtocolInfo.GetContentType().GetChars(), "image"))
     {
       item.SetArt("thumb", std::string(resource.m_Uri));
     }

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -486,11 +486,11 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
   {
     // remap Root virtualpath://upnproot/ to id "0"
     const NPT_String encodedRootObjectId = EncodeObjectId("virtualpath://upnproot/");
-    if (StringUtils::EqualsNoCase(object->m_ObjectID, encodedRootObjectId))
+    if (StringUtils::EqualsNoCase(object->m_ObjectID.GetChars(), encodedRootObjectId.GetChars()))
       object->m_ObjectID = EncodeObjectId("0");
 
     // remap Parent Root virtualpath://upnproot/ to id "0"
-    if (StringUtils::EqualsNoCase(object->m_ParentID, encodedRootObjectId))
+    if (StringUtils::EqualsNoCase(object->m_ParentID.GetChars(), encodedRootObjectId.GetChars()))
       object->m_ParentID = EncodeObjectId("0");
   }
 

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -577,7 +577,7 @@ bool SorterAscending(const SortItem &left, const SortItem &right)
   if (preliminarySort(left, right, true, result, labelLeft, labelRight))
     return result;
 
-  return StringUtils::AlphaNumericCompare(labelLeft.c_str(), labelRight.c_str()) < 0;
+  return StringUtils::AlphaNumericCompare(labelLeft, labelRight) < 0;
 }
 
 bool SorterDescending(const SortItem &left, const SortItem &right)
@@ -587,7 +587,7 @@ bool SorterDescending(const SortItem &left, const SortItem &right)
   if (preliminarySort(left, right, true, result, labelLeft, labelRight))
     return result;
 
-  return StringUtils::AlphaNumericCompare(labelLeft.c_str(), labelRight.c_str()) > 0;
+  return StringUtils::AlphaNumericCompare(labelLeft, labelRight) > 0;
 }
 
 bool SorterIgnoreFoldersAscending(const SortItem &left, const SortItem &right)
@@ -597,7 +597,7 @@ bool SorterIgnoreFoldersAscending(const SortItem &left, const SortItem &right)
   if (preliminarySort(left, right, false, result, labelLeft, labelRight))
     return result;
 
-  return StringUtils::AlphaNumericCompare(labelLeft.c_str(), labelRight.c_str()) < 0;
+  return StringUtils::AlphaNumericCompare(labelLeft, labelRight) < 0;
 }
 
 bool SorterIgnoreFoldersDescending(const SortItem &left, const SortItem &right)
@@ -607,7 +607,7 @@ bool SorterIgnoreFoldersDescending(const SortItem &left, const SortItem &right)
   if (preliminarySort(left, right, false, result, labelLeft, labelRight))
     return result;
 
-  return StringUtils::AlphaNumericCompare(labelLeft.c_str(), labelRight.c_str()) > 0;
+  return StringUtils::AlphaNumericCompare(labelLeft, labelRight) > 0;
 }
 
 bool SorterIndirectAscending(const SortItemPtr &left, const SortItemPtr &right)

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -658,21 +658,34 @@ bool StringUtils::EndsWithNoCase(std::string_view str1, std::string_view str2) n
   return EqualsNoCase(str1.substr(str1.size() - str2.size()), str2);
 }
 
-std::vector<std::string> StringUtils::Split(const std::string& input, const std::string& delimiter, unsigned int iMaxStrings)
+std::vector<std::string> StringUtils::Split(std::string_view input,
+                                            std::string_view delimiter,
+                                            unsigned int iMaxStrings)
 {
   std::vector<std::string> result;
   SplitTo(std::back_inserter(result), input, delimiter, iMaxStrings);
   return result;
 }
 
-std::vector<std::string> StringUtils::Split(const std::string& input, const char delimiter, size_t iMaxStrings)
+std::vector<std::string> StringUtils::Split(std::string_view input,
+                                            char delimiter,
+                                            size_t iMaxStrings)
 {
   std::vector<std::string> result;
   SplitTo(std::back_inserter(result), input, delimiter, iMaxStrings);
   return result;
 }
 
-std::vector<std::string> StringUtils::Split(const std::string& input, const std::vector<std::string>& delimiters)
+std::vector<std::string> StringUtils::Split(std::string_view input,
+                                            std::span<const std::string> delimiters)
+{
+  std::vector<std::string> result;
+  SplitTo(std::back_inserter(result), input, delimiters);
+  return result;
+}
+
+std::vector<std::string> StringUtils::Split(std::string_view input,
+                                            std::span<const std::string_view> delimiters)
 {
   std::vector<std::string> result;
   SplitTo(std::back_inserter(result), input, delimiters);

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1750,14 +1750,27 @@ int StringUtils::FindBestMatch(std::string_view str,
   return FindBestMatchT(str, strings, matchscore);
 }
 
-bool StringUtils::ContainsKeyword(const std::string &str, const std::vector<std::string> &keywords)
+template<typename StringLike>
+[[nodiscard]] bool ContainsKeywordT(std::string_view str, std::span<StringLike> keywords) noexcept
 {
-  for (std::vector<std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it)
+  for (auto it = keywords.begin(); it != keywords.end(); ++it)
   {
     if (str.find(*it) != str.npos)
       return true;
   }
   return false;
+}
+
+bool StringUtils::ContainsKeyword(std::string_view str,
+                                  std::span<const std::string_view> keywords) noexcept
+{
+  return ContainsKeywordT(str, keywords);
+}
+
+bool StringUtils::ContainsKeyword(std::string_view str,
+                                  std::span<const std::string> keywords) noexcept
+{
+  return ContainsKeywordT(str, keywords);
 }
 
 size_t StringUtils::utf8_strlen(std::string_view s) noexcept

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1899,7 +1899,7 @@ std::string StringUtils::FormatFileSize(uint64_t bytes)
 
 bool StringUtils::Contains(std::string_view str,
                            std::string_view keyword,
-                           bool isCaseInsensitive /* = true */)
+                           bool isCaseInsensitive /* = true */) noexcept
 {
   if (isCaseInsensitive)
   {

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -65,9 +65,10 @@ namespace
  * \return The converted number, otherwise fallback if conversion fails
  */
 template<typename T>
-T NumberFromSS(std::string_view str, T fallback) noexcept
+T NumberFromSS(std::string_view str, T fallback)
 {
-  std::istringstream iss{str.data()};
+  std::string strCopy{str}; // TODO: Remove with C++26
+  std::istringstream iss{std::move(strCopy)};
   T result{fallback};
   iss >> result;
   return result;

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1214,7 +1214,10 @@ static uint32_t UTF8ToUnicode(const unsigned char* z, int nKey, unsigned char& b
   every pair comparison made. That approach was found to be 10 times slower than using this
   separate routine.
 */
-int StringUtils::AlphaNumericCollation(int nKey1, const void* pKey1, int nKey2, const void* pKey2)
+int StringUtils::AlphaNumericCollation(int nKey1,
+                                       const void* pKey1,
+                                       int nKey2,
+                                       const void* pKey2) noexcept
 {
   // Get exact matches of shorter text to start of larger test fast
   int n = std::min(nKey1, nKey2);

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -632,95 +632,30 @@ int StringUtils::Replace(std::wstring& str, std::wstring_view oldStr, std::wstri
   return replacedChars;
 }
 
-bool StringUtils::StartsWith(const std::string &str1, const std::string &str2)
+bool StringUtils::StartsWith(std::string_view str1, std::string_view str2) noexcept
 {
-  return str1.compare(0, str2.size(), str2) == 0;
+  return str1.starts_with(str2);
 }
 
-bool StringUtils::StartsWith(const std::string &str1, const char *s2)
-{
-  return StartsWith(str1.c_str(), s2);
-}
-
-bool StringUtils::StartsWith(const char *s1, const char *s2)
-{
-  while (*s2 != '\0')
-  {
-    if (*s1 != *s2)
-      return false;
-    s1++;
-    s2++;
-  }
-  return true;
-}
-
-bool StringUtils::StartsWithNoCase(const std::string &str1, const std::string &str2)
-{
-  return StartsWithNoCase(str1.c_str(), str2.c_str());
-}
-
-bool StringUtils::StartsWithNoCase(const std::string &str1, const char *s2)
-{
-  return StartsWithNoCase(str1.c_str(), s2);
-}
-
-bool StringUtils::StartsWithNoCase(const char *s1, const char *s2)
-{
-  while (*s2 != '\0')
-  {
-    if (::tolower(*s1) != ::tolower(*s2))
-      return false;
-    s1++;
-    s2++;
-  }
-  return true;
-}
-
-bool StringUtils::EndsWith(const std::string &str1, const std::string &str2)
+bool StringUtils::StartsWithNoCase(std::string_view str1, std::string_view str2) noexcept
 {
   if (str1.size() < str2.size())
     return false;
-  return str1.compare(str1.size() - str2.size(), str2.size(), str2) == 0;
+
+  return EqualsNoCase(str1.substr(0, str2.size()), str2);
 }
 
-bool StringUtils::EndsWith(const std::string &str1, const char *s2)
+bool StringUtils::EndsWith(std::string_view str1, std::string_view str2) noexcept
 {
-  size_t len2 = strlen(s2);
-  if (str1.size() < len2)
-    return false;
-  return str1.compare(str1.size() - len2, len2, s2) == 0;
+  return str1.ends_with(str2);
 }
 
-bool StringUtils::EndsWithNoCase(const std::string &str1, const std::string &str2)
+bool StringUtils::EndsWithNoCase(std::string_view str1, std::string_view str2) noexcept
 {
   if (str1.size() < str2.size())
     return false;
-  const char *s1 = str1.c_str() + str1.size() - str2.size();
-  const char *s2 = str2.c_str();
-  while (*s2 != '\0')
-  {
-    if (::tolower(*s1) != ::tolower(*s2))
-      return false;
-    s1++;
-    s2++;
-  }
-  return true;
-}
 
-bool StringUtils::EndsWithNoCase(const std::string &str1, const char *s2)
-{
-  size_t len2 = strlen(s2);
-  if (str1.size() < len2)
-    return false;
-  const char *s1 = str1.c_str() + str1.size() - len2;
-  while (*s2 != '\0')
-  {
-    if (::tolower(*s1) != ::tolower(*s2))
-      return false;
-    s1++;
-    s2++;
-  }
-  return true;
+  return EqualsNoCase(str1.substr(str1.size() - str2.size()), str2);
 }
 
 std::vector<std::string> StringUtils::Split(const std::string& input, const std::string& delimiter, unsigned int iMaxStrings)

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1865,17 +1865,17 @@ void StringUtils::Tokenize(std::string_view input,
   }
 }
 
-uint32_t StringUtils::ToUint32(std::string_view str, uint32_t fallback /* = 0 */) noexcept
+uint32_t StringUtils::ToUint32(std::string_view str, uint32_t fallback /* = 0 */)
 {
   return NumberFromSS(str, fallback);
 }
 
-uint64_t StringUtils::ToUint64(std::string_view str, uint64_t fallback /* = 0 */) noexcept
+uint64_t StringUtils::ToUint64(std::string_view str, uint64_t fallback /* = 0 */)
 {
   return NumberFromSS(str, fallback);
 }
 
-float StringUtils::ToFloat(std::string_view str, float fallback /* = 0.0f */) noexcept
+float StringUtils::ToFloat(std::string_view str, float fallback /* = 0.0f */)
 {
   return NumberFromSS(str, fallback);
 }

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1707,9 +1707,11 @@ bool StringUtils::ValidateUUID(const std::string &uuid)
   return (guidRE.RegFind(uuid.c_str()) == 0);
 }
 
-double StringUtils::CompareFuzzy(const std::string &left, const std::string &right)
+double StringUtils::CompareFuzzy(std::string_view left, std::string_view right) noexcept
 {
-  return (0.5 + fstrcmp(left.c_str(), right.c_str()) * (left.length() + right.length())) / 2.0;
+  return (0.5 + fmemcmp(left.data(), left.size(), right.data(), right.size()) *
+                    (left.length() + right.length())) /
+         2.0;
 }
 
 int StringUtils::FindBestMatch(const std::string &str, const std::vector<std::string> &strings, double &matchscore)

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1569,14 +1569,14 @@ std::string StringUtils::BinaryStringToString(std::string_view in)
   return out;
 }
 
-std::string StringUtils::ToHexadecimal(const std::string& in)
+std::string StringUtils::ToHexadecimal(std::string_view in)
 {
   std::ostringstream ss;
   ss << std::hex;
   for (unsigned char ch : in) {
     ss << std::setw(2) << std::setfill('0') << static_cast<unsigned long> (ch);
   }
-  return ss.str();
+  return std::move(ss).str();
 }
 
 // return -1 if not, else return the utf8 char length.

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -39,6 +39,7 @@
 #include <inttypes.h>
 #include <iomanip>
 #include <math.h>
+#include <numeric>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -530,15 +531,14 @@ std::string& StringUtils::TrimRight(std::string &str, const char* const chars)
   return str;
 }
 
-int StringUtils::ReturnDigits(const std::string& str)
+int StringUtils::ReturnDigits(std::string_view str) noexcept
 {
-  std::stringstream ss;
-  for (const auto& character : str)
-  {
-    if (isdigit(character))
-      ss << character;
-  }
-  return atoi(ss.str().c_str());
+  return std::accumulate(str.begin(), str.end(), int64_t{},
+                         [](int64_t i, char c)
+                         {
+                           int tmp = c - '0';
+                           return (tmp >= 0 && tmp <= 9) ? (i * 10) + tmp : i;
+                         });
 }
 
 std::string& StringUtils::RemoveDuplicatedSpacesAndTabs(std::string& str)

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -353,61 +353,61 @@ wchar_t toupperUnicode(const wchar_t& c)
   return c;
 }
 
-template<typename Str, typename Fn>
-void transformString(const Str& input, Str& output, Fn fn)
+template<typename StrIn, typename StrOut, typename Fn>
+void transformString(const StrIn& input, StrOut& output, Fn fn)
 {
   std::transform(input.begin(), input.end(), output.begin(), fn);
 }
 
-std::string StringUtils::ToUpper(const std::string& str)
+std::string StringUtils::ToUpper(std::string_view str)
 {
   std::string result(str.size(), '\0');
   transformString(str, result, ::toupper);
   return result;
 }
 
-std::wstring StringUtils::ToUpper(const std::wstring& str)
+std::wstring StringUtils::ToUpper(std::wstring_view str)
 {
   std::wstring result(str.size(), '\0');
   transformString(str, result, toupperUnicode);
   return result;
 }
 
-void StringUtils::ToUpper(std::string &str)
+void StringUtils::ToUpper(std::string& str) noexcept
 {
   transformString(str, str, ::toupper);
 }
 
-void StringUtils::ToUpper(std::wstring &str)
+void StringUtils::ToUpper(std::wstring& str) noexcept
 {
   transformString(str, str, toupperUnicode);
 }
 
-std::string StringUtils::ToLower(const std::string& str)
+std::string StringUtils::ToLower(std::string_view str)
 {
   std::string result(str.size(), '\0');
   transformString(str, result, ::tolower);
   return result;
 }
 
-std::wstring StringUtils::ToLower(const std::wstring& str)
+std::wstring StringUtils::ToLower(std::wstring_view str)
 {
   std::wstring result(str.size(), '\0');
   transformString(str, result, tolowerUnicode);
   return result;
 }
 
-void StringUtils::ToLower(std::string &str)
+void StringUtils::ToLower(std::string& str) noexcept
 {
   transformString(str, str, ::tolower);
 }
 
-void StringUtils::ToLower(std::wstring &str)
+void StringUtils::ToLower(std::wstring& str) noexcept
 {
   transformString(str, str, tolowerUnicode);
 }
 
-void StringUtils::ToCapitalize(std::string &str)
+void StringUtils::ToCapitalize(std::string& str) noexcept
 {
   std::wstring wstr;
   g_charsetConverter.utf8ToW(str, wstr);
@@ -415,7 +415,7 @@ void StringUtils::ToCapitalize(std::string &str)
   g_charsetConverter.wToUTF8(wstr, str);
 }
 
-void StringUtils::ToCapitalize(std::wstring &str)
+void StringUtils::ToCapitalize(std::wstring& str) noexcept
 {
   const std::locale& loc = g_langInfo.GetSystemLocale();
   bool isFirstLetter = true;

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1882,7 +1882,7 @@ float StringUtils::ToFloat(std::string_view str, float fallback /* = 0.0f */)
 
 std::string StringUtils::FormatFileSize(uint64_t bytes)
 {
-  const std::array<std::string, 6> units{{"B", "kB", "MB", "GB", "TB", "PB"}};
+  static constexpr std::array<std::string_view, 6> units{{"B", "kB", "MB", "GB", "TB", "PB"}};
   if (bytes < 1000)
     return Format("{}B", bytes);
 

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1696,7 +1696,7 @@ std::string StringUtils::CreateUUID()
   auto guid = guidGenerator.newGuid();
 
   std::stringstream strGuid; strGuid << guid;
-  return strGuid.str();
+  return std::move(strGuid).str();
 #endif
 }
 

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1508,8 +1508,7 @@ int StringUtils::asciixdigitvalue(char chr)
   return -1;
 }
 
-
-void StringUtils::RemoveCRLF(std::string& strLine)
+void StringUtils::RemoveCRLF(std::string& strLine) noexcept
 {
   StringUtils::TrimRight(strLine, "\n\r");
 }

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1348,20 +1348,19 @@ int StringUtils::DateStringToYYYYMMDD(std::string_view dateString)
     return -1;
 }
 
-std::string StringUtils::ISODateToLocalizedDate(const std::string& strIsoDate)
+std::string StringUtils::ISODateToLocalizedDate(std::string_view strIsoDate)
 {
   // Convert ISO8601 date strings YYYY, YYYY-MM, or YYYY-MM-DD to (partial) localized date strings
   CDateTime date;
-  std::string formattedDate = strIsoDate;
-  if (formattedDate.size() == 10)
+  if (strIsoDate.size() == 10)
   {
-    date.SetFromDBDate(strIsoDate);
-    formattedDate = date.GetAsLocalizedDate();
+    date.SetFromDBDate(std::string(strIsoDate));
+    return date.GetAsLocalizedDate();
   }
-  else if (formattedDate.size() == 7)
+  else if (strIsoDate.size() == 7)
   {
-    std::string strFormat = date.GetAsLocalizedDate(false);
-    std::string tempdate;
+    const std::string strFormat = date.GetAsLocalizedDate(false);
+    std::string result;
     // find which date separator we are using.  Can be -./
     size_t pos = strFormat.find_first_of("-./");
     if (pos != std::string::npos)
@@ -1370,21 +1369,21 @@ std::string StringUtils::ISODateToLocalizedDate(const std::string& strIsoDate)
       std::string sep = strFormat.substr(pos, 1);
       if (yearFirst)
       { // build formatted date with year first, then separator and month
-        tempdate = formattedDate.substr(0, 4);
-        tempdate += sep;
-        tempdate += formattedDate.substr(5, 2);
+        result = strIsoDate.substr(0, 4);
+        result += sep;
+        result += strIsoDate.substr(5, 2);
       }
       else
       {
-        tempdate = formattedDate.substr(5, 2);
-        tempdate += sep;
-        tempdate += formattedDate.substr(0, 4);
+        result = strIsoDate.substr(5, 2);
+        result += sep;
+        result += strIsoDate.substr(0, 4);
       }
-      formattedDate = tempdate;
+      return result;
     }
   // return either just the year or the locally formatted version of the ISO date
   }
-  return formattedDate;
+  return std::string{strIsoDate};
 }
 
 long StringUtils::TimeStringToSeconds(std::string_view timeString)

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1386,7 +1386,7 @@ std::string StringUtils::ISODateToLocalizedDate(const std::string& strIsoDate)
   return formattedDate;
 }
 
-long StringUtils::TimeStringToSeconds(const std::string &timeString)
+long StringUtils::TimeStringToSeconds(std::string_view timeString)
 {
   std::string strCopy(timeString);
   StringUtils::Trim(strCopy);

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1782,36 +1782,36 @@ size_t StringUtils::utf8_strlen(std::string_view s) noexcept
   return std::count_if(s.begin(), s.end(), [](char c) { return (c & 0xC0) != 0x80; });
 }
 
-std::string StringUtils::Paramify(const std::string &param)
+std::string StringUtils::Paramify(std::string param)
 {
-  std::string result = param;
   // escape backspaces
-  StringUtils::Replace(result, "\\", "\\\\");
+  StringUtils::Replace(param, "\\", "\\\\");
   // escape double quotes
-  StringUtils::Replace(result, "\"", "\\\"");
+  StringUtils::Replace(param, "\"", "\\\"");
 
   // add double quotes around the whole string
-  return "\"" + result + "\"";
+  param.insert(param.begin(), '"');
+  param.push_back('"');
+
+  return param;
 }
 
-std::string StringUtils::DeParamify(const std::string& param)
+std::string StringUtils::DeParamify(std::string param)
 {
-  std::string result = param;
-
   // remove double quotes around the whole string
-  if (StringUtils::StartsWith(result, "\"") && StringUtils::EndsWith(result, "\""))
+  if (StringUtils::StartsWith(param, "\"") && StringUtils::EndsWith(param, "\""))
   {
-    result.erase(0, 1);
-    result.pop_back();
+    param.erase(param.begin());
+    param.pop_back();
 
     // unescape double quotes
-    StringUtils::Replace(result, "\\\"", "\"");
+    StringUtils::Replace(param, "\\\"", "\"");
 
     // unescape backspaces
-    StringUtils::Replace(result, "\\\\", "\\");
+    StringUtils::Replace(param, "\\\\", "\\");
   }
 
-  return result;
+  return param;
 }
 
 std::vector<std::string> StringUtils::Tokenize(const std::string &input, const std::string &delimiters)

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -557,7 +557,7 @@ bool StringUtils::IsSpecialCharacter(char c) noexcept
   return std::ranges::any_of(view, [c](char ch) { return ch == c; });
 }
 
-std::string StringUtils::ReplaceSpecialCharactersWithSpace(const std::string& str)
+std::string StringUtils::ReplaceSpecialCharactersWithSpace(std::string_view str)
 {
   std::string result;
   bool prevCharWasSpecial = false;

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -459,15 +459,15 @@ int StringUtils::CompareNoCase(std::string_view str1,
          ::tolower(static_cast<unsigned char>(*diff.in2));
 }
 
-std::string StringUtils::Left(const std::string &str, size_t count)
+std::string StringUtils::Left(std::string_view str, size_t count)
 {
   count = std::max((size_t)0, std::min(count, str.size()));
-  return str.substr(0, count);
+  return {str, 0, count};
 }
 
-std::string StringUtils::Mid(const std::string &str, size_t first, size_t count /* = string::npos */)
+std::string StringUtils::Mid(std::string_view str, size_t first, size_t count /* = string::npos */)
 {
-  if (first + count > str.size())
+  if (count == str.npos || first + count > str.size())
     count = str.size() - first;
 
   if (first > str.size())
@@ -475,13 +475,13 @@ std::string StringUtils::Mid(const std::string &str, size_t first, size_t count 
 
   assert(first + count <= str.size());
 
-  return str.substr(first, count);
+  return {str, first, count};
 }
 
-std::string StringUtils::Right(const std::string &str, size_t count)
+std::string StringUtils::Right(std::string_view str, size_t count)
 {
   count = std::max((size_t)0, std::min(count, str.size()));
-  return str.substr(str.size() - count);
+  return {str, str.size() - count, count};
 }
 
 std::string& StringUtils::Trim(std::string &str)

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1745,15 +1745,9 @@ bool StringUtils::ContainsKeyword(const std::string &str, const std::vector<std:
   return false;
 }
 
-size_t StringUtils::utf8_strlen(const char *s)
+size_t StringUtils::utf8_strlen(std::string_view s) noexcept
 {
-  size_t length = 0;
-  while (*s)
-  {
-    if ((*s++ & 0xC0) != 0x80)
-      length++;
-  }
-  return length;
+  return std::count_if(s.begin(), s.end(), [](char c) { return (c & 0xC0) != 0x80; });
 }
 
 std::string StringUtils::Paramify(const std::string &param)

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -581,7 +581,7 @@ std::string StringUtils::ReplaceSpecialCharactersWithSpace(std::string_view str)
   return result;
 }
 
-int StringUtils::Replace(std::string &str, char oldChar, char newChar)
+int StringUtils::Replace(std::string& str, char oldChar, char newChar) noexcept
 {
   int replacedChars = 0;
   for (std::string::iterator it = str.begin(); it != str.end(); ++it)
@@ -596,7 +596,7 @@ int StringUtils::Replace(std::string &str, char oldChar, char newChar)
   return replacedChars;
 }
 
-int StringUtils::Replace(std::string &str, const std::string &oldStr, const std::string &newStr)
+int StringUtils::Replace(std::string& str, std::string_view oldStr, std::string_view newStr)
 {
   if (oldStr.empty())
     return 0;
@@ -614,7 +614,7 @@ int StringUtils::Replace(std::string &str, const std::string &oldStr, const std:
   return replacedChars;
 }
 
-int StringUtils::Replace(std::wstring &str, const std::wstring &oldStr, const std::wstring &newStr)
+int StringUtils::Replace(std::wstring& str, std::wstring_view oldStr, std::wstring_view newStr)
 {
   if (oldStr.empty())
     return 0;

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1664,7 +1664,7 @@ int StringUtils::FindEndBracket(std::string_view str,
   return (int)std::string::npos;
 }
 
-void StringUtils::WordToDigits(std::string &word)
+void StringUtils::WordToDigits(std::string& word) noexcept
 {
   static const char word_to_letter[] = "22233344455566677778889999";
   StringUtils::ToLower(word);

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -551,13 +551,10 @@ std::string& StringUtils::RemoveDuplicatedSpacesAndTabs(std::string& str) noexce
   return str;
 }
 
-bool StringUtils::IsSpecialCharacter(char c)
+bool StringUtils::IsSpecialCharacter(char c) noexcept
 {
   static constexpr std::string_view view(" .-_+,!'\"\t/\\*?#$%&@()[]{}");
-  if (std::any_of(view.begin(), view.end(), [c](char ch) { return ch == c; }))
-    return true;
-  else
-    return false;
+  return std::ranges::any_of(view, [c](char ch) { return ch == c; });
 }
 
 std::string StringUtils::ReplaceSpecialCharactersWithSpace(const std::string& str)

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1048,29 +1048,29 @@ static wchar_t GetCollationWeight(const wchar_t& r)
 // returns negative if left < right, positive if left > right
 // and 0 if they are identical.
 // See also the equivalent StringUtils::AlphaNumericCollation() for UFT8 data
-int64_t StringUtils::AlphaNumericCompare(const wchar_t* left, const wchar_t* right)
+int64_t StringUtils::AlphaNumericCompare(std::wstring_view left, std::wstring_view right) noexcept
 {
-  const wchar_t *l = left;
-  const wchar_t *r = right;
-  const wchar_t *ld, *rd;
+  auto l = left.begin();
+  auto r = right.begin();
+  std::wstring_view::const_iterator ld, rd;
   wchar_t lc, rc;
   int64_t lnum, rnum;
   bool lsym, rsym;
-  while (*l != 0 && *r != 0)
+  while (l != left.end() && r != right.end())
   {
     // check if we have a numerical value
     if (*l >= L'0' && *l <= L'9' && *r >= L'0' && *r <= L'9')
     {
       ld = l;
       lnum = *ld++ - L'0';
-      while (*ld >= L'0' && *ld <= L'9' && ld < l + 15)
+      while (ld != left.end() && *ld >= L'0' && *ld <= L'9' && ld < l + 15)
       { // compare only up to 15 digits
         lnum *= 10;
         lnum += *ld++ - L'0';
       }
       rd = r;
       rnum = *rd++ - L'0';
-      while (*rd >= L'0' && *rd <= L'9' && rd < r + 15)
+      while (rd != right.end() && *rd >= L'0' && *rd <= L'9' && rd < r + 15)
       { // compare only up to 15 digits
         rnum *= 10;
         rnum += *rd++ - L'0';
@@ -1147,11 +1147,11 @@ int64_t StringUtils::AlphaNumericCompare(const wchar_t* left, const wchar_t* rig
     }
     l++; r++;
   }
-  if (*r)
+  if (r != right.end())
   { // r is longer
     return -1;
   }
-  else if (*l)
+  else if (l != left.end())
   { // l is longer
     return 1;
   }

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1814,47 +1814,51 @@ std::string StringUtils::DeParamify(std::string param)
   return param;
 }
 
-std::vector<std::string> StringUtils::Tokenize(const std::string &input, const std::string &delimiters)
+std::vector<std::string> StringUtils::Tokenize(std::string_view input, std::string_view delimiters)
 {
   std::vector<std::string> tokens;
   Tokenize(input, tokens, delimiters);
   return tokens;
 }
 
-void StringUtils::Tokenize(const std::string& input, std::vector<std::string>& tokens, const std::string& delimiters)
+void StringUtils::Tokenize(std::string_view input,
+                           std::vector<std::string>& tokens,
+                           std::string_view delimiters)
 {
   tokens.clear();
   // Skip delimiters at beginning.
-  std::string::size_type dataPos = input.find_first_not_of(delimiters);
-  while (dataPos != std::string::npos)
+  std::string_view::size_type dataPos = input.find_first_not_of(delimiters);
+  while (dataPos != std::string_view::npos)
   {
     // Find next delimiter
-    const std::string::size_type nextDelimPos = input.find_first_of(delimiters, dataPos);
+    const std::string_view::size_type nextDelimPos = input.find_first_of(delimiters, dataPos);
     // Found a token, add it to the vector.
-    tokens.push_back(input.substr(dataPos, nextDelimPos - dataPos));
+    tokens.emplace_back(input.substr(dataPos, nextDelimPos - dataPos));
     // Skip delimiters.  Note the "not_of"
     dataPos = input.find_first_not_of(delimiters, nextDelimPos);
   }
 }
 
-std::vector<std::string> StringUtils::Tokenize(const std::string &input, const char delimiter)
+std::vector<std::string> StringUtils::Tokenize(std::string_view input, const char delimiter)
 {
   std::vector<std::string> tokens;
   Tokenize(input, tokens, delimiter);
   return tokens;
 }
 
-void StringUtils::Tokenize(const std::string& input, std::vector<std::string>& tokens, const char delimiter)
+void StringUtils::Tokenize(std::string_view input,
+                           std::vector<std::string>& tokens,
+                           const char delimiter)
 {
   tokens.clear();
   // Skip delimiters at beginning.
-  std::string::size_type dataPos = input.find_first_not_of(delimiter);
-  while (dataPos != std::string::npos)
+  std::string_view::size_type dataPos = input.find_first_not_of(delimiter);
+  while (dataPos != std::string_view::npos)
   {
     // Find next delimiter
-    const std::string::size_type nextDelimPos = input.find(delimiter, dataPos);
+    const std::string_view::size_type nextDelimPos = input.find(delimiter, dataPos);
     // Found a token, add it to the vector.
-    tokens.push_back(input.substr(dataPos, nextDelimPos - dataPos));
+    tokens.emplace_back(input.substr(dataPos, nextDelimPos - dataPos));
     // Skip delimiters.  Note the "not_of"
     dataPos = input.find_first_not_of(delimiter, nextDelimPos);
   }

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1455,7 +1455,7 @@ std::string StringUtils::MillisecondsToTimeString(std::chrono::milliseconds mill
   return strTimeString;
 }
 
-bool StringUtils::IsNaturalNumber(const std::string& str)
+bool StringUtils::IsNaturalNumber(std::string_view str) noexcept
 {
   size_t i = 0, n = 0;
   // allow whitespace,digits,whitespace
@@ -1470,7 +1470,7 @@ bool StringUtils::IsNaturalNumber(const std::string& str)
   return i == str.size() && n > 0;
 }
 
-bool StringUtils::IsInteger(const std::string& str)
+bool StringUtils::IsInteger(std::string_view str) noexcept
 {
   size_t i = 0, n = 0;
   // allow whitespace,-,digits,whitespace

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -542,30 +542,12 @@ int StringUtils::ReturnDigits(std::string_view str) noexcept
                          });
 }
 
-std::string& StringUtils::RemoveDuplicatedSpacesAndTabs(std::string& str)
+std::string& StringUtils::RemoveDuplicatedSpacesAndTabs(std::string& str) noexcept
 {
-  std::string::iterator it = str.begin();
-  bool onSpace = false;
-  while(it != str.end())
-  {
-    if (*it == '\t')
-      *it = ' ';
-
-    if (*it == ' ')
-    {
-      if (onSpace)
-      {
-        it = str.erase(it);
-        continue;
-      }
-      else
-        onSpace = true;
-    }
-    else
-      onSpace = false;
-
-    ++it;
-  }
+  StringUtils::Replace(str, '\t', ' ');
+  const auto [first, last] =
+      std::ranges::unique(str, [](char a, char b) { return a == ' ' && b == ' '; });
+  str.erase(first, last);
   return str;
 }
 

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -777,7 +777,7 @@ std::vector<std::string> StringUtils::SplitMulti(std::span<const std::string> in
 }
 
 // returns the number of occurrences of strFind in strInput.
-int StringUtils::FindNumber(const std::string& strInput, const std::string &strFind)
+int StringUtils::FindNumber(std::string_view strInput, std::string_view strFind) noexcept
 {
   size_t pos = strInput.find(strFind, 0);
   int numfound = 0;

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1714,13 +1714,16 @@ double StringUtils::CompareFuzzy(std::string_view left, std::string_view right) 
          2.0;
 }
 
-int StringUtils::FindBestMatch(const std::string &str, const std::vector<std::string> &strings, double &matchscore)
+template<typename StringLike>
+[[nodiscard]] int FindBestMatchT(std::string_view str,
+                                 std::span<StringLike> strings,
+                                 double& matchscore) noexcept
 {
   int best = -1;
   matchscore = 0;
 
   int i = 0;
-  for (std::vector<std::string>::const_iterator it = strings.begin(); it != strings.end(); ++it, i++)
+  for (auto it = strings.begin(); it != strings.end(); ++it, i++)
   {
     int maxlength = std::max(str.length(), it->length());
     double score = StringUtils::CompareFuzzy(str, *it) / maxlength;
@@ -1731,6 +1734,20 @@ int StringUtils::FindBestMatch(const std::string &str, const std::vector<std::st
     }
   }
   return best;
+}
+
+int StringUtils::FindBestMatch(std::string_view str,
+                               std::span<const std::string_view> strings,
+                               double& matchscore) noexcept
+{
+  return FindBestMatchT(str, strings, matchscore);
+}
+
+int StringUtils::FindBestMatch(std::string_view str,
+                               std::span<const std::string> strings,
+                               double& matchscore) noexcept
+{
+  return FindBestMatchT(str, strings, matchscore);
 }
 
 bool StringUtils::ContainsKeyword(const std::string &str, const std::vector<std::string> &keywords)

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -692,14 +692,15 @@ std::vector<std::string> StringUtils::Split(std::string_view input,
   return result;
 }
 
-std::vector<std::string> StringUtils::SplitMulti(const std::vector<std::string>& input,
-                                                 const std::vector<std::string>& delimiters,
-                                                 size_t iMaxStrings /* = 0 */)
+template<typename StringLikeA, typename StringLikeB>
+[[nodiscard]] std::vector<std::string> SplitMultiT(std::span<const StringLikeA> input,
+                                                   std::span<const StringLikeB> delimiters,
+                                                   size_t iMaxStrings /* = 0 */)
 {
   if (input.empty())
     return std::vector<std::string>();
 
-  std::vector<std::string> results(input);
+  std::vector<std::string> results(input.begin(), input.end());
 
   if (delimiters.empty() || (iMaxStrings > 0 && iMaxStrings <= input.size()))
     return results;
@@ -745,6 +746,34 @@ std::vector<std::string> StringUtils::SplitMulti(const std::vector<std::string>&
       break;  //Stop trying any more delimiters
   }
   return results;
+}
+
+std::vector<std::string> StringUtils::SplitMulti(std::span<const std::string> input,
+                                                 std::span<const std::string> delimiters,
+                                                 size_t iMaxStrings /* = 0 */)
+{
+  return SplitMultiT(input, delimiters, iMaxStrings);
+}
+
+std::vector<std::string> StringUtils::SplitMulti(std::span<const std::string_view> input,
+                                                 std::span<const std::string_view> delimiters,
+                                                 size_t iMaxStrings /*= 0*/)
+{
+  return SplitMultiT(input, delimiters, iMaxStrings);
+}
+
+std::vector<std::string> StringUtils::SplitMulti(std::span<const std::string_view> input,
+                                                 std::span<const std::string> delimiters,
+                                                 size_t iMaxStrings /*= 0*/)
+{
+  return SplitMultiT(input, delimiters, iMaxStrings);
+}
+
+std::vector<std::string> StringUtils::SplitMulti(std::span<const std::string> input,
+                                                 std::span<const std::string_view> delimiters,
+                                                 size_t iMaxStrings /*= 0*/)
+{
+  return SplitMultiT(input, delimiters, iMaxStrings);
 }
 
 // returns the number of occurrences of strFind in strInput.

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -40,6 +40,7 @@
 #include <iomanip>
 #include <math.h>
 #include <numeric>
+#include <ranges>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -484,13 +485,13 @@ std::string StringUtils::Right(std::string_view str, size_t count)
   return {str, str.size() - count, count};
 }
 
-std::string& StringUtils::Trim(std::string &str)
+std::string& StringUtils::Trim(std::string& str) noexcept
 {
   TrimLeft(str);
   return TrimRight(str);
 }
 
-std::string& StringUtils::Trim(std::string &str, const char* const chars)
+std::string& StringUtils::Trim(std::string& str, std::string_view chars) noexcept
 {
   TrimLeft(str, chars);
   return TrimRight(str, chars);
@@ -503,28 +504,28 @@ static int isspace_c(char c)
   return (c & 0x80) == 0 && ::isspace(c);
 }
 
-std::string& StringUtils::TrimLeft(std::string &str)
+std::string& StringUtils::TrimLeft(std::string& str) noexcept
 {
-  str.erase(str.begin(),
-            std::find_if(str.begin(), str.end(), [](char s) { return isspace_c(s) == 0; }));
+  str.erase(str.begin(), std::ranges::find_if(str, [](char s) { return isspace_c(s) == 0; }));
   return str;
 }
 
-std::string& StringUtils::TrimLeft(std::string &str, const char* const chars)
+std::string& StringUtils::TrimLeft(std::string& str, std::string_view chars) noexcept
 {
   size_t nidx = str.find_first_not_of(chars);
   str.erase(0, nidx);
   return str;
 }
 
-std::string& StringUtils::TrimRight(std::string &str)
+std::string& StringUtils::TrimRight(std::string& str) noexcept
 {
-  str.erase(std::find_if(str.rbegin(), str.rend(), [](char s) { return isspace_c(s) == 0; }).base(),
+  str.erase(std::ranges::find_if(std::views::reverse(str), [](char s) { return isspace_c(s) == 0; })
+                .base(),
             str.end());
   return str;
 }
 
-std::string& StringUtils::TrimRight(std::string &str, const char* const chars)
+std::string& StringUtils::TrimRight(std::string& str, std::string_view chars) noexcept
 {
   size_t nidx = str.find_last_not_of(chars);
   str.erase(str.npos == nidx ? 0 : ++nidx);

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1644,18 +1644,21 @@ size_t StringUtils::FindWords(std::string_view str, std::string_view wordLowerCa
 }
 
 // assumes it is called from after the first open bracket is found
-int StringUtils::FindEndBracket(const std::string &str, char opener, char closer, int startPos)
+int StringUtils::FindEndBracket(std::string_view str,
+                                char opener,
+                                char closer,
+                                int startPos /*=0*/) noexcept
 {
   int blocks = 1;
-  for (unsigned int i = startPos; i < str.size(); i++)
+  for (auto iter = str.begin() + startPos; iter != str.end(); ++iter)
   {
-    if (str[i] == opener)
+    if (*iter == opener)
       blocks++;
-    else if (str[i] == closer)
+    else if (*iter == closer)
     {
       blocks--;
       if (!blocks)
-        return i;
+        return std::distance(str.begin(), iter);
     }
   }
 

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1487,7 +1487,7 @@ bool StringUtils::IsInteger(std::string_view str) noexcept
   return i == str.size() && n > 0;
 }
 
-int StringUtils::asciidigitvalue(char chr)
+int StringUtils::asciidigitvalue(char chr) noexcept
 {
   if (!isasciidigit(chr))
     return -1;
@@ -1495,7 +1495,7 @@ int StringUtils::asciidigitvalue(char chr)
   return chr - '0';
 }
 
-int StringUtils::asciixdigitvalue(char chr)
+int StringUtils::asciixdigitvalue(char chr) noexcept
 {
   int v = asciidigitvalue(chr);
   if (v >= 0)

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1335,7 +1335,7 @@ int StringUtils::AlphaNumericCollation(int nKey1,
   return (nKey1 - nKey2);
 }
 
-int StringUtils::DateStringToYYYYMMDD(const std::string &dateString)
+int StringUtils::DateStringToYYYYMMDD(std::string_view dateString)
 {
   std::vector<std::string> days = StringUtils::Split(dateString, '-');
   if (days.size() == 1)

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -496,9 +496,9 @@ public:
    * \param keyword The string to search for
    * \return True if the keyword if found.
    */
-  static bool Contains(std::string_view str,
-                       std::string_view keyword,
-                       bool isCaseInsensitive = true);
+  [[nodiscard]] static bool Contains(std::string_view str,
+                                     std::string_view keyword,
+                                     bool isCaseInsensitive = true) noexcept;
 
 private:
   /*!

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -362,7 +362,7 @@ public:
   static void WordToDigits(std::string& word) noexcept;
   [[nodiscard]] static std::string CreateUUID();
   [[nodiscard]] static bool ValidateUUID(const std::string& uuid); // NB only validates syntax
-  static double CompareFuzzy(const std::string &left, const std::string &right);
+  [[nodiscard]] static double CompareFuzzy(std::string_view left, std::string_view right) noexcept;
   static int FindBestMatch(const std::string &str, const std::vector<std::string> &strings, double &matchscore);
   static bool ContainsKeyword(const std::string &str, const std::vector<std::string> &keywords);
 

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -323,25 +323,25 @@ public:
   /* The next several isasciiXX and asciiXXvalue functions are locale independent (US-ASCII only),
    * as opposed to standard ::isXX (::isalpha, ::isdigit...) which are locale dependent.
    * Next functions get parameter as char and don't need double cast ((int)(unsigned char) is required for standard functions). */
-  inline static bool isasciidigit(char chr) // locale independent
+  [[nodiscard]] inline static bool isasciidigit(char chr) noexcept // locale independent
   {
     return chr >= '0' && chr <= '9';
   }
-  inline static bool isasciixdigit(char chr) // locale independent
+  [[nodiscard]] inline static bool isasciixdigit(char chr) noexcept // locale independent
   {
     return (chr >= '0' && chr <= '9') || (chr >= 'a' && chr <= 'f') || (chr >= 'A' && chr <= 'F');
   }
-  static int asciidigitvalue(char chr); // locale independent
-  static int asciixdigitvalue(char chr); // locale independent
-  inline static bool isasciiuppercaseletter(char chr) // locale independent
+  [[nodiscard]] static int asciidigitvalue(char chr) noexcept; // locale independent
+  [[nodiscard]] static int asciixdigitvalue(char chr) noexcept; // locale independent
+  [[nodiscard]] inline static bool isasciiuppercaseletter(char chr) noexcept // locale independent
   {
     return (chr >= 'A' && chr <= 'Z');
   }
-  inline static bool isasciilowercaseletter(char chr) // locale independent
+  [[nodiscard]] inline static bool isasciilowercaseletter(char chr) noexcept // locale independent
   {
     return (chr >= 'a' && chr <= 'z');
   }
-  inline static bool isasciialphanum(char chr) // locale independent
+  [[nodiscard]] inline static bool isasciialphanum(char chr) noexcept // locale independent
   {
     return isasciiuppercaseletter(chr) || isasciilowercaseletter(chr) || isasciidigit(chr);
   }

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -303,7 +303,7 @@ public:
    \return the formatted time
    \sa TIME_FORMAT
    */
-  static std::string MillisecondsToTimeString(std::chrono::milliseconds milliSeconds);
+  [[nodiscard]] static std::string MillisecondsToTimeString(std::chrono::milliseconds milliSeconds);
 
   /*! \brief check whether a string is a natural number.
    Matches [ \t]*[0-9]+[ \t]*

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -438,10 +438,16 @@ public:
     2. Empty tokens are ignored.
    \return a vector of tokens
    */
-  static std::vector<std::string> Tokenize(const std::string& input, const std::string& delimiters);
-  static void Tokenize(const std::string& input, std::vector<std::string>& tokens, const std::string& delimiters);
-  static std::vector<std::string> Tokenize(const std::string& input, const char delimiter);
-  static void Tokenize(const std::string& input, std::vector<std::string>& tokens, const char delimiter);
+  [[nodiscard]] static std::vector<std::string> Tokenize(std::string_view input,
+                                                         std::string_view delimiters);
+  static void Tokenize(std::string_view input,
+                       std::vector<std::string>& tokens,
+                       std::string_view delimiters);
+  [[nodiscard]] static std::vector<std::string> Tokenize(std::string_view input,
+                                                         const char delimiter);
+  static void Tokenize(std::string_view input,
+                       std::vector<std::string>& tokens,
+                       const char delimiter);
 
   /*!
    * \brief Converts a string to a unsigned int number.

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -275,7 +275,8 @@ public:
                                                            std::span<const std::string> delimiters,
                                                            size_t iMaxStrings = 0);
   [[nodiscard]] static int FindNumber(std::string_view strInput, std::string_view strFind) noexcept;
-  static int64_t AlphaNumericCompare(const wchar_t *left, const wchar_t *right);
+  [[nodiscard]] static int64_t AlphaNumericCompare(std::wstring_view left,
+                                                   std::wstring_view right) noexcept;
   static int AlphaNumericCollation(int nKey1, const void* pKey1, int nKey2, const void* pKey2);
   static long TimeStringToSeconds(const std::string &timeString);
   static void RemoveCRLF(std::string& strLine);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -282,7 +282,7 @@ public:
                                                  int nKey2,
                                                  const void* pKey2) noexcept;
   [[nodiscard]] static long TimeStringToSeconds(std::string_view timeString);
-  static void RemoveCRLF(std::string& strLine);
+  static void RemoveCRLF(std::string& strLine) noexcept;
 
   /*! \brief utf8 version of strlen - skips any non-starting bytes in the count, thus returning the number of utf8 characters
    \param s c-string to find the length of.

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -120,7 +120,7 @@ public:
   static std::string& TrimLeft(std::string& str, std::string_view chars) noexcept;
   static std::string& TrimRight(std::string& str) noexcept;
   static std::string& TrimRight(std::string& str, std::string_view chars) noexcept;
-  static std::string& RemoveDuplicatedSpacesAndTabs(std::string& str);
+  static std::string& RemoveDuplicatedSpacesAndTabs(std::string& str) noexcept;
 
   /*! \brief Check if the character is a special character.
 

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -281,7 +281,7 @@ public:
                                                  const void* pKey1,
                                                  int nKey2,
                                                  const void* pKey2) noexcept;
-  static long TimeStringToSeconds(const std::string &timeString);
+  [[nodiscard]] static long TimeStringToSeconds(std::string_view timeString);
   static void RemoveCRLF(std::string& strLine);
 
   /*! \brief utf8 version of strlen - skips any non-starting bytes in the count, thus returning the number of utf8 characters

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -114,12 +114,12 @@ public:
                                        size_t first,
                                        size_t count = std::string_view::npos);
   [[nodiscard]] static std::string Right(std::string_view str, size_t count);
-  static std::string& Trim(std::string &str);
-  static std::string& Trim(std::string &str, const char* const chars);
-  static std::string& TrimLeft(std::string &str);
-  static std::string& TrimLeft(std::string &str, const char* const chars);
-  static std::string& TrimRight(std::string &str);
-  static std::string& TrimRight(std::string &str, const char* const chars);
+  static std::string& Trim(std::string& str) noexcept;
+  static std::string& Trim(std::string& str, std::string_view chars) noexcept;
+  static std::string& TrimLeft(std::string& str) noexcept;
+  static std::string& TrimLeft(std::string& str, std::string_view chars) noexcept;
+  static std::string& TrimRight(std::string& str) noexcept;
+  static std::string& TrimRight(std::string& str, std::string_view chars) noexcept;
   static std::string& RemoveDuplicatedSpacesAndTabs(std::string& str);
 
   /*! \brief Check if the character is a special character.

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -277,7 +277,10 @@ public:
   [[nodiscard]] static int FindNumber(std::string_view strInput, std::string_view strFind) noexcept;
   [[nodiscard]] static int64_t AlphaNumericCompare(std::wstring_view left,
                                                    std::wstring_view right) noexcept;
-  static int AlphaNumericCollation(int nKey1, const void* pKey1, int nKey2, const void* pKey2);
+  [[nodiscard]] static int AlphaNumericCollation(int nKey1,
+                                                 const void* pKey1,
+                                                 int nKey2,
+                                                 const void* pKey2) noexcept;
   static long TimeStringToSeconds(const std::string &timeString);
   static void RemoveCRLF(std::string& strLine);
 

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -488,7 +488,7 @@ public:
       \param cstr the const pointer to char
       \return the resulting std::string or ""
    */
-  static std::string CreateFromCString(const char* cstr);
+  [[nodiscard]] static std::string CreateFromCString(const char* cstr);
 
   /*!
    * \brief Check if a keyword string is contained on another string.

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -357,7 +357,7 @@ public:
                                           char opener,
                                           char closer,
                                           int startPos = 0) noexcept;
-  static int DateStringToYYYYMMDD(const std::string &dateString);
+  [[nodiscard]] static int DateStringToYYYYMMDD(std::string_view dateString);
   static std::string ISODateToLocalizedDate (const std::string& strIsoDate);
   static void WordToDigits(std::string &word);
   static std::string CreateUUID();

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -140,11 +140,14 @@ public:
   [[nodiscard]] static bool EndsWithNoCase(std::string_view str1, std::string_view str2) noexcept;
 
   template<typename CONTAINER>
-  static std::string Join(const CONTAINER &strings, const std::string& delimiter)
+  [[nodiscard]] static std::string Join(const CONTAINER& strings, std::string_view delimiter)
   {
     std::string result;
     for (const auto& str : strings)
-      result += str + delimiter;
+    {
+      result += str;
+      result += delimiter;
+    }
 
     if (!result.empty())
       result.erase(result.size() - delimiter.size());

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -359,7 +359,7 @@ public:
                                           int startPos = 0) noexcept;
   [[nodiscard]] static int DateStringToYYYYMMDD(std::string_view dateString);
   [[nodiscard]] static std::string ISODateToLocalizedDate(std::string_view strIsoDate);
-  static void WordToDigits(std::string &word);
+  static void WordToDigits(std::string& word) noexcept;
   static std::string CreateUUID();
   static bool ValidateUUID(const std::string &uuid); // NB only validates syntax
   static double CompareFuzzy(const std::string &left, const std::string &right);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -311,14 +311,14 @@ public:
    \param str the string to check
    \return true if the string is a natural number, false otherwise.
    */
-  static bool IsNaturalNumber(const std::string& str);
+  [[nodiscard]] static bool IsNaturalNumber(std::string_view str) noexcept;
 
   /*! \brief check whether a string is an integer.
    Matches [ \t]*[\-]*[0-9]+[ \t]*
    \param str the string to check
    \return true if the string is an integer, false otherwise.
    */
-  static bool IsInteger(const std::string& str);
+  [[nodiscard]] static bool IsInteger(std::string_view str) noexcept;
 
   /* The next several isasciiXX and asciiXXvalue functions are locale independent (US-ASCII only),
    * as opposed to standard ::isXX (::isalpha, ::isdigit...) which are locale dependent.

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -345,7 +345,7 @@ public:
   {
     return isasciiuppercaseletter(chr) || isasciilowercaseletter(chr) || isasciidigit(chr);
   }
-  static std::string SizeToString(int64_t size);
+  [[nodiscard]] static std::string SizeToString(int64_t size);
   static const std::string Empty;
   static size_t FindWords(const char *str, const char *wordLowerCase);
   static int FindEndBracket(const std::string &str, char opener, char closer, int startPos = 0);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -104,11 +104,10 @@ public:
   static void ToLower(std::wstring& str) noexcept;
   static void ToCapitalize(std::string& str) noexcept;
   static void ToCapitalize(std::wstring& str) noexcept;
-  static bool EqualsNoCase(const std::string &str1, const std::string &str2);
-  static bool EqualsNoCase(const std::string &str1, const char *s2);
-  static bool EqualsNoCase(const char *s1, const char *s2);
-  static int CompareNoCase(const std::string& str1, const std::string& str2, size_t n = 0);
-  static int CompareNoCase(const char* s1, const char* s2, size_t n = 0);
+  [[nodiscard]] static bool EqualsNoCase(std::string_view str1, std::string_view str2) noexcept;
+  [[nodiscard]] static int CompareNoCase(std::string_view str1,
+                                         std::string_view str2,
+                                         size_t n = 0) noexcept;
   static int ReturnDigits(const std::string &str);
   static std::string Left(const std::string &str, size_t count);
   static std::string Mid(const std::string &str, size_t first, size_t count = std::string::npos);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -420,7 +420,7 @@ public:
    \param param String to escape/paramify
    \return Escaped/Paramified string
    */
-  static std::string Paramify(const std::string &param);
+  [[nodiscard]] static std::string Paramify(std::string param);
 
   /*! \brief Unescapes the given string.
 
@@ -429,7 +429,7 @@ public:
    \param param String to unescape/deparamify
    \return Unescaped/Deparamified string
    */
-  static std::string DeParamify(const std::string& param);
+  [[nodiscard]] static std::string DeParamify(std::string param);
 
   /*! \brief Split a string by the specified delimiters.
    Splits a string using one or more delimiting characters, ignoring empty tokens.

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -382,7 +382,7 @@ public:
   \param param String to convert
   \return Converted string
   */
-  static std::string BinaryStringToString(const std::string& in);
+  [[nodiscard]] static std::string BinaryStringToString(std::string_view in);
   /**
    * Convert each character in the string to its hexadecimal
    * representation and return the concatenated result

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -353,7 +353,10 @@ public:
   static const std::string Empty;
   [[nodiscard]] static size_t FindWords(std::string_view str,
                                         std::string_view wordLowerCase) noexcept;
-  static int FindEndBracket(const std::string &str, char opener, char closer, int startPos = 0);
+  [[nodiscard]] static int FindEndBracket(std::string_view str,
+                                          char opener,
+                                          char closer,
+                                          int startPos = 0) noexcept;
   static int DateStringToYYYYMMDD(const std::string &dateString);
   static std::string ISODateToLocalizedDate (const std::string& strIsoDate);
   static void WordToDigits(std::string &word);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -288,7 +288,7 @@ public:
    \param s c-string to find the length of.
    \return the number of utf8 characters in the string.
    */
-  static size_t utf8_strlen(const char *s);
+  [[nodiscard]] static size_t utf8_strlen(std::string_view s) noexcept;
 
   /*! \brief convert a time in seconds to a string based on the given time format
    \param seconds time in seconds

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -514,6 +514,10 @@ struct sortstringbyname
   {
     return StringUtils::CompareNoCase(strItem1, strItem2) < 0;
   }
+  bool operator()(std::string_view strItem1, std::string_view strItem2) const
+  {
+    return StringUtils::CompareNoCase(strItem1, strItem2) < 0;
+  }
 };
 
 } // namespace KODI::UTILS

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -455,7 +455,7 @@ public:
    * \param fallback [OPT] The number to return when the conversion fails
    * \return The converted number, otherwise fallback if conversion fails
    */
-  static uint32_t ToUint32(std::string_view str, uint32_t fallback = 0) noexcept;
+  static uint32_t ToUint32(std::string_view str, uint32_t fallback = 0);
 
   /*!
    * \brief Converts a string to a unsigned long long number.
@@ -463,7 +463,7 @@ public:
    * \param fallback [OPT] The number to return when the conversion fails
    * \return The converted number, otherwise fallback if conversion fails
    */
-  static uint64_t ToUint64(std::string_view str, uint64_t fallback = 0) noexcept;
+  static uint64_t ToUint64(std::string_view str, uint64_t fallback = 0);
 
   /*!
    * \brief Converts a string to a float number.
@@ -471,7 +471,7 @@ public:
    * \param fallback [OPT] The number to return when the conversion fails
    * \return The converted number, otherwise fallback if conversion fails
    */
-  static float ToFloat(std::string_view str, float fallback = 0.0f) noexcept;
+  static float ToFloat(std::string_view str, float fallback = 0.0f);
 
   /*!
    * Returns bytes in a human readable format using the smallest unit that will fit `bytes` in at

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -369,7 +369,10 @@ public:
   [[nodiscard]] static int FindBestMatch(std::string_view str,
                                          std::span<const std::string> strings,
                                          double& matchscore) noexcept;
-  static bool ContainsKeyword(const std::string &str, const std::vector<std::string> &keywords);
+  [[nodiscard]] static bool ContainsKeyword(std::string_view str,
+                                            std::span<const std::string_view> keywords) noexcept;
+  [[nodiscard]] static bool ContainsKeyword(std::string_view str,
+                                            std::span<const std::string> keywords) noexcept;
 
   /*! \brief Convert the string of binary chars to the actual string.
 

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -361,7 +361,7 @@ public:
   [[nodiscard]] static std::string ISODateToLocalizedDate(std::string_view strIsoDate);
   static void WordToDigits(std::string& word) noexcept;
   [[nodiscard]] static std::string CreateUUID();
-  static bool ValidateUUID(const std::string &uuid); // NB only validates syntax
+  [[nodiscard]] static bool ValidateUUID(const std::string& uuid); // NB only validates syntax
   static double CompareFuzzy(const std::string &left, const std::string &right);
   static int FindBestMatch(const std::string &str, const std::vector<std::string> &strings, double &matchscore);
   static bool ContainsKeyword(const std::string &str, const std::vector<std::string> &keywords);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -360,7 +360,7 @@ public:
   [[nodiscard]] static int DateStringToYYYYMMDD(std::string_view dateString);
   [[nodiscard]] static std::string ISODateToLocalizedDate(std::string_view strIsoDate);
   static void WordToDigits(std::string& word) noexcept;
-  static std::string CreateUUID();
+  [[nodiscard]] static std::string CreateUUID();
   static bool ValidateUUID(const std::string &uuid); // NB only validates syntax
   static double CompareFuzzy(const std::string &left, const std::string &right);
   static int FindBestMatch(const std::string &str, const std::vector<std::string> &strings, double &matchscore);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -455,7 +455,7 @@ public:
    * \param fallback [OPT] The number to return when the conversion fails
    * \return The converted number, otherwise fallback if conversion fails
    */
-  static uint32_t ToUint32(std::string_view str, uint32_t fallback = 0);
+  [[nodiscard]] static uint32_t ToUint32(std::string_view str, uint32_t fallback = 0);
 
   /*!
    * \brief Converts a string to a unsigned long long number.
@@ -463,7 +463,7 @@ public:
    * \param fallback [OPT] The number to return when the conversion fails
    * \return The converted number, otherwise fallback if conversion fails
    */
-  static uint64_t ToUint64(std::string_view str, uint64_t fallback = 0);
+  [[nodiscard]] static uint64_t ToUint64(std::string_view str, uint64_t fallback = 0);
 
   /*!
    * \brief Converts a string to a float number.
@@ -471,7 +471,7 @@ public:
    * \param fallback [OPT] The number to return when the conversion fails
    * \return The converted number, otherwise fallback if conversion fails
    */
-  static float ToFloat(std::string_view str, float fallback = 0.0f);
+  [[nodiscard]] static float ToFloat(std::string_view str, float fallback = 0.0f);
 
   /*!
    * Returns bytes in a human readable format using the smallest unit that will fit `bytes` in at

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -131,9 +131,9 @@ public:
   [[nodiscard]] static bool IsSpecialCharacter(char c) noexcept;
 
   [[nodiscard]] static std::string ReplaceSpecialCharactersWithSpace(std::string_view str);
-  static int Replace(std::string &str, char oldChar, char newChar);
-  static int Replace(std::string &str, const std::string &oldStr, const std::string &newStr);
-  static int Replace(std::wstring &str, const std::wstring &oldStr, const std::wstring &newStr);
+  static int Replace(std::string& str, char oldChar, char newChar) noexcept;
+  static int Replace(std::string& str, std::string_view oldStr, std::string_view newStr);
+  static int Replace(std::wstring& str, std::wstring_view oldStr, std::wstring_view newStr);
   static bool StartsWith(const std::string &str1, const std::string &str2);
   static bool StartsWith(const std::string &str1, const char *s2);
   static bool StartsWith(const char *s1, const char *s2);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -389,7 +389,7 @@ public:
    *
    * example: "abc\n" -> "6162630a"
    */
-  static std::string ToHexadecimal(const std::string& in);
+  [[nodiscard]] static std::string ToHexadecimal(std::string_view in);
   /*! \brief Format the string with locale separators.
 
   Format the string with locale separators.

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -108,7 +108,7 @@ public:
   [[nodiscard]] static int CompareNoCase(std::string_view str1,
                                          std::string_view str2,
                                          size_t n = 0) noexcept;
-  static int ReturnDigits(const std::string &str);
+  [[nodiscard]] static int ReturnDigits(std::string_view str) noexcept;
   static std::string Left(const std::string &str, size_t count);
   static std::string Mid(const std::string &str, size_t first, size_t count = std::string::npos);
   static std::string Right(const std::string &str, size_t count);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -363,7 +363,12 @@ public:
   [[nodiscard]] static std::string CreateUUID();
   [[nodiscard]] static bool ValidateUUID(const std::string& uuid); // NB only validates syntax
   [[nodiscard]] static double CompareFuzzy(std::string_view left, std::string_view right) noexcept;
-  static int FindBestMatch(const std::string &str, const std::vector<std::string> &strings, double &matchscore);
+  [[nodiscard]] static int FindBestMatch(std::string_view str,
+                                         std::span<const std::string_view> strings,
+                                         double& matchscore) noexcept;
+  [[nodiscard]] static int FindBestMatch(std::string_view str,
+                                         std::span<const std::string> strings,
+                                         double& matchscore) noexcept;
   static bool ContainsKeyword(const std::string &str, const std::vector<std::string> &keywords);
 
   /*! \brief Convert the string of binary chars to the actual string.

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -92,8 +92,8 @@ public:
     return fmt::format(fmt::runtime(format), EnumToInt(std::forward<Args>(args))...);
   }
 
-  static std::string FormatV(PRINTF_FORMAT_STRING const char *fmt, va_list args);
-  static std::wstring FormatV(PRINTF_FORMAT_STRING const wchar_t *fmt, va_list args);
+  [[nodiscard]] static std::string FormatV(PRINTF_FORMAT_STRING const char* fmt, va_list args);
+  [[nodiscard]] static std::wstring FormatV(PRINTF_FORMAT_STRING const wchar_t* fmt, va_list args);
   static std::string ToUpper(const std::string& str);
   static std::wstring ToUpper(const std::wstring& str);
   static void ToUpper(std::string &str);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -260,9 +260,20 @@ public:
   \param delimiters Delimiter strings to be used to split the input strings
   \param iMaxStrings (optional) Maximum number of resulting split strings
   */
-  static std::vector<std::string> SplitMulti(const std::vector<std::string>& input,
-                                             const std::vector<std::string>& delimiters,
-                                             size_t iMaxStrings = 0);
+  [[nodiscard]] static std::vector<std::string> SplitMulti(std::span<const std::string> input,
+                                                           std::span<const std::string> delimiters,
+                                                           size_t iMaxStrings = 0);
+  [[nodiscard]] static std::vector<std::string> SplitMulti(
+      std::span<const std::string_view> input,
+      std::span<const std::string_view> delimiters,
+      size_t iMaxStrings = 0);
+  [[nodiscard]] static std::vector<std::string> SplitMulti(
+      std::span<const std::string> input,
+      std::span<const std::string_view> delimiters,
+      size_t iMaxStrings = 0);
+  [[nodiscard]] static std::vector<std::string> SplitMulti(std::span<const std::string_view> input,
+                                                           std::span<const std::string> delimiters,
+                                                           size_t iMaxStrings = 0);
   static int FindNumber(const std::string& strInput, const std::string &strFind);
   static int64_t AlphaNumericCompare(const wchar_t *left, const wchar_t *right);
   static int AlphaNumericCollation(int nKey1, const void* pKey1, int nKey2, const void* pKey2);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -94,16 +94,16 @@ public:
 
   [[nodiscard]] static std::string FormatV(PRINTF_FORMAT_STRING const char* fmt, va_list args);
   [[nodiscard]] static std::wstring FormatV(PRINTF_FORMAT_STRING const wchar_t* fmt, va_list args);
-  static std::string ToUpper(const std::string& str);
-  static std::wstring ToUpper(const std::wstring& str);
-  static void ToUpper(std::string &str);
-  static void ToUpper(std::wstring &str);
-  static std::string ToLower(const std::string& str);
-  static std::wstring ToLower(const std::wstring& str);
-  static void ToLower(std::string &str);
-  static void ToLower(std::wstring &str);
-  static void ToCapitalize(std::string &str);
-  static void ToCapitalize(std::wstring &str);
+  [[nodiscard]] static std::string ToUpper(std::string_view str);
+  [[nodiscard]] static std::wstring ToUpper(std::wstring_view str);
+  static void ToUpper(std::string& str) noexcept;
+  static void ToUpper(std::wstring& str) noexcept;
+  [[nodiscard]] static std::string ToLower(std::string_view str);
+  [[nodiscard]] static std::wstring ToLower(std::wstring_view str);
+  static void ToLower(std::string& str) noexcept;
+  static void ToLower(std::wstring& str) noexcept;
+  static void ToCapitalize(std::string& str) noexcept;
+  static void ToCapitalize(std::wstring& str) noexcept;
   static bool EqualsNoCase(const std::string &str1, const std::string &str2);
   static bool EqualsNoCase(const std::string &str1, const char *s2);
   static bool EqualsNoCase(const char *s1, const char *s2);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -109,9 +109,11 @@ public:
                                          std::string_view str2,
                                          size_t n = 0) noexcept;
   [[nodiscard]] static int ReturnDigits(std::string_view str) noexcept;
-  static std::string Left(const std::string &str, size_t count);
-  static std::string Mid(const std::string &str, size_t first, size_t count = std::string::npos);
-  static std::string Right(const std::string &str, size_t count);
+  [[nodiscard]] static std::string Left(std::string_view str, size_t count);
+  [[nodiscard]] static std::string Mid(std::string_view str,
+                                       size_t first,
+                                       size_t count = std::string_view::npos);
+  [[nodiscard]] static std::string Right(std::string_view str, size_t count);
   static std::string& Trim(std::string &str);
   static std::string& Trim(std::string &str, const char* const chars);
   static std::string& TrimLeft(std::string &str);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -481,7 +481,7 @@ public:
    * For example: 1024 bytes will be formatted as "1.00kB", 10240 bytes as "10.0kB" and
    * 102400 bytes as "100kB". See TestStringUtils for more examples.
    */
-  static std::string FormatFileSize(uint64_t bytes);
+  [[nodiscard]] static std::string FormatFileSize(uint64_t bytes);
 
   /*! \brief Converts a cstring pointer (const char*) to a std::string.
              In case nullptr is passed the result is an empty string.

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -134,16 +134,10 @@ public:
   static int Replace(std::string& str, char oldChar, char newChar) noexcept;
   static int Replace(std::string& str, std::string_view oldStr, std::string_view newStr);
   static int Replace(std::wstring& str, std::wstring_view oldStr, std::wstring_view newStr);
-  static bool StartsWith(const std::string &str1, const std::string &str2);
-  static bool StartsWith(const std::string &str1, const char *s2);
-  static bool StartsWith(const char *s1, const char *s2);
-  static bool StartsWithNoCase(const std::string &str1, const std::string &str2);
-  static bool StartsWithNoCase(const std::string &str1, const char *s2);
-  static bool StartsWithNoCase(const char *s1, const char *s2);
-  static bool EndsWith(const std::string &str1, const std::string &str2);
-  static bool EndsWith(const std::string &str1, const char *s2);
-  static bool EndsWithNoCase(const std::string &str1, const std::string &str2);
-  static bool EndsWithNoCase(const std::string &str1, const char *s2);
+  [[nodiscard]] static bool StartsWith(std::string_view str1, std::string_view str2) noexcept;
+  [[nodiscard]] static bool StartsWithNoCase(std::string_view str1, std::string_view str2) noexcept;
+  [[nodiscard]] static bool EndsWith(std::string_view str1, std::string_view str2) noexcept;
+  [[nodiscard]] static bool EndsWithNoCase(std::string_view str1, std::string_view str2) noexcept;
 
   template<typename CONTAINER>
   static std::string Join(const CONTAINER &strings, const std::string& delimiter)

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -130,7 +130,7 @@ public:
    */
   [[nodiscard]] static bool IsSpecialCharacter(char c) noexcept;
 
-  static std::string ReplaceSpecialCharactersWithSpace(const std::string& str);
+  [[nodiscard]] static std::string ReplaceSpecialCharactersWithSpace(std::string_view str);
   static int Replace(std::string &str, char oldChar, char newChar);
   static int Replace(std::string &str, const std::string &oldStr, const std::string &newStr);
   static int Replace(std::wstring &str, const std::wstring &oldStr, const std::wstring &newStr);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -351,7 +351,8 @@ public:
   }
   [[nodiscard]] static std::string SizeToString(int64_t size);
   static const std::string Empty;
-  static size_t FindWords(const char *str, const char *wordLowerCase);
+  [[nodiscard]] static size_t FindWords(std::string_view str,
+                                        std::string_view wordLowerCase) noexcept;
   static int FindEndBracket(const std::string &str, char opener, char closer, int startPos = 0);
   static int DateStringToYYYYMMDD(const std::string &dateString);
   static std::string ISODateToLocalizedDate (const std::string& strIsoDate);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -128,7 +128,7 @@ public:
 
    \param c Input character to be checked
    */
-  static bool IsSpecialCharacter(char c);
+  [[nodiscard]] static bool IsSpecialCharacter(char c) noexcept;
 
   static std::string ReplaceSpecialCharactersWithSpace(const std::string& str);
   static int Replace(std::string &str, char oldChar, char newChar);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -358,7 +358,7 @@ public:
                                           char closer,
                                           int startPos = 0) noexcept;
   [[nodiscard]] static int DateStringToYYYYMMDD(std::string_view dateString);
-  static std::string ISODateToLocalizedDate (const std::string& strIsoDate);
+  [[nodiscard]] static std::string ISODateToLocalizedDate(std::string_view strIsoDate);
   static void WordToDigits(std::string &word);
   static std::string CreateUUID();
   static bool ValidateUUID(const std::string &uuid); // NB only validates syntax

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -399,7 +399,7 @@ public:
   \return Formatted string
   */
   template<typename T>
-  static std::string FormatNumber(T num)
+  [[nodiscard]] static std::string FormatNumber(T num)
   {
     std::stringstream ss;
 // ifdef is needed because when you set _ITERATOR_DEBUG_LEVEL=0 and you use custom numpunct you will get runtime error in debug mode
@@ -409,7 +409,7 @@ public:
 #endif
     ss.precision(1);
     ss << std::fixed << num;
-    return ss.str();
+    return std::move(ss).str();
   }
 
   /*! \brief Escapes the given string to be able to be used as a parameter.

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -296,7 +296,8 @@ public:
    \return the formatted time
    \sa TIME_FORMAT
    */
-  static std::string SecondsToTimeString(long seconds, TIME_FORMAT format = TIME_FORMAT_GUESS);
+  [[nodiscard]] static std::string SecondsToTimeString(long seconds,
+                                                       TIME_FORMAT format = TIME_FORMAT_GUESS);
 
   /*! \brief convert a milliseconds value to a time string in the TIME_FORMAT_HH_MM_SS format
    \param milliSeconds time in milliseconds

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -274,7 +274,7 @@ public:
   [[nodiscard]] static std::vector<std::string> SplitMulti(std::span<const std::string_view> input,
                                                            std::span<const std::string> delimiters,
                                                            size_t iMaxStrings = 0);
-  static int FindNumber(const std::string& strInput, const std::string &strFind);
+  [[nodiscard]] static int FindNumber(std::string_view strInput, std::string_view strFind) noexcept;
   static int64_t AlphaNumericCompare(const wchar_t *left, const wchar_t *right);
   static int AlphaNumericCollation(int nKey1, const void* pKey1, int nKey2, const void* pKey2);
   static long TimeStringToSeconds(const std::string &timeString);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -341,9 +341,13 @@ public:
   {
     return (chr >= 'a' && chr <= 'z');
   }
+  [[nodiscard]] inline static bool isasciiletter(char chr) noexcept // locale independent
+  {
+    return isasciiuppercaseletter(chr) || isasciilowercaseletter(chr);
+  }
   [[nodiscard]] inline static bool isasciialphanum(char chr) noexcept // locale independent
   {
-    return isasciiuppercaseletter(chr) || isasciilowercaseletter(chr) || isasciidigit(chr);
+    return isasciiletter(chr) || isasciidigit(chr);
   }
   [[nodiscard]] static std::string SizeToString(int64_t size);
   static const std::string Empty;

--- a/xbmc/utils/test/TestStringUtils.cpp
+++ b/xbmc/utils/test/TestStringUtils.cpp
@@ -9,6 +9,9 @@
 #include "utils/StringUtils.h"
 
 #include <algorithm>
+#include <limits>
+#include <string>
+#include <string_view>
 
 #include <gtest/gtest.h>
 enum class ECG
@@ -136,6 +139,11 @@ TEST(TestStringUtils, EqualsNoCase)
   EXPECT_TRUE(StringUtils::EqualsNoCase(refstr, "tEsT"));
 }
 
+TEST(TestStringUtils, ReturnDigits)
+{
+  EXPECT_EQ(123456, StringUtils::ReturnDigits("H1el2lo 3Wor4ld56"));
+}
+
 TEST(TestStringUtils, Left)
 {
   std::string refstr, varstr;
@@ -209,6 +217,10 @@ TEST(TestStringUtils, Trim)
   std::string varstr = " test test   ";
   StringUtils::Trim(varstr);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+
+  varstr = "ababtest testabab";
+  StringUtils::Trim(varstr, "ab");
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 }
 
 TEST(TestStringUtils, TrimLeft)
@@ -217,6 +229,11 @@ TEST(TestStringUtils, TrimLeft)
 
   std::string varstr = " test test   ";
   StringUtils::TrimLeft(varstr);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+
+  refstr = "test testabab";
+  varstr = "ababtest testabab";
+  StringUtils::TrimLeft(varstr, "ab");
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 }
 
@@ -227,6 +244,27 @@ TEST(TestStringUtils, TrimRight)
   std::string varstr = " test test   ";
   StringUtils::TrimRight(varstr);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+
+  refstr = "ababtest test";
+  varstr = "ababtest testabab";
+  StringUtils::TrimRight(varstr, "ab");
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+}
+
+TEST(TestStringUtils, RemoveDuplicatedSpacesAndTabs)
+{
+  const std::string refstr = " test test ";
+
+  std::string varstr = "\t\ttest  test \t";
+  StringUtils::RemoveDuplicatedSpacesAndTabs(varstr);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+}
+
+TEST(TestStringUtils, ReplaceSpecialCharactersWithSpace)
+{
+  const std::string input("a .-_+b,!'c\"\tde/\\f*?g#$%h&@(i)[j]{k}");
+  const std::string output = StringUtils::ReplaceSpecialCharactersWithSpace(input);
+  EXPECT_STREQ(output.c_str(), "a b c de f g h i j k ");
 }
 
 TEST(TestStringUtils, Replace)
@@ -341,6 +379,27 @@ TEST(TestStringUtils, Split)
   EXPECT_STREQ("a bc  d ef ghi ", StringUtils::Split("a bc  d ef ghi ", 'z').at(0).c_str());
 }
 
+TEST(TestStringUtils, SplitMulti)
+{
+  const std::vector<std::string> input{"aaa::bbb", "cc:c##ddd::eee"};
+  const std::vector<std::string> delims{"::", "##"};
+
+  EXPECT_EQ(std::vector<std::string>({"aaa", "bbb", "cc:c", "ddd", "eee"}),
+            StringUtils::SplitMulti(input, delims));
+  EXPECT_EQ(std::vector<std::string>({"aaa::bbb", "cc:c##ddd::eee"}),
+            StringUtils::SplitMulti(input, delims, 1));
+  EXPECT_EQ(std::vector<std::string>({"aaa::bbb", "cc:c##ddd::eee"}),
+            StringUtils::SplitMulti(input, delims, 2));
+  EXPECT_EQ(std::vector<std::string>({"aaa", "bbb", "cc:c##ddd::eee"}),
+            StringUtils::SplitMulti(input, delims, 3));
+  EXPECT_EQ(std::vector<std::string>({"aaa", "bbb", "cc:c##ddd", "eee"}),
+            StringUtils::SplitMulti(input, delims, 4));
+  EXPECT_EQ(std::vector<std::string>({"aaa", "bbb", "cc:c", "ddd", "eee"}),
+            StringUtils::SplitMulti(input, delims, 5));
+  EXPECT_EQ(std::vector<std::string>({"aaa", "bbb", "cc:c", "ddd", "eee"}),
+            StringUtils::SplitMulti(input, delims, 6));
+}
+
 TEST(TestStringUtils, FindNumber)
 {
   EXPECT_EQ(3, StringUtils::FindNumber("aabcaadeaa", "aa"));
@@ -398,6 +457,12 @@ TEST(TestStringUtils, SecondsToTimeString)
   ref = "21:30:55";
   var = StringUtils::SecondsToTimeString(77455);
   EXPECT_STREQ(ref.c_str(), var.c_str());
+}
+
+TEST(TestStringUtils, MillisecondsToTimeString)
+{
+  EXPECT_STREQ(StringUtils::MillisecondsToTimeString(std::chrono::milliseconds(53254549)).c_str(),
+               "14:47:34.549");
 }
 
 TEST(TestStringUtils, IsNaturalNumber)
@@ -551,6 +616,38 @@ TEST(TestStringUtils, FindBestMatch)
   EXPECT_EQ(refdouble, vardouble);
 }
 
+TEST(TestStringUtils, ContainsKeyword)
+{
+  using namespace std::literals::string_literals;
+  const auto str = "alpha beta gamma delta"s;
+  EXPECT_TRUE(StringUtils::ContainsKeyword(str, std::vector{"alpha"s}));
+  EXPECT_TRUE(StringUtils::ContainsKeyword(str, std::vector{"beta"s}));
+  EXPECT_TRUE(StringUtils::ContainsKeyword(str, std::vector{"delta"s, "alpha"s}));
+  EXPECT_TRUE(StringUtils::ContainsKeyword(str, std::vector{"other"s, "beta"s}));
+  EXPECT_TRUE(StringUtils::ContainsKeyword(str, std::vector{"mm"s}));
+  EXPECT_FALSE(StringUtils::ContainsKeyword(str, std::vector{"epsilon"s}));
+  EXPECT_FALSE(StringUtils::ContainsKeyword(str, std::vector{"alphaa"s}));
+  EXPECT_FALSE(StringUtils::ContainsKeyword(str, std::vector{"alpha gamma"s}));
+}
+
+TEST(TestStringUtils, BinaryStringToString)
+{
+  EXPECT_STREQ("abc", StringUtils::BinaryStringToString("\\97\\98\\99").c_str());
+  EXPECT_STREQ("aabbcc", StringUtils::BinaryStringToString("a\\97\\98b\\99c").c_str());
+}
+
+TEST(TestStringUtils, ToHexadecimal)
+{
+  EXPECT_STREQ("", StringUtils::ToHexadecimal("").c_str());
+  EXPECT_STREQ("616263", StringUtils::ToHexadecimal("abc").c_str());
+  std::string a{"a\0b\n", 4};
+  EXPECT_STREQ("6100620a", StringUtils::ToHexadecimal(a).c_str());
+  std::string nul{"\0", 1};
+  EXPECT_STREQ("00", StringUtils::ToHexadecimal(nul).c_str());
+  std::string ff{"\xFF", 1};
+  EXPECT_STREQ("ff", StringUtils::ToHexadecimal(ff).c_str());
+}
+
 TEST(TestStringUtils, Paramify)
 {
   const char *input = "some, very \\ odd \"string\"";
@@ -560,20 +657,66 @@ TEST(TestStringUtils, Paramify)
   EXPECT_STREQ(ref, result.c_str());
 }
 
-TEST(TestStringUtils, sortstringbyname)
+TEST(TestStringUtils, DeParamify)
 {
-  std::vector<std::string> strarray;
-  strarray.emplace_back("B");
-  strarray.emplace_back("c");
-  strarray.emplace_back("a");
-  std::sort(strarray.begin(), strarray.end(), sortstringbyname());
-
-  EXPECT_STREQ("a", strarray[0].c_str());
-  EXPECT_STREQ("B", strarray[1].c_str());
-  EXPECT_STREQ("c", strarray[2].c_str());
+  std::string input("\"some, very \\\\ odd \\\"string\\\"\"");
+  const std::string result = StringUtils::DeParamify(input);
+  EXPECT_STREQ("some, very \\ odd \"string\"", result.c_str());
 }
 
-TEST(TestStringUtils, FileSizeFormat)
+TEST(TestStringUtils, Tokenize)
+{
+  const std::string input("aaa,bbb;ccc,;ddd;");
+  const std::string delims(",;.");
+  const std::vector<std::string> result = StringUtils::Tokenize(input, delims);
+  EXPECT_EQ(4, result.size());
+  EXPECT_STREQ("aaa", result[0].c_str());
+  EXPECT_STREQ("bbb", result[1].c_str());
+  EXPECT_STREQ("ccc", result[2].c_str());
+  EXPECT_STREQ("ddd", result[3].c_str());
+}
+
+TEST(TestStringUtils, ToUint32)
+{
+  EXPECT_EQ(0, StringUtils::ToUint32(""));
+  EXPECT_EQ(0, StringUtils::ToUint32("abc"));
+  EXPECT_EQ(0, StringUtils::ToUint32("abc123"));
+  EXPECT_EQ(0, StringUtils::ToUint32("0"));
+  EXPECT_EQ(0, StringUtils::ToUint32("-0"));
+  EXPECT_EQ(127536, StringUtils::ToUint32("127536"));
+  EXPECT_EQ(127536, StringUtils::ToUint32("127536abc"));
+  EXPECT_EQ(std::numeric_limits<uint32_t>::max(), StringUtils::ToUint32("-1"));
+  EXPECT_EQ(std::numeric_limits<uint32_t>::max(), StringUtils::ToUint32("4294967295"));
+  EXPECT_EQ(std::numeric_limits<uint32_t>::max(), StringUtils::ToUint32("999999999999"));
+}
+
+TEST(TestStringUtils, ToUint64)
+{
+  EXPECT_EQ(0, StringUtils::ToUint64(""));
+  EXPECT_EQ(0, StringUtils::ToUint64("abc"));
+  EXPECT_EQ(0, StringUtils::ToUint64("abc123"));
+  EXPECT_EQ(0, StringUtils::ToUint64("0"));
+  EXPECT_EQ(0, StringUtils::ToUint64("-0"));
+  EXPECT_EQ(127536, StringUtils::ToUint64("127536"));
+  EXPECT_EQ(127536, StringUtils::ToUint64("127536abc"));
+  EXPECT_EQ(std::numeric_limits<uint64_t>::max(), StringUtils::ToUint64("-1"));
+  EXPECT_EQ(std::numeric_limits<uint64_t>::max(), StringUtils::ToUint64("18446744073709551615"));
+  EXPECT_EQ(std::numeric_limits<uint64_t>::max(),
+            StringUtils::ToUint64("9999999999999999999999999999"));
+}
+
+TEST(TestStringUtils, ToFloat)
+{
+  EXPECT_FLOAT_EQ(0.0, StringUtils::ToFloat(""));
+  EXPECT_FLOAT_EQ(0.0, StringUtils::ToFloat("abc"));
+  EXPECT_FLOAT_EQ(0.0, StringUtils::ToFloat("abc1.0"));
+  EXPECT_FLOAT_EQ(0.0, StringUtils::ToFloat("0.0"));
+  EXPECT_FLOAT_EQ(0.0, StringUtils::ToFloat("-0.0"));
+  EXPECT_FLOAT_EQ(1.5, StringUtils::ToFloat("1.5"));
+  EXPECT_FLOAT_EQ(-1.5, StringUtils::ToFloat("-1.5"));
+}
+
+TEST(TestStringUtils, FormatFileSize)
 {
   EXPECT_STREQ("0B", StringUtils::FormatFileSize(0).c_str());
 
@@ -596,14 +739,23 @@ TEST(TestStringUtils, FileSizeFormat)
   EXPECT_STREQ("5432PB", StringUtils::FormatFileSize(6115888293969133568).c_str());
 }
 
-TEST(TestStringUtils, ToHexadecimal)
+TEST(TestStringUtils, Contains)
 {
-  EXPECT_STREQ("", StringUtils::ToHexadecimal("").c_str());
-  EXPECT_STREQ("616263", StringUtils::ToHexadecimal("abc").c_str());
-  std::string a{"a\0b\n", 4};
-  EXPECT_STREQ("6100620a", StringUtils::ToHexadecimal(a).c_str());
-  std::string nul{"\0", 1};
-  EXPECT_STREQ("00", StringUtils::ToHexadecimal(nul).c_str());
-  std::string ff{"\xFF", 1};
-  EXPECT_STREQ("ff", StringUtils::ToHexadecimal(ff).c_str());
+  EXPECT_TRUE(StringUtils::Contains("abcDEFghi", "dEf"));
+  EXPECT_FALSE(StringUtils::Contains("abcDEFghi", "dEf", false));
+  EXPECT_FALSE(StringUtils::Contains("abcdefg", "cdfg"));
+  EXPECT_FALSE(StringUtils::Contains("abcdefg", "cdfg", false));
+}
+
+TEST(TestStringUtils, sortstringbyname)
+{
+  std::vector<std::string> strarray;
+  strarray.emplace_back("B");
+  strarray.emplace_back("c");
+  strarray.emplace_back("a");
+  std::sort(strarray.begin(), strarray.end(), sortstringbyname());
+
+  EXPECT_STREQ("a", strarray[0].c_str());
+  EXPECT_STREQ("B", strarray[1].c_str());
+  EXPECT_STREQ("c", strarray[2].c_str());
 }

--- a/xbmc/windowing/wayland/SeatSelection.cpp
+++ b/xbmc/windowing/wayland/SeatSelection.cpp
@@ -92,7 +92,7 @@ CSeatSelection::CSeatSelection(CConnection& connection, wayland::seat_t const& s
       auto mimeIt = std::find_first_of(MIME_TYPES_PREFERENCE.cbegin(), MIME_TYPES_PREFERENCE.cend(),
                                        m_mimeTypeOffers.cbegin(), m_mimeTypeOffers.cend(),
                                        // static_cast needed for overload resolution
-                                       static_cast<bool (*)(std::string const&, std::string const&)> (&StringUtils::EqualsNoCase));
+                                       StringUtils::EqualsNoCase);
       if (mimeIt != MIME_TYPES_PREFERENCE.cend())
       {
         m_matchedMimeType = *mimeIt;


### PR DESCRIPTION
## Description

The first commit adds unit tests for `StringUtils` functions that were missing them.

The following commits modernize the `StringUtils` API and implementation in the following ways:

- Use `std::string_view` in many places to pass strings into functions
   - It's better than using `const std::string&` in cases the caller doesn't already have a `std::string` object as no temporary `std::string` needs to be constructed. If the caller already has a `std::string` the `std::string_view` construction is trivial
   - It's better than using `const char*` as information about string length can be passed into the function saving potentially a `strlen` call
- Using `std::span` instead of `const std::vector&` arguments for similar reasons as above
- Add `[[nodiscard]]` if throwing away the function result would make calling the function pointless
- Add `noexcept` because why not
- Use algorithms from the `<algorithm>` header instead of raw loops for some implementations

I tried to split this into small commits that should be fairly easy to review one-by-one.

This PR doesn't go all the way in some cases, e.g. I think it would be beneficial if `Split` and `Tokenize` return `std::vector<std::string_view>` instead of `std::vector<std::string>` but this probably needs some refactoring on the caller side so this is left for a later PR.

## Motivation and context

This hopefully makes `StringUtils` more flexible to use. It also can help with performance, after this change the unit tests are slightly faster and do fewer allocations according to Valgrinds Callgrind and DHAT. Adding `[[nodiscard]]` discovered the error fixed by #25556.

## How has this been tested?

Adding unit tests and running Kodi.

## What is the effect on users?

None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
