### PR TITLE
[guilib] CGUIWindow::DoProcess: Only focus default control if it can be focused.

### DIFF
--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -337,7 +337,7 @@ void CGUIWindow::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregi
   // check if currently focused control can have it
   // and fallback to default control if not
   CGUIControl* focusedControl = GetFocusedControl();
-  if (focusedControl && !focusedControl->CanFocus())
+  if (focusedControl && !focusedControl->CanFocus() && focusedControl->GetID() != m_defaultControl)
     SET_CONTROL_FOCUS(m_defaultControl, 0);
 }
 


### PR DESCRIPTION
Fixes cause of error log entries "Control x in window y has been asked to focus, but it can't":

```log
2024-11-20 18:03:58.714 T:5162062   error <general>: Control 50 in window 10025 has been asked to focus, but it can't
```

Sometimes the default control cannot be focused, for example, when busy spinner is active on top of other windows.

I was able to reproduce this when opening TV-shows -> Click on a show with ~~multiple seasons~~ **a single season**. But this is just an example.

Runtime-tested on macOS and Android, latest Kodi master.

@neo1973 could you please review?