### PR TITLE
VP: Only reset content info cache on videoplayer close

### DIFF
--- a/xbmc/cores/DataCacheCore.cpp
+++ b/xbmc/cores/DataCacheCore.cpp
@@ -47,11 +47,14 @@ void CDataCacheCore::Reset()
     std::unique_lock<CCriticalSection> lock(m_renderSection);
     m_renderInfo = {};
   }
-  {
-    std::unique_lock<CCriticalSection> lock(m_contentSection);
-    m_contentInfo.Reset();
-  }
+  ResetContentInfo();
   m_timeInfo = {};
+}
+
+void CDataCacheCore::ResetContentInfo()
+{
+  std::unique_lock<CCriticalSection> lock(m_contentSection);
+  m_contentInfo.Reset();
 }
 
 bool CDataCacheCore::HasAVInfoChanges()

--- a/xbmc/cores/DataCacheCore.h
+++ b/xbmc/cores/DataCacheCore.h
@@ -23,6 +23,7 @@ public:
   virtual ~CDataCacheCore();
   static CDataCacheCore& GetInstance();
   void Reset();
+  void ResetContentInfo();
   bool HasAVInfoChanges();
   void SignalVideoInfoChange();
   void SignalAudioInfoChange();

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -756,7 +756,7 @@ bool CVideoPlayer::CloseFile(bool reopen)
   }
 
   m_Edl.Clear();
-  CServiceBroker::GetDataCacheCore().Reset();
+  CServiceBroker::GetDataCacheCore().ResetContentInfo();
 
   m_HasVideo = false;
   m_HasAudio = false;


### PR DESCRIPTION
## Description
It seems that `CDataCacheCore` is not only used to store data to be consumed by the info interface but also affects rendering. So https://github.com/xbmc/xbmc/commit/401294dffedb798cc9dcb1c4061ecd3db1ce8cac caused issues when we open a stream with the player already active. Hence this "reverts" to the old implementation where we only cleared the content info (edl/chapter stuff).

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/25993

## How has this been tested?
Runtime tested

## What is the effect on users?
Should fix the aforementioned issue.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

