### PR TITLE
Fix Stream Details Save After Playback

### DIFF
--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -171,7 +171,8 @@ void CSaveFileState::DoWork(CFileItem& item,
           }
         }
 
-        if (item.HasVideoInfoTag() && item.GetVideoInfoTag()->HasStreamDetails())
+        if (item.HasVideoInfoTag() && item.GetVideoInfoTag()->HasStreamDetails() &&
+            !item.IsLiveTV())
         {
           CFileItem dbItem(item);
 
@@ -180,7 +181,7 @@ void CSaveFileState::DoWork(CFileItem& item,
               dbItem.GetVideoInfoTag()->m_streamDetails != item.GetVideoInfoTag()->m_streamDetails)
           {
             const int idFile = videodatabase.SetStreamDetailsForFile(
-                item.GetVideoInfoTag()->m_streamDetails, item.GetDynPath());
+                item.GetVideoInfoTag()->m_streamDetails, progressTrackingFile);
             if (item.GetVideoContentType() == VideoDbContentType::MOVIES)
               videodatabase.SetFileForMovie(item.GetDynPath(), item.GetVideoInfoTag()->m_iDbId,
                                             idFile);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

A couple fixes in CSaveFileState::DoWork() for the stream details.

- [fix] Restore the logic calculating the URL used to save the stream details. It was recently bypassed by #24720 and caused PVR to check for the existence of stream details using the item path, but they were later saved with the item's dynpath instead.  Restoring the original logic and keeping the bluray specific changes should work for everybody.

- [improvement] don't save stream details for PVR live streams

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Oddities found while fixing a nested transaction problem in CSaveFileState::DoWork().

Stream details kept being saved when stopping a PVR live stream even when not changing.
That path/dynpath issue likely affects other types of files and not just live PVR, now excluded by this PR.

@ksooo advised it didn't make sense to save stream details for live pvr streams.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

PVR, local and smb files.

bluray discs and ISO tested by @78andyp

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Stream details saved more consistently for all item types.

Stopping live PVR streams is a bit faster.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
