### PR TITLE
[Estury][PVR][cores][video] Improve support for media flags for PVR recordings

### DIFF
--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -366,7 +366,7 @@
 		<param name="visible">true</param>
 		<definition>
 			<control type="grouplist">
-				<visible>Window.IsActive(Home) | Window.IsActive(10025)</visible>
+				<visible>Window.IsActive(Home) | Window.IsActive(10025) | Window.IsActive(TVRecordings) | Window.IsActive(RadioRecordings)</visible>
 				<orientation>horizontal</orientation>
 				<right>20</right>
 				<bottom>0</bottom>

--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -366,144 +366,147 @@
 		</control>
 	</include>
 	<include name="PVRInfoPanel">
-		<control type="group">
-			<visible>!ListItem.IsFolder</visible>
-			<control type="image">
-				<top>135</top>
-				<left>630</left>
-				<width>200</width>
-				<height>200</height>
-				<aspectratio align="center" aligny="center">keep</aspectratio>
-				<texture fallback="DefaultTVShows.png">$VAR[ChannelListEPGIconVar]</texture>
-				<visible>!String.IsEmpty(ListItem.ChannelName)</visible>
-				<fadetime>200</fadetime>
-			</control>
+		<param name="bottom">list_bottom_offset</param>
+		<definition>
 			<control type="group">
-				<top>120</top>
-				<left>0</left>
-				<width>600</width>
-				<control type="label">
-					<height>262</height>
-					<font>font45</font>
-					<label>$INFO[ListItem.ChannelName]</label>
-				</control>
-				<control type="label">
-					<top>60</top>
+				<visible>!ListItem.IsFolder</visible>
+				<control type="image">
+					<top>135</top>
+					<left>630</left>
+					<width>200</width>
 					<height>200</height>
-					<label>$VAR[PVRInfoPanelDateDurationLabel]</label>
+					<aspectratio align="center" aligny="center">keep</aspectratio>
+					<texture fallback="DefaultTVShows.png">$VAR[ChannelListEPGIconVar]</texture>
+					<visible>!String.IsEmpty(ListItem.ChannelName)</visible>
+					<fadetime>200</fadetime>
 				</control>
-				<control type="progress">
-					<top>200</top>
-					<height>12</height>
-					<colordiffuse>88FFFFFF</colordiffuse>
-					<info>ListItem.Progress</info>
-					<visible>Integer.IsGreater(ListItem.Progress,0)</visible>
+				<control type="group">
+					<top>120</top>
+					<left>0</left>
+					<width>600</width>
+					<control type="label">
+						<height>262</height>
+						<font>font45</font>
+						<label>$INFO[ListItem.ChannelName]</label>
+					</control>
+					<control type="label">
+						<top>60</top>
+						<height>200</height>
+						<label>$VAR[PVRInfoPanelDateDurationLabel]</label>
+					</control>
+					<control type="progress">
+						<top>200</top>
+						<height>12</height>
+						<colordiffuse>88FFFFFF</colordiffuse>
+						<info>ListItem.Progress</info>
+						<visible>Integer.IsGreater(ListItem.Progress,0)</visible>
+					</control>
+					<control type="progress">
+						<top>200</top>
+						<height>12</height>
+						<colordiffuse>88FFFFFF</colordiffuse>
+						<info>ListItem.PercentPlayed</info>
+						<visible>Integer.IsGreater(ListItem.PercentPlayed,0)</visible>
+					</control>
 				</control>
-				<control type="progress">
-					<top>200</top>
-					<height>12</height>
-					<colordiffuse>88FFFFFF</colordiffuse>
-					<info>ListItem.PercentPlayed</info>
-					<visible>Integer.IsGreater(ListItem.PercentPlayed,0)</visible>
+				<control type="label">
+					<top>365</top>
+					<width>830</width>
+					<height>262</height>
+					<font>font36_title</font>
+					<label>$INFO[ListItem.Title] $INFO[ListItem.Year,([COLOR grey],[/COLOR])]</label>
+					<scroll>true</scroll>
+					<visible>!ListItem.HasEpg</visible>
 				</control>
-			</control>
-			<control type="label">
-				<top>365</top>
-				<width>830</width>
-				<height>262</height>
-				<font>font36_title</font>
-				<label>$INFO[ListItem.Title] $INFO[ListItem.Year,([COLOR grey],[/COLOR])]</label>
-				<scroll>true</scroll>
-				<visible>!ListItem.HasEpg</visible>
-			</control>
-			<control type="label">
-				<top>365</top>
-				<width>830</width>
-				<height>262</height>
-				<font>font36_title</font>
-				<label>$INFO[ListItem.EpgEventTitle] $INFO[ListItem.Year,([COLOR grey],[/COLOR])]</label>
-				<scroll>true</scroll>
-				<visible>ListItem.HasEpg</visible>
-			</control>
-			<control type="label">
-				<top>410</top>
-				<width>830</width>
-				<height>70</height>
-				<scroll>true</scroll>
-				<label>[I]$VAR[SeasonEpisodeAndNameLabel][/I]</label>
-			</control>
-			<control type="textbox">
-				<top>465</top>
-				<width>830</width>
-				<bottom>list_bottom_offset</bottom>
-				<label>$VAR[PVRInstanceName,,[CR]]$INFO[ListItem.MediaProviders,[COLOR grey]$LOCALIZE[19334]:[/COLOR] ,[CR]]$VAR[FlagLabel,,[CR]]$INFO[ListItem.Genre,[COLOR grey]$LOCALIZE[515]:[/COLOR] ,[CR]]$INFO[ListItem.ParentalRatingCode,[COLOR grey]$LOCALIZE[31017]: [/COLOR],[CR]]$INFO[ListItem.TimerType,[COLOR grey]$LOCALIZE[803]:[/COLOR] ,[CR]]$VAR[RecordingSizeLabel]$VAR[ExpirationDateTimeLabel]$INFO[ListItem.Plot,[CR]]</label>
-				<autoscroll delay="10000" time="3000" repeat="10000">Skin.HasSetting(AutoScroll)</autoscroll>
-			</control>
-		</control>
-		<control type="group">
-			<visible>ListItem.IsFolder</visible>
-			<top>list_top_offset</top>
-			<control type="label">
-				<top>10</top>
-				<width>830</width>
-				<height>262</height>
-				<label>$LOCALIZE[19076] ($INFO[Container(5000).NumItems,[B],[/B] $LOCALIZE[31036]]) $INFO[ListItem.Property(recordingsize),- $LOCALIZE[20161]: [B],[/B]]</label>
-				<font>font37</font>
-				<visible>!ListItem.IsParentFolder</visible>
+				<control type="label">
+					<top>365</top>
+					<width>830</width>
+					<height>262</height>
+					<font>font36_title</font>
+					<label>$INFO[ListItem.EpgEventTitle] $INFO[ListItem.Year,([COLOR grey],[/COLOR])]</label>
+					<scroll>true</scroll>
+					<visible>ListItem.HasEpg</visible>
+				</control>
+				<control type="label">
+					<top>410</top>
+					<width>830</width>
+					<height>70</height>
+					<scroll>true</scroll>
+					<label>[I]$VAR[SeasonEpisodeAndNameLabel][/I]</label>
+				</control>
+				<control type="textbox">
+					<top>465</top>
+					<width>830</width>
+					<bottom>$PARAM[bottom]</bottom>
+					<label>$VAR[PVRInstanceName,,[CR]]$INFO[ListItem.MediaProviders,[COLOR grey]$LOCALIZE[19334]:[/COLOR] ,[CR]]$VAR[FlagLabel,,[CR]]$INFO[ListItem.Genre,[COLOR grey]$LOCALIZE[515]:[/COLOR] ,[CR]]$INFO[ListItem.ParentalRatingCode,[COLOR grey]$LOCALIZE[31017]: [/COLOR],[CR]]$INFO[ListItem.TimerType,[COLOR grey]$LOCALIZE[803]:[/COLOR] ,[CR]]$VAR[RecordingSizeLabel]$VAR[ExpirationDateTimeLabel]$INFO[ListItem.Plot,[CR]]</label>
+					<autoscroll delay="10000" time="3000" repeat="10000">Skin.HasSetting(AutoScroll)</autoscroll>
+				</control>
 			</control>
 			<control type="group">
-				<left>-10</left>
-				<top>60</top>
-				<visible>!ListItem.IsParentFolder</visible>
-				<control type="panel" id="5000">
-					<top>20</top>
+				<visible>ListItem.IsFolder</visible>
+				<top>list_top_offset</top>
+				<control type="label">
+					<top>10</top>
 					<width>830</width>
-					<bottom>100</bottom>
-					<orientation>vertical</orientation>
-					<focusedlayout height="100" width="780">
-						<control type="label">
-							<visible>!String.IsEqual(ListItem.ChannelName, ListItem.Label)</visible>
-							<left>10</left>
-							<height>90</height>
-							<width>830</width>
-							<aligny>center</aligny>
-							<label>$VAR[RecordingDateSizeLabel]$INFO[ListItem.Label]$VAR[SeasonEpisodeAndNameLabel, (,)]$INFO[ListItem.Property(totalcount), (, $LOCALIZE[31036])]</label>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-						<control type="label">
-							<visible>String.IsEqual(ListItem.ChannelName, ListItem.Label)</visible>
-							<left>10</left>
-							<height>90</height>
-							<width>830</width>
-							<aligny>center</aligny>
-							<label>[COLOR grey]$INFO[ListItem.ChannelName,,[CR]][/COLOR]$INFO[ListItem.EpgEventTitle]$VAR[SeasonEpisodeAndNameLabel, (,)]</label>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-					</focusedlayout>
-					<itemlayout height="100" width="780">
-						<control type="label">
-							<visible>!String.IsEqual(ListItem.ChannelName, ListItem.Label)</visible>
-							<left>10</left>
-							<height>90</height>
-							<width>830</width>
-							<aligny>center</aligny>
-							<label>$VAR[RecordingDateSizeLabel]$INFO[ListItem.Label]$VAR[SeasonEpisodeAndNameLabel, (,)]$INFO[ListItem.Property(totalcount), (, $LOCALIZE[31036])]</label>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-						<control type="label">
-							<visible>String.IsEqual(ListItem.ChannelName, ListItem.Label)</visible>
-							<left>10</left>
-							<height>90</height>
-							<width>830</width>
-							<aligny>center</aligny>
-							<label>[COLOR grey]$INFO[ListItem.ChannelName,,[CR]][/COLOR]$INFO[ListItem.EpgEventTitle]$VAR[SeasonEpisodeAndNameLabel, (,)]</label>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-					</itemlayout>
-					<content sortby="$PARAM[folder_sortby]" sortorder="$PARAM[folder_sortorder]">$INFO[ListItem.FilenameAndPath]</content>
+					<height>262</height>
+					<label>$LOCALIZE[19076] ($INFO[Container(5000).NumItems,[B],[/B] $LOCALIZE[31036]]) $INFO[ListItem.Property(recordingsize),- $LOCALIZE[20161]: [B],[/B]]</label>
+					<font>font37</font>
+					<visible>!ListItem.IsParentFolder</visible>
+				</control>
+				<control type="group">
+					<left>-10</left>
+					<top>60</top>
+					<visible>!ListItem.IsParentFolder</visible>
+					<control type="panel" id="5000">
+						<top>20</top>
+						<width>830</width>
+						<bottom>$PARAM[bottom]</bottom>
+						<orientation>vertical</orientation>
+						<focusedlayout height="100" width="780">
+							<control type="label">
+								<visible>!String.IsEqual(ListItem.ChannelName, ListItem.Label)</visible>
+								<left>10</left>
+								<height>90</height>
+								<width>830</width>
+								<aligny>center</aligny>
+								<label>$VAR[RecordingDateSizeLabel]$INFO[ListItem.Label]$VAR[SeasonEpisodeAndNameLabel, (,)]$INFO[ListItem.Property(totalcount), (, $LOCALIZE[31036])]</label>
+								<shadowcolor>text_shadow</shadowcolor>
+							</control>
+							<control type="label">
+								<visible>String.IsEqual(ListItem.ChannelName, ListItem.Label)</visible>
+								<left>10</left>
+								<height>90</height>
+								<width>830</width>
+								<aligny>center</aligny>
+								<label>[COLOR grey]$INFO[ListItem.ChannelName,,[CR]][/COLOR]$INFO[ListItem.EpgEventTitle]$VAR[SeasonEpisodeAndNameLabel, (,)]</label>
+								<shadowcolor>text_shadow</shadowcolor>
+							</control>
+						</focusedlayout>
+						<itemlayout height="100" width="780">
+							<control type="label">
+								<visible>!String.IsEqual(ListItem.ChannelName, ListItem.Label)</visible>
+								<left>10</left>
+								<height>90</height>
+								<width>830</width>
+								<aligny>center</aligny>
+								<label>$VAR[RecordingDateSizeLabel]$INFO[ListItem.Label]$VAR[SeasonEpisodeAndNameLabel, (,)]$INFO[ListItem.Property(totalcount), (, $LOCALIZE[31036])]</label>
+								<shadowcolor>text_shadow</shadowcolor>
+							</control>
+							<control type="label">
+								<visible>String.IsEqual(ListItem.ChannelName, ListItem.Label)</visible>
+								<left>10</left>
+								<height>90</height>
+								<width>830</width>
+								<aligny>center</aligny>
+								<label>[COLOR grey]$INFO[ListItem.ChannelName,,[CR]][/COLOR]$INFO[ListItem.EpgEventTitle]$VAR[SeasonEpisodeAndNameLabel, (,)]</label>
+								<shadowcolor>text_shadow</shadowcolor>
+							</control>
+						</itemlayout>
+						<content sortby="$PARAM[folder_sortby]" sortorder="$PARAM[folder_sortorder]">$INFO[ListItem.FilenameAndPath]</content>
+					</control>
 				</control>
 			</control>
-		</control>
+		</definition>
 	</include>
 	<include name="RDSInfoLine">
 		<control type="grouplist">
@@ -766,5 +769,42 @@
 				<visible>Control.IsVisible($PARAM[control_id])</visible>
 			</control>
 		</definition>
+	</include>
+	<include name="PVRBackendDiskspace">
+		<control type="label">
+			<left>0</left>
+			<bottom>70</bottom>
+			<width>830</width>
+			<height>20</height>
+			<font>font37</font>
+			<label>$INFO[PVR.ClientName]$INFO[PVR.InstanceName, (,)]</label>
+		</control>
+		<control type="group">
+			<visible>!Integer.IsGreater(PVR.BackendDiskspaceProgr,100)</visible>
+			<control type="label">
+				<left>0</left>
+				<bottom>20</bottom>
+				<width>610</width>
+				<height>20</height>
+				<label>[COLOR grey]$LOCALIZE[19116]:[/COLOR] $INFO[PVR.BackendDiskspace]</label>
+			</control>
+			<control type="progress">
+				<right>25</right>
+				<bottom>10</bottom>
+				<width>200</width>
+				<height>12</height>
+				<info>PVR.BackendDiskspaceProgr</info>
+			</control>
+		</control>
+		<control type="group">
+			<visible>Integer.IsGreater(PVR.BackendDiskspaceProgr,100)</visible>
+			<control type="label">
+				<left>0</left>
+				<bottom>20</bottom>
+				<width>610</width>
+				<height>20</height>
+				<label>[COLOR grey]$LOCALIZE[19116]:[/COLOR] $LOCALIZE[13205]</label>
+			</control>
+		</control>
 	</include>
 </includes>

--- a/addons/skin.estuary/xml/MyPVRRecordings.xml
+++ b/addons/skin.estuary/xml/MyPVRRecordings.xml
@@ -65,30 +65,11 @@
 				<param name="info_visible" value="true" />
 			</include>
 			<control type="group">
-				<depth>DepthBars</depth>
-				<right>20</right>
-				<width>850</width>
-				<include>OpenClose_Right</include>
 				<bottom>0</bottom>
-				<height>60</height>
-				<control type="label">
-					<right>220</right>
-					<width>610</width>
-					<height>20</height>
-					<label>$INFO[PVR.backenddiskspace]</label>
-					<shadowcolor>black</shadowcolor>
-					<align>right</align>
-					<font>font27</font>
-					<visible>!Integer.IsGreater(PVR.backenddiskspaceprogr,100)</visible>
-				</control>
-				<control type="progress">
-					<right>0</right>
-					<top>17</top>
-					<width>200</width>
-					<height>12</height>
-					<info>PVR.backenddiskspaceprogr</info>
-					<visible>!Integer.IsGreater(PVR.backenddiskspaceprogr,100)</visible>
-				</control>
+				<height>70</height>
+				<animation effect="fade" start="0" end="100" time="300" delay="300">WindowOpen</animation>
+				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
+				<include condition="!Skin.HasSetting(hide_mediaflags)">MediaFlags</include>
 			</control>
 			<control type="group">
 				<include>MediaMenuCommon</include>

--- a/addons/skin.estuary/xml/MyPVRRecordings.xml
+++ b/addons/skin.estuary/xml/MyPVRRecordings.xml
@@ -53,10 +53,18 @@
 					<orientation>vertical</orientation>
 					<animation effect="zoom" start="100,100" end="50,100" center="-50,0" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(73)">conditional</animation>
 				</control>
-				<include content="PVRInfoPanel">
-					<param name="folder_sortby" value="date" />
-					<param name="folder_sortorder" value="descending" />
-				</include>
+				<control type="group">
+					<include content="PVRInfoPanel">
+						<param name="folder_sortby" value="date" />
+						<param name="folder_sortorder" value="descending" />
+						<param name="bottom" value="200" />
+					</include>
+					<control type="group">
+						<bottom>list_bottom_offset</bottom>
+						<height>60</height>
+						<include content="PVRBackendDiskspace"/>
+					</control>
+				</control>
 			</control>
 			<include content="TopBar">
 				<param name="breadcrumbs_label" value="$VAR[BreadcrumbsPVRRecordingsVar]" />

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -7087,7 +7087,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///                  \anchor ListItem_PVRClientName
 ///                  _string_,
 ///     @return If selected item is of type PVR (recording\, timer\, EPG)\, the name of the PVR client
-///     add-on\, as specified by the add-on developer. Empty if theitem is not of type PVR.
+///     add-on\, as specified by the add-on developer. Empty if the item is not of type PVR.
 ///     <p><hr>
 ///     @skinning_v22 **[New Infolabel]** \link ListItem_PVRClientName `ListItem.PVRClientName`\endlink
 ///     <p>
@@ -8384,6 +8384,23 @@ const infomap playlist[] =       {{ "length",           PLAYLIST_LENGTH },
 ///     @skinning_v22 **[New Integer Value]** \link PVR_ClientCount `PVR.ClientCount`\endlink
 ///     <p>
 ///   }
+///   \table_row3{   <b>`PVR.ClientName`</b>,
+///                  \anchor PVR_ClientName
+///                  _string_,
+///     @return The name of the PVR client add-on\, as specified by the add-on developer.
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link PVR_ClientName `PVR.ClientName`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`PVR.InstanceName`</b>,
+///                  \anchor PVR_InstanceName
+///                  _string_,
+///     @return The name of the instance of the PVR client add-on\, as specified by the user in
+///     the add-on settings. Empty if the PVR client add-on does not support multiple instances.
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link PVR_InstanceName `PVR.InstanceName`\endlink
+///     <p>
+///   }
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
@@ -8467,7 +8484,9 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
                                   { "timeshiftprogressbufferstart", PVR_TIMESHIFT_PROGRESS_BUFFER_START },
                                   { "timeshiftprogressbufferend", PVR_TIMESHIFT_PROGRESS_BUFFER_END },
                                   { "epgeventicon",               PVR_EPG_EVENT_ICON },
-                                  { "clientcount",                PVR_CLIENT_COUNT }};
+                                  { "clientcount",                PVR_CLIENT_COUNT },
+                                  { "clientname",                 PVR_CLIENT_NAME },
+                                  { "instancename",               PVR_INSTANCE_NAME }};
 // clang-format on
 
 /// \page modules__infolabels_boolean_conditions

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2060,7 +2060,7 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
 
   CFileItem item(strMovie, false);
   if ((NETWORK::IsInternetStream(item) && !URIUtils::IsOnLAN(item.GetDynPath())) ||
-      PLAYLIST::IsPlayList(item) || item.IsLiveTV() || !VIDEO::IsVideo(item))
+      PLAYLIST::IsPlayList(item) || item.IsPVR() || !VIDEO::IsVideo(item))
     return;
 
   CLog::Log(LOGDEBUG, "{}: Searching for subtitles...", __FUNCTION__);

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -259,7 +259,8 @@ bool CDVDFileInfo::CanExtract(const CFileItem& fileItem)
   if (fileItem.m_bIsFolder)
     return false;
 
-  if ((URIUtils::IsPVR(fileItem.GetPath()) && !PVR::ProvidesStreamForThumbExtraction(fileItem)) ||
+  if ((URIUtils::IsPVR(fileItem.GetPath()) &&
+       !PVR::ProvidesStreamForMetaDataExtraction(fileItem)) ||
       // plugin path not fully resolved
       URIUtils::IsPlugin(fileItem.GetDynPath()) || URIUtils::IsUPnP(fileItem.GetPath()) ||
       NETWORK::IsInternetStream(fileItem) || VIDEO::IsDiscStub(fileItem) ||
@@ -308,11 +309,6 @@ bool CDVDFileInfo::GetFileStreamDetails(CFileItem *pItem)
   if (!pInputStream)
     return false;
 
-  if (pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER))
-  {
-    return false;
-  }
-
   if (pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD) || !pInputStream->Open())
   {
     return false;
@@ -322,7 +318,10 @@ bool CDVDFileInfo::GetFileStreamDetails(CFileItem *pItem)
   if (pDemuxer)
   {
     bool retVal = DemuxerToStreamDetails(pInputStream, pDemuxer, pItem->GetVideoInfoTag()->m_streamDetails, strFileNameAndPath);
-    ProcessExternalSubtitles(pItem);
+
+    if (!pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER))
+      ProcessExternalSubtitles(pItem);
+
     delete pDemuxer;
     return retVal;
   }

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -18,7 +18,6 @@
 #include "network/NetworkFileItemClassify.h"
 #include "pictures/Picture.h"
 #include "playlists/PlayListFileItemClassify.h"
-#include "pvr/PVRThumbLoader.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/MemUtils.h"
@@ -29,20 +28,20 @@
 #ifdef HAVE_LIBBLURAY
 #include "DVDInputStreams/DVDInputStreamBluray.h"
 #endif
-#include "DVDInputStreams/DVDFactoryInputStream.h"
-#include "DVDDemuxers/DVDDemux.h"
-#include "DVDDemuxers/DVDDemuxUtils.h"
-#include "DVDDemuxers/DVDFactoryDemuxer.h"
 #include "DVDCodecs/DVDFactoryCodec.h"
 #include "DVDCodecs/Video/DVDVideoCodec.h"
 #include "DVDCodecs/Video/DVDVideoCodecFFmpeg.h"
+#include "DVDDemuxers/DVDDemux.h"
+#include "DVDDemuxers/DVDDemuxUtils.h"
 #include "DVDDemuxers/DVDDemuxVobsub.h"
+#include "DVDDemuxers/DVDFactoryDemuxer.h"
+#include "DVDInputStreams/DVDFactoryInputStream.h"
+#include "DVDInputStreams/InputStreamPVRBase.h"
 #include "Process/ProcessInfo.h"
-
-#include "filesystem/File.h"
-#include "cores/FFmpeg.h"
 #include "TextureCache.h"
 #include "Util.h"
+#include "cores/FFmpeg.h"
+#include "filesystem/File.h"
 #include "utils/LangCodeExpander.h"
 
 #include <cstdlib>
@@ -260,7 +259,7 @@ bool CDVDFileInfo::CanExtract(const CFileItem& fileItem)
     return false;
 
   if ((URIUtils::IsPVR(fileItem.GetPath()) &&
-       !PVR::ProvidesStreamForMetaDataExtraction(fileItem)) ||
+       !CInputStreamPVRBase::ProvidesStreamForMetaDataExtraction(fileItem)) ||
       // plugin path not fully resolved
       URIUtils::IsPlugin(fileItem.GetDynPath()) || URIUtils::IsUPnP(fileItem.GetPath()) ||
       NETWORK::IsInternetStream(fileItem) || VIDEO::IsDiscStub(fileItem) ||

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.cpp
@@ -15,6 +15,7 @@
 #include "pvr/addons/PVRClient.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/URIUtils.h"
 #include "utils/log.h"
 
 CInputStreamPVRBase::CInputStreamPVRBase(IVideoPlayer* pPlayer, const CFileItem& fileitem)
@@ -351,4 +352,18 @@ void CInputStreamPVRBase::UpdateStreamMap()
   }
 
   m_streamMap = newStreamMap;
+}
+
+bool CInputStreamPVRBase::ProvidesStreamForMetaDataExtraction(const CFileItem& item)
+{
+  // Note: We must not rely on presence of a recording info tag here, but path is always set.
+  if (URIUtils::IsPVRRecording(item.GetPath()))
+  {
+    const std::shared_ptr<const PVR::CPVRClient> client{
+        CServiceBroker::GetPVRManager().GetClient(item)};
+    if (client)
+      return client->GetClientCapabilities().SupportsMultipleRecordedStreams();
+  }
+
+  return false;
 }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.h
@@ -30,6 +30,8 @@ class CInputStreamPVRBase
   , public CDVDInputStream::IDemux
 {
 public:
+  static bool ProvidesStreamForMetaDataExtraction(const CFileItem& item);
+
   CInputStreamPVRBase(IVideoPlayer* pPlayer, const CFileItem& fileitem);
   ~CInputStreamPVRBase() override;
   bool Open() override;

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -684,6 +684,8 @@ static constexpr unsigned int SYSTEM_LOCALE = 1012;
 #define PVR_TIMESHIFT_SEEKBAR             (PVR_STRINGS_START + 73)
 #define PVR_BACKEND_PROVIDERS             (PVR_STRINGS_START + 74)
 #define PVR_BACKEND_CHANNEL_GROUPS        (PVR_STRINGS_START + 75)
+#define PVR_CLIENT_NAME                   (PVR_STRINGS_START + 76)
+#define PVR_INSTANCE_NAME                 (PVR_STRINGS_START + 77)
 
 #define PVR_INTS_START  1300
 #define PVR_CLIENT_COUNT  (PVR_INTS_START)

--- a/xbmc/pvr/PVRThumbLoader.cpp
+++ b/xbmc/pvr/PVRThumbLoader.cpp
@@ -14,32 +14,13 @@
 #include "TextureCache.h"
 #include "imagefiles/ImageFileURL.h"
 #include "pvr/PVRManager.h"
-#include "pvr/addons/PVRClient.h"
-#include "pvr/filesystem/PVRGUIDirectory.h"
-#include "settings/AdvancedSettings.h"
-#include "settings/Settings.h"
-#include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
-#include "utils/URIUtils.h"
 #include "utils/log.h"
 
 #include <ctime>
 
 namespace PVR
 {
-bool ProvidesStreamForMetaDataExtraction(const CFileItem& item)
-{
-  // Note: We must not rely on presence of a recording info tag here, but path is always set.
-  if (URIUtils::IsPVRRecording(item.GetPath()))
-  {
-    const std::shared_ptr<const CPVRClient> client{CServiceBroker::GetPVRManager().GetClient(item)};
-    if (client)
-      return client->GetClientCapabilities().SupportsMultipleRecordedStreams();
-  }
-
-  return false;
-}
-
 bool CPVRThumbLoader::LoadItem(CFileItem* item)
 {
   bool result = LoadItemCached(item);

--- a/xbmc/pvr/PVRThumbLoader.cpp
+++ b/xbmc/pvr/PVRThumbLoader.cpp
@@ -27,7 +27,7 @@
 
 namespace PVR
 {
-bool ProvidesStreamForThumbExtraction(const CFileItem& item)
+bool ProvidesStreamForMetaDataExtraction(const CFileItem& item)
 {
   // Note: We must not rely on presence of a recording info tag here, but path is always set.
   if (URIUtils::IsPVRRecording(item.GetPath()))

--- a/xbmc/pvr/PVRThumbLoader.h
+++ b/xbmc/pvr/PVRThumbLoader.h
@@ -14,8 +14,6 @@
 
 namespace PVR
 {
-bool ProvidesStreamForMetaDataExtraction(const CFileItem& item);
-
 class CPVRThumbLoader : public CThumbLoader
 {
 public:
@@ -39,4 +37,4 @@ private:
   bool m_bInvalidated = false;
 };
 
-}
+} // namespace PVR

--- a/xbmc/pvr/PVRThumbLoader.h
+++ b/xbmc/pvr/PVRThumbLoader.h
@@ -14,7 +14,7 @@
 
 namespace PVR
 {
-bool ProvidesStreamForThumbExtraction(const CFileItem& item);
+bool ProvidesStreamForMetaDataExtraction(const CFileItem& item);
 
 class CPVRThumbLoader : public CThumbLoader
 {

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -600,6 +600,8 @@ std::vector<SBackend> CPVRClients::GetBackendProperties() const
           properties.numRecordings = iAmount;
         if (client->GetRecordingsAmount(true, iAmount) == PVR_ERROR_NO_ERROR)
           properties.numDeletedRecordings = iAmount;
+        properties.clientname = client->GetClientName();
+        properties.instancename = client->GetInstanceName();
         properties.name = client->GetBackendName();
         properties.version = client->GetBackendVersion();
         properties.host = client->GetConnectionString();

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -46,6 +46,8 @@ typedef std::map<int, std::shared_ptr<CPVRClient>> CPVRClientMap;
    */
 struct SBackend
 {
+  std::string clientname;
+  std::string instancename;
   std::string name;
   std::string version;
   std::string host;

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -76,6 +76,8 @@ void CPVRGUIInfo::ResetProperties()
   m_bHasRadioRecordings = false;
   m_iCurrentActiveClient = 0;
   m_strPlayingClientName.clear();
+  m_strClientName.clear();
+  m_strInstanceName.clear();
   m_strBackendName.clear();
   m_strBackendVersion.clear();
   m_strBackendHost.clear();
@@ -1172,6 +1174,12 @@ bool CPVRGUIInfo::GetPVRLabel(const CFileItem* item,
     case PVR_ACTUAL_STREAM_PROVIDER:
       CharInfoProvider(strValue);
       return true;
+    case PVR_CLIENT_NAME:
+      CharInfoClientName(strValue);
+      return true;
+    case PVR_INSTANCE_NAME:
+      CharInfoInstanceName(strValue);
+      return true;
     case PVR_BACKEND_NAME:
       CharInfoBackendName(strValue);
       return true;
@@ -1960,6 +1968,18 @@ void CPVRGUIInfo::CharInfoFrontendStatus(std::string& strValue) const
     strValue = g_localizeStrings.Get(13205);
 }
 
+void CPVRGUIInfo::CharInfoClientName(std::string& strValue) const
+{
+  m_updateBackendCacheRequested = true;
+  strValue = m_strClientName;
+}
+
+void CPVRGUIInfo::CharInfoInstanceName(std::string& strValue) const
+{
+  m_updateBackendCacheRequested = true;
+  strValue = m_strInstanceName;
+}
+
 void CPVRGUIInfo::CharInfoBackendName(std::string& strValue) const
 {
   m_updateBackendCacheRequested = true;
@@ -2101,6 +2121,8 @@ void CPVRGUIInfo::UpdateBackendCache()
   }
 
   // Store some defaults
+  m_strClientName = g_localizeStrings.Get(13205);
+  m_strInstanceName = g_localizeStrings.Get(13205);
   m_strBackendName = g_localizeStrings.Get(13205);
   m_strBackendVersion = g_localizeStrings.Get(13205);
   m_strBackendHost = g_localizeStrings.Get(13205);
@@ -2118,6 +2140,8 @@ void CPVRGUIInfo::UpdateBackendCache()
   {
     const auto& backend = m_backendProperties[m_iCurrentActiveClient];
 
+    m_strClientName = backend.clientname;
+    m_strInstanceName = backend.instancename;
     m_strBackendName = backend.name;
     m_strBackendVersion = backend.version;
     m_strBackendHost = backend.host;

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
@@ -142,6 +142,8 @@ private:
   void CharInfoUNC(std::string& strValue) const;
   void CharInfoFrontendName(std::string& strValue) const;
   void CharInfoFrontendStatus(std::string& strValue) const;
+  void CharInfoClientName(std::string& strValue) const;
+  void CharInfoInstanceName(std::string& strValue) const;
   void CharInfoBackendName(std::string& strValue) const;
   void CharInfoBackendVersion(std::string& strValue) const;
   void CharInfoBackendHost(std::string& strValue) const;
@@ -170,6 +172,8 @@ private:
   bool m_bHasRadioRecordings;
   unsigned int m_iCurrentActiveClient;
   std::string m_strPlayingClientName;
+  std::string m_strClientName;
+  std::string m_strInstanceName;
   std::string m_strBackendName;
   std::string m_strBackendVersion;
   std::string m_strBackendHost;

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -423,6 +423,7 @@ void CPVRRecording::UpdateMetadata(CVideoDatabase& db, const CPVRClient& client)
   }
 
   m_lastPlayed = db.GetLastPlayed(m_strFileNameAndPath);
+  db.GetStreamDetails(m_strFileNameAndPath, m_streamDetails);
 
   m_bGotMetaData = true;
 }

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -163,7 +163,7 @@ public:
   std::vector<EDL::Edit> GetEdl() const;
 
   /*!
-   * @brief Get the resume point and play count from the database if the
+   * @brief Get metadata like the resume point and play count from the database if the
    * client doesn't handle it itself.
    * @param db The database to read the data from.
    * @param client The client this recording belongs to.

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4220,6 +4220,18 @@ CVideoInfoTag CVideoDatabase::GetDetailsByTypeAndId(VideoDbContentType type, int
   return {};
 }
 
+bool CVideoDatabase::GetStreamDetails(const std::string& filenameAndPath, CStreamDetails& details)
+{
+  CVideoInfoTag tag;
+  tag.m_iFileId = GetFileId(filenameAndPath);
+  if (GetStreamDetails(tag))
+  {
+    details = tag.m_streamDetails;
+    return true;
+  }
+  return false;
+}
+
 bool CVideoDatabase::GetStreamDetails(CFileItem& item)
 {
   // Note that this function (possibly) creates VideoInfoTags for items that don't have one yet!

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -22,6 +22,7 @@
 
 class CFileItem;
 class CFileItemList;
+class CStreamDetails;
 class CVideoSettings;
 class CGUIDialogProgress;
 class CGUIDialogProgressBarHandle;
@@ -701,6 +702,7 @@ public:
   bool GetResumePoint(CVideoInfoTag& tag);
   bool GetStreamDetails(CFileItem& item);
   bool GetStreamDetails(CVideoInfoTag& tag);
+  bool GetStreamDetails(const std::string& filenameAndPath, CStreamDetails& details);
   bool GetDetailsByTypeAndId(CFileItem& item, VideoDbContentType type, int id);
   CVideoInfoTag GetDetailsByTypeAndId(VideoDbContentType type, int id);
 


### PR DESCRIPTION
* PVR core: Allow stream details extraction for PVR recordings, if multiple streams is supported by the providing add-on.
* Estuary: Show media flags in PVR recordings window (instead of backend disk usage, which does not work well for multiclient setups and is also available in system info).

<img width="1710" alt="Screenshot_2024-10-25_at_23_38_29" src="https://github.com/user-attachments/assets/9dcc980c-225b-448e-a558-5c8bc92f7ed0">
<img width="1710" alt="Screenshot_2024-10-30_at_20_18_00" src="https://github.com/user-attachments/assets/7eb89a36-9b01-4706-8d9b-daca3c5ab08d">

Runtime-tested on macOS and android, latest master.

@phunkyfish can you please review the code changes?
@jjd-uk  do the skin changes okay to you?