### PR TITLE
[tools/depends] init and propogate python version number from VERSION file

### DIFF
--- a/cmake/modules/FindPython.cmake
+++ b/cmake/modules/FindPython.cmake
@@ -27,11 +27,6 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
      OR CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
     set(Python3_USE_STATIC_LIBS TRUE)
     set(Python3_ROOT_DIR ${libdir})
-
-    if(KODI_DEPENDSBUILD)
-      # Force set to tools/depends python version
-      set(PYTHON_VER 3.12)
-    endif()
   endif()
 
   # Provide root dir to search for Python if provided

--- a/tools/depends/Makefile.include.in
+++ b/tools/depends/Makefile.include.in
@@ -108,7 +108,9 @@ VERSION.TXT := $(CMAKE_SOURCE_DIR)/version.txt
 APP_NAME=$(shell awk '/APP_NAME/ {print tolower($$2)}' $(VERSION.TXT))
 
 # Python related vars
-PYTHON_VERSION=3.12
+# version populated from tools/depends/target/python3/PYTHON3-VERSION file
+NATIVE_PYTHON_VERSION=@native_py_version@
+PYTHON_VERSION=@target_py_version@
 PYTHON_SITE_PKG=@prefix@/@deps_dir@/lib/python${PYTHON_VERSION}/site-packages
 
 ifeq ($(CPU), arm64)

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -679,6 +679,16 @@ if test "$ffmpeg_options" = "default"; then
   ffmpeg_options="$ffmpeg_options_default"
 fi
 
+# Read python major.minor version from native PYTHON-VERSION file
+m4_define([NATIVE_PYTHON_FILE_INPUT],m4_quote(m4_include([native/python3/PYTHON3-VERSION])))
+m4_define([NATIVE_PYTHON_MAJOR_MINOR],m4_bregexp(NATIVE_PYTHON_FILE_INPUT,[VERSION=\([0-9]+\.[0-9]+\)\.[0-9]+\s*?],[\1]))
+native_py_version=m4_defn([NATIVE_PYTHON_MAJOR_MINOR])
+
+# Read python major.minor version from target PYTHON-VERSION file
+m4_define([TARGET_PYTHON_FILE_INPUT],m4_quote(m4_include([target/python3/PYTHON3-VERSION])))
+m4_define([TARGET_PYTHON_MAJOR_MINOR],m4_bregexp(TARGET_PYTHON_FILE_INPUT,[VERSION=\([0-9]+\.[0-9]+\)\.[0-9]+\s*?],[\1]))
+target_py_version=m4_defn([TARGET_PYTHON_MAJOR_MINOR])
+
 if test "$platform_os" = "android"; then
 echo -e
   AC_SUBST(use_sdk_path)
@@ -688,6 +698,8 @@ echo -e
   AC_SUBST(build_tools_path)
 fi
 
+AC_SUBST(native_py_version)
+AC_SUBST(target_py_version)
 AC_SUBST(meson_system)
 AC_SUBST(meson_cpu)
 AC_SUBST(use_debug)

--- a/tools/depends/native/python3/Makefile
+++ b/tools/depends/native/python3/Makefile
@@ -8,8 +8,6 @@ CONFIGURE=./configure --prefix=$(NATIVEPREFIX) \
                       --without-pymalloc \
                       --with-system-ffi
 
-NATIVE_SITEPACKAGES=$(NATIVEPREFIX)/lib/python$(PYTHON_VERSION)/site-packages
-
 ifeq ($(OS),linux)
   CONFIGURE += --with-system-expat
 endif

--- a/tools/depends/native/pythonmodule-setuptools/Makefile
+++ b/tools/depends/native/pythonmodule-setuptools/Makefile
@@ -2,7 +2,7 @@ include ../../Makefile.include PYTHONMODULE-SETUPTOOLS-VERSION ../../download-fi
 PLATFORM=$(NATIVEPLATFORM)
 DEPS= ../../Makefile.include Makefile PYTHONMODULE-SETUPTOOLS-VERSION ../../download-files.include 01-distutils-flag.patch
 
-LIBDYLIB=$(PLATFORM)/dist/$(LIBNAME)-$(VERSION)-py$(PYTHON_VERSION).egg
+LIBDYLIB=$(PLATFORM)/dist/$(LIBNAME)-$(VERSION)-py$(NATIVE_PYTHON_VERSION).egg
 
 all: .installed-$(PLATFORM)
 
@@ -12,7 +12,7 @@ $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 
 .installed-$(PLATFORM): $(PLATFORM)
 	cd $(PLATFORM); patch -p1 -i ../01-distutils-flag.patch
-	cd $(PLATFORM); PYTHONPATH="$(NATIVEPREFIX)/lib/python${PYTHON_VERSION}/site-packages" $(NATIVEPREFIX)/bin/python3 setup.py install --prefix=$(NATIVEPREFIX)
+	cd $(PLATFORM); PYTHONPATH="$(NATIVEPREFIX)/lib/python${NATIVE_PYTHON_VERSION}/site-packages" $(NATIVEPREFIX)/bin/python3 setup.py install --prefix=$(NATIVEPREFIX)
 	touch $@
 
 clean:

--- a/tools/depends/target/Toolchain.cmake.in
+++ b/tools/depends/target/Toolchain.cmake.in
@@ -218,5 +218,7 @@ set(PROJECT_BUILDENV CC_FOR_BUILD=${CC_FOR_BUILD}
 # variable to easily set host/target env for non cmake internal dep builds
 set(DEP_BUILDENV ${CMAKE_COMMAND} -E env ${PROJECT_TARGETENV} ${PROJECT_BUILDENV})
 
-set(KODI_DEPENDSBUILD 1)
+# version populated from tools/depends/target/python3/PYTHON3-VERSION file
+set(PYTHON_VER @target_py_version@)
 
+set(KODI_DEPENDSBUILD 1)


### PR DESCRIPTION
## Description
python version variable that is used throughout tools/depends, and then also propagated to platform toolchain file for use in cmake build system are now derived from the target PYTHON3-VERSION file.

## Motivation and context
python version no longer needs to be updated in multiple places when a major python change occurs. version variable is now read from targets PYTHON3-VERSION file

## How has this been tested?
locally

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
