### PR TITLE
MediaSources: Rename SOURCE_TYPE_DVD and SOURCE_TYPE_VIRTUAL_DVD

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1156,12 +1156,12 @@ bool CFileItem::IsBluray() const
 
 bool CFileItem::IsDVD() const
 {
-  return URIUtils::IsDVD(m_strPath) || m_iDriveType == CMediaSource::SOURCE_TYPE_DVD;
+  return URIUtils::IsDVD(m_strPath) || m_iDriveType == CMediaSource::SOURCE_TYPE_OPTICAL_DISC;
 }
 
 bool CFileItem::IsOnDVD() const
 {
-  return URIUtils::IsOnDVD(m_strPath) || m_iDriveType == CMediaSource::SOURCE_TYPE_DVD;
+  return URIUtils::IsOnDVD(m_strPath) || m_iDriveType == CMediaSource::SOURCE_TYPE_OPTICAL_DISC;
 }
 
 bool CFileItem::IsNfs() const

--- a/xbmc/MediaSource.cpp
+++ b/xbmc/MediaSource.cpp
@@ -49,13 +49,13 @@ void CMediaSource::FromNameAndPaths(const std::string &category, const std::stri
     m_iDriveType = SOURCE_TYPE_VPATH;
   else if (StringUtils::StartsWithNoCase(strPath, "udf:"))
   {
-    m_iDriveType = SOURCE_TYPE_VIRTUAL_DVD;
+    m_iDriveType = SOURCE_TYPE_VIRTUAL_OPTICAL_DISC;
     strPath = "D:\\";
   }
   else if (URIUtils::IsISO9660(strPath))
-    m_iDriveType = SOURCE_TYPE_VIRTUAL_DVD;
+    m_iDriveType = SOURCE_TYPE_VIRTUAL_OPTICAL_DISC;
   else if (URIUtils::IsDVD(strPath))
-    m_iDriveType = SOURCE_TYPE_DVD;
+    m_iDriveType = SOURCE_TYPE_OPTICAL_DISC;
   else if (URIUtils::IsRemote(strPath))
     m_iDriveType = SOURCE_TYPE_REMOTE;
   else if (URIUtils::IsHD(strPath))

--- a/xbmc/MediaSource.h
+++ b/xbmc/MediaSource.h
@@ -24,13 +24,13 @@ class CMediaSource final
 public:
   enum SourceType
   {
-    SOURCE_TYPE_UNKNOWN      = 0,
-    SOURCE_TYPE_LOCAL        = 1,
-    SOURCE_TYPE_DVD          = 2,
-    SOURCE_TYPE_VIRTUAL_DVD  = 3,
-    SOURCE_TYPE_REMOTE       = 4,
-    SOURCE_TYPE_VPATH        = 5,
-    SOURCE_TYPE_REMOVABLE    = 6
+    SOURCE_TYPE_UNKNOWN = 0,
+    SOURCE_TYPE_LOCAL = 1,
+    SOURCE_TYPE_OPTICAL_DISC = 2,
+    SOURCE_TYPE_VIRTUAL_OPTICAL_DISC = 3,
+    SOURCE_TYPE_REMOTE = 4,
+    SOURCE_TYPE_VPATH = 5,
+    SOURCE_TYPE_REMOVABLE = 6
   };
 
   bool operator==(const CMediaSource &right) const;
@@ -50,9 +50,9 @@ public:
   Unknown source, maybe a wrong path.
   - SOURCE_TYPE_LOCAL \n
   Harddisk source.
-  - SOURCE_TYPE_DVD \n
+  - SOURCE_TYPE_OPTICAL_DISC \n
   DVD-ROM source of the build in drive, strPath may vary.
-  - SOURCE_TYPE_VIRTUAL_DVD \n
+  - SOURCE_TYPE_VIRTUAL_OPTICAL_DISC \n
   DVD-ROM source, strPath is fix.
   - SOURCE_TYPE_REMOTE \n
   Network source.

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -561,7 +561,7 @@ void CGUIDialogFileBrowser::OnClick(int iItem)
 
 bool CGUIDialogFileBrowser::HaveDiscOrConnection( int iDriveType )
 {
-  if ( iDriveType == CMediaSource::SOURCE_TYPE_DVD )
+  if (iDriveType == CMediaSource::SOURCE_TYPE_OPTICAL_DISC)
   {
     if (!CServiceBroker::GetMediaManager().IsDiscInDrive())
     {

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -60,7 +60,8 @@ bool CSourcesDirectory::GetDirectory(const VECSOURCES &sources, CFileItemList &i
 
     std::string strIcon;
     // We have the real DVD-ROM, set icon on disktype
-    if (share.m_iDriveType == CMediaSource::SOURCE_TYPE_DVD && share.m_strThumbnailImage.empty())
+    if (share.m_iDriveType == CMediaSource::SOURCE_TYPE_OPTICAL_DISC &&
+        share.m_strThumbnailImage.empty())
     {
       CUtil::GetDVDDriveIcon( pItem->GetPath(), strIcon );
       // CDetectDVDMedia::SetNewDVDShareUrl() caches disc thumb as special://temp/dvdicon.tbn

--- a/xbmc/filesystem/VirtualDirectory.cpp
+++ b/xbmc/filesystem/VirtualDirectory.cpp
@@ -176,7 +176,7 @@ void CVirtualDirectory::GetSources(VECSOURCES &shares) const
   for (unsigned int i = 0; i < shares.size(); ++i)
   {
     CMediaSource& share = shares[i];
-    if (share.m_iDriveType == CMediaSource::SOURCE_TYPE_DVD)
+    if (share.m_iDriveType == CMediaSource::SOURCE_TYPE_OPTICAL_DISC)
     {
       if (CServiceBroker::GetMediaManager().IsAudio(share.strPath))
       {

--- a/xbmc/platform/darwin/osx/storage/OSXStorageProvider.cpp
+++ b/xbmc/platform/darwin/osx/storage/OSXStorageProvider.cpp
@@ -131,7 +131,7 @@ void COSXStorageProvider::GetRemovableDrives(VECSOURCES& removableDrives)
               if (mediaKind != NULL &&
                   (CFStringCompare(mediaKind, CFSTR(kIOCDMediaClass), 0) == kCFCompareEqualTo ||
                   CFStringCompare(mediaKind, CFSTR(kIODVDMediaClass), 0) == kCFCompareEqualTo))
-                share.m_iDriveType = CMediaSource::SOURCE_TYPE_DVD;
+                share.m_iDriveType = CMediaSource::SOURCE_TYPE_OPTICAL_DISC;
             }
             removableDrives.push_back(share);
           }

--- a/xbmc/platform/linux/storage/UDevProvider.cpp
+++ b/xbmc/platform/linux/storage/UDevProvider.cpp
@@ -175,7 +175,7 @@ void CUDevProvider::GetDisks(VECSOURCES& disks, bool removable)
     if (isRemovable)
     {
       if (optical)
-        share.m_iDriveType = CMediaSource::SOURCE_TYPE_DVD;
+        share.m_iDriveType = CMediaSource::SOURCE_TYPE_OPTICAL_DISC;
       else
         share.m_iDriveType = CMediaSource::SOURCE_TYPE_REMOVABLE;
     }

--- a/xbmc/platform/linux/storage/UDisks2Provider.cpp
+++ b/xbmc/platform/linux/storage/UDisks2Provider.cpp
@@ -184,7 +184,7 @@ CMediaSource CUDisks2Provider::Filesystem::ToMediaShare() const
   source.strPath = m_mountPoint;
   source.strName = GetDisplayName();
   if (IsOptical())
-    source.m_iDriveType = CMediaSource::SOURCE_TYPE_DVD;
+    source.m_iDriveType = CMediaSource::SOURCE_TYPE_OPTICAL_DISC;
   else if (m_block->m_isSystem)
     source.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
   else

--- a/xbmc/platform/linux/storage/UDisksProvider.cpp
+++ b/xbmc/platform/linux/storage/UDisksProvider.cpp
@@ -135,7 +135,7 @@ CMediaSource CUDiskDevice::ToMediaShare() const
   else
     source.strName = m_Label;
   if (m_isOptical)
-    source.m_iDriveType = CMediaSource::SOURCE_TYPE_DVD;
+    source.m_iDriveType = CMediaSource::SOURCE_TYPE_OPTICAL_DISC;
   else if (m_isSystemInternal)
     source.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
   else

--- a/xbmc/platform/win10/storage/Win10StorageProvider.cpp
+++ b/xbmc/platform/win10/storage/Win10StorageProvider.cpp
@@ -107,12 +107,11 @@ void CStorageProvider::GetRemovableDrives(VECSOURCES &removableDrives)
 
       UINT uDriveType = GetDriveTypeA(driveLetter.c_str());
       source.strPath = "win-lib://removable/" + driveLetter + "/";
-      source.m_iDriveType = (
-        (uDriveType == DRIVE_FIXED) ? CMediaSource::SOURCE_TYPE_LOCAL :
-        (uDriveType == DRIVE_REMOTE) ? CMediaSource::SOURCE_TYPE_REMOTE :
-        (uDriveType == DRIVE_CDROM) ? CMediaSource::SOURCE_TYPE_DVD :
-        (uDriveType == DRIVE_REMOVABLE) ? CMediaSource::SOURCE_TYPE_REMOVABLE :
-        CMediaSource::SOURCE_TYPE_UNKNOWN);
+      source.m_iDriveType = ((uDriveType == DRIVE_FIXED)    ? CMediaSource::SOURCE_TYPE_LOCAL
+                             : (uDriveType == DRIVE_REMOTE) ? CMediaSource::SOURCE_TYPE_REMOTE
+                             : (uDriveType == DRIVE_CDROM)  ? CMediaSource::SOURCE_TYPE_OPTICAL_DISC
+                             : (uDriveType == DRIVE_REMOVABLE) ? CMediaSource::SOURCE_TYPE_REMOVABLE
+                                                               : CMediaSource::SOURCE_TYPE_UNKNOWN);
 
       removableDrives.push_back(source);
     }
@@ -262,12 +261,11 @@ void CStorageProvider::GetDrivesByType(VECSOURCES & localDrives, Drive_Types eDr
     share.m_ignore = true;
     if (!bUseDCD)
     {
-      share.m_iDriveType = (
-        (uDriveType == DRIVE_FIXED) ? CMediaSource::SOURCE_TYPE_LOCAL :
-        (uDriveType == DRIVE_REMOTE) ? CMediaSource::SOURCE_TYPE_REMOTE :
-        (uDriveType == DRIVE_CDROM) ? CMediaSource::SOURCE_TYPE_DVD :
-        (uDriveType == DRIVE_REMOVABLE) ? CMediaSource::SOURCE_TYPE_REMOVABLE :
-        CMediaSource::SOURCE_TYPE_UNKNOWN);
+      share.m_iDriveType = ((uDriveType == DRIVE_FIXED)    ? CMediaSource::SOURCE_TYPE_LOCAL
+                            : (uDriveType == DRIVE_REMOTE) ? CMediaSource::SOURCE_TYPE_REMOTE
+                            : (uDriveType == DRIVE_CDROM)  ? CMediaSource::SOURCE_TYPE_OPTICAL_DISC
+                            : (uDriveType == DRIVE_REMOVABLE) ? CMediaSource::SOURCE_TYPE_REMOVABLE
+                                                              : CMediaSource::SOURCE_TYPE_UNKNOWN);
     }
 
     AddOrReplace(localDrives, share);

--- a/xbmc/platform/win32/storage/Win32StorageProvider.cpp
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.cpp
@@ -279,12 +279,12 @@ void CWin32StorageProvider::GetDrivesByType(VECSOURCES &localDrives, Drive_Types
         share.m_ignore= true;
         if( !bUseDCD )
         {
-          share.m_iDriveType= (
-           ( uDriveType == DRIVE_FIXED  )    ? CMediaSource::SOURCE_TYPE_LOCAL :
-           ( uDriveType == DRIVE_REMOTE )    ? CMediaSource::SOURCE_TYPE_REMOTE :
-           ( uDriveType == DRIVE_CDROM  )    ? CMediaSource::SOURCE_TYPE_DVD :
-           ( uDriveType == DRIVE_REMOVABLE ) ? CMediaSource::SOURCE_TYPE_REMOVABLE :
-             CMediaSource::SOURCE_TYPE_UNKNOWN );
+          share.m_iDriveType =
+              ((uDriveType == DRIVE_FIXED)       ? CMediaSource::SOURCE_TYPE_LOCAL
+               : (uDriveType == DRIVE_REMOTE)    ? CMediaSource::SOURCE_TYPE_REMOTE
+               : (uDriveType == DRIVE_CDROM)     ? CMediaSource::SOURCE_TYPE_OPTICAL_DISC
+               : (uDriveType == DRIVE_REMOVABLE) ? CMediaSource::SOURCE_TYPE_REMOVABLE
+                                                 : CMediaSource::SOURCE_TYPE_UNKNOWN);
         }
 
         AddOrReplace(localDrives, share);
@@ -392,7 +392,7 @@ bool CDetectDisc::DoWork()
     share.strStatus = g_localizeStrings.Get(446);
   share.strName = share.strPath;
   share.m_ignore = true;
-  share.m_iDriveType = CMediaSource::SOURCE_TYPE_DVD;
+  share.m_iDriveType = CMediaSource::SOURCE_TYPE_OPTICAL_DISC;
   CServiceBroker::GetMediaManager().AddAutoSource(share, m_bautorun);
 #endif
   return true;

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -613,7 +613,8 @@ std::string CMediaManager::GetDiscPath()
   m_platformStorage->GetRemovableDrives(drives);
   for(unsigned i = 0; i < drives.size(); ++i)
   {
-    if(drives[i].m_iDriveType == CMediaSource::SOURCE_TYPE_DVD && !drives[i].strPath.empty())
+    if (drives[i].m_iDriveType == CMediaSource::SOURCE_TYPE_OPTICAL_DISC &&
+        !drives[i].strPath.empty())
       return drives[i].strPath;
   }
 

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1206,7 +1206,7 @@ bool CGUIMediaWindow::OnSelect(int item)
  */
 bool CGUIMediaWindow::HaveDiscOrConnection(const std::string& strPath, int iDriveType)
 {
-  if (iDriveType==CMediaSource::SOURCE_TYPE_DVD)
+  if (iDriveType == CMediaSource::SOURCE_TYPE_OPTICAL_DISC)
   {
     if (!CServiceBroker::GetMediaManager().IsDiscInDrive(strPath))
     {
@@ -1371,7 +1371,7 @@ void CGUIMediaWindow::GetDirectoryHistoryString(const CFileItem* pItem, std::str
 
     // History string of the DVD drive
     // must be handled separately
-    if (pItem->m_iDriveType == CMediaSource::SOURCE_TYPE_DVD)
+    if (pItem->m_iDriveType == CMediaSource::SOURCE_TYPE_OPTICAL_DISC)
     {
       // Remove disc label from item label
       // and use as history string, m_strPath

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -697,7 +697,7 @@ void CGUIWindowFileManager::OnStart(CFileItem *pItem, const std::string &player)
 
 bool CGUIWindowFileManager::HaveDiscOrConnection( std::string& strPath, int iDriveType )
 {
-  if ( iDriveType == CMediaSource::SOURCE_TYPE_DVD )
+  if (iDriveType == CMediaSource::SOURCE_TYPE_OPTICAL_DISC)
   {
     if (!CServiceBroker::GetMediaManager().IsDiscInDrive(strPath))
     {
@@ -898,7 +898,7 @@ void CGUIWindowFileManager::GetDirectoryHistoryString(const CFileItem* pItem, st
 
     // History string of the DVD drive
     // must be handled separately
-    if (pItem->m_iDriveType == CMediaSource::SOURCE_TYPE_DVD)
+    if (pItem->m_iDriveType == CMediaSource::SOURCE_TYPE_OPTICAL_DISC)
     {
       // Remove disc label from item label
       // and use as history string, m_strPath


### PR DESCRIPTION
## Description
Another simple/cosmetic change. In Kodi/XBMC everything optical/disc related is called DVD from a time where only DVD drives where available. Rename those type of sources to `SOURCE_TYPE_OPTICAL_DISC` and `SOURCE_TYPE_VIRTUAL_OPTICAL_DISC` to make it more generic and avoid confusion with the actual media types.
