### PR TITLE
[DBWrappers] Detect Incorrect Transaction Usage

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -567,9 +567,14 @@ void MysqlDatabase::start_transaction()
 {
   if (active)
   {
+    assert(!_in_transaction);
     mysql_autocommit(conn, false);
     CLog::LogFC(LOGDEBUG, LOGDATABASE, "Mysql Start transaction");
-    _in_transaction = true;
+
+    if (_in_transaction)
+      CLog::LogF(LOGERROR, "error: nested transactions are not supported.");
+    else
+      _in_transaction = true;
   }
 }
 
@@ -577,6 +582,7 @@ void MysqlDatabase::commit_transaction()
 {
   if (active)
   {
+    assert(_in_transaction);
     mysql_commit(conn);
     mysql_autocommit(conn, true);
     CLog::LogFC(LOGDEBUG, LOGDATABASE, "Mysql commit transaction");
@@ -588,6 +594,7 @@ void MysqlDatabase::rollback_transaction()
 {
   if (active)
   {
+    assert(_in_transaction);
     mysql_rollback(conn);
     mysql_autocommit(conn, true);
     CLog::LogFC(LOGDEBUG, LOGDATABASE, "Mysql rollback transaction");

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -566,9 +566,14 @@ void SqliteDatabase::start_transaction()
 {
   if (active)
   {
+    assert(!_in_transaction);
     sqlite3_exec(conn, "begin IMMEDIATE", NULL, NULL, NULL);
     CLog::LogFC(LOGDEBUG, LOGDATABASE, "Sqlite start transaction");
-    _in_transaction = true;
+
+    if (_in_transaction)
+      CLog::LogF(LOGERROR, "error: nested transactions are not supported.");
+    else
+      _in_transaction = true;
   }
 }
 
@@ -576,6 +581,7 @@ void SqliteDatabase::commit_transaction()
 {
   if (active)
   {
+    assert(_in_transaction);
     sqlite3_exec(conn, "commit", NULL, NULL, NULL);
     CLog::LogFC(LOGDEBUG, LOGDATABASE, "Sqlite commit transaction");
     _in_transaction = false;
@@ -586,6 +592,7 @@ void SqliteDatabase::rollback_transaction()
 {
   if (active)
   {
+    assert(_in_transaction);
     sqlite3_exec(conn, "rollback", NULL, NULL, NULL);
     CLog::LogFC(LOGDEBUG, LOGDATABASE, "Sqlite rollback transaction");
     _in_transaction = false;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Add asserts in the db wrappers to check that there is at most one transaction and that a commit or rollback comes after a start.
Make the nested transactions visible as errors in user logs.

This is a very light solution to avoid future bugs, it could be made more strict later by returning an error (ie throwing an exception).

Other solutions could be to hide the nested transactions from the db with a refcount of the start/end of transaction to start/commit only the outermost transaction, or to start using save points to fake the nesting.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Nested transactions are not supported by Sqlite or Mysql/MariaDB but well-meaning database changes occasionally create such situations and they can go undetected for a while.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It builds and runs.
Fixing any actual nested transaction is besides the scope of this PR, though light testing and library scanning didn't turn up anything.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Improved logging of database transaction problems.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
