### PR TITLE
[Video] A few video extras fixes

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24448,7 +24448,19 @@ msgctxt "#40038"
 msgid "The default version of a movie with multiple versions cannot be added to another movie. Please move or remove the other versions first."
 msgstr ""
 
-#empty strings with id 40039 to 40199
+#. Remove video extra dialog title
+#: xbmc/video/dialogs/GUIDialogVideoManager.cpp
+msgctxt "#40039"
+msgid "Remove video extra"
+msgstr ""
+
+#. Remove video extra dialog text
+#: xbmc/video/dialogs/GUIDialogVideoManager.cpp
+msgctxt "#40040"
+msgid "Are you sure to remove the extra \"{0:s}\"?"
+msgstr ""
+
+#empty strings with id 40041 to 40199
 
 #. Select default video version setting
 #: system/settings/settings.xml

--- a/xbmc/InfoScanner.cpp
+++ b/xbmc/InfoScanner.cpp
@@ -13,7 +13,7 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
-bool CInfoScanner::HasNoMedia(const std::string &strDirectory) const
+bool CInfoScanner::HasNoMedia(const std::string& strDirectory)
 {
   std::string noMediaFile = URIUtils::AddFileToFolder(strDirectory, ".nomedia");
 

--- a/xbmc/InfoScanner.h
+++ b/xbmc/InfoScanner.h
@@ -54,7 +54,7 @@ public:
    \param strDirectory Directory to scan
    \return true if there is a .nomedia file
    */
-  bool HasNoMedia(const std::string& strDirectory) const;
+  static bool HasNoMedia(const std::string& strDirectory);
 
   //! \brief Set whether or not to show a progress dialog.
   void ShowDialog(bool show) { m_showDialog = show; }

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -1162,7 +1162,10 @@ JSONRPC_STATUS CVideoLibrary::RemoveVideo(const CVariant &parameterObject)
     return InternalError;
 
   if (parameterObject.isMember("movieid"))
-    videodatabase.DeleteMovie((int)parameterObject["movieid"].asInteger());
+  {
+    if (!videodatabase.DeleteMovie((int)parameterObject["movieid"].asInteger()))
+      return InternalError;
+  }
   else if (parameterObject.isMember("tvshowid"))
     videodatabase.DeleteTvShow((int)parameterObject["tvshowid"].asInteger());
   else if (parameterObject.isMember("episodeid"))

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -12667,13 +12667,6 @@ bool CVideoDatabase::AddVideoAsset(VideoDbContentType itemType,
       return false;
     }
 
-    if (videoAssetType == VideoAssetType::VERSION &&
-        !SetVideoVersionDefaultArt(idFile, item.GetVideoInfoTag()->m_iDbId, itemType))
-    {
-      RollbackTransaction();
-      return false;
-    }
-
     if (!SetArtForItem(idFile, MediaTypeVideoVersion, item.GetArt()))
     {
       RollbackTransaction();

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3693,21 +3693,24 @@ void CVideoDatabase::DeleteBookMarkForEpisode(const CVideoInfoTag& tag)
 }
 
 //********************************************************************************************************************************
-void CVideoDatabase::DeleteMovie(int idMovie,
+bool CVideoDatabase::DeleteMovie(int idMovie,
                                  DeleteMovieCascadeAction ca /* = ALL_ASSETS */,
                                  DeleteMovieHashAction hashAction /* = HASH_DELETE */)
 {
   if (idMovie < 0)
-    return;
+    return false;
+
+  if (nullptr == m_pDB)
+    return false;
+  if (nullptr == m_pDS)
+    return false;
+
+  const bool inTransaction{m_pDB->in_transaction()};
 
   try
   {
-    if (nullptr == m_pDB)
-      return;
-    if (nullptr == m_pDS)
-      return;
-
-    BeginTransaction();
+    if (!inTransaction)
+      BeginTransaction();
 
     const int idFile{GetDbId(PrepareSQL("SELECT idFile FROM movie WHERE idMovie=%i", idMovie))};
     DeleteStreamDetails(idFile);
@@ -3739,9 +3742,10 @@ void CVideoDatabase::DeleteMovie(int idMovie,
       {
         if (!DeleteVideoAsset(pDS->fv(0).get_asInt()))
         {
-          RollbackTransaction();
+          if (!inTransaction)
+            RollbackTransaction();
           pDS->close();
-          return;
+          return false;
         }
         pDS->next();
       }
@@ -3751,13 +3755,18 @@ void CVideoDatabase::DeleteMovie(int idMovie,
     //! @todo move this below CommitTransaction() once UPnP doesn't rely on this anymore
     AnnounceRemove(MediaTypeMovie, idMovie);
 
-    CommitTransaction();
+    if (!inTransaction)
+      CommitTransaction();
+
+    return true;
   }
   catch (...)
   {
     CLog::LogF(LOGERROR, "failed");
-    RollbackTransaction();
+    if (!inTransaction)
+      RollbackTransaction();
   }
+  return false;
 }
 
 void CVideoDatabase::DeleteTvShow(const std::string& strPath)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -616,7 +616,14 @@ public:
 
   int UpdateDetailsForMovie(int idMovie, CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, const std::set<std::string> &updatedDetails);
 
-  void DeleteMovie(int idMovie,
+  /*!
+   * \brief Remove a movie from the library.
+   * \param[in] idMovie The id of the movie
+   * \param[in] action Versions of the movie to be deleted
+   * \param[in] hashAction Preserve or invalidate the hash of the movie path
+   * \return operation success. true for success, false for failure
+   */
+  bool DeleteMovie(int idMovie,
                    DeleteMovieCascadeAction action = DeleteMovieCascadeAction::ALL_ASSETS,
                    DeleteMovieHashAction hashAction = DeleteMovieHashAction::HASH_DELETE);
   void DeleteTvShow(int idTvShow, bool bKeepId = false);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -420,7 +420,8 @@ namespace KODI::VIDEO
         break;
 
       // add video extras to library
-      if (foundSomething && !m_ignoreVideoExtras && IsVideoExtrasFolder(*pItem))
+      if (foundSomething && content == CONTENT_MOVIES && settings.parent_name &&
+          !m_ignoreVideoExtras && IsVideoExtrasFolder(*pItem))
       {
         if (AddVideoExtras(items, content, pItem->GetPath()))
         {
@@ -2462,7 +2463,7 @@ namespace KODI::VIDEO
     // get the library item which was added previously with the specified conent type
     for (const auto& item : items)
     {
-      if (content == CONTENT_MOVIES)
+      if (content == CONTENT_MOVIES && !item->m_bIsFolder)
       {
         dbId = m_database.GetMovieId(item->GetPath());
         if (dbId != -1)

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2493,15 +2493,15 @@ namespace KODI::VIDEO
                       CURL::GetRedacted(item->GetPath()));
           }
 
-          const std::string typeVideoVersion =
+          const std::string extraTypeName =
               CGUIDialogVideoManagerExtras::GenerateVideoExtra(path, item->GetPath());
 
-          const int idVideoVersion = m_database.AddVideoVersionType(
-              typeVideoVersion, VideoAssetTypeOwner::AUTO, VideoAssetType::EXTRA);
+          const int idVideoAssetType = m_database.AddVideoVersionType(
+              extraTypeName, VideoAssetTypeOwner::AUTO, VideoAssetType::EXTRA);
 
           GetArtwork(item.get(), content, true, true, "");
 
-          if (m_database.AddVideoAsset(ContentToVideoDbType(content), dbId, idVideoVersion,
+          if (m_database.AddVideoAsset(ContentToVideoDbType(content), dbId, idVideoAssetType,
                                        VideoAssetType::EXTRA, *item.get()))
           {
             CLog::Log(LOGDEBUG, "VideoInfoScanner: Added video extra {}",

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -315,9 +315,8 @@ namespace KODI::VIDEO
                                  DIR_FLAG_DEFAULTS);
         // do not consider inner folders with .nomedia
         items.erase(std::remove_if(items.begin(), items.end(),
-                                   [this](const CFileItemPtr& item) {
-                                     return item->m_bIsFolder && HasNoMedia(item->GetPath());
-                                   }),
+                                   [](const CFileItemPtr& item)
+                                   { return item->m_bIsFolder && HasNoMedia(item->GetPath()); }),
                     items.end());
         items.Stack();
 
@@ -1029,8 +1028,7 @@ namespace KODI::VIDEO
         // Listing that ignores files inside and below folders containing .nomedia files.
         CDirectory::EnumerateDirectory(
             item->GetPath(), [&items](const std::shared_ptr<CFileItem>& item) { items.Add(item); },
-            [this](const std::shared_ptr<CFileItem>& folder)
-            { return !HasNoMedia(folder->GetPath()); },
+            [](const std::shared_ptr<CFileItem>& folder) { return !HasNoMedia(folder->GetPath()); },
             true, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions(), flags);
 
         // fast hash failed - compute slow one
@@ -2480,6 +2478,9 @@ namespace KODI::VIDEO
       return false;
     }
 
+    // No need to check for .nomedia in the current directory, the caller already checked and this
+    // function would not have been called if it existed.
+
     // Add video extras to library
     CDirectory::EnumerateDirectory(
         path,
@@ -2513,8 +2514,8 @@ namespace KODI::VIDEO
                       CURL::GetRedacted(item->GetPath()));
           }
         },
-        [](auto) { return true; }, true,
-        CServiceBroker::GetFileExtensionProvider().GetVideoExtensions(), DIR_FLAG_DEFAULTS);
+        [](const std::shared_ptr<CFileItem>& dirItem) { return !HasNoMedia(dirItem->GetPath()); },
+        true, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions(), DIR_FLAG_DEFAULTS);
 
     return true;
   }

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1421,7 +1421,8 @@ bool CGUIDialogVideoInfo::DeleteVideoItemFromDatabase(const std::shared_ptr<CFil
   switch (type)
   {
     case VideoDbContentType::MOVIES:
-      database.DeleteMovie(item->GetVideoInfoTag()->m_iDbId);
+      if (!database.DeleteMovie(item->GetVideoInfoTag()->m_iDbId))
+        return false;
       break;
     case VideoDbContentType::EPISODES:
       database.DeleteEpisode(item->GetVideoInfoTag()->m_iDbId);

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -304,10 +304,30 @@ void CGUIDialogVideoManager::Play()
 
 void CGUIDialogVideoManager::Remove()
 {
-  // confirm to remove
+  const VideoAssetType assetType = GetVideoAssetType();
+  int titleMsgId;
+  int textMsgId;
+
+  switch (assetType)
+  {
+    case VideoAssetType::VERSION:
+      titleMsgId = 40018;
+      textMsgId = 40020;
+      break;
+    case VideoAssetType::EXTRA:
+      titleMsgId = 40039;
+      textMsgId = 40040;
+      break;
+    default:
+      assert(false);
+      CLog::LogF(LOGERROR, "Unknown asset type ({})", static_cast<int>(assetType));
+      return;
+  }
+
+  // confirm the removal
   if (!CGUIDialogYesNo::ShowAndGetInput(
-          CVariant(40018),
-          StringUtils::Format(g_localizeStrings.Get(40020),
+          titleMsgId,
+          StringUtils::Format(g_localizeStrings.Get(textMsgId),
                               m_selectedVideoAsset->GetVideoInfoTag()->GetAssetInfo().GetTitle())))
   {
     return;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

One commit per point.

- Do not scan for extras in a flat folder structure (setting "Movies are in separate folders that match the movie title" is turned off)

- Change AddVideoExtras() to ignore folders when looking for the movie to attach the contents of an "Extras" folder to.
The function enumerates the folder containing the extras folder, but at least with Windows, folders are returned before files. In a recursive situation, this caused the wrong movie parent to be identified (a "sub"-movie contained in a folder at the same level as the extras folder, instead of the movie folder containing the extras folder).
See an example in context paragraph.

- Adapted the video asset removal confirmation dialog to the type of asset

- Fixed nested db transaction in CVideoDatabase::DeleteMovie(). Some callers create a transaction, others don't so DeleteMovie() now creates a transaction only when there isn't one yet and returns error codes to let the caller deal with errors and do the right thing with an already open transaction.

- Modified CVIdeoDatabase::AddVideoAsset to not modify the name of an existing asset already attached to the owner (preserves customized name of extras during library scans). There is a separate rename function SetVideoVersion().

- Honour .nomedia marker in subdirectories of extras folder (was already followed for extras folder itself).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Some issues found while reviewing the wiki article on video extras.

- For the following structure and setting "Movies are in separate folders that match the movie title" = OFF

```
...\Movies
...\Movies\Extras\making of.mp4
...\Movies\Extras\interview with the director.mp4
...\Movies\Dune (1984).mp4
...\Movies\Lucy (2014).mp4
````
It's not clear what the library scanner should do with the extras. Actual results: the extras are attached to the first movie (Dune(1984)). There is no convention to designate which movie the extras belong to, and adding them to all movies is not possible due to the db design. It seems best to block this undefined case, and that's the explanation currently in the wiki.

- For the following structure and setting "Movies are in separate folders that match the movie title" = ON and "Scan recursively" = ON

```
...\Movies
...\Movies\Dune (1984)
...\Movies\Dune (1984)\dune.mp4
...\Movies\Dune (1984)\Extras\making of.mp4
...\Movies\Dune (1984)\Lucy (2014)
...\Movies\Dune (1984)\Lucy (2014)\lucy.mp4
...\Movies\Dune (1984)\Lucy (2014)\Extras\making of.mp4
```
It's not expected to be a common situation but the outcome is still surprising, on Windows at least: both extras get attached to the "inner" movie Lucy(2014).

- The video asset removal confirmation dialog title and messages always refer to a video version, even when removing an extra

- video library scans revert the video extra names to the default names (the filename), overwriting user changes.
For example change the name of an extra, add another video file to the extras folder and update the library. The new file is detected and added as extra, but at the same time the name of the existing extra is changed back to default.

- .nomedia files are not honoured in subfolders of the extras directory

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Scanned movies and tv shows, with all combinations of "Movies are in separate folders that match the movie title" and "Scan recursively", with an Extras folder in different locations.

Removal of video extra (and version for negative testing).

## Screenshots (if appropriate):

Video extra removal dialog with correct title and text:
![image](https://github.com/user-attachments/assets/00efacb1-93b6-44d8-8c73-f9dc3cac707c)


## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Fixed a few unusual situations involving video extras and library scans, fixed extra removal dialog messages.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
