### PR TITLE
[addons] Fix compiler warnings: conversion from 'size_t' to 'unsigned int', possible loss of data

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/General.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/General.h
@@ -135,7 +135,7 @@ public:
   {
     FreeResources(*source, *size);
     *source = nullptr;
-    *size = values.size();
+    *size = static_cast<unsigned int>(values.size());
     if (*size)
       *source = AllocAndCopyData(values);
   }
@@ -261,7 +261,7 @@ public:
   {
     FreeResources(*source, *size);
     *source = nullptr;
-    *size = values.size();
+    *size = static_cast<unsigned int>(values.size());
     if (*size)
       *source = AllocAndCopyData(values);
   }
@@ -872,7 +872,7 @@ public:
   {
     FreeResources(*source, *size);
     *source = nullptr;
-    *size = defs.size();
+    *size = static_cast<unsigned int>(defs.size());
     if (*size)
       *source = AllocAndCopyData(defs);
   }
@@ -1042,7 +1042,7 @@ public:
   {
     FreeResources(*source, *size);
     *source = nullptr;
-    *size = values.size();
+    *size = static_cast<unsigned int>(values.size());
     if (*size)
       *source = AllocAndCopyData(values);
   }


### PR DESCRIPTION
Fixes compiler warnings I spotted in build logs.

@neo1973 could you please have a look?