### PR TITLE
Restore Library Scan Performance

### DIFF
--- a/xbmc/TextureDatabase.cpp
+++ b/xbmc/TextureDatabase.cpp
@@ -362,6 +362,8 @@ bool CTextureDatabase::AddCachedTexture(const std::string &url, const CTextureDe
     if (!m_pDS)
       return false;
 
+    BeginTransaction();
+
     std::string sql = PrepareSQL("DELETE FROM texture WHERE url='%s'", url.c_str());
     m_pDS->exec(sql);
 
@@ -373,10 +375,13 @@ bool CTextureDatabase::AddCachedTexture(const std::string &url, const CTextureDe
     // set the size information
     sql = PrepareSQL("INSERT INTO sizes (idtexture, size, usecount, lastusetime, width, height) VALUES(%u, 1, 1, CURRENT_TIMESTAMP, %u, %u)", textureID, details.width, details.height);
     m_pDS->exec(sql);
+
+    CommitTransaction();
   }
   catch (...)
   {
     CLog::Log(LOGERROR, "{} failed on url '{}'", __FUNCTION__, url);
+    RollbackTransaction();
   }
   return true;
 }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1464,6 +1464,8 @@ int CVideoDatabase::GetMusicVideoId(const std::string& strFilenameAndPath)
 //********************************************************************************************************************************
 int CVideoDatabase::AddNewMovie(CVideoInfoTag& details)
 {
+  assert(m_pDB->in_transaction());
+
   const auto filePath = details.GetPath();
 
   try
@@ -1480,8 +1482,6 @@ int CVideoDatabase::AddNewMovie(CVideoInfoTag& details)
         return -1;
     }
 
-    BeginTransaction();
-
     m_pDS->exec(
         PrepareSQL("INSERT INTO movie (idMovie, idFile) VALUES (NULL, %i)", details.m_iFileId));
     details.m_iDbId = static_cast<int>(m_pDS->lastinsertid());
@@ -1491,14 +1491,11 @@ int CVideoDatabase::AddNewMovie(CVideoInfoTag& details)
                    details.m_iFileId, details.m_iDbId, MediaTypeMovie, VideoAssetType::VERSION,
                    VIDEO_VERSION_ID_DEFAULT));
 
-    CommitTransaction();
-
     return details.m_iDbId;
   }
   catch (...)
   {
     CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, filePath);
-    RollbackTransaction();
   }
   return -1;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

* Removed the unnecessary db transaction in CVideoDatabase::AddNewMovie().

It was added in the video versions initial commit and made sense in isolation because the insert to movie and videoversion should succeed or fail as a group, but did not take into account the transaction already setup by the caller, SetDetailsForMovie(). 

Sqlite and Mysql/MariaDB don't support nested transactions so each of the follow up inserts invoked by SetDetailForMovie (actors, art creation for example) ran in its own individual automatic transactions with lower performance due to the additional synchronization to make sure the data is safely stored after each transaction.

SetDetailsForMovie() is the only caller of AddNewMovie() so removing the transaction in AddNewMovie seems best, with an assert to guard against future misuse.

Measured speedups: 27x for local Sqlite db on HDD, 2x for local Sqlite db on SSD, 1.4x for remote MariaDB

There are likely other places in the code where inserts could be grouped in transactions for significant speedups.

* Second commit is for a similar pattern identified during troubleshooting, with the texture caching this time (CTextureDatabase::AddCachedTexture)

With Sqlite on HDD and a desktop class CPU, storing the data in the texture db is the largest cost and grouping the delete and the 2 insert statements in a transaction cuts the time in half (~200ms before, ~100ms with the change)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #25656 / forum https://forum.kodi.tv/showthread.php?tid=377576 - slow scan speed since v21 beta 2

The problem is particularly noticeable with a local Sqlite db stored on HDD.
It probably hadn't been widely reported because SSD performance mostly masks the problem for small batches, and Mysql/MariaDB is affected even less, though there is a difference.

While investigating, noticed that the texture caching code was suffering from a similar pattern and applied a similar fix.

Will backport to v21.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Windows 10, library scan with Sqlite on HDD and SSD and remote Mysql/MariaDB.
See #25656 for a test directory structure.

Adding content is the only way to go into the modified code path.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Significant speed increase of library scans (back to v20 level) as well as faster artwork caching.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
