### PR TITLE
[Video] Add smart playlist rule types for movies with versions and extras

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -14387,7 +14387,19 @@ msgctxt "#20474"
 msgid "HDR type"
 msgstr ""
 
-#empty strings from id 20475 to 21329
+#. Used in smart playlists as rule field name to select items that have multiple versions
+#: xbmc/playlists/SmartPlayList.cpp
+msgctxt "#20475"
+msgid "Has multiple versions"
+msgstr ""	
+
+#. Used in smart playlists as rule field name to select items that have video extras
+#: xbmc/playlists/SmartPlayList.cpp
+msgctxt "#20476"
+msgid "Has video extras"
+msgstr ""
+
+#empty strings from id 20477 to 21329
 #up to 21329 is reserved for the video db !! !
 
 #: system/settings/settings.xml

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -134,6 +134,8 @@ static const translateField fields[] = {
   { "albumstatus",       FieldAlbumStatus,             CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 38081 },
   { "albumduration",     FieldAlbumDuration,           CDatabaseQueryRule::SECONDS_FIELD,  StringValidation::IsTime,             false, 180 },
   { "hdrtype",           FieldHdrType,                 CDatabaseQueryRule::TEXTIN_FIELD,   NULL,                                 false, 20474 },
+  { "hasversions",       FieldHasVideoVersions,        CDatabaseQueryRule::BOOLEAN_FIELD,  NULL,                                 false, 20475 },
+  { "hasextras",         FieldHasVideoExtras,          CDatabaseQueryRule::BOOLEAN_FIELD,  NULL,                                 false, 20476 },
 };
 // clang-format on
 
@@ -477,6 +479,8 @@ std::vector<Field> CSmartPlaylistRule::GetFields(const std::string &type)
     fields.push_back(FieldSet);
     fields.push_back(FieldTag);
     fields.push_back(FieldDateAdded);
+    fields.push_back(FieldHasVideoVersions);
+    fields.push_back(FieldHasVideoExtras);
     isVideo = true;
   }
   else if (type == "musicvideos")
@@ -788,6 +792,8 @@ std::string CSmartPlaylistRule::GetBooleanQuery(const std::string &negate, const
       return "movie_view.idFile " + negate + " IN (SELECT DISTINCT idFile FROM bookmark WHERE type = 1)";
     else if (m_field == FieldTrailer)
       return negate + GetField(m_field, strType) + "!= ''";
+    else if (m_field == FieldHasVideoVersions || m_field == FieldHasVideoExtras)
+      return negate + GetField(m_field, strType);
   }
   else if (strType == "episodes")
   {

--- a/xbmc/utils/DatabaseUtils.cpp
+++ b/xbmc/utils/DatabaseUtils.cpp
@@ -227,6 +227,10 @@ std::string DatabaseUtils::GetField(Field field, const MediaType &mediaType, Dat
     else if (field == FieldLastPlayed) return "movie_view.lastPlayed";
     else if (field == FieldDateAdded) return "movie_view.dateAdded";
     else if (field == FieldUserRating) return "movie_view.userrating";
+    else if (field == FieldHasVideoVersions)
+      return "movie_view.hasVideoVersions";
+    else if (field == FieldHasVideoExtras)
+      return "movie_view.hasVideoExtras";
 
     if (!result.empty())
       return result;

--- a/xbmc/utils/DatabaseUtils.h
+++ b/xbmc/utils/DatabaseUtils.h
@@ -151,6 +151,8 @@ typedef enum
   FieldHdrType,
   FieldProvider,
   FieldUserPreference,
+  FieldHasVideoVersions,
+  FieldHasVideoExtras,
   FieldMax
 } Field;
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Added a couple smart playlist rule search fields of type movie:
- hasversions - boolean - true for movies with multiple versions
- hasextras - boolean - true for movies with video extras

Both rely on the native video versions/extras library feature.

I don't understand how to control the sort order in the rule types selection dialog, the 2 new types ended up somewhere in the middle.

wiki: https://kodi.wiki/view/Smart_playlists/Rules_and_groupings

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Ability to select movies that have multiple versions or extras using a smart playlist.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Movies with single/multiple version and/or extras in the library.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Ability to create smart playlist that filter movies with/without versions and/or extras.

## Screenshots (if appropriate):

example smartplaylist:
```
<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
<smartplaylist type="movies">
    <name>Movies with extras</name>
    <match>all</match>
    <rule field="hasextras" operator="true"/>
</smartplaylist>
```

smart playlist editor:

![image](https://github.com/user-attachments/assets/1802dd1a-83dd-4b60-b7b5-68d3899b581c)

![image](https://github.com/user-attachments/assets/096f3291-27cb-4a3a-afaf-902e650da3b6)

![image](https://github.com/user-attachments/assets/d5a02a37-44b3-4309-9ef4-40d3b09aa509)

Only movies in the library with extras returned (* icon)
![image](https://github.com/user-attachments/assets/f80f649d-54e8-4f2d-89cb-5e5020841290)



## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
