### PR TITLE
[Video] Fix blank codec and incorrect channels for some PCM audio streams

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
@@ -117,14 +117,12 @@ std::string CDemuxStreamAudio::GetStreamType()
     case AV_CODEC_ID_VORBIS:
       strInfo = "Vorbis ";
       break;
-    case AV_CODEC_ID_PCM_BLURAY:
-    case AV_CODEC_ID_PCM_DVD:
-      strInfo = "PCM ";
-      break;
     default:
-      strInfo = "";
       break;
   }
+
+  if (codec >= AV_CODEC_ID_PCM_S16LE && codec <= AV_CODEC_ID_PCM_SGA)
+    strInfo = "PCM ";
 
   strInfo += m_channelLayoutName;
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1637,10 +1637,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         st->iBitsPerSample = pStream->codecpar->bits_per_raw_sample;
         char buf[32] = {};
         // https://github.com/FFmpeg/FFmpeg/blob/6ccc3989d15/doc/APIchanges#L50-L53
-        AVChannelLayout layout = {};
-        av_channel_layout_from_mask(&layout, st->iChannelLayout);
-        av_channel_layout_describe(&layout, buf, sizeof(buf));
-        av_channel_layout_uninit(&layout);
+        av_channel_layout_describe(&pStream->codecpar->ch_layout, buf, sizeof(buf));
         st->m_channelLayoutName = buf;
         if (st->iBitsPerSample == 0)
           st->iBitsPerSample = pStream->codecpar->bits_per_coded_sample;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

- Complete the migration to the new channel layout API in CDVDDemuxFFmpeg::AddStream: feed the channel layout provided in the codecpar structure directly into the new API av_channel_layout_describe.
Instead of attempting a conversion to the old API and back to new again, with information loss and no handling of the situation of channels >0 and 0 mask (the provided sample).

- AV_CODEC_ID_PCM_S16LE was not defined in CDemuxStreamAudio::GetStreamType(). Added the currently defined range of PCM codec ids to return "PCM". Testing as a range should be fine since the values are part of the public API. I didn't find an ffmpeg function returning all pcm formats or a is_pcm(), which would be preferable.

Testing the range of pcm id doesn't fit well in the current switch/case structure...
I could have done:
```
    default:
      if (codec >= AV_CODEC_ID_PCM_S16LE && codec <= AV_CODEC_ID_PCM_SGA)
        strInfo = "PCM ";
      else
        strInfo = "";
      break;
```
but that's doesn't look good to me either.


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Sample provided by @jjd-uk showed an empty audio codec description and 0 channels in audio selection, even though it plays fine with audio.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tried the sample and other videos with different codecs and channel counts.

I don't have other pcm examples and don't know if the missing layout is to be expected  with that codec family.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Shows correct codec information for more videos.

## Screenshots (if appropriate):
before (no codec, 0 channels instead of 2)
![image](https://github.com/user-attachments/assets/a738ece3-3277-45ed-bfb2-f4ba7c77994e)

after:
![image](https://github.com/user-attachments/assets/496a5db1-538b-4a64-965c-aa897bafdbb1)
It shows " 2 channels" because of the blank layout mask of the stream.
With a standard stereo mask, it would show "stereo".

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
