### PR TITLE
[Windows] Make XAudio2 work with Windows 8 and code improvements

### DIFF
--- a/xbmc/cores/AudioEngine/CMakeLists.txt
+++ b/xbmc/cores/AudioEngine/CMakeLists.txt
@@ -106,7 +106,8 @@ endif()
 if(CORE_SYSTEM_NAME MATCHES windows)
   list(APPEND SOURCES Sinks/AESinkWASAPI.cpp
                       Sinks/AESinkXAudio.cpp
-                      Sinks/windows/AESinkFactoryWin.cpp)
+                      Sinks/windows/AESinkFactoryWin.cpp
+                      Sinks/windows/AESinkFactoryWinRT.cpp)
   list(APPEND HEADERS Sinks/AESinkWASAPI.h
                       Sinks/AESinkXAudio.h
                       Sinks/windows/AESinkFactoryWin.h)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -502,6 +502,7 @@ bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &form
 
   HRESULT hr;
   IXAudio2MasteringVoice* pMasterVoice = nullptr;
+  const wchar_t* pDevice = device.c_str();
   // ForegroundOnlyMedia/BackgroundCapableMedia replaced in Windows 10 by Movie/Media
   const AUDIO_STREAM_CATEGORY streamCategory{
       CSysInfo::IsWindowsVersionAtLeast(CSysInfo::WindowsVersionWin10)
@@ -511,7 +512,7 @@ bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &form
   if (!bdefault)
   {
     hr = m_xAudio2->CreateMasteringVoice(&pMasterVoice, wfxex.Format.nChannels,
-                                         wfxex.Format.nSamplesPerSec, 0, device.c_str(), nullptr,
+                                         wfxex.Format.nSamplesPerSec, 0, pDevice, nullptr,
                                          streamCategory);
   }
 
@@ -524,11 +525,11 @@ bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &form
                  "Trying the default device...",
                  KODI::PLATFORM::WINDOWS::FromW(device));
     }
-
     // smartphone issue: providing device ID (even default ID) causes E_NOINTERFACE result
     // workaround: device = nullptr will initialize default audio endpoint
+    pDevice = nullptr;
     hr = m_xAudio2->CreateMasteringVoice(&pMasterVoice, wfxex.Format.nChannels,
-                                         wfxex.Format.nSamplesPerSec, 0, nullptr, nullptr,
+                                         wfxex.Format.nSamplesPerSec, 0, pDevice, nullptr,
                                          streamCategory);
     if (FAILED(hr) || !pMasterVoice)
     {
@@ -603,8 +604,8 @@ bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &form
         wfxex.Format.nAvgBytesPerSec   = wfxex.Format.nSamplesPerSec * wfxex.Format.nBlockAlign;
 
         hr = m_xAudio2->CreateMasteringVoice(&m_masterVoice, wfxex.Format.nChannels,
-                                             wfxex.Format.nSamplesPerSec, 0, device.c_str(),
-                                             nullptr, streamCategory);
+                                             wfxex.Format.nSamplesPerSec, 0, pDevice, nullptr,
+                                             streamCategory);
         if (SUCCEEDED(hr))
         {
           hr = m_xAudio2->CreateSourceVoice(&m_sourceVoice, &wfxex.Format, 0, XAUDIO2_DEFAULT_FREQ_RATIO, &m_voiceCallback);
@@ -633,8 +634,8 @@ bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &form
         wfxex.Format.nAvgBytesPerSec   = wfxex.Format.nSamplesPerSec * wfxex.Format.nBlockAlign;
 
         if (SUCCEEDED(m_xAudio2->CreateMasteringVoice(&m_masterVoice, wfxex.Format.nChannels,
-                                                      wfxex.Format.nSamplesPerSec, 0,
-                                                      device.c_str(), nullptr, streamCategory)) &&
+                                                      wfxex.Format.nSamplesPerSec, 0, pDevice,
+                                                      nullptr, streamCategory)) &&
             SUCCEEDED(m_xAudio2->CreateSourceVoice(&m_sourceVoice, &wfxex.Format, 0,
                                                    XAUDIO2_DEFAULT_FREQ_RATIO, &m_voiceCallback)))
           goto initialize;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -413,6 +413,10 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
 
     for (int j = 0; j < WASAPISampleRateCount; j++)
     {
+      if (WASAPISampleRates[j] < XAUDIO2_MIN_SAMPLE_RATE ||
+          WASAPISampleRates[j] > XAUDIO2_MAX_SAMPLE_RATE)
+        continue;
+
       SafeDestroyVoice(&mSourceVoice);
       SafeDestroyVoice(&mMasterVoice);
 
@@ -588,6 +592,10 @@ bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &form
 
       for (int i = 0 ; i < WASAPISampleRateCount; i++)
       {
+        if (WASAPISampleRates[j] < XAUDIO2_MIN_SAMPLE_RATE ||
+            WASAPISampleRates[j] > XAUDIO2_MAX_SAMPLE_RATE)
+          continue;
+
         wfxex.Format.nSamplesPerSec    = WASAPISampleRates[i];
         wfxex.Format.nAvgBytesPerSec   = wfxex.Format.nSamplesPerSec * wfxex.Format.nBlockAlign;
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.h
@@ -13,14 +13,10 @@
 
 #include <stdint.h>
 
-#include <mmdeviceapi.h>
-#include <ppltasks.h>
-#include <wrl/implements.h>
 #include <x3daudio.h>
 #include <xapofx.h>
 #include <xaudio2.h>
 #include <xaudio2fx.h>
-#pragma comment(lib,"xaudio2.lib")
 
 class CAESinkXAudio : public IAESink
 {

--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin.h
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin.h
@@ -175,7 +175,6 @@ static const sampleFormat testFormats[] = { {KSDATAFORMAT_SUBTYPE_IEEE_FLOAT, 32
 
 struct RendererDetail
 {
-  std::string strDevicePath;
   std::string strDeviceId;
   std::string strDescription;
   std::string strWinDevType;
@@ -198,9 +197,13 @@ class CAESinkFactoryWin
 {
 public:
   /*
-    Gets list of audio renderers available on platform
+    Gets list of available audio renderers - using MMDevice
   */
   static std::vector<RendererDetail> GetRendererDetails();
+  /*
+    Gets list of available audio renderers - using WinRT
+  */
+  static std::vector<RendererDetail> GetRendererDetailsWinRT();
   /*
     Gets default device id
   */

--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin10.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin10.cpp
@@ -6,117 +6,21 @@
  *  See LICENSES/README.md for more information.
  */
 #include "AESinkFactoryWin.h"
-#include "utils/log.h"
 
-#include "platform/win10/AsyncHelpers.h"
 #include "platform/win32/CharsetConverter.h"
 
 #include <mmdeviceapi.h>
 #include <mmreg.h>
 #include <winrt/Windows.Devices.Enumeration.h>
-#include <winrt/Windows.Media.Devices.Core.h>
 #include <winrt/Windows.Media.Devices.h>
 
 using namespace winrt::Windows::Devices::Enumeration;
 using namespace winrt::Windows::Media::Devices;
-using namespace winrt::Windows::Media::Devices::Core;
 using namespace Microsoft::WRL;
-
-static winrt::hstring PKEY_Device_FriendlyName = L"System.ItemNameDisplay";
-static winrt::hstring PKEY_AudioEndpoint_FormFactor = L"{1da5d803-d492-4edd-8c23-e0c0ffee7f0e} 0";
-static winrt::hstring PKEY_AudioEndpoint_ControlPanelPageProvider = L"{1da5d803-d492-4edd-8c23-e0c0ffee7f0e} 1";
-static winrt::hstring PKEY_AudioEndpoint_Association = L"{1da5d803-d492-4edd-8c23-e0c0ffee7f0e} 2";
-static winrt::hstring PKEY_AudioEndpoint_PhysicalSpeakers = L"{1da5d803-d492-4edd-8c23-e0c0ffee7f0e} 3";
-static winrt::hstring PKEY_AudioEndpoint_GUID = L"{1da5d803-d492-4edd-8c23-e0c0ffee7f0e} 4";
-static winrt::hstring PKEY_AudioEndpoint_Disable_SysFx = L"{1da5d803-d492-4edd-8c23-e0c0ffee7f0e} 5";
-static winrt::hstring PKEY_AudioEndpoint_FullRangeSpeakers = L"{1da5d803-d492-4edd-8c23-e0c0ffee7f0e} 6";
-static winrt::hstring PKEY_AudioEndpoint_Supports_EventDriven_Mode = L"{1da5d803-d492-4edd-8c23-e0c0ffee7f0e} 7";
-static winrt::hstring PKEY_AudioEndpoint_JackSubType = L"{1da5d803-d492-4edd-8c23-e0c0ffee7f0e} 8";
-static winrt::hstring PKEY_AudioEndpoint_Default_VolumeInDb = L"{1da5d803-d492-4edd-8c23-e0c0ffee7f0e} 9";
-static winrt::hstring PKEY_AudioEngine_DeviceFormat = L"{f19f064d-082c-4e27-bc73-6882a1bb8e4c} 0";
-static winrt::hstring PKEY_Device_EnumeratorName = L"{a45c254e-df1c-4efd-8020-67d146a850e0} 24";
 
 std::vector<RendererDetail> CAESinkFactoryWin::GetRendererDetails()
 {
-  std::vector<RendererDetail> list;
-  try
-  {
-    // Get the string identifier of the audio renderer
-    auto defaultId = MediaDevice::GetDefaultAudioRenderId(AudioDeviceRole::Default);
-    auto audioSelector = MediaDevice::GetAudioRenderSelector();
-
-    // Add custom properties to the query
-    DeviceInformationCollection devInfocollection = Wait(DeviceInformation::FindAllAsync(audioSelector,
-      {
-          PKEY_AudioEndpoint_FormFactor,
-          PKEY_AudioEndpoint_GUID,
-          PKEY_AudioEndpoint_PhysicalSpeakers,
-          PKEY_AudioEngine_DeviceFormat,
-          PKEY_Device_EnumeratorName
-      }));
-    if (devInfocollection == nullptr || devInfocollection.Size() == 0)
-      goto failed;
-
-    for (unsigned int i = 0; i < devInfocollection.Size(); i++)
-    {
-      RendererDetail details;
-
-      DeviceInformation devInfo = devInfocollection.GetAt(i);
-      if (devInfo.Properties().Size() == 0)
-        goto failed;
-
-      winrt::IInspectable propObj = nullptr;
-
-      propObj = devInfo.Properties().Lookup(PKEY_AudioEndpoint_FormFactor);
-      if (!propObj)
-        goto failed;
-
-      details.strWinDevType = winEndpoints[propObj.as<winrt::IPropertyValue>().GetUInt32()].winEndpointType;
-      details.eDeviceType = winEndpoints[propObj.as<winrt::IPropertyValue>().GetUInt32()].aeDeviceType;
-
-      unsigned long ulChannelMask = 0;
-      unsigned int nChannels = 0;
-
-      propObj = devInfo.Properties().Lookup(PKEY_AudioEngine_DeviceFormat);
-      if (propObj)
-      {
-        winrt::com_array<uint8_t> com_arr;
-        propObj.as<winrt::IPropertyValue>().GetUInt8Array(com_arr);
-
-        WAVEFORMATEXTENSIBLE* smpwfxex = (WAVEFORMATEXTENSIBLE*)com_arr.data();
-        nChannels = std::max(std::min(smpwfxex->Format.nChannels, (WORD)8), (WORD)2);
-        ulChannelMask = smpwfxex->dwChannelMask;
-      }
-      else
-      {
-        // suppose stereo
-        nChannels = 2;
-        ulChannelMask = 3;
-      }
-
-      propObj = devInfo.Properties().Lookup(PKEY_AudioEndpoint_PhysicalSpeakers);
-      details.uiChannelMask = propObj ? propObj.as<winrt::IPropertyValue>().GetUInt32() : ulChannelMask;
-      details.nChannels = nChannels;
-
-      details.strDescription = KODI::PLATFORM::WINDOWS::FromW(devInfo.Name().c_str());
-      details.strDeviceId = KODI::PLATFORM::WINDOWS::FromW(devInfo.Id().c_str());
-
-      // on Windows UWP device Id is same as Path
-      details.strDevicePath = details.strDeviceId;
-
-      details.bDefault = (devInfo.Id() == defaultId);
-
-      list.push_back(details);
-    }
-    return list;
-  }
-  catch (...)
-  {
-  }
-
-failed:
-  CLog::Log(LOGERROR, __FUNCTION__": Failed to enumerate audio renderer devices.");
-  return list;
+  return GetRendererDetailsWinRT();
 }
 
 class CAudioInterfaceActivator : public winrt::implements<CAudioInterfaceActivator, IActivateAudioInterfaceCompletionHandler>

--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp
@@ -147,7 +147,6 @@ std::vector<RendererDetail> CAESinkFactoryWin::GetRendererDetails()
       if (wstrDDID.compare(pwszID) == 0)
         details.bDefault = true;
 
-      details.strDevicePath = KODI::PLATFORM::WINDOWS::FromW(pwszID);
       CoTaskMemFree(pwszID);
     }
 

--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWinRT.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWinRT.cpp
@@ -1,0 +1,124 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "AESinkFactoryWin.h"
+#include "utils/log.h"
+
+#include "platform/win10/AsyncHelpers.h"
+#include "platform/win32/CharsetConverter.h"
+
+#include <winrt/windows.devices.enumeration.h>
+#include <winrt/windows.foundation.collections.h>
+#include <winrt/windows.foundation.h>
+#include <winrt/windows.media.devices.core.h>
+#include <winrt/windows.media.devices.h>
+
+namespace winrt
+{
+using namespace Windows::Foundation;
+}
+
+using namespace winrt::Windows::Devices::Enumeration;
+using namespace winrt::Windows::Media::Devices;
+using namespace winrt::Windows::Media::Devices::Core;
+
+// clang-format off
+static winrt::hstring PKEY_Device_FriendlyName = L"System.ItemNameDisplay";
+static winrt::hstring PKEY_AudioEndpoint_FormFactor = L"{1da5d803-d492-4edd-8c23-e0c0ffee7f0e} 0";
+static winrt::hstring PKEY_AudioEndpoint_ControlPanelPageProvider = L"{1da5d803-d492-4edd-8c23-e0c0ffee7f0e} 1";
+static winrt::hstring PKEY_AudioEndpoint_Association = L"{1da5d803-d492-4edd-8c23-e0c0ffee7f0e} 2";
+static winrt::hstring PKEY_AudioEndpoint_PhysicalSpeakers = L"{1da5d803-d492-4edd-8c23-e0c0ffee7f0e} 3";
+static winrt::hstring PKEY_AudioEndpoint_GUID = L"{1da5d803-d492-4edd-8c23-e0c0ffee7f0e} 4";
+static winrt::hstring PKEY_AudioEndpoint_Disable_SysFx = L"{1da5d803-d492-4edd-8c23-e0c0ffee7f0e} 5";
+static winrt::hstring PKEY_AudioEndpoint_FullRangeSpeakers = L"{1da5d803-d492-4edd-8c23-e0c0ffee7f0e} 6";
+static winrt::hstring PKEY_AudioEndpoint_Supports_EventDriven_Mode = L"{1da5d803-d492-4edd-8c23-e0c0ffee7f0e} 7";
+static winrt::hstring PKEY_AudioEndpoint_JackSubType = L"{1da5d803-d492-4edd-8c23-e0c0ffee7f0e} 8";
+static winrt::hstring PKEY_AudioEndpoint_Default_VolumeInDb = L"{1da5d803-d492-4edd-8c23-e0c0ffee7f0e} 9";
+static winrt::hstring PKEY_AudioEngine_DeviceFormat = L"{f19f064d-082c-4e27-bc73-6882a1bb8e4c} 0";
+static winrt::hstring PKEY_Device_EnumeratorName = L"{a45c254e-df1c-4efd-8020-67d146a850e0} 24";
+// clang-format on
+
+std::vector<RendererDetail> CAESinkFactoryWin::GetRendererDetailsWinRT()
+{
+  std::vector<RendererDetail> list;
+  try
+  {
+    // Get the string identifier of the audio renderer
+    auto defaultId = MediaDevice::GetDefaultAudioRenderId(AudioDeviceRole::Default);
+    auto audioSelector = MediaDevice::GetAudioRenderSelector();
+
+    // Add custom properties to the query
+    DeviceInformationCollection devInfoCollection = Wait(DeviceInformation::FindAllAsync(
+        audioSelector, {PKEY_AudioEndpoint_FormFactor, PKEY_AudioEndpoint_GUID,
+                        PKEY_AudioEndpoint_PhysicalSpeakers, PKEY_AudioEngine_DeviceFormat,
+                        PKEY_Device_EnumeratorName}));
+
+    if (devInfoCollection == nullptr || devInfoCollection.Size() == 0)
+      goto failed;
+
+    for (const DeviceInformation& devInfo : devInfoCollection)
+    {
+      RendererDetail details;
+
+      if (devInfo.Properties().Size() == 0)
+        goto failed;
+
+      winrt::IInspectable propObj = nullptr;
+
+      propObj = devInfo.Properties().Lookup(PKEY_AudioEndpoint_FormFactor);
+      if (!propObj)
+        goto failed;
+
+      const uint32_t indexFF{propObj.as<winrt::IPropertyValue>().GetUInt32()};
+      details.strWinDevType = winEndpoints[indexFF].winEndpointType;
+      details.eDeviceType = winEndpoints[indexFF].aeDeviceType;
+
+      DWORD ulChannelMask = 0;
+      unsigned int nChannels = 0;
+
+      propObj = devInfo.Properties().Lookup(PKEY_AudioEngine_DeviceFormat);
+      if (propObj)
+      {
+        winrt::com_array<uint8_t> com_arr;
+        propObj.as<winrt::IPropertyValue>().GetUInt8Array(com_arr);
+
+        WAVEFORMATEXTENSIBLE* smpwfxex = (WAVEFORMATEXTENSIBLE*)com_arr.data();
+        nChannels = std::max(std::min(smpwfxex->Format.nChannels, (WORD)8), (WORD)2);
+        ulChannelMask = smpwfxex->dwChannelMask;
+      }
+      else
+      {
+        // suppose stereo
+        nChannels = 2;
+        ulChannelMask = 3;
+      }
+
+      propObj = devInfo.Properties().Lookup(PKEY_AudioEndpoint_PhysicalSpeakers);
+
+      details.uiChannelMask = propObj ? propObj.as<winrt::IPropertyValue>().GetUInt32()
+                                      : static_cast<unsigned int>(ulChannelMask);
+
+      details.nChannels = nChannels;
+
+      details.strDescription = KODI::PLATFORM::WINDOWS::FromW(devInfo.Name().c_str());
+      details.strDeviceId = KODI::PLATFORM::WINDOWS::FromW(devInfo.Id().c_str());
+
+      details.bDefault = (devInfo.Id() == defaultId);
+
+      list.push_back(details);
+    }
+    return list;
+  }
+  catch (...)
+  {
+  }
+
+failed:
+  CLog::LogF(LOGERROR, "Failed to enumerate audio renderer devices.");
+  return list;
+}

--- a/xbmc/platform/win10/AsyncHelpers.h
+++ b/xbmc/platform/win10/AsyncHelpers.h
@@ -12,6 +12,10 @@
 #include <ppltasks.h>
 #include <sdkddkver.h>
 
+#ifndef TARGET_WINDOWS_STORE
+#include <winrt/windows.foundation.h>
+#endif
+
 namespace winrt
 {
   using namespace Windows::Foundation;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Follow up PR of #25068 to make Xaudio output work on Windows 8.1 as well, and additional code improvements.

* The previous PR used the name returned by mmdevice enumeration to open an xaudio sink by name but those names are not accepted by Windows 8, which requires the names as enumerated on Xbox or UWP desktop build.

for example `\\?\SWD#MMDEVAPI#{0.0.0.00000000}.{a4ec9140-07bf-4031-9bb1-01f49002e272}#{e6327cad-dcec-4949-ae8a-991e976a79d2}`

Those names also work on Windows 10 and 11. Solved the compatibility issue with a refactor of the enumeration code, now shared between Xbox/UWP and desktop.

* Another issue was the different names and versions of the xaudio dll (2.8 or 2.9) depending on the OS. There is also a redistributable version that could have been installed by games on some computers (2.9 redist).
The minimum requirement for Kodi is version 2.8, bundled with Windows 8.1 so there is no need to install the redist package for a higher version. Instead, probe the system to dynamically load the highest version available (2.9 redist > 2,9 > 2.8)

* Finally, miscellaneous code improvements, one per commit.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Windows 8 is a supported platform that includes XAudio support but it did not work in Kodi.
Noticed various code issues.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 8, default and named devices, builtin speakers / earbuds, hdmi audio devices.
Windows 10 and 11 desktop and UWP to check for no adverse effects, with speakers, hdmi, spdif, usb.

no bluetooth audio device available for testing.
Xbox not tested.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Xaudio is more modern than DirectSound and is now available for all Kodi-supported Windows versions.
Still very new on desktop so not the default sink.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
