### PR TITLE
glob the classpath in CMake instead of Java

### DIFF
--- a/xbmc/interfaces/swig/CMakeLists.txt
+++ b/xbmc/interfaces/swig/CMakeLists.txt
@@ -1,9 +1,9 @@
 function(generate_file file)
-  set(classpath ${groovy_SOURCE_DIR}/lib/*
-                ${apache-commons-lang_SOURCE_DIR}/*
-                ${apache-commons-text_SOURCE_DIR}/*
-                ${CMAKE_SOURCE_DIR}/tools/codegenerator
-                ${CMAKE_CURRENT_SOURCE_DIR}/../python)
+  file(GLOB classpath ${groovy_SOURCE_DIR}/lib/*
+                      ${apache-commons-lang_SOURCE_DIR}/*
+                      ${apache-commons-text_SOURCE_DIR}/*
+                      ${CMAKE_SOURCE_DIR}/tools/codegenerator
+                      ${CMAKE_CURRENT_SOURCE_DIR}/../python)
   if(NOT CORE_SYSTEM_NAME STREQUAL windows AND NOT CORE_SYSTEM_NAME STREQUAL windowsstore)
     set(devnull "/dev/null")
     string(REPLACE ";" ":" classpath "${classpath}")


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
As discovered in #24225, using wildcard in `java -cp` can work incorrectly in a mixed-bitness container with bind-mounted filesystems. Move the responsiblity of globbing to CMake itself, which works correctly.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes building Kodi inside QEMU-emulated ARM chroot on x86_64.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test-build this commit on top of Raspberry Pi OS's downstream fork [1].

[1]\: https://github.com/popcornmix/xbmc/tree/rpios_omega

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
