### PR TITLE
[utils] Add new label mask for plugin listitem label2 values

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmcplugin.h
+++ b/xbmc/interfaces/legacy/ModuleXbmcplugin.h
@@ -245,6 +245,7 @@ namespace XBMCAddon
     /// | SORT_METHOD_VIDEO_SORT_TITLE            | SORT_METHOD_FULLPATH        | SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE |
     /// | SORT_METHOD_LABEL_IGNORE_FOLDERS        | SORT_METHOD_CHANNEL         |                                         |
     /// @note to add multiple sort methods just call the method multiple times.
+    /// @note see LabelFormatter.cpp for list of available metadata masks
     ///
     ///
     /// ------------------------------------------------------------------------

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -98,12 +98,13 @@ using namespace MUSIC_INFO;
  *  %d - Date and Time
  *  %e - Original release date
  *  %f - bpm
+ *  %h - plugin label2
  *  %p - Last Played
  *  %r - User Rating
  *  *t - Date Taken (suitable for Pictures)
  */
 
-#define MASK_CHARS "NSATBGYFLDIJRCKMEPHZOQUVXWabcdefiprstuv"
+#define MASK_CHARS "NSATBGYFLDIJRCKMEPHZOQUVXWabcdefhiprstuv"
 
 CLabelFormatter::CLabelFormatter(const std::string &mask, const std::string &mask2)
 {
@@ -371,6 +372,9 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
   case 'f': // BPM
     if (music)
       value = std::to_string(music->GetBPM());
+    break;
+  case 'h': //plugin label2
+    value = item->GetLabel2();
     break;
   }
   if (!value.empty())


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Adds a new label mask %h to access a ListItem's Label2 value

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Plugins create listitems via call to `xbmcgui.ListItem([label, label2, path, offscreen])` that can create a minimal ListItem for cases such as isFolder.  Alternatively label2 also has a setter `xbmcgui.ListItem().setLabel2(label)`

For folder items, this is a convenient way to create the folders.  However, the skin info label for ListItem.Label2  is context-dependent using the container content type and sort method via the set of label masks in utils/LabelFormatter.cpp.   PR#16075 updated the masks to allow plugin folder ListItems to set the label2 mask in the sorting method eg. ` xbmcplugin.addSortMethod(handle, sortMethod [,labelMask, label2Mask]) `, in particular for 
`xbmcplugin.SORT_METHOD_NONE `  `xbmcplugin.SORT_METHOD_LABEL ` `xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE `.  But label2Mask currently does not support a mask to return the ListItem's label2.

This PR adds new mask '%h' that returns the ListItem's label2 value.  A typical use case is `xbmcplugin.addSortMethod(handle, xbmcplugin.SORT_METHOD_NONE, '%L',  '%h)` To provide the ListItem's label and label 2 to skin for display as `$INFO[ListItem.Label]` and `$INFO[ListItem.Label2]`.  Skin support is required (default Estuary does not display `$INFO[ListIem.Label2]` in all cases)
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built on VS 2022 and run on Windows x64.  Tested using a custom plugin to use the addSortMethod and new label mask.  Modified Estuary skin to display label2 when Container.Content() (content not set in plugin) and verified the ListItem's label2 value was displayed.  Also ran plugin (with new label mask) in Kodi 21.0 and verified that the new mask had no effect (so plugin remains backward-compatible).

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Plugins can set label2 on ListItems and skin can display the label

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
