### PR TITLE
Linux/Udev: Fix optical detection logic

### DIFF
--- a/xbmc/platform/linux/storage/UDevProvider.cpp
+++ b/xbmc/platform/linux/storage/UDevProvider.cpp
@@ -271,11 +271,12 @@ bool CUDevProvider::PumpDriveChangeEvents(IStorageEventsCallback *callback)
       if (strcmp(action, "change") == 0 && !(bd && strcmp(bd, "1") == 0))
       {
         const char *optical = udev_device_get_property_value(dev, "ID_CDROM");
-        bool isOptical = optical && (strcmp(optical, "1") != 0);
+        const bool isOptical = optical && (strcmp(optical, "1") == 0);
         storageDevice.type =
             isOptical ? MEDIA_DETECT::STORAGE::Type::OPTICAL : MEDIA_DETECT::STORAGE::Type::UNKNOWN;
+        storageDevice.path = devnode;
 
-        if (mountpoint && !isOptical)
+        if (mountpoint && isOptical)
         {
           CLog::Log(LOGINFO, "UDev: Changed / Added {}", mountpoint);
           if (callback)


### PR DESCRIPTION
## Description
Currently for Discs we continuously poll for the drive state when most of the storage providers have ways to trigger events on change. One of such providers is udev on linux.
While investigating some future implementation I realized the condition checks for isOptical is actually wrong. 
`bool isOptical = optical && (strcmp(optical, "1") != 0);` will return false if the drive is optical and true otherwise. So, just invert the checks we currently do to keep the logic correct.
Also, the path of the storage device is empty and we can just populate it with the devnode path.