### PR TITLE
[peripherals] Honour an explicit CEC standby when Kodi is not the active source

### DIFF
--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -2026,8 +2026,13 @@ bool CPeripheralCecAdapter::ToggleDeviceState(CecStateChange mode /*= STATE_SWIT
 {
   if (!IsRunning())
     return false;
-  if (m_cecAdapter->IsLibCECActiveSource() &&
-      (mode == STATE_SWITCH_TOGGLE || mode == STATE_STANDBY))
+
+  /* being the active source is what allows us to stand the system down again, so it decides which
+     way a toggle goes. an explicit standby is the user asking for it, and is always honoured. */
+  const bool bStandby = mode == STATE_STANDBY ||
+                        (mode == STATE_SWITCH_TOGGLE && m_cecAdapter->IsLibCECActiveSource());
+
+  if (bStandby)
   {
     CLog::Log(LOGDEBUG, "{} - putting CEC device on standby...", __FUNCTION__);
     StandbyDevices();

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -89,6 +89,18 @@ class CPeripheralCecAdapter : public CPeripheralHID,
   friend class CPeripheralCecAdapterUpdateThread;
   friend class CPeripheralCecAdapterReopenJob;
 
+  enum class CecCommandState {
+    WAITING_ACTIVATE,
+    WAITING_STAND_BY,
+    PROCESSED
+  };
+
+  enum class CecPowerState {
+    ACTIVE,
+    STAND_BY,
+    IN_TRANSITION
+  };
+
 public:
   CPeripheralCecAdapter(CPeripherals& manager,
                         const PeripheralScanResult& scanResult,
@@ -152,6 +164,7 @@ private:
   void SetAudioSystemConnected(bool bSetTo);
   void SetMenuLanguage(const char* strLanguage);
   void OnTvStandby(void);
+  CecPowerState GetConnectedDevicesPowerState() const;
 
   // callbacks from libCEC
   static void CecLogMessage(void* cbParam, const CEC::cec_log_message* message);
@@ -186,8 +199,7 @@ private:
   CEC::ICECCallbacks m_callbacks;
   mutable CCriticalSection m_critSection;
   CEC::libcec_configuration m_configuration;
-  bool m_bActiveSourcePending;
-  bool m_bStandbyPending;
+  CecCommandState m_cecCommandState;
   CDateTime m_preventActivateSourceOnPlay;
   bool m_bActiveSourceBeforeStandby;
   bool m_bOnPlayReceived;


### PR DESCRIPTION
## Description
Added enums for more accurate management CEC peripherals state

## Motivation and context
When using  Pulse 8 CEC adapter kodi can't switch off the TV set. 

## How has this been tested?
It was tested on a Intel(R) Celeron(R) J4125 CPU based computer. TV set connected to it by a hdmi cable through pulse8 CEC adapter.

## What is the effect on users?
Users can switch-on and off peripheral CEC devices  connected to  a KODI center

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
