### PR TITLE
[Settings] Fix visibility of sections acc. to dependencies (#25647)

### DIFF
--- a/xbmc/settings/lib/SettingSection.cpp
+++ b/xbmc/settings/lib/SettingSection.cpp
@@ -168,7 +168,7 @@ SettingList CSettingGroup::GetSettings(SettingLevel level) const
 bool CSettingGroup::ContainsVisibleSettings(const SettingLevel level) const
 {
   return std::any_of(m_settings.begin(), m_settings.end(), [&level](const SettingPtr& setting) {
-    return setting->GetLevel() <= level && setting->MeetsRequirements() && setting->IsVisible();
+    return setting->GetLevel() <= level && (setting->MeetsRequirements() || setting->IsVisible());
   });
 }
 
@@ -263,7 +263,7 @@ SettingGroupList CSettingCategory::GetGroups(SettingLevel level) const
   SettingGroupList groups;
   for (const auto& group : m_groups)
   {
-    if (group->MeetsRequirements() && group->IsVisible() && group->ContainsVisibleSettings(level))
+    if ((group->MeetsRequirements() || group->IsVisible()) && group->ContainsVisibleSettings(level))
       groups.push_back(group);
   }
 


### PR DESCRIPTION
## Description
Fix for  issue #25647:  Sections in addon settings stay hidden even if settings get visible in meantime

## Motivation and context
This solves the problem that sections that are initially hidden since settings inside are hidden by dependencies stay hidden even if settings inside get visible acc. new values and changed dependencies

Especially it fixes addons that have more complex setting dialogs esp. with actions that changes values of the setting's category that is displayed at this moment. Example is https://github.com/Heckie75/kodi-addon-timers

The motivation was to fix https://github.com/Heckie75/kodi-addon-timers/issues/43

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
I have written an addon to test this change manually, see [script.example.zip](https://github.com/user-attachments/files/16694960/script.example.zip)

I have tested:
1. Section in settings dialog is initially hidden since setting inside is hidden by dependency
2. Section in settings dialog is hidden since setting inside is hidden by <visible>false</visible>
3. Section in settings dialog is always displayed since there is one setting inside displayed
4. Changed condition dependency by action triggered inside addon settings dialog
6. Tested settings with dependencies of type _visible_ and _enable_ (_enable_ does not seem to have effect on _MeetRequirements_)

<!--- Include details of your testing environment, and the tests you ran to -->
Tested in branch Omega (v21) under Linux Ubuntu 22.04.4 LTS (x11)

<!--- see how your change affects other areas of the code, etc. -->
Unclear if this code is used for internal settings of Kodi, too.

## What is the effect on users?

## Screenshots (if appropriate):
see https://github.com/xbmc/xbmc/issues/25647

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
