### PR TITLE
changed: move CFileItem::GetFolderThumb to ArtUtils

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1868,7 +1868,7 @@ std::string CFileItem::GetUserMusicThumb(bool alwaysCheckRemote /* = false */, b
     for (const auto& i : thumbs)
     {
       std::string strFileName = i.asString();
-      std::string folderThumb(GetFolderThumb(strFileName));
+      std::string folderThumb(ART::GetFolderThumb(*this, strFileName));
       if (CFile::Exists(folderThumb))   // folder.jpg
         return folderThumb;
       size_t period = strFileName.find_last_of('.');
@@ -2026,26 +2026,6 @@ std::string CFileItem::GetLocalArt(const std::string& artFile, bool useFolder) c
       return URIUtils::ReplaceExtension(strFile, "-" + artFile);
   }
   return "";
-}
-
-std::string CFileItem::GetFolderThumb(const std::string &folderJPG /* = "folder.jpg" */) const
-{
-  std::string strFolder = m_strPath;
-
-  if (IsStack() ||
-      URIUtils::IsInRAR(strFolder) ||
-      URIUtils::IsInZIP(strFolder))
-  {
-    URIUtils::GetParentPath(m_strPath,strFolder);
-  }
-
-  if (IsMultiPath())
-    strFolder = CMultiPathDirectory::GetFirstPath(m_strPath);
-
-  if (IsPlugin())
-    return "";
-
-  return URIUtils::AddFileToFolder(strFolder, folderJPG);
 }
 
 std::string CFileItem::GetMovieName(bool bUseFolderNames /* = false */) const

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -445,8 +445,6 @@ public:
    */
   std::string GetThumbHideIfUnwatched(const CFileItem* item) const;
 
-  // Gets the folder image associated with this item (defaults to folder.jpg)
-  std::string GetFolderThumb(const std::string &folderJPG = "folder.jpg") const;
   // Gets the correct movie title
   std::string GetMovieName(bool bUseFolderNames = false) const;
 

--- a/xbmc/ThumbLoader.cpp
+++ b/xbmc/ThumbLoader.cpp
@@ -114,7 +114,7 @@ std::string CProgramThumbLoader::GetLocalThumb(const CFileItem &item)
   // look for the thumb
   if (item.m_bIsFolder)
   {
-    std::string folderThumb = item.GetFolderThumb();
+    const std::string folderThumb = ART::GetFolderThumb(item);
     if (CFileUtils::Exists(folderThumb))
       return folderThumb;
   }

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -35,6 +35,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
+#include "utils/ArtUtils.h"
 #include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -387,7 +388,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
         items.Add(current);
       }
       // see if there's a local thumb for this item
-      std::string folderThumb = item->GetFolderThumb();
+      std::string folderThumb = ART::GetFolderThumb(*item);
       if (CFileUtils::Exists(folderThumb))
       {
         CFileItemPtr local(new CFileItem("thumb://Local", false));

--- a/xbmc/utils/ArtUtils.cpp
+++ b/xbmc/utils/ArtUtils.cpp
@@ -13,6 +13,7 @@
 #include "ServiceBroker.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
+#include "filesystem/MultiPathDirectory.h"
 #include "filesystem/StackDirectory.h"
 #include "music/MusicFileItemClassify.h"
 #include "network/NetworkFileItemClassify.h"
@@ -151,6 +152,24 @@ void FillInDefaultIcon(CFileItem& item)
     else if (URIUtils::IsInZIP(item.GetPath()))
       item.SetOverlayImage(CGUIListItem::ICON_OVERLAY_ZIP);
   }
+}
+
+std::string GetFolderThumb(const CFileItem& item, const std::string& folderJPG /* = "folder.jpg" */)
+{
+  std::string strFolder = item.GetPath();
+
+  if (item.IsStack() || URIUtils::IsInRAR(strFolder) || URIUtils::IsInZIP(strFolder))
+  {
+    URIUtils::GetParentPath(item.GetPath(), strFolder);
+  }
+
+  if (item.IsMultiPath())
+    strFolder = CMultiPathDirectory::GetFirstPath(item.GetPath());
+
+  if (item.IsPlugin())
+    return "";
+
+  return URIUtils::AddFileToFolder(strFolder, folderJPG);
 }
 
 std::string GetLocalFanart(const CFileItem& item)

--- a/xbmc/utils/ArtUtils.h
+++ b/xbmc/utils/ArtUtils.h
@@ -19,13 +19,21 @@ namespace KODI::ART
 void FillInDefaultIcon(CFileItem& item);
 
 /*!
+ * \brief Get the folder image associated with item.
+ * \param item Item to get folder image for
+ * \param folderJPG Thumb file to use
+ * \return Folder thumb file appropriate for item
+ */
+std::string GetFolderThumb(const CFileItem& item, const std::string& folderJPG = "folder.jpg");
+
+/*!
  \brief Get the local fanart for item if it exists
  \return path to the local fanart for this item, or empty if none exists
  \sa GetFolderThumb, GetTBNFile
  */
 std::string GetLocalFanart(const CFileItem& item);
 
-// Gets the .tbn file associated with an item
+//! \brief Get the .tbn file associated with an item
 std::string GetTBNFile(const CFileItem& item);
 
 } // namespace KODI::ART

--- a/xbmc/utils/test/TestArtUtils.cpp
+++ b/xbmc/utils/test/TestArtUtils.cpp
@@ -123,6 +123,33 @@ class GetTbnTest : public testing::WithParamInterface<TbnTest>, public testing::
 {
 };
 
+struct FolderTest
+{
+  std::string path;
+  std::string thumb;
+  std::string result;
+};
+
+const auto folder_thumb_tests = std::array{
+    FolderTest{"c:\\dir\\", "art.jpg", "c:\\dir\\art.jpg"},
+    FolderTest{"/home/user/", "folder.jpg", "/home/user/folder.jpg"},
+    FolderTest{"plugin://plugin.video.foo/", "folder.jpg", ""},
+    FolderTest{"stack:///home/user/bar/foo-cd1.avi , /home/user/bar/foo-cd2.avi", "folder.jpg",
+               "/home/user/bar/folder.jpg"},
+    FolderTest{"stack:///home/user/cd1/foo-cd1.avi , /home/user/cd2/foo-cd2.avi", "artist.jpg",
+               "/home/user/artist.jpg"},
+    FolderTest{"zip://%2fhome%2fuser%2fbar.zip/foo.avi", "cover.png",
+               "zip://%2fhome%2fuser%2fbar.zip/cover.png"},
+    FolderTest{"rar://%2fhome%2fuser%2fbar.rar/foo.avi", "cover.png",
+               "rar://%2fhome%2fuser%2fbar.rar/cover.png"},
+    FolderTest{"multipath://%2fhome%2fuser%2fbar%2f/%2fhome%2fuser%2ffoo%2f", "folder.jpg",
+               "/home/user/bar/folder.jpg"},
+};
+
+class FolderThumbTest : public testing::WithParamInterface<FolderTest>, public testing::Test
+{
+};
+
 } // namespace
 
 TEST_P(FillInDefaultIconTest, FillInDefaultIcon)
@@ -139,6 +166,15 @@ TEST_P(FillInDefaultIconTest, FillInDefaultIcon)
 }
 
 INSTANTIATE_TEST_SUITE_P(TestArtUtils, FillInDefaultIconTest, testing::ValuesIn(icon_tests));
+
+TEST_P(FolderThumbTest, GetFolderThumb)
+{
+  CFileItem item(GetParam().path, true);
+  const std::string thumb = ART::GetFolderThumb(item, GetParam().thumb);
+  EXPECT_EQ(thumb, GetParam().result);
+}
+
+INSTANTIATE_TEST_SUITE_P(TestArtUtils, FolderThumbTest, testing::ValuesIn(folder_thumb_tests));
 
 TEST_P(GetLocalFanartTest, GetLocalFanart)
 {


### PR DESCRIPTION
## Description
Move another function out of CFIleItem.

## Motivation and context
Less code in CFileItem

## How has this been tested?
It builds + I have added tests

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
