### PR TITLE
CRepository: avoid copying stringstream

### DIFF
--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -165,7 +165,7 @@ bool CRepository::FetchChecksum(const std::string& url,
     ss.write(temp, read);
   if (read <= -1)
     return false;
-  checksum = ss.str();
+  checksum = std::move(ss).str();
   std::size_t pos = checksum.find_first_of(" \n");
   if (pos != std::string::npos)
   {


### PR DESCRIPTION
## Description

Avoid unnecessary copying of `std::sttingstream` instance in CRepository

## Motivation and context

@neo1973 suggested this change in #25683 but it has become out of scope for that PR
so I decided to make a new one not to forget the review point.

## How has this been tested?

Debian. Debian never changes (c)

## What is the effect on users?

Less memory consumption?

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
