### PR TITLE
[Utils] Move MillisecondsToTimeString to StringUtils

### DIFF
--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -152,8 +152,6 @@ public:
   std::optional<std::chrono::milliseconds> GetNextSceneMarker(Direction direction,
                                                               std::chrono::milliseconds clockTime);
 
-  static std::string MillisecondsToTimeString(std::chrono::milliseconds milliSeconds);
-
 private:
   // total cut time (edl cuts) in ms
   std::chrono::milliseconds m_totalCutTime;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2433,8 +2433,9 @@ void CVideoPlayer::CheckAutoSceneSkip()
         (m_playSpeed < 0 && correctClock < (edit->end - 1s)))
     {
       CLog::Log(LOGDEBUG, "{} - Clock in EDL cut [{} - {}]: {}. Automatically skipping over.",
-                __FUNCTION__, CEdl::MillisecondsToTimeString(edit->start),
-                CEdl::MillisecondsToTimeString(edit->end), CEdl::MillisecondsToTimeString(clock));
+                __FUNCTION__, StringUtils::MillisecondsToTimeString(edit->start),
+                StringUtils::MillisecondsToTimeString(edit->end),
+                StringUtils::MillisecondsToTimeString(clock));
 
       // Seeking either goes to the start or the end of the cut depending on the play direction.
       std::chrono::milliseconds seek = m_playSpeed >= 0 ? edit->end : edit->start;
@@ -2473,8 +2474,9 @@ void CVideoPlayer::CheckAutoSceneSkip()
         CLog::Log(LOGDEBUG,
                   "{} - Clock in commercial break [{} - {}]: {}. Automatically skipping to end of "
                   "commercial break",
-                  __FUNCTION__, CEdl::MillisecondsToTimeString(edit->start),
-                  CEdl::MillisecondsToTimeString(edit->end), CEdl::MillisecondsToTimeString(clock));
+                  __FUNCTION__, StringUtils::MillisecondsToTimeString(edit->start),
+                  StringUtils::MillisecondsToTimeString(edit->end),
+                  StringUtils::MillisecondsToTimeString(clock));
 
         CDVDMsgPlayerSeek::CMode mode;
         mode.time = edit->end.count();

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1509,6 +1509,14 @@ std::string StringUtils::SecondsToTimeString(long lSeconds, TIME_FORMAT format)
   return strHMS;
 }
 
+std::string StringUtils::MillisecondsToTimeString(std::chrono::milliseconds milliSeconds)
+{
+  std::string strTimeString = StringUtils::SecondsToTimeString(
+      std::chrono::duration_cast<std::chrono::seconds>(milliSeconds).count(), TIME_FORMAT_HH_MM_SS);
+  strTimeString += StringUtils::Format(".{:03}", milliSeconds.count() % 1000);
+  return strTimeString;
+}
+
 bool StringUtils::IsNaturalNumber(const std::string& str)
 {
   size_t i = 0, n = 0;

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -19,12 +19,13 @@
 //
 //------------------------------------------------------------------------
 
+#include <chrono>
+#include <locale>
+#include <sstream>
 #include <stdarg.h>
 #include <stdint.h>
 #include <string>
 #include <vector>
-#include <sstream>
-#include <locale>
 
 // workaround for broken [[deprecated]] in coverity
 #if defined(__COVERITY__)
@@ -267,6 +268,13 @@ public:
    \sa TIME_FORMAT
    */
   static std::string SecondsToTimeString(long seconds, TIME_FORMAT format = TIME_FORMAT_GUESS);
+
+  /*! \brief convert a milliseconds value to a time string in the TIME_FORMAT_HH_MM_SS format
+   \param milliSeconds time in milliseconds
+   \return the formatted time
+   \sa TIME_FORMAT
+   */
+  static std::string MillisecondsToTimeString(std::chrono::milliseconds milliSeconds);
 
   /*! \brief check whether a string is a natural number.
    Matches [ \t]*[0-9]+[ \t]*


### PR DESCRIPTION
## Description
I am reorganizing EDL to move the provider implementation into each specific implementation. This `MillisecondsToTimeString` utils function is dumped into the main EDL class when it just ends up calling the corresponding method in `StringUtils`. Since all callers already include `StringUtils`, just move it there.

## Motivation and context
Small cleanup to easy the refactor

## How has this been tested?
Compiled, ran tests.

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

