### PR TITLE
[Estuary] Video Versions - Add poster fallback

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -703,8 +703,10 @@
 	</variable>
 	<variable name="VideoListThumbVar">
 		<value condition="!String.IsEmpty(Container(6).ListItem.Art(landscape))">$INFO[Container(6).ListItem.Art(landscape)]</value>
+		<value condition="!String.IsEmpty(Container(6).ListItem.Art(poster))">$INFO[Container(6).ListItem.Art(poster)]</value>
 		<value condition="!String.IsEmpty(Container(6).ListItem.Art(thumb))">$INFO[Container(6).ListItem.Art(thumb)]</value>
 		<value condition="!String.IsEmpty(Container(50).ListItem.Art(landscape))">$INFO[Container(50).ListItem.Art(landscape)]</value>
+		<value condition="!String.IsEmpty(Container(50).ListItem.Art(poster))">$INFO[Container(50).ListItem.Art(poster)]</value>
 		<value condition="!String.IsEmpty(Container(50).ListItem.Art(thumb))">$INFO[Container(50).ListItem.Art(thumb)]</value>
 		<value>$INFO[ListItem.Art(thumb)]</value>
 	</variable>


### PR DESCRIPTION
## Description
Add poster fallback in the Video Version dialogs.

## Motivation and context
Landscape art is the preferred artwork type in the version lists as it makes best use of space. If landscape art is not present then it would fallback to a video thumb. 

After @Hitcher asked why poster was not displayed I decided to add a poster fallback before thumb is used.  

## Screenshots (if appropriate):

**Before**

![image](https://github.com/user-attachments/assets/9db8b401-8ae2-4bf2-b25b-fd75c2992f70)
![image](https://github.com/user-attachments/assets/2cea816b-9a1f-48ff-992b-83ae2ffe736e)


**After**
 
![image](https://github.com/user-attachments/assets/86a97993-e5ab-4499-9f8e-f87107da90a5)
![image](https://github.com/user-attachments/assets/f339c112-ed2a-40d7-8b09-2f1337066c9a)


## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
