### PR TITLE
[IFile][CFile] Rework `ReadString` into `ReadLine`

### DIFF
--- a/xbmc/CueDocument.cpp
+++ b/xbmc/CueDocument.cpp
@@ -80,10 +80,9 @@ public:
   bool ReadLine(std::string &line) override
   {
     // Read the next line.
-    while (m_file.ReadString(m_szBuffer, 1023)) // Bigger than MAX_PATH_SIZE, for usage with relax!
+    while (m_file.ReadLine(line))
     {
       // Remove the white space at the beginning and end of the line.
-      line = m_szBuffer;
       StringUtils::Trim(line);
       if (!line.empty())
         return true;
@@ -104,7 +103,6 @@ public:
 private:
   CFile m_file;
   bool m_opened;
-  char m_szBuffer[1024]{};
 };
 
 class BufferReader

--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -872,7 +872,8 @@ bool Interface_Filesystem::read_file_string(void* kodiBase,
     return false;
   }
 
-  return static_cast<CFile*>(file)->ReadString(szLine, lineLength);
+  return static_cast<CFile*>(file)->ReadLine(szLine, lineLength).code !=
+         CFile::ReadLineResult::FAILURE;
 }
 
 ssize_t Interface_Filesystem::write_file(void* kodiBase, void* file, const void* ptr, size_t size)

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -1057,8 +1057,8 @@ extern "C"
     {
       if (pFile->GetPosition() < pFile->GetLength())
       {
-        bool bRead = pFile->ReadString(pszString, num);
-        if (bRead)
+        auto result = pFile->ReadLine(pszString, num);
+        if (result.code != CFile::ReadLineResult::FAILURE)
         {
           return pszString;
         }

--- a/xbmc/cores/RetroPlayer/cheevos/Cheevos.cpp
+++ b/xbmc/cores/RetroPlayer/cheevos/Cheevos.cpp
@@ -85,7 +85,7 @@ bool CCheevos::LoadData()
   response.CURLOpen(0);
 
   char responseStr[RESPONSE_SIZE];
-  response.ReadString(responseStr, RESPONSE_SIZE);
+  response.ReadLine(responseStr, RESPONSE_SIZE);
 
   response.Close();
 

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -297,7 +297,8 @@ std::vector<BLURAY_TITLE_INFO*> CBlurayDirectory::GetUserPlaylists()
   std::string discInfPath = URIUtils::AddFileToFolder(root, "disc.inf");
   std::vector<BLURAY_TITLE_INFO*> userTitles;
   CFile file;
-  char buffer[1025];
+  std::string line;
+  line.reserve(1024);
 
   if (file.Open(discInfPath))
   {
@@ -311,13 +312,13 @@ std::vector<BLURAY_TITLE_INFO*> CBlurayDirectory::GetUserPlaylists()
     }
 
     uint8_t maxLines = 100;
-    while ((maxLines > 0) && file.ReadString(buffer, 1024))
+    while ((maxLines > 0) && file.ReadLine(line))
     {
       maxLines--;
-      if (StringUtils::StartsWithNoCase(buffer, "playlists"))
+      if (StringUtils::StartsWithNoCase(line, "playlists"))
       {
         int pos = 0;
-        while ((pos = pl.RegFind(buffer, static_cast<unsigned int>(pos))) >= 0)
+        while ((pos = pl.RegFind(line, static_cast<unsigned int>(pos))) >= 0)
         {
           std::string playlist = pl.GetMatch(0);
           uint32_t len = static_cast<uint32_t>(playlist.length());

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -46,7 +46,10 @@ namespace XFILE
       int64_t GetLength() override;
       int Stat(const CURL& url, struct __stat64* buffer) override;
       void Close() override;
-      bool ReadString(char *szLine, int iLineLength) override { return m_state->ReadString(szLine, iLineLength); }
+      ReadLineResult ReadLine(char* buffer, std::size_t bufferSize) override
+      {
+        return m_state->ReadLine(buffer, bufferSize);
+      }
       ssize_t Read(void* lpBuf, size_t uiBufSize) override { return m_state->Read(lpBuf, uiBufSize); }
       ssize_t Write(const void* lpBuf, size_t uiBufSize) override;
       const std::string GetProperty(XFILE::FileProperty type, const std::string &name = "") const override;
@@ -129,7 +132,7 @@ namespace XFILE
 
           bool Seek(int64_t pos);
           ssize_t Read(void* lpBuf, size_t uiBufSize);
-          bool ReadString(char *szLine, int iLineLength);
+          ReadLineResult ReadLine(char* buffer, std::size_t bufferSize);
           int8_t FillBuffer(unsigned int want);
           void SetReadBuffer(const void* lpBuf, int64_t uiBufSize);
 

--- a/xbmc/filesystem/FTPDirectory.cpp
+++ b/xbmc/filesystem/FTPDirectory.cpp
@@ -13,6 +13,7 @@
 #include "FileItem.h"
 #include "FileItemList.h"
 #include "URL.h"
+#include "filesystem/IFile.h"
 #include "utils/CharsetConverter.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -43,7 +44,7 @@ bool CFTPDirectory::GetDirectory(const CURL& url2, CFileItemList &items)
   bool serverNotUseUTF8 = url.GetProtocolOption("utf8") == "0";
 
   char buffer[MAX_PATH + 1024];
-  while( reader.ReadString(buffer, sizeof(buffer)) )
+  while (reader.ReadLine(buffer, sizeof(buffer)).code == IFile::ReadLineResult::OK)
   {
     std::string strBuffer = buffer;
 

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -78,9 +78,28 @@ public:
    * \param line[OUT] The line read
    * \return True if has success, otherwise false for EOF or error
    */
-  bool ReadString(std::vector<char>& line);
+  bool ReadLine(std::string& line);
 
-  bool ReadString(char *szLine, int iLineLength);
+  /**
+   * See \ref IFile::ReadLineResult
+   */
+  struct ReadLineResult
+  {
+    enum class ResultCode
+    {
+      FAILURE,
+      TRUNCATED,
+      OK,
+    };
+    using enum ResultCode;
+
+    ResultCode code;
+    std::size_t length;
+  };
+  /**
+   * See \ref IFile
+   */
+  ReadLineResult ReadLine(char* buffer, std::size_t bufferSize);
   /**
    * Attempt to write bufSize bytes from buffer bufPtr into currently opened file.
    * @param bufPtr  pointer to buffer

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -92,7 +92,27 @@ public:
    *         -1 in case of any explicit error
    */
   virtual ssize_t Write(const void* bufPtr, size_t bufSize) { return -1;}
-  virtual bool ReadString(char *szLine, int iLineLength);
+  struct ReadLineResult
+  {
+    enum class ResultCode
+    {
+      FAILURE, ///< Recondition violated, e.g. buffer is nullptr, file not open, EOF already reached, ...
+      TRUNCATED, ///< The line is longer than the supplied buffer. The next read continues reading of the line
+      OK, ///< Read a line
+    };
+    using enum ResultCode;
+
+    ResultCode code; ///< The result of the read operation
+    std::size_t length; ///< length of the read string without null terminator
+  };
+  /**
+   * Reads a line from a file into \p buffer. Reads at most \p bufferLength - 1 bytes from the file.
+   * \p buffer is unchanged in case the returned result code is FAILURE. The read line can contain '\0' characters
+   * @param buffer The buffer into which the line is wrote
+   * @param bufferSize The size of \p buffer
+   * @return See \ref ReadLineResult
+   */
+  virtual ReadLineResult ReadLine(char* buffer, std::size_t bufferSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET) = 0;
   virtual void Close() = 0;
   virtual int64_t GetPosition() = 0;

--- a/xbmc/filesystem/test/TestZipFile.cpp
+++ b/xbmc/filesystem/test/TestZipFile.cpp
@@ -55,7 +55,7 @@ TEST_F(TestZipFile, Read)
   file.Flush();
   EXPECT_EQ(20, file.GetPosition());
   EXPECT_TRUE(!memcmp("About\n-----\nXBMC is ", buf, sizeof(buf) - 1));
-  EXPECT_TRUE(file.ReadString(buf, sizeof(buf)));
+  EXPECT_TRUE(file.ReadLine(buf, sizeof(buf)).code != XFILE::CFile::ReadLineResult::FAILURE);
   EXPECT_EQ(39, file.GetPosition());
   EXPECT_STREQ("an award-winning fr", buf);
   EXPECT_EQ(100, file.Seek(100));

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -64,7 +64,7 @@ CPlayListM3U::~CPlayListM3U(void) = default;
 
 bool CPlayListM3U::Load(const std::string& strFileName)
 {
-  std::vector<char> vLine;
+  std::string strLine;
   std::string strInfo;
   std::vector<std::pair<std::string, std::string> > properties;
 
@@ -88,9 +88,8 @@ bool CPlayListM3U::Load(const std::string& strFileName)
     return false;
   }
 
-  while (file.ReadString(vLine))
+  while (file.ReadLine(strLine))
   {
-    std::string strLine(vLine.begin(), vLine.end());
     StringUtils::Trim(strLine);
 
     if (StringUtils::StartsWith(strLine, InfoMarker))

--- a/xbmc/playlists/PlayListPLS.cpp
+++ b/xbmc/playlists/PlayListPLS.cpp
@@ -79,19 +79,18 @@ bool CPlayListPLS::Load(const std::string &strFile)
     return false;
   }
 
-  char szLine[4096];
   std::string strLine;
+  strLine.reserve(1024);
 
   // run through looking for the [playlist] marker.
   // if we find another http stream, then load it.
   while (true)
   {
-    if ( !file.ReadString(szLine, sizeof(szLine) ) )
+    if (!file.ReadLine(strLine))
     {
       file.Close();
       return size() > 0;
     }
-    strLine = szLine;
     StringUtils::Trim(strLine);
     if(StringUtils::EqualsNoCase(strLine, START_PLAYLIST_MARKER))
       break;
@@ -102,9 +101,8 @@ bool CPlayListPLS::Load(const std::string &strFile)
   }
 
   bool bFailed = false;
-  while (file.ReadString(szLine, sizeof(szLine) ) )
+  while (file.ReadLine(strLine))
   {
-    strLine = szLine;
     StringUtils::RemoveCRLF(strLine);
     size_t iPosEqual = strLine.find('=');
     if (iPosEqual != std::string::npos)

--- a/xbmc/playlists/PlayListURL.cpp
+++ b/xbmc/playlists/PlayListURL.cpp
@@ -30,8 +30,8 @@ CPlayListURL::~CPlayListURL(void) = default;
 
 bool CPlayListURL::Load(const std::string& strFileName)
 {
-  char szLine[4096];
   std::string strLine;
+  strLine.reserve(1024);
 
   Clear();
 
@@ -45,16 +45,14 @@ bool CPlayListURL::Load(const std::string& strFileName)
     return false;
   }
 
-  while (file.ReadString(szLine, 1024))
+  while (file.ReadLine(strLine))
   {
-    strLine = szLine;
     StringUtils::RemoveCRLF(strLine);
 
     if (StringUtils::StartsWith(strLine, "[InternetShortcut]"))
     {
-      if (file.ReadString(szLine,1024))
+      if (file.ReadLine(strLine))
       {
-        strLine  = szLine;
         StringUtils::RemoveCRLF(strLine);
         if (StringUtils::StartsWith(strLine, "URL="))
         {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The function signature of `IFile::ReadString` and `CFile::ReadString` has a major shortcoming: There is no way to detect if a full line or only what fits into the buffer has been read. Also the name doesn't make it clear that it's reading lines.

This PR renames `ReadString` into `ReadLine` and gives it rich error handling capabilities. In addition it returns the number of read bytes which allows proper processing of lines containing `'\0'` bytes and saves some `strlen` calls.

Lastly the better error handling is used to correct the implementation of the `CFile::ReadLine` overload that's reading an arbitrary long line . This fixes #25980. Also the function signature has been changed to work on a `std::string` instead of a `std::vector<char>` as this is was callers want anyway.

**If this approach is welcome I will add unit tests before merging.**

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This fixes #25980. Also the old interface was too vague which caused confusion in the past, see e.g. #22222.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests are passing and the example from #25980 doesn't crash.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
