### PR TITLE
[utils] Fix GroupUtils::Group in-progress count calculation.

### DIFF
--- a/xbmc/utils/GroupUtils.cpp
+++ b/xbmc/utils/GroupUtils.cpp
@@ -125,8 +125,7 @@ bool GroupUtils::Group(GroupBy groupBy, const std::string &baseDir, const CFileI
           iWatched++;
 
         // handle resume points
-        CBookmark bookmark = movieInfo->GetResumePoint();
-        if (bookmark.IsSet())
+        if (movieInfo->GetResumePoint().IsPartWay())
           inProgress++;
 
         //accumulate the path for a multipath construction


### PR DESCRIPTION
For "in progress" count we want to include only movies which have a play position > 0 set. This is what `CBookMark::IsPartWay` is the right method for. `CBookMark::IsSet` however also returns `true` if play position is `0`.

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 maybe you can have a look?
