### PR TITLE
fixed: GetFolderThumb for archives

### DIFF
--- a/xbmc/utils/ArtUtils.cpp
+++ b/xbmc/utils/ArtUtils.cpp
@@ -158,9 +158,15 @@ std::string GetFolderThumb(const CFileItem& item, const std::string& folderJPG /
 {
   std::string strFolder = item.GetPath();
 
-  if (item.IsStack() || URIUtils::IsInRAR(strFolder) || URIUtils::IsInZIP(strFolder))
+  if (item.IsStack())
   {
     URIUtils::GetParentPath(item.GetPath(), strFolder);
+  }
+
+  if (URIUtils::IsInRAR(strFolder) || URIUtils::IsInZIP(strFolder))
+  {
+    const CURL url(strFolder);
+    strFolder = URIUtils::GetDirectory(url.GetHostName());
   }
 
   if (item.IsMultiPath())

--- a/xbmc/utils/test/TestArtUtils.cpp
+++ b/xbmc/utils/test/TestArtUtils.cpp
@@ -138,10 +138,7 @@ const auto folder_thumb_tests = std::array{
                "/home/user/bar/folder.jpg"},
     FolderTest{"stack:///home/user/cd1/foo-cd1.avi , /home/user/cd2/foo-cd2.avi", "artist.jpg",
                "/home/user/artist.jpg"},
-    FolderTest{"zip://%2fhome%2fuser%2fbar.zip/foo.avi", "cover.png",
-               "zip://%2fhome%2fuser%2fbar.zip/cover.png"},
-    FolderTest{"rar://%2fhome%2fuser%2fbar.rar/foo.avi", "cover.png",
-               "rar://%2fhome%2fuser%2fbar.rar/cover.png"},
+    FolderTest{"zip://%2fhome%2fuser%2fbar.zip/foo.avi", "cover.png", "/home/user/cover.png"},
     FolderTest{"multipath://%2fhome%2fuser%2fbar%2f/%2fhome%2fuser%2ffoo%2f", "folder.jpg",
                "/home/user/bar/folder.jpg"},
 };


### PR DESCRIPTION
## Description
The intention of this code was to look in the folder holding the archive. I have no idea when this broke, likely years ago..

## Motivation and context
Fix folder thumbs for archives.

## How has this been tested?
Using the modified test

## What is the effect on users?
Folder thumbs should be correctly obtained for archived media again. It is possible some users will see a change if they have folder.jpg in their movie folders.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
