### PR TITLE
[PVR][addons] PVR Add-on API changes + Implementation: Custom Timer Settings

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/General.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/General.h
@@ -23,8 +23,8 @@ namespace addon
 //==============================================================================
 /// @defgroup cpp_kodi_addon_pvr_Defs_PVRTypeIntValue class PVRTypeIntValue
 /// @ingroup cpp_kodi_addon_pvr_Defs_General
-/// @brief **PVR add-on type value**\n
-/// Representation of a <b>`<int, std::string>`</b> event related value.
+/// @brief **PVR add-on int type value**\n
+/// Representation of a <b>`<int, std::string>`</b> value.
 ///
 /// ----------------------------------------------------------------------------
 ///
@@ -92,7 +92,7 @@ public:
     for (unsigned int i = 0; i < source.size(); ++i)
     {
       values[i].iValue = source[i].GetCStructure()->iValue;
-      AllocResources(source[i].GetCStructure(), &values[i]);
+      AllocResources(source[i].GetCStructure(), &values[i]); // handles strDescription
     }
     return values;
   }
@@ -104,7 +104,7 @@ public:
     for (unsigned int i = 0; i < size; ++i)
     {
       values[i].iValue = source[i].iValue;
-      AllocResources(&source[i], &values[i]);
+      AllocResources(&source[i], &values[i]); // handles strDescription
     }
     return values;
   }
@@ -143,6 +143,913 @@ public:
 private:
   PVRTypeIntValue(const PVR_ATTRIBUTE_INT_VALUE* data) : DynamicCStructHdl(data) {}
   PVRTypeIntValue(PVR_ATTRIBUTE_INT_VALUE* data) : DynamicCStructHdl(data) {}
+};
+///@}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @defgroup cpp_kodi_addon_pvr_Defs_PVRTypeStringValue class PVRTypeStringValue
+/// @ingroup cpp_kodi_addon_pvr_Defs_General
+/// @brief **PVR add-on string type value**\n
+/// Representation of a <b>`<std::string, std::string>`</b> value.
+///
+/// ----------------------------------------------------------------------------
+///
+/// @copydetails cpp_kodi_addon_pvr_Defs_PVRTypeStringValue_Help
+///
+///@{
+class PVRTypeStringValue : public DynamicCStructHdl<PVRTypeStringValue, PVR_ATTRIBUTE_STRING_VALUE>
+{
+  friend class CInstancePVRClient;
+
+public:
+  /*! \cond PRIVATE */
+  PVRTypeStringValue(const PVRTypeStringValue& data) : DynamicCStructHdl(data) {}
+  /*! \endcond */
+
+  /// @defgroup cpp_kodi_addon_pvr_Defs_PVRTypeStringValue_Help Value Help
+  /// @ingroup cpp_kodi_addon_pvr_Defs_PVRTypeStringValue
+  ///
+  /// <b>The following table contains values that can be set with @ref cpp_kodi_addon_pvr_Defs_PVRTypeStringValue :</b>
+  /// | Name | Type | Set call | Get call
+  /// |------|------|----------|----------
+  /// | **Value** | `std::string` | @ref PVRTypeStringValue::SetValue "SetValue" | @ref PVRTypeStringValue::GetValue "GetValue"
+  /// | **Description** | `std::string` | @ref PVRTypeStringValue::SetDescription "SetDescription" | @ref PVRTypeStringValue::GetDescription "GetDescription"
+  ///
+  /// @remark Further can there be used his class constructor to set values.
+
+  /// @addtogroup cpp_kodi_addon_pvr_Defs_PVRTypeStringValue
+  ///@{
+
+  /// @brief Default class constructor.
+  PVRTypeStringValue() = default;
+
+  /// @brief Class constructor with integrated value set.
+  ///
+  /// @param[in] value Type identification value
+  /// @param[in] description Type description text
+  PVRTypeStringValue(const std::string& value, const std::string& description)
+  {
+    SetValue(value);
+    SetDescription(description);
+  }
+
+  /// @brief To set with the identification value.
+  void SetValue(const std::string& value)
+  {
+    ReallocAndCopyString(&m_cStructure->strValue, value.c_str());
+  }
+
+  /// @brief To get with the identification value.
+  std::string GetValue() const { return m_cStructure->strValue ? m_cStructure->strValue : ""; }
+
+  /// @brief To set with the description text of the value.
+  void SetDescription(const std::string& description)
+  {
+    ReallocAndCopyString(&m_cStructure->strDescription, description.c_str());
+  }
+
+  /// @brief To get with the description text of the value.
+  std::string GetDescription() const
+  {
+    return m_cStructure->strDescription ? m_cStructure->strDescription : "";
+  }
+  ///@}
+
+  static PVR_ATTRIBUTE_STRING_VALUE* AllocAndCopyData(const std::vector<PVRTypeStringValue>& source)
+  {
+    PVR_ATTRIBUTE_STRING_VALUE* values = new PVR_ATTRIBUTE_STRING_VALUE[source.size()]{};
+    for (unsigned int i = 0; i < source.size(); ++i)
+      AllocResources(source[i].GetCStructure(), &values[i]); // handles strValue, strDescription
+    return values;
+  }
+
+  static PVR_ATTRIBUTE_STRING_VALUE* AllocAndCopyData(const PVR_ATTRIBUTE_STRING_VALUE* source,
+                                                      unsigned int size)
+  {
+    PVR_ATTRIBUTE_STRING_VALUE* values = new PVR_ATTRIBUTE_STRING_VALUE[size]{};
+    for (unsigned int i = 0; i < size; ++i)
+      AllocResources(&source[i], &values[i]); // handles strValue, strDescription
+    return values;
+  }
+
+  static void AllocResources(const PVR_ATTRIBUTE_STRING_VALUE* source,
+                             PVR_ATTRIBUTE_STRING_VALUE* target)
+  {
+    target->strValue = AllocAndCopyString(source->strValue);
+    target->strDescription = AllocAndCopyString(source->strDescription);
+  }
+
+  static void FreeResources(PVR_ATTRIBUTE_STRING_VALUE* target)
+  {
+    FreeString(target->strValue);
+    target->strValue = nullptr;
+    FreeString(target->strDescription);
+    target->strDescription = nullptr;
+  }
+
+  static void FreeResources(PVR_ATTRIBUTE_STRING_VALUE* values, unsigned int size)
+  {
+    for (unsigned int i = 0; i < size; ++i)
+      FreeResources(&values[i]);
+    delete[] values;
+  }
+
+  static void ReallocAndCopyData(PVR_ATTRIBUTE_STRING_VALUE** source,
+                                 unsigned int* size,
+                                 const std::vector<PVRTypeStringValue>& values)
+  {
+    FreeResources(*source, *size);
+    *source = nullptr;
+    *size = values.size();
+    if (*size)
+      *source = AllocAndCopyData(values);
+  }
+
+private:
+  PVRTypeStringValue(const PVR_ATTRIBUTE_STRING_VALUE* data) : DynamicCStructHdl(data) {}
+  PVRTypeStringValue(PVR_ATTRIBUTE_STRING_VALUE* data) : DynamicCStructHdl(data) {}
+};
+///@}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @defgroup cpp_kodi_addon_pvr_Defs_PVRIntSettingDefinition class PVRIntSettingDefinition
+/// @ingroup cpp_kodi_addon_pvr_Defs_General
+/// @brief **PVR add-on integer setting definition**\n
+/// Representation of an integer setting definition.
+///
+/// ----------------------------------------------------------------------------
+///
+/// @copydetails cpp_kodi_addon_pvr_Defs_PVRIntSettingDefinition_Help
+///
+///@{
+class PVRIntSettingDefinition
+  : public DynamicCStructHdl<PVRIntSettingDefinition, PVR_INT_SETTING_DEFINITION>
+{
+  friend class CInstancePVRClient;
+
+public:
+  /*! \cond PRIVATE */
+  PVRIntSettingDefinition() { m_cStructure->iStep = 1; }
+  PVRIntSettingDefinition(const PVRIntSettingDefinition& def) : DynamicCStructHdl(def) {}
+  /*! \endcond */
+
+  /// @defgroup cpp_kodi_addon_pvr_Defs_General_PVRIntSettingDefinition_Help Value Help
+  /// @ingroup cpp_kodi_addon_pvr_Defs_General_PVRIntSettingDefinition
+  /// ----------------------------------------------------------------------------
+  ///
+  /// <b>The following table contains values that can be set with @ref cpp_kodi_addon_pvr_Defs_General_PVRIntSettingDefinition :</b>
+  /// | Name | Type | Set call | Get call | Usage
+  /// |------|------|----------|----------|-----------
+  /// | **Values** | @ref cpp_kodi_addon_pvr_Defs_PVRTypeIntValue "PVRTypeIntValue" | @ref PVRIntSettingDefinition::SetValues "SetValues" | @ref PVRIntSettingDefinition:GetValues "GetValues" | *optional*
+  /// | **Default value** | `int`| @ref PVRIntSettingDefinition::SetDefaultValue "SetDefaultValue" | @ref PVRIntSettingDefinition::GetDefaultValue "GetDefaultValue" | *optional*
+  /// | **Min value** | `int`| @ref PVRIntSettingDefinition::SetMinValue "SetMinValue" | @ref PVRIntSettingDefinition::GetMinValue "GetMinValue" | *optional*
+  /// | **Step** | `int`| @ref PVRIntSettingDefinition::SetStep "SetStep" | @ref PVRIntSettingDefinition::GetStep "GetStep" | *optional*
+  /// | **Max value** | `int`| @ref PVRIntSettingDefinition::SetMaxValue "SetMaxValue" | @ref PVRIntSettingDefinition::GetMaxValue "GetMaxValue" | *optional*
+  ///
+
+  /// @addtogroup cpp_kodi_addon_pvr_Defs_PVRIntSettingDefinition
+  ///@{
+
+  /// @brief Class constructor with integrated values.
+  ///
+  /// @param[in] settingValues possible setting values
+  /// @param[in] defaultValue default setting value
+  /// @param[in] minValue minimim setting value
+  /// @param[in] step amount to change values from min to max
+  /// @param[in] maxValue maximum setting value
+  PVRIntSettingDefinition(const std::vector<PVRTypeIntValue>& settingValues,
+                          int defaultValue,
+                          int minValue,
+                          int step,
+                          int maxValue)
+  {
+    SetValues(settingValues);
+    SetDefaultValue(defaultValue);
+    SetMinValue(minValue);
+    SetStep(step);
+    SetMaxValue(maxValue);
+  }
+
+  /// @brief **optional**\n
+  /// value definitions.
+  ///
+  /// Array containing the possible settings values. If left blank, any int value is accepted.
+  ///
+  /// @param[in] values List of possible values
+  /// @param[in] defaultValue [opt] The default value in list, can also be
+  ///                               set by @ref SetDefaultValue()
+  ///
+  /// --------------------------------------------------------------------------
+  ///
+  /// @copydetails cpp_kodi_addon_pvr_Defs_PVRTypeIntValue_Help
+  void SetValues(const std::vector<PVRTypeIntValue>& values, int defaultValue = -1)
+  {
+    PVRTypeIntValue::ReallocAndCopyData(&m_cStructure->values, &m_cStructure->iValuesSize, values);
+    if (defaultValue != -1)
+      m_cStructure->iDefaultValue = defaultValue;
+  }
+
+  /// @brief To get with @ref SetValues changed values.
+  std::vector<PVRTypeIntValue> GetValues() const
+  {
+    std::vector<PVRTypeIntValue> ret;
+    for (unsigned int i = 0; i < m_cStructure->iValuesSize; ++i)
+      ret.emplace_back(m_cStructure->values[i].iValue, m_cStructure->values[i].strDescription);
+    return ret;
+  }
+
+  /// @brief **optional**\n
+  /// The default value for this setting.
+  void SetDefaultValue(int defaultValue) { m_cStructure->iDefaultValue = defaultValue; }
+
+  /// @brief To get with @ref SetDefaultValue changed values.
+  int GetDefaultValue() const { return m_cStructure->iDefaultValue; }
+
+  /// @brief **optional**\n
+  /// The minimum value for this setting.
+  void SetMinValue(int minValue) { m_cStructure->iMinValue = minValue; }
+
+  /// @brief To get with @ref SetMinValue changed values.
+  int GetMinValue() const { return m_cStructure->iMinValue; }
+
+  /// @brief **optional**\n
+  /// The amount for increasing the values for this setting from min to max.
+  void SetStep(int step) { m_cStructure->iStep = step; }
+
+  /// @brief To get with @ref SetStep changed values.
+  int GetStep() const { return m_cStructure->iStep; }
+
+  /// @brief **optional**\n
+  /// The maximum value for this setting.
+  void SetMaxValue(int maxValue) { m_cStructure->iMaxValue = maxValue; }
+
+  /// @brief To get with @ref SetMaxValue changed values.
+  int GetMaxValue() const { return m_cStructure->iMaxValue; }
+  ///@}
+
+  static PVR_INT_SETTING_DEFINITION* AllocAndCopyData(const PVRIntSettingDefinition& source)
+  {
+    PVR_INT_SETTING_DEFINITION* def = new PVR_INT_SETTING_DEFINITION{};
+    AllocResources(source.GetCStructure(), def); // handles values, iValuesSize
+    def->iDefaultValue = source.GetCStructure()->iDefaultValue;
+    def->iMinValue = source.GetCStructure()->iMinValue;
+    def->iStep = source.GetCStructure()->iStep;
+    def->iMaxValue = source.GetCStructure()->iMaxValue;
+    return def;
+  }
+
+  static PVR_INT_SETTING_DEFINITION* AllocAndCopyData(PVR_INT_SETTING_DEFINITION* source)
+  {
+    PVR_INT_SETTING_DEFINITION* def = new PVR_INT_SETTING_DEFINITION{};
+    AllocResources(source, def); // handles values, iValuesSize
+    def->iDefaultValue = source->iDefaultValue;
+    def->iMinValue = source->iMinValue;
+    def->iStep = source->iStep;
+    def->iMaxValue = source->iMaxValue;
+    return def;
+  }
+
+  static void AllocResources(const PVR_INT_SETTING_DEFINITION* source,
+                             PVR_INT_SETTING_DEFINITION* target)
+  {
+    target->values = PVRTypeIntValue::AllocAndCopyData(source->values, source->iValuesSize);
+    target->iValuesSize = source->iValuesSize;
+  }
+
+  static void FreeResources(PVR_INT_SETTING_DEFINITION* target)
+  {
+    PVRTypeIntValue::FreeResources(target->values, target->iValuesSize);
+    target->values = nullptr;
+    target->iValuesSize = 0;
+  }
+
+  static void ReallocAndCopyData(PVR_INT_SETTING_DEFINITION** source,
+                                 const PVRIntSettingDefinition& def)
+  {
+    if (*source)
+      FreeResources(*source);
+    *source = AllocAndCopyData(def);
+  }
+
+private:
+  PVRIntSettingDefinition(const PVR_INT_SETTING_DEFINITION* def) : DynamicCStructHdl(def) {}
+  PVRIntSettingDefinition(PVR_INT_SETTING_DEFINITION* def) : DynamicCStructHdl(def) {}
+};
+///@}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @defgroup cpp_kodi_addon_pvr_Defs_PVRStringSettingDefinition class PVRStringSettingDefinition
+/// @ingroup cpp_kodi_addon_pvr_Defs_General
+/// @brief **PVR add-on string setting definition**\n
+/// Representation of a string setting definition.
+///
+/// ----------------------------------------------------------------------------
+///
+/// @copydetails cpp_kodi_addon_pvr_Defs_PVRStringSettingDefinition_Help
+///
+///@{
+class PVRStringSettingDefinition
+  : public DynamicCStructHdl<PVRStringSettingDefinition, PVR_STRING_SETTING_DEFINITION>
+{
+  friend class CInstancePVRClient;
+
+public:
+  /*! \cond PRIVATE */
+  PVRStringSettingDefinition() { m_cStructure->bAllowEmptyValue = true; }
+  PVRStringSettingDefinition(const PVRStringSettingDefinition& def) : DynamicCStructHdl(def) {}
+  /*! \endcond */
+
+  /// @defgroup cpp_kodi_addon_pvr_Defs_General_PVRStringSettingDefinition_Help Value Help
+  /// @ingroup cpp_kodi_addon_pvr_Defs_General_PVRStringSettingDefinition
+  /// ----------------------------------------------------------------------------
+  ///
+  /// <b>The following table contains values that can be set with @ref cpp_kodi_addon_pvr_Defs_General_PVRStringSettingDefinition :</b>
+  /// | Name | Type | Set call | Get call | Usage
+  /// |------|------|----------|----------|-----------
+  /// | **Values** | @ref cpp_kodi_addon_pvr_Defs_PVRTypeStringValue "PVRTypeStringValue" | @ref PVRStringSettingDefinition::SetValues "SetValues" | @ref PVRStringSettingDefinition:GetValues "GetValues" | *optional*
+  /// | **Default value** | `std::string`| @ref PVRStringSettingDefinition::SetDefaultValue "SetDefaultValue" | @ref PVRStringSettingDefinition::GetDefaultValue "GetDefaultValue" | *optional*
+  /// | **Allow empty value** | `bool`| @ref PVRStringSettingDefinition::SetAllowEmptyValue "SetAllowEmptyValue" | @ref PVRStringSettingDefinition::GetetAllowEmptyValue "GetetAllowEmptyValue" | *optional*
+  ///
+
+  /// @addtogroup cpp_kodi_addon_pvr_Defs_PVRStringSettingDefinition
+  ///@{
+
+  /// @brief Class constructor with integrated values.
+  ///
+  /// @param[in] settingValues possible setting values
+  /// @param[in] defaultValue default setting value
+  /// @param[in] allowEmptyValues allow empty values flag
+  PVRStringSettingDefinition(const std::vector<PVRTypeStringValue>& settingValues,
+                             const std::string& defaultValue,
+                             bool allowEmptyValue)
+  {
+    SetValues(settingValues);
+    SetDefaultValue(defaultValue);
+    SetAllowEmptyValue(allowEmptyValue);
+  }
+
+  /// @brief **optional**\n
+  /// value definitions.
+  ///
+  /// Array containing the possible settings values. If left blank, any string value is accepted.
+  ///
+  /// @param[in] values List of possible values
+  /// @param[in] defaultValue [opt] The default value in list, can also be
+  ///                               set by @ref SetDefaultValue()
+  ///
+  /// --------------------------------------------------------------------------
+  ///
+  /// @copydetails cpp_kodi_addon_pvr_Defs_PVRTypeStringValue_Help
+  void SetValues(const std::vector<PVRTypeStringValue>& values,
+                 const std::string& defaultValue = "")
+  {
+    PVRTypeStringValue::ReallocAndCopyData(&m_cStructure->values, &m_cStructure->iValuesSize,
+                                           values);
+    ReallocAndCopyString(&m_cStructure->strDefaultValue, defaultValue.c_str());
+  }
+
+  /// @brief To get with @ref SetValues changed values.
+  std::vector<PVRTypeStringValue> GetValues() const
+  {
+    std::vector<PVRTypeStringValue> ret;
+    for (unsigned int i = 0; i < m_cStructure->iValuesSize; ++i)
+      ret.emplace_back(m_cStructure->values[i].strValue, m_cStructure->values[i].strDescription);
+    return ret;
+  }
+
+  /// @brief **optional**\n
+  /// The default value for this setting.
+  void SetDefaultValue(const std::string& defaultValue)
+  {
+    ReallocAndCopyString(&m_cStructure->strDefaultValue, defaultValue.c_str());
+  }
+
+  /// @brief To get with @ref SetDefaultValue changed values.
+  std::string GetDefaultValue() const
+  {
+    return m_cStructure->strDefaultValue ? m_cStructure->strDefaultValue : "";
+  }
+
+  /// @brief **optional**\n
+  /// The allow empty values flag for this setting.
+  void SetAllowEmptyValue(bool allowEmptyValue)
+  {
+    m_cStructure->bAllowEmptyValue = allowEmptyValue;
+  }
+
+  /// @brief To get with @ref SetAllowEmptyValue changed values.
+  bool GetAllowEmptyValue() const { return m_cStructure->bAllowEmptyValue; }
+  ///@}
+
+  static PVR_STRING_SETTING_DEFINITION* AllocAndCopyData(const PVRStringSettingDefinition& source)
+  {
+    PVR_STRING_SETTING_DEFINITION* def = new PVR_STRING_SETTING_DEFINITION{};
+    AllocResources(source.GetCStructure(), def); // handles strDefaultValue, values, iValuesSize
+    def->bAllowEmptyValue = source.GetCStructure()->bAllowEmptyValue;
+    return def;
+  }
+
+  static PVR_STRING_SETTING_DEFINITION* AllocAndCopyData(PVR_STRING_SETTING_DEFINITION* source)
+  {
+    PVR_STRING_SETTING_DEFINITION* def = new PVR_STRING_SETTING_DEFINITION{};
+    AllocResources(source, def); // handles strDefaultValue, values, iValuesSize
+    def->bAllowEmptyValue = source->bAllowEmptyValue;
+    return def;
+  }
+
+  static void AllocResources(const PVR_STRING_SETTING_DEFINITION* source,
+                             PVR_STRING_SETTING_DEFINITION* target)
+  {
+    target->strDefaultValue = AllocAndCopyString(source->strDefaultValue);
+    target->values = PVRTypeStringValue::AllocAndCopyData(source->values, source->iValuesSize);
+    target->iValuesSize = source->iValuesSize;
+  }
+
+  static void FreeResources(PVR_STRING_SETTING_DEFINITION* target)
+  {
+    PVRTypeStringValue::FreeResources(target->values, target->iValuesSize);
+    target->values = nullptr;
+    target->iValuesSize = 0;
+
+    FreeString(target->strDefaultValue);
+    target->strDefaultValue = nullptr;
+  }
+
+  static void ReallocAndCopyData(PVR_STRING_SETTING_DEFINITION** source,
+                                 const PVRStringSettingDefinition& def)
+  {
+    if (*source)
+      FreeResources(*source);
+    *source = AllocAndCopyData(def);
+  }
+
+private:
+  PVRStringSettingDefinition(const PVR_STRING_SETTING_DEFINITION* def) : DynamicCStructHdl(def) {}
+  PVRStringSettingDefinition(PVR_STRING_SETTING_DEFINITION* def) : DynamicCStructHdl(def) {}
+};
+///@}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @defgroup cpp_kodi_addon_pvr_Defs_PVRSettingDefinition class PVRSettingDefinition
+/// @ingroup cpp_kodi_addon_pvr_Defs_General
+/// @brief **PVR add-on setting definition**\n
+/// Representation of a setting definition.
+///
+/// ----------------------------------------------------------------------------
+///
+/// @copydetails cpp_kodi_addon_pvr_Defs_PVRSettingDefinition_Help
+///
+///@{
+class PVRSettingDefinition : public DynamicCStructHdl<PVRSettingDefinition, PVR_SETTING_DEFINITION>
+{
+  friend class CInstancePVRClient;
+
+public:
+  /*! \cond PRIVATE */
+  PVRSettingDefinition() = default;
+  PVRSettingDefinition(const PVRSettingDefinition& type) : DynamicCStructHdl(type) {}
+  /*! \endcond */
+
+  /// @defgroup cpp_kodi_addon_pvr_Defs_General_PVRSettingDefinition_Help Value Help
+  /// @ingroup cpp_kodi_addon_pvr_Defs_General_PVRSettingDefinition
+  /// ----------------------------------------------------------------------------
+  ///
+  /// <b>The following table contains values that can be set with @ref cpp_kodi_addon_pvr_Defs_General_PVRSettingDefinition :</b>
+  /// | Name | Type | Set call | Get call | Usage
+  /// |------|------|----------|----------|-----------
+  /// | **Identifier** | `unsigned int` | @ref PVRSettingDefinition::SetId "SetId" | @ref PVRSettingDefinition::GetId "GetId" | *required to set*
+  /// | **Name** | `std::string` | @ref PVRSettingDefinition::SetName "SetName" | @ref PVRSettingDefinition::GetName "GetName" | *required to set*
+  /// | **Type** | @ref PVR_SETTING_TYPE | @ref PVRSettingDefinition::SetType "SetType" | @ref PVRSettingDefinition:GetType "GetType" | *required to set*
+  /// | | | | | |
+  /// | **Read-only conditions** | `uint64_t`| @ref PVRSettingDefinition::SetReadonlyConditions "SetReadonlyConditions" | @ref PVRSettingDefinition::GetReadonlyConditions "GetReadonlyConditions" | *optional*
+  /// | | | | | |
+  /// | **Int Definition** | @ref cpp_kodi_addon_pvr_Defs_PVRIntSettingDefinition "PVRIntSettingDefinition" | @ref PVRSettingDefinition::SetIntDefinition "SetIntDefinition" | @ref PVRSettingDefinition:GetIntDefinition "GetIntDefinition" | *optional*
+  /// | **String Definition** | @ref cpp_kodi_addon_pvr_Defs_PVRStringSettingDefinition "PVRStringSettingDefinition" | @ref PVRSettingDefinition::SetStringValues "SetStringDefinition" | @ref PVRSettingDefinition:GetStringDefinition "GetStringDefinition" | *optional*
+  ///
+
+  /// @addtogroup cpp_kodi_addon_pvr_Defs_PVRSettingDefinition
+  ///@{
+
+  /// @brief Class constructor with integrated values.
+  ///
+  /// @param[in] settingDefId Setting definition identification value
+  /// @param[in] settingDefName Setting definition name
+  /// @param[in] readonlyConditions readonly conditions value
+  /// @param[in] settingDef int setting definition
+  PVRSettingDefinition(unsigned int settingDefId,
+                       const std::string& settingDefName,
+                       uint64_t readonlyConditions,
+                       const PVRIntSettingDefinition& settingDef)
+  {
+    SetId(settingDefId);
+    SetName(settingDefName);
+    SetType(PVR_SETTING_TYPE::INTEGER);
+    SetReadonlyConditions(readonlyConditions);
+    SetIntDefinition(settingDef);
+  }
+
+  /// @brief Class constructor with integrated values.
+  ///
+  /// @param[in] settingDefId Setting definition identification value
+  /// @param[in] settingDefName Setting definition name
+  /// @param[in] readonlyConditions readonly conditions value
+  /// @param[in] settingDef string setting definition
+  PVRSettingDefinition(unsigned int settingDefId,
+                       const std::string& settingDefName,
+                       uint64_t readonlyConditions,
+                       const PVRStringSettingDefinition& settingDef)
+  {
+    SetId(settingDefId);
+    SetName(settingDefName);
+    SetType(PVR_SETTING_TYPE::STRING);
+    SetReadonlyConditions(readonlyConditions);
+    SetStringDefinition(settingDef);
+  }
+
+  /// @brief Class constructor with integrated values.
+  ///
+  /// @param[in] settingDefId Setting definition identification value
+  /// @param[in] settingDefName Setting definition name
+  /// @param[in] eType Setting type
+  /// @param[in] readonlyConditions readonly conditions value
+  /// @param[in] intSettingDef int setting definition
+  /// @param[in] stringSettingDef string setting definition
+  PVRSettingDefinition(unsigned int settingDefId,
+                       const std::string& settingDefName,
+                       PVR_SETTING_TYPE eType,
+                       uint64_t readonlyConditions,
+                       const PVRIntSettingDefinition& intSettingDef,
+                       const PVRStringSettingDefinition& stringSettingDef)
+  {
+    SetId(settingDefId);
+    SetName(settingDefName);
+    SetType(eType);
+    SetReadonlyConditions(readonlyConditions);
+    SetIntDefinition(intSettingDef);
+    SetStringDefinition(stringSettingDef);
+  }
+
+  /// @brief **required**\n
+  /// This setting definition's identifier.
+  void SetId(unsigned int defId) { m_cStructure->iId = defId; }
+
+  /// @brief To get with @ref SetId changed values.
+  unsigned int GetId() const { return m_cStructure->iId; }
+
+  /// @brief **required**\n
+  /// A short localized string with the name of the setting.
+  void SetName(const std::string& name)
+  {
+    ReallocAndCopyString(&m_cStructure->strName, name.c_str());
+  }
+
+  /// @brief To get with @ref SetName changed values.
+  std::string GetName() const { return m_cStructure->strName ? m_cStructure->strName : ""; }
+
+  /// @brief **required**\n
+  /// This setting definition's identifier.
+  void SetType(PVR_SETTING_TYPE eType) { m_cStructure->eType = eType; }
+
+  /// @brief To get with @ref SetType changed values.
+  PVR_SETTING_TYPE GetType() const { return m_cStructure->eType; }
+
+  /// @brief **optional**\n
+  /// The read-only conditions value for this setting.
+  /// @ref cpp_kodi_addon_pvr_Defs_General_PVR_SETTING_READONLY_CONDITION "PVR_SETTING_READONLY_CONDITION_*" enum values
+  void SetReadonlyConditions(uint64_t conditions)
+  {
+    m_cStructure->iReadonlyConditions = conditions;
+  }
+
+  /// @brief To get with @ref SetReadonlyConditions changed values.
+  uint64_t GetReadonlyConditions() const { return m_cStructure->iReadonlyConditions; }
+
+  //----------------------------------------------------------------------------
+
+  /// @brief **optional**\n
+  /// @param[in] def integer setting definition
+  ///
+  /// --------------------------------------------------------------------------
+  ///
+  /// @copydetails cpp_kodi_addon_pvr_Defs_PVRIntSettingDefinition_Help
+  void SetIntDefinition(const PVRIntSettingDefinition& def)
+  {
+    PVRIntSettingDefinition::ReallocAndCopyData(&m_cStructure->intSettingDefinition, def);
+  }
+
+  /// @brief To get with @ref SetIntDefinition changed values.
+  PVRIntSettingDefinition GetIntDefinition() const
+  {
+    PVRIntSettingDefinition ret;
+    if (m_cStructure->intSettingDefinition)
+    {
+      std::vector<PVRTypeIntValue> settingValues;
+      settingValues.reserve(m_cStructure->intSettingDefinition->iValuesSize);
+      for (unsigned int i = 0; i < m_cStructure->intSettingDefinition->iValuesSize; ++i)
+      {
+        settingValues.emplace_back(m_cStructure->intSettingDefinition->values[i].iValue,
+                                   m_cStructure->intSettingDefinition->values[i].strDescription);
+      }
+      ret.SetValues(std::move(settingValues));
+      ret.SetDefaultValue(m_cStructure->intSettingDefinition->iDefaultValue);
+      ret.SetMinValue(m_cStructure->intSettingDefinition->iMinValue);
+      ret.SetStep(m_cStructure->intSettingDefinition->iStep);
+      ret.SetMaxValue(m_cStructure->intSettingDefinition->iMaxValue);
+    }
+    return ret;
+  }
+
+  //----------------------------------------------------------------------------
+
+  /// @brief **optional**\n
+  /// @param[in] def string setting definition
+  ///
+  /// --------------------------------------------------------------------------
+  ///
+  /// @copydetails cpp_kodi_addon_pvr_Defs_PVRStringSettingDefinition_Help
+  void SetStringDefinition(const PVRStringSettingDefinition& def)
+  {
+    PVRStringSettingDefinition::ReallocAndCopyData(&m_cStructure->stringSettingDefinition, def);
+  }
+
+  /// @brief To get with @ref SetStringDefinition changed values.
+  PVRStringSettingDefinition GetStringDefinition() const
+  {
+    PVRStringSettingDefinition ret;
+    if (m_cStructure->stringSettingDefinition)
+    {
+      std::vector<PVRTypeStringValue> settingValues;
+      settingValues.reserve(m_cStructure->stringSettingDefinition->iValuesSize);
+      for (unsigned int i = 0; i < m_cStructure->stringSettingDefinition->iValuesSize; ++i)
+      {
+        settingValues.emplace_back(m_cStructure->stringSettingDefinition->values[i].strValue,
+                                   m_cStructure->stringSettingDefinition->values[i].strDescription);
+      }
+      ret.SetValues(std::move(settingValues));
+      ret.SetDefaultValue(m_cStructure->stringSettingDefinition->strDefaultValue);
+    }
+    return ret;
+  }
+  ///@}
+
+  static PVR_SETTING_DEFINITION** AllocAndCopyData(const std::vector<PVRSettingDefinition>& source)
+  {
+    PVR_SETTING_DEFINITION** defs = new PVR_SETTING_DEFINITION* [source.size()] {};
+    for (unsigned int i = 0; i < source.size(); ++i)
+    {
+      defs[i] = new PVR_SETTING_DEFINITION{};
+      defs[i]->iId = source[i].GetCStructure()->iId;
+      defs[i]->eType = source[i].GetCStructure()->eType;
+      defs[i]->iReadonlyConditions = source[i].GetCStructure()->iReadonlyConditions;
+      AllocResources(source[i].GetCStructure(),
+                     defs[i]); // handles strName, intSettingDefinition, stringSettingDefinition
+    }
+    return defs;
+  }
+
+  static PVR_SETTING_DEFINITION** AllocAndCopyData(PVR_SETTING_DEFINITION** source,
+                                                   unsigned int size)
+  {
+    PVR_SETTING_DEFINITION** defs = new PVR_SETTING_DEFINITION* [size] {};
+    for (unsigned int i = 0; i < size; ++i)
+    {
+      defs[i] = new PVR_SETTING_DEFINITION{};
+      defs[i]->iId = source[i]->iId;
+      defs[i]->eType = source[i]->eType;
+      defs[i]->iReadonlyConditions = source[i]->iReadonlyConditions;
+      AllocResources(source[i],
+                     defs[i]); // handles strName, intSettingDefinition, stringSettingDefinition
+    }
+    return defs;
+  }
+
+  static void AllocResources(const PVR_SETTING_DEFINITION* source, PVR_SETTING_DEFINITION* target)
+  {
+    target->strName = AllocAndCopyString(source->strName);
+    if (source->intSettingDefinition)
+      target->intSettingDefinition =
+          PVRIntSettingDefinition::AllocAndCopyData(source->intSettingDefinition);
+    if (source->stringSettingDefinition)
+      target->stringSettingDefinition =
+          PVRStringSettingDefinition::AllocAndCopyData(source->stringSettingDefinition);
+  }
+
+  static void FreeResources(PVR_SETTING_DEFINITION* target)
+  {
+    FreeString(target->strName);
+    target->strName = nullptr;
+
+    if (target->intSettingDefinition)
+    {
+      PVRIntSettingDefinition::FreeResources(target->intSettingDefinition);
+      target->intSettingDefinition = nullptr;
+    }
+
+    if (target->stringSettingDefinition)
+    {
+      PVRStringSettingDefinition::FreeResources(target->stringSettingDefinition);
+      target->stringSettingDefinition = nullptr;
+    }
+  }
+
+  static void FreeResources(PVR_SETTING_DEFINITION** defs, unsigned int size)
+  {
+    for (unsigned int i = 0; i < size; ++i)
+    {
+      FreeResources(defs[i]);
+      delete defs[i];
+    }
+    delete[] defs;
+  }
+
+  static void ReallocAndCopyData(PVR_SETTING_DEFINITION*** source,
+                                 unsigned int* size,
+                                 const std::vector<PVRSettingDefinition>& defs)
+  {
+    FreeResources(*source, *size);
+    *source = nullptr;
+    *size = defs.size();
+    if (*size)
+      *source = AllocAndCopyData(defs);
+  }
+
+private:
+  PVRSettingDefinition(const PVR_SETTING_DEFINITION* def) : DynamicCStructHdl(def) {}
+  PVRSettingDefinition(PVR_SETTING_DEFINITION* def) : DynamicCStructHdl(def) {}
+};
+///@}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @defgroup cpp_kodi_addon_pvr_Defs_General_PVRSettingKeyValuePair class PVRSettingKeyValuePair
+/// @ingroup cpp_kodi_addon_pvr_Defs_General
+/// @brief **Key-value pair of two ints**\n
+/// To hold a pair of two ints.
+///
+/// ----------------------------------------------------------------------------
+///
+/// @copydetails cpp_kodi_addon_pvr_Defs_General_PVRSettingKeyValuePair_Help
+///
+///@{
+class PVRSettingKeyValuePair
+  : public DynamicCStructHdl<PVRSettingKeyValuePair, PVR_SETTING_KEY_VALUE_PAIR>
+{
+  friend class CInstancePVRClient;
+
+public:
+  /*! \cond PRIVATE */
+  PVRSettingKeyValuePair(const PVRSettingKeyValuePair& pair) : DynamicCStructHdl(pair) {}
+  /*! \endcond */
+
+  /// @defgroup cpp_kodi_addon_pvr_Defs_General_PVRSettingKeyValuePair_Help Value Help
+  /// @ingroup cpp_kodi_addon_pvr_Defs_General_PVRSettingKeyValuePair
+  ///
+  /// <b>The following table contains values that can be set with @ref cpp_kodi_addon_pvr_Defs_General_PVRSettingKeyValuePair :</b>
+  /// | Name | Type | Set call | Get call
+  /// |------|------|----------|----------
+  /// | **Key** | `unsigned int` | @ref PVRSettingKeyValuePair::SetKey "SetKey" | @ref PVRSettingKeyValuePair::GetKey "GetKey"
+  /// | **Type** | @ref PVR_SETTING_TYPE | @ref PVRSettingKeyValuePair::SetType "SetType" | @ref PVRSettingKeyValuePair:GetType "GetType" | *required to set*
+  /// | **Int Value** | `int` | @ref PVRSettingKeyValuePair::SetIntValue "SetIntValue" | @ref PVRSettingKeyValuePair::GetIntValue "GetIntValue"
+  /// | **String Value** | `std::string` | @ref PVRSettingKeyValuePair::SetStringValue "SetStringValue" | @ref PVRSettingKeyValuePair::GetStringValue "GetStringValue"
+
+  /// @addtogroup cpp_kodi_addon_pvr_Defs_General_PVRSettingKeyValuePair
+  ///@{
+
+  /// @brief Default class constructor.
+  PVRSettingKeyValuePair() = default;
+
+  /// @brief Class constructor with integrated value set.
+  ///
+  /// @param[in] key The key
+  /// @param[in] value The value
+  PVRSettingKeyValuePair(unsigned int key, int value)
+  {
+    SetKey(key);
+    SetType(PVR_SETTING_TYPE::INTEGER);
+    SetIntValue(value);
+  }
+
+  /// @brief Class constructor with integrated value set.
+  ///
+  /// @param[in] key The key
+  /// @param[in] value The value
+  PVRSettingKeyValuePair(unsigned int key, const std::string& value)
+  {
+    SetKey(key);
+    SetType(PVR_SETTING_TYPE::STRING);
+    SetStringValue(value);
+  }
+
+  /// @brief Class constructor with integrated value set.
+  ///
+  /// @param[in] key The key
+  /// @param[in] eType The type
+  /// @param[in] intValue The int value
+  /// @param[in] stringValue The string value
+  PVRSettingKeyValuePair(unsigned int key,
+                         PVR_SETTING_TYPE eType,
+                         int intValue,
+                         const std::string& stringValue)
+  {
+    SetKey(key);
+    SetType(eType);
+    SetIntValue(intValue);
+    SetStringValue(stringValue);
+  }
+
+  /// @brief To set with the key.
+  void SetKey(unsigned int key) { m_cStructure->iKey = key; }
+
+  /// @brief To get with the key.
+  unsigned GetKey() const { return m_cStructure->iKey; }
+
+  /// @brief **required**\n
+  /// This key value pair's type.
+  void SetType(PVR_SETTING_TYPE eType) { m_cStructure->eType = eType; }
+
+  /// @brief To get with @ref SetType changed values.
+  PVR_SETTING_TYPE GetType() const { return m_cStructure->eType; }
+
+  /// @brief To set with the value.
+  void SetIntValue(int value) { m_cStructure->iValue = value; }
+
+  /// @brief To get with the value.
+  int GetIntValue() const { return m_cStructure->iValue; }
+
+  /// @brief To set with the value.
+  void SetStringValue(const std::string& value)
+  {
+    ReallocAndCopyString(&m_cStructure->strValue, value.c_str());
+  }
+
+  /// @brief To get with the value.
+  std::string GetStringValue() const
+  {
+    return m_cStructure->strValue ? m_cStructure->strValue : "";
+  }
+  ///@}
+
+  static PVR_SETTING_KEY_VALUE_PAIR* AllocAndCopyData(
+      const std::vector<PVRSettingKeyValuePair>& values)
+  {
+    PVR_SETTING_KEY_VALUE_PAIR* pairs = new PVR_SETTING_KEY_VALUE_PAIR[values.size()]{};
+    for (unsigned int i = 0; i < values.size(); ++i)
+    {
+      pairs[i].iKey = values[i].GetCStructure()->iKey;
+      pairs[i].eType = values[i].GetCStructure()->eType;
+      pairs[i].iValue = values[i].GetCStructure()->iValue;
+      AllocResources(values[i].GetCStructure(), &pairs[i]); // handles strValue
+    }
+    return pairs;
+  }
+
+  static PVR_SETTING_KEY_VALUE_PAIR* AllocAndCopyData(const PVR_SETTING_KEY_VALUE_PAIR* source,
+                                                      unsigned int size)
+  {
+    PVR_SETTING_KEY_VALUE_PAIR* pairs = new PVR_SETTING_KEY_VALUE_PAIR[size]{};
+    for (unsigned int i = 0; i < size; ++i)
+    {
+      pairs[i].iKey = source[i].iKey;
+      pairs[i].eType = source[i].eType;
+      pairs[i].iValue = source[i].iValue;
+      AllocResources(&source[i], &pairs[i]); // handles strValue
+    }
+    return pairs;
+  }
+
+  static void AllocResources(const PVR_SETTING_KEY_VALUE_PAIR* source,
+                             PVR_SETTING_KEY_VALUE_PAIR* target)
+  {
+    target->strValue = AllocAndCopyString(source->strValue);
+  }
+
+  static void FreeResources(PVR_SETTING_KEY_VALUE_PAIR* target) { FreeString(target->strValue); }
+
+  static void FreeResources(PVR_SETTING_KEY_VALUE_PAIR* pairs, unsigned int size)
+  {
+    for (unsigned int i = 0; i < size; ++i)
+      FreeResources(&pairs[i]);
+    delete[] pairs;
+  }
+
+  static void ReallocAndCopyData(PVR_SETTING_KEY_VALUE_PAIR** source,
+                                 unsigned int* size,
+                                 const std::vector<PVRSettingKeyValuePair>& values)
+  {
+    FreeResources(*source, *size);
+    *source = nullptr;
+    *size = values.size();
+    if (*size)
+      *source = AllocAndCopyData(values);
+  }
+
+private:
+  PVRSettingKeyValuePair(const PVR_SETTING_KEY_VALUE_PAIR* pair) : DynamicCStructHdl(pair) {}
+  PVRSettingKeyValuePair(PVR_SETTING_KEY_VALUE_PAIR* pair) : DynamicCStructHdl(pair) {}
 };
 ///@}
 //------------------------------------------------------------------------------

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Timers.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Timers.h
@@ -88,6 +88,7 @@ public:
   /// | **Genre type** | `int` | @ref PVRTimer::SetGenreType "SetGenreType" | @ref PVRTimer::GetGenreType "GetGenreType" | *optional*
   /// | **Genre sub type** | `int` | @ref PVRTimer::SetGenreSubType "SetGenreSubType" | @ref PVRTimer::GetGenreSubType "GetGenreSubType" | *optional*
   /// | **Series link** | `std::string` | @ref PVRTimer::SetSeriesLink "SetSeriesLink" | @ref PVRTimer::GetSeriesLink "GetSeriesLink" | *optional*
+  /// | **Custom properties** | @ref cpp_kodi_addon_pvr_Defs_PVRSettingKeyValuePair "PVRSettingKeyValuePair" | @ref PVRTimer::SetCustomProperties "SetCustomProperties" | @ref PVRTimer::GetCustomProperties "GetCustomProperties" | *optional*
 
   /// @addtogroup cpp_kodi_addon_pvr_Defs_Timer_PVRTimer
   ///@{
@@ -461,6 +462,39 @@ public:
   {
     return m_cStructure->strSeriesLink ? m_cStructure->strSeriesLink : "";
   }
+
+  //----------------------------------------------------------------------------
+
+  /// @brief **optional**\n
+  /// Array containing the custom properties.
+  ///
+  /// @param[in] properties List of properties.
+  ///
+  /// --------------------------------------------------------------------------
+  ///
+  /// @copydetails cpp_kodi_addon_pvr_Defs_General_PVRSettingKeyValuePair_Help
+  void SetCustomProperties(const std::vector<PVRSettingKeyValuePair>& properties)
+  {
+    PVRSettingKeyValuePair::ReallocAndCopyData(&m_cStructure->customProps,
+                                               &m_cStructure->iCustomPropsSize, properties);
+  }
+
+  /// @brief To get with @ref SetCustomProperties changed values
+  std::vector<PVRSettingKeyValuePair> GetCustomProperties() const
+  {
+    std::vector<PVRSettingKeyValuePair> ret;
+    if (m_cStructure->iCustomPropsSize)
+    {
+      ret.reserve(m_cStructure->iCustomPropsSize);
+      for (unsigned int i = 0; i < m_cStructure->iCustomPropsSize; ++i)
+      {
+        ret.emplace_back(m_cStructure->customProps[i].iKey, m_cStructure->customProps[i].eType,
+                         m_cStructure->customProps[i].iValue,
+                         m_cStructure->customProps[i].strValue);
+      }
+    }
+    return ret;
+  }
   ///@}
 
   static void AllocResources(const PVR_TIMER* source, PVR_TIMER* target)
@@ -470,6 +504,10 @@ public:
     target->strDirectory = AllocAndCopyString(source->strDirectory);
     target->strSummary = AllocAndCopyString(source->strSummary);
     target->strSeriesLink = AllocAndCopyString(source->strSeriesLink);
+
+    target->customProps =
+        PVRSettingKeyValuePair::AllocAndCopyData(source->customProps, source->iCustomPropsSize);
+    target->iCustomPropsSize = source->iCustomPropsSize;
   }
 
   static void FreeResources(PVR_TIMER* target)
@@ -479,6 +517,10 @@ public:
     FreeString(target->strDirectory);
     FreeString(target->strSummary);
     FreeString(target->strSeriesLink);
+
+    PVRSettingKeyValuePair::FreeResources(target->customProps, target->iCustomPropsSize);
+    target->customProps = nullptr;
+    target->iCustomPropsSize = 0;
   }
 
 private:
@@ -583,6 +625,8 @@ public:
   /// | | | | | |
   /// | **Max recordings selection** | @ref cpp_kodi_addon_pvr_Defs_PVRTypeIntValue "PVRTypeIntValue" | @ref PVRTimerType::SetMaxRecordings "SetMaxRecordings" | @ref PVRTimerType::GetMaxRecordings "GetMaxRecordings" | *optional*
   /// | **Max recordings default** | `int`| @ref PVRTimerType::SetMaxRecordingsDefault "SetMaxRecordingsDefault" | @ref PVRTimerType::GetMaxRecordingsDefault "GetMaxRecordingsDefault" | *optional*
+  /// | | | | | |
+  /// | **Custom setting definitions**|  @ref cpp_kodi_addon_pvr_Defs_PVRSettingDefinition "PVRSettingDefinition" | @ref PVRTimerType::SetCustomSettingDefinitions "SetCustomSettingDefinitions" | @ref PVRTimerType::GetCustomSettingDefinitions "GetCustomSettingDefinitions" | *optional*
   ///
 
   /// @addtogroup cpp_kodi_addon_pvr_Defs_Timer_PVRTimerType
@@ -822,7 +866,7 @@ public:
   /// @brief **optional**\n
   /// Array containing the possible values of @ref PVRTimer::SetMaxRecordings().
   ///
-  /// @param[in] maxRecordings List of lifetimes values
+  /// @param[in] maxRecordings List of max recordings values
   /// @param[in] maxRecordingsDefault [opt] The default value in list, can also be
   ///                                 set by @ref SetMaxRecordingsDefault()
   ///
@@ -859,6 +903,78 @@ public:
 
   /// @brief To get with @ref SetMaxRecordingsDefault changed values
   int GetMaxRecordingsDefault() const { return m_cStructure->iMaxRecordingsDefault; }
+
+  //----------------------------------------------------------------------------
+
+  /// @brief **optional**\n
+  /// Array containing the possible custom integer setting definitions.
+  ///
+  /// @param[in] defs List of integer setting definitions.
+  ///
+  /// --------------------------------------------------------------------------
+  ///
+  /// @copydetails cpp_kodi_addon_pvr_Defs_General_PVRIntSettingDefinition_Help
+  void SetCustomSettingDefinitions(const std::vector<PVRSettingDefinition>& defs)
+  {
+    PVRSettingDefinition::ReallocAndCopyData(&m_cStructure->customSettingDefs,
+                                             &m_cStructure->iCustomSettingDefsSize, defs);
+  }
+
+  /// @brief To get with @ref SetCustomSettingDefinitions changed values
+  std::vector<PVRSettingDefinition> GetCustomSettingDefinitions() const
+  {
+    std::vector<PVRSettingDefinition> ret;
+    if (m_cStructure->iCustomSettingDefsSize)
+    {
+      ret.reserve(m_cStructure->iCustomSettingDefsSize);
+      for (unsigned int i = 0; i < m_cStructure->iCustomSettingDefsSize; ++i)
+      {
+        const PVR_SETTING_DEFINITION* def{m_cStructure->customSettingDefs[i]};
+
+        PVRIntSettingDefinition intDef;
+        if (def->intSettingDefinition)
+        {
+          const PVR_INT_SETTING_DEFINITION* intSettingDef{def->intSettingDefinition};
+
+          std::vector<PVRTypeIntValue> intValues;
+          if (intSettingDef->iValuesSize)
+          {
+            intValues.reserve(intSettingDef->iValuesSize);
+            for (unsigned int j = 0; j < intSettingDef->iValuesSize; ++j)
+            {
+              intValues.emplace_back(intSettingDef->values[j].iValue,
+                                     intSettingDef->values[j].strDescription);
+            }
+          }
+          intDef = {intValues, intSettingDef->iDefaultValue, intSettingDef->iMinValue,
+                    intSettingDef->iStep, intSettingDef->iMaxValue};
+        }
+
+        PVRStringSettingDefinition stringDef;
+        if (def->stringSettingDefinition)
+        {
+          const PVR_STRING_SETTING_DEFINITION* stringSettingDef{def->stringSettingDefinition};
+
+          std::vector<PVRTypeStringValue> stringValues;
+          if (stringSettingDef->iValuesSize)
+          {
+            stringValues.reserve(stringSettingDef->iValuesSize);
+            for (unsigned int j = 0; j < stringSettingDef->iValuesSize; ++j)
+            {
+              stringValues.emplace_back(stringSettingDef->values[j].strValue,
+                                        stringSettingDef->values[j].strDescription);
+            }
+          }
+          stringDef = {stringValues, stringSettingDef->strDefaultValue,
+                       stringSettingDef->bAllowEmptyValue};
+        }
+
+        ret.emplace_back(def->iId, def->strName, def->eType, def->iReadonlyConditions, intDef,
+                         stringDef);
+      }
+    }
+    return ret;
+  }
   ///@}
 
   static void AllocResources(const PVR_TIMER_TYPE* source, PVR_TIMER_TYPE* target)
@@ -894,6 +1010,12 @@ public:
       target->maxRecordings =
           PVRTypeIntValue::AllocAndCopyData(source->maxRecordings, source->iMaxRecordingsSize);
     }
+
+    if (target->iCustomSettingDefsSize)
+    {
+      target->customSettingDefs = PVRSettingDefinition::AllocAndCopyData(
+          source->customSettingDefs, source->iCustomSettingDefsSize);
+    }
   }
 
   static void FreeResources(PVR_TIMER_TYPE* target)
@@ -921,6 +1043,10 @@ public:
     PVRTypeIntValue::FreeResources(target->maxRecordings, target->iMaxRecordingsSize);
     target->maxRecordings = nullptr;
     target->iMaxRecordingsSize = 0;
+
+    PVRSettingDefinition::FreeResources(target->customSettingDefs, target->iCustomSettingDefsSize);
+    target->customSettingDefs = nullptr;
+    target->iCustomSettingDefsSize = 0;
   }
 
 private:

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_defines.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_defines.h
@@ -20,13 +20,22 @@ extern "C"
 #endif /* __cplusplus */
 
   /*!
-   * @brief "C" Representation of a general attribute integer value.
+   * @brief "C" Representation of an integer value, including a description.
    */
   typedef struct PVR_ATTRIBUTE_INT_VALUE
   {
     int iValue;
     const char* strDescription;
   } PVR_ATTRIBUTE_INT_VALUE;
+
+  /*!
+   * @brief "C" Representation of a string value, including a description
+   */
+  typedef struct PVR_ATTRIBUTE_STRING_VALUE
+  {
+    const char* strValue;
+    const char* strDescription;
+  } PVR_ATTRIBUTE_STRING_VALUE;
 
   /*!
    * @brief "C" Representation of a named value.

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h
@@ -13,6 +13,7 @@
 #include "pvr_defines.h"
 
 #include <stdbool.h>
+#include <stdint.h>
 
 //¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯
 // "C" Definitions group 1 - General PVR
@@ -130,6 +131,56 @@ extern "C"
     /// @brief __1__ : From EPG, but playing back as live
     PVR_SOURCE_EPG_AS_LIVE = 1,
   } PVR_SOURCE;
+  ///@}
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  /// @defgroup cpp_kodi_addon_pvr_Defs_General_PVR_SETTING_READONLY_CONDITION enum PVR_SETTING_READONLY_CONDITION
+  /// @ingroup cpp_kodi_addon_pvr_Defs_General
+  /// @brief **Read-only conditions for settings**\n
+  /// To define read-only conditions for settings.
+  ///
+  ///@{
+  typedef enum PVR_SETTING_READONLY_CONDITION
+  {
+    /// @brief __0000 0000 0000 0000 0000 0000 0000 0000__ :\n Empty value.
+    PVR_SETTING_READONLY_CONDITION_NONE = 0,
+
+    /// @brief __0000 0000 0000 0000 0000 0000 0000 0001__ :\n Readonly, if associated timer is
+    /// disabled (PVR_TIMER_STATE_DISABLED. Applicable to timer settings only).
+    PVR_SETTING_READONLY_CONDITION_TIMER_DISABLED = (1 << 0),
+
+    /// @brief __0000 0000 0000 0000 0000 0000 0000 0010__ :\n Readonly, if associated timer is
+    /// scheduled (PVR_TIMER_STATE_SCHEDULED. Applicable to timer settings only).
+    PVR_SETTING_READONLY_CONDITION_TIMER_SCHEDULED = (1 << 1),
+
+    /// @brief __0000 0000 0000 0000 0000 0000 0000 0100__ :\n Readonly, if associated timer is
+    /// currently recording (PVR_TIMER_STATE_RECORDING. Applicable to timer settings only).
+    PVR_SETTING_READONLY_CONDITION_TIMER_RECORDING = (1 << 2),
+
+    /// @brief __0000 0000 0000 0000 0000 0000 0000 1000__ :\n Readonly, if associated timer is
+    /// currently recording (PVR_TIMER_STATE_COMPLETED. Applicable to timer settings only).
+    PVR_SETTING_READONLY_CONDITION_TIMER_COMPLETED = (1 << 3),
+
+  } PVR_SETTING_READONLY_CONDITION;
+  ///@}
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  /// @defgroup cpp_kodi_addon_pvr_Defs_General_PVR_SETTING_TYPE enum PVR_SETTING_TYPE
+  /// @ingroup cpp_kodi_addon_pvr_Defs_General
+  /// @brief **PVR setting type**\n
+  ///
+  ///@{
+  typedef enum PVR_SETTING_TYPE
+  {
+    /// @brief __0__ : Integer
+    INTEGER = 0,
+
+    /// @brief __1__ : String
+    STRING = 1,
+
+  } PVR_SETTING_TYPE;
   ///@}
   //----------------------------------------------------------------------------
 
@@ -323,6 +374,75 @@ extern "C"
     unsigned int iRecordingsLifetimesSize;
     struct PVR_ATTRIBUTE_INT_VALUE* recordingsLifetimeValues;
   } PVR_ADDON_CAPABILITIES;
+
+  /*!
+   * @brief "C" Representation of an integer setting definition.
+   *
+   * Structure used to interface in "C" between Kodi and Addon.
+   *
+   * See @ref cpp_kodi_addon_pvr_Defs_PVRIntSettingDefinition "kodi::addon::PVRIntSettingDefinition"
+   * for description of values.
+   */
+  typedef struct PVR_INT_SETTING_DEFINITION
+  {
+    unsigned int iValuesSize;
+    struct PVR_ATTRIBUTE_INT_VALUE* values;
+    int iDefaultValue;
+    int iMinValue;
+    int iStep;
+    int iMaxValue;
+  } PVR_INT_SETTING_DEFINITION;
+
+  /*!
+ * @brief "C" Representation of a string setting definition.
+ *
+ * Structure used to interface in "C" between Kodi and Addon.
+ *
+ * See @ref cpp_kodi_addon_pvr_Defs_PVRStringSettingDefinition "kodi::addon::PVRStringSettingDefinition"
+ * for description of values.
+ */
+  typedef struct PVR_STRING_SETTING_DEFINITION
+  {
+    unsigned int iValuesSize;
+    struct PVR_ATTRIBUTE_STRING_VALUE* values;
+    const char* strDefaultValue;
+    bool bAllowEmptyValue;
+  } PVR_STRING_SETTING_DEFINITION;
+
+  /*!
+ * @brief "C" Representation of a setting definition.
+ *
+ * Structure used to interface in "C" between Kodi and Addon.
+ *
+ * See @ref cpp_kodi_addon_pvr_Defs_PVRSettingDefinition "kodi::addon::PVRSettingDefinition"
+ * for description of values.
+ */
+  typedef struct PVR_SETTING_DEFINITION
+  {
+    unsigned int iId;
+    const char* strName;
+    enum PVR_SETTING_TYPE eType;
+    uint64_t iReadonlyConditions;
+    struct PVR_INT_SETTING_DEFINITION* intSettingDefinition;
+    struct PVR_STRING_SETTING_DEFINITION* stringSettingDefinition;
+  } PVR_SETTING_DEFINITION;
+
+  /*!
+   * @brief "C" Representation of a key-value pair, either {int,int} or {int,string}, depending on
+   * the type set.
+   *
+   * Structure used to interface in "C" between Kodi and Addon.
+   *
+   * See @ref cpp_kodi_addon_pvr_Defs_PVRSettingKeyValuePair "kodi::addon::PVRSettingKeyValuePair" for description
+   * of values.
+   */
+  typedef struct PVR_SETTING_KEY_VALUE_PAIR
+  {
+    unsigned int iKey;
+    enum PVR_SETTING_TYPE eType;
+    int iValue;
+    const char* strValue;
+  } PVR_SETTING_KEY_VALUE_PAIR;
 
 #ifdef __cplusplus
 }

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_timers.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_timers.h
@@ -298,7 +298,7 @@ extern "C"
     /// @brief __1__ : The timer is scheduled for recording.
     PVR_TIMER_STATE_SCHEDULED = 1,
 
-    /// @brief __2__ : The timer is currently recordings.
+    /// @brief __2__ : The timer is currently recording.
     PVR_TIMER_STATE_RECORDING = 2,
 
     /// @brief __3__ : The recording completed successfully.
@@ -310,19 +310,17 @@ extern "C"
     /// @brief __5__ : The timer was scheduled, but was canceled.
     PVR_TIMER_STATE_CANCELLED = 5,
 
-    /// @brief __6__ : The scheduled timer conflicts with another one, but will be
-    /// recorded.
+    /// @brief __6__ : The scheduled timer conflicts with another one, but will be recorded.
     PVR_TIMER_STATE_CONFLICT_OK = 6,
 
-    /// @brief __7__ : The scheduled timer conflicts with another one and won't be
-    /// recorded.
+    /// @brief __7__ : The scheduled timer conflicts with another one and won't be recorded.
     PVR_TIMER_STATE_CONFLICT_NOK = 7,
 
     /// @brief __8__ : The timer is scheduled, but can't be recorded for some reason.
     PVR_TIMER_STATE_ERROR = 8,
 
-    /// @brief __9__ : The timer was disabled by the user, can be enabled via setting
-    /// the state to @ref PVR_TIMER_STATE_SCHEDULED.
+    /// @brief __9__ : The timer was disabled by the user, can be enabled via setting the state to
+    /// @ref PVR_TIMER_STATE_SCHEDULED.
     PVR_TIMER_STATE_DISABLED = 9,
   } PVR_TIMER_STATE;
   ///@}
@@ -365,10 +363,12 @@ extern "C"
     int iGenreType;
     int iGenreSubType;
     const char* strSeriesLink;
+    unsigned int iCustomPropsSize;
+    struct PVR_SETTING_KEY_VALUE_PAIR* customProps;
   } PVR_TIMER;
 
   /*!
-   * @brief "C" PVR add-on timer event type.
+   * @brief "C" PVR add-on timer type.
    *
    * Structure used to interface in "C" between Kodi and Addon.
    *
@@ -400,6 +400,9 @@ extern "C"
     unsigned int iMaxRecordingsSize;
     struct PVR_ATTRIBUTE_INT_VALUE* maxRecordings;
     int iMaxRecordingsDefault;
+
+    unsigned int iCustomSettingDefsSize;
+    struct PVR_SETTING_DEFINITION** customSettingDefs;
   } PVR_TIMER_TYPE;
 
 #ifdef __cplusplus

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -130,7 +130,7 @@
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"
 
-#define ADDON_INSTANCE_VERSION_PVR                    "9.0.1"
+#define ADDON_INSTANCE_VERSION_PVR                    "9.1.0"
 #define ADDON_INSTANCE_VERSION_PVR_MIN                "9.0.0"
 #define ADDON_INSTANCE_VERSION_PVR_XML_ID             "kodi.binary.instance.pvr"
 #define ADDON_INSTANCE_VERSION_PVR_DEPENDS            "c-api/addon-instance/pvr.h" \

--- a/xbmc/pvr/addons/PVRClientCapabilities.cpp
+++ b/xbmc/pvr/addons/PVRClientCapabilities.cpp
@@ -55,13 +55,13 @@ void CPVRClientCapabilities::InitRecordingsLifetimeValues()
     {
       const auto& lifetime{m_addonCapabilities->recordingsLifetimeValues[i]};
       const int iValue{lifetime.iValue};
-      std::string strDescr{lifetime.strDescription ? lifetime.strDescription : ""};
-      if (strDescr.empty())
+      std::string description{lifetime.strDescription ? lifetime.strDescription : ""};
+      if (description.empty())
       {
         // No description given by addon. Create one from value.
-        strDescr = std::to_string(iValue);
+        description = std::to_string(iValue);
       }
-      m_recordingsLifetimeValues.emplace_back(strDescr, iValue);
+      m_recordingsLifetimeValues.emplace_back(description, iValue);
     }
   }
   else if (SupportsRecordingsLifetimeChange())

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
@@ -11,6 +11,7 @@
 #include "XBDateTime.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_channels.h" // PVR_CHANNEL_INVALID_UID
 #include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
+#include "pvr/settings/IPVRSettingsContainer.h"
 #include "settings/SettingConditions.h"
 #include "settings/dialogs/GUIDialogSettingsManualBase.h"
 #include "settings/lib/SettingDependency.h"
@@ -23,13 +24,15 @@
 class CSetting;
 
 struct IntegerSettingOption;
+struct StringSettingOption;
 
 namespace PVR
 {
+class CPVRCustomTimerSettings;
 class CPVRTimerInfoTag;
 class CPVRTimerType;
 
-class CGUIDialogPVRTimerSettings : public CGUIDialogSettingsManualBase
+class CGUIDialogPVRTimerSettings : public CGUIDialogSettingsManualBase, public IPVRSettingsContainer
 {
 public:
   CGUIDialogPVRTimerSettings();
@@ -39,6 +42,24 @@ public:
 
   void SetTimer(const std::shared_ptr<CPVRTimerInfoTag>& timer);
 
+  // implementation of IPVRSettingsContainer
+  void AddMultiIntSetting(const std::shared_ptr<CSettingGroup>& group,
+                          const std::string& settingName,
+                          int settingValue) override;
+  void AddSingleIntSetting(const std::shared_ptr<CSettingGroup>& group,
+                           const std::string& settingName,
+                           int settingValue,
+                           int minValue,
+                           int step,
+                           int maxValue) override;
+  void AddMultiStringSetting(const std::shared_ptr<CSettingGroup>& group,
+                             const std::string& settingName,
+                             const std::string& settingValue) override;
+  void AddSingleStringSetting(const std::shared_ptr<CSettingGroup>& group,
+                              const std::string& settingName,
+                              const std::string& settingValue,
+                              bool allowEmptyValue) override;
+
 protected:
   // implementation of ISettingCallback
   void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
@@ -46,6 +67,7 @@ protected:
 
   // specialization of CGUIDialogSettingsBase
   bool AllowResettingSettings() const override { return false; }
+  std::string GetSettingsLabel(const std::shared_ptr<ISetting>& setting) override;
   bool Save() override;
   void SetupView() override;
 
@@ -104,6 +126,14 @@ private:
                                std::vector<IntegerSettingOption>& list,
                                int& current,
                                void* data);
+  static void CustomIntSettingDefinitionsFiller(const std::shared_ptr<const CSetting>& setting,
+                                                std::vector<IntegerSettingOption>& list,
+                                                int& current,
+                                                void* data);
+  static void CustomStringSettingDefinitionsFiller(const std::shared_ptr<const CSetting>& setting,
+                                                   std::vector<StringSettingOption>& list,
+                                                   std::string& current,
+                                                   void* data);
 
   static std::string WeekdaysValueFormatter(const std::shared_ptr<const CSetting>& setting);
 
@@ -164,6 +194,8 @@ private:
   } ChannelDescriptor;
 
   typedef std::map<int, ChannelDescriptor> ChannelEntriesMap;
+
+  std::unique_ptr<CPVRCustomTimerSettings> m_customTimerSettings;
 
   std::shared_ptr<CPVRTimerInfoTag> m_timerInfoTag;
   TypeEntriesMap m_typeEntries;

--- a/xbmc/pvr/settings/CMakeLists.txt
+++ b/xbmc/pvr/settings/CMakeLists.txt
@@ -1,7 +1,18 @@
-set(SOURCES PVRIntSettingValues.cpp
-            PVRSettings.cpp)
+set(SOURCES PVRCustomTimerSettings.cpp
+            PVRIntSettingDefinition.cpp
+            PVRIntSettingValues.cpp
+            PVRSettings.cpp
+            PVRStringSettingDefinition.cpp
+            PVRStringSettingValues.cpp
+            PVRTimerSettingDefinition.cpp)
 
-set(HEADERS PVRIntSettingValues.h
-            PVRSettings.h)
+set(HEADERS IPVRSettingsContainer.h
+            PVRCustomTimerSettings.h
+            PVRIntSettingDefinition.h
+            PVRIntSettingValues.h
+            PVRSettings.h
+            PVRStringSettingDefinition.h
+            PVRStringSettingValues.h
+            PVRTimerSettingDefinition.h)
 
 core_add_library(pvr_settings)

--- a/xbmc/pvr/settings/IPVRSettingsContainer.h
+++ b/xbmc/pvr/settings/IPVRSettingsContainer.h
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <memory>
+
+class CSettingGroup;
+
+namespace PVR
+{
+class IPVRSettingsContainer
+{
+public:
+  virtual ~IPVRSettingsContainer() = default;
+
+  virtual void AddMultiIntSetting(const std::shared_ptr<CSettingGroup>& group,
+                                  const std::string& settingName,
+                                  int settingValue)
+  {
+  }
+  virtual void AddSingleIntSetting(const std::shared_ptr<CSettingGroup>& group,
+                                   const std::string& settingName,
+                                   int settingValue,
+                                   int minValue,
+                                   int step,
+                                   int maxValue)
+  {
+  }
+  virtual void AddMultiStringSetting(const std::shared_ptr<CSettingGroup>& group,
+                                     const std::string& settingName,
+                                     const std::string& settingValue)
+  {
+  }
+  virtual void AddSingleStringSetting(const std::shared_ptr<CSettingGroup>& group,
+                                      const std::string& settingName,
+                                      const std::string& settingValue,
+                                      bool allowEmptyValue)
+  {
+  }
+};
+} // namespace PVR

--- a/xbmc/pvr/settings/PVRCustomTimerSettings.cpp
+++ b/xbmc/pvr/settings/PVRCustomTimerSettings.cpp
@@ -1,0 +1,256 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRCustomTimerSettings.h"
+
+#include "pvr/settings/IPVRSettingsContainer.h"
+#include "pvr/settings/PVRTimerSettingDefinition.h"
+#include "pvr/timers/PVRTimerType.h"
+#include "settings/lib/Setting.h"
+#include "utils/StringUtils.h"
+#include "utils/log.h"
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace PVR
+{
+static constexpr const char* SETTING_TMR_CUSTOM_INT{"customsetting.int"};
+static constexpr const char* SETTING_TMR_CUSTOM_STRING{"customsetting.string"};
+
+CPVRCustomTimerSettings::CPVRCustomTimerSettings(
+    const CPVRTimerType& timerType,
+    const CPVRTimerInfoTag::CustomPropsMap& customProps,
+    const std::map<int, std::shared_ptr<CPVRTimerType>>& typeEntries)
+  : m_customProps(customProps)
+{
+  unsigned int idx{0};
+  for (const auto& type : typeEntries)
+  {
+    const std::vector<std::shared_ptr<const CPVRTimerSettingDefinition>>& settingDefs{
+        type.second->GetCustomSettingDefinitions()};
+    for (const auto& settingDef : settingDefs)
+    {
+      std::string settingIdPrefix;
+      if (settingDef->IsIntDefinition())
+      {
+        settingIdPrefix = SETTING_TMR_CUSTOM_INT;
+      }
+      else if (settingDef->IsStringDefinition())
+      {
+        settingIdPrefix = SETTING_TMR_CUSTOM_STRING;
+      }
+      else
+      {
+        CLog::LogF(LOGERROR, "Unknown custom setting definition ignored!");
+        continue;
+      }
+
+      const std::string settingId{StringUtils::Format("{}-{}", settingIdPrefix, idx)};
+      m_customSettingDefs.insert({settingId, settingDef});
+      ++idx;
+    }
+  }
+
+  SetTimerType(timerType);
+}
+
+void CPVRCustomTimerSettings::SetTimerType(const CPVRTimerType& timerType)
+{
+  CPVRTimerInfoTag::CustomPropsMap newCustomProps;
+  for (const auto& entry : m_customSettingDefs)
+  {
+    // Complete custom props for given type.
+    const CPVRTimerSettingDefinition& def{*entry.second};
+    if (def.GetTimerTypeId() == timerType.GetTypeId() &&
+        def.GetClientId() == timerType.GetClientId())
+    {
+      const auto it{m_customProps.find(def.GetId())};
+      if (it == m_customProps.cend())
+        newCustomProps.insert({def.GetId(), {def.GetType(), def.GetDefaultValue()}});
+      else
+        newCustomProps.insert({def.GetId(), {(*it).second.type, (*it).second.value}});
+    }
+  }
+  m_customProps = newCustomProps;
+}
+
+void CPVRCustomTimerSettings::AddSettings(IPVRSettingsContainer& settingsContainer,
+                                          const std::shared_ptr<CSettingGroup>& group)
+{
+  for (const auto& settingDef : m_customSettingDefs)
+  {
+    const CPVRTimerSettingDefinition& def{*settingDef.second};
+    const auto it{m_customProps.find(def.GetId())};
+    if (it == m_customProps.cend())
+      continue;
+
+    const std::string settingName{settingDef.first};
+    if (IsCustomIntSetting(settingName))
+    {
+      const int intValue{(*it).second.value.asInteger32()};
+      const CPVRIntSettingDefinition& intDef{def.GetIntDefinition()};
+      if (intDef.GetValues().empty())
+        settingsContainer.AddSingleIntSetting(group, settingName, intValue, intDef.GetMinValue(),
+                                              intDef.GetStepValue(), intDef.GetMaxValue());
+      else
+        settingsContainer.AddMultiIntSetting(group, settingName, intValue);
+    }
+    else if (IsCustomStringSetting(settingName))
+    {
+      const std::string stringValue{(*it).second.value.asString()};
+      const CPVRStringSettingDefinition& stringDef{def.GetStringDefinition()};
+      if (stringDef.GetValues().empty())
+        settingsContainer.AddSingleStringSetting(group, settingName, stringValue,
+                                                 stringDef.IsAllowEmptyValue());
+      else
+        settingsContainer.AddMultiStringSetting(group, settingName, stringValue);
+    }
+  }
+}
+
+bool CPVRCustomTimerSettings::IsCustomSetting(const std::string& settingId) const
+{
+  return IsCustomIntSetting(settingId) || IsCustomStringSetting(settingId);
+}
+
+bool CPVRCustomTimerSettings::IsCustomIntSetting(const std::string& settingId) const
+{
+  return settingId.starts_with(SETTING_TMR_CUSTOM_INT);
+}
+
+bool CPVRCustomTimerSettings::IsCustomStringSetting(const std::string& settingId) const
+{
+  return settingId.starts_with(SETTING_TMR_CUSTOM_STRING);
+}
+
+bool CPVRCustomTimerSettings::UpdateIntProperty(const std::shared_ptr<const CSetting>& setting)
+{
+  const auto def{GetSettingDefintion(setting->GetId())};
+  if (!def)
+  {
+    CLog::LogF(LOGERROR, "Custom int setting definition not found");
+    return false;
+  }
+
+  CVariant& prop{m_customProps[def->GetId()].value};
+  prop = std::static_pointer_cast<const CSettingInt>(setting)->GetValue();
+  return true;
+}
+
+bool CPVRCustomTimerSettings::UpdateStringProperty(const std::shared_ptr<const CSetting>& setting)
+{
+  const auto def{GetSettingDefintion(setting->GetId())};
+  if (!def)
+  {
+    CLog::LogF(LOGERROR, "Custom string setting definition not found");
+    return false;
+  }
+
+  CVariant& prop{m_customProps[def->GetId()].value};
+  prop = std::static_pointer_cast<const CSettingString>(setting)->GetValue();
+  return true;
+}
+
+std::string CPVRCustomTimerSettings::GetSettingsLabel(const std::string& settingId) const
+{
+  const auto def{GetSettingDefintion(settingId)};
+  if (!def)
+    return {};
+
+  return def->GetName();
+}
+
+bool CPVRCustomTimerSettings::IntSettingDefinitionsFiller(const std::string& settingId,
+                                                          std::vector<IntegerSettingOption>& list,
+                                                          int& current)
+{
+  const auto def{GetSettingDefintion(settingId)};
+  if (!def)
+  {
+    CLog::LogF(LOGERROR, "Custom setting definition not found");
+    return false;
+  }
+
+  const std::vector<SettingIntValue>& values{def->GetIntDefinition().GetValues()};
+  std::transform(values.cbegin(), values.cend(), std::back_inserter(list),
+                 [](const auto& value) { return IntegerSettingOption(value.first, value.second); });
+
+  const auto it2{m_customProps.find(def->GetId())};
+  if (it2 != m_customProps.cend())
+    current = (*it2).second.value.asInteger32();
+  else
+    current = def->GetIntDefinition().GetDefaultValue();
+
+  return true;
+}
+
+bool CPVRCustomTimerSettings::StringSettingDefinitionsFiller(const std::string& settingId,
+                                                             std::vector<StringSettingOption>& list,
+                                                             std::string& current)
+{
+  const auto def{GetSettingDefintion(settingId)};
+  if (!def)
+  {
+    CLog::LogF(LOGERROR, "Custom setting definition not found");
+    return false;
+  }
+
+  const std::vector<SettingStringValue>& values{def->GetStringDefinition().GetValues()};
+  std::transform(values.cbegin(), values.cend(), std::back_inserter(list),
+                 [](const auto& value) { return StringSettingOption(value.first, value.second); });
+
+  const auto it2{m_customProps.find(def->GetId())};
+  if (it2 != m_customProps.cend())
+    current = (*it2).second.value.asString();
+  else
+    current = def->GetStringDefinition().GetDefaultValue();
+
+  return true;
+}
+
+bool CPVRCustomTimerSettings::IsSettingReadonlyForTimerState(const std::string& settingId,
+                                                             PVR_TIMER_STATE timerState) const
+{
+  const auto def{GetSettingDefintion(settingId)};
+  if (!def)
+  {
+    CLog::LogF(LOGERROR, "Custom setting definition not found");
+    return false;
+  }
+
+  return def->IsReadonlyForTimerState(timerState);
+}
+
+bool CPVRCustomTimerSettings::IsSettingSupportedForTimerType(const std::string& settingId,
+                                                             const CPVRTimerType& timerType) const
+{
+  const auto def{GetSettingDefintion(settingId)};
+  if (!def)
+  {
+    CLog::LogF(LOGERROR, "Custom setting definition not found");
+    return false;
+  }
+
+  return timerType.GetClientId() == def->GetClientId() &&
+         timerType.GetTypeId() == def->GetTimerTypeId();
+}
+
+std::shared_ptr<const CPVRTimerSettingDefinition> CPVRCustomTimerSettings::GetSettingDefintion(
+    const std::string& settingId) const
+{
+  const auto it{m_customSettingDefs.find(settingId)};
+  if (it == m_customSettingDefs.cend())
+    return {};
+
+  return (*it).second;
+}
+} // namespace PVR

--- a/xbmc/pvr/settings/PVRCustomTimerSettings.h
+++ b/xbmc/pvr/settings/PVRCustomTimerSettings.h
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_timers.h" // PVR_TIMER_STATE
+#include "pvr/timers/PVRTimerInfoTag.h"
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+class CSetting;
+class CSettingGroup;
+struct IntegerSettingOption;
+struct StringSettingOption;
+
+namespace PVR
+{
+class CPVRTimerSettingDefinition;
+class CPVRTimerType;
+class IPVRSettingsContainer;
+
+class CPVRCustomTimerSettings
+{
+public:
+  CPVRCustomTimerSettings(const CPVRTimerType& timerType,
+                          const CPVRTimerInfoTag::CustomPropsMap& customProps,
+                          const std::map<int, std::shared_ptr<CPVRTimerType>>& typeEntries);
+  virtual ~CPVRCustomTimerSettings() = default;
+
+  void SetTimerType(const CPVRTimerType& timerType);
+
+  void AddSettings(IPVRSettingsContainer& settingsContainer,
+                   const std::shared_ptr<CSettingGroup>& group);
+
+  bool IsCustomSetting(const std::string& settingId) const;
+  bool IsCustomIntSetting(const std::string& settingId) const;
+  bool IsCustomStringSetting(const std::string& settingId) const;
+
+  const CPVRTimerInfoTag::CustomPropsMap& GetProperties() const { return m_customProps; }
+
+  bool UpdateIntProperty(const std::shared_ptr<const CSetting>& setting);
+  bool UpdateStringProperty(const std::shared_ptr<const CSetting>& setting);
+
+  std::string GetSettingsLabel(const std::string& settingId) const;
+
+  bool IntSettingDefinitionsFiller(const std::string& settingId,
+                                   std::vector<IntegerSettingOption>& list,
+                                   int& current);
+  bool StringSettingDefinitionsFiller(const std::string& settingId,
+                                      std::vector<StringSettingOption>& list,
+                                      std::string& current);
+
+  bool IsSettingReadonlyForTimerState(const std::string& settingId,
+                                      PVR_TIMER_STATE timerState) const;
+  bool IsSettingSupportedForTimerType(const std::string& setting,
+                                      const CPVRTimerType& timerType) const;
+
+private:
+  std::shared_ptr<const CPVRTimerSettingDefinition> GetSettingDefintion(
+      const std::string& settingId) const;
+
+  using CustomSettingDefinitionsMap =
+      std::map<std::string,
+               std::shared_ptr<const CPVRTimerSettingDefinition>>; // setting id, setting def
+
+  CustomSettingDefinitionsMap m_customSettingDefs;
+  CPVRTimerInfoTag::CustomPropsMap m_customProps;
+};
+} // namespace PVR

--- a/xbmc/pvr/settings/PVRIntSettingDefinition.cpp
+++ b/xbmc/pvr/settings/PVRIntSettingDefinition.cpp
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRIntSettingDefinition.h"
+
+#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h"
+
+namespace PVR
+{
+CPVRIntSettingDefinition::CPVRIntSettingDefinition(const PVR_INT_SETTING_DEFINITION& def)
+  : m_values{def.values, def.iValuesSize, def.iDefaultValue},
+    m_minValue{def.iMinValue},
+    m_step{def.iStep},
+    m_maxValue{def.iMaxValue}
+{
+}
+
+bool CPVRIntSettingDefinition::operator==(const CPVRIntSettingDefinition& right) const
+{
+  return (m_values == right.m_values && m_minValue == right.m_minValue && m_step == right.m_step &&
+          m_maxValue == right.m_maxValue);
+}
+
+bool CPVRIntSettingDefinition::operator!=(const CPVRIntSettingDefinition& right) const
+{
+  return !(*this == right);
+}
+} // namespace PVR

--- a/xbmc/pvr/settings/PVRIntSettingDefinition.h
+++ b/xbmc/pvr/settings/PVRIntSettingDefinition.h
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "pvr/settings/PVRIntSettingValues.h"
+
+#include <vector>
+
+struct PVR_INT_SETTING_DEFINITION;
+
+namespace PVR
+{
+class CPVRIntSettingDefinition
+{
+public:
+  CPVRIntSettingDefinition() = default;
+  explicit CPVRIntSettingDefinition(const PVR_INT_SETTING_DEFINITION& def);
+
+  virtual ~CPVRIntSettingDefinition() = default;
+
+  bool operator==(const CPVRIntSettingDefinition& right) const;
+  bool operator!=(const CPVRIntSettingDefinition& right) const;
+
+  const std::vector<SettingIntValue>& GetValues() const { return m_values.GetValues(); }
+  int GetDefaultValue() const { return m_values.GetDefaultValue(); }
+  int GetMinValue() const { return m_minValue; }
+  int GetStepValue() const { return m_step; }
+  int GetMaxValue() const { return m_maxValue; }
+
+private:
+  CPVRIntSettingValues m_values;
+  int m_minValue{0};
+  int m_step{0};
+  int m_maxValue{0};
+};
+} // namespace PVR

--- a/xbmc/pvr/settings/PVRIntSettingValues.cpp
+++ b/xbmc/pvr/settings/PVRIntSettingValues.cpp
@@ -29,17 +29,17 @@ CPVRIntSettingValues::CPVRIntSettingValues(struct PVR_ATTRIBUTE_INT_VALUE* value
     {
       const int value{values[i].iValue};
       const char* desc{values[i].strDescription};
-      std::string strDescr{desc ? desc : ""};
-      if (strDescr.empty())
+      std::string description{desc ? desc : ""};
+      if (description.empty())
       {
         // No description given by addon. Create one from value.
         if (defaultDescriptionResourceId > 0)
-          strDescr = StringUtils::Format(
+          description = StringUtils::Format(
               "{} {}", g_localizeStrings.Get(defaultDescriptionResourceId), value);
         else
-          strDescr = std::to_string(value);
+          description = std::to_string(value);
       }
-      m_values.emplace_back(strDescr, value);
+      m_values.emplace_back(description, value);
     }
   }
 }

--- a/xbmc/pvr/settings/PVRIntSettingValues.cpp
+++ b/xbmc/pvr/settings/PVRIntSettingValues.cpp
@@ -44,6 +44,10 @@ CPVRIntSettingValues::CPVRIntSettingValues(struct PVR_ATTRIBUTE_INT_VALUE* value
   }
 }
 
+CPVRIntSettingValues::CPVRIntSettingValues(int defaultValue) : m_defaultValue(defaultValue)
+{
+}
+
 CPVRIntSettingValues::CPVRIntSettingValues(struct PVR_ATTRIBUTE_INT_VALUE* values,
                                            unsigned int valuesSize,
                                            unsigned int defaultValue,
@@ -59,4 +63,8 @@ CPVRIntSettingValues::CPVRIntSettingValues(const std::vector<SettingIntValue>& v
 {
 }
 
+bool CPVRIntSettingValues::operator==(const CPVRIntSettingValues& right) const
+{
+  return (m_defaultValue == right.m_defaultValue && m_values == right.m_values);
+}
 } // namespace PVR

--- a/xbmc/pvr/settings/PVRIntSettingValues.h
+++ b/xbmc/pvr/settings/PVRIntSettingValues.h
@@ -21,7 +21,8 @@ using SettingIntValue = std::pair<std::string, int>;
 class CPVRIntSettingValues
 {
 public:
-  CPVRIntSettingValues(int defaultValue) : m_defaultValue(defaultValue) {}
+  CPVRIntSettingValues() = default;
+  explicit CPVRIntSettingValues(int defaultValue);
   CPVRIntSettingValues(struct PVR_ATTRIBUTE_INT_VALUE* values,
                        unsigned int valuesSize,
                        int defaultValue,
@@ -34,10 +35,7 @@ public:
 
   virtual ~CPVRIntSettingValues() = default;
 
-  bool operator==(const CPVRIntSettingValues& right) const
-  {
-    return (m_defaultValue == right.m_defaultValue && m_values == right.m_values);
-  }
+  bool operator==(const CPVRIntSettingValues& right) const;
 
   const std::vector<SettingIntValue>& GetValues() const { return m_values; }
   int GetDefaultValue() const { return m_defaultValue; }

--- a/xbmc/pvr/settings/PVRStringSettingDefinition.cpp
+++ b/xbmc/pvr/settings/PVRStringSettingDefinition.cpp
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRStringSettingDefinition.h"
+
+#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h"
+
+namespace PVR
+{
+CPVRStringSettingDefinition::CPVRStringSettingDefinition(const PVR_STRING_SETTING_DEFINITION& def)
+  : m_values{def.values, def.iValuesSize, def.strDefaultValue},
+    m_allowEmptyValue{def.bAllowEmptyValue}
+{
+}
+
+bool CPVRStringSettingDefinition::operator==(const CPVRStringSettingDefinition& right) const
+{
+  return (m_values == right.m_values && m_allowEmptyValue == right.m_allowEmptyValue);
+}
+
+bool CPVRStringSettingDefinition::operator!=(const CPVRStringSettingDefinition& right) const
+{
+  return !(*this == right);
+}
+} // namespace PVR

--- a/xbmc/pvr/settings/PVRStringSettingDefinition.h
+++ b/xbmc/pvr/settings/PVRStringSettingDefinition.h
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "pvr/settings/PVRStringSettingValues.h"
+
+#include <vector>
+
+struct PVR_STRING_SETTING_DEFINITION;
+
+namespace PVR
+{
+class CPVRStringSettingDefinition
+{
+public:
+  CPVRStringSettingDefinition() = default;
+  explicit CPVRStringSettingDefinition(const PVR_STRING_SETTING_DEFINITION& def);
+
+  virtual ~CPVRStringSettingDefinition() = default;
+
+  bool operator==(const CPVRStringSettingDefinition& right) const;
+  bool operator!=(const CPVRStringSettingDefinition& right) const;
+
+  const std::vector<SettingStringValue>& GetValues() const { return m_values.GetValues(); }
+  const std::string& GetDefaultValue() const { return m_values.GetDefaultValue(); }
+
+  bool IsAllowEmptyValue() const { return m_allowEmptyValue; }
+
+private:
+  CPVRStringSettingValues m_values;
+  bool m_allowEmptyValue{true};
+};
+} // namespace PVR

--- a/xbmc/pvr/settings/PVRStringSettingValues.cpp
+++ b/xbmc/pvr/settings/PVRStringSettingValues.cpp
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRStringSettingValues.h"
+
+#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_defines.h"
+#include "guilib/LocalizeStrings.h"
+#include "utils/StringUtils.h"
+
+#include <string>
+
+namespace PVR
+{
+CPVRStringSettingValues::CPVRStringSettingValues(struct PVR_ATTRIBUTE_STRING_VALUE* values,
+                                                 unsigned int valuesSize,
+                                                 const std::string& defaultValue,
+                                                 int defaultDescriptionResourceId /* = 0 */)
+  : m_defaultValue(defaultValue)
+{
+  if (values && valuesSize > 0)
+  {
+    m_values.reserve(valuesSize);
+    for (unsigned int i = 0; i < valuesSize; ++i)
+    {
+      const std::string value{values[i].strValue ? values[i].strValue : ""};
+      const char* desc{values[i].strDescription};
+      std::string strDescr{desc ? desc : ""};
+      if (strDescr.empty())
+      {
+        // No description given by addon. Create one from value.
+        if (defaultDescriptionResourceId > 0)
+          strDescr = StringUtils::Format(
+              "{} {}", g_localizeStrings.Get(defaultDescriptionResourceId), value);
+        else
+          strDescr = value;
+      }
+      m_values.emplace_back(strDescr, value);
+    }
+  }
+}
+
+bool CPVRStringSettingValues::operator==(const CPVRStringSettingValues& right) const
+{
+  return (m_defaultValue == right.m_defaultValue && m_values == right.m_values);
+}
+} // namespace PVR

--- a/xbmc/pvr/settings/PVRStringSettingValues.cpp
+++ b/xbmc/pvr/settings/PVRStringSettingValues.cpp
@@ -29,17 +29,17 @@ CPVRStringSettingValues::CPVRStringSettingValues(struct PVR_ATTRIBUTE_STRING_VAL
     {
       const std::string value{values[i].strValue ? values[i].strValue : ""};
       const char* desc{values[i].strDescription};
-      std::string strDescr{desc ? desc : ""};
-      if (strDescr.empty())
+      std::string description{desc ? desc : ""};
+      if (description.empty())
       {
         // No description given by addon. Create one from value.
         if (defaultDescriptionResourceId > 0)
-          strDescr = StringUtils::Format(
+          description = StringUtils::Format(
               "{} {}", g_localizeStrings.Get(defaultDescriptionResourceId), value);
         else
-          strDescr = value;
+          description = value;
       }
-      m_values.emplace_back(strDescr, value);
+      m_values.emplace_back(description, value);
     }
   }
 }

--- a/xbmc/pvr/settings/PVRStringSettingValues.h
+++ b/xbmc/pvr/settings/PVRStringSettingValues.h
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+struct PVR_ATTRIBUTE_STRING_VALUE;
+
+namespace PVR
+{
+using SettingStringValue = std::pair<std::string, std::string>;
+
+class CPVRStringSettingValues
+{
+public:
+  CPVRStringSettingValues() = default;
+  CPVRStringSettingValues(struct PVR_ATTRIBUTE_STRING_VALUE* values,
+                          unsigned int valuesSize,
+                          const std::string& defaultValue,
+                          int defaultDescriptionResourceId = 0);
+
+  virtual ~CPVRStringSettingValues() = default;
+
+  bool operator==(const CPVRStringSettingValues& right) const;
+
+  const std::vector<SettingStringValue>& GetValues() const { return m_values; }
+  const std::string& GetDefaultValue() const { return m_defaultValue; }
+
+private:
+  std::vector<SettingStringValue> m_values;
+  std::string m_defaultValue;
+};
+} // namespace PVR

--- a/xbmc/pvr/settings/PVRTimerSettingDefinition.cpp
+++ b/xbmc/pvr/settings/PVRTimerSettingDefinition.cpp
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRTimerSettingDefinition.h"
+
+#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h"
+#include "utils/Variant.h"
+#include "utils/log.h"
+
+namespace PVR
+{
+std::vector<std::shared_ptr<const CPVRTimerSettingDefinition>> CPVRTimerSettingDefinition::
+    CreateSettingDefinitionsList(int clientId,
+                                 unsigned int timerTypeId,
+                                 struct PVR_SETTING_DEFINITION** defs,
+                                 unsigned int settingDefsSize)
+{
+  std::vector<std::shared_ptr<const CPVRTimerSettingDefinition>> defsList;
+  if (defs && settingDefsSize > 0)
+  {
+    defsList.reserve(settingDefsSize);
+    for (unsigned int i = 0; i < settingDefsSize; ++i)
+    {
+      const PVR_SETTING_DEFINITION* def{defs[i]};
+      if (def)
+      {
+        defsList.emplace_back(
+            std::make_shared<const CPVRTimerSettingDefinition>(clientId, timerTypeId, *def));
+      }
+    }
+  }
+  return defsList;
+}
+
+CPVRTimerSettingDefinition::CPVRTimerSettingDefinition(int clientId,
+                                                       unsigned int timerTypeId,
+                                                       const PVR_SETTING_DEFINITION& def)
+  : m_clientId(clientId),
+    m_timerTypeId(timerTypeId),
+    m_id(def.iId),
+    m_name(def.strName ? def.strName : ""),
+    m_type(def.eType),
+    m_readonlyConditions(def.iReadonlyConditions)
+{
+  if (def.intSettingDefinition)
+    m_intDefinition = CPVRIntSettingDefinition{*def.intSettingDefinition};
+  if (def.stringSettingDefinition)
+    m_stringDefinition = CPVRStringSettingDefinition{*def.stringSettingDefinition};
+}
+
+bool CPVRTimerSettingDefinition::operator==(const CPVRTimerSettingDefinition& right) const
+{
+  return (m_id == right.m_id && m_name == right.m_name && m_type == right.m_type &&
+          m_readonlyConditions == right.m_readonlyConditions &&
+          m_intDefinition == right.m_intDefinition &&
+          m_stringDefinition == right.m_stringDefinition);
+}
+
+bool CPVRTimerSettingDefinition::operator!=(const CPVRTimerSettingDefinition& right) const
+{
+  return !(*this == right);
+}
+
+CVariant CPVRTimerSettingDefinition::GetDefaultValue() const
+{
+  if (GetType() == PVR_SETTING_TYPE::INTEGER)
+    return CVariant{GetIntDefinition().GetDefaultValue()};
+  else if (GetType() == PVR_SETTING_TYPE::STRING)
+    return CVariant{GetStringDefinition().GetDefaultValue()};
+
+  CLog::LogF(LOGERROR, "Unknown setting type for custom property");
+  return {};
+}
+
+bool CPVRTimerSettingDefinition::IsReadonlyForTimerState(PVR_TIMER_STATE timerState) const
+{
+  switch (timerState)
+  {
+    case PVR_TIMER_STATE_DISABLED:
+      return m_readonlyConditions & PVR_SETTING_READONLY_CONDITION_TIMER_DISABLED;
+    case PVR_TIMER_STATE_SCHEDULED:
+    case PVR_TIMER_STATE_CONFLICT_OK:
+    case PVR_TIMER_STATE_CONFLICT_NOK:
+      return m_readonlyConditions & PVR_SETTING_READONLY_CONDITION_TIMER_SCHEDULED;
+    case PVR_TIMER_STATE_RECORDING:
+      return m_readonlyConditions & PVR_SETTING_READONLY_CONDITION_TIMER_RECORDING;
+    case PVR_TIMER_STATE_COMPLETED:
+    case PVR_TIMER_STATE_ABORTED:
+    case PVR_TIMER_STATE_CANCELLED:
+    case PVR_TIMER_STATE_ERROR:
+      return m_readonlyConditions & PVR_SETTING_READONLY_CONDITION_TIMER_COMPLETED;
+    default:
+      CLog::LogF(LOGWARNING, "Unhandled timer state {}", timerState);
+      break;
+  }
+  return false;
+}
+} // namespace PVR

--- a/xbmc/pvr/settings/PVRTimerSettingDefinition.h
+++ b/xbmc/pvr/settings/PVRTimerSettingDefinition.h
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h"
+#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_timers.h"
+#include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
+#include "pvr/settings/PVRIntSettingDefinition.h"
+#include "pvr/settings/PVRStringSettingDefinition.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+class CVariant;
+
+namespace PVR
+{
+class CPVRTimerSettingDefinition
+{
+public:
+  static std::vector<std::shared_ptr<const CPVRTimerSettingDefinition>>
+  CreateSettingDefinitionsList(int clientId,
+                               unsigned int timerTypeId,
+                               struct PVR_SETTING_DEFINITION** defs,
+                               unsigned int settingDefsSize);
+
+  CPVRTimerSettingDefinition(int clientId,
+                             unsigned int timerTypeId,
+                             const PVR_SETTING_DEFINITION& def);
+
+  virtual ~CPVRTimerSettingDefinition() = default;
+
+  bool operator==(const CPVRTimerSettingDefinition& right) const;
+  bool operator!=(const CPVRTimerSettingDefinition& right) const;
+
+  int GetClientId() const { return m_clientId; }
+  unsigned int GetTimerTypeId() const { return m_timerTypeId; }
+  unsigned int GetId() const { return m_id; }
+  const std::string& GetName() const { return m_name; }
+  PVR_SETTING_TYPE GetType() const { return m_type; }
+  CVariant GetDefaultValue() const;
+
+  bool IsIntDefinition() const { return m_type == PVR_SETTING_TYPE::INTEGER; }
+  bool IsStringDefinition() const { return m_type == PVR_SETTING_TYPE::STRING; }
+  const CPVRIntSettingDefinition& GetIntDefinition() const { return m_intDefinition; }
+  const CPVRStringSettingDefinition& GetStringDefinition() const { return m_stringDefinition; }
+
+  bool IsReadonlyForTimerState(PVR_TIMER_STATE timerState) const;
+
+private:
+  int m_clientId{PVR_CLIENT_INVALID_UID};
+  unsigned int m_timerTypeId{PVR_TIMER_TYPE_NONE};
+  unsigned int m_id{0};
+  std::string m_name;
+  PVR_SETTING_TYPE m_type{PVR_SETTING_TYPE::INTEGER};
+  uint64_t m_readonlyConditions{PVR_SETTING_READONLY_CONDITION_NONE};
+  CPVRIntSettingDefinition m_intDefinition;
+  CPVRStringSettingDefinition m_stringDefinition;
+};
+} // namespace PVR

--- a/xbmc/pvr/timers/PVRTimerType.h
+++ b/xbmc/pvr/timers/PVRTimerType.h
@@ -19,9 +19,15 @@
 
 struct PVR_TIMER_TYPE;
 
+namespace ADDON
+{
+class CAddonVersion;
+}
+
 namespace PVR
 {
 class CPVRClient;
+class CPVRTimerSettingDefinition;
 
 static const int DEFAULT_RECORDING_PRIORITY = 50;
 static const int DEFAULT_RECORDING_LIFETIME = 99; // days
@@ -64,7 +70,9 @@ public:
                                                              int iClientId);
 
   CPVRTimerType();
-  CPVRTimerType(const PVR_TIMER_TYPE& type, int iClientId);
+  CPVRTimerType(const PVR_TIMER_TYPE& type,
+                int iClientId,
+                const ADDON::CAddonVersion& addonApiVersion);
   CPVRTimerType(unsigned int iTypeId, uint64_t iAttributes, const std::string& strDescription = "");
 
   virtual ~CPVRTimerType();
@@ -461,6 +469,16 @@ public:
    */
   int GetRecordingGroupDefault() const { return m_recordingGroupValues.GetDefaultValue(); }
 
+  /*!
+   * @brief Get custom setting definitions for this type.
+   * @return The list of settings or an empty list if none present.
+   */
+  const std::vector<std::shared_ptr<const CPVRTimerSettingDefinition>>&
+  GetCustomSettingDefinitions() const
+  {
+    return m_customSettingDefs;
+  }
+
 private:
   void InitDescription();
   void InitAttributeValues(const PVR_TIMER_TYPE& type);
@@ -469,6 +487,7 @@ private:
   void InitMaxRecordingsValues(const PVR_TIMER_TYPE& type);
   void InitPreventDuplicateEpisodesValues(const PVR_TIMER_TYPE& type);
   void InitRecordingGroupValues(const PVR_TIMER_TYPE& type);
+  void InitCustomSettingDefinitions(const PVR_TIMER_TYPE& type);
 
   int m_iClientId = PVR_CLIENT_INVALID_UID;
   unsigned int m_iTypeId;
@@ -479,5 +498,6 @@ private:
   CPVRIntSettingValues m_maxRecordingsValues{0};
   CPVRIntSettingValues m_preventDupEpisodesValues{DEFAULT_RECORDING_DUPLICATEHANDLING};
   CPVRIntSettingValues m_recordingGroupValues{0};
+  std::vector<std::shared_ptr<const CPVRTimerSettingDefinition>> m_customSettingDefs;
 };
 } // namespace PVR


### PR DESCRIPTION
This is something I had on my todo list for quite a while already: Add-on supplied custom timer settings.

With this PR PVR client add-ons can define custom string and integer settings for timers. Definition includes a localized setting name, possible setting values (incl. localized description per value), default value and other attributes.

The definitions are attached to timer types. If present, the settings will be integrated automatically in the timer settings dialog and appear from users perspective as every other timer setting. Values can be changed there and will be handed back to the add-on.

Kodi will (and can) not interpret the settings in any way. The data will just be routed form the add-on to Kodi and vice versa.

Lots of code was added for both API and core for the implementation of this feature. However, For an add-on it should be quite simple and not much code is needed. A will open a PR with a reference implementation for pvr.hts soon.

As some new API structs and enums are introduced, the needed boilerplate code for the C++ API wrapper summed up to > 1K LOC. For the core code I wanted to have it in a real OOP style, so couple of new classes here, which should ensure readability and long term maintainability of the new code.

Last, the concept is so designed, that the API can easily be extended to add other setting types (currently "only" string and integer settings are supported). Strict encapsulation of the core implementation also helps here. To proof this, I started with integer settings and added string settings later. ;-)

Best, although we face an API change here, no add-on must be recompiled. I added two runtime API version checks were needed. That's all that was needed. One more time: well structured code helps maintainability.

I runtime-tested the changes carefully, including setups were "old" add-ons were used together with a "new" Kodi. I found no problems (does no mean that there are no bugs, though).

@phunkyfish I hope that you find some time to review the changes soon. I know it is a lot of code, but I hope that the design I've chosen and the clean implementation helps here.