### PR TITLE
[guilib] Fix activation of value/browse controls in Smart Playlist Rule dialog

### DIFF
--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -422,13 +422,11 @@ std::vector<std::pair<std::string, int>> CGUIDialogSmartPlaylistRule::GetValidOp
     break;
 
   case CDatabaseQueryRule::PLAYLIST_FIELD:
-    CONTROL_ENABLE(CONTROL_BROWSE);
     labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_EQUALS));
     labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL));
     break;
 
   case CDatabaseQueryRule::BOOLEAN_FIELD:
-    CONTROL_DISABLE(CONTROL_VALUE);
     labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_TRUE));
     labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_FALSE));
     break;
@@ -507,17 +505,18 @@ void CGUIDialogSmartPlaylistRule::UpdateButtons()
     m_rule.m_field = PLAYLIST::CSmartPlaylistRule::GetFields(m_type)[0];
   SET_CONTROL_LABEL(CONTROL_FIELD, PLAYLIST::CSmartPlaylistRule::GetLocalizedField(m_rule.m_field));
 
-  CONTROL_ENABLE(CONTROL_VALUE);
-  if (PLAYLIST::CSmartPlaylistRule::IsFieldBrowseable(m_rule.m_field))
-    CONTROL_ENABLE(CONTROL_BROWSE);
-  else
-    CONTROL_DISABLE(CONTROL_BROWSE);
+  const CDatabaseQueryRule::FIELD_TYPE fieldType = m_rule.GetFieldType(m_rule.m_field);
+
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_VALUE, fieldType != CDatabaseQueryRule::BOOLEAN_FIELD);
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_BROWSE,
+                              PLAYLIST::CSmartPlaylistRule::IsFieldBrowseable(m_rule.m_field));
+
   SET_CONTROL_LABEL(CONTROL_OPERATOR, std::get<0>(OperatorLabel(m_rule.m_operator)));
 
   // update label2 appropriately
   SET_CONTROL_LABEL2(CONTROL_VALUE, m_rule.GetParameter());
   CGUIEditControl::INPUT_TYPE type = CGUIEditControl::INPUT_TYPE_TEXT;
-  CDatabaseQueryRule::FIELD_TYPE fieldType = m_rule.GetFieldType(m_rule.m_field);
+
   switch (fieldType)
   {
   case CDatabaseQueryRule::TEXT_FIELD:


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The logic controlling the value and browse controls activation was split between GetValidOperators() and UpdateButtons() and there were conflicts and errors.

fix: removed from GetValidOperators() (not invoked in important use cases) and consolidated in UpdateButtons().
- value field: enabled, except for boolean rules.
- browse button: enabled for browseable rules (many besides playlists/virtual folders, such as title, year, ...)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Noticed the enabled value field for a boolean rule and how the code supposed to disable it was not taking effect.
As discussed in Slack.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added rules of all types, opened existing rules.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

No confusion for boolean smart playlist rules.

## Screenshots (if appropriate):
before:
![image](https://github.com/user-attachments/assets/cadc26c7-fc7f-4287-a822-f8e4f7e674d0)

after:
![image-1](https://github.com/user-attachments/assets/9f1ce262-5e91-495b-889e-b11ff93f1c24)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
