### PR TITLE
Fix some UB like memcpy(NULL, NULL, 0)

### DIFF
--- a/lib/libUPnP/Neptune/Source/Core/NptUtils.cpp
+++ b/lib/libUPnP/Neptune/Source/Core/NptUtils.cpp
@@ -376,7 +376,7 @@ NPT_HexString(const unsigned char* data,
     while (data_size--) {
         NPT_ByteToHex(*src++, dst, uppercase);
         dst += 2;
-        if (data_size) {
+        if (data_size && separator_length) {
             NPT_CopyMemory(dst, separator, separator_length);
             dst += separator_length;
         }

--- a/lib/libUPnP/patches/0055-libUPnP-Fix-some-UB-like-memcpy.patch
+++ b/lib/libUPnP/patches/0055-libUPnP-Fix-some-UB-like-memcpy.patch
@@ -1,0 +1,25 @@
+From 6b0bc3602465eede68f1e04cf4835d1347bc9d69 Mon Sep 17 00:00:00 2001
+From: Yu Xiao <1918256943@qq.com>
+Date: Fri, 11 Oct 2024 18:02:35 +0800
+Subject: [PATCH] fix some UB like memcpy(NULL, NULL, 0)
+
+---
+ lib/libUPnP/Neptune/Source/Core/NptUtils.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/libUPnP/Neptune/Source/Core/NptUtils.cpp b/lib/libUPnP/Neptune/Source/Core/NptUtils.cpp
+index f427f8b..b2a641c 100644
+--- a/lib/libUPnP/Neptune/Source/Core/NptUtils.cpp
++++ b/lib/libUPnP/Neptune/Source/Core/NptUtils.cpp
+@@ -376,7 +376,7 @@ NPT_HexString(const unsigned char* data,
+     while (data_size--) {
+         NPT_ByteToHex(*src++, dst, uppercase);
+         dst += 2;
+-        if (data_size) {
++        if (data_size && separator_length) {
+             NPT_CopyMemory(dst, separator, separator_length);
+             dst += separator_length;
+         }
+--
+2.44.0.windows.1
+

--- a/xbmc-xrandr.c
+++ b/xbmc-xrandr.c
@@ -597,7 +597,8 @@ static void set_transform(
   dest->filter = strdup(filter);
   dest->nparams = nparams;
   dest->params = malloc(nparams * sizeof(XFixed));
-  memcpy(dest->params, params, nparams * sizeof(XFixed));
+  if (nparams)
+    memcpy(dest->params, params, nparams * sizeof(XFixed));
 }
 
 static void copy_transform(transform_t* dest, transform_t* src)

--- a/xbmc-xrandr.c
+++ b/xbmc-xrandr.c
@@ -596,9 +596,13 @@ static void set_transform(
   dest->transform = *transform;
   dest->filter = strdup(filter);
   dest->nparams = nparams;
-  dest->params = malloc(nparams * sizeof(XFixed));
   if (nparams)
+  {
+    dest->params = malloc(nparams * sizeof(XFixed));
     memcpy(dest->params, params, nparams * sizeof(XFixed));
+  }
+  else
+    dest->params = NULL;
 }
 
 static void copy_transform(transform_t* dest, transform_t* src)

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -42,7 +42,7 @@ CDateTimeSpan::CDateTimeSpan(const CDateTimeSpan& span)
   m_timeSpan.lowDateTime = span.m_timeSpan.lowDateTime;
 }
 
-CDateTimeSpan::CDateTimeSpan(int day, int hour, int minute, int second)
+CDateTimeSpan::CDateTimeSpan(int day, int hour, int minute, int second) : CDateTimeSpan()
 {
   SetDateTimeSpan(day, hour, minute, second);
 }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
@@ -485,7 +485,8 @@ DemuxPacket* CDVDDemuxCC::Decode()
 
         pPacket = CDVDDemuxUtils::AllocateDemuxPacket(data.size());
         pPacket->iSize = data.size();
-        memcpy(pPacket->pData, data.c_str(), pPacket->iSize);
+        if (pPacket->iSize)
+          memcpy(pPacket->pData, data.c_str(), pPacket->iSize);
 
         pPacket->iStreamId = service;
         pPacket->pts = m_streamdata[i].pts;

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -1634,7 +1634,10 @@ std::string MysqlDatabase::mysql_vmprintf(const char* zFormat, va_list ap)
 
   mysqlStrAccumInit(&acc, zBase, sizeof(zBase), MYSQL_MAX_LENGTH);
   mysqlVXPrintf(&acc, 0, zFormat, ap);
-  return mysqlStrAccumFinish(&acc);
+  std::string strResult = mysqlStrAccumFinish(&acc);
+  // Free acc.zText to avoid memory leak.
+  mysqlStrAccumReset(&acc);
+  return strResult;
 }
 
 //************* MysqlDataset implementation ***************


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
There are some undefined behaviors like `memcpy(NULL, NULL, 0)` in current source code.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #25819 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Just some trivial change.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Eliminating undefined behaviors make program more stable.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
