### PR TITLE
[CUtil] Add a regex cache to `ExcludeFileOrFolder` and utilize it in the library scanners

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -10,6 +10,7 @@
 #include "network/NetworkFileItemClassify.h"
 #include "playlists/PlayListFileItemClassify.h"
 #include "video/VideoFileItemClassify.h"
+
 #if defined(TARGET_DARWIN)
 #include <sys/param.h>
 #include <mach-o/dyld.h>
@@ -44,6 +45,7 @@
 #include <algorithm>
 #include <array>
 #include <stdlib.h>
+#include <tuple>
 #ifdef HAS_UPNP
 #include "filesystem/UPnPDirectory.h"
 #endif
@@ -623,21 +625,50 @@ std::string CUtil::GetSplashPath()
   return CSpecialProtocol::TranslatePathConvertCase(*it);
 }
 
-bool CUtil::ExcludeFileOrFolder(const std::string& strFileOrFolder, const std::vector<std::string>& regexps)
+bool CUtil::ExcludeFileOrFolder(const std::string& strFileOrFolder,
+                                const std::vector<std::string>& regexps,
+                                RegexCache* regexCache /*= nullptr*/)
 {
   if (strFileOrFolder.empty())
     return false;
 
-  CRegExp regExExcludes(true, CRegExp::autoUtf8);  // case insensitive regex
+  // If the cache is supplied the regex is created directly in the cache,
+  // if it's not supplied we create one local
+  std::optional<CRegExp> localRegex;
+  if (!regexCache)
+    localRegex.emplace(true, CRegExp::autoUtf8); // case insensitive regex
 
   for (const auto &regexp : regexps)
   {
-    if (!regExExcludes.RegComp(regexp.c_str()))
-    { // invalid regexp - complain in logs
-      CLog::Log(LOGERROR, "{}: Invalid exclude RegExp:'{}'", __FUNCTION__, regexp);
-      continue;
-    }
-    if (regExExcludes.RegFind(strFileOrFolder) > -1)
+    const auto regexToUse = [&]() -> CRegExp*
+    {
+      CRegExp* regexToInitialize = nullptr;
+      if (regexCache)
+      {
+        auto [iter, inserted] = regexCache->try_emplace(regexp, true, CRegExp::autoUtf8);
+        if (!inserted)
+          // already in the cache, no initialization necessary
+          return &(iter->second);
+        else
+          regexToInitialize = &(iter->second);
+      }
+      else
+        // the local regex needs to be always (re)initialized
+        regexToInitialize = &(*localRegex);
+
+      if (!regexToInitialize->RegComp(regexp.c_str()))
+      {
+        CLog::Log(LOGERROR, "{}: Invalid exclude RegExp:'{}'", __FUNCTION__, regexp);
+        if (regexCache)
+          // initialization failed, remove from the cache again
+          regexCache->erase(regexp);
+        return nullptr;
+      }
+
+      return regexToInitialize;
+    }();
+
+    if (regexToUse && regexToUse->RegFind(strFileOrFolder) > -1)
     {
       CLog::LogF(LOGDEBUG, "File '{}' excluded. (Matches exclude rule RegExp: '{}')", CURL::GetRedacted(strFileOrFolder), regexp);
       return true;

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -10,12 +10,14 @@
 
 #include "MediaSource.h" // Definition of std::vector<CMediaSource>
 #include "utils/Digest.h"
+#include "utils/RegExp.h"
 
 #include <climits>
 #include <cmath>
 #include <span>
 #include <stdint.h>
 #include <string.h>
+#include <unordered_map>
 #include <vector>
 
 //! \brief Enumeration of filesystem types for LegalPath/FileName
@@ -86,7 +88,10 @@ public:
   static void RunShortcut(const char* szPath);
   static std::string GetHomePath(
       const std::string& strTarget = "KODI_HOME"); // default target is "KODI_HOME"
-  static bool ExcludeFileOrFolder(const std::string& strFileOrFolder, const std::vector<std::string>& regexps);
+  using RegexCache = std::unordered_map<std::string, CRegExp>;
+  static bool ExcludeFileOrFolder(const std::string& strFileOrFolder,
+                                  const std::vector<std::string>& regexps,
+                                  RegexCache* regexCache = nullptr);
   static void GetFileAndProtocol(const std::string& strURL, std::string& strDir);
   static int GetDVDIfoTitle(const std::string& strPathFile);
 

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -18,7 +18,6 @@
 #include "ServiceBroker.h"
 #include "TextureCache.h"
 #include "URL.h"
-#include "Util.h"
 #include "addons/AddonSystemSettings.h"
 #include "addons/Scraper.h"
 #include "addons/addoninfo/AddonType.h"
@@ -278,6 +277,7 @@ void CMusicInfoScanner::Process()
     CLog::Log(LOGERROR, "MusicInfoScanner: Exception while scanning.");
   }
   m_musicDatabase.Close();
+  m_regexCache.clear();
   CLog::Log(LOGDEBUG, "{} - Finished scan", __FUNCTION__);
 
   m_bRunning = false;
@@ -489,7 +489,7 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
   // Discard all excluded files defined by m_musicExcludeRegExps
   const std::vector<std::string> &regexps = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_audioExcludeFromScanRegExps;
 
-  if (CUtil::ExcludeFileOrFolder(strDirectory, regexps))
+  if (CUtil::ExcludeFileOrFolder(strDirectory, regexps, &m_regexCache))
     return true;
 
   if (HasNoMedia(strDirectory))
@@ -581,7 +581,7 @@ CInfoScanner::InfoRet CMusicInfoScanner::ScanTags(const CFileItemList& items,
 
     CFileItemPtr pItem = items[i];
 
-    if (CUtil::ExcludeFileOrFolder(pItem->GetPath(), regexps))
+    if (CUtil::ExcludeFileOrFolder(pItem->GetPath(), regexps, &m_regexCache))
       continue;
 
     if (pItem->IsFolder() || PLAYLIST::IsPlayList(*pItem) || pItem->IsPicture() ||

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -57,8 +57,11 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <chrono>
 #include <string_view>
 #include <utility>
+
+#include <fmt/chrono.h>
 
 using namespace KODI;
 using namespace MUSIC_INFO;
@@ -198,11 +201,10 @@ void CMusicInfoScanner::Process()
 
       m_musicDatabase.EmptyCache();
 
-      auto elapsed =
-          std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - tick);
-      CLog::Log(LOGINFO,
-                "My Music: Scanning for music info using worker thread, operation took {}s",
-                elapsed.count());
+      auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::steady_clock::now() - tick);
+      CLog::Log(LOGINFO, "My Music: Scanning for music info using worker thread, operation took {}",
+                elapsed);
     }
     if (m_scanType == 1) // load album info
     {

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -574,7 +574,8 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
 CInfoScanner::InfoRet CMusicInfoScanner::ScanTags(const CFileItemList& items,
                                                   CFileItemList& scannedItems)
 {
-  std::vector<std::string> regexps = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_audioExcludeFromScanRegExps;
+  const std::vector<std::string>& regexps =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_audioExcludeFromScanRegExps;
 
   for (int i = 0; i < items.Size(); ++i)
   {

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -11,6 +11,7 @@
 #include "InfoScanner.h"
 #include "MusicAlbumInfo.h"
 #include "MusicInfoScraper.h"
+#include "Util.h"
 #include "music/MusicDatabase.h"
 #include "threads/IRunnable.h"
 #include "threads/Thread.h"
@@ -277,6 +278,7 @@ protected:
   int m_scanType = 0; // 0 - load from files, 1 - albums, 2 - artists
   int m_idSourcePath;
   CMusicDatabase m_musicDatabase;
+  CUtil::RegexCache m_regexCache;
 
   std::set<int> m_albumsAdded;
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -16,7 +16,6 @@
 #include "SetInfoTag.h"
 #include "TextureCache.h"
 #include "URL.h"
-#include "Util.h"
 #include "VideoInfoDownloader.h"
 #include "cores/VideoPlayer/DVDFileInfo.h"
 #include "dialogs/GUIDialogExtendedProgressBar.h"
@@ -435,7 +434,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         content == ContentType::TVSHOWS ? m_advancedSettings->m_tvshowExcludeFromScanRegExps
                                         : m_advancedSettings->m_moviesExcludeFromScanRegExps;
 
-    if (CUtil::ExcludeFileOrFolder(strDirectory, regexps))
+    if (CUtil::ExcludeFileOrFolder(strDirectory, regexps, &m_regexCache))
       return true;
 
     if (HasNoMedia(strDirectory))
@@ -722,7 +721,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
       if (CUtil::ExcludeFileOrFolder(pItem->GetPath(),
                                      (content == ContentType::TVSHOWS)
                                          ? m_advancedSettings->m_tvshowExcludeFromScanRegExps
-                                         : m_advancedSettings->m_moviesExcludeFromScanRegExps))
+                                         : m_advancedSettings->m_moviesExcludeFromScanRegExps,
+                                     &m_regexCache))
         continue;
 
       if (info2->Content() == ContentType::MOVIES || info2->Content() == ContentType::MUSICVIDEOS)
@@ -1419,7 +1419,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         continue;
 
       // Discard all exclude files defined by regExExcludes
-      if (CUtil::ExcludeFileOrFolder(items[i]->GetPath(), regexps))
+      if (CUtil::ExcludeFileOrFolder(items[i]->GetPath(), regexps, &m_regexCache))
         continue;
 
       /*
@@ -2615,7 +2615,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
     for (int i = 0; i < items.Size(); ++i)
     {
-      if (items[i]->IsFolder() && !CUtil::ExcludeFileOrFolder(items[i]->GetPath(), excludes))
+      if (items[i]->IsFolder() &&
+          !CUtil::ExcludeFileOrFolder(items[i]->GetPath(), excludes, &m_regexCache))
         return false;
     }
     return true;

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "InfoScanner.h"
+#include "Util.h"
 #include "VideoDatabase.h"
 #include "addons/Scraper.h"
 #include "guilib/GUIListItem.h"
@@ -329,5 +330,6 @@ namespace KODI::VIDEO
     std::set<int> m_pathsToClean;
     std::shared_ptr<CAdvancedSettings> m_advancedSettings;
     CVideoDatabase::ScraperCache m_scraperCache;
+    mutable CUtil::RegexCache m_regexCache;
   };
   } // namespace KODI::VIDEO


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Scanning media checks **a lot** if certain files or dictionaries should be excluded from a scan by applying regular expressions. Those regex are recreated over and over in that process. This PR adds the option to inject a cache into `CUtil::ExcludeFileOrFolder` so this redundant work is avoided. With the cache it's also worth to optimize the regex more as they are created only once and used often.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

On my Raspberry Pi 3B scanning my already fully indexed TV show DB takes about 2.5 min while one core is 100% utilized. The goal is to make this faster.

~Using Valgrinds Callgrind I measure \~200 mio instructions rescanning my already fully indexed TV show DB on master and only \~85 mio with this change. For users having additional excludes via advancedsettings.xml this difference should be larger. On my development PC this doesn't really make a difference because scanning is mostly IO limited but I hope it makes a difference on embedded devices.~

Forget above numbers, [Valgrinds cycle detection](https://valgrind.org/docs/manual/cl-manual.html#cl-manual.cycles) was actually removing most of the computational heavy stuff :slightly_frowning_face: So the actual benefit is probably somewhere between small to insignificant.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Rescanning my TV shows.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Hopefully faster scans on low end devices.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
