### PR TITLE
RenderManager: add latency tweak by resolution

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -878,14 +878,15 @@ void CRenderManager::PresentBlend(bool clear, DWORD flags, DWORD alpha)
 void CRenderManager::UpdateLatencyTweak()
 {
   float fps = CServiceBroker::GetWinSystem()->GetGfxContext().GetFPS();
+  const RESOLUTION_INFO res = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
   const bool isHDREnabled = CServiceBroker::GetWinSystem()->GetOSHDRStatus() == HDR_STATUS::HDR_ON;
 
   float refresh = fps;
   if (CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution() == RES_WINDOW)
     refresh = 0; // No idea about refresh rate when windowed, just get the default latency
   m_latencyTweak = static_cast<double>(
-      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->GetLatencyTweak(refresh,
-                                                                                     isHDREnabled));
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->GetLatencyTweak(
+          refresh, isHDREnabled, res.iScreenHeight));
 }
 
 void CRenderManager::UpdateResolution()

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -766,6 +766,10 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
         XMLUtils::GetFloat(pRefreshVideoLatency, "hdrextradelay", videolatency.hdrextradelay,
                            -600.0f, 600.0f);
 
+        if (pRefreshVideoLatency->QueryUnsignedAttribute("resolution", &videolatency.resolution) ==
+            TIXML_NO_ATTRIBUTE)
+          videolatency.resolution = 0;
+
         if (videolatency.refreshmin > 0.0f && videolatency.refreshmax >= videolatency.refreshmin)
           m_videoRefreshLatency.push_back(videolatency);
         else
@@ -1406,12 +1410,14 @@ void CAdvancedSettings::AddSettingsFile(const std::string &filename)
   m_settingsFiles.push_back(filename);
 }
 
-float CAdvancedSettings::GetLatencyTweak(float refreshrate, bool isHDREnabled) const
+float CAdvancedSettings::GetLatencyTweak(float refreshrate, bool isHDREnabled,
+                                         unsigned int resolution) const
 {
   float delay{};
   const auto& latency = std::ranges::find_if(
-      m_videoRefreshLatency, [refreshrate](const auto& param)
-      { return refreshrate >= param.refreshmin && refreshrate <= param.refreshmax; });
+      m_videoRefreshLatency, [refreshrate, resolution](const auto& param)
+      { return (refreshrate >= param.refreshmin && refreshrate <= param.refreshmax) &&
+               (param.resolution == resolution || param.resolution == 0); });
 
   if (latency != m_videoRefreshLatency.cend()) //refresh rate specific setting is found
   {

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -97,6 +97,8 @@ struct RefreshVideoLatency
   float refreshmin;
   float refreshmax;
 
+  unsigned int resolution;
+
   float delay;
   float hdrextradelay;
 };
@@ -358,7 +360,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::vector<std::string> m_settingsFiles;
     void ParseSettingsFile(const std::string &file);
 
-    float GetLatencyTweak(float refreshrate, bool isHDREnabled) const;
+    float GetLatencyTweak(float refreshrate, bool isHDREnabled, unsigned int resolution) const;
     bool m_initialized{false};
 
     void SetDebugMode(bool debug);


### PR DESCRIPTION
Filter latency tweak by used display resolution.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Add possibility to filter advanced settings latency tweak by used display resolution.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some hardware setup do need a user tweak for like `2160p24hz` but not for `1080p24hz`.
So there is a need of split same refresh rates but used with different resolutions.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By Kodi log.

By adding the new attributes to node `refresh` the tweak is much more flexible:
`width="3840" height="2160"`

Sample XML:
```xml
<advancedsettings>
  <video>
    <latency>
      <!-- Default latency for all modes -->
      <delay>10</delay>
      <hdrextradelay>0</hdrextradelay>
      <!-- Default latency for all modes with refresh rate 24Hz -->
      <refresh>
        <rate>24</rate>
        <delay>25</delay>
      </refresh>
      <!-- Default latency for 1080p with refresh rate 24Hz -->
      <refresh width="1920" height="1080">
        <rate>24</rate>
        <delay>75</delay>
      </refresh>
      <!-- Default latency for 2160p with refresh rate 24Hz -->
      <refresh width="3840" height="2160">
        <rate>24</rate>
        <delay>150</delay>
      </refresh>
    </latency>
  </video>
</advancedsettings>
```
So result is default delay is `10ms` for all modes with all refresh rates.
`25ms` for all 24Hz modes with any resolution.
`75ms` for 1080p24Hz. Like 720p24Hz is still untouched at `25ms`.
`150ms` for 2160p24Hz. Like 1080p24Hz and others are still untouched at their previously configured tweak.

Both attribute must match to display resolution or both must be `0` (or not set at all) to be ignored.
## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
More possibilities for tweak adjustment.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
