### PR TITLE
Move CXBMCApp::GetExternalStorage to CAndroidStorageProvider

### DIFF
--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -36,7 +36,7 @@
 #if defined(TARGET_ANDROID)
 #include "utils/FileUtils.h"
 
-#include "platform/android/activity/XBMCApp.h"
+#include "platform/android/storage/AndroidStorageProvider.h"
 #endif
 
 #ifdef TARGET_WINDOWS_STORE
@@ -249,7 +249,8 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
 #if defined(TARGET_ANDROID)
     // add the default android music directory
     std::string path;
-    if (CXBMCApp::GetExternalStorage(path, "music") && !path.empty() && CDirectory::Exists(path))
+    if (CAndroidStorageProvider::GetExternalStorage(path, "music") && !path.empty() &&
+        CDirectory::Exists(path))
     {
       share1.strPath = path;
       share1.strName = g_localizeStrings.Get(20240);
@@ -303,7 +304,8 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
 #if defined(TARGET_ANDROID)
     // add the default android video directory
     std::string path;
-    if (CXBMCApp::GetExternalStorage(path, "videos") && !path.empty() && CFileUtils::Exists(path))
+    if (CAndroidStorageProvider::GetExternalStorage(path, "videos") && !path.empty() &&
+        CFileUtils::Exists(path))
     {
       share1.strPath = path;
       share1.strName = g_localizeStrings.Get(20241);
@@ -349,7 +351,8 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
 #if defined(TARGET_ANDROID)
     // add the default android music directory
     std::string path;
-    if (CXBMCApp::GetExternalStorage(path, "pictures") && !path.empty() && CFileUtils::Exists(path))
+    if (CAndroidStorageProvider::GetExternalStorage(path, "pictures") && !path.empty() &&
+        CFileUtils::Exists(path))
     {
       share1.strPath = path;
       share1.strName = g_localizeStrings.Get(20242);
@@ -358,7 +361,8 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
     }
 
     path.clear();
-    if (CXBMCApp::GetExternalStorage(path, "photos") && !path.empty() && CFileUtils::Exists(path))
+    if (CAndroidStorageProvider::GetExternalStorage(path, "photos") && !path.empty() &&
+        CFileUtils::Exists(path))
     {
       share1.strPath = path;
       share1.strName = g_localizeStrings.Get(20243);

--- a/xbmc/platform/android/PlatformAndroid.cpp
+++ b/xbmc/platform/android/PlatformAndroid.cpp
@@ -17,6 +17,7 @@
 
 #include "platform/android/activity/XBMCApp.h"
 #include "platform/android/powermanagement/AndroidPowerSyscall.h"
+#include "platform/android/storage/AndroidStorageProvider.h"
 
 #include <stdlib.h>
 
@@ -66,7 +67,7 @@ void CPlatformAndroid::PlatformSyslog()
       CJNIBuild::BRAND, CJNIBuild::MODEL, CJNIBuild::HARDWARE);
 
   std::string extstorage;
-  bool extready = CXBMCApp::GetExternalStorage(extstorage);
+  const bool extready = CAndroidStorageProvider::GetExternalStorage(extstorage);
   CLog::Log(
       LOGINFO, "External storage path = {}; status = {}; Permissions = {}{}", extstorage,
       extready ? "ok" : "nok",

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -81,7 +81,6 @@
 #include <androidjni/Cursor.h>
 #include <androidjni/Display.h>
 #include <androidjni/DisplayManager.h>
-#include <androidjni/Environment.h>
 #include <androidjni/File.h>
 #include <androidjni/Intent.h>
 #include <androidjni/IntentFilter.h>
@@ -1089,42 +1088,6 @@ bool CXBMCApp::StartActivity(const std::string& package,
 int CXBMCApp::GetBatteryLevel() const
 {
   return m_batteryLevel;
-}
-
-bool CXBMCApp::GetExternalStorage(std::string &path, const std::string &type /* = "" */)
-{
-  std::string sType;
-  std::string mountedState;
-  bool mounted = false;
-
-  if(type == "files" || type.empty())
-  {
-    CJNIFile external = CJNIEnvironment::getExternalStorageDirectory();
-    if (external)
-      path = external.getAbsolutePath();
-  }
-  else
-  {
-    if (type == "music")
-      sType = "Music"; // Environment.DIRECTORY_MUSIC
-    else if (type == "videos")
-      sType = "Movies"; // Environment.DIRECTORY_MOVIES
-    else if (type == "pictures")
-      sType = "Pictures"; // Environment.DIRECTORY_PICTURES
-    else if (type == "photos")
-      sType = "DCIM"; // Environment.DIRECTORY_DCIM
-    else if (type == "downloads")
-      sType = "Download"; // Environment.DIRECTORY_DOWNLOADS
-    if (!sType.empty())
-    {
-      CJNIFile external = CJNIEnvironment::getExternalStoragePublicDirectory(sType);
-      if (external)
-        path = external.getAbsolutePath();
-    }
-  }
-  mountedState = CJNIEnvironment::getExternalStorageState();
-  mounted = (mountedState == "mounted" || mountedState == "mounted_ro");
-  return mounted && !path.empty();
 }
 
 // Used in Application.cpp to figure out volume steps

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -166,13 +166,6 @@ public:
                             const std::string& className = std::string());
   std::vector<androidPackage> GetApplications() const;
 
-  /*!
-   * \brief If external storage is available, it returns the path for the external storage (for the specified type)
-   * \param path will contain the path of the external storage (for the specified type)
-   * \param type optional type. Possible values are "", "files", "music", "videos", "pictures", "photos, "downloads"
-   * \return true if external storage is available and a valid path has been stored in the path parameter
-   */
-  static bool GetExternalStorage(std::string& path, const std::string& type = "");
   static int GetMaxSystemVolume();
   static float GetSystemVolume();
   static void SetSystemVolume(float percent);

--- a/xbmc/platform/android/storage/AndroidStorageProvider.h
+++ b/xbmc/platform/android/storage/AndroidStorageProvider.h
@@ -30,6 +30,14 @@ public:
 
   bool PumpDriveChangeEvents(IStorageEventsCallback* callback) override;
 
+  /*!
+   * \brief If external storage is available, it returns the path for the external storage (for the specified type)
+   * \param path will contain the path of the external storage (for the specified type)
+   * \param type optional type. Possible values are "", "files", "music", "videos", "pictures", "photos, "downloads"
+   * \return true if external storage is available and a valid path has been stored in the path parameter
+   */
+  static bool GetExternalStorage(std::string& path, const std::string& type = "");
+
 private:
   std::string unescape(const std::string& str);
   VECSOURCES m_removableDrives;


### PR DESCRIPTION
## Description
Move CXBMCApp::GetExternalStorage function to CAndroidStorageProvider class.

## Motivation and context
Less code in CXBMCApp, this function is related to Android storage.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
