### PR TITLE
[PVR] Remember date and time channels were obtained from a client for…

### DIFF
--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -14,6 +14,8 @@
 #include <map>
 #include <vector>
 
+class CDateTime;
+
 namespace PVR
 {
   class CPVRChannel;
@@ -64,7 +66,7 @@ namespace PVR
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    int GetSchemaVersion() const override { return 46; }
+    int GetSchemaVersion() const override { return 47; }
 
     /*!
      * @brief Get the default sqlite database filename.
@@ -101,6 +103,13 @@ namespace PVR
      * @return The priority.
      */
     int GetPriority(const CPVRClient& client) const;
+
+    /*!
+     * @brief Get the date and time first channels were added for the given client.
+     * @param client The client.
+     * @return The date and time first channels were added.
+     */
+    CDateTime GetDateTimeFirstChannelsAdded(const CPVRClient& client) const;
 
     /*!
      * @brief Get the numeric client ID for given addon ID and instance ID from the database.

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "XBDateTime.h"
 #include "addons/binary-addons/AddonInstanceHandler.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr.h"
 #include "pvr/addons/PVRClientCapabilities.h"
@@ -806,6 +807,18 @@ public:
   void SetPriority(int iPriority);
 
   /*!
+   * @brief Get the date and time first channels were added for this client.
+   * @return The date and time first channels were added.
+   */
+  const CDateTime& GetDateTimeFirstChannelsAdded() const;
+
+  /*!
+   * @brief Set the date and time first channels were added for this client.
+   * @param dateTime The date and time first channels were added.
+   */
+  void SetDateTimeFirstChannelsAdded(const CDateTime& dateTime);
+
+  /*!
    * @brief Obtain the chunk size to use when reading streams.
    * @param iChunkSize the chunk size in bytes.
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
@@ -1066,6 +1079,8 @@ private:
   std::vector<std::shared_ptr<CPVRTimerType>>
       m_timertypes; /*!< timer types supported by this backend */
   mutable std::optional<int> m_priority; /*!< priority of the client */
+  mutable std::optional<CDateTime>
+      m_firstChannelsAdded; /*!< date and time the first channels were added for this client */
 
   /* cached data */
   std::string m_strBackendName; /*!< the cached backend version */


### PR DESCRIPTION
… the first time, to not populate 'Recently added channels' widget with those channels.

Motivation: Initial implementation of "Recently added channels" widget can cause user confusion as for fresh installations, all channels were listed here. This is technically correct, but not really what users expect. They want the channels obtained from the PVR clients on very first `GetChannels` PVR Add-on API call ignored and only new channels returned on subsequent calls to `GetChannels` listed in the widget.

This PR implements this behavior. When a new client is added to the system, the time stamp of first successful `GetChannels` API call will be remembered now in TV database and the recently added channels widget only displays channels added after that date.

Runtime-tested on macOS, latest Kodi master.

@phunkyfish please review, thanks.