### PR TITLE
Port Dialog: Fix resetting daisy-chained controllers

### DIFF
--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -460,8 +460,7 @@ void CGameClientInput::ResetPorts()
   std::lock_guard<std::recursive_mutex> lock(m_portMutex);
 
   const CControllerTree& controllerTree = GetDefaultControllerTree();
-  for (const CPortNode& port : controllerTree.GetPorts())
-    ConnectController(port.GetAddress(), port.GetActiveController().GetController());
+  ResetPorts(controllerTree.GetPorts());
 }
 
 bool CGameClientInput::HasAgent() const
@@ -736,4 +735,17 @@ ControllerVector CGameClientInput::GetControllers(const CGameClient& gameClient)
   }
 
   return controllers;
+}
+
+void CGameClientInput::ResetPorts(const PortVec& ports)
+{
+  for (const CPortNode& port : ports)
+  {
+    // Reset port
+    const CControllerNode& activeController = port.GetActiveController();
+    ConnectController(port.GetAddress(), activeController.GetController());
+
+    // Reset child ports
+    ResetPorts(activeController.GetHub().GetPorts());
+  }
 }

--- a/xbmc/games/addons/input/GameClientInput.h
+++ b/xbmc/games/addons/input/GameClientInput.h
@@ -117,6 +117,7 @@ private:
   // Helper functions
   static ControllerVector GetControllers(const CGameClient& gameClient);
   static void ActivateControllers(CControllerHub& hub);
+  void ResetPorts(const PortVec& port);
 
   // Input properties
   IGameInputCallback* m_inputCallback = nullptr;


### PR DESCRIPTION
## Description

I noticed a spot where a recursive call was missing, causing daisy-chained ports to not reset beyond the root. This PR fixes the bug by adding the missing recursive call.

## How has this been tested?

Tested on macOS ARM with the Opera core.

3DO controllers are daisy-chained, see [topology.xml](https://github.com/kodi-game/game.libretro.opera/blob/master/game.libretro.opera/resources/topology.xml):

```xml
<?xml version="1.0" encoding="UTF-8"?>
<logicaltopology>
  <port id="1">
    <accepts controller="game.controller.3do">
      <port id="1">
        <accepts controller="game.controller.3do">
          <port id="1">
            <accepts controller="game.controller.3do">
              <port id="1">
                <accepts controller="game.controller.3do">
                  <port id="1">
                    <accepts controller="game.controller.3do">
                      <port id="1">
                        <accepts controller="game.controller.3do"/>
                      </port>
                    </accepts>
                  </port>
                </accepts>
              </port>
            </accepts>
          </port>
        </accepts>
      </port>
    </accepts>
  </port>
</logicaltopology>
```

Disabling the first child causes all subsequent controllers to be disabled:

![Screenshot 2024-12-14 at 3 20 55 AM](https://github.com/user-attachments/assets/d47b20d7-5403-4b0a-b47a-c8c8b9064707)

After this PR, pressing "Reset" will reset child ports also, allowing daisy-chained controllers to be reset.

![Screenshot 2024-12-14 at 3 20 59 AM](https://github.com/user-attachments/assets/c23cc5f1-f7d0-4ef4-98a8-d320def584f7)

## What is the effect on users?

* Fixed resetting daisy-chained controllers in the Port Dialog

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
