### PR TITLE
Fix CDDB lookups

### DIFF
--- a/xbmc/network/cddb.cpp
+++ b/xbmc/network/cddb.cpp
@@ -126,11 +126,10 @@ bool Xcddb::Send( const void *buffer, int bytes )
 {
   std::unique_ptr<char[]> tmp_buffer(new char[bytes + 10]);
   strcpy(tmp_buffer.get(), (const char*)buffer);
-  tmp_buffer.get()[bytes] = '.';
-  tmp_buffer.get()[bytes + 1] = 0x0d;
-  tmp_buffer.get()[bytes + 2] = 0x0a;
-  tmp_buffer.get()[bytes + 3] = 0x00;
-  int iErr = send((SOCKET)m_cddb_socket, (const char*)tmp_buffer.get(), bytes + 3, 0);
+  tmp_buffer.get()[bytes] = 0x0d;
+  tmp_buffer.get()[bytes + 1] = 0x0a;
+  tmp_buffer.get()[bytes + 2] = 0x00;
+  int iErr = send((SOCKET)m_cddb_socket, (const char*)tmp_buffer.get(), bytes + 2, 0);
   if (iErr <= 0)
   {
     return false;


### PR DESCRIPTION
## Description
This fixes CDDB lookups on gnudb.org for audio cd's.
Currently these lookups will fail.

Checking the communication between Kodi and gnudb.org i noticed
Kodi terminates every request with a `.`

So during a lookup, instead of requesting info for a cd with an id of `1234abcd` it will ask for `1234abcd.`
gnudb will respond with a 'No such CD entry in database' message. 
(also see the debuglog provided here https://forum.kodi.tv/showthread.php?tid=378247)

There's no mention in the gnudb documentation that requests need to be `.` terminated.
Only that the server responses are `.` terminated.
https://gnudb.org/howtognudb.php

**Please check if my changes are code correct as i'm no c++ coder by any means.**

## Motivation and context
Users can not retrieve cd info when ripping or playing cd's in Kodi.
Also the CU LRC Lyrics script will not work with audio cd's, since there's no artist / track title info available.

## How has this been tested?
I've tested it by playing several cd's in Kodi before and after this change.

## What is the effect on users?
Users can now see the artistname and track title in Kodi when  they're playing audio cd's.

## Screenshots (if appropriate):
Wireshark trace before the change:
![before](https://github.com/user-attachments/assets/e7fafa87-aa00-480b-9f68-50c0c3a646ab)

Wireshark trace after the change:
![after](https://github.com/user-attachments/assets/cb7a7d55-53c5-47b3-9da6-24970a268e9f)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
