### PR TITLE
[VideoPlayer] Fix and improve subtitle stream selection

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24230,7 +24230,19 @@ msgctxt "#39203"
 msgid "Adjust the space between lines of text. Setting a value too low may cause boxes to overlap when the \"Background type\" setting is used."
 msgstr ""
 
-#empty strings from id 39204 to 39999
+#. Setting to make CC subtitles for hearing impaired only
+#: system/settings/settings.xml
+msgctxt "#39204"
+msgid "Set CC subtitles only for the hearing impaired"
+msgstr ""
+
+#. Help text for setting of label #39204
+#: system/settings/settings.xml
+msgctxt "#39205"
+msgid "By enabling it, CC subtitles will be labeled for the hearing impaired; this will affect the automatic selection of subtitles, which unless otherwise specified will not be displayed by default."
+msgstr ""
+
+#empty strings from id 39206 to 39999
 
 # 40000 to 40800 are reserved for Video Versions feature
 

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -588,6 +588,13 @@
           <control type="toggle" />
         </setting>
       </group>
+      <group id="4" label="39187">
+        <setting id="subtitles.captionsimpaired" type="boolean" label="39204" help="39205">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+      </group>
     </category>
     <category id="subtitles" label="287" help="37033">
       <group id="1" label="39186">

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -801,12 +801,12 @@ bool CLangInfo::SetLanguage(std::string language /* = "" */, bool reloadServices
   return true;
 }
 
-const std::string& CLangInfo::GetAudioLanguage() const
+const std::string& CLangInfo::GetAudioLanguage(bool allowFallback) const
 {
-  if (!m_audioLanguage.empty())
-    return m_audioLanguage;
+  if (allowFallback && m_audioLanguage.empty())
+    return m_languageCodeGeneral;
 
-  return m_languageCodeGeneral;
+  return m_audioLanguage;
 }
 
 void CLangInfo::SetAudioLanguage(const std::string& language, bool isIso6392 /* = false */)
@@ -836,12 +836,12 @@ void CLangInfo::SetAudioLanguage(const std::string& language, bool isIso6392 /* 
   m_audioLanguage = langISO6392; // empty value for error cases
 }
 
-const std::string& CLangInfo::GetSubtitleLanguage() const
+const std::string& CLangInfo::GetSubtitleLanguage(bool allowFallback) const
 {
-  if (!m_subtitleLanguage.empty())
-    return m_subtitleLanguage;
+  if (allowFallback && m_subtitleLanguage.empty())
+    return m_languageCodeGeneral;
 
-  return m_languageCodeGeneral;
+  return m_subtitleLanguage;
 }
 
 void CLangInfo::SetSubtitleLanguage(const std::string& language, bool isIso6392 /* = false */)

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -105,10 +105,11 @@ public:
 
   /*
    * \brief Get the audio language in ISO 639-2 format.
-   * \return The language code (user-defined also allowed), otherwise if "default", "original" or "mediadefault" is set
-   *         to the audio language setting, will fallback to a general language code (e.g. eng)
+   * \param allowFallback If set to true, when audio language setting is set to "default", "original" or "mediadefault"
+   *                      the returned value can fallback to a general language code (e.g. eng), otherwise an empty value is returned.
+   * \return The language code (user-defined also allowed). The value can be empty when allowFallback if set to false.
    */
-  const std::string& GetAudioLanguage() const;
+  const std::string& GetAudioLanguage(bool allowFallback) const;
 
   /*
    * \brief Set the audio language.
@@ -121,10 +122,11 @@ public:
 
   /*
    * \brief Get the subtitle language in ISO 639-2 format.
-   * \return The language code (user-defined also allowed), otherwise if "default", "original" is set
-   *         to the subtitle language setting, will fallback to a general language code (e.g. eng)
+   * \param allowFallback If set to true, when audio language setting is set to "default", "original"
+   *                      the returned value can fallback to a general language code (e.g. eng), otherwise an empty value is returned.
+   * \return The language code (user-defined also allowed). The value can be empty when allowFallback if set to false.
    */
-  const std::string& GetSubtitleLanguage() const;
+  const std::string& GetSubtitleLanguage(bool allowFallback) const;
 
   /*
    * \brief Set the subtitle language.

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
@@ -9,8 +9,11 @@
 #include "DVDDemuxCC.h"
 
 #include "DVDDemuxUtils.h"
+#include "ServiceBroker.h"
 #include "cores/VideoPlayer/DVDCodecs/Overlay/contrib/cc_decoder708.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/ColorUtils.h"
 #include "utils/StringUtils.h"
 
@@ -402,8 +405,13 @@ void CDVDDemuxCC::Handler(int service, void *userdata)
   {
     CDemuxStreamSubtitle stream;
     stream.source = STREAM_SOURCE_VIDEOMUX;
-    stream.language = "cc";
-    stream.flags = FLAG_HEARING_IMPAIRED;
+    stream.name = "CC";
+    stream.language = "und";
+
+    auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+    if (settings->GetBool(CSettings::SETTING_SUBTITLES_CAPTIONSIMPAIRED))
+      stream.flags = FLAG_HEARING_IMPAIRED;
+
     stream.codec = AV_CODEC_ID_TEXT;
     stream.uniqueId = service;
     ctx->m_streams.push_back(std::move(stream));

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -86,68 +86,105 @@ using namespace std::chrono_literals;
 class PredicateSubtitleFilter
 {
 private:
-  std::string audiolang;
-  bool original;
-  bool nosub;
-  bool onlyforced;
-  int currentSubStream;
+  // Played audio language,
+  // may differ from the language setting if the movie does not provide it the desired language
+  std::string m_playedAudioLang;
+  std::string m_subLang;
+  bool m_isPrefOriginal;
+  bool m_isPrefForced;
+  bool m_isPrefHearingImp;
+  bool m_isSubNone;
+  int m_subStream;
+
 public:
-  /** \brief The class' operator() decides if the given (subtitle) SelectionStream is relevant wrt.
-   *          preferred subtitle language and audio language. If the subtitle is relevant <B>false</B> false is returned.
-   *
-   *          A subtitle is relevant if
-   *          - it was previously selected, or
-   *          - it's an external sub, or
-   *          - it's a forced sub and "original stream's language" was selected and audio stream language matches, or
-   *          - it's a default and a forced sub (could lead to users seeing forced subs in a foreign language!), or
-   *          - its language matches the preferred subtitle's language (unequal to "original stream's language")
+  /*
+   * \brief The class' operator() decides if the given (subtitle) SelectionStream can match user settings, so relevant.
+   *        If the subtitle is relevant "false" is returned.
    */
   explicit PredicateSubtitleFilter(const std::string& lang, int subStream)
-  : audiolang(lang),
-    currentSubStream(subStream)
+    : m_playedAudioLang(lang), m_subStream(subStream)
   {
-    const std::string subtitleLang = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_LOCALE_SUBTITLELANGUAGE);
-    original = StringUtils::EqualsNoCase(subtitleLang, "original");
-    nosub = StringUtils::EqualsNoCase(subtitleLang, "none");
-    onlyforced = StringUtils::EqualsNoCase(subtitleLang, "forced_only");
+    auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+    const std::string subLangSetting =
+        settings->GetString(CSettings::SETTING_LOCALE_SUBTITLELANGUAGE);
+
+    m_isSubNone = StringUtils::EqualsNoCase(subLangSetting, "none");
+    m_isPrefOriginal = StringUtils::EqualsNoCase(subLangSetting, "original");
+    m_isPrefForced = StringUtils::EqualsNoCase(subLangSetting, "forced_only");
+    m_isPrefHearingImp = settings->GetBool(CSettings::SETTING_ACCESSIBILITY_SUBHEARING);
+
+    m_subLang = g_langInfo.GetSubtitleLanguage(false);
+    if (m_subLang.empty()) // No language set (due to none, original, forced_only settings)
+    {
+      m_subLang = g_langInfo.GetAudioLanguage(false);
+      if (m_subLang.empty()) // No language set (due to default, original, mediadefault settings)
+        m_subLang = m_playedAudioLang;
+    }
+
+    // Dont allow "forced" setting to be combined with "impaired" setting
+    if (m_isPrefHearingImp && m_isPrefForced)
+      m_isPrefForced = false;
   };
 
   bool operator()(const SelectionStream& ss) const
   {
-    if (ss.type_index == currentSubStream)
+    if (ss.type_index == m_subStream)
       return false;
 
-    if (nosub)
+    if (m_isSubNone)
       return true;
 
-    if (onlyforced)
+    const bool isExternal = STREAM_SOURCE_MASK(ss.source) == STREAM_SOURCE_DEMUX_SUB ||
+                            STREAM_SOURCE_MASK(ss.source) == STREAM_SOURCE_TEXT;
+    const bool isCC = STREAM_SOURCE_MASK(ss.source) == STREAM_SOURCE_VIDEOMUX;
+
+    // External subtitles with unknown language always allow it
+    if (isExternal && (ss.language.empty() || ss.language == "und"))
     {
-      if ((ss.flags & StreamFlags::FLAG_FORCED) && g_LangCodeExpander.CompareISO639Codes(ss.language, audiolang))
+      return false;
+    }
+
+    const bool isSameSubLang = g_LangCodeExpander.CompareISO639Codes(ss.language, m_subLang);
+
+    if (m_isPrefHearingImp)
+    {
+      const int checkFlags = FLAG_ORIGINAL | FLAG_HEARING_IMPAIRED;
+      if ((ss.flags & checkFlags) == checkFlags)
+        return false;
+
+      // to consider CC streams may not have the language code
+      if ((ss.flags & StreamFlags::FLAG_HEARING_IMPAIRED) &&
+          (isSameSubLang || (isCC && (ss.language.empty() || ss.language == "und"))))
+      {
+        return false;
+      }
+      // fallback to regular subtitles
+      if (isSameSubLang && (ss.flags & FLAG_FORCED) == 0)
+        return false;
+
+      return true;
+    }
+
+    if (m_isPrefOriginal)
+    {
+      if ((ss.flags & FLAG_ORIGINAL))
+        return false;
+    }
+    else if (m_isPrefForced)
+    {
+      if ((ss.flags & StreamFlags::FLAG_FORCED) && isSameSubLang)
         return false;
       else
         return true;
     }
 
-    if(STREAM_SOURCE_MASK(ss.source) == STREAM_SOURCE_DEMUX_SUB || STREAM_SOURCE_MASK(ss.source) == STREAM_SOURCE_TEXT)
-      return false;
-
-    if ((ss.flags & StreamFlags::FLAG_FORCED) && g_LangCodeExpander.CompareISO639Codes(ss.language, audiolang))
-      return false;
-
-    if ((ss.flags & StreamFlags::FLAG_FORCED) && (ss.flags & StreamFlags::FLAG_DEFAULT))
-      return false;
-
-    if (ss.language == "cc" && ss.flags & StreamFlags::FLAG_HEARING_IMPAIRED)
-      return false;
-
-    if(!original)
+    // can fall here only when "forced" and "impaired" are disabled,
+    // it always enable subs if language is unknown for external and CC
+    if ((isSameSubLang || (isCC && (ss.language.empty() || ss.language == "und"))) &&
+        (ss.flags & FLAG_FORCED) == 0 && (ss.flags & FLAG_HEARING_IMPAIRED) == 0)
     {
-      std::string subtitle_language = g_langInfo.GetSubtitleLanguage();
-      if (g_LangCodeExpander.CompareISO639Codes(subtitle_language, ss.language))
-        return false;
-    }
-    else if (ss.flags & StreamFlags::FLAG_DEFAULT)
       return false;
+    }
 
     return true;
   }
@@ -175,7 +212,7 @@ public:
     {
       if (!StringUtils::EqualsNoCase(settings->GetString(CSettings::SETTING_LOCALE_AUDIOLANGUAGE), "original"))
       {
-        std::string audio_language = g_langInfo.GetAudioLanguage();
+        std::string audio_language = g_langInfo.GetAudioLanguage(true);
         PREDICATE_RETURN(g_LangCodeExpander.CompareISO639Codes(audio_language, lh.language)
           , g_LangCodeExpander.CompareISO639Codes(audio_language, rh.language));
       }
@@ -216,91 +253,147 @@ public:
   };
 };
 
-/** \brief The class' operator() decides if the given (subtitle) SelectionStream lh is 'better than' the given (subtitle) SelectionStream rh.
-*          If lh is 'better than' rh the return value is true, false otherwise.
-*
-*          A subtitle lh is 'better than' a subtitle rh (in evaluation order) if
-*          - lh was previously selected, or
-*          - lh is an external sub and rh not, or
-*          - lh is a forced sub and ("original stream's language" was selected or subtitles are off) and audio stream language matches sub language and rh not, or
-*          - lh is a default sub and ("original stream's language" was selected or subtitles are off) and audio stream language matches sub language and rh not, or
-*          - lh is a sub where audio stream language matches sub language and (original stream's language" was selected or subtitles are off) and rh not, or
-*          - lh is a forced sub and a default sub ("original stream's language" was selected or subtitles are off)
-*          - lh is an external sub and its language matches the preferred subtitle's language (unequal to "original stream's language") and rh not, or
-*          - lh is language matches the preferred subtitle's language (unequal to "original stream's language") and rh not, or
-*          - lh is a default sub and rh not
-*/
+/*
+ * \brief The class' operator() decides if the given (subtitle) SelectionStream lh is 'better than'
+ *        the given (subtitle) SelectionStream rh.
+ *        If lh is 'better than' rh the return value is true, false otherwise.
+ *        The priority sequence is exactly as shown by the code sequence of the operator() method.
+ *
+ *        NOTE: Dont exists a "default" setting for subtitles, as there is for audio (media default),
+ *              so the default flag will give a priority over another only when two streams
+ *              have same properties (e.g. same language with a same flag, but a different codec, author, etc...).
+ */
 class PredicateSubtitlePriority
 {
 private:
-  std::string audiolang;
-  bool original;
-  bool subson;
-  PredicateSubtitleFilter filter;
-  int subStream;
+  std::string m_playedAudioLang;
+  std::string m_subLang;
+  bool m_isPrefOriginal;
+  bool m_isPrefForced;
+  bool m_isPrefHearingImp;
+  PredicateSubtitleFilter m_filter;
+  int m_subStream;
+
 public:
-  explicit PredicateSubtitlePriority(const std::string& lang, int stream, bool ison)
-  : audiolang(lang),
-    original(StringUtils::EqualsNoCase(CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_LOCALE_SUBTITLELANGUAGE), "original")),
-    subson(ison),
-    filter(lang, stream),
-    subStream(stream)
+  explicit PredicateSubtitlePriority(const std::string& lang, int stream)
+    : m_playedAudioLang(lang), m_filter(lang, stream), m_subStream(stream)
   {
+    auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+    const std::string subLangSetting =
+        settings->GetString(CSettings::SETTING_LOCALE_SUBTITLELANGUAGE);
+
+    m_isPrefOriginal = StringUtils::EqualsNoCase(subLangSetting, "original");
+    m_isPrefForced = StringUtils::EqualsNoCase(subLangSetting, "forced_only");
+    m_isPrefHearingImp = settings->GetBool(CSettings::SETTING_ACCESSIBILITY_SUBHEARING);
+
+    m_subLang = g_langInfo.GetSubtitleLanguage(false);
+    if (m_subLang.empty()) // No language set (due to none, original, forced_only settings)
+    {
+      m_subLang = g_langInfo.GetAudioLanguage(false);
+      if (m_subLang.empty()) // No language set (due to default, original, mediadefault settings)
+        m_subLang = m_playedAudioLang;
+    }
+
+    // Dont allow "forced" setting to be combined with "impaired" setting
+    if (m_isPrefHearingImp && m_isPrefForced)
+      m_isPrefForced = false;
   };
 
-  bool relevant(const SelectionStream& ss) const
-  {
-    return !filter(ss);
-  }
+  // \brief Check if a stream can match the user settings
+  bool relevant(const SelectionStream& ss) const { return !m_filter(ss); }
 
   bool operator()(const SelectionStream& lh, const SelectionStream& rh) const
   {
-    PREDICATE_RETURN(relevant(lh)
-                   , relevant(rh));
+    PREDICATE_RETURN(lh.type_index == m_subStream, rh.type_index == m_subStream);
 
-    PREDICATE_RETURN(lh.type_index == subStream
-                   , rh.type_index == subStream);
+    const bool isLexternal = STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_DEMUX_SUB ||
+                             STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_TEXT;
+    const bool isRexternal = STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_DEMUX_SUB ||
+                             STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_TEXT;
 
-    // prefer external subs
-    PREDICATE_RETURN(STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_DEMUX_SUB || STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_TEXT
-                   , STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_DEMUX_SUB || STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_TEXT);
+    // prefer external subs (note that this prevents any fallback to internal subs)
+    PREDICATE_RETURN(isLexternal, isRexternal);
 
-    if (!subson || original)
+    const bool isLSameSubLang = g_LangCodeExpander.CompareISO639Codes(lh.language, m_subLang);
+    const bool isRSameSubLang = g_LangCodeExpander.CompareISO639Codes(rh.language, m_subLang);
+
+    if (m_isPrefHearingImp)
     {
-      PREDICATE_RETURN(lh.flags & StreamFlags::FLAG_FORCED && g_LangCodeExpander.CompareISO639Codes(lh.language, audiolang)
-                     , rh.flags & StreamFlags::FLAG_FORCED && g_LangCodeExpander.CompareISO639Codes(rh.language, audiolang));
+      if (m_isPrefOriginal)
+      {
+        int checkFlags = FLAG_ORIGINAL | FLAG_HEARING_IMPAIRED | FLAG_DEFAULT;
+        PREDICATE_RETURN((lh.flags & checkFlags) == checkFlags,
+                         (rh.flags & checkFlags) == checkFlags);
 
-      PREDICATE_RETURN(lh.flags & StreamFlags::FLAG_DEFAULT && g_LangCodeExpander.CompareISO639Codes(lh.language, audiolang)
-                     , rh.flags & StreamFlags::FLAG_DEFAULT && g_LangCodeExpander.CompareISO639Codes(rh.language, audiolang));
+        checkFlags = FLAG_ORIGINAL | FLAG_HEARING_IMPAIRED;
+        PREDICATE_RETURN((lh.flags & checkFlags) == checkFlags,
+                         (rh.flags & checkFlags) == checkFlags);
+      }
 
-      PREDICATE_RETURN(g_LangCodeExpander.CompareISO639Codes(lh.language, audiolang)
-                     , g_LangCodeExpander.CompareISO639Codes(rh.language, audiolang));
+      int checkFlags = FLAG_HEARING_IMPAIRED | FLAG_DEFAULT;
+      PREDICATE_RETURN((lh.flags & checkFlags) == checkFlags && isLSameSubLang,
+                       (rh.flags & checkFlags) == checkFlags && isRSameSubLang);
 
-      PREDICATE_RETURN((lh.flags & (StreamFlags::FLAG_FORCED | StreamFlags::FLAG_DEFAULT)) == (StreamFlags::FLAG_FORCED | StreamFlags::FLAG_DEFAULT)
-                     , (rh.flags & (StreamFlags::FLAG_FORCED | StreamFlags::FLAG_DEFAULT)) == (StreamFlags::FLAG_FORCED | StreamFlags::FLAG_DEFAULT));
-
+      checkFlags = FLAG_HEARING_IMPAIRED;
+      PREDICATE_RETURN((lh.flags & checkFlags) == checkFlags && isLSameSubLang,
+                       (rh.flags & checkFlags) == checkFlags && isRSameSubLang);
     }
 
-    std::string subtitle_language = g_langInfo.GetSubtitleLanguage();
-    if (!original)
+    if (m_isPrefOriginal)
     {
-      PREDICATE_RETURN((STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_DEMUX_SUB || STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_TEXT) && g_LangCodeExpander.CompareISO639Codes(subtitle_language, lh.language)
-                     , (STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_DEMUX_SUB || STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_TEXT) && g_LangCodeExpander.CompareISO639Codes(subtitle_language, rh.language));
+      // "is included" is used to not consider forced and impaired
+      const bool isLincluded =
+          (lh.flags & FLAG_FORCED) == 0 && (lh.flags & FLAG_HEARING_IMPAIRED) == 0;
+      const bool isRincluded =
+          (rh.flags & FLAG_FORCED) == 0 && (rh.flags & FLAG_HEARING_IMPAIRED) == 0;
+
+      // try find original (default) in audio language
+      const int checkFlags = FLAG_ORIGINAL | FLAG_DEFAULT;
+      PREDICATE_RETURN(isLincluded && (lh.flags & checkFlags) == checkFlags && isLSameSubLang,
+                       isRincluded && (rh.flags & checkFlags) == checkFlags && isRSameSubLang);
+
+      // try find original in audio language
+      PREDICATE_RETURN(isLincluded && (lh.flags & FLAG_ORIGINAL) && isLSameSubLang,
+                       isRincluded && (rh.flags & FLAG_ORIGINAL) && isRSameSubLang);
+
+      // try find original (default) with any language
+      PREDICATE_RETURN(isLincluded && (lh.flags & checkFlags) == checkFlags,
+                       isRincluded && (rh.flags & checkFlags) == checkFlags);
+
+      // try find original with any language
+      PREDICATE_RETURN(isLincluded && (lh.flags & FLAG_ORIGINAL),
+                       isRincluded && (rh.flags & FLAG_ORIGINAL));
+    }
+    else if (m_isPrefForced)
+    {
+      const int checkFlags = FLAG_FORCED | FLAG_DEFAULT;
+      PREDICATE_RETURN((lh.flags & checkFlags) == checkFlags && isLSameSubLang,
+                       (rh.flags & checkFlags) == checkFlags && isRSameSubLang);
+
+      PREDICATE_RETURN((lh.flags & FLAG_FORCED) && isLSameSubLang,
+                       (rh.flags & FLAG_FORCED) && isRSameSubLang);
+
+      // dont return false here, allow you to fallback on regular sub
+      // its just listitem pre-selection courtesy, in any case the sub will be not enabled
     }
 
-    if (!original)
+    // "is included" is used to not consider forced and impaired
+    const bool isLincluded =
+        (lh.flags & FLAG_FORCED) == 0 && (lh.flags & FLAG_HEARING_IMPAIRED) == 0;
+    const bool isRincluded =
+        (rh.flags & FLAG_FORCED) == 0 && (rh.flags & FLAG_HEARING_IMPAIRED) == 0;
+
+    // try find regular (default)
+    PREDICATE_RETURN(isLincluded && lh.flags & FLAG_DEFAULT && isLSameSubLang,
+                     isRincluded && rh.flags & FLAG_DEFAULT && isRSameSubLang);
+    // try find regular
+    PREDICATE_RETURN(isLincluded && isLSameSubLang, isRincluded && isRSameSubLang);
+
+    // if all previous conditions do not match, allow fallback to "unknown" language
+    if (!m_isPrefForced && isLincluded && (lh.language.empty() || lh.language == "und"))
     {
-      PREDICATE_RETURN(g_LangCodeExpander.CompareISO639Codes(subtitle_language, lh.language)
-                     , g_LangCodeExpander.CompareISO639Codes(subtitle_language, rh.language));
-
-      bool hearingimp = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_ACCESSIBILITY_SUBHEARING);
-      PREDICATE_RETURN(!hearingimp ? !(lh.flags & StreamFlags::FLAG_HEARING_IMPAIRED) : lh.flags & StreamFlags::FLAG_HEARING_IMPAIRED
-                     , !hearingimp ? !(rh.flags & StreamFlags::FLAG_HEARING_IMPAIRED) : rh.flags & StreamFlags::FLAG_HEARING_IMPAIRED);
+      return true;
     }
-
-    PREDICATE_RETURN(lh.flags & StreamFlags::FLAG_DEFAULT
-                   , rh.flags & StreamFlags::FLAG_DEFAULT);
-
     return false;
   }
 };
@@ -956,9 +1049,7 @@ void CVideoPlayer::OpenDefaultStreams(bool reset)
 
   // open subtitle stream
   SelectionStream as = m_SelectionStreams.Get(STREAM_AUDIO, GetAudioStream());
-  PredicateSubtitlePriority psp(as.language,
-                                m_processInfo->GetVideoSettings().m_SubtitleStream,
-                                m_processInfo->GetVideoSettings().m_SubtitleOn);
+  PredicateSubtitlePriority psp(as.language, m_processInfo->GetVideoSettings().m_SubtitleStream);
   valid = false;
   // We need to close CC subtitles to avoid conflicts with external sub stream
   if (m_CurrentSubtitle.source == STREAM_SOURCE_VIDEOMUX)
@@ -971,8 +1062,8 @@ void CVideoPlayer::OpenDefaultStreams(bool reset)
       valid = true;
       if(!psp.relevant(stream))
         visible = false;
-      else if(stream.flags & StreamFlags::FLAG_FORCED)
-        visible = true;
+      //else if(stream.flags & StreamFlags::FLAG_FORCED)
+      //  visible = true;
       break;
     }
   }

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -152,6 +152,7 @@ public:
   static constexpr auto SETTING_LOCALE_SUBTITLELANGUAGE = "locale.subtitlelanguage";
   static constexpr auto SETTING_SUBTITLES_PARSECAPTIONS = "subtitles.parsecaptions";
   static constexpr auto SETTING_SUBTITLES_CAPTIONSALIGN = "subtitles.captionsalign";
+  static constexpr auto SETTING_SUBTITLES_CAPTIONSIMPAIRED = "subtitles.captionsimpaired";
   static constexpr auto SETTING_SUBTITLES_ALIGN = "subtitles.align";
   static constexpr auto SETTING_SUBTITLES_STEREOSCOPICDEPTH = "subtitles.stereoscopicdepth";
   static constexpr auto SETTING_SUBTITLES_FONTNAME = "subtitles.fontname";

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -27,7 +27,7 @@ typedef struct LCENTRY
 } LCENTRY;
 
 extern const std::array<struct LCENTRY, 188> g_iso639_1;
-extern const std::array<struct LCENTRY, 540> g_iso639_2;
+extern const std::array<struct LCENTRY, 541> g_iso639_2;
 
 struct ISO639
 {
@@ -797,7 +797,7 @@ const std::array<struct LCENTRY, 188> g_iso639_1 = {{
 // clang-format on
 
 // clang-format off
-const std::array<struct LCENTRY, 540> g_iso639_2 = {{
+const std::array<struct LCENTRY, 541> g_iso639_2 = {{
     {MAKECODE('\0', 'a', 'b', 'k'), "Abkhaz"},
     {MAKECODE('\0', 'a', 'b', 'k'), "Abkhazian"},
     {MAKECODE('\0', 'a', 'c', 'e'), "Achinese"},
@@ -921,6 +921,7 @@ const std::array<struct LCENTRY, 540> g_iso639_2 = {{
     {MAKECODE('\0', 'd', 'e', 'l'), "Delaware"},
     {MAKECODE('\0', 'd', 'i', 'n'), "Dinka"},
     {MAKECODE('\0', 'd', 'i', 'v'), "Divehi"},
+    {MAKECODE('\0', 'd', 'i', 'v'), "Dhivehi"},
     {MAKECODE('\0', 'd', 'o', 'i'), "Dogri"},
     {MAKECODE('\0', 'd', 'g', 'r'), "Dogrib"},
     {MAKECODE('\0', 'd', 'r', 'a'), "Dravidian (Other)"},

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -171,8 +171,9 @@ bool CStreamDetailSubtitle::IsWorseThan(const CStreamDetail &that) const
 
   // the best subtitle should be the one in the user's preferred language
   // If preferred language is set to "original" this is "eng"
-  return m_strLanguage.empty() ||
-    g_LangCodeExpander.CompareISO639Codes(static_cast<const CStreamDetailSubtitle &>(that).m_strLanguage, g_langInfo.GetSubtitleLanguage());
+  return m_strLanguage.empty() || g_LangCodeExpander.CompareISO639Codes(
+                                      static_cast<const CStreamDetailSubtitle&>(that).m_strLanguage,
+                                      g_langInfo.GetSubtitleLanguage(true));
 }
 
 CStreamDetailSubtitle& CStreamDetailSubtitle::operator=(const CStreamDetailSubtitle &that)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
i started rework this part, starting from impaired problems and then i improved also other use cases

**problems fixed:**
1) if you set "original", kodi select and show the "forced" track based on audio language (ref. issue #25617)
2) "hearing impaired" setting dont works combined with "original"
3) "hearing impaired" setting apparently do nothing with "forced", now if both are enabled "forced" is internally disabled
4) if you set a sub language, and the video played dont have it, kodi still show a language based on audio language, that usually its different (does not comply with the chosen language), now if a sub language dont exists subtitles become disabled
5) "default" flag on all use cases was not so well handled, i handled some more distinctions on code
6) Changes to videos with embedded CC subtitles (read section below)
7) Wrong subs language selection can happens when: _audio language setting is set to a language not provided by the video played, and subtitle language setting is set to a language not provided by the video played or "forced"_. This will lead to a wrong subs language at playback startup. Caused by the fact that the code only considered the audio language coming from the audio track to be played without considering the audio language settings (ref. issue #15672)

### About subtitles "default" flag
from what i understood on the subtitles the "default" flag is not so important since it is used only
to give more priority to a stream, for the case when there are two streams with same properties (lang and flags, but maybe different author version or codec)
On kodi there is no “Media default” setting for subs in the GUI, such as happens on audio language setting, and there is no intention to implement it

### Note for the case 4
this problem was mentioned also on 
https://github.com/xbmc/xbmc/blob/ed8f18b779b28ee62e5e1154e839479680612700/xbmc/cores/VideoPlayer/VideoPlayer.cpp#L103
this behaviour make no sense to me, a user set a subtitle language because should want to display only that language, but kodi fallback to the audio language when missing, this does not match the GUI setting, this bug(?) or weird feature is not documented anywhere, so now has been changed, if the language is missing dont show nothing

### Changes to videos with embedded CC subtitles
The current behaviour of Kodi was:
on CC stream mark it as "hearing impaired", but on stream selection full ignore the "impaired" flag and treat it as regular subtitle

I find this behaviour inconsistent, that also make the subtitle selection code more hard to understand,
when a subtitle is defined/marked as “impaired” it should be treated as such, not force it with a different behavior

as also explained on wiki https://en.wikipedia.org/wiki/Closed_captioning CC subtitles are generally regular subtitles,
in some cases there may be countries that treat them for hearing impaired, but its not a rule.

what changes i have done: i removed the "impaired" flag previously set by default to CC streams. CC streams can be identified now by the "CC" name on description

![immagine](https://github.com/user-attachments/assets/274a6863-806e-4c2b-b33b-741e675ca4e3)

the behavior remains the same as before,
plus i added a new setting that allows you to reassign the "impaired" flag to CC streams
![immagine](https://github.com/user-attachments/assets/29b4a9e3-bdbc-4020-9677-5d00250cf8f4)
this allows you to change the stream auto-selection behaviour of subtitles and can also prevent them from being automatically selected if not desired

the `language = "cc"` on `CDVDDemuxCC` demuxer has been removed
https://github.com/xbmc/xbmc/blob/9f5b450620cc4fb284ea654ea4d71b3982af2b28/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp#L405
"cc" language code was sort of hack and an invalid lang code,
the only uses of "cc" lang was on the stream selection code that i have also removed since not needed anymore.
Instead of "cc" on CC will be set "und" thats an expected language code internally allowed for "undetermined" language case

### sidenotes
i removed the `subson` variable that was changing behaviour of the sort order (the order of priority) for unclear reasons to me,
if subtitles are disabled i dont see why there should be a different sort order
if some one has some reminescence of this say so, i found apparently no possible problems in its removal

I add missing Dhivehi to ISO 639-2, this lack wasted my time in testing, because caused different behavior in subtitle selection due to incorrect coversion of the language code, anyway the root of problem has been fixed by #26011

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #25617
fix #24777
fix #15672

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- basic things with self modified mkv that contains more subs
- mkv with more external subtitles (subs with same mkv filename but with appended "-eng-forced.srt", "-eng-impaired.srt", etc...),
- videos with embedded CC
- PVR iptv m3u with embedded CC

DVD is not affected by this PR change

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
appropriate subtitle selected on playback start
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
