### PR TITLE
[PVR] CAddonTimer: Fix memory corruption caused by freed string data transferred to add-on.

### DIFF
--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -269,7 +269,8 @@ public:
         prop.iKey = entry.first;
         prop.eType = entry.second.type;
         prop.iValue = entry.second.value.asInteger32();
-        prop.strValue = entry.second.value.asString().c_str();
+        m_customPropStringValues.emplace_back(entry.second.value.asString());
+        prop.strValue = m_customPropStringValues.back().c_str();
         ++idx;
       }
       customProps = m_customProps.get();
@@ -283,6 +284,7 @@ private:
   const std::string m_directory;
   const std::string m_summary;
   const std::string m_seriesLink;
+  std::vector<std::string> m_customPropStringValues;
   std::unique_ptr<PVR_SETTING_KEY_VALUE_PAIR[]> m_customProps;
 };
 


### PR DESCRIPTION
Fixes an issue where corrupted string data were transferred from Kodi via pvr.hts to tvheadend backend, namely for the custom string property "Comment", which is used for timers and timer rules.

Screenshot showing the problem in tvheadend GUI:

<img width="1557" alt="Screenshot_2024-10-18_at_08_09_02" src="https://github.com/user-attachments/assets/422ba269-ead5-4176-bb2f-737d908616c1">

Runtime-tested on macOS and Android, latest kodi master.

@phunkyfish should be easy to review. We must ensure that string data will not be destroyed until the add-on call was done.
