### PR TITLE
GL/GLES: add advanced setting to override GL_VERSION

### DIFF
--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -44,21 +44,26 @@ bool CRenderSystemGL::InitRenderSystem()
   // Get the GL version number
   m_RenderVersionMajor = 0;
   m_RenderVersionMinor = 0;
+
   const char* ver = (const char*)glGetString(GL_VERSION);
-  if (ver != 0)
-  {
-    sscanf(ver, "%d.%d", &m_RenderVersionMajor, &m_RenderVersionMinor);
-    m_RenderVersion = ver;
-  }
-  else
+  if (ver == 0)
   {
     CLog::Log(LOGFATAL, "CRenderSystemGL::{} - glGetString(GL_VERSION) returned NULL, exiting",
               __FUNCTION__);
     std::terminate();
   }
 
-  CLog::Log(LOGINFO, "CRenderSystemGL::{} - Version: {}, Major: {}, Minor: {}", __FUNCTION__, ver,
-            m_RenderVersionMajor, m_RenderVersionMinor);
+  const std::string& verOverride =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_openGLVersionOverride;
+  if (verOverride.empty())
+    m_RenderVersion = ver;
+  else
+    m_RenderVersion = verOverride;
+
+  sscanf(m_RenderVersion.data(), "%d.%d", &m_RenderVersionMajor, &m_RenderVersionMinor);
+
+  CLog::Log(LOGINFO, "CRenderSystemGL::{} - Version: {}, Major: {}, Minor: {}", __FUNCTION__,
+            m_RenderVersion, m_RenderVersionMajor, m_RenderVersionMinor);
 
   m_RenderExtensions  = " ";
   if (m_RenderVersionMajor > 3 ||

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -49,19 +49,26 @@ bool CRenderSystemGLES::InitRenderSystem()
   m_RenderVersionMinor = 0;
 
   const char* ver = (const char*)glGetString(GL_VERSION);
-  if (ver != 0)
-  {
-    sscanf(ver, "%d.%d", &m_RenderVersionMajor, &m_RenderVersionMinor);
-    if (!m_RenderVersionMajor)
-      sscanf(ver, "%*s %*s %d.%d", &m_RenderVersionMajor, &m_RenderVersionMinor);
-    m_RenderVersion = ver;
-  }
-  else
+  if (ver == 0)
   {
     CLog::Log(LOGFATAL, "CRenderSystemGLES::{} - glGetString(GL_VERSION) returned NULL, exiting",
               __FUNCTION__);
     std::terminate();
   }
+
+  const std::string& verOverride =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_openGLVersionOverride;
+  if (verOverride.empty())
+    m_RenderVersion = ver;
+  else
+    m_RenderVersion = verOverride;
+
+  sscanf(m_RenderVersion.data(), "%d.%d", &m_RenderVersionMajor, &m_RenderVersionMinor);
+  if (!m_RenderVersionMajor)
+    sscanf(m_RenderVersion.data(), "%*s %*s %d.%d", &m_RenderVersionMajor, &m_RenderVersionMinor);
+
+  CLog::Log(LOGINFO, "CRenderSystemGLES::{} - Version: {}, Major: {}, Minor: {}", __FUNCTION__,
+            m_RenderVersion, m_RenderVersionMajor, m_RenderVersionMinor);
 
   // Get our driver vendor and renderer
   const char *tmpVendor = (const char*) glGetString(GL_VENDOR);

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1241,6 +1241,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   }
 
   XMLUtils::GetBoolean(pRootElement, "opengldebugging", m_openGlDebugging);
+  XMLUtils::GetString(pRootElement, "openglversionoverride", m_openGLVersionOverride);
 
   // load in the settings overrides
   CServiceBroker::GetSettingsComponent()->GetSettings()->LoadHidden(pRootElement);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -372,6 +372,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::string m_stereoscopicregex_tab;
 
     bool m_openGlDebugging;
+    std::string m_openGLVersionOverride;
 
     std::string m_userAgent;
     uint32_t m_nfsTimeout;


### PR DESCRIPTION
## Description
The PR provides an easy way to replace the GL_VERSION string by adding the advanced setting:
```
<advancedsettings>
  <openglversionoverride>3.2</openglversionoverride>
</advancedsettings>
```

## Motivation and context
This is mostly for debugging purposes, but might also enable devices with faulty drivers to run using a narrower feature set (e.g. GLES 2.0).

Note that the setting doesn't have influence on the actual version of the GL/GLES context.  

## How has this been tested?
Valid replacements (which are compatible with the GL/GLES context) are working fine. 

For example, a GLES context with the string "2.0" will handle dual channel textures as GL_LUMINANCE_ALPHA, instead of GL_RG.

For GL, valid ranges for the GL 4.6 context on my machine would be 3.2 to 4.6. Older feature sets would need adjustment of the actual context, which is not straight forward.

## What is the effect on users?
None.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
