### PR TITLE
[Estuary] Channel Guide Breadcrumb: Add channel name, align formatting…

### DIFF
--- a/addons/skin.estuary/xml/DialogPVRChannelGuide.xml
+++ b/addons/skin.estuary/xml/DialogPVRChannelGuide.xml
@@ -135,7 +135,7 @@
 					<height>70</height>
 					<font>font45</font>
 					<aligny>center</aligny>
-					<label>$LOCALIZE[19069]$INFO[Container(11).ListItem.StartDate, - ]</label>
+					<label>$VAR[BreadcrumbsPVRChannelGuideVar]$INFO[Container(11).ListItem.StartDate, / ]</label>
 					<shadowcolor>black</shadowcolor>
 				</control>
 			</control>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -543,6 +543,10 @@
 		<value condition="PVR.IsPlayingRadio">$LOCALIZE[19021] / $LOCALIZE[19019] / $INFO[VideoPlayer.ChannelGroup]</value>
 		<value>$LOCALIZE[19019] / $INFO[VideoPlayer.ChannelGroup]</value>
 	</variable>
+	<variable name="BreadcrumbsPVRChannelGuideVar">
+		<value condition="PVR.IsPlayingTV">$LOCALIZE[19020] / $LOCALIZE[19069] / $INFO[VideoPlayer.ChannelName]</value>
+		<value>$LOCALIZE[19021] / $LOCALIZE[19069] / $INFO[VideoPlayer.ChannelName]</value>
+	</variable>
 	<variable name="BreadcrumbsGameVar">
 		<value>$LOCALIZE[15016]</value>
 	</variable>


### PR DESCRIPTION
… with the other breadcrumbs.

Before:

<img width="1710" alt="Screenshot 2024-10-22 at 23 02 39" src="https://github.com/user-attachments/assets/753d847d-262f-45c4-b20a-e261e3f47b9e">

After:

<img width="1710" alt="Screenshot 2024-10-22 at 23 08 33" src="https://github.com/user-attachments/assets/864f4ced-8d7c-4bd2-bdce-ade5b4237bf3">

@jjd-uk please review, thanks.