### PR TITLE
[VideoPlayer] fix conditions for forced PGS/VobSub subtitles

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1062,8 +1062,12 @@ void CVideoPlayer::OpenDefaultStreams(bool reset)
       valid = true;
       if(!psp.relevant(stream))
         visible = false;
-      //else if(stream.flags & StreamFlags::FLAG_FORCED)
-      //  visible = true;
+
+      // close the stream when not visible and not candidate for forced subtitles
+      // relevant only for forced subtitles within the stream (not container flags)
+      if (!visible && !g_LangCodeExpander.CompareISO639Codes(stream.language, as.language))
+        valid = false;
+
       break;
     }
   }
@@ -3024,6 +3028,14 @@ void CVideoPlayer::HandleMessages()
         SetEnableStream(m_CurrentSubtitle, false);
 
       SetSubtitleVisibleInternal(isVisible);
+
+      const auto& ss = m_SelectionStreams.Get(STREAM_SUBTITLE, GetSubtitle());
+      const auto& as = m_SelectionStreams.Get(STREAM_AUDIO, GetAudioStream());
+
+      // close the stream when not visible and not candidate for forced subtitles
+      // relevant only for forced subtitles within the stream (not container flags)
+      if (!isVisible && !g_LangCodeExpander.CompareISO639Codes(ss.language, as.language))
+        CloseStream(m_CurrentSubtitle, false);
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_SET_PROGRAM))
     {


### PR DESCRIPTION
## Description
[VideoPlayer] fix conditions for default enable forced PGS/VobSub subtitles

Fix https://github.com/xbmc/xbmc/issues/26050

## Motivation and context
In very specific circumstances are displayed by default wrong forced subtitle track and is not possible disable.

See: https://github.com/xbmc/xbmc/issues/26050 and forum https://forum.kodi.tv/showthread.php?tid=379599

This is because stream selection algorithm only picks the "best" track, based on user settings preferences, all available tracks and selected audio language, etc. but always ends up selecting one track (even when is disabled and not visible). 

Since the selected track is parsed to read possible PGS / VobSub forced subs (individual forced flag inside the stream) is possible displays forced subs on unexpected language (not selected language and not matching with audio language).

However, this only happens under very rare conditions: subtitles are all marked as forced (inside stream) and there is no normal or forced subtitle track in the same language as the audio.

New additional condition is audio language match when subtitle track only is opened for possible forced subs (the track has not been explicitly selected for any other reason).

NOTE: 
This modification only affects the conditions to "default enable" subtitle tracks. User always can change subtitles later from context playback menu i.e: enable other track or or maybe the same track that was not activated due to the changes in this PR.

## How has this been tested?
Runtime Windows x64 with prepared samples in https://github.com/xbmc/xbmc/issues/26050#issuecomment-2532290029

## What is the effect on users?
Prevent forced subtitles from being displayed in an unexpected language (not selected language and does not match the audio language).

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
