### PR TITLE
[subtitles][libass] add fallback value for no PlayRes

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -365,12 +365,31 @@ void CDVDSubtitlesLibass::ApplyStyle(const std::shared_ptr<struct style>& subSty
     free(style->Name);
     style->Name = strdup("KodiDefault");
 
+    // PlayResY and PlayResX are mandatory but some out-of-spec files do not specify them
+    // if both PlayRes are not specified libass fallback to 288x384
+    double playResY = static_cast<double>(m_track->PlayResY);
+    if (m_track->PlayResY == 0 && m_track->PlayResX == 0)
+    {
+      CLog::LogF(LOGWARNING, "PlayResX and PlayResY are not defined in subtitle file. This may "
+                             "cause unexpected rendering issues.");
+      playResY = 288.0;
+    }
+    else if (m_track->PlayResY == 0 && m_track->PlayResX > 0)
+    {
+      // This use case depend strictly on library implementation anyway
+      // the common behavior of the library is to calculate with an aspect ratio of 4/3
+      CLog::LogF(
+          LOGWARNING,
+          "PlayResY is not defined in subtitle file. This may cause unexpected rendering issues.");
+      playResY = std::max(1.0, static_cast<double>(m_track->PlayResX) * 3 / 4);
+    }
+
     // Calculate the scale
     // Font size, borders, etc... are specified in pixel unit in scaled
     // for a window height of 720, so we need to rescale to our PlayResY
-    double playResY{static_cast<double>(m_track->PlayResY)};
     double scaleDefault{playResY / 720};
     double scale{scaleDefault};
+
     if (m_subtitleType == NATIVE &&
         (subStyle->assOverrideStyles == OverrideStyles::STYLES ||
          subStyle->assOverrideStyles == OverrideStyles::STYLES_POSITIONS ||


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
User provided a .ass subtitle without PlayResX / PlayResY values that usually must be provided
since the value is 0, cause a wrong behaviour in the scaling calculations

the calculated fallbacks values for PlayResX / PlayResY are specified here
https://github.com/libass/libass/blob/6a759836e5e76bb7b69b0ac244eea76b0d290512/libass/ass.c#L1782-L1795
since they are verified only when libass redering start, we cant get the corrected values

the fix consist in the imitate the libass sources behaviours and print to the log when this happens
i choosen to not copy libass sources 1:1 because has not much sense if the upstream change in future

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #23481
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
you can use [test.zip](https://github.com/user-attachments/files/17521683/test.zip)
with any mkv with same file name

then enable/disable fonts override sub setting

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
show text in the right place and not on top/outside of the screen

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
