### PR TITLE
[Windows][AE} WASAPI sink fixes and improvements

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -763,17 +763,17 @@ bool CAESinkWASAPI::InitializeExclusive(AEAudioFormat &format)
   else if (format.m_dataFormat == AE_FMT_RAW) //No sense in trying other formats for passthrough.
     return false;
 
-  CLog::Log(LOGWARNING,
-            "AESinkWASAPI: IsFormatSupported failed ({}) - trying to find a compatible format",
-            WASAPIErrToStr(hr));
+  CLog::LogF(LOGWARNING,
+             "format {} not supported by the device - trying to find a compatible format",
+             CAEUtil::DataFormatToStr(format.m_dataFormat));
 
   requestedChannels = wfxex.Format.nChannels;
   desired_map = CAESinkFactoryWin::SpeakerMaskFromAEChannels(format.m_channelLayout);
 
   /* The requested format is not supported by the device.  Find something that works */
-  CLog::Log(LOGWARNING,
-            "AESinkWASAPI: Input channels are [{}] - Trying to find a matching output layout",
-            std::string(format.m_channelLayout));
+  CLog::LogF(LOGWARNING, "Input channels are [{}] - Trying to find a matching output layout",
+             std::string(format.m_channelLayout));
+
   for (int layout = -1; layout <= (int)ARRAYSIZE(layoutsList); layout++)
   {
     // if requested layout is not supported, try standard layouts which contain

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -396,7 +396,10 @@ void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
     deviceInfo.m_channels.Reset();
     deviceInfo.m_dataFormats.clear();
     deviceInfo.m_sampleRates.clear();
+    deviceInfo.m_streamTypes.clear();
     deviceChannels.Reset();
+    add192 = false;
+    add48 = false;
 
     for (unsigned int c = 0; c < WASAPI_SPEAKER_COUNT; c++)
     {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -254,8 +254,7 @@ unsigned int CAESinkWASAPI::AddPackets(uint8_t **data, unsigned int frames, unsi
     return 0;
 
   HRESULT hr;
-  BYTE *buf;
-  DWORD flags = 0;
+  BYTE* buf;
 
 #ifndef _DEBUG
   LARGE_INTEGER timerStart;
@@ -293,9 +292,8 @@ unsigned int CAESinkWASAPI::AddPackets(uint8_t **data, unsigned int frames, unsi
       return INT_MAX;
     }
 
-    memset(buf, 0, NumFramesRequested * m_format.m_frameSize); //fill buffer with silence
-
-    hr = m_pRenderClient->ReleaseBuffer(NumFramesRequested, flags); //pass back to audio driver
+    hr = m_pRenderClient->ReleaseBuffer(NumFramesRequested,
+                                        AUDCLNT_BUFFERFLAGS_SILENT); //pass back to audio driver
     if (FAILED(hr))
     {
       #ifdef _DEBUG
@@ -359,7 +357,7 @@ unsigned int CAESinkWASAPI::AddPackets(uint8_t **data, unsigned int frames, unsi
          NumFramesRequested * m_format.m_frameSize);
   m_bufferPtr = 0;
 
-  hr = m_pRenderClient->ReleaseBuffer(NumFramesRequested, flags); //pass back to audio driver
+  hr = m_pRenderClient->ReleaseBuffer(NumFramesRequested, 0); //pass back to audio driver
   if (FAILED(hr))
   {
 #ifdef _DEBUG

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -904,6 +904,20 @@ initialize:
   format.m_sampleRate    = wfxex.Format.nSamplesPerSec; //PCM: Sample rate.  RAW: Link speed
   format.m_frameSize     = (wfxex.Format.wBitsPerSample >> 3) * wfxex.Format.nChannels;
 
+  ComPtr<IAudioClient2> audioClient2;
+  if (SUCCEEDED(m_pAudioClient.As(&audioClient2)))
+  {
+    AudioClientProperties props = {};
+    props.cbSize = sizeof(props);
+    // ForegroundOnlyMedia/BackgroundCapableMedia replaced in Windows 10 by Movie/Media
+    props.eCategory = CSysInfo::IsWindowsVersionAtLeast(CSysInfo::WindowsVersionWin10)
+                          ? AudioCategory_Media
+                          : AudioCategory_ForegroundOnlyMedia;
+
+    if (FAILED(hr = audioClient2->SetClientProperties(&props)))
+      CLog::LogF(LOGERROR, "unable to set audio category, {}", WASAPIErrToStr(hr));
+  }
+
   REFERENCE_TIME audioSinkBufferDurationMsec, hnsLatency;
 
   audioSinkBufferDurationMsec = (REFERENCE_TIME)500000;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Fixed a couple issues in the WASAPI sink
- some variables were not reset in the devices enumeration, which caused passthrough formats and incorrect data formats to leak to the next device enumerated
- incorrect assumption that all devices support 16 bit formats, causing no sampling frequencies to be detected for those devices. 16 bit will still be given priority because it's widely supported and likely to have the widest range of sample frequencies available, but if not enumerated before, will fallback to the first enumerated format.

and small improvements
- more informative message when the AE provided format fails in InitializeExclusive
- specify an audio category for the audio stream
- use the silent buffer flag for ReleaseBuffer() to treat the initial frames as silence without having to clear the buffer content with memset.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Noticed oddities in logs provided for a wasapi issue in the forum https://forum.kodi.tv/showthread.php?tid=378807 (no valid sampling rates)
Other oddities in own logs (spdif and headphones with TrueHD capability, headphone with no formats because the device supported only 24 bit formats)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Windows 8, 10, 11. Stereo only, no multichannel equipment available. Speakers, headphones, spdif, hdmi, audio jack of usb-c docking station with support for only 24 bit formats

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
The changes are of cosmetic nature. They improve the enumeration and logging of the capabilities of the audio devices when using WASAPI output, but the actual opening/initialization of the sink is done with separate code that doesn't suffer from the issues addressed here.

## Screenshots (if appropriate):

Log before:
```
2024-09-24 22:39:46.206 T:25100    info <general>: Enumerated WASAPI devices:
2024-09-24 22:39:46.206 T:25100    info <general>:     Device 1
2024-09-24 22:39:46.206 T:25100    info <general>:         m_deviceName      : {8B86C4F2-2178-4F37-953D-443C52C788B3}
2024-09-24 22:39:46.206 T:25100    info <general>:         m_displayName     : HDMI - 2 - LG TV (AMD High Definition Audio Device)
2024-09-24 22:39:46.207 T:25100    info <general>:         m_displayNameExtra: WASAPI: 2 - LG TV (AMD High Definition Audio Device)
2024-09-24 22:39:46.207 T:25100    info <general>:         m_deviceType      : AE_DEVTYPE_HDMI
2024-09-24 22:39:46.207 T:25100    info <general>:         m_channels        : FL, FR
2024-09-24 22:39:46.207 T:25100    info <general>:         m_sampleRates     : 192000,96000,48000,44100,32000
2024-09-24 22:39:46.207 T:25100    info <general>:         m_dataFormats     : AE_FMT_S24NE4MSB,AE_FMT_S16NE,AE_FMT_S16LE,AE_FMT_S16BE,AE_FMT_RAW
2024-09-24 22:39:46.207 T:25100    info <general>:         m_streamTypes     : STREAM_TYPE_DTSHD,STREAM_TYPE_DTSHD_MA,STREAM_TYPE_TRUEHD,STREAM_TYPE_EAC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3
2024-09-24 22:39:46.207 T:25100    info <general>:     Device 2
2024-09-24 22:39:46.207 T:25100    info <general>:         m_deviceName      : {A4EC9140-07BF-4031-9BB1-01F49002E272}
2024-09-24 22:39:46.207 T:25100    info <general>:         m_displayName     : SPDIF - Digital Audio (S/PDIF) (4- High Definition Audio Device)
2024-09-24 22:39:46.207 T:25100    info <general>:         m_displayNameExtra: WASAPI: Digital Audio (S/PDIF) (4- High Definition Audio Device)
2024-09-24 22:39:46.207 T:25100    info <general>:         m_deviceType      : AE_DEVTYPE_IEC958
2024-09-24 22:39:46.207 T:25100    info <general>:         m_channels        : FL, FR
2024-09-24 22:39:46.208 T:25100    info <general>:         m_sampleRates     : 192000,96000,88200,48000,44100,32000
2024-09-24 22:39:46.208 T:25100    info <general>:         m_dataFormats     : AE_FMT_S24NE4MSB,AE_FMT_S16NE,AE_FMT_S16LE,AE_FMT_S16BE,AE_FMT_RAW
2024-09-24 22:39:46.208 T:25100    info <general>:         m_streamTypes     : STREAM_TYPE_DTSHD,STREAM_TYPE_DTSHD_MA,STREAM_TYPE_TRUEHD,STREAM_TYPE_EAC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3
2024-09-24 22:39:46.208 T:25100    info <general>:     Device 3
2024-09-24 22:39:46.208 T:25100    info <general>:         m_deviceName      : {CC3779BD-59AA-4845-BEAA-2DEDD96E7AE5}
2024-09-24 22:39:46.208 T:25100    info <general>:         m_displayName     : Headphones - Headphones (Realtek USB Audio)
2024-09-24 22:39:46.208 T:25100    info <general>:         m_displayNameExtra: WASAPI: Headphones (Realtek USB Audio)
2024-09-24 22:39:46.208 T:25100    info <general>:         m_deviceType      : AE_DEVTYPE_PCM
2024-09-24 22:39:46.208 T:25100    info <general>:         m_channels        : FL, FR
2024-09-24 22:39:46.208 T:25100    info <general>:         m_sampleRates     : 192000,48000
2024-09-24 22:39:46.208 T:25100    info <general>:         m_dataFormats     : AE_FMT_S24NE3,AE_FMT_S24LE3,AE_FMT_S24BE3,AE_FMT_RAW
2024-09-24 22:39:46.208 T:25100    info <general>:         m_streamTypes     : STREAM_TYPE_DTSHD,STREAM_TYPE_DTSHD_MA,STREAM_TYPE_TRUEHD,STREAM_TYPE_EAC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3
2024-09-24 22:39:46.209 T:25100    info <general>:     Device 4
2024-09-24 22:39:46.209 T:25100    info <general>:         m_deviceName      : default
2024-09-24 22:39:46.209 T:25100    info <general>:         m_displayName     : default
2024-09-24 22:39:46.209 T:25100    info <general>:         m_displayNameExtra: 
2024-09-24 22:39:46.209 T:25100    info <general>:         m_deviceType      : AE_DEVTYPE_PCM
2024-09-24 22:39:46.209 T:25100    info <general>:         m_channels        : FL, FR
2024-09-24 22:39:46.209 T:25100    info <general>:         m_sampleRates     : 192000,48000
2024-09-24 22:39:46.209 T:25100    info <general>:         m_dataFormats     : AE_FMT_S24NE3,AE_FMT_S24LE3,AE_FMT_S24BE3,AE_FMT_RAW
2024-09-24 22:39:46.209 T:25100    info <general>:         m_streamTypes     : STREAM_TYPE_DTSHD,STREAM_TYPE_DTSHD_MA,STREAM_TYPE_TRUEHD,STREAM_TYPE_EAC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3
```

Log after, no impossible passthrough formats for spdif or analog devices, correct sampling frequencies for device without 16 bit formats
```
2024-09-24 22:34:05.230 T:19340    info <general>: Enumerated WASAPI devices:
2024-09-24 22:34:05.230 T:19340    info <general>:     Device 1
2024-09-24 22:34:05.230 T:19340    info <general>:         m_deviceName      : {8B86C4F2-2178-4F37-953D-443C52C788B3}
2024-09-24 22:34:05.230 T:19340    info <general>:         m_displayName     : HDMI - 2 - LG TV (AMD High Definition Audio Device)
2024-09-24 22:34:05.230 T:19340    info <general>:         m_displayNameExtra: WASAPI: 2 - LG TV (AMD High Definition Audio Device)
2024-09-24 22:34:05.230 T:19340    info <general>:         m_deviceType      : AE_DEVTYPE_HDMI
2024-09-24 22:34:05.230 T:19340    info <general>:         m_channels        : FL, FR
2024-09-24 22:34:05.230 T:19340    info <general>:         m_sampleRates     : 192000,96000,48000,44100,32000
2024-09-24 22:34:05.230 T:19340    info <general>:         m_dataFormats     : AE_FMT_S24NE4MSB,AE_FMT_S16NE,AE_FMT_S16LE,AE_FMT_S16BE,AE_FMT_RAW
2024-09-24 22:34:05.230 T:19340    info <general>:         m_streamTypes     : STREAM_TYPE_DTSHD,STREAM_TYPE_DTSHD_MA,STREAM_TYPE_TRUEHD,STREAM_TYPE_EAC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3
2024-09-24 22:34:05.231 T:19340    info <general>:     Device 2
2024-09-24 22:34:05.231 T:19340    info <general>:         m_deviceName      : {A4EC9140-07BF-4031-9BB1-01F49002E272}
2024-09-24 22:34:05.231 T:19340    info <general>:         m_displayName     : SPDIF - Digital Audio (S/PDIF) (4- High Definition Audio Device)
2024-09-24 22:34:05.231 T:19340    info <general>:         m_displayNameExtra: WASAPI: Digital Audio (S/PDIF) (4- High Definition Audio Device)
2024-09-24 22:34:05.231 T:19340    info <general>:         m_deviceType      : AE_DEVTYPE_IEC958
2024-09-24 22:34:05.231 T:19340    info <general>:         m_channels        : FL, FR
2024-09-24 22:34:05.231 T:19340    info <general>:         m_sampleRates     : 192000,96000,88200,48000,44100,32000
2024-09-24 22:34:05.231 T:19340    info <general>:         m_dataFormats     : AE_FMT_S24NE4MSB,AE_FMT_S16NE,AE_FMT_S16LE,AE_FMT_S16BE,AE_FMT_RAW
2024-09-24 22:34:05.231 T:19340    info <general>:         m_streamTypes     : STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3
2024-09-24 22:34:05.231 T:19340    info <general>:     Device 3
2024-09-24 22:34:05.231 T:19340    info <general>:         m_deviceName      : {CC3779BD-59AA-4845-BEAA-2DEDD96E7AE5}
2024-09-24 22:34:05.231 T:19340    info <general>:         m_displayName     : Headphones - Headphones (Realtek USB Audio)
2024-09-24 22:34:05.232 T:19340    info <general>:         m_displayNameExtra: WASAPI: Headphones (Realtek USB Audio)
2024-09-24 22:34:05.232 T:19340    info <general>:         m_deviceType      : AE_DEVTYPE_PCM
2024-09-24 22:34:05.232 T:19340    info <general>:         m_channels        : FL, FR
2024-09-24 22:34:05.232 T:19340    info <general>:         m_sampleRates     : 48000
2024-09-24 22:34:05.232 T:19340    info <general>:         m_dataFormats     : AE_FMT_S24NE3,AE_FMT_S24LE3,AE_FMT_S24BE3
2024-09-24 22:34:05.232 T:19340    info <general>:         m_streamTypes     : No passthrough capabilities
2024-09-24 22:34:05.232 T:19340    info <general>:     Device 4
2024-09-24 22:34:05.232 T:19340    info <general>:         m_deviceName      : default
2024-09-24 22:34:05.232 T:19340    info <general>:         m_displayName     : default
2024-09-24 22:34:05.232 T:19340    info <general>:         m_displayNameExtra: 
2024-09-24 22:34:05.232 T:19340    info <general>:         m_deviceType      : AE_DEVTYPE_PCM
2024-09-24 22:34:05.232 T:19340    info <general>:         m_channels        : FL, FR
2024-09-24 22:34:05.232 T:19340    info <general>:         m_sampleRates     : 48000
2024-09-24 22:34:05.232 T:19340    info <general>:         m_dataFormats     : AE_FMT_S24NE3,AE_FMT_S24LE3,AE_FMT_S24BE3
2024-09-24 22:34:05.232 T:19340    info <general>:         m_streamTypes     : No passthrough capabilities
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
