### PR TITLE
[Estuary] Fix Channel Guide breadcrumb.

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -544,8 +544,9 @@
 		<value>$LOCALIZE[19019] / $INFO[VideoPlayer.ChannelGroup]</value>
 	</variable>
 	<variable name="BreadcrumbsPVRChannelGuideVar">
-		<value condition="PVR.IsPlayingTV">$LOCALIZE[19020] / $LOCALIZE[19069] / $INFO[VideoPlayer.ChannelName]</value>
-		<value>$LOCALIZE[19021] / $LOCALIZE[19069] / $INFO[VideoPlayer.ChannelName]</value>
+		<value condition="Window.IsActive(TVChannels)">$LOCALIZE[19020] / $LOCALIZE[19069] / $INFO[ListItem.ChannelName]</value>
+		<value condition="Window.IsActive(RadioChannels)">$LOCALIZE[19021] / $LOCALIZE[19069] / $INFO[ListItem.ChannelName]</value>
+		<value condition="!String.IsEmpty(ListItem.ChannelName)">$LOCALIZE[19069] / $INFO[ListItem.ChannelName]</value>
 	</variable>
 	<variable name="BreadcrumbsGameVar">
 		<value>$LOCALIZE[15016]</value>


### PR DESCRIPTION
My first approach to include the channel name in chall guide's bredcrumb was faulty, because I did not know that the guide can also be brought up when not playing anything, for example from the context menu of a channel displayed in the recently watched channels widget on Estuary home screen. 

Thus, using "PVR.IsPlayingLiveTV" condition was wrong. This PR fixes that by now using other conditions and "ListItem.ChannelName". Unfortunately, when not triggered from channels window I do not know whether a channel is TV or radio. But I do not see this as a problem.

<img width="1710" alt="Screenshot_2024-11-08_at_15_40_29" src="https://github.com/user-attachments/assets/a08dfdb5-7dd5-4668-991c-c42cbe2b8465">
<img width="1710" alt="Screenshot_2024-11-09_at_12_15_09" src="https://github.com/user-attachments/assets/426166dd-8363-485e-a3ee-82ff4606b61e">

@jjd-uk could you please have a look.
