### PR TITLE
[video] Scan art for video extras

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4971,24 +4971,31 @@ void CVideoDatabase::UpdateArtForItem(int mediaId, const MediaType& mediaType)
   AnnounceUpdate(mediaType, mediaId);
 }
 
-void CVideoDatabase::SetArtForItem(int mediaId, const MediaType &mediaType, const std::map<std::string, std::string> &art)
+bool CVideoDatabase::SetArtForItem(int mediaId,
+                                   const MediaType& mediaType,
+                                   const std::map<std::string, std::string>& art)
 {
-  for (const auto &i : art)
-    SetArtForItem(mediaId, mediaType, i.first, i.second);
+  for (const auto& i : art)
+    if (!SetArtForItem(mediaId, mediaType, i.first, i.second))
+      return false;
+  return true;
 }
 
-void CVideoDatabase::SetArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType, const std::string &url)
+bool CVideoDatabase::SetArtForItem(int mediaId,
+                                   const MediaType& mediaType,
+                                   const std::string& artType,
+                                   const std::string& url)
 {
   try
   {
     if (nullptr == m_pDB)
-      return;
+      return false;
     if (nullptr == m_pDS)
-      return;
+      return false;
 
     // don't set <foo>.<bar> art types - these are derivative types from parent items
     if (artType.find('.') != std::string::npos)
-      return;
+      return true;
 
     std::string sql = PrepareSQL("SELECT art_id,url FROM art WHERE media_id=%i AND media_type='%s' AND type='%s'", mediaId, mediaType.c_str(), artType.c_str());
     m_pDS->query(sql);
@@ -5009,15 +5016,19 @@ void CVideoDatabase::SetArtForItem(int mediaId, const MediaType &mediaType, cons
       sql = PrepareSQL("INSERT INTO art(media_id, media_type, type, url) VALUES (%d, '%s', '%s', '%s')", mediaId, mediaType.c_str(), artType.c_str(), url.c_str());
       m_pDS->exec(sql);
     }
+    return true;
   }
   catch (...)
   {
     CLog::Log(LOGERROR, "{}({}, '{}', '{}', '{}') failed", __FUNCTION__, mediaId, mediaType,
               artType, url);
+    return false;
   }
 }
 
-bool CVideoDatabase::GetArtForItem(int mediaId, const MediaType &mediaType, std::map<std::string, std::string> &art)
+bool CVideoDatabase::GetArtForItem(int mediaId,
+                                   const MediaType& mediaType,
+                                   std::map<std::string, std::string>& art)
 {
   try
   {
@@ -5035,7 +5046,7 @@ bool CVideoDatabase::GetArtForItem(int mediaId, const MediaType &mediaType, std:
       m_pDS2->next();
     }
     m_pDS2->close();
-    return !art.empty();
+    return true;
   }
   catch (...)
   {
@@ -10687,7 +10698,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
       if (StringUtils::StartsWith(movie.m_strTrailer, movie.m_strPath))
         movie.m_strTrailer = movie.m_strTrailer.substr(movie.m_strPath.size());
       std::map<std::string, std::string> artwork;
-      if (GetArtForItem(movie.m_iDbId, movie.m_type, artwork) && singleFile)
+      if (GetArtForItem(movie.m_iDbId, movie.m_type, artwork) && !artwork.empty() && singleFile)
       {
         TiXmlElement additionalNode("art");
         for (const auto &i : artwork)
@@ -10840,7 +10851,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
     {
       CVideoInfoTag movie = GetDetailsForMusicVideo(m_pDS, VideoDbDetailsAll);
       std::map<std::string, std::string> artwork;
-      if (GetArtForItem(movie.m_iDbId, movie.m_type, artwork) && singleFile)
+      if (GetArtForItem(movie.m_iDbId, movie.m_type, artwork) && !artwork.empty() && singleFile)
       {
         TiXmlElement additionalNode("art");
         for (const auto &i : artwork)
@@ -10935,7 +10946,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
       GetTvShowSeasonArt(tvshow.m_iDbId, seasonArt);
 
       std::map<std::string, std::string> artwork;
-      if (GetArtForItem(tvshow.m_iDbId, tvshow.m_type, artwork) && singleFile)
+      if (GetArtForItem(tvshow.m_iDbId, tvshow.m_type, artwork) && !artwork.empty() && singleFile)
       {
         TiXmlElement additionalNode("art");
         for (const auto &i : artwork)
@@ -11043,10 +11054,11 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
       {
         CVideoInfoTag episode = GetDetailsForEpisode(pDS, VideoDbDetailsAll);
         std::map<std::string, std::string> artwork;
-        if (GetArtForItem(episode.m_iDbId, MediaTypeEpisode, artwork) && singleFile)
+        if (GetArtForItem(episode.m_iDbId, MediaTypeEpisode, artwork) && !artwork.empty() &&
+            singleFile)
         {
           TiXmlElement additionalNode("art");
-          for (const auto &i : artwork)
+          for (const auto& i : artwork)
             XMLUtils::SetString(&additionalNode, i.first.c_str(), i.second);
           episode.Save(pMain->LastChild(), "episodedetails", true, &additionalNode);
         }
@@ -12626,13 +12638,25 @@ bool CVideoDatabase::AddVideoAsset(VideoDbContentType itemType,
                              "WHERE idFile = %i",
                              dbId, mediaType.c_str(), videoAssetType, idVideoAsset, idFile));
 
-    if (item.GetVideoInfoTag()->HasStreamDetails())
-      SetStreamDetailsForFileId(item.GetVideoInfoTag()->m_streamDetails, idFile);
+    if (item.GetVideoInfoTag()->HasStreamDetails() &&
+        !SetStreamDetailsForFileId(item.GetVideoInfoTag()->m_streamDetails, idFile))
+    {
+      RollbackTransaction();
+      return false;
+    }
 
-    if (videoAssetType == VideoAssetType::VERSION)
-      SetVideoVersionDefaultArt(idFile, item.GetVideoInfoTag()->m_iDbId, itemType);
+    if (videoAssetType == VideoAssetType::VERSION &&
+        !SetVideoVersionDefaultArt(idFile, item.GetVideoInfoTag()->m_iDbId, itemType))
+    {
+      RollbackTransaction();
+      return false;
+    }
 
-    SetArtForItem(idFile, MediaTypeVideoVersion, item.GetArt());
+    if (!SetArtForItem(idFile, MediaTypeVideoVersion, item.GetArt()))
+    {
+      RollbackTransaction();
+      return false;
+    }
 
     CommitTransaction();
 
@@ -12803,7 +12827,7 @@ std::string CVideoDatabase::GetVideoVersionById(int id)
   return GetSingleValue(PrepareSQL("SELECT name FROM videoversiontype WHERE id=%i", id), m_pDS2);
 }
 
-void CVideoDatabase::SetVideoVersionDefaultArt(int dbId, int idFrom, VideoDbContentType type)
+bool CVideoDatabase::SetVideoVersionDefaultArt(int dbId, int idFrom, VideoDbContentType type)
 {
   MediaType mediaType;
   VideoContentTypeToString(type, mediaType);
@@ -12812,8 +12836,13 @@ void CVideoDatabase::SetVideoVersionDefaultArt(int dbId, int idFrom, VideoDbCont
   if (GetArtForItem(idFrom, mediaType, art))
   {
     for (const auto& it : art)
-      SetArtForItem(dbId, MediaTypeVideoVersion, it.first, it.second);
+      if (!SetArtForItem(dbId, MediaTypeVideoVersion, it.first, it.second))
+        return false;
   }
+  else
+    return false;
+
+  return true;
 }
 
 std::vector<std::string> CVideoDatabase::GetUsedImages(

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -12588,14 +12588,14 @@ void CVideoDatabase::SetVideoVersion(int idFile, int idVideoVersion)
   }
 }
 
-void CVideoDatabase::AddVideoAsset(VideoDbContentType itemType,
+bool CVideoDatabase::AddVideoAsset(VideoDbContentType itemType,
                                    int dbId,
                                    int idVideoVersion,
                                    VideoAssetType videoAssetType,
                                    CFileItem& item)
 {
   if (!m_pDB || !m_pDS)
-    return;
+    return false;
 
   assert(m_pDB->in_transaction() == false);
 
@@ -12605,11 +12605,11 @@ void CVideoDatabase::AddVideoAsset(VideoDbContentType itemType,
     mediaType = MediaTypeMovie;
   }
   else
-    return;
+    return false;
 
   int idFile = AddFile(item.GetPath());
   if (idFile < 0)
-    return;
+    return false;
 
   try
   {
@@ -12631,12 +12631,17 @@ void CVideoDatabase::AddVideoAsset(VideoDbContentType itemType,
     if (videoAssetType == VideoAssetType::VERSION)
       SetVideoVersionDefaultArt(idFile, item.GetVideoInfoTag()->m_iDbId, itemType);
 
+    SetArtForItem(idFile, MediaTypeVideoVersion, item.GetArt());
+
     CommitTransaction();
+
+    return true;
   }
   catch (...)
   {
     CLog::LogF(LOGERROR, "failed for video {}", dbId);
     RollbackTransaction();
+    return false;
   }
 }
 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1093,9 +1093,19 @@ public:
   int AddVideoVersionType(const std::string& typeVideoVersion,
                           VideoAssetTypeOwner owner,
                           VideoAssetType assetType);
+  /*!
+   * \brief Create a new video asset from the provided item and type and attach it to an owner
+   * A file record is created for items with a path new to the database.
+   * \param[in] itemType Parent's type
+   * \param[in] dbId  Parent's id
+   * \param[in] idVideoAsset Video asset identifier / name
+   * \param[in] videoAssetType Type of the video asset
+   * \param[in] item Item to be made into a video asset
+   * \return Success status. true:success, false:failure
+   */
   bool AddVideoAsset(VideoDbContentType itemType,
                      int dbId,
-                     int idVideoVersion,
+                     int idVideoAsset,
                      VideoAssetType videoAssetType,
                      CFileItem& item);
   bool DeleteVideoAsset(int idFile);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1093,7 +1093,7 @@ public:
   int AddVideoVersionType(const std::string& typeVideoVersion,
                           VideoAssetTypeOwner owner,
                           VideoAssetType assetType);
-  void AddVideoAsset(VideoDbContentType itemType,
+  bool AddVideoAsset(VideoDbContentType itemType,
                      int dbId,
                      int idVideoVersion,
                      VideoAssetType videoAssetType,

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -988,9 +988,16 @@ public:
     }
   }
 
-  void SetArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType, const std::string &url);
-  void SetArtForItem(int mediaId, const MediaType &mediaType, const std::map<std::string, std::string> &art);
-  bool GetArtForItem(int mediaId, const MediaType &mediaType, std::map<std::string, std::string> &art);
+  bool SetArtForItem(int mediaId,
+                     const MediaType& mediaType,
+                     const std::string& artType,
+                     const std::string& url);
+  bool SetArtForItem(int mediaId,
+                     const MediaType& mediaType,
+                     const std::map<std::string, std::string>& art);
+  bool GetArtForItem(int mediaId,
+                     const MediaType& mediaType,
+                     std::map<std::string, std::string>& art);
   std::string GetArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType);
 
   void UpdateArtForItem(int mediaId, const MediaType& mediaType);
@@ -1113,7 +1120,7 @@ public:
   bool GetVideoVersionTypes(VideoDbContentType idContent,
                             VideoAssetType asset,
                             CFileItemList& items);
-  void SetVideoVersionDefaultArt(int dbId, int idFrom, VideoDbContentType type);
+  bool SetVideoVersionDefaultArt(int dbId, int idFrom, VideoDbContentType type);
   void InitializeVideoVersionTypeTable(int schemaVersion);
   void UpdateVideoVersionTypeTable();
   bool GetVideoVersionsNav(const std::string& strBaseDir,

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2498,11 +2498,19 @@ namespace KODI::VIDEO
           const int idVideoVersion = m_database.AddVideoVersionType(
               typeVideoVersion, VideoAssetTypeOwner::AUTO, VideoAssetType::EXTRA);
 
-          m_database.AddVideoAsset(ContentToVideoDbType(content), dbId, idVideoVersion,
-                                   VideoAssetType::EXTRA, *item.get());
+          GetArtwork(item.get(), content, true, true, "");
 
-          CLog::Log(LOGDEBUG, "VideoInfoScanner: Added video extras {}",
-                    CURL::GetRedacted(item->GetPath()));
+          if (m_database.AddVideoAsset(ContentToVideoDbType(content), dbId, idVideoVersion,
+                                       VideoAssetType::EXTRA, *item.get()))
+          {
+            CLog::Log(LOGDEBUG, "VideoInfoScanner: Added video extra {}",
+                      CURL::GetRedacted(item->GetPath()));
+          }
+          else
+          {
+            CLog::Log(LOGERROR, "VideoInfoScanner: Failed to add video extra {}",
+                      CURL::GetRedacted(item->GetPath()));
+          }
         },
         [](auto) { return true; }, true,
         CServiceBroker::GetFileExtensionProvider().GetVideoExtensions(), DIR_FLAG_DEFAULTS);

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -426,7 +426,7 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
               artwork))
         item.AppendArt(artwork);
     }
-    else if (m_videoDatabase->GetArtForItem(tag.m_iDbId, tag.m_type, artwork))
+    else if (m_videoDatabase->GetArtForItem(tag.m_iDbId, tag.m_type, artwork) && !artwork.empty())
     {
       item.AppendArt(artwork);
     }

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -418,7 +418,7 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
         CVideoInfoTag details;
         m_database.GetTvShowInfo("", details, params.GetTvShowId());
         std::map<std::string, std::string> art;
-        if (m_database.GetArtForItem(details.m_iDbId, details.m_type, art))
+        if (m_database.GetArtForItem(details.m_iDbId, details.m_type, art) && !art.empty())
         {
           items.AppendArt(art, details.m_type);
           items.SetArtFallback("fanart", "tvshow.fanart");
@@ -456,7 +456,8 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
             seasonID = items[firstIndex]->GetVideoInfoTag()->m_iIdSeason;
 
           CGUIListItem::ArtMap seasonArt;
-          if (seasonID > -1 && m_database.GetArtForItem(seasonID, MediaTypeSeason, seasonArt))
+          if (seasonID > -1 && m_database.GetArtForItem(seasonID, MediaTypeSeason, seasonArt) &&
+              !seasonArt.empty())
           {
             items.AppendArt(seasonArt, MediaTypeSeason);
             // set an art fallback for "thumb"
@@ -473,7 +474,8 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
         if (params.GetSetId() > 0)
         {
           CGUIListItem::ArtMap setArt;
-          if (m_database.GetArtForItem(params.GetSetId(), MediaTypeVideoCollection, setArt))
+          if (m_database.GetArtForItem(params.GetSetId(), MediaTypeVideoCollection, setArt) &&
+              !setArt.empty())
           {
             items.AppendArt(setArt, MediaTypeVideoCollection);
             items.SetArtFallback("fanart", "set.fanart");


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Detect art for extras in library update / scan new content.

Uses the same patterns as movies:
- generic art type names that will apply to all extras in the folder (ex. poster.jpg, fanart.png, ...)
- art type prefixed by the extra name + "-" applies only to the specific extra name (ex. extra1-poster.jpg).

No art detected: falls back to a default thumb extracted from the extra, same as before.

Some of the scanned art types will never be displayed as skins don't show every art type for extras since at this time they're visible only in the extra selection for playback and in the extras manager dialog.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fill some missing features for video extras.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added art of different types to the extras directory, some named after the art type, some prefixed with an extra name.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Ability to set extras art when they're scanned into the library, instead of having to set it manually with the Extras Manager dialog afterwards.

## Screenshots (if appropriate):

With the following file structure:
![image](https://github.com/user-attachments/assets/4e96f0dc-d08e-43ca-b04c-d81760b6d1af)

extra1 receives the art extra1-fanart.jpg and extra1-poster.jpg
extra2 and extra3 receive the art of fanart.jpg and poster.jpg
extras in subdir1 and subdir2 receive art from their respective subfolders (if any), not from the parent folder.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
