### PR TITLE
GL/GLES: Fix shader clipped font rendering

### DIFF
--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -202,21 +202,26 @@ void CGUIFontTTFGL::LastEnd()
         // clip using vertex shader
         renderSystem->ResetScissors();
 
-        float x1 =
-            m_vertexTrans[i].m_clip.x1 - m_vertexTrans[i].m_translateX - m_vertexTrans[i].m_offsetX;
-        float y1 =
-            m_vertexTrans[i].m_clip.y1 - m_vertexTrans[i].m_translateY - m_vertexTrans[i].m_offsetY;
-        float x2 =
-            m_vertexTrans[i].m_clip.x2 - m_vertexTrans[i].m_translateX - m_vertexTrans[i].m_offsetX;
-        float y2 =
-            m_vertexTrans[i].m_clip.y2 - m_vertexTrans[i].m_translateY - m_vertexTrans[i].m_offsetY;
+        const float clipBoundaries[4] = {
+            (m_vertexTrans[i].m_clip.x1 - m_vertexTrans[i].m_translateX -
+             m_vertexTrans[i].m_offsetX) /
+                context.GetGUIScaleX(),
+            (m_vertexTrans[i].m_clip.y1 - m_vertexTrans[i].m_translateY -
+             m_vertexTrans[i].m_offsetY) /
+                context.GetGUIScaleY(),
+            (m_vertexTrans[i].m_clip.x2 - m_vertexTrans[i].m_translateX -
+             m_vertexTrans[i].m_offsetX) /
+                context.GetGUIScaleX(),
+            (m_vertexTrans[i].m_clip.y2 - m_vertexTrans[i].m_translateY -
+             m_vertexTrans[i].m_offsetY) /
+                context.GetGUIScaleY()};
 
-        glUniform4f(clipUniformLoc, x1, y1, x2, y2);
+        glUniform4fv(clipUniformLoc, 1, clipBoundaries);
 
-        // setup texture step
-        float stepX = context.GetGUIScaleX() / (static_cast<float>(m_textureWidth));
-        float stepY = context.GetGUIScaleY() / (static_cast<float>(m_textureHeight));
-        glUniform4f(coordStepUniformLoc, stepX, stepY, 1.0f, 1.0f);
+        const float textureSteps[4] = {1.f / static_cast<float>(m_textureWidth),
+                                       1.f / static_cast<float>(m_textureHeight), 1.f, 1.f};
+
+        glUniform4fv(coordStepUniformLoc, 1, textureSteps);
       }
 
       // calculate the fractional offset to the ideal position

--- a/xbmc/guilib/GUIFontTTFGLES.cpp
+++ b/xbmc/guilib/GUIFontTTFGLES.cpp
@@ -197,21 +197,26 @@ void CGUIFontTTFGLES::LastEnd()
         // clip using vertex shader
         renderSystem->ResetScissors();
 
-        float x1 =
-            m_vertexTrans[i].m_clip.x1 - m_vertexTrans[i].m_translateX - m_vertexTrans[i].m_offsetX;
-        float y1 =
-            m_vertexTrans[i].m_clip.y1 - m_vertexTrans[i].m_translateY - m_vertexTrans[i].m_offsetY;
-        float x2 =
-            m_vertexTrans[i].m_clip.x2 - m_vertexTrans[i].m_translateX - m_vertexTrans[i].m_offsetX;
-        float y2 =
-            m_vertexTrans[i].m_clip.y2 - m_vertexTrans[i].m_translateY - m_vertexTrans[i].m_offsetY;
+        const float clipBoundaries[4] = {
+            (m_vertexTrans[i].m_clip.x1 - m_vertexTrans[i].m_translateX -
+             m_vertexTrans[i].m_offsetX) /
+                context.GetGUIScaleX(),
+            (m_vertexTrans[i].m_clip.y1 - m_vertexTrans[i].m_translateY -
+             m_vertexTrans[i].m_offsetY) /
+                context.GetGUIScaleY(),
+            (m_vertexTrans[i].m_clip.x2 - m_vertexTrans[i].m_translateX -
+             m_vertexTrans[i].m_offsetX) /
+                context.GetGUIScaleX(),
+            (m_vertexTrans[i].m_clip.y2 - m_vertexTrans[i].m_translateY -
+             m_vertexTrans[i].m_offsetY) /
+                context.GetGUIScaleY()};
 
-        glUniform4f(clipUniformLoc, x1, y1, x2, y2);
+        glUniform4fv(clipUniformLoc, 1, clipBoundaries);
 
-        // setup texture step
-        float stepX = context.GetGUIScaleX() / (static_cast<float>(m_textureWidth));
-        float stepY = context.GetGUIScaleY() / (static_cast<float>(m_textureHeight));
-        glUniform4f(coordStepUniformLoc, stepX, stepY, 1.0f, 1.0f);
+        const float textureSteps[4] = {1.f / static_cast<float>(m_textureWidth),
+                                       1.f / static_cast<float>(m_textureHeight), 1.f, 1.f};
+
+        glUniform4fv(coordStepUniformLoc, 1, textureSteps);
       }
 
       // calculate the fractional offset to the ideal position


### PR DESCRIPTION
## Description
Shader based font clipping now accounts for resolutions different to the skin grid.

## Motivation and context
Fixes rotated text.

## How has this been tested?
Arctic Zephyr now renders fine at 4k.

## What is the effect on users?
Rotated text now renders correctly at 4k.

## Screenshots (if appropriate):
Before:
![image](https://github.com/user-attachments/assets/0dba3779-3f64-42b0-93e1-21aa17f75330)

After:
![image](https://github.com/user-attachments/assets/0b4b7d30-9c9d-4011-9da4-e4b24b99fa1b)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
