### PR TITLE
NetworkLinux: fix computing the length of the packet

### DIFF
--- a/xbmc/platform/linux/network/NetworkLinux.cpp
+++ b/xbmc/platform/linux/network/NetworkLinux.cpp
@@ -41,7 +41,7 @@ struct IcmpPacket
 
   uint16_t Checksum()
   {
-    auto data = reinterpret_cast<const uint16_t*>(&header);
+    auto data = reinterpret_cast<const uint16_t*>(this);
     unsigned int length = sizeof(IcmpPacket);
 
     unsigned int sum;

--- a/xbmc/platform/linux/network/NetworkLinux.cpp
+++ b/xbmc/platform/linux/network/NetworkLinux.cpp
@@ -42,7 +42,7 @@ struct IcmpPacket
   uint16_t Checksum()
   {
     auto data = reinterpret_cast<const uint16_t*>(&header);
-    unsigned int length = sizeof(header) + sizeof(data);
+    unsigned int length = sizeof(IcmpPacket);
 
     unsigned int sum;
 


### PR DESCRIPTION
I noticed this when I used this code as a reference for another project. I did the initial implementation so it's my bad.

```
when using sizeof(data) previously it would use the variable data instead of the data member. This made
the sizeof use the sizeof a pointer instead of sizeof the data member. This didn't actaully seem to cause
any issues as most of the data is zeros and wouldn't influence the checksum. This fixes the length and
makes the code more genuine.
```
