### PR TITLE
Faster video scan approach

### DIFF
--- a/addons/metadata.demo.movies/demo.py
+++ b/addons/metadata.demo.movies/demo.py
@@ -27,7 +27,7 @@ action = params.get('action')
 if action == 'find':
     title = params['title']
     year = params.get('year', 'not specified')
-    xbmc.log(f'Find movie with title "{title}" from year {year}', xbmc.LOGDEBUG)
+    xbmc.log(f'Searching for movie "{title}" from year {year}', xbmc.LOGDEBUG)
 
     liz = xbmcgui.ListItem('Demo movie 1', offscreen=True)
     liz.setArt({'thumb': 'DefaultVideo.png'})

--- a/addons/metadata.demo.tv/demo.py
+++ b/addons/metadata.demo.tv/demo.py
@@ -27,7 +27,7 @@ action = params.get('action')
 if action == 'find':
     title = params['title']
     year = params.get('year', 'not specified')
-    xbmc.log(f'Find movie with title "{title}" from year {year}', xbmc.LOGDEBUG)
+    xbmc.log(f'Searching for movie "{title}" from year {year}', xbmc.LOGDEBUG)
 
     liz = xbmcgui.ListItem('Demo show 1', offscreen=True)
     liz.setArt({'thumb': 'DefaultVideo.png'})

--- a/addons/metadata.themoviedb.org.python/python/scraper.py
+++ b/addons/metadata.themoviedb.org.python/python/scraper.py
@@ -26,7 +26,7 @@ def get_tmdb_scraper(settings):
     return TMDBMovieScraper(ADDON_SETTINGS, language, certcountry)
 
 def search_for_movie(title, year, handle, settings):
-    log("Find movie with title '{title}' from year '{year}'".format(title=title, year=year), xbmc.LOGINFO)
+    log("Searching for movie '{title}' from year '{year}'".format(title=title, year=year), xbmc.LOGINFO)
     title = _strip_trailing_article(title)
     search_results = get_tmdb_scraper(settings).search(title, year)
     if not search_results:

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -14398,7 +14398,12 @@ msgctxt "#20474"
 msgid "HDR type"
 msgstr ""
 
-#empty strings from id 20475 to 21329
+#: xbmc/video/VideoInfoScanner.cpp
+msgctxt "#20475"
+msgid "Listing media files"
+msgstr ""
+
+#empty strings from id 20476 to 21329
 #up to 21329 is reserved for the video db !! !
 
 #: system/settings/settings.xml

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -46,6 +46,18 @@ CFileItemList::CFileItemList(const std::string& strPath) : CFileItem(strPath, tr
 {
 }
 
+// Copy constructor:
+CFileItemList::CFileItemList(const CFileItemList& other) : CFileItem(other)
+{
+  Copy(other, true);
+}
+
+// Move constructor:
+CFileItemList::CFileItemList(CFileItemList&& other) noexcept
+  : CFileItem(std::move(other)), m_items(std::move(other.m_items))
+{
+}
+
 CFileItemList::~CFileItemList()
 {
   Clear();

--- a/xbmc/FileItemList.h
+++ b/xbmc/FileItemList.h
@@ -31,7 +31,10 @@ public:
 
   CFileItemList();
   explicit CFileItemList(const std::string& strPath);
+  CFileItemList(const CFileItemList& other);
+  CFileItemList(CFileItemList&& other) noexcept;
   ~CFileItemList() override;
+
   void Archive(CArchive& ar) override;
   CFileItemPtr operator[](int iItem);
   const CFileItemPtr operator[](int iItem) const;

--- a/xbmc/video/VideoFileItemClassify.cpp
+++ b/xbmc/video/VideoFileItemClassify.cpp
@@ -149,4 +149,9 @@ bool IsVideoExtrasFolder(const CFileItem& item)
          StringUtils::EqualsNoCase(URIUtils::GetFileOrFolderName(item.GetPath()), "extras");
 }
 
+bool IsVideoInExtrasFolder(const CFileItem& item)
+{
+  return StringUtils::EqualsNoCase(URIUtils::GetFileOrFolderName(item.GetPath()), "extras");
+}
+
 } // namespace KODI::VIDEO

--- a/xbmc/video/VideoFileItemClassify.h
+++ b/xbmc/video/VideoFileItemClassify.h
@@ -47,4 +47,7 @@ bool IsVideoDb(const CFileItem& item);
 //! \brief Check whether an item is a video extras folder item.
 bool IsVideoExtrasFolder(const CFileItem& item);
 
+//! \brief Check whether an item is within a video extras folder.
+bool IsVideoInExtrasFolder(const CFileItem& item);
+
 } // namespace KODI::VIDEO

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "FileItemList.h"
 #include "InfoScanner.h"
 #include "VideoDatabase.h"
 #include "addons/Scraper.h"
@@ -106,8 +107,28 @@ namespace KODI::VIDEO
     static std::string GetMovieSetInfoFolder(const std::string& setTitle);
 
   protected:
+    struct SourcePathContent
+    {
+      std::string rootPath;
+      SScanSettings scrapperScanSettings;
+      CONTENT_TYPE contentType;
+      CFileItemList items;
+
+      SourcePathContent(std::string a, SScanSettings b, CONTENT_TYPE c)
+        : rootPath(a), scrapperScanSettings(b), contentType(c), items() {};
+    };
+
     virtual void Process();
     bool DoScan(const std::string& strDirectory) override;
+    bool DoScan(const std::vector<SourcePathContent>& _pathsContent);
+
+    void LoadRemoteItems(const std::string& strDirectory,
+                         CFileItemList& remoteDirectoryItems,
+                         SScanSettings scrapperScanSettings,
+                         CONTENT_TYPE contentType);
+    bool IsPathAllowedForScan(const std::string& strDirectory,
+                              SScanSettings scrapperScanSettings,
+                              CONTENT_TYPE contentType);
 
     INFO_RET RetrieveInfoForTvShow(CFileItem *pItem, bool bDirNames, ADDON::ScraperPtr &scraper, bool useLocal, CScraperUrl* pURL, bool fetchEpisodes, CGUIDialogProgress* pDlgProgress);
     INFO_RET RetrieveInfoForMovie(CFileItem *pItem, bool bDirNames, ADDON::ScraperPtr &scraper, bool useLocal, CScraperUrl* pURL, CGUIDialogProgress* pDlgProgress);

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -115,7 +115,7 @@ namespace KODI::VIDEO
       CFileItemList items;
 
       SourcePathContent(std::string a, SScanSettings b, CONTENT_TYPE c)
-        : rootPath(a), scrapperScanSettings(b), contentType(c), items() {};
+        : rootPath(a), scrapperScanSettings(b), contentType(c), items(){};
     };
 
     virtual void Process();

--- a/xbmc/video/tags/VideoTagLoaderNFO.cpp
+++ b/xbmc/video/tags/VideoTagLoaderNFO.cpp
@@ -52,9 +52,10 @@ CInfoScanner::INFO_TYPE CVideoTagLoaderNFO::Load(CVideoInfoTag& tag,
     result = nfoReader.Create(m_path, m_info);
 
   if (result == CInfoScanner::FULL_NFO || result == CInfoScanner::COMBINED_NFO)
+  {
     nfoReader.GetDetails(tag, nullptr, prioritise);
-
-  if (result == CInfoScanner::URL_NFO || result == CInfoScanner::COMBINED_NFO)
+  }
+  else if (result == CInfoScanner::URL_NFO || result == CInfoScanner::COMBINED_NFO)
   {
     m_url = nfoReader.ScraperUrl();
     m_info = nfoReader.GetScraperInfo();


### PR DESCRIPTION
## Description
This PR is an attempt to improve video scan by solving 2 issues:
1) progress bar report:
All videos are listed at the beginning of the scan, then videos are scanned sequentially which allows to report a relevant progress bar status that is not anymore constantly reverted to zero percent at each new folder scanned.

2) scan performance:
The function "DoScan" is not recursive anymore and does not repeat tasks anymore (it was previously, in some cases, re-listing over and over video medias.). Then it detects faster if a media is already in the DB or if it must be scanned.

NOTE: I'm a new contributor so please let me know if I missed some things.


## Motivation and context
I was not happy seeing kodi library update taking forever on my setup. I looked for solutions and found that other users were experimenting the same issues.

## How has this been tested?
I could not find test framework in kodi so I created a fake setup environment simulating the presence of 460 video items (movies and TV Shows) 
I compiled kodi from Omega branch and from this PR and compared the scan performance of both builds on the same hardware.

Note: After the first initial scan I got around 70% of videos recognized so next scans are constantly trying to fetch medias infos of 30% of the library.
At this stage, here are the results of "Update library":
Omega build: 112s
This PR build:  34s

Performance gain should be bigger for users having most of their medias already recognized as this algorithm is very fast at skipping medias already in DB.

## What is the effect on users?
Faster video scan performance.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
