### PR TITLE
[DirectoryFactory] Store CFileItem mimetype to CURL, to avoid forced HTTP HEAD requests

### DIFF
--- a/xbmc/filesystem/DirectoryFactory.cpp
+++ b/xbmc/filesystem/DirectoryFactory.cpp
@@ -97,7 +97,14 @@ using namespace XFILE;
  */
 IDirectory* CDirectoryFactory::Create(const CFileItem& item)
 {
-  return Create(CURL{item.GetDynPath()});
+  CURL curl{item.GetDynPath()};
+
+  // Store the mimetype, allowing the PlayListFactory to set it on the created FileItem
+  const std::string& mimeType = item.GetMimeType();
+  if (!mimeType.empty())
+    curl.SetOption("mimetype", mimeType);
+
+  return Create(curl);
 }
 
 /*!

--- a/xbmc/filesystem/PlaylistFileDirectory.cpp
+++ b/xbmc/filesystem/PlaylistFileDirectory.cpp
@@ -25,12 +25,11 @@ namespace XFILE
 
   bool CPlaylistFileDirectory::GetDirectory(const CURL& url, CFileItemList& items)
   {
-    const std::string pathToUrl = url.Get();
-    std::unique_ptr<PLAYLIST::CPlayList> pPlayList(PLAYLIST::CPlayListFactory::Create(pathToUrl));
+    std::unique_ptr<PLAYLIST::CPlayList> pPlayList(PLAYLIST::CPlayListFactory::Create(url));
     if (nullptr != pPlayList)
     {
       // load it
-      if (!pPlayList->Load(pathToUrl))
+      if (!pPlayList->Load(url.Get()))
         return false; //hmmm unable to load playlist?
 
       PLAYLIST::CPlayList playlist = *pPlayList;
@@ -47,12 +46,11 @@ namespace XFILE
 
   bool CPlaylistFileDirectory::ContainsFiles(const CURL& url)
   {
-    const std::string pathToUrl = url.Get();
-    std::unique_ptr<PLAYLIST::CPlayList> pPlayList(PLAYLIST::CPlayListFactory::Create(pathToUrl));
+    std::unique_ptr<PLAYLIST::CPlayList> pPlayList(PLAYLIST::CPlayListFactory::Create(url));
     if (nullptr != pPlayList)
     {
       // load it
-      if (!pPlayList->Load(pathToUrl))
+      if (!pPlayList->Load(url.Get()))
         return false; //hmmm unable to load playlist?
 
       return (pPlayList->size() > 1);

--- a/xbmc/playlists/PlayListFactory.cpp
+++ b/xbmc/playlists/PlayListFactory.cpp
@@ -9,6 +9,7 @@
 #include "PlayListFactory.h"
 
 #include "FileItem.h"
+#include "URL.h"
 #include "network/NetworkFileItemClassify.h"
 #include "playlists/PlayListASX.h"
 #include "playlists/PlayListB4S.h"
@@ -24,6 +25,19 @@
 
 namespace KODI::PLAYLIST
 {
+
+CPlayList* CPlayListFactory::Create(const CURL& url)
+{
+  CFileItem item{url.Get(), false};
+
+  if (url.HasOption("mimetype"))
+  {
+    item.SetContentLookup(false);
+    item.SetMimeType(url.GetOption("mimetype"));
+  }
+
+  return Create(item);
+}
 
 CPlayList* CPlayListFactory::Create(const std::string& filename)
 {

--- a/xbmc/playlists/PlayListFactory.h
+++ b/xbmc/playlists/PlayListFactory.h
@@ -20,6 +20,7 @@ namespace KODI::PLAYLIST
   class CPlayListFactory
   {
   public:
+    static CPlayList* Create(const CURL& url);
     static CPlayList* Create(const std::string& filename);
     static CPlayList* Create(const CFileItem& item);
     static bool IsPlaylist(const CURL& url);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This will fix inputstream PVR binary addons and playlists like STRM that set mimetype to the CFileItem or by using `#KODIPROP:mimetype`

currently the mimetype is passed correctly to Kodi core,
but when the FileItem arrive to `CDirectoryFactory::Create` is converted to `CURL` object
which leads to the loss of all CFileItem infos
then at later time a new `CFileItem` will be created based on the `CURL` object, since there is no CFileItem original infos, is created from scratch, without mimetype

After investigated more, i found that  `CURL` object can host optional extradata, so i stored the mimetype to it, to avoid deeper changes

the `PLAYLIST::CPlayListFactory::Create` with CURL, is used only on the methods of `CPlaylistFileDirectory` seems to be quite reliable as change

~_i havent had time to check if it is needed backport to kodi21, i will check at later time or tomorrow_~ backport needed

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #25652
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Can be tested with these fake STRM (PVR use same code path)
Multi videos playlist: [MULTI_FAKE.strm.txt](https://github.com/user-attachments/files/16740481/MULTI_FAKE.strm.txt)
Single video: [SINGLE_FAKE.strm.txt](https://github.com/user-attachments/files/16740482/SINGLE_FAKE.strm.txt)

Videos have fake links, just to check if on the log debug you see printed `CCurlFile::XFILE::CCurlFile::GetMimeType` errors
that should not appears if the fix works

other way to test it is use PVR pvr.iptvsimple by using appropriate STRM's

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Users can have `#KODIPROP:mimetype` working on playlists (currently broken)
PVR addons can works without that kodi core force make HTTP HEAD requests (so without take in account of the specified mimetype)

some particular video services dont like HTTP HEAD requests and can lead to broken playback beause block manifest download (this is caused often due to custom kodi user-agent), this will prevent this problem

On windows noticieable kodi freezes for some secs happens each time HTTP HEAD request fails, this seem to be a CURL problem, anyway this allow to avoid also this problem

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
