### PR TITLE
[PVR] Delete metadata from video db on delete of recordings.

### DIFF
--- a/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
@@ -126,11 +126,14 @@ private:
       items.Add(item);
     }
 
+    const auto recordings{CServiceBroker::GetPVRManager().Recordings()};
     return std::accumulate(
-        items.cbegin(), items.cend(), true, [this](bool success, const auto& itemToDelete) {
+        items.cbegin(), items.cend(), true,
+        [this, &recordings](bool success, const auto& itemToDelete)
+        {
           return (itemToDelete->IsPVRRecording() &&
                   (!m_bWatchedOnly || itemToDelete->GetPVRRecordingInfoTag()->GetPlayCount() > 0) &&
-                  !itemToDelete->GetPVRRecordingInfoTag()->Delete())
+                  !recordings->DeleteRecording(itemToDelete->GetPVRRecordingInfoTag()))
                      ? false
                      : success;
         });

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -427,6 +427,11 @@ void CPVRRecording::UpdateMetadata(CVideoDatabase& db, const CPVRClient& client)
   m_bGotMetaData = true;
 }
 
+void CPVRRecording::DeleteMetadata(CVideoDatabase& db)
+{
+  db.EraseAllForFile(m_strFileNameAndPath);
+}
+
 std::vector<EDL::Edit> CPVRRecording::GetEdl() const
 {
   std::vector<EDL::Edit> edls;

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -171,6 +171,12 @@ public:
   void UpdateMetadata(CVideoDatabase& db, const CPVRClient& client);
 
   /*!
+   * @brief Delete metadata like the resume point and play count from the database.
+   * @param db The database to delete the data from.
+   */
+  void DeleteMetadata(CVideoDatabase& db);
+
+  /*!
    * @brief Update this tag with the contents of the given tag.
    * @param tag The new tag info.
    * @param client The client this recording belongs to.

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -356,6 +356,17 @@ bool CPVRRecordings::ResetResumePoint(const std::shared_ptr<CPVRRecording>& reco
   return bResult;
 }
 
+bool CPVRRecordings::DeleteRecording(const std::shared_ptr<CPVRRecording>& recording)
+{
+  CVideoDatabase& db = GetVideoDatabase();
+  if (db.IsOpen() && recording->Delete())
+  {
+    recording->DeleteMetadata(db);
+    return true;
+  }
+  return false;
+}
+
 CVideoDatabase& CPVRRecordings::GetVideoDatabase()
 {
   if (!m_database)

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -83,6 +83,13 @@ public:
   bool ResetResumePoint(const std::shared_ptr<CPVRRecording>& recording);
 
   /*!
+   * @brief Delete a recording in the backend, cleanup db enries.
+   * @param recording The recording
+   * @return True on success, false otherwise
+   */
+  bool DeleteRecording(const std::shared_ptr<CPVRRecording>& recording);
+
+  /*!
    * @brief Get a list of all recordings
    * @return the list of all recordings
    */

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -12000,6 +12000,44 @@ void CVideoDatabase::EraseAllForPath(const std::string& path)
   }
 }
 
+void CVideoDatabase::EraseAllForFile(const std::string& fileNameAndPath)
+{
+  try
+  {
+    const int fileId{GetFileId(fileNameAndPath)};
+    if (fileId != -1)
+    {
+      std::string sql = PrepareSQL("DELETE FROM settings WHERE idFile = %i", fileId);
+      m_pDS->exec(sql);
+
+      sql = PrepareSQL("DELETE FROM bookmark WHERE idFile = %i", fileId);
+      m_pDS->exec(sql);
+
+      sql = PrepareSQL("DELETE FROM streamdetails WHERE idFile = %i", fileId);
+      m_pDS->exec(sql);
+
+      sql = PrepareSQL("DELETE FROM files WHERE idFile = %i", fileId);
+      m_pDS->exec(sql);
+
+      std::string path;
+      std::string fileName;
+      SplitPath(fileNameAndPath, path, fileName);
+      const int pathId{GetPathId(path)};
+      if (pathId != -1)
+      {
+        sql = PrepareSQL("DELETE FROM path WHERE idPath = %i "
+                         "AND NOT EXISTS (SELECT 1 FROM files WHERE files.idPath = %i)",
+                         pathId, pathId);
+        m_pDS->exec(sql);
+      }
+    }
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+  }
+}
+
 std::string CVideoDatabase::GetVideoItemTitle(VideoDbContentType itemType, int dbId)
 {
   switch (itemType)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -685,6 +685,12 @@ public:
    */
   void EraseAllForPath(const std::string& path);
 
+  /**
+   * Erases all entries for the given file, including path entry if no longer used
+   * @param fileNameAndPath The name and path of the file to erase db entries for
+   */
+  void EraseAllForFile(const std::string& fileNameAndPath);
+
   bool GetStackTimes(const std::string &filePath, std::vector<uint64_t> &times);
   void SetStackTimes(const std::string &filePath, const std::vector<uint64_t> &times);
 


### PR DESCRIPTION
For PVR recordings, we might write various data to the video database, like playback settings (which subtitle language, which stream to use, etc.), play position, play count, stream details.

So for, this data gets only deleted when clearing PVR data manually via Kodi settings.

This PR changes that meta data which are store in the video database get deleted when deleting a recording in Kodi. This is not perfect as we cannot detect when a recording was deleted via the PVR backend GUI, but definitely an improvement.

Runtime-tested on macOS and Android, latest master.

@phunkyfish can you please review.