### PR TITLE
[GUI] Introduce GUI Announcement Handlers

### DIFF
--- a/cmake/treedata/common/subdirs.txt
+++ b/cmake/treedata/common/subdirs.txt
@@ -16,6 +16,7 @@ xbmc/dialogs                                    dialogs
 xbmc/favourites                                 favourites
 xbmc/guilib                                     guilib
 xbmc/guilib/guiinfo                             guilib_guiinfo
+xbmc/guilib/handlers                            guilib_announcement_handlers
 xbmc/guilib/listproviders                       guilib_listproviders
 xbmc/imagefiles                                 imagefiles
 xbmc/messaging                                  messaging

--- a/xbmc/guilib/GUIComponent.cpp
+++ b/xbmc/guilib/GUIComponent.cpp
@@ -18,6 +18,7 @@
 #include "TextureManager.h"
 #include "URL.h"
 #include "dialogs/GUIDialogYesNo.h"
+#include "handlers/GUIAnnouncementHandlerContainer.h"
 
 #include <memory>
 
@@ -28,7 +29,8 @@ CGUIComponent::CGUIComponent()
     m_stereoscopicsManager(std::make_unique<CStereoscopicsManager>()),
     m_guiInfoManager(std::make_unique<CGUIInfoManager>()),
     m_guiColorManager(std::make_unique<CGUIColorManager>()),
-    m_guiAudioManager(std::make_unique<CGUIAudioManager>())
+    m_guiAudioManager(std::make_unique<CGUIAudioManager>()),
+    m_announcementHandlerContainer(std::make_unique<CGUIAnnouncementHandlerContainer>())
 {
 }
 

--- a/xbmc/guilib/GUIComponent.h
+++ b/xbmc/guilib/GUIComponent.h
@@ -18,6 +18,7 @@ class CStereoscopicsManager;
 class CGUIInfoManager;
 class CGUIColorManager;
 class CGUIAudioManager;
+class CGUIAnnouncementHandlerContainer;
 
 class CGUIComponent
 {
@@ -47,4 +48,5 @@ protected:
   std::unique_ptr<CGUIInfoManager> m_guiInfoManager;
   std::unique_ptr<CGUIColorManager> m_guiColorManager;
   std::unique_ptr<CGUIAudioManager> m_guiAudioManager;
+  std::unique_ptr<CGUIAnnouncementHandlerContainer> m_announcementHandlerContainer;
 };

--- a/xbmc/guilib/handlers/CMakeLists.txt
+++ b/xbmc/guilib/handlers/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(SOURCES GUIAnnouncementHandlerContainer.cpp
+            sources/GUISourcesAnnouncementHandler.cpp)
+
+set(HEADERS GUIAnnouncementHandlerContainer.h
+            sources/GUISourcesAnnouncementHandler.h)
+
+core_add_library(guilib_announcement_handlers)

--- a/xbmc/guilib/handlers/GUIAnnouncementHandlerContainer.cpp
+++ b/xbmc/guilib/handlers/GUIAnnouncementHandlerContainer.cpp
@@ -1,0 +1,16 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GUIAnnouncementHandlerContainer.h"
+
+#include "sources/GUISourcesAnnouncementHandler.h"
+
+CGUIAnnouncementHandlerContainer::CGUIAnnouncementHandlerContainer()
+{
+  m_announcementHandlers.emplace_back(std::make_unique<CGUISourcesAnnouncementHandler>());
+}

--- a/xbmc/guilib/handlers/GUIAnnouncementHandlerContainer.h
+++ b/xbmc/guilib/handlers/GUIAnnouncementHandlerContainer.h
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "interfaces/IAnnouncer.h"
+
+#include <memory>
+#include <vector>
+
+/*!
+\brief This class is a container of announcement handlers per application component. It allows the GUI Layer
+to execute GUI Actions upon receiving announcements from other components effectively decoupling GUI
+from other components.
+*/
+class CGUIAnnouncementHandlerContainer final
+{
+public:
+  CGUIAnnouncementHandlerContainer();
+  ~CGUIAnnouncementHandlerContainer() = default;
+
+private:
+  std::vector<std::unique_ptr<ANNOUNCEMENT::IAnnouncer>> m_announcementHandlers;
+};

--- a/xbmc/guilib/handlers/sources/GUISourcesAnnouncementHandler.cpp
+++ b/xbmc/guilib/handlers/sources/GUISourcesAnnouncementHandler.cpp
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GUISourcesAnnouncementHandler.h"
+
+#include "GUIUserMessages.h"
+#include "ServiceBroker.h"
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIWindowManager.h"
+#include "interfaces/AnnouncementManager.h"
+
+CGUISourcesAnnouncementHandler::CGUISourcesAnnouncementHandler()
+{
+  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
+}
+
+CGUISourcesAnnouncementHandler::~CGUISourcesAnnouncementHandler()
+{
+  CServiceBroker::GetAnnouncementManager()->RemoveAnnouncer(this);
+}
+
+void CGUISourcesAnnouncementHandler::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                                              const std::string& sender,
+                                              const std::string& message,
+                                              const CVariant& data)
+{
+  // We are only interested in sources changes
+  if ((flag & ANNOUNCEMENT::Sources) == 0)
+    return;
+
+  if (message == "OnAdded" || message == "OnRemoved" || message == "OnUpdated")
+  {
+    CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);
+    message.SetStringParam(data.asString());
+    CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(message);
+  }
+}

--- a/xbmc/guilib/handlers/sources/GUISourcesAnnouncementHandler.h
+++ b/xbmc/guilib/handlers/sources/GUISourcesAnnouncementHandler.h
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "interfaces/IAnnouncer.h"
+
+/*!
+\brief Handler for announcements of type sources
+*/
+class CGUISourcesAnnouncementHandler : public ANNOUNCEMENT::IAnnouncer
+{
+public:
+  CGUISourcesAnnouncementHandler();
+  ~CGUISourcesAnnouncementHandler();
+
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                const std::string& sender,
+                const std::string& message,
+                const CVariant& data) override;
+};

--- a/xbmc/interfaces/IAnnouncer.h
+++ b/xbmc/interfaces/IAnnouncer.h
@@ -13,33 +13,35 @@
 class CVariant;
 namespace ANNOUNCEMENT
 {
-  enum AnnouncementFlag
-  {
-    Player        = 0x001,
-    Playlist      = 0x002,
-    GUI           = 0x004,
-    System        = 0x008,
-    VideoLibrary  = 0x010,
-    AudioLibrary  = 0x020,
-    Application   = 0x040,
-    Input         = 0x080,
-    PVR           = 0x100,
-    Other         = 0x200,
-    Info          = 0x400
-  };
+enum AnnouncementFlag
+{
+  Player = 0x001,
+  Playlist = 0x002,
+  GUI = 0x004,
+  System = 0x008,
+  VideoLibrary = 0x010,
+  AudioLibrary = 0x020,
+  Application = 0x040,
+  Input = 0x080,
+  PVR = 0x100,
+  Other = 0x200,
+  Info = 0x400,
+  Sources = 0x800
+};
 
-  const auto ANNOUNCE_ALL = (Player | Playlist | GUI | System | VideoLibrary | AudioLibrary | Application | Input | ANNOUNCEMENT::PVR | Other);
+const auto ANNOUNCE_ALL = (Player | Playlist | GUI | System | VideoLibrary | AudioLibrary |
+                           Application | Input | ANNOUNCEMENT::PVR | Other);
 
-  /*!
+/*!
     \brief Returns a string representation for the
     given AnnouncementFlag
     \param notification Specific AnnouncementFlag
     \return String representation of the given AnnouncementFlag
     */
-  inline const char *AnnouncementFlagToString(const AnnouncementFlag &notification)
+inline const char* AnnouncementFlagToString(const AnnouncementFlag& notification)
+{
+  switch (notification)
   {
-    switch (notification)
-    {
     case Player:
       return "Player";
     case Playlist:
@@ -62,10 +64,12 @@ namespace ANNOUNCEMENT
       return "Other";
     case Info:
       return "Info";
+    case Sources:
+      return "Sources";
     default:
       return "Unknown";
-    }
   }
+}
 
   class IAnnouncer
   {

--- a/xbmc/network/ZeroconfBrowser.h
+++ b/xbmc/network/ZeroconfBrowser.h
@@ -89,8 +89,7 @@ public:
   void Stop();
 
   ///returns the list of found services
-  /// if this is updated, the following message with "zeroconf://" as path is sent:
-  /// CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);
+  /// if this is updated, a source update announcement with "zeroconf://" as path is sent:
   std::vector<ZeroconfService> GetFoundServices();
   ///@}
 

--- a/xbmc/network/mdns/ZeroconfBrowserMDNS.cpp
+++ b/xbmc/network/mdns/ZeroconfBrowserMDNS.cpp
@@ -8,11 +8,8 @@
 
 #include "ZeroconfBrowserMDNS.h"
 
-#include "GUIUserMessages.h"
 #include "ServiceBroker.h"
-#include "guilib/GUIComponent.h"
-#include "guilib/GUIMessage.h"
-#include "guilib/GUIWindowManager.h"
+#include "interfaces/AnnouncementManager.h"
 #include "network/DNSNameCache.h"
 #include "utils/log.h"
 
@@ -88,10 +85,11 @@ void DNSSD_API CZeroconfBrowserMDNS::BrowserCallback(DNSServiceRef browser,
     }
     if(! (flags & kDNSServiceFlagsMoreComing) )
     {
-      CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);
-      message.SetStringParam("zeroconf://");
-      CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(message);
-      CLog::Log(LOGDEBUG, "ZeroconfBrowserMDNS::BrowserCallback sent gui update for path zeroconf://");
+      CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Sources, "OnUpdated",
+                                                         CVariant{"zeroconf://"});
+      CLog::Log(
+          LOGDEBUG,
+          "ZeroconfBrowserMDNS::BrowserCallback sent source update announce for path zeroconf://");
     }
   }
   else

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -13,7 +13,6 @@
 #include "UPnP.h"
 
 #include "FileItem.h"
-#include "GUIUserMessages.h"
 #include "ServiceBroker.h"
 #include "UPnPInternal.h"
 #include "UPnPRenderer.h"
@@ -21,8 +20,7 @@
 #include "UPnPSettings.h"
 #include "URL.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
-#include "guilib/GUIComponent.h"
-#include "guilib/GUIWindowManager.h"
+#include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "network/Network.h"
 #include "profiles/ProfileManager.h"
@@ -171,19 +169,15 @@ public:
   // PLT_MediaBrowser methods
   bool OnMSAdded(PLT_DeviceDataReference& device) override
   {
-    CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);
-    message.SetStringParam("upnp://");
-    CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(message);
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Sources, "OnAdded",
+                                                       CVariant{"upnp://"});
 
     return PLT_SyncMediaBrowser::OnMSAdded(device);
   }
   void OnMSRemoved(PLT_DeviceDataReference& device) override
   {
-    PLT_SyncMediaBrowser::OnMSRemoved(device);
-
-    CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);
-    message.SetStringParam("upnp://");
-    CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(message);
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Sources, "OnRemoved",
+                                                       CVariant{"upnp://"});
 
     PLT_SyncMediaBrowser::OnMSRemoved(device);
   }
@@ -202,9 +196,8 @@ public:
     }
 
     m_logger->debug("notified container update {}", (const char*)path);
-    CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);
-    message.SetStringParam(path.GetChars());
-    CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(message);
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Sources, "OnUpdated",
+                                                       CVariant{path.GetChars()});
   }
 
   bool MarkWatched(const CFileItem& item, const bool watched)

--- a/xbmc/platform/android/network/ZeroconfBrowserAndroid.cpp
+++ b/xbmc/platform/android/network/ZeroconfBrowserAndroid.cpp
@@ -8,11 +8,8 @@
 
 #include "ZeroconfBrowserAndroid.h"
 
-#include "GUIUserMessages.h"
 #include "ServiceBroker.h"
-#include "guilib/GUIComponent.h"
-#include "guilib/GUIMessage.h"
-#include "guilib/GUIWindowManager.h"
+#include "interfaces/AnnouncementManager.h"
 #include "network/DNSNameCache.h"
 #include "utils/log.h"
 
@@ -241,10 +238,10 @@ void CZeroconfBrowserAndroidDiscover::onServiceFound(const jni::CJNINsdServiceIn
             s.GetName(), s.GetType(), s.GetDomain());
   m_browser->addDiscoveredService(this, s);
 
-  CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);
-  message.SetStringParam("zeroconf://");
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(message);
-  CLog::Log(LOGDEBUG, "CZeroconfBrowserAndroidDiscover::onServiceFound sent gui update for path zeroconf://");
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Sources, "OnUpdated",
+                                                     CVariant{"zeroconf://"});
+  CLog::Log(LOGDEBUG, "CZeroconfBrowserAndroidDiscover::onServiceFound sent source update announce "
+                      "for path zeroconf://");
 }
 
 void CZeroconfBrowserAndroidDiscover::onServiceLost(const jni::CJNINsdServiceInfo& serviceInfo)

--- a/xbmc/platform/darwin/network/ZeroconfBrowserDarwin.cpp
+++ b/xbmc/platform/darwin/network/ZeroconfBrowserDarwin.cpp
@@ -8,11 +8,8 @@
 
 #include "ZeroconfBrowserDarwin.h"
 
-#include "GUIUserMessages.h"
 #include "ServiceBroker.h"
-#include "guilib/GUIComponent.h"
-#include "guilib/GUIMessage.h"
-#include "guilib/GUIWindowManager.h"
+#include "interfaces/AnnouncementManager.h"
 #include "utils/log.h"
 
 #include "platform/darwin/DarwinUtils.h"
@@ -168,10 +165,10 @@ void CZeroconfBrowserDarwin::BrowserCallback(CFNetServiceBrowserRef browser, CFO
     }
     if (! (flags & kCFNetServiceFlagMoreComing) )
     {
-      CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);
-      message.SetStringParam("zeroconf://");
-      CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(message);
-      CLog::Log(LOGDEBUG, "CZeroconfBrowserDarwin::BrowserCallback sent gui update for path zeroconf://");
+      CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Sources, "OnUpdated",
+                                                         CVariant{"zeroconf://"});
+      CLog::Log(LOGDEBUG, "CZeroconfBrowserDarwin::BrowserCallback sent sources update "
+                          "announcement for path zeroconf://");
     }
   } else
   {


### PR DESCRIPTION
## Description
This PR introduces a `GUIAnnouncementContainer` as a container of specific component handlers so that the GUI layer can react accordingly whenever some event takes place. This allows us to have a foundation where other handlers can be developed/added and we can slowly but incrementally work towards decoupling the GUI from the main application.

As for specific handlers I have just created one for "Sources" announcements and applied the announces to the UPnP class as a first step. There are other components such as zeroconf that can also take advantage of this `GUISourcesHandler` with minimal effort (I plan to do it once this one goes in).

## Motivation and context
Have a foundation to start removing GUI callbacks from headless components

## How has this been tested?
Runtime tested with UPnP and breakpoints on specific places. This only makes the components reactive to events rather than executing the main logic directly in the affected announcer component

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

