### PR TITLE
[Android] Setting to ignore the capabilities reported by the codec component

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -23,6 +23,7 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
 #include "media/decoderfilter/DecoderFilterManager.h"
 #include "messaging/ApplicationMessenger.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/SettingUtils.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -828,9 +829,16 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
                          return profileLevel.profile() == profile;
                        }) == profileLevels.cend())
       {
-        CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec::Open profile not supported: {}",
+        CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec::Open: Profile {} not supported",
                   profile);
-        continue;
+        if (CServiceBroker::GetSettingsComponent()
+                ->GetAdvancedSettings()
+                ->m_videoBypassCodecProfile)
+          CLog::Log(
+              LOGINFO,
+              "CDVDVideoCodecAndroidMediaCodec::Open: Ignore profile not supported for the codec");
+        else
+          continue;
       }
     }
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -647,6 +647,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetInt(pElement, "useocclusionquery", m_videoCaptureUseOcclusionQuery, -1, 1);
     XMLUtils::GetBoolean(pElement,"vdpauInvTelecine",m_videoVDPAUtelecine);
     XMLUtils::GetBoolean(pElement,"vdpauHDdeintSkipChroma",m_videoVDPAUdeintSkipChromaHD);
+    XMLUtils::GetBoolean(pElement, "bypasscodecprofile", m_videoBypassCodecProfile);
 
     TiXmlElement* pAdjustRefreshrate = pElement->FirstChildElement("adjustrefreshrate");
     if (pAdjustRefreshrate)

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -175,6 +175,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     std::string m_videoDefaultPlayer;
     float m_videoPlayCountMinimumPercent;
+    bool m_videoBypassCodecProfile = false; // Android only to bypass reported codec capabilities
 
     float m_slideshowBlackBarCompensation;
     float m_slideshowZoomAmount;


### PR DESCRIPTION
## Description
On some Android device when querying the capabilities of certain codec components, the device has an issue and does not report all the video profile/level combinations that it actually supports.

Hardware playback is discarded and falling back to software decode (FFmpeg)
```
  info <general>: CDVDVideoCodecAndroidMediaCodec::Open Testing codec: OMX.MTK.VIDEO.DECODER.AVC
 error <general>: CDVDVideoCodecAndroidMediaCodec::Open profile not supported: 16
  ...
 error <general>: CDVDVideoCodecAndroidMediaCodec::Open Failed to create Android MediaCodec
  info <general>: CDVDVideoCodecFFmpeg::Open() Using codec: H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10
```
I propose to add an advanced setting ~~in the GUI~~ so that the user can force to ignore this check and the videos will try to play with the selected codec.

~~Settings [Expert mode] -> Player -> Video-> Bypass the capabilities reported by the codec - MediaCodec~~

Usage:

```xml
<advancedsettings version="1.0">
  <video>
    <bypasscodecprofile>true</bypasscodecprofile>
 </video>
</advancedsettings>
```


Fix issue https://github.com/xbmc/xbmc/issues/25870

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
