### PR TITLE
[tools/depends][native] python fix multithread dir creation failure

### DIFF
--- a/tools/depends/native/python3/Makefile
+++ b/tools/depends/native/python3/Makefile
@@ -31,7 +31,8 @@ $(LIBDYLIB): $(PLATFORM)
 	cd $(PLATFORM); $(MAKE)
 
 .installed-$(PLATFORM): $(LIBDYLIB)
-	cd $(PLATFORM); $(MAKE) install
+# We specifically use -j1 as some threading issues can occur with install directory creation
+	cd $(PLATFORM); $(MAKE) install -j1
 	touch $@
 
 clean:


### PR DESCRIPTION
## Description
Fix intermittent CI failures building native python. While log is valid (not long) https://jenkins.kodi.tv/job/OSX-64/36117/consoleFull

## Motivation and context
At times we run across the following CI failure

07:12:39 install: mkdir /Users/Shared/jenkins/workspace/OSX-64/tools/depends/xbmc-depends/arm-darwin22.6.0-native/lib/python3.12: File exists
07:12:39 make[3]: *** [sharedinstall] Error 71

Make the install just use a single thread. We do this in the target python3 install already for the same reason.

## How has this been tested?
Target python 3 has been using the same change for a while

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
