### PR TITLE
RenderManager: improve VideoPicture comparison for HDR

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
@@ -81,5 +81,46 @@ VideoPicture& VideoPicture::SetParams(const VideoPicture &pic)
   return *this;
 }
 
+bool VideoPicture::CompareDisplayMetadata(const VideoPicture& pic) const
+{
+  if (this->hasDisplayMetadata != pic.hasDisplayMetadata)
+    return false;
+
+  // both this and pic not has display metadata (e.g. SDR video)
+  // returns true because it is equal and there is no need to compare
+  if (!pic.hasDisplayMetadata)
+    return true;
+
+  // both this and pic has display metadata
+  return this->displayMetadata.max_luminance.num == pic.displayMetadata.max_luminance.num &&
+         this->displayMetadata.max_luminance.den == pic.displayMetadata.max_luminance.den &&
+         this->displayMetadata.min_luminance.num == pic.displayMetadata.min_luminance.num &&
+         this->displayMetadata.min_luminance.den == pic.displayMetadata.min_luminance.den;
+}
+
+bool VideoPicture::CompareLightMetadata(const VideoPicture& pic) const
+{
+  if (this->hasLightMetadata != pic.hasLightMetadata)
+    return false;
+
+  // both this and pic not has light metadata (e.g. SDR video)
+  // returns true because it is equal and there is no need to compare
+  if (!pic.hasLightMetadata)
+    return true;
+
+  // both this and pic has light metadata
+  return this->lightMetadata.MaxCLL == pic.lightMetadata.MaxCLL &&
+         this->lightMetadata.MaxFALL == pic.lightMetadata.MaxFALL;
+}
+
+bool VideoPicture::IsSameParams(const VideoPicture& pic) const
+{
+  return this->iWidth == pic.iWidth && this->iHeight == pic.iHeight &&
+         this->iDisplayWidth == pic.iDisplayWidth && this->iDisplayHeight == pic.iDisplayHeight &&
+         this->stereoMode == pic.stereoMode && this->color_primaries == pic.color_primaries &&
+         this->color_transfer == pic.color_transfer && this->hdrType == pic.hdrType &&
+         CompareDisplayMetadata(pic) && CompareLightMetadata(pic);
+}
+
 VideoPicture::VideoPicture(VideoPicture const&) = default;
 VideoPicture& VideoPicture::operator=(VideoPicture const&) = default;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -41,6 +41,7 @@ public:
   VideoPicture& CopyRef(const VideoPicture &pic);
   VideoPicture& SetParams(const VideoPicture &pic);
   void Reset(); // reinitialize members, videoBuffer will be released if set!
+  bool IsSameParams(const VideoPicture& pic) const;
 
   CVideoBuffer *videoBuffer = nullptr;
 
@@ -81,6 +82,9 @@ public:
 private:
   VideoPicture(VideoPicture const&);
   VideoPicture& operator=(VideoPicture const&);
+
+  bool CompareDisplayMetadata(const VideoPicture& pic) const;
+  bool CompareLightMetadata(const VideoPicture& pic) const;
 };
 
 #define DVP_FLAG_TOP_FIELD_FIRST    0x00000001

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -10,7 +10,6 @@
 
 /* to use the same as player */
 #include "../VideoPlayer/DVDClock.h"
-#include "../VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
 #include "RenderCapture.h"
 #include "RenderFactory.h"
 #include "RenderFlags.h"
@@ -98,15 +97,8 @@ bool CRenderManager::Configure(const VideoPicture& picture, float fps, unsigned 
     if (!m_bRenderGUI)
       return true;
 
-    if (m_width == picture.iWidth &&
-        m_height == picture.iHeight &&
-        m_dwidth == picture.iDisplayWidth &&
-        m_dheight == picture.iDisplayHeight &&
-        m_fps == fps &&
-        m_orientation == orientation &&
-        m_stereomode == picture.stereoMode &&
-        m_NumberBuffers == buffers &&
-        m_pRenderer != nullptr &&
+    if (m_picture.IsSameParams(picture) && m_fps == fps && m_orientation == orientation &&
+        m_NumberBuffers == buffers && m_pRenderer != nullptr &&
         !m_pRenderer->ConfigChanged(picture))
     {
       return true;
@@ -138,13 +130,9 @@ bool CRenderManager::Configure(const VideoPicture& picture, float fps, unsigned 
 
   {
     std::unique_lock<CCriticalSection> lock(m_statelock);
-    m_width = picture.iWidth;
-    m_height = picture.iHeight,
-    m_dwidth = picture.iDisplayWidth;
-    m_dheight = picture.iDisplayHeight;
+    m_picture.SetParams(picture);
     m_fps = fps;
     m_orientation = orientation;
-    m_stereomode = picture.stereoMode;
     m_NumberBuffers  = buffers;
     m_renderState = STATE_CONFIGURING;
     m_stateEvent.Reset();
@@ -237,7 +225,7 @@ bool CRenderManager::Configure()
     m_clockSync.Reset();
     m_dvdClock.SetVsyncAdjust(0);
     m_overlays.Reset();
-    m_overlays.SetStereoMode(m_stereomode);
+    m_overlays.SetStereoMode(m_picture.stereoMode);
 
     m_renderState = STATE_CONFIGURED;
 
@@ -411,8 +399,7 @@ void CRenderManager::UnInit()
   DeleteRenderer();
 
   m_renderState = STATE_UNCONFIGURED;
-  m_width = 0;
-  m_height = 0;
+  m_picture.Reset();
   m_bRenderGUI = false;
   RemoveCaptures();
 
@@ -702,7 +689,8 @@ RESOLUTION CRenderManager::GetResolution()
     return res;
 
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_OFF)
-    res = CResolutionUtils::ChooseBestResolution(m_fps, m_width, m_height, !m_stereomode.empty());
+    res = CResolutionUtils::ChooseBestResolution(m_fps, m_picture.iWidth, m_picture.iHeight,
+                                                 !m_picture.stereoMode.empty());
 
   return res;
 }
@@ -908,7 +896,8 @@ void CRenderManager::UpdateResolution()
     {
       if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_OFF && m_fps > 0.0f)
       {
-        RESOLUTION res = CResolutionUtils::ChooseBestResolution(m_fps, m_width, m_height, !m_stereomode.empty());
+        RESOLUTION res = CResolutionUtils::ChooseBestResolution(
+            m_fps, m_picture.iWidth, m_picture.iHeight, !m_picture.stereoMode.empty());
         CServiceBroker::GetWinSystem()->GetGfxContext().SetVideoResolution(res, false);
         UpdateLatencyTweak();
         if (m_pRenderer)
@@ -925,9 +914,9 @@ void CRenderManager::TriggerUpdateResolution(float fps, int width, int height, s
   if (width)
   {
     m_fps = fps;
-    m_width = width;
-    m_height = height;
-    m_stereomode = stereomode;
+    m_picture.iWidth = width;
+    m_picture.iHeight = height;
+    m_picture.stereoMode = stereomode;
   }
   m_bTriggerUpdateResolution = true;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -10,6 +10,7 @@
 
 #include "DVDClock.h"
 #include "DebugRenderer.h"
+#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
 #include "cores/VideoPlayer/VideoRenderers/BaseRenderer.h"
 #include "cores/VideoPlayer/VideoRenderers/OverlayRenderer.h"
 #include "cores/VideoSettings.h"
@@ -204,15 +205,12 @@ protected:
   std::deque<int> m_discard;
 
   std::unique_ptr<VideoPicture> m_pConfigPicture;
-  unsigned int m_width = 0;
-  unsigned int m_height = 0;
-  unsigned int m_dwidth = 0;
-  unsigned int m_dheight = 0;
+
+  VideoPicture m_picture{};
+
   float m_fps = 0.0;
   unsigned int m_orientation = 0;
   int m_NumberBuffers = 0;
-  std::string m_stereomode;
-
   int m_lateframes = -1;
   double m_presentpts = 0.0;
   EPRESENTSTEP m_presentstep = PRESENT_IDLE;


### PR DESCRIPTION
## Description
RenderManager: improve VideoPicture comparison for HDR videos

Fix https://github.com/xbmc/xbmc/issues/24166

## Motivation and context
While working on https://github.com/xbmc/xbmc/pull/26021 found that only are compared limited fields of VideoPicture and nothing related to HDR type or metadata.

With this PR also triggers render re-configure e.g. if switching to video with same dimensions and fps but different HDR type or even same HDR type but different display metadata or light metadata.

Also added color_primaries and color_transfer comparison.
 
## How has this been tested?
Runtime Windows playing different videos without stop previous video.

Specifically tested the case of 4K video with same HDR type (HDR10) but different metadata.

## What is the effect on users?
Fixes some issues like https://github.com/xbmc/xbmc/issues/24166 if different video is playback without stopping previous and videos has different HDR metadata or in case of SDR videos different color primaries, etc.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
