### PR TITLE
[tools/depends][target] pythonmodule-setuptools remove win executables

### DIFF
--- a/tools/depends/target/pythonmodule-setuptools/Makefile
+++ b/tools/depends/target/pythonmodule-setuptools/Makefile
@@ -11,6 +11,7 @@ $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 
 .installed-$(PLATFORM): $(PLATFORM)
 	cd $(PLATFORM); PYTHONPATH="$(PYTHON_SITE_PKG)" $(NATIVEPREFIX)/bin/python3 setup.py install --prefix=$(PREFIX)
+	find $(PYTHON_SITE_PKG)/*setuptools* -type f -name "*.exe" -exec rm -f {} \;
 	touch $@
 
 clean:


### PR DESCRIPTION
## Description
Setuptools copies a bunch of windows executables. Apple platforms inadvertently strip these files out as part of a packaging step, but android/webos ship them still. Delete the files as an install step of the module to cleanup for everyone.

## Motivation and context

As per latest android nightly - kodi-20241107-e8b5874a-PR25940-arm64-v8a
```
 % find /kodi-20241107-e8b5874a-PR25940-arm64-v8a/assets/python3.12/lib/python3.12/site-packages -type f -name "*.exe" -print0 | xargs -0 ls -lhS
   574K  1 Jan  1981 kodi-20241107-e8b5874a-PR25940-arm64-v8a/assets/python3.12/lib/python3.12/site-packages/setuptools-72.1.0-py3.12.egg/setuptools/_distutils/command/wininst-14.0-amd64.exe
   448K  1 Jan  1981 kodi-20241107-e8b5874a-PR25940-arm64-v8a/assets/python3.12/lib/python3.12/site-packages/setuptools-72.1.0-py3.12.egg/setuptools/_distutils/command/wininst-14.0.exe
   219K  1 Jan  1981 kodi-20241107-e8b5874a-PR25940-arm64-v8a/assets/python3.12/lib/python3.12/site-packages/setuptools-72.1.0-py3.12.egg/setuptools/_distutils/command/wininst-9.0-amd64.exe
   217K  1 Jan  1981 kodi-20241107-e8b5874a-PR25940-arm64-v8a/assets/python3.12/lib/python3.12/site-packages/setuptools-72.1.0-py3.12.egg/setuptools/_distutils/command/wininst-10.0-amd64.exe
   192K  1 Jan  1981 kodi-20241107-e8b5874a-PR25940-arm64-v8a/assets/python3.12/lib/python3.12/site-packages/setuptools-72.1.0-py3.12.egg/setuptools/_distutils/command/wininst-9.0.exe
   187K  1 Jan  1981 kodi-20241107-e8b5874a-PR25940-arm64-v8a/assets/python3.12/lib/python3.12/site-packages/setuptools-72.1.0-py3.12.egg/setuptools/_distutils/command/wininst-10.0.exe
    64K  1 Jan  1981 kodi-20241107-e8b5874a-PR25940-arm64-v8a/assets/python3.12/lib/python3.12/site-packages/setuptools-72.1.0-py3.12.egg/setuptools/_distutils/command/wininst-7.1.exe
    60K  1 Jan  1981 kodi-20241107-e8b5874a-PR25940-arm64-v8a/assets/python3.12/lib/python3.12/site-packages/setuptools-72.1.0-py3.12.egg/setuptools/_distutils/command/wininst-6.0.exe
    60K  1 Jan  1981 kodi-20241107-e8b5874a-PR25940-arm64-v8a/assets/python3.12/lib/python3.12/site-packages/setuptools-72.1.0-py3.12.egg/setuptools/_distutils/command/wininst-8.0.exe
    14K  1 Jan  1981 kodi-20241107-e8b5874a-PR25940-arm64-v8a/assets/python3.12/lib/python3.12/site-packages/setuptools-72.1.0-py3.12.egg/setuptools/cli-64.exe
    14K  1 Jan  1981 kodi-20241107-e8b5874a-PR25940-arm64-v8a/assets/python3.12/lib/python3.12/site-packages/setuptools-72.1.0-py3.12.egg/setuptools/gui-64.exe
    14K  1 Jan  1981 kodi-20241107-e8b5874a-PR25940-arm64-v8a/assets/python3.12/lib/python3.12/site-packages/setuptools-72.1.0-py3.12.egg/setuptools/cli-arm64.exe
    14K  1 Jan  1981 kodi-20241107-e8b5874a-PR25940-arm64-v8a/assets/python3.12/lib/python3.12/site-packages/setuptools-72.1.0-py3.12.egg/setuptools/gui-arm64.exe
    12K  1 Jan  1981 kodi-20241107-e8b5874a-PR25940-arm64-v8a/assets/python3.12/lib/python3.12/site-packages/setuptools-72.1.0-py3.12.egg/setuptools/cli-32.exe
    12K  1 Jan  1981 kodi-20241107-e8b5874a-PR25940-arm64-v8a/assets/python3.12/lib/python3.12/site-packages/setuptools-72.1.0-py3.12.egg/setuptools/cli.exe
    12K  1 Jan  1981 kodi-20241107-e8b5874a-PR25940-arm64-v8a/assets/python3.12/lib/python3.12/site-packages/setuptools-72.1.0-py3.12.egg/setuptools/gui-32.exe
    12K  1 Jan  1981 kodi-20241107-e8b5874a-PR25940-arm64-v8a/assets/python3.12/lib/python3.12/site-packages/setuptools-72.1.0-py3.12.egg/setuptools/gui.exe

```
Same story with webos

Have included files sizes for reference. Maybe that'll cut out near 2 mb?

## How has this been tested?
Locally

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
