### PR TITLE
[video] Remove unnecessary stream details extraction in version/extra addition

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -12661,7 +12661,7 @@ bool CVideoDatabase::AddVideoAsset(VideoDbContentType itemType,
       }
     }
 
-    if (item.GetVideoInfoTag()->HasStreamDetails() &&
+    if (item.HasVideoInfoTag() && item.GetVideoInfoTag()->HasStreamDetails() &&
         !SetStreamDetailsForFileId(item.GetVideoInfoTag()->m_streamDetails, idFile))
     {
       RollbackTransaction();

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -193,7 +193,7 @@ bool CGUIDialogVideoManagerExtras::AddVideoExtra()
         }
       }
 
-      // Additional constraints for the converion of a movie version
+      // Additional constraints for the conversion of a movie version
       if (newAsset.m_assetType == VideoAssetType::VERSION &&
           m_database.IsDefaultVideoVersion(newAsset.m_idFile))
       {
@@ -220,8 +220,10 @@ bool CGUIDialogVideoManagerExtras::AddVideoExtra()
 
     CFileItem item{path, false};
 
-    if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-            CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS))
+    // Imperfect test of the existence of stream details but comes at no extra cost.
+    // File is already a video asset implies stream details were extracted => skip extraction
+    if (newAsset.m_idFile <= 0 && CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                                      CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS))
     {
       CDVDFileInfo::GetFileStreamDetails(&item);
       CLog::LogF(LOGDEBUG, "Extracted filestream details from video file {}",

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -589,8 +589,10 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
 
     CFileItem item{path, false};
 
-    if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-            CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS))
+    // Imperfect test of the existence of stream details but comes at no extra cost.
+    // File is already a video asset implies stream details were extracted => skip extraction
+    if (newAsset.m_idFile <= 0 && CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                                      CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS))
     {
       CDVDFileInfo::GetFileStreamDetails(&item);
       CLog::LogF(LOGDEBUG, "Extracted filestream details from video file {}",


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

* Skip stream details extraction from the video when a file added to a movie as version or extra is already a version or extra of another movie.
The stream details were extracted the first time the file was added as version or extra to a movie.

There are more situation where the extraction could be skipped but a db query would be needed to test. This imperfect test comes free because derived from a query earlier in the procedure (GetVideoVersionInfo()).

~~* second commit: refactor the code adding a file as version or extra. It was kept very similar in the versions and extras manager dialogs to facilitate the merge.~~

~~There are many localized messages and they cause many ugly if (version) else if (extra) conditions but I didn't find a satisfying way to refactor them. About half of the messages are tied to the type of dialog and can be handled decently with class inheritance, but the rest is conditional to the current asset type of the file or follow complex conditions.
Maybe how to handle the messages will become clearer if another type of video assets is ever added.~~

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Noticed during testing that moving a video asset between movies caused an unnecessary stream details extraction.

~~The code adding a file as movie version or extra could easily get out of sync and create weird behaviors in the future.~~

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Exercised the different cases handled by the new AddVideoAssetFilePicker() function (formerly CGUIDialogVideoManagerExtras::AddVideoExtra() and CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker())
new unknow file, file that's a version of the same movie, file that's an extra of the same movie,  file that's a version of a different movie, file that's an extra of a different movie, file that's the default version of another movie.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Moving a version or extra to a different movie is slightly faster.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
