### PR TITLE
GUILIB: Load greyscale textures as such, instead of converting to RGBA

### DIFF
--- a/xbmc/guilib/FFmpegImage.h
+++ b/xbmc/guilib/FFmpegImage.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2012-2018 Team Kodi
+ *  Copyright (C) 2012-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -62,6 +62,8 @@ public:
 
   bool LoadImageFromMemory(unsigned char* buffer, unsigned int bufSize,
                            unsigned int width, unsigned int height) override;
+  unsigned int GetKDFormat() override;
+  unsigned int GetKDSwizzle() override;
   bool Decode(unsigned char * const pixels, unsigned int width, unsigned int height,
               unsigned int pitch, unsigned int format) override;
   bool CreateThumbnailFromSurface(unsigned char* bufferin, unsigned int width,
@@ -78,7 +80,12 @@ public:
 private:
   static void FreeIOCtx(AVIOContext** ioctx);
   AVFrame* ExtractFrame();
-  bool DecodeFrame(AVFrame* m_pFrame, unsigned int width, unsigned int height, unsigned int pitch, unsigned char * const pixels);
+  bool DecodeFrame(AVFrame* m_pFrame,
+                   unsigned int width,
+                   unsigned int height,
+                   unsigned int pitch,
+                   unsigned char* const pixels,
+                   AVPixelFormat dstFormat);
   static int EncodeFFmpegFrame(AVCodecContext *avctx, AVPacket *pkt, int *got_packet, AVFrame *frame);
   static int DecodeFFmpegFrame(AVCodecContext *avctx, AVFrame *frame, int *got_frame, AVPacket *pkt);
   static AVPixelFormat ConvertFormats(AVFrame* frame);

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -314,14 +314,26 @@ bool CTexture::LoadIImage(IImage* pImage,
   // swscale headers for more info.
   unsigned int textureWidth = ((width + 15) / 16) * 16;
 
-  Allocate(textureWidth, height, XB_FMT_A8R8G8B8);
+  const unsigned int format = pImage->GetKDFormat();
+  const KD_TEX_SWIZ swizzle = static_cast<KD_TEX_SWIZ>(pImage->GetKDSwizzle());
+
+  if (format && SupportsFormat(static_cast<KD_TEX_FMT>(format), swizzle))
+  {
+    m_textureFormat = static_cast<KD_TEX_FMT>(format);
+    m_textureSwizzle = swizzle;
+    Allocate(textureWidth, height);
+  }
+  else
+  {
+    Allocate(textureWidth, height, XB_FMT_A8R8G8B8);
+  }
 
   m_imageWidth = std::min(m_imageWidth, textureWidth);
 
   if (m_pixels == nullptr)
     return false;
 
-  if (!pImage->Decode(m_pixels, width, height, GetPitch(), XB_FMT_A8R8G8B8))
+  if (!pImage->Decode(m_pixels, width, height, GetPitch(), format ? format : static_cast<unsigned int>(XB_FMT_A8R8G8B8)))
     return false;
 
   if (pImage->Orientation())

--- a/xbmc/guilib/TextureBase.cpp
+++ b/xbmc/guilib/TextureBase.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -24,9 +24,14 @@
 void CTextureBase::Allocate(uint32_t width, uint32_t height, XB_FMT format)
 {
   SetKDFormat(format);
+  m_format = format;
+  Allocate(width, height);
+}
+
+void CTextureBase::Allocate(uint32_t width, uint32_t height)
+{
   m_imageWidth = m_originalWidth = width;
   m_imageHeight = m_originalHeight = height;
-  m_format = format;
   m_orientation = 0;
 
   m_textureWidth = m_imageWidth;

--- a/xbmc/guilib/TextureBase.h
+++ b/xbmc/guilib/TextureBase.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -78,6 +78,7 @@ public:
 
   // allocates staging texture space.
   void Allocate(uint32_t width, uint32_t height, XB_FMT format);
+  void Allocate(uint32_t width, uint32_t height);
   void ClampToEdge();
 
   /*! \brief rounds to power of two. deprecated. */

--- a/xbmc/guilib/iimage.h
+++ b/xbmc/guilib/iimage.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2012-2018 Team Kodi
+ *  Copyright (C) 2012-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -25,6 +25,16 @@ public:
    \return true if the image could be loaded
    */
   virtual bool LoadImageFromMemory(unsigned char* buffer, unsigned int bufSize, unsigned int width, unsigned int height)=0;
+  /*!
+   \brief The decoder can offer a more suiting Kodi texture format (for example KD_TEX_FMT_SDR_R8), in addition to the legacy XB_FMT_A8R8G8B8. 
+   \return The Kodi texture format.
+   */
+  virtual unsigned int GetKDFormat() { return 0; }
+  /*!
+   \brief Specifies how the decoded texture has to be swizzled (default KD_TEX_SWIZ_RGBA).
+   \return The Kodi texture swizzle.
+   */
+  virtual unsigned int GetKDSwizzle() { return 0; }
   /*!
    \brief Decodes the previously loaded image data to the output buffer in 32 bit raw bits
    \param pixels The output buffer


### PR DESCRIPTION
## Description
This PR allows to load non-XBT greyscale textures to the GPU.

## Motivation and context
Previously, greyscale textures would be converted to RGBA textures, before they were uploaded to the GPU. As the rendering paths of GL and GLES support single channel textures, this unnecessary step is avoided. 

Other formats/swizzles could be added in the future.

## How has this been tested?
Runs on my desktop and on my Odroid C2.

## What is the effect on users?
In case of Estuary:
- Less RAM usage (-6MB)
- Less memory bandwidth used (-400MB/s at 60fps if otherwise uncompressed)
- Faster handling/upload of greyscale textures

## Screenshots (if appropriate):
Estuary's primary.jpg:
![image](https://github.com/user-attachments/assets/4b96f7d9-120f-4c40-a7b0-44e6c2c32ffb)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
