### PR TITLE
LegacyPathTranslation: modernize

### DIFF
--- a/xbmc/utils/LegacyPathTranslation.cpp
+++ b/xbmc/utils/LegacyPathTranslation.cpp
@@ -11,95 +11,91 @@
 #include "URL.h"
 #include "utils/StringUtils.h"
 
-typedef struct Translator {
-  const char *legacyPath;
-  const char *newPath;
-} Translator;
+#include <algorithm>
+#include <string>
+#include <unordered_map>
+
+namespace
+{
 
 // ATTENTION: Make sure the longer match strings go first
-// because the string match is performed with StringUtils::StartsWith()
-static Translator s_videoDbTranslator[] = {
-  { "videodb://1/1",  "videodb://movies/genres" },
-  { "videodb://1/2",  "videodb://movies/titles" },
-  { "videodb://1/3",  "videodb://movies/years" },
-  { "videodb://1/4",  "videodb://movies/actors" },
-  { "videodb://1/5",  "videodb://movies/directors" },
-  { "videodb://1/6",  "videodb://movies/studios" },
-  { "videodb://1/7",  "videodb://movies/sets" },
-  { "videodb://1/8",  "videodb://movies/countries" },
-  { "videodb://1/9",  "videodb://movies/tags" },
-  { "videodb://1",    "videodb://movies" },
-  { "videodb://2/1",  "videodb://tvshows/genres" },
-  { "videodb://2/2",  "videodb://tvshows/titles" },
-  { "videodb://2/3",  "videodb://tvshows/years" },
-  { "videodb://2/4",  "videodb://tvshows/actors" },
-  { "videodb://2/5",  "videodb://tvshows/studios" },
-  { "videodb://2/9",  "videodb://tvshows/tags" },
-  { "videodb://2",    "videodb://tvshows" },
-  { "videodb://3/1",  "videodb://musicvideos/genres" },
-  { "videodb://3/2",  "videodb://musicvideos/titles" },
-  { "videodb://3/3",  "videodb://musicvideos/years" },
-  { "videodb://3/4",  "videodb://musicvideos/artists" },
-  { "videodb://3/5",  "videodb://musicvideos/albums" },
-  { "videodb://3/9",  "videodb://musicvideos/tags" },
-  { "videodb://3",    "videodb://musicvideos" },
-  { "videodb://4",    "videodb://recentlyaddedmovies" },
-  { "videodb://5",    "videodb://recentlyaddedepisodes" },
-  { "videodb://6",    "videodb://recentlyaddedmusicvideos" }
-};
-
-#define VideoDbTranslatorSize sizeof(s_videoDbTranslator) / sizeof(Translator)
+// because the string match is performed with ::starts_with()
+const auto s_videoDbTranslator = std::unordered_map<std::string, std::string>{
+    {"videodb://1/1", "videodb://movies/genres"},
+    {"videodb://1/2", "videodb://movies/titles"},
+    {"videodb://1/3", "videodb://movies/years"},
+    {"videodb://1/4", "videodb://movies/actors"},
+    {"videodb://1/5", "videodb://movies/directors"},
+    {"videodb://1/6", "videodb://movies/studios"},
+    {"videodb://1/7", "videodb://movies/sets"},
+    {"videodb://1/8", "videodb://movies/countries"},
+    {"videodb://1/9", "videodb://movies/tags"},
+    {"videodb://1", "videodb://movies"},
+    {"videodb://2/1", "videodb://tvshows/genres"},
+    {"videodb://2/2", "videodb://tvshows/titles"},
+    {"videodb://2/3", "videodb://tvshows/years"},
+    {"videodb://2/4", "videodb://tvshows/actors"},
+    {"videodb://2/5", "videodb://tvshows/studios"},
+    {"videodb://2/9", "videodb://tvshows/tags"},
+    {"videodb://2", "videodb://tvshows"},
+    {"videodb://3/1", "videodb://musicvideos/genres"},
+    {"videodb://3/2", "videodb://musicvideos/titles"},
+    {"videodb://3/3", "videodb://musicvideos/years"},
+    {"videodb://3/4", "videodb://musicvideos/artists"},
+    {"videodb://3/5", "videodb://musicvideos/albums"},
+    {"videodb://3/9", "videodb://musicvideos/tags"},
+    {"videodb://3", "videodb://musicvideos"},
+    {"videodb://4", "videodb://recentlyaddedmovies"},
+    {"videodb://5", "videodb://recentlyaddedepisodes"},
+    {"videodb://6", "videodb://recentlyaddedmusicvideos"}};
 
 // ATTENTION: Make sure the longer match strings go first
-// because the string match is performed with StringUtils::StartsWith()
-static Translator s_musicDbTranslator[] = {
-  { "musicdb://10",   "musicdb://singles" },
-  { "musicdb://1",    "musicdb://genres" },
-  { "musicdb://2",    "musicdb://artists" },
-  { "musicdb://3",    "musicdb://albums" },
-  { "musicdb://4",    "musicdb://songs" },
-  { "musicdb://5/1",  "musicdb://top100/albums" },
-  { "musicdb://5/2",  "musicdb://top100/songs" },
-  { "musicdb://5",    "musicdb://top100" },
-  { "musicdb://6",    "musicdb://recentlyaddedalbums" },
-  { "musicdb://7",    "musicdb://recentlyplayedalbums" },
-  { "musicdb://8",    "musicdb://compilations" },
-  { "musicdb://9",    "musicdb://years" }
-};
+// because the string match is performed with ::starts_with()
+const auto s_musicDbTranslator =
+    std::unordered_map<std::string, std::string>{{"musicdb://10", "musicdb://singles"},
+                                                 {"musicdb://1", "musicdb://genres"},
+                                                 {"musicdb://2", "musicdb://artists"},
+                                                 {"musicdb://3", "musicdb://albums"},
+                                                 {"musicdb://4", "musicdb://songs"},
+                                                 {"musicdb://5/1", "musicdb://top100/albums"},
+                                                 {"musicdb://5/2", "musicdb://top100/songs"},
+                                                 {"musicdb://5", "musicdb://top100"},
+                                                 {"musicdb://6", "musicdb://recentlyaddedalbums"},
+                                                 {"musicdb://7", "musicdb://recentlyplayedalbums"},
+                                                 {"musicdb://8", "musicdb://compilations"},
+                                                 {"musicdb://9", "musicdb://years"}};
 
-#define MusicDbTranslatorSize sizeof(s_musicDbTranslator) / sizeof(Translator)
-
-std::string CLegacyPathTranslation::TranslateVideoDbPath(const CURL &legacyPath)
-{
-  return TranslatePath(legacyPath.Get(), s_videoDbTranslator, VideoDbTranslatorSize);
-}
-
-std::string CLegacyPathTranslation::TranslateMusicDbPath(const CURL &legacyPath)
-{
-  return TranslatePath(legacyPath.Get(), s_musicDbTranslator, MusicDbTranslatorSize);
-}
-
-std::string CLegacyPathTranslation::TranslateVideoDbPath(const std::string &legacyPath)
-{
-  return TranslatePath(legacyPath, s_videoDbTranslator, VideoDbTranslatorSize);
-}
-
-std::string CLegacyPathTranslation::TranslateMusicDbPath(const std::string &legacyPath)
-{
-  return TranslatePath(legacyPath, s_musicDbTranslator, MusicDbTranslatorSize);
-}
-
-std::string CLegacyPathTranslation::TranslatePath(const std::string &legacyPath, Translator *translationMap, size_t translationMapSize)
+std::string TranslatePath(const std::string& legacyPath,
+                          const std::unordered_map<std::string, std::string>& translationMap)
 {
   std::string newPath = legacyPath;
-  for (size_t index = 0; index < translationMapSize; index++)
-  {
-    if (StringUtils::StartsWithNoCase(newPath, translationMap[index].legacyPath))
-    {
-      StringUtils::Replace(newPath, translationMap[index].legacyPath, translationMap[index].newPath);
-      break;
-    }
-  }
+  const std::string lowPath = StringUtils::ToLower(legacyPath);
+  const auto it = std::find_if(translationMap.begin(), translationMap.end(),
+                               [&lowPath](const auto& e) { return lowPath.starts_with(e.first); });
+  if (it != translationMap.end())
+    StringUtils::Replace(newPath, it->first, it->second);
 
   return newPath;
+}
+
+} // namespace
+
+std::string CLegacyPathTranslation::TranslateVideoDbPath(const CURL& legacyPath)
+{
+  return TranslatePath(legacyPath.Get(), s_videoDbTranslator);
+}
+
+std::string CLegacyPathTranslation::TranslateMusicDbPath(const CURL& legacyPath)
+{
+  return TranslatePath(legacyPath.Get(), s_musicDbTranslator);
+}
+
+std::string CLegacyPathTranslation::TranslateVideoDbPath(const std::string& legacyPath)
+{
+  return TranslatePath(legacyPath, s_videoDbTranslator);
+}
+
+std::string CLegacyPathTranslation::TranslateMusicDbPath(const std::string& legacyPath)
+{
+  return TranslatePath(legacyPath, s_musicDbTranslator);
 }

--- a/xbmc/utils/LegacyPathTranslation.h
+++ b/xbmc/utils/LegacyPathTranslation.h
@@ -30,8 +30,8 @@ public:
    \param legacyPath Path in the old videodb:// format using numbers
    \return Path in the new videodb:// format using descriptive strings
    */
-  static std::string TranslateVideoDbPath(const CURL &legacyPath);
-  static std::string TranslateVideoDbPath(const std::string &legacyPath);
+  static std::string TranslateVideoDbPath(const CURL& legacyPath);
+  static std::string TranslateVideoDbPath(const std::string& legacyPath);
 
   /*!
    \brief Translates old musicdb:// paths to new ones
@@ -39,9 +39,6 @@ public:
    \param legacyPath Path in the old musicdb:// format using numbers
    \return Path in the new musicdb:// format using descriptive strings
    */
-  static std::string TranslateMusicDbPath(const CURL &legacyPath);
-  static std::string TranslateMusicDbPath(const std::string &legacyPath);
-
-private:
-  static std::string TranslatePath(const std::string &legacyPath, Translator *translationMap, size_t translationMapSize);
+  static std::string TranslateMusicDbPath(const CURL& legacyPath);
+  static std::string TranslateMusicDbPath(const std::string& legacyPath);
 };


### PR DESCRIPTION
use std::unordered_map

## Description
Use unordered_map instead of C array.

## Motivation and context
Modern is good.

## How has this been tested?
It builds

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
