### PR TITLE
Games: Fix $VAR[] and $INFO[] usage in <controllerdiffuse> tag

### DIFF
--- a/xbmc/games/controllers/guicontrols/GUIGameController.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.cpp
@@ -89,6 +89,8 @@ void CGUIGameController::UpdateInfo(const CGUIListItem* item /* = nullptr */)
 {
   CGUIImage::UpdateInfo(item);
 
+  m_controllerDiffuse.Update(item);
+
   if (item != nullptr)
   {
     std::string controllerId;


### PR DESCRIPTION
## Description

This PR fixes the use of skin variables and info tags (`$VAR[]` and `$INFO[]`) in the `<controllerdiffuse>` tag for game controllers shown in the UI.

## Motivation and context

Reported by @Ch1llb0 (OSMC skin developer) here: https://github.com/xbmc/xbmc/pull/23548#issuecomment-2081517045

Fixes https://github.com/xbmc/xbmc/issues/25578.

## How has this been tested?

Included in latest round of test builds: https://github.com/garbear/xbmc/releases/tag/retroplayer-21.1-20241213

Tested on macOS ARM with a PS4 controller.

I made the following changes:

* Added a new variable

```patch
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -795,4 +795,7 @@
                <value condition="ListItem.IsStereoscopic">$INFO[ListItem.Duration,$LOCALIZE[180]: ][CR]$VAR[VideoCodecVar,, ]$INFO[ListItem.VideoResolution,| , ]$VAR[VideoResolutionTypeVar,, ]$VAR[VideoHDRVar,| , ]| 3D $INFO[ListItem.VideoAspect,| ,:1 ]$VAR[AudioCodecVar,| , ]$VAR[AudioChannelsVar]</value>
                <value>$INFO[ListItem.Duration,$LOCALIZE[180]: ][CR]$VAR[VideoCodecVar,, ]$INFO[ListItem.VideoResolution,| , ]$VAR[VideoResolutionTypeVar,, ]$VAR[VideoHDRVar,| , ]$INFO[ListItem.VideoAspect,| ,:1 ]$VAR[AudioCodecVar,| , ]$VAR[AudioChannelsVar]</value>
        </variable>
+       <variable name="button_focus">
+               <value>button_focus</value>
+       </variable>
 </includes>
```

* Replaced controller ports with static fileitems in the GameAgents window, hardcoded to PS4 controller:

```patch
--- a/addons/skin.estuary/xml/Includes_Games.xml
+++ b/addons/skin.estuary/xml/Includes_Games.xml
@@ -374,7 +374,8 @@
                                                                <texture>$INFO[ListItem.Icon]</texture>
                                                                <controllerid>$INFO[ListItem.Property(game.controllerid)]</controllerid>
                                                                <controlleraddress>$INFO[ListItem.FilenameAndPath]</controlleraddress>
-                                                               <controllerdiffuse>button_focus</controllerdiffuse>
+                                                               <controllerdiffuse>$INFO[ListItem.Property(game.controllerdiffuse)]</controllerdiffuse>
+                                                               <peripherallocation>darwin/inputdevice/0</peripherallocation>
                                                        </control>
                                                </itemlayout>
                                                <focusedlayout width="96" height="96">
@@ -382,54 +383,63 @@
                                                                <texture>$INFO[ListItem.Icon]</texture>
                                                                <controllerid>$INFO[ListItem.Property(game.controllerid)]</controllerid>
                                                                <controlleraddress>$INFO[ListItem.FilenameAndPath]</controlleraddress>
-                                                               <controllerdiffuse>button_focus</controllerdiffuse>
+                                                               <controllerdiffuse>$INFO[ListItem.Property(game.controllerdiffuse)]</controllerdiffuse>
+                                                               <peripherallocation>darwin/inputdevice/0</peripherallocation>
                                                        </control>
                                                </focusedlayout>
-                                               <!--
-                                                       Note to skinners: this control can be populated
-                                                       with static content for testing.
                                                <content>
                                                        <item>
                                                                <icon>DefaultAddonNone.png</icon>
                                                        </item>
                                                        <item>
                                                                <property name="game.controllerid">game.controller.snes</property>
+                                                               <property name="game.controllerdiffuse">$VAR[button_focus]</property>
                                                        </item>
                                                        <item>
                                                                <property name="game.controllerid">game.controller.snes</property>
+                                                               <property name="game.controllerdiffuse">$VAR[button_focus]</property>
                                                        </item>
                                                        <item>
                                                                <property name="game.controllerid">game.controller.snes</property>
+                                                               <property name="game.controllerdiffuse">$VAR[button_focus]</property>
                                                        </item>
                                                        <item>
                                                                <property name="game.controllerid">game.controller.snes</property>
+                                                               <property name="game.controllerdiffuse">$VAR[button_focus]</property>
                                                        </item>
                                                        <item>
                                                                <property name="game.controllerid">game.controller.snes</property>
+                                                               <property name="game.controllerdiffuse">$VAR[button_focus]</property>
                                                        </item>
                                                        <item>
                                                                <property name="game.controllerid">game.controller.snes</property>
+                                                               <property name="game.controllerdiffuse">$VAR[button_focus]</property>
                                                        </item>
                                                        <item>
                                                                <property name="game.controllerid">game.controller.snes</property>
+                                                               <property name="game.controllerdiffuse">$VAR[button_focus]</property>
                                                        </item>
                                                        <item>
                                                                <property name="game.controllerid">game.controller.snes</property>
+                                                               <property name="game.controllerdiffuse">$VAR[button_focus]</property>
                                                        </item>
                                                        <item>
                                                                <property name="game.controllerid">game.controller.snes</property>
+                                                               <property name="game.controllerdiffuse">$VAR[button_focus]</property>
                                                        </item>
                                                        <item>
                                                                <property name="game.controllerid">game.controller.snes</property>
+                                                               <property name="game.controllerdiffuse">$VAR[button_focus]</property>
                                                        </item>
                                                        <item>
                                                                <property name="game.controllerid">game.controller.snes</property>
+                                                               <property name="game.controllerdiffuse">$VAR[button_focus]</property>
                                                        </item>
                                                        <item>
                                                                <property name="game.controllerid">game.controller.snes</property>
+                                                               <property name="game.controllerdiffuse">$VAR[button_focus]</property>
                                                        </item>
                                                </content>
-                                               -->
                                        </control>
                                </control>
                                <control type="group">
```

Result: When the PS4 controller (`darwin/inputdevice/0`) is activated, the controllers with `$VAR[]` and `$INFO[]` are now highlighted correctly:

![Screenshot 2024-12-12 at 9 33 28 PM](https://github.com/user-attachments/assets/9fa1c270-1673-4acd-8d56-1de16ec871fc)

## What is the effect on users?

Effect on skinners:

* Fixed `$VAR[]` and `$INFO[]` usage in `<controllerdiffuse>` tag. 

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
