### PR TITLE
[PVR] Remove GUIWindowPVRBase::DoRefresh() - not needed anymore, as P…

### DIFF
--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
@@ -31,7 +31,6 @@
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgInfoTag.h"
-#include "pvr/windows/GUIWindowPVRBase.h"
 #include "settings/Settings.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
@@ -220,14 +219,6 @@ bool CPVRGUIActionsChannels::HideChannel(const CFileItem& item) const
   if (!groups->Get(channel->IsRadio())
            ->RemoveFromGroup(groups->GetGroupAll(channel->IsRadio()), groupMember))
     return false;
-
-  CGUIWindowPVRBase* pvrWindow =
-      dynamic_cast<CGUIWindowPVRBase*>(CServiceBroker::GetGUI()->GetWindowManager().GetWindow(
-          CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow()));
-  if (pvrWindow)
-    pvrWindow->DoRefresh();
-  else
-    CLog::LogF(LOGERROR, "Called on non-pvr window. No refresh possible.");
 
   return true;
 }

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -74,12 +74,6 @@ namespace PVR
     void Notify(const PVREvent& event);
     virtual void NotifyEvent(const PVREvent& event);
 
-    /*!
-     * @brief Refresh window content.
-     * @return true, if refresh succeeded, false otherwise.
-     */
-    bool DoRefresh() { return Refresh(true); }
-
     bool ActivatePreviousChannelGroup();
     bool ActivateNextChannelGroup();
     bool OpenChannelGroupSelectionDialog();


### PR DESCRIPTION
…VR window refresh is triggered via messages nowadays.

What subject says: Code is not needed anymore.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish could you please review.