### PR TITLE
[Android] Fix resuming paused media playback not working via play|pause media key press.

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -220,6 +220,11 @@ void CXBMCApp::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
       m_mediaSessionUpdated = false;
       UpdateSessionState();
     }
+    else if (message == "OnAVStart")
+    {
+      m_mediaSessionUpdated = false;
+      UpdateSessionState();
+    }
   }
   else if (flag & Info)
   {


### PR DESCRIPTION
## Description
#24986 introduced a regression, which led to `CXBMXApp::m_playback_state` not being correctly initialized in `CXBMXApp::OnPlaybackStarted`. 

Calls to `appPlayer->HasVideo()`and `appPlayer->HasAudio()` done there both can return `false` at that time because the stream was not opened yet.

In that case, `CXBMXApp::m_playback_state` was initialized only with `PLAYBACK_STATE_PLAYING`, not additionally with `PLAYBACK_STATE_VIDEO` and/or `PLAYBACK_STATE_AUDIO`, which would set at least another bit in `CXBMXApp::m_playback_state`. Now, when pressing the play|pause media key, this works, playback will be paused. `PLAYBACK_STATE_PLAYING` bit will be removed from `CXBMXApp::m_playback_state` in `CXBMXApp::OnPlaybackPaused`, making `CXBMXApp::m_playback_state` value 0 (== `PLAYBACK_STATE_STOPPED`). Now pressing play|pause media key to unpause will not work, because of: 

```c++
    if (m_playback_state == PLAYBACK_STATE_STOPPED)
    {
      CLog::Log(LOGINFO, "Ignore MEDIA_BUTTON intent: no media playing");
      return;
    }
```

Fix is to update `CXBMXApp::m_playback_state` on  Announcer's "OnAVStart" event which will be sent once after stream was fully initialized, thus `appPlayer->HasVideo()`and `appPlayer->HasAudio()` returning the right values then.

Actually, this never worked reliably, but before above mentioned PR, the state got updated after `CXBMXApp::OnPlaybackStarted` on regular base so state got eventually consistent.

## Motivation and context
Wanted to have working unpause with media key "play|pause" again.

## How has this been tested?
Inserted additional temporary log messages to understand the problem and to verify the fix.
Runtime-tested on my NVidia Shield Pro 2019.

## What is the effect on users?
Working unpause with media key "play|pause" again.

## Screenshots (if appropriate):
n/a

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
