### PR TITLE
[PVR] Recently added channels widget: Do not remove watched channels

### DIFF
--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -746,9 +746,6 @@ bool CPVRGUIDirectory::GetChannelsDirectory(CFileItemList& results) const
 
         if (dateAdded)
         {
-          if (channel->LastWatched())
-            continue;
-
           const CDateTime dtChannelAdded{channel->DateTimeAdded()};
           if (!dtChannelAdded.IsValid())
             continue;


### PR DESCRIPTION
Initially I thought it would be cute to follow the approach of the recently added movies/shows widgets/nodes to remove watched items from that list, but after using the new widget for a while it seems to me what is okay for movies feels somehow wrong for Live TV channels.

Runtime-tested on macOS and Android, latest kodi master.

@phunkyfish no-brainer, code-wise.