### PR TITLE
[favourites] Cleanup target cache on playback end - resume info and o…

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -55,6 +55,7 @@
 #include "dialogs/GUIDialogSimpleMenu.h"
 #include "events/EventLog.h"
 #include "events/NotificationEvent.h"
+#include "favourites/FavouritesService.h"
 #include "filesystem/Directory.h"
 #include "filesystem/DirectoryCache.h"
 #include "filesystem/DirectoryFactory.h"
@@ -2862,6 +2863,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
   case GUI_MSG_PLAYBACK_STOPPED:
   {
     CServiceBroker::GetPVRManager().OnPlaybackStopped(*m_itemCurrentFile);
+    CServiceBroker::GetFavouritesService().OnPlaybackStopped(*m_itemCurrentFile);
 
     CVariant data(CVariant::VariantTypeObject);
     data["end"] = false;
@@ -2880,6 +2882,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
   case GUI_MSG_PLAYBACK_ENDED:
   {
     CServiceBroker::GetPVRManager().OnPlaybackEnded(*m_itemCurrentFile);
+    CServiceBroker::GetFavouritesService().OnPlaybackEnded(*m_itemCurrentFile);
 
     CVariant data(CVariant::VariantTypeObject);
     data["end"] = true;

--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -171,6 +171,30 @@ void CFavouritesService::ReInit(std::string userDataFolder)
     CLog::Log(LOGDEBUG, "CFavourites::Load - no userdata favourites found, skipping");
 }
 
+void CFavouritesService::CleanupTargetsCache(const CFileItem& item)
+{
+  // Cleanup cache. Resume info etc. of cached target items might need refresh.
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+
+  const std::string dynPath{item.GetDynPath()};
+  std::erase_if(m_targets,
+                [&dynPath](const auto& entry)
+                {
+                  auto const& [key, value] = entry;
+                  return (value->GetDynPath() == dynPath);
+                });
+}
+
+void CFavouritesService::OnPlaybackStopped(const CFileItem& item)
+{
+  CleanupTargetsCache(item);
+}
+
+void CFavouritesService::OnPlaybackEnded(const CFileItem& item)
+{
+  CleanupTargetsCache(item);
+}
+
 bool CFavouritesService::Persist()
 {
   CXBMCTinyXML2 doc;

--- a/xbmc/favourites/FavouritesService.h
+++ b/xbmc/favourites/FavouritesService.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "FileItemList.h"
 #include "threads/CriticalSection.h"
 #include "utils/EventStream.h"
@@ -18,6 +17,8 @@
 #include <unordered_map>
 #include <vector>
 
+class CFileItem;
+
 class CFavouritesService
 {
 public:
@@ -26,6 +27,9 @@ public:
 
   /** For profiles*/
   void ReInit(std::string userDataFolder);
+
+  void OnPlaybackStopped(const CFileItem& item);
+  void OnPlaybackEnded(const CFileItem& item);
 
   bool IsFavourited(const CFileItem& item, int contextWindow) const;
   std::shared_ptr<CFileItem> GetFavourite(const CFileItem& item, int contextWindow) const;
@@ -53,6 +57,8 @@ private:
 
   void OnUpdated();
   bool Persist();
+
+  void CleanupTargetsCache(const CFileItem& item);
 
   std::string m_userDataFolder;
   CFileItemList m_favourites;


### PR DESCRIPTION
…ther data of cached items might need refresh.

Upon playback stop we need to cleanup the favourites target items cache, so that updated resume information etc. are available once the favourite is used (e.g. open context menu).

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 could you please have a look?

