### PR TITLE
[Android] Setting to enable/disable the Decoderfilter

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7614,7 +7614,17 @@ msgctxt "#13457"
 msgid "Prefer VAAPI render method"
 msgstr ""
 
-#empty strings from id 13458 to 13459
+#. This filter disables certain Android software decoders, leaving only hardware decoders available for video playback.
+#: system/settings/settings.xml
+msgctxt "#13458"
+msgid "Use Decoder filter"
+msgstr ""
+
+#. Description of setting with label #13458 "Use Decoder filter"
+#: system/settings/settings.xml
+msgctxt "#13459"
+msgid "Enable/Disable the filter that blocks certain Android software decoders. This filter is configurable via the [userdata]/decoderfilter.xml file."
+msgstr "
 
 #: system/settings/settings.xml
 msgctxt "#13460"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -174,6 +174,15 @@
           </updates>
           <control type="toggle" />
         </setting>
+        <setting id="videoplayer.usedecoderfilter" type="boolean" label="13458" help="13459">
+          <requirement>HAS_MEDIACODEC</requirement>
+          <level>3</level>
+          <default>true</default>
+          <updates>
+            <update type="change" />
+          </updates>
+          <control type="toggle" />
+        </setting>
         <setting id="videoplayer.usedxva2" type="boolean" label="13427" help="36158">
           <requirement>HasDXVA2</requirement>
           <level>2</level>

--- a/xbmc/application/ApplicationSettingsHandling.cpp
+++ b/xbmc/application/ApplicationSettingsHandling.cpp
@@ -66,6 +66,7 @@ void CApplicationSettingsHandling::RegisterSettings()
                                        CSettings::SETTING_VIDEOSCREEN_TESTPATTERN,
                                        CSettings::SETTING_VIDEOPLAYER_USEMEDIACODEC,
                                        CSettings::SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE,
+                                       CSettings::SETTING_VIDEOPLAYER_USEDECODERFILTER,
                                        CSettings::SETTING_AUDIOOUTPUT_VOLUMESTEPS,
                                        CSettings::SETTING_SOURCE_VIDEOS,
                                        CSettings::SETTING_SOURCE_MUSIC,

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -758,8 +758,13 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
       continue;
 
     m_codecname = codec_info.getName();
-    if (!CServiceBroker::GetDecoderFilterManager()->isValid(m_codecname, m_hints))
+    if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+            CSettings::SETTING_VIDEOPLAYER_USEDECODERFILTER) &&
+        (!CServiceBroker::GetDecoderFilterManager()->isValid(m_codecname, m_hints)))
+    {
+      CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::Open: Codec disabled: {}", m_codecname);
       continue;
+    }
 
     CLog::Log(LOGINFO, "CDVDVideoCodecAndroidMediaCodec::Open Testing codec: {}", m_codecname);
 

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -123,6 +123,7 @@ public:
   static constexpr auto SETTING_VIDEOPLAYER_USEMEDIACODEC = "videoplayer.usemediacodec";
   static constexpr auto SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE =
       "videoplayer.usemediacodecsurface";
+  static constexpr auto SETTING_VIDEOPLAYER_USEDECODERFILTER = "videoplayer.usedecoderfilter";
   static constexpr auto SETTING_VIDEOPLAYER_USEVDPAU = "videoplayer.usevdpau";
   static constexpr auto SETTING_VIDEOPLAYER_USEVDPAUMIXER = "videoplayer.usevdpaumixer";
   static constexpr auto SETTING_VIDEOPLAYER_USEVDPAUMPEG2 = "videoplayer.usevdpaumpeg2";


### PR DESCRIPTION
## Description
The DecoderFilter is used to disable certain Android codecs on the device,  such as the `OMX.google` software decoders.

I propose to add a setting in the GUI to enable/disable the Decoderfilter in a simple way.

This setting is useful for certain Android devices that do not have hardware decoders and need to be able to play DRM content.

Fix issue https://github.com/xbmc/xbmc/issues/24844

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
