### PR TITLE
GL: clean up GUI shaders

### DIFF
--- a/system/shaders/GL/1.2/gl_shader_frag_default.glsl
+++ b/system/shaders/GL/1.2/gl_shader_frag_default.glsl
@@ -1,21 +1,9 @@
 /*
- *      Copyright (C) 2010-2013 Team XBMC
- *      http://xbmc.org
+ *  Copyright (C) 2010-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
  *
- *  This Program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2, or (at your option)
- *  any later version.
- *
- *  This Program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with XBMC; see the file COPYING.  If not, see
- *  <http://www.gnu.org/licenses/>.
- *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
  */
 
 #version 120
@@ -23,7 +11,7 @@
 uniform vec4 m_unicol;
 
 // SM_DEFAULT shader
-void main ()
+void main()
 {
   gl_FragColor = m_unicol;
 }

--- a/system/shaders/GL/1.2/gl_shader_frag_fonts.glsl
+++ b/system/shaders/GL/1.2/gl_shader_frag_fonts.glsl
@@ -1,34 +1,20 @@
 /*
- *      Copyright (C) 2010-2013 Team XBMC
- *      http://xbmc.org
+ *  Copyright (C) 2010-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
  *
- *  This Program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2, or (at your option)
- *  any later version.
- *
- *  This Program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with XBMC; see the file COPYING.  If not, see
- *  <http://www.gnu.org/licenses/>.
- *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
  */
 
 #version 120
 
 uniform sampler2D m_samp0;
-varying vec4 m_cord0;
+varying vec2 m_cord0;
 varying vec4 m_colour;
 
 // SM_FONTS shader
-void main ()
+void main()
 {
-  gl_FragColor.r   = m_colour.r;
-  gl_FragColor.g   = m_colour.g;
-  gl_FragColor.b   = m_colour.b;
-  gl_FragColor.a   = m_colour.a * texture2D(m_samp0, m_cord0.xy).r;
+  gl_FragColor = m_colour;
+  gl_FragColor.a *= texture2D(m_samp0, m_cord0).r;
 }

--- a/system/shaders/GL/1.2/gl_shader_frag_multi.glsl
+++ b/system/shaders/GL/1.2/gl_shader_frag_multi.glsl
@@ -1,32 +1,20 @@
 /*
- *      Copyright (C) 2010-2013 Team XBMC
- *      http://xbmc.org
+ *  Copyright (C) 2010-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
  *
- *  This Program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2, or (at your option)
- *  any later version.
- *
- *  This Program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with XBMC; see the file COPYING.  If not, see
- *  <http://www.gnu.org/licenses/>.
- *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
  */
 
 #version 120
 
 uniform sampler2D m_samp0;
 uniform sampler2D m_samp1;
-varying vec4 m_cord0;
-varying vec4 m_cord1;
+varying vec2 m_cord0;
+varying vec2 m_cord1;
 
 // SM_MULTI shader
-void main ()
+void main()
 {
-  gl_FragColor.rgba = (texture2D(m_samp0, m_cord0.xy) * texture2D(m_samp1, m_cord1.xy)).rgba;
+  gl_FragColor = texture2D(m_samp0, m_cord0) * texture2D(m_samp1, m_cord1);
 }

--- a/system/shaders/GL/1.2/gl_shader_frag_multi_blendcolor.glsl
+++ b/system/shaders/GL/1.2/gl_shader_frag_multi_blendcolor.glsl
@@ -1,33 +1,21 @@
 /*
- *      Copyright (C) 2010-2013 Team XBMC
- *      http://xbmc.org
+ *  Copyright (C) 2010-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
  *
- *  This Program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2, or (at your option)
- *  any later version.
- *
- *  This Program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with XBMC; see the file COPYING.  If not, see
- *  <http://www.gnu.org/licenses/>.
- *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
  */
 
 #version 120
 
 uniform sampler2D m_samp0;
 uniform sampler2D m_samp1;
-varying vec4 m_cord0;
-varying vec4 m_cord1;
+varying vec2 m_cord0;
+varying vec2 m_cord1;
 uniform vec4 m_unicol;
 
 // SM_MULTI shader
-void main ()
+void main()
 {
-  gl_FragColor.rgba = m_unicol * texture2D(m_samp0, m_cord0.xy) * texture2D(m_samp1, m_cord1.xy);
+  gl_FragColor = m_unicol * texture2D(m_samp0, m_cord0) * texture2D(m_samp1, m_cord1);
 }

--- a/system/shaders/GL/1.2/gl_shader_frag_texture.glsl
+++ b/system/shaders/GL/1.2/gl_shader_frag_texture.glsl
@@ -1,31 +1,19 @@
 /*
- *      Copyright (C) 2010-2013 Team XBMC
- *      http://xbmc.org
+ *  Copyright (C) 2010-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
  *
- *  This Program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2, or (at your option)
- *  any later version.
- *
- *  This Program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with XBMC; see the file COPYING.  If not, see
- *  <http://www.gnu.org/licenses/>.
- *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
  */
 
 #version 120
 
 uniform sampler2D m_samp0;
 uniform vec4 m_unicol;
-varying vec4 m_cord0;
+varying vec2 m_cord0;
 
 // SM_TEXTURE shader
 void main ()
 {
-  gl_FragColor.rgba = vec4(texture2D(m_samp0, m_cord0.xy).rgba * m_unicol);
+  gl_FragColor = texture2D(m_samp0, m_cord0) * m_unicol;
 }

--- a/system/shaders/GL/1.2/gl_shader_frag_texture_noblend.glsl
+++ b/system/shaders/GL/1.2/gl_shader_frag_texture_noblend.glsl
@@ -1,30 +1,18 @@
 /*
- *      Copyright (C) 2010-2013 Team XBMC
- *      http://xbmc.org
+ *  Copyright (C) 2010-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
  *
- *  This Program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2, or (at your option)
- *  any later version.
- *
- *  This Program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with XBMC; see the file COPYING.  If not, see
- *  <http://www.gnu.org/licenses/>.
- *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
  */
 
 #version 120
 
 uniform sampler2D m_samp0;
-varying vec4 m_cord0;
+varying vec2 m_cord0;
 
 // SM_TEXTURE_NOBLEND shader
-void main ()
+void main()
 {
-  gl_FragColor.rgba = vec4(texture2D(m_samp0, m_cord0.xy).rgba);
+  gl_FragColor = texture2D(m_samp0, m_cord0);
 }

--- a/system/shaders/GL/1.2/gl_shader_vert.glsl
+++ b/system/shaders/GL/1.2/gl_shader_vert.glsl
@@ -1,42 +1,30 @@
 /*
- *      Copyright (C) 2010-2013 Team XBMC
- *      http://xbmc.org
+ *  Copyright (C) 2010-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
  *
- *  This Program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2, or (at your option)
- *  any later version.
- *
- *  This Program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with XBMC; see the file COPYING.  If not, see
- *  <http://www.gnu.org/licenses/>.
- *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
  */
 
 #version 120
 
-attribute vec4 m_attrpos;
+attribute vec2 m_attrpos;
 attribute vec4 m_attrcol;
-attribute vec4 m_attrcord0;
-attribute vec4 m_attrcord1;
-varying vec4 m_cord0;
-varying vec4 m_cord1;
+attribute vec2 m_attrcord0;
+attribute vec2 m_attrcord1;
+varying vec2 m_cord0;
+varying vec2 m_cord1;
 varying vec4 m_colour;
 uniform mat4 m_proj;
 uniform mat4 m_model;
 uniform float m_depth;
 
-void main ()
+void main()
 {
-  mat4 mvp    = m_proj * m_model;
-  gl_Position = mvp * m_attrpos;
+  mat4 mvp = m_proj * m_model;
+  gl_Position = mvp * vec4(m_attrpos, 0., 1.);
   gl_Position.z = m_depth * gl_Position.w;
-  m_colour    = m_attrcol;
-  m_cord0     = m_attrcord0;
-  m_cord1     = m_attrcord1;
+  m_colour = m_attrcol;
+  m_cord0 = m_attrcord0;
+  m_cord1 = m_attrcord1;
 }

--- a/system/shaders/GL/1.2/gl_shader_vert_clip.glsl
+++ b/system/shaders/GL/1.2/gl_shader_vert_clip.glsl
@@ -8,12 +8,12 @@
 
 #version 120
 
-attribute vec4 m_attrpos;
+attribute vec2 m_attrpos;
 attribute vec4 m_attrcol;
-attribute vec4 m_attrcord0;
-attribute vec4 m_attrcord1;
-varying vec4 m_cord0;
-varying vec4 m_cord1;
+attribute vec2 m_attrcord0;
+attribute vec2 m_attrcord1;
+varying vec2 m_cord0;
+varying vec2 m_cord1;
 varying vec4 m_colour;
 uniform mat4 m_matrix;
 uniform vec4 m_shaderClip;
@@ -24,20 +24,20 @@ uniform float m_depth;
 // possible (e.g. when rotating). it can't discard triangles, but it may 
 // degenerate them.
 
-void main ()
+void main()
 {
   // limit the vertices to the clipping area
-  vec4 position = m_attrpos;
-  position.xy = clamp(position.xy, m_shaderClip.xy, m_shaderClip.zw);
+  vec4 position = vec4(0., 0., 0., 1.);
+  position.xy = clamp(m_attrpos, m_shaderClip.xy, m_shaderClip.zw);
   gl_Position = m_matrix * position;
 
   // set rendering depth
   gl_Position.z = m_depth * gl_Position.w;
 
   // correct texture coordinates for clipped vertices
-  vec2 clipDist = m_attrpos.xy - position.xy;
-  m_cord0.xy = m_attrcord0.xy - clipDist * m_cordStep.xy;
-  m_cord1.xy = m_attrcord1.xy - clipDist * m_cordStep.zw;
+  vec2 clipDist = m_attrpos - position.xy;
+  m_cord0 = m_attrcord0 - clipDist * m_cordStep.xy;
+  m_cord1 = m_attrcord1 - clipDist * m_cordStep.zw;
 
   m_colour = m_attrcol;
 }

--- a/system/shaders/GL/1.2/gl_shader_vert_default.glsl
+++ b/system/shaders/GL/1.2/gl_shader_vert_default.glsl
@@ -1,32 +1,20 @@
 /*
- *      Copyright (C) 2010-2013 Team XBMC
- *      http://xbmc.org
+ *  Copyright (C) 2010-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
  *
- *  This Program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2, or (at your option)
- *  any later version.
- *
- *  This Program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with XBMC; see the file COPYING.  If not, see
- *  <http://www.gnu.org/licenses/>.
- *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
  */
 
 #version 120
 
-attribute vec4 m_attrpos;
+attribute vec2 m_attrpos;
 uniform mat4 m_proj;
 uniform mat4 m_model;
 
-void main ()
+void main()
 {
-  mat4 mvp    = m_proj * m_model;
-  gl_Position = mvp * m_attrpos;
+  mat4 mvp = m_proj * m_model;
+  gl_Position = mvp * vec4(m_attrpos, 0., 1.);
   gl_Position.z = -1. * gl_Position.w;
 }

--- a/system/shaders/GL/1.2/gl_shader_vert_simple.glsl
+++ b/system/shaders/GL/1.2/gl_shader_vert_simple.glsl
@@ -8,21 +8,21 @@
 
 #version 120
 
-attribute vec4 m_attrpos;
+attribute vec2 m_attrpos;
 attribute vec4 m_attrcol;
-attribute vec4 m_attrcord0;
-attribute vec4 m_attrcord1;
-varying vec4 m_cord0;
-varying vec4 m_cord1;
+attribute vec2 m_attrcord0;
+attribute vec2 m_attrcord1;
+varying vec2 m_cord0;
+varying vec2 m_cord1;
 varying vec4 m_colour;
 uniform mat4 m_matrix;
 uniform float m_depth;
 
-void main ()
+void main()
 {
-  gl_Position = m_matrix * m_attrpos;
+  gl_Position = m_matrix * vec4(m_attrpos, 0., 1.);
   gl_Position.z = m_depth * gl_Position.w;
-  m_colour    = m_attrcol;
-  m_cord0     = m_attrcord0;
-  m_cord1     = m_attrcord1;
+  m_colour = m_attrcol;
+  m_cord0 = m_attrcord0;
+  m_cord1 = m_attrcord1;
 }

--- a/system/shaders/GL/1.5/gl_shader_frag_default.glsl
+++ b/system/shaders/GL/1.5/gl_shader_frag_default.glsl
@@ -1,10 +1,18 @@
+/*
+ *  Copyright (C) 2010-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
 #version 150
 
 uniform vec4 m_unicol;
 out vec4 fragColor;
 
 // SM_DEFAULT shader
-void main ()
+void main()
 {
   fragColor = m_unicol;
 #if defined(KODI_LIMITED_RANGE)

--- a/system/shaders/GL/1.5/gl_shader_frag_fonts.glsl
+++ b/system/shaders/GL/1.5/gl_shader_frag_fonts.glsl
@@ -1,17 +1,23 @@
+/*
+ *  Copyright (C) 2010-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
 #version 150
 
 uniform sampler2D m_samp0;
-in vec4 m_cord0;
+in vec2 m_cord0;
 in vec4 m_colour;
 out vec4 fragColor;
 
 // SM_FONTS shader
-void main ()
+void main()
 {
-  fragColor.r = m_colour.r;
-  fragColor.g = m_colour.g;
-  fragColor.b = m_colour.b;
-  fragColor.a = m_colour.a * texture(m_samp0, m_cord0.xy).r;
+  fragColor = m_colour;
+  fragColor.a *= texture(m_samp0, m_cord0).r;
 #if defined(KODI_LIMITED_RANGE)
   fragColor.rgb *= (235.0-16.0) / 255.0;
   fragColor.rgb += 16.0 / 255.0;

--- a/system/shaders/GL/1.5/gl_shader_frag_multi.glsl
+++ b/system/shaders/GL/1.5/gl_shader_frag_multi.glsl
@@ -1,15 +1,23 @@
+/*
+ *  Copyright (C) 2010-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
 #version 150
 
 uniform sampler2D m_samp0;
 uniform sampler2D m_samp1;
-in vec4 m_cord0;
-in vec4 m_cord1;
+in vec2 m_cord0;
+in vec2 m_cord1;
 out vec4 fragColor;
 
 // SM_MULTI shader
-void main ()
+void main()
 {
-  fragColor.rgba = (texture(m_samp0, m_cord0.xy) * texture(m_samp1, m_cord1.xy)).rgba;
+  fragColor = texture(m_samp0, m_cord0) * texture(m_samp1, m_cord1);
 #if defined(KODI_LIMITED_RANGE)
   fragColor.rgb *= (235.0-16.0) / 255.0;
   fragColor.rgb += 16.0 / 255.0;

--- a/system/shaders/GL/1.5/gl_shader_frag_multi_blendcolor.glsl
+++ b/system/shaders/GL/1.5/gl_shader_frag_multi_blendcolor.glsl
@@ -1,16 +1,24 @@
+/*
+ *  Copyright (C) 2010-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
 #version 150
 
 uniform sampler2D m_samp0;
 uniform sampler2D m_samp1;
 uniform vec4 m_unicol;
-in vec4 m_cord0;
-in vec4 m_cord1;
+in vec2 m_cord0;
+in vec2 m_cord1;
 out vec4 fragColor;
 
 // SM_MULTI shader
-void main ()
+void main()
 {
-  fragColor.rgba = m_unicol * texture(m_samp0, m_cord0.xy) * texture(m_samp1, m_cord1.xy);
+  fragColor = m_unicol * texture(m_samp0, m_cord0) * texture(m_samp1, m_cord1);
 #if defined(KODI_LIMITED_RANGE)
   fragColor.rgb *= (235.0-16.0) / 255.0;
   fragColor.rgb += 16.0 / 255.0;

--- a/system/shaders/GL/1.5/gl_shader_frag_texture.glsl
+++ b/system/shaders/GL/1.5/gl_shader_frag_texture.glsl
@@ -1,14 +1,22 @@
+/*
+ *  Copyright (C) 2010-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
 #version 150
 
 uniform sampler2D m_samp0;
 uniform vec4 m_unicol;
-in vec4 m_cord0;
+in vec2 m_cord0;
 out vec4 fragColor;
 
 // SM_TEXTURE shader
-void main ()
+void main()
 {
-  fragColor.rgba = vec4(texture(m_samp0, m_cord0.xy).rgba * m_unicol);
+  fragColor = texture(m_samp0, m_cord0) * m_unicol;
 #if defined(KODI_LIMITED_RANGE)
   fragColor.rgb *= (235.0-16.0) / 255.0;
   fragColor.rgb += 16.0 / 255.0;

--- a/system/shaders/GL/1.5/gl_shader_frag_texture_lim.glsl
+++ b/system/shaders/GL/1.5/gl_shader_frag_texture_lim.glsl
@@ -1,14 +1,22 @@
+/*
+ *  Copyright (C) 2010-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
 #version 150
 
 uniform sampler2D m_samp0;
 uniform vec4 m_unicol;
-in vec4 m_cord0;
+in vec2 m_cord0;
 out vec4 fragColor;
 
 // SM_TEXTURE shader
-void main ()
+void main()
 {
-  fragColor.rgba = vec4(texture(m_samp0, m_cord0.xy).rgba * m_unicol);
+  fragColor = texture(m_samp0, m_cord0) * m_unicol;
 #if !defined(KODI_LIMITED_RANGE)
   fragColor.rgb = clamp((fragColor.rgb-(16.0/255.0)) * 255.0/219.0, 0, 1);
 #endif

--- a/system/shaders/GL/1.5/gl_shader_frag_texture_noblend.glsl
+++ b/system/shaders/GL/1.5/gl_shader_frag_texture_noblend.glsl
@@ -1,13 +1,21 @@
+/*
+ *  Copyright (C) 2010-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
 #version 150
 
 uniform sampler2D m_samp0;
-in vec4 m_cord0;
+in vec2 m_cord0;
 out vec4 fragColor;
 
 // SM_TEXTURE_NOBLEND shader
-void main ()
+void main()
 {
-  fragColor.rgba = vec4(texture(m_samp0, m_cord0.xy).rgba);
+  fragColor = texture(m_samp0, m_cord0);
 #if defined(KODI_LIMITED_RANGE)
   fragColor.rgb *= (235.0-16.0) / 255.0;
   fragColor.rgb += 16.0 / 255.0;

--- a/system/shaders/GL/1.5/gl_shader_vert.glsl
+++ b/system/shaders/GL/1.5/gl_shader_vert.glsl
@@ -1,22 +1,30 @@
+/*
+ *  Copyright (C) 2010-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+ 
 #version 150
 
-in vec4 m_attrpos;
+in vec2 m_attrpos;
 in vec4 m_attrcol;
-in vec4 m_attrcord0;
-in vec4 m_attrcord1;
-out vec4 m_cord0;
-out vec4 m_cord1;
+in vec2 m_attrcord0;
+in vec2 m_attrcord1;
+out vec2 m_cord0;
+out vec2 m_cord1;
 out vec4 m_colour;
 uniform mat4 m_proj;
 uniform mat4 m_model;
 uniform float m_depth;
 
-void main ()
+void main()
 {
-  mat4 mvp    = m_proj * m_model;
-  gl_Position = mvp * m_attrpos;
+  mat4 mvp = m_proj * m_model;
+  gl_Position = mvp * vec4(m_attrpos, 0., 1.);
   gl_Position.z = m_depth * gl_Position.w;
-  m_colour    = m_attrcol;
-  m_cord0     = m_attrcord0;
-  m_cord1     = m_attrcord1;
+  m_colour = m_attrcol;
+  m_cord0 = m_attrcord0;
+  m_cord1 = m_attrcord1;
 }

--- a/system/shaders/GL/1.5/gl_shader_vert_clip.glsl
+++ b/system/shaders/GL/1.5/gl_shader_vert_clip.glsl
@@ -8,12 +8,12 @@
 
 #version 150
 
-in vec4 m_attrpos;
+in vec2 m_attrpos;
 in vec4 m_attrcol;
-in vec4 m_attrcord0;
-in vec4 m_attrcord1;
-out vec4 m_cord0;
-out vec4 m_cord1;
+in vec2 m_attrcord0;
+in vec2 m_attrcord1;
+out vec2 m_cord0;
+out vec2 m_cord1;
 out vec4 m_colour;
 uniform mat4 m_matrix;
 uniform vec4 m_shaderClip;
@@ -24,20 +24,20 @@ uniform float m_depth;
 // possible (e.g. when rotating). it can't discard triangles, but it may 
 // degenerate them.
 
-void main ()
+void main()
 {
   // limit the vertices to the clipping area
-  vec4 position = m_attrpos;
-  position.xy = clamp(position.xy, m_shaderClip.xy, m_shaderClip.zw);
+  vec4 position = vec4(0., 0., 0., 1.);
+  position.xy = clamp(m_attrpos, m_shaderClip.xy, m_shaderClip.zw);
   gl_Position = m_matrix * position;
 
   // set rendering depth
   gl_Position.z = m_depth * gl_Position.w;
 
   // correct texture coordinates for clipped vertices
-  vec2 clipDist = m_attrpos.xy - position.xy;
-  m_cord0.xy = m_attrcord0.xy - clipDist * m_cordStep.xy;
-  m_cord1.xy = m_attrcord1.xy - clipDist * m_cordStep.zw;
+  vec2 clipDist = m_attrpos - position.xy;
+  m_cord0 = m_attrcord0 - clipDist * m_cordStep.xy;
+  m_cord1 = m_attrcord1 - clipDist * m_cordStep.zw;
 
   m_colour = m_attrcol;
 }

--- a/system/shaders/GL/1.5/gl_shader_vert_default.glsl
+++ b/system/shaders/GL/1.5/gl_shader_vert_default.glsl
@@ -1,12 +1,20 @@
+/*
+ *  Copyright (C) 2010-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
 #version 150
 
-in vec4 m_attrpos;
+in vec2 m_attrpos;
 uniform mat4 m_proj;
 uniform mat4 m_model;
 
-void main ()
+void main()
 {
-  mat4 mvp    = m_proj * m_model;
-  gl_Position = mvp * m_attrpos;
+  mat4 mvp = m_proj * m_model;
+  gl_Position = mvp * vec4(m_attrpos, 0., 1.);
   gl_Position.z = -1. * gl_Position.w;
 }

--- a/system/shaders/GL/1.5/gl_shader_vert_simple.glsl
+++ b/system/shaders/GL/1.5/gl_shader_vert_simple.glsl
@@ -8,21 +8,21 @@
 
 #version 150
 
-in vec4 m_attrpos;
+in vec2 m_attrpos;
 in vec4 m_attrcol;
-in vec4 m_attrcord0;
-in vec4 m_attrcord1;
-out vec4 m_cord0;
-out vec4 m_cord1;
+in vec2 m_attrcord0;
+in vec2 m_attrcord1;
+out vec2 m_cord0;
+out vec2 m_cord1;
 out vec4 m_colour;
 uniform mat4 m_matrix;
 uniform float m_depth;
 
 void main ()
 {
-  gl_Position = m_matrix * m_attrpos;
+  gl_Position = m_matrix * vec4(m_attrpos, 0., 1.);
   gl_Position.z = m_depth * gl_Position.w;
-  m_colour    = m_attrcol;
-  m_cord0     = m_attrcord0;
-  m_cord1     = m_attrcord1;
+  m_colour = m_attrcol;
+  m_cord0 = m_attrcord0;
+  m_cord1 = m_attrcord1;
 }


### PR DESCRIPTION
## Description
This is mostly a cleanup of our GUI shaders. 

## Motivation and context
Some shaders had no or old license headers. Shader input/outputs were using vectors with more fields than necessary (vec4 vs vec2). There was also some redundant information (for example ".rgba" swizzles).

## How has this been tested?
Still runs and looks fine.

## What is the effect on users?
None. Maybe a tiny performance increase.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
