### PR TITLE
[Backport] System Info: Two improvements

### DIFF
--- a/addons/skin.estuary/xml/SettingsSystemInfo.xml
+++ b/addons/skin.estuary/xml/SettingsSystemInfo.xml
@@ -79,6 +79,11 @@
 					<width>1400</width>
 					<font>Mono26</font>
 				</control>
+				<control type="label" id="13">
+					<height>47</height>
+					<width>1400</width>
+					<font>Mono26</font>
+				</control>
 			</control>
 			<control type="textbox" id="30">
 				<left>420</left>

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -21,6 +21,9 @@
 #include "utils/StringUtils.h"
 #include "utils/SystemInfo.h"
 
+constexpr int CONTROL_TEXT_START = 2;
+constexpr int CONTROL_TEXT_END = 13; // 12 lines
+
 #define CONTROL_TB_POLICY   30
 #define CONTROL_BT_STORAGE  94
 #define CONTROL_BT_DEFAULT  95
@@ -90,7 +93,7 @@ bool CGUIWindowSystemInfo::OnMessage(CGUIMessage& message)
 
 void CGUIWindowSystemInfo::FrameMove()
 {
-  int i = 2;
+  int i = CONTROL_TEXT_START;
   if (m_section == CONTROL_BT_DEFAULT)
   {
     SET_CONTROL_LABEL(40, g_localizeStrings.Get(20154));
@@ -109,7 +112,7 @@ void CGUIWindowSystemInfo::FrameMove()
     if (m_diskUsage.empty())
       m_diskUsage = CServiceBroker::GetMediaManager().GetDiskUsage();
 
-    for (size_t d = 0; d < m_diskUsage.size(); d++)
+    for (size_t d = 0; d < m_diskUsage.size() && d <= CONTROL_TEXT_END - CONTROL_TEXT_START; ++d)
     {
       SET_CONTROL_LABEL(i++, m_diskUsage[d]);
     }
@@ -218,7 +221,7 @@ void CGUIWindowSystemInfo::FrameMove()
   else if (m_section == CONTROL_BT_PVR)
   {
     SET_CONTROL_LABEL(40, g_localizeStrings.Get(19166));
-    int i = 2;
+    int i = CONTROL_TEXT_START;
 
     SetControlLabel(i++, "{}: {}", 19120, PVR_BACKEND_NUMBER);
     i++;  // empty line
@@ -244,7 +247,7 @@ void CGUIWindowSystemInfo::FrameMove()
 
 void CGUIWindowSystemInfo::ResetLabels()
 {
-  for (int i = 2; i < 13; i++)
+  for (int i = CONTROL_TEXT_START; i <= CONTROL_TEXT_END; ++i)
   {
     SET_CONTROL_LABEL(i, "");
   }

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -63,6 +63,7 @@ bool CGUIWindowSystemInfo::OnMessage(CGUIMessage& message)
     {
       CGUIWindow::OnMessage(message);
       m_diskUsage.clear();
+      m_privacyPolicyLoaded = false;
       return true;
     }
     break;
@@ -80,8 +81,7 @@ bool CGUIWindowSystemInfo::OnMessage(CGUIMessage& message)
         SET_CONTROL_HIDDEN(CONTROL_TB_POLICY);
       else if (m_section == CONTROL_BT_POLICY)
       {
-        SET_CONTROL_LABEL(CONTROL_TB_POLICY, CServiceBroker::GetGUI()->GetInfoManager().GetLabel(
-                                                 SYSTEM_PRIVACY_POLICY, INFO::DEFAULT_CONTEXT));
+        LoadPrivacyPolicy();
         SET_CONTROL_VISIBLE(CONTROL_TB_POLICY);
       }
       return true;
@@ -251,7 +251,6 @@ void CGUIWindowSystemInfo::ResetLabels()
   {
     SET_CONTROL_LABEL(i, "");
   }
-  SET_CONTROL_LABEL(CONTROL_TB_POLICY, "");
 }
 
 void CGUIWindowSystemInfo::SetControlLabel(int id, const char *format, int label, int info)
@@ -260,4 +259,14 @@ void CGUIWindowSystemInfo::SetControlLabel(int id, const char *format, int label
       format, g_localizeStrings.Get(label),
       CServiceBroker::GetGUI()->GetInfoManager().GetLabel(info, INFO::DEFAULT_CONTEXT));
   SET_CONTROL_LABEL(id, tmpStr);
+}
+
+void CGUIWindowSystemInfo::LoadPrivacyPolicy()
+{
+  if (!m_privacyPolicyLoaded)
+  {
+    m_privacyPolicyLoaded = true;
+    SET_CONTROL_LABEL(CONTROL_TB_POLICY, CServiceBroker::GetGUI()->GetInfoManager().GetLabel(
+                                             SYSTEM_PRIVACY_POLICY, INFO::DEFAULT_CONTEXT));
+  }
 }

--- a/xbmc/windows/GUIWindowSystemInfo.h
+++ b/xbmc/windows/GUIWindowSystemInfo.h
@@ -24,6 +24,8 @@ private:
   int  m_section;
   void ResetLabels();
   void SetControlLabel(int id, const char *format, int label, int info);
+  void LoadPrivacyPolicy();
   std::vector<std::string> m_diskUsage;
+  bool m_privacyPolicyLoaded{false};
 };
 


### PR DESCRIPTION
## Description

Backport of https://github.com/xbmc/xbmc/pull/26034.

## Motivation and context

Fixes some small problems in the System Info dialog: Only max of 10 drives are shown instead of 11, over 28 mounted drives overwrite the privacy policy text, and the privacy policy responsiveness has been improved.

## How has this been tested?

Included in my 2024-12-03 test builds, based on Omega: https://github.com/garbear/xbmc/releases/tag/retroplayer-21.1-20241203

## What is the effect on users?

* Improved responsiveness in the System Info dialog

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
