### PR TITLE
[Backport] Games: Fix $VAR[] and $INFO[] usage in <controllerdiffuse> tag

### DIFF
--- a/xbmc/games/controllers/guicontrols/GUIGameController.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.cpp
@@ -89,6 +89,8 @@ void CGUIGameController::UpdateInfo(const CGUIListItem* item /* = nullptr */)
 {
   CGUIImage::UpdateInfo(item);
 
+  m_controllerDiffuse.Update(item);
+
   if (item != nullptr)
   {
     std::string controllerId;


### PR DESCRIPTION
## Description

Backport of https://github.com/xbmc/xbmc/pull/26090

## Motivation and context

Opening backport PR now to get it on the radar for v21.2.

## How has this been tested?

Included in latest round of test builds: https://github.com/garbear/xbmc/releases/tag/retroplayer-21.1-20241213

## What is the effect on users?

Effect on skinners:

* Fixed `$VAR[]` and `$INFO[]` usage in `<controllerdiffuse>` tag. 

## Screenshots

![Screenshot 2024-12-12 at 9 33 28 PM](https://github.com/user-attachments/assets/9fa1c270-1673-4acd-8d56-1de16ec871fc)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
