### PR TITLE
[PVR] Fix support for EPG gap tags timers.

### DIFF
--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
@@ -562,7 +562,7 @@ bool CPVRGUIActionsTimers::SetRecordingOnChannel(const std::shared_ptr<CPVRChann
 
       const std::shared_ptr<CPVRTimerInfoTag> newTimer(
           epgTag ? CPVRTimerInfoTag::CreateFromEpg(epgTag, false)
-                 : CPVRTimerInfoTag::CreateInstantTimerTag(channel, iDuration));
+                 : CPVRTimerInfoTag::CreateInstantTimerTag(channel, iDuration * 60));
 
       if (newTimer)
         bReturn = CServiceBroker::GetPVRManager().Timers()->AddTimer(newTimer);
@@ -984,7 +984,7 @@ void CPVRGUIActionsTimers::AnnounceReminder(const std::shared_ptr<CPVRTimerInfoT
     }
     else
     {
-      int iDuration = (timer->EndAsUTC() - timer->StartAsUTC()).GetSecondsTotal() / 60;
+      const int iDuration{(timer->EndAsUTC() - timer->StartAsUTC()).GetSecondsTotal()};
       newTimer = CPVRTimerInfoTag::CreateTimerTag(timer->Channel(), timer->StartAsUTC(), iDuration);
     }
 

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
@@ -207,11 +207,17 @@ bool CPVRGUIActionsTimers::AddTimer(const CFileItem& item,
       ParentalCheckResult::SUCCESS)
     return false;
 
+  CDateTime gapStart;
+  int gapDuration{CPVRTimerInfoTag::DEFAULT_PVRRECORD_INSTANTRECORDTIME};
   std::shared_ptr<CPVREpgInfoTag> epgTag = CPVRItem(item).GetEpgInfoTag();
   if (epgTag)
   {
     if (epgTag->IsGapTag())
-      epgTag.reset(); // for gap tags, we can only create instant timers
+    {
+      gapStart = epgTag->StartAsUTC();
+      gapDuration = (epgTag->EndAsUTC() - gapStart).GetSecondsTotal();
+      epgTag.reset(); // for gap tags, we can only create instant or time-based timers
+    }
   }
   else if (bCreateRule)
   {
@@ -232,9 +238,28 @@ bool CPVRGUIActionsTimers::AddTimer(const CFileItem& item,
     return false;
   }
 
-  std::shared_ptr<CPVRTimerInfoTag> newTimer(
-      epgTag ? CPVRTimerInfoTag::CreateFromEpg(epgTag, bCreateRule)
-             : CPVRTimerInfoTag::CreateInstantTimerTag(channel));
+  std::shared_ptr<CPVRTimerInfoTag> newTimer;
+  if (epgTag)
+  {
+    newTimer = CPVRTimerInfoTag::CreateFromEpg(epgTag, bCreateRule);
+  }
+  else if (gapStart.IsValid() &&
+           gapDuration != CPVRTimerInfoTag::DEFAULT_PVRRECORD_INSTANTRECORDTIME)
+  {
+    if (gapStart <= CDateTime::GetUTCDateTime())
+      gapStart = CDateTime{time_t{0}}; // special PVR addon API value for an instant recording
+
+    // prevent super long recordings for channels without any epg data
+    gapDuration = std::min(
+        m_settings.GetIntValue(CSettings::SETTING_PVRRECORD_INSTANTRECORDTIME) * 60, gapDuration);
+
+    newTimer = CPVRTimerInfoTag::CreateTimerTag(channel, gapStart, gapDuration);
+  }
+  else
+  {
+    newTimer = CPVRTimerInfoTag::CreateInstantTimerTag(channel);
+  }
+
   if (!newTimer)
   {
     if (bCreateRule && bFallbackToOneShotTimer)

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -791,7 +791,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateFromDate(
     if (bInstantStart)
       epgTag = channel->GetEPGNow();
     else if (channel->GetEPG())
-      epgTag = channel->GetEPG()->GetTagBetween(start, start + CDateTimeSpan(0, 0, iDuration, 0));
+      epgTag = channel->GetEPG()->GetTagBetween(start, start + CDateTimeSpan(0, 0, 0, iDuration));
   }
 
   std::shared_ptr<CPVRTimerInfoTag> newTimer;
@@ -853,16 +853,17 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateFromDate(
 
   if (iDuration == DEFAULT_PVRRECORD_INSTANTRECORDTIME)
     iDuration = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
-        CSettings::SETTING_PVRRECORD_INSTANTRECORDTIME);
+                    CSettings::SETTING_PVRRECORD_INSTANTRECORDTIME) *
+                60;
 
   if (bInstantStart)
   {
-    CDateTime endTime = now + CDateTimeSpan(0, 0, iDuration ? iDuration : 120, 0);
+    const CDateTime endTime{now + CDateTimeSpan(0, 0, 0, iDuration ? iDuration : 2 * 60 * 60)};
     newTimer->SetEndFromUTC(endTime);
   }
   else
   {
-    CDateTime endTime = start + CDateTimeSpan(0, 0, iDuration ? iDuration : 120, 0);
+    const CDateTime endTime{start + CDateTimeSpan(0, 0, 0, iDuration ? iDuration : 2 * 60 * 60)};
     newTimer->SetEndFromUTC(endTime);
   }
 

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -635,8 +635,8 @@ bool CPVRTimers::UpdateEntries(int iMaxNotificationDelay)
               {
                 const CDateTimeSpan duration = timer->EndAsUTC() - timer->StartAsUTC();
                 const std::shared_ptr<CPVRTimerInfoTag> childTimer =
-                    CPVRTimerInfoTag::CreateReminderFromDate(
-                        nextStart, duration.GetSecondsTotal() / 60, timer);
+                    CPVRTimerInfoTag::CreateReminderFromDate(nextStart, duration.GetSecondsTotal(),
+                                                             timer);
                 if (childTimer)
                 {
                   bChanged = true;
@@ -1062,7 +1062,7 @@ bool CPVRTimers::AddLocalTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag, boo
       {
         const CDateTimeSpan duration = persistedTimer->EndAsUTC() - persistedTimer->StartAsUTC();
         const std::shared_ptr<CPVRTimerInfoTag> childTimer =
-            CPVRTimerInfoTag::CreateReminderFromDate(nextStart, duration.GetSecondsTotal() / 60,
+            CPVRTimerInfoTag::CreateReminderFromDate(nextStart, duration.GetSecondsTotal(),
                                                      persistedTimer);
         if (childTimer)
         {


### PR DESCRIPTION
Adds support to create time-based timers for "EPG gap tags" (gaps in the guide). Formerly only timers starting now, regardless which time was selected in the guide window, were supported.

Runtime-tested on macOS and Android, latest xbmc master.

@phunkyfish could you please review.