### PR TITLE
Fix rendering for EGL_KHR_partial_update enabled platforms

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1367,7 +1367,6 @@ bool CGUIWindowManager::Render()
     m_tracker.CleanMarkedRegions(10);
 
   CDirtyRegionList dirtyRegions = m_tracker.GetDirtyRegions();
-  CServiceBroker::GetWinSystem()->SetDirtyRegions(dirtyRegions);
 
   bool hasRendered = false;
   // If we visualize the regions we will always render the entire viewport
@@ -1393,6 +1392,9 @@ bool CGUIWindowManager::Render()
     {
       if (i.IsEmpty())
         continue;
+
+      if (!hasRendered)
+        CServiceBroker::GetWinSystem()->SetDirtyRegions(dirtyRegions);
 
       CServiceBroker::GetWinSystem()->GetGfxContext().SetScissors(i);
       RenderPass();

--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -667,13 +667,16 @@ void CEGLContextUtils::SetDamagedRegions(const CDirtyRegionList& dirtyRegions)
   }
   else
   {
-    EGLint height = eglQuerySurface(m_eglDisplay, m_eglSurface, EGL_HEIGHT, &height);
+    EGLint height = 1080;
+    eglQuerySurface(m_eglDisplay, m_eglSurface, EGL_HEIGHT, &height);
     std::vector<Rect> rects;
     rects.reserve(dirtyRegions.size());
     for (const auto& region : dirtyRegions)
     {
-      rects.push_back({static_cast<EGLint>(region.x1), static_cast<EGLint>(height - region.y2),
-                       static_cast<EGLint>(region.Width()), static_cast<EGLint>(region.Height())});
+      rects.push_back({static_cast<EGLint>(std::round(region.x1)),
+                       static_cast<EGLint>(std::round(height - region.y2)),
+                       static_cast<EGLint>(std::round(region.Width())),
+                       static_cast<EGLint>(std::round(region.Height()))});
     }
     m_eglSetDamageRegionKHR(m_eglDisplay, m_eglSurface, reinterpret_cast<EGLint*>(rects.data()),
                             rects.size());

--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -659,16 +659,23 @@ void CEGLContextUtils::SetDamagedRegions(const CDirtyRegionList& dirtyRegions)
     return;
 
   using Rect = std::array<EGLint, 4>;
+  EGLBoolean damageRegionsResult = EGL_FALSE;
   if (dirtyRegions.empty())
   {
     // add a single (empty) entry, otherwise the whole frame gets rendered
     static Rect zeroRect{};
-    m_eglSetDamageRegionKHR(m_eglDisplay, m_eglSurface, zeroRect.data(), 1);
+    damageRegionsResult = m_eglSetDamageRegionKHR(m_eglDisplay, m_eglSurface, zeroRect.data(), 1);
   }
   else
   {
     EGLint height = 1080;
-    eglQuerySurface(m_eglDisplay, m_eglSurface, EGL_HEIGHT, &height);
+    if (eglQuerySurface(m_eglDisplay, m_eglSurface, EGL_HEIGHT, &height) != EGL_TRUE &&
+        !m_damageRegionError)
+    {
+      CLog::LogF(LOGERROR, "eglQuerySurface failed ({:#x})", eglGetError());
+      m_damageRegionError = true;
+    }
+
     std::vector<Rect> rects;
     rects.reserve(dirtyRegions.size());
     for (const auto& region : dirtyRegions)
@@ -678,8 +685,14 @@ void CEGLContextUtils::SetDamagedRegions(const CDirtyRegionList& dirtyRegions)
                        static_cast<EGLint>(std::round(region.Width())),
                        static_cast<EGLint>(std::round(region.Height()))});
     }
-    m_eglSetDamageRegionKHR(m_eglDisplay, m_eglSurface, reinterpret_cast<EGLint*>(rects.data()),
-                            rects.size());
+    damageRegionsResult = m_eglSetDamageRegionKHR(
+        m_eglDisplay, m_eglSurface, reinterpret_cast<EGLint*>(rects.data()), rects.size());
+  }
+
+  if (damageRegionsResult != EGL_TRUE && !m_damageRegionError)
+  {
+    CLog::LogF(LOGERROR, "Setting damaged region failed ({:#x})", eglGetError());
+    m_damageRegionError = true;
   }
 }
 

--- a/xbmc/utils/EGLUtils.h
+++ b/xbmc/utils/EGLUtils.h
@@ -246,4 +246,5 @@ private:
   PFNEGLSETDAMAGEREGIONKHRPROC m_eglSetDamageRegionKHR{nullptr};
   bool m_partialUpdateSupport{false};
   bool m_bufferAgeSupport{false};
+  bool m_damageRegionError{false};
 };


### PR DESCRIPTION
## Description
Final touches for platforms with EGL_KHR_partial_update support. The main issue is that `eglQuerySurface(m_eglDisplay, m_eglSurface, EGL_HEIGHT, &height)` returns just 1 on current Mesa for some reason :(. 

## Motivation and context
Fixes rendering on EGL_KHR_partial_update enabled platforms.

## How has this been tested?
Runs fine with every algorithmdirtyregions type on my Odroid C2 on Libreelec 13.

## What is the effect on users?
Display the UI properly on Panfrost/Lima systems.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
