### PR TITLE
Python: allow building against Python 3.13

### DIFF
--- a/xbmc/interfaces/python/swig.cpp
+++ b/xbmc/interfaces/python/swig.cpp
@@ -75,6 +75,9 @@ namespace PythonBindings
 #if PY_VERSION_HEX >= 0x030C00A1
       0,
 #endif
+#if PY_VERSION_HEX >= 0x030D00A4
+      0,
+#endif
     };
 
     static int size = (long*)&(py_type_object_header.tp_name) - (long*)&py_type_object_header;


### PR DESCRIPTION
Fedora 41 ships with python 3.13. It currently fails to build.

https://fedoraproject.org/wiki/Releases/41/ChangeSet#Changes/Python3.13

```
home/lukas/Documents/git/xbmc/xbmc/interfaces/python/swig.cpp: In constructor ‘PythonBindings::TypeInfo::TypeInfo(const std::type_info&)’:
/home/lukas/Documents/git/xbmc/xbmc/interfaces/python/swig.cpp:78:5: error: missing initializer for member ‘_typeobject::tp_versions_used’ [-Werror=missing-field-initializers]
   78 |     };
      |     ^
```

I haven't actually runtime tested this but it builds :)

This will probably need a backport also