### PR TITLE
[addons] PVR Add-on API: Fix initialization of PVRRecording::iClientProviderUid

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Recordings.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Recordings.h
@@ -56,6 +56,7 @@ public:
     m_cStructure->iChannelUid = PVR_RECORDING_VALUE_NOT_AVAILABLE;
     m_cStructure->channelType = PVR_RECORDING_CHANNEL_TYPE_UNKNOWN;
     m_cStructure->sizeInBytes = PVR_RECORDING_VALUE_NOT_AVAILABLE;
+    m_cStructure->iClientProviderUid = PVR_PROVIDER_INVALID_UID;
   }
   PVRRecording(const PVRRecording& recording) : DynamicCStructHdl(recording) {}
   /*! \endcond */

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -130,7 +130,7 @@
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"
 
-#define ADDON_INSTANCE_VERSION_PVR                    "9.0.0"
+#define ADDON_INSTANCE_VERSION_PVR                    "9.0.1"
 #define ADDON_INSTANCE_VERSION_PVR_MIN                "9.0.0"
 #define ADDON_INSTANCE_VERSION_PVR_XML_ID             "kodi.binary.instance.pvr"
 #define ADDON_INSTANCE_VERSION_PVR_DEPENDS            "c-api/addon-instance/pvr.h" \

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -120,6 +120,11 @@ CPVRRecording::CPVRRecording(const PVR_RECORDING& recording, unsigned int iClien
     m_strProviderName = recording.strProviderName;
   m_iClientProviderUniqueId = recording.iClientProviderUid;
 
+  // Workaround for C++ PVR Add-on API wrapper not initializing this value correctly until API 9.0.1
+  //! @todo Remove with next incompatible API bump.
+  if (m_iClientProviderUniqueId == 0)
+    m_iClientProviderUniqueId = PVR_PROVIDER_INVALID_UID;
+
   SetGenre(recording.iGenreType, recording.iGenreSubType,
            recording.strGenreDescription ? recording.strGenreDescription : "");
   CVideoInfoTag::SetPlayCount(recording.iPlayCount);


### PR DESCRIPTION
Seems we forgot this when we added the feature to the PVR Add-on API. Will cause problems once we actually start to use the PVR Providers API.

@phunkyfish please review.