### PR TITLE
[UPnP] Do not scan for external subs for UPnP renderer

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -795,7 +795,8 @@ bool CVideoPlayer::OpenInputStream()
     // find any available external subtitles
     std::vector<std::string> filenames;
 
-    if (!URIUtils::IsUPnP(m_item.GetPath()))
+    if (!URIUtils::IsUPnP(m_item.GetPath()) &&
+        !m_item.GetProperty("no-ext-subs-scan").asBoolean(false))
       CUtil::ScanForExternalSubtitles(m_item.GetDynPath(), filenames);
 
     // load any subtitles from file item

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -686,6 +686,7 @@ NPT_Result CUPnPRenderer::PlayMedia(const NPT_String& uri,
   }
   else
   {
+    item->SetProperty("no-ext-subs-scan", true);
     CFileItemList* l = new CFileItemList; //don't delete,
     l->Add(std::make_shared<CFileItem>(*item));
     CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, -1, -1, static_cast<void*>(l));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Don't look for external subtitles when Kodi is used as a UPnP renderer.
Set a new property "no-ext-subs-scan" on the FileItem to skip the external subs scan when opening the stream.

Unsure about the property name, could have called it something like "original-url-in-browseable-source" instead.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It is dangerous to manipulate the urls used with the UPnP protocol. Technically a controller could pass any url, including some that are browseable and expose a filesystem, but it cannot be detected and relied on.

For example, with the UMS and Gerbera UPnP server, Kodi ends up downloading the entire video when attempting to locate external subs, delaying the start of the playback and using a lot of RAM.
This is the same issue that was resolved by #24922, for the UPnP renderer path this time.

As a side effect, this may fix #25417 where the ext subs scan creates a problem in the cache.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Used BubbleUPnP to control Kodi renderer to play from UMS UPnP server.
The log doesn't contain the line "Searching for subtitles..." anymore. Playback starts immediately,

Don't have a way to repro issue #25417, will rely on op to test.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Playback as a UPnP renderer starts faster and for some UPnP controllers/servers it will be possible to play more than one video.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
