### PR TITLE
[videodb] Fix Nested Transactions - Video DB Creation/Upgrade, PVR Stop

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -208,6 +208,7 @@ void CVideoDatabase::CreateTables()
   CLog::Log(LOGINFO, "create videoversiontype table");
   m_pDS->exec("CREATE TABLE videoversiontype (id INTEGER PRIMARY KEY, name TEXT, owner INTEGER, "
               "itemType INTEGER)");
+  CLog::Log(LOGINFO, "populate videoversiontype table");
   InitializeVideoVersionTypeTable(GetSchemaVersion());
 
   CLog::Log(LOGINFO, "create videoversion table");
@@ -12013,10 +12014,10 @@ std::string CVideoDatabase::GetVideoItemTitle(VideoDbContentType itemType, int d
 
 void CVideoDatabase::InitializeVideoVersionTypeTable(int schemaVersion)
 {
+  assert(m_pDB->in_transaction());
+
   try
   {
-    BeginTransaction();
-
     for (int id = VIDEO_VERSION_ID_BEGIN; id <= VIDEO_VERSION_ID_END; ++id)
     {
       // Exclude removed pre-populated "quality" values
@@ -12037,13 +12038,11 @@ void CVideoDatabase::InitializeVideoVersionTypeTable(int schemaVersion)
             type.c_str(), VideoAssetTypeOwner::SYSTEM, VideoAssetType::VERSION));
       }
     }
-
-    CommitTransaction();
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
-    RollbackTransaction();
+    CLog::LogF(LOGERROR, "failed");
+    throw;
   }
 }
 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -601,8 +601,9 @@ public:
    * \brief Clear any existing stream details and add the new provided details to a file.
    * \param[in] details New stream details
    * \param[in] idFile Identifier of the file
+   * \return operation success. true for success, false for failure
    */
-  void SetStreamDetailsForFileId(const CStreamDetails& details, int idFile);
+  bool SetStreamDetailsForFileId(const CStreamDetails& details, int idFile);
 
   bool SetSingleValue(VideoDbContentType type, int dbId, int dbField, const std::string& strValue);
   bool SetSingleValue(VideoDbContentType type,


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Follow up of previous PRs on nested db transactions (not supported by Sqlite or Mysql).

- video db creation / upgrade

InitializeVideoVersionTypeTable() creates its own transaction, which looks like a good idea, but it causes a nested transaction (and now an assert) during the creation of a new video database or the upgrade of a db older than v123 (ie Nexus or older).

For both call paths to InitializeVideoVersionTypeTable() a transaction already exists.
Errors would manifest as exceptions and callers in the stack are ready to catch them, so the solution here looks like the removal of the unnecessary inside transaction.

- PVR playback stop

CSaveFileState::DoWork() creates a big transaction for Sqlite performance (#19367) and for data integrity the br movie fileid update created a nested local transaction.
DoWork() had other error-handling/data integrity issues, this commit fixes it for the block involved in the nested transaction but more work remains in DoWork()
Design of the app looks like only CDatabase and lower layers handle the db wrappers exceptions. External codes uses error codes for error handling, the solution used here.
Ugly error codes are expected to disappear with upcoming #25140 that reworks the br movie fileid update.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

assert() for a brand new installation of Kodi, or upgrade from v20.
The problem did not create corruption or a very noticeable slow down, though there was one (see testing)

assert() when stopping pvr or video addons.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

New installation, upgrade from v20. I don't have older sqlite db to try, but it wouldn't make a difference as the problematic code was added by the video versions feature in v21.

mysql/mariadb and sqlite on SSD performance: difference not really measurable.
sqlite on HDD:
- new video db creation before: 300ms, after: 20ms
- upgrade of db with 2000 movies and 1000 shows from v121 to v133, before: 800ms after: 600ms

Started/stopped local files, pvr streams, video addons.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

The speedup is not noticeable by users on Windows desktop computer.
Maybe on low power devices / slow drives or cards.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
