### PR TITLE
Fix include for GCC14

### DIFF
--- a/xbmc/cores/VideoPlayer/Interface/StreamInfo.h
+++ b/xbmc/cores/VideoPlayer/Interface/StreamInfo.h
@@ -10,6 +10,7 @@
 
 #include "utils/Geometry.h"
 
+#include <cstdint>
 #include <string>
 
 template <typename T> class CRectGen;


### PR DESCRIPTION
## Description
Adds missing include.

## Motivation and context
After https://github.com/xbmc/xbmc/pull/25762, Kodi does not compile on GCC14. It compiles by adding the include.

## How has this been tested?
Kodi compiles again on Manjaro.

## What is the effect on users?
Kodi compiles.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
