### PR TITLE
[uwp][build] Restore ability to run UWP builds on Windows 10

### DIFF
--- a/cmake/scripts/windows/ArchSetup.cmake
+++ b/cmake/scripts/windows/ArchSetup.cmake
@@ -1,9 +1,9 @@
-# Minimum SDK version we support
-set(VS_MINIMUM_SDK_VERSION 10.0.22621.0)
+# Minimum SDK version required to build
+set(VS_MINIMUM_BUILD_SDK_VERSION 10.0.22621.0)
 
-if(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION VERSION_LESS VS_MINIMUM_SDK_VERSION)
+if(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION VERSION_LESS VS_MINIMUM_BUILD_SDK_VERSION)
   message(FATAL_ERROR "Detected Windows SDK version is ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}.\n"
-    "Windows SDK ${VS_MINIMUM_SDK_VERSION} or higher is required.\n"
+    "Windows SDK ${VS_MINIMUM_BUILD_SDK_VERSION} or higher is required.\n"
     "INFO: Windows SDKs can be installed from the Visual Studio installer.")
 endif()
 

--- a/cmake/scripts/windowsstore/ArchSetup.cmake
+++ b/cmake/scripts/windowsstore/ArchSetup.cmake
@@ -1,9 +1,11 @@
-# Minimum SDK version we support
-set(VS_MINIMUM_SDK_VERSION 10.0.22621.0)
+# Minimum SDK version required to build
+set(VS_MINIMUM_BUILD_SDK_VERSION 10.0.22621.0)
+# Minimum OS version to run the app
+set(VS_MINIMUM_SDK_VERSION 10.0.18362.0)
 
-if(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION VERSION_LESS VS_MINIMUM_SDK_VERSION)
+if(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION VERSION_LESS VS_MINIMUM_BUILD_SDK_VERSION)
   message(FATAL_ERROR "Detected Windows SDK version is ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}.\n"
-    "Windows SDK ${VS_MINIMUM_SDK_VERSION} or higher is required.\n"
+    "Windows SDK ${VS_MINIMUM_BUILD_SDK_VERSION} or higher is required.\n"
     "INFO: Windows SDKs can be installed from the Visual Studio installer.")
 endif()
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Rework part of PR #24689, which bumped Windows SDK requirement to 11.0.22621.0

At the same time, due to the way variables are propagated and used in cmake, it bumped the minimum OS version required to run the app to Windows 11 22H2. A system error is raised when attempting to run with Windows 10.

Solution: separate variables for the minimum OS needed to run the app and the minimum SDK required to build the app.

notes
- Change applied to both Windows desktop and UWP builds to keep the files similar, though it is only needed for UWP and could be removed for Windows desktop.
- Min OS to run the app could be bumped from 18362 (Windows 10 19H1) to 19041 (Windows 10 22H2, the final version so far). The matching SDK doesn't have to be installed on the build computer.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Unable to run UWP builds on Windows 10 due to insufficient OS version.
Used to run correctly before PR #24689, and the new SDK code is not needed on UWP.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Build and ran on Windows 10 with 22621 and 18632 sdk installed.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

None for regular users, the UWP builds are not published. Helps with development of UWP without Xbox.

## Screenshots (if appropriate):
Before:
![image](https://github.com/user-attachments/assets/d75f2ef4-9cf6-4c27-ad2d-eb49a9e5a09d)

![image](https://github.com/user-attachments/assets/9b316369-b9c1-4b5b-b14e-48ae156f3516)

After:
![image](https://github.com/user-attachments/assets/c2d67621-8dc1-4e67-b3f7-8538381bb6cb)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
