### PR TITLE
[PVR] Add possibility to make copies of EPG saved searches (e.g. to use an existing search as a template for a new search).

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -11855,7 +11855,19 @@ msgctxt "#19354"
 msgid "Play only this programme"
 msgstr ""
 
-#empty strings from id 19355 to 19498
+#. Label of a context menu entry to create a copy of an EPG saved saerch
+#: xbmc/pvr/PVRContextMenus.cpp
+msgctxt "#19355"
+msgid "Duplicate"
+msgstr ""
+
+#. Initial title of a duplicated EPG saved search.
+#: xbmc/pvr/PVRContextMenus.cpp
+msgctxt "#19356"
+msgid "Copy of '{0:s}'"
+msgstr ""
+
+#empty strings from id 19357 to 19498
 
 #. label for epg genre value
 #: xbmc/pvr/epg/Epg.cpp

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -81,6 +81,7 @@ DECL_STATICCONTEXTMENUITEM(ExecuteSearch);
 DECL_STATICCONTEXTMENUITEM(EditSearch);
 DECL_STATICCONTEXTMENUITEM(RenameSearch);
 DECL_STATICCONTEXTMENUITEM(ChooseIconForSearch);
+DECL_STATICCONTEXTMENUITEM(DuplicateSearch);
 DECL_STATICCONTEXTMENUITEM(DeleteSearch);
 
 class PVRClientMenuHook : public IContextMenuItem
@@ -749,6 +750,19 @@ bool ChooseIconForSearch::Execute(const std::shared_ptr<CFileItem>& item) const
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// Duplicate a saved search
+
+bool DuplicateSearch::IsVisible(const CFileItem& item) const
+{
+  return item.HasEPGSearchFilter();
+}
+
+bool DuplicateSearch::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().DuplicateSavedSearch(*item);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // Delete saved search
 
 bool DeleteSearch::IsVisible(const CFileItem& item) const
@@ -794,6 +808,7 @@ CPVRContextMenuManager::CPVRContextMenuManager()
         std::make_shared<CONTEXTMENUITEM::EditSearch>(21450), /* Edit */
         std::make_shared<CONTEXTMENUITEM::RenameSearch>(118), /* Rename */
         std::make_shared<CONTEXTMENUITEM::ChooseIconForSearch>(19284), /* Choose icon */
+        std::make_shared<CONTEXTMENUITEM::DuplicateSearch>(19355), /* Duplicate */
         std::make_shared<CONTEXTMENUITEM::DeleteSearch>(117), /* Delete */
     })
 {

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -590,7 +590,7 @@ int CPVRDatabase::GetClientID(const std::string& addonID, unsigned int instanceI
   if (ExecuteQuery(sql))
     return static_cast<int>(m_pDS->lastinsertid());
 
-  return -1;
+  return PVR_CLIENT_INVALID_UID;
 }
 
 /********** Channel provider methods **********/
@@ -1306,7 +1306,8 @@ std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRDatabase::GetTimers(
         newTag->m_iClientIndex = -m_pDS->fv("iClientIndex").get_asInt();
         newTag->m_iParentClientIndex = m_pDS->fv("iParentClientIndex").get_asInt();
         newTag->m_iClientId = m_pDS->fv("iClientId").get_asInt();
-        newTag->SetTimerType(CPVRTimerType::CreateFromIds(m_pDS->fv("iTimerType").get_asInt(), -1));
+        newTag->SetTimerType(CPVRTimerType::CreateFromIds(m_pDS->fv("iTimerType").get_asInt(),
+                                                          PVR_CLIENT_INVALID_UID));
         newTag->m_state = static_cast<PVR_TIMER_STATE>(m_pDS->fv("iState").get_asInt());
         newTag->m_strTitle = m_pDS->fv("sTitle").get_asString().c_str();
         newTag->m_iClientChannelUid = m_pDS->fv("iClientChannelUid").get_asInt();

--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -1442,7 +1442,7 @@ bool CPVREpgDatabase::Persist(CPVREpgSearchFilter& epgSearch)
 
   // Insert a new entry if this is a new search, replace the existing otherwise
   std::string strQuery;
-  if (epgSearch.GetDatabaseId() == -1)
+  if (epgSearch.GetDatabaseId() == PVR_EPG_SEARCH_INVALID_DATABASE_ID)
     strQuery = PrepareSQL(
         "INSERT INTO savedsearches "
         "(sTitle, sLastExecutedDateTime, sSearchTerm, bSearchInDescription, bIsCaseSensitive, "
@@ -1510,7 +1510,7 @@ bool CPVREpgDatabase::Persist(CPVREpgSearchFilter& epgSearch)
   if (bReturn)
   {
     // Set the database id for searches persisted for the first time
-    if (epgSearch.GetDatabaseId() == -1)
+    if (epgSearch.GetDatabaseId() == PVR_EPG_SEARCH_INVALID_DATABASE_ID)
       epgSearch.SetDatabaseId(static_cast<int>(m_pDS->lastinsertid()));
 
     epgSearch.SetChanged(false);
@@ -1521,7 +1521,7 @@ bool CPVREpgDatabase::Persist(CPVREpgSearchFilter& epgSearch)
 
 bool CPVREpgDatabase::UpdateSavedSearchLastExecuted(const CPVREpgSearchFilter& epgSearch)
 {
-  if (epgSearch.GetDatabaseId() == -1)
+  if (epgSearch.GetDatabaseId() == PVR_EPG_SEARCH_INVALID_DATABASE_ID)
     return false;
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
@@ -1534,7 +1534,7 @@ bool CPVREpgDatabase::UpdateSavedSearchLastExecuted(const CPVREpgSearchFilter& e
 
 bool CPVREpgDatabase::Delete(const CPVREpgSearchFilter& epgSearch)
 {
-  if (epgSearch.GetDatabaseId() == -1)
+  if (epgSearch.GetDatabaseId() == PVR_EPG_SEARCH_INVALID_DATABASE_ID)
     return false;
 
   CLog::LogFC(LOGDEBUG, LOGEPG, "Deleting saved search '{}' from the database",

--- a/xbmc/pvr/epg/EpgSearchFilter.cpp
+++ b/xbmc/pvr/epg/EpgSearchFilter.cpp
@@ -28,8 +28,7 @@
 
 using namespace PVR;
 
-CPVREpgSearchFilter::CPVREpgSearchFilter(bool bRadio)
-: m_bIsRadio(bRadio)
+CPVREpgSearchFilter::CPVREpgSearchFilter(bool bRadio) : m_bIsRadio(bRadio)
 {
   Reset();
 }
@@ -366,7 +365,8 @@ void CPVREpgSearchFilter::RemoveDuplicates(std::vector<std::shared_ptr<CPVREpgIn
   for (auto it = results.begin(); it != results.end();)
   {
     it = results.erase(std::remove_if(results.begin(), results.end(),
-                                      [&it](const std::shared_ptr<const CPVREpgInfoTag>& entry) {
+                                      [&it](const std::shared_ptr<const CPVREpgInfoTag>& entry)
+                                      {
                                         return *it != entry && (*it)->Title() == entry->Title() &&
                                                (*it)->Plot() == entry->Plot() &&
                                                (*it)->PlotOutline() == entry->PlotOutline();
@@ -414,10 +414,12 @@ bool CPVREpgSearchFilter::MatchFreeToAir(const std::shared_ptr<const CPVREpgInfo
 
 bool CPVREpgSearchFilter::MatchTimers(const std::shared_ptr<const CPVREpgInfoTag>& tag) const
 {
-  return (!m_bIgnorePresentTimers || !CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(tag));
+  return (!m_bIgnorePresentTimers ||
+          !CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(tag));
 }
 
 bool CPVREpgSearchFilter::MatchRecordings(const std::shared_ptr<const CPVREpgInfoTag>& tag) const
 {
-  return (!m_bIgnorePresentRecordings || !CServiceBroker::GetPVRManager().Recordings()->GetRecordingForEpgTag(tag));
+  return (!m_bIgnorePresentRecordings ||
+          !CServiceBroker::GetPVRManager().Recordings()->GetRecordingForEpgTag(tag));
 }

--- a/xbmc/pvr/epg/EpgSearchFilter.h
+++ b/xbmc/pvr/epg/EpgSearchFilter.h
@@ -18,6 +18,8 @@
 
 namespace PVR
 {
+static constexpr int PVR_EPG_SEARCH_INVALID_DATABASE_ID{-1};
+
 class CPVREpgInfoTag;
 
 class CPVREpgSearchFilter
@@ -165,13 +167,13 @@ private:
   // PVR specific filters
   bool m_bIsRadio; /*!< True to filter radio channels only, false to tv only */
   int m_iClientID = PVR_CLIENT_INVALID_UID; /*!< The client id */
-  int m_iChannelGroupID{-1}; /*! The channel group id */
+  int m_iChannelGroupID{-1}; /*!< The channel group id */
   int m_iChannelUID = -1; /*!< The channel uid */
   bool m_bFreeToAirOnly; /*!< Include free to air channels only */
   bool m_bIgnorePresentTimers; /*!< True to ignore currently present timers, false if not */
   bool m_bIgnorePresentRecordings; /*!< True to ignore currently active recordings, false if not */
 
-  int m_iDatabaseId = -1;
+  int m_iDatabaseId{PVR_EPG_SEARCH_INVALID_DATABASE_ID};
   std::string m_title;
   std::string m_iconPath;
   CDateTime m_lastExecutedDateTime;

--- a/xbmc/pvr/epg/EpgSearchFilter.h
+++ b/xbmc/pvr/epg/EpgSearchFilter.h
@@ -18,162 +18,162 @@
 
 namespace PVR
 {
-  class CPVREpgInfoTag;
+class CPVREpgInfoTag;
 
-  class CPVREpgSearchFilter
-  {
-  public:
-    CPVREpgSearchFilter() = delete;
+class CPVREpgSearchFilter
+{
+public:
+  CPVREpgSearchFilter() = delete;
 
-    /*!
-     * @brief ctor.
-     * @param bRadio the type of channels to search - if true, 'radio'. 'tv', otherwise.
-     */
-    explicit CPVREpgSearchFilter(bool bRadio);
+  /*!
+   * @brief ctor.
+   * @param bRadio the type of channels to search - if true, 'radio'. 'tv', otherwise.
+   */
+  explicit CPVREpgSearchFilter(bool bRadio);
 
-    /*!
-     * @brief Clear this filter.
-     */
-    void Reset();
+  /*!
+   * @brief Clear this filter.
+   */
+  void Reset();
 
-    /*!
-     * @brief Return the path for this filter.
-     * @return the path.
-     */
-    std::string GetPath() const;
+  /*!
+   * @brief Return the path for this filter.
+   * @return the path.
+   */
+  std::string GetPath() const;
 
-    /*!
-     * @brief Check if a tag will be filtered or not.
-     * @param tag The tag to check.
-     * @return True if this tag matches the filter, false if not.
-     */
-    bool FilterEntry(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
+  /*!
+   * @brief Check if a tag will be filtered or not.
+   * @param tag The tag to check.
+   * @return True if this tag matches the filter, false if not.
+   */
+  bool FilterEntry(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
 
-    /*!
-     * @brief remove duplicates from a list of epg tags.
-     * @param results The list of epg tags.
-     */
-    static void RemoveDuplicates(std::vector<std::shared_ptr<CPVREpgInfoTag>>& results);
+  /*!
+   * @brief remove duplicates from a list of epg tags.
+   * @param results The list of epg tags.
+   */
+  static void RemoveDuplicates(std::vector<std::shared_ptr<CPVREpgInfoTag>>& results);
 
-    /*!
-     * @brief Get the type of channels to search.
-     * @return true, if 'radio'. false, otherwise.
-     */
-    bool IsRadio() const { return m_bIsRadio; }
+  /*!
+   * @brief Get the type of channels to search.
+   * @return true, if 'radio'. false, otherwise.
+   */
+  bool IsRadio() const { return m_bIsRadio; }
 
-    const std::string& GetSearchTerm() const { return m_searchData.m_strSearchTerm; }
-    void SetSearchTerm(const std::string& strSearchTerm);
+  const std::string& GetSearchTerm() const { return m_searchData.m_strSearchTerm; }
+  void SetSearchTerm(const std::string& strSearchTerm);
 
-    void SetSearchPhrase(const std::string& strSearchPhrase);
+  void SetSearchPhrase(const std::string& strSearchPhrase);
 
-    bool IsCaseSensitive() const { return m_bIsCaseSensitive; }
-    void SetCaseSensitive(bool bIsCaseSensitive);
+  bool IsCaseSensitive() const { return m_bIsCaseSensitive; }
+  void SetCaseSensitive(bool bIsCaseSensitive);
 
-    bool ShouldSearchInDescription() const { return m_searchData.m_bSearchInDescription; }
-    void SetSearchInDescription(bool bSearchInDescription);
+  bool ShouldSearchInDescription() const { return m_searchData.m_bSearchInDescription; }
+  void SetSearchInDescription(bool bSearchInDescription);
 
-    int GetGenreType() const { return m_searchData.m_iGenreType; }
-    void SetGenreType(int iGenreType);
+  int GetGenreType() const { return m_searchData.m_iGenreType; }
+  void SetGenreType(int iGenreType);
 
-    int GetMinimumDuration() const { return m_iMinimumDuration; }
-    void SetMinimumDuration(int iMinimumDuration);
+  int GetMinimumDuration() const { return m_iMinimumDuration; }
+  void SetMinimumDuration(int iMinimumDuration);
 
-    int GetMaximumDuration() const { return m_iMaximumDuration; }
-    void SetMaximumDuration(int iMaximumDuration);
+  int GetMaximumDuration() const { return m_iMaximumDuration; }
+  void SetMaximumDuration(int iMaximumDuration);
 
-    bool ShouldIgnoreFinishedBroadcasts() const { return m_searchData.m_bIgnoreFinishedBroadcasts; }
-    void SetIgnoreFinishedBroadcasts(bool bIgnoreFinishedBroadcasts);
+  bool ShouldIgnoreFinishedBroadcasts() const { return m_searchData.m_bIgnoreFinishedBroadcasts; }
+  void SetIgnoreFinishedBroadcasts(bool bIgnoreFinishedBroadcasts);
 
-    bool ShouldIgnoreFutureBroadcasts() const { return m_searchData.m_bIgnoreFutureBroadcasts; }
-    void SetIgnoreFutureBroadcasts(bool bIgnoreFutureBroadcasts);
+  bool ShouldIgnoreFutureBroadcasts() const { return m_searchData.m_bIgnoreFutureBroadcasts; }
+  void SetIgnoreFutureBroadcasts(bool bIgnoreFutureBroadcasts);
 
-    const CDateTime& GetStartDateTime() const { return m_searchData.m_startDateTime; }
-    void SetStartDateTime(const CDateTime& startDateTime);
+  const CDateTime& GetStartDateTime() const { return m_searchData.m_startDateTime; }
+  void SetStartDateTime(const CDateTime& startDateTime);
 
-    bool IsStartAnyTime() const { return m_searchData.m_startAnyTime; }
-    void SetStartAnyTime(bool startAnyTime);
+  bool IsStartAnyTime() const { return m_searchData.m_startAnyTime; }
+  void SetStartAnyTime(bool startAnyTime);
 
-    const CDateTime& GetEndDateTime() const { return m_searchData.m_endDateTime; }
-    void SetEndDateTime(const CDateTime& endDateTime);
+  const CDateTime& GetEndDateTime() const { return m_searchData.m_endDateTime; }
+  void SetEndDateTime(const CDateTime& endDateTime);
 
-    bool IsEndAnyTime() const { return m_searchData.m_endAnyTime; }
-    void SetEndAnyTime(bool endAnyTime);
+  bool IsEndAnyTime() const { return m_searchData.m_endAnyTime; }
+  void SetEndAnyTime(bool endAnyTime);
 
-    bool ShouldIncludeUnknownGenres() const { return m_searchData.m_bIncludeUnknownGenres; }
-    void SetIncludeUnknownGenres(bool bIncludeUnknownGenres);
+  bool ShouldIncludeUnknownGenres() const { return m_searchData.m_bIncludeUnknownGenres; }
+  void SetIncludeUnknownGenres(bool bIncludeUnknownGenres);
 
-    bool ShouldRemoveDuplicates() const { return m_bRemoveDuplicates; }
-    void SetRemoveDuplicates(bool bRemoveDuplicates);
+  bool ShouldRemoveDuplicates() const { return m_bRemoveDuplicates; }
+  void SetRemoveDuplicates(bool bRemoveDuplicates);
 
-    int GetClientID() const { return m_iClientID; }
-    void SetClientID(int iClientID);
+  int GetClientID() const { return m_iClientID; }
+  void SetClientID(int iClientID);
 
-    int GetChannelGroupID() const { return m_iChannelGroupID; }
-    void SetChannelGroupID(int iChannelGroupID);
+  int GetChannelGroupID() const { return m_iChannelGroupID; }
+  void SetChannelGroupID(int iChannelGroupID);
 
-    int GetChannelUID() const { return m_iChannelUID; }
-    void SetChannelUID(int iChannelUID);
+  int GetChannelUID() const { return m_iChannelUID; }
+  void SetChannelUID(int iChannelUID);
 
-    bool IsFreeToAirOnly() const { return m_bFreeToAirOnly; }
-    void SetFreeToAirOnly(bool bFreeToAirOnly);
+  bool IsFreeToAirOnly() const { return m_bFreeToAirOnly; }
+  void SetFreeToAirOnly(bool bFreeToAirOnly);
 
-    bool ShouldIgnorePresentTimers() const { return m_bIgnorePresentTimers; }
-    void SetIgnorePresentTimers(bool bIgnorePresentTimers);
+  bool ShouldIgnorePresentTimers() const { return m_bIgnorePresentTimers; }
+  void SetIgnorePresentTimers(bool bIgnorePresentTimers);
 
-    bool ShouldIgnorePresentRecordings() const { return m_bIgnorePresentRecordings; }
-    void SetIgnorePresentRecordings(bool bIgnorePresentRecordings);
+  bool ShouldIgnorePresentRecordings() const { return m_bIgnorePresentRecordings; }
+  void SetIgnorePresentRecordings(bool bIgnorePresentRecordings);
 
-    int GetDatabaseId() const { return m_iDatabaseId; }
-    void SetDatabaseId(int iDatabaseId);
+  int GetDatabaseId() const { return m_iDatabaseId; }
+  void SetDatabaseId(int iDatabaseId);
 
-    const std::string& GetTitle() const { return m_title; }
-    void SetTitle(const std::string& title);
+  const std::string& GetTitle() const { return m_title; }
+  void SetTitle(const std::string& title);
 
-    const std::string& GetIconPath() const { return m_iconPath; }
-    void SetIconPath(const std::string& iconPath);
+  const std::string& GetIconPath() const { return m_iconPath; }
+  void SetIconPath(const std::string& iconPath);
 
-    const CDateTime& GetLastExecutedDateTime() const { return m_lastExecutedDateTime; }
-    void SetLastExecutedDateTime(const CDateTime& lastExecutedDateTime);
+  const CDateTime& GetLastExecutedDateTime() const { return m_lastExecutedDateTime; }
+  void SetLastExecutedDateTime(const CDateTime& lastExecutedDateTime);
 
-    const PVREpgSearchData& GetEpgSearchData() const { return m_searchData; }
-    void SetEpgSearchDataFiltered() { m_bEpgSearchDataFiltered = true; }
+  const PVREpgSearchData& GetEpgSearchData() const { return m_searchData; }
+  void SetEpgSearchDataFiltered() { m_bEpgSearchDataFiltered = true; }
 
-    bool IsChanged() const { return m_bChanged; }
-    void SetChanged(bool bChanged) { m_bChanged = bChanged; }
+  bool IsChanged() const { return m_bChanged; }
+  void SetChanged(bool bChanged) { m_bChanged = bChanged; }
 
-  private:
-    bool MatchGenre(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
-    bool MatchDuration(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
-    bool MatchStartAndEndTimes(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
-    bool MatchSearchTerm(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
-    bool MatchChannel(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
-    bool MatchChannelGroup(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
-    bool MatchFreeToAir(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
-    bool MatchTimers(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
-    bool MatchRecordings(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
+private:
+  bool MatchGenre(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
+  bool MatchDuration(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
+  bool MatchStartAndEndTimes(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
+  bool MatchSearchTerm(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
+  bool MatchChannel(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
+  bool MatchChannelGroup(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
+  bool MatchFreeToAir(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
+  bool MatchTimers(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
+  bool MatchRecordings(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
 
-    bool m_bChanged = false;
+  bool m_bChanged = false;
 
-    PVREpgSearchData m_searchData;
-    bool m_bEpgSearchDataFiltered = false;
+  PVREpgSearchData m_searchData;
+  bool m_bEpgSearchDataFiltered = false;
 
-    bool m_bIsCaseSensitive; /*!< Do a case sensitive search */
-    int m_iMinimumDuration; /*!< The minimum duration for an entry */
-    int m_iMaximumDuration; /*!< The maximum duration for an entry */
-    bool m_bRemoveDuplicates; /*!< True to remove duplicate events, false if not */
+  bool m_bIsCaseSensitive; /*!< Do a case sensitive search */
+  int m_iMinimumDuration; /*!< The minimum duration for an entry */
+  int m_iMaximumDuration; /*!< The maximum duration for an entry */
+  bool m_bRemoveDuplicates; /*!< True to remove duplicate events, false if not */
 
-    // PVR specific filters
-    bool m_bIsRadio; /*!< True to filter radio channels only, false to tv only */
-    int m_iClientID = PVR_CLIENT_INVALID_UID; /*!< The client id */
-    int m_iChannelGroupID{-1}; /*! The channel group id */
-    int m_iChannelUID = -1; /*!< The channel uid */
-    bool m_bFreeToAirOnly; /*!< Include free to air channels only */
-    bool m_bIgnorePresentTimers; /*!< True to ignore currently present timers (future recordings), false if not */
-    bool m_bIgnorePresentRecordings; /*!< True to ignore currently active recordings, false if not */
+  // PVR specific filters
+  bool m_bIsRadio; /*!< True to filter radio channels only, false to tv only */
+  int m_iClientID = PVR_CLIENT_INVALID_UID; /*!< The client id */
+  int m_iChannelGroupID{-1}; /*! The channel group id */
+  int m_iChannelUID = -1; /*!< The channel uid */
+  bool m_bFreeToAirOnly; /*!< Include free to air channels only */
+  bool m_bIgnorePresentTimers; /*!< True to ignore currently present timers, false if not */
+  bool m_bIgnorePresentRecordings; /*!< True to ignore currently active recordings, false if not */
 
-    int m_iDatabaseId = -1;
-    std::string m_title;
-    std::string m_iconPath;
-    CDateTime m_lastExecutedDateTime;
-  };
-}
+  int m_iDatabaseId = -1;
+  std::string m_title;
+  std::string m_iconPath;
+  CDateTime m_lastExecutedDateTime;
+};
+} // namespace PVR

--- a/xbmc/pvr/guilib/PVRGUIActionsEPG.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsEPG.cpp
@@ -30,6 +30,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
+#include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
 
@@ -245,6 +246,24 @@ bool CPVRGUIActionsEPG::ChooseIconForSavedSearch(const CFileItem& item)
 
   searchFilter->SetIconPath(icon);
   CServiceBroker::GetPVRManager().EpgContainer().PersistSavedSearch(*searchFilter);
+  return true;
+}
+
+bool CPVRGUIActionsEPG::DuplicateSavedSearch(const CFileItem& item)
+{
+  const auto searchFilter{item.GetEPGSearchFilter()};
+
+  if (!searchFilter)
+  {
+    CLog::LogF(LOGERROR, "Wrong item type. No EPG search filter present.");
+    return false;
+  }
+
+  const auto dupedSearchFilter{std::make_shared<CPVREpgSearchFilter>(*searchFilter)};
+  dupedSearchFilter->SetDatabaseId(PVR_EPG_SEARCH_INVALID_DATABASE_ID); // force new db entry
+  dupedSearchFilter->SetTitle(StringUtils::Format(g_localizeStrings.Get(19356), // Copy of '<title>'
+                                                  searchFilter->GetTitle()));
+  CServiceBroker::GetPVRManager().EpgContainer().PersistSavedSearch(*dupedSearchFilter);
   return true;
 }
 

--- a/xbmc/pvr/guilib/PVRGUIActionsEPG.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsEPG.h
@@ -76,6 +76,13 @@ public:
   bool ChooseIconForSavedSearch(const CFileItem& item);
 
   /*!
+   * @brief Duplicate a saved search.
+   * @param item The item containing a search filter.
+   * @return True on success, false otherwise.
+   */
+  bool DuplicateSavedSearch(const CFileItem& item);
+
+  /*!
    * @brief Delete a saved search. Opens confirmation dialog before deleting.
    * @param item The item containing a search filter.
    * @return True on success, false otherwise.

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -455,7 +455,7 @@ void CGUIWindowPVRSearchBase::ExecuteSearch()
   }
 
   // Save if not a transient search
-  if (m_searchfilter->GetDatabaseId() != -1)
+  if (m_searchfilter->GetDatabaseId() != PVR_EPG_SEARCH_INVALID_DATABASE_ID)
     CServiceBroker::GetPVRManager().EpgContainer().UpdateSavedSearchLastExecuted(*m_searchfilter);
 }
 


### PR DESCRIPTION
A small functional enhancement which find very handy to "template" existing Saved EPG Searches to create other searches.

![screenshot00002](https://github.com/user-attachments/assets/798a80ff-8fee-44cc-8b7f-886d3434cca3)
![screenshot00003](https://github.com/user-attachments/assets/55b85415-fb47-4703-9297-e3f8ef0ffa57)
![screenshot00004](https://github.com/user-attachments/assets/130d36b6-ba24-4c95-877b-5c94a5b4e5ef)

The other commits is just cleanup along the lines.

Runtime-tested on macOS and Android, latest xbmc master.

@phunkyfish can you please review? Best done commit-by-commit.