### PR TITLE
Games: Fix delay opening context menu on all file items

### DIFF
--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -20,6 +20,7 @@
 #include "filesystem/CurlFile.h"
 #include "filesystem/File.h"
 #include "filesystem/ZipFile.h"
+#include "games/GameServices.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "utils/Base64.h"
 #include "utils/Digest.h"
@@ -146,6 +147,13 @@ CRepository::CRepository(const AddonInfoPtr& addonInfo) : CAddon(addonInfo, Addo
       CLog::Log(LOGWARNING, "Repository add-on {} disabled peer verification for add-on downloads in path {} - this is insecure and will make your Kodi installation vulnerable to attacks if enabled!", ID(), datadir.GetRedacted());
     }
   }
+}
+
+void CRepository::OnPostInstall(bool update, bool modal)
+{
+  // The repo may contain game add-ons, which can introduce new file
+  // extensions to the list of known game extensions
+  CServiceBroker::GetGameServices().OnAddonRepoInstalled();
 }
 
 bool CRepository::FetchChecksum(const std::string& url,

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -58,6 +58,9 @@ public:
   };
   ResolveResult ResolvePathAndHash(AddonPtr const& addon) const;
 
+  // Implementation of CAddon
+  void OnPostInstall(bool update, bool modal) override;
+
 private:
   static bool FetchChecksum(const std::string& url,
                             std::string& checksum,

--- a/xbmc/games/GameServices.cpp
+++ b/xbmc/games/GameServices.cpp
@@ -29,6 +29,9 @@ CGameServices::CGameServices(CControllerManager& controllerManager,
     m_gameSettings(new CGameSettings()),
     m_agentInput(std::make_unique<CAgentInput>(peripheralManager, inputManager))
 {
+  // Load the add-ons from the database asynchronously
+  m_initializationTask =
+      std::async(std::launch::async, []() { CGameUtils::UpdateInstallableAddons(); });
 }
 
 CGameServices::~CGameServices() = default;

--- a/xbmc/games/GameServices.cpp
+++ b/xbmc/games/GameServices.cpp
@@ -11,6 +11,7 @@
 #include "controllers/Controller.h"
 #include "controllers/ControllerManager.h"
 #include "games/GameSettings.h"
+#include "games/GameUtils.h"
 #include "games/agents/input/AgentInput.h"
 #include "profiles/ProfileManager.h"
 
@@ -66,4 +67,9 @@ std::string CGameServices::TranslateFeature(const std::string& controllerId,
 std::string CGameServices::GetSavestatesFolder() const
 {
   return m_profileManager.GetSavestatesFolder();
+}
+
+void CGameServices::OnAddonRepoInstalled()
+{
+  CGameUtils::UpdateInstallableAddons();
 }

--- a/xbmc/games/GameServices.h
+++ b/xbmc/games/GameServices.h
@@ -10,6 +10,7 @@
 
 #include "controllers/ControllerTypes.h"
 
+#include <future>
 #include <memory>
 #include <string>
 
@@ -89,6 +90,9 @@ private:
   // Game services
   std::unique_ptr<CGameSettings> m_gameSettings;
   std::unique_ptr<CAgentInput> m_agentInput;
+
+  // Game threads
+  std::future<void> m_initializationTask;
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/GameServices.h
+++ b/xbmc/games/GameServices.h
@@ -72,6 +72,14 @@ public:
 
   CAgentInput& AgentInput() { return *m_agentInput; }
 
+  /*!
+   * \brief Called when an add-on repo is installed
+   *
+   * If the repo contains game add-ons, it can introduce new file extensions
+   * to the list of known game extensions.
+   */
+  void OnAddonRepoInstalled();
+
 private:
   // Construction parameters
   CControllerManager& m_controllerManager;

--- a/xbmc/games/GameUtils.h
+++ b/xbmc/games/GameUtils.h
@@ -10,6 +10,7 @@
 
 #include "GameTypes.h"
 
+#include <mutex>
 #include <set>
 #include <string>
 
@@ -71,6 +72,12 @@ public:
    */
   static bool IsStandaloneGame(const ADDON::AddonPtr& addon);
 
+  /*!
+   * \brief Called when the cache of installable game add-ons should be
+   * refreshed, such as when a new add-on repo is installed
+   */
+  static void UpdateInstallableAddons();
+
 private:
   static void GetGameClients(const CFileItem& file,
                              GameClientVector& candidates,
@@ -101,6 +108,22 @@ private:
    * \return True if the game client is enabled, false otherwise
    */
   static bool Enable(const std::string& gameClient);
+
+  /*!
+   * \brief Cache of installable game add-ons used to compute the list of
+   * known game file extensions
+   */
+  static ADDON::VECADDONS m_installableGameAddons;
+
+  /*!
+   * \brief Set to true to update cache of installable game add-ons
+   */
+  static bool m_checkInstallable;
+
+  /*!
+   * \brief Mutex to guard list of installable game add-ons
+   */
+  static std::mutex m_installableMutex;
 };
 } // namespace GAME
 } // namespace KODI


### PR DESCRIPTION
## Description

@ksooo reported a noticeable delay when opening the context menu on file items, because the checks for game extensions hammer the add-on database.

To eliminate the delay, I've added caching for the database results. A new hook is also added for when add-on repos are installed, which could include game add-ons with new file extensions.

## Motivation and context

@ksooo does this in his personal builds to solve the delay:

```patch
diff --git a/xbmc/games/GameUtils.cpp b/xbmc/games/GameUtils.cpp
index 600abe1dbfb5d..923f2b4dabf2b 100644
--- a/xbmc/games/GameUtils.cpp
+++ b/xbmc/games/GameUtils.cpp
@@ -218,6 +218,8 @@ bool CGameUtils::HasGameExtension(const std::string& path)
       return true;
   }
 
+// Very expensive, may slow down video ctx menu creation by seconds
+#if 0
   // Check remote add-ons
   gameClients.clear();
   if (CServiceBroker::GetAddonMgr().GetInstallableAddons(gameClients, AddonType::GAMEDLL))
@@ -229,7 +231,7 @@ bool CGameUtils::HasGameExtension(const std::string& path)
         return true;
     }
   }
-
+#endif
   return false;
 }
 ```

## How has this been tested?

Tested on my M2 macbook, games still show up in the browser.

TODO: Test on a Linux box without game add-ons, then install the libretro buildbot repo, then check that games show up without restarting.

## What is the effect on users?

* Fixed delay when opening the context menu for some items.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
