### PR TITLE
Add single/dual channel texture support to XBT textures

### DIFF
--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -75,6 +75,11 @@ const char* GetFormatString(KD_TEX_FMT format)
 
 void Usage()
 {
+  puts("Texture Packer Version 3");
+  puts("");
+  puts("Tool to pack XBT 3 texture files, used in Kodi Piers (v22).");
+  puts("Accepts the following file formats as input: PNG (preferred), JPG and GIF.");
+  puts("");
   puts("Usage:");
   puts("  -help            Show this screen.");
   puts("  -input <dir>     Input directory. Default: current dir");

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -56,36 +56,21 @@
 namespace
 {
 
-const char *GetFormatString(unsigned int format)
+const char* GetFormatString(KD_TEX_FMT format)
 {
   switch (format)
   {
-  case XB_FMT_DXT1:
-    return "DXT1 ";
-  case XB_FMT_DXT3:
-    return "DXT3 ";
-  case XB_FMT_DXT5:
-    return "DXT5 ";
-  case XB_FMT_DXT5_YCoCg:
-    return "YCoCg";
-  case XB_FMT_A8R8G8B8:
-    return "ARGB ";
-  case XB_FMT_A8:
-    return "A8   ";
-  default:
-    return "?????";
+    case KD_TEX_FMT_SDR_R8:
+      return "R8   ";
+    case KD_TEX_FMT_SDR_RG8:
+      return "RG8  ";
+    case KD_TEX_FMT_SDR_RGBA8:
+      return "RGBA8";
+    case KD_TEX_FMT_SDR_BGRA8:
+      return "BGRA8";
+    default:
+      return "?????";
   }
-}
-
-bool HasAlpha(unsigned char* argb, unsigned int width, unsigned int height)
-{
-  unsigned char* p = argb + 3; // offset of alpha
-  for (unsigned int i = 0; i < 4 * width * height; i += 4)
-  {
-    if (p[i] != 0xff)
-      return true;
-  }
-  return false;
 }
 
 void Usage()
@@ -121,6 +106,10 @@ private:
   CXBTFFrame CreateXBTFFrame(DecodedFrame& decodedFrame, CXBTFWriter& writer) const;
 
   bool CheckDupe(MD5Context* ctx, unsigned int pos);
+
+  void ConvertToSingleChannel(RGBAImage& image, uint32_t channel);
+  void ConvertToDualChannel(RGBAImage& image);
+  void ReduceChannels(RGBAImage& image);
 
   DecoderManager decoderManager;
 
@@ -196,11 +185,12 @@ CXBTFFrame TexturePacker::CreateXBTFFrame(DecodedFrame& decodedFrame, CXBTFWrite
   const unsigned int delay = decodedFrame.delay;
   const unsigned int width = decodedFrame.rgbaImage.width;
   const unsigned int height = decodedFrame.rgbaImage.height;
-  const unsigned int size = width * height * 4;
-  const XB_FMT format = XB_FMT_A8R8G8B8;
+  const uint32_t bpp = decodedFrame.rgbaImage.bbp;
+  const unsigned int size = width * height * (bpp / 8);
+  const uint32_t format = static_cast<uint32_t>(decodedFrame.rgbaImage.textureFormat) |
+                          static_cast<uint32_t>(decodedFrame.rgbaImage.textureAlpha) |
+                          static_cast<uint32_t>(decodedFrame.rgbaImage.textureSwizzle);
   unsigned char* data = (unsigned char*)decodedFrame.rgbaImage.pixels.data();
-
-  const bool hasAlpha = HasAlpha(data, width, height);
 
   CXBTFFrame frame;
   lzo_uint packedSize = size;
@@ -246,7 +236,7 @@ CXBTFFrame TexturePacker::CreateXBTFFrame(DecodedFrame& decodedFrame, CXBTFWrite
   frame.SetUnpackedSize(size);
   frame.SetWidth(width);
   frame.SetHeight(height);
-  frame.SetFormat(hasAlpha ? format : static_cast<XB_FMT>(format | XB_FMT_OPAQUE));
+  frame.SetFormat(format);
   frame.SetDuration(delay);
   return frame;
 }
@@ -276,6 +266,111 @@ bool TexturePacker::CheckDupe(MD5Context* ctx,
   m_dupes[pos] = pos;
 
   return false;
+}
+
+void TexturePacker::ConvertToSingleChannel(RGBAImage& image, uint32_t channel)
+{
+  uint32_t size = (image.width * image.height);
+  for (uint32_t i = 0; i < size; i++)
+  {
+    image.pixels[i] = image.pixels[i * 4 + channel];
+  }
+
+  image.textureFormat = KD_TEX_FMT_SDR_R8;
+
+  image.bbp = 8;
+  image.pitch = 1 * image.width;
+}
+
+void TexturePacker::ConvertToDualChannel(RGBAImage& image)
+{
+  uint32_t size = (image.width * image.height);
+  for (uint32_t i = 0; i < size; i++)
+  {
+    image.pixels[i * 2] = image.pixels[i * 4];
+    image.pixels[i * 2 + 1] = image.pixels[i * 4 + 3];
+  }
+  image.textureFormat = KD_TEX_FMT_SDR_RG8;
+  image.bbp = 16;
+  image.pitch = 2 * image.width;
+}
+
+void TexturePacker::ReduceChannels(RGBAImage& image)
+{
+  if (image.textureFormat != KD_TEX_FMT_SDR_BGRA8)
+    return;
+
+  uint32_t size = (image.width * image.height);
+  uint8_t red = image.pixels[0];
+  uint8_t green = image.pixels[1];
+  uint8_t blue = image.pixels[2];
+  uint8_t alpha = image.pixels[3];
+  bool uniformRed = true;
+  bool uniformGreen = true;
+  bool uniformBlue = true;
+  bool uniformAlpha = true;
+  bool isGrey = true;
+  bool isIntensity = true;
+
+  // Checks each pixel for various properties.
+  for (uint32_t i = 0; i < size; i++)
+  {
+    if (image.pixels[i * 4] != red)
+      uniformRed = false;
+    if (image.pixels[i * 4 + 1] != green)
+      uniformGreen = false;
+    if (image.pixels[i * 4 + 2] != blue)
+      uniformBlue = false;
+    if (image.pixels[i * 4 + 3] != alpha)
+      uniformAlpha = false;
+    if (image.pixels[i * 4] != image.pixels[i * 4 + 1] ||
+        image.pixels[i * 4] != image.pixels[i * 4 + 2])
+      isGrey = false;
+    if (image.pixels[i * 4] != image.pixels[i * 4 + 1] ||
+        image.pixels[i * 4] != image.pixels[i * 4 + 2] ||
+        image.pixels[i * 4] != image.pixels[i * 4 + 3])
+      isIntensity = false;
+  }
+
+  if (uniformAlpha && alpha != 0xff)
+    printf("WARNING: uniform alpha detected! Consider using diffusecolor!\n");
+
+  bool isWhite = red == 0xff && green == 0xff && blue == 0xff;
+  if (uniformRed && uniformGreen && uniformBlue && !isWhite)
+    printf("WARNING: uniform color detected! Consider using diffusecolor!\n");
+
+  if (isIntensity)
+  {
+    // this is an intensity (GL_INTENSITY) texture
+    ConvertToSingleChannel(image, 0);
+    image.textureSwizzle = KD_TEX_SWIZ_RRRR;
+  }
+  else if (uniformAlpha && alpha == 0xff)
+  {
+    // we have a opaque texture, L or RGBX
+    if (isGrey)
+    {
+      ConvertToSingleChannel(image, 1);
+      image.textureSwizzle = KD_TEX_SWIZ_RRR1;
+    }
+    image.textureAlpha = KD_TEX_ALPHA_OPAQUE;
+  }
+  else if (uniformRed && uniformGreen && uniformBlue && isWhite)
+  {
+    // an alpha only texture
+    ConvertToSingleChannel(image, 3);
+    image.textureSwizzle = KD_TEX_SWIZ_111R;
+  }
+  else if (isGrey)
+  {
+    // a LA texture
+    ConvertToDualChannel(image);
+    image.textureSwizzle = KD_TEX_SWIZ_RRRG;
+  }
+  else
+  {
+    // BGRA
+  }
 }
 
 int TexturePacker::createBundle(const std::string& InputDir, const std::string& OutputFile)
@@ -312,6 +407,9 @@ int TexturePacker::createBundle(const std::string& InputDir, const std::string& 
       continue;
     }
 
+    for (unsigned int j = 0; j < frames.frameList.size(); j++)
+      ReduceChannels(frames.frameList[j].rgbaImage);
+
     printf("%s\n", output.c_str());
     bool skip=false;
     if (m_dupecheck)
@@ -342,7 +440,7 @@ int TexturePacker::createBundle(const std::string& InputDir, const std::string& 
         file.GetFrames().push_back(frame);
         printf("    frame %4i (delay:%4i)                         %s%c (%d,%d @ %" PRIu64
                " bytes)\n",
-               j, frame.GetDuration(), GetFormatString(frame.GetFormat()),
+               j, frame.GetDuration(), GetFormatString(frame.GetKDFormat()),
                frame.HasAlpha() ? ' ' : '*', frame.GetWidth(), frame.GetHeight(),
                frame.GetUnpackedSize());
       }

--- a/tools/depends/native/TexturePacker/src/decoder/IDecoder.h
+++ b/tools/depends/native/TexturePacker/src/decoder/IDecoder.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "guilib/TextureFormats.h"
+
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -52,8 +54,11 @@ public:
   std::vector<uint8_t> pixels;
   int width = 0; // width
   int height = 0; // height
-  int bbp = 0; // bits per pixel
+  int bbp = 32; // bits per pixel
   int pitch = 0; // rowsize in bytes
+  KD_TEX_FMT textureFormat{KD_TEX_FMT_SDR_BGRA8};
+  KD_TEX_ALPHA textureAlpha{KD_TEX_ALPHA_STRAIGHT};
+  KD_TEX_SWIZ textureSwizzle{KD_TEX_SWIZ_RGBA};
 };
 
 class DecodedFrame

--- a/xbmc/filesystem/XbtFile.cpp
+++ b/xbmc/filesystem/XbtFile.cpp
@@ -12,6 +12,7 @@
 #include "filesystem/File.h"
 #include "filesystem/XbtManager.h"
 #include "guilib/TextureBundleXBT.h"
+#include "guilib/TextureFormats.h"
 #include "guilib/XBTFReader.h"
 #include "utils/StringUtils.h"
 
@@ -312,6 +313,42 @@ XB_FMT CXbtFile::GetImageFormat() const
     return XB_FMT_UNKNOWN;
 
   return frame.GetFormat();
+}
+
+KD_TEX_FMT CXbtFile::GetKDFormat() const
+{
+  CXBTFFrame frame;
+  if (!GetFirstFrame(frame))
+    return KD_TEX_FMT_UNKNOWN;
+
+  return frame.GetKDFormat();
+}
+
+KD_TEX_FMT CXbtFile::GetKDFormatType() const
+{
+  CXBTFFrame frame;
+  if (!GetFirstFrame(frame))
+    return KD_TEX_FMT_UNKNOWN;
+
+  return frame.GetKDFormatType();
+}
+
+KD_TEX_ALPHA CXbtFile::GetKDAlpha() const
+{
+  CXBTFFrame frame;
+  if (!GetFirstFrame(frame))
+    return KD_TEX_ALPHA_OPAQUE;
+
+  return frame.GetKDAlpha();
+}
+
+KD_TEX_SWIZ CXbtFile::GetKDSwizzle() const
+{
+  CXBTFFrame frame;
+  if (!GetFirstFrame(frame))
+    return KD_TEX_SWIZ_RGBA;
+
+  return frame.GetKDSwizzle();
 }
 
 bool CXbtFile::HasImageAlpha() const

--- a/xbmc/filesystem/XbtFile.h
+++ b/xbmc/filesystem/XbtFile.h
@@ -43,6 +43,10 @@ public:
   uint32_t GetImageWidth() const;
   uint32_t GetImageHeight() const;
   XB_FMT GetImageFormat() const;
+  KD_TEX_FMT GetKDFormat() const;
+  KD_TEX_FMT GetKDFormatType() const;
+  KD_TEX_ALPHA GetKDAlpha() const;
+  KD_TEX_SWIZ GetKDSwizzle() const;
   bool HasImageAlpha() const;
 
 private:

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -377,7 +377,7 @@ bool CTexture::UploadFromMemory(unsigned int width,
       CLog::LogF(LOGERROR, "Could not allocate {} bytes. Out of memory.", size);
       return false;
     }
-    memcpy(m_pixels, pixels, size);
+    std::memcpy(m_pixels, pixels, size);
   }
 
   return true;

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -16,8 +16,10 @@
 #include "filesystem/ResourceFile.h"
 #include "filesystem/XbtFile.h"
 #include "guilib/TextureBase.h"
+#include "guilib/TextureFormats.h"
 #include "guilib/iimage.h"
 #include "guilib/imagefactory.h"
+#include "messaging/ApplicationMessenger.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
@@ -184,9 +186,21 @@ bool CTexture::LoadFromFileInternal(const std::string& texturePath,
     XFILE::CXbtFile xbtFile;
     if (!xbtFile.Open(url))
       return false;
-
-    return LoadFromMemory(xbtFile.GetImageWidth(), xbtFile.GetImageHeight(), 0,
-                          xbtFile.GetImageFormat(), xbtFile.HasImageAlpha(), buf.data());
+    if (xbtFile.GetKDFormatType())
+    {
+      return UploadFromMemory(xbtFile.GetImageWidth(), xbtFile.GetImageHeight(), 0, buf.data(),
+                              xbtFile.GetKDFormat(), xbtFile.GetKDAlpha(), xbtFile.GetKDSwizzle());
+    }
+    else if (xbtFile.GetImageFormat() == XB_FMT_A8R8G8B8)
+    {
+      KD_TEX_ALPHA alpha = xbtFile.HasImageAlpha() ? KD_TEX_ALPHA_STRAIGHT : KD_TEX_ALPHA_OPAQUE;
+      return UploadFromMemory(xbtFile.GetImageWidth(), xbtFile.GetImageHeight(), 0, buf.data(),
+                              KD_TEX_FMT_SDR_BGRA8, alpha, KD_TEX_SWIZ_RGBA);
+    }
+    else
+    {
+      return false;
+    }
   }
 
   IImage* pImage;
@@ -271,7 +285,7 @@ bool CTexture::LoadIImage(IImage* pImage,
   if (pImage->Orientation())
     m_orientation = pImage->Orientation() - 1;
 
-  m_hasAlpha = pImage->hasAlpha();
+  m_textureAlpha = pImage->hasAlpha() ? KD_TEX_ALPHA_STRAIGHT : KD_TEX_ALPHA_OPAQUE;
   m_originalWidth = pImage->originalWidth();
   m_originalHeight = pImage->originalHeight();
   m_imageWidth = pImage->Width();
@@ -308,8 +322,64 @@ bool CTexture::LoadFromMemory(unsigned int width,
   m_imageWidth = m_originalWidth = width;
   m_imageHeight = m_originalHeight = height;
   m_format = format;
-  m_hasAlpha = hasAlpha;
+  m_textureAlpha = hasAlpha ? KD_TEX_ALPHA_STRAIGHT : KD_TEX_ALPHA_OPAQUE;
   Update(width, height, pitch, format, pixels, false);
+  return true;
+}
+
+bool CTexture::UploadFromMemory(unsigned int width,
+                                unsigned int height,
+                                unsigned int pitch,
+                                unsigned char* pixels,
+                                KD_TEX_FMT format,
+                                KD_TEX_ALPHA alpha,
+                                KD_TEX_SWIZ swizzle)
+{
+  m_imageWidth = m_textureWidth = m_originalWidth = width;
+  m_imageHeight = m_textureHeight = m_originalHeight = height;
+  m_textureFormat = format;
+  m_textureAlpha = alpha;
+  m_textureSwizzle = swizzle;
+
+  if (!SupportsFormat(m_textureFormat, m_textureSwizzle) && !ConvertToLegacy(width, height, pixels))
+  {
+    CLog::LogF(
+        LOGERROR,
+        "Failed to upload texture. Format {} and swizzle {} not supported by the texture pipeline.",
+        m_textureFormat, m_textureSwizzle);
+
+    m_loadedToGPU = true;
+    return false;
+  }
+
+  if (CServiceBroker::GetAppMessenger()->IsProcessThread())
+  {
+    if (m_pixels)
+    {
+      LoadToGPU();
+    }
+    else
+    {
+      // just a borrowed buffer
+      m_pixels = pixels;
+      m_bCacheMemory = true;
+      LoadToGPU();
+      m_bCacheMemory = false;
+      m_pixels = nullptr;
+    }
+  }
+  else if (!m_pixels)
+  {
+    size_t size = GetPitch() * GetRows();
+    m_pixels = static_cast<unsigned char*>(KODI::MEMORY::AlignedMalloc(size, 32));
+    if (m_pixels == nullptr)
+    {
+      CLog::LogF(LOGERROR, "Could not allocate {} bytes. Out of memory.", size);
+      return false;
+    }
+    memcpy(m_pixels, pixels, size);
+  }
+
   return true;
 }
 

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -74,6 +74,24 @@ public:
                       XB_FMT format,
                       bool hasAlpha,
                       const unsigned char* pixels);
+  /*! \brief Attempts to upload a texture directly from a provided buffer
+   Unlike LoadFromMemory() which copies the texture into an intermediate buffer, the texture gets uploaded directly to
+   the GPU if circumstances allow.
+   \param width the width of the texture.
+   \param height the height of the texture.
+   \param pitch the pitch of the texture.
+   \param pixels pointer to the texture buffer.
+   \param format the format of the texture.
+   \param alpha the alpha type of the texture.
+   \param swizzle the swizzle pattern of the texture.
+   */
+  bool UploadFromMemory(unsigned int width,
+                        unsigned int height,
+                        unsigned int pitch,
+                        unsigned char* pixels,
+                        KD_TEX_FMT format = KD_TEX_FMT_SDR_RGBA8,
+                        KD_TEX_ALPHA alpha = KD_TEX_ALPHA_OPAQUE,
+                        KD_TEX_SWIZ swizzle = KD_TEX_SWIZ_RGBA);
   bool LoadPaletted(unsigned int width,
                     unsigned int height,
                     unsigned int pitch,
@@ -101,6 +119,16 @@ public:
    */
   virtual void SyncGPU(){};
   virtual void BindToUnit(unsigned int unit) = 0;
+
+  /*! 
+   * \brief Checks if the processing pipeline can handle the texture format/swizzle
+   \param format the format of the texture.
+   \return true if the texturing pipeline supports the format
+   */
+  virtual bool SupportsFormat(KD_TEX_FMT textureFormat, KD_TEX_SWIZ textureSwizzle)
+  {
+    return !(textureFormat & KD_TEX_FMT_TYPE_MASK) && textureSwizzle == KD_TEX_SWIZ_RGBA;
+  }
 
 private:
   // no copy constructor

--- a/xbmc/guilib/TextureBase.cpp
+++ b/xbmc/guilib/TextureBase.cpp
@@ -432,16 +432,16 @@ bool CTextureBase::ConvertToLegacy(uint32_t width, uint32_t height, uint8_t* src
     for (int32_t i = size - 1; i >= 0; i--)
     {
       m_pixels[i * 4 + 3] = src[i];
-      m_pixels[i * 4 + 2] = char(0xff);
-      m_pixels[i * 4 + 1] = char(0xff);
-      m_pixels[i * 4] = char(0xff);
+      m_pixels[i * 4 + 2] = 0xff;
+      m_pixels[i * 4 + 1] = 0xff;
+      m_pixels[i * 4] = 0xff;
     }
   }
   else if (m_textureSwizzle == KD_TEX_SWIZ_RRR1)
   {
     for (int32_t i = size - 1; i >= 0; i--)
     {
-      m_pixels[i * 4 + 3] = char(0xff);
+      m_pixels[i * 4 + 3] = 0xff;
       m_pixels[i * 4 + 2] = src[i];
       m_pixels[i * 4 + 1] = src[i];
       m_pixels[i * 4] = src[i];

--- a/xbmc/guilib/TextureBase.cpp
+++ b/xbmc/guilib/TextureBase.cpp
@@ -398,3 +398,77 @@ void CTextureBase::SetKDFormat(XB_FMT xbFMT)
       return;
   }
 }
+
+bool CTextureBase::ConvertToLegacy(uint32_t width, uint32_t height, uint8_t* src)
+{
+  if (m_textureFormat == KD_TEX_FMT_SDR_BGRA8 && m_textureSwizzle == KD_TEX_SWIZ_RGBA)
+  {
+    m_format = XB_FMT_A8R8G8B8;
+    return true;
+  }
+
+  if (m_textureFormat == KD_TEX_FMT_SDR_R8)
+  {
+    if (m_textureSwizzle != KD_TEX_SWIZ_111R && m_textureSwizzle != KD_TEX_SWIZ_RRR1 &&
+        m_textureSwizzle != KD_TEX_SWIZ_RRRR)
+      return false;
+  }
+  else if (m_textureFormat == KD_TEX_FMT_SDR_RG8)
+  {
+    if (m_textureSwizzle != KD_TEX_SWIZ_RRRG)
+      return false;
+  }
+  else
+  {
+    return false;
+  }
+
+  size_t size = GetPitch() * GetRows();
+
+  Allocate(width, height, XB_FMT_A8R8G8B8);
+
+  if (m_textureSwizzle == KD_TEX_SWIZ_111R)
+  {
+    for (int32_t i = size - 1; i >= 0; i--)
+    {
+      m_pixels[i * 4 + 3] = src[i];
+      m_pixels[i * 4 + 2] = char(0xff);
+      m_pixels[i * 4 + 1] = char(0xff);
+      m_pixels[i * 4] = char(0xff);
+    }
+  }
+  else if (m_textureSwizzle == KD_TEX_SWIZ_RRR1)
+  {
+    for (int32_t i = size - 1; i >= 0; i--)
+    {
+      m_pixels[i * 4 + 3] = char(0xff);
+      m_pixels[i * 4 + 2] = src[i];
+      m_pixels[i * 4 + 1] = src[i];
+      m_pixels[i * 4] = src[i];
+    }
+  }
+  else if (m_textureSwizzle == KD_TEX_SWIZ_RRRR)
+  {
+    for (int32_t i = size - 1; i >= 0; i--)
+    {
+      m_pixels[i * 4 + 3] = src[i];
+      m_pixels[i * 4 + 2] = src[i];
+      m_pixels[i * 4 + 1] = src[i];
+      m_pixels[i * 4] = src[i];
+    }
+  }
+  else if (m_textureSwizzle == KD_TEX_SWIZ_RRRG)
+  {
+    for (int32_t i = size / 2 - 1; i >= 0; i--)
+    {
+      m_pixels[i * 4 + 3] = src[i * 2 + 1];
+      m_pixels[i * 4 + 2] = src[i * 2];
+      m_pixels[i * 4 + 1] = src[i * 2];
+      m_pixels[i * 4] = src[i * 2];
+    }
+  }
+
+  m_textureFormat = KD_TEX_FMT_SDR_BGRA8;
+  m_textureSwizzle = KD_TEX_SWIZ_RGBA;
+  return true;
+}

--- a/xbmc/guilib/TextureBase.h
+++ b/xbmc/guilib/TextureBase.h
@@ -30,8 +30,11 @@ public:
   CTextureBase() = default;
   ~CTextureBase() = default;
 
-  bool HasAlpha() const { return m_hasAlpha; }
-  void SetAlpha(bool hasAlpha) { m_hasAlpha = hasAlpha; }
+  bool HasAlpha() const { return m_textureAlpha != KD_TEX_ALPHA_OPAQUE; }
+  void SetAlpha(bool hasAlpha)
+  {
+    m_textureAlpha = hasAlpha ? KD_TEX_ALPHA_STRAIGHT : KD_TEX_ALPHA_OPAQUE;
+  }
 
   /*! \brief sets mipmapping. do not use in new code. will be replaced with proper scaling. */
   void SetMipmapping() { m_mipmapping = true; }
@@ -92,6 +95,10 @@ protected:
 
   void SetKDFormat(XB_FMT xbFMT);
 
+  /*! \brief Textures might be in a single/dual channel format with L/A/I/LA swizzle. DX and GLES 2.0 don't 
+  handle some/all at the moment. This function can convert the texture into a traditional BGRA format.*/
+  bool ConvertToLegacy(uint32_t width, uint32_t height, uint8_t* src);
+
   uint32_t m_imageWidth{0};
   uint32_t m_imageHeight{0};
   uint32_t m_textureWidth{0};
@@ -110,7 +117,6 @@ protected:
 
   XB_FMT m_format{XB_FMT_UNKNOWN}; // legacy XB format, deprecated
   int32_t m_orientation{0};
-  bool m_hasAlpha{true};
   bool m_mipmapping{false};
   TEXTURE_SCALING m_scalingMethod{TEXTURE_SCALING::LINEAR};
   bool m_bCacheMemory{false};

--- a/xbmc/guilib/TextureBundleXBT.cpp
+++ b/xbmc/guilib/TextureBundleXBT.cpp
@@ -16,6 +16,7 @@
 #include "commons/ilog.h"
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/XbtManager.h"
+#include "guilib/TextureFormats.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -237,9 +238,18 @@ std::unique_ptr<CTexture> CTextureBundleXBT::ConvertFrameToTexture(const std::st
 
   // create an xbmc texture
   std::unique_ptr<CTexture> texture = CTexture::CreateTexture();
-  texture->LoadFromMemory(frame.GetWidth(), frame.GetHeight(), 0, frame.GetFormat(),
-                          frame.HasAlpha(), buffer.data());
 
+  if (frame.GetKDFormatType())
+  {
+    texture->UploadFromMemory(frame.GetWidth(), frame.GetHeight(), 0, buffer.data(),
+                              frame.GetKDFormat(), frame.GetKDAlpha(), frame.GetKDSwizzle());
+  }
+  else if (frame.GetFormat() == XB_FMT_A8R8G8B8)
+  {
+    KD_TEX_ALPHA alpha = frame.HasAlpha() ? KD_TEX_ALPHA_STRAIGHT : KD_TEX_ALPHA_OPAQUE;
+    texture->UploadFromMemory(frame.GetWidth(), frame.GetHeight(), 0, buffer.data(),
+                              KD_TEX_FMT_SDR_BGRA8, alpha, KD_TEX_SWIZ_RGBA);
+  }
   return texture;
 }
 

--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -234,6 +234,13 @@ void CGLTexture::LoadToGPU()
     m_textureWidth = maxSize;
   }
 
+  // there might not be any padding for the following formats, so we have to
+  // read one/two bytes at the time.
+  if (m_textureFormat == KD_TEX_FMT_SDR_R8)
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+  if (m_textureFormat == KD_TEX_FMT_SDR_RG8)
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 2);
+
   SetSwizzle();
 
   TextureFormat glFormat = GetFormatGL(m_textureFormat);

--- a/xbmc/guilib/TextureGL.h
+++ b/xbmc/guilib/TextureGL.h
@@ -43,6 +43,11 @@ public:
   void SyncGPU() override;
   void BindToUnit(unsigned int unit) override;
 
+  bool SupportsFormat(KD_TEX_FMT textureFormat, KD_TEX_SWIZ textureSwizzle) override
+  {
+    return true;
+  }
+
 protected:
   void SetSwizzle();
   TextureFormat GetFormatGL(KD_TEX_FMT textureFormat);

--- a/xbmc/guilib/TextureGLES.h
+++ b/xbmc/guilib/TextureGLES.h
@@ -38,6 +38,7 @@ public:
   void DestroyTextureObject() override;
   void LoadToGPU() override;
   void BindToUnit(unsigned int unit) override;
+  bool SupportsFormat(KD_TEX_FMT textureFormat, KD_TEX_SWIZ textureSwizzle) override;
 
 protected:
   void SetSwizzle(bool swapRB);

--- a/xbmc/guilib/XBTF.cpp
+++ b/xbmc/guilib/XBTF.cpp
@@ -72,14 +72,14 @@ void CXBTFFrame::SetUnpackedSize(uint64_t size)
   m_unpackedSize = size;
 }
 
-void CXBTFFrame::SetFormat(XB_FMT format)
+void CXBTFFrame::SetFormat(uint32_t format)
 {
   m_format = format;
 }
 
 XB_FMT CXBTFFrame::GetFormat(bool raw) const
 {
-  return raw ? m_format : static_cast<XB_FMT>(m_format & XB_FMT_MASK);
+  return static_cast<XB_FMT>(raw ? m_format : m_format & XB_FMT_MASK);
 }
 
 uint64_t CXBTFFrame::GetOffset() const
@@ -114,6 +114,26 @@ uint64_t CXBTFFrame::GetHeaderSize() const
     sizeof(m_duration);
 
   return result;
+}
+
+KD_TEX_FMT CXBTFFrame::GetKDFormat() const
+{
+  return static_cast<KD_TEX_FMT>(m_format & KD_TEX_FMT_MASK);
+}
+
+KD_TEX_FMT CXBTFFrame::GetKDFormatType() const
+{
+  return static_cast<KD_TEX_FMT>(m_format & KD_TEX_FMT_TYPE_MASK);
+}
+
+KD_TEX_ALPHA CXBTFFrame::GetKDAlpha() const
+{
+  return static_cast<KD_TEX_ALPHA>(m_format & KD_TEX_ALPHA_MASK);
+}
+
+KD_TEX_SWIZ CXBTFFrame::GetKDSwizzle() const
+{
+  return static_cast<KD_TEX_SWIZ>(m_format & KD_TEX_SWIZ_MASK);
 }
 
 CXBTFFile::CXBTFFile()

--- a/xbmc/guilib/XBTF.h
+++ b/xbmc/guilib/XBTF.h
@@ -29,7 +29,7 @@ public:
   void SetWidth(uint32_t width);
 
   XB_FMT GetFormat(bool raw = false) const;
-  void SetFormat(XB_FMT format);
+  void SetFormat(uint32_t format);
 
   uint32_t GetHeight() const;
   void SetHeight(uint32_t height);
@@ -51,10 +51,15 @@ public:
   bool IsPacked() const;
   bool HasAlpha() const;
 
+  KD_TEX_FMT GetKDFormat() const;
+  KD_TEX_FMT GetKDFormatType() const;
+  KD_TEX_ALPHA GetKDAlpha() const;
+  KD_TEX_SWIZ GetKDSwizzle() const;
+
 private:
   uint32_t m_width;
   uint32_t m_height;
-  XB_FMT m_format;
+  uint32_t m_format;
   uint64_t m_packedSize;
   uint64_t m_unpackedSize;
   uint64_t m_offset;

--- a/xbmc/guilib/XBTF.h
+++ b/xbmc/guilib/XBTF.h
@@ -16,7 +16,8 @@
 #include <stdint.h>
 
 static const std::string XBTF_MAGIC = "XBTF";
-static const std::string XBTF_VERSION = "2";
+static const std::string XBTF_VERSION = "3";
+static const char XBTF_VERSION_MIN = '2';
 
 #include "TextureFormats.h"
 

--- a/xbmc/guilib/XBTFReader.cpp
+++ b/xbmc/guilib/XBTFReader.cpp
@@ -29,6 +29,17 @@ static bool ReadString(FILE* file, char* str, size_t max_length)
   return (fread(str, max_length, 1, file) == 1);
 }
 
+static bool ReadChar(FILE* file, char& value)
+{
+  if (file == nullptr)
+    return false;
+
+  if (fread(&value, sizeof(char), 1, file) != 1)
+    return false;
+
+  return true;
+}
+
 static bool ReadUInt32(FILE* file, uint32_t& value)
 {
   if (file == nullptr)
@@ -89,11 +100,11 @@ bool CXBTFReader::Open(const std::string& path)
     return false;
 
   // read the version
-  char version[1];
-  if (!ReadString(m_file, version, sizeof(version)))
+  char version;
+  if (!ReadChar(m_file, version))
     return false;
 
-  if (strncmp(XBTF_VERSION.c_str(), version, sizeof(version)) != 0)
+  if (version < XBTF_VERSION_MIN)
     return false;
 
   unsigned int nofFiles;


### PR DESCRIPTION
## Description
This PR adds support for single and dual channel textures to the texture packer and the XBT processing path.

The packer will convert the provided textures to a R8/RG8 texture with an related swizzle, if possible.

The XBT loader will pass the texture/swizzle on, so the texture can be directly uploaded to the GPU (GL/GLES 3.0). On systems which don't support such textures (DX, GLES 2.0 only for luminance/uminance+alpha), the texture will be converted to BGRA.

This is a revival of https://github.com/xbmc/xbmc/pull/21557, but from a (slightly) different angle.

## Motivation and context
Including such textures has a lot of advantages:
- less disk space used (-500KB for Estuary)
- smaller package size (-100KB)
- smaller memory footprint (storage/bandwidth) on the GPU if supported (-50%/-75%)
- faster load times

## How has this been tested?
Runs fine under GL/GLES.

## What is the effect on users?
Potentially less jank and more FPS.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
