### PR TITLE
[CURL] Preserve slashes between protocol and path

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -471,8 +471,11 @@ std::string CURL::GetWithoutOptions() const
   std::string strGet = GetWithoutFilename();
 
   // Prevent double slash when concatenating host part and filename part
-  if (m_strFileName.size() && (m_strFileName[0] == '/' || m_strFileName[0] == '\\') && URIUtils::HasSlashAtEnd(strGet))
+  if (!m_strFileName.empty() && (m_strFileName[0] == '/' || m_strFileName[0] == '\\') &&
+      URIUtils::HasSlashAtEnd(strGet) && !(IsProtocol("http") || IsProtocol("https")))
+  {
     URIUtils::RemoveSlashAtEnd(strGet);
+  }
 
   return strGet + m_strFileName;
 }

--- a/xbmc/test/TestURL.cpp
+++ b/xbmc/test/TestURL.cpp
@@ -70,3 +70,10 @@ const TestURLGetWithoutUserDetailsData values[] = {
 };
 
 INSTANTIATE_TEST_SUITE_P(URL, TestURLGetWithoutUserDetails, ValuesIn(values));
+
+TEST(TestURLGetWithoutOptions, PreserveSlashesBetweenProtocolAndPath)
+{
+  std::string url{"https://example.com//stream//example/index.m3u8"};
+  CURL input{url};
+  EXPECT_EQ(input.GetWithoutOptions(), url);
+}


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
the http rfc2396 specs say that at least 2 slashes are allowed
but it do not specify how this should be handled, and so its behavior is defined by the server backend

from my pov if a url is constructed according to specific rules kodi should not alter it
and currently kodi curl wrongly remove a single slash
therefore i limited this slash removal for protocols other than http

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #25666
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
you can debug with this fake .strm file
```
#KODIPROP:mimetype=application/dash+xml
#KODIPROP:inputstreamaddon=inputstream.adaptive
#KODIPROP:inputstream=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=hls
http://thetestwebsite.com//stream//example/index.m3u8
```
and see curl logging

before
```
2024-10-08 13:46:35.900 T:33756   debug <general>: CurlFile::XFILE::CCurlFile::Open - <http://thetestwebsite.com/stream//example/index.m3u8>
2024-10-08 13:46:36.083 T:33756   debug <general>: Curl::Debug - HEADER_OUT: GET /stream//example/index.m3u8 HTTP/1.1
```
after
```
2024-10-08 13:48:26.821 T:15236   debug <general>: CurlFile::XFILE::CCurlFile::Open - <http://thetestwebsite.com//stream//example/index.m3u8>
2024-10-08 13:43:48.052 T:6468    debug <general>: Curl::Debug - HEADER_OUT: GET http://thetestwebsite.com//stream//example/index.m3u8 HTTP/1.1
```

user confirmed to works https://github.com/xbmc/xbmc/issues/25666#issuecomment-2424114726

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Can play videos

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
