### PR TITLE
Texturepacker: add compressed texture support

### DIFF
--- a/tools/depends/native/TexturePacker/src/CMakeLists.txt
+++ b/tools/depends/native/TexturePacker/src/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SOURCES md5.cpp
             decoder/GIFDecoder.cpp
             decoder/GifHelper.cpp
             decoder/JPGDecoder.cpp
+            decoder/KTXDecoder.cpp
             decoder/PNGDecoder.cpp
             ${KODI_SOURCE_DIR}/xbmc/guilib/XBTF.cpp)
 

--- a/tools/depends/native/TexturePacker/src/DecoderManager.h
+++ b/tools/depends/native/TexturePacker/src/DecoderManager.h
@@ -32,6 +32,8 @@ class DecoderManager
     ~DecoderManager() = default;
 
     bool IsSupportedGraphicsFile(std::string_view filename);
+    bool IsSubstitutionFile(std::string_view filename);
+    void SubstitudeFileName(KD_TEX_FMT& family, std::string& filename);
     bool LoadFile(const std::string& filename, DecodedFrames& frames);
     void EnableVerboseOutput() { verbose = true; }
 

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -1,23 +1,12 @@
 /*
- *      Copyright (C) 2005-2014 Team XBMC
- *      http://kodi.tv
+ *  Copyright (C) 2004-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
  *
- *  This Program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2, or (at your option)
- *  any later version.
- *
- *  This Program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with XBMC; see the file COPYING.  If not, see
- *  <http://www.gnu.org/licenses/>.
- *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
  */
 
+// clang-format off
 #ifdef TARGET_WINDOWS
 #include <sys/types.h>
 #define __STDC_FORMAT_MACROS
@@ -27,10 +16,12 @@
 #include <inttypes.h>
 #define platform_stricmp strcasecmp
 #endif
+#include <algorithm>
 #include <cerrno>
 #include <dirent.h>
 #include <map>
 
+#include "guilib/TextureFormats.h"
 #include "guilib/XBTF.h"
 #include "guilib/XBTFReader.h"
 
@@ -49,9 +40,8 @@
 #include <lzo/lzo1x.h>
 #include <sys/stat.h>
 
-#define FLAGS_USE_LZO     1
-
 #define DIR_SEPARATOR '/'
+// clang-format on
 
 namespace
 {
@@ -68,24 +58,94 @@ const char* GetFormatString(KD_TEX_FMT format)
       return "RGBA8";
     case KD_TEX_FMT_SDR_BGRA8:
       return "BGRA8";
+    case KD_TEX_FMT_S3TC_RGB8:
+    case KD_TEX_FMT_S3TC_RGB8_A1:
+    case KD_TEX_FMT_S3TC_RGB8_A4:
+    case KD_TEX_FMT_S3TC_RGBA8:
+      return "S3TC ";
+    case KD_TEX_FMT_RGTC_R11:
+    case KD_TEX_FMT_RGTC_RG11:
+      return "RGTC ";
+    case KD_TEX_FMT_BPTC_RGB16F:
+    case KD_TEX_FMT_BPTC_RGBA8:
+      return "BPTC ";
+    case KD_TEX_FMT_ETC1_RGB8:
+      return "ETC1 ";
+    case KD_TEX_FMT_ETC2_R11:
+    case KD_TEX_FMT_ETC2_RG11:
+    case KD_TEX_FMT_ETC2_RGB8:
+    case KD_TEX_FMT_ETC2_RGB8_A1:
+    case KD_TEX_FMT_ETC2_RGBA8:
+      return "ETC2 ";
+    case KD_TEX_FMT_ASTC_LDR_4x4:
+    case KD_TEX_FMT_ASTC_LDR_5x4:
+    case KD_TEX_FMT_ASTC_LDR_5x5:
+    case KD_TEX_FMT_ASTC_LDR_6x5:
+    case KD_TEX_FMT_ASTC_LDR_6x6:
+    case KD_TEX_FMT_ASTC_LDR_8x5:
+    case KD_TEX_FMT_ASTC_LDR_8x6:
+    case KD_TEX_FMT_ASTC_LDR_8x8:
+    case KD_TEX_FMT_ASTC_LDR_10x5:
+    case KD_TEX_FMT_ASTC_LDR_10x6:
+    case KD_TEX_FMT_ASTC_LDR_10x8:
+    case KD_TEX_FMT_ASTC_LDR_10x10:
+    case KD_TEX_FMT_ASTC_LDR_12x10:
+    case KD_TEX_FMT_ASTC_LDR_12x12:
+      return "ASTC ";
     default:
       return "?????";
   }
 }
 
+// clang-format off
 void Usage()
 {
   puts("Texture Packer Version 3");
   puts("");
-  puts("Tool to pack XBT 3 texture files, used in Kodi Piers (v22).");
-  puts("Accepts the following file formats as input: PNG (preferred), JPG and GIF.");
+  puts("Tool to pack XBT 3 texture files, used in Kodi Piers (v22) and newer.");
+  puts("Accepts the following file formats as input:");
+  puts("-PNG (preferred)");
+  puts("-KTX (for compressed textures)");
+  puts("-JPG");
+  puts("-GIF");
+  puts("");
   puts("");
   puts("Usage:");
   puts("  -help            Show this screen.");
   puts("  -input <dir>     Input directory. Default: current dir");
   puts("  -output <dir>    Output directory/filename. Default: Textures.xbt");
   puts("  -dupecheck       Enable duplicate file detection. Reduces output file size. Default: off");
+  puts("  -nocompress      Disable LZO compression. Default: off");
+  puts("  -astc            Substitution of *.astc.ktx files. Default: off");
+  puts("  -bptc            Substitution of *.bptc.ktx files. Default: off");
+  puts("  -etc1            Substitution of *.etc1.ktx files. Default: off");
+  puts("  -etc2            Substitution of *.etc2.ktx files. Default: off");
+  puts("  -rgtc            Substitution of *.rgtc.ktx files. Default: off");
+  puts("  -s3tc            Substitution of *.s3tc.ktx files. Default: off");
+  puts("");
+  puts("");
+  puts("Substitution of files");
+  puts("");
+  puts("The goal of file substitution is to create specialised texture bundles, containing a "
+       "specific set of (compressed) textures. If compressed textures with the right file names "
+       "are provided and substitution is enabled, the uncompressed (raw) textures get replaced by "
+       "their compressed counterpart. The set should reflect capabilities of the target platform. "
+       "Typical sets would be:");
+  puts("-Embedded (GLES 2.0): ETC1 (Mali Utgard, VideoCore IV)");
+  puts("-Embedded (GLES 3.0): ETC2, ETC1 (early Mali Midgard)");
+  puts("-Emdedded (Modern): ASTC, ETC2, ETC1 (late Mali Midgard, VideoCore VI)");
+  puts("-Desktop (Legacy): S3TC (NVidia Ion)");
+  puts("-Desktop (Modern): BPTC, RGTC, S3TC (DX11 capable hardware)");
+  puts("");
+  puts("For example, if the switch \"-s3tc\" is active, files with the ending \"*.png.s3tc.ktx\" "
+       "will be placed as \"*.png\" in the XBT file. This means that the content of a file with the "
+       "name of \"icon.png\" will be replaced by the content of the file \"icon.png.s3tc.ktx\".");
+  puts("");
+  puts("Any file with such an substitution \"extension\" won't be packed directly. If multiple "
+       "switches are active, the priority is as follows (decreasing): ASTC, BPTC, ETC2, RGTC, ETC1 "
+       "and S3TC.");
 }
+// clang-format on
 
 } // namespace
 
@@ -102,11 +162,16 @@ public:
   int createBundle(const std::string& InputDir, const std::string& OutputFile);
 
   void SetFlags(unsigned int flags) { m_flags = flags; }
+  void EnableTextureFamily(KD_TEX_FMT format) { m_enabledTextureFamilies.emplace_back(format); }
+  void DisableCompression() { m_compress = false; }
 
 private:
   void CreateSkeletonHeader(CXBTFWriter& xbtfWriter,
                             const std::string& fullPath,
                             const std::string& relativePath = "");
+
+  void SubstitudeFile(CXBTFWriter& xbtfWriter, const std::string& fileName);
+  unsigned int GetSubstitutionPriority(KD_TEX_FMT textureFamily);
 
   CXBTFFrame CreateXBTFFrame(DecodedFrame& decodedFrame, CXBTFWriter& writer) const;
 
@@ -123,6 +188,9 @@ private:
 
   bool m_dupecheck{false};
   unsigned int m_flags{0};
+  bool m_compress{true};
+
+  std::vector<KD_TEX_FMT> m_enabledTextureFamilies{};
 };
 
 void TexturePacker::CreateSkeletonHeader(CXBTFWriter& xbtfWriter,
@@ -168,9 +236,20 @@ void TexturePacker::CreateSkeletonHeader(CXBTFWriter& xbtfWriter,
 
           fileName += dp->d_name;
 
-          CXBTFFile file;
-          file.SetPath(fileName);
-          xbtfWriter.AddFile(file);
+          if (decoderManager.IsSubstitutionFile(fileName))
+          {
+            SubstitudeFile(xbtfWriter, fileName);
+          }
+          else if (xbtfWriter.Exists(fileName))
+          {
+            continue;
+          }
+          else
+          {
+            CXBTFFile file;
+            file.SetPath(fileName);
+            xbtfWriter.AddFile(file);
+          }
         }
       }
     }
@@ -185,13 +264,65 @@ void TexturePacker::CreateSkeletonHeader(CXBTFWriter& xbtfWriter,
   }
 }
 
+void TexturePacker::SubstitudeFile(CXBTFWriter& xbtfWriter, const std::string& fileName)
+{
+  CXBTFFile file;
+  std::string substitutedFileName = fileName;
+  KD_TEX_FMT textureFamily = KD_TEX_FMT_UNKNOWN;
+  decoderManager.SubstitudeFileName(textureFamily, substitutedFileName);
+
+  if (std::find(m_enabledTextureFamilies.begin(), m_enabledTextureFamilies.end(), textureFamily) ==
+      m_enabledTextureFamilies.end())
+    return;
+
+  const unsigned int priority = GetSubstitutionPriority(textureFamily);
+  const bool exists = xbtfWriter.Get(substitutedFileName, file);
+
+  if (file.GetSubstitutionPriority() >= priority)
+    return;
+  file.SetSubstitutionPriority(priority);
+
+  if (exists)
+  {
+    file.SetRealPath(fileName);
+    xbtfWriter.UpdateFile(file);
+  }
+  else
+  {
+    file.SetPath(substitutedFileName);
+    file.SetRealPath(fileName);
+    xbtfWriter.AddFile(file);
+  }
+}
+
+unsigned int TexturePacker::GetSubstitutionPriority(KD_TEX_FMT textureFamily)
+{
+  switch (textureFamily)
+  {
+    case KD_TEX_FMT_ASTC_LDR:
+      return 6;
+    case KD_TEX_FMT_BPTC:
+      return 5;
+    case KD_TEX_FMT_ETC2:
+      return 4;
+    case KD_TEX_FMT_RGTC:
+      return 3;
+    case KD_TEX_FMT_ETC1:
+      return 2;
+    case KD_TEX_FMT_S3TC:
+      return 1;
+    case KD_TEX_FMT_SDR:
+    default:
+      return 0;
+  }
+}
+
 CXBTFFrame TexturePacker::CreateXBTFFrame(DecodedFrame& decodedFrame, CXBTFWriter& writer) const
 {
   const unsigned int delay = decodedFrame.delay;
   const unsigned int width = decodedFrame.rgbaImage.width;
   const unsigned int height = decodedFrame.rgbaImage.height;
-  const uint32_t bpp = decodedFrame.rgbaImage.bbp;
-  const unsigned int size = width * height * (bpp / 8);
+  const unsigned int size = decodedFrame.rgbaImage.size;
   const uint32_t format = static_cast<uint32_t>(decodedFrame.rgbaImage.textureFormat) |
                           static_cast<uint32_t>(decodedFrame.rgbaImage.textureAlpha) |
                           static_cast<uint32_t>(decodedFrame.rgbaImage.textureSwizzle);
@@ -200,7 +331,7 @@ CXBTFFrame TexturePacker::CreateXBTFFrame(DecodedFrame& decodedFrame, CXBTFWrite
   CXBTFFrame frame;
   lzo_uint packedSize = size;
 
-  if ((m_flags & FLAGS_USE_LZO) == FLAGS_USE_LZO)
+  if (m_compress)
   {
     // grab a temporary buffer for unpacking into
     packedSize = size + size / 16 + 64 + 3; // see simple.c in lzo
@@ -285,6 +416,7 @@ void TexturePacker::ConvertToSingleChannel(RGBAImage& image, uint32_t channel)
 
   image.bbp = 8;
   image.pitch = 1 * image.width;
+  image.size = size;
 }
 
 void TexturePacker::ConvertToDualChannel(RGBAImage& image)
@@ -298,6 +430,7 @@ void TexturePacker::ConvertToDualChannel(RGBAImage& image)
   image.textureFormat = KD_TEX_FMT_SDR_RG8;
   image.bbp = 16;
   image.pitch = 2 * image.width;
+  image.size = 2 * size;
 }
 
 void TexturePacker::ReduceChannels(RGBAImage& image)
@@ -399,14 +532,14 @@ int TexturePacker::createBundle(const std::string& InputDir, const std::string& 
     CXBTFFile& file = files[i];
 
     std::string fullPath = InputDir;
-    fullPath += file.GetPath();
+    fullPath += file.GetRealPath();
 
     std::string output = file.GetPath();
 
     DecodedFrames frames;
     bool loaded = decoderManager.LoadFile(fullPath, frames);
 
-    if (!loaded)
+    if (!loaded || frames.frameList.empty())
     {
       fprintf(stderr, "...unable to load image %s\n", file.GetPath().c_str());
       continue;
@@ -421,7 +554,7 @@ int TexturePacker::createBundle(const std::string& InputDir, const std::string& 
     {
       for (unsigned int j = 0; j < frames.frameList.size(); j++)
         MD5Update(&ctx, (const uint8_t*)frames.frameList[j].rgbaImage.pixels.data(),
-                  frames.frameList[j].rgbaImage.height * frames.frameList[j].rgbaImage.pitch);
+                  frames.frameList[j].rgbaImage.size);
 
       if (CheckDupe(&ctx, i))
       {
@@ -489,7 +622,7 @@ int main(int argc, char* argv[])
 
   TexturePacker texturePacker;
 
-  texturePacker.SetFlags(FLAGS_USE_LZO);
+  bool rawSDRTextures = true;
 
   for (unsigned int i = 1; i < args.size(); ++i)
   {
@@ -520,11 +653,46 @@ int main(int argc, char* argv[])
       while ((c = (char *)strchr(OutputFilename.c_str(), '\\')) != NULL) *c = '/';
 #endif
     }
+    else if (!strcmp(args[i], "-nosdr"))
+    {
+      rawSDRTextures = false;
+    }
+    else if (!strcmp(args[i], "-etc1"))
+    {
+      texturePacker.EnableTextureFamily(KD_TEX_FMT_ETC1);
+    }
+    else if (!strcmp(args[i], "-etc2"))
+    {
+      texturePacker.EnableTextureFamily(KD_TEX_FMT_ETC2);
+    }
+    else if (!strcmp(args[i], "-astc"))
+    {
+      texturePacker.EnableTextureFamily(KD_TEX_FMT_ASTC_LDR);
+    }
+    else if (!strcmp(args[i], "-s3tc"))
+    {
+      texturePacker.EnableTextureFamily(KD_TEX_FMT_S3TC);
+    }
+    else if (!strcmp(args[i], "-rgtc"))
+    {
+      texturePacker.EnableTextureFamily(KD_TEX_FMT_RGTC);
+    }
+    else if (!strcmp(args[i], "-bptc"))
+    {
+      texturePacker.EnableTextureFamily(KD_TEX_FMT_BPTC);
+    }
+    else if (!strcmp(args[i], "-nocompress"))
+    {
+      texturePacker.DisableCompression();
+    }
     else
     {
       fprintf(stderr, "Unrecognized command line flag: %s\n", args[i]);
     }
   }
+
+  if (rawSDRTextures)
+    texturePacker.EnableTextureFamily(KD_TEX_FMT_SDR);
 
   if (!valid)
   {

--- a/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.cpp
@@ -60,6 +60,7 @@ bool GIFDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
         frame.rgbaImage.width = width;
         frame.rgbaImage.bbp = 32;
         frame.rgbaImage.pitch = pitch;
+        frame.rgbaImage.size = height * pitch;
         frame.delay = extractedFrames[i]->m_delay;
 
         frames.frameList.push_back(frame);

--- a/tools/depends/native/TexturePacker/src/decoder/IDecoder.h
+++ b/tools/depends/native/TexturePacker/src/decoder/IDecoder.h
@@ -1,21 +1,9 @@
 /*
- *      Copyright (C) 2014 Team Kodi
- *      http://kodi.tv
+ *  Copyright (C) 2014-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
  *
- *  This Program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2, or (at your option)
- *  any later version.
- *
- *  This Program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with XBMC; see the file COPYING.  If not, see
- *  <http://www.gnu.org/licenses/>.
- *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
  */
 
 #pragma once
@@ -41,9 +29,14 @@ class IDecoder
     virtual const char* GetDecoderName() = 0;
 
     const std::vector<std::string>& GetSupportedExtensions() const { return m_extensions; }
+    const std::vector<std::pair<std::string, KD_TEX_FMT>>& GetSupportedSubstitutions() const
+    {
+      return m_substitutions;
+    }
 
   protected:
     std::vector<std::string> m_extensions;
+    std::vector<std::pair<std::string, KD_TEX_FMT>> m_substitutions;
 };
 
 class RGBAImage
@@ -56,6 +49,7 @@ public:
   int height = 0; // height
   int bbp = 32; // bits per pixel
   int pitch = 0; // rowsize in bytes
+  size_t size = 0; // image size in bytes
   KD_TEX_FMT textureFormat{KD_TEX_FMT_SDR_BGRA8};
   KD_TEX_ALPHA textureAlpha{KD_TEX_ALPHA_STRAIGHT};
   KD_TEX_SWIZ textureSwizzle{KD_TEX_SWIZ_RGBA};

--- a/tools/depends/native/TexturePacker/src/decoder/JPGDecoder.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/JPGDecoder.cpp
@@ -130,6 +130,7 @@ bool JPGDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
   frame.rgbaImage.width = cinfo.image_width;
   frame.rgbaImage.bbp = 32;
   frame.rgbaImage.pitch = 4 * cinfo.image_width;
+  frame.rgbaImage.size = 4 * cinfo.image_width * cinfo.image_height;
 
   frames.frameList.push_back(frame);
 

--- a/tools/depends/native/TexturePacker/src/decoder/KTXDecoder.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/KTXDecoder.cpp
@@ -1,0 +1,269 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "KTXDecoder.h"
+
+#include "SimpleFS.h"
+#include "guilib/TextureFormats.h"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace
+{
+// clang-format off
+static const std::map<uint32_t, TextureProperties> TextureMapping
+{
+  // S3TC
+  {0x83F0, {KD_TEX_FMT_S3TC_RGB8, KD_TEX_ALPHA_OPAQUE}}, // GL_COMPRESSED_RGB_S3TC_DXT1_EXT
+  {0x83F1, {KD_TEX_FMT_S3TC_RGB8_A1}}, // GL_COMPRESSED_RGBA_S3TC_DXT1_EXT
+  {0x83F2, {KD_TEX_FMT_S3TC_RGB8_A4}}, // GL_COMPRESSED_RGBA_S3TC_DXT3_EXT
+  {0x83F3, {KD_TEX_FMT_S3TC_RGBA8}}, // GL_COMPRESSED_RGBA_S3TC_DXT5_EXT
+  {0x8C4C, {KD_TEX_FMT_S3TC_RGB8, KD_TEX_ALPHA_OPAQUE}}, // GL_COMPRESSED_SRGB_S3TC_DXT1_EXT
+  {0x8C4D, {KD_TEX_FMT_S3TC_RGB8_A1}}, // GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT
+  {0x8C4E, {KD_TEX_FMT_S3TC_RGB8_A4}}, // GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT
+  {0x8C4F, {KD_TEX_FMT_S3TC_RGBA8}}, // GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT
+  // ETC1
+  {0x8D64, {KD_TEX_FMT_ETC1_RGB8, KD_TEX_ALPHA_OPAQUE}}, // GL_ETC1_RGB8_OES
+  // RGTC
+  {0x8DBB, {KD_TEX_FMT_RGTC_R11, KD_TEX_ALPHA_STRAIGHT, KD_TEX_SWIZ_111R}}, // GL_COMPRESSED_RED_RGTC1_EXT, interpret as alpha texture
+  {0x8DBD, {KD_TEX_FMT_RGTC_RG11, KD_TEX_ALPHA_STRAIGHT, KD_TEX_SWIZ_RRRG}}, // GL_COMPRESSED_RED_GREEN_RGTC2_EXT
+  // BPTC
+  {0x8E8C, {KD_TEX_FMT_BPTC_RGBA8}}, // GL_COMPRESSED_RGBA_BPTC_UNORM
+  {0x8E8D, {KD_TEX_FMT_BPTC_RGBA8}}, // GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM
+  {0x8E8F, {KD_TEX_FMT_BPTC_RGB16F}}, // GL_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT
+  // ETC2
+  {0x9270, {KD_TEX_FMT_ETC2_R11, KD_TEX_ALPHA_STRAIGHT, KD_TEX_SWIZ_111R}}, // GL_COMPRESSED_R11_EAC, interpret as alpha texture
+  {0x9272, {KD_TEX_FMT_ETC2_RG11, KD_TEX_ALPHA_STRAIGHT, KD_TEX_SWIZ_RRRG}}, // GL_COMPRESSED_RG11_EAC
+  {0x9274, {KD_TEX_FMT_ETC2_RGB8, KD_TEX_ALPHA_OPAQUE}}, // GL_COMPRESSED_RGB8_ETC2
+  {0x9275, {KD_TEX_FMT_ETC2_RGB8, KD_TEX_ALPHA_OPAQUE}}, // GL_COMPRESSED_SRGB8_ETC2
+  {0x9276, {KD_TEX_FMT_ETC2_RGB8_A1}}, // GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2
+  {0x9277, {KD_TEX_FMT_ETC2_RGB8_A1}}, // GL_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2
+  {0x9278, {KD_TEX_FMT_ETC2_RGBA8}}, // GL_COMPRESSED_RGBA8_ETC2_EAC
+  {0x9279, {KD_TEX_FMT_ETC2_RGBA8}}, // GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC
+  // ASTC, just LDR for now
+  {0x93B0, {KD_TEX_FMT_ASTC_LDR_4x4}}, // GL_COMPRESSED_RGBA_ASTC_4x4_KHR
+  {0x93B1, {KD_TEX_FMT_ASTC_LDR_5x4}}, // GL_COMPRESSED_RGBA_ASTC_5x4_KHR
+  {0x93B2, {KD_TEX_FMT_ASTC_LDR_5x5}}, // GL_COMPRESSED_RGBA_ASTC_5x5_KHR
+  {0x93B3, {KD_TEX_FMT_ASTC_LDR_6x5}}, // GL_COMPRESSED_RGBA_ASTC_6x5_KHR
+  {0x93B4, {KD_TEX_FMT_ASTC_LDR_6x6}}, // GL_COMPRESSED_RGBA_ASTC_6x6_KHR
+  {0x93B5, {KD_TEX_FMT_ASTC_LDR_8x5}}, // GL_COMPRESSED_RGBA_ASTC_8x5_KHR
+  {0x93B6, {KD_TEX_FMT_ASTC_LDR_8x6}}, // GL_COMPRESSED_RGBA_ASTC_8x6_KHR
+  {0x93B7, {KD_TEX_FMT_ASTC_LDR_8x8}}, // GL_COMPRESSED_RGBA_ASTC_8x8_KHR
+  {0x93B8, {KD_TEX_FMT_ASTC_LDR_10x5}}, // GL_COMPRESSED_RGBA_ASTC_10x5_KHR
+  {0x93B9, {KD_TEX_FMT_ASTC_LDR_10x6}}, // GL_COMPRESSED_RGBA_ASTC_10x6_KHR
+  {0x93BA, {KD_TEX_FMT_ASTC_LDR_10x8}}, // GL_COMPRESSED_RGBA_ASTC_10x8_KHR
+  {0x93BB, {KD_TEX_FMT_ASTC_LDR_10x10}}, // GL_COMPRESSED_RGBA_ASTC_10x10_KHR
+  {0x93BC, {KD_TEX_FMT_ASTC_LDR_12x10}}, // GL_COMPRESSED_RGBA_ASTC_12x10_KHR
+  {0x93BD, {KD_TEX_FMT_ASTC_LDR_12x12}}, // GL_COMPRESSED_RGBA_ASTC_12x12_KHR
+  {0x93D0, {KD_TEX_FMT_ASTC_LDR_4x4}}, // GL_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR
+  {0x93D1, {KD_TEX_FMT_ASTC_LDR_5x4}}, // GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR
+  {0x93D2, {KD_TEX_FMT_ASTC_LDR_5x5}}, // GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR
+  {0x93D3, {KD_TEX_FMT_ASTC_LDR_6x5}}, // GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x5_KHR
+  {0x93D4, {KD_TEX_FMT_ASTC_LDR_6x6}}, // GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x6_KHR
+  {0x93D5, {KD_TEX_FMT_ASTC_LDR_8x5}}, // GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x5_KHR
+  {0x93D6, {KD_TEX_FMT_ASTC_LDR_8x6}}, // GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x6_KHR
+  {0x93D7, {KD_TEX_FMT_ASTC_LDR_8x8}}, // GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR
+  {0x93D8, {KD_TEX_FMT_ASTC_LDR_10x5}}, // GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR
+  {0x93D9, {KD_TEX_FMT_ASTC_LDR_10x6}}, // GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x6_KHR
+  {0x93DA, {KD_TEX_FMT_ASTC_LDR_10x8}}, // GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x8_KHR
+  {0x93DB, {KD_TEX_FMT_ASTC_LDR_10x10}}, // GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR
+  {0x93DC, {KD_TEX_FMT_ASTC_LDR_12x10}}, // GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR
+  {0x93DD, {KD_TEX_FMT_ASTC_LDR_12x12}}, // GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR,
+};
+
+static const std::map<std::string, KD_TEX_SWIZ> SwizzleKeys
+{
+  {"KD_TEX_SWIZ_RGBA", KD_TEX_SWIZ_RGBA}, 
+  {"KD_TEX_SWIZ_RGB1", KD_TEX_SWIZ_RGB1},
+  {"KD_TEX_SWIZ_RRR1", KD_TEX_SWIZ_RRR1}, 
+  {"KD_TEX_SWIZ_111R", KD_TEX_SWIZ_111R},
+  {"KD_TEX_SWIZ_RRRG", KD_TEX_SWIZ_RRRG}, 
+  {"KD_TEX_SWIZ_RRRR", KD_TEX_SWIZ_RRRR},
+  {"KD_TEX_SWIZ_GGG1", KD_TEX_SWIZ_GGG1}, 
+  {"KD_TEX_SWIZ_111G", KD_TEX_SWIZ_111G},
+  {"KD_TEX_SWIZ_GGGA", KD_TEX_SWIZ_GGGA}, 
+  {"KD_TEX_SWIZ_GGGG", KD_TEX_SWIZ_GGGG},
+  {"KD_TEX_SWIZ_SDF", KD_TEX_SWIZ_SDF},   
+  {"KD_TEX_SWIZ_RGB_SDF", KD_TEX_SWIZ_RGB_SDF},
+  {"KD_TEX_SWIZ_MSDF", KD_TEX_SWIZ_MSDF},
+};
+
+static const std::map<std::string, KD_TEX_ALPHA> AlphaKeys
+{
+  {"KD_TEX_ALPHA_STRAIGHT", KD_TEX_ALPHA_STRAIGHT},
+  {"KD_TEX_ALPHA_OPAQUE", KD_TEX_ALPHA_OPAQUE},
+  {"KD_TEX_ALPHA_PREMULTIPLIED", KD_TEX_ALPHA_PREMULTIPLIED},
+};
+// clang-format on
+} // namespace
+
+KTXDecoder::KTXDecoder()
+{
+  m_extensions.emplace_back(".ktx");
+  m_substitutions.emplace_back(".astc.ktx", KD_TEX_FMT_ASTC_LDR);
+  m_substitutions.emplace_back(".bptc.ktx", KD_TEX_FMT_BPTC);
+  m_substitutions.emplace_back(".etc1.ktx", KD_TEX_FMT_ETC1);
+  m_substitutions.emplace_back(".etc2.ktx", KD_TEX_FMT_ETC2);
+  m_substitutions.emplace_back(".rgtc.ktx", KD_TEX_FMT_RGTC);
+  m_substitutions.emplace_back(".s3tc.ktx", KD_TEX_FMT_S3TC);
+}
+
+bool KTXDecoder::CanDecode(const std::string& filename)
+{
+  CFile fp;
+  if (!fp.Open(filename))
+    return false;
+
+  std::array<unsigned char, 12> magic;
+  if (fp.Read(&magic, sizeof(magic)) != sizeof(magic))
+    return false;
+
+  if (magic != m_magic)
+    return false;
+
+  std::array<unsigned char, 4> endianess;
+  if (fp.Read(&endianess, sizeof(endianess)) != sizeof(endianess))
+    return false;
+
+  if (endianess != m_endianess)
+    return false;
+
+  return true;
+}
+
+bool KTXDecoder::LoadFile(const std::string& filename, DecodedFrames& frames)
+{
+  CFile fp;
+  if (!fp.Open(filename))
+    return false;
+
+  if (fp.Seek(28) != 28)
+    return false;
+
+  uint32_t glInternalFormat;
+  if (fp.Read(&glInternalFormat, sizeof(glInternalFormat)) != sizeof(glInternalFormat))
+    return false;
+
+  DecodedFrame frame;
+
+  if (!ParseFormat(frame.rgbaImage, glInternalFormat))
+    return false;
+
+  uint32_t glBaseInternalFormat;
+  if (fp.Read(&glBaseInternalFormat, sizeof(glBaseInternalFormat)) != sizeof(glBaseInternalFormat))
+    return false;
+
+  uint32_t width;
+  if (fp.Read(&width, sizeof(width)) != sizeof(width))
+    return false;
+
+  uint32_t height;
+  if (fp.Read(&height, sizeof(height)) != sizeof(height))
+    return false;
+
+  uint32_t depth;
+  if (fp.Read(&depth, sizeof(depth)) != sizeof(depth))
+    return false;
+
+  uint32_t numberOfArrayElements;
+  if (fp.Read(&numberOfArrayElements, sizeof(numberOfArrayElements)) !=
+      sizeof(numberOfArrayElements))
+    return false;
+
+  uint32_t numberOfFaces;
+  if (fp.Read(&numberOfFaces, sizeof(numberOfFaces)) != sizeof(numberOfFaces))
+    return false;
+
+  uint32_t numberOfMipmapLevels;
+  if (fp.Read(&numberOfMipmapLevels, sizeof(numberOfMipmapLevels)) != sizeof(numberOfMipmapLevels))
+    return false;
+
+  uint32_t bytesOfKeyValueData;
+  if (fp.Read(&bytesOfKeyValueData, sizeof(bytesOfKeyValueData)) != sizeof(bytesOfKeyValueData))
+    return false;
+
+  // sanity check
+  if (bytesOfKeyValueData > 2048)
+    return false;
+
+  // pad to 4 bytes
+  while (bytesOfKeyValueData % 4)
+    bytesOfKeyValueData++;
+
+  std::vector<uint8_t> keyValueData;
+  keyValueData.resize(bytesOfKeyValueData);
+  if (fp.Read(keyValueData.data(), keyValueData.size()) != keyValueData.size())
+    return false;
+
+  ParseKeys(frame.rgbaImage, keyValueData);
+
+  uint32_t size;
+  if (fp.Read(&size, sizeof(size)) != sizeof(size))
+    return false;
+
+  frame.rgbaImage.width = width;
+  frame.rgbaImage.height = height;
+
+  frame.rgbaImage.pixels.resize(size);
+  frame.rgbaImage.size = size;
+
+  if (fp.Read(frame.rgbaImage.pixels.data(), size) != size)
+    return false;
+
+  frames.frameList.push_back(frame);
+
+  return true;
+}
+
+bool KTXDecoder::ParseFormat(RGBAImage& image, uint32_t format)
+{
+  TextureProperties glFormat{};
+
+  const auto it = TextureMapping.find(format);
+  if (it == TextureMapping.cend())
+    return false;
+  {
+    glFormat = it->second;
+  }
+  image.textureFormat = it->second.textureFormat;
+  image.textureAlpha = it->second.textureAlpha;
+  image.textureSwizzle = it->second.textureSwizzle;
+
+  return true;
+}
+
+void KTXDecoder::ParseKeys(RGBAImage& image, std::vector<uint8_t>& keyValueData)
+{
+  for (auto it = SwizzleKeys.begin(); it != SwizzleKeys.end(); ++it)
+  {
+    if (std::search(keyValueData.begin(), keyValueData.end(), it->first.begin(), it->first.end()) !=
+        keyValueData.end())
+    {
+      image.textureSwizzle = it->second;
+      break;
+    }
+  }
+
+  for (auto it = AlphaKeys.begin(); it != AlphaKeys.end(); ++it)
+  {
+    if (std::search(keyValueData.begin(), keyValueData.end(), it->first.begin(), it->first.end()) !=
+        keyValueData.end())
+    {
+      image.textureAlpha = it->second;
+      break;
+    }
+  }
+}

--- a/tools/depends/native/TexturePacker/src/decoder/KTXDecoder.h
+++ b/tools/depends/native/TexturePacker/src/decoder/KTXDecoder.h
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "IDecoder.h"
+#include "guilib/TextureFormats.h"
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+struct TextureProperties
+{
+  KD_TEX_FMT textureFormat{KD_TEX_FMT_SDR_BGRA8};
+  KD_TEX_ALPHA textureAlpha{KD_TEX_ALPHA_STRAIGHT};
+  KD_TEX_SWIZ textureSwizzle{KD_TEX_SWIZ_RGBA};
+};
+
+class KTXDecoder : public IDecoder
+{
+public:
+  KTXDecoder();
+  ~KTXDecoder() override = default;
+  bool CanDecode(const std::string& filename) override;
+  bool LoadFile(const std::string& filename, DecodedFrames& frames) override;
+  const char* GetImageFormatName() override { return "KTX"; }
+  const char* GetDecoderName() override { return "KTX decoder"; }
+
+private:
+  bool ParseFormat(RGBAImage& image, uint32_t format);
+  void ParseKeys(RGBAImage& image, std::vector<uint8_t>& keyValueData);
+
+  static constexpr std::array<unsigned char, 12> m_magic{0xAB, 'K',  'T',  'X',  ' ',  '1',
+                                                         '1',  0xBB, '\r', '\n', 0x1A, '\n'};
+  static constexpr std::array<unsigned char, 4> m_endianess{0x01, 0x02, 0x03, 0x04};
+};

--- a/tools/depends/native/TexturePacker/src/decoder/PNGDecoder.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/PNGDecoder.cpp
@@ -21,6 +21,7 @@
 #include "PNGDecoder.h"
 
 #include "SimpleFS.h"
+#include "guilib/TextureFormats.h"
 
 #include <png.h>
 
@@ -214,6 +215,7 @@ bool PNGDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
   frame.rgbaImage.width = temp_width;
   frame.rgbaImage.bbp = 32;
   frame.rgbaImage.pitch = 4 * temp_width;
+  frame.rgbaImage.size = 4 * temp_width * temp_height;
 
   frames.frameList.push_back(frame);
   // clean up

--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -245,14 +245,15 @@ void CGLTexture::LoadToGPU()
 
   TextureFormat glFormat = GetFormatGL(m_textureFormat);
 
-  if (glFormat.format == GL_FALSE)
+  if (glFormat.internalFormat == GL_FALSE)
   {
     CLog::LogF(LOGDEBUG, "Failed to load texture. Unsupported format {}", m_textureFormat);
     m_loadedToGPU = true;
     return;
   }
 
-  if ((m_textureFormat & KD_TEX_FMT_SDR) || (m_textureFormat & KD_TEX_FMT_HDR))
+  if ((m_textureFormat & KD_TEX_FMT_TYPE_MASK) == KD_TEX_FMT_SDR ||
+      (m_textureFormat & KD_TEX_FMT_TYPE_MASK) == KD_TEX_FMT_HDR)
   {
     glTexImage2D(GL_TEXTURE_2D, 0, glFormat.internalFormat, m_textureWidth, m_textureHeight, 0,
                  glFormat.format, glFormat.type, m_pixels);

--- a/xbmc/guilib/TextureGLES.cpp
+++ b/xbmc/guilib/TextureGLES.cpp
@@ -311,7 +311,8 @@ void CGLESTexture::LoadToGPU()
     return;
   }
 
-  if ((m_textureFormat & KD_TEX_FMT_SDR) || (m_textureFormat & KD_TEX_FMT_HDR))
+  if ((m_textureFormat & KD_TEX_FMT_TYPE_MASK) == KD_TEX_FMT_SDR ||
+      (m_textureFormat & KD_TEX_FMT_TYPE_MASK) == KD_TEX_FMT_HDR)
   {
     glTexImage2D(GL_TEXTURE_2D, 0, glesFormat.internalFormat, m_textureWidth, m_textureHeight, 0,
                  glesFormat.format, glesFormat.type, m_pixels);
@@ -430,8 +431,9 @@ TextureFormat CGLESTexture::GetFormatGLES20(KD_TEX_FMT textureFormat)
       glFormat.format = glFormat.internalFormat = GL_RGBA;
     }
   }
-  else if (textureFormat & KD_TEX_FMT_SDR || textureFormat & KD_TEX_FMT_HDR ||
-           textureFormat & KD_TEX_FMT_ETC1)
+  else if ((m_textureFormat & KD_TEX_FMT_TYPE_MASK) == KD_TEX_FMT_SDR ||
+           (m_textureFormat & KD_TEX_FMT_TYPE_MASK) == KD_TEX_FMT_HDR ||
+           (m_textureFormat & KD_TEX_FMT_TYPE_MASK) == KD_TEX_FMT_ETC1)
   {
     const auto it = TextureMappingGLES20.find(textureFormat);
     if (it != TextureMappingGLES20.cend())
@@ -452,7 +454,8 @@ TextureFormat CGLESTexture::GetFormatGLES30(KD_TEX_FMT textureFormat)
 {
   TextureFormat glFormat;
 
-  if (textureFormat & KD_TEX_FMT_SDR || textureFormat & KD_TEX_FMT_HDR)
+  if ((m_textureFormat & KD_TEX_FMT_TYPE_MASK) == KD_TEX_FMT_SDR ||
+      (m_textureFormat & KD_TEX_FMT_TYPE_MASK) == KD_TEX_FMT_HDR)
   {
 #if defined(GL_ES_VERSION_3_0)
     const auto it = TextureMappingGLES30.find(textureFormat);

--- a/xbmc/guilib/XBTF.cpp
+++ b/xbmc/guilib/XBTF.cpp
@@ -149,6 +149,7 @@ const std::string& CXBTFFile::GetPath() const
 void CXBTFFile::SetPath(const std::string& path)
 {
   m_path = path;
+  m_realPath = path;
 }
 
 uint32_t CXBTFFile::GetLoop() const

--- a/xbmc/guilib/XBTF.h
+++ b/xbmc/guilib/XBTF.h
@@ -75,6 +75,15 @@ public:
   const std::string& GetPath() const;
   void SetPath(const std::string& path);
 
+  const std::string& GetRealPath() const { return m_realPath; }
+  void SetRealPath(const std::string& path) { m_realPath = path; }
+
+  unsigned int GetSubstitutionPriority() const { return m_substitutionPriority; }
+  void SetSubstitutionPriority(unsigned int substitutionPriority)
+  {
+    m_substitutionPriority = substitutionPriority;
+  }
+
   uint32_t GetLoop() const;
   void SetLoop(uint32_t loop);
 
@@ -88,7 +97,9 @@ public:
   static const size_t MaximumPathLength = 256;
 
 private:
-  std::string m_path;
+  std::string m_path; // path used in skin, e.g. icon.png
+  std::string m_realPath; // actual file path, might be icon.png.astc.ktx
+  unsigned int m_substitutionPriority{0};
   uint32_t m_loop = 0;
   std::vector<CXBTFFrame> m_frames;
 };


### PR DESCRIPTION
## Description
The PR adds support for compressed textures to the texture packer. Compressed textures can be supplied via KTX containers. 

There are switches to allow the packer to substitute normally uncompressed files with compressed counterparts. This makes it possible to generate texture packs which are tailored to different families of devices. For more information, see https://github.com/xbmc/xbmc/blob/31b17010d14b78268241f311de24149eccf127d7/tools/depends/native/TexturePacker/src/TexturePacker.cpp#L127 

## Motivation and context
The texture footprint of Estuary in Omega was 47.6MB. By using single and dual channel formats, it had been reduced to 12.5MB. With most compression schemes, it can be reduced further to around 6.5MB. By using ASTC, the footprint is just 3.1MB, a 93% reduction compared to Omega.

By using compressed formats, the texture upload should be faster, as less data is read from disk and moved around. The amount of GPU-RAM used should be considerably lower. The same should apply for memory bandwidth used by the GPU. This frees precious resources for the rest of the system.

The loss in image quality is virtually imperceivable. 

To generate the KTX textures, I've created a python script which feeds various encoders. It is pretty hacky atm, but I'm planning on submitting it in the future.

The next step would be to add a way to distribute and enable such texture packs. For testing, I'm attaching a XBT file for Estuary, containing BPTC and RGTC textures. By replacing the file "addons/skin.estuary/media/Textures.xbt" with [Textures.xbt.zip](https://github.com/user-attachments/files/17422875/Textures.xbt.zip), the skin should load the compressed textures on Linux/Mesa systems.

## How has this been tested?
Various texture profiles render fine on my desktop system.

## What is the effect on users?
Right now, it won't have any effect.

## Screenshots (if appropriate):
All XBT textures in this screenshot are in an ASTC 8x8 format, with a bitrate of 2 bit/pixel. 
![image](https://github.com/user-attachments/assets/98dd6b46-db34-454d-9d52-2abb488e3a9f)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
