### PR TITLE
RetroPlayer: OpenGL Plumbing

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -19134,7 +19134,13 @@ msgctxt "#35270"
 msgid "Your account is not verified. Please check your email to complete your sign up."
 msgstr ""
 
-#empty strings from id 35271 to 35504
+#. Error message shown when an OpenGL game is played, as OpenGL is not currently supported
+#: xbmc/games/addons/GameClient.cpp
+msgctxt "#35271"
+msgid "This game requires OpenGL support for 3D rendering. OpenGL support is still under development."
+msgstr ""
+
+#empty strings from id 35272 to 35504
 
 #. connection state "host unreachable"
 #: xbmc/pvr/addons/PVRClients.cpp

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Game.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Game.h
@@ -573,6 +573,21 @@ public:
   ///
   ///@{
 
+  //==========================================================================
+  /// @brief **Callback to Kodi Function**\n
+  /// Enable hardware rendering functionality
+  ///
+  /// @return True if hardware rendering was enabled, false otherwise
+  ///
+  /// @remarks Only called from addon itself
+  ///
+  bool EnableHardwareRendering(const game_hw_rendering_properties& properties)
+  {
+    return m_instanceData->toKodi->EnableHardwareRendering(m_instanceData->toKodi->kodiInstance,
+                                                           &properties);
+  }
+  //----------------------------------------------------------------------------
+
   //============================================================================
   /// @brief Invalidates the current HW context and reinitializes GPU resources
   ///

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h
@@ -318,10 +318,14 @@ extern "C"
   } GAME_HW_CONTEXT_TYPE;
   //----------------------------------------------------------------------------
 
-  //============================================================================
-  /// @brief **Hardware framebuffer properties**
+  //==============================================================================
+  /// @brief **Hardware rendering properties**
   ///
-  typedef struct game_stream_hw_framebuffer_properties
+  /// These properties are needed early on, so instead of passing them when the
+  /// stream is opened, they are passed in EnableHardwareRendering(). As a
+  /// result, the struct passed to OpenStream() is empty.
+  ///
+  typedef struct game_hw_rendering_properties
   {
     /// @brief The API to use.
     ///
@@ -371,6 +375,19 @@ extern "C"
 
     /// @brief Creates a debug context.
     bool debug_context;
+
+  } ATTR_PACKED game_hw_rendering_properties;
+  //------------------------------------------------------------------------------
+
+  //==============================================================================
+  /// @brief **Hardware framebuffer properties**
+  ///
+  /// This struct is empty because hardware rendering properties are passed via
+  /// EnableHardwareRendering().
+  ///
+  typedef struct game_stream_hw_framebuffer_properties
+  {
+    char dummy; // Occupier for empty struct
   } ATTR_PACKED game_stream_hw_framebuffer_properties;
   //----------------------------------------------------------------------------
 
@@ -1193,6 +1210,7 @@ extern "C"
   {
     KODI_HANDLE kodiInstance;
 
+    bool (*EnableHardwareRendering)(void*, const game_hw_rendering_properties*);
     void (*CloseGame)(KODI_HANDLE kodiInstance);
     KODI_GAME_STREAM_HANDLE (*OpenStream)(KODI_HANDLE, const struct game_stream_properties*);
     bool (*GetStreamBuffer)(KODI_HANDLE,

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -97,8 +97,8 @@
 #define ADDON_INSTANCE_VERSION_AUDIOENCODER_DEPENDS   "c-api/addon-instance/audioencoder.h" \
                                                       "addon-instance/AudioEncoder.h"
 
-#define ADDON_INSTANCE_VERSION_GAME                   "3.0.2"
-#define ADDON_INSTANCE_VERSION_GAME_MIN               "3.0.0"
+#define ADDON_INSTANCE_VERSION_GAME                   "4.0.0"
+#define ADDON_INSTANCE_VERSION_GAME_MIN               "4.0.0"
 #define ADDON_INSTANCE_VERSION_GAME_XML_ID            "kodi.binary.instance.game"
 #define ADDON_INSTANCE_VERSION_GAME_DEPENDS           "addon-instance/Game.h"
 

--- a/xbmc/cores/RetroPlayer/OpenGL_Roadmap.md
+++ b/xbmc/cores/RetroPlayer/OpenGL_Roadmap.md
@@ -1,0 +1,70 @@
+# OpenGL Roadmap for RetroPlayer
+
+OpenGL support in RetroPlayer will enable hardware rendering for cores that require OpenGL. This roadmap outlines the key tasks needed to complete its integration in Kodi.
+
+The OpenGL tracking issue is: https://github.com/xbmc/xbmc/issues/17743
+
+## Current Status
+
+The foundational work for OpenGL support in RetroPlayer has been merged, including:
+
+- **Plumbing APIs:** RetroPlayer APIs now support OpenGL procedures and framebuffer streams ([PR #26091](https://github.com/xbmc/xbmc/pull/26091))
+- **Integration with Game API:** The Game API has been extended to connect libretro cores with OpenGL rendering functionality.
+- **Core Compatibility:** Initial testing has verified that OpenGL cores, such as Mupen64Plus and Beetle PSX HW, can interface with RetroPlayer without crashing.
+
+## Remaining Work
+
+### VAOs and Rendering Pipeline
+
+The use of Vertex Array Objects (VAOs) is a critical step in modernizing RetroPlayer's rendering pipeline. VAOs streamline the management of vertex attributes, making the OpenGL rendering process more efficient and less error-prone.
+
+- **Current Progress:** The removal of global VAOs has been addressed in [PR #22211: Remove Global VAOs](https://github.com/xbmc/xbmc/pull/22211), which simplifies the rendering pipeline.
+- **Next Step:** Review and merge [PR #22211](https://github.com/xbmc/xbmc/pull/22211) to finalize VAO updates.
+- The PR has been rebased here: https://github.com/garbear/xbmc/commits/retro-gl-v3
+
+Once the VAO work is completed, RetroPlayer will benefit from a cleaner and more maintainable rendering architecture.
+
+### Frame Buffer Object (FBO) Renderbuffers
+
+Mostly done. Original work [here](https://github.com/lrusak/xbmc/commits/retro-gl-v3) and rebased work [here](https://github.com/garbear/xbmc/commits/retro-gl-v3).
+
+### Synchronization
+
+The main synchronization challenges for OpenGL support in RetroPlayer stem from the separation of the game loop (which updates game state) and the rendering thread (which processes graphics).
+
+- **GL Context Management:**
+  OpenGL contexts are bound to threads, requiring careful management to ensure that rendering operations occur exclusively on  the rendering thread. Context sharing between threads needs to be avoided or strictly synchronized.
+
+- **Dynamic Resolution Changes:**
+  Dynamic resolution adjustments during gameplay add complexity. Both threads must coordinate to resize and reallocate frame buffers seamlessly, without causing crashes or visual glitches.
+
+#### GL Context Management
+
+Managing OpenGL contexts in RetroPlayer presents unique challenges due to its multithreaded architecture. Key considerations include:
+
+- **Thread Binding:**
+  OpenGL contexts are thread-specific. RetroPlayer must ensure that rendering occurs on a dedicated rendering thread without interfering with the game loop.
+
+- **Context Resetting:**
+  When switching contexts (e.g., during resolution changes), RetroPlayer must reinitialize OpenGL state while avoiding disruptions to ongoing operations.
+
+- **Multiple Platforms:**
+  Context management strategies must accommodate platform-specific OpenGL implementations, such as OpenGL ES for ARM-based devices or Metal wrappers for macOS.
+
+To address these challenges, RetroPlayer can leverage context creation and management best practices, such as ensuring all rendering occurs on the same thread and using thread-safe proxy functions for OpenGL operations initiated by the game loop.
+
+#### Dynamic Resolution Changes
+
+Needed to accommodate gameplay scenarios where resolution changes are required mid-session, such as switching between fullscreen and windowed modes or adapting to performance constraints. This requires:
+
+- **Real-Time Buffer Resizing:**
+  Ensure frame buffers are resized and reallocated without disrupting gameplay or introducing visual artifacts.
+
+- **Synchronization with Rendering Thread:**
+  Both the game loop and the rendering thread must coordinate to apply resolution changes seamlessly.
+
+---
+
+## Conclusion
+
+RetroPlayer's OpenGL support is well underway, with foundational work completed and key APIs in place. The remaining tasks include finalizing VAO updates, completing FBO renderbuffers, addressing synchronization challenges, and implementing dynamic resolution support. With these enhancements, RetroPlayer will achieve robust OpenGL integration, paving the way for future advancements like Vulkan support and broader hardware compatibility.

--- a/xbmc/cores/RetroPlayer/RetroPlayerTypes.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayerTypes.h
@@ -31,5 +31,17 @@ enum class DataAlignment
   DATA_UNALIGNED,
   DATA_ALIGNED,
 };
+
+/*!
+ * \brief A function pointer representing a hardware procedure
+ *
+ * This type alias is used to dynamically load and invoke hardware-specific
+ * procedures, such as OpenGL or OpenGL ES functions, at runtime. The function
+ * pointer can be retrieved using the `GetHwProcedureAddress` method in
+ * \ref CRPProcessInfo.
+ *
+ * \note The function must be cast to the appropriate signature before use
+ */
+using HwProcedureAddress = void (*)();
 } // namespace RETRO
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/buffers/BaseRenderBuffer.h
+++ b/xbmc/cores/RetroPlayer/buffers/BaseRenderBuffer.h
@@ -30,6 +30,7 @@ public:
   IRenderBufferPool* GetPool() override { return m_pool.get(); }
   DataAccess GetMemoryAccess() const override;
   DataAlignment GetMemoryAlignment() const override;
+  uintptr_t GetCurrentFramebuffer() override { return 0; }
 
 protected:
   // Reference counting

--- a/xbmc/cores/RetroPlayer/buffers/IRenderBuffer.h
+++ b/xbmc/cores/RetroPlayer/buffers/IRenderBuffer.h
@@ -43,6 +43,7 @@ public:
   virtual size_t GetFrameSize() const = 0;
   virtual uint8_t* GetMemory() = 0;
   virtual void ReleaseMemory() {}
+  virtual uintptr_t GetCurrentFramebuffer() = 0;
   virtual bool UploadTexture() = 0;
   virtual void BindToUnit(unsigned int unit) {}
   virtual void SetHeader(void* header) {}

--- a/xbmc/cores/RetroPlayer/process/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/process/CMakeLists.txt
@@ -4,4 +4,9 @@ set(SOURCES RPProcessInfo.cpp
 set(HEADERS RPProcessInfo.h
 )
 
+if(TARGET ${APP_NAME_LC}::EGL)
+  list(APPEND SOURCES egl/RPProcessInfoEGL.cpp)
+  list(APPEND HEADERS egl/RPProcessInfoEGL.h)
+endif()
+
 core_add_library(rp-process)

--- a/xbmc/cores/RetroPlayer/process/RPProcessInfo.h
+++ b/xbmc/cores/RetroPlayer/process/RPProcessInfo.h
@@ -146,6 +146,15 @@ public:
    */
   SCALINGMETHOD GetDefaultScalingMethod() const { return m_defaultScalingMethod; }
 
+  /*!
+   * \brief Get a symbol from the hardware context
+   *
+   * \param symbol The symbol's name
+   *
+   * \return A function pointer for the specified symbol, or nullptr if
+   *         unavailable
+   */
+  virtual HwProcedureAddress GetHwProcedureAddress(const char* symbol) { return nullptr; }
   ///}
 
   /// @name Player video info

--- a/xbmc/cores/RetroPlayer/process/egl/RPProcessInfoEGL.cpp
+++ b/xbmc/cores/RetroPlayer/process/egl/RPProcessInfoEGL.cpp
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2017-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "RPProcessInfoEGL.h"
+
+#include <EGL/egl.h>
+
+using namespace KODI;
+using namespace RETRO;
+
+CRPProcessInfoEGL::CRPProcessInfoEGL(std::string platformName)
+  : CRPProcessInfo(std::move(platformName))
+{
+}
+
+HwProcedureAddress CRPProcessInfoEGL::GetHwProcedureAddress(const char* symbol)
+{
+  return static_cast<HwProcedureAddress>(eglGetProcAddress(symbol));
+}

--- a/xbmc/cores/RetroPlayer/process/egl/RPProcessInfoEGL.h
+++ b/xbmc/cores/RetroPlayer/process/egl/RPProcessInfoEGL.h
@@ -17,7 +17,7 @@ class CRPProcessInfoEGL : public CRPProcessInfo
 {
 public:
   CRPProcessInfoEGL(std::string platformName);
-  virtual ~CRPProcessInfoEGL() override = default;
+  ~CRPProcessInfoEGL() override = default;
 
   // Implementation of CRPProcessInfo
   HwProcedureAddress GetHwProcedureAddress(const char* symbol) override;

--- a/xbmc/cores/RetroPlayer/process/egl/RPProcessInfoEGL.h
+++ b/xbmc/cores/RetroPlayer/process/egl/RPProcessInfoEGL.h
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (C) 2017-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+#pragma once
+
+#include "cores/RetroPlayer/process/RPProcessInfo.h"
+
+namespace KODI
+{
+namespace RETRO
+{
+class CRPProcessInfoEGL : public CRPProcessInfo
+{
+public:
+  CRPProcessInfoEGL(std::string platformName);
+  virtual ~CRPProcessInfoEGL() override = default;
+
+  // Implementation of CRPProcessInfo
+  HwProcedureAddress GetHwProcedureAddress(const char* symbol) override;
+};
+} // namespace RETRO
+} // namespace KODI

--- a/xbmc/cores/RetroPlayer/process/gbm/RPProcessInfoGbm.cpp
+++ b/xbmc/cores/RetroPlayer/process/gbm/RPProcessInfoGbm.cpp
@@ -11,7 +11,7 @@
 using namespace KODI;
 using namespace RETRO;
 
-CRPProcessInfoGbm::CRPProcessInfoGbm() : CRPProcessInfo("GBM")
+CRPProcessInfoGbm::CRPProcessInfoGbm() : CRPProcessInfoEGL("GBM")
 {
 }
 

--- a/xbmc/cores/RetroPlayer/process/gbm/RPProcessInfoGbm.h
+++ b/xbmc/cores/RetroPlayer/process/gbm/RPProcessInfoGbm.h
@@ -8,16 +8,17 @@
 
 #pragma once
 
-#include "cores/RetroPlayer/process/RPProcessInfo.h"
+#include "cores/RetroPlayer/process/egl/RPProcessInfoEGL.h"
 
 namespace KODI
 {
 namespace RETRO
 {
-class CRPProcessInfoGbm : public CRPProcessInfo
+class CRPProcessInfoGbm : public CRPProcessInfoEGL
 {
 public:
   CRPProcessInfoGbm();
+  ~CRPProcessInfoGbm() override = default;
 
   static std::unique_ptr<CRPProcessInfo> Create();
   static void Register();

--- a/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.cpp
+++ b/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.cpp
@@ -11,7 +11,7 @@
 using namespace KODI;
 using namespace RETRO;
 
-CRPProcessInfoWayland::CRPProcessInfoWayland() : CRPProcessInfo("Wayland")
+CRPProcessInfoWayland::CRPProcessInfoWayland() : CRPProcessInfoEGL("Wayland")
 {
 }
 

--- a/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.h
+++ b/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.h
@@ -8,16 +8,17 @@
 
 #pragma once
 
-#include "cores/RetroPlayer/process/RPProcessInfo.h"
+#include "cores/RetroPlayer/process/egl/RPProcessInfoEGL.h"
 
 namespace KODI
 {
 namespace RETRO
 {
-class CRPProcessInfoWayland : public CRPProcessInfo
+class CRPProcessInfoWayland : public CRPProcessInfoEGL
 {
 public:
   CRPProcessInfoWayland();
+  ~CRPProcessInfoWayland() override = default;
 
   static std::unique_ptr<CRPProcessInfo> Create();
   static void Register();

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -265,6 +265,35 @@ void CRPRenderManager::AddFrame(const uint8_t* data,
   }
 }
 
+bool CRPRenderManager::Create(unsigned int width, unsigned int height)
+{
+  //! @todo
+  return false;
+}
+
+uintptr_t CRPRenderManager::GetCurrentFramebuffer(unsigned int width, unsigned int height)
+{
+  for (IRenderBufferPool* bufferPool : m_processInfo.GetBufferManager().GetBufferPools())
+  {
+    if (!bufferPool->HasVisibleRenderer())
+      continue;
+
+    IRenderBuffer* renderBuffer = bufferPool->GetBuffer(width, height);
+    if (renderBuffer != nullptr)
+    {
+      m_pendingBuffers.emplace_back(renderBuffer);
+      return renderBuffer->GetCurrentFramebuffer();
+    }
+  }
+
+  return 0;
+}
+
+void CRPRenderManager::RenderFrame()
+{
+  //! @todo
+}
+
 void CRPRenderManager::SetSpeed(double speed)
 {
   m_speed = speed;

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -101,6 +101,14 @@ public:
                 unsigned int orientationDegCW);
   void Flush();
 
+  // Hardware rendering functions
+  //! @todo These are only examples pulled from the history of the OpenGL
+  //! effort and the required redesign will probably remove or change these
+  //! functions.
+  bool Create(unsigned int width, unsigned int height);
+  uintptr_t GetCurrentFramebuffer(unsigned int width, unsigned int height);
+  void RenderFrame();
+
   // Functions called from the player
   void SetSpeed(double speed);
 

--- a/xbmc/cores/RetroPlayer/streams/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/streams/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES RetroPlayerAudio.cpp
+            RetroPlayerRendering.cpp
             RetroPlayerStreamTypes.cpp
             RetroPlayerVideo.cpp
             RPStreamManager.cpp
@@ -7,6 +8,7 @@ set(SOURCES RetroPlayerAudio.cpp
 set(HEADERS IRetroPlayerStream.h
             IStreamManager.h
             RetroPlayerAudio.h
+            RetroPlayerRendering.h
             RetroPlayerStreamTypes.h
             RetroPlayerVideo.h
             RPStreamManager.h

--- a/xbmc/cores/RetroPlayer/streams/IStreamManager.h
+++ b/xbmc/cores/RetroPlayer/streams/IStreamManager.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "RetroPlayerStreamTypes.h"
+#include "cores/RetroPlayer/RetroPlayerTypes.h"
 
 namespace KODI
 {
@@ -35,6 +36,15 @@ public:
    * \param stream The stream to close
    */
   virtual void CloseStream(StreamPtr stream) = 0;
+
+  /*!
+   * \brief Get a symbol from the hardware context
+   *
+   * \param symbol The symbol's name
+   *
+   * \return A function pointer for the specified symbol
+   */
+  virtual HwProcedureAddress GetHwProcedureAddress(const char* symbol) = 0;
 };
 
 } // namespace RETRO

--- a/xbmc/cores/RetroPlayer/streams/RPStreamManager.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RPStreamManager.cpp
@@ -11,6 +11,7 @@
 #include "IRetroPlayerStream.h"
 #include "RetroPlayerAudio.h"
 #include "RetroPlayerVideo.h"
+#include "cores/RetroPlayer/process/RPProcessInfo.h"
 
 using namespace KODI;
 using namespace RETRO;
@@ -62,4 +63,9 @@ void CRPStreamManager::CloseStream(StreamPtr stream)
 
     stream->CloseStream();
   }
+}
+
+HwProcedureAddress CRPStreamManager::GetHwProcedureAddress(const char* symbol)
+{
+  return m_processInfo.GetHwProcedureAddress(symbol);
 }

--- a/xbmc/cores/RetroPlayer/streams/RPStreamManager.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RPStreamManager.cpp
@@ -10,6 +10,7 @@
 
 #include "IRetroPlayerStream.h"
 #include "RetroPlayerAudio.h"
+#include "RetroPlayerRendering.h"
 #include "RetroPlayerVideo.h"
 #include "cores/RetroPlayer/process/RPProcessInfo.h"
 
@@ -45,7 +46,7 @@ StreamPtr CRPStreamManager::CreateStream(StreamType streamType)
     }
     case StreamType::HW_BUFFER:
     {
-      // return StreamPtr(new CRetroPlayerHardware(m_renderManager, m_processInfo)); //! @todo
+      return StreamPtr(new CRetroPlayerRendering(m_renderManager, m_processInfo));
     }
     default:
       break;

--- a/xbmc/cores/RetroPlayer/streams/RPStreamManager.h
+++ b/xbmc/cores/RetroPlayer/streams/RPStreamManager.h
@@ -29,6 +29,7 @@ public:
   // Implementation of IStreamManager
   StreamPtr CreateStream(StreamType streamType) override;
   void CloseStream(StreamPtr stream) override;
+  HwProcedureAddress GetHwProcedureAddress(const char* symbol) override;
 
 private:
   // Construction parameters

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerRendering.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerRendering.cpp
@@ -33,30 +33,30 @@ CRetroPlayerRendering::~CRetroPlayerRendering()
 
 bool CRetroPlayerRendering::OpenStream(const StreamProperties& properties)
 {
-  const HwFramebufferProperties& hwProperties =
+  [[maybe_unused]] const HwFramebufferProperties& hwProperties =
       static_cast<const HwFramebufferProperties&>(properties);
 
-  const AVPixelFormat pixfmt = hwProperties.pixfmt;
-  const unsigned int nominalWidth = hwProperties.nominalWidth;
-  const unsigned int nominalHeight = hwProperties.nominalHeight;
-  const unsigned int maxWidth = hwProperties.maxWidth;
-  const unsigned int maxHeight = hwProperties.maxHeight;
-  const float pixelAspectRatio = hwProperties.pixelAspectRatio;
+  //! @todo
+  const AVPixelFormat pixelFormat = AV_PIX_FMT_NONE;
+  const unsigned int width = 640;
+  const unsigned int height = 480;
+  const float pixelAspectRatio = 1.0f;
 
-  CLog::Log(
-      LOGDEBUG,
-      "RetroPlayer[RENDERING]: Creating rendering stream - format {}, nominal {}x{}, max {}x{}",
-      CRenderTranslator::TranslatePixelFormat(pixfmt), nominalWidth, nominalHeight, maxWidth,
-      maxHeight);
+  CLog::Log(LOGDEBUG, "RetroPlayer[RENDERING]: Creating rendering stream - width {}, height {}",
+            width, height);
 
-  m_processInfo.SetVideoPixelFormat(pixfmt);
-  m_processInfo.SetVideoDimensions(nominalWidth, nominalHeight); // Report nominal height for now
+  m_processInfo.SetVideoPixelFormat(pixelFormat);
+  m_processInfo.SetVideoDimensions(width, height);
 
-  if (!m_renderManager.Configure(pixfmt, nominalWidth, nominalHeight, maxWidth, maxHeight,
-                                 pixelAspectRatio))
+  if (!m_renderManager.Configure(pixelFormat, width, height, width, height, pixelAspectRatio))
     return false;
 
-  return m_renderManager.Create(maxWidth, maxHeight);
+  CLog::Log(LOGDEBUG, "RetroPlayer[RENDERING]: Render manager configured");
+
+  //! @todo: This must be called from the rendering thread
+  //return m_renderManager.Create(width, height);
+
+  return false;
 }
 
 void CRetroPlayerRendering::CloseStream()

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerRendering.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerRendering.cpp
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (C) 2017-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "RetroPlayerRendering.h"
+
+#include "cores/RetroPlayer/process/RPProcessInfo.h"
+#include "cores/RetroPlayer/rendering/RPRenderManager.h"
+#include "cores/RetroPlayer/rendering/RenderTranslator.h"
+#include "utils/log.h"
+
+using namespace KODI;
+using namespace RETRO;
+
+CRetroPlayerRendering::CRetroPlayerRendering(CRPRenderManager& renderManager,
+                                             CRPProcessInfo& processInfo)
+  : m_renderManager(renderManager), m_processInfo(processInfo)
+{
+  CLog::Log(LOGDEBUG, "RetroPlayer[RENDERING]: Initializing rendering");
+}
+
+CRetroPlayerRendering::~CRetroPlayerRendering()
+{
+  CLog::Log(LOGDEBUG, "RetroPlayer[RENDERING]: Deinitializing rendering");
+
+  CloseStream();
+  m_renderManager.Deinitialize();
+}
+
+bool CRetroPlayerRendering::OpenStream(const StreamProperties& properties)
+{
+  const HwFramebufferProperties& hwProperties =
+      static_cast<const HwFramebufferProperties&>(properties);
+
+  const AVPixelFormat pixfmt = hwProperties.pixfmt;
+  const unsigned int nominalWidth = hwProperties.nominalWidth;
+  const unsigned int nominalHeight = hwProperties.nominalHeight;
+  const unsigned int maxWidth = hwProperties.maxWidth;
+  const unsigned int maxHeight = hwProperties.maxHeight;
+  const float pixelAspectRatio = hwProperties.pixelAspectRatio;
+
+  CLog::Log(
+      LOGDEBUG,
+      "RetroPlayer[RENDERING]: Creating rendering stream - format {}, nominal {}x{}, max {}x{}",
+      CRenderTranslator::TranslatePixelFormat(pixfmt), nominalWidth, nominalHeight, maxWidth,
+      maxHeight);
+
+  m_processInfo.SetVideoPixelFormat(pixfmt);
+  m_processInfo.SetVideoDimensions(nominalWidth, nominalHeight); // Report nominal height for now
+
+  if (!m_renderManager.Configure(pixfmt, nominalWidth, nominalHeight, maxWidth, maxHeight,
+                                 pixelAspectRatio))
+    return false;
+
+  return m_renderManager.Create(maxWidth, maxHeight);
+}
+
+void CRetroPlayerRendering::CloseStream()
+{
+  CLog::Log(LOGDEBUG, "RetroPlayer[RENDERING]: Closing rendering stream");
+
+  //! @todo
+}
+
+bool CRetroPlayerRendering::GetStreamBuffer(unsigned int width,
+                                            unsigned int height,
+                                            StreamBuffer& buffer)
+{
+  HwFramebufferBuffer& hwBuffer = static_cast<HwFramebufferBuffer&>(buffer);
+
+  hwBuffer.framebuffer = m_renderManager.GetCurrentFramebuffer(width, height);
+
+  return true;
+}
+
+void CRetroPlayerRendering::AddStreamData(const StreamPacket& packet)
+{
+  // This is left here in case anything gets added to the api in the future
+  [[maybe_unused]] const HwFramebufferPacket& hwPacket =
+      static_cast<const HwFramebufferPacket&>(packet);
+
+  m_renderManager.RenderFrame();
+}

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerRendering.h
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerRendering.h
@@ -17,6 +17,9 @@ extern "C"
 #include <libavutil/pixfmt.h>
 }
 
+//! @todo RetroPlayer needs an abstraction for GAME_HW_CONTEXT_TYPE
+#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h"
+
 namespace KODI
 {
 namespace RETRO
@@ -26,27 +29,33 @@ class CRPRenderManager;
 
 struct HwFramebufferProperties : public StreamProperties
 {
-  HwFramebufferProperties(AVPixelFormat pixfmt,
-                          unsigned int nominalWidth,
-                          unsigned int nominalHeight,
-                          unsigned int maxWidth,
-                          unsigned int maxHeight,
-                          float pixelAspectRatio)
-    : pixfmt(pixfmt),
-      nominalWidth(nominalWidth),
-      nominalHeight(nominalHeight),
-      maxWidth(maxWidth),
-      maxHeight(maxHeight),
-      pixelAspectRatio(pixelAspectRatio)
+  HwFramebufferProperties(GAME_HW_CONTEXT_TYPE contextType,
+                          bool depth,
+                          bool stencil,
+                          bool bottomLeftOrigin,
+                          unsigned int versionMajor,
+                          unsigned int versionMinor,
+                          bool cacheContext,
+                          bool debugContext)
+    : contextType(contextType),
+      depth(depth),
+      stencil(stencil),
+      bottomLeftOrigin(bottomLeftOrigin),
+      versionMajor(versionMajor),
+      versionMinor(versionMinor),
+      cacheContext(cacheContext),
+      debugContext(debugContext)
   {
   }
 
-  AVPixelFormat pixfmt;
-  unsigned int nominalWidth;
-  unsigned int nominalHeight;
-  unsigned int maxWidth;
-  unsigned int maxHeight;
-  float pixelAspectRatio;
+  GAME_HW_CONTEXT_TYPE contextType;
+  bool depth;
+  bool stencil;
+  bool bottomLeftOrigin;
+  unsigned int versionMajor;
+  unsigned int versionMinor;
+  bool cacheContext;
+  bool debugContext;
 };
 
 struct HwFramebufferBuffer : public StreamBuffer

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerRendering.h
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerRendering.h
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (C) 2017-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+#pragma once
+
+#include "IRetroPlayerStream.h"
+#include "RetroPlayerStreamTypes.h"
+
+#include <stdint.h>
+
+extern "C"
+{
+#include <libavutil/pixfmt.h>
+}
+
+namespace KODI
+{
+namespace RETRO
+{
+class CRPProcessInfo;
+class CRPRenderManager;
+
+struct HwFramebufferProperties : public StreamProperties
+{
+  HwFramebufferProperties(AVPixelFormat pixfmt,
+                          unsigned int nominalWidth,
+                          unsigned int nominalHeight,
+                          unsigned int maxWidth,
+                          unsigned int maxHeight,
+                          float pixelAspectRatio)
+    : pixfmt(pixfmt),
+      nominalWidth(nominalWidth),
+      nominalHeight(nominalHeight),
+      maxWidth(maxWidth),
+      maxHeight(maxHeight),
+      pixelAspectRatio(pixelAspectRatio)
+  {
+  }
+
+  AVPixelFormat pixfmt;
+  unsigned int nominalWidth;
+  unsigned int nominalHeight;
+  unsigned int maxWidth;
+  unsigned int maxHeight;
+  float pixelAspectRatio;
+};
+
+struct HwFramebufferBuffer : public StreamBuffer
+{
+  HwFramebufferBuffer() = default;
+  HwFramebufferBuffer(uintptr_t framebuffer) : framebuffer(framebuffer) {}
+
+  uintptr_t framebuffer{};
+};
+
+struct HwFramebufferPacket : public StreamPacket
+{
+  HwFramebufferPacket() = default;
+  HwFramebufferPacket(uintptr_t framebuffer) : framebuffer(framebuffer) {}
+
+  uintptr_t framebuffer{};
+};
+
+class CRetroPlayerRendering : public IRetroPlayerStream
+{
+public:
+  CRetroPlayerRendering(CRPRenderManager& m_renderManager, CRPProcessInfo& m_processInfo);
+
+  ~CRetroPlayerRendering() override;
+
+  // Implementation of IRetroPlayerStream
+  bool OpenStream(const StreamProperties& properties) override;
+  bool GetStreamBuffer(unsigned int width, unsigned int height, StreamBuffer& buffer) override;
+  void AddStreamData(const StreamPacket& packet) override;
+  void CloseStream() override;
+
+private:
+  // Construction parameters
+  CRPRenderManager& m_renderManager;
+  CRPProcessInfo& m_processInfo;
+};
+} // namespace RETRO
+} // namespace KODI

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -11,6 +11,8 @@
 #include "GameClientSubsystem.h"
 #include "addons/binary-addons/AddonDll.h"
 #include "addons/kodi-dev-kit/include/kodi/addon-instance/Game.h"
+#include "games/GameTypes.h"
+#include "games/addons/streams/GameClientStreamHwFramebuffer.h"
 #include "threads/CriticalSection.h"
 
 #include <atomic>
@@ -113,7 +115,9 @@ public:
  * from 1,200 lines to just over 600. Reducing this further is the challenge.
  * You must now choose whether to accept.
  */
-class CGameClient : public ADDON::CAddonDll, private CGameClientStruct
+class CGameClient : public ADDON::CAddonDll,
+                    public IHwFramebufferCallback,
+                    private CGameClientStruct
 {
 public:
   explicit CGameClient(const ADDON::AddonInfoPtr& addonInfo);
@@ -170,6 +174,9 @@ public:
   bool Serialize(uint8_t* data, size_t size);
   bool Deserialize(const uint8_t* data, size_t size);
 
+  // Implementation of IHwFramebufferCallback
+  void HardwareContextReset() override;
+
   /*!
    * @brief To get the interface table used between addon and kodi
    * @todo This function becomes removed after old callback library system
@@ -197,6 +204,8 @@ private:
    * @brief Callback functions from addon to kodi
    */
   //@{
+  static bool cb_enable_hardware_rendering(void* kodiInstance,
+                                           const game_hw_rendering_properties* properties);
   static void cb_close_game(KODI_HANDLE kodiInstance);
   static KODI_GAME_STREAM_HANDLE cb_open_stream(KODI_HANDLE kodiInstance,
                                                 const game_stream_properties* properties);

--- a/xbmc/games/addons/streams/CMakeLists.txt
+++ b/xbmc/games/addons/streams/CMakeLists.txt
@@ -1,10 +1,12 @@
 set(SOURCES GameClientStreamAudio.cpp
+            GameClientStreamHwFramebuffer.cpp
             GameClientStreams.cpp
             GameClientStreamSwFramebuffer.cpp
             GameClientStreamVideo.cpp
 )
 
 set(HEADERS GameClientStreamAudio.h
+            GameClientStreamHwFramebuffer.h
             GameClientStreams.h
             GameClientStreamSwFramebuffer.h
             GameClientStreamVideo.h

--- a/xbmc/games/addons/streams/GameClientStreamHwFramebuffer.cpp
+++ b/xbmc/games/addons/streams/GameClientStreamHwFramebuffer.cpp
@@ -1,0 +1,147 @@
+/*
+ *  Copyright (C) 2018-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GameClientStreamHwFramebuffer.h"
+
+#include "addons/kodi-dev-kit/include/kodi/addon-instance/Game.h"
+#include "cores/RetroPlayer/streams/RetroPlayerRendering.h"
+#include "utils/StringUtils.h"
+#include "utils/log.h"
+
+using namespace KODI;
+using namespace GAME;
+
+CGameClientStreamHwFramebuffer::CGameClientStreamHwFramebuffer(
+    IHwFramebufferCallback& callback, const game_hw_rendering_properties& hwProperties)
+  : m_callback(callback),
+    m_hwProperties(std::make_unique<const game_hw_rendering_properties>(hwProperties))
+{
+}
+
+bool CGameClientStreamHwFramebuffer::OpenStream(RETRO::IRetroPlayerStream* stream,
+                                                const game_stream_properties& properties)
+{
+  RETRO::CRetroPlayerRendering* renderingStream =
+      dynamic_cast<RETRO::CRetroPlayerRendering*>(stream);
+  if (renderingStream == nullptr)
+  {
+    CLog::Log(LOGERROR, "GAME: RetroPlayer stream is not an audio stream");
+    return false;
+  }
+
+  std::unique_ptr<RETRO::HwFramebufferProperties> hwProperties =
+      TranslateProperties(*m_hwProperties);
+
+  if (stream->OpenStream(*hwProperties))
+  {
+    m_stream = stream;
+    m_callback.HardwareContextReset();
+  }
+
+  return m_stream != nullptr;
+}
+
+void CGameClientStreamHwFramebuffer::CloseStream()
+{
+  if (m_stream != nullptr)
+  {
+    m_stream->CloseStream();
+    m_stream = nullptr;
+  }
+}
+
+bool CGameClientStreamHwFramebuffer::GetBuffer(unsigned int width,
+                                               unsigned int height,
+                                               game_stream_buffer& buffer)
+{
+  if (buffer.type != GAME_STREAM_HW_FRAMEBUFFER)
+    return false;
+
+  if (m_stream != nullptr)
+  {
+    RETRO::HwFramebufferBuffer hwFramebufferBuffer;
+    if (m_stream->GetStreamBuffer(0, 0, static_cast<RETRO::StreamBuffer&>(hwFramebufferBuffer)))
+    {
+      buffer.hw_framebuffer.framebuffer = hwFramebufferBuffer.framebuffer;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void CGameClientStreamHwFramebuffer::AddData(const game_stream_packet& packet)
+{
+  if (packet.type != GAME_STREAM_HW_FRAMEBUFFER)
+    return;
+
+  if (m_stream != nullptr)
+  {
+    const game_stream_hw_framebuffer_packet& hwFramebuffer = packet.hw_framebuffer;
+
+    RETRO::HwFramebufferPacket hwFramebufferPacket{hwFramebuffer.framebuffer};
+    m_stream->AddStreamData(static_cast<const RETRO::StreamPacket&>(hwFramebufferPacket));
+  }
+}
+
+void CGameClientStreamHwFramebuffer::LogHwProperties(
+    const game_hw_rendering_properties& hwProperties)
+{
+  const std::string strContextType = CGameClientStreamHwFramebuffer::GetContextName(
+      hwProperties.context_type, hwProperties.version_major, hwProperties.version_minor);
+
+  CLog::Log(LOGINFO, "Enabling hardware rendering for {}", strContextType);
+  CLog::Log(LOGDEBUG, "  depth: {}", hwProperties.depth ? "true" : "false");
+  CLog::Log(LOGDEBUG, "  stencil: {}", hwProperties.stencil ? "true" : "false");
+  CLog::Log(LOGDEBUG, "  bottomLeftOrigin: {}", hwProperties.bottom_left_origin ? "true" : "false");
+  CLog::Log(LOGDEBUG, "  cacheContext: {}", hwProperties.cache_context ? "true" : "false");
+  CLog::Log(LOGDEBUG, "  debugContext: {}", hwProperties.debug_context ? "true" : "false");
+}
+
+std::string CGameClientStreamHwFramebuffer::GetContextName(GAME_HW_CONTEXT_TYPE contextType,
+                                                           unsigned int versionMajor,
+                                                           unsigned int versionMinor)
+{
+  std::string strContextType;
+
+  switch (contextType)
+  {
+    case GAME_HW_CONTEXT_OPENGL:
+      strContextType = "OpenGL 2.x";
+      break;
+    case GAME_HW_CONTEXT_OPENGLES2:
+      strContextType = "OpenGLES 2.0";
+      break;
+    case GAME_HW_CONTEXT_OPENGL_CORE:
+      strContextType = StringUtils::Format("OpenGL {}.{}", versionMajor, versionMinor);
+      break;
+    case GAME_HW_CONTEXT_OPENGLES3:
+      strContextType = "OpenGLES 3.0";
+      break;
+    case GAME_HW_CONTEXT_OPENGLES_VERSION:
+      strContextType = StringUtils::Format("OpenGLES {}.{}", versionMajor, versionMinor);
+      break;
+    case GAME_HW_CONTEXT_VULKAN:
+      strContextType = "Vulkan";
+      break;
+    default:
+      strContextType = "Unknown";
+      break;
+  }
+
+  return strContextType;
+}
+
+std::unique_ptr<RETRO::HwFramebufferProperties> CGameClientStreamHwFramebuffer::TranslateProperties(
+    const game_hw_rendering_properties& hwProperties)
+{
+  return std::make_unique<RETRO::HwFramebufferProperties>(
+      hwProperties.context_type, hwProperties.depth, hwProperties.stencil,
+      hwProperties.bottom_left_origin, hwProperties.version_major, hwProperties.version_minor,
+      hwProperties.cache_context, hwProperties.debug_context);
+}

--- a/xbmc/games/addons/streams/GameClientStreamHwFramebuffer.h
+++ b/xbmc/games/addons/streams/GameClientStreamHwFramebuffer.h
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (C) 2018-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "IGameClientStream.h"
+#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h"
+
+#include <memory>
+
+namespace KODI
+{
+namespace RETRO
+{
+class IRetroPlayerStream;
+struct HwFramebufferProperties;
+} // namespace RETRO
+
+namespace GAME
+{
+
+class IHwFramebufferCallback
+{
+public:
+  virtual ~IHwFramebufferCallback() = default;
+
+  /*!
+   * \brief Invalidates the current HW context and reinitializes GPU resources
+   *
+   * Any GL state is lost, and must not be deinitialized explicitly.
+   */
+  virtual void HardwareContextReset() = 0;
+};
+
+class CGameClientStreamHwFramebuffer : public IGameClientStream
+{
+public:
+  CGameClientStreamHwFramebuffer(IHwFramebufferCallback& callback,
+                                 const game_hw_rendering_properties& hwProperties);
+  ~CGameClientStreamHwFramebuffer() override = default;
+
+  // Implementation of IGameClientStream
+  bool OpenStream(RETRO::IRetroPlayerStream* stream,
+                  const game_stream_properties& properties) override;
+  void CloseStream() override;
+  bool GetBuffer(unsigned int width, unsigned int height, game_stream_buffer& buffer) override;
+  void AddData(const game_stream_packet& packet) override;
+
+  // Public utility functions
+  static void LogHwProperties(const game_hw_rendering_properties& hwProperties);
+
+private:
+  // Private utility functions
+  static std::string GetContextName(GAME_HW_CONTEXT_TYPE contextType,
+                                    unsigned int versionMajor,
+                                    unsigned int versionMinor);
+  static std::unique_ptr<RETRO::HwFramebufferProperties> TranslateProperties(
+      const game_hw_rendering_properties& hwProperties);
+
+  // Construction parameters
+  IHwFramebufferCallback& m_callback;
+
+  // Stream parameters
+  RETRO::IRetroPlayerStream* m_stream{nullptr};
+
+  // Hardware rendering parameters
+  const std::unique_ptr<const game_hw_rendering_properties> m_hwProperties;
+};
+
+} // namespace GAME
+} // namespace KODI

--- a/xbmc/games/addons/streams/GameClientStreams.h
+++ b/xbmc/games/addons/streams/GameClientStreams.h
@@ -34,11 +34,21 @@ class CGameClientStreams
 public:
   CGameClientStreams(CGameClient& gameClient);
 
+  // Lifecycle functions
   void Initialize(RETRO::IStreamManager& streamManager);
   void Deinitialize();
 
+  // Stream management functions
   IGameClientStream* OpenStream(const game_stream_properties& properties);
   void CloseStream(IGameClientStream* stream);
+
+  // HW rendering functions
+  bool EnableHardwareRendering(const game_hw_rendering_properties& properties);
+  game_proc_address_t GetHwProcedureAddress(const char* sym);
+  bool HardwareRenderingAttempted() const
+  {
+    return m_hwProperties.context_type != GAME_HW_CONTEXT_NONE;
+  }
 
 private:
   // Utility functions
@@ -52,6 +62,9 @@ private:
 
   // Stream parameters
   std::map<IGameClientStream*, RETRO::StreamPtr> m_streams;
+
+  // Hardware rendering parameters
+  game_hw_rendering_properties m_hwProperties{};
 };
 
 } // namespace GAME


### PR DESCRIPTION
## Description

This PR adds a lot of the plumbing that's been finished so far for OpenGL support in RetroPlayer.

It first extends RetroPlayer APIs to handle GL procs and framebuffer streams. Then it modifies the Game API to connect libretro cores up to this new functionality.

In the future, a new kind of renderbuffer will be implemented, an FBO renderbuffer. With this PR, it should be possible to implement the new renderbuffer type without further changes to the existing APIs or internal render manager implementation.

To complete GL support, we'll likely need modifications to rendering synchronization. That might end up being a pretty invasive change, but should be independent of the changes here. 

Requires a game.libretro PR: https://github.com/kodi-game/game.libretro/pull/129

## Motivation and context

OpenGL tracking issue: https://github.com/xbmc/xbmc/issues/17743

The code here is taken from the last time @lrusak and I worked on GL back in 2022: https://github.com/lrusak/xbmc/commits/retro-gl-v3/

The plumbing (up until the Game API bump in that branch) is relatively finished and complete, so I'll get it in master to reduce our technical debt and make it easier for future contributors to continue carrying the torch for GL in RetroPlayer.

I've prepared a branch that contains the additional FBO work gone into GL on top of this PR. It can serve as a starting place for future authors to pick up and advance the current work. Here's the branch: https://github.com/garbear/xbmc/commits/retro-gl-v3. Note that it includes a rebased #22211.

## How has this been tested?

Included in latest round of test builds: https://github.com/garbear/xbmc/releases/tag/retroplayer-21.1-20241213

Tested on my macbook M2. I tried some existing SW rendering cores, no regression were noted.

Next, I'll do further testing with GL cores. I suspect that many currently crash, which would be fixed by this PR. Before merging, I may also implement a dialog that notifies the user that GL support is WIP to handle the error more gracefully.

EDIT: I've done further testing on GL cores.

I verified that Mupen64-Next errs out when loading a game without crashing.

I tried Craft, and it also correctly aborts when HW rendering isn't available. However, it crashes when unloading - I'm preparing a patch for this. I've recorded the issue here: https://github.com/kodi-game/game.libretro.craft/issues/3

![Screenshot 2024-12-13 at 9 27 05 PM](https://github.com/user-attachments/assets/23671813-1085-476e-a904-3a32875c943a)

## What is the effect on users?

* Possibly fixes errors running unsupported OpenGL cores *(to be determined)*

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

(I'll check the "Bug fix" item if GL cores crash before this PR and are handled gracefully after)