### PR TITLE
[Revert] Dynamic Selection of DRM planes with GBM

### DIFF
--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
@@ -54,8 +54,6 @@ public:
   virtual const VideoPicture& GetPicture() const { return m_picture; }
   virtual uint32_t GetWidth() const { return GetPicture().iWidth; }
   virtual uint32_t GetHeight() const { return GetPicture().iHeight; }
-  virtual uint32_t GetXOffset() const { return GetPicture().m_xOffset; }
-  virtual uint32_t GetYOffset() const { return GetPicture().m_yOffset; }
 
   virtual AVDRMFrameDescriptor* GetDescriptor() const = 0;
   virtual bool IsValid() const { return true; }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
@@ -58,8 +58,6 @@ void VideoPicture::Reset()
 
   iWidth = 0;
   iHeight = 0;
-  m_xOffset = 0;
-  m_yOffset = 0;
   iDisplayWidth = 0;
   iDisplayHeight = 0;
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -75,8 +75,6 @@ public:
 
   unsigned int iWidth;
   unsigned int iHeight;
-  unsigned int m_xOffset{0};
-  unsigned int m_yOffset{0};
   unsigned int iDisplayWidth;           //< width of the picture without black bars
   unsigned int iDisplayHeight;          //< height of the picture without black bars
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -505,8 +505,6 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
 {
   pVideoPicture->iWidth = m_pFrame->width;
   pVideoPicture->iHeight = m_pFrame->height;
-  pVideoPicture->m_xOffset = m_pFrame->crop_left;
-  pVideoPicture->m_yOffset = m_pFrame->crop_top;
 
   double aspect_ratio = 0;
   AVRational pixel_aspect = m_pFrame->sample_aspect_ratio;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -77,7 +77,7 @@ CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
     if (!plane)
       return nullptr;
 
-    if (!drm->FindVideoPlane(format, modifier))
+    if (!plane->SupportsFormatAndModifier(format, modifier))
       return nullptr;
 
     return new CRendererDRMPRIME();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -118,10 +118,9 @@ bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
     flags = DRM_MODE_FB_MODIFIERS;
 
   // add the video frame FB
-  ret = drmModeAddFB2WithModifiers(m_DRM->GetFileDescriptor(),
-                                   buffer->GetWidth() + buffer->GetXOffset(),
-                                   buffer->GetHeight() + buffer->GetYOffset(), layer->format,
-                                   handles, pitches, offsets, modifier, &buffer->m_fb_id, flags);
+  ret = drmModeAddFB2WithModifiers(m_DRM->GetFileDescriptor(), buffer->GetWidth(),
+                                   buffer->GetHeight(), layer->format, handles, pitches, offsets,
+                                   modifier, &buffer->m_fb_id, flags);
   if (ret < 0)
   {
     CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::{} - failed to add fb {}, ret = {}",
@@ -189,8 +188,8 @@ void CVideoLayerBridgeDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer, cons
   auto plane = m_DRM->GetVideoPlane();
   m_DRM->AddProperty(plane, "FB_ID", buffer->m_fb_id);
   m_DRM->AddProperty(plane, "CRTC_ID", m_DRM->GetCrtc()->GetCrtcId());
-  m_DRM->AddProperty(plane, "SRC_X", buffer->GetXOffset() << 16);
-  m_DRM->AddProperty(plane, "SRC_Y", buffer->GetYOffset() << 16);
+  m_DRM->AddProperty(plane, "SRC_X", 0);
+  m_DRM->AddProperty(plane, "SRC_Y", 0);
   m_DRM->AddProperty(plane, "SRC_W", buffer->GetWidth() << 16);
   m_DRM->AddProperty(plane, "SRC_H", buffer->GetHeight() << 16);
   m_DRM->AddProperty(plane, "CRTC_X", static_cast<int32_t>(destRect.x1) & ~1);

--- a/xbmc/windowing/gbm/drm/DRMObject.cpp
+++ b/xbmc/windowing/gbm/drm/DRMObject.cpp
@@ -105,25 +105,6 @@ std::optional<uint64_t> CDRMObject::GetPropertyValue(std::string_view name,
   return {};
 }
 
-std::optional<std::span<uint64_t, 2>> CDRMObject::GetRangePropertyLimits(std::string_view name)
-{
-  auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
-                               [&name](const auto& prop) { return prop->name == name; });
-
-  if (property == m_propsInfo.end())
-    return {};
-
-  auto prop = property->get();
-
-  if (!static_cast<bool>(drm_property_type_is(prop, DRM_MODE_PROP_RANGE)))
-    return {};
-
-  if (prop->count_values != 2)
-    return {};
-
-  return std::make_optional<std::span<uint64_t, 2>>(prop->values, 2);
-}
-
 bool CDRMObject::SetProperty(const std::string& name, uint64_t value)
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
@@ -148,15 +129,4 @@ bool CDRMObject::SupportsProperty(const std::string& name)
     return true;
 
   return false;
-}
-
-std::optional<bool> CDRMObject::IsPropertyImmutable(std::string_view name)
-{
-  auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
-                               [&name](const auto& prop) { return prop->name == name; });
-
-  if (property == m_propsInfo.end())
-    return {};
-
-  return static_cast<bool>(drm_property_type_is(property->get(), DRM_MODE_PROP_IMMUTABLE));
 }

--- a/xbmc/windowing/gbm/drm/DRMObject.h
+++ b/xbmc/windowing/gbm/drm/DRMObject.h
@@ -12,7 +12,6 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <span>
 #include <string_view>
 #include <vector>
 
@@ -41,8 +40,6 @@ public:
 
   bool SetProperty(const std::string& name, uint64_t value);
   bool SupportsProperty(const std::string& name);
-  std::optional<bool> IsPropertyImmutable(std::string_view name);
-  std::optional<std::span<uint64_t, 2>> GetRangePropertyLimits(std::string_view name);
 
 protected:
   explicit CDRMObject(int fd);

--- a/xbmc/windowing/gbm/drm/DRMUtils.h
+++ b/xbmc/windowing/gbm/drm/DRMUtils.h
@@ -64,8 +64,6 @@ public:
   static uint32_t FourCCWithoutAlpha(uint32_t fourcc);
 
   void SetInFenceFd(int fd) { m_inFenceFd = fd; }
-  bool FindVideoPlane(uint32_t format, uint64_t modifier);
-  bool FindGuiPlane();
   int TakeOutFenceFd()
   {
     int fd{-1};
@@ -91,13 +89,13 @@ protected:
   int m_inFenceFd{-1};
   int m_outFenceFd{-1};
 
-  std::vector<std::unique_ptr<CDRMCrtc>> m_crtcs;
   std::vector<std::unique_ptr<CDRMPlane>> m_planes;
 
 private:
   bool FindConnector();
   bool FindEncoder();
   bool FindCrtc();
+  bool FindPlanes();
   bool FindPreferredMode();
   bool RestoreOriginalMode();
   RESOLUTION_INFO GetResolutionInfo(drmModeModeInfoPtr mode);
@@ -108,6 +106,7 @@ private:
 
   std::vector<std::unique_ptr<CDRMConnector>> m_connectors;
   std::vector<std::unique_ptr<CDRMEncoder>> m_encoders;
+  std::vector<std::unique_ptr<CDRMCrtc>> m_crtcs;
 };
 
 }


### PR DESCRIPTION
## Description

Fixes #25845.

## Motivation and context

#24431 tried to improve support for rockchip SOCs but in the process broke other platforms. A fix doesn't seem trivial so lets revert for now.

@hbiyik : A better approach can always be submitted again and we'll go through a new round of reviews :slightly_smiling_face: 

## How has this been tested?

It's a straight revert, so should be fine.

## What is the effect on users?

Working Kodi on Linux systems with Intel graphics again. Unfortunately worse functionality on rockchip SOCs.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
