### PR TITLE
Games: Offer to install missing dependencies on game launch

### DIFF
--- a/xbmc/games/addons/GameClientProperties.h
+++ b/xbmc/games/addons/GameClientProperties.h
@@ -78,6 +78,9 @@ private:
   void AddProxyDll(const GameClientPtr& gameClient);
   bool HasProxyDll(const std::string& strLibPath) const;
 
+  // Utility functions
+  static bool InstallDependencies(const std::vector<std::string>& addons);
+
   // Construction parameters
   const CGameClient& m_parent;
   AddonProps_Game& m_properties;


### PR DESCRIPTION
## Description

This PR fixes a small edge case: When an emulator is installed, but the corresponding controller profiles aren't.

Ideally this won't happen, as emulators list the controller profiles in their requires section. However, recently I built an emulator locally, and it wouldn't load out of the box because the controller profile wasn't installed.

Instead, attempt to simply install the missing controller profiles.

## Motivation and context

Avoids a possible UX disaster where the game just doesn't load.

## How has this been tested?

Tested on my latest `retroplayer-21.1` branch.

Included in my next round of test builds.

## What is the effect on users?

* Minor UX improvement when launching games

## Screenshots (if appropriate):

Before:

![Screenshot from 2024-09-01 21-03-54](https://github.com/user-attachments/assets/c65dcace-6ad6-4c99-8520-f363ad1a9ef5)

After:

![Screenshot from 2024-09-01 21-16-10](https://github.com/user-attachments/assets/2f7bc78a-7917-40ad-a3cb-b7abd997689c)

![Screenshot from 2024-09-01 21-16-13](https://github.com/user-attachments/assets/3ff78c53-8409-45f7-b64d-b644eb023548)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
