### PR TITLE
[PVR] Cleanup: Get rid of magic numbers for client ID

### DIFF
--- a/xbmc/pvr/CMakeLists.txt
+++ b/xbmc/pvr/CMakeLists.txt
@@ -19,6 +19,7 @@ set(HEADERS IPVRComponent.h
             PVRChannelGroupImageFileLoader.h
             PVRChannelNumberInputHandler.h
             PVRComponentRegistration.h
+            PVRConstants.h
             PVRContextMenus.h
             PVRDatabase.h
             PVRDescrambleInfo.h

--- a/xbmc/pvr/PVRConstants.h
+++ b/xbmc/pvr/PVRConstants.h
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+namespace PVR
+{
+/*!
+ * @brief Denotes an invalid PVR client UID.
+ */
+static constexpr int PVR_CLIENT_INVALID_UID{-1};
+
+} // namespace PVR

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -13,6 +13,7 @@
 #include "addons/addoninfo/AddonInfo.h"
 #include "addons/addoninfo/AddonType.h"
 #include "dbwrappers/dataset.h"
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "pvr/addons/PVRClient.h"
 #include "pvr/addons/PVRClientUID.h"
 #include "pvr/channels/PVRChannel.h"
@@ -410,7 +411,7 @@ bool CPVRDatabase::DeleteClients()
 
 bool CPVRDatabase::Persist(const CPVRClient& client)
 {
-  if (client.GetID() == PVR_INVALID_CLIENT_ID)
+  if (client.GetID() == PVR_CLIENT_INVALID_UID)
     return false;
 
   CLog::LogFC(LOGDEBUG, LOGPVR, "Persisting client {} to database", client.GetID());
@@ -432,7 +433,7 @@ bool CPVRDatabase::Persist(const CPVRClient& client)
 
 bool CPVRDatabase::Delete(const CPVRClient& client)
 {
-  if (client.GetID() == PVR_INVALID_CLIENT_ID)
+  if (client.GetID() == PVR_CLIENT_INVALID_UID)
     return false;
 
   CLog::LogFC(LOGDEBUG, LOGPVR, "Deleting client {} from the database", client.GetID());
@@ -447,7 +448,7 @@ bool CPVRDatabase::Delete(const CPVRClient& client)
 
 int CPVRDatabase::GetPriority(const CPVRClient& client) const
 {
-  if (client.GetID() == PVR_INVALID_CLIENT_ID)
+  if (client.GetID() == PVR_CLIENT_INVALID_UID)
     return 0;
 
   CLog::LogFC(LOGDEBUG, LOGPVR, "Getting priority for client {} from the database", client.GetID());
@@ -465,7 +466,7 @@ int CPVRDatabase::GetPriority(const CPVRClient& client) const
 
 CDateTime CPVRDatabase::GetDateTimeFirstChannelsAdded(const CPVRClient& client) const
 {
-  if (client.GetID() == PVR_INVALID_CLIENT_ID)
+  if (client.GetID() == PVR_CLIENT_INVALID_UID)
     return {};
 
   CLog::LogFC(LOGDEBUG, LOGPVR,

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -115,7 +115,7 @@ namespace PVR
      * @brief Get the numeric client ID for given addon ID and instance ID from the database.
      * @param addonID The addon ID.
      * @param instanceID The instance ID.
-     * @return The client ID on success, -1 otherwise.
+     * @return The client ID on success, PVR_CLIENT_INVALID_UID otherwise.
      */
     int GetClientID(const std::string& addonID, unsigned int instanceID);
 

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -14,6 +14,7 @@
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "pvr/PVRComponentRegistration.h"
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "pvr/PVRDatabase.h"
 #include "pvr/PVRPlaybackState.h"
 #include "pvr/addons/PVRClient.h"
@@ -281,7 +282,7 @@ std::shared_ptr<CPVRClients> CPVRManager::Clients() const
 
 std::shared_ptr<CPVRClient> CPVRManager::GetClient(const CFileItem& item) const
 {
-  int iClientID = PVR_INVALID_CLIENT_ID;
+  int iClientID = PVR_CLIENT_INVALID_UID;
 
   if (item.HasPVRChannelInfoTag())
     iClientID = item.GetPVRChannelInfoTag()->ClientID();

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -69,7 +69,7 @@ void CPVRPlaybackState::ReInit()
 
   Clear();
 
-  if (m_playingClientId != -1)
+  if (m_playingClientId != PVR_CLIENT_INVALID_UID)
   {
     if (m_playingChannelUniqueId != -1)
     {
@@ -123,7 +123,7 @@ void CPVRPlaybackState::ClearData()
   m_strPlayingRecordingUniqueId.clear();
   m_playingEpgTagChannelUniqueId = -1;
   m_playingEpgTagUniqueId = 0;
-  m_playingClientId = -1;
+  m_playingClientId = PVR_CLIENT_INVALID_UID;
   m_strPlayingClientName.clear();
 }
 
@@ -217,7 +217,7 @@ void CPVRPlaybackState::OnPlaybackStarted(const CFileItem& item)
     CLog::LogFC(LOGERROR, LOGPVR, "Channel item without channel group member!");
   }
 
-  if (m_playingClientId != -1)
+  if (m_playingClientId != PVR_CLIENT_INVALID_UID)
   {
     const std::shared_ptr<const CPVRClient> client =
         CServiceBroker::GetPVRManager().GetClient(m_playingClientId);

--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "threads/CriticalSection.h"
 #include "utils/ContentUtils.h"
 
@@ -181,7 +182,7 @@ public:
 
   /*!
    * @brief Get the ID of the playing client, if there is one.
-   * @return The ID or -1 if no client is playing.
+   * @return The ID or PVR_CLIENT_INVALID_UID if no client is playing.
    */
   int GetPlayingClientID() const;
 
@@ -289,7 +290,7 @@ private:
   std::shared_ptr<CPVRChannelGroupMember> m_previousToLastPlayedChannelRadio;
   std::string m_strPlayingClientName;
   int m_playingGroupId = -1;
-  int m_playingClientId = -1;
+  int m_playingClientId = PVR_CLIENT_INVALID_UID;
   int m_playingChannelUniqueId = -1;
   std::string m_strPlayingRecordingUniqueId;
   int m_playingEpgTagChannelUniqueId = -1;

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -18,6 +18,7 @@
 #include "events/NotificationEvent.h"
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/LocalizeStrings.h"
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "pvr/PVRDatabase.h"
 #include "pvr/PVRDescrambleInfo.h"
 #include "pvr/PVRManager.h"
@@ -1999,7 +2000,7 @@ void CPVRClient::SetPriority(int iPriority)
   if (m_priority != iPriority)
   {
     m_priority = iPriority;
-    if (m_iClientId > PVR_INVALID_CLIENT_ID)
+    if (m_iClientId != PVR_CLIENT_INVALID_UID)
     {
       CServiceBroker::GetPVRManager().GetTVDatabase()->Persist(*this);
     }
@@ -2010,7 +2011,7 @@ void CPVRClient::SetPriority(int iPriority)
 int CPVRClient::GetPriority() const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
-  if (!m_priority.has_value() && m_iClientId > PVR_INVALID_CLIENT_ID)
+  if (!m_priority.has_value() && m_iClientId != PVR_CLIENT_INVALID_UID)
   {
     m_priority = CServiceBroker::GetPVRManager().GetTVDatabase()->GetPriority(*this);
   }
@@ -2020,7 +2021,7 @@ int CPVRClient::GetPriority() const
 const CDateTime& CPVRClient::GetDateTimeFirstChannelsAdded() const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
-  if (!m_firstChannelsAdded.has_value() && m_iClientId > PVR_INVALID_CLIENT_ID)
+  if (!m_firstChannelsAdded.has_value() && m_iClientId != PVR_CLIENT_INVALID_UID)
   {
     m_firstChannelsAdded =
         CServiceBroker::GetPVRManager().GetTVDatabase()->GetDateTimeFirstChannelsAdded(*this);
@@ -2034,7 +2035,7 @@ void CPVRClient::SetDateTimeFirstChannelsAdded(const CDateTime& dateTime)
   if (m_firstChannelsAdded != dateTime)
   {
     m_firstChannelsAdded = dateTime;
-    if (m_iClientId > PVR_INVALID_CLIENT_ID)
+    if (m_iClientId != PVR_CLIENT_INVALID_UID)
     {
       CServiceBroker::GetPVRManager().GetTVDatabase()->Persist(*this);
     }

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -50,9 +50,6 @@ class CPVRTimerInfoTag;
 class CPVRTimerType;
 class CPVRTimersContainer;
 
-static constexpr int PVR_ANY_CLIENT_ID = -1;
-static constexpr int PVR_INVALID_CLIENT_ID = -2;
-
 /*!
  * Interface from Kodi to a PVR add-on.
  *

--- a/xbmc/pvr/addons/PVRClientUID.cpp
+++ b/xbmc/pvr/addons/PVRClientUID.cpp
@@ -8,6 +8,7 @@
 
 #include "PVRClientUID.h"
 
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "pvr/PVRDatabase.h"
 #include "utils/log.h"
 
@@ -40,14 +41,14 @@ int CPVRClientUID::GetUID() const
       if (!db.Open())
       {
         CLog::LogF(LOGERROR, "Unable to open TV database!");
-        return -1;
+        return PVR_CLIENT_INVALID_UID;
       }
 
       m_uid = db.GetClientID(m_addonID, m_instanceID);
-      if (m_uid == -1)
+      if (m_uid == PVR_CLIENT_INVALID_UID)
       {
         CLog::LogF(LOGERROR, "Unable to get client id from TV database!");
-        return -1;
+        return PVR_CLIENT_INVALID_UID;
       }
 
       s_idMap.insert({{m_addonID, m_instanceID}, m_uid});

--- a/xbmc/pvr/addons/PVRClientUID.h
+++ b/xbmc/pvr/addons/PVRClientUID.h
@@ -26,7 +26,7 @@ public:
 
   /*!
    * @brief Return the numeric UID.
-   * @return The numeric UID.
+   * @return The numeric UID, or PVR_CLIENT_INVALID_UID on error.
    */
   int GetUID() const;
 

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -15,6 +15,7 @@
 #include "addons/addoninfo/AddonType.h"
 #include "guilib/LocalizeStrings.h"
 #include "messaging/ApplicationMessenger.h"
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "pvr/PVREventLogJob.h"
 #include "pvr/PVRManager.h"
 #include "pvr/PVRPlaybackState.h"
@@ -290,7 +291,7 @@ void CPVRClients::OnAddonEvent(const AddonEvent& event)
 
 std::shared_ptr<CPVRClient> CPVRClients::GetClient(int clientId) const
 {
-  if (clientId <= PVR_INVALID_CLIENT_ID)
+  if (clientId == PVR_CLIENT_INVALID_UID)
     return {};
 
   std::unique_lock<CCriticalSection> lock(m_critSection);

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -394,7 +394,7 @@ int CPVRClients::GetFirstCreatedClientID() const
   std::unique_lock<CCriticalSection> lock(m_critSection);
   const auto it = std::find_if(m_clientMap.cbegin(), m_clientMap.cend(),
                                [](const auto& client) { return client.second->ReadyToUse(); });
-  return it != m_clientMap.cend() ? (*it).second->GetID() : -1;
+  return it != m_clientMap.cend() ? (*it).second->GetID() : PVR_CLIENT_INVALID_UID;
 }
 
 PVR_ERROR CPVRClients::GetCallableClients(CPVRClientMap& clientsReady,

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -148,7 +148,7 @@ struct SBackend
 
     /*!
      * @brief Get the ID of the first created client.
-     * @return the ID or -1 if no clients are created;
+     * @return the ID or PVR_CLIENT_INVALID_UID if no clients are created;
      */
     int GetFirstCreatedClientID() const;
 

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -12,6 +12,7 @@
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_channels.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_providers.h"
 #include "pvr/PVRCachedImage.h"
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "pvr/channels/PVRChannelNumber.h"
 #include "threads/CriticalSection.h"
 #include "utils/ISerializable.h"
@@ -544,7 +545,8 @@ private:
    */
   //@{
   int m_iUniqueId = -1; /*!< the unique identifier for this channel */
-  int m_iClientId = -1; /*!< the identifier of the client that serves this channel */
+  int m_iClientId =
+      PVR_CLIENT_INVALID_UID; /*!< the identifier of the client that serves this channel */
   CPVRChannelNumber m_clientChannelNumber; /*!< the channel number on the client */
   std::string m_strClientChannelName; /*!< the name of this channel on the client */
   std::string

--- a/xbmc/pvr/channels/PVRChannelGroupMember.h
+++ b/xbmc/pvr/channels/PVRChannelGroupMember.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "pvr/channels/PVRChannelNumber.h"
 #include "utils/ISerializable.h"
 #include "utils/ISortable.h"
@@ -79,8 +80,8 @@ public:
 
 private:
   int m_iGroupID = -1;
-  int m_iGroupClientID = -1;
-  int m_iChannelClientID = -1;
+  int m_iGroupClientID = PVR_CLIENT_INVALID_UID;
+  int m_iChannelClientID = PVR_CLIENT_INVALID_UID;
   int m_iChannelUID = -1;
   int m_iChannelDatabaseID = -1;
   bool m_bIsRadio = false;

--- a/xbmc/pvr/channels/PVRChannelsPath.cpp
+++ b/xbmc/pvr/channels/PVRChannelsPath.cpp
@@ -66,7 +66,7 @@ CPVRChannelsPath::CPVRChannelsPath(const std::string& strPath)
         {
           m_kind = Kind::GROUP; // pvr://channels/(tv|radio)/<all-channels-wildcard>@-1
           m_groupName = segment;
-          m_groupClientID = -1; // local
+          m_groupClientID = PVR_CLIENT_INVALID_UID; // local
           break;
         }
 
@@ -79,7 +79,7 @@ CPVRChannelsPath::CPVRChannelsPath(const std::string& strPath)
           if (groupClientID.find_first_not_of("-0123456789") == std::string::npos)
           {
             m_groupClientID = std::atoi(groupClientID.c_str());
-            if (m_groupClientID >= -1)
+            if (m_groupClientID >= PVR_CLIENT_INVALID_UID)
             {
               m_kind = Kind::GROUP; // pvr://channels/(tv|radio)/<groupname>@<clientid>
               break;
@@ -195,7 +195,8 @@ CPVRChannelsPath::CPVRChannelsPath(bool bRadio,
                                    int iChannelUID)
   : m_bRadio(bRadio)
 {
-  if (!strGroupName.empty() && iGroupClientID >= -1 && !strAddonID.empty() && iChannelUID >= 0)
+  if (!strGroupName.empty() && iGroupClientID >= PVR_CLIENT_INVALID_UID && !strAddonID.empty() &&
+      iChannelUID >= 0)
   {
     m_kind = Kind::CHANNEL;
     m_groupName = strGroupName;

--- a/xbmc/pvr/channels/PVRChannelsPath.h
+++ b/xbmc/pvr/channels/PVRChannelsPath.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "addons/IAddon.h"
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 
 class CDateTime;
 
@@ -71,7 +72,7 @@ namespace PVR
     bool m_bRadio = false;;
     std::string m_path;
     std::string m_groupName;
-    int m_groupClientID{-1};
+    int m_groupClientID{PVR_CLIENT_INVALID_UID};
     std::string m_addonID;
     ADDON::AddonInstanceId m_instanceID{ADDON::ADDON_SINGLETON_INSTANCE_ID};
     int m_iChannelUID = -1;

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -297,7 +297,8 @@ void CGUIDialogPVRGuideSearch::UpdateSearchFilter()
   m_searchFilter->SetMaximumDuration(GetSpinValue(CONTROL_SPIN_MAX_DURATION));
 
   auto it = m_channelsMap.find(GetSpinValue(CONTROL_SPIN_CHANNELS));
-  m_searchFilter->SetClientID(it == m_channelsMap.end() ? -1 : (*it).second->ChannelClientID());
+  m_searchFilter->SetClientID(it == m_channelsMap.end() ? PVR_CLIENT_INVALID_UID
+                                                        : (*it).second->ChannelClientID());
   m_searchFilter->SetChannelUID(it == m_channelsMap.end() ? -1 : (*it).second->ChannelUID());
   m_searchFilter->SetChannelGroupID(GetSpinValue(CONTROL_SPIN_GROUPS));
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -13,6 +13,7 @@
 #include "guilib/GUIMessage.h"
 #include "guilib/LocalizeStrings.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClient.h"
 #include "pvr/addons/PVRClients.h"
@@ -888,9 +889,10 @@ void CGUIDialogPVRTimerSettings::InitializeChannelsList()
   // and for reminder rules another one representing any channel from any client.
   const CPVRClientMap clients = CServiceBroker::GetPVRManager().Clients()->GetCreatedClients();
   if (clients.size() > 1)
-    m_channelEntries.insert({index++, ChannelDescriptor(PVR_CHANNEL_INVALID_UID, PVR_ANY_CLIENT_ID,
-                                                        // Any channel from any client
-                                                        g_localizeStrings.Get(854))});
+    m_channelEntries.insert(
+        {index++, ChannelDescriptor(PVR_CHANNEL_INVALID_UID, PVR_CLIENT_INVALID_UID,
+                                    // Any channel from any client
+                                    g_localizeStrings.Get(854))});
 
   for (const auto& client : clients)
   {
@@ -977,7 +979,7 @@ void CGUIDialogPVRTimerSettings::ChannelsFiller(const SettingConstPtr& setting,
     for (const auto& channelEntry : pThis->m_channelEntries)
     {
       // Only include channels for the currently selected timer type or all channels if type is client-independent.
-      if (pThis->m_timerType->GetClientId() == PVR_ANY_CLIENT_ID || // client-independent
+      if (pThis->m_timerType->GetClientId() == PVR_CLIENT_INVALID_UID || // client-independent
           pThis->m_timerType->GetClientId() == channelEntry.second.clientId)
       {
         // Do not add "any channel" entry if not supported by selected timer type.
@@ -987,7 +989,7 @@ void CGUIDialogPVRTimerSettings::ChannelsFiller(const SettingConstPtr& setting,
 
         // Do not add "any channel from any client" entry for reminder rules.
         if (channelEntry.second.channelUid == PVR_CHANNEL_INVALID_UID &&
-            channelEntry.second.clientId == PVR_ANY_CLIENT_ID &&
+            channelEntry.second.clientId == PVR_CLIENT_INVALID_UID &&
             !pThis->m_timerType->IsReminder() && !pThis->m_timerType->IsTimerRule())
           continue;
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
@@ -10,6 +10,7 @@
 
 #include "XBDateTime.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_channels.h" // PVR_CHANNEL_INVALID_UID
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "settings/SettingConditions.h"
 #include "settings/dialogs/GUIDialogSettingsManualBase.h"
 #include "settings/lib/SettingDependency.h"
@@ -148,7 +149,7 @@ private:
     std::string description;
 
     ChannelDescriptor(int _channelUid = PVR_CHANNEL_INVALID_UID,
-                      int _clientId = -1,
+                      int _clientId = PVR_CLIENT_INVALID_UID,
                       const std::string& _description = "")
       : channelUid(_channelUid), clientId(_clientId), description(_description)
     {

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -533,7 +533,8 @@ bool CPVREpg::IsValid() const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   if (ScraperName() == "client")
-    return m_channelData->ClientId() != -1 && m_channelData->UniqueClientChannelId() != PVR_CHANNEL_INVALID_UID;
+    return m_channelData->ClientId() != PVR_CLIENT_INVALID_UID &&
+           m_channelData->UniqueClientChannelId() != PVR_CHANNEL_INVALID_UID;
 
   return true;
 }

--- a/xbmc/pvr/epg/EpgChannelData.h
+++ b/xbmc/pvr/epg/EpgChannelData.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
+
 #include <ctime>
 #include <string>
 
@@ -46,7 +48,7 @@ public:
 
 private:
   const bool m_bIsRadio = false;
-  const int m_iClientId = -1;
+  const int m_iClientId = PVR_CLIENT_INVALID_UID;
   const int m_iUniqueClientChannelId = -1;
 
   bool m_bIsHidden = false;

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -40,7 +40,7 @@ namespace PVR
 class CEpgUpdateRequest
 {
 public:
-  CEpgUpdateRequest() : CEpgUpdateRequest(-1, PVR_CHANNEL_INVALID_UID) {}
+  CEpgUpdateRequest() : CEpgUpdateRequest(PVR_CLIENT_INVALID_UID, PVR_CHANNEL_INVALID_UID) {}
   CEpgUpdateRequest(int iClientID, int iUniqueChannelID) : m_iClientID(iClientID), m_iUniqueChannelID(iUniqueChannelID) {}
 
   void Deliver(const std::shared_ptr<CPVREpg>& epg);

--- a/xbmc/pvr/epg/EpgSearchFilter.cpp
+++ b/xbmc/pvr/epg/EpgSearchFilter.cpp
@@ -45,7 +45,7 @@ void CPVREpgSearchFilter::Reset()
   m_bRemoveDuplicates = false;
 
   /* pvr specific filters */
-  m_iClientID = -1;
+  m_iClientID = PVR_CLIENT_INVALID_UID;
   m_iChannelGroupID = -1;
   m_iChannelUID = -1;
   m_bFreeToAirOnly = false;
@@ -363,7 +363,7 @@ void CPVREpgSearchFilter::RemoveDuplicates(std::vector<std::shared_ptr<CPVREpgIn
 bool CPVREpgSearchFilter::MatchChannel(const std::shared_ptr<const CPVREpgInfoTag>& tag) const
 {
   return tag && (tag->IsRadio() == m_bIsRadio) &&
-         (m_iClientID == -1 || tag->ClientID() == m_iClientID) &&
+         (m_iClientID == PVR_CLIENT_INVALID_UID || tag->ClientID() == m_iClientID) &&
          (m_iChannelUID == -1 || tag->UniqueChannelID() == m_iChannelUID) &&
          CServiceBroker::GetPVRManager().Clients()->IsCreatedClient(tag->ClientID());
 }

--- a/xbmc/pvr/epg/EpgSearchFilter.h
+++ b/xbmc/pvr/epg/EpgSearchFilter.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "XBDateTime.h"
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "pvr/epg/EpgSearchData.h"
 
 #include <memory>
@@ -158,7 +159,7 @@ namespace PVR
 
     // PVR specific filters
     bool m_bIsRadio; /*!< True to filter radio channels only, false to tv only */
-    int m_iClientID = -1; /*!< The client id */
+    int m_iClientID = PVR_CLIENT_INVALID_UID; /*!< The client id */
     int m_iChannelGroupID{-1}; /*! The channel group id */
     int m_iChannelUID = -1; /*!< The channel uid */
     bool m_bFreeToAirOnly; /*!< Include free to air channels only */

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -14,6 +14,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "input/WindowTranslator.h"
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClient.h"
 #include "pvr/addons/PVRClients.h"
@@ -693,7 +694,7 @@ bool GetTimersSubDirectory(const CPVRTimersPath& path,
   for (const auto& timer : timers)
   {
     if ((timer->IsRadio() == bRadio) && timer->HasParent() &&
-        (iClientId == PVR_ANY_CLIENT_ID || timer->ClientID() == iClientId) &&
+        (iClientId == PVR_CLIENT_INVALID_UID || timer->ClientID() == iClientId) &&
         (timer->ParentClientIndex() == iParentId) && (!bHideDisabled || !timer->IsDisabled()))
     {
       item = std::make_shared<CFileItem>(timer);

--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
@@ -19,6 +19,7 @@
 #include "input/actions/ActionIDs.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "pvr/PVRItem.h"
 #include "pvr/PVRManager.h"
 #include "pvr/PVRPlaybackState.h"
@@ -233,7 +234,7 @@ bool CPVRGUIActionsChannels::HideChannel(const CFileItem& item) const
 
 bool CPVRGUIActionsChannels::StartChannelScan()
 {
-  return StartChannelScan(PVR_INVALID_CLIENT_ID);
+  return StartChannelScan(PVR_CLIENT_INVALID_UID);
 }
 
 bool CPVRGUIActionsChannels::StartChannelScan(int clientId)
@@ -246,7 +247,7 @@ bool CPVRGUIActionsChannels::StartChannelScan(int clientId)
       CServiceBroker::GetPVRManager().Clients()->GetClientsSupportingChannelScan();
   m_bChannelScanRunning = true;
 
-  if (clientId != PVR_INVALID_CLIENT_ID)
+  if (clientId != PVR_CLIENT_INVALID_UID)
   {
     const auto it =
         std::find_if(possibleScanClients.cbegin(), possibleScanClients.cend(),

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -252,7 +252,7 @@ void CPVRRecording::ToSortable(SortItem& sortable, Field field) const
 void CPVRRecording::Reset()
 {
   m_strRecordingId.clear();
-  m_iClientId = -1;
+  m_iClientId = PVR_CLIENT_INVALID_UID;
   m_strChannelName.clear();
   m_strDirectory.clear();
   m_iPriority = -1;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -529,7 +529,7 @@ std::string CPVRTimerInfoTag::GetWeekdaysString() const
 
 bool CPVRTimerInfoTag::IsOwnedByClient() const
 {
-  return m_timerType->GetClientId() > -1;
+  return m_timerType->GetClientId() > PVR_CLIENT_INVALID_UID;
 }
 
 bool CPVRTimerInfoTag::AddToClient() const

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -227,7 +227,7 @@ public:
 
   /*!
    * @brief The ID of the client for this timer.
-   * @return The client ID or -1  if this is a local timer.
+   * @return The client ID or PVR_CLIENT_INVALID_UID  if this is a local timer.
    */
   int ClientID() const { return m_iClientId; }
 

--- a/xbmc/pvr/timers/PVRTimerRuleMatcher.cpp
+++ b/xbmc/pvr/timers/PVRTimerRuleMatcher.cpp
@@ -10,7 +10,7 @@
 
 #include "XBDateTime.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_channels.h" // PVR_CHANNEL_INVALID_UID
-#include "pvr/addons/PVRClient.h" // PVR_ANY_CLIENT_ID
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "utils/RegExp.h"
@@ -92,7 +92,7 @@ bool CPVRTimerRuleMatcher::MatchChannel(const std::shared_ptr<const CPVREpgInfoT
 {
   if (m_timerRule->GetTimerType()->SupportsAnyChannel() &&
       m_timerRule->ClientChannelUID() == PVR_CHANNEL_INVALID_UID &&
-      (m_timerRule->ClientID() == PVR_ANY_CLIENT_ID ||
+      (m_timerRule->ClientID() == PVR_CLIENT_INVALID_UID ||
        m_timerRule->ClientID() == epgTag->ClientID()))
     return true; // matches any channel from any client / any channel from a certain client
 

--- a/xbmc/pvr/timers/PVRTimerType.cpp
+++ b/xbmc/pvr/timers/PVRTimerType.cpp
@@ -127,10 +127,10 @@ std::shared_ptr<CPVRTimerType> CPVRTimerType::CreateFromIds(unsigned int iTypeId
   if (it != types.cend())
     return (*it);
 
-  if (iClientId != -1)
+  if (iClientId != PVR_CLIENT_INVALID_UID)
   {
     // fallback. try to obtain local timer type.
-    std::shared_ptr<CPVRTimerType> type = CreateFromIds(iTypeId, -1);
+    std::shared_ptr<CPVRTimerType> type = CreateFromIds(iTypeId, PVR_CLIENT_INVALID_UID);
     if (type)
       return type;
   }
@@ -153,10 +153,11 @@ std::shared_ptr<CPVRTimerType> CPVRTimerType::CreateFromAttributes(uint64_t iMus
   if (it != types.cend())
     return (*it);
 
-  if (iClientId != -1)
+  if (iClientId != PVR_CLIENT_INVALID_UID)
   {
     // fallback. try to obtain local timer type.
-    std::shared_ptr<CPVRTimerType> type = CreateFromAttributes(iMustHaveAttr, iMustNotHaveAttr, -1);
+    std::shared_ptr<CPVRTimerType> type =
+        CreateFromAttributes(iMustHaveAttr, iMustNotHaveAttr, PVR_CLIENT_INVALID_UID);
     if (type)
       return type;
   }

--- a/xbmc/pvr/timers/PVRTimerType.h
+++ b/xbmc/pvr/timers/PVRTimerType.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_timers.h"
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 
 #include <memory>
 #include <string>
@@ -400,7 +401,7 @@ namespace PVR
     void InitPreventDuplicateEpisodesValues(const PVR_TIMER_TYPE& type);
     void InitRecordingGroupValues(const PVR_TIMER_TYPE& type);
 
-    int m_iClientId = -1;
+    int m_iClientId = PVR_CLIENT_INVALID_UID;
     unsigned int m_iTypeId;
     uint64_t m_iAttributes;
     std::string m_strDescription;

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -9,6 +9,7 @@
 #include "PVRTimers.h"
 
 #include "ServiceBroker.h"
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "pvr/PVRDatabase.h"
 #include "pvr/PVREventLogJob.h"
 #include "pvr/PVRManager.h"
@@ -1243,7 +1244,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetTimerRule(
         const auto it = std::find_if(tagsEntry.second.cbegin(), tagsEntry.second.cend(),
                                      [iClientId, iParentClientIndex](const auto& timersEntry)
                                      {
-                                       return (timersEntry->ClientID() == PVR_ANY_CLIENT_ID ||
+                                       return (timersEntry->ClientID() == PVR_CLIENT_INVALID_UID ||
                                                timersEntry->ClientID() == iClientId) &&
                                               timersEntry->ClientIndex() == iParentClientIndex;
                                      });

--- a/xbmc/pvr/timers/PVRTimersPath.cpp
+++ b/xbmc/pvr/timers/PVRTimersPath.cpp
@@ -8,6 +8,7 @@
 
 #include "PVRTimersPath.h"
 
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
@@ -69,7 +70,7 @@ bool CPVRTimersPath::Init(const std::string& strPath)
 
   if (!m_bValid || m_bRoot)
   {
-    m_iClientId = -1;
+    m_iClientId = PVR_CLIENT_INVALID_UID;
     m_iParentId = 0;
   }
   else

--- a/xbmc/pvr/timers/PVRTimersPath.h
+++ b/xbmc/pvr/timers/PVRTimersPath.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
+
 #include <string>
 
 namespace PVR
@@ -44,7 +46,7 @@ private:
   bool m_bRoot = false;
   bool m_bRadio = false;
   bool m_bTimerRules = false;
-  int m_iClientId = -1;
+  int m_iClientId = PVR_CLIENT_INVALID_UID;
   int m_iParentId = 0;
 };
 } // namespace PVR


### PR DESCRIPTION
Cleans up the mess we had with different constants, magic numbers for client ids. Now, we consequently use a constant `PVR_CLIENT_INVALID_UID`. Thanks @phunkyfish for the nudge in another PR.

Note there was (from ancient times) a define for invalid client id with a numerical value of -2. This is a value which only can get reality if a user manually patches the PVR database. Maybe this was different in former times, but today we can just remove this constant, which is what I did.

BTW: Same love could be applied to channel uid and other PVR uids, where we often don't use respective constants/defines. But this is for another PR.

Runtime-tested on macOS, latest Kodi master.

@phunkyfish please review.