### PR TITLE
[PVR] Timer settings dialog: Fix settings read-only conditions for in-progress recordings

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -1365,8 +1365,8 @@ bool CGUIDialogPVRTimerSettings::TypeReadOnlyCondition(const std::string& condit
   if (pThis->m_timerInfoTag->State() == PVR_TIMER_STATE_RECORDING)
   {
     if (cond == SETTING_TMR_TYPE || cond == SETTING_TMR_CHANNEL || cond == SETTING_TMR_BEGIN_PRE ||
-        cond == SETTING_TMR_START_DAY || cond == SETTING_TMR_BEGIN || SETTING_TMR_PRIORITY ||
-        cond == SETTING_TMR_DIR)
+        cond == SETTING_TMR_START_DAY || cond == SETTING_TMR_BEGIN ||
+        cond == SETTING_TMR_PRIORITY || cond == SETTING_TMR_DIR)
       return false;
   }
 


### PR DESCRIPTION
Change intended with https://github.com/xbmc/xbmc/pull/25687 did not work, because the condition was always true due to a stupid mistake on my end (a `cond == ` for checking `priority`setting was missing).

Runtime-tested on macOS, latest xbmc master.

@phunkyfish would be nice if you could review this one.