### PR TITLE
[Omega backport] Change width of XBMC_keysym.scancode member from 8 to 32 bit

### DIFF
--- a/xbmc/input/keyboard/XBMC_keyboard.h
+++ b/xbmc/input/keyboard/XBMC_keyboard.h
@@ -38,7 +38,7 @@
  */
 struct XBMC_keysym
 {
-  unsigned char scancode; /* hardware specific scancode */
+  uint32_t scancode; /* hardware specific scancode */
   XBMCKey sym; /* SDL virtual keysym */
   XBMCMod mod; /* current key modifiers */
   uint16_t unicode; /* translated character */

--- a/xbmc/input/keyboard/XBMC_keytable.cpp
+++ b/xbmc/input/keyboard/XBMC_keytable.cpp
@@ -18,7 +18,7 @@ using namespace KEYBOARD;
 namespace
 {
 // The array of XBMCKEYTABLEs used in XBMC.
-// scancode, sym, unicode, ascii, vkey, keyname
+// sym, unicode, ascii, vkey, keyname
 // clang-format off
 static const XBMCKEYTABLE XBMCKeyTable[] = {
     {XBMCK_BACKSPACE, 0, 0, XBMCVK_BACK, "backspace"},

--- a/xbmc/platform/android/activity/AndroidKey.cpp
+++ b/xbmc/platform/android/activity/AndroidKey.cpp
@@ -270,7 +270,7 @@ bool CAndroidKey::onKeyboardEvent(AInputEvent *event)
                                repeat, flags, (state & AMETA_ALT_ON) ? "yes" : "no",
                                (state & AMETA_SHIFT_ON) ? "yes" : "no",
                                (state & AMETA_SYM_ON) ? "yes" : "no");
-      XBMC_Key((uint8_t)keycode, sym, modifiers, unicode, false);
+      XBMC_Key(static_cast<uint32_t>(keycode), sym, modifiers, unicode, false);
       break;
 
     case AKEY_EVENT_ACTION_UP:
@@ -281,7 +281,7 @@ bool CAndroidKey::onKeyboardEvent(AInputEvent *event)
                                repeat, flags, (state & AMETA_ALT_ON) ? "yes" : "no",
                                (state & AMETA_SHIFT_ON) ? "yes" : "no",
                                (state & AMETA_SYM_ON) ? "yes" : "no");
-      XBMC_Key((uint8_t)keycode, sym, modifiers, unicode, true);
+      XBMC_Key(static_cast<uint32_t>(keycode), sym, modifiers, unicode, true);
       break;
 
     case AKEY_EVENT_ACTION_MULTIPLE:
@@ -310,7 +310,8 @@ bool CAndroidKey::onKeyboardEvent(AInputEvent *event)
   return ret;
 }
 
-void CAndroidKey::XBMC_Key(uint8_t code, uint16_t key, uint16_t modifiers, uint16_t unicode, bool up)
+void CAndroidKey::XBMC_Key(
+    uint32_t code, uint16_t key, uint16_t modifiers, uint16_t unicode, bool up)
 {
   CWinSystemAndroid* winSystem(dynamic_cast<CWinSystemAndroid*>(CServiceBroker::GetWinSystem()));
   if (!winSystem)

--- a/xbmc/platform/android/activity/AndroidKey.h
+++ b/xbmc/platform/android/activity/AndroidKey.h
@@ -22,7 +22,7 @@ public:
 
   static void SetHandleMediaKeys(bool enable) { m_handleMediaKeys = enable; }
   static void SetHandleSearchKeys(bool enable) { m_handleSearchKeys = enable; }
-  static void XBMC_Key(uint8_t code, uint16_t key, uint16_t modifiers, uint16_t unicode, bool up);
+  static void XBMC_Key(uint32_t code, uint16_t key, uint16_t modifiers, uint16_t unicode, bool up);
 
 protected:
   static bool m_handleMediaKeys;

--- a/xbmc/platform/linux/input/LibInputKeyboard.cpp
+++ b/xbmc/platform/linux/input/LibInputKeyboard.cpp
@@ -433,12 +433,7 @@ void CLibInputKeyboard::ProcessKey(libinput_event_keyboard *e)
     unicode = 0;
   }
 
-  uint32_t scancode = libinput_event_keyboard_get_key(e);
-  if (scancode > std::numeric_limits<unsigned char>::max())
-  {
-    // Kodi scancodes are limited to unsigned char, pretend the scancode is unknown on overflow
-    scancode = 0;
-  }
+  const uint32_t scancode = libinput_event_keyboard_get_key(e);
 
   // flush composer if set (after a finished sequence)
   if (flushComposer)

--- a/xbmc/windowing/wayland/InputProcessorKeyboard.cpp
+++ b/xbmc/windowing/wayland/InputProcessorKeyboard.cpp
@@ -150,12 +150,6 @@ void CInputProcessorKeyboard::ConvertAndSendKey(std::uint32_t scancode, bool pre
     // it does not fit
     utf32 = 0;
   }
-  if (scancode > std::numeric_limits<unsigned char>::max())
-  {
-    // Kodi scancodes are limited to unsigned char, pretend the scancode is unknown
-    // on overflow
-    scancode = 0;
-  }
 
   // flush composer if set (after a finished sequence)
   if (flushComposer)
@@ -189,7 +183,10 @@ void CInputProcessorKeyboard::ConvertAndSendKey(std::uint32_t scancode, bool pre
   }
 }
 
-XBMC_Event CInputProcessorKeyboard::SendKey(unsigned char scancode, XBMCKey key, std::uint16_t unicodeCodepoint, bool pressed)
+XBMC_Event CInputProcessorKeyboard::SendKey(uint32_t scancode,
+                                            XBMCKey key,
+                                            std::uint16_t unicodeCodepoint,
+                                            bool pressed)
 {
   assert(m_keymap);
 

--- a/xbmc/windowing/wayland/InputProcessorKeyboard.h
+++ b/xbmc/windowing/wayland/InputProcessorKeyboard.h
@@ -56,7 +56,7 @@ private:
   CInputProcessorKeyboard& operator=(CInputProcessorKeyboard const& other) = delete;
 
   void ConvertAndSendKey(std::uint32_t scancode, bool pressed);
-  XBMC_Event SendKey(unsigned char scancode, XBMCKey key, std::uint16_t unicodeCodepoint, bool pressed);
+  XBMC_Event SendKey(uint32_t scancode, XBMCKey key, std::uint16_t unicodeCodepoint, bool pressed);
   /**
    * Notify the outside world about key composing events
    *

--- a/xbmc/windowing/win10/WinEventsWin10.cpp
+++ b/xbmc/windowing/win10/WinEventsWin10.cpp
@@ -401,7 +401,10 @@ void CWinEventsWin10::OnPointerWheelChanged(const CoreWindow&, const PointerEven
   MessagePush(&newEvent);
 }
 
-void CWinEventsWin10::Kodi_KeyEvent(unsigned int vkey, unsigned scancode, unsigned keycode, bool isDown)
+void CWinEventsWin10::Kodi_KeyEvent(unsigned int vkey,
+                                    uint32_t scancode,
+                                    unsigned keycode,
+                                    bool isDown)
 {
   using State = CoreVirtualKeyStates;
 

--- a/xbmc/windowing/win10/WinEventsWin10.h
+++ b/xbmc/windowing/win10/WinEventsWin10.h
@@ -67,7 +67,7 @@ private:
 
   void OnResize(float width, float height);
   void UpdateWindowSize();
-  void Kodi_KeyEvent(unsigned int vkey, unsigned scancode, unsigned keycode, bool isDown);
+  void Kodi_KeyEvent(unsigned int vkey, uint32_t scancode, unsigned keycode, bool isDown);
   void HandleWindowSizeChanged();
 
   Concurrency::concurrent_queue<XBMC_Event> m_events;

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -154,7 +154,7 @@ static XBMC_keysym *TranslateKey(WPARAM vkey, UINT scancode, XBMC_keysym *keysym
   uint8_t keystate[256];
 
   /* Set the keysym information */
-  keysym->scancode = static_cast<unsigned char>(scancode);
+  keysym->scancode = static_cast<uint32_t>(scancode);
   keysym->unicode = 0;
 
   if ((vkey == VK_RETURN) && (scancode & 0x100))


### PR DESCRIPTION
## Description

This is a backport of the changes from https://github.com/xbmc/xbmc/pull/26041 to Omega branch.

## Motivation and context
See https://github.com/xbmc/xbmc/pull/26041.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
In a superficial diff between the master branch and Omega branch I did not see any relevant changes to input code.

To create this PR I just rebased my commits from https://github.com/xbmc/xbmc/pull/26041 onto the current Omega branch, then built and ran the test suite.

I then did the same tests as for https://github.com/xbmc/xbmc/pull/26041, and mainly checked that a) I don't see any new broken behavior, and b) the "Keyboard: scancode: ..." debug message now shows a correct scancode.

<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
See https://github.com/xbmc/xbmc/pull/26041.

<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
