### PR TITLE
filesystem: kill VECSOURCES typedefs

### DIFF
--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -481,9 +481,9 @@ bool CGUIPassword::CheckMenuLock(int iWindowID)
 
 bool CGUIPassword::LockSource(const std::string& strType, const std::string& strName, bool bState)
 {
-  VECSOURCES* pShares = CMediaSourceSettings::GetInstance().GetSources(strType);
+  std::vector<CMediaSource>* pShares = CMediaSourceSettings::GetInstance().GetSources(strType);
   bool bResult = false;
-  for (IVECSOURCES it=pShares->begin();it != pShares->end();++it)
+  for (std::vector<CMediaSource>::iterator it = pShares->begin(); it != pShares->end(); ++it)
   {
     if (it->strName == strName)
     {
@@ -507,8 +507,8 @@ void CGUIPassword::LockSources(bool lock)
   const char* strTypes[] = {"programs", "music", "video", "pictures", "files", "games"};
   for (const char* const strType : strTypes)
   {
-    VECSOURCES *shares = CMediaSourceSettings::GetInstance().GetSources(strType);
-    for (IVECSOURCES it=shares->begin();it != shares->end();++it)
+    std::vector<CMediaSource>* shares = CMediaSourceSettings::GetInstance().GetSources(strType);
+    for (std::vector<CMediaSource>::iterator it = shares->begin(); it != shares->end(); ++it)
       if (it->m_iLockMode != LOCK_MODE_EVERYONE)
         it->m_iHasLock = lock ? LOCK_STATE_LOCKED : LOCK_STATE_LOCK_BUT_UNLOCKED;
   }
@@ -522,8 +522,8 @@ void CGUIPassword::RemoveSourceLocks()
   const char* strTypes[] = {"programs", "music", "video", "pictures", "files", "games"};
   for (const char* const strType : strTypes)
   {
-    VECSOURCES *shares = CMediaSourceSettings::GetInstance().GetSources(strType);
-    for (IVECSOURCES it=shares->begin();it != shares->end();++it)
+    std::vector<CMediaSource>* shares = CMediaSourceSettings::GetInstance().GetSources(strType);
+    for (std::vector<CMediaSource>::iterator it = shares->begin(); it != shares->end(); ++it)
       if (it->m_iLockMode != LOCK_MODE_EVERYONE) // remove old info
       {
         it->m_iHasLock = LOCK_STATE_NO_LOCK;
@@ -538,7 +538,8 @@ void CGUIPassword::RemoveSourceLocks()
   CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
 }
 
-bool CGUIPassword::IsDatabasePathUnlocked(const std::string& strPath, VECSOURCES& vecSources)
+bool CGUIPassword::IsDatabasePathUnlocked(const std::string& strPath,
+                                          std::vector<CMediaSource>& sources)
 {
   const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
@@ -555,10 +556,10 @@ bool CGUIPassword::IsDatabasePathUnlocked(const std::string& strPath, VECSOURCES
 
   // try to find the best matching source
   bool bName = false;
-  int iIndex = CUtil::GetMatchingSource(strPath, vecSources, bName);
+  int iIndex = CUtil::GetMatchingSource(strPath, sources, bName);
 
-  if (iIndex > -1 && iIndex < static_cast<int>(vecSources.size()))
-    if (vecSources[iIndex].m_iHasLock < LOCK_STATE_LOCKED)
+  if (iIndex > -1 && iIndex < static_cast<int>(sources.size()))
+    if (sources[iIndex].m_iHasLock < LOCK_STATE_LOCKED)
       return true;
 
   return false;
@@ -573,12 +574,12 @@ bool CGUIPassword::IsMediaPathUnlocked(const std::shared_ptr<CProfileManager>& p
     if (!g_passwordManager.bMasterUser &&
         profileManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
     {
-      VECSOURCES& vecSources = *CMediaSourceSettings::GetInstance().GetSources(strType);
+      std::vector<CMediaSource>& sources = *CMediaSourceSettings::GetInstance().GetSources(strType);
       bool bName = false;
-      int iIndex = CUtil::GetMatchingSource(m_strMediaSourcePath, vecSources, bName);
-      if (iIndex > -1 && iIndex < static_cast<int>(vecSources.size()))
+      int iIndex = CUtil::GetMatchingSource(m_strMediaSourcePath, sources, bName);
+      if (iIndex > -1 && iIndex < static_cast<int>(sources.size()))
       {
-        return g_passwordManager.IsItemUnlocked(&vecSources[iIndex], strType);
+        return g_passwordManager.IsItemUnlocked(&sources[iIndex], strType);
       }
     }
   }
@@ -588,9 +589,9 @@ bool CGUIPassword::IsMediaPathUnlocked(const std::shared_ptr<CProfileManager>& p
 
 bool CGUIPassword::IsMediaFileUnlocked(const std::string& type, const std::string& file) const
 {
-  std::vector<CMediaSource>* vecSources = CMediaSourceSettings::GetInstance().GetSources(type);
+  std::vector<CMediaSource>* sources = CMediaSourceSettings::GetInstance().GetSources(type);
 
-  if (!vecSources)
+  if (!sources)
   {
     CLog::Log(LOGERROR,
               "{}: CMediaSourceSettings::GetInstance().GetSources(\"{}\") returned nullptr.",
@@ -603,10 +604,10 @@ bool CGUIPassword::IsMediaFileUnlocked(const std::string& type, const std::strin
   bool isSourceName{false};
   const std::string fileBasePath = URIUtils::GetBasePath(file);
 
-  int iIndex = CUtil::GetMatchingSource(fileBasePath, *vecSources, isSourceName);
+  int iIndex = CUtil::GetMatchingSource(fileBasePath, *sources, isSourceName);
 
-  if (iIndex > -1 && iIndex < static_cast<int>(vecSources->size()))
-    return (*vecSources)[iIndex].m_iHasLock < LOCK_STATE_LOCKED;
+  if (iIndex > -1 && iIndex < static_cast<int>(sources->size()))
+    return (*sources)[iIndex].m_iHasLock < LOCK_STATE_LOCKED;
 
   return true;
 }

--- a/xbmc/GUIPassword.h
+++ b/xbmc/GUIPassword.h
@@ -19,8 +19,6 @@ class CFileItem;
 class CMediaSource;
 class CProfileManager;
 
-typedef std::vector<CMediaSource> VECSOURCES;
-
 class CGUIPassword : public ISettingCallback
 {
 public:
@@ -64,7 +62,7 @@ public:
   bool LockSource(const std::string& strType, const std::string& strName, bool bState);
   void LockSources(bool lock);
   void RemoveSourceLocks();
-  bool IsDatabasePathUnlocked(const std::string& strPath, VECSOURCES& vecSources);
+  bool IsDatabasePathUnlocked(const std::string& strPath, std::vector<CMediaSource>& sources);
 
   /*! \brief Helper function to test if a matching mediasource is currently unlocked
    for a given media file

--- a/xbmc/MediaSource.cpp
+++ b/xbmc/MediaSource.cpp
@@ -77,7 +77,7 @@ bool CMediaSource::operator==(const CMediaSource &share) const
   return true;
 }
 
-void AddOrReplace(VECSOURCES& sources, const VECSOURCES& extras)
+void AddOrReplace(std::vector<CMediaSource>& sources, const std::vector<CMediaSource>& extras)
 {
   unsigned int i;
   for( i=0;i<extras.size();++i )
@@ -96,7 +96,7 @@ void AddOrReplace(VECSOURCES& sources, const VECSOURCES& extras)
   }
 }
 
-void AddOrReplace(VECSOURCES& sources, const CMediaSource& source)
+void AddOrReplace(std::vector<CMediaSource>& sources, const CMediaSource& source)
 {
   unsigned int i;
   for( i=0;i<sources.size();++i )

--- a/xbmc/MediaSource.h
+++ b/xbmc/MediaSource.h
@@ -17,7 +17,7 @@
 /*!
 \ingroup windows
 \brief Represents a share.
-\sa VECMediaSource, IVECSOURCES
+\sa VECMediaSource, std::vector<CMediaSource>::iterator
 */
 class CMediaSource final
 {
@@ -90,20 +90,5 @@ public:
   bool m_allowSharing = true; /// <Allow browsing of source from UPnP / WebServer
 };
 
-/*!
-\ingroup windows
-\brief A vector to hold CMediaSource objects.
-\sa CMediaSource, IVECSOURCES
-*/
-typedef std::vector<CMediaSource> VECSOURCES;
-
-/*!
-\ingroup windows
-\brief Iterator of VECSOURCES.
-\sa CMediaSource, VECSOURCES
-*/
-typedef std::vector<CMediaSource>::iterator IVECSOURCES;
-typedef std::vector<CMediaSource>::const_iterator CIVECSOURCES;
-
-void AddOrReplace(VECSOURCES& sources, const VECSOURCES& extras);
-void AddOrReplace(VECSOURCES& sources, const CMediaSource& source);
+void AddOrReplace(std::vector<CMediaSource>& sources, const std::vector<CMediaSource>& extras);
+void AddOrReplace(std::vector<CMediaSource>& sources, const CMediaSource& source);

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1214,7 +1214,9 @@ void CUtil::SplitParams(const std::string &paramString, std::vector<std::string>
     parameters.push_back(parameter);
 }
 
-int CUtil::GetMatchingSource(const std::string& strPath1, VECSOURCES& VECSOURCES, bool& bIsSourceName)
+int CUtil::GetMatchingSource(const std::string& strPath1,
+                             std::vector<CMediaSource>& sources,
+                             bool& bIsSourceName)
 {
   if (strPath1.empty())
     return -1;
@@ -1245,9 +1247,9 @@ int CUtil::GetMatchingSource(const std::string& strPath1, VECSOURCES& VECSOURCES
   int iIndex = -1;
 
   // we first test the NAME of a source
-  for (int i = 0; i < (int)VECSOURCES.size(); ++i)
+  for (int i = 0; i < static_cast<int>(sources.size()); ++i)
   {
-    const CMediaSource &share = VECSOURCES[i];
+    const CMediaSource& share = sources[i];
     std::string strName = share.strName;
 
     // special cases for dvds
@@ -1284,9 +1286,9 @@ int CUtil::GetMatchingSource(const std::string& strPath1, VECSOURCES& VECSOURCES
 
   size_t iLength = 0;
   size_t iLenPath = strDest.size();
-  for (int i = 0; i < (int)VECSOURCES.size(); ++i)
+  for (int i = 0; i < static_cast<int>(sources.size()); ++i)
   {
-    const CMediaSource &share = VECSOURCES[i];
+    const CMediaSource& share = sources[i];
 
     // does it match a source name?
     if (share.strPath.substr(0,8) == "shout://")
@@ -1351,7 +1353,7 @@ int CUtil::GetMatchingSource(const std::string& strPath1, VECSOURCES& VECSOURCES
 
       bIsSourceName = false;
       bool bDummy;
-      return GetMatchingSource(strPath, VECSOURCES, bDummy);
+      return GetMatchingSource(strPath, sources, bDummy);
     }
 
     CLog::Log(LOGDEBUG, "CUtil::GetMatchingSource: no matching source found for [{}]", strPath1);

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "MediaSource.h" // Definition of VECSOURCES
+#include "MediaSource.h" // Definition of std::vector<CMediaSource>
 #include "utils/Digest.h"
 
 #include <climits>
@@ -154,7 +154,9 @@ public:
    \param parameters the returned parameters
    */
   static void SplitParams(const std::string& paramString, std::vector<std::string>& parameters);
-  static int GetMatchingSource(const std::string& strPath, VECSOURCES& VECSOURCES, bool& bIsSourceName);
+  static int GetMatchingSource(const std::string& strPath,
+                               std::vector<CMediaSource>& sources,
+                               bool& bIsSourceName);
   static std::string TranslateSpecialSource(const std::string &strSpecial);
   static void DeleteDirectoryCache(const std::string &prefix = "");
   static void DeleteMusicDatabaseDirectoryCache();

--- a/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
@@ -208,7 +208,7 @@ void CGUIWindowAddonBrowser::InstallFromZip()
   else
   {
     // pop up filebrowser to grab an installed folder
-    VECSOURCES shares = *CMediaSourceSettings::GetInstance().GetSources("files");
+    std::vector<CMediaSource> shares = *CMediaSourceSettings::GetInstance().GetSources("files");
     CServiceBroker::GetMediaManager().GetLocalDrives(shares);
     CServiceBroker::GetMediaManager().GetNetworkLocations(shares);
     std::string path;

--- a/xbmc/addons/interfaces/gui/dialogs/FileBrowser.cpp
+++ b/xbmc/addons/interfaces/gui/dialogs/FileBrowser.cpp
@@ -70,7 +70,7 @@ bool Interface_GUIDialogFileBrowser::show_and_get_directory(KODI_HANDLE kodiBase
 
   std::string strPath = path_in;
 
-  VECSOURCES vecShares;
+  std::vector<CMediaSource> vecShares;
   GetVECShares(vecShares, shares, strPath);
   bool bRet = CGUIDialogFileBrowser::ShowAndGetDirectory(vecShares, heading, strPath, write_only);
   if (bRet)
@@ -107,7 +107,7 @@ bool Interface_GUIDialogFileBrowser::show_and_get_file(KODI_HANDLE kodiBase,
 
   std::string strPath = path_in;
 
-  VECSOURCES vecShares;
+  std::vector<CMediaSource> vecShares;
   GetVECShares(vecShares, shares, strPath);
   bool bRet = CGUIDialogFileBrowser::ShowAndGetFile(vecShares, mask, heading, strPath, use_thumbs,
                                                     use_file_directories);
@@ -179,7 +179,7 @@ bool Interface_GUIDialogFileBrowser::show_and_get_file_list(KODI_HANDLE kodiBase
     return false;
   }
 
-  VECSOURCES vecShares;
+  std::vector<CMediaSource> vecShares;
   GetVECShares(vecShares, shares, "");
 
   std::vector<std::string> pathsInt;
@@ -224,7 +224,7 @@ bool Interface_GUIDialogFileBrowser::show_and_get_source(KODI_HANDLE kodiBase,
 
   std::string strPath = path_in;
 
-  VECSOURCES vecShares;
+  std::vector<CMediaSource> vecShares;
   if (additionalShare)
     GetVECShares(vecShares, additionalShare, strPath);
   bool bRet =
@@ -259,7 +259,7 @@ bool Interface_GUIDialogFileBrowser::show_and_get_image(KODI_HANDLE kodiBase,
 
   std::string strPath = path_in;
 
-  VECSOURCES vecShares;
+  std::vector<CMediaSource> vecShares;
   GetVECShares(vecShares, shares, strPath);
   bool bRet = CGUIDialogFileBrowser::ShowAndGetImage(vecShares, heading, strPath);
   if (bRet)
@@ -290,7 +290,7 @@ bool Interface_GUIDialogFileBrowser::show_and_get_image_list(KODI_HANDLE kodiBas
     return false;
   }
 
-  VECSOURCES vecShares;
+  std::vector<CMediaSource> vecShares;
   GetVECShares(vecShares, shares, "");
 
   std::vector<std::string> pathsInt;
@@ -335,7 +335,7 @@ void Interface_GUIDialogFileBrowser::clear_file_list(KODI_HANDLE kodiBase,
   }
 }
 
-void Interface_GUIDialogFileBrowser::GetVECShares(VECSOURCES& vecShares,
+void Interface_GUIDialogFileBrowser::GetVECShares(std::vector<CMediaSource>& vecShares,
                                                   const std::string& strShares,
                                                   const std::string& strPath)
 {
@@ -352,35 +352,35 @@ void Interface_GUIDialogFileBrowser::GetVECShares(VECSOURCES& vecShares,
   found = strShares.find("programs");
   if (found != std::string::npos)
   {
-    VECSOURCES* sources = CMediaSourceSettings::GetInstance().GetSources("programs");
+    std::vector<CMediaSource>* sources = CMediaSourceSettings::GetInstance().GetSources("programs");
     if (sources != nullptr)
       vecShares.insert(vecShares.end(), sources->begin(), sources->end());
   }
   found = strShares.find("files");
   if (found != std::string::npos)
   {
-    VECSOURCES* sources = CMediaSourceSettings::GetInstance().GetSources("files");
+    std::vector<CMediaSource>* sources = CMediaSourceSettings::GetInstance().GetSources("files");
     if (sources != nullptr)
       vecShares.insert(vecShares.end(), sources->begin(), sources->end());
   }
   found = strShares.find("music");
   if (found != std::string::npos)
   {
-    VECSOURCES* sources = CMediaSourceSettings::GetInstance().GetSources("music");
+    std::vector<CMediaSource>* sources = CMediaSourceSettings::GetInstance().GetSources("music");
     if (sources != nullptr)
       vecShares.insert(vecShares.end(), sources->begin(), sources->end());
   }
   found = strShares.find("video");
   if (found != std::string::npos)
   {
-    VECSOURCES* sources = CMediaSourceSettings::GetInstance().GetSources("video");
+    std::vector<CMediaSource>* sources = CMediaSourceSettings::GetInstance().GetSources("video");
     if (sources != nullptr)
       vecShares.insert(vecShares.end(), sources->begin(), sources->end());
   }
   found = strShares.find("pictures");
   if (found != std::string::npos)
   {
-    VECSOURCES* sources = CMediaSourceSettings::GetInstance().GetSources("pictures");
+    std::vector<CMediaSource>* sources = CMediaSourceSettings::GetInstance().GetSources("pictures");
     if (sources != nullptr)
       vecShares.insert(vecShares.end(), sources->begin(), sources->end());
   }

--- a/xbmc/addons/interfaces/gui/dialogs/FileBrowser.h
+++ b/xbmc/addons/interfaces/gui/dialogs/FileBrowser.h
@@ -15,8 +15,6 @@
 
 class CMediaSource;
 
-typedef std::vector<CMediaSource> VECSOURCES;
-
 extern "C"
 {
 
@@ -107,7 +105,7 @@ extern "C"
     //@}
 
   private:
-    static void GetVECShares(VECSOURCES& vecShares,
+    static void GetVECShares(std::vector<CMediaSource>& vecShares,
                              const std::string& strShares,
                              const std::string& strPath);
   };

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -403,7 +403,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       items.Add(nothumb);
 
       std::string strThumb;
-      VECSOURCES shares;
+      std::vector<CMediaSource> shares;
       CServiceBroker::GetMediaManager().GetLocalDrives(shares);
       if (!CGUIDialogFileBrowser::ShowAndGetImage(items, shares, g_localizeStrings.Get(1030), strThumb))
         return false;
@@ -544,7 +544,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
 
 CMediaSource *CGUIDialogContextMenu::GetShare(const std::string &type, const CFileItem *item)
 {
-  VECSOURCES *shares = CMediaSourceSettings::GetInstance().GetSources(type);
+  std::vector<CMediaSource>* shares = CMediaSourceSettings::GetInstance().GetSources(type);
   if (!shares || !item)
     return nullptr;
   for (unsigned int i = 0; i < shares->size(); i++)
@@ -609,7 +609,7 @@ void CGUIDialogContextMenu::OnDeinitWindow(int nextWindowID)
 
 std::string CGUIDialogContextMenu::GetDefaultShareNameByType(const std::string &strType)
 {
-  VECSOURCES *pShares = CMediaSourceSettings::GetInstance().GetSources(strType);
+  std::vector<CMediaSource>* pShares = CMediaSourceSettings::GetInstance().GetSources(strType);
   std::string strDefault = CMediaSourceSettings::GetInstance().GetDefaultSource(strType);
 
   if (!pShares) return "";

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -606,7 +606,12 @@ void CGUIDialogFileBrowser::OnWindowUnload()
   m_viewControl.Reset();
 }
 
-bool CGUIDialogFileBrowser::ShowAndGetImage(const CFileItemList &items, const VECSOURCES &shares, const std::string &heading, std::string &result, bool* flip, int label)
+bool CGUIDialogFileBrowser::ShowAndGetImage(const CFileItemList& items,
+                                            const std::vector<CMediaSource>& shares,
+                                            const std::string& heading,
+                                            std::string& result,
+                                            bool* flip,
+                                            int label)
 {
   CGUIDialogFileBrowser *browser = new CGUIDialogFileBrowser();
   if (!browser)
@@ -648,22 +653,29 @@ bool CGUIDialogFileBrowser::ShowAndGetImage(const CFileItemList &items, const VE
   return confirmed;
 }
 
-bool CGUIDialogFileBrowser::ShowAndGetImage(const VECSOURCES &shares, const std::string &heading, std::string &path)
+bool CGUIDialogFileBrowser::ShowAndGetImage(const std::vector<CMediaSource>& shares,
+                                            const std::string& heading,
+                                            std::string& path)
 {
   return ShowAndGetFile(shares, CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(), heading, path, true); // true for use thumbs
 }
 
-bool CGUIDialogFileBrowser::ShowAndGetImageList(const VECSOURCES &shares, const std::string &heading, std::vector<std::string> &path)
+bool CGUIDialogFileBrowser::ShowAndGetImageList(const std::vector<CMediaSource>& shares,
+                                                const std::string& heading,
+                                                std::vector<std::string>& path)
 {
   return ShowAndGetFileList(shares, CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(), heading, path, true); // true for use thumbs
 }
 
-bool CGUIDialogFileBrowser::ShowAndGetDirectory(const VECSOURCES &shares, const std::string &heading, std::string &path, bool bWriteOnly)
+bool CGUIDialogFileBrowser::ShowAndGetDirectory(const std::vector<CMediaSource>& shares,
+                                                const std::string& heading,
+                                                std::string& path,
+                                                bool bWriteOnly)
 {
   // an extension mask of "/" ensures that no files are shown
   if (bWriteOnly)
   {
-    VECSOURCES shareWritable;
+    std::vector<CMediaSource> shareWritable;
     for (unsigned int i=0;i<shares.size();++i)
     {
       if (shares[i].IsWritable())
@@ -676,7 +688,12 @@ bool CGUIDialogFileBrowser::ShowAndGetDirectory(const VECSOURCES &shares, const 
   return ShowAndGetFile(shares, "/", heading, path);
 }
 
-bool CGUIDialogFileBrowser::ShowAndGetFile(const VECSOURCES &shares, const std::string &mask, const std::string &heading, std::string &path, bool useThumbs /* = false */, bool useFileDirectories /* = false */)
+bool CGUIDialogFileBrowser::ShowAndGetFile(const std::vector<CMediaSource>& shares,
+                                           const std::string& mask,
+                                           const std::string& heading,
+                                           std::string& path,
+                                           bool useThumbs /* = false */,
+                                           bool useFileDirectories /* = false */)
 {
   CGUIDialogFileBrowser *browser = new CGUIDialogFileBrowser();
   if (!browser)
@@ -727,7 +744,7 @@ bool CGUIDialogFileBrowser::ShowAndGetFile(const std::string &directory, const s
   // add a single share for this directory
   if (!singleList)
   {
-    VECSOURCES shares;
+    std::vector<CMediaSource> shares;
     CMediaSource share;
     share.strPath = directory;
     URIUtils::RemoveSlashAtEnd(share.strPath); // this is needed for the dodgy code in WINDOW_INIT
@@ -767,7 +784,7 @@ bool CGUIDialogFileBrowser::ShowAndGetFile(const std::string &directory, const s
   { // "Browse for thumb"
     CServiceBroker::GetGUI()->GetWindowManager().Remove(browser->GetID());
     delete browser;
-    VECSOURCES shares;
+    std::vector<CMediaSource> shares;
     CServiceBroker::GetMediaManager().GetLocalDrives(shares);
 
     return ShowAndGetFile(shares, mask, heading, path, useThumbs,useFileDirectories);
@@ -777,7 +794,12 @@ bool CGUIDialogFileBrowser::ShowAndGetFile(const std::string &directory, const s
   return confirmed;
 }
 
-bool CGUIDialogFileBrowser::ShowAndGetFileList(const VECSOURCES &shares, const std::string &mask, const std::string &heading, std::vector<std::string> &path, bool useThumbs /* = false */, bool useFileDirectories /* = false */)
+bool CGUIDialogFileBrowser::ShowAndGetFileList(const std::vector<CMediaSource>& shares,
+                                               const std::string& mask,
+                                               const std::string& heading,
+                                               std::vector<std::string>& path,
+                                               bool useThumbs /* = false */,
+                                               bool useFileDirectories /* = false */)
 {
   CGUIDialogFileBrowser *browser = new CGUIDialogFileBrowser();
   if (!browser)
@@ -812,7 +834,11 @@ void CGUIDialogFileBrowser::SetHeading(const std::string &heading)
   SET_CONTROL_LABEL(CONTROL_HEADING_LABEL, heading);
 }
 
-bool CGUIDialogFileBrowser::ShowAndGetSource(std::string &path, bool allowNetworkShares, VECSOURCES* additionalShare /* = NULL */, const std::string& strType /* = "" */)
+bool CGUIDialogFileBrowser::ShowAndGetSource(
+    std::string& path,
+    bool allowNetworkShares,
+    std::vector<CMediaSource>* additionalShare /* = NULL */,
+    const std::string& strType /* = "" */)
 {
   // Technique is
   // 1.  Show Filebrowser with currently defined local, and optionally the network locations.
@@ -835,7 +861,7 @@ bool CGUIDialogFileBrowser::ShowAndGetSource(std::string &path, bool allowNetwor
   // Add it to our window manager
   CServiceBroker::GetGUI()->GetWindowManager().AddUniqueInstance(browser);
 
-  VECSOURCES shares;
+  std::vector<CMediaSource> shares;
   if (!strType.empty())
   {
     if (additionalShare)
@@ -877,7 +903,7 @@ bool CGUIDialogFileBrowser::ShowAndGetSource(std::string &path, bool allowNetwor
   return confirmed;
 }
 
-void CGUIDialogFileBrowser::SetSources(const VECSOURCES &shares)
+void CGUIDialogFileBrowser::SetSources(const std::vector<CMediaSource>& shares)
 {
   m_shares = shares;
   if (!m_shares.size() && m_addSourceType.empty())
@@ -939,7 +965,7 @@ bool CGUIDialogFileBrowser::OnPopupMenu(int iItem)
     if (m_addNetworkShareEnabled)
     {
       std::string strOldPath=m_selectedPath,newPath=m_selectedPath;
-      VECSOURCES shares=m_shares;
+      std::vector<CMediaSource> shares = m_shares;
       if (CGUIDialogNetworkSetup::ShowAndGetNetworkAddress(newPath))
       {
         CServiceBroker::GetMediaManager().SetLocationPath(strOldPath, newPath);

--- a/xbmc/dialogs/GUIDialogFileBrowser.h
+++ b/xbmc/dialogs/GUIDialogFileBrowser.h
@@ -34,16 +34,41 @@ public:
   bool IsConfirmed() { return m_bConfirmed; }
   void SetHeading(const std::string &heading);
 
-  static bool ShowAndGetDirectory(const VECSOURCES &shares, const std::string &heading, std::string &path, bool bWriteOnly=false);
-  static bool ShowAndGetFile(const VECSOURCES &shares, const std::string &mask, const std::string &heading, std::string &path, bool useThumbs = false, bool useFileDirectories = false);
+  static bool ShowAndGetDirectory(const std::vector<CMediaSource>& shares,
+                                  const std::string& heading,
+                                  std::string& path,
+                                  bool bWriteOnly = false);
+  static bool ShowAndGetFile(const std::vector<CMediaSource>& shares,
+                             const std::string& mask,
+                             const std::string& heading,
+                             std::string& path,
+                             bool useThumbs = false,
+                             bool useFileDirectories = false);
   static bool ShowAndGetFile(const std::string &directory, const std::string &mask, const std::string &heading, std::string &path, bool useThumbs = false, bool useFileDirectories = false, bool singleList = false);
-  static bool ShowAndGetSource(std::string &path, bool allowNetworkShares, VECSOURCES* additionalShare = NULL, const std::string& strType="");
-  static bool ShowAndGetFileList(const VECSOURCES &shares, const std::string &mask, const std::string &heading, std::vector<std::string> &path, bool useThumbs = false, bool useFileDirectories = false);
-  static bool ShowAndGetImage(const VECSOURCES &shares, const std::string &heading, std::string &path);
-  static bool ShowAndGetImage(const CFileItemList &items, const VECSOURCES &shares, const std::string &heading, std::string &path, bool* flip=NULL, int label=21371);
-  static bool ShowAndGetImageList(const VECSOURCES &shares, const std::string &heading, std::vector<std::string> &path);
+  static bool ShowAndGetSource(std::string& path,
+                               bool allowNetworkShares,
+                               std::vector<CMediaSource>* additionalShare = NULL,
+                               const std::string& strType = "");
+  static bool ShowAndGetFileList(const std::vector<CMediaSource>& shares,
+                                 const std::string& mask,
+                                 const std::string& heading,
+                                 std::vector<std::string>& path,
+                                 bool useThumbs = false,
+                                 bool useFileDirectories = false);
+  static bool ShowAndGetImage(const std::vector<CMediaSource>& shares,
+                              const std::string& heading,
+                              std::string& path);
+  static bool ShowAndGetImage(const CFileItemList& items,
+                              const std::vector<CMediaSource>& shares,
+                              const std::string& heading,
+                              std::string& path,
+                              bool* flip = NULL,
+                              int label = 21371);
+  static bool ShowAndGetImageList(const std::vector<CMediaSource>& shares,
+                                  const std::string& heading,
+                                  std::vector<std::string>& path);
 
-  void SetSources(const VECSOURCES &shares);
+  void SetSources(const std::vector<CMediaSource>& shares);
 
   void OnItemLoaded(CFileItem *item) override {};
 
@@ -64,7 +89,7 @@ protected:
   void OnEditMediaSource(CFileItem* pItem);
   CGUIControl *GetFirstFocusableControl(int id) override;
 
-  VECSOURCES m_shares;
+  std::vector<CMediaSource> m_shares;
   XFILE::CVirtualDirectory m_rootDir;
   CFileItemList* m_vecItems;
   CFileItem* m_Directory;

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -152,7 +152,7 @@ bool CGUIDialogMediaSource::ShowAndAddMediaSource(const std::string &type)
 
 bool CGUIDialogMediaSource::ShowAndEditMediaSource(const std::string &type, const std::string&share)
 {
-  VECSOURCES* pShares = CMediaSourceSettings::GetInstance().GetSources(type);
+  std::vector<CMediaSource>* pShares = CMediaSourceSettings::GetInstance().GetSources(type);
   if (pShares)
   {
     for (unsigned int i = 0;i<pShares->size();++i)
@@ -197,7 +197,7 @@ std::string CGUIDialogMediaSource::GetUniqueMediaSourceName()
   // Get unique source name for this media type
   unsigned int i, j = 2;
   bool bConfirmed = false;
-  VECSOURCES* pShares = CMediaSourceSettings::GetInstance().GetSources(m_type);
+  std::vector<CMediaSource>* pShares = CMediaSourceSettings::GetInstance().GetSources(m_type);
   std::string strName = m_name;
   while (!bConfirmed)
   {
@@ -237,7 +237,7 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
   // Ignore current path is best at this stage??
   std::string path = m_paths->Get(item)->GetPath();
   bool allowNetworkShares(m_type != "programs");
-  VECSOURCES extraShares;
+  std::vector<CMediaSource> extraShares;
 
   if (m_name != CUtil::GetTitleFromPath(path))
     m_bNameChanged = true;

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -312,12 +312,12 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   }
   else if (m_rule.m_field == FieldPath)
   {
-    VECSOURCES sources;
+    std::vector<CMediaSource> sources;
     if (m_type == "songs" || m_type == "mixed")
       sources = *CMediaSourceSettings::GetInstance().GetSources("music");
     if (PLAYLIST::CSmartPlaylist::IsVideoType(m_type))
     {
-      VECSOURCES sources2 = *CMediaSourceSettings::GetInstance().GetSources("video");
+      std::vector<CMediaSource> sources2 = *CMediaSourceSettings::GetInstance().GetSources("video");
       sources.insert(sources.end(),sources2.begin(),sources2.end());
     }
     CServiceBroker::GetMediaManager().GetLocalDrives(sources);

--- a/xbmc/favourites/FavouritesUtils.cpp
+++ b/xbmc/favourites/FavouritesUtils.cpp
@@ -56,7 +56,7 @@ bool ChooseAndSetNewThumbnail(CFileItem& item)
   prefilledItems.Add(none);
 
   std::string thumb;
-  VECSOURCES sources;
+  std::vector<CMediaSource> sources;
   CServiceBroker::GetMediaManager().GetLocalDrives(sources);
   if (CGUIDialogFileBrowser::ShowAndGetImage(prefilledItems, sources, g_localizeStrings.Get(1030),
                                              thumb)) // Browse for image

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -38,8 +38,8 @@ bool CSourcesDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   std::string type(url.GetFileName());
   URIUtils::RemoveSlashAtEnd(type);
 
-  VECSOURCES sources;
-  VECSOURCES *sourcesFromType = CMediaSourceSettings::GetInstance().GetSources(type);
+  std::vector<CMediaSource> sources;
+  std::vector<CMediaSource>* sourcesFromType = CMediaSourceSettings::GetInstance().GetSources(type);
   if (!sourcesFromType)
     return false;
 
@@ -49,7 +49,7 @@ bool CSourcesDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   return GetDirectory(sources, items);
 }
 
-bool CSourcesDirectory::GetDirectory(const VECSOURCES &sources, CFileItemList &items)
+bool CSourcesDirectory::GetDirectory(const std::vector<CMediaSource>& sources, CFileItemList& items)
 {
   for (unsigned int i = 0; i < sources.size(); ++i)
   {

--- a/xbmc/filesystem/SourcesDirectory.h
+++ b/xbmc/filesystem/SourcesDirectory.h
@@ -13,7 +13,6 @@
 #include <vector>
 
 class CMediaSource;
-typedef std::vector<CMediaSource> VECSOURCES;
 
 namespace XFILE
 {
@@ -23,7 +22,7 @@ namespace XFILE
     CSourcesDirectory(void);
     ~CSourcesDirectory(void) override;
     bool GetDirectory(const CURL& url, CFileItemList &items) override;
-    bool GetDirectory(const VECSOURCES &sources, CFileItemList &items);
+    bool GetDirectory(const std::vector<CMediaSource>& sources, CFileItemList& items);
     bool Exists(const CURL& url) override;
     bool AllowAll() const override { return true; }
   };

--- a/xbmc/filesystem/VirtualDirectory.cpp
+++ b/xbmc/filesystem/VirtualDirectory.cpp
@@ -35,12 +35,12 @@ CVirtualDirectory::~CVirtualDirectory(void) = default;
 
 /*!
  \brief Add shares to the virtual directory
- \param VECSOURCES Shares to add
- \sa CMediaSource, VECSOURCES
+ \param std::vector<CMediaSource> Shares to add
+ \sa CMediaSource, std::vector<CMediaSource>
  */
-void CVirtualDirectory::SetSources(const VECSOURCES& vecSources)
+void CVirtualDirectory::SetSources(const std::vector<CMediaSource>& sources)
 {
-  m_vecSources = vecSources;
+  m_sources = sources;
 }
 
 /*!
@@ -82,7 +82,7 @@ bool CVirtualDirectory::GetDirectory(const CURL& url, CFileItemList &items, bool
   items.SetPath(strPath);
 
   // grab our shares
-  VECSOURCES shares;
+  std::vector<CMediaSource> shares;
   GetSources(shares);
   CSourcesDirectory dir;
   return dir.GetDirectory(shares, items);
@@ -101,7 +101,9 @@ void CVirtualDirectory::CancelDirectory()
  \note The parameter \e strPath can not be a share with directory. Eg. "iso9660://dir" will return \e false.
     It must be "iso9660://".
  */
-bool CVirtualDirectory::IsSource(const std::string& strPath, VECSOURCES *sources, std::string *name) const
+bool CVirtualDirectory::IsSource(const std::string& strPath,
+                                 std::vector<CMediaSource>* sources,
+                                 std::string* name) const
 {
   std::string strPathCpy = strPath;
   StringUtils::TrimRight(strPathCpy, "/\\");
@@ -112,7 +114,7 @@ bool CVirtualDirectory::IsSource(const std::string& strPath, VECSOURCES *sources
   if(URIUtils::IsDOSPath(strPathCpy))
     StringUtils::Replace(strPathCpy, '/', '\\');
 
-  VECSOURCES shares;
+  std::vector<CMediaSource> shares;
   if (sources)
     shares = *sources;
   else
@@ -144,7 +146,7 @@ bool CVirtualDirectory::IsSource(const std::string& strPath, VECSOURCES *sources
 bool CVirtualDirectory::IsInSource(const std::string &path) const
 {
   bool isSourceName;
-  VECSOURCES shares;
+  std::vector<CMediaSource> shares;
   GetSources(shares);
   int iShare = CUtil::GetMatchingSource(path, shares, isSourceName);
   if (URIUtils::IsOnDVD(path))
@@ -163,9 +165,9 @@ bool CVirtualDirectory::IsInSource(const std::string &path) const
   return (iShare > -1);
 }
 
-void CVirtualDirectory::GetSources(VECSOURCES &shares) const
+void CVirtualDirectory::GetSources(std::vector<CMediaSource>& shares) const
 {
-  shares = m_vecSources;
+  shares = m_sources;
   // add our plug n play shares
 
   if (m_allowNonLocalSources)

--- a/xbmc/filesystem/VirtualDirectory.h
+++ b/xbmc/filesystem/VirtualDirectory.h
@@ -29,26 +29,19 @@ namespace XFILE
     bool GetDirectory(const CURL& url, CFileItemList &items) override;
     void CancelDirectory() override;
     bool GetDirectory(const CURL& url, CFileItemList &items, bool bUseFileDirectories, bool keepImpl);
-    void SetSources(const VECSOURCES& vecSources);
-    inline unsigned int GetNumberOfSources()
-    {
-      return static_cast<uint32_t>(m_vecSources.size());
-    }
+    void SetSources(const std::vector<CMediaSource>& sources);
+    inline unsigned int GetNumberOfSources() { return static_cast<uint32_t>(m_sources.size()); }
 
-    bool IsSource(const std::string& strPath, VECSOURCES *sources = NULL, std::string *name = NULL) const;
+    bool IsSource(const std::string& strPath,
+                  std::vector<CMediaSource>* sources = NULL,
+                  std::string* name = NULL) const;
     bool IsInSource(const std::string& strPath) const;
 
-    inline const CMediaSource& operator [](const int index) const
-    {
-      return m_vecSources[index];
-    }
+    inline const CMediaSource& operator[](const int index) const { return m_sources[index]; }
 
-    inline CMediaSource& operator[](const int index)
-    {
-      return m_vecSources[index];
-    }
+    inline CMediaSource& operator[](const int index) { return m_sources[index]; }
 
-    void GetSources(VECSOURCES &sources) const;
+    void GetSources(std::vector<CMediaSource>& sources) const;
 
     void AllowNonLocalSources(bool allow) { m_allowNonLocalSources = allow; }
 
@@ -58,7 +51,7 @@ namespace XFILE
   protected:
     void CacheThumbs(CFileItemList &items);
 
-    VECSOURCES m_vecSources;
+    std::vector<CMediaSource> m_sources;
     bool m_allowNonLocalSources;
     std::shared_ptr<IDirectory> m_pDir;
   };

--- a/xbmc/games/windows/GUIViewStateWindowGames.cpp
+++ b/xbmc/games/windows/GUIViewStateWindowGames.cpp
@@ -70,14 +70,14 @@ std::string CGUIViewStateWindowGames::GetExtensions()
   return StringUtils::Join(exts, "|");
 }
 
-VECSOURCES& CGUIViewStateWindowGames::GetSources()
+std::vector<CMediaSource>& CGUIViewStateWindowGames::GetSources()
 {
-  VECSOURCES* pGameSources = CMediaSourceSettings::GetInstance().GetSources("games");
+  std::vector<CMediaSource>* pGameSources = CMediaSourceSettings::GetInstance().GetSources("games");
 
   // Guard against source type not existing
   if (pGameSources == nullptr)
   {
-    static VECSOURCES empty;
+    static std::vector<CMediaSource> empty;
     return empty;
   }
 

--- a/xbmc/games/windows/GUIViewStateWindowGames.h
+++ b/xbmc/games/windows/GUIViewStateWindowGames.h
@@ -27,7 +27,7 @@ public:
   // implementation of CGUIViewState
   std::string GetLockType() override;
   std::string GetExtensions() override;
-  VECSOURCES& GetSources() override;
+  std::vector<CMediaSource>& GetSources() override;
 
 protected:
   // implementation of CGUIViewState

--- a/xbmc/games/windows/GUIWindowGames.cpp
+++ b/xbmc/games/windows/GUIWindowGames.cpp
@@ -291,7 +291,7 @@ std::string CGUIWindowGames::GetStartFolder(const std::string& dir)
   }
 
   SetupShares();
-  VECSOURCES shares;
+  std::vector<CMediaSource> shares;
   m_rootDir.GetSources(shares);
   bool bIsSourceName = false;
   int iIndex = CUtil::GetMatchingSource(dir, shares, bIsSourceName);

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -122,7 +122,7 @@ static int ExportLibrary(const std::vector<std::string>& params)
   if (StringUtils::EqualsNoCase(params[0], "music"))
     iHeading = 20196;
   std::string path;
-  VECSOURCES shares;
+  std::vector<CMediaSource> shares;
   CServiceBroker::GetMediaManager().GetLocalDrives(shares);
   CServiceBroker::GetMediaManager().GetNetworkLocations(shares);
   CServiceBroker::GetMediaManager().GetRemovableDrives(shares);

--- a/xbmc/interfaces/builtins/SkinBuiltins.cpp
+++ b/xbmc/interfaces/builtins/SkinBuiltins.cpp
@@ -191,7 +191,7 @@ static int SetPath(const std::vector<std::string>& params)
 {
   int string = CSkinSettings::GetInstance().TranslateString(params[0]);
   std::string value = CSkinSettings::GetInstance().GetString(string);
-  VECSOURCES localShares;
+  std::vector<CMediaSource> localShares;
   CServiceBroker::GetMediaManager().GetLocalDrives(localShares);
   CServiceBroker::GetMediaManager().GetNetworkLocations(localShares);
   if (params.size() > 1)
@@ -227,7 +227,7 @@ static int SetFile(const std::vector<std::string>& params)
 {
   int string = CSkinSettings::GetInstance().TranslateString(params[0]);
   std::string value = CSkinSettings::GetInstance().GetString(string);
-  VECSOURCES localShares;
+  std::vector<CMediaSource> localShares;
   CServiceBroker::GetMediaManager().GetLocalDrives(localShares);
 
   // Note. can only browse one addon type from here
@@ -289,7 +289,7 @@ static int SetImage(const std::vector<std::string>& params)
 {
   int string = CSkinSettings::GetInstance().TranslateString(params[0]);
   std::string value = CSkinSettings::GetInstance().GetString(string);
-  VECSOURCES localShares;
+  std::vector<CMediaSource> localShares;
   CServiceBroker::GetMediaManager().GetLocalDrives(localShares);
   if (params.size() > 1)
   {

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -39,7 +39,7 @@ JSONRPC_STATUS CFileOperations::GetRootDirectory(const std::string &method, ITra
   std::string media = parameterObject["media"].asString();
   StringUtils::ToLower(media);
 
-  VECSOURCES *sources = CMediaSourceSettings::GetInstance().GetSources(media);
+  std::vector<CMediaSource>* sources = CMediaSourceSettings::GetInstance().GetSources(media);
   if (sources)
   {
     CFileItemList items;

--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -222,9 +222,9 @@ namespace XBMCAddon
       DelayedCallGuard dcguard(languageHook);
       std::string value;
       std::string mask = maskparam;
-      VECSOURCES *shares = CMediaSourceSettings::GetInstance().GetSources(s_shares);
+      std::vector<CMediaSource>* shares = CMediaSourceSettings::GetInstance().GetSources(s_shares);
 
-      VECSOURCES localShares;
+      std::vector<CMediaSource> localShares;
       if (!shares)
       {
         CServiceBroker::GetMediaManager().GetLocalDrives(localShares);
@@ -255,11 +255,11 @@ namespace XBMCAddon
                           bool useFileDirectories, const String& defaultt )
     {
       DelayedCallGuard dcguard(languageHook);
-      VECSOURCES *shares = CMediaSourceSettings::GetInstance().GetSources(s_shares);
+      std::vector<CMediaSource>* shares = CMediaSourceSettings::GetInstance().GetSources(s_shares);
       std::vector<String> valuelist;
       String lmask = mask;
 
-      VECSOURCES localShares;
+      std::vector<CMediaSource> localShares;
       if (!shares)
       {
         CServiceBroker::GetMediaManager().GetLocalDrives(localShares);

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -54,7 +54,7 @@ std::string CGUIViewStateWindowMusic::GetExtensions()
   return CServiceBroker::GetFileExtensionProvider().GetMusicExtensions();
 }
 
-VECSOURCES& CGUIViewStateWindowMusic::GetSources()
+std::vector<CMediaSource>& CGUIViewStateWindowMusic::GetSources()
 {
   return CGUIViewState::GetSources();
 }
@@ -571,7 +571,7 @@ void CGUIViewStateWindowMusicNav::AddOnlineShares()
   if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bVirtualShares)
     return;
 
-  VECSOURCES *musicSources = CMediaSourceSettings::GetInstance().GetSources("music");
+  std::vector<CMediaSource>* musicSources = CMediaSourceSettings::GetInstance().GetSources("music");
 
   for (int i = 0; i < (int)musicSources->size(); ++i)
   {
@@ -579,7 +579,7 @@ void CGUIViewStateWindowMusicNav::AddOnlineShares()
   }
 }
 
-VECSOURCES& CGUIViewStateWindowMusicNav::GetSources()
+std::vector<CMediaSource>& CGUIViewStateWindowMusicNav::GetSources()
 {
   //  Setup shares we want to have
   m_sources.clear();
@@ -639,7 +639,7 @@ bool CGUIViewStateWindowMusicPlaylist::HideParentDirItems()
   return true;
 }
 
-VECSOURCES& CGUIViewStateWindowMusicPlaylist::GetSources()
+std::vector<CMediaSource>& CGUIViewStateWindowMusicPlaylist::GetSources()
 {
   m_sources.clear();
   //  Playlist share

--- a/xbmc/music/GUIViewStateMusic.h
+++ b/xbmc/music/GUIViewStateMusic.h
@@ -15,7 +15,7 @@ class CGUIViewStateWindowMusic : public CGUIViewState
 public:
   explicit CGUIViewStateWindowMusic(const CFileItemList& items) : CGUIViewState(items) {}
 protected:
-  VECSOURCES& GetSources() override;
+  std::vector<CMediaSource>& GetSources() override;
   KODI::PLAYLIST::Id GetPlaylist() const override;
   bool AutoPlayNextItem() override;
   std::string GetLockType() override;
@@ -65,7 +65,7 @@ public:
 
 protected:
   void SaveViewState() override;
-  VECSOURCES& GetSources() override;
+  std::vector<CMediaSource>& GetSources() override;
 
 private:
   void AddOnlineShares();
@@ -81,5 +81,5 @@ protected:
   KODI::PLAYLIST::Id GetPlaylist() const override;
   bool AutoPlayNextItem() override;
   bool HideParentDirItems() override;
-  VECSOURCES& GetSources() override;
+  std::vector<CMediaSource>& GetSources() override;
 };

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -10221,7 +10221,7 @@ bool CMusicDatabase::DeleteAlbumSources(int idAlbum)
   return ExecuteQuery(PrepareSQL("DELETE FROM album_source WHERE idAlbum = %i", idAlbum));
 }
 
-bool CMusicDatabase::CheckSources(VECSOURCES& sources)
+bool CMusicDatabase::CheckSources(std::vector<CMediaSource>& sources)
 {
   if (sources.empty())
   {
@@ -10283,7 +10283,7 @@ bool CMusicDatabase::CheckSources(VECSOURCES& sources)
 bool CMusicDatabase::MigrateSources()
 {
   //Fetch music sources from xml
-  VECSOURCES sources(*CMediaSourceSettings::GetInstance().GetSources("music"));
+  std::vector<CMediaSource> sources(*CMediaSourceSettings::GetInstance().GetSources("music"));
 
   std::string strSQL;
   try
@@ -10323,7 +10323,7 @@ bool CMusicDatabase::MigrateSources()
 bool CMusicDatabase::UpdateSources()
 {
   //Check library and xml sources match
-  VECSOURCES sources(*CMediaSourceSettings::GetInstance().GetSources("music"));
+  std::vector<CMediaSource> sources(*CMediaSourceSettings::GetInstance().GetSources("music"));
   if (CheckSources(sources))
     return true;
 

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -982,7 +982,7 @@ private:
   /*! \brief Checks that source table matches sources.xml
   returns true when they do
   */
-  bool CheckSources(VECSOURCES& sources);
+  bool CheckSources(std::vector<CMediaSource>& sources);
 
   /*! \brief Initially fills source table from sources.xml for use only at
   migration of db from an earlier version than 72

--- a/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
+++ b/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
@@ -229,7 +229,7 @@ void CGUIDialogInfoProviderSettings::OnSettingAction(const std::shared_ptr<const
     CGUIDialogAddonSettings::ShowForAddon(m_artistscraper, false);
   else if (settingId == CSettings::SETTING_MUSICLIBRARY_ARTISTSFOLDER)
   {
-    VECSOURCES shares;
+    std::vector<CMediaSource> shares;
     CServiceBroker::GetMediaManager().GetLocalDrives(shares);
     CServiceBroker::GetMediaManager().GetNetworkLocations(shares);
     CServiceBroker::GetMediaManager().GetRemovableDrives(shares);

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -706,7 +706,8 @@ std::string CGUIDialogMusicInfo::GetContent()
     return "albums";
 }
 
-void CGUIDialogMusicInfo::AddItemPathToFileBrowserSources(VECSOURCES &sources, const CFileItem &item)
+void CGUIDialogMusicInfo::AddItemPathToFileBrowserSources(std::vector<CMediaSource>& sources,
+                                                          const CFileItem& item)
 {
   std::string itemDir;
   std::string artistFolder;
@@ -900,7 +901,7 @@ void CGUIDialogMusicInfo::OnGetArt()
   // never used by Kodi again, but there is no obvious way to clear these
   // thumbs from the cache automatically.
   std::string result;
-  VECSOURCES sources(*CMediaSourceSettings::GetInstance().GetSources("music"));
+  std::vector<CMediaSource> sources(*CMediaSourceSettings::GetInstance().GetSources("music"));
   CGUIDialogMusicInfo::AddItemPathToFileBrowserSources(sources, *m_item);
   CServiceBroker::GetMediaManager().GetLocalDrives(sources);
   if (CGUIDialogFileBrowser::ShowAndGetImage(items, sources, g_localizeStrings.Get(13511), result) &&

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.h
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.h
@@ -37,7 +37,8 @@ public:
   bool HasListItems() const override { return true; }
   CFileItemPtr GetCurrentListItem(int offset = 0) override;
   std::string GetContent();
-  static void AddItemPathToFileBrowserSources(VECSOURCES &sources, const CFileItem &item);
+  static void AddItemPathToFileBrowserSources(std::vector<CMediaSource>& sources,
+                                              const CFileItem& item);
   void SetDiscography(CMusicDatabase& database) const;
   void SetSongs(const VECSONGS &songs) const;
   void SetArtTypeList(CFileItemList& artlist);

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -413,7 +413,7 @@ void CGUIDialogSongInfo::OnGetArt()
 
   // Show list of possible art for user selection
   std::string result;
-  VECSOURCES sources(*CMediaSourceSettings::GetInstance().GetSources("music"));
+  std::vector<CMediaSource> sources(*CMediaSourceSettings::GetInstance().GetSources("music"));
   // Add album folder as source (could be disc set)
   std::string albumpath = m_song->GetProperty("album_path").asString();
   if (!albumpath.empty())

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -921,10 +921,10 @@ void CGUIWindowMusicNav::AddSearchFolder()
   if (viewState)
   {
     // add our remove the musicsearch source
-    VECSOURCES &sources = viewState->GetSources();
+    std::vector<CMediaSource>& sources = viewState->GetSources();
     bool haveSearchSource = false;
     bool needSearchSource = !GetProperty("search").empty() || !m_searchWithEdit; // we always need it if we don't have the edit control
-    for (IVECSOURCES it = sources.begin(); it != sources.end(); ++it)
+    for (std::vector<CMediaSource>::iterator it = sources.begin(); it != sources.end(); ++it)
     {
       CMediaSource& share = *it;
       if (share.strPath == "musicsearch://")

--- a/xbmc/music/windows/GUIWindowMusicNav.h
+++ b/xbmc/music/windows/GUIWindowMusicNav.h
@@ -41,7 +41,7 @@ protected:
   bool GetSongsFromPlayList(const std::string& strPlayList, CFileItemList &items);
   bool ManageInfoProvider(const CFileItemPtr& item);
 
-  VECSOURCES m_shares;
+  std::vector<CMediaSource> m_shares;
 
   // searching
   void OnSearchUpdate();

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.h
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.h
@@ -40,5 +40,5 @@ protected:
   bool MoveCurrentPlayListItem(int iItem, int iAction, bool bUpdate = true);
 
   int m_movingFrom;
-  VECSOURCES m_shares;
+  std::vector<CMediaSource> m_shares;
 };

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -211,7 +211,7 @@ void CGUIDialogNetworkSetup::InitializeSettings()
 void CGUIDialogNetworkSetup::OnServerBrowse()
 {
   // open a filebrowser dialog with the current address
-  VECSOURCES shares;
+  std::vector<CMediaSource> shares;
   std::string path = ConstructPath();
   // get the share as the base path
   CMediaSource share;

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -662,13 +662,15 @@ static void AddHostsFromMediaSource(const CMediaSource& source, std::vector<std:
   }
 }
 
-static void AddHostsFromVecSource(const VECSOURCES& sources, std::vector<std::string>& hosts)
+static void AddHostsFromVecSource(const std::vector<CMediaSource>& sources,
+                                  std::vector<std::string>& hosts)
 {
   for (const auto& it : sources)
     AddHostsFromMediaSource(it, hosts);
 }
 
-static void AddHostsFromVecSource(const VECSOURCES* sources, std::vector<std::string>& hosts)
+static void AddHostsFromVecSource(const std::vector<CMediaSource>* sources,
+                                  std::vector<std::string>& hosts)
 {
   if (sources)
     AddHostsFromVecSource(*sources, hosts);

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
@@ -44,7 +44,7 @@ CHTTPVfsHandler::CHTTPVfsHandler(const HTTPRequest &request)
           realPath = CURL(realPath).GetHostName();
 
         // Check manually configured sources
-        VECSOURCES *sources = NULL;
+        std::vector<CMediaSource>* sources = NULL;
         for (unsigned int index = 0; index < size && !accessible; index++)
         {
           sources = CMediaSourceSettings::GetInstance().GetSources(sourceTypes[index]);
@@ -76,7 +76,7 @@ CHTTPVfsHandler::CHTTPVfsHandler(const HTTPRequest &request)
         if (!accessible)
         {
           bool isSource;
-          VECSOURCES removableSources;
+          std::vector<CMediaSource> removableSources;
           CServiceBroker::GetMediaManager().GetRemovableDrives(removableSources);
           int sourceIndex = CUtil::GetMatchingSource(realPath, removableSources, isSource);
           if (sourceIndex >= 0 && sourceIndex < static_cast<int>(removableSources.size()) &&

--- a/xbmc/pictures/GUIViewStatePictures.cpp
+++ b/xbmc/pictures/GUIViewStatePictures.cpp
@@ -71,14 +71,15 @@ std::string CGUIViewStateWindowPictures::GetExtensions()
   return extensions;
 }
 
-VECSOURCES& CGUIViewStateWindowPictures::GetSources()
+std::vector<CMediaSource>& CGUIViewStateWindowPictures::GetSources()
 {
-  VECSOURCES *pictureSources = CMediaSourceSettings::GetInstance().GetSources("pictures");
+  std::vector<CMediaSource>* pictureSources =
+      CMediaSourceSettings::GetInstance().GetSources("pictures");
 
   // Guard against source type not existing
   if (pictureSources == nullptr)
   {
-    static VECSOURCES empty;
+    static std::vector<CMediaSource> empty;
     return empty;
   }
 

--- a/xbmc/pictures/GUIViewStatePictures.h
+++ b/xbmc/pictures/GUIViewStatePictures.h
@@ -17,7 +17,7 @@ public:
 
   std::string GetLockType() override;
   std::string GetExtensions() override;
-  VECSOURCES& GetSources() override;
+  std::vector<CMediaSource>& GetSources() override;
 
 protected:
   void SaveViewState() override;

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -597,7 +597,7 @@ std::string CGUIWindowPictures::GetStartFolder(const std::string &dir)
     return "addons://sources/image/";
 
   SetupShares();
-  VECSOURCES shares;
+  std::vector<CMediaSource> shares;
   m_rootDir.GetSources(shares);
   bool bIsSourceName = false;
   int iIndex = CUtil::GetMatchingSource(dir, shares, bIsSourceName);

--- a/xbmc/platform/android/storage/AndroidStorageProvider.cpp
+++ b/xbmc/platform/android/storage/AndroidStorageProvider.cpp
@@ -123,7 +123,7 @@ std::string CAndroidStorageProvider::unescape(const std::string& str)
   return retString;
 }
 
-void CAndroidStorageProvider::GetLocalDrives(VECSOURCES &localDrives)
+void CAndroidStorageProvider::GetLocalDrives(std::vector<CMediaSource>& localDrives)
 {
   CMediaSource share;
 
@@ -143,7 +143,7 @@ void CAndroidStorageProvider::GetLocalDrives(VECSOURCES &localDrives)
   localDrives.push_back(share);
 }
 
-void CAndroidStorageProvider::GetRemovableDrives(VECSOURCES& removableDrives)
+void CAndroidStorageProvider::GetRemovableDrives(std::vector<CMediaSource>& removableDrives)
 {
   bool inError = false;
 
@@ -167,7 +167,7 @@ void CAndroidStorageProvider::GetRemovableDrives(VECSOURCES& removableDrives)
 
     if (!inError)
     {
-      VECSOURCES droidDrives;
+      std::vector<CMediaSource> droidDrives;
 
       for (int i = 0; i < vols.size(); ++i)
       {
@@ -393,7 +393,7 @@ std::vector<std::string> CAndroidStorageProvider::GetDiskUsage()
     result.push_back(usage);
 
   // add removable storage
-  VECSOURCES drives;
+  std::vector<CMediaSource> drives;
   GetRemovableDrives(drives);
   for (unsigned int i = 0; i < drives.size(); i++)
   {
@@ -407,7 +407,7 @@ std::vector<std::string> CAndroidStorageProvider::GetDiskUsage()
 
 bool CAndroidStorageProvider::PumpDriveChangeEvents(IStorageEventsCallback *callback)
 {
-  VECSOURCES drives;
+  std::vector<CMediaSource> drives;
   GetRemovableDrives(drives);
   bool changed = m_removableDrives != drives;
   m_removableDrives = std::move(drives);

--- a/xbmc/platform/android/storage/AndroidStorageProvider.h
+++ b/xbmc/platform/android/storage/AndroidStorageProvider.h
@@ -24,8 +24,8 @@ public:
   void Stop() override {}
   bool Eject(const std::string& mountpath) override { return false; }
 
-  void GetLocalDrives(VECSOURCES& localDrives) override;
-  void GetRemovableDrives(VECSOURCES& removableDrives) override;
+  void GetLocalDrives(std::vector<CMediaSource>& localDrives) override;
+  void GetRemovableDrives(std::vector<CMediaSource>& removableDrives) override;
   std::vector<std::string> GetDiskUsage() override;
 
   bool PumpDriveChangeEvents(IStorageEventsCallback* callback) override;
@@ -40,7 +40,7 @@ public:
 
 private:
   std::string unescape(const std::string& str);
-  VECSOURCES m_removableDrives;
+  std::vector<CMediaSource> m_removableDrives;
   unsigned int m_removableLength;
 
   static std::set<std::string> GetRemovableDrives();

--- a/xbmc/platform/darwin/ios-common/storage/IOSStorageProvider.h
+++ b/xbmc/platform/darwin/ios-common/storage/IOSStorageProvider.h
@@ -22,8 +22,8 @@ public:
   void Initialize() override {}
   void Stop() override {}
 
-  void GetLocalDrives(VECSOURCES& localDrives) override;
-  void GetRemovableDrives(VECSOURCES& removableDrives) override {}
+  void GetLocalDrives(std::vector<CMediaSource>& localDrives) override;
+  void GetRemovableDrives(std::vector<CMediaSource>& removableDrives) override {}
 
   std::vector<std::string> GetDiskUsage(void) override;
 

--- a/xbmc/platform/darwin/ios-common/storage/IOSStorageProvider.mm
+++ b/xbmc/platform/darwin/ios-common/storage/IOSStorageProvider.mm
@@ -18,7 +18,7 @@ std::unique_ptr<IStorageProvider> IStorageProvider::CreateInstance()
   return std::make_unique<CIOSStorageProvider>();
 }
 
-void CIOSStorageProvider::GetLocalDrives(VECSOURCES& localDrives)
+void CIOSStorageProvider::GetLocalDrives(std::vector<CMediaSource>& localDrives)
 {
   CMediaSource share;
 

--- a/xbmc/platform/darwin/osx/storage/OSXStorageProvider.cpp
+++ b/xbmc/platform/darwin/osx/storage/OSXStorageProvider.cpp
@@ -31,7 +31,7 @@ COSXStorageProvider::COSXStorageProvider()
   PumpDriveChangeEvents(NULL);
 }
 
-void COSXStorageProvider::GetLocalDrives(VECSOURCES& localDrives)
+void COSXStorageProvider::GetLocalDrives(std::vector<CMediaSource>& localDrives)
 {
   CMediaSource share;
 
@@ -93,7 +93,7 @@ void COSXStorageProvider::GetLocalDrives(VECSOURCES& localDrives)
   }
 }
 
-void COSXStorageProvider::GetRemovableDrives(VECSOURCES& removableDrives)
+void COSXStorageProvider::GetRemovableDrives(std::vector<CMediaSource>& removableDrives)
 {
   DASessionRef session = DASessionCreate(kCFAllocatorDefault);
   if (session)

--- a/xbmc/platform/darwin/osx/storage/OSXStorageProvider.h
+++ b/xbmc/platform/darwin/osx/storage/OSXStorageProvider.h
@@ -23,8 +23,8 @@ public:
   void Initialize() override {}
   void Stop() override {}
 
-  void GetLocalDrives(VECSOURCES& localDrives) override;
-  void GetRemovableDrives(VECSOURCES& removableDrives) override;
+  void GetLocalDrives(std::vector<CMediaSource>& localDrives) override;
+  void GetRemovableDrives(std::vector<CMediaSource>& removableDrives) override;
 
   std::vector<std::string> GetDiskUsage() override;
 

--- a/xbmc/platform/linux/storage/LinuxStorageProvider.cpp
+++ b/xbmc/platform/linux/storage/LinuxStorageProvider.cpp
@@ -54,7 +54,7 @@ void CLinuxStorageProvider::Stop()
   m_instance->Stop();
 }
 
-void CLinuxStorageProvider::GetLocalDrives(VECSOURCES &localDrives)
+void CLinuxStorageProvider::GetLocalDrives(std::vector<CMediaSource>& localDrives)
 {
   // Home directory
   CMediaSource share;
@@ -70,7 +70,7 @@ void CLinuxStorageProvider::GetLocalDrives(VECSOURCES &localDrives)
   m_instance->GetLocalDrives(localDrives);
 }
 
-void CLinuxStorageProvider::GetRemovableDrives(VECSOURCES &removableDrives)
+void CLinuxStorageProvider::GetRemovableDrives(std::vector<CMediaSource>& removableDrives)
 {
   m_instance->GetRemovableDrives(removableDrives);
 }

--- a/xbmc/platform/linux/storage/LinuxStorageProvider.h
+++ b/xbmc/platform/linux/storage/LinuxStorageProvider.h
@@ -20,8 +20,8 @@ public:
 
   void Initialize() override;
   void Stop() override;
-  void GetLocalDrives(VECSOURCES &localDrives) override;
-  void GetRemovableDrives(VECSOURCES &removableDrives) override;
+  void GetLocalDrives(std::vector<CMediaSource>& localDrives) override;
+  void GetRemovableDrives(std::vector<CMediaSource>& removableDrives) override;
   bool Eject(const std::string& mountpath) override;
   std::vector<std::string> GetDiskUsage() override;
   bool PumpDriveChangeEvents(IStorageEventsCallback *callback) override;

--- a/xbmc/platform/linux/storage/UDevProvider.cpp
+++ b/xbmc/platform/linux/storage/UDevProvider.cpp
@@ -91,7 +91,7 @@ void CUDevProvider::Stop()
   udev_unref(m_udev);
 }
 
-void CUDevProvider::GetDisks(VECSOURCES& disks, bool removable)
+void CUDevProvider::GetDisks(std::vector<CMediaSource>& disks, bool removable)
 {
   // enumerate existing block devices
   struct udev_enumerate *u_enum = udev_enumerate_new(m_udev);
@@ -188,12 +188,12 @@ void CUDevProvider::GetDisks(VECSOURCES& disks, bool removable)
   udev_enumerate_unref(u_enum);
 }
 
-void CUDevProvider::GetLocalDrives(VECSOURCES &localDrives)
+void CUDevProvider::GetLocalDrives(std::vector<CMediaSource>& localDrives)
 {
   GetDisks(localDrives, false);
 }
 
-void CUDevProvider::GetRemovableDrives(VECSOURCES &removableDrives)
+void CUDevProvider::GetRemovableDrives(std::vector<CMediaSource>& removableDrives)
 {
   GetDisks(removableDrives, true);
 }

--- a/xbmc/platform/linux/storage/UDevProvider.h
+++ b/xbmc/platform/linux/storage/UDevProvider.h
@@ -25,8 +25,8 @@ public:
   void Initialize() override;
   void Stop() override;
 
-  void GetLocalDrives(VECSOURCES &localDrives) override;
-  void GetRemovableDrives(VECSOURCES &removableDrives) override;
+  void GetLocalDrives(std::vector<CMediaSource>& localDrives) override;
+  void GetRemovableDrives(std::vector<CMediaSource>& removableDrives) override;
 
   bool Eject(const std::string& mountpath) override;
 
@@ -35,7 +35,7 @@ public:
   bool PumpDriveChangeEvents(IStorageEventsCallback *callback) override;
 
 private:
-  void GetDisks(VECSOURCES& devices, bool removable);
+  void GetDisks(std::vector<CMediaSource>& devices, bool removable);
 
   struct udev         *m_udev;
   struct udev_monitor *m_udevMon;

--- a/xbmc/platform/linux/storage/UDisks2Provider.cpp
+++ b/xbmc/platform/linux/storage/UDisks2Provider.cpp
@@ -318,7 +318,7 @@ std::vector<std::string> CUDisks2Provider::GetDiskUsage()
   return legacy.GetDiskUsage();
 }
 
-void CUDisks2Provider::GetDisks(VECSOURCES &devices, bool enumerateRemovable)
+void CUDisks2Provider::GetDisks(std::vector<CMediaSource>& devices, bool enumerateRemovable)
 {
   for (const auto &elt: m_filesystems)
   {

--- a/xbmc/platform/linux/storage/UDisks2Provider.h
+++ b/xbmc/platform/linux/storage/UDisks2Provider.h
@@ -159,10 +159,10 @@ public:
 
   std::vector<std::string> GetDiskUsage() override;
 
-  void GetLocalDrives(VECSOURCES &localDrives) override
+  void GetLocalDrives(std::vector<CMediaSource>& localDrives) override
   { GetDisks(localDrives, false); }
 
-  void GetRemovableDrives(VECSOURCES &removableDrives) override
+  void GetRemovableDrives(std::vector<CMediaSource>& removableDrives) override
   { GetDisks(removableDrives, true); }
 
   void Stop() override
@@ -177,7 +177,7 @@ private:
 
   std::string m_daemonVersion;
 
-  void GetDisks(VECSOURCES &devices, bool enumerateRemovable);
+  void GetDisks(std::vector<CMediaSource>& devices, bool enumerateRemovable);
 
   void DriveAdded(Drive *drive);
   bool DriveRemoved(const std::string& object);

--- a/xbmc/platform/linux/storage/UDisksProvider.cpp
+++ b/xbmc/platform/linux/storage/UDisksProvider.cpp
@@ -391,7 +391,7 @@ std::vector<std::string> CUDisksProvider::EnumerateDisks()
   return devices;
 }
 
-void CUDisksProvider::GetDisks(VECSOURCES& devices, bool EnumerateRemovable)
+void CUDisksProvider::GetDisks(std::vector<CMediaSource>& devices, bool EnumerateRemovable)
 {
   for (auto& itr : m_AvailableDevices)
   {

--- a/xbmc/platform/linux/storage/UDisksProvider.h
+++ b/xbmc/platform/linux/storage/UDisksProvider.h
@@ -101,8 +101,14 @@ public:
   void Initialize() override;
   void Stop() override { }
 
-  void GetLocalDrives(VECSOURCES &localDrives) override { GetDisks(localDrives, false); }
-  void GetRemovableDrives(VECSOURCES &removableDrives) override { GetDisks(removableDrives, true); }
+  void GetLocalDrives(std::vector<CMediaSource>& localDrives) override
+  {
+    GetDisks(localDrives, false);
+  }
+  void GetRemovableDrives(std::vector<CMediaSource>& removableDrives) override
+  {
+    GetDisks(removableDrives, true);
+  }
 
   bool Eject(const std::string& mountpath) override;
 
@@ -121,7 +127,7 @@ private:
 
   std::vector<std::string> EnumerateDisks();
 
-  void GetDisks(VECSOURCES& devices, bool EnumerateRemovable);
+  void GetDisks(std::vector<CMediaSource>& devices, bool EnumerateRemovable);
 
   int m_DaemonVersion;
 

--- a/xbmc/platform/posix/PosixMountProvider.cpp
+++ b/xbmc/platform/posix/PosixMountProvider.cpp
@@ -25,7 +25,7 @@ void CPosixMountProvider::Initialize()
   CLog::Log(LOGDEBUG, "Selected Posix mount as storage provider");
 }
 
-void CPosixMountProvider::GetDrives(VECSOURCES &drives)
+void CPosixMountProvider::GetDrives(std::vector<CMediaSource>& drives)
 {
   std::vector<std::string> result;
 
@@ -136,7 +136,7 @@ bool CPosixMountProvider::Eject(const std::string& mountpath)
 
 bool CPosixMountProvider::PumpDriveChangeEvents(IStorageEventsCallback *callback)
 {
-  VECSOURCES drives;
+  std::vector<CMediaSource> drives;
   GetRemovableDrives(drives);
   bool changed = drives.size() != m_removableLength;
   m_removableLength = drives.size();

--- a/xbmc/platform/posix/PosixMountProvider.h
+++ b/xbmc/platform/posix/PosixMountProvider.h
@@ -22,8 +22,9 @@ public:
   void Initialize() override;
   void Stop() override { }
 
-  void GetLocalDrives(VECSOURCES &localDrives) override { GetDrives(localDrives); }
-  void GetRemovableDrives(VECSOURCES &removableDrives) override { /*GetDrives(removableDrives);*/ }
+  void GetLocalDrives(std::vector<CMediaSource>& localDrives) override { GetDrives(localDrives); }
+  void GetRemovableDrives(std::vector<CMediaSource>& removableDrives) override
+  { /*GetDrives(removableDrives);*/ }
 
   std::vector<std::string> GetDiskUsage() override;
 
@@ -31,7 +32,7 @@ public:
 
   bool PumpDriveChangeEvents(IStorageEventsCallback *callback) override;
 private:
-  void GetDrives(VECSOURCES &drives);
+  void GetDrives(std::vector<CMediaSource>& drives);
 
   unsigned int m_removableLength;
 };

--- a/xbmc/platform/win10/storage/Win10StorageProvider.cpp
+++ b/xbmc/platform/win10/storage/Win10StorageProvider.cpp
@@ -44,7 +44,7 @@ CStorageProvider::~CStorageProvider()
 void CStorageProvider::Initialize()
 {
   m_changed = false;
-  VECSOURCES vShare;
+  std::vector<CMediaSource> vShare;
   GetDrivesByType(vShare, DVD_DRIVES);
   if (!vShare.empty())
     CServiceBroker::GetMediaManager().SetHasOpticalDrive(true);
@@ -67,7 +67,7 @@ void CStorageProvider::Initialize()
   m_watcher.Start();
 }
 
-void CStorageProvider::GetLocalDrives(VECSOURCES &localDrives)
+void CStorageProvider::GetLocalDrives(std::vector<CMediaSource>& localDrives)
 {
   CMediaSource share;
   share.strPath = CSpecialProtocol::TranslatePath("special://home");
@@ -79,7 +79,7 @@ void CStorageProvider::GetLocalDrives(VECSOURCES &localDrives)
   GetDrivesByType(localDrives, LOCAL_DRIVES, true);
 }
 
-void CStorageProvider::GetRemovableDrives(VECSOURCES &removableDrives)
+void CStorageProvider::GetRemovableDrives(std::vector<CMediaSource>& removableDrives)
 {
   using KODI::PLATFORM::WINDOWS::FromW;
 
@@ -124,7 +124,7 @@ void CStorageProvider::GetRemovableDrives(VECSOURCES &removableDrives)
 
 std::string CStorageProvider::GetFirstOpticalDeviceFileName()
 {
-  VECSOURCES vShare;
+  std::vector<CMediaSource> vShare;
   std::string strdevice = "\\\\.\\";
   GetDrivesByType(vShare, DVD_DRIVES);
 
@@ -187,7 +187,9 @@ bool CStorageProvider::PumpDriveChangeEvents(IStorageEventsCallback *callback)
   return res;
 }
 
-void CStorageProvider::GetDrivesByType(VECSOURCES & localDrives, Drive_Types eDriveType, bool bonlywithmedia)
+void CStorageProvider::GetDrivesByType(std::vector<CMediaSource>& localDrives,
+                                       Drive_Types eDriveType,
+                                       bool bonlywithmedia)
 {
   DWORD drivesBits = GetLogicalDrives();
   if (drivesBits == 0)

--- a/xbmc/platform/win10/storage/Win10StorageProvider.h
+++ b/xbmc/platform/win10/storage/Win10StorageProvider.h
@@ -23,8 +23,8 @@ public:
   void Initialize() override;
   void Stop() override { }
 
-  void GetLocalDrives(VECSOURCES &localDrives) override;
-  void GetRemovableDrives(VECSOURCES &removableDrives) override;
+  void GetLocalDrives(std::vector<CMediaSource>& localDrives) override;
+  void GetRemovableDrives(std::vector<CMediaSource>& removableDrives) override;
   std::string GetFirstOpticalDeviceFileName() override;
   bool Eject(const std::string& mountpath) override;
   std::vector<std::string> GetDiskUsage() override;
@@ -38,7 +38,9 @@ private:
     REMOVABLE_DRIVES,
     DVD_DRIVES
   };
-  static void GetDrivesByType(VECSOURCES &localDrives, Drive_Types eDriveType = ALL_DRIVES, bool bonlywithmedia = false);
+  static void GetDrivesByType(std::vector<CMediaSource>& localDrives,
+                              Drive_Types eDriveType = ALL_DRIVES,
+                              bool bonlywithmedia = false);
 
   winrt::Windows::Devices::Enumeration::DeviceWatcher m_watcher{ nullptr };
   std::atomic<bool> m_changed;

--- a/xbmc/platform/win32/storage/Win32StorageProvider.cpp
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.cpp
@@ -31,7 +31,7 @@ std::unique_ptr<IStorageProvider> IStorageProvider::CreateInstance()
 void CWin32StorageProvider::Initialize()
 {
   // check for a DVD drive
-  VECSOURCES vShare;
+  std::vector<CMediaSource> vShare;
   GetDrivesByType(vShare, DVD_DRIVES);
   if(!vShare.empty())
     CServiceBroker::GetMediaManager().SetHasOpticalDrive(true);
@@ -48,7 +48,7 @@ void CWin32StorageProvider::Initialize()
 #endif
 }
 
-void CWin32StorageProvider::GetLocalDrives(VECSOURCES &localDrives)
+void CWin32StorageProvider::GetLocalDrives(std::vector<CMediaSource>& localDrives)
 {
   CMediaSource share;
   wchar_t profilePath[MAX_PATH];
@@ -65,14 +65,14 @@ void CWin32StorageProvider::GetLocalDrives(VECSOURCES &localDrives)
   GetDrivesByType(localDrives, LOCAL_DRIVES);
 }
 
-void CWin32StorageProvider::GetRemovableDrives(VECSOURCES &removableDrives)
+void CWin32StorageProvider::GetRemovableDrives(std::vector<CMediaSource>& removableDrives)
 {
   GetDrivesByType(removableDrives, REMOVABLE_DRIVES, true);
 }
 
 std::string CWin32StorageProvider::GetFirstOpticalDeviceFileName()
 {
-  VECSOURCES vShare;
+  std::vector<CMediaSource> vShare;
   std::string strdevice = "\\\\.\\";
   GetDrivesByType(vShare, DVD_DRIVES);
 
@@ -175,7 +175,9 @@ bool CWin32StorageProvider::PumpDriveChangeEvents(IStorageEventsCallback *callba
   return b;
 }
 
-void CWin32StorageProvider::GetDrivesByType(VECSOURCES &localDrives, Drive_Types eDriveType, bool bonlywithmedia)
+void CWin32StorageProvider::GetDrivesByType(std::vector<CMediaSource>& localDrives,
+                                            Drive_Types eDriveType,
+                                            bool bonlywithmedia)
 {
   using KODI::PLATFORM::WINDOWS::FromW;
 

--- a/xbmc/platform/win32/storage/Win32StorageProvider.h
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.h
@@ -31,8 +31,8 @@ public:
   virtual void Initialize();
   virtual void Stop() { }
 
-  virtual void GetLocalDrives(VECSOURCES &localDrives);
-  virtual void GetRemovableDrives(VECSOURCES &removableDrives);
+  virtual void GetLocalDrives(std::vector<CMediaSource>& localDrives);
+  virtual void GetRemovableDrives(std::vector<CMediaSource>& removableDrives);
   virtual std::string GetFirstOpticalDeviceFileName();
 
   virtual bool Eject(const std::string& mountpath);
@@ -45,7 +45,9 @@ public:
   static bool xbevent;
 
 private:
-  static void GetDrivesByType(VECSOURCES &localDrives, Drive_Types eDriveType=ALL_DRIVES, bool bonlywithmedia=false);
+  static void GetDrivesByType(std::vector<CMediaSource>& localDrives,
+                              Drive_Types eDriveType = ALL_DRIVES,
+                              bool bonlywithmedia = false);
   static DEVINST GetDrivesDevInstByDiskNumber(long DiskNumber);
 };
 

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -225,7 +225,7 @@ void CGUIDialogProfileSettings::OnSettingAction(const std::shared_ptr<const CSet
   const std::string &settingId = setting->GetId();
   if (settingId == SETTING_PROFILE_IMAGE)
   {
-    VECSOURCES shares;
+    std::vector<CMediaSource> shares;
     CServiceBroker::GetMediaManager().GetLocalDrives(shares);
 
     CFileItemList items;
@@ -361,7 +361,7 @@ void CGUIDialogProfileSettings::InitializeSettings()
 
 bool CGUIDialogProfileSettings::GetProfilePath(std::string &directory, bool isDefault)
 {
-  VECSOURCES shares;
+  std::vector<CMediaSource> shares;
   CMediaSource share;
   share.strName = g_localizeStrings.Get(13200);
   share.strPath = "special://masterprofile/profiles/";

--- a/xbmc/programs/GUIViewStatePrograms.cpp
+++ b/xbmc/programs/GUIViewStatePrograms.cpp
@@ -51,7 +51,7 @@ std::string CGUIViewStateWindowPrograms::GetExtensions()
   return ".cut";
 }
 
-VECSOURCES& CGUIViewStateWindowPrograms::GetSources()
+std::vector<CMediaSource>& CGUIViewStateWindowPrograms::GetSources()
 {
 #if defined(TARGET_ANDROID)
   {
@@ -66,7 +66,8 @@ VECSOURCES& CGUIViewStateWindowPrograms::GetSources()
   }
 #endif
 
-  VECSOURCES *programSources = CMediaSourceSettings::GetInstance().GetSources("programs");
+  std::vector<CMediaSource>* programSources =
+      CMediaSourceSettings::GetInstance().GetSources("programs");
   AddOrReplace(*programSources, CGUIViewState::GetSources());
   return *programSources;
 }

--- a/xbmc/programs/GUIViewStatePrograms.h
+++ b/xbmc/programs/GUIViewStatePrograms.h
@@ -19,6 +19,6 @@ protected:
   void SaveViewState() override;
   std::string GetLockType() override;
   std::string GetExtensions() override;
-  VECSOURCES& GetSources() override;
+  std::vector<CMediaSource>& GetSources() override;
 };
 

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -154,7 +154,7 @@ std::string CGUIWindowPrograms::GetStartFolder(const std::string &dir)
     return "androidapp://sources/apps/";
 
   SetupShares();
-  VECSOURCES shares;
+  std::vector<CMediaSource> shares;
   m_rootDir.GetSources(shares);
   bool bIsSourceName = false;
   int iIndex = CUtil::GetMatchingSource(dir, shares, bIsSourceName);

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -426,7 +426,7 @@ bool CGUIDialogPVRChannelManager::OnClickButtonChannelLogo()
   items.Add(nothumb);
 
   std::string strThumb;
-  VECSOURCES shares;
+  std::vector<CMediaSource> shares;
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   if (settings->GetString(CSettings::SETTING_PVRMENU_ICONPATH) != "")
   {

--- a/xbmc/pvr/guilib/PVRGUIActionsEPG.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsEPG.cpp
@@ -231,7 +231,7 @@ bool CPVRGUIActionsEPG::ChooseIconForSavedSearch(const CFileItem& item)
   items.Add(std::move(nothumb));
 
   std::string icon;
-  VECSOURCES sources;
+  std::vector<CMediaSource> sources;
   CServiceBroker::GetMediaManager().GetLocalDrives(sources);
   if (!CGUIDialogFileBrowser::ShowAndGetImage(items, sources,
                                               g_localizeStrings.Get(19285), // Browse for icon

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -228,7 +228,7 @@ void CDisplaySettings::OnSettingAction(const std::shared_ptr<const CSetting>& se
   if (settingId == "videoscreen.cms3dlut")
   {
     std::string path = std::static_pointer_cast<const CSettingString>(setting)->GetValue();
-    VECSOURCES shares;
+    std::vector<CMediaSource> shares;
     CServiceBroker::GetMediaManager().GetLocalDrives(shares);
     if (CGUIDialogFileBrowser::ShowAndGetFile(shares, ".3dlut", g_localizeStrings.Get(36580), path))
     {
@@ -238,7 +238,7 @@ void CDisplaySettings::OnSettingAction(const std::shared_ptr<const CSetting>& se
   else if (settingId == "videoscreen.displayprofile")
   {
     std::string path = std::static_pointer_cast<const CSettingString>(setting)->GetValue();
-    VECSOURCES shares;
+    std::vector<CMediaSource> shares;
     CServiceBroker::GetMediaManager().GetLocalDrives(shares);
     if (CGUIDialogFileBrowser::ShowAndGetFile(shares, ".icc|.icm", g_localizeStrings.Get(36581), path))
     {

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -331,7 +331,7 @@ void CMediaSettings::OnSettingAction(const std::shared_ptr<const CSetting>& sett
   else if (settingId == CSettings::SETTING_MUSICLIBRARY_IMPORT)
   {
     std::string path;
-    VECSOURCES shares;
+    std::vector<CMediaSource> shares;
     CServiceBroker::GetMediaManager().GetLocalDrives(shares);
     CServiceBroker::GetMediaManager().GetNetworkLocations(shares);
     CServiceBroker::GetMediaManager().GetRemovableDrives(shares);
@@ -355,7 +355,7 @@ void CMediaSettings::OnSettingAction(const std::shared_ptr<const CSetting>& sett
   else if (settingId == CSettings::SETTING_VIDEOLIBRARY_IMPORT)
   {
     std::string path;
-    VECSOURCES shares;
+    std::vector<CMediaSource> shares;
     CServiceBroker::GetMediaManager().GetLocalDrives(shares);
     CServiceBroker::GetMediaManager().GetNetworkLocations(shares);
     CServiceBroker::GetMediaManager().GetRemovableDrives(shares);

--- a/xbmc/settings/MediaSourceSettings.cpp
+++ b/xbmc/settings/MediaSourceSettings.cpp
@@ -142,7 +142,7 @@ void CMediaSourceSettings::Clear()
   m_gameSources.clear();
 }
 
-VECSOURCES* CMediaSourceSettings::GetSources(const std::string& type)
+std::vector<CMediaSource>* CMediaSourceSettings::GetSources(const std::string& type)
 {
   if (type == "programs" || type == "myprograms")
     return &m_programSources;
@@ -192,11 +192,11 @@ bool CMediaSourceSettings::UpdateSource(const std::string& strType,
                                         const std::string& strUpdateChild,
                                         const std::string& strUpdateValue)
 {
-  VECSOURCES* pShares = GetSources(strType);
+  std::vector<CMediaSource>* pShares = GetSources(strType);
   if (pShares == NULL)
     return false;
 
-  for (IVECSOURCES it = pShares->begin(); it != pShares->end(); ++it)
+  for (std::vector<CMediaSource>::iterator it = pShares->begin(); it != pShares->end(); ++it)
   {
     if (it->strName == strOldName)
     {
@@ -231,13 +231,13 @@ bool CMediaSourceSettings::DeleteSource(const std::string& strType,
                                         const std::string& strPath,
                                         bool virtualSource /* = false */)
 {
-  VECSOURCES* pShares = GetSources(strType);
+  std::vector<CMediaSource>* pShares = GetSources(strType);
   if (pShares == NULL)
     return false;
 
   bool found = false;
 
-  for (IVECSOURCES it = pShares->begin(); it != pShares->end(); ++it)
+  for (std::vector<CMediaSource>::iterator it = pShares->begin(); it != pShares->end(); ++it)
   {
     if (it->strName == strName && it->strPath == strPath)
     {
@@ -256,7 +256,7 @@ bool CMediaSourceSettings::DeleteSource(const std::string& strType,
 
 bool CMediaSourceSettings::AddShare(const std::string& type, const CMediaSource& share)
 {
-  VECSOURCES* pShares = GetSources(type);
+  std::vector<CMediaSource>* pShares = GetSources(type);
   if (pShares == NULL)
     return false;
 
@@ -295,13 +295,13 @@ bool CMediaSourceSettings::UpdateShare(const std::string& type,
                                        const std::string& oldName,
                                        const CMediaSource& share)
 {
-  VECSOURCES* pShares = GetSources(type);
+  std::vector<CMediaSource>* pShares = GetSources(type);
   if (pShares == NULL)
     return false;
 
   // update our current share list
   CMediaSource* pShare = NULL;
-  for (IVECSOURCES it = pShares->begin(); it != pShares->end(); ++it)
+  for (std::vector<CMediaSource>::iterator it = pShares->begin(); it != pShares->end(); ++it)
   {
     if (it->strName == oldName)
     {
@@ -442,7 +442,7 @@ bool CMediaSourceSettings::GetSource(const std::string& category,
 
 void CMediaSourceSettings::GetSources(const tinyxml2::XMLNode* rootElement,
                                       const std::string& tagName,
-                                      VECSOURCES& items,
+                                      std::vector<CMediaSource>& items,
                                       std::string& defaultString)
 {
 
@@ -490,7 +490,7 @@ void CMediaSourceSettings::GetSources(const tinyxml2::XMLNode* rootElement,
 
 bool CMediaSourceSettings::SetSources(tinyxml2::XMLNode* root,
                                       const char* section,
-                                      const VECSOURCES& shares,
+                                      const std::vector<CMediaSource>& shares,
                                       const std::string& defaultPath) const
 {
   auto* doc = root->GetDocument();
@@ -501,7 +501,7 @@ bool CMediaSourceSettings::SetSources(tinyxml2::XMLNode* root,
     return false;
 
   XMLUtils::SetPath(sectionNode, "default", defaultPath);
-  for (CIVECSOURCES it = shares.begin(); it != shares.end(); ++it)
+  for (std::vector<CMediaSource>::const_iterator it = shares.begin(); it != shares.end(); ++it)
   {
     const CMediaSource& share = *it;
     if (share.m_ignore)

--- a/xbmc/settings/MediaSourceSettings.h
+++ b/xbmc/settings/MediaSourceSettings.h
@@ -36,7 +36,7 @@ public:
   bool Save(const std::string &file) const;
   void Clear();
 
-  VECSOURCES* GetSources(const std::string &type);
+  std::vector<CMediaSource>* GetSources(const std::string& type);
   const std::string& GetDefaultSource(const std::string &type) const;
   void SetDefaultSource(const std::string &type, const std::string &source);
 
@@ -55,19 +55,19 @@ private:
   bool GetSource(const std::string& category, const tinyxml2::XMLNode* source, CMediaSource& share);
   void GetSources(const tinyxml2::XMLNode* rootElement,
                   const std::string& tagName,
-                  VECSOURCES& items,
+                  std::vector<CMediaSource>& items,
                   std::string& defaultString);
   bool SetSources(tinyxml2::XMLNode* rootNode,
                   const char* section,
-                  const VECSOURCES& shares,
+                  const std::vector<CMediaSource>& shares,
                   const std::string& defaultPath) const;
 
-  VECSOURCES m_programSources;
-  VECSOURCES m_pictureSources;
-  VECSOURCES m_fileSources;
-  VECSOURCES m_musicSources;
-  VECSOURCES m_videoSources;
-  VECSOURCES m_gameSources;
+  std::vector<CMediaSource> m_programSources;
+  std::vector<CMediaSource> m_pictureSources;
+  std::vector<CMediaSource> m_fileSources;
+  std::vector<CMediaSource> m_musicSources;
+  std::vector<CMediaSource> m_videoSources;
+  std::vector<CMediaSource> m_gameSources;
 
   std::string m_defaultProgramSource;
   std::string m_defaultMusicSource;

--- a/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
@@ -148,7 +148,7 @@ void CGUIDialogLibExportSettings::OnSettingAction(const std::shared_ptr<const CS
   if (settingId == CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER && !m_settings.IsToLibFolders() &&
       !m_settings.IsArtistFoldersOnly())
   {
-    VECSOURCES shares;
+    std::vector<CMediaSource> shares;
     CServiceBroker::GetMediaManager().GetLocalDrives(shares);
     CServiceBroker::GetMediaManager().GetNetworkLocations(shares);
     CServiceBroker::GetMediaManager().GetRemovableDrives(shares);

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -1173,7 +1173,7 @@ bool CGUIControlButtonSetting::GetPath(const std::shared_ptr<CSettingPath>& path
 
   std::string path = pathSetting->GetValue();
 
-  VECSOURCES shares;
+  std::vector<CMediaSource> shares;
   bool localSharesOnly = false;
   const std::vector<std::string>& sources = pathSetting->GetSources();
   for (const auto& source : sources)
@@ -1182,7 +1182,7 @@ bool CGUIControlButtonSetting::GetPath(const std::shared_ptr<CSettingPath>& path
       localSharesOnly = true;
     else
     {
-      VECSOURCES* sources = CMediaSourceSettings::GetInstance().GetSources(source);
+      std::vector<CMediaSource>* sources = CMediaSourceSettings::GetInstance().GetSources(source);
       if (sources != NULL)
         shares.insert(shares.end(), sources->begin(), sources->end());
     }

--- a/xbmc/storage/IStorageProvider.h
+++ b/xbmc/storage/IStorageProvider.h
@@ -70,8 +70,8 @@ public:
   virtual void Initialize() = 0;
   virtual void Stop() = 0;
 
-  virtual void GetLocalDrives(VECSOURCES &localDrives) = 0;
-  virtual void GetRemovableDrives(VECSOURCES &removableDrives) = 0;
+  virtual void GetLocalDrives(std::vector<CMediaSource>& localDrives) = 0;
+  virtual void GetRemovableDrives(std::vector<CMediaSource>& removableDrives) = 0;
   virtual std::string GetFirstOpticalDeviceFileName()
   {
 #ifdef HAS_OPTICAL_DRIVE

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -146,20 +146,20 @@ bool CMediaManager::SaveSources()
   return doc.SaveFile(MEDIA_SOURCES_XML);
 }
 
-void CMediaManager::GetLocalDrives(VECSOURCES &localDrives, bool includeQ)
+void CMediaManager::GetLocalDrives(std::vector<CMediaSource>& localDrives, bool includeQ)
 {
   std::unique_lock<CCriticalSection> lock(m_CritSecStorageProvider);
   m_platformStorage->GetLocalDrives(localDrives);
 }
 
-void CMediaManager::GetRemovableDrives(VECSOURCES &removableDrives)
+void CMediaManager::GetRemovableDrives(std::vector<CMediaSource>& removableDrives)
 {
   std::unique_lock<CCriticalSection> lock(m_CritSecStorageProvider);
   if (m_platformStorage)
     m_platformStorage->GetRemovableDrives(removableDrives);
 }
 
-void CMediaManager::GetNetworkLocations(VECSOURCES &locations, bool autolocations)
+void CMediaManager::GetNetworkLocations(std::vector<CMediaSource>& locations, bool autolocations)
 {
   for (unsigned int i = 0; i < m_locations.size(); i++)
   {
@@ -609,7 +609,7 @@ std::string CMediaManager::GetDiscPath()
 #else
 
   std::unique_lock<CCriticalSection> lock(m_CritSecStorageProvider);
-  VECSOURCES drives;
+  std::vector<CMediaSource> drives;
   m_platformStorage->GetRemovableDrives(drives);
   for(unsigned i = 0; i < drives.size(); ++i)
   {

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "IStorageProvider.h"
-#include "MediaSource.h" // for VECSOURCES
+#include "MediaSource.h" // for std::vector<CMediaSource>
 #include "storage/discs/IDiscDriveHandler.h"
 #include "threads/CriticalSection.h"
 #include "utils/DiscsUtils.h"
@@ -42,9 +42,9 @@ public:
   bool LoadSources();
   bool SaveSources();
 
-  void GetLocalDrives(VECSOURCES &localDrives, bool includeQ = true);
-  void GetRemovableDrives(VECSOURCES &removableDrives);
-  void GetNetworkLocations(VECSOURCES &locations, bool autolocations = true);
+  void GetLocalDrives(std::vector<CMediaSource>& localDrives, bool includeQ = true);
+  void GetRemovableDrives(std::vector<CMediaSource>& removableDrives);
+  void GetNetworkLocations(std::vector<CMediaSource>& locations, bool autolocations = true);
 
   bool AddNetworkLocation(const std::string &path);
   bool HasLocation(const std::string& path) const;

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -145,7 +145,7 @@ bool CFileUtils::RemoteAccessAllowed(const std::string &strPath)
   // Check manually added sources (held in sources.xml)
   for (const std::string& sourceName : SourceNames)
   {
-    VECSOURCES* sources = CMediaSourceSettings::GetInstance().GetSources(sourceName);
+    std::vector<CMediaSource>* sources = CMediaSourceSettings::GetInstance().GetSources(sourceName);
     int sourceIndex = CUtil::GetMatchingSource(realPath, *sources, isSource);
     if (sourceIndex >= 0 && sourceIndex < static_cast<int>(sources->size()) &&
         sources->at(sourceIndex).m_iHasLock != LOCK_STATE_LOCKED &&
@@ -153,7 +153,7 @@ bool CFileUtils::RemoteAccessAllowed(const std::string &strPath)
       return true;
   }
   // Check auto-mounted sources
-  VECSOURCES sources;
+  std::vector<CMediaSource> sources;
   CServiceBroker::GetMediaManager().GetRemovableDrives(
       sources); // Sources returned always have m_allowsharing = true
   //! @todo Make sharing of auto-mounted sources user configurable

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -45,7 +45,7 @@ PLAYLIST::Id CGUIViewStateWindowVideo::GetPlaylist() const
   return PLAYLIST::Id::TYPE_VIDEO;
 }
 
-VECSOURCES& CGUIViewStateWindowVideo::GetSources()
+std::vector<CMediaSource>& CGUIViewStateWindowVideo::GetSources()
 {
   AddLiveTVSources();
   return CGUIViewState::GetSources();
@@ -383,7 +383,7 @@ void CGUIViewStateWindowVideoNav::SaveViewState()
   }
 }
 
-VECSOURCES& CGUIViewStateWindowVideoNav::GetSources()
+std::vector<CMediaSource>& CGUIViewStateWindowVideoNav::GetSources()
 {
   //  Setup shares we want to have
   m_sources.clear();
@@ -442,7 +442,7 @@ bool CGUIViewStateWindowVideoPlaylist::HideParentDirItems()
   return true;
 }
 
-VECSOURCES& CGUIViewStateWindowVideoPlaylist::GetSources()
+std::vector<CMediaSource>& CGUIViewStateWindowVideoPlaylist::GetSources()
 {
   m_sources.clear();
   //  Playlist share

--- a/xbmc/video/GUIViewStateVideo.h
+++ b/xbmc/video/GUIViewStateVideo.h
@@ -16,7 +16,7 @@ public:
   explicit CGUIViewStateWindowVideo(const CFileItemList& items) : CGUIViewState(items) {}
 
 protected:
-  VECSOURCES& GetSources() override;
+  std::vector<CMediaSource>& GetSources() override;
   std::string GetLockType() override;
   KODI::PLAYLIST::Id GetPlaylist() const override;
   std::string GetExtensions() override;
@@ -40,7 +40,7 @@ public:
 
 protected:
   void SaveViewState() override;
-  VECSOURCES& GetSources() override;
+  std::vector<CMediaSource>& GetSources() override;
 };
 
 class CGUIViewStateWindowVideoPlaylist : public CGUIViewStateWindowVideo
@@ -52,7 +52,7 @@ protected:
   void SaveViewState() override;
   bool HideExtensions() override;
   bool HideParentDirItems() override;
-  VECSOURCES& GetSources() override;
+  std::vector<CMediaSource>& GetSources() override;
   bool AutoPlayNextItem() override { return false; }
 };
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -10059,7 +10059,8 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
     if (m_pDS2->num_rows() > 0)
     {
       std::string filesToTestForDelete;
-      VECSOURCES videoSources(*CMediaSourceSettings::GetInstance().GetSources("video"));
+      std::vector<CMediaSource> videoSources(
+          *CMediaSourceSettings::GetInstance().GetSources("video"));
       CServiceBroker::GetMediaManager().GetRemovableDrives(videoSources);
 
       int total = m_pDS2->num_rows();
@@ -10458,7 +10459,7 @@ std::vector<int> CVideoDatabase::CleanMediaType(const std::string &mediaType, co
                     parentPathIdField.c_str(),
                     table.c_str(), cleanableFileIDs.c_str());
 
-  VECSOURCES videoSources(*CMediaSourceSettings::GetInstance().GetSources("video"));
+  std::vector<CMediaSource> videoSources(*CMediaSourceSettings::GetInstance().GetSources("video"));
   CServiceBroker::GetMediaManager().GetRemovableDrives(videoSources);
 
   // map of parent path ID to boolean pair (if not exists and user choice)

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -146,7 +146,7 @@ std::string CGUIDialogSubtitleSettings::BrowseForSubtitle()
 
   strMask += extras;
 
-  VECSOURCES shares(*CMediaSourceSettings::GetInstance().GetSources("video"));
+  std::vector<CMediaSource> shares(*CMediaSourceSettings::GetInstance().GetSources("video"));
   if (CMediaSettings::GetInstance().GetAdditionalSubtitleDirectoryChecked() != -1 && !CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_SUBTITLES_CUSTOMPATH).empty())
   {
     CMediaSource share;

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -110,7 +110,7 @@ bool CGUIDialogVideoManagerExtras::AddVideoExtra()
   const MediaType mediaType{m_videoAsset->GetVideoInfoTag()->m_type};
 
   // prompt to choose a video file
-  VECSOURCES sources{*CMediaSourceSettings::GetInstance().GetSources("files")};
+  std::vector<CMediaSource> sources{*CMediaSourceSettings::GetInstance().GetSources("files")};
 
   CServiceBroker::GetMediaManager().GetLocalDrives(sources);
   CServiceBroker::GetMediaManager().GetNetworkLocations(sources);

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -479,7 +479,7 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
   const MediaType mediaType{m_videoAsset->GetVideoInfoTag()->m_type};
 
   // prompt to choose a video file
-  VECSOURCES sources{*CMediaSourceSettings::GetInstance().GetSources("files")};
+  std::vector<CMediaSource> sources{*CMediaSourceSettings::GetInstance().GetSources("files")};
 
   CServiceBroker::GetMediaManager().GetLocalDrives(sources);
   CServiceBroker::GetMediaManager().GetNetworkLocations(sources);

--- a/xbmc/video/windows/GUIWindowVideoNav.h
+++ b/xbmc/video/windows/GUIWindowVideoNav.h
@@ -56,7 +56,7 @@ protected:
   bool OnClick(int iItem, const std::string &player = "") override;
   std::string GetStartFolder(const std::string &dir) override;
 
-  VECSOURCES m_shares;
+  std::vector<CMediaSource> m_shares;
 
 private:
   virtual SelectFirstUnwatchedItem GetSettingSelectFirstUnwatchedItem();

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.h
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.h
@@ -40,5 +40,5 @@ protected:
   void SavePlayList();
 
   int m_movingFrom;
-  VECSOURCES m_shares;
+  std::vector<CMediaSource> m_shares;
 };

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -52,7 +52,7 @@ using namespace ADDON;
 using namespace PVR;
 
 std::string CGUIViewState::m_strPlaylistDirectory;
-VECSOURCES CGUIViewState::m_sources;
+std::vector<CMediaSource> CGUIViewState::m_sources;
 
 CGUIViewState* CGUIViewState::GetViewState(int windowId, const CFileItemList& items)
 {
@@ -462,15 +462,15 @@ std::string CGUIViewState::GetExtensions()
   return "";
 }
 
-VECSOURCES& CGUIViewState::GetSources()
+std::vector<CMediaSource>& CGUIViewState::GetSources()
 {
   return m_sources;
 }
 
 void CGUIViewState::AddLiveTVSources()
 {
-  VECSOURCES *sources = CMediaSourceSettings::GetInstance().GetSources("video");
-  for (IVECSOURCES it = sources->begin(); it != sources->end(); ++it)
+  std::vector<CMediaSource>* sources = CMediaSourceSettings::GetInstance().GetSources("video");
+  for (std::vector<CMediaSource>::iterator it = sources->begin(); it != sources->end(); ++it)
   {
     if (URIUtils::IsLiveTV((*it).strPath))
     {

--- a/xbmc/view/GUIViewState.h
+++ b/xbmc/view/GUIViewState.h
@@ -58,7 +58,7 @@ public:
 
   virtual std::string GetLockType();
   virtual std::string GetExtensions();
-  virtual VECSOURCES& GetSources();
+  virtual std::vector<CMediaSource>& GetSources();
 
 protected:
   explicit CGUIViewState(const CFileItemList& items);  // no direct object creation, use GetViewState()
@@ -93,7 +93,7 @@ protected:
   std::vector<GUIViewSortDetails> m_sortMethods;
   int m_currentSortMethod;
 
-  static VECSOURCES m_sources;
+  static std::vector<CMediaSource> m_sources;
   static std::string m_strPlaylistDirectory;
 };
 

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -866,7 +866,7 @@ bool CGUIMediaWindow::Update(const std::string &strDirectory, bool updateFilterP
   if (m_vecItems->GetLabel().empty())
   {
     // Removable sources
-    VECSOURCES removables;
+    std::vector<CMediaSource> removables;
     CServiceBroker::GetMediaManager().GetRemovableDrives(removables);
     for (const auto& s : removables)
     {

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -1301,7 +1301,7 @@ void CGUIWindowFileManager::SetInitialPath(const std::string &path)
       m_Directory[0]->SetPath("");
 
       bool bIsSourceName = false;
-      VECSOURCES shares;
+      std::vector<CMediaSource> shares;
       m_rootDir.GetSources(shares);
       int iIndex = CUtil::GetMatchingSource(strDestination, shares, bIsSourceName);
       if (iIndex > -1


### PR DESCRIPTION
## Description
This PR kills the following annoying `typedefs`:

```
typedef std::vector<CMediaSource> VECSOURCES;
typedef std::vector<CMediaSource>::iterator IVECSOURCES;
typedef std::vector<CMediaSource>::const_iterator CIVECSOURCES;
```

No other changes included.