### PR TITLE
Fix art announce update after #25812

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4956,6 +4956,11 @@ void CVideoDatabase::SetVideoSettings(int idFile, const CVideoSettings &setting)
   }
 }
 
+void CVideoDatabase::UpdateArtForItem(int mediaId, const MediaType& mediaType)
+{
+  AnnounceUpdate(mediaType, mediaId);
+}
+
 void CVideoDatabase::SetArtForItem(int mediaId, const MediaType &mediaType, const std::map<std::string, std::string> &art)
 {
   for (const auto &i : art)
@@ -4994,8 +4999,6 @@ void CVideoDatabase::SetArtForItem(int mediaId, const MediaType &mediaType, cons
       sql = PrepareSQL("INSERT INTO art(media_id, media_type, type, url) VALUES (%d, '%s', '%s', '%s')", mediaId, mediaType.c_str(), artType.c_str(), url.c_str());
       m_pDS->exec(sql);
     }
-
-    AnnounceUpdate(mediaType, mediaId);
   }
   catch (...)
   {

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -984,6 +984,8 @@ public:
   bool GetArtForItem(int mediaId, const MediaType &mediaType, std::map<std::string, std::string> &art);
   std::string GetArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType);
 
+  void UpdateArtForItem(int mediaId, const MediaType& mediaType);
+
   /*!
    * \brief Retrieve all art for the given video asset, with optional fallback to the art of the
    * parent/owner of the asset

--- a/xbmc/video/VideoItemArtworkHandler.cpp
+++ b/xbmc/video/VideoItemArtworkHandler.cpp
@@ -141,6 +141,8 @@ void CVideoItemArtworkHandler::PersistArt(const std::string& art)
 
   videodb.SetArtForItem(m_item->GetVideoInfoTag()->m_iDbId, m_item->GetVideoInfoTag()->m_type,
                         m_artType, art);
+
+  videodb.UpdateArtForItem(m_item->GetVideoInfoTag()->m_iDbId, m_artType);
 }
 
 void CVideoItemArtworkHandler::AddItemPathStringToFileBrowserSources(


### PR DESCRIPTION
## Description
Fix art announce update after https://github.com/xbmc/xbmc/pull/25812

## Motivation and context
After https://github.com/xbmc/xbmc/pull/25812 when scanning library at startup (or on demand) and new items added all posters on main screen "blinks" continuously because `AnnounceUpdate` is called for every art item added in background.

See video:

https://github.com/user-attachments/assets/4545f2ce-924b-4803-95c7-df707b60ba68

FYI
@78andyp 

Fix consist on move `AnnounceUpdate` call to `VideoItemArtworkHandler.cpp` then only is called when changes are due "ArtworkHandler", not always that one art item is added in background.


## How has this been tested?
Runtime Windows x64. 
Tested scanning library and also tested manual art update continue working (changed art is updated in main screen).

This effect (posters redrawing) is also reproducible on Android (Shield).


## What is the effect on users?
Fixes continuous redrawing of all posters on the main screen during library scanning.


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
