### PR TITLE
[Backport][Windows] Fix crash when audio device not has 'PKEY_Device_EnumeratorName' property

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp
@@ -130,14 +130,16 @@ std::vector<RendererDetail> CAESinkFactoryWin::GetRendererDetails()
     PropVariantClear(&varName);
 
     hr = pProperty->GetValue(PKEY_Device_EnumeratorName, &varName);
-    if (FAILED(hr))
+    if (SUCCEEDED(hr) && varName.pwszVal != nullptr)
     {
-      CLog::LogF(LOGERROR, "Retrieval of endpoint enumerator name failed.");
-      goto failed;
+      details.strDeviceEnumerator = KODI::PLATFORM::WINDOWS::FromW(varName.pwszVal);
+      StringUtils::ToUpper(details.strDeviceEnumerator);
     }
-
-    details.strDeviceEnumerator = KODI::PLATFORM::WINDOWS::FromW(varName.pwszVal);
-    StringUtils::ToUpper(details.strDeviceEnumerator);
+    else
+    {
+      CLog::LogF(LOGDEBUG, "Retrieval of endpoint enumerator name failed: {}.",
+                 (FAILED(hr)) ? "'GetValue' has failed" : "'varName.pwszVal' is NULL");
+    }
     PropVariantClear(&varName);
 
     if (pDevice->GetId(&pwszID) == S_OK)


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/25648



## What is the effect on users?
Fix crash when computer is accessed with RDP.



## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
