### PR TITLE
Add a scaling factor to `XBMC_ResizeEvent`

### DIFF
--- a/xbmc/application/AppInboundProtocol.cpp
+++ b/xbmc/application/AppInboundProtocol.cpp
@@ -70,7 +70,8 @@ void CAppInboundProtocol::HandleEvents()
           if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_fullScreen)
           {
             CServiceBroker::GetWinSystem()->GetGfxContext().ApplyWindowResize(
-                newEvent.resize.width, newEvent.resize.height);
+                newEvent.resize.width * newEvent.resize.scale,
+                newEvent.resize.height * newEvent.resize.scale);
 
             const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
             settings->SetInt(CSettings::SETTING_WINDOW_WIDTH, newEvent.resize.width);

--- a/xbmc/application/AppInboundProtocol.cpp
+++ b/xbmc/application/AppInboundProtocol.cpp
@@ -69,12 +69,12 @@ void CAppInboundProtocol::HandleEvents()
         {
           if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_fullScreen)
           {
-            CServiceBroker::GetWinSystem()->GetGfxContext().ApplyWindowResize(newEvent.resize.w,
-                                                                              newEvent.resize.h);
+            CServiceBroker::GetWinSystem()->GetGfxContext().ApplyWindowResize(
+                newEvent.resize.width, newEvent.resize.height);
 
             const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-            settings->SetInt(CSettings::SETTING_WINDOW_WIDTH, newEvent.resize.w);
-            settings->SetInt(CSettings::SETTING_WINDOW_HEIGHT, newEvent.resize.h);
+            settings->SetInt(CSettings::SETTING_WINDOW_WIDTH, newEvent.resize.width);
+            settings->SetInt(CSettings::SETTING_WINDOW_HEIGHT, newEvent.resize.height);
             settings->Save();
           }
           else

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -1519,8 +1519,8 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
   {
     XBMC_Event newEvent = {};
     newEvent.type = XBMC_VIDEORESIZE;
-    newEvent.resize.w = pMsg->param1;
-    newEvent.resize.h = pMsg->param2;
+    newEvent.resize.width = pMsg->param1;
+    newEvent.resize.height = pMsg->param2;
     m_pAppPort->OnEvent(newEvent);
     CServiceBroker::GetGUI()->GetWindowManager().MarkDirty();
   }

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -1521,6 +1521,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
     newEvent.type = XBMC_VIDEORESIZE;
     newEvent.resize.width = pMsg->param1;
     newEvent.resize.height = pMsg->param2;
+    newEvent.resize.scale = 1.0;
     m_pAppPort->OnEvent(newEvent);
     CServiceBroker::GetGUI()->GetWindowManager().MarkDirty();
   }

--- a/xbmc/windowing/X11/WinEventsX11.cpp
+++ b/xbmc/windowing/X11/WinEventsX11.cpp
@@ -384,8 +384,8 @@ bool CWinEventsX11::MessagePump()
         m_structureChanged = true;
         XBMC_Event newEvent = {};
         newEvent.type = XBMC_VIDEORESIZE;
-        newEvent.resize.w = xevent.xconfigure.width;
-        newEvent.resize.h = xevent.xconfigure.height;
+        newEvent.resize.width = xevent.xconfigure.width;
+        newEvent.resize.height = xevent.xconfigure.height;
         if (appPort)
           ret |= appPort->OnEvent(newEvent);
         CServiceBroker::GetGUI()->GetWindowManager().MarkDirty();

--- a/xbmc/windowing/X11/WinEventsX11.cpp
+++ b/xbmc/windowing/X11/WinEventsX11.cpp
@@ -386,6 +386,7 @@ bool CWinEventsX11::MessagePump()
         newEvent.type = XBMC_VIDEORESIZE;
         newEvent.resize.width = xevent.xconfigure.width;
         newEvent.resize.height = xevent.xconfigure.height;
+        newEvent.resize.scale = 1.0;
         if (appPort)
           ret |= appPort->OnEvent(newEvent);
         CServiceBroker::GetGUI()->GetWindowManager().MarkDirty();

--- a/xbmc/windowing/XBMC_events.h
+++ b/xbmc/windowing/XBMC_events.h
@@ -59,6 +59,7 @@ typedef struct XBMC_MouseButtonEvent {
 typedef struct XBMC_ResizeEvent {
   int width; /* New width */
   int height; /* New height */
+  double scale; /* Scaling factor */
 } XBMC_ResizeEvent;
 
 typedef struct XBMC_MoveEvent {

--- a/xbmc/windowing/XBMC_events.h
+++ b/xbmc/windowing/XBMC_events.h
@@ -57,8 +57,8 @@ typedef struct XBMC_MouseButtonEvent {
    mode with the new width and height.
  */
 typedef struct XBMC_ResizeEvent {
-	int w;		/* New width */
-	int h;		/* New height */
+  int width; /* New width */
+  int height; /* New height */
 } XBMC_ResizeEvent;
 
 typedef struct XBMC_MoveEvent {

--- a/xbmc/windowing/osx/OpenGL/WindowControllerMacOS.mm
+++ b/xbmc/windowing/osx/OpenGL/WindowControllerMacOS.mm
@@ -64,6 +64,7 @@
     newEvent.type = XBMC_VIDEORESIZE;
     newEvent.resize.width = static_cast<int>(rect.size.width);
     newEvent.resize.height = static_cast<int>(rect.size.height);
+    newEvent.resize.scale = 1.0;
 
     // check for valid sizes cause in some cases
     // we are hit during fullscreen transition from macos

--- a/xbmc/windowing/osx/OpenGL/WindowControllerMacOS.mm
+++ b/xbmc/windowing/osx/OpenGL/WindowControllerMacOS.mm
@@ -62,13 +62,13 @@
 
     XBMC_Event newEvent = {};
     newEvent.type = XBMC_VIDEORESIZE;
-    newEvent.resize.w = static_cast<int>(rect.size.width);
-    newEvent.resize.h = static_cast<int>(rect.size.height);
+    newEvent.resize.width = static_cast<int>(rect.size.width);
+    newEvent.resize.height = static_cast<int>(rect.size.height);
 
     // check for valid sizes cause in some cases
     // we are hit during fullscreen transition from macos
     // and might be technically "zero" sized
-    if (newEvent.resize.w != 0 && newEvent.resize.h != 0)
+    if (newEvent.resize.width != 0 && newEvent.resize.height != 0)
     {
       std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
       if (appPort)

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -888,7 +888,7 @@ void CWinSystemWayland::SetResolutionInternal(CSizeInt size, std::int32_t scale,
       {
         XBMC_Event msg{};
         msg.type = XBMC_VIDEORESIZE;
-        msg.resize = {sizes.bufferSize.Width(), sizes.bufferSize.Height()};
+        msg.resize = {sizes.bufferSize.Width(), sizes.bufferSize.Height(), 1.0};
         // FIXME
         dynamic_cast<CWinEventsWayland&>(*m_winEvents).MessagePush(&msg);
         m_waitingForApply = true;

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -888,7 +888,8 @@ void CWinSystemWayland::SetResolutionInternal(CSizeInt size, std::int32_t scale,
       {
         XBMC_Event msg{};
         msg.type = XBMC_VIDEORESIZE;
-        msg.resize = {sizes.bufferSize.Width(), sizes.bufferSize.Height(), 1.0};
+        msg.resize = {sizes.surfaceSize.Width(), sizes.surfaceSize.Height(),
+                      static_cast<double>(scale)};
         // FIXME
         dynamic_cast<CWinEventsWayland&>(*m_winEvents).MessagePush(&msg);
         m_waitingForApply = true;

--- a/xbmc/windowing/win10/WinEventsWin10.cpp
+++ b/xbmc/windowing/win10/WinEventsWin10.cpp
@@ -186,6 +186,7 @@ void CWinEventsWin10::UpdateWindowSize()
   newEvent.type = XBMC_VIDEORESIZE;
   newEvent.resize.width = size.Width;
   newEvent.resize.height = size.Height;
+  newEvent.resize.scale = 1.0;
   if (g_application.GetRenderGUI() && !DX::Windowing()->IsAlteringWindow() &&
       newEvent.resize.width > 0 && newEvent.resize.height > 0)
     MessagePush(&newEvent);

--- a/xbmc/windowing/win10/WinEventsWin10.cpp
+++ b/xbmc/windowing/win10/WinEventsWin10.cpp
@@ -184,9 +184,10 @@ void CWinEventsWin10::UpdateWindowSize()
 
   XBMC_Event newEvent = {};
   newEvent.type = XBMC_VIDEORESIZE;
-  newEvent.resize.w = size.Width;
-  newEvent.resize.h = size.Height;
-  if (g_application.GetRenderGUI() && !DX::Windowing()->IsAlteringWindow() && newEvent.resize.w > 0 && newEvent.resize.h > 0)
+  newEvent.resize.width = size.Width;
+  newEvent.resize.height = size.Height;
+  if (g_application.GetRenderGUI() && !DX::Windowing()->IsAlteringWindow() &&
+      newEvent.resize.width > 0 && newEvent.resize.height > 0)
     MessagePush(&newEvent);
 }
 

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -610,16 +610,16 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
         {
           g_sizeMoveSizing = false;
           newEvent.type = XBMC_VIDEORESIZE;
-          newEvent.resize.w = g_sizeMoveWidth;
-          newEvent.resize.h = g_sizeMoveHight;
+          newEvent.resize.width = g_sizeMoveWidth;
+          newEvent.resize.height = g_sizeMoveHight;
 
           // tell the device about new size
-          DX::Windowing()->OnResize(newEvent.resize.w, newEvent.resize.h);
+          DX::Windowing()->OnResize(newEvent.resize.width, newEvent.resize.height);
           // tell the application about new size
           const auto& components = CServiceBroker::GetAppComponents();
           const auto appPower = components.GetComponent<CApplicationPowerHandling>();
           if (appPower->GetRenderGUI() && !DX::Windowing()->IsAlteringWindow() &&
-              newEvent.resize.w > 0 && newEvent.resize.h > 0)
+              newEvent.resize.width > 0 && newEvent.resize.height > 0)
           {
             if (appPort)
               appPort->OnEvent(newEvent);
@@ -672,18 +672,18 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
         {
           // API call such as SetWindowPos or SwapChain->SetFullscreenState
           newEvent.type = XBMC_VIDEORESIZE;
-          newEvent.resize.w = g_sizeMoveWidth;
-          newEvent.resize.h = g_sizeMoveHight;
+          newEvent.resize.width = g_sizeMoveWidth;
+          newEvent.resize.height = g_sizeMoveHight;
 
-          CLog::LogFC(LOGDEBUG, LOGWINDOWING, "window resize event {} x {}", newEvent.resize.w,
-                      newEvent.resize.h);
+          CLog::LogFC(LOGDEBUG, LOGWINDOWING, "window resize event {} x {}", newEvent.resize.width,
+                      newEvent.resize.height);
           // tell device about new size
-          DX::Windowing()->OnResize(newEvent.resize.w, newEvent.resize.h);
+          DX::Windowing()->OnResize(newEvent.resize.width, newEvent.resize.height);
           // tell application about size changes
           const auto& components = CServiceBroker::GetAppComponents();
           const auto appPower = components.GetComponent<CApplicationPowerHandling>();
           if (appPower->GetRenderGUI() && !DX::Windowing()->IsAlteringWindow() &&
-              newEvent.resize.w > 0 && newEvent.resize.h > 0)
+              newEvent.resize.width > 0 && newEvent.resize.height > 0)
           {
             if (appPort)
               appPort->OnEvent(newEvent);

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -612,6 +612,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
           newEvent.type = XBMC_VIDEORESIZE;
           newEvent.resize.width = g_sizeMoveWidth;
           newEvent.resize.height = g_sizeMoveHight;
+          newEvent.resize.scale = 1.0;
 
           // tell the device about new size
           DX::Windowing()->OnResize(newEvent.resize.width, newEvent.resize.height);
@@ -674,6 +675,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
           newEvent.type = XBMC_VIDEORESIZE;
           newEvent.resize.width = g_sizeMoveWidth;
           newEvent.resize.height = g_sizeMoveHight;
+          newEvent.resize.scale = 1.0;
 
           CLog::LogFC(LOGDEBUG, LOGWINDOWING, "window resize event {} x {}", newEvent.resize.width,
                       newEvent.resize.height);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

This adds a scaling factor to `XBMC_ResizeEvent`. The scaling factor is applied to the resolution when setting the window size. Before this the already scaled resolution was passed in the event which made it impossible to distinguish what the intended resolution and actually rendered resolution are.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This fixes the issue of windowed Kodi doubling  in size on every start when using Wayland with a scaling factor > 100%. The root of the problem was  in `CAppInboundProtocol` where the already scaled resolution was stored as the user intended resolution in the Kodi settings:

https://github.com/xbmc/xbmc/blob/33107725f9d8054d8807ea2423ae4117a24e68a6/xbmc/application/AppInboundProtocol.cpp#L67-L86

By having a separate scale factor this condition can be handled.

Issue reports:

- https://github.com/xbmc/xbmc/issues/18348#issuecomment-2465744892
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1031975
- https://forum.kodi.tv/showthread.php?tid=379100

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on Arch running KWin with a 125% scale factor. Non Wayland systems shouldn't see a change as their scale factor is always 1.0.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Kodi window doesn't double in size until it refuses to start.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
