### PR TITLE
[settings] CSettingsManager::GetSetting: Only complain about not finding a setting when all settings were loaded already.

### DIFF
--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -532,7 +532,8 @@ SettingPtr CSettingsManager::GetSetting(const std::string &id) const
     return setting->second.setting;
   }
 
-  m_logger->debug("requested setting ({}) was not found.", id);
+  if (m_loaded)
+    m_logger->debug("requested setting ({}) was not found.", id);
   return nullptr;
 }
 


### PR DESCRIPTION
Reduces debug logspam during add-on settings initialization when add-on requests first setting value.

```log
2024-11-21 23:52:18.442 T:577038   debug <CSettingsManager>: requested setting (autorec_approxtime) was not found.
```

During initialization of the settings of an add-on it can happen that a setting value cannot be found. Namely all settings having default values and were never touched by a user will not be present in user's add-on settings.xml file. With add-ons defining lots of sensible default settings this can happen a lot and is nothing that needs to be logged. This is just normal behavior. OTOH, logging this can produce hundreds (in my case) of pointless log entries.

<img width="1670" alt="Screenshot 2024-11-22 at 08 35 32" src="https://github.com/user-attachments/assets/0437ca07-cb27-4847-bb27-22a4912a2478">

@neo1973 maybe you can have a look?