### PR TITLE
[LangInfo] Fix set/get language code setting

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -799,7 +799,6 @@ bool CLangInfo::SetLanguage(std::string language /* = "" */, bool reloadServices
   return true;
 }
 
-// three char language code (not win32 specific)
 const std::string& CLangInfo::GetAudioLanguage() const
 {
   if (!m_audioLanguage.empty())
@@ -808,17 +807,33 @@ const std::string& CLangInfo::GetAudioLanguage() const
   return m_languageCodeGeneral;
 }
 
-void CLangInfo::SetAudioLanguage(const std::string& language)
+void CLangInfo::SetAudioLanguage(const std::string& language, bool isIso6392 /* = false */)
 {
-  if (language.empty()
-    || StringUtils::EqualsNoCase(language, "default")
-    || StringUtils::EqualsNoCase(language, "original")
-    || StringUtils::EqualsNoCase(language, "mediadefault")
-    || !g_LangCodeExpander.ConvertToISO6392B(language, m_audioLanguage))
+  if (language.empty() || StringUtils::EqualsNoCase(language, "default") ||
+      StringUtils::EqualsNoCase(language, "original") ||
+      StringUtils::EqualsNoCase(language, "mediadefault"))
+  {
     m_audioLanguage.clear();
+    return;
+  }
+
+  std::string langISO6392;
+  if (isIso6392)
+  {
+    g_LangCodeExpander.ConvertToISO6392B(language, langISO6392);
+  }
+  else
+  {
+    if (g_LangCodeExpander.ConvertToISO6391(language, langISO6392))
+    {
+      // if following conversion (to ISO 639-2) fails it should be because
+      // the language code has been defined by the user, so ignore it
+      g_LangCodeExpander.ConvertISO6391ToISO6392B(langISO6392, langISO6392);
+    }
+  }
+  m_audioLanguage = langISO6392; // empty value for error cases
 }
 
-// three char language code (not win32 specific)
 const std::string& CLangInfo::GetSubtitleLanguage() const
 {
   if (!m_subtitleLanguage.empty())
@@ -827,13 +842,30 @@ const std::string& CLangInfo::GetSubtitleLanguage() const
   return m_languageCodeGeneral;
 }
 
-void CLangInfo::SetSubtitleLanguage(const std::string& language)
+void CLangInfo::SetSubtitleLanguage(const std::string& language, bool isIso6392 /* = false */)
 {
-  if (language.empty()
-    || StringUtils::EqualsNoCase(language, "default")
-    || StringUtils::EqualsNoCase(language, "original")
-    || !g_LangCodeExpander.ConvertToISO6392B(language, m_subtitleLanguage))
+  if (language.empty() || StringUtils::EqualsNoCase(language, "default") ||
+      StringUtils::EqualsNoCase(language, "original"))
+  {
     m_subtitleLanguage.clear();
+    return;
+  }
+
+  std::string langISO6392;
+  if (isIso6392)
+  {
+    g_LangCodeExpander.ConvertToISO6392B(language, langISO6392);
+  }
+  else
+  {
+    if (g_LangCodeExpander.ConvertToISO6391(language, langISO6392))
+    {
+      // if following conversion (to ISO 639-2) fails it should be because
+      // the language code has been defined by the user, so ignore it
+      g_LangCodeExpander.ConvertISO6391ToISO6392B(langISO6392, langISO6392);
+    }
+  }
+  m_subtitleLanguage = langISO6392; // empty value for error cases
 }
 
 // two character codes as defined in ISO639

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -103,18 +103,37 @@ public:
   */
   bool SetLanguage(std::string strLanguage = "", bool reloadServices = true);
 
+  /*
+   * \brief Get the audio language in ISO 639-2 format.
+   * \return The language code (user-defined also allowed), otherwise if "default", "original" or "mediadefault" is set
+   *         to the audio language setting, will fallback to a general language code (e.g. eng)
+   */
   const std::string& GetAudioLanguage() const;
-  // language can either be a two char language code as defined in ISO639
-  // or a three char language code
-  // or a language name in english (as used by XBMC)
-  void SetAudioLanguage(const std::string& language);
 
-  // three char language code (not win32 specific)
+  /*
+   * \brief Set the audio language.
+   * \param language The language can either be a two char language code,
+   *        or a three char language code, or a language name in english,
+   *        also user-defined languages are allowed.
+   * \param isIso6392 Defines that language is in ISO 639-2 format, otherwise will be considered as ISO 639-1 format.
+   */
+  void SetAudioLanguage(const std::string& language, bool isIso6392 = false);
+
+  /*
+   * \brief Get the subtitle language in ISO 639-2 format.
+   * \return The language code (user-defined also allowed), otherwise if "default", "original" is set
+   *         to the subtitle language setting, will fallback to a general language code (e.g. eng)
+   */
   const std::string& GetSubtitleLanguage() const;
-  // language can either be a two char language code as defined in ISO639
-  // or a three char language code
-  // or a language name in english (as used by XBMC)
-  void SetSubtitleLanguage(const std::string& language);
+
+  /*
+   * \brief Set the subtitle language.
+   * \param language The language can either be a two char language code,
+   *        or a three char language code, or a language name in english,
+   *        also user-defined languages are allowed.
+   * \param isIso6392 Defines that language is in ISO 639-2 format, otherwise will be considered as ISO 639-1 format.
+   */
+  void SetSubtitleLanguage(const std::string& language, bool isIso6392 = false);
 
   const std::string GetDVDMenuLanguage() const;
   const std::string GetDVDAudioLanguage() const;
@@ -314,10 +333,9 @@ protected:
   CTemperature::Unit m_temperatureUnit;
   CSpeed::Unit m_speedUnit;
 
-  std::string m_audioLanguage;
-  std::string m_subtitleLanguage;
-  // this is the general (not win32-specific) three char language code
-  std::string m_languageCodeGeneral;
+  std::string m_audioLanguage; // ISO 639-2 three char (not win32 specific)
+  std::string m_subtitleLanguage; // ISO 639-2 three char (not win32 specific)
+  std::string m_languageCodeGeneral; // ISO 639-2 three char (not win32-specific)
 };
 
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
the GUI audio/subtitle language settings make use of language fillers, these fillers get the list of language from the ISO 639-1 list
see AddLanguages on methods
https://github.com/xbmc/xbmc/blob/819d190e08835828e6bb1bb92a278c75bf329b3e/xbmc/LangInfo.cpp#L1242-L1265
https://github.com/xbmc/xbmc/blob/819d190e08835828e6bb1bb92a278c75bf329b3e/xbmc/LangInfo.cpp#L1542-L1549
but our ISO 639-1 list looks like to have some custom "full length" language names
idk the reason behind this but maybe to make more user friendly the GUI (?!) or there are other reasons maybe some kind of legacy compatibility

an example is "Greek" (el) this from specs is defined as "Greek, Modern (1453–)" (el)
so we have a kind of simplified "full length" name

but the problem is that our ISO 639-2 list make use of the standard names, in the case above "Greek, Modern (1453–)" thats correct.

but this incongruence custom vs specs names, make impossible a lookup conversion from the lang name to lang code

we cant change the language list names without breaking user settings, and also i think its more correct make a conversion from the exact ISO instead to mixing ISO 639-1 with ISO 639-2 as done until now.

so since the GUI show the ISO 639-1 list i changed the code to convert the setting value from ISO 639-1 by default

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #26004 
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
i created a custom mkv with greek language,
tested mkv with language code with country e.g. `fr-CA` combined with user defined advancedsetting lang code (test possible regression)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
language selected correctly on playback start

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
