### PR TITLE
[Android] Avoid failure when getInterfaceName() method returns null

### DIFF
--- a/xbmc/platform/android/network/NetworkAndroid.cpp
+++ b/xbmc/platform/android/network/NetworkAndroid.cpp
@@ -360,7 +360,7 @@ void CNetworkAndroid::RetrieveInterfaces()
 
 void CNetworkAndroid::onAvailable(const CJNINetwork n)
 {
-  CLog::Log(LOGDEBUG, "CNetworkAndroid::onAvailable The default network is now: {}", n.toString());
+  CLog::Log(LOGDEBUG, "CNetworkAndroid::onAvailable: The default network is now: {}", n.toString());
 
   CJNIConnectivityManager connman{CJNIContext::getSystemService(CJNIContext::CONNECTIVITY_SERVICE)};
   CJNILinkProperties lp = connman.getLinkProperties(n);
@@ -368,6 +368,13 @@ void CNetworkAndroid::onAvailable(const CJNINetwork n)
   if (lp)
   {
     CJNINetworkInterface intf = CJNINetworkInterface::getByName(lp.getInterfaceName());
+    if (xbmc_jnienv()->ExceptionCheck())
+    {
+      xbmc_jnienv()->ExceptionClear();
+      CLog::Log(LOGERROR, "CNetworkAndroid::onAvailable: Cannot get interface by name: {}",
+                lp.getInterfaceName());
+      return;
+    }
     if (intf)
       m_defaultInterface = std::make_unique<CNetworkInterfaceAndroid>(n, lp, intf);
   }


### PR DESCRIPTION
## Description
Check that the [getInterfaceName()](https://developer.android.com/reference/android/net/LinkProperties#getInterfaceName()) method may return `null` causing the app to crash.

Try to fix the issue https://github.com/xbmc/xbmc/issues/25815 when the interface name for the link is not set.

Log:
```
D Kodi    : debug <general>: CNetworkAndroid::onAvailable The default network is now: 101
...
E AndroidRuntime: FATAL EXCEPTION: ConnectivityThread
E AndroidRuntime: Process: org.xbmc.kodi, PID: 6716
E AndroidRuntime: java.lang.NullPointerException: Attempt to read from field 'java.util.List java.net.NetworkInterface.childs' on a null object reference
E AndroidRuntime:        at java.net.NetworkInterface.getAll(NetworkInterface.java:498)
E AndroidRuntime:        at java.net.NetworkInterface.getByName(NetworkInterface.java:298)
E AndroidRuntime:        at org.xbmc.kodi.interfaces.XBMCConnectivityManagerNetworkCallback._onAvailable(Native Method)
E AndroidRuntime:        at org.xbmc.kodi.interfaces.XBMCConnectivityManagerNetworkCallback.onAvailable(XBMCConnectivityManagerNetworkCallback.java:13)
E AndroidRuntime:        at android.net.ConnectivityManager$NetworkCallback.onAvailable(ConnectivityManager.java:3322)
E AndroidRuntime:        at android.net.ConnectivityManager$CallbackHandler.handleMessage(ConnectivityManager.java:3607)
E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:106)
E AndroidRuntime:        at android.os.Looper.loop(Looper.java:223)
E AndroidRuntime:        at android.os.HandlerThread.run(HandlerThread.java:67)
``` 

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
