### PR TITLE
[utils] KODI::ART::FillInDefaultIcon: Remove PVR compile time dependency

### DIFF
--- a/xbmc/utils/ArtUtils.cpp
+++ b/xbmc/utils/ArtUtils.cpp
@@ -86,6 +86,10 @@ void FillInDefaultIcon(CFileItem& item)
         // PVR deleted recording
         item.SetArt("icon", "DefaultVideoDeleted.png");
       }
+      else if (item.IsPVRProvider())
+      {
+        item.SetArt("icon", "DefaultPVRProvider.png");
+      }
       else if (PLAYLIST::IsPlayList(item) || PLAYLIST::IsSmartPlayList(item))
       {
         item.SetArt("icon", "DefaultPlaylist.png");

--- a/xbmc/utils/ArtUtils.cpp
+++ b/xbmc/utils/ArtUtils.cpp
@@ -17,7 +17,6 @@
 #include "music/MusicFileItemClassify.h"
 #include "network/NetworkFileItemClassify.h"
 #include "playlists/PlayListFileItemClassify.h"
-#include "pvr/channels/PVRChannel.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/FileExtensionProvider.h"
@@ -60,11 +59,10 @@ void FillInDefaultIcon(CFileItem& item)
        * be ordered with most frequently seen types first.  Also bear
        * in mind the complexity of the code behind the check in the
        * case of IsWhatever() returns false.
-       * @todo get rid of PVR compile time dependency
        */
       if (item.IsPVRChannel())
       {
-        if (item.GetPVRChannelInfoTag()->IsRadio())
+        if (URIUtils::IsPVRRadioChannel(item.GetPath()))
           item.SetArt("icon", "DefaultMusicSongs.png");
         else
           item.SetArt("icon", "DefaultTVShows.png");

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -998,6 +998,19 @@ bool URIUtils::IsPVRChannel(const std::string& strFile)
   return IsProtocol(strFile, "pvr") && CPVRChannelsPath(strFile).IsChannel();
 }
 
+bool URIUtils::IsPVRRadioChannel(const std::string& strFile)
+{
+  if (IsStack(strFile))
+    return IsPVRRadioChannel(CStackDirectory::GetFirstStackedFile(strFile));
+
+  if (IsProtocol(strFile, "pvr"))
+  {
+    const CPVRChannelsPath path{strFile};
+    return path.IsChannel() && path.IsRadio();
+  }
+  return false;
+}
+
 bool URIUtils::IsPVRChannelGroup(const std::string& strFile)
 {
   if (IsStack(strFile))

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -184,6 +184,7 @@ public:
   static bool IsLibraryContent(const std::string& strFile);
   static bool IsPVR(const std::string& strFile);
   static bool IsPVRChannel(const std::string& strFile);
+  static bool IsPVRRadioChannel(const std::string& strFile);
   static bool IsPVRChannelGroup(const std::string& strFile);
   static bool IsPVRGuideItem(const std::string& strFile);
 

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -322,6 +322,19 @@ TEST_F(TestURIUtils, IsLiveTV)
   EXPECT_TRUE(URIUtils::IsLiveTV("whatever://path/to/file.pvr"));
 }
 
+TEST_F(TestURIUtils, IsPVRRadioChannel)
+{
+  // pvr://channels/(tv|radio)/<groupname>@<clientid>/<instanceid>@<addonid>_<channeluid>.pvr
+  EXPECT_TRUE(
+      URIUtils::IsPVRRadioChannel("pvr://channels/radio/groupname@0815/1@pvr.demo_4711.pvr"));
+  EXPECT_FALSE(URIUtils::IsPVRRadioChannel(
+      "pvr://channels/tv/groupname@0815/1@pvr.demo_4711.pvr")); // a tv channel
+  EXPECT_FALSE(
+      URIUtils::IsPVRRadioChannel("pvr://channels/radio/")); // root folder for all radio channels
+  EXPECT_FALSE(
+      URIUtils::IsPVRRadioChannel("pvr://channels/radio/groupname@0815/")); // a radio channel group
+}
+
 TEST_F(TestURIUtils, IsMultiPath)
 {
   EXPECT_TRUE(URIUtils::IsMultiPath("multipath://path/to/file"));


### PR DESCRIPTION
Follow-up to #25539 

* Remove PVR compile time dependency
* Re-add support for PVR Providers which was accidentally removed by above mentioned PR (thanks @phunkyfish for reporting this)

@notspiff can you please review.