### PR TITLE
[PVR] Fix resume of PVR recordings if 'play next video automatically' is active.

### DIFF
--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
@@ -141,6 +141,7 @@ bool CPVRGUIActionsPlayback::PlayRecording(const CFileItem& item, bool bCheckRes
       }
 
       const auto parentItem = std::make_shared<CFileItem>(parentPath, true);
+      parentItem->LoadDetails();
       if (item.GetStartOffset() == STARTOFFSET_RESUME)
         parentItem->SetStartOffset(STARTOFFSET_RESUME);
 


### PR DESCRIPTION
What subject says: Resume of recordings was not working (always started from the beginning) if setting "play next video automatically" is active and "uncategorized" content is to be included.

It seems https://github.com/xbmc/xbmc/pull/26026 revealed that bug.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish could you please have a look? Thanks.