### PR TITLE
[addons] add missing flag to filesystem translation from binary add-ons

### DIFF
--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -153,6 +153,9 @@ unsigned int Interface_Filesystem::TranslateFileReadBitsToKodi(unsigned int addo
     kodiFlags |= READ_AFTER_WRITE;
   if (addonFlags & ADDON_READ_REOPEN)
     kodiFlags |= READ_REOPEN;
+  //! @todo Add ADDON_READ_NO_BUFFER to filesystem.h in the binary addon devkit
+  if (addonFlags & READ_NO_BUFFER)
+    kodiFlags |= READ_NO_BUFFER;
 
   return kodiFlags;
 }

--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -151,7 +151,7 @@ unsigned int Interface_Filesystem::TranslateFileReadBitsToKodi(unsigned int addo
     kodiFlags |= READ_AUDIO_VIDEO;
   if (addonFlags & ADDON_READ_AFTER_WRITE)
     kodiFlags |= READ_AFTER_WRITE;
-  if (addonFlags & READ_REOPEN)
+  if (addonFlags & ADDON_READ_REOPEN)
     kodiFlags |= READ_REOPEN;
 
   return kodiFlags;


### PR DESCRIPTION
## Description
READ_NO_BUFFER is not translated from binary add-ons to Kodi due it being missing in the translation code.

Background: https://github.com/xbmc/xbmc/issues/24869

## Motivation and context
The flag should be translated

## How has this been tested?
By a user who found the error and spotted the omission.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
