### PR TITLE
[posix] Exit gracefully on SIGHUP, too.

### DIFF
--- a/xbmc/platform/posix/main.cpp
+++ b/xbmc/platform/posix/main.cpp
@@ -37,7 +37,6 @@ extern "C" void XBMC_POSIX_HandleSignal(int sig)
 }
 } // namespace
 
-
 int main(int argc, char* argv[])
 {
 #if defined(_DEBUG)
@@ -47,12 +46,13 @@ int main(int argc, char* argv[])
     fprintf(stderr, "Failed to set core size limit (%s).\n", strerror(errno));
 #endif
 
-  // Set up global SIGINT/SIGTERM handler
+  // Set up global SIGINT/SIGHUP/SIGTERM handler
   struct sigaction signalHandler;
   std::memset(&signalHandler, 0, sizeof(signalHandler));
   signalHandler.sa_handler = &XBMC_POSIX_HandleSignal;
   signalHandler.sa_flags = SA_RESTART;
   sigaction(SIGINT, &signalHandler, nullptr);
+  sigaction(SIGHUP, &signalHandler, nullptr);
   sigaction(SIGTERM, &signalHandler, nullptr);
 
   setlocale(LC_NUMERIC, "C");


### PR DESCRIPTION
## Description
Will make Kodi shut down gracefully when receiving SIGHUP just like now with SIGTERM.

## Motivation and context
This might make life easier if running Kodi from a systemd unit, or in a cgroup in general.
If the cgroup leader process (usually a wrapper script like `kodi-standalone` or `kodi`) or flatpak's bubblewrap, ends, the Linux kernel will send SIGHUP to all other members of that cgroup.

## How has this been tested?
I put Kodi in a systemd service to start on boot. I tried the Flatpak distribution, which does not propagate SIGTERM to its children and wait for them, resulting in Kodi being terminated hard with SIGHUP.

The discussion in https://github.com/graysky2/kodi-standalone-service/issues/54 made me dig deeper.

I added SIGHUP to the list of caught and handled signals, and now it shuts down cleanly without the need of wrapping the termination in a custom kill-and-wait command.

## What is the effect on users?
Kodi should shut down cleanly and safely (flushing files on disk, closing databases, etc.) like with SIGTERM now.

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
