### PR TITLE
[PVR] [PVR] Async EPG update: Fix removal of EPG events notified as 'deleted', take 2

### DIFF
--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -223,8 +223,8 @@ bool CPVREpg::UpdateEntry(const std::shared_ptr<CPVREpgInfoTag>& tag, EPG_EVENT_
     }
     else
     {
-      // Delete running/future events and past events if they are older than epg linger time setting
-      if ((existingTag->EndAsUTC() >= CDateTime::GetUTCDateTime()) || IsTagExpired(existingTag))
+      // Delete future events and past events if they are older than epg linger time setting
+      if ((existingTag->StartAsUTC() > CDateTime::GetUTCDateTime()) || IsTagExpired(existingTag))
       {
         m_tags.DeleteEntry(existingTag);
       }


### PR DESCRIPTION
We need to tweak the fix for #25779 a bit. We do only want to delete future events from local EPG. Everything else is managed by EPG linger time setting.

Runtime-tested on macOS and Android, latest xbmc master.

@phunkyfish one more to review, please.