### PR TITLE
[video] Fix the scan of extras previously scanned as movies

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2487,32 +2487,44 @@ namespace KODI::VIDEO
         path,
         [this, content, dbId, path](const std::shared_ptr<CFileItem>& item)
         {
-          if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-                  CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS))
-          {
-            CDVDFileInfo::GetFileStreamDetails(item.get());
-            CLog::Log(LOGDEBUG, "VideoInfoScanner: Extracted filestream details from video file {}",
-                      CURL::GetRedacted(item->GetPath()));
-          }
-
           const std::string extraTypeName =
               CGUIDialogVideoManagerExtras::GenerateVideoExtra(path, item->GetPath());
 
           const int idVideoAssetType = m_database.AddVideoVersionType(
               extraTypeName, VideoAssetTypeOwner::AUTO, VideoAssetType::EXTRA);
 
-          GetArtwork(item.get(), content, true, true, "");
+          // the video may have been added to the library as a movie earlier (different settings)
+          const int idMovie{m_database.GetMovieId(item->GetPath())};
 
-          if (m_database.AddVideoAsset(ContentToVideoDbType(content), dbId, idVideoAssetType,
-                                       VideoAssetType::EXTRA, *item.get()))
+          if (idMovie <= 0)
           {
-            CLog::Log(LOGDEBUG, "VideoInfoScanner: Added video extra {}",
-                      CURL::GetRedacted(item->GetPath()));
+            if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                    CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS))
+            {
+              CDVDFileInfo::GetFileStreamDetails(item.get());
+              CLog::Log(LOGDEBUG,
+                        "VideoInfoScanner: Extracted filestream details from video file {}",
+                        CURL::GetRedacted(item->GetPath()));
+            }
+
+            GetArtwork(item.get(), content, true, true, "");
+
+            if (m_database.AddVideoAsset(ContentToVideoDbType(content), dbId, idVideoAssetType,
+                                         VideoAssetType::EXTRA, *item.get()))
+            {
+              CLog::Log(LOGDEBUG, "VideoInfoScanner: Added video extra {}",
+                        CURL::GetRedacted(item->GetPath()));
+            }
+            else
+            {
+              CLog::Log(LOGERROR, "VideoInfoScanner: Failed to add video extra {}",
+                        CURL::GetRedacted(item->GetPath()));
+            }
           }
           else
           {
-            CLog::Log(LOGERROR, "VideoInfoScanner: Failed to add video extra {}",
-                      CURL::GetRedacted(item->GetPath()));
+            m_database.ConvertVideoToVersion(ContentToVideoDbType(content), idMovie, dbId,
+                                             idVideoAssetType, VideoAssetType::EXTRA);
           }
         },
         [](const std::shared_ptr<CFileItem>& dirItem) { return !HasNoMedia(dirItem->GetPath()); },


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Modified the library scanner to check if the extra exists as a movie in the library before creating a new video asset (AddVideoAsset).
If that's the case, use the conversion to asset instead (ConvertVideoToVersion). It knows how to remove the library entry, move any existing attached asset, and create the new extra.

future: unite the library scanner code path with the extras manager "Add file" function.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Found out that with the setting "ignore video extras on scan" turned on, scans of extras create movies in the library, but changing the setting to off later to recognize extras leaves the movie entry in the library when the movie of the extra is rescanned.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The change only affects the library scan.
Checked that an extra previously scanned as movie doesn't leave a movie entry when converted into an extra by a later scan
Checked that there is no change when scanning a new extra, or an extra already known as an extra.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

No movie left behind for extra previously recognized as a movie, then scanned into a proper extra.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
