### PR TITLE
[PVR] CPVRTimerInfoTag::UpdateSummary: Add support for timer types no…

### DIFF
--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -343,7 +343,11 @@ void CPVRTimerInfoTag::UpdateSummary()
   const std::string startDate(StartAsLocalTime().GetAsLocalizedDate());
   const std::string endDate(EndAsLocalTime().GetAsLocalizedDate());
 
-  if (m_bEndAnyTime)
+  if (!m_timerType->SupportsStartTime() || !m_timerType->SupportsEndTime())
+  {
+    m_strSummary = GetWeekdaysString();
+  }
+  else if (m_bEndAnyTime)
   {
     m_strSummary = StringUtils::Format(
         "{} {} {}",


### PR DESCRIPTION
…t supporting start/end time.

Fix is not to include start/stop date and time in the timer summary (which can be seen for example in the PVR Timers and PVR Timer rules windows) in case the respective timer type does not support start/end date and time.

Summary can even be empty in this case if the timer type does also not support "day of week", which is fine.

Runtime-tested on macOS, latest Kodi master.

@phunkyfish should be a no-brainer to review this.