### PR TITLE
AudioEngine: add null sink for use on platforms that may not want audio output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ endif()
 
 core_find_git_rev(APP_SCMID FULL)
 
-set(AUDIO_BACKENDS_LIST "" CACHE STRING "Available audio backends")
+set(AUDIO_BACKENDS_LIST "null" CACHE STRING "Available audio backends")
 set(GL_INTERFACES_LIST "" CACHE STRING "Available GL interfaces")
 
 # Dynamically loaded libraries built with the project

--- a/xbmc/cores/AudioEngine/CMakeLists.txt
+++ b/xbmc/cores/AudioEngine/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES AEResampleFactory.cpp
             Engines/ActiveAE/ActiveAEStream.cpp
             Engines/ActiveAE/ActiveAESound.cpp
             Engines/ActiveAE/ActiveAESettings.cpp
+            Sinks/AENullSink.cpp
             Utils/AEBitstreamPacker.cpp
             Utils/AEChannelInfo.cpp
             Utils/AEDeviceInfo.cpp
@@ -158,6 +159,11 @@ endif()
 if("webos" IN_LIST CORE_PLATFORM_NAME_LC)
   list(APPEND SOURCES Sinks/AESinkStarfish.cpp)
   list(APPEND HEADERS Sinks/AESinkStarfish.h)
+endif()
+
+if(CORE_SYSTEM_NAME STREQUAL linux OR CORE_SYSTEM_NAME STREQUAL freebsd)
+  list(APPEND SOURCES Sinks/AENullSink.cpp)
+  list(APPEND HEADERS Sinks/AENullSink.h)
 endif()
 
 if(CORE_SYSTEM_NAME STREQUAL freebsd)

--- a/xbmc/cores/AudioEngine/Sinks/AENullSink.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AENullSink.cpp
@@ -1,0 +1,103 @@
+#include "AENullSink.h"
+
+#include "AESinkFactory.h"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+namespace
+{
+
+constexpr std::chrono::duration<double, std::ratio<1>> DEFAULT_BUFFER_DURATION = 0.200s;
+constexpr int DEFAULT_PERIODS = 4;
+constexpr std::chrono::duration<double, std::ratio<1>> DEFAULT_PERIOD_DURATION =
+    DEFAULT_BUFFER_DURATION / DEFAULT_PERIODS;
+
+} // namespace
+
+bool CAENullSink::Register()
+{
+  AE::AESinkRegEntry entry;
+  entry.sinkName = "NULL";
+  entry.createFunc = CAENullSink::Create;
+  entry.enumerateFunc = CAENullSink::EnumerateDevicesEx;
+  entry.cleanupFunc = CAENullSink::Destroy;
+  AE::CAESinkFactory::RegisterSink(entry);
+
+  return true;
+}
+
+std::unique_ptr<IAESink> CAENullSink::Create(std::string& device, AEAudioFormat& desiredFormat)
+{
+  auto sink = std::make_unique<CAENullSink>();
+  if (sink->Initialize(desiredFormat, device))
+    return sink;
+
+  return {};
+}
+
+void CAENullSink::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
+{
+  CAEDeviceInfo info;
+  info.m_deviceType = AE_DEVTYPE_PCM;
+  info.m_deviceName = "Default";
+  info.m_displayName = "Default";
+  info.m_displayNameExtra = "Default Output Device (NULL)";
+  info.m_wantsIECPassthrough = true;
+  info.m_dataFormats.emplace_back(AEDataFormat::AE_FMT_FLOAT);
+
+  constexpr std::array<unsigned int, 13> sampleRates = {
+      8000, 11025, 16000, 22050, 32000, 44100, 48000, 64000, 88200, 96000, 176400, 192000, 384000,
+  };
+
+  std::for_each(sampleRates.cbegin(), sampleRates.cend(),
+                [&info](const auto& rate) { info.m_sampleRates.emplace_back(rate); });
+
+  info.m_channels = CAEChannelInfo(AE_CH_LAYOUT_7_1);
+
+  constexpr std::array<CAEStreamInfo::DataType, 10> streamTypes = {
+      CAEStreamInfo::STREAM_TYPE_AC3,      CAEStreamInfo::STREAM_TYPE_DTS_512,
+      CAEStreamInfo::STREAM_TYPE_DTS_1024, CAEStreamInfo::STREAM_TYPE_DTS_2048,
+      CAEStreamInfo::STREAM_TYPE_DTSHD,    CAEStreamInfo::STREAM_TYPE_DTSHD_CORE,
+      CAEStreamInfo::STREAM_TYPE_EAC3,     CAEStreamInfo::STREAM_TYPE_MLP,
+      CAEStreamInfo::STREAM_TYPE_TRUEHD,   CAEStreamInfo::STREAM_TYPE_DTSHD_MA,
+  };
+
+  std::for_each(streamTypes.cbegin(), streamTypes.cend(),
+                [&info](const auto& streamType) { info.m_streamTypes.emplace_back(streamType); });
+
+  info.m_dataFormats.emplace_back(AEDataFormat::AE_FMT_RAW);
+  info.m_deviceType = AE_DEVTYPE_HDMI;
+
+  list.emplace_back(info);
+}
+
+void CAENullSink::Destroy()
+{
+  // nothing to do here
+}
+
+bool CAENullSink::Initialize(AEAudioFormat& format, std::string& device)
+{
+  format.m_frameSize =
+      format.m_channelLayout.Count() * CAEUtil::DataFormatToBits(format.m_dataFormat) / 8;
+  format.m_frames = std::nearbyint(DEFAULT_PERIOD_DURATION.count() * format.m_sampleRate);
+
+  m_format = format;
+
+  return true;
+}
+
+unsigned int CAENullSink::AddPackets(uint8_t** data, unsigned int frames, unsigned int offset)
+{
+  const auto period = std::chrono::duration<double, std::ratio<1>>(static_cast<double>(frames) /
+                                                                   m_format.m_sampleRate);
+
+  std::this_thread::sleep_for(period);
+
+  return frames;
+}

--- a/xbmc/cores/AudioEngine/Sinks/AENullSink.h
+++ b/xbmc/cores/AudioEngine/Sinks/AENullSink.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "cores/AudioEngine/Interfaces/AESink.h"
+#include "cores/AudioEngine/Utils/AEDeviceInfo.h"
+
+class CAENullSink : public IAESink
+{
+public:
+  static bool Register();
+  static std::unique_ptr<IAESink> Create(std::string& device, AEAudioFormat& desiredFormat);
+  static void EnumerateDevicesEx(AEDeviceInfoList& list, bool force = false);
+  static void Destroy();
+
+  const char* GetName() override { return "NULL"; }
+
+  CAENullSink() = default;
+  ~CAENullSink() override = default;
+
+  bool Initialize(AEAudioFormat& format, std::string& device) override;
+
+  void Deinitialize() override {}
+
+  double GetCacheTotal() override { return 0.0; }
+
+  double GetLatency() override { return 0.0; }
+
+  unsigned int AddPackets(uint8_t** data, unsigned int frames, unsigned int offset) override;
+
+  void AddPause(unsigned int millis) override {}
+
+  void GetDelay(AEDelayStatus& status) override {}
+
+  void Drain() override {}
+
+  bool HasVolume() override { return false; }
+
+  void SetVolume(float volume) override {}
+
+private:
+  AEAudioFormat m_format;
+};

--- a/xbmc/platform/freebsd/PlatformFreebsd.cpp
+++ b/xbmc/platform/freebsd/PlatformFreebsd.cpp
@@ -10,6 +10,7 @@
 
 #include "ServiceBroker.h"
 #include "application/AppParams.h"
+#include "cores/AudioEngine/Sinks/AENullSink.h"
 #include "utils/StringUtils.h"
 
 #include "platform/freebsd/OptionalsReg.h"
@@ -104,6 +105,10 @@ bool CPlatformFreebsd::InitStageOne()
     OPTIONALS::ALSARegister();
     OPTIONALS::PulseAudioRegister(true);
   }
+  else if (sink == "null")
+  {
+    CAENullSink::Register();
+  }
   else
   {
     if (!OPTIONALS::PulseAudioRegister(false))
@@ -112,7 +117,10 @@ bool CPlatformFreebsd::InitStageOne()
       {
         if (!OPTIONALS::SndioRegister())
         {
-          OPTIONALS::OSSRegister();
+          if (!OPTIONALS::OSSRegister())
+          {
+            CAENullSink::Register();
+          }
         }
       }
     }

--- a/xbmc/platform/linux/PlatformLinux.cpp
+++ b/xbmc/platform/linux/PlatformLinux.cpp
@@ -10,6 +10,7 @@
 
 #include "ServiceBroker.h"
 #include "application/AppParams.h"
+#include "cores/AudioEngine/Sinks/AENullSink.h"
 #include "filesystem/SpecialProtocol.h"
 
 #if defined(HAS_ALSA)
@@ -116,6 +117,10 @@ bool CPlatformLinux::InitStageOne()
     OPTIONALS::ALSARegister();
     OPTIONALS::PulseAudioRegister(true);
   }
+  else if (sink == "null")
+  {
+    CAENullSink::Register();
+  }
   else
   {
     if (!OPTIONALS::PulseAudioRegister(false))
@@ -124,7 +129,10 @@ bool CPlatformLinux::InitStageOne()
       {
         if (!OPTIONALS::ALSARegister())
         {
-          OPTIONALS::SndioRegister();
+          if (!OPTIONALS::SndioRegister())
+          {
+            CAENullSink::Register();
+          }
         }
       }
     }


### PR DESCRIPTION
This allows kodi to run properly without building an audio backend. This would be helpful for those wanting to run in a Docker container or other VM applications. Or maybe headless? 😉 

Kodi will build successfully it no audio backends are enabled
```
-DENABLE_ALSA=OFF -DENABLE_PULSEAUDIO=OFF -DENABLE_PIPEWIRE=OFF
```
However there will be runtime issues as `AudioEngine` will fail to run properly
```
2024-10-30 14:14:49.356 T:724430 warning <general>: CActiveAE::StateMachine - signal: 23 from port: timer not handled for state: 1
```
vs

```
2024-10-30 14:13:39.932 T:722579    info <general>: Found 1 Lists of Devices
2024-10-30 14:13:39.932 T:722579    info <general>: Enumerated NULL devices:
2024-10-30 14:13:39.932 T:722579    info <general>:     Device 1
2024-10-30 14:13:39.932 T:722579    info <general>:         m_deviceName      : Default
2024-10-30 14:13:39.932 T:722579    info <general>:         m_displayName     : Default
2024-10-30 14:13:39.932 T:722579    info <general>:         m_displayNameExtra: Default Output Device (NULL)
2024-10-30 14:13:39.932 T:722579    info <general>:         m_deviceType      : AE_DEVTYPE_HDMI
2024-10-30 14:13:39.932 T:722579    info <general>:         m_channels        : FL, FR, FC, LFE, BL, BR, SL, SR
2024-10-30 14:13:39.932 T:722579    info <general>:         m_sampleRates     : 8000,11025,16000,22050,32000,44100,48000,64000,88200,96000,176400,192000,384000
2024-10-30 14:13:39.932 T:722579    info <general>:         m_dataFormats     : AE_FMT_FLOAT,AE_FMT_RAW
2024-10-30 14:13:39.932 T:722579    info <general>:         m_streamTypes     : STREAM_TYPE_AC3,STREAM_TYPE_DTS_512,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTSHD,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_EAC3,STREAM_TYPE_MLP,STR>
2024-10-30 14:13:39.932 T:722580    info <general>: CActiveAESink::OpenSink - initialize sink
2024-10-30 14:13:39.932 T:722580   debug <general>: CActiveAESink::OpenSink - trying to open device NULL:Default
2024-10-30 14:13:39.932 T:722580   debug <general>: CActiveAESink::OpenSink - NULL Initialized:
2024-10-30 14:13:39.932 T:722580   debug <general>:   Output Device : Default
2024-10-30 14:13:39.932 T:722580   debug <general>:   Sample Rate   : 44100
2024-10-30 14:13:39.932 T:722580   debug <general>:   Sample Format : AE_FMT_FLOAT
2024-10-30 14:13:39.932 T:722580   debug <general>:   Channel Count : 2
2024-10-30 14:13:39.932 T:722580   debug <general>:   Channel Layout: FL, FR
2024-10-30 14:13:39.932 T:722580   debug <general>:   Frames        : 2205
2024-10-30 14:13:39.932 T:722580   debug <general>:   Frame Size    : 8
```

A better fix would be to disable audio engine completely, however, that would be a very involved change at the moment.

I'm not sure if this would be beneficial on non linux/freebsd platforms, but it can always be adjusted.