### PR TITLE
[PVR] Fix CPVRTimerType::GetPriorityValues().

### DIFF
--- a/xbmc/pvr/timers/PVRTimerType.h
+++ b/xbmc/pvr/timers/PVRTimerType.h
@@ -389,7 +389,7 @@ public:
    */
   const std::vector<SettingIntValue>& GetPriorityValues() const
   {
-    return m_lifetimeValues.GetValues();
+    return m_priorityValues.GetValues();
   }
 
   /*!


### PR DESCRIPTION
Fixes a c/p error that slipped in with a0beaa0af4167582319dc9c9014a8d6825aba4ac.

Runtime-tested on macOS, latest xbmc master.

@phunkyfish this is a no-brainer to review.