### PR TITLE
[BP] Shut down gracefully if OpenGL context is not properly set up

### DIFF
--- a/xbmc/guilib/Shader.cpp
+++ b/xbmc/guilib/Shader.cpp
@@ -151,8 +151,13 @@ bool CGLSLVertexShader::Compile()
   {
     GLchar log[LOG_SIZE];
     CLog::Log(LOGERROR, "GL: Error compiling vertex shader");
-    glGetShaderInfoLog(m_vertexShader, LOG_SIZE, NULL, log);
-    CLog::Log(LOGERROR, "{}", log);
+    GLsizei length;
+    glGetShaderInfoLog(m_vertexShader, LOG_SIZE, &length, log);
+    if (length > 0)
+    {
+      CLog::Log(LOGERROR, "GL: Vertex Shader compilation log:");
+      CLog::Log(LOGERROR, "{}", log);
+    }
     m_lastLog = log;
     m_compiled = false;
   }
@@ -163,8 +168,8 @@ bool CGLSLVertexShader::Compile()
     glGetShaderInfoLog(m_vertexShader, LOG_SIZE, &length, log);
     if (length > 0)
     {
-      CLog::Log(LOGDEBUG, "GL: Vertex Shader compilation log:");
-      CLog::Log(LOGDEBUG, "{}", log);
+      CLog::Log(LOGERROR, "GL: Vertex Shader compilation log:");
+      CLog::Log(LOGERROR, "{}", log);
     }
     m_lastLog = log;
     m_compiled = true;
@@ -204,8 +209,13 @@ bool CGLSLPixelShader::Compile()
   {
     GLchar log[LOG_SIZE];
     CLog::Log(LOGERROR, "GL: Error compiling pixel shader");
-    glGetShaderInfoLog(m_pixelShader, LOG_SIZE, NULL, log);
-    CLog::Log(LOGERROR, "{}", log);
+    GLsizei length;
+    glGetShaderInfoLog(m_pixelShader, LOG_SIZE, &length, log);
+    if (length > 0)
+    {
+      CLog::Log(LOGERROR, "GL: Pixel Shader compilation log:");
+      CLog::Log(LOGERROR, "{}", log);
+    }
     m_lastLog = log;
     m_compiled = false;
   }
@@ -216,8 +226,8 @@ bool CGLSLPixelShader::Compile()
     glGetShaderInfoLog(m_pixelShader, LOG_SIZE, &length, log);
     if (length > 0)
     {
-      CLog::Log(LOGDEBUG, "GL: Pixel Shader compilation log:");
-      CLog::Log(LOGDEBUG, "{}", log);
+      CLog::Log(LOGERROR, "GL: Pixel Shader compilation log:");
+      CLog::Log(LOGERROR, "{}", log);
     }
     m_lastLog = log;
     m_compiled = true;

--- a/xbmc/utils/GLUtils.cpp
+++ b/xbmc/utils/GLUtils.cpp
@@ -219,7 +219,7 @@ void LogGraphicsInfo()
     CLog::Log(LOGINFO, "GL_GPU_MEMORY_INFO_DEDICATED_VIDMEM_NVX = {}", mem);
   }
 
-  std::string extensions;
+  std::string extensions = "";
 #if defined(HAS_GL)
   unsigned int renderVersionMajor, renderVersionMinor;
   CServiceBroker::GetRenderSystem()->GetRenderVersion(renderVersionMajor, renderVersionMinor);
@@ -233,15 +233,21 @@ void LogGraphicsInfo()
       GLint i;
       for (i = 0; i < n; i++)
       {
-        extensions += (const char*)glGetStringi(GL_EXTENSIONS, i);
-        extensions += " ";
+        const char* extension = reinterpret_cast<const char*>(glGetStringi(GL_EXTENSIONS, i));
+        if (extension)
+        {
+          extensions += extension;
+          extensions += " ";
+        }
       }
     }
   }
   else
 #endif
   {
-    extensions += (const char*) glGetString(GL_EXTENSIONS);
+    const char* extension = reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS));
+    if (s)
+      extensions += extension;
   }
 
   if (!extensions.empty())


### PR DESCRIPTION
## Description

Refactor CRenderingSystem{GL,GLES} to avoid crashes

## Motivation and context

See #25245 nd #25243

## How has this been tested?

First spotted on @anohren 's i386 machine and then reproduced on my AMD64 one - see #25245

## What is the effect on users?

Kodi should shut down gracefully instead of crashing and leaving files in dangling state!

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
