### PR TITLE
[PVR] Timer settings dialog: Ensure that the order of timer custom se…

### DIFF
--- a/xbmc/pvr/settings/PVRCustomTimerSettings.cpp
+++ b/xbmc/pvr/settings/PVRCustomTimerSettings.cpp
@@ -55,7 +55,7 @@ CPVRCustomTimerSettings::CPVRCustomTimerSettings(
       }
 
       const std::string settingId{StringUtils::Format("{}-{}", settingIdPrefix, idx)};
-      m_customSettingDefs.insert({settingId, settingDef});
+      m_customSettingDefs.emplace_back(std::make_pair(settingId, settingDef));
       ++idx;
     }
   }
@@ -247,7 +247,8 @@ bool CPVRCustomTimerSettings::IsSettingSupportedForTimerType(const std::string& 
 std::shared_ptr<const CPVRTimerSettingDefinition> CPVRCustomTimerSettings::GetSettingDefintion(
     const std::string& settingId) const
 {
-  const auto it{m_customSettingDefs.find(settingId)};
+  const auto it{std::find_if(m_customSettingDefs.cbegin(), m_customSettingDefs.cend(),
+                             [&settingId](const auto& entry) { return entry.first == settingId; })};
   if (it == m_customSettingDefs.cend())
     return {};
 

--- a/xbmc/pvr/settings/PVRCustomTimerSettings.h
+++ b/xbmc/pvr/settings/PVRCustomTimerSettings.h
@@ -11,9 +11,9 @@
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_timers.h" // PVR_TIMER_STATE
 #include "pvr/timers/PVRTimerInfoTag.h"
 
-#include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 class CSetting;
@@ -67,11 +67,11 @@ private:
   std::shared_ptr<const CPVRTimerSettingDefinition> GetSettingDefintion(
       const std::string& settingId) const;
 
-  using CustomSettingDefinitionsMap =
-      std::map<std::string,
-               std::shared_ptr<const CPVRTimerSettingDefinition>>; // setting id, setting def
+  using CustomSettingDefinitionsVector = std::vector<
+      std::pair<std::string,
+                std::shared_ptr<const CPVRTimerSettingDefinition>>>; // setting id, setting def
 
-  CustomSettingDefinitionsMap m_customSettingDefs;
+  CustomSettingDefinitionsVector m_customSettingDefs;
   CPVRTimerInfoTag::CustomPropsMap m_customProps;
 };
 } // namespace PVR


### PR DESCRIPTION
…ttings matches the order defined by the add-on.

Timer settings dialog should display the custom settings in exactly the order they are specified by the add-on. Using a sorted map in `CPVRCustomTimerSettings` to store the settings broke that order. Now we use a vector.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish could you please review? Thanks.

