### PR TITLE
[PVR] EPG search dialog: Enhance start/end time matching.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -3704,6 +3704,7 @@ msgid "Any channel"
 msgstr ""
 
 #. Label of "Start any time" radio button in PVR timer settings dialog
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 #: xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
 msgctxt "#810"
 msgid "Start any time"
@@ -3750,6 +3751,7 @@ msgid "Record only new episodes"
 msgstr ""
 
 #. Label of "End any time" radio button in PVR timer settings dialog
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 #: xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
 msgctxt "#817"
 msgid "End any time"

--- a/addons/skin.estuary/xml/DialogPVRGuideSearch.xml
+++ b/addons/skin.estuary/xml/DialogPVRGuideSearch.xml
@@ -5,12 +5,12 @@
 	<controls>
 		<control type="group">
 			<centertop>50%</centertop>
-			<height>890</height>
+			<height>960</height>
 			<centerleft>50%</centerleft>
 			<width>1780</width>
 			<include content="DialogBackgroundCommons">
 				<param name="width" value="1780" />
-				<param name="height" value="890" />
+				<param name="height" value="960" />
 				<param name="header_label" value="$LOCALIZE[19142]" />
 				<param name="header_id" value="2" />
 			</include>
@@ -41,7 +41,7 @@
 				<left>10</left>
 				<top>210</top>
 				<width>1460</width>
-				<height>675</height>
+				<height>740</height>
 				<texture border="40">buttons/dialogbutton-nofo.png</texture>
 			</control>
 			<control type="grouplist" id="5000">
@@ -69,16 +69,23 @@
 				<control type="edit" id="14">
 					<description>Start Date</description>
 					<width>710</width>
-					<onright>16</onright>
+					<onright>15</onright>
 					<include>DefaultSettingButton</include>
 					<label>$LOCALIZE[19128]</label>
 				</control>
-				<control type="edit" id="15">
-					<description>Stop Date</description>
+				<control type="radiobutton" id="32">
+					<description>Start any time</description>
+					<width>710</width>
+					<onright>33</onright>
+					<include>DefaultSettingButton</include>
+					<label>$LOCALIZE[810]</label>
+				</control>
+				<control type="edit" id="16">
+					<description>Start time</description>
 					<width>710</width>
 					<onright>17</onright>
 					<include>DefaultSettingButton</include>
-					<label>$LOCALIZE[19129]</label>
+					<label>$LOCALIZE[19126]</label>
 				</control>
 				<control type="radiobutton" id="30">
 					<description>Ignore finished broadcasts</description>
@@ -138,17 +145,24 @@
 					<include>DefaultSettingButton</include>
 					<label>$LOCALIZE[19131]</label>
 				</control>
-				<control type="edit" id="16">
-					<description>Start time</description>
+				<control type="edit" id="15">
+					<description>Stop Date</description>
 					<width>710</width>
 					<onleft>14</onleft>
 					<include>DefaultSettingButton</include>
-					<label>$LOCALIZE[19126]</label>
+					<label>$LOCALIZE[19129]</label>
+				</control>
+				<control type="radiobutton" id="33">
+					<description>End any time</description>
+					<width>710</width>
+					<onleft>32</onleft>
+					<include>DefaultSettingButton</include>
+					<label>$LOCALIZE[817]</label>
 				</control>
 				<control type="edit" id="17">
 					<description>Stop time</description>
 					<width>710</width>
-					<onleft>15</onleft>
+					<onleft>16</onleft>
 					<include>DefaultSettingButton</include>
 					<label>$LOCALIZE[19127]</label>
 				</control>

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -51,6 +51,8 @@ using namespace PVR;
 static constexpr int CONTROL_BTN_SAVE = 29;
 static constexpr int CONTROL_BTN_IGNORE_FINISHED = 30;
 static constexpr int CONTROL_BTN_IGNORE_FUTURE = 31;
+static constexpr int CONTROL_BTN_START_ANY_TIME = 32;
+static constexpr int CONTROL_BTN_END_ANY_TIME = 33;
 
 CGUIDialogPVRGuideSearch::CGUIDialogPVRGuideSearch()
   : CGUIDialog(WINDOW_DIALOG_PVR_GUIDE_SEARCH, "DialogPVRGuideSearch.xml")
@@ -225,6 +227,12 @@ bool CGUIDialogPVRGuideSearch::OnMessage(CGUIMessage& message)
         UpdateChannelSpin();
         return true;
       }
+      else if (iControl == CONTROL_BTN_START_ANY_TIME || iControl == CONTROL_BTN_END_ANY_TIME)
+      {
+        UpdateSearchFilter();
+        Update();
+        return true;
+      }
     }
     break;
   }
@@ -316,6 +324,9 @@ void CGUIDialogPVRGuideSearch::UpdateSearchFilter()
     m_searchFilter->SetEndDateTime(end);
     m_endDateTime = end;
   }
+
+  m_searchFilter->SetStartAnyTime(IsRadioSelected(CONTROL_BTN_START_ANY_TIME));
+  m_searchFilter->SetEndAnyTime(IsRadioSelected(CONTROL_BTN_END_ANY_TIME));
 }
 
 void CGUIDialogPVRGuideSearch::Update()
@@ -340,6 +351,10 @@ void CGUIDialogPVRGuideSearch::Update()
                        m_searchFilter->ShouldIgnoreFinishedBroadcasts());
   SET_CONTROL_SELECTED(GetID(), CONTROL_BTN_IGNORE_FUTURE,
                        m_searchFilter->ShouldIgnoreFutureBroadcasts());
+  SET_CONTROL_SELECTED(GetID(), CONTROL_BTN_START_ANY_TIME, m_searchFilter->IsStartAnyTime());
+  SET_CONTROL_SELECTED(GetID(), CONTROL_BTN_END_ANY_TIME, m_searchFilter->IsEndAnyTime());
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_EDIT_START_TIME, !m_searchFilter->IsStartAnyTime());
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_EDIT_STOP_TIME, !m_searchFilter->IsEndAnyTime());
 
   // Set start/end datetime fields
   m_startDateTime = m_searchFilter->GetStartDateTime();

--- a/xbmc/pvr/epg/EpgDatabase.h
+++ b/xbmc/pvr/epg/EpgDatabase.h
@@ -66,7 +66,7 @@ namespace PVR
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    int GetSchemaVersion() const override { return 18; }
+    int GetSchemaVersion() const override { return 19; }
 
     /*!
      * @brief Get the default sqlite database filename.

--- a/xbmc/pvr/epg/EpgSearchData.h
+++ b/xbmc/pvr/epg/EpgSearchData.h
@@ -25,8 +25,10 @@ struct PVREpgSearchData
   int m_iGenreType = EPG_SEARCH_UNSET; /*!< The genre type for an entry */
   bool m_bIgnoreFinishedBroadcasts; /*!< True to ignore finished broadcasts, false if not */
   bool m_bIgnoreFutureBroadcasts; /*!< True to ignore future broadcasts, false if not */
-  CDateTime m_startDateTime; /*!< The minimum start time for an entry */
-  CDateTime m_endDateTime; /*!< The maximum end time for an entry */
+  CDateTime m_startDateTime; /*!< The minimum start date and time for an entry */
+  CDateTime m_endDateTime; /*!< The maximum end date and time for an entry */
+  bool m_startAnyTime{true}; /*!< Match any start time */
+  bool m_endAnyTime{true}; /*!< Match any end time */
 
   void Reset()
   {
@@ -38,6 +40,8 @@ struct PVREpgSearchData
     m_bIgnoreFutureBroadcasts = false;
     m_startDateTime.SetValid(false);
     m_endDateTime.SetValid(false);
+    m_startAnyTime = true;
+    m_endAnyTime = true;
   }
 };
 

--- a/xbmc/pvr/epg/EpgSearchFilter.cpp
+++ b/xbmc/pvr/epg/EpgSearchFilter.cpp
@@ -149,11 +149,29 @@ void CPVREpgSearchFilter::SetStartDateTime(const CDateTime& startDateTime)
   }
 }
 
+void CPVREpgSearchFilter::SetStartAnyTime(bool startAnyTime)
+{
+  if (m_searchData.m_startAnyTime != startAnyTime)
+  {
+    m_searchData.m_startAnyTime = startAnyTime;
+    m_bChanged = true;
+  }
+}
+
 void CPVREpgSearchFilter::SetEndDateTime(const CDateTime& endDateTime)
 {
   if (m_searchData.m_endDateTime != endDateTime)
   {
     m_searchData.m_endDateTime = endDateTime;
+    m_bChanged = true;
+  }
+}
+
+void CPVREpgSearchFilter::SetEndAnyTime(bool endAnyTime)
+{
+  if (m_searchData.m_endAnyTime != endAnyTime)
+  {
+    m_searchData.m_endAnyTime = endAnyTime;
     m_bChanged = true;
   }
 }

--- a/xbmc/pvr/epg/EpgSearchFilter.h
+++ b/xbmc/pvr/epg/EpgSearchFilter.h
@@ -90,8 +90,14 @@ namespace PVR
     const CDateTime& GetStartDateTime() const { return m_searchData.m_startDateTime; }
     void SetStartDateTime(const CDateTime& startDateTime);
 
+    bool IsStartAnyTime() const { return m_searchData.m_startAnyTime; }
+    void SetStartAnyTime(bool startAnyTime);
+
     const CDateTime& GetEndDateTime() const { return m_searchData.m_endDateTime; }
     void SetEndDateTime(const CDateTime& endDateTime);
+
+    bool IsEndAnyTime() const { return m_searchData.m_endAnyTime; }
+    void SetEndAnyTime(bool endAnyTime);
 
     bool ShouldIncludeUnknownGenres() const { return m_searchData.m_bIncludeUnknownGenres; }
     void SetIncludeUnknownGenres(bool bIncludeUnknownGenres);


### PR DESCRIPTION
This implements the functional improvement for handling EPG search start/end time as suggested in https://github.com/xbmc/xbmc/issues/25738#issuecomment-2354289542 ff. 

New behavior is optional. Existing behavior is still available and activated as default to (hopefully) avoid confusion of users and not to "break" exiting saved searches.

<img width="1614" alt="Screenshot 2024-09-20 at 08 23 55" src="https://github.com/user-attachments/assets/ea71c93b-f68b-483e-b002-77ae01f29248">

Requires version bump of EPG database, to be able to store/restore the new search attributes.

Runtime-tested on macOS, latest Kodi master.

@phunkyfish can you please review.

@thomazz-nl fyi