### PR TITLE
[videoplayer] Restore User Chosen Subtitle Visibility

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -197,6 +197,33 @@ struct SortLanguage
   }
 };
 
+struct SpecialLanguageSetting
+{
+  std::string_view m_code;
+  int m_message;
+};
+
+// Elements sorted in order of appearance in the settings
+constexpr auto specialAudioLangSettings = std::array{
+    SpecialLanguageSetting{audioLanguageMediaDefault, 307},
+    SpecialLanguageSetting{audioLanguageOriginal, 308},
+    SpecialLanguageSetting{audioLanguageDefault, 309},
+};
+
+// Elements in order of appearance in the settings
+constexpr auto specialSubtitlesLangSettings = std::array{
+    SpecialLanguageSetting{subLanguageNone, 231},
+    SpecialLanguageSetting{subLanguageForcedOnly, 13207},
+    SpecialLanguageSetting{subLanguageOriginal, 308},
+    SpecialLanguageSetting{subLanguageDefault, 309},
+};
+
+// Elements in order of appearance in the settings
+constexpr auto specialSubtitlesDownloadLangSettings = std::array{
+    SpecialLanguageSetting{subLanguageOriginal, 308},
+    SpecialLanguageSetting{subLanguageDefault, 309},
+};
+
 CLangInfo::CRegion::CRegion()
 {
   SetDefaults();
@@ -812,9 +839,11 @@ const std::string& CLangInfo::GetAudioLanguage(bool allowFallback) const
 
 void CLangInfo::SetAudioLanguage(const std::string& language, bool isIso6392 /* = false */)
 {
-  if (language.empty() || StringUtils::EqualsNoCase(language, audioLanguageDefault) ||
-      StringUtils::EqualsNoCase(language, audioLanguageOriginal) ||
-      StringUtils::EqualsNoCase(language, audioLanguageMediaDefault))
+  if (language.empty() || std::ranges::find_if(specialAudioLangSettings,
+                                               [&language](const SpecialLanguageSetting& setting) {
+                                                 return StringUtils::EqualsNoCase(language,
+                                                                                  setting.m_code);
+                                               }) != specialAudioLangSettings.end())
   {
     m_audioLanguage.clear();
     return;
@@ -847,10 +876,11 @@ const std::string& CLangInfo::GetSubtitleLanguage(bool allowFallback) const
 
 void CLangInfo::SetSubtitleLanguage(const std::string& language, bool isIso6392 /* = false */)
 {
-  if (language.empty() || StringUtils::EqualsNoCase(language, subLanguageDefault) ||
-      StringUtils::EqualsNoCase(language, subLanguageOriginal) ||
-      StringUtils::EqualsNoCase(language, subLanguageForcedOnly) ||
-      StringUtils::EqualsNoCase(language, subLanguageNone))
+  if (language.empty() || std::ranges::find_if(specialSubtitlesLangSettings,
+                                               [&language](const SpecialLanguageSetting& setting) {
+                                                 return StringUtils::EqualsNoCase(language,
+                                                                                  setting.m_code);
+                                               }) != specialSubtitlesLangSettings.end())
   {
     m_subtitleLanguage.clear();
     return;
@@ -1253,12 +1283,12 @@ void CLangInfo::SettingOptionsAudioStreamLanguagesFiller(const SettingConstPtr& 
                                                          std::vector<StringSettingOption>& list,
                                                          std::string& /*current*/)
 {
-  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(307),
-                    std::string{audioLanguageMediaDefault});
-  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(308),
-                    std::string{audioLanguageOriginal});
-  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(309),
-                    std::string{audioLanguageDefault});
+  for (const auto& special : specialAudioLangSettings)
+  {
+    list.emplace_back(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(special.m_message),
+        std::string{special.m_code});
+  }
 
   AddLanguages(list);
 }
@@ -1267,14 +1297,12 @@ void CLangInfo::SettingOptionsSubtitleStreamLanguagesFiller(const SettingConstPt
                                                             std::vector<StringSettingOption>& list,
                                                             std::string& /*current*/)
 {
-  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(231),
-                    std::string{subLanguageNone});
-  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13207),
-                    std::string{subLanguageForcedOnly});
-  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(308),
-                    std::string{subLanguageOriginal});
-  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(309),
-                    std::string{subLanguageDefault});
+  for (const auto& special : specialSubtitlesLangSettings)
+  {
+    list.emplace_back(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(special.m_message),
+        std::string{special.m_code});
+  }
 
   AddLanguages(list);
 }
@@ -1284,10 +1312,12 @@ void CLangInfo::SettingOptionsSubtitleDownloadlanguagesFiller(
     std::vector<StringSettingOption>& list,
     std::string& /*current*/)
 {
-  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(308),
-                    std::string{subLanguageOriginal});
-  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(309),
-                    std::string{subLanguageDefault});
+  for (const auto& special : specialSubtitlesDownloadLangSettings)
+  {
+    list.emplace_back(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(special.m_message),
+        std::string{special.m_code});
+  }
 
   AddLanguages(list);
 }

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -47,7 +47,7 @@ std::string GetDateStringWithFormat(const CDateTime& date, const std::string& fo
 }
 } // namespace
 
-using namespace PVR;
+using namespace KODI::LANGINFO;
 
 static std::string shortDateFormats[] = {
     // clang-format off
@@ -812,9 +812,9 @@ const std::string& CLangInfo::GetAudioLanguage(bool allowFallback) const
 
 void CLangInfo::SetAudioLanguage(const std::string& language, bool isIso6392 /* = false */)
 {
-  if (language.empty() || StringUtils::EqualsNoCase(language, "default") ||
-      StringUtils::EqualsNoCase(language, "original") ||
-      StringUtils::EqualsNoCase(language, "mediadefault"))
+  if (language.empty() || StringUtils::EqualsNoCase(language, audioLanguageDefault) ||
+      StringUtils::EqualsNoCase(language, audioLanguageOriginal) ||
+      StringUtils::EqualsNoCase(language, audioLanguageMediaDefault))
   {
     m_audioLanguage.clear();
     return;
@@ -847,8 +847,8 @@ const std::string& CLangInfo::GetSubtitleLanguage(bool allowFallback) const
 
 void CLangInfo::SetSubtitleLanguage(const std::string& language, bool isIso6392 /* = false */)
 {
-  if (language.empty() || StringUtils::EqualsNoCase(language, "default") ||
-      StringUtils::EqualsNoCase(language, "original"))
+  if (language.empty() || StringUtils::EqualsNoCase(language, subLanguageDefault) ||
+      StringUtils::EqualsNoCase(language, subLanguageOriginal))
   {
     m_subtitleLanguage.clear();
     return;
@@ -1252,11 +1252,11 @@ void CLangInfo::SettingOptionsAudioStreamLanguagesFiller(const SettingConstPtr& 
                                                          std::string& /*current*/)
 {
   list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(307),
-                    "mediadefault");
+                    std::string{audioLanguageMediaDefault});
   list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(308),
-                    "original");
+                    std::string{audioLanguageOriginal});
   list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(309),
-                    "default");
+                    std::string{audioLanguageDefault});
 
   AddLanguages(list);
 }
@@ -1265,13 +1265,14 @@ void CLangInfo::SettingOptionsSubtitleStreamLanguagesFiller(const SettingConstPt
                                                             std::vector<StringSettingOption>& list,
                                                             std::string& /*current*/)
 {
-  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(231), "none");
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(231),
+                    std::string{subLanguageNone});
   list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13207),
-                    "forced_only");
+                    std::string{subLanguageForcedOnly});
   list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(308),
-                    "original");
+                    std::string{subLanguageOriginal});
   list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(309),
-                    "default");
+                    std::string{subLanguageDefault});
 
   AddLanguages(list);
 }
@@ -1282,9 +1283,9 @@ void CLangInfo::SettingOptionsSubtitleDownloadlanguagesFiller(
     std::string& /*current*/)
 {
   list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(308),
-                    "original");
+                    std::string{subLanguageOriginal});
   list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(309),
-                    "default");
+                    std::string{subLanguageDefault});
 
   AddLanguages(list);
 }

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -848,7 +848,9 @@ const std::string& CLangInfo::GetSubtitleLanguage(bool allowFallback) const
 void CLangInfo::SetSubtitleLanguage(const std::string& language, bool isIso6392 /* = false */)
 {
   if (language.empty() || StringUtils::EqualsNoCase(language, subLanguageDefault) ||
-      StringUtils::EqualsNoCase(language, subLanguageOriginal))
+      StringUtils::EqualsNoCase(language, subLanguageOriginal) ||
+      StringUtils::EqualsNoCase(language, subLanguageForcedOnly) ||
+      StringUtils::EqualsNoCase(language, subLanguageNone))
   {
     m_subtitleLanguage.clear();
     return;

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -47,6 +47,20 @@ enum class MeridiemSymbol
   AM
 };
 
+namespace KODI::LANGINFO
+{
+// audio language special values
+constexpr std::string_view audioLanguageMediaDefault = "mediadefault";
+constexpr std::string_view audioLanguageOriginal = "original";
+constexpr std::string_view audioLanguageDefault = "default";
+
+// subtitles language special values
+constexpr std::string_view subLanguageNone = "none";
+constexpr std::string_view subLanguageForcedOnly = "forced_only";
+constexpr std::string_view subLanguageOriginal = "original";
+constexpr std::string_view subLanguageDefault = "default";
+} // namespace KODI::LANGINFO
+
 class CLangInfo : public ISettingCallback, public ISettingsHandler
 {
 public:

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -111,9 +111,9 @@ public:
     const std::string subLangSetting =
         settings->GetString(CSettings::SETTING_LOCALE_SUBTITLELANGUAGE);
 
-    m_isSubNone = StringUtils::EqualsNoCase(subLangSetting, "none");
-    m_isPrefOriginal = StringUtils::EqualsNoCase(subLangSetting, "original");
-    m_isPrefForced = StringUtils::EqualsNoCase(subLangSetting, "forced_only");
+    m_isSubNone = StringUtils::EqualsNoCase(subLangSetting, LANGINFO::subLanguageNone);
+    m_isPrefOriginal = StringUtils::EqualsNoCase(subLangSetting, LANGINFO::subLanguageOriginal);
+    m_isPrefForced = StringUtils::EqualsNoCase(subLangSetting, LANGINFO::subLanguageForcedOnly);
     m_isPrefHearingImp = settings->GetBool(CSettings::SETTING_ACCESSIBILITY_SUBHEARING);
 
     m_subLang = g_langInfo.GetSubtitleLanguage(false);
@@ -211,13 +211,15 @@ public:
 
     const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
 
-    if (!StringUtils::EqualsNoCase(settings->GetString(CSettings::SETTING_LOCALE_AUDIOLANGUAGE), "mediadefault"))
+    if (!StringUtils::EqualsNoCase(settings->GetString(CSettings::SETTING_LOCALE_AUDIOLANGUAGE),
+                                   LANGINFO::audioLanguageMediaDefault))
     {
-      if (!StringUtils::EqualsNoCase(settings->GetString(CSettings::SETTING_LOCALE_AUDIOLANGUAGE), "original"))
+      if (!StringUtils::EqualsNoCase(settings->GetString(CSettings::SETTING_LOCALE_AUDIOLANGUAGE),
+                                     LANGINFO::audioLanguageOriginal))
       {
         std::string audio_language = g_langInfo.GetAudioLanguage(true);
-        PREDICATE_RETURN(g_LangCodeExpander.CompareISO639Codes(audio_language, lh.language)
-          , g_LangCodeExpander.CompareISO639Codes(audio_language, rh.language));
+        PREDICATE_RETURN(g_LangCodeExpander.CompareISO639Codes(audio_language, lh.language),
+                         g_LangCodeExpander.CompareISO639Codes(audio_language, rh.language));
       }
       else
       {
@@ -285,8 +287,8 @@ public:
     const std::string subLangSetting =
         settings->GetString(CSettings::SETTING_LOCALE_SUBTITLELANGUAGE);
 
-    m_isPrefOriginal = StringUtils::EqualsNoCase(subLangSetting, "original");
-    m_isPrefForced = StringUtils::EqualsNoCase(subLangSetting, "forced_only");
+    m_isPrefOriginal = StringUtils::EqualsNoCase(subLangSetting, LANGINFO::subLanguageOriginal);
+    m_isPrefForced = StringUtils::EqualsNoCase(subLangSetting, LANGINFO::subLanguageForcedOnly);
     m_isPrefHearingImp = settings->GetBool(CSettings::SETTING_ACCESSIBILITY_SUBHEARING);
 
     m_subLang = g_langInfo.GetSubtitleLanguage(false);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1055,8 +1055,10 @@ void CVideoPlayer::OpenDefaultStreams(bool reset)
     m_processInfo->ResetAudioCodecInfo();
   }
 
-  // enable  or disable subtitles
+  // enable or disable subtitles
   bool visible = m_processInfo->GetVideoSettings().m_SubtitleOn;
+  const bool isDefaultVideosettings =
+      m_processInfo->GetVideoSettings().m_isDefaultVideoSettings.value_or(true);
 
   // open subtitle stream
   SelectionStream as = m_SelectionStreams.Get(StreamType::AUDIO, GetAudioStream());
@@ -1071,19 +1073,23 @@ void CVideoPlayer::OpenDefaultStreams(bool reset)
     if (OpenStream(m_CurrentSubtitle, stream.demuxerId, stream.id, stream.source))
     {
       valid = true;
-      if(!psp.relevant(stream))
-        visible = false;
-
-      // Image type subtitles (e.g. VOBSUB) can support "forced" flag on overlays (images)
-      // so you need to keep the stream open to parse "forced" flag on each image
-      // since we leave the stream open by default, it is necessary to close it
-      // if the language does not match the preferences.
-      if (!visible && StreamUtils::IsCodecSupportForcedOverlay(stream.codecId) &&
-          !g_LangCodeExpander.CompareISO639Codes(stream.language, as.language))
+      // default settings: let the predicates control sub visibility
+      // video specific settings: respect the user's choice
+      if (isDefaultVideosettings)
       {
-        valid = false;
-      }
+        if (!psp.relevant(stream))
+          visible = false;
 
+        // Image type subtitles (e.g. VOBSUB) can support "forced" flag on overlays (images)
+        // so you need to keep the stream open to parse "forced" flag on each image
+        // since we leave the stream open by default, it is necessary to close it
+        // if the language does not match the preferences.
+        if (!visible && StreamUtils::IsCodecSupportForcedOverlay(stream.codecId) &&
+            !g_LangCodeExpander.CompareISO639Codes(stream.language, as.language))
+        {
+          valid = false;
+        }
+      }
       break;
     }
   }

--- a/xbmc/cores/VideoSettings.h
+++ b/xbmc/cores/VideoSettings.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -10,6 +10,7 @@
 
 #include "utils/Map.h"
 
+#include <optional>
 #include <string_view>
 
 #include <fmt/format.h>
@@ -228,6 +229,8 @@ public:
   float m_ToneMapParam;
   int m_Orientation;
   int m_CenterMixLevel; // relative to metadata or default
+  std::optional<bool>
+      m_isDefaultVideoSettings; //!< true: default video settings, false: video specific
 };
 
 class CCriticalSection;

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -53,6 +53,8 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
     return false;
 
   std::unique_lock lock(m_critical);
+
+  m_defaultVideoSettings.m_isDefaultVideoSettings = true;
   const TiXmlElement *pElement = settings->FirstChildElement("defaultvideosettings");
   if (pElement)
   {

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5034,6 +5034,7 @@ bool CVideoDatabase::GetVideoSettings(int idFile, CVideoSettings &settings)
       settings.m_Orientation = m_pDS->fv("Orientation").get_asInt();
       settings.m_CenterMixLevel = m_pDS->fv("CenterMixLevel").get_asInt();
       m_pDS->close();
+      settings.m_isDefaultVideoSettings = false;
       return true;
     }
     m_pDS->close();

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -374,7 +374,7 @@ void CGUIDialogSubtitles::Search(const std::string &search/*=""*/)
 
   std::string preferredLanguage = settings->GetString(CSettings::SETTING_LOCALE_SUBTITLELANGUAGE);
 
-  if (StringUtils::EqualsNoCase(preferredLanguage, "original"))
+  if (StringUtils::EqualsNoCase(preferredLanguage, KODI::LANGINFO::subLanguageOriginal))
   {
     AudioStreamInfo info;
     std::string strLanguage;
@@ -388,7 +388,7 @@ void CGUIDialogSubtitles::Search(const std::string &search/*=""*/)
 
     preferredLanguage = strLanguage;
   }
-  else if (StringUtils::EqualsNoCase(preferredLanguage, "default"))
+  else if (StringUtils::EqualsNoCase(preferredLanguage, KODI::LANGINFO::subLanguageDefault))
     preferredLanguage = g_langInfo.GetEnglishLanguageName();
 
   url.SetOption("preferredlanguage", preferredLanguage);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

After stopping and restarting a video, the sub visibility sometimes changes because the priority and filter rules in OpenDefaultStreams override the video settings m_SubtitleOn value.
See example situations  in "Motivation and context".

This is partly caused by the user changing only the visibility and not switching sub track (m_SubtitleStream remains -1 so the condition of relevant() to restore the previous active track doesn't work).

The solution of the PR is to distinguish the first play of the video with the default system settings from the following plays (with video specific settings, if the user changed anything).

First play: let the priority and rules override the default system value If there are any overrides, the effective visibility status is saved to video settings.
Next plays: restore the video setting, without any override by priority/relevance allowed.

Refactored a bit the code related to the special languages "None" "Forced Only" "Default" "Original"

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Users changes of the subs visibility should be restored on the next play of a video.

For example, with default Kodi settings (subtitles are set to on by default for all videos, sub language is the special value "forced only" (or "none" carried over from v21):
- Play a video with non-forced subs. Subs not initially visible as expected. Turn on the first subs track (or press T) and they're visible. Stop playback. Play the video again > subs are hidden again, instead of visible per user choice.

- Set a preferred language (ex en)
- Play a video with subtitles of that language > appear by default. Turn them off with the OSD or the key T and they're hidden. Stop playback. Play the video again > subs visible again instead of hidden per user choice.


## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

subtitles on and off by default, videos with no subs, videos with only irrelevant tracks, videos with only forced tracks, videos with mixes of tracks.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

When playing a video a second time, the visibility of the subs is the same as chosen by the user in the first play.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
