### PR TITLE
Update DVDSubtitlesLibass.cpp

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -463,9 +463,12 @@ void CDVDSubtitlesLibass::ApplyStyle(const std::shared_ptr<struct style>& subSty
     }
 
     // ass_set_line_spacing do not scale, so we have to scale to frame size
-    ass_set_line_spacing(m_renderer,
+    if (m_subtitleType != NATIVE)
+    {
+      ass_set_line_spacing(m_renderer,
                          lineSpacing / playResY * static_cast<double>(opts.frameHeight));
-
+    }
+    
     style->Blur = (10.00 / 100 * subStyle->blur);
 
     // Set the margins (in pixel)


### PR DESCRIPTION
Just fixed issues/23481: Override Subtitles Fonts will result in wrong position of subtitle

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
DVDSubtitlesLibass.cpp

line:465
// ass_set_line_spacing do not scale, so we have to scale to frame size
if (m_subtitleType != NATIVE)
{
ass_set_line_spacing(m_renderer,
lineSpacing / playResY * static_cast(opts.frameHeight));
}

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
(https://github.com/xbmc/xbmc/issues/23481)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test on TV Box Android 9.
Test on Fire Stick TV 4K, Android 7.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
The subtitle should stay at the correct position when "Override Subtitle fonts" is enabled.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
