### PR TITLE
VideoPlayer: move part of the GUI messages to a GUI handler via annou…

### DIFF
--- a/xbmc/guilib/handlers/CMakeLists.txt
+++ b/xbmc/guilib/handlers/CMakeLists.txt
@@ -1,7 +1,9 @@
 set(SOURCES GUIAnnouncementHandlerContainer.cpp
-            sources/GUISourcesAnnouncementHandler.cpp)
+            sources/GUISourcesAnnouncementHandler.cpp
+            player/GUIPlayerAnnouncementHandler.cpp)
 
 set(HEADERS GUIAnnouncementHandlerContainer.h
-            sources/GUISourcesAnnouncementHandler.h)
+            sources/GUISourcesAnnouncementHandler.h
+            player/GUIPlayerAnnouncementHandler.h)
 
 core_add_library(guilib_announcement_handlers)

--- a/xbmc/guilib/handlers/GUIAnnouncementHandlerContainer.cpp
+++ b/xbmc/guilib/handlers/GUIAnnouncementHandlerContainer.cpp
@@ -8,9 +8,11 @@
 
 #include "GUIAnnouncementHandlerContainer.h"
 
+#include "player/GUIPlayerAnnouncementHandler.h"
 #include "sources/GUISourcesAnnouncementHandler.h"
 
 CGUIAnnouncementHandlerContainer::CGUIAnnouncementHandlerContainer()
 {
   m_announcementHandlers.emplace_back(std::make_unique<CGUISourcesAnnouncementHandler>());
+  m_announcementHandlers.emplace_back(std::make_unique<CGUIPlayerAnnouncementHandler>());
 }

--- a/xbmc/guilib/handlers/player/GUIPlayerAnnouncementHandler.cpp
+++ b/xbmc/guilib/handlers/player/GUIPlayerAnnouncementHandler.cpp
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GUIPlayerAnnouncementHandler.h"
+
+#include "GUIUserMessages.h"
+#include "ServiceBroker.h"
+#include "dialogs/GUIDialogKaiToast.h"
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIWindowManager.h"
+#include "guilib/LocalizeStrings.h"
+#include "interfaces/AnnouncementManager.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
+
+CGUIPlayerAnnouncementHandler::CGUIPlayerAnnouncementHandler()
+{
+  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this, ANNOUNCEMENT::Player);
+}
+
+CGUIPlayerAnnouncementHandler::~CGUIPlayerAnnouncementHandler()
+{
+  CServiceBroker::GetAnnouncementManager()->RemoveAnnouncer(this);
+}
+
+void CGUIPlayerAnnouncementHandler::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                                             const std::string& sender,
+                                             const std::string& message,
+                                             const CVariant& data)
+{
+  if (message == "OnCommercial")
+  {
+    const std::shared_ptr<CAdvancedSettings> advancedSettings =
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+    if (advancedSettings && advancedSettings->m_EdlDisplayCommbreakNotifications)
+    {
+      CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), data.asString());
+    }
+  }
+  else if (message == "SourceSlow")
+  {
+    CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(21454),
+                                          g_localizeStrings.Get(21455));
+  }
+  else if (message == "OnToggleSkipCommercials")
+  {
+    CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011),
+                                          g_localizeStrings.Get(data.asBoolean() ? 25013 : 25012));
+  }
+  else if (message == "OnProcessInfo")
+  {
+    if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() !=
+        WINDOW_DIALOG_PLAYER_PROCESS_INFO)
+    {
+      CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(
+          WINDOW_DIALOG_PLAYER_PROCESS_INFO);
+    }
+  }
+  else if (message == "OnPlaybackFailed")
+  {
+    CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(16026),
+                                          g_localizeStrings.Get(16029));
+  }
+#if defined(HAVE_LIBBLURAY)
+  else if (message == "OnBlurayMenuError")
+  {
+    CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25008),
+                                          g_localizeStrings.Get(25009));
+  }
+  else if (message == "OnBlurayEncryptedError")
+  {
+    CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(16026),
+                                          g_localizeStrings.Get(29805));
+  }
+#endif
+  else if (message == "OnMenu")
+  {
+    CGUIMessage msg(GUI_MSG_VIDEO_MENU_STARTED, 0, 0);
+    CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+  }
+}

--- a/xbmc/guilib/handlers/player/GUIPlayerAnnouncementHandler.h
+++ b/xbmc/guilib/handlers/player/GUIPlayerAnnouncementHandler.h
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "interfaces/IAnnouncer.h"
+
+/*!
+\brief Handler for announcements of type player
+*/
+class CGUIPlayerAnnouncementHandler : public ANNOUNCEMENT::IAnnouncer
+{
+public:
+  CGUIPlayerAnnouncementHandler();
+  ~CGUIPlayerAnnouncementHandler();
+
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                const std::string& sender,
+                const std::string& message,
+                const CVariant& data) override;
+};


### PR DESCRIPTION
…cements

## Description
This is similar to https://github.com/xbmc/xbmc/pull/25831 but for videoplayer. Doesn't remove all dependencies but it's a step forward.

## Motivation and context
Remove GUI coupling

## How has this been tested?
Runtime tested with EDL and player process info. Other use-cases should also work.

## What is the effect on users?
None, internal refactor

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

