### PR TITLE
[guilib] Fonts: Cache width calculation

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -745,8 +745,14 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
 
 float CGUIFontTTF::GetTextWidthInternal(const vecText& text)
 {
+  const std::u32string key(text.begin(), text.end());
+  if (m_textWidthCache.contains(key))
+    return m_textWidthCache[key];
+
   const std::vector<Glyph> glyphs = GetHarfBuzzShapedGlyphs(text);
-  return GetTextWidthInternal(text, glyphs);
+  const float width = GetTextWidthInternal(text, glyphs);
+  m_textWidthCache[key] = width;
+  return width;
 }
 
 // this routine assumes a single line (i.e. it was called from GUITextLayout)

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <stdint.h>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <ft2build.h>
@@ -284,4 +285,5 @@ private:
   CGUIFontTTF(const CGUIFontTTF&) = delete;
   CGUIFontTTF& operator=(const CGUIFontTTF&) = delete;
   int m_referenceCount{0};
+  std::unordered_map<std::u32string, float> m_textWidthCache{};
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Cache the width calculation in `CGUIFontTTF`

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When using the skin arctic horizon 2 I always encountered a severe lag when switching between the movie and shows tab. Profiling showed that most time was spend in `CGUIFontTTF::GetHarfBuzzShapedGlyphs` called from `CGUIFontTTF::GetTextWidthInternal`. That is because `GetHarfBuzzShapedGlyphs` renders the glyphs using harfbuzz which is slow.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
macOS / arctic horizon 2

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Less lag in the UI

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
