### PR TITLE
[PVR] Cleanup: Factor out CPVRTimerType setting values into class CPVRIntSettingValues.

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -1091,8 +1091,8 @@ void CGUIDialogPVRTimerSettings::DupEpisodesFiller(const SettingConstPtr& settin
   {
     list.clear();
 
-    std::vector<std::pair<std::string, int>> values;
-    pThis->m_timerType->GetPreventDuplicateEpisodesValues(values);
+    const std::vector<SettingIntValue>& values{
+        pThis->m_timerType->GetPreventDuplicateEpisodesValues()};
     std::transform(values.cbegin(), values.cend(), std::back_inserter(list), [](const auto& value) {
       return IntegerSettingOption(value.first, value.second);
     });
@@ -1136,8 +1136,7 @@ void CGUIDialogPVRTimerSettings::PrioritiesFiller(const SettingConstPtr& setting
   {
     list.clear();
 
-    std::vector<std::pair<std::string, int>> values;
-    pThis->m_timerType->GetPriorityValues(values);
+    const std::vector<SettingIntValue>& values{pThis->m_timerType->GetPriorityValues()};
     std::transform(values.cbegin(), values.cend(), std::back_inserter(list), [](const auto& value) {
       return IntegerSettingOption(value.first, value.second);
     });
@@ -1173,8 +1172,7 @@ void CGUIDialogPVRTimerSettings::LifetimesFiller(const SettingConstPtr& setting,
   {
     list.clear();
 
-    std::vector<std::pair<std::string, int>> values;
-    pThis->m_timerType->GetLifetimeValues(values);
+    const std::vector<SettingIntValue>& values{pThis->m_timerType->GetLifetimeValues()};
     std::transform(values.cbegin(), values.cend(), std::back_inserter(list), [](const auto& value) {
       return IntegerSettingOption(value.first, value.second);
     });
@@ -1212,8 +1210,7 @@ void CGUIDialogPVRTimerSettings::MaxRecordingsFiller(const SettingConstPtr& sett
   {
     list.clear();
 
-    std::vector<std::pair<std::string, int>> values;
-    pThis->m_timerType->GetMaxRecordingsValues(values);
+    const std::vector<SettingIntValue>& values{pThis->m_timerType->GetMaxRecordingsValues()};
     std::transform(values.cbegin(), values.cend(), std::back_inserter(list), [](const auto& value) {
       return IntegerSettingOption(value.first, value.second);
     });
@@ -1249,8 +1246,7 @@ void CGUIDialogPVRTimerSettings::RecordingGroupFiller(const SettingConstPtr& set
   {
     list.clear();
 
-    std::vector<std::pair<std::string, int>> values;
-    pThis->m_timerType->GetRecordingGroupValues(values);
+    const std::vector<SettingIntValue>& values{pThis->m_timerType->GetRecordingGroupValues()};
     std::transform(values.cbegin(), values.cend(), std::back_inserter(list), [](const auto& value) {
       return IntegerSettingOption(value.first, value.second);
     });

--- a/xbmc/pvr/settings/CMakeLists.txt
+++ b/xbmc/pvr/settings/CMakeLists.txt
@@ -1,5 +1,7 @@
-set(SOURCES PVRSettings.cpp)
+set(SOURCES PVRIntSettingValues.cpp
+            PVRSettings.cpp)
 
-set(HEADERS PVRSettings.h)
+set(HEADERS PVRIntSettingValues.h
+            PVRSettings.h)
 
 core_add_library(pvr_settings)

--- a/xbmc/pvr/settings/PVRIntSettingValues.cpp
+++ b/xbmc/pvr/settings/PVRIntSettingValues.cpp
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRIntSettingValues.h"
+
+#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_defines.h"
+#include "guilib/LocalizeStrings.h"
+#include "utils/StringUtils.h"
+
+#include <string>
+
+namespace PVR
+{
+CPVRIntSettingValues::CPVRIntSettingValues(struct PVR_ATTRIBUTE_INT_VALUE* values,
+                                           unsigned int valuesSize,
+                                           int defaultValue,
+                                           int defaultDescriptionResourceId /* = 0 */)
+  : m_defaultValue(defaultValue)
+{
+  if (values && valuesSize > 0)
+  {
+    m_values.reserve(valuesSize);
+    for (unsigned int i = 0; i < valuesSize; ++i)
+    {
+      const int value{values[i].iValue};
+      const char* desc{values[i].strDescription};
+      std::string strDescr{desc ? desc : ""};
+      if (strDescr.empty())
+      {
+        // No description given by addon. Create one from value.
+        if (defaultDescriptionResourceId > 0)
+          strDescr = StringUtils::Format(
+              "{} {}", g_localizeStrings.Get(defaultDescriptionResourceId), value);
+        else
+          strDescr = std::to_string(value);
+      }
+      m_values.emplace_back(strDescr, value);
+    }
+  }
+}
+
+CPVRIntSettingValues::CPVRIntSettingValues(struct PVR_ATTRIBUTE_INT_VALUE* values,
+                                           unsigned int valuesSize,
+                                           unsigned int defaultValue,
+                                           int defaultDescriptionResourceId /* = 0 */)
+  : CPVRIntSettingValues(
+        values, valuesSize, static_cast<int>(defaultValue), defaultDescriptionResourceId)
+{
+}
+
+CPVRIntSettingValues::CPVRIntSettingValues(const std::vector<SettingIntValue>& values,
+                                           int defaultValue)
+  : m_values(values), m_defaultValue(defaultValue)
+{
+}
+
+} // namespace PVR

--- a/xbmc/pvr/settings/PVRIntSettingValues.h
+++ b/xbmc/pvr/settings/PVRIntSettingValues.h
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+struct PVR_ATTRIBUTE_INT_VALUE;
+
+namespace PVR
+{
+using SettingIntValue = std::pair<std::string, int>;
+
+class CPVRIntSettingValues
+{
+public:
+  CPVRIntSettingValues(int defaultValue) : m_defaultValue(defaultValue) {}
+  CPVRIntSettingValues(struct PVR_ATTRIBUTE_INT_VALUE* values,
+                       unsigned int valuesSize,
+                       int defaultValue,
+                       int defaultDescriptionResourceId = 0);
+  CPVRIntSettingValues(struct PVR_ATTRIBUTE_INT_VALUE* values,
+                       unsigned int valuesSize,
+                       unsigned int defaultValue,
+                       int defaultDescriptionResourceId = 0);
+  CPVRIntSettingValues(const std::vector<SettingIntValue>& values, int defaultValue);
+
+  virtual ~CPVRIntSettingValues() = default;
+
+  bool operator==(const CPVRIntSettingValues& right) const
+  {
+    return (m_defaultValue == right.m_defaultValue && m_values == right.m_values);
+  }
+
+  const std::vector<SettingIntValue>& GetValues() const { return m_values; }
+  int GetDefaultValue() const { return m_defaultValue; }
+
+private:
+  std::vector<SettingIntValue> m_values;
+  int m_defaultValue{0};
+};
+} // namespace PVR

--- a/xbmc/pvr/timers/PVRTimerType.cpp
+++ b/xbmc/pvr/timers/PVRTimerType.cpp
@@ -179,15 +179,10 @@ bool CPVRTimerType::operator==(const CPVRTimerType& right) const
   return (m_iClientId == right.m_iClientId && m_iTypeId == right.m_iTypeId &&
           m_iAttributes == right.m_iAttributes && m_strDescription == right.m_strDescription &&
           m_priorityValues == right.m_priorityValues &&
-          m_iPriorityDefault == right.m_iPriorityDefault &&
           m_lifetimeValues == right.m_lifetimeValues &&
-          m_iLifetimeDefault == right.m_iLifetimeDefault &&
           m_maxRecordingsValues == right.m_maxRecordingsValues &&
-          m_iMaxRecordingsDefault == right.m_iMaxRecordingsDefault &&
           m_preventDupEpisodesValues == right.m_preventDupEpisodesValues &&
-          m_iPreventDupEpisodesDefault == right.m_iPreventDupEpisodesDefault &&
-          m_recordingGroupValues == right.m_recordingGroupValues &&
-          m_iRecordingGroupDefault == right.m_iRecordingGroupDefault);
+          m_recordingGroupValues == right.m_recordingGroupValues);
 }
 
 bool CPVRTimerType::operator!=(const CPVRTimerType& right) const
@@ -202,15 +197,10 @@ void CPVRTimerType::Update(const CPVRTimerType& type)
   m_iAttributes = type.m_iAttributes;
   m_strDescription = type.m_strDescription;
   m_priorityValues = type.m_priorityValues;
-  m_iPriorityDefault = type.m_iPriorityDefault;
   m_lifetimeValues = type.m_lifetimeValues;
-  m_iLifetimeDefault = type.m_iLifetimeDefault;
   m_maxRecordingsValues = type.m_maxRecordingsValues;
-  m_iMaxRecordingsDefault = type.m_iMaxRecordingsDefault;
   m_preventDupEpisodesValues = type.m_preventDupEpisodesValues;
-  m_iPreventDupEpisodesDefault = type.m_iPreventDupEpisodesDefault;
   m_recordingGroupValues = type.m_recordingGroupValues;
-  m_iRecordingGroupDefault = type.m_iRecordingGroupDefault;
 }
 
 void CPVRTimerType::InitDescription()
@@ -252,174 +242,77 @@ void CPVRTimerType::InitPriorityValues(const PVR_TIMER_TYPE& type)
 {
   if (type.iPrioritiesSize > 0)
   {
-    for (unsigned int i = 0; i < type.iPrioritiesSize; ++i)
-    {
-      const int value{type.priorities[i].iValue};
-      const char* desc{type.priorities[i].strDescription};
-      std::string strDescr{desc ? desc : ""};
-      if (strDescr.empty())
-      {
-        // No description given by addon. Create one from value.
-        strDescr = std::to_string(value);
-      }
-      m_priorityValues.emplace_back(strDescr, value);
-    }
-
-    m_iPriorityDefault = type.iPrioritiesDefault;
+    m_priorityValues = {type.priorities, type.iPrioritiesSize, type.iPrioritiesDefault};
   }
   else if (SupportsPriority())
   {
     // No values given by addon, but priority supported. Use default values 1..100
+    std::vector<SettingIntValue> values;
     for (int i = 1; i < 101; ++i)
-      m_priorityValues.emplace_back(std::to_string(i), i);
+      values.emplace_back(std::to_string(i), i);
 
-    m_iPriorityDefault = DEFAULT_RECORDING_PRIORITY;
+    m_priorityValues = {values, DEFAULT_RECORDING_PRIORITY};
   }
   else
   {
     // No priority supported.
-    m_iPriorityDefault = DEFAULT_RECORDING_PRIORITY;
+    m_priorityValues = {DEFAULT_RECORDING_PRIORITY};
   }
-}
-
-void CPVRTimerType::GetPriorityValues(std::vector<std::pair<std::string, int>>& list) const
-{
-  std::copy(m_priorityValues.cbegin(), m_priorityValues.cend(), std::back_inserter(list));
 }
 
 void CPVRTimerType::InitLifetimeValues(const PVR_TIMER_TYPE& type)
 {
   if (type.iLifetimesSize > 0)
   {
-    for (unsigned int i = 0; i < type.iLifetimesSize; ++i)
-    {
-      const int value{type.lifetimes[i].iValue};
-      const char* desc{type.lifetimes[i].strDescription};
-      std::string strDescr{desc ? desc : ""};
-      if (strDescr.empty())
-      {
-        // No description given by addon. Create one from value.
-        strDescr = std::to_string(value);
-      }
-      m_lifetimeValues.emplace_back(strDescr, value);
-    }
-
-    m_iLifetimeDefault = type.iLifetimesDefault;
+    m_lifetimeValues = {type.lifetimes, type.iLifetimesSize, type.iLifetimesDefault};
   }
   else if (SupportsLifetime())
   {
     // No values given by addon, but lifetime supported. Use default values 1..365
+    std::vector<SettingIntValue> values;
     for (int i = 1; i < 366; ++i)
     {
-      m_lifetimeValues.emplace_back(StringUtils::Format(g_localizeStrings.Get(17999), i),
-                                    i); // "{} days"
+      values.emplace_back(StringUtils::Format(g_localizeStrings.Get(17999), i),
+                          i); // "{} days"
     }
-    m_iLifetimeDefault = DEFAULT_RECORDING_LIFETIME;
+    m_lifetimeValues = {values, DEFAULT_RECORDING_LIFETIME};
   }
   else
   {
     // No lifetime supported.
-    m_iLifetimeDefault = DEFAULT_RECORDING_LIFETIME;
+    m_lifetimeValues = {DEFAULT_RECORDING_LIFETIME};
   }
-}
-
-void CPVRTimerType::GetLifetimeValues(std::vector<std::pair<std::string, int>>& list) const
-{
-  std::copy(m_lifetimeValues.cbegin(), m_lifetimeValues.cend(), std::back_inserter(list));
 }
 
 void CPVRTimerType::InitMaxRecordingsValues(const PVR_TIMER_TYPE& type)
 {
-  if (type.iMaxRecordingsSize > 0)
-  {
-    for (unsigned int i = 0; i < type.iMaxRecordingsSize; ++i)
-    {
-      const int value{type.maxRecordings[i].iValue};
-      const char* desc{type.maxRecordings[i].strDescription};
-      std::string strDescr{desc ? desc : ""};
-      if (strDescr.empty())
-      {
-        // No description given by addon. Create one from value.
-        strDescr = std::to_string(value);
-      }
-      m_maxRecordingsValues.emplace_back(strDescr, value);
-    }
-
-    m_iMaxRecordingsDefault = type.iMaxRecordingsDefault;
-  }
-}
-
-void CPVRTimerType::GetMaxRecordingsValues(std::vector<std::pair<std::string, int>>& list) const
-{
-  std::copy(m_maxRecordingsValues.cbegin(), m_maxRecordingsValues.cend(), std::back_inserter(list));
+  m_maxRecordingsValues = {type.maxRecordings, type.iMaxRecordingsSize, type.iMaxRecordingsDefault};
 }
 
 void CPVRTimerType::InitPreventDuplicateEpisodesValues(const PVR_TIMER_TYPE& type)
 {
   if (type.iPreventDuplicateEpisodesSize > 0)
   {
-    for (unsigned int i = 0; i < type.iPreventDuplicateEpisodesSize; ++i)
-    {
-      const int value{type.preventDuplicateEpisodes[i].iValue};
-      const char* desc{type.preventDuplicateEpisodes[i].strDescription};
-      std::string strDescr{desc ? desc : ""};
-      if (strDescr.empty())
-      {
-        // No description given by addon. Create one from value.
-        strDescr = std::to_string(value);
-      }
-      m_preventDupEpisodesValues.emplace_back(strDescr, value);
-    }
-
-    m_iPreventDupEpisodesDefault = type.iPreventDuplicateEpisodesDefault;
+    m_preventDupEpisodesValues = {type.preventDuplicateEpisodes, type.iPreventDuplicateEpisodesSize,
+                                  type.iPreventDuplicateEpisodesDefault};
   }
   else if (SupportsRecordOnlyNewEpisodes())
   {
     // No values given by addon, but prevent duplicate episodes supported. Use default values 0..1
-    m_preventDupEpisodesValues.emplace_back(g_localizeStrings.Get(815), 0); // "Record all episodes"
-    m_preventDupEpisodesValues.emplace_back(g_localizeStrings.Get(816),
-                                            1); // "Record only new episodes"
-    m_iPreventDupEpisodesDefault = DEFAULT_RECORDING_DUPLICATEHANDLING;
+    m_preventDupEpisodesValues = {
+        {{g_localizeStrings.Get(815) /* "Record all episodes" */, 0},
+         {g_localizeStrings.Get(816) /* "Record only new episodes" */, 1}},
+        DEFAULT_RECORDING_DUPLICATEHANDLING};
   }
   else
   {
     // No prevent duplicate episodes supported.
-    m_iPreventDupEpisodesDefault = DEFAULT_RECORDING_DUPLICATEHANDLING;
+    m_preventDupEpisodesValues = {DEFAULT_RECORDING_DUPLICATEHANDLING};
   }
-}
-
-void CPVRTimerType::GetPreventDuplicateEpisodesValues(
-    std::vector<std::pair<std::string, int>>& list) const
-{
-  std::copy(m_preventDupEpisodesValues.cbegin(), m_preventDupEpisodesValues.cend(),
-            std::back_inserter(list));
 }
 
 void CPVRTimerType::InitRecordingGroupValues(const PVR_TIMER_TYPE& type)
 {
-  if (type.iRecordingGroupSize > 0)
-  {
-    for (unsigned int i = 0; i < type.iRecordingGroupSize; ++i)
-    {
-      const int value{type.recordingGroup[i].iValue};
-      const char* desc{type.recordingGroup[i].strDescription};
-      std::string strDescr{desc ? desc : ""};
-      if (strDescr.empty())
-      {
-        // No description given by addon. Create one from value.
-        strDescr = StringUtils::Format("{} {}",
-                                       g_localizeStrings.Get(811), // Recording group
-                                       value);
-      }
-      m_recordingGroupValues.emplace_back(strDescr, value);
-    }
-
-    m_iRecordingGroupDefault = type.iRecordingGroupDefault;
-  }
-}
-
-void CPVRTimerType::GetRecordingGroupValues(std::vector<std::pair<std::string, int>>& list) const
-{
-  std::copy(m_recordingGroupValues.cbegin(), m_recordingGroupValues.cend(),
-            std::back_inserter(list));
+  m_recordingGroupValues = {type.recordingGroup, type.iRecordingGroupSize,
+                            type.iRecordingGroupDefault, 811 /* Recording group */};
 }

--- a/xbmc/pvr/timers/PVRTimerType.cpp
+++ b/xbmc/pvr/timers/PVRTimerType.cpp
@@ -34,71 +34,52 @@ const std::vector<std::shared_ptr<CPVRTimerType>> CPVRTimerType::GetAllTypes()
   int iTypeId = PVR_TIMER_TYPE_NONE;
 
   // one time time-based reminder
-  allTypes.emplace_back(std::make_shared<CPVRTimerType>(++iTypeId,
-                                                        PVR_TIMER_TYPE_IS_MANUAL |
-                                                        PVR_TIMER_TYPE_IS_REMINDER |
-                                                        PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
-                                                        PVR_TIMER_TYPE_SUPPORTS_START_TIME |
-                                                        PVR_TIMER_TYPE_SUPPORTS_END_TIME));
+  allTypes.emplace_back(std::make_shared<CPVRTimerType>(
+      ++iTypeId, PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_IS_REMINDER |
+                     PVR_TIMER_TYPE_SUPPORTS_CHANNELS | PVR_TIMER_TYPE_SUPPORTS_START_TIME |
+                     PVR_TIMER_TYPE_SUPPORTS_END_TIME));
 
   // one time epg-based reminder
-  allTypes.emplace_back(std::make_shared<CPVRTimerType>(++iTypeId,
-                                                        PVR_TIMER_TYPE_IS_REMINDER |
-                                                        PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
-                                                        PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
-                                                        PVR_TIMER_TYPE_SUPPORTS_START_TIME |
-                                                        PVR_TIMER_TYPE_SUPPORTS_START_MARGIN));
+  allTypes.emplace_back(std::make_shared<CPVRTimerType>(
+      ++iTypeId, PVR_TIMER_TYPE_IS_REMINDER | PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
+                     PVR_TIMER_TYPE_SUPPORTS_CHANNELS | PVR_TIMER_TYPE_SUPPORTS_START_TIME |
+                     PVR_TIMER_TYPE_SUPPORTS_START_MARGIN));
 
   // time-based reminder rule
-  allTypes.emplace_back(std::make_shared<CPVRTimerType>(++iTypeId,
-                                                        PVR_TIMER_TYPE_IS_REPEATING |
-                                                        PVR_TIMER_TYPE_IS_MANUAL |
-                                                        PVR_TIMER_TYPE_IS_REMINDER |
-                                                        PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
-                                                        PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
-                                                        PVR_TIMER_TYPE_SUPPORTS_START_TIME |
-                                                        PVR_TIMER_TYPE_SUPPORTS_END_TIME |
-                                                        PVR_TIMER_TYPE_SUPPORTS_FIRST_DAY |
-                                                        PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS));
+  allTypes.emplace_back(std::make_shared<CPVRTimerType>(
+      ++iTypeId, PVR_TIMER_TYPE_IS_REPEATING | PVR_TIMER_TYPE_IS_MANUAL |
+                     PVR_TIMER_TYPE_IS_REMINDER | PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
+                     PVR_TIMER_TYPE_SUPPORTS_CHANNELS | PVR_TIMER_TYPE_SUPPORTS_START_TIME |
+                     PVR_TIMER_TYPE_SUPPORTS_END_TIME | PVR_TIMER_TYPE_SUPPORTS_FIRST_DAY |
+                     PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS));
 
   // one time read-only time-based reminder (created by timer rule)
-  allTypes.emplace_back(std::make_shared<CPVRTimerType>(++iTypeId,
-                                                        PVR_TIMER_TYPE_IS_MANUAL |
-                                                        PVR_TIMER_TYPE_IS_REMINDER |
-                                                        PVR_TIMER_TYPE_IS_READONLY |
-                                                        PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
-                                                        PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
-                                                        PVR_TIMER_TYPE_SUPPORTS_START_TIME |
-                                                        PVR_TIMER_TYPE_SUPPORTS_END_TIME,
-                                                        g_localizeStrings.Get(819))); // One time (Scheduled by timer rule)
+  allTypes.emplace_back(std::make_shared<CPVRTimerType>(
+      ++iTypeId,
+      PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_IS_REMINDER | PVR_TIMER_TYPE_IS_READONLY |
+          PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE | PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
+          PVR_TIMER_TYPE_SUPPORTS_START_TIME | PVR_TIMER_TYPE_SUPPORTS_END_TIME,
+      g_localizeStrings.Get(819))); // One time (Scheduled by timer rule)
 
   // epg-based reminder rule
-  allTypes.emplace_back(std::make_shared<CPVRTimerType>(++iTypeId,
-                                                        PVR_TIMER_TYPE_IS_REPEATING |
-                                                        PVR_TIMER_TYPE_IS_REMINDER |
-                                                        PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
-                                                        PVR_TIMER_TYPE_SUPPORTS_TITLE_EPG_MATCH |
-                                                        PVR_TIMER_TYPE_SUPPORTS_FULLTEXT_EPG_MATCH |
-                                                        PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
-                                                        PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL |
-                                                        PVR_TIMER_TYPE_SUPPORTS_START_TIME |
-                                                        PVR_TIMER_TYPE_SUPPORTS_START_ANYTIME |
-                                                        PVR_TIMER_TYPE_SUPPORTS_END_TIME |
-                                                        PVR_TIMER_TYPE_SUPPORTS_END_ANYTIME |
-                                                        PVR_TIMER_TYPE_SUPPORTS_FIRST_DAY |
-                                                        PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS |
-                                                        PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN));
+  allTypes.emplace_back(std::make_shared<CPVRTimerType>(
+      ++iTypeId, PVR_TIMER_TYPE_IS_REPEATING | PVR_TIMER_TYPE_IS_REMINDER |
+                     PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
+                     PVR_TIMER_TYPE_SUPPORTS_TITLE_EPG_MATCH |
+                     PVR_TIMER_TYPE_SUPPORTS_FULLTEXT_EPG_MATCH | PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
+                     PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL | PVR_TIMER_TYPE_SUPPORTS_START_TIME |
+                     PVR_TIMER_TYPE_SUPPORTS_START_ANYTIME | PVR_TIMER_TYPE_SUPPORTS_END_TIME |
+                     PVR_TIMER_TYPE_SUPPORTS_END_ANYTIME | PVR_TIMER_TYPE_SUPPORTS_FIRST_DAY |
+                     PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS | PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN));
 
   // one time read-only epg-based reminder (created by timer rule)
-  allTypes.emplace_back(std::make_shared<CPVRTimerType>(++iTypeId,
-                                                        PVR_TIMER_TYPE_IS_REMINDER |
-                                                        PVR_TIMER_TYPE_IS_READONLY |
-                                                        PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
-                                                        PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
-                                                        PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
-                                                        PVR_TIMER_TYPE_SUPPORTS_START_TIME |
-                                                        PVR_TIMER_TYPE_SUPPORTS_START_MARGIN,
-                                                        g_localizeStrings.Get(819))); // One time (Scheduled by timer rule)
+  allTypes.emplace_back(std::make_shared<CPVRTimerType>(
+      ++iTypeId,
+      PVR_TIMER_TYPE_IS_REMINDER | PVR_TIMER_TYPE_IS_READONLY |
+          PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE | PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
+          PVR_TIMER_TYPE_SUPPORTS_CHANNELS | PVR_TIMER_TYPE_SUPPORTS_START_TIME |
+          PVR_TIMER_TYPE_SUPPORTS_START_MARGIN,
+      g_localizeStrings.Get(819))); // One time (Scheduled by timer rule)
 
   return allTypes;
 }
@@ -121,9 +102,9 @@ std::shared_ptr<CPVRTimerType> CPVRTimerType::CreateFromIds(unsigned int iTypeId
 {
   const std::vector<std::shared_ptr<CPVRTimerType>> types = GetAllTypes();
   const auto it =
-      std::find_if(types.cbegin(), types.cend(), [iClientId, iTypeId](const auto& type) {
-        return type->GetClientId() == iClientId && type->GetTypeId() == iTypeId;
-      });
+      std::find_if(types.cbegin(), types.cend(),
+                   [iClientId, iTypeId](const auto& type)
+                   { return type->GetClientId() == iClientId && type->GetTypeId() == iTypeId; });
   if (it != types.cend())
     return (*it);
 
@@ -145,7 +126,8 @@ std::shared_ptr<CPVRTimerType> CPVRTimerType::CreateFromAttributes(uint64_t iMus
 {
   const std::vector<std::shared_ptr<CPVRTimerType>> types = GetAllTypes();
   const auto it = std::find_if(types.cbegin(), types.cend(),
-                               [iClientId, iMustHaveAttr, iMustNotHaveAttr](const auto& type) {
+                               [iClientId, iMustHaveAttr, iMustNotHaveAttr](const auto& type)
+                               {
                                  return type->GetClientId() == iClientId &&
                                         (type->GetAttributes() & iMustHaveAttr) == iMustHaveAttr &&
                                         (type->GetAttributes() & iMustNotHaveAttr) == 0;
@@ -167,9 +149,8 @@ std::shared_ptr<CPVRTimerType> CPVRTimerType::CreateFromAttributes(uint64_t iMus
   return {};
 }
 
-CPVRTimerType::CPVRTimerType() :
-  m_iTypeId(PVR_TIMER_TYPE_NONE),
-  m_iAttributes(PVR_TIMER_TYPE_ATTRIBUTE_NONE)
+CPVRTimerType::CPVRTimerType()
+  : m_iTypeId(PVR_TIMER_TYPE_NONE), m_iAttributes(PVR_TIMER_TYPE_ATTRIBUTE_NONE)
 {
 }
 
@@ -193,12 +174,10 @@ CPVRTimerType::CPVRTimerType(unsigned int iTypeId,
 
 CPVRTimerType::~CPVRTimerType() = default;
 
-bool CPVRTimerType::operator ==(const CPVRTimerType& right) const
+bool CPVRTimerType::operator==(const CPVRTimerType& right) const
 {
-  return (m_iClientId == right.m_iClientId &&
-          m_iTypeId == right.m_iTypeId &&
-          m_iAttributes == right.m_iAttributes &&
-          m_strDescription == right.m_strDescription &&
+  return (m_iClientId == right.m_iClientId && m_iTypeId == right.m_iTypeId &&
+          m_iAttributes == right.m_iAttributes && m_strDescription == right.m_strDescription &&
           m_priorityValues == right.m_priorityValues &&
           m_iPriorityDefault == right.m_iPriorityDefault &&
           m_lifetimeValues == right.m_lifetimeValues &&
@@ -211,7 +190,7 @@ bool CPVRTimerType::operator ==(const CPVRTimerType& right) const
           m_iRecordingGroupDefault == right.m_iRecordingGroupDefault);
 }
 
-bool CPVRTimerType::operator !=(const CPVRTimerType& right) const
+bool CPVRTimerType::operator!=(const CPVRTimerType& right) const
 {
   return !(*this == right);
 }
@@ -242,23 +221,20 @@ void CPVRTimerType::InitDescription()
     int id;
     if (m_iAttributes & PVR_TIMER_TYPE_IS_REPEATING)
     {
-      id = (m_iAttributes & PVR_TIMER_TYPE_IS_MANUAL)
-        ? 822  // "Timer rule"
-        : 823; // "Timer rule (guide-based)"
+      id = (m_iAttributes & PVR_TIMER_TYPE_IS_MANUAL) ? 822 // "Timer rule"
+                                                      : 823; // "Timer rule (guide-based)"
     }
     else
     {
-      id = (m_iAttributes & PVR_TIMER_TYPE_IS_MANUAL)
-        ? 820  // "One time"
-        : 821; // "One time (guide-based)
+      id = (m_iAttributes & PVR_TIMER_TYPE_IS_MANUAL) ? 820 // "One time"
+                                                      : 821; // "One time (guide-based)
     }
     m_strDescription = g_localizeStrings.Get(id);
   }
 
   // add reminder/recording prefix
-  int prefixId = (m_iAttributes & PVR_TIMER_TYPE_IS_REMINDER)
-    ? 824  // Reminder: ...
-    : 825; // Recording: ...
+  int prefixId = (m_iAttributes & PVR_TIMER_TYPE_IS_REMINDER) ? 824 // Reminder: ...
+                                                              : 825; // Recording: ...
 
   m_strDescription = StringUtils::Format(g_localizeStrings.Get(prefixId), m_strDescription);
 }
@@ -401,7 +377,8 @@ void CPVRTimerType::InitPreventDuplicateEpisodesValues(const PVR_TIMER_TYPE& typ
   {
     // No values given by addon, but prevent duplicate episodes supported. Use default values 0..1
     m_preventDupEpisodesValues.emplace_back(g_localizeStrings.Get(815), 0); // "Record all episodes"
-    m_preventDupEpisodesValues.emplace_back(g_localizeStrings.Get(816), 1); // "Record only new episodes"
+    m_preventDupEpisodesValues.emplace_back(g_localizeStrings.Get(816),
+                                            1); // "Record only new episodes"
     m_iPreventDupEpisodesDefault = DEFAULT_RECORDING_DUPLICATEHANDLING;
   }
   else
@@ -411,7 +388,8 @@ void CPVRTimerType::InitPreventDuplicateEpisodesValues(const PVR_TIMER_TYPE& typ
   }
 }
 
-void CPVRTimerType::GetPreventDuplicateEpisodesValues(std::vector<std::pair<std::string, int>>& list) const
+void CPVRTimerType::GetPreventDuplicateEpisodesValues(
+    std::vector<std::pair<std::string, int>>& list) const
 {
   std::copy(m_preventDupEpisodesValues.cbegin(), m_preventDupEpisodesValues.cend(),
             std::back_inserter(list));
@@ -440,7 +418,7 @@ void CPVRTimerType::InitRecordingGroupValues(const PVR_TIMER_TYPE& type)
   }
 }
 
-void CPVRTimerType::GetRecordingGroupValues(std::vector< std::pair<std::string, int>>& list) const
+void CPVRTimerType::GetRecordingGroupValues(std::vector<std::pair<std::string, int>>& list) const
 {
   std::copy(m_recordingGroupValues.cbegin(), m_recordingGroupValues.cend(),
             std::back_inserter(list));

--- a/xbmc/pvr/timers/PVRTimerType.h
+++ b/xbmc/pvr/timers/PVRTimerType.h
@@ -10,6 +10,7 @@
 
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_timers.h"
 #include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
+#include "pvr/settings/PVRIntSettingValues.h"
 
 #include <memory>
 #include <string>
@@ -384,63 +385,81 @@ public:
 
   /*!
    * @brief Obtain a list with all possible values for the priority attribute.
-   * @param list out, the list with the values or an empty list, if priority is not supported by this type.
+   * @return the list with the values or an empty list, if priority is not supported by this type.
    */
-  void GetPriorityValues(std::vector<std::pair<std::string, int>>& list) const;
+  const std::vector<SettingIntValue>& GetPriorityValues() const
+  {
+    return m_lifetimeValues.GetValues();
+  }
 
   /*!
    * @brief Obtain the default value for the priority attribute.
    * @return the default value.
    */
-  int GetPriorityDefault() const { return m_iPriorityDefault; }
+  int GetPriorityDefault() const { return m_priorityValues.GetDefaultValue(); }
 
   /*!
    * @brief Obtain a list with all possible values for the lifetime attribute.
-   * @param list out, the list with the values or an empty list, if lifetime is not supported by this type.
+   * @return the list with the values or an empty list, if lifetime is not supported by this type.
    */
-  void GetLifetimeValues(std::vector<std::pair<std::string, int>>& list) const;
+  const std::vector<SettingIntValue>& GetLifetimeValues() const
+  {
+    return m_lifetimeValues.GetValues();
+  }
 
   /*!
    * @brief Obtain the default value for the lifetime attribute.
    * @return the default value.
    */
-  int GetLifetimeDefault() const { return m_iLifetimeDefault; }
+  int GetLifetimeDefault() const { return m_lifetimeValues.GetDefaultValue(); }
 
   /*!
    * @brief Obtain a list with all possible values for the MaxRecordings attribute.
-   * @param list out, the list with the values or an empty list, if MaxRecordings is not supported by this type.
+   * @return the list with the values or an empty list, if MaxRecordings is not supported by this type.
    */
-  void GetMaxRecordingsValues(std::vector<std::pair<std::string, int>>& list) const;
+  const std::vector<SettingIntValue>& GetMaxRecordingsValues() const
+  {
+    return m_maxRecordingsValues.GetValues();
+  }
 
   /*!
    * @brief Obtain the default value for the MaxRecordings attribute.
    * @return the default value.
    */
-  int GetMaxRecordingsDefault() const { return m_iMaxRecordingsDefault; }
+  int GetMaxRecordingsDefault() const { return m_maxRecordingsValues.GetDefaultValue(); }
 
   /*!
    * @brief Obtain a list with all possible values for the duplicate episode prevention attribute.
-   * @param list out, the list with the values or an empty list, if duplicate episode prevention is not supported by this type.
+   * @return the list with the values or an empty list, if duplicate episode prevention is not supported by this type.
    */
-  void GetPreventDuplicateEpisodesValues(std::vector<std::pair<std::string, int>>& list) const;
+  const std::vector<SettingIntValue>& GetPreventDuplicateEpisodesValues() const
+  {
+    return m_preventDupEpisodesValues.GetValues();
+  }
 
   /*!
    * @brief Obtain the default value for the duplicate episode prevention attribute.
    * @return the default value.
    */
-  int GetPreventDuplicateEpisodesDefault() const { return m_iPreventDupEpisodesDefault; }
+  int GetPreventDuplicateEpisodesDefault() const
+  {
+    return m_preventDupEpisodesValues.GetDefaultValue();
+  }
 
   /*!
    * @brief Obtain a list with all possible values for the recording group attribute.
-   * @param list out, the list with the values or an empty list, if recording group is not supported by this type.
+   * @return the list with the values or an empty list, if recording group is not supported by this type.
    */
-  void GetRecordingGroupValues(std::vector<std::pair<std::string, int>>& list) const;
+  const std::vector<SettingIntValue>& GetRecordingGroupValues() const
+  {
+    return m_recordingGroupValues.GetValues();
+  }
 
   /*!
    * @brief Obtain the default value for the Recording Group attribute.
    * @return the default value.
    */
-  int GetRecordingGroupDefault() const { return m_iRecordingGroupDefault; }
+  int GetRecordingGroupDefault() const { return m_recordingGroupValues.GetDefaultValue(); }
 
 private:
   void InitDescription();
@@ -455,15 +474,10 @@ private:
   unsigned int m_iTypeId;
   uint64_t m_iAttributes;
   std::string m_strDescription;
-  std::vector<std::pair<std::string, int>> m_priorityValues;
-  int m_iPriorityDefault = DEFAULT_RECORDING_PRIORITY;
-  std::vector<std::pair<std::string, int>> m_lifetimeValues;
-  int m_iLifetimeDefault = DEFAULT_RECORDING_LIFETIME;
-  std::vector<std::pair<std::string, int>> m_maxRecordingsValues;
-  int m_iMaxRecordingsDefault = 0;
-  std::vector<std::pair<std::string, int>> m_preventDupEpisodesValues;
-  unsigned int m_iPreventDupEpisodesDefault = DEFAULT_RECORDING_DUPLICATEHANDLING;
-  std::vector<std::pair<std::string, int>> m_recordingGroupValues;
-  unsigned int m_iRecordingGroupDefault = 0;
+  CPVRIntSettingValues m_priorityValues{DEFAULT_RECORDING_PRIORITY};
+  CPVRIntSettingValues m_lifetimeValues{DEFAULT_RECORDING_LIFETIME};
+  CPVRIntSettingValues m_maxRecordingsValues{0};
+  CPVRIntSettingValues m_preventDupEpisodesValues{DEFAULT_RECORDING_DUPLICATEHANDLING};
+  CPVRIntSettingValues m_recordingGroupValues{0};
 };
 } // namespace PVR

--- a/xbmc/pvr/timers/PVRTimerType.h
+++ b/xbmc/pvr/timers/PVRTimerType.h
@@ -20,400 +20,450 @@ struct PVR_TIMER_TYPE;
 
 namespace PVR
 {
-  class CPVRClient;
+class CPVRClient;
 
-  static const int DEFAULT_RECORDING_PRIORITY = 50;
-  static const int DEFAULT_RECORDING_LIFETIME = 99; // days
-  static const unsigned int DEFAULT_RECORDING_DUPLICATEHANDLING = 0;
+static const int DEFAULT_RECORDING_PRIORITY = 50;
+static const int DEFAULT_RECORDING_LIFETIME = 99; // days
+static const unsigned int DEFAULT_RECORDING_DUPLICATEHANDLING = 0;
 
-  class CPVRTimerType
+class CPVRTimerType
+{
+public:
+  /*!
+   * @brief Return a list with all known timer types.
+   * @return A list of timer types or an empty list if no types available.
+   */
+  static const std::vector<std::shared_ptr<CPVRTimerType>> GetAllTypes();
+
+  /*!
+   * @brief Return the first available timer type from given client.
+   * @param client the PVR client.
+   * @return A timer type or NULL if none available.
+   */
+  static const std::shared_ptr<CPVRTimerType> GetFirstAvailableType(
+      const std::shared_ptr<const CPVRClient>& client);
+
+  /*!
+   * @brief Create a timer type from given timer type id and client id.
+   * @param iTimerType the timer type id.
+   * @param iClientId the PVR client id.
+   * @return A timer type instance.
+   */
+  static std::shared_ptr<CPVRTimerType> CreateFromIds(unsigned int iTypeId, int iClientId);
+
+  /*!
+   * @brief Create a timer type from given timer type attributes and client id.
+   * @param iMustHaveAttr a combination of PVR_TIMER_TYPE_* attributes the type to create must have.
+   * @param iMustNotHaveAttr a combination of PVR_TIMER_TYPE_* attributes the type to create must not have.
+   * @param iClientId the PVR client id.
+   * @return A timer type instance.
+   */
+  static std::shared_ptr<CPVRTimerType> CreateFromAttributes(uint64_t iMustHaveAttr,
+                                                             uint64_t iMustNotHaveAttr,
+                                                             int iClientId);
+
+  CPVRTimerType();
+  CPVRTimerType(const PVR_TIMER_TYPE& type, int iClientId);
+  CPVRTimerType(unsigned int iTypeId, uint64_t iAttributes, const std::string& strDescription = "");
+
+  virtual ~CPVRTimerType();
+
+  CPVRTimerType(const CPVRTimerType& type) = delete;
+  CPVRTimerType& operator=(const CPVRTimerType& orig) = delete;
+
+  bool operator==(const CPVRTimerType& right) const;
+  bool operator!=(const CPVRTimerType& right) const;
+
+  /*!
+   * @brief Update the data of this instance with the data given by another type instance.
+   * @param type The instance containing the updated data.
+   */
+  void Update(const CPVRTimerType& type);
+
+  /*!
+   * @brief Get the PVR client id for this type.
+   * @return The PVR client id.
+   */
+  int GetClientId() const { return m_iClientId; }
+
+  /*!
+   * @brief Get the numeric type id of this type.
+   * @return The type id.
+   */
+  unsigned int GetTypeId() const { return m_iTypeId; }
+
+  /*!
+   * @brief Get the plain text (UI) description of this type.
+   * @return The description.
+   */
+  const std::string& GetDescription() const { return m_strDescription; }
+
+  /*!
+   * @brief Get the attributes of this type.
+   * @return The attributes.
+   */
+  uint64_t GetAttributes() const { return m_iAttributes; }
+
+  /*!
+   * @brief Check whether this type is for timer rules or one time timers.
+   * @return True if type represents a timer rule, false otherwise.
+   */
+  bool IsTimerRule() const { return (m_iAttributes & PVR_TIMER_TYPE_IS_REPEATING) > 0; }
+
+  /*!
+   * @brief Check whether this type is for reminder timers or recording timers.
+   * @return True if type represents a reminder timer, false otherwise.
+   */
+  bool IsReminder() const { return (m_iAttributes & PVR_TIMER_TYPE_IS_REMINDER) > 0; }
+
+  /*!
+   * @brief Check whether this type is for timer rules or one time timers.
+   * @return True if type represents a one time timer, false otherwise.
+   */
+  bool IsOnetime() const { return !IsTimerRule(); }
+
+  /*!
+   * @brief Check whether this type is for epg-based or manual timers.
+   * @return True if manual, false otherwise.
+   */
+  bool IsManual() const { return (m_iAttributes & PVR_TIMER_TYPE_IS_MANUAL) > 0; }
+
+  /*!
+   * @brief Check whether this type is for epg-based or manual timers.
+   * @return True if epg-based, false otherwise.
+   */
+  bool IsEpgBased() const { return !IsManual(); }
+
+  /*!
+   * @brief Check whether this type is for epg-based timer rules.
+   * @return True if epg-based timer rule, false otherwise.
+   */
+  bool IsEpgBasedTimerRule() const { return IsEpgBased() && IsTimerRule(); }
+
+  /*!
+   * @brief Check whether this type is for one time epg-based timers.
+   * @return True if one time epg-based, false otherwise.
+   */
+  bool IsEpgBasedOnetime() const { return IsEpgBased() && IsOnetime(); }
+
+  /*!
+   * @brief Check whether this type is for manual timer rules.
+   * @return True if manual timer rule, false otherwise.
+   */
+  bool IsManualTimerRule() const { return IsManual() && IsTimerRule(); }
+
+  /*!
+   * @brief Check whether this type is for one time manual timers.
+   * @return True if one time manual, false otherwise.
+   */
+  bool IsManualOnetime() const { return IsManual() && IsOnetime(); }
+
+  /*!
+   * @brief Check whether this type is readonly (must not be modified after initial creation).
+   * @return True if readonly, false otherwise.
+   */
+  bool IsReadOnly() const { return (m_iAttributes & PVR_TIMER_TYPE_IS_READONLY) > 0; }
+
+  /*!
+   * @brief Check whether this type allows deletion.
+   * @return True if type allows deletion, false otherwise.
+   */
+  bool AllowsDelete() const { return !IsReadOnly() || SupportsReadOnlyDelete(); }
+
+  /*!
+   * @brief Check whether this type forbids creation of new timers of this type.
+   * @return True if new instances are forbidden, false otherwise.
+   */
+  bool ForbidsNewInstances() const
   {
-  public:
-    /*!
-     * @brief Return a list with all known timer types.
-     * @return A list of timer types or an empty list if no types available.
-     */
-    static const std::vector<std::shared_ptr<CPVRTimerType>> GetAllTypes();
+    return (m_iAttributes & PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES) > 0;
+  }
 
-    /*!
-     * @brief Return the first available timer type from given client.
-     * @param client the PVR client.
-     * @return A timer type or NULL if none available.
-     */
-    static const std::shared_ptr<CPVRTimerType> GetFirstAvailableType(
-        const std::shared_ptr<const CPVRClient>& client);
+  /*!
+   * @brief Check whether this timer type is forbidden when epg tag info is present.
+   * @return True if new instances are forbidden when epg info is present, false otherwise.
+   */
+  bool ForbidsEpgTagOnCreate() const
+  {
+    return (m_iAttributes & PVR_TIMER_TYPE_FORBIDS_EPG_TAG_ON_CREATE) > 0;
+  }
 
-    /*!
-     * @brief Create a timer type from given timer type id and client id.
-     * @param iTimerType the timer type id.
-     * @param iClientId the PVR client id.
-     * @return A timer type instance.
-     */
-    static std::shared_ptr<CPVRTimerType> CreateFromIds(unsigned int iTypeId, int iClientId);
+  /*!
+   * @brief Check whether this timer type requires epg tag info to be present.
+   * @return True if new instances require EPG info, false otherwise.
+   */
+  bool RequiresEpgTagOnCreate() const
+  {
+    return (m_iAttributes & (PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
+                             PVR_TIMER_TYPE_REQUIRES_EPG_SERIES_ON_CREATE |
+                             PVR_TIMER_TYPE_REQUIRES_EPG_SERIESLINK_ON_CREATE)) > 0;
+  }
 
-    /*!
-     * @brief Create a timer type from given timer type attributes and client id.
-     * @param iMustHaveAttr a combination of PVR_TIMER_TYPE_* attributes the type to create must have.
-     * @param iMustNotHaveAttr a combination of PVR_TIMER_TYPE_* attributes the type to create must not have.
-     * @param iClientId the PVR client id.
-     * @return A timer type instance.
-     */
-    static std::shared_ptr<CPVRTimerType> CreateFromAttributes(uint64_t iMustHaveAttr,
-                                                               uint64_t iMustNotHaveAttr,
-                                                               int iClientId);
+  /*!
+   * @brief Check whether this timer type requires epg tag info including series attributes to be present.
+   * @return True if new instances require an EPG tag with series attributes, false otherwise.
+   */
+  bool RequiresEpgSeriesOnCreate() const
+  {
+    return (m_iAttributes & PVR_TIMER_TYPE_REQUIRES_EPG_SERIES_ON_CREATE) > 0;
+  }
 
-    CPVRTimerType();
-    CPVRTimerType(const PVR_TIMER_TYPE& type, int iClientId);
-    CPVRTimerType(unsigned int iTypeId,
-                  uint64_t iAttributes,
-                  const std::string& strDescription = "");
+  /*!
+   * @brief Check whether this timer type requires epg tag info including a series link to be present.
+   * @return True if new instances require an EPG tag with a series link, false otherwise.
+   */
+  bool RequiresEpgSeriesLinkOnCreate() const
+  {
+    return (m_iAttributes & PVR_TIMER_TYPE_REQUIRES_EPG_SERIESLINK_ON_CREATE) > 0;
+  }
 
-    virtual ~CPVRTimerType();
+  /*!
+   * @brief Check whether this type supports the "enabling/disabling" of timers of its type.
+   * @return True if "enabling/disabling" feature is supported, false otherwise.
+   */
+  bool SupportsEnableDisable() const
+  {
+    return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE) > 0;
+  }
 
-    CPVRTimerType(const CPVRTimerType& type) = delete;
-    CPVRTimerType& operator=(const CPVRTimerType& orig) = delete;
+  /*!
+   * @brief Check whether this type supports channels.
+   * @return True if channels are supported, false otherwise.
+   */
+  bool SupportsChannels() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_CHANNELS) > 0; }
 
-    bool operator ==(const CPVRTimerType& right) const;
-    bool operator !=(const CPVRTimerType& right) const;
+  /*!
+   * @brief Check whether this type supports start time.
+   * @return True if start time values are supported, false otherwise.
+   */
+  bool SupportsStartTime() const
+  {
+    return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_START_TIME) > 0;
+  }
 
-    /*!
-     * @brief Update the data of this instance with the data given by another type instance.
-     * @param type The instance containing the updated data.
-     */
-    void Update(const CPVRTimerType& type);
+  /*!
+   * @brief Check whether this type supports end time.
+   * @return True if end time values are supported, false otherwise.
+   */
+  bool SupportsEndTime() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_END_TIME) > 0; }
+  /*!
+   * @brief Check whether this type supports start any time.
+   * @return True if start any time is supported, false otherwise.
+   */
+  bool SupportsStartAnyTime() const
+  {
+    return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_START_ANYTIME) > 0;
+  }
 
-    /*!
-     * @brief Get the PVR client id for this type.
-     * @return The PVR client id.
-     */
-    int GetClientId() const { return m_iClientId; }
+  /*!
+   * @brief Check whether this type supports end any time.
+   * @return True if end any time is supported, false otherwise.
+   */
+  bool SupportsEndAnyTime() const
+  {
+    return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_END_ANYTIME) > 0;
+  }
 
-    /*!
-     * @brief Get the numeric type id of this type.
-     * @return The type id.
-     */
-    unsigned int GetTypeId() const { return m_iTypeId; }
+  /*!
+   * @brief Check whether this type supports matching a search string against epg episode title.
+   * @return True if title matching is supported, false otherwise.
+   */
+  bool SupportsEpgTitleMatch() const
+  {
+    return (m_iAttributes & (PVR_TIMER_TYPE_SUPPORTS_TITLE_EPG_MATCH |
+                             PVR_TIMER_TYPE_SUPPORTS_FULLTEXT_EPG_MATCH)) > 0;
+  }
 
-    /*!
-     * @brief Get the plain text (UI) description of this type.
-     * @return The description.
-     */
-    const std::string& GetDescription() const { return m_strDescription; }
+  /*!
+   * @brief Check whether this type supports matching a search string against extended (fulltext) epg data. This
+            includes title matching.
+   * @return True if fulltext matching is supported, false otherwise.
+   */
+  bool SupportsEpgFulltextMatch() const
+  {
+    return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_FULLTEXT_EPG_MATCH) > 0;
+  }
 
-    /*!
-     * @brief Get the attributes of this type.
-     * @return The attributes.
-     */
-    uint64_t GetAttributes() const { return m_iAttributes; }
+  /*!
+   * @brief Check whether this type supports a first day the timer is active.
+   * @return True if first day is supported, false otherwise.
+   */
+  bool SupportsFirstDay() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_FIRST_DAY) > 0; }
 
-    /*!
-     * @brief Check whether this type is for timer rules or one time timers.
-     * @return True if type represents a timer rule, false otherwise.
-     */
-    bool IsTimerRule() const { return (m_iAttributes & PVR_TIMER_TYPE_IS_REPEATING) > 0; }
+  /*!
+   * @brief Check whether this type supports weekdays for timer schedules.
+   * @return True if weekdays are supported, false otherwise.
+   */
+  bool SupportsWeekdays() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS) > 0; }
 
-    /*!
-     * @brief Check whether this type is for reminder timers or recording timers.
-     * @return True if type represents a reminder timer, false otherwise.
-     */
-    bool IsReminder() const { return (m_iAttributes & PVR_TIMER_TYPE_IS_REMINDER) > 0; }
+  /*!
+   * @brief Check whether this type supports the "record only new episodes" feature.
+   * @return True if the "record only new episodes" feature is supported, false otherwise.
+   */
+  bool SupportsRecordOnlyNewEpisodes() const
+  {
+    return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_RECORD_ONLY_NEW_EPISODES) > 0;
+  }
 
-    /*!
-     * @brief Check whether this type is for timer rules or one time timers.
-     * @return True if type represents a one time timer, false otherwise.
-     */
-    bool IsOnetime() const { return !IsTimerRule(); }
+  /*!
+   * @brief Check whether this type supports pre record time.
+   * @return True if pre record time is supported, false otherwise.
+   */
+  bool SupportsStartMargin() const
+  {
+    return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_START_MARGIN) > 0 ||
+           (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN) > 0;
+  }
 
-    /*!
-     * @brief Check whether this type is for epg-based or manual timers.
-     * @return True if manual, false otherwise.
-     */
-    bool IsManual() const { return (m_iAttributes & PVR_TIMER_TYPE_IS_MANUAL) > 0; }
+  /*!
+   * @brief Check whether this type supports post record time.
+   * @return True if post record time is supported, false otherwise.
+   */
+  bool SupportsEndMargin() const
+  {
+    return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_END_MARGIN) > 0 ||
+           (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN) > 0;
+  }
 
-    /*!
-     * @brief Check whether this type is for epg-based or manual timers.
-     * @return True if epg-based, false otherwise.
-     */
-    bool IsEpgBased() const { return !IsManual(); }
+  /*!
+   * @brief Check whether this type supports recording priorities.
+   * @return True if recording priority is supported, false otherwise.
+   */
+  bool SupportsPriority() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_PRIORITY) > 0; }
 
-    /*!
-     * @brief Check whether this type is for epg-based timer rules.
-     * @return True if epg-based timer rule, false otherwise.
-     */
-    bool IsEpgBasedTimerRule() const { return IsEpgBased() && IsTimerRule(); }
+  /*!
+   * @brief Check whether this type supports lifetime for recordings.
+   * @return True if recording lifetime is supported, false otherwise.
+   */
+  bool SupportsLifetime() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_LIFETIME) > 0; }
 
-    /*!
-     * @brief Check whether this type is for one time epg-based timers.
-     * @return True if one time epg-based, false otherwise.
-     */
-    bool IsEpgBasedOnetime() const { return IsEpgBased() && IsOnetime(); }
+  /*!
+   * @brief Check whether this type supports MaxRecordings for recordings.
+   * @return True if MaxRecordings is supported, false otherwise.
+   */
+  bool SupportsMaxRecordings() const
+  {
+    return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_MAX_RECORDINGS) > 0;
+  }
 
-    /*!
-     * @brief Check whether this type is for manual timer rules.
-     * @return True if manual timer rule, false otherwise.
-     */
-    bool IsManualTimerRule() const { return IsManual() && IsTimerRule(); }
+  /*!
+   * @brief Check whether this type supports user specified recording folders.
+   * @return True if recording folders are supported, false otherwise.
+   */
+  bool SupportsRecordingFolders() const
+  {
+    return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS) > 0;
+  }
 
-    /*!
-     * @brief Check whether this type is for one time manual timers.
-     * @return True if one time manual, false otherwise.
-     */
-    bool IsManualOnetime() const { return IsManual() && IsOnetime(); }
+  /*!
+   * @brief Check whether this type supports recording groups.
+   * @return True if recording groups are supported, false otherwise.
+   */
+  bool SupportsRecordingGroup() const
+  {
+    return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP) > 0;
+  }
 
-    /*!
-     * @brief Check whether this type is readonly (must not be modified after initial creation).
-     * @return True if readonly, false otherwise.
-     */
-    bool IsReadOnly() const { return (m_iAttributes & PVR_TIMER_TYPE_IS_READONLY) > 0; }
+  /*!
+   * @brief Check whether this type supports 'any channel', for example for defining a timer rule that should match any channel instead of a particular channel.
+   * @return True if any channel is supported, false otherwise.
+   */
+  bool SupportsAnyChannel() const
+  {
+    return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL) > 0;
+  }
 
-    /*!
-     * @brief Check whether this type allows deletion.
-     * @return True if type allows deletion, false otherwise.
-     */
-    bool AllowsDelete() const { return !IsReadOnly() || SupportsReadOnlyDelete(); }
+  /*!
+   * @brief Check whether this type supports deletion of an otherwise read-only timer.
+   * @return True if read-only deletion is supported, false otherwise.
+   */
+  bool SupportsReadOnlyDelete() const
+  {
+    return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_READONLY_DELETE) > 0;
+  }
 
-    /*!
-     * @brief Check whether this type forbids creation of new timers of this type.
-     * @return True if new instances are forbidden, false otherwise.
-     */
-    bool ForbidsNewInstances() const { return (m_iAttributes & PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES) > 0; }
+  /*!
+   * @brief Obtain a list with all possible values for the priority attribute.
+   * @param list out, the list with the values or an empty list, if priority is not supported by this type.
+   */
+  void GetPriorityValues(std::vector<std::pair<std::string, int>>& list) const;
 
-    /*!
-     * @brief Check whether this timer type is forbidden when epg tag info is present.
-     * @return True if new instances are forbidden when epg info is present, false otherwise.
-     */
-    bool ForbidsEpgTagOnCreate() const { return (m_iAttributes & PVR_TIMER_TYPE_FORBIDS_EPG_TAG_ON_CREATE) > 0; }
+  /*!
+   * @brief Obtain the default value for the priority attribute.
+   * @return the default value.
+   */
+  int GetPriorityDefault() const { return m_iPriorityDefault; }
 
-    /*!
-     * @brief Check whether this timer type requires epg tag info to be present.
-     * @return True if new instances require EPG info, false otherwise.
-     */
-    bool RequiresEpgTagOnCreate() const { return (m_iAttributes & (PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
-                                                                   PVR_TIMER_TYPE_REQUIRES_EPG_SERIES_ON_CREATE |
-                                                                   PVR_TIMER_TYPE_REQUIRES_EPG_SERIESLINK_ON_CREATE)) > 0; }
+  /*!
+   * @brief Obtain a list with all possible values for the lifetime attribute.
+   * @param list out, the list with the values or an empty list, if lifetime is not supported by this type.
+   */
+  void GetLifetimeValues(std::vector<std::pair<std::string, int>>& list) const;
 
-    /*!
-     * @brief Check whether this timer type requires epg tag info including series attributes to be present.
-     * @return True if new instances require an EPG tag with series attributes, false otherwise.
-     */
-    bool RequiresEpgSeriesOnCreate() const { return (m_iAttributes & PVR_TIMER_TYPE_REQUIRES_EPG_SERIES_ON_CREATE) > 0; }
+  /*!
+   * @brief Obtain the default value for the lifetime attribute.
+   * @return the default value.
+   */
+  int GetLifetimeDefault() const { return m_iLifetimeDefault; }
 
-    /*!
-     * @brief Check whether this timer type requires epg tag info including a series link to be present.
-     * @return True if new instances require an EPG tag with a series link, false otherwise.
-     */
-    bool RequiresEpgSeriesLinkOnCreate() const { return (m_iAttributes & PVR_TIMER_TYPE_REQUIRES_EPG_SERIESLINK_ON_CREATE) > 0; }
+  /*!
+   * @brief Obtain a list with all possible values for the MaxRecordings attribute.
+   * @param list out, the list with the values or an empty list, if MaxRecordings is not supported by this type.
+   */
+  void GetMaxRecordingsValues(std::vector<std::pair<std::string, int>>& list) const;
 
-    /*!
-     * @brief Check whether this type supports the "enabling/disabling" of timers of its type.
-     * @return True if "enabling/disabling" feature is supported, false otherwise.
-     */
-    bool SupportsEnableDisable() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE) > 0; }
+  /*!
+   * @brief Obtain the default value for the MaxRecordings attribute.
+   * @return the default value.
+   */
+  int GetMaxRecordingsDefault() const { return m_iMaxRecordingsDefault; }
 
-    /*!
-     * @brief Check whether this type supports channels.
-     * @return True if channels are supported, false otherwise.
-     */
-    bool SupportsChannels() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_CHANNELS) > 0; }
+  /*!
+   * @brief Obtain a list with all possible values for the duplicate episode prevention attribute.
+   * @param list out, the list with the values or an empty list, if duplicate episode prevention is not supported by this type.
+   */
+  void GetPreventDuplicateEpisodesValues(std::vector<std::pair<std::string, int>>& list) const;
 
-    /*!
-     * @brief Check whether this type supports start time.
-     * @return True if start time values are supported, false otherwise.
-     */
-    bool SupportsStartTime() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_START_TIME) > 0; }
+  /*!
+   * @brief Obtain the default value for the duplicate episode prevention attribute.
+   * @return the default value.
+   */
+  int GetPreventDuplicateEpisodesDefault() const { return m_iPreventDupEpisodesDefault; }
 
-    /*!
-     * @brief Check whether this type supports end time.
-     * @return True if end time values are supported, false otherwise.
-     */
-    bool SupportsEndTime() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_END_TIME) > 0; }
-    /*!
-     * @brief Check whether this type supports start any time.
-     * @return True if start any time is supported, false otherwise.
-     */
-    bool SupportsStartAnyTime() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_START_ANYTIME) > 0; }
+  /*!
+   * @brief Obtain a list with all possible values for the recording group attribute.
+   * @param list out, the list with the values or an empty list, if recording group is not supported by this type.
+   */
+  void GetRecordingGroupValues(std::vector<std::pair<std::string, int>>& list) const;
 
-    /*!
-     * @brief Check whether this type supports end any time.
-     * @return True if end any time is supported, false otherwise.
-     */
-    bool SupportsEndAnyTime() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_END_ANYTIME) > 0; }
+  /*!
+   * @brief Obtain the default value for the Recording Group attribute.
+   * @return the default value.
+   */
+  int GetRecordingGroupDefault() const { return m_iRecordingGroupDefault; }
 
-    /*!
-     * @brief Check whether this type supports matching a search string against epg episode title.
-     * @return True if title matching is supported, false otherwise.
-     */
-    bool SupportsEpgTitleMatch() const { return (m_iAttributes & (PVR_TIMER_TYPE_SUPPORTS_TITLE_EPG_MATCH | PVR_TIMER_TYPE_SUPPORTS_FULLTEXT_EPG_MATCH)) > 0; }
+private:
+  void InitDescription();
+  void InitAttributeValues(const PVR_TIMER_TYPE& type);
+  void InitPriorityValues(const PVR_TIMER_TYPE& type);
+  void InitLifetimeValues(const PVR_TIMER_TYPE& type);
+  void InitMaxRecordingsValues(const PVR_TIMER_TYPE& type);
+  void InitPreventDuplicateEpisodesValues(const PVR_TIMER_TYPE& type);
+  void InitRecordingGroupValues(const PVR_TIMER_TYPE& type);
 
-    /*!
-     * @brief Check whether this type supports matching a search string against extended (fulltext) epg data. This
-              includes title matching.
-     * @return True if fulltext matching is supported, false otherwise.
-     */
-    bool SupportsEpgFulltextMatch() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_FULLTEXT_EPG_MATCH) > 0; }
-
-    /*!
-     * @brief Check whether this type supports a first day the timer is active.
-     * @return True if first day is supported, false otherwise.
-     */
-    bool SupportsFirstDay() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_FIRST_DAY) > 0; }
-
-    /*!
-     * @brief Check whether this type supports weekdays for timer schedules.
-     * @return True if weekdays are supported, false otherwise.
-     */
-    bool SupportsWeekdays() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS) > 0; }
-
-    /*!
-     * @brief Check whether this type supports the "record only new episodes" feature.
-     * @return True if the "record only new episodes" feature is supported, false otherwise.
-     */
-    bool SupportsRecordOnlyNewEpisodes() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_RECORD_ONLY_NEW_EPISODES) > 0; }
-
-    /*!
-     * @brief Check whether this type supports pre record time.
-     * @return True if pre record time is supported, false otherwise.
-     */
-    bool SupportsStartMargin() const
-    {
-      return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_START_MARGIN) > 0 ||
-             (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN) > 0;
-    }
-
-    /*!
-     * @brief Check whether this type supports post record time.
-     * @return True if post record time is supported, false otherwise.
-     */
-    bool SupportsEndMargin() const
-    {
-      return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_END_MARGIN) > 0 ||
-             (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN) > 0;
-    }
-
-    /*!
-     * @brief Check whether this type supports recording priorities.
-     * @return True if recording priority is supported, false otherwise.
-     */
-    bool SupportsPriority() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_PRIORITY) > 0; }
-
-    /*!
-     * @brief Check whether this type supports lifetime for recordings.
-     * @return True if recording lifetime is supported, false otherwise.
-     */
-    bool SupportsLifetime() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_LIFETIME) > 0; }
-
-    /*!
-     * @brief Check whether this type supports MaxRecordings for recordings.
-     * @return True if MaxRecordings is supported, false otherwise.
-     */
-    bool SupportsMaxRecordings() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_MAX_RECORDINGS) > 0; }
-
-    /*!
-     * @brief Check whether this type supports user specified recording folders.
-     * @return True if recording folders are supported, false otherwise.
-     */
-    bool SupportsRecordingFolders() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS) > 0; }
-
-    /*!
-     * @brief Check whether this type supports recording groups.
-     * @return True if recording groups are supported, false otherwise.
-     */
-    bool SupportsRecordingGroup() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP) > 0; }
-
-    /*!
-     * @brief Check whether this type supports 'any channel', for example for defining a timer rule that should match any channel instead of a particular channel.
-     * @return True if any channel is supported, false otherwise.
-     */
-    bool SupportsAnyChannel() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL) > 0; }
-
-    /*!
-     * @brief Check whether this type supports deletion of an otherwise read-only timer.
-     * @return True if read-only deletion is supported, false otherwise.
-     */
-    bool SupportsReadOnlyDelete() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_READONLY_DELETE) > 0; }
-
-    /*!
-     * @brief Obtain a list with all possible values for the priority attribute.
-     * @param list out, the list with the values or an empty list, if priority is not supported by this type.
-     */
-    void GetPriorityValues(std::vector<std::pair<std::string, int>>& list) const;
-
-    /*!
-     * @brief Obtain the default value for the priority attribute.
-     * @return the default value.
-     */
-    int GetPriorityDefault() const { return m_iPriorityDefault; }
-
-    /*!
-     * @brief Obtain a list with all possible values for the lifetime attribute.
-     * @param list out, the list with the values or an empty list, if lifetime is not supported by this type.
-     */
-    void GetLifetimeValues(std::vector<std::pair<std::string, int>>& list) const;
-
-    /*!
-     * @brief Obtain the default value for the lifetime attribute.
-     * @return the default value.
-     */
-    int GetLifetimeDefault() const { return m_iLifetimeDefault; }
-
-    /*!
-     * @brief Obtain a list with all possible values for the MaxRecordings attribute.
-     * @param list out, the list with the values or an empty list, if MaxRecordings is not supported by this type.
-     */
-    void GetMaxRecordingsValues(std::vector<std::pair<std::string, int>>& list) const;
-
-    /*!
-     * @brief Obtain the default value for the MaxRecordings attribute.
-     * @return the default value.
-     */
-    int GetMaxRecordingsDefault() const { return m_iMaxRecordingsDefault; }
-
-    /*!
-     * @brief Obtain a list with all possible values for the duplicate episode prevention attribute.
-     * @param list out, the list with the values or an empty list, if duplicate episode prevention is not supported by this type.
-     */
-    void GetPreventDuplicateEpisodesValues(std::vector<std::pair<std::string, int>>& list) const;
-
-    /*!
-     * @brief Obtain the default value for the duplicate episode prevention attribute.
-     * @return the default value.
-     */
-    int GetPreventDuplicateEpisodesDefault() const { return m_iPreventDupEpisodesDefault; }
-
-    /*!
-     * @brief Obtain a list with all possible values for the recording group attribute.
-     * @param list out, the list with the values or an empty list, if recording group is not supported by this type.
-     */
-    void GetRecordingGroupValues(std::vector<std::pair<std::string, int>>& list) const;
-
-    /*!
-     * @brief Obtain the default value for the Recording Group attribute.
-     * @return the default value.
-     */
-    int GetRecordingGroupDefault() const { return m_iRecordingGroupDefault; }
-
-  private:
-    void InitDescription();
-    void InitAttributeValues(const PVR_TIMER_TYPE& type);
-    void InitPriorityValues(const PVR_TIMER_TYPE& type);
-    void InitLifetimeValues(const PVR_TIMER_TYPE& type);
-    void InitMaxRecordingsValues(const PVR_TIMER_TYPE& type);
-    void InitPreventDuplicateEpisodesValues(const PVR_TIMER_TYPE& type);
-    void InitRecordingGroupValues(const PVR_TIMER_TYPE& type);
-
-    int m_iClientId = PVR_CLIENT_INVALID_UID;
-    unsigned int m_iTypeId;
-    uint64_t m_iAttributes;
-    std::string m_strDescription;
-    std::vector< std::pair<std::string, int> > m_priorityValues;
-    int m_iPriorityDefault = DEFAULT_RECORDING_PRIORITY;
-    std::vector< std::pair<std::string, int> > m_lifetimeValues;
-    int m_iLifetimeDefault = DEFAULT_RECORDING_LIFETIME;
-    std::vector< std::pair<std::string, int> > m_maxRecordingsValues;
-    int m_iMaxRecordingsDefault = 0;
-    std::vector< std::pair<std::string, int> > m_preventDupEpisodesValues;
-    unsigned int m_iPreventDupEpisodesDefault = DEFAULT_RECORDING_DUPLICATEHANDLING;
-    std::vector< std::pair<std::string, int> > m_recordingGroupValues;
-    unsigned int m_iRecordingGroupDefault = 0;
-  };
-}
+  int m_iClientId = PVR_CLIENT_INVALID_UID;
+  unsigned int m_iTypeId;
+  uint64_t m_iAttributes;
+  std::string m_strDescription;
+  std::vector<std::pair<std::string, int>> m_priorityValues;
+  int m_iPriorityDefault = DEFAULT_RECORDING_PRIORITY;
+  std::vector<std::pair<std::string, int>> m_lifetimeValues;
+  int m_iLifetimeDefault = DEFAULT_RECORDING_LIFETIME;
+  std::vector<std::pair<std::string, int>> m_maxRecordingsValues;
+  int m_iMaxRecordingsDefault = 0;
+  std::vector<std::pair<std::string, int>> m_preventDupEpisodesValues;
+  unsigned int m_iPreventDupEpisodesDefault = DEFAULT_RECORDING_DUPLICATEHANDLING;
+  std::vector<std::pair<std::string, int>> m_recordingGroupValues;
+  unsigned int m_iRecordingGroupDefault = 0;
+};
+} // namespace PVR


### PR DESCRIPTION
More cleanup to eliminate duplicate code.

1st commit is only clang-format to make diff of the second commit readable and Jenkins happy.

Runtime-tested on macOS, latest xbmc master.

@phunkyfish can you please review.