### PR TITLE
Controller Dialog: Focus "OK" button by default in installation dialog

### DIFF
--- a/xbmc/games/controllers/dialogs/ControllerInstaller.cpp
+++ b/xbmc/games/controllers/dialogs/ControllerInstaller.cpp
@@ -74,6 +74,7 @@ void CControllerInstaller::Process()
   pSelectDialog->SetHeading(39020); // "The following additional add-ons will be installed"
   pSelectDialog->SetUseDetails(true);
   pSelectDialog->EnableButton(true, 186); // "OK""
+  pSelectDialog->SetButtonFocus(true);
   for (const auto& it : items)
     pSelectDialog->Add(*it);
   pSelectDialog->Open();


### PR DESCRIPTION
## Description

As title says, this PR is a single-liner that focuses the "OK" button in the dialog to install controller profiles.

Auto-focus for the OK button was added in https://github.com/xbmc/xbmc/pull/16802.

## Motivation and context

Noticed this small UX improvement while working on https://github.com/xbmc/xbmc/pull/25691.

## How has this been tested?

Tested on my latest `retroplayer-21.1` branch.

Included in my next round of test builds.

## What is the effect on users?

* Small UX improvement

## Screenshots (if appropriate):

Before, opening the installation dialog:

![Screenshot from 2024-09-01 21-17-05](https://github.com/user-attachments/assets/129d0056-ca66-4af0-ac8e-6ae6ed387464)

After, opening the installation dialog:

![Screenshot from 2024-09-01 21-17-54](https://github.com/user-attachments/assets/0e17a1cc-69cf-4efe-b757-750ed4b7a60d)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
