### PR TITLE
CDirectory: do not cache empty directories

### DIFF
--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -252,8 +252,8 @@ bool CDirectory::GetDirectory(const CURL& url,
         }
       }
 
-      // cache the directory, if necessary
-      if (!(hints.flags & DIR_FLAG_BYPASS_CACHE))
+      // cache the directory, if it is not empty and no DIR_FLAG_BYPASS_CACHE flag is set
+      if (!(hints.flags & DIR_FLAG_BYPASS_CACHE) && !items.IsEmpty())
         g_directoryCache.SetDirectory(realURL.Get(), items, pDirectory->GetCacheType(url));
     }
 


### PR DESCRIPTION
## Description

Empty directories cached by various providers (i.e subtitle scanner)
can make `CFile::Open` to return `false` if the "directory" is a dynamic
Internet stream. This happens in #25417, where Kodi as the UPnP renderer
plays the video via HTTP just fine for the first time but fails to play
second and subsequent times before Kodi restart.

The flow in that bug is as follows:

1. On first video playback after Kodi startup, `g_directoryCache` has
   no HTTP "directory" inside and `FileExists` returns `false` but
   `bPathInCache` is also `false` thus video file plays

2. Subtitle scanner attempts to scan HTTP directory with no listing,
   sees 0 items inside and caches it once

3. On subsequent video run, `CFile::Open` expects file name to be in
   cache of the directory that subtitle scanner previously populated
   via `CDirectory::GetDirectory` (`CDirectoryCache::FileExists` is
   expected to return `true` or, at least, return `false` but set
   `bPathInCache` to `false` indicating that both no directory and
   no file inside are known to the cache).

   As the video path is dynamic, and it was never stored in directory
   cache (either via `CDirectoryCache::SetDirectory` or
   `CDirectoryCache::AddFile`), the video file path appears not to be
   in that cache and `CDirectoryCache::FileExists` returns `false`
   while `bPathInCache` is true, triggering `CDVDInputStreamFile::Open`
   to fail which in turn makes `CVideoPlayer::OpenInputStream` fail, too.

The solution is not to cache empty directories - if HTTP or any other
directory is listable, then it can be cavhed but if not, it is either
a dynamic pseudo-directory (served by a CGI script) or just an empty
dir somewhere that is not interesting to us.


## Motivation and context

Fix #25417

## How has this been tested?

@arminfuerst tested it on v22 Piers

## What is the effect on users?

Atbleast, UPnP renderer inside Kodi plays dvery video send to it

## Screenshots (if appropriate):

## Types of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:

- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
