### PR TITLE
[PVR] Timer settings dialog: Some properties should be read-only for in-progress recordings

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -1361,6 +1361,15 @@ bool CGUIDialogPVRTimerSettings::TypeReadOnlyCondition(const std::string& condit
       return true;
   }
 
+  /* Handle recordings in progress. */
+  if (pThis->m_timerInfoTag->State() == PVR_TIMER_STATE_RECORDING)
+  {
+    if (cond == SETTING_TMR_TYPE || cond == SETTING_TMR_CHANNEL || cond == SETTING_TMR_BEGIN_PRE ||
+        cond == SETTING_TMR_START_DAY || cond == SETTING_TMR_BEGIN || SETTING_TMR_PRIORITY ||
+        cond == SETTING_TMR_DIR)
+      return false;
+  }
+
   // Let the PVR client decide...
   int idx = std::static_pointer_cast<const CSettingInt>(setting)->GetValue();
   const auto entry = pThis->m_typeEntries.find(idx);


### PR DESCRIPTION
Interesting, that nobody noticed that so far. If a recording is in progress, certain timer properties simply make no sense to be editable, like start time and pre padding time.

This PR makes those properties read-only, dependent on the state of the timer.

Runtime-tested on macOS and Android, latest xbmc master.

@phunkyfish could you please review.