### PR TITLE
[PVR] Make reminders created from reminder rules editable.

### DIFF
--- a/xbmc/pvr/timers/PVRTimerType.cpp
+++ b/xbmc/pvr/timers/PVRTimerType.cpp
@@ -57,7 +57,7 @@ const std::vector<std::shared_ptr<CPVRTimerType>> CPVRTimerType::GetAllTypes()
   // one time read-only time-based reminder (created by timer rule)
   allTypes.emplace_back(std::make_shared<CPVRTimerType>(
       ++iTypeId,
-      PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_IS_REMINDER | PVR_TIMER_TYPE_IS_READONLY |
+      PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_IS_REMINDER |
           PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE | PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
           PVR_TIMER_TYPE_SUPPORTS_START_TIME | PVR_TIMER_TYPE_SUPPORTS_END_TIME,
       g_localizeStrings.Get(819))); // One time (Scheduled by timer rule)
@@ -76,10 +76,9 @@ const std::vector<std::shared_ptr<CPVRTimerType>> CPVRTimerType::GetAllTypes()
   // one time read-only epg-based reminder (created by timer rule)
   allTypes.emplace_back(std::make_shared<CPVRTimerType>(
       ++iTypeId,
-      PVR_TIMER_TYPE_IS_REMINDER | PVR_TIMER_TYPE_IS_READONLY |
-          PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE | PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
-          PVR_TIMER_TYPE_SUPPORTS_CHANNELS | PVR_TIMER_TYPE_SUPPORTS_START_TIME |
-          PVR_TIMER_TYPE_SUPPORTS_START_MARGIN,
+      PVR_TIMER_TYPE_IS_REMINDER | PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
+          PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE | PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
+          PVR_TIMER_TYPE_SUPPORTS_START_TIME | PVR_TIMER_TYPE_SUPPORTS_START_MARGIN,
       g_localizeStrings.Get(819))); // One time (Scheduled by timer rule)
 
   return allTypes;


### PR DESCRIPTION
With this small change, some of the settings of reminders created by a reminder timer rule are now editable.

Example: 

<img width="1379" alt="Screenshot_2024-11-09_at_12_42_23" src="https://github.com/user-attachments/assets/c57abcfd-406d-4cc5-93c6-3414e31f2faa">
 
<img width="1375" alt="Screenshot_2024-11-09_at_12_40_52" src="https://github.com/user-attachments/assets/a160a086-44b8-4f98-9de2-ef00c87e66da">

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish could you please review?