### PR TITLE
[Video] Fix Audio Codec Description for DVD Playback

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5429,6 +5429,7 @@ msgid "File browser"
 msgstr ""
 
 #. Audio Channel count
+#: xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
 #: xbmc/video/dialogs/GUIDialogAudioSettings.cpp
 msgctxt "#10127"
 msgid "channels"
@@ -6727,6 +6728,7 @@ msgstr ""
 #: xbmc/GUIInfoManager.cpp
 #: xbmc/LangInfo.cpp
 #: xbmc/addons/gui/GUIDialogAddonSettings.cpp
+#: xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
 #: xbmc/music/MusicDatabase.cpp
 #: xbmc/peripherals/bus/PeripheralBus.cpp
 #: xbmc/peripherals/devices/Peripheral.cpp
@@ -17070,6 +17072,7 @@ msgstr ""
 
 #. Other informations, in list selector (if present)
 #: xbmc/pvr/dialogs/GUIDialogPVRRadioRDSInfo.cpp
+#: xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
 msgctxt "#29921"
 msgid "Other"
 msgstr ""
@@ -22347,7 +22350,19 @@ msgctxt "#37002"
 msgid "(Director's comments 2)"
 msgstr ""
 
-#empty strings from id 37003 to 37013
+#. DVD short name for 1.0 channel layout
+#: xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+msgctxt "#37003"
+msgid "mono"
+msgstr ""
+
+#. DVD short name for 2.0 channel layout
+#: xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+msgctxt "#37004"
+msgid "stereo"
+msgstr ""
+
+#empty strings from id 37005 to 37013
 
 #: xbmc/GUIInfoManager.cpp
 msgctxt "#37014"

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -1026,60 +1026,62 @@ void CDVDInputStreamNavigator::SetAudioStreamName(AudioStreamInfo &info, const a
   switch(audio_attributes.audio_format)
   {
   case DVD_AUDIO_FORMAT_AC3:
-    info.name += " AC3";
+    info.codecDesc = "AC3";
     info.codecName = "ac3";
     break;
   case DVD_AUDIO_FORMAT_UNKNOWN_1:
-    info.name += " UNKNOWN #1";
+    info.codecDesc = g_localizeStrings.Get(13205); // "Unknown"
+    CLog::LogF(LOGINFO, "unknown dvd audio codec DVD_AUDIO_FORMAT_UNKNOWN_1");
     break;
   case DVD_AUDIO_FORMAT_MPEG:
-    info.name += " MPEG AUDIO";
+    info.codecDesc = "MPEG-1";
     info.codecName = "mp1";
     break;
   case DVD_AUDIO_FORMAT_MPEG2_EXT:
-    info.name += " MP2 Ext.";
+    info.codecDesc = "MPEG-2";
     info.codecName = "mp2";
     break;
   case DVD_AUDIO_FORMAT_LPCM:
-    info.name += " LPCM";
+    info.codecDesc = "LPCM";
     info.codecName = "pcm";
     break;
   case DVD_AUDIO_FORMAT_UNKNOWN_5:
-    info.name += " UNKNOWN #5";
+    info.codecDesc = g_localizeStrings.Get(13205); // "Unknown"
+    CLog::LogF(LOGINFO, "unknown dvd audio codec DVD_AUDIO_FORMAT_UNKNOWN_5");
     break;
   case DVD_AUDIO_FORMAT_DTS:
-    info.name += " DTS";
+    info.codecDesc = "DTS";
     info.codecName = "dts";
     break;
   case DVD_AUDIO_FORMAT_SDDS:
-    info.name += " SDDS";
+    info.codecDesc = "SDDS";
     break;
   default:
-    info.name += " Other";
+    info.codecDesc = g_localizeStrings.Get(13205); // "Unknown"
+    CLog::LogF(LOGINFO, "unknown dvd audio codec");
     break;
   }
+
+  info.codecDesc.append(" ");
 
   switch(audio_attributes.channels + 1)
   {
   case 1:
-    info.name += " Mono";
+    info.codecDesc += g_localizeStrings.Get(37003); // "mono"
     break;
   case 2:
-    info.name += " Stereo";
+    info.codecDesc += g_localizeStrings.Get(37004); // "stereo"
     break;
   case 6:
-    info.name += " 5.1";
+    info.codecDesc += "5.1";
     break;
   case 7:
-    info.name += " 6.1";
+    info.codecDesc += "6.1";
     break;
   default:
-    char temp[32];
-    snprintf(temp, sizeof(temp), " %d-chs", audio_attributes.channels + 1);
-    info.name += temp;
+    info.codecDesc += StringUtils::Format("{:d} {}", audio_attributes.channels + 1,
+                                          g_localizeStrings.Get(10127)); // "channels"
   }
-
-  StringUtils::TrimLeft(info.name);
 }
 
 AudioStreamInfo CDVDInputStreamNavigator::GetAudioStreamInfo(const int iId)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Aligned the information provided for stream selection of DVD audio streams with ffmpeg demux streams.
Use the proper fields and favor ffmpeg stream info (more reliable/detailed) when available. For example:

before:
name = (Director's comments) AC3 5.1
codecDesc = empty
bitrate = empty

after:
name = (Director's comments)
codecDesc = AC3 5.1(side)
bitrate = 448000

ffmpeg info provides a more accurate channels count and description (ex. with IFO nav data: 4 channels, with ffmpeg: 3.1 or quad)

Notes:
- Filling the bitrate field has an impact in the new stream selection dialogs since it's a factor in the streams sorting.
- Some info can be provided by both IFO and demuxer data. I didn't eliminate the partial duplication of the decoding because when a video starts (ie before and during menus, going to main feature and back), CSelectionStreams::Update() seems to be called twice. First with null ffmpeg demuxer (can't rely on ffmpeg info) and then a second time with a valid demuxer (prioritize the demux info). I don't know if the second call always happens and didn't want to disturb something that works, likely receives relatively little testing/use and maybe nobody in the team knows anymore.

Maybe in the future the name could be empty in favor of StreamFlags usage - visually impaired IFO attribute is handled throughout Kodi as a flag value but commentaries are not (assuming that's what StreamFlags::FLAG_COMMENT is for)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

needed for #25947.

Currently when playing a DVD, an audio stream name contains codec name + channel layout and the codec description is empty. This makes things complicated for skins.

For DVD the codec description was built only from IFO information but there are sometimes inaccuracies (channels count in one of my samples) and it doesn't take into account the backwards compatible DTS-ES found on some DVD.

Channel counts with multiple layouts (ex. 4 channels can be 3.1, 4.0) show as 4 channels, even when more detailed info is available in the stream.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

A few DVD with DD+, ac3 stereo, dts streams.
Don't have a DVD with dts-es but tested with an dts-es in mkv that a correct codec desc is built.

Tested DVD with a DTS track declared as 5 channels in IFO > is actually 6 channels, now displayed as such.
1 channel volume is lower than the others, so it's a bit like 4.1 but technically it isn't.

Tested DVD with quad AC3 track. Showed 4 channels, now shows quad (side).

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

More consistent / accurate display of DVD audio streams information.

## Screenshots (if appropriate):

The change is not very significant at this point because the skins work around the problem but it will allow more interesting display of the information.
before

![image](https://github.com/user-attachments/assets/e372f6cc-1171-4c8a-a882-a1159b3c127d)

![image](https://github.com/user-attachments/assets/c3302c75-331f-47f8-adf5-0cb2257d07a3)


after (like other ffmpeg demuxer streams)

![image](https://github.com/user-attachments/assets/00cc9f0f-f822-4937-94bf-a2a85ec9a70a)

![image](https://github.com/user-attachments/assets/469c2fa8-8e22-4c91-aa7c-b5016bef1ee4)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
