### PR TITLE
System Info: Two improvements

### DIFF
--- a/addons/skin.estuary/xml/SettingsSystemInfo.xml
+++ b/addons/skin.estuary/xml/SettingsSystemInfo.xml
@@ -79,6 +79,11 @@
 					<width>1400</width>
 					<font>Mono26</font>
 				</control>
+				<control type="label" id="13">
+					<height>47</height>
+					<width>1400</width>
+					<font>Mono26</font>
+				</control>
 			</control>
 			<control type="textbox" id="30">
 				<left>420</left>

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -21,6 +21,9 @@
 #include "utils/StringUtils.h"
 #include "utils/SystemInfo.h"
 
+constexpr int CONTROL_TEXT_START = 2;
+constexpr int CONTROL_TEXT_END = 13; // 12 lines
+
 #define CONTROL_TB_POLICY   30
 #define CONTROL_BT_STORAGE  94
 #define CONTROL_BT_DEFAULT  95
@@ -90,7 +93,7 @@ bool CGUIWindowSystemInfo::OnMessage(CGUIMessage& message)
 
 void CGUIWindowSystemInfo::FrameMove()
 {
-  int i = 2;
+  int i = CONTROL_TEXT_START;
   if (m_section == CONTROL_BT_DEFAULT)
   {
     SET_CONTROL_LABEL(40, g_localizeStrings.Get(20154));
@@ -109,7 +112,7 @@ void CGUIWindowSystemInfo::FrameMove()
     if (m_diskUsage.empty())
       m_diskUsage = CServiceBroker::GetMediaManager().GetDiskUsage();
 
-    for (size_t d = 0; d < m_diskUsage.size(); d++)
+    for (size_t d = 0; d < m_diskUsage.size() && d <= CONTROL_TEXT_END - CONTROL_TEXT_START; ++d)
     {
       SET_CONTROL_LABEL(i++, m_diskUsage[d]);
     }
@@ -218,7 +221,7 @@ void CGUIWindowSystemInfo::FrameMove()
   else if (m_section == CONTROL_BT_PVR)
   {
     SET_CONTROL_LABEL(40, g_localizeStrings.Get(19166));
-    int i = 2;
+    int i = CONTROL_TEXT_START;
 
     SetControlLabel(i++, "{}: {}", 19120, PVR_BACKEND_NUMBER);
     i++;  // empty line
@@ -244,7 +247,7 @@ void CGUIWindowSystemInfo::FrameMove()
 
 void CGUIWindowSystemInfo::ResetLabels()
 {
-  for (int i = 2; i < 13; i++)
+  for (int i = CONTROL_TEXT_START; i <= CONTROL_TEXT_END; ++i)
   {
     SET_CONTROL_LABEL(i, "");
   }

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -63,6 +63,7 @@ bool CGUIWindowSystemInfo::OnMessage(CGUIMessage& message)
     {
       CGUIWindow::OnMessage(message);
       m_diskUsage.clear();
+      m_privacyPolicyLoaded = false;
       return true;
     }
     break;
@@ -80,8 +81,7 @@ bool CGUIWindowSystemInfo::OnMessage(CGUIMessage& message)
         SET_CONTROL_HIDDEN(CONTROL_TB_POLICY);
       else if (m_section == CONTROL_BT_POLICY)
       {
-        SET_CONTROL_LABEL(CONTROL_TB_POLICY, CServiceBroker::GetGUI()->GetInfoManager().GetLabel(
-                                                 SYSTEM_PRIVACY_POLICY, INFO::DEFAULT_CONTEXT));
+        LoadPrivacyPolicy();
         SET_CONTROL_VISIBLE(CONTROL_TB_POLICY);
       }
       return true;
@@ -251,7 +251,6 @@ void CGUIWindowSystemInfo::ResetLabels()
   {
     SET_CONTROL_LABEL(i, "");
   }
-  SET_CONTROL_LABEL(CONTROL_TB_POLICY, "");
 }
 
 void CGUIWindowSystemInfo::SetControlLabel(int id, const char *format, int label, int info)
@@ -260,4 +259,14 @@ void CGUIWindowSystemInfo::SetControlLabel(int id, const char *format, int label
       format, g_localizeStrings.Get(label),
       CServiceBroker::GetGUI()->GetInfoManager().GetLabel(info, INFO::DEFAULT_CONTEXT));
   SET_CONTROL_LABEL(id, tmpStr);
+}
+
+void CGUIWindowSystemInfo::LoadPrivacyPolicy()
+{
+  if (!m_privacyPolicyLoaded)
+  {
+    m_privacyPolicyLoaded = true;
+    SET_CONTROL_LABEL(CONTROL_TB_POLICY, CServiceBroker::GetGUI()->GetInfoManager().GetLabel(
+                                             SYSTEM_PRIVACY_POLICY, INFO::DEFAULT_CONTEXT));
+  }
 }

--- a/xbmc/windows/GUIWindowSystemInfo.h
+++ b/xbmc/windows/GUIWindowSystemInfo.h
@@ -24,6 +24,8 @@ private:
   int  m_section;
   void ResetLabels();
   void SetControlLabel(int id, const char *format, int label, int info);
+  void LoadPrivacyPolicy();
   std::vector<std::string> m_diskUsage;
+  bool m_privacyPolicyLoaded{false};
 };
 


### PR DESCRIPTION
## Description

This PR contains two fixes for the System Info window.

The second fix is a delay when mousing over the Privacy Policy window every time. This is caused by parsing the long, formatted privacy policy, which is loaded from `special://xbmc/privacy-policy.txt`, on every mouse-over.

The first fix is needed for the second fix, as more than 27 mounted drives will overwrite the privacy policy text (starting from control ID=2 and going past the policy text with control ID=30). Which isn't a problem now, as the privacy policy is reloaded every time (causing the delay). But when the privacy policy is cached in the second commit, it causes an issue, requiring the first commit. (After installing the Xcode simulators, my macbook has like 40 mounts, causing the issue.)

As a result of this PR, there's still a delay when the Privacy Policy is first viewed, but subsequent mouse-overs cause no delay.

## Motivation and context

Needed to improve Donation Link In upcoming Settings PR: https://github.com/xbmc/xbmc/pull/26035

When subsequent mouse-overs cause no delay, there's noticeably more responsiveness when navigating on and off of the privacy policy link in the System Info dialog.

## How has this been tested?

Tested on my macbook M2. See screenshots.

## What is the effect on users?

* Improved responsiveness in the System Info window.

## Screenshots (if appropriate):

Currently, only 10 mounts are shown (11 lines of text), but the 28th mount overwrites the Privacy Policy text (with ID 30):

![Screenshot 2024-12-01 at 8 44 40 PM](https://github.com/user-attachments/assets/2c52b4e6-513f-4c7e-8240-8f886c1a8f45)

Showing the overwritten Privacy Policy text:

![Screenshot 2024-12-01 at 8 44 22 PM](https://github.com/user-attachments/assets/4df0445e-6d16-4882-84f5-8cc972a9c502)

After these fixes, up to 11 mounts (12 lines of text) are shown:

![Screenshot 2024-12-01 at 8 38 00 PM](https://github.com/user-attachments/assets/ff8cdfb6-6629-44cf-ab97-1aaf623c63dd)

And the Privacy Policy is always shown when mousing over, initially with a delay and subsequently (in the same window) with no delay:

![Screenshot 2024-12-01 at 8 17 37 PM](https://github.com/user-attachments/assets/81ad3cc6-cca7-4dc1-aab0-91865a3ed474)


## Types of change
<!-- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
