### PR TITLE
DVDVideoCodec: remove some not necessary definitions in .cpp

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
@@ -16,9 +16,6 @@
 //******************************************************************************
 // VideoPicture
 //******************************************************************************
-
-VideoPicture::VideoPicture() = default;
-
 VideoPicture::~VideoPicture()
 {
   if (videoBuffer)
@@ -121,6 +118,3 @@ bool VideoPicture::IsSameParams(const VideoPicture& pic) const
          this->color_transfer == pic.color_transfer && this->hdrType == pic.hdrType &&
          CompareDisplayMetadata(pic) && CompareLightMetadata(pic);
 }
-
-VideoPicture::VideoPicture(VideoPicture const&) = default;
-VideoPicture& VideoPicture::operator=(VideoPicture const&) = default;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -36,7 +36,7 @@ class CSetting;
 struct VideoPicture
 {
 public:
-  VideoPicture();
+  VideoPicture() = default;
   ~VideoPicture();
   VideoPicture& CopyRef(const VideoPicture &pic);
   VideoPicture& SetParams(const VideoPicture &pic);
@@ -80,8 +80,8 @@ public:
   unsigned int iDisplayHeight;          //< height of the picture without black bars
 
 private:
-  VideoPicture(VideoPicture const&);
-  VideoPicture& operator=(VideoPicture const&);
+  VideoPicture(VideoPicture const&) = default;
+  VideoPicture& operator=(VideoPicture const&) = default;
 
   bool CompareDisplayMetadata(const VideoPicture& pic) const;
   bool CompareLightMetadata(const VideoPicture& pic) const;


### PR DESCRIPTION
## Description
DVDVideoCodec: remove some not necessary definitions in .cpp

## Motivation and context
Less confusing code. No functional changes.

## How has this been tested?
Runtime Windows

## What is the effect on users?
nothing

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
