### PR TITLE
[Windows] Fix Fasthash for Movies Scan

### DIFF
--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -131,18 +131,20 @@ public:
   // CURL interface
   static bool Exists(const CURL& file, bool bUseCache = true);
   static bool Delete(const CURL& file);
-  /**
-  * Fills struct __stat64 with information about file specified by filename
-  * For st_mode function will set correctly _S_IFDIR (directory) flag and may set
-  * _S_IREAD (read permission), _S_IWRITE (write permission) flags if such
-  * information is available. Function may set st_size (file size), st_atime,
-  * st_mtime, st_ctime (access, modification, creation times).
-  * Any other flags and members of __stat64 that didn't updated with actual file
-  * information will be set to zero (st_nlink can be set ether to 1 or zero).
-  * @param file        specifies requested file
-  * @param buffer      pointer to __stat64 buffer to receive information about file
-  * @return zero of success, -1 otherwise.
-  */
+  /*!
+   * \brief Fills struct __stat64 with information about file specified by url.
+   *
+   * For st_mode function will set correctly _S_IFDIR (directory) flag and may set
+   * _S_IREAD (read permission), _S_IWRITE (write permission) flags if such
+   * information is available. Function may set st_size (file size), st_atime,
+   * st_mtime, st_ctime (access, modification, creation times).
+   * Any other flags and members of __stat64 that didn't updated with actual file
+   * information will be set to zero (st_nlink can be set ether to 1 or zero).
+   *
+   * \param[in] file specifies requested file. Ends with a directory separator for directories.
+   * \param[out] buffer pointer to __stat64 buffer to receive information about file
+   * \return zero for success, -1 otherwise.
+   */
   static int  Stat(const CURL& file, struct __stat64* buffer);
   static bool Rename(const CURL& file, const CURL& urlNew);
   static bool Copy(const CURL& file, const CURL& dest, XFILE::IFileCallback* pCallback = NULL, void* pContext = NULL);
@@ -150,18 +152,21 @@ public:
 
   // string interface
   static bool Exists(const std::string& strFileName, bool bUseCache = true);
-  /**
-  * Fills struct __stat64 with information about file specified by filename
-  * For st_mode function will set correctly _S_IFDIR (directory) flag and may set
-  * _S_IREAD (read permission), _S_IWRITE (write permission) flags if such
-  * information is available. Function may set st_size (file size), st_atime,
-  * st_mtime, st_ctime (access, modification, creation times).
-  * Any other flags and members of __stat64 that didn't updated with actual file
-  * information will be set to zero (st_nlink can be set ether to 1 or zero).
-  * @param strFileName specifies requested file
-  * @param buffer      pointer to __stat64 buffer to receive information about file
-  * @return zero of success, -1 otherwise.
-  */
+  /*!
+   * \brief Fills struct __stat64 with information about file specified by filename.
+   *
+   * For st_mode function will set correctly _S_IFDIR (directory) flag and may set
+   * _S_IREAD (read permission), _S_IWRITE (write permission) flags if such
+   * information is available. Function may set st_size (file size), st_atime,
+   * st_mtime, st_ctime (access, modification, creation times).
+   * Any other flags and members of __stat64 that didn't updated with actual file
+   * information will be set to zero (st_nlink can be set ether to 1 or zero).
+   *
+   * \param[in] strFileName specifies requested file. Ends with a directory separator for
+   * directories.
+   * \param[out] buffer pointer to __stat64 buffer to receive information about file
+   * \return zero for success, -1 otherwise.
+   */
   static int  Stat(const std::string& strFileName, struct __stat64* buffer);
   /**
   * Fills struct __stat64 with information about currently open file

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -49,30 +49,32 @@ public:
   virtual bool OpenForWrite(const CURL& url, bool bOverWrite = false) { return false; }
   virtual bool ReOpen(const CURL& url) { return false; }
   virtual bool Exists(const CURL& url) = 0;
-  /**
-   * Fills struct __stat64 with information about file specified by url.
+  /*!
+   * \brief Fills struct __stat64 with information about file specified by url.
+   *
    * For st_mode function will set correctly _S_IFDIR (directory) flag and may set
    * _S_IREAD (read permission), _S_IWRITE (write permission) flags if such
    * information is available. Function may set st_size (file size), st_atime,
    * st_mtime, st_ctime (access, modification, creation times).
    * Any other flags and members of __stat64 that didn't updated with actual file
    * information will be set to zero (st_nlink can be set ether to 1 or zero).
-   * @param url         specifies requested file
-   * @param buffer      pointer to __stat64 buffer to receive information about file
-   * @return zero of success, -1 otherwise.
+   *
+   * \param[in] url specifies requested file. Ends with a directory separator for directories.
+   * \param[out] buffer pointer to __stat64 buffer to receive information about file
+   * \return zero for success, -1 otherwise.
    */
   virtual int Stat(const CURL& url, struct __stat64* buffer) = 0;
   /**
-   * Fills struct __stat64 with information about currently open file
-   * For st_mode function will set correctly _S_IFDIR (directory) flag and may set
-   * _S_IREAD (read permission), _S_IWRITE (write permission) flags if such
-   * information is available. Function may set st_size (file size), st_atime,
-   * st_mtime, st_ctime (access, modification, creation times).
-   * Any other flags and members of __stat64 that didn't updated with actual file
-   * information will be set to zero (st_nlink can be set ether to 1 or zero).
-   * @param buffer      pointer to __stat64 buffer to receive information about file
-   * @return zero of success, -1 otherwise.
-   */
+  * Fills struct __stat64 with information about currently open file
+  * For st_mode function will set correctly _S_IFDIR (directory) flag and may set
+  * _S_IREAD (read permission), _S_IWRITE (write permission) flags if such
+  * information is available. Function may set st_size (file size), st_atime,
+  * st_mtime, st_ctime (access, modification, creation times).
+  * Any other flags and members of __stat64 that didn't updated with actual file
+  * information will be set to zero (st_nlink can be set ether to 1 or zero).
+  * @param buffer      pointer to __stat64 buffer to receive information about file
+  * @return zero of success, -1 otherwise.
+  */
   virtual int Stat(struct __stat64* buffer);
   /**
    * Attempt to read bufSize bytes from currently opened file into buffer bufPtr.

--- a/xbmc/platform/win32/filesystem/Win32File.cpp
+++ b/xbmc/platform/win32/filesystem/Win32File.cpp
@@ -466,6 +466,10 @@ int CWin32File::Stat(const CURL& url, struct __stat64* statData)
     return -1;
   }
 
+  // stat of directories requires the removal of the trailing slash
+  if (pathnameW.back() == L'\\')
+    pathnameW.pop_back();
+
   if (pathnameW.length() <= 6) // 6 is length of "\\?\x:"
     return -1; // pathnameW is empty or points to device ("\\?\x:"), on win32 stat() for devices is not supported
 
@@ -502,7 +506,7 @@ int CWin32File::Stat(const CURL& url, struct __stat64* statData)
   if (!m_smbFile)
   {
     assert(pathnameW.compare(0, 4, L"\\\\?\\", 4) == 0);
-    assert(pathnameW.length() >= 7); // '7' is the minimal length of "\\?\x:\"
+    assert(pathnameW.length() >= 7); // '7' is the minimal length of "\\?\x:y"
     assert(pathnameW[5] == L':');
     const wchar_t driveLetter = pathnameW[4];
     assert((driveLetter >= L'A' && driveLetter <= L'Z') || (driveLetter >= L'a' && driveLetter <= L'z'));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The library scanner tries to detect unchanged directories containing movies and music videos with a fast hash algorithm, which uses XFILE::CFile::Stat() on directories.

However Stat() fails on Windows platform with local and mapped/smb drives because the paths end with a slash.

The PR removes the trailing \ and adds Doxygen documentation of the possibility of filenames with ending slash for directories.

The speedup of scan with fast hash vs regular hash varies but network filesystems have more potential for improvement.
Testing showed 15% scan time improvement on local drive and 40% for same library on a mapped network drive.

Other filesystems such as nfs have their own path sanitization and already use fasthash.
Others may not (not available to me for testing) and would need a similar change to take advantage of fasthash.

Fix not made generic (removing the ending slash before calling Stat) because that ending slash is the only hint that it's a directory and not a file. Some filesystems may need different ways to stat files and directories (for example ftp, with file listings - although broken now)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Found out while stepping through the video scanner that fast hash always fails and regular hash is used with Windows.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Scanned movies on local drive and NAS mapped network drive.
Tried stat'ing a drive like X: or the root of a network drive \\server\drive or smb://server/drive. Those fail by design, no change.
Confirmed that the hashes were replaced with fast hashes in the db on first scan and then remained stable,
The log indicates that fast has is used.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Faster scan of unchanged movies and music videos with Windows.
First scan take longer to convert from regular to fast hash.

## Screenshots (if appropriate):

on a test library of 200 movies:

before
```
2024-12-14 20:56:15.754 T:21680   debug <general>: VideoInfoScanner: Skipping dir 'Y:\Movies\2012 (2009)\' due to no change
2024-12-14 20:56:15.781 T:21680   debug <general>: VideoInfoScanner: Skipping dir 'Y:\Movies\3000 Miles to Graceland (2001)\' due to no change
2024-12-14 20:56:15.784 T:21680    info <general>: VideoInfoScanner: Finished scan. Scanning for video info took 4464 ms
```

after
```
2024-12-14 20:30:37.641 T:11152   debug <general>: VideoInfoScanner: Skipping dir 'Y:\Movies\2012 (2009)\' due to no change (fasthash)
2024-12-14 20:30:37.651 T:11152   debug <general>: VideoInfoScanner: Skipping dir 'Y:\Movies\3000 Miles to Graceland (2001)\' due to no change (fasthash)
2024-12-14 20:30:37.654 T:11152    info <general>: VideoInfoScanner: Finished scan. Scanning for video info took 3150 ms
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
