### PR TITLE
[tools/depends][target] Python3 build _scproxy module if a platform supports it

### DIFF
--- a/tools/depends/target/python3/Makefile
+++ b/tools/depends/target/python3/Makefile
@@ -54,7 +54,6 @@ PY_MODULES = py_cv_module_audioop=n/a \
              py_cv_module_readline=n/a \
              py_cv_module__curses=n/a \
              py_cv_module__curses_panel=n/a \
-             py_cv_module__scproxy=n/a \
              py_cv_module_xx=n/a \
              py_cv_module_xxlimited=n/a \
              py_cv_module_xxlimited_35=n/a \
@@ -74,7 +73,8 @@ PY_MODULES+= py_cv_module__decimal=n/a \
 
 
 ifeq ($(OS), darwin_embedded)
-  PY_MODULES+= py_cv_module__posixsubprocess=n/a
+  PY_MODULES+= py_cv_module__posixsubprocess=n/a \
+               py_cv_module__scproxy=n/a
 endif
 
 # configuration settings


### PR DESCRIPTION
## Description
Configure detection will disable correctly for most platforms. ios/tvos we explicitly disable, as we dont use the new python ios/tvos building as yet

## Motivation and context
@ksooo 

## How has this been tested?
@ksooo 

## What is the effect on users?
Apparently some python addons fail on macos without _scproxy

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
