### PR TITLE
[AnnouncementManager] Announce item playcount changes with UniqueID for video plugins

### DIFF
--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -235,7 +235,7 @@ void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag,
       object["item"]["title"] = title;
 
       if (!item->GetVideoInfoTag()->GetDefaultUniqueID().empty())
-        object["item"]["uniqueID"] = item->GetVideoInfoTag()->GetUniqueID();
+        object["item"]["uniqueid"] = item->GetVideoInfoTag()->GetUniqueID();
 
       switch (item->GetVideoContentType())
       {

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -234,6 +234,9 @@ void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag,
         title = item->GetLabel();
       object["item"]["title"] = title;
 
+      if (!item->GetVideoInfoTag()->GetDefaultUniqueID().empty())
+        object["item"]["uniqueID"] = item->GetVideoInfoTag()->GetUniqueID();
+
       switch (item->GetVideoContentType())
       {
         case VideoDbContentType::MOVIES:

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -6753,7 +6753,8 @@ CDateTime CVideoDatabase::SetPlayCount(const CFileItem& item, int count, const C
 
     m_pDS->exec(strSQL);
 
-    if (item.HasVideoInfoTag() && (item.GetVideoInfoTag()->m_iDbId > 0 || !item.GetVideoInfoTag()->GetUniqueID().empty()))
+    if (item.HasVideoInfoTag() &&
+        (item.GetVideoInfoTag()->m_iDbId > 0 || !item.GetVideoInfoTag()->GetUniqueID().empty()))
     {
       CVariant data;
       if (CVideoLibraryQueue::GetInstance().IsScanningLibrary())

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -6753,8 +6753,7 @@ CDateTime CVideoDatabase::SetPlayCount(const CFileItem& item, int count, const C
 
     m_pDS->exec(strSQL);
 
-    // We only need to announce changes to video items in the library
-    if (item.HasVideoInfoTag() && item.GetVideoInfoTag()->m_iDbId > 0)
+    if (item.HasVideoInfoTag() && (item.GetVideoInfoTag()->m_iDbId > 0 || !item.GetVideoInfoTag()->GetUniqueID().empty()))
     {
       CVariant data;
       if (CVideoLibraryQueue::GetInstance().IsScanningLibrary())


### PR DESCRIPTION
## Description
In VideoDatabase.cpp we allow announcement not only for items that have DbIds but also any that have a Default UniqueID. 

In the AnnouncementManager, if the announced item doesn't have a dbid, but it does have a Default UniqueID, we attach the UniqueID to the announcement.

## Motivation and context
Items created by Video plugins have the "Mark Watched" and "Mark Unwatched" context menu items, but invoking them does nothing.

This change ensures a notification is sent when these menu items are invoked, given the video plugin had attached a UniqueID to the listed item.

This allows the video plugin to mark said video watched or unwatched in their backend.

## How has this been tested?
Kodi was locally compiled and run in Windows 11 and the change manually tested against a video plugin.

## What is the effect on users?
VideoLibrary OnUpdate notification is now sent when video plugin list items are marked watched or unwatched, if the list item has a UniqueID associated with it.

## Types of change
- [x] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
