### PR TITLE
[WASAPI] use device default period

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
@@ -73,4 +73,5 @@ private:
 
     std::vector<uint8_t> m_buffer;
     int m_bufferPtr{0};
+    HANDLE m_hTask = NULL;
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Use the default buffer duration with WASAPI. On most system it is 10ms.
Raise audio thread priority as recommended by MS (Audio class - Pro Audio would likely be overkill).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix Dell usb-c docking station audio port with glitching audio with Kodi but not other programs.
WASAPI event mode doesn't trigger events at the correct frequency when the buffer size deviates much from the default, for example with Kodi's default 50ms or even 100ms for USB.

PR also to provide a test build for issue reported in forum https://forum.kodi.tv/showthread.php?tid=378807
Strange out of memory error reported by audioclient->Initialize. Maybe this is related to the size of the buffer, which this change would address.

This is unlikely to cause compatibility problems with the devices that worked fine already because the default buffer would be used, but will increase cpu load because AE thread does more than just feeding the buffer on event, though not that much (more investigation needed).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Light testing with Windows 10, speakers, usb, spdif at this point
More testing will be done (windows 8.1, 11, passthrough, old computer with slow cpu)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Fix sound glitches with WASAPI output for some devices.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
