### PR TITLE
[Settings] Parse subtitle/audio delay step from advancedsettings.xml

### DIFF
--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -395,11 +395,13 @@ JSONRPC_STATUS CPlayerOperations::SetAudioDelay(const std::string& method,
       const auto appPlayer = components.GetComponent<CApplicationPlayer>();
       float videoAudioDelayRange =
           CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoAudioDelayRange;
+      float videoAudioDelayStep =
+          CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoAudioDelayStep;
 
       if (parameterObject["offset"].isDouble())
       {
         float offset = static_cast<float>(parameterObject["offset"].asDouble());
-        offset = MathUtils::RoundF(offset, AUDIO_DELAY_STEP);
+        offset = MathUtils::RoundF(offset, videoAudioDelayStep);
         if (offset > videoAudioDelayRange)
           offset = videoAudioDelayRange;
         else if (offset < -videoAudioDelayRange)
@@ -412,14 +414,14 @@ JSONRPC_STATUS CPlayerOperations::SetAudioDelay(const std::string& method,
         CVideoSettings vs = appPlayer->GetVideoSettings();
         if (parameterObject["offset"].asString().compare("increment") == 0)
         {
-          vs.m_AudioDelay += AUDIO_DELAY_STEP;
+          vs.m_AudioDelay += videoAudioDelayStep;
           if (vs.m_AudioDelay > videoAudioDelayRange)
             vs.m_AudioDelay = videoAudioDelayRange;
           appPlayer->SetAVDelay(vs.m_AudioDelay);
         }
         else
         {
-          vs.m_AudioDelay -= AUDIO_DELAY_STEP;
+          vs.m_AudioDelay -= videoAudioDelayStep;
           if (vs.m_AudioDelay < -videoAudioDelayRange)
             vs.m_AudioDelay = -videoAudioDelayRange;
           appPlayer->SetAVDelay(vs.m_AudioDelay);

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -141,7 +141,9 @@ void CAdvancedSettings::Initialize()
   m_audioPlayCountMinimumPercent = 90.0f;
 
   m_videoSubsDelayRange = 60;
+  m_videoSubsDelayStep = 0.1f;
   m_videoAudioDelayRange = 10;
+  m_videoAudioDelayStep = 0.025f;
   m_videoUseTimeSeeking = true;
   m_videoTimeSeekForward = 30;
   m_videoTimeSeekBackward = -30;
@@ -603,7 +605,9 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetString(pElement, "stereoscopicregexsbs", m_stereoscopicregex_sbs);
     XMLUtils::GetString(pElement, "stereoscopicregextab", m_stereoscopicregex_tab);
     XMLUtils::GetFloat(pElement, "subsdelayrange", m_videoSubsDelayRange, 10, 600);
+    XMLUtils::GetFloat(pElement, "subsdelaystep", m_videoSubsDelayStep, 0, 1.0f);
     XMLUtils::GetFloat(pElement, "audiodelayrange", m_videoAudioDelayRange, 10, 600);
+    XMLUtils::GetFloat(pElement, "audiodelaystep", m_videoAudioDelayStep, 0, 1.0f);
     XMLUtils::GetString(pElement, "defaultplayer", m_videoDefaultPlayer);
     XMLUtils::GetBoolean(pElement, "fullscreenonmoviestart", m_fullScreenOnMovieStart);
     // 101 on purpose - can be used to never automark as watched

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -129,7 +129,9 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool  m_omlSync = true;
 
     float m_videoSubsDelayRange;
+    float m_videoSubsDelayStep;
     float m_videoAudioDelayRange;
+    float m_videoAudioDelayStep;
     bool m_videoUseTimeSeeking;
     int m_videoTimeSeekForward;
     int m_videoTimeSeekBackward;

--- a/xbmc/settings/MediaSettings.h
+++ b/xbmc/settings/MediaSettings.h
@@ -24,9 +24,6 @@
 
 class TiXmlNode;
 
-// Step used to increase/decrease audio delay
-static constexpr float AUDIO_DELAY_STEP = 0.025f;
-
 typedef enum {
   WatchedModeAll        = 0,
   WatchedModeUnwatched,

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -151,72 +151,84 @@ bool CPlayerController::OnAction(const CAction &action)
       case ACTION_SUBTITLE_DELAY_MIN:
       {
         float videoSubsDelayRange = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoSubsDelayRange;
+        float videoSubsDelayStep =
+            CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoSubsDelayStep;
         CVideoSettings vs = appPlayer->GetVideoSettings();
-        vs.m_SubtitleDelay -= 0.1f;
+        vs.m_SubtitleDelay -= videoSubsDelayStep;
         if (vs.m_SubtitleDelay < -videoSubsDelayRange)
           vs.m_SubtitleDelay = -videoSubsDelayRange;
         appPlayer->SetSubTitleDelay(vs.m_SubtitleDelay);
 
         ShowSlider(action.GetID(), 22006, appPlayer->GetVideoSettings().m_SubtitleDelay,
-                   -videoSubsDelayRange, 0.1f, videoSubsDelayRange);
+                   -videoSubsDelayRange, videoSubsDelayStep, videoSubsDelayRange);
         return true;
       }
 
       case ACTION_SUBTITLE_DELAY_PLUS:
       {
         float videoSubsDelayRange = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoSubsDelayRange;
+        float videoSubsDelayStep =
+            CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoSubsDelayStep;
         CVideoSettings vs = appPlayer->GetVideoSettings();
-        vs.m_SubtitleDelay += 0.1f;
+        vs.m_SubtitleDelay += videoSubsDelayStep;
         if (vs.m_SubtitleDelay > videoSubsDelayRange)
           vs.m_SubtitleDelay = videoSubsDelayRange;
         appPlayer->SetSubTitleDelay(vs.m_SubtitleDelay);
 
         ShowSlider(action.GetID(), 22006, appPlayer->GetVideoSettings().m_SubtitleDelay,
-                   -videoSubsDelayRange, 0.1f, videoSubsDelayRange);
+                   -videoSubsDelayRange, videoSubsDelayStep, videoSubsDelayRange);
         return true;
       }
 
       case ACTION_SUBTITLE_DELAY:
       {
         float videoSubsDelayRange = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoSubsDelayRange;
+        float videoSubsDelayStep =
+            CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoSubsDelayStep;
         ShowSlider(action.GetID(), 22006, appPlayer->GetVideoSettings().m_SubtitleDelay,
-                   -videoSubsDelayRange, 0.1f, videoSubsDelayRange, true);
+                   -videoSubsDelayRange, videoSubsDelayStep, videoSubsDelayRange, true);
         return true;
       }
 
       case ACTION_AUDIO_DELAY:
       {
         float videoAudioDelayRange = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoAudioDelayRange;
+        float videoAudioDelayStep =
+            CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoAudioDelayStep;
         ShowSlider(action.GetID(), 297, appPlayer->GetVideoSettings().m_AudioDelay,
-                   -videoAudioDelayRange, AUDIO_DELAY_STEP, videoAudioDelayRange, true);
+                   -videoAudioDelayRange, videoAudioDelayStep, videoAudioDelayRange, true);
         return true;
       }
 
       case ACTION_AUDIO_DELAY_MIN:
       {
         float videoAudioDelayRange = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoAudioDelayRange;
+        float videoAudioDelayStep =
+            CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoAudioDelayStep;
         CVideoSettings vs = appPlayer->GetVideoSettings();
-        vs.m_AudioDelay -= AUDIO_DELAY_STEP;
+        vs.m_AudioDelay -= videoAudioDelayStep;
         if (vs.m_AudioDelay < -videoAudioDelayRange)
           vs.m_AudioDelay = -videoAudioDelayRange;
         appPlayer->SetAVDelay(vs.m_AudioDelay);
 
         ShowSlider(action.GetID(), 297, appPlayer->GetVideoSettings().m_AudioDelay,
-                   -videoAudioDelayRange, AUDIO_DELAY_STEP, videoAudioDelayRange);
+                   -videoAudioDelayRange, videoAudioDelayStep, videoAudioDelayRange);
         return true;
       }
 
       case ACTION_AUDIO_DELAY_PLUS:
       {
         float videoAudioDelayRange = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoAudioDelayRange;
+        float videoAudioDelayStep =
+            CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoAudioDelayStep;
         CVideoSettings vs = appPlayer->GetVideoSettings();
-        vs.m_AudioDelay += AUDIO_DELAY_STEP;
+        vs.m_AudioDelay += videoAudioDelayStep;
         if (vs.m_AudioDelay > videoAudioDelayRange)
           vs.m_AudioDelay = videoAudioDelayRange;
         appPlayer->SetAVDelay(vs.m_AudioDelay);
 
         ShowSlider(action.GetID(), 297, appPlayer->GetVideoSettings().m_AudioDelay,
-                   -videoAudioDelayRange, AUDIO_DELAY_STEP, videoAudioDelayRange);
+                   -videoAudioDelayRange, videoAudioDelayStep, videoAudioDelayRange);
         return true;
       }
 
@@ -582,9 +594,21 @@ void CPlayerController::OnSliderChange(void *data, CGUISliderControl *slider)
           m_sliderAction == ACTION_VOLAMP_DOWN ||
           m_sliderAction == ACTION_VOLAMP)
     slider->SetTextValue(CGUIDialogAudioSettings::FormatDecibel(slider->GetFloatValue()));
-  else
+  else if (m_sliderAction == ACTION_SUBTITLE_DELAY || m_sliderAction == ACTION_SUBTITLE_DELAY_MIN ||
+           m_sliderAction == ACTION_SUBTITLE_DELAY_PLUS)
+  {
+    float videoSubsDelayStep =
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoSubsDelayStep;
     slider->SetTextValue(
-        CGUIDialogAudioSettings::FormatDelay(slider->GetFloatValue(), AUDIO_DELAY_STEP));
+        CGUIDialogAudioSettings::FormatDelay(slider->GetFloatValue(), videoSubsDelayStep));
+  }
+  else
+  {
+    float videoAudioDelayStep =
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoAudioDelayStep;
+    slider->SetTextValue(
+        CGUIDialogAudioSettings::FormatDelay(slider->GetFloatValue(), videoAudioDelayStep));
+  }
 
   auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -282,7 +282,7 @@ void CGUIDialogAudioSettings::InitializeSettings()
     std::shared_ptr<CSettingNumber> settingAudioDelay = AddSlider(
         groupAudio, SETTING_AUDIO_DELAY, 297, SettingLevel::Basic, videoSettings.m_AudioDelay, 0,
         -CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoAudioDelayRange,
-        AUDIO_DELAY_STEP,
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoAudioDelayStep,
         CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoAudioDelayRange, 297,
         usePopup);
     std::static_pointer_cast<CSettingControlSlider>(settingAudioDelay->GetControl())->SetFormatter(SettingFormatterDelay);

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -299,7 +299,13 @@ void CGUIDialogSubtitleSettings::InitializeSettings()
   // subtitle delay setting
   if (SupportsSubtitleFeature(IPlayerSubtitleCaps::OFFSET))
   {
-    std::shared_ptr<CSettingNumber> settingSubtitleDelay = AddSlider(groupSubtitles, SETTING_SUBTITLE_DELAY, 22006, SettingLevel::Basic, videoSettings.m_SubtitleDelay, 0, -CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoSubsDelayRange, 0.1f, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoSubsDelayRange, 22006, usePopup);
+    std::shared_ptr<CSettingNumber> settingSubtitleDelay = AddSlider(
+        groupSubtitles, SETTING_SUBTITLE_DELAY, 22006, SettingLevel::Basic,
+        videoSettings.m_SubtitleDelay, 0,
+        -CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoSubsDelayRange,
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoSubsDelayStep,
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoSubsDelayRange, 22006,
+        usePopup);
     std::static_pointer_cast<CSettingControlSlider>(settingSubtitleDelay->GetControl())->SetFormatter(SettingFormatterDelay);
   }
 


### PR DESCRIPTION
## Description
This PR adds support for two tags in advancedsettings.xml, under the `video` section:
- `subsdelaystep` (to go with `subsdelayrange`)
- `audiodelaystep` (to go with `audiodelayrange`)

By default, the existing values of 100 ms and 25 ms, respectively, are used.

## Motivation and context
The current delay steps are hardcoded and unconfigurable.

## How has this been tested?
Tested on macOS 14.5 with Xcode 16.0.
Tried various values for each tag, including edge cases of negative and very large.

## What is the effect on users?
Users can customize the subtitle and audio delay steps to their liking.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
