### PR TITLE
[PVR] Async EPG update: Fix removal of EPG events notified as 'deleted'.

### DIFF
--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -223,7 +223,8 @@ bool CPVREpg::UpdateEntry(const std::shared_ptr<CPVREpgInfoTag>& tag, EPG_EVENT_
     }
     else
     {
-      if (IsTagExpired(existingTag))
+      // Delete running/future events and past events if they are older than epg linger time setting
+      if ((existingTag->EndAsUTC() >= CDateTime::GetUTCDateTime()) || IsTagExpired(existingTag))
       {
         m_tags.DeleteEntry(existingTag);
       }


### PR DESCRIPTION
Fixes https://github.com/kodi-pvr/pvr.hts/issues/345

Runtime-tested by me on macOS and Android.
Runtime-tested by issue reporter on Linux.

@phunkyfish please review.