### PR TITLE
xbmc/interfaces: Allow PlayOrQueueMedia builtin to resume non-video-database items

### DIFF
--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -495,8 +495,11 @@ int PlayOrQueueMedia(const std::vector<std::string>& params, bool forcePlay)
       CMediaSettings::GetInstance().SetMediaStartWindowed(true);
     else if (StringUtils::EqualsNoCase(params[i], "resume"))
     {
-      // force the item to resume (if applicable)
-      if (VIDEO::UTILS::GetItemResumeInformation(item).isResumable)
+      // Force the item to resume (if applicable).
+      // If item is provided by a plugin, we don't know if this can be resumed or not at this point,
+      // that information was lost when the item was turned into a string but we were told to resume
+      // so we will try to do that.
+      if (item.IsPlugin() || VIDEO::UTILS::GetItemResumeInformation(item).isResumable)
         item.SetStartOffset(STARTOFFSET_RESUME);
       else
         item.SetStartOffset(0);


### PR DESCRIPTION
## Description
Updated PlayMedia command to only check for "isResumable" when asked to "resume" when the item is a videodb item. Because in every other case the query will return false.

## Motivation and context
This is to fix being able to resume a non-video-database video that was launched from a DirectoryProvider. This occurs in my case when launching a video addon video from a widget.

## How has this been tested?
This was tested on a Win64 machine using a homescreen widget created by the skin Arctic Zephyr: Reloaded. A plugin that exhibits the issue is available in the comments as well as a video detailing how to setup the widget to test out.

## What is the effect on users?
Users of video addons should be able to resume items from widgets when they previously would not be able to

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
