### PR TITLE
Texturepacker: identify swizzle of uniform white/opaque texture as RRR1

### DIFF
--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -344,13 +344,7 @@ void TexturePacker::ReduceChannels(RGBAImage& image)
   if (uniformRed && uniformGreen && uniformBlue && !isWhite)
     printf("WARNING: uniform color detected! Consider using diffusecolor!\n");
 
-  if (isIntensity)
-  {
-    // this is an intensity (GL_INTENSITY) texture
-    ConvertToSingleChannel(image, 0);
-    image.textureSwizzle = KD_TEX_SWIZ_RRRR;
-  }
-  else if (uniformAlpha && alpha == 0xff)
+  if (uniformAlpha && alpha == 0xff)
   {
     // we have a opaque texture, L or RGBX
     if (isGrey)
@@ -365,6 +359,12 @@ void TexturePacker::ReduceChannels(RGBAImage& image)
     // an alpha only texture
     ConvertToSingleChannel(image, 3);
     image.textureSwizzle = KD_TEX_SWIZ_111R;
+  }
+  else if (isIntensity)
+  {
+    // this is an intensity (GL_INTENSITY) texture
+    ConvertToSingleChannel(image, 0);
+    image.textureSwizzle = KD_TEX_SWIZ_RRRR;
   }
   else if (isGrey)
   {


### PR DESCRIPTION
## Description
With the PR, textures with just a white and opaque surface (#FFFFFFFF) are now identified as a greyscale texture (swizzle RRR1), instead of an intensity texture (RRRR).

## Motivation and context
Estuary uses such textures for simple opaque surfaces. Having such an intensity texture would render just fine, but it would also force the element to be rendered in the back to front rendering pass, due to the implied transparency of the texture. A greyscale texture is opaque, so that the element can be an occluder in the front to back pass. 

## How has this been tested?
Still renders fine. Affected elements are now rendering in the front to back pass.

## What is the effect on users?
A bit better performance in some situations.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
