### PR TITLE
[guilib] Fix bookmark deletion in presence of chapters

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3554,7 +3554,9 @@ void CVideoDatabase::AddBookMarkToFile(const std::string& strFilenameAndPath, co
   }
 }
 
-void CVideoDatabase::ClearBookMarkOfFile(const std::string& strFilenameAndPath, CBookmark& bookmark, CBookmark::EType type /*= CBookmark::STANDARD*/)
+void CVideoDatabase::ClearBookMarkOfFile(const std::string& strFilenameAndPath,
+                                         const CBookmark& bookmark,
+                                         CBookmark::EType type /*= CBookmark::STANDARD*/)
 {
   try
   {

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -707,7 +707,9 @@ public:
   void AddBookMarkToFile(const std::string& strFilenameAndPath, const CBookmark &bookmark, CBookmark::EType type = CBookmark::STANDARD);
   bool GetResumeBookMark(const std::string& strFilenameAndPath, CBookmark &bookmark);
   void DeleteResumeBookMark(const CFileItem& item);
-  void ClearBookMarkOfFile(const std::string& strFilenameAndPath, CBookmark& bookmark, CBookmark::EType type = CBookmark::STANDARD);
+  void ClearBookMarkOfFile(const std::string& strFilenameAndPath,
+                           const CBookmark& bookmark,
+                           CBookmark::EType type = CBookmark::STANDARD);
   void ClearBookMarksOfFile(const std::string& strFilenameAndPath, CBookmark::EType type = CBookmark::STANDARD);
   void ClearBookMarksOfFile(int idFile, CBookmark::EType type = CBookmark::STANDARD);
   bool GetBookMarkForEpisode(const CVideoInfoTag& tag, CBookmark& bookmark);

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -161,38 +161,66 @@ bool CGUIDialogVideoBookmarks::OnAction(const CAction &action)
   return CGUIDialog::OnAction(action);
 }
 
+int CGUIDialogVideoBookmarks::ItemToBookmarkIndex(int item) const
+{
+  if (item < 0 || item >= static_cast<int>(m_vecItems->Size()))
+    return -1;
+
+  const std::shared_ptr<CFileItem> fileItem{m_vecItems->Get(item)};
+
+  if (!fileItem->GetProperty("isbookmark").asBoolean(false))
+    return -1;
+
+  const int bookmarkIdx{fileItem->GetProperty("bookmark").asInteger32(-1)};
+  if (bookmarkIdx < 0 || bookmarkIdx >= static_cast<int>(m_bookmarks.size()))
+  {
+    CLog::LogF(LOGERROR, "invalid bookmark index {} for {} bookmark(s)", bookmarkIdx,
+               m_bookmarks.size());
+    return -1;
+  }
+  return bookmarkIdx;
+}
 
 void CGUIDialogVideoBookmarks::OnPopupMenu(int item)
 {
-  if (item < 0 || item >= (int) m_bookmarks.size())
+  const int bookmarkIdx{ItemToBookmarkIndex(item)};
+  if (bookmarkIdx < 0)
     return;
+
+  const CBookmark& bm{m_bookmarks[bookmarkIdx]};
 
   // highlight the item
   (*m_vecItems)[item]->Select(true);
 
   CContextButtons choices;
-  choices.Add(1, (m_bookmarks[item].type == CBookmark::EPISODE ? 20405 : 20404)); // "Remove episode bookmark" or "Remove bookmark"
+  choices.Add(1, (bm.type == CBookmark::EPISODE
+                      ? 20405
+                      : 20404)); // "Remove episode bookmark" or "Remove bookmark"
 
-  int button = CGUIDialogContextMenu::ShowAndGetChoice(choices);
+  const int button{CGUIDialogContextMenu::ShowAndGetChoice(choices)};
 
   // unhighlight the item
   (*m_vecItems)[item]->Select(false);
 
   if (button == 1)
-    Delete(item);
+    Delete(bm);
 }
 
 void CGUIDialogVideoBookmarks::Delete(int item)
 {
-  if ( item>=0 && (unsigned)item < m_bookmarks.size() )
-  {
-    CVideoDatabase videoDatabase;
-    videoDatabase.Open();
-    const std::string path{g_application.CurrentFileItem().GetDynPath()};
-    videoDatabase.ClearBookMarkOfFile(path, m_bookmarks[item], m_bookmarks[item].type);
-    videoDatabase.Close();
-    CUtil::DeleteVideoDatabaseDirectoryCache();
-  }
+  const int bookmarkIdx{ItemToBookmarkIndex(item)};
+  if (bookmarkIdx >= 0)
+    Delete(m_bookmarks[bookmarkIdx]);
+}
+
+void CGUIDialogVideoBookmarks::Delete(const CBookmark& bm)
+{
+  CVideoDatabase videoDatabase;
+  videoDatabase.Open();
+  const std::string path{g_application.CurrentFileItem().GetDynPath()};
+  videoDatabase.ClearBookMarkOfFile(path, bm, bm.type);
+  videoDatabase.Close();
+  CUtil::DeleteVideoDatabaseDirectoryCache();
   Update();
 }
 
@@ -230,6 +258,7 @@ void CGUIDialogVideoBookmarks::OnRefreshList()
     item->SetProperty("resumepoint", m_bookmarks[i].timeInSeconds);
     item->SetProperty("playerstate", m_bookmarks[i].playerState);
     item->SetProperty("isbookmark", "true");
+    item->SetProperty("bookmark", i);
     items.push_back(item);
   }
 

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -216,7 +216,9 @@ void CGUIDialogVideoBookmarks::Delete(int item)
 void CGUIDialogVideoBookmarks::Delete(const CBookmark& bm)
 {
   CVideoDatabase videoDatabase;
-  videoDatabase.Open();
+  if (!videoDatabase.Open())
+    return;
+
   const std::string path{g_application.CurrentFileItem().GetDynPath()};
   videoDatabase.ClearBookMarkOfFile(path, bm, bm.type);
   videoDatabase.Close();
@@ -233,7 +235,9 @@ void CGUIDialogVideoBookmarks::OnRefreshList()
   m_filePath = g_application.CurrentFileItem().GetDynPath();
 
   CVideoDatabase videoDatabase;
-  videoDatabase.Open();
+  if (!videoDatabase.Open())
+    return;
+
   videoDatabase.GetBookMarksForFile(m_filePath, m_bookmarks);
   videoDatabase.GetBookMarksForFile(m_filePath, m_bookmarks, CBookmark::EPISODE, true);
   videoDatabase.Close();
@@ -317,7 +321,8 @@ void CGUIDialogVideoBookmarks::OnRefreshList()
 void CGUIDialogVideoBookmarks::Update()
 {
   CVideoDatabase videoDatabase;
-  videoDatabase.Open();
+  if (!videoDatabase.Open())
+    return;
 
   if (g_application.CurrentFileItem().HasVideoInfoTag() && g_application.CurrentFileItem().GetVideoInfoTag()->m_iEpisode > -1)
   {
@@ -377,7 +382,9 @@ void CGUIDialogVideoBookmarks::GotoBookmark(int item)
 void CGUIDialogVideoBookmarks::ClearBookmarks()
 {
   CVideoDatabase videoDatabase;
-  videoDatabase.Open();
+  if (!videoDatabase.Open())
+    return;
+
   const std::string path{g_application.CurrentFileItem().GetDynPath()};
   videoDatabase.ClearBookMarksOfFile(path, CBookmark::STANDARD);
   videoDatabase.ClearBookMarksOfFile(path, CBookmark::RESUME);
@@ -388,7 +395,6 @@ void CGUIDialogVideoBookmarks::ClearBookmarks()
 
 bool CGUIDialogVideoBookmarks::AddBookmark(CVideoInfoTag* tag)
 {
-  CVideoDatabase videoDatabase;
   CBookmark bookmark;
   bookmark.timeInSeconds = (int)g_application.GetTime();
   bookmark.totalTimeInSeconds = (int)g_application.GetTotalTime();
@@ -486,7 +492,10 @@ bool CGUIDialogVideoBookmarks::AddBookmark(CVideoInfoTag* tag)
 
   free(pixels);
 
-  videoDatabase.Open();
+  CVideoDatabase videoDatabase;
+  if (!videoDatabase.Open())
+    return false;
+
   if (tag)
     videoDatabase.AddBookMarkForEpisode(*tag, bookmark);
   else
@@ -525,7 +534,9 @@ bool CGUIDialogVideoBookmarks::AddEpisodeBookmark()
 {
   std::vector<CVideoInfoTag> episodes;
   CVideoDatabase videoDatabase;
-  videoDatabase.Open();
+  if (!videoDatabase.Open())
+    return false;
+
   videoDatabase.GetEpisodesByFile(g_application.CurrentFile(), episodes);
   videoDatabase.Close();
   if (!episodes.empty())
@@ -573,7 +584,8 @@ bool CGUIDialogVideoBookmarks::OnAddEpisodeBookmark()
   if (g_application.CurrentFileItem().HasVideoInfoTag() && g_application.CurrentFileItem().GetVideoInfoTag()->m_iEpisode > -1)
   {
     CVideoDatabase videoDatabase;
-    videoDatabase.Open();
+    if (!videoDatabase.Open())
+      return bReturn;
     std::vector<CVideoInfoTag> episodes;
     videoDatabase.GetEpisodesByFile(g_application.CurrentFile(),episodes);
     if (episodes.size() > 1)

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.h
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.h
@@ -62,6 +62,14 @@ protected:
   VECBOOKMARKS m_bookmarks;
 
 private:
+  /*!
+   * \brief Return the bookmark index for the list item.
+   * \param[in] item Item number in the list
+   * \return bookmark index in m_bookmarks, or -1 for an invalid or a non-bookmark item.
+   */
+  int ItemToBookmarkIndex(int item) const;
+  void Delete(const CBookmark& bm);
+
   std::string m_filePath;
   CCriticalSection m_refreshSection;
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Fix the Delete functionality of the bookmark dialog to work correctly for videos that have chapters.
It was using the index of the selected list item as an index in the bookmarks array, ignoring the chapters present in the list.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #26074

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Video with and without chapters, added multiple bookmarks at different positions relative to chapters to confirm correct indexes are used.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Bookmarks added to videos that have chapters can now be removed by user with the bookmarks dialog.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
