### PR TITLE
[Windows] Fix vulnerability in wasapi for missing 'PKEY_Device_EnumeratorName' property

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp
@@ -156,7 +156,7 @@ struct AEWASAPIDeviceWin32 : public IAEWASAPIDevice
 {
   friend CAESinkFactoryWin;
 
-  HRESULT AEWASAPIDeviceWin32::Activate(IAudioClient** ppAudioClient)
+  HRESULT Activate(IAudioClient** ppAudioClient)
   {
     HRESULT hr = S_FALSE;
 
@@ -181,13 +181,13 @@ struct AEWASAPIDeviceWin32 : public IAEWASAPIDevice
     return hr;
   };
 
-  int AEWASAPIDeviceWin32::Release() override
+  int Release() override
   {
     delete this;
     return 0;
   };
 
-  bool AEWASAPIDeviceWin32::IsUSBDevice() override
+  bool IsUSBDevice() override
   {
     bool ret = false;
     ComPtr<IPropertyStore> pProperty = nullptr;

--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp
@@ -117,7 +117,7 @@ std::vector<RendererDetail> CAESinkFactoryWin::GetRendererDetails()
     PropVariantClear(&varName);
 
     hr = pProperty->GetValue(PKEY_Device_EnumeratorName, &varName);
-    if (SUCCEEDED(hr) && varName.pwszVal != nullptr)
+    if (SUCCEEDED(hr) && varName.vt != VT_EMPTY)
     {
       details.strDeviceEnumerator = KODI::PLATFORM::WINDOWS::FromW(varName.pwszVal);
       StringUtils::ToUpper(details.strDeviceEnumerator);
@@ -199,9 +199,12 @@ struct AEWASAPIDeviceWin32 : public IAEWASAPIDevice
       return ret;
     hr = pProperty->GetValue(PKEY_Device_EnumeratorName, &varName);
 
-    std::string str = KODI::PLATFORM::WINDOWS::FromW(varName.pwszVal);
-    StringUtils::ToUpper(str);
-    ret = (str == "USB");
+    if (SUCCEEDED(hr) && varName.vt != VT_EMPTY)
+    {
+      std::string str = KODI::PLATFORM::WINDOWS::FromW(varName.pwszVal);
+      StringUtils::ToUpper(str);
+      ret = (str == "USB");
+    }
     PropVariantClear(&varName);
     return ret;
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Same fix as #25648, for the WASAPI sink this time. Modified the IsUSBDevice() function to test for VT_EMPTY after retrieving the property, as described in MS doc, and don't attempt to use the invalid pointer.

Also silenced a few VS warnings in struct AEWASAPIDeviceWin32 function definitions.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The WASAPI sink is affected by the same problem that required a fix with #25648. It calls a IsUSBDevice() function that queries the property PKEY_Device_EnumeratorName, but it's not provided with RDP connections.

testing of @thexai showed that wasapi can't be used with RDP (maybe the exclusive mode?) so it's not going to cause real crash but it's still a good idea to include protection in the code, and for consistency.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Without RDP still works the same.
@thexai tested RDP and wasapi can't be used so no impact either.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
