### PR TITLE
[cores] CInputStreamPVRBase: Optimize: Only close the stream if it is…

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.cpp
@@ -40,8 +40,9 @@ bool CInputStreamPVRBase::IsEOF()
 
 bool CInputStreamPVRBase::Open()
 {
-  if (CDVDInputStream::Open() && OpenPVRStream())
+  if (!m_isOpen && CDVDInputStream::Open() && OpenPVRStream())
   {
+    m_isOpen = true;
     m_eof = false;
     m_StreamProps->iStreamCount = 0;
     return true;
@@ -54,9 +55,13 @@ bool CInputStreamPVRBase::Open()
 
 void CInputStreamPVRBase::Close()
 {
-  ClosePVRStream();
-  CDVDInputStream::Close();
-  m_eof = true;
+  if (m_isOpen)
+  {
+    ClosePVRStream();
+    CDVDInputStream::Close();
+    m_eof = true;
+    m_isOpen = false;
+  }
 }
 
 int CInputStreamPVRBase::Read(uint8_t* buf, int buf_size)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.h
@@ -80,4 +80,5 @@ protected:
   std::shared_ptr<PVR_STREAM_PROPERTIES> m_StreamProps;
   std::map<int, std::shared_ptr<CDemuxStream>> m_streamMap;
   std::shared_ptr<PVR::CPVRClient> m_client;
+  bool m_isOpen{false};
 };


### PR DESCRIPTION
… open. Only open the stream if it is not open.

Just a small optimization to avoid unneeded add-on calls. There are use cases where the stream instance gets created and without opening the stream it will be directly destroyed afterwards. No close call to the add-on needed in this case.

Runtime-tested on macOS, latest kodi master.

@phunkyfish please review. Should be straight forward.