### PR TITLE
[guilib] Fix video stream sorting by fps on SortComparerStreamVideo

### DIFF
--- a/xbmc/video/guilib/VideoStreamSelectHelper.cpp
+++ b/xbmc/video/guilib/VideoStreamSelectHelper.cpp
@@ -88,6 +88,10 @@ struct VideoStreamInfoExt : VideoStreamInfo
     isForced = info.flags & StreamFlags::FLAG_FORCED;
     isHearingImpaired = info.flags & StreamFlags::FLAG_HEARING_IMPAIRED;
     isVisualImpaired = info.flags & StreamFlags::FLAG_VISUAL_IMPAIRED;
+
+    fps = static_cast<float>(info.fpsRate);
+    if (fps > 0.0f && info.fpsScale > 0)
+      fps /= info.fpsScale;
   }
 
   int streamId{0};
@@ -96,6 +100,7 @@ struct VideoStreamInfoExt : VideoStreamInfo
   bool isForced{false};
   bool isHearingImpaired{false};
   bool isVisualImpaired{false};
+  float fps{0.0f};
 };
 
 struct AudioStreamInfoExt : AudioStreamInfo
@@ -164,13 +169,9 @@ struct SortComparerStreamVideo
     {
       return a.hdrType < b.hdrType;
     }
-    if (a.fpsRate != b.fpsRate)
+    if (a.fps != b.fps)
     {
-      return a.fpsRate < b.fpsRate;
-    }
-    if (a.fpsScale != b.fpsScale)
-    {
-      return a.fpsScale < b.fpsScale;
+      return a.fps < b.fps;
     }
     if (a.height != b.height)
     {
@@ -328,12 +329,7 @@ void KODI::VIDEO::GUILIB::OpenDialogSelectVideoStream()
                           std::to_string(info.width) + "x" + std::to_string(info.height));
     fileItem->SetProperty("stream.bitrate",
                           static_cast<int>(std::lrint(static_cast<double>(info.bitrate) / 1000.0)));
-
-    float fps = static_cast<float>(info.fpsRate);
-    if (fps > 0.0f && info.fpsScale > 0)
-      fps /= info.fpsScale;
-
-    fileItem->SetProperty("stream.fps", ConvertFpsToString(fps));
+    fileItem->SetProperty("stream.fps", ConvertFpsToString(info.fps));
 
     fileItem->SetProperty("stream.is3d", !info.stereoMode.empty() && info.stereoMode != "mono");
     fileItem->SetProperty("stream.stereomode", info.stereoMode);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
by using demuxers like inputstream adaptive,
can happens that fpsRate and fpsScale initially come from manifest metadata, but, when you play a stream these are updated with the real video stream metadata this can lead to different values, e.g.

manifest provide 24000:1000
played video stream provide 48:2 (that come from demuxer metadata)

so cause a difference in the sort order,
to fix it precalculate the fps in advance


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
i was testing inputstream adaptive streams

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
initial list:
![immagine](https://github.com/user-attachments/assets/5d272f58-bcf3-4aef-b4d8-fd2a408abc5d)
reopened video list, after selected the 1680x750,
you can notice from the first screenshot, that the highlighted entry has been moved on a wrong position
![immagine](https://github.com/user-attachments/assets/2cfc9814-237b-417b-b13a-bb63968cfd86)


## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
have a consistent video streams list

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
