### PR TITLE
[AE][XAudio2] Fix Drain and Deinitialize

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -239,18 +239,8 @@ unsigned int CAESinkXAudio::AddPackets(uint8_t **data, unsigned int frames, unsi
   LARGE_INTEGER timerStop;
   LARGE_INTEGER timerFreq;
 #endif
-  size_t dataLenght = frames * m_format.m_frameSize;
 
-  struct buffer_ctx *ctx = new buffer_ctx;
-  ctx->data = new uint8_t[dataLenght];
-  ctx->frames = frames;
-  ctx->sink = this;
-  memcpy(ctx->data, data[0] + offset * m_format.m_frameSize, dataLenght);
-
-  XAUDIO2_BUFFER xbuffer = {};
-  xbuffer.AudioBytes = dataLenght;
-  xbuffer.pAudioData = ctx->data;
-  xbuffer.pContext = ctx;
+  XAUDIO2_BUFFER xbuffer = BuildXAudio2Buffer(data, frames, offset);
 
   if (!m_running) //first time called, pre-fill buffer then start voice
   {
@@ -259,7 +249,7 @@ unsigned int CAESinkXAudio::AddPackets(uint8_t **data, unsigned int frames, unsi
     if (FAILED(hr))
     {
       CLog::LogF(LOGERROR, "voice submit buffer failed due to {}", WASAPIErrToStr(hr));
-      delete ctx;
+      delete xbuffer.pContext;
       return 0;
     }
     hr = m_sourceVoice->Start(0, XAUDIO2_COMMIT_NOW);
@@ -267,7 +257,7 @@ unsigned int CAESinkXAudio::AddPackets(uint8_t **data, unsigned int frames, unsi
     {
       CLog::LogF(LOGERROR, "voice start failed due to {}", WASAPIErrToStr(hr));
       m_isDirty = true; //flag new device or re-init needed
-      delete ctx;
+      delete xbuffer.pContext;
       return INT_MAX;
     }
     m_sinkFrames += frames;
@@ -292,7 +282,7 @@ unsigned int CAESinkXAudio::AddPackets(uint8_t **data, unsigned int frames, unsi
     if (eventAudioCallback != WAIT_OBJECT_0)
     {
       CLog::LogF(LOGERROR, "voice buffer timed out");
-      delete ctx;
+      delete xbuffer.pContext;
       return INT_MAX;
     }
   }
@@ -319,7 +309,7 @@ unsigned int CAESinkXAudio::AddPackets(uint8_t **data, unsigned int frames, unsi
     #ifdef _DEBUG
     CLog::LogF(LOGERROR, "submiting buffer failed due to {}", WASAPIErrToStr(hr));
 #endif
-    delete ctx;
+    delete xbuffer.pContext;
     return INT_MAX;
   }
 
@@ -843,23 +833,49 @@ void CAESinkXAudio::Drain()
   if(!m_sourceVoice)
     return;
 
-  AEDelayStatus status;
-  GetDelay(status);
-
-  KODI::TIME::Sleep(std::chrono::milliseconds(static_cast<int>(status.GetDelay() * 500)));
-
   if (m_running)
   {
     try
     {
+      // Contrary to MS doc, the voice must play a buffer with end of stream flag for the voice
+      // SamplesPlayed counter to be reset.
+      // Per MS doc, Discontinuity() may not take effect until after the entire buffer queue is
+      // consumed, which wouldn't invoke the callback or reset the voice stats.
+      // Solution: submit a 1 sample buffer with end of stream flag and wait for StreamEnd callback
+      // The StreamEnd event is manual reset so that it cannot be missed even if raised before this
+      // code starts waiting for it
+
+      AddEndOfStreamPacket();
+
+      constexpr uint32_t waitSafety = 100; // extra ms wait in case of scheduler issue
+      DWORD waitRc =
+          WaitForSingleObject(m_voiceCallback.m_StreamEndEvent,
+                              m_framesInBuffers * 1000 / m_format.m_sampleRate + waitSafety);
+
+      if (waitRc != WAIT_OBJECT_0)
+      {
+        if (waitRc == WAIT_FAILED)
+        {
+          //! @todo use FormatMessage for a human readable error message
+          CLog::LogF(LOGERROR,
+                     "error WAIT_FAILED while waiting for queued buffers to drain. GetLastError:{}",
+                     GetLastError());
+        }
+        else
+        {
+          CLog::LogF(LOGERROR, "error {} while waiting for queued buffers to drain.", waitRc);
+        }
+      }
+
       m_sourceVoice->Stop();
-      m_sourceVoice->FlushSourceBuffers();
+      ResetEvent(m_voiceCallback.m_StreamEndEvent);
+
       m_sinkFrames = 0;
       m_framesInBuffers = 0;
     }
     catch (...)
     {
-      CLog::Log(LOGDEBUG, "{}: Invalidated source voice - Releasing", __FUNCTION__);
+      CLog::Log(LOGERROR, "{}: Invalidated source voice - Releasing", __FUNCTION__);
     }
   }
   m_running = false;
@@ -886,4 +902,49 @@ bool CAESinkXAudio::IsUSBDevice()
     pProperty->Release();
 #endif
   return false;
+}
+
+bool CAESinkXAudio::AddEndOfStreamPacket()
+{
+  constexpr unsigned int frames{1};
+
+  XAUDIO2_BUFFER xbuffer = BuildXAudio2Buffer(nullptr, frames, 0);
+  xbuffer.Flags = XAUDIO2_END_OF_STREAM;
+
+  HRESULT hr = m_sourceVoice->SubmitSourceBuffer(&xbuffer);
+
+  if (hr != S_OK)
+  {
+    CLog::LogF(LOGERROR, "SubmitSourceBuffer failed due to {:X}", hr);
+    delete xbuffer.pContext;
+    return false;
+  }
+
+  m_sinkFrames += frames;
+  m_framesInBuffers += frames;
+  return true;
+}
+
+XAUDIO2_BUFFER CAESinkXAudio::BuildXAudio2Buffer(uint8_t** data,
+                                                 unsigned int frames,
+                                                 unsigned int offset)
+{
+  const unsigned int dataLength{frames * m_format.m_frameSize};
+
+  struct buffer_ctx* ctx = new buffer_ctx;
+  ctx->data = new uint8_t[dataLength];
+  ctx->frames = frames;
+  ctx->sink = this;
+
+  if (data)
+    memcpy(ctx->data, data[0] + offset * m_format.m_frameSize, dataLength);
+  else
+    CAEUtil::GenerateSilence(m_format.m_dataFormat, m_format.m_frameSize, ctx->data, frames);
+
+  XAUDIO2_BUFFER xbuffer{};
+  xbuffer.AudioBytes = dataLength;
+  xbuffer.pAudioData = ctx->data;
+  xbuffer.pContext = ctx;
+
+  return xbuffer;
 }

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
@@ -607,3 +607,25 @@ int CAEUtil::GetAVChannelIndex(enum AEChannel aechannel, uint64_t layout)
   av_channel_layout_uninit(&ch_layout);
   return idx;
 }
+
+void CAEUtil::GenerateSilence(AEDataFormat format,
+                              unsigned int frameSize,
+                              void* buffer,
+                              unsigned int frames)
+
+{
+  const unsigned int dataLength{frames * frameSize};
+
+  switch (format)
+  {
+    case AV_SAMPLE_FMT_U8:
+    case AV_SAMPLE_FMT_U8P:
+      memset(buffer, 0x80, dataLength);
+      break;
+
+    default:
+      // binary representation of 0 in all other formats regardless of number of bits per sample
+      // is a concatenation of 0 bytes.
+      memset(buffer, 0, dataLength);
+  }
+}

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.h
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.h
@@ -178,4 +178,8 @@ public:
   static uint64_t GetAVChannelMask(enum AEChannel aechannel);
   static enum AVChannel GetAVChannel(enum AEChannel aechannel);
   static int GetAVChannelIndex(enum AEChannel aechannel, uint64_t layout);
+  static void GenerateSilence(AEDataFormat format,
+                              unsigned int frameSize,
+                              void* buffer,
+                              unsigned int frames);
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Solve a few issues of the XAudio2 sink when pausing/stopping playback.

Drain:
- wait for the buffered data to be played, as expected by AE, instead of flushing
- fix the voice statistics reset for correct delay reporting to AE when playback resumes
- fix the queued frames count after Drain

Deinitialize (sink destruction):
- wait for buffer callbacks before destroying the voice to avoid memory leak

PR submitted before adding XAudio2 for Windows desktop, because that will makes lots of changes to the sink and backporting will be more complicated then, and the port to Windows desktop will not be backported.

The issues of Drain() come in part from a difference between the MS doc and the actual behavior of XAudio2.
The voice statistic PlayedSamples is not reset after Stop + FlushSourceBuffers but still contains the number of samples played since the beginning of playback.
It is later compared with the count of samples submitted to the sink since playback resume and looks like a huge delay to AE, resulting in no sound.
m_framesInBuffer is also not reset properly because of the buffers callback executed async after Drain() was finished. This often causes another error in the wait for an empty buffer, which gets the sink recreated and masks the delay issue.
See https://stackoverflow.com/questions/65754955/how-to-reset-a-ixaudio2sourcevoices-samplesplayed-counter-after-flushing-sour for a confirmation and workaround ideas.

The solution used here is to submit a buffer of 1 frame with the end of stream flag. The statistics are correctly reset after playing that buffer, and waiting for the buffers to play makes the m_framesInBuffers reset work correctly.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The problem with Drain() was noticed while testing PR #25068 to enable XAudio2 for Windows desktop.
Sometimes there was no sound after pausing and resuming playback.

Troubleshooting revealed that the issue happened when Drain() was called for the sink but not Deinitialize before playback resumes.
Happens for example 1 minute after pausing with "Keep audio device alive" set to 1 minute. Waiting much longer than 1 min caused the sink to be recreated, masking the problem.
Most of the time even with 1 minute pause the sink automatically recovers, making this difficult to track.

Then examined the Deinitialize function, added logging to the buffer callbacks and noticed nothing in the log when the voices are destroyed without waiting for the callbacks. That likely caused a memory leak.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran several weeks on Windows 10 and 8 x64 build combined with PR #25068 that enables XAudio2 playback on Windows desktop version. Made sure to exercise the problematic case of the 1 minute pause many times.
Tried the same desktop build a couple times on Windows 11 to confirm that the bug happens too and is fixed by the PR.

Tested with UWP build of Kodi on Windows 10.


Xbox testing is needed. Normal playback, but also pause, wait 1 minute and a few seconds, resume (with  "Keep audio device alive" set to 1 min)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

No unexpected audio drop.

## Screenshots (if appropriate):

Logs with additional logging code in sink AddPackets, Drain,  CActiveAE::RunStages()

Before, 1 minute pause and sink doesn't recover:
```
2024-08-25 16:03:38.600 T:16632   debug <general>: Keyboard: scancode: 0x39, sym: 0x20 (space), unicode: 0x20, modifier: 0x0
2024-08-25 16:03:38.601 T:16632   debug <general>: CInputManager::HandleKey: space (0xf020) pressed, window 12005, action is Pause
2024-08-25 16:03:38.644 T:31948   debug <general>: CDVDAudio::Pause - pausing audio stream
... 1 minute wait irrelevant lines removed ...
2024-08-25 16:04:38.684 T:17112   debug <general>: CAESinkXAudio::GetDelay: m_sinkFrames: 3261120 m_sampleRate: 48000 xaudio2_voice_state pCurrentBufferContext: 0x19b8aa116c0 BuffersQueued: 1 SamplesPlayed: 3260160
> Drain() function called
2024-08-25 16:04:38.684 T:17112   debug <general>: CAESinkXAudio::Drain: before wait for drain - xaudio2_voice_state pCurrentBufferContext: 0x19b8aa116c0 BuffersQueued: 1 SamplesPlayed: 3260160
2024-08-25 16:04:38.684 T:17112   debug <general>: CAESinkXAudio::Drain
2024-08-25 16:04:38.694 T:11484   debug <general>: CAESinkXAudio::buffer_ctx::~buffer_ctx: freeing buffer ctx while draining
> resume playback
2024-08-25 16:04:48.657 T:16632   debug <general>: Keyboard: scancode: 0x39, sym: 0x20 (space), unicode: 0x20, modifier: 0x0
2024-08-25 16:04:48.657 T:16632   debug <general>: CInputManager::HandleKey: space (0xf020) pressed, window 12005, action is Pause
2024-08-25 16:04:48.664 T:31948   debug <general>: CDVDAudio::Resume - resume audio stream
2024-08-25 16:04:48.664 T:34332   debug <general>: ActiveAE - start sync of audio stream
2024-08-25 16:04:48.665 T:17112   debug <general>: CAESinkXAudio::AddPackets: was not running - stop, prime with buffer, start. m_sinkFrames: 0 m_framesInBuffer: 64576 xaudio2_voice_state pCurrentBufferContext: 0x0 BuffersQueued: 0 SamplesPlayed: 3260160
> incorrect m_framesInBuffer, should be 0 and SamplesPlayed, should be 0
2024-08-25 16:04:48.665 T:17112   debug <general>: CAESinkXAudio::AddPackets: was not running - after start. m_sinkFrames: 960 m_framesInBuffer: 0 xaudio2_voice_state pCurrentBufferContext: 0x19b8aa10f40 BuffersQueued: 1 SamplesPlayed: 3260160
2024-08-25 16:04:48.665 T:34332 warning <general>: ActiveAE - large audio sync error: -384307168202214208.000000 - delay: 384307168202214528.000000 - pts: 8019.000000 - playingPts: -384307168202206528.000000
... more large audio sync error messages ...
2024-08-25 16:04:48.667 T:34332 warning <general>: ActiveAE - large audio sync error: -384307168202214144.000000 - delay: 384307168202214656.000000 - pts: 8199.000000 - playingPts: -384307168202206464.000000
2024-08-25 16:04:48.684 T:17112   debug <general>: CAESinkXAudio::GetDelay: m_sinkFrames: 3840 m_sampleRate: 48000 xaudio2_voice_state pCurrentBufferContext: 0x19b8aa11360 BuffersQueued: 3 SamplesPlayed: 3261120
... large audio sync errors continue until playback stop ...
```

Before, 1 minute pause and the sink recovers due to second bug:
```
2024-08-25 15:55:09.177 T:16632   debug <general>: CInputManager::HandleKey: space (0xf020) pressed, window 12005, action is Pause
2024-08-25 15:55:09.193 T:14280   debug <general>: CDVDAudio::Pause - pausing audio stream
... 1 minute wait irrelevant lines removed ...
2024-08-25 15:56:09.233 T:17112   debug <general>: CAESinkXAudio::GetDelay: m_sinkFrames: 3055680 m_sampleRate: 48000 xaudio2_voice_state pCurrentBufferContext: 0x19b8aa118a0 BuffersQueued: 2 SamplesPlayed: 3053760
> Drain() function called
2024-08-25 15:56:09.233 T:17112   debug <general>: CAESinkXAudio::Drain: before wait for drain - xaudio2_voice_state pCurrentBufferContext: 0x19b8aa118a0 BuffersQueued: 2 SamplesPlayed: 3053760
2024-08-25 15:56:09.242 T:35180   debug <general>: CAESinkXAudio::buffer_ctx::~buffer_ctx: freeing buffer ctx while draining
2024-08-25 15:56:09.243 T:35180   debug <general>: CAESinkXAudio::buffer_ctx::~buffer_ctx: freeing buffer ctx while draining
> resume playback
2024-08-25 15:56:13.026 T:16632   debug <general>: Keyboard: scancode: 0x39, sym: 0x20 (space), unicode: 0x20, modifier: 0x0
2024-08-25 15:56:13.994 T:16632   debug <general>: CInputManager::HandleKey: space (0xf020) pressed, window 12005, action is Pause
2024-08-25 15:56:14.003 T:14280   debug <general>: CDVDAudio::Resume - resume audio stream
2024-08-25 15:56:14.003 T:17112   debug <general>: CAESinkXAudio::AddPackets: adding packets while draining. running false frames 960 m_sinkFrames 0 m_framesInBuffer 63616
2024-08-25 15:56:14.003 T:34332   debug <general>: ActiveAE - start sync of audio stream
2024-08-25 15:56:14.003 T:17112   debug <general>: CAESinkXAudio::AddPackets: was not running - stop, prime with buffer, start. m_sinkFrames: 0 m_framesInBuffer: 63616 xaudio2_voice_state pCurrentBufferContext: 0x0 BuffersQueued: 0 SamplesPlayed: 3053760
2024-08-25 15:56:14.004 T:17112   debug <general>: CAESinkXAudio::AddPackets: was not running - after start. m_sinkFrames: 960 m_framesInBuffer: 64576 xaudio2_voice_state pCurrentBufferContext: 0x19b8aa11ea0 BuffersQueued: 1 SamplesPlayed: 3053760
2024-08-25 15:56:14.004 T:34332 warning <general>: ActiveAE - large audio sync error: -384307168202218368.000000 - delay: 384307168202218688.000000 - pts: 3700.000000 - playingPts: -384307168202214976.000000
... more large audio sync errors ...
2024-08-25 15:56:14.006 T:34332 warning <general>: ActiveAE - large audio sync error: -384307168202218368.000000 - 
delay: 384307168202218880.000000 - pts: 3879.000000 - playingPts: -384307168202214976.000000
> second bug eventually kills the sink and it is recreated
2024-08-25 15:56:15.123 T:17112   error <general>: CAESinkXAudio::AddPackets: voice buffer timed out
2024-08-25 15:56:15.123 T:17112   error <general>: CActiveAESink::OutputSamples - sink returned error
2024-08-25 15:56:15.123 T:17112   debug <general>: CAESinkXAudio::Deinitialize: destroying the sink
> the sink is recreated, audio works again and the error is masked
```

Log after:
```
2024-08-25 15:18:01.669 T:11840   debug <general>: CInputManager::HandleKey: space (0xf020) pressed, window 12005, action is Pause
2024-08-25 15:18:01.688 T:15572   debug <general>: CDVDAudio::Pause - pausing audio stream
... 1 minute wait irrelevant lines removed ...
2024-08-25 15:19:01.708 T:14136   debug <general>: CAESinkXAudio::GetDelay: m_sinkFrames: 2942400 m_sampleRate: 48000 xaudio2_voice_state pCurrentBufferContext: 0x2069fb4bf20 BuffersQueued: 2 SamplesPlayed: 2940480
> Drain() function called
2024-08-25 15:19:01.708 T:14136   debug <general>: CAESinkXAudio::Drain: before wait for drain - xaudio2_voice_state pCurrentBufferContext: 0x2069fb4bf20 BuffersQueued: 2 SamplesPlayed: 2940480
2024-08-25 15:19:01.728 T:13404   debug <general>: CAESinkXAudio::buffer_ctx::~buffer_ctx: freeing buffer ctx while draining
2024-08-25 15:19:01.747 T:13404   debug <general>: CAESinkXAudio::buffer_ctx::~buffer_ctx: freeing buffer ctx while draining
2024-08-25 15:19:01.758 T:13404   debug <general>: CAESinkXAudio::buffer_ctx::~buffer_ctx: freeing buffer ctx while draining
2024-08-25 15:19:01.758 T:13404   debug <general>: CAESinkXAudio::VoiceCallback::OnStreamEnd: on stream end
2024-08-25 15:19:07.091 T:11840   debug <general>: Keyboard: scancode: 0x39, sym: 0x20 (space), unicode: 0x20, modifier: 0x0
2024-08-25 15:19:07.093 T:11840   debug <general>: CInputManager::HandleKey: space (0xf020) pressed, window 12005, action is Pause
2024-08-25 15:19:07.104 T:15572   debug <general>: CDVDAudio::Resume - resume audio stream
> AddPackets() to resume playback
2024-08-25 15:19:07.105 T:14136   debug <general>: CAESinkXAudio::AddPackets: was not running - stop, prime with buffer, start. m_sinkFrames: 0 m_framesInBuffer: 0 xaudio2_voice_state pCurrentBufferContext: 0x0 BuffersQueued: 0 SamplesPlayed: 0
2024-08-25 15:19:07.105 T:14136   debug <general>: CAESinkXAudio::AddPackets: was not running - after start. m_sinkFrames: 960 m_framesInBuffer: 960 xaudio2_voice_state pCurrentBufferContext: 0x2069fb4bbc0 BuffersQueued: 1 SamplesPlayed: 0
2024-08-25 15:19:07.105 T:13056   debug <general>: ActiveAE - start sync of audio stream
2024-08-25 15:19:07.218 T:13056   debug <general>: ActiveAE::SyncStream - average error of 222.588531, start adjusting
2024-08-25 15:19:07.439 T:13056   debug <general>: ActiveAE::SyncStream - average error 25.388575 below threshold of 30.000000
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
