### PR TITLE
[Windows] fix FFmpeg rebuild when version changes locally (non-merged changes)

### DIFF
--- a/tools/buildsteps/windows/buildhelpers.sh
+++ b/tools/buildsteps/windows/buildhelpers.sh
@@ -159,13 +159,14 @@ do_clean_get() {
 
 PATH_CHANGE_REV_FILENAME=".last_success_revision"
 
-#hash a dir based on the git revision and $TRIPLET
+#hash a dir based on the git revision and $version
 #params paths to be hashed
 function getBuildHash ()
 {
+  local version="$(extractVersion $3)"
   local hashStr
   hashStr="$(git rev-list HEAD --max-count=1  -- $@)"
-  hashStr="$hashStr $@ $TRIPLET"
+  hashStr="$hashStr $@ $version"
   echo $hashStr
 }
 
@@ -206,4 +207,12 @@ function tagSuccessFulBuild ()
   # tag last successful build with revisions of the given dir
   # needs to match the checks in function getBuildHash
   echo "$(getBuildHash $pathToTag $@)" > $pathToTag/$PATH_CHANGE_REV_FILENAME
+}
+
+function extractVersion()
+{
+  local file="$1"
+  local ver=$(grep "VERSION=" $file | sed 's/VERSION=//g;s/#.*$//g;/^$/d')
+
+  echo $ver
 }


### PR DESCRIPTION
## Description
[Windows] fix FFmpeg rebuild when version changes locally (non-merged changes)

## Motivation and context
In some circumstances (when testing new FFmpeg verions) build fails or not rebuild because changes are not detected. This seems works fine when switching kodi branch but not when testing different FFmpeg build in same kodi branch.

This PR adds FFmpeg version to  `.last_success_revision` signature:

**Before**
`0644589cb993af64dc59019cf679ae15c69894c1 /xbmc/project/BuildDependencies/mingwlibs/x64 /xbmc/tools/buildsteps/windows /xbmc/tools/depends/target/ffmpeg/FFMPEG-VERSION x64`

**After**
`0644589cb993af64dc59019cf679ae15c69894c1 /xbmc/project/BuildDependencies/mingwlibs/x64 /xbmc/tools/buildsteps/windows /xbmc/tools/depends/target/ffmpeg/FFMPEG-VERSION 6.0.1`

In this way even if hash not changes, different FFmpeg version always triggers rebuild.

Note that x64 (`$TRIPLET` variable) is redundant because also is present in path, then removed.

## How has this been tested?
Build Windows x64 testing FFmpeg 7.1 in https://github.com/xbmc/xbmc/pull/24972

## What is the effect on users?
Triggers rebuild of FFmpeg when apply changes locally (.diff) without merge.

This maybe also fixes Windows Jenkins issues for PR's of new FFmpeg versions... (not sure if is same issue)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
