### PR TITLE
[filesystem][addons devkit] Update file read flags documentation

### DIFF
--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -153,8 +153,7 @@ unsigned int Interface_Filesystem::TranslateFileReadBitsToKodi(unsigned int addo
     kodiFlags |= READ_AFTER_WRITE;
   if (addonFlags & ADDON_READ_REOPEN)
     kodiFlags |= READ_REOPEN;
-  //! @todo Add ADDON_READ_NO_BUFFER to filesystem.h in the binary addon devkit
-  if (addonFlags & READ_NO_BUFFER)
+  if (addonFlags & ADDON_READ_NO_BUFFER)
     kodiFlags |= READ_NO_BUFFER;
 
   return kodiFlags;

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/filesystem.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/filesystem.h
@@ -63,6 +63,9 @@ extern "C"
     /// @brief **0000 0000 0010** :\n
     /// Indicate that that caller support read in the minimum defined
     /// chunk size, this disables internal cache then.
+    /// This flag is deprecated, instead use ADDON_READ_NO_CACHE to disable FileCache and
+    /// ADDON_READ_NO_BUFFER to disable StreamBuffer. On the contrary to explicitly indicate that
+    /// the file has audio/video content (suitable for caching), use the ADDON_READ_AUDIO_VIDEO flag.
     ADDON_READ_CHUNKED = 0x02,
 
     /// @brief **0000 0000 0100** :\n
@@ -83,8 +86,9 @@ extern "C"
     ADDON_READ_MULTI_STREAM = 0x20,
 
     /// @brief **0000 0100 0000** :\n
-    /// indicate to the caller file is audio and/or video (and e.g. may
-    /// grow).
+    /// Indicate to the caller file is audio and/or video and is suitable for caching with FileCache or StreamBuffer.
+    /// The final method used will depend on the user's settings and file location, e.g. user can disable FileCache.
+    /// This flag ensures that at least the buffer size necessary to read with the appropriate chunk size will be used.
     ADDON_READ_AUDIO_VIDEO = 0x40,
 
     /// @brief **0000 1000 0000** :\n
@@ -93,7 +97,11 @@ extern "C"
 
     /// @brief **0001 0000 0000** :\n
     /// Indicate that caller want to reopen a file if its already open.
-    ADDON_READ_REOPEN = 0x100
+    ADDON_READ_REOPEN = 0x100,
+
+    /// @brief **0010 0000 0000** :\n
+    /// Indicate that caller want open a file without intermediate buffer regardless to file type.
+    ADDON_READ_NO_BUFFER = 0x200,
   } OpenFileFlags;
   ///@}
   //----------------------------------------------------------------------------

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -62,7 +62,7 @@
 #define ADDON_GLOBAL_VERSION_AUDIOENGINE_DEPENDS      "AudioEngine.h" \
                                                       "c-api/audio_engine.h"
 
-#define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.1.8"
+#define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.1.9"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_MIN           "1.1.7"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_XML_ID        "kodi.binary.global.filesystem"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_DEPENDS       "Filesystem.h" \

--- a/xbmc/filesystem/IFileTypes.h
+++ b/xbmc/filesystem/IFileTypes.h
@@ -14,39 +14,41 @@ namespace XFILE
 {
 
 /* indicate that caller can handle truncated reads, where function returns before entire buffer has been filled */
-  static const unsigned int READ_TRUNCATED = 0x01;
+static const unsigned int READ_TRUNCATED = 0x01;
 
 /* indicate that that caller support read in the minimum defined chunk size, this disables internal cache then */
-  static const unsigned int READ_CHUNKED = 0x02;
+static const unsigned int READ_CHUNKED = 0x02;
 
 /* use cache to access this file */
-  static const unsigned int READ_CACHED = 0x04;
+static const unsigned int READ_CACHED = 0x04;
 
 /* open without caching. regardless to file type. */
-  static const unsigned int READ_NO_CACHE = 0x08;
+static const unsigned int READ_NO_CACHE = 0x08;
 
 /* calculate bitrate for file while reading */
-  static const unsigned int READ_BITRATE = 0x10;
+static const unsigned int READ_BITRATE = 0x10;
 
 /* indicate to the caller we will seek between multiple streams in the file frequently */
-  static const unsigned int READ_MULTI_STREAM = 0x20;
+static const unsigned int READ_MULTI_STREAM = 0x20;
 
-/* indicate to the caller file is audio and/or video (and e.g. may grow) */
-  static const unsigned int READ_AUDIO_VIDEO = 0x40;
+// Indicate to the caller file is audio and/or video and is suitable for caching with FileCache or StreamBuffer.
+// The final method used will depend on the user's settings and file location, e.g. user can disable FileCache.
+// This flag ensures that at least the buffer size necessary to read with the appropriate chunk size will be used.
+static const unsigned int READ_AUDIO_VIDEO = 0x40;
 
 /* indicate that caller will do write operations before reading  */
-  static const unsigned int READ_AFTER_WRITE = 0x80;
+static const unsigned int READ_AFTER_WRITE = 0x80;
 
 /* indicate that caller want to reopen a file if its already open  */
-  static const unsigned int READ_REOPEN = 0x100;
+static const unsigned int READ_REOPEN = 0x100;
 
 /* indicate that caller want open a file without intermediate buffer regardless to file type */
-  static const unsigned int READ_NO_BUFFER = 0x200;
+static const unsigned int READ_NO_BUFFER = 0x200;
 
 struct SNativeIoControl
 {
-  unsigned long int   request;
-  void*               param;
+  unsigned long int request;
+  void* param;
 };
 
 struct SCacheStatus


### PR DESCRIPTION
## Description
[filesystem][addons devkit] Update file read flags documentation

## Motivation and context
Follow-up of https://github.com/xbmc/xbmc/pull/25834.

Now that fix is merged and backported to Omega, this PR (for master only) updates the documentation and adds the missing `ADDON_READ_NO_BUFFER` flag.

## How has this been tested?
Builds, no functional changes.

## What is the effect on users?
nothing

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
