### PR TITLE
[VideoPlayer] Make sure process info is updated on close

### DIFF
--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -49,7 +49,7 @@ CProcessInfo::CProcessInfo()
 
 void CProcessInfo::SetDataCache(CDataCacheCore *cache)
 {
-  m_dataCache = cache;;
+  m_dataCache = cache;
 
   ResetVideoCodecInfo();
   m_renderGuiLayer = false;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -757,6 +757,7 @@ bool CVideoPlayer::CloseFile(bool reopen)
 
   m_Edl.Clear();
   CServiceBroker::GetDataCacheCore().Reset();
+  m_processInfo->SetDataCache(&CServiceBroker::GetDataCacheCore());
 
   m_HasVideo = false;
   m_HasAudio = false;


### PR DESCRIPTION
## Description
This is an alternative to https://github.com/xbmc/xbmc/pull/26014 to fix https://github.com/xbmc/xbmc/issues/25993.
IMHO the current logic of resetting the datacachecore on `CloseFile` is correct  not being the root cause for the fault.
@smp79 mind give it a go and check if it fixes the issue?

## Motivation and context
DatacacheCore is only updated if the state stored in processinfo is different from the new one. This is done to avoid doing copies of the data:
https://github.com/xbmc/xbmc/blob/master/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp#L623-L629. If we reset the datacachecore it might happen that `m_renderGuiLayer` and `m_dataCache->GetGuiRender(gui)` stop getting synchronised. Hence we need to reset `ProcessInfo` also to defaults (which is done by `CProcessInfo::SetDataCache`)

## How has this been tested?
Runtime tested, playing a second video (dvd iso) while another file is still playing. Variables are now correctly synchronized. 

## What is the effect on users?
Should fix lagging described in https://github.com/xbmc/xbmc/issues/25993

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)


