### PR TITLE
[Omega][dvdread] fix warning 'gcc_struct' attribute directive ignored

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/ifo_types.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/ifo_types.h
@@ -29,7 +29,8 @@
 
 #if defined(__GNUC__)
 #if __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 95)
-#if (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)) && !defined(__clang__)
+#if (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)) && !defined(__clang__) && \
+    !defined(__arm__) && !defined(__aarch64__)
 #define ATTRIBUTE_PACKED __attribute__((packed, gcc_struct))
 #else
 #define ATTRIBUTE_PACKED __attribute__((packed))


### PR DESCRIPTION
this is because 'gcc_struct' being undefined for arm

Backport of #25385, as said by @fuzzard this should fix builds on WebOS and LINUX-aarch64-GLES.
