### PR TITLE
[guilib] CDirectoryProvider: Fix races/crashes due to concurrently di…

### DIFF
--- a/xbmc/guilib/listproviders/DirectoryProvider.h
+++ b/xbmc/guilib/listproviders/DirectoryProvider.h
@@ -85,6 +85,7 @@ public:
 private:
   UpdateState m_updateState = OK;
   unsigned int m_jobID = 0;
+  bool m_updatePending{false};
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_url;
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_target;
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_sortMethod;


### PR DESCRIPTION
…rectory jobs for same directory.

`CJobManager::CancelJob` is async. Rescheduling same job directly after this call leads to two identical jobs working on the same resources and running simultaneously for an undefined amount of time. This can lead to various races and even crashes:

<img width="1289" alt="Screenshot 2024-10-26 at 22 20 55" src="https://github.com/user-attachments/assets/263d7133-321f-428f-bbf2-1a52c5638a98">
<img width="1265" alt="Screenshot 2024-10-26 at 22 20 11" src="https://github.com/user-attachments/assets/2942dad4-3cbf-4f52-a6f1-8e17868ec606">
<img width="1550" alt="Screenshot 2024-10-26 at 13 51 12" src="https://github.com/user-attachments/assets/78a1a650-80c5-4479-a0f4-0674538d9e3c">

Fix is not to cancel the current job upon arrival of another refresh request, but first let the current job finish , then schedule another one.

Runtime-tested on macOS, latets master, where I was able reproduce the crashes (and the fix) reliably.

@enen92 maybe something you can review?
