### PR TITLE
[video] Fix resume of (Non-)Videodatabase items if 'play next video automatically' is active.

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2293,6 +2293,18 @@ bool CFileItem::LoadDetails()
     return false;
   }
 
+  if (GetProperty("IsVideoFolder").asBoolean(false))
+  {
+    const std::shared_ptr<CFileItem> loadedItem{VIDEO::UTILS::LoadVideoFilesFolderInfo(*this)};
+    if (loadedItem)
+    {
+      UpdateInfo(*loadedItem);
+      return true;
+    }
+    CLog::LogF(LOGERROR, "Error filling video files folder item details (path={})", GetPath());
+    return false;
+  }
+
   //! @todo add support for other types on demand.
   CLog::LogF(LOGDEBUG, "Unsupported item type (path={})", GetPath());
   return false;

--- a/xbmc/video/VideoUtils.h
+++ b/xbmc/video/VideoUtils.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 
 class CFileItem;
@@ -63,5 +64,12 @@ ResumeInformation GetItemResumeInformation(const CFileItem& item);
  \return The resume information.
  */
 ResumeInformation GetStackPartResumeInformation(const CFileItem& item, unsigned int partNumber);
+
+/*!
+ \brief For a given non-library folder containing video files, load info from the video database.
+ \param folder The folder to load
+ \return The item containing the folder including loaded info.
+ */
+std::shared_ptr<CFileItem> LoadVideoFilesFolderInfo(const CFileItem& folder);
 
 } // namespace KODI::VIDEO::UTILS

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -220,6 +220,9 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
           content = "files";
 
         items.SetContent(content);
+
+        // Get play counts and resume bookmarks for the items.
+        db.GetPlayCounts(items.GetPath(), items);
       }
     }
 
@@ -424,6 +427,7 @@ void PlayItem(
       }
 
       const auto parentItem = std::make_shared<CFileItem>(parentPath, true);
+      parentItem->SetProperty("IsVideoFolder", true);
       parentItem->LoadDetails();
       if (item->GetStartOffset() == STARTOFFSET_RESUME)
         parentItem->SetStartOffset(STARTOFFSET_RESUME);

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -424,6 +424,7 @@ void PlayItem(
       }
 
       const auto parentItem = std::make_shared<CFileItem>(parentPath, true);
+      parentItem->LoadDetails();
       if (item->GetStartOffset() == STARTOFFSET_RESUME)
         parentItem->SetStartOffset(STARTOFFSET_RESUME);
 


### PR DESCRIPTION
With 'play next video automatically' active, selecting 'resume from ...' in item's context menu did not work.

This is fall-out from https://github.com/xbmc/xbmc/pull/26026

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 can you please have a look?  