### PR TITLE
[guilib] Smart Playlist Rule Dialog Improvements

### DIFF
--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -421,7 +421,7 @@ void CGUIEditControl::SetInputType(CGUIEditControl::INPUT_TYPE type, const CVari
     m_inputHeading = heading.asString();
   else if (heading.isInteger() && heading.asInteger())
     m_inputHeading = g_localizeStrings.Get(static_cast<uint32_t>(heading.asInteger()));
-  //! @todo Verify the current input string?
+  ValidateInput();
 }
 
 void CGUIEditControl::RecalcRightLabelPosition()

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -353,12 +353,13 @@ void CGUIEditControl::OnClick()
     }
     case INPUT_TYPE_DATE:
     {
-      CDateTime dateTime;
-      dateTime.SetFromDBDate(utf8);
-      if (dateTime < CDateTime(2000,1, 1, 0, 0, 0))
-        dateTime = CDateTime(2000, 1, 1, 0, 0, 0);
       KODI::TIME::SystemTime date;
-      dateTime.GetAsSystemTime(date);
+      CDateTime dateTime;
+      if (dateTime.SetFromDBDate(utf8))
+        dateTime.GetAsSystemTime(date);
+      else
+        KODI::TIME::GetLocalTime(&date);
+
       if (CGUIDialogNumeric::ShowAndGetDate(date, !m_inputHeading.empty() ? m_inputHeading : g_localizeStrings.Get(21420)))
       {
         dateTime = CDateTime(date);

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -264,15 +264,14 @@ bool CSmartPlaylistRule::Validate(const std::string &input, void *data)
   if (validator == NULL)
     return true;
 
-  // split the input into multiple values and validate every value separately
-  std::vector<std::string> values = StringUtils::Split(input, RULE_VALUE_SEPARATOR);
-  for (std::vector<std::string>::const_iterator it = values.begin(); it != values.end(); ++it)
-  {
-    if (!validator(*it, data))
-      return false;
-  }
+  if (input.empty())
+    return validator("", data);
 
-  return true;
+  // Split the input into multiple values and validate every value separately
+  const std::vector<std::string> values{StringUtils::Split(input, RULE_VALUE_SEPARATOR)};
+
+  return (std::all_of(values.begin(), values.end(),
+                      [data, validator](const auto& s) { return validator(s, data); }));
 }
 
 bool CSmartPlaylistRule::ValidateRating(const std::string &input, void *data)

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -10,6 +10,7 @@
 
 #include "ServiceBroker.h"
 #include "Util.h"
+#include "XBDateTime.h"
 #include "dbwrappers/Database.h"
 #include "filesystem/File.h"
 #include "filesystem/SmartPlaylistDirectory.h"
@@ -27,8 +28,10 @@
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
+#include <charconv>
 #include <cstdlib>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <vector>
@@ -72,16 +75,16 @@ static const translateField fields[] = {
   { "year",              FieldYear,                    CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  true,  562 },
   { "time",              FieldTime,                    CDatabaseQueryRule::SECONDS_FIELD,  StringValidation::IsTime,             false, 180 },
   { "playcount",         FieldPlaycount,               CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 567 },
-  { "lastplayed",        FieldLastPlayed,              CDatabaseQueryRule::DATE_FIELD,     NULL,                                 false, 568 },
+  { "lastplayed",        FieldLastPlayed,              CDatabaseQueryRule::DATE_FIELD,     CSmartPlaylistRule::ValidateDate,     false, 568 },
   { "inprogress",        FieldInProgress,              CDatabaseQueryRule::BOOLEAN_FIELD,  NULL,                                 false, 575 },
   { "rating",            FieldRating,                  CDatabaseQueryRule::REAL_FIELD,     CSmartPlaylistRule::ValidateRating,   false, 563 },
   { "userrating",        FieldUserRating,              CDatabaseQueryRule::REAL_FIELD,     CSmartPlaylistRule::ValidateMyRating, false, 38018 },
   { "votes",             FieldVotes,                   CDatabaseQueryRule::REAL_FIELD,     StringValidation::IsPositiveInteger,  false, 205 },
   { "top250",            FieldTop250,                  CDatabaseQueryRule::NUMERIC_FIELD,  NULL,                                 false, 13409 },
   { "mpaarating",        FieldMPAA,                    CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 20074 },
-  { "dateadded",         FieldDateAdded,               CDatabaseQueryRule::DATE_FIELD,     NULL,                                 false, 570 },
-  { "datemodified",      FieldDateModified,            CDatabaseQueryRule::DATE_FIELD,     NULL,                                 false, 39119 },
-  { "datenew",           FieldDateNew,                 CDatabaseQueryRule::DATE_FIELD,     NULL,                                 false, 21877 },
+  { "dateadded",         FieldDateAdded,               CDatabaseQueryRule::DATE_FIELD,     CSmartPlaylistRule::ValidateDate,     false, 570 },
+  { "datemodified",      FieldDateModified,            CDatabaseQueryRule::DATE_FIELD,     CSmartPlaylistRule::ValidateDate,     false, 39119 },
+  { "datenew",           FieldDateNew,                 CDatabaseQueryRule::DATE_FIELD,     CSmartPlaylistRule::ValidateDate,     false, 21877 },
   { "genre",             FieldGenre,                   CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  515 },
   { "plot",              FieldPlot,                    CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 207 },
   { "plotoutline",       FieldPlotOutline,             CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 203 },
@@ -90,7 +93,7 @@ static const translateField fields[] = {
   { "director",          FieldDirector,                CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20339 },
   { "actor",             FieldActor,                   CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20337 },
   { "writers",           FieldWriter,                  CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20417 },
-  { "airdate",           FieldAirDate,                 CDatabaseQueryRule::DATE_FIELD,     NULL,                                 false, 20416 },
+  { "airdate",           FieldAirDate,                 CDatabaseQueryRule::DATE_FIELD,     CSmartPlaylistRule::ValidateDate,     false, 20416 },
   { "hastrailer",        FieldTrailer,                 CDatabaseQueryRule::BOOLEAN_FIELD,  NULL,                                 false, 20423 },
   { "studio",            FieldStudio,                  CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  572 },
   { "country",           FieldCountry,                 CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  574 },
@@ -290,6 +293,60 @@ bool CSmartPlaylistRule::ValidateMyRating(const std::string &input, void *data)
 
   int rating = atoi(strRating.c_str());
   return StringValidation::IsPositiveInteger(input, data) && rating <= 10;
+}
+
+namespace
+{
+template<typename T>
+std::optional<T> ToNumeric(std::string_view str)
+{
+  const char* end{str.data() + str.size()};
+  T result{};
+
+  auto [ptr, ec] = std::from_chars(str.data(), end, result);
+
+  if (ec != std::errc{} || ptr != end || result < 0)
+    return std::nullopt;
+
+  return result;
+}
+} // namespace
+
+bool CSmartPlaylistRule::ValidateDate(const std::string& input, void* data)
+{
+  if (!data)
+    return false;
+
+  CSmartPlaylistRule* rule = static_cast<CSmartPlaylistRule*>(data);
+
+  //! @todo implement a validation for relative dates
+  if (rule->m_operator == CDatabaseQueryRule::OPERATOR_IN_THE_LAST ||
+      rule->m_operator == CDatabaseQueryRule::OPERATOR_NOT_IN_THE_LAST)
+    return true;
+
+  // The date format must be YYYY-MM-DD
+  if (input.size() != 10)
+    return false;
+
+  const std::string_view sv{input};
+
+  if (sv[4] != '-' || sv[7] != '-')
+    return false;
+
+  const auto year{ToNumeric<int>(sv.substr(0, 4))};
+  if (!year.has_value())
+    return false;
+
+  const auto month{ToNumeric<int>(sv.substr(5, 2))};
+  if (!month.has_value())
+    return false;
+
+  const auto day{ToNumeric<int>(sv.substr(8, 2))};
+  if (!day.has_value())
+    return false;
+
+  CDateTime dt;
+  return dt.SetDate(year.value(), month.value(), day.value());
 }
 
 std::vector<Field> CSmartPlaylistRule::GetFields(const std::string &type)

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -50,6 +50,7 @@ public:
   static bool Validate(const std::string &input, void *data);
   static bool ValidateRating(const std::string &input, void *data);
   static bool ValidateMyRating(const std::string &input, void *data);
+  static bool ValidateDate(const std::string& input, void* data);
 
 protected:
   std::string GetField(int field, const std::string& type) const override;

--- a/xbmc/utils/StringValidation.cpp
+++ b/xbmc/utils/StringValidation.cpp
@@ -25,6 +25,9 @@ bool StringValidation::IsTime(const std::string &input, void *data)
   std::string strTime = input;
   StringUtils::Trim(strTime);
 
+  if (strTime.empty())
+    return false;
+
   if (StringUtils::EndsWithNoCase(strTime, " min"))
   {
     strTime = StringUtils::Left(strTime, strTime.size() - 4);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

A few improvements of the smart playlist rule dialog (separate commits for each point)

- added a date format validation for rules of type DATE_FIELD and operators after/before (YYYY-MM-DD as required by the DB) - no change to the date entry dialog, which presents the date in the user's local format.
- correctly parse date rules with a date earlier than Jan 1st, 2000 (which was previously chosen for some reason to mean "invalid date"
- default date changed to the current date, rather than Jan 1st, 2000
- apply the validation to a blank value when the rule type is validated (before: a documented behavior of StringUtils::Split() returns an empty vector for a blank string, resulting in a skip of the validation)
- modified the IsTime validation (ex: movie duration) to reject blank values. They're not valid for any operator.
- apply the validation when creating a new rule, when opening the dialog for existing rules, when changing the field of the rule, when changing the operator (before: validated only when when changing the value)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Reports in forum of failing smart playlist because of incorrect date values, made possible by the lack of validation.
https://forum.kodi.tv/showthread.php?tid=379453

The dialog also allows the creation of rules with blank values even though the field validation requires one.

idea for future change: different hint texts for the different fields, instead of the single hint text set by the skin.
and of course add more validations. For some types, empty value validity depends on the operator (ex. string is [blank] > makes sense. string begins with [blank] > doesn't make sense)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

creation of new rule, modification of existing rule.
date type fields, also other validated types such rule creation with invalid date isnew rule, change the field between all types 
## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Foolproof the creation of smart playlist using date rules.
Rules missing values for fields that require one cannot be created anymore.

## Screenshots (if appropriate):

invalid date / invalid date format: text in red, OK disabled
![image](https://github.com/user-attachments/assets/921355ad-99e7-4103-8e4c-b327456a36f2)

relative date: no validation at this time.
![image](https://github.com/user-attachments/assets/9ad90865-baa0-49be-8b4d-5807ed6eceac)

blank value for a validated field that doesn't allow empty values: text in red, OK disabled
![image](https://github.com/user-attachments/assets/e41017f1-0bb0-4dcf-9e57-6790fdfea5fe)

empty duration is no longer valid for any operator
![image](https://github.com/user-attachments/assets/bd79c981-5dbc-4f42-878e-49d693541c5e)

unvalidated field: no change, the value field doesn't turn red, OK is always enabled
![image](https://github.com/user-attachments/assets/09518d86-a1e5-4e61-9674-d76d49a99e33)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
