### PR TITLE
Announcements: Allow Announcer receivers to register only for the types they are actually interested in 

### DIFF
--- a/xbmc/games/dialogs/osd/DialogGameVolume.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVolume.cpp
@@ -75,7 +75,7 @@ void CDialogGameVolume::OnInitWindow()
   if (dialogVolumeBar != nullptr)
     dialogVolumeBar->RegisterCallback(this);
 
-  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
+  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this, ANNOUNCEMENT::Application);
 }
 
 void CDialogGameVolume::OnDeinitWindow(int nextWindowID)
@@ -113,7 +113,7 @@ void CDialogGameVolume::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
                                  const std::string& message,
                                  const CVariant& data)
 {
-  if (flag == ANNOUNCEMENT::Application && message == "OnVolumeChanged")
+  if (message == "OnVolumeChanged")
   {
     const float volumePercent = static_cast<float>(data["volume"].asDouble());
 

--- a/xbmc/guilib/handlers/sources/GUISourcesAnnouncementHandler.cpp
+++ b/xbmc/guilib/handlers/sources/GUISourcesAnnouncementHandler.cpp
@@ -16,7 +16,7 @@
 
 CGUISourcesAnnouncementHandler::CGUISourcesAnnouncementHandler()
 {
-  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
+  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this, ANNOUNCEMENT::Sources);
 }
 
 CGUISourcesAnnouncementHandler::~CGUISourcesAnnouncementHandler()
@@ -29,10 +29,6 @@ void CGUISourcesAnnouncementHandler::Announce(ANNOUNCEMENT::AnnouncementFlag fla
                                               const std::string& message,
                                               const CVariant& data)
 {
-  // We are only interested in sources changes
-  if ((flag & ANNOUNCEMENT::Sources) == 0)
-    return;
-
   if (message == "OnAdded" || message == "OnRemoved" || message == "OnUpdated")
   {
     CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);

--- a/xbmc/guilib/listproviders/DirectoryProvider.cpp
+++ b/xbmc/guilib/listproviders/DirectoryProvider.cpp
@@ -293,10 +293,6 @@ void CDirectoryProvider::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
                                   const std::string& message,
                                   const CVariant& data)
 {
-  // we are only interested in library, player and GUI changes
-  if ((flag & (ANNOUNCEMENT::VideoLibrary | ANNOUNCEMENT::AudioLibrary | ANNOUNCEMENT::Player | ANNOUNCEMENT::GUI)) == 0)
-    return;
-
   {
     std::unique_lock<CCriticalSection> lock(m_section);
     // we don't need to refresh anything if there are no fitting
@@ -675,7 +671,9 @@ bool CDirectoryProvider::UpdateURL()
   if (!m_isSubscribed)
   {
     m_isSubscribed = true;
-    CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
+    CServiceBroker::GetAnnouncementManager()->AddAnnouncer(
+        this, ANNOUNCEMENT::VideoLibrary | ANNOUNCEMENT::AudioLibrary | ANNOUNCEMENT::Player |
+                  ANNOUNCEMENT::GUI);
     CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CDirectoryProvider::OnAddonEvent);
     CServiceBroker::GetRepositoryUpdater().Events().Subscribe(this, &CDirectoryProvider::OnAddonRepositoryEvent);
     CServiceBroker::GetPVRManager().Events().Subscribe(this, &CDirectoryProvider::OnPVRManagerEvent);

--- a/xbmc/interfaces/AnnouncementManager.h
+++ b/xbmc/interfaces/AnnouncementManager.h
@@ -16,7 +16,7 @@
 
 #include <list>
 #include <memory>
-#include <vector>
+#include <unordered_map>
 
 class CFileItem;
 class CVariant;
@@ -33,6 +33,7 @@ namespace ANNOUNCEMENT
     void Deinitialize();
 
     void AddAnnouncer(IAnnouncer *listener);
+    void AddAnnouncer(IAnnouncer* listener, int flagMask);
     void RemoveAnnouncer(IAnnouncer *listener);
 
     void Announce(AnnouncementFlag flag, const std::string& message);
@@ -90,6 +91,6 @@ namespace ANNOUNCEMENT
 
     CCriticalSection m_announcersCritSection;
     CCriticalSection m_queueCritSection;
-    std::vector<IAnnouncer *> m_announcers;
+    std::unordered_map<IAnnouncer*, int> m_announcers;
   };
 }

--- a/xbmc/interfaces/IAnnouncer.h
+++ b/xbmc/interfaces/IAnnouncer.h
@@ -30,7 +30,7 @@ enum AnnouncementFlag
 };
 
 const auto ANNOUNCE_ALL = (Player | Playlist | GUI | System | VideoLibrary | AudioLibrary |
-                           Application | Input | ANNOUNCEMENT::PVR | Other);
+                           Application | Input | ANNOUNCEMENT::PVR | Other | Info | Sources);
 
 /*!
     \brief Returns a string representation for the

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -167,10 +167,6 @@ void CAirPlayServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
                               const std::string& message,
                               const CVariant& data)
 {
-  // We are only interested in player changes
-  if ((flag & ANNOUNCEMENT::Player) == 0)
-    return;
-
   std::unique_lock<CCriticalSection> lock(ServerInstanceLock);
 
   if (sender == ANNOUNCEMENT::CAnnouncementManager::ANNOUNCEMENT_SENDER && ServerInstance)
@@ -323,7 +319,7 @@ CAirPlayServer::CAirPlayServer(int port, bool nonlocal) : CThread("AirPlayServer
   m_nonlocal = nonlocal;
   m_usePassword = false;
   m_origVolume = -1;
-  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
+  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this, ANNOUNCEMENT::Player);
 }
 
 CAirPlayServer::~CAirPlayServer()

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -173,8 +173,7 @@ void CAirTunesServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
                                const std::string& message,
                                const CVariant& data)
 {
-  if ((flag & ANNOUNCEMENT::Player) &&
-      sender == ANNOUNCEMENT::CAnnouncementManager::ANNOUNCEMENT_SENDER)
+  if (sender == ANNOUNCEMENT::CAnnouncementManager::ANNOUNCEMENT_SENDER)
   {
     if ((message == "OnPlay" || message == "OnResume") && m_streamStarted)
     {
@@ -685,7 +684,7 @@ void CAirTunesServer::RegisterActionListener(bool doRegister)
 
   if (doRegister)
   {
-    CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
+    CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this, ANNOUNCEMENT::Player);
     appListener->RegisterActionListener(this);
     ServerInstance->Create();
   }

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -54,7 +54,8 @@ CUPnPRenderer::CUPnPRenderer(const char* friendly_name,
                              unsigned int port /*= 0*/)
   : PLT_MediaRenderer(friendly_name, show_ip, uuid, port)
 {
-  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
+  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this, ANNOUNCEMENT::Player |
+                                                                   ANNOUNCEMENT::Application);
 }
 
 /*----------------------------------------------------------------------

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -130,7 +130,8 @@ NPT_Result CUPnPServer::SetupServices()
   OnScanCompleted(VideoLibrary);
 
   // now safe to start passing on new notifications
-  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
+  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this, ANNOUNCEMENT::VideoLibrary |
+                                                                   ANNOUNCEMENT::AudioLibrary);
 
   return result;
 }

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -136,7 +136,7 @@ void CPeripherals::Initialise()
   m_eventScanner->Start();
 
   CServiceBroker::GetAppMessenger()->RegisterReceiver(this);
-  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
+  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this, ANNOUNCEMENT::Player);
 }
 
 void CPeripherals::Clear()
@@ -1019,8 +1019,7 @@ void CPeripherals::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
                             const std::string& message,
                             const CVariant& data)
 {
-  if (flag == ANNOUNCEMENT::Player &&
-      sender == ANNOUNCEMENT::CAnnouncementManager::ANNOUNCEMENT_SENDER)
+  if (sender == ANNOUNCEMENT::CAnnouncementManager::ANNOUNCEMENT_SENDER)
   {
     if (message == "OnQuit")
     {

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -370,7 +370,8 @@ void CPeripheralCecAdapter::Process(void)
     m_bActiveSourceBeforeStandby = false;
   }
 
-  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
+  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(
+      this, ANNOUNCEMENT::System | ANNOUNCEMENT::GUI | ANNOUNCEMENT::Player);
 
   m_queryThread = new CPeripheralCecAdapterUpdateThread(this, &m_configuration);
   m_queryThread->Create(false);

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -152,7 +152,7 @@ CGUIWindowSlideShow::CGUIWindowSlideShow(void)
   m_loadType = KEEP_IN_MEMORY;
   m_bLoadNextPic = false;
   CServiceBroker::GetSlideShowDelegator().SetDelegate(this);
-  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
+  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this, ANNOUNCEMENT::Player);
   Reset();
 }
 
@@ -167,14 +167,11 @@ void CGUIWindowSlideShow::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
                                    const std::string& message,
                                    const CVariant& data)
 {
-  if (flag & ANNOUNCEMENT::Player)
+  if (message == "OnPlay" || message == "OnResume")
   {
-    if (message == "OnPlay" || message == "OnResume")
-    {
-      if (data.isMember("player") && data["player"].isMember("playerid") &&
-          data["player"]["playerid"] == static_cast<int>(PLAYLIST::Id::TYPE_VIDEO))
-        Close();
-    }
+    if (data.isMember("player") && data["player"].isMember("playerid") &&
+        data["player"]["playerid"] == static_cast<int>(PLAYLIST::Id::TYPE_VIDEO))
+      Close();
   }
 }
 

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -474,7 +474,8 @@ void CXBMCApp::UnregisterDisplayListener()
 
 void CXBMCApp::Initialize()
 {
-  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
+  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(
+      this, ANNOUNCEMENT::Input | ANNOUNCEMENT::Player | ANNOUNCEMENT::Info);
 }
 
 void CXBMCApp::Deinitialize()

--- a/xbmc/platform/darwin/osx/HotKeyController.mm
+++ b/xbmc/platform/darwin/osx/HotKeyController.mm
@@ -16,7 +16,8 @@
 CHotKeyController::CHotKeyController()
 {
   m_mediaKeytap = [CMediaKeyTap new];
-  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
+  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this,
+                                                         ANNOUNCEMENT::GUI | ANNOUNCEMENT::Player);
 }
 
 CHotKeyController::~CHotKeyController()

--- a/xbmc/platform/linux/input/LibInputHandler.cpp
+++ b/xbmc/platform/linux/input/LibInputHandler.cpp
@@ -99,7 +99,7 @@ CLibInputHandler::CLibInputHandler() : CThread("libinput")
   m_touch = std::make_unique<CLibInputTouch>();
   m_settings = std::make_unique<CLibInputSettings>(this);
 
-  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
+  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this, ANNOUNCEMENT::System);
 }
 
 CLibInputHandler::~CLibInputHandler()

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -210,7 +210,7 @@ CPVRManager::CPVRManager()
                 CSettings::SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD,
                 CSettings::SETTING_PVRPARENTAL_ENABLED, CSettings::SETTING_PVRPARENTAL_DURATION})
 {
-  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
+  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this, ANNOUNCEMENT::GUI);
   m_actionListener.Init(*this);
 
   CLog::LogFC(LOGDEBUG, LOGPVR, "PVR Manager instance created");

--- a/xbmc/windowing/win10/WinEventsWin10.cpp
+++ b/xbmc/windowing/win10/WinEventsWin10.cpp
@@ -157,7 +157,7 @@ void CWinEventsWin10::InitEventHandlers(const CoreWindow& window)
       m_smtc.ButtonPressed(CWinEventsWin10::OnSystemMediaButtonPressed);
     }
     m_smtc.IsEnabled(true);;
-    CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
+    CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this, ANNOUNCEMENT::Player);
   }
   if (CSysInfo::GetWindowsDeviceFamily() == CSysInfo::WindowsDeviceFamily::Xbox)
   {

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -32,7 +32,8 @@ CGUIWindowHome::CGUIWindowHome(void) : CGUIWindow(WINDOW_HOME, "Home.xml")
   m_updateRA = (Audio | Video | Totals);
   m_loadType = KEEP_IN_MEMORY;
 
-  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
+  CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this, ANNOUNCEMENT::VideoLibrary |
+                                                                   ANNOUNCEMENT::AudioLibrary);
 }
 
 CGUIWindowHome::~CGUIWindowHome(void)
@@ -80,10 +81,6 @@ void CGUIWindowHome::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
 
   CLog::Log(LOGDEBUG, LOGANNOUNCE, "GOT ANNOUNCEMENT, type: {}, from {}, message {}",
             AnnouncementFlagToString(flag), sender, message);
-
-  // we are only interested in library changes
-  if ((flag & (ANNOUNCEMENT::VideoLibrary | ANNOUNCEMENT::AudioLibrary)) == 0)
-    return;
 
   if (data.isMember("transaction") && data["transaction"].asBoolean())
     return;


### PR DESCRIPTION
## Description
Brought up by @notspiff both in slack and also in https://github.com/xbmc/xbmc/pull/25832. Currently the announcement interface simply broadcasts all announcements to any registered listener and they are then in charge of filtering the announcement by type. While there are receivers that are interested in receiving all of them (namely python and jsonrpc) others really just consume one or two types of announcements.

## Motivation and context
Restrict sending announcements on the manager instead of in all receivers. Should improve performance marginally.

## How has this been tested?
Runtime tested with breakpoints

## What is the effect on users?
None, less overhead probably

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
