### PR TITLE
GL/GLES: Optimize font vertices

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -1214,10 +1214,10 @@ void CGUIFontTTF::RenderCharacter(CGraphicContext& context,
 #else
   // when scaling by shader, we have to grow the vertex and texture coords
   // by .5 or we would ommit pixels when animating.
-  const float tl = (texture.x1 - .5f) * m_textureScaleX;
-  const float tr = (texture.x2 + .5f) * m_textureScaleX;
-  const float tt = (texture.y1 - .5f) * m_textureScaleY;
-  const float tb = (texture.y2 + .5f) * m_textureScaleY;
+  const uint16_t tl = std::round((texture.x1 - .5f) * UINT16_MAX * m_textureScaleX);
+  const uint16_t tr = std::round((texture.x2 + .5f) * UINT16_MAX * m_textureScaleX);
+  const uint16_t tt = std::round((texture.y1 - .5f) * UINT16_MAX * m_textureScaleY);
+  const uint16_t tb = std::round((texture.y2 + .5f) * UINT16_MAX * m_textureScaleY);
 #endif
 
   vertices.resize(vertices.size() + VERTEX_PER_GLYPH);
@@ -1277,25 +1277,21 @@ void CGUIFontTTF::RenderCharacter(CGraphicContext& context,
   v[0].v = tt;
   v[0].x = vertex.x1 - xOffset - 0.5f;
   v[0].y = vertex.y1 - yOffset - 0.5f;
-  v[0].z = 0;
 
   v[1].u = tl;
   v[1].v = tb;
   v[1].x = vertex.x1 - xOffset - 0.5f;
   v[1].y = vertex.y2 - yOffset + 0.5f;
-  v[1].z = 0;
 
   v[2].u = tr;
   v[2].v = tt;
   v[2].x = vertex.x2 - xOffset + 0.5f;
   v[2].y = vertex.y1 - yOffset - 0.5f;
-  v[2].z = 0;
 
   v[3].u = tr;
   v[3].v = tb;
   v[3].x = vertex.x2 - xOffset + 0.5f;
   v[3].y = vertex.y2 - yOffset + 0.5f;
-  v[3].z = 0;
 #endif
 }
 

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -64,9 +64,9 @@ struct SVertex
 #else
 struct SVertex
 {
-  float x, y, z;
+  float x, y;
   unsigned char r, g, b, a;
-  float u, v;
+  uint16_t u, v;
 };
 #endif
 

--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -258,13 +258,13 @@ void CGUIFontTTFGL::LastEnd()
         // Set up the offsets of the various vertex attributes within the buffer
         // object bound to GL_ARRAY_BUFFER
         glVertexAttribPointer(
-            posLoc, 3, GL_FLOAT, GL_FALSE, sizeof(SVertex),
+            posLoc, 2, GL_FLOAT, GL_FALSE, sizeof(SVertex),
             reinterpret_cast<GLvoid*>(character * sizeof(SVertex) * 4 + offsetof(SVertex, x)));
         glVertexAttribPointer(
             colLoc, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(SVertex),
             reinterpret_cast<GLvoid*>(character * sizeof(SVertex) * 4 + offsetof(SVertex, r)));
         glVertexAttribPointer(
-            tex0Loc, 2, GL_FLOAT, GL_FALSE, sizeof(SVertex),
+            tex0Loc, 2, GL_UNSIGNED_SHORT, GL_TRUE, sizeof(SVertex),
             reinterpret_cast<GLvoid*>(character * sizeof(SVertex) * 4 + offsetof(SVertex, u)));
 
         glDrawElements(GL_TRIANGLES, 6 * count, GL_UNSIGNED_SHORT, 0);

--- a/xbmc/guilib/GUIFontTTFGLES.cpp
+++ b/xbmc/guilib/GUIFontTTFGLES.cpp
@@ -253,13 +253,13 @@ void CGUIFontTTFGLES::LastEnd()
         // Set up the offsets of the various vertex attributes within the buffer
         // object bound to GL_ARRAY_BUFFER
         glVertexAttribPointer(
-            posLoc, 3, GL_FLOAT, GL_FALSE, sizeof(SVertex),
+            posLoc, 2, GL_FLOAT, GL_FALSE, sizeof(SVertex),
             reinterpret_cast<GLvoid*>(character * sizeof(SVertex) * 4 + offsetof(SVertex, x)));
         glVertexAttribPointer(
             colLoc, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(SVertex),
             reinterpret_cast<GLvoid*>(character * sizeof(SVertex) * 4 + offsetof(SVertex, r)));
         glVertexAttribPointer(
-            tex0Loc, 2, GL_FLOAT, GL_FALSE, sizeof(SVertex),
+            tex0Loc, 2, GL_UNSIGNED_SHORT, GL_TRUE, sizeof(SVertex),
             reinterpret_cast<GLvoid*>(character * sizeof(SVertex) * 4 + offsetof(SVertex, u)));
 
         glDrawElements(GL_TRIANGLES, 6 * count, GL_UNSIGNED_SHORT, 0);


### PR DESCRIPTION
## Description
The PR reduces the size of font vertices. 

## Motivation and context
Previously, we would carry an unused depth component ("z") in the vertex data. The texture coordinates were supplied by two floats. The unused depth has been removed, and the texture coordinates are now unsigned shorts.

This lowers the size of one vertex from 24 bytes to 16 (-33%).

## How has this been tested?
Still renders fine on my machine.

## What is the effect on users?
Maybe a tiny bit more performance.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
