### PR TITLE
GUIWindowVideoNav: Support selecting the first unwatched episode or season in video plugins too.

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -362,12 +362,12 @@ NodeType CGUIWindowVideoNav::GetNodeType(const CFileItemList& items)
   {
     return CVideoDatabaseDirectory::GetDirectoryChildType(items.GetPath());
   }
-  
+
   if (items.GetContent() == "seasons")
   {
     return NodeType::SEASONS;
   }
-  
+
   if (items.GetContent() == "episodes")
   {
     return NodeType::EPISODES;

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -432,7 +432,6 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
           if (!videoUrl.FromString(items.GetPath()))
             return false;
 
-          // This -2 is an indicator for the video database to not filter on season.
           videoUrl.AppendPath("-2/");
           return GetDirectory(videoUrl.ToString(), items);
         }

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -75,26 +75,26 @@ using namespace KODI::MESSAGING;
 
 namespace
 {
-  NodeType GetItemListNodeType(const CFileItemList& items)
+NodeType GetItemListNodeType(const CFileItemList& items)
+{
+  if (VIDEO::IsVideoDb(items))
   {
-    if (VIDEO::IsVideoDb(items))
-    {
-      return CVideoDatabaseDirectory::GetDirectoryChildType(items.GetPath());
-    }
-
-    if (items.GetContent() == "seasons")
-    {
-      return NodeType::SEASONS;
-    }
-
-    if (items.GetContent() == "episodes")
-    {
-      return NodeType::EPISODES;
-    }
-
-    return NodeType::NONE;
+    return CVideoDatabaseDirectory::GetDirectoryChildType(items.GetPath());
   }
+
+  if (items.GetContent() == "seasons")
+  {
+    return NodeType::SEASONS;
+  }
+
+  if (items.GetContent() == "episodes")
+  {
+    return NodeType::EPISODES;
+  }
+
+  return NodeType::NONE;
 }
+} // namespace
 
 CGUIWindowVideoNav::CGUIWindowVideoNav(void)
     : CGUIWindowVideoBase(WINDOW_VIDEO_NAV, "MyVideoNav.xml")
@@ -275,9 +275,9 @@ SelectFirstUnwatchedItem CGUIWindowVideoNav::GetSettingSelectFirstUnwatchedItem(
 
   if (nodeType == NodeType::SEASONS || nodeType == NodeType::EPISODES)
   {
-    const int iValue = CServiceBroker::GetSettingsComponent()->GetSettings()
-        ->GetInt(CSettings::SETTING_VIDEOLIBRARY_TVSHOWSSELECTFIRSTUNWATCHEDITEM);
-    
+    const int iValue = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+        CSettings::SETTING_VIDEOLIBRARY_TVSHOWSSELECTFIRSTUNWATCHEDITEM);
+
     if (iValue >= static_cast<int>(SelectFirstUnwatchedItem::NEVER) &&
         iValue <= static_cast<int>(SelectFirstUnwatchedItem::ALWAYS))
     {

--- a/xbmc/video/windows/GUIWindowVideoNav.h
+++ b/xbmc/video/windows/GUIWindowVideoNav.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "GUIWindowVideoBase.h"
-#include "filesystem/VideoDatabaseDirectory/DirectoryNode.h"
 
 class CFileItemList;
 
@@ -64,5 +63,4 @@ private:
   virtual IncludeAllSeasonsAndSpecials GetSettingIncludeAllSeasonsAndSpecials();
   virtual int GetFirstUnwatchedItemIndex(bool includeAllSeasons, bool includeSpecials);
   void SelectFirstUnwatched();
-  static XFILE::VIDEODATABASEDIRECTORY::NodeType GetNodeType(const CFileItemList& items);
 };

--- a/xbmc/video/windows/GUIWindowVideoNav.h
+++ b/xbmc/video/windows/GUIWindowVideoNav.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "GUIWindowVideoBase.h"
+#include "filesystem/VideoDatabaseDirectory/DirectoryNode.h"
 
 class CFileItemList;
 
@@ -63,4 +64,5 @@ private:
   virtual IncludeAllSeasonsAndSpecials GetSettingIncludeAllSeasonsAndSpecials();
   virtual int GetFirstUnwatchedItemIndex(bool includeAllSeasons, bool includeSpecials);
   void SelectFirstUnwatched();
+  static XFILE::VIDEODATABASEDIRECTORY::NodeType GetNodeType(const CFileItemList& items);
 };


### PR DESCRIPTION
## Description
Extracts the logic for getting the `NodeType` of an items query in `CGUIWindowVideoNav` to a separate function that also supports using `GetContent` in addition to querying the VideoDatabase for the node type.

## Motivation and context
This change is to allow video plugin developers to also respect the option to select the first unwatched episode when listing episodes for TV-Shows and Seasons.

## How has this been tested?
This has been tested on Windows 11 x64 locally using a custom Video Plugin and the regular Video Database implementation.

## What is the effect on users?
When using supported video plugins and the option to select the first unwatched episode is enabled, the first unwatched episode should now be selected when listing episodes from the video plugins.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
