### PR TITLE
Estuary: make dialog header opaque

### DIFF
--- a/addons/skin.estuary/colors/brown.xml
+++ b/addons/skin.estuary/colors/brown.xml
@@ -3,6 +3,7 @@
 	<color name="primary_background">FF563529</color>
 	<color name="secondary_background">33738627</color>
 	<color name="dialog_tint">FF282524</color>
+	<color name="dialog_header_tint">FF674336</color>
 	<color name="button_focus">FF83513F</color>
 	<color name="button_alt_focus">8083513F</color>
 	<color name="selected">FFFF4400</color>

--- a/addons/skin.estuary/colors/charcoal.xml
+++ b/addons/skin.estuary/colors/charcoal.xml
@@ -3,6 +3,7 @@
 	<color name="primary_background">FF666666</color>
 	<color name="secondary_background">4D808080</color>
 	<color name="dialog_tint">FF262626</color>
+	<color name="dialog_header_tint">FF7C7C7C</color>
 	<color name="button_focus">FFA2A2A2</color>
 	<color name="button_alt_focus">80A2A2A2</color>
 	<color name="selected">FFFFB70F</color>

--- a/addons/skin.estuary/colors/chartreuse.xml
+++ b/addons/skin.estuary/colors/chartreuse.xml
@@ -3,6 +3,7 @@
 	<color name="primary_background">FF3B5E12</color>
 	<color name="secondary_background">3398FF05</color>
 	<color name="dialog_tint">FF202920</color>
+	<color name="dialog_header_tint">FF408609</color>
 	<color name="button_focus">FF4FAF00</color>
 	<color name="button_alt_focus">804FAF00</color>
 	<color name="selected">FF24C6C9</color>

--- a/addons/skin.estuary/colors/concrete.xml
+++ b/addons/skin.estuary/colors/concrete.xml
@@ -3,6 +3,7 @@
 	<color name="primary_background">FF4B5F69</color>
 	<color name="secondary_background">33DA845C</color>
 	<color name="dialog_tint">FF242728</color>
+	<color name="dialog_header_tint">FF4D636D</color>
 	<color name="button_focus">FF607D8B</color>
 	<color name="button_alt_focus">80607D8B</color>
 	<color name="selected">FFFF8C00</color>

--- a/addons/skin.estuary/colors/defaults.xml
+++ b/addons/skin.estuary/colors/defaults.xml
@@ -3,6 +3,7 @@
 	<color name="primary_background">FF0E597E</color>
 	<color name="secondary_background">330BAA8E</color>
 	<color name="dialog_tint">FF1A2123</color>
+	<color name="dialog_header_tint">FF147995</color>
 	<color name="background">FF000000</color>
 	<color name="bg_image">FF909090</color>
 	<color name="bg_overlay">30FFFFFF</color>

--- a/addons/skin.estuary/colors/gold.xml
+++ b/addons/skin.estuary/colors/gold.xml
@@ -3,6 +3,7 @@
 	<color name="primary_background">FF966300</color>
 	<color name="secondary_background">33FFFF00</color>
 	<color name="dialog_tint">FF2B2B22</color>
+	<color name="dialog_header_tint">FF9D810A</color>
 	<color name="button_focus">FFCFA700</color>
 	<color name="button_alt_focus">80CFA700</color>
 	<color name="selected">FFFFF000</color>

--- a/addons/skin.estuary/colors/green.xml
+++ b/addons/skin.estuary/colors/green.xml
@@ -3,6 +3,7 @@
 	<color name="primary_background">FF1C6E45</color>
 	<color name="secondary_background">3300A3CC</color>
 	<color name="dialog_tint">FF1F2722</color>
+	<color name="dialog_header_tint">FF22995F</color>
 	<color name="button_focus">FF24CA7A</color>
 	<color name="button_alt_focus">8024CA7A</color>
 	<color name="selected">FF14D519</color>

--- a/addons/skin.estuary/colors/maroon.xml
+++ b/addons/skin.estuary/colors/maroon.xml
@@ -3,6 +3,7 @@
 	<color name="primary_background">FF6B1414</color>
 	<color name="secondary_background">33DB2C83</color>
 	<color name="dialog_tint">FF262020</color>
+	<color name="dialog_header_tint">FF940B09</color>
 	<color name="button_focus">FFC40300</color>
 	<color name="button_alt_focus">80C40300</color>
 	<color name="selected">FF24C6C9</color>

--- a/addons/skin.estuary/colors/midnight.xml
+++ b/addons/skin.estuary/colors/midnight.xml
@@ -3,6 +3,7 @@
 	<color name="primary_background">FF11375C</color>
 	<color name="secondary_background">334F4F9E</color>
 	<color name="dialog_tint">FF181B1E</color>
+	<color name="dialog_header_tint">FF234F7B</color>
 	<color name="button_focus">FF2866A4</color>
 	<color name="button_alt_focus">802866A4</color>
 	<color name="selected">FF5BE5EE</color>

--- a/addons/skin.estuary/colors/orange.xml
+++ b/addons/skin.estuary/colors/orange.xml
@@ -3,6 +3,7 @@
 	<color name="primary_background">FFA74012</color>
 	<color name="secondary_background">33BDAE12</color>
 	<color name="dialog_tint">FF2B2621</color>
+	<color name="dialog_header_tint">FFBF7509</color>
 	<color name="button_focus">FFFF9800</color>
 	<color name="button_alt_focus">80FF9800</color>
 	<color name="selected">FFFFF100</color>

--- a/addons/skin.estuary/colors/pink.xml
+++ b/addons/skin.estuary/colors/pink.xml
@@ -3,6 +3,7 @@
 	<color name="primary_background">FFA61558</color>
 	<color name="secondary_background">3363BCE9</color>
 	<color name="dialog_tint">FF2B2225</color>
+	<color name="dialog_header_tint">FFB01F50</color>
 	<color name="button_focus">FFE91E63</color>
 	<color name="button_alt_focus">80E91E63</color>
 	<color name="selected">FF94D800</color>

--- a/addons/skin.estuary/colors/rose.xml
+++ b/addons/skin.estuary/colors/rose.xml
@@ -3,6 +3,7 @@
 	<color name="primary_background">FFA22A66</color>
 	<color name="secondary_background">33FFB3D7</color>
 	<color name="dialog_tint">FF251F24</color>
+	<color name="dialog_header_tint">FFBD6C94</color>
 	<color name="button_focus">FFFF8EC4</color>
 	<color name="button_alt_focus">80FF8EC4</color>
 	<color name="selected">FFFF0261</color>

--- a/addons/skin.estuary/colors/teal.xml
+++ b/addons/skin.estuary/colors/teal.xml
@@ -3,6 +3,7 @@
 	<color name="primary_background">FF00665C</color>
 	<color name="secondary_background">33F07942</color>
 	<color name="dialog_tint">FF222A2A</color>
+	<color name="dialog_header_tint">FF0A756B</color>
 	<color name="button_focus">FF009688</color>
 	<color name="button_alt_focus">80009688</color>
 	<color name="selected">FFC67F03</color>

--- a/addons/skin.estuary/colors/violet.xml
+++ b/addons/skin.estuary/colors/violet.xml
@@ -3,6 +3,7 @@
 	<color name="primary_background">FF5B1C80</color>
 	<color name="secondary_background">33FFB3D7</color>
 	<color name="dialog_tint">FF27222A</color>
+	<color name="dialog_header_tint">FF9242BF</color>
 	<color name="button_focus">FFC050FF</color>
 	<color name="button_alt_focus">80C050FF</color>
 	<color name="selected">FFFF0054</color>

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -930,15 +930,15 @@
 				<left>0</left>
 				<top>0</top>
 				<right>0</right>
-				<bottom>0</bottom>
-				<texture colordiffuse="dialog_tint">colors/white.png</texture>
+				<height>70</height>
+				<texture colordiffuse="dialog_header_tint">colors/white.png</texture>
 			</control>
 			<control type="image">
 				<left>0</left>
-				<top>0</top>
+				<top>70</top>
 				<right>0</right>
-				<height>70</height>
-				<texture colordiffuse="button_focus" border="2">colors/white70.png</texture>
+				<bottom>0</bottom>
+				<texture colordiffuse="dialog_tint">colors/white.png</texture>
 			</control>
 			<control type="label" id="$PARAM[header_id]">
 				<left>40</left>


### PR DESCRIPTION
## Description
With the PR, dialog headers of Estuary are now opaque. The main dialog body doesn't extend "under" the header anymore.

## Motivation and context
It reduces some overdraw when a dialog is active. 

## How has this been tested?
Still renders fine.

## What is the effect on users?
A bit better performance on dialogs.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
