### PR TITLE
[PVR] Expose EpisodePart for recordings

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -582,8 +582,8 @@
 		<value condition="Player.HasAudio">[COLOR grey]$INFO[MusicPlayer.Album][/COLOR]$INFO[MusicPlayer.Year, [,] ]</value>
 	</variable>
 	<variable name="PlayerLabel3">
-		<value condition="VideoPlayer.Content(livetv) + !String.IsEmpty(VideoPlayer.Episode) + String.IsEmpty(VideoPlayer.EpisodePart)">$INFO[VideoPlayer.Season,$LOCALIZE[20373]: , ]$INFO[VideoPlayer.Episode,$LOCALIZE[20359]: ]</value>
-		<value condition="VideoPlayer.Content(livetv) + !String.IsEmpty(VideoPlayer.Episode) + !String.IsEmpty(VideoPlayer.EpisodePart)">$INFO[VideoPlayer.Season,$LOCALIZE[20373]: , ]$INFO[VideoPlayer.Episode,$LOCALIZE[20359]: ]$INFO[VideoPlayer.EpisodePart,/]</value>
+		<value condition="VideoPlayer.Content(livetv) | PVR.IsPlayingRecording + !String.IsEmpty(VideoPlayer.Episode) + String.IsEmpty(VideoPlayer.EpisodePart)">$INFO[VideoPlayer.Season,$LOCALIZE[20373]: , ]$INFO[VideoPlayer.Episode,$LOCALIZE[20359]: ]</value>
+		<value condition="VideoPlayer.Content(livetv) | PVR.IsPlayingRecording + !String.IsEmpty(VideoPlayer.Episode) + !String.IsEmpty(VideoPlayer.EpisodePart)">$INFO[VideoPlayer.Season,$LOCALIZE[20373]: , ]$INFO[VideoPlayer.Episode,$LOCALIZE[20359]: ]$INFO[VideoPlayer.EpisodePart,/]</value>
 		<value condition="VideoPlayer.Content(movies) | VideoPlayer.Content(livetv) + String.IsEmpty(VideoPlayer.Episode)">$INFO[VideoPlayer.Genre]</value>
 		<value condition="VideoPlayer.Content(episodes)">$INFO[VideoPlayer.TvShowTitle]</value>
 		<value condition="Player.HasAudio">$INFO[MusicPlayer.TrackNumber,,: ][COLOR=grey]$INFO[Player.Title][/COLOR]</value>

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_recordings.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_recordings.h
@@ -61,12 +61,13 @@ extern "C"
   //============================================================================
   /// @ingroup cpp_kodi_addon_pvr_Defs_Recording_PVRRecording
   /// @brief Special @ref kodi::addon::PVRRecording::SetSeriesNumber() and
-  /// @ref kodi::addon::PVRRecording::SetEpisodeNumber() value to indicate it is
-  /// not to be used.
+  /// @ref kodi::addon::PVRRecording::SetEpisodeNumber() and
+  /// @ref kodi::addon::PVRRecording::SetEpisodePartNumber() value to indicate
+  /// it is not to be used.
   ///
   /// Used if recording has no valid season and/or episode info.
   ///
-#define PVR_RECORDING_INVALID_SERIES_EPISODE EPG_TAG_INVALID_SERIES_EPISODE
+#define PVR_RECORDING_INVALID_SERIES_EPISODE -1
   //----------------------------------------------------------------------------
 
   //============================================================================

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -135,7 +135,7 @@ public:
     strEpisodeName = m_episodeName.c_str();
     iSeriesNumber = recording.m_iSeason;
     iEpisodeNumber = recording.m_iEpisode;
-    iEpisodePartNumber = PVR_RECORDING_INVALID_SERIES_EPISODE; //! @todo
+    iEpisodePartNumber = recording.EpisodePart();
     iYear = recording.GetYear();
     strDirectory = m_directory.c_str();
     strPlotOutline = m_plotOutline.c_str();

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -593,6 +593,13 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
       case LISTITEM_PARENTAL_RATING_SOURCE:
         strValue = recording->GetParentalRatingSource();
         return true;
+      case VIDEOPLAYER_EPISODEPART:
+      case LISTITEM_EPISODEPART:
+        if (recording->m_iEpisode > 0 && recording->EpisodePart() > 0)
+        {
+          strValue = std::to_string(recording->EpisodePart());
+          return true;
+        }
     }
     return false;
   }

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -9,7 +9,6 @@
 #include "PVRRecording.h"
 
 #include "ServiceBroker.h"
-#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_recordings.h"
 #include "cores/EdlEdit.h"
 #include "guilib/LocalizeStrings.h"
 #include "pvr/PVRManager.h"
@@ -91,6 +90,7 @@ CPVRRecording::CPVRRecording(const PVR_RECORDING& recording, unsigned int iClien
     m_strShowTitle = recording.strEpisodeName;
   m_iSeason = recording.iSeriesNumber;
   m_iEpisode = recording.iEpisodeNumber;
+  m_episodePartNumber = recording.iEpisodePartNumber;
   if (recording.iYear > 0)
     SetYear(recording.iYear);
   m_iClientId = iClientId;
@@ -192,7 +192,8 @@ bool CPVRRecording::operator==(const CPVRRecording& right) const
           m_parentalRating == right.m_parentalRating &&
           m_parentalRatingCode == right.m_parentalRatingCode &&
           m_parentalRatingIcon == right.m_parentalRatingIcon &&
-          m_parentalRatingSource == right.m_parentalRatingSource);
+          m_parentalRatingSource == right.m_parentalRatingSource &&
+          m_episodePartNumber == right.m_episodePartNumber);
 }
 
 bool CPVRRecording::operator!=(const CPVRRecording& right) const
@@ -220,6 +221,7 @@ void CPVRRecording::Serialize(CVariant& value) const
   value["parentalratingcode"] = m_parentalRatingCode;
   value["parentalratingicon"] = m_parentalRatingIcon;
   value["parentalratingsource"] = m_parentalRatingSource;
+  value["episodepart"] = m_episodePartNumber;
 
   if (!value.isMember("art"))
     value["art"] = CVariant(CVariant::VariantTypeObject);
@@ -256,8 +258,9 @@ void CPVRRecording::Reset()
   m_bIsDeleted = false;
   m_bInProgress = true;
   m_iEpgEventId = EPG_TAG_INVALID_UID;
-  m_iSeason = -1;
-  m_iEpisode = -1;
+  m_iSeason = PVR_RECORDING_INVALID_SERIES_EPISODE;
+  m_iEpisode = PVR_RECORDING_INVALID_SERIES_EPISODE;
+  m_episodePartNumber = PVR_RECORDING_INVALID_SERIES_EPISODE;
   m_iChannelUid = PVR_CHANNEL_INVALID_UID;
   m_bRadio = false;
   m_iFlags = PVR_RECORDING_FLAG_UNDEFINED;
@@ -438,6 +441,7 @@ void CPVRRecording::Update(const CPVRRecording& tag, const CPVRClient& client)
   m_strShowTitle = tag.m_strShowTitle;
   m_iSeason = tag.m_iSeason;
   m_iEpisode = tag.m_iEpisode;
+  m_episodePartNumber = tag.m_episodePartNumber;
   SetPremiered(tag.GetPremiered());
   m_recordingTime = tag.m_recordingTime;
   m_iPriority = tag.m_iPriority;
@@ -745,4 +749,10 @@ const std::string& CPVRRecording::GetParentalRatingSource() const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_parentalRatingSource;
+}
+
+int CPVRRecording::EpisodePart() const
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+  return m_episodePartNumber;
 }

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -10,6 +10,7 @@
 
 #include "XBDateTime.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_providers.h"
+#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_recordings.h"
 #include "pvr/PVRCachedImage.h"
 #include "threads/CriticalSection.h"
 #include "threads/SystemClock.h"
@@ -523,6 +524,12 @@ public:
    */
   const std::string& GetParentalRatingSource() const;
 
+  /*!
+   * @brief Get the episode part number of this recording.
+   * @return The episode part number.
+   */
+  int EpisodePart() const;
+
 private:
   CPVRRecording(const CPVRRecording& tag) = delete;
   CPVRRecording& operator=(const CPVRRecording& other) = delete;
@@ -561,6 +568,7 @@ private:
   std::string m_parentalRatingCode; /*!< Parental rating code */
   std::string m_parentalRatingIcon; /*!< parental rating icon path */
   std::string m_parentalRatingSource; /*!< parental rating source */
+  int m_episodePartNumber{PVR_RECORDING_INVALID_SERIES_EPISODE}; /*!< episode part number */
 
   mutable CCriticalSection m_critSection;
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
PR 25439 exposed the EpisodePart for PVR EPG items to skins.  This PR continues the logic to expose the EpisodePart for PVR Recordings that were added in PVR API 9.0
<!--- Describe your change in detail here. -->
Added  EpisodePart to the Recording PVRGUI logic.  Contacted @Karellen and there is no scraper or NFO support for the EpisodePart so it is PVR only.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
EpisodePart has been part Kodi logic but is being exposed in Piers.  After making a recording from guide data and backend that supports the EpisodePart it logical to display that on recording

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Test with a version of pvr.demo that supports EpisodePart on recordings https://github.com/kodi-pvr/pvr.demo/pull/165

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Improved user experience  with supported recordings.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/4b5b72be-4184-4761-a03b-4bab8d880c85)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [] **Improvement** (non-breaking change which improves existing functionality)
- [X ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
Forum needs an update 
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
