### PR TITLE
[pvr] Narrowing Casts Cleanup

### DIFF
--- a/xbmc/pvr/PVRChannelNumberInputHandler.cpp
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.cpp
@@ -21,17 +21,17 @@
 using namespace PVR;
 using namespace std::chrono_literals;
 
-CPVRChannelNumberInputHandler::CPVRChannelNumberInputHandler()
-  : CPVRChannelNumberInputHandler(CServiceBroker::GetSettingsComponent()
-                                      ->GetAdvancedSettings()
-                                      ->m_iPVRNumericChannelSwitchTimeout,
-                                  CHANNEL_NUMBER_INPUT_MAX_DIGITS)
+namespace
 {
-}
+constexpr size_t CHANNEL_NUMBER_INPUT_MAX_DIGITS = 5;
 
-CPVRChannelNumberInputHandler::CPVRChannelNumberInputHandler(
-    int iDelay, int iMaxDigits /* = CHANNEL_NUMBER_INPUT_MAX_DIGITS */)
-  : m_iDelay(iDelay), m_iMaxDigits(iMaxDigits), m_timer(this)
+} // unnamed namespace
+
+CPVRChannelNumberInputHandler::CPVRChannelNumberInputHandler()
+  : m_delay(CServiceBroker::GetSettingsComponent()
+                ->GetAdvancedSettings()
+                ->m_iPVRNumericChannelSwitchTimeout),
+    m_timer(this)
 {
 }
 
@@ -96,7 +96,7 @@ void CPVRChannelNumberInputHandler::AppendChannelNumberCharacter(char cCharacter
       return;
   }
 
-  if (m_inputBuffer.size() == static_cast<size_t>(m_iMaxDigits))
+  if (m_inputBuffer.size() == CHANNEL_NUMBER_INPUT_MAX_DIGITS)
   {
     m_inputBuffer.erase(m_inputBuffer.begin());
     SetLabel(m_inputBuffer);
@@ -134,7 +134,7 @@ void CPVRChannelNumberInputHandler::AppendChannelNumberCharacter(char cCharacter
   }
 
   if (!m_timer.IsRunning())
-    m_timer.Start(std::chrono::milliseconds(m_iDelay));
+    m_timer.Start(std::chrono::milliseconds(m_delay));
   else
     m_timer.Restart();
 }

--- a/xbmc/pvr/PVRChannelNumberInputHandler.h
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.h
@@ -29,17 +29,7 @@ struct PVRChannelNumberInputChangedEvent
 class CPVRChannelNumberInputHandler : private ITimerCallback
 {
 public:
-  static const int CHANNEL_NUMBER_INPUT_MAX_DIGITS = 5;
-
   CPVRChannelNumberInputHandler();
-
-  /*!
-   * @brief ctor.
-   * @param iDelay timer delay in millisecods.
-   * @param iMaxDigits maximum number of display digits to use.
-   */
-  CPVRChannelNumberInputHandler(int iDelay, int iMaxDigits = CHANNEL_NUMBER_INPUT_MAX_DIGITS);
-
   ~CPVRChannelNumberInputHandler() override = default;
 
   /*!
@@ -107,8 +97,7 @@ private:
   void SetLabel(const std::string& label);
 
   std::vector<std::string> m_sortedChannelNumbers;
-  const int m_iDelay;
-  const int m_iMaxDigits;
+  const uint32_t m_delay;
   std::string m_inputBuffer;
   std::string m_label;
   CTimer m_timer;

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -980,13 +980,11 @@ std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRDatabase::Get(
         newMember->m_iGroupID = group.GroupID();
         newMember->m_iGroupClientID = group.GetClientID();
         newMember->m_bIsRadio = m_pDS->fv("bIsRadio").get_asBool();
-        newMember->m_channelNumber = {
-            static_cast<unsigned int>(m_pDS->fv("iChannelNumber").get_asInt()),
-            static_cast<unsigned int>(m_pDS->fv("iSubChannelNumber").get_asInt())};
-        newMember->m_clientChannelNumber = {
-            static_cast<unsigned int>(m_pDS->fv("iClientChannelNumber").get_asInt()),
-            static_cast<unsigned int>(m_pDS->fv("iClientSubChannelNumber").get_asInt())};
-        newMember->m_iOrder = static_cast<int>(m_pDS->fv("iOrder").get_asInt());
+        newMember->m_channelNumber = {m_pDS->fv("iChannelNumber").get_asUInt(),
+                                      m_pDS->fv("iSubChannelNumber").get_asUInt()};
+        newMember->m_clientChannelNumber = {m_pDS->fv("iClientChannelNumber").get_asUInt(),
+                                            m_pDS->fv("iClientSubChannelNumber").get_asUInt()};
+        newMember->m_iOrder = m_pDS->fv("iOrder").get_asInt();
         newMember->SetGroupName(group.GroupName());
 
         results.emplace_back(newMember);

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -44,6 +44,7 @@
 #include "pvr/timers/PVRTimers.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/MathUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
@@ -169,8 +170,7 @@ public:
     iGenreType = recording.GenreType();
     iGenreSubType = recording.GenreSubType();
     iPlayCount = recording.GetLocalPlayCount();
-    iLastPlayedPosition =
-        static_cast<int>(std::lrint(recording.GetLocalResumePoint().timeInSeconds));
+    iLastPlayedPosition = MathUtils::round_int(recording.GetLocalResumePoint().timeInSeconds);
     bIsDeleted = recording.IsDeleted();
     iEpgEventId = recording.BroadcastUid();
     iChannelUid = recording.ChannelUid();

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -304,12 +304,11 @@ std::shared_ptr<CPVRClient> CPVRClients::GetClient(int clientId) const
   return {};
 }
 
-int CPVRClients::CreatedClientAmount() const
+size_t CPVRClients::CreatedClientAmount() const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
-  return static_cast<int>(std::count_if(m_clientMap.cbegin(), m_clientMap.cend(),
-                                        [](const auto& client)
-                                        { return client.second->ReadyToUse(); }));
+  return std::count_if(m_clientMap.cbegin(), m_clientMap.cend(),
+                       [](const auto& client) { return client.second->ReadyToUse(); });
 }
 
 bool CPVRClients::HasCreatedClients() const
@@ -438,7 +437,7 @@ PVR_ERROR CPVRClients::GetCallableClients(CPVRClientMap& clientsReady,
   return clientsNotReady.empty() ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
 }
 
-int CPVRClients::EnabledClientAmount() const
+size_t CPVRClients::EnabledClientAmount() const
 {
   CPVRClientMap clientMap;
   {
@@ -447,9 +446,9 @@ int CPVRClients::EnabledClientAmount() const
   }
 
   ADDON::CAddonMgr& addonMgr = CServiceBroker::GetAddonMgr();
-  return static_cast<int>(std::count_if(
-      clientMap.cbegin(), clientMap.cend(),
-      [&addonMgr](const auto& client) { return !addonMgr.IsAddonDisabled(client.second->ID()); }));
+  return std::count_if(clientMap.cbegin(), clientMap.cend(),
+                       [&addonMgr](const auto& client)
+                       { return !addonMgr.IsAddonDisabled(client.second->ID()); });
 }
 
 bool CPVRClients::IsEnabledClient(int clientId) const

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -167,12 +167,11 @@ void CPVRClients::UpdateClients(
     auto progressHandler = std::make_unique<CPVRGUIProgressHandler>(
         g_localizeStrings.Get(19239)); // Creating PVR clients
 
-    unsigned int i = 0;
+    size_t i = 0;
     for (const auto& client : clientsToCreate)
     {
-      progressHandler->UpdateProgress(
-          client->Name(), i++,
-          static_cast<unsigned int>(clientsToCreate.size() + clientsToReCreate.size()));
+      progressHandler->UpdateProgress(client->Name(), i++,
+                                      clientsToCreate.size() + clientsToReCreate.size());
 
       const ADDON_STATUS status = client->Create();
 
@@ -192,9 +191,8 @@ void CPVRClients::UpdateClients(
 
     for (const auto& clientInfo : clientsToReCreate)
     {
-      progressHandler->UpdateProgress(
-          clientInfo.second, i++,
-          static_cast<unsigned int>(clientsToCreate.size() + clientsToReCreate.size()));
+      progressHandler->UpdateProgress(clientInfo.second, i++,
+                                      clientsToCreate.size() + clientsToReCreate.size());
 
       // stop and recreate client
       StopClient(clientInfo.first, true /* restart */);

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -120,7 +120,7 @@ struct SBackend
      * @brief Get the number of created clients.
      * @return The amount of created clients.
      */
-    int CreatedClientAmount() const;
+    size_t CreatedClientAmount() const;
 
     /*!
      * @brief Check whether there are any created clients.
@@ -164,7 +164,7 @@ struct SBackend
      * @brief Get the number of enabled clients.
      * @return The amount of enabled clients.
      */
-    int EnabledClientAmount() const;
+    size_t EnabledClientAmount() const;
 
     /*!
      * @brief Check whether a given client ID points to an enabled client.

--- a/xbmc/pvr/channels/PVRChannelGroupSettings.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupSettings.cpp
@@ -86,7 +86,8 @@ bool CPVRChannelGroupSettings::UpdateUseBackendChannelOrder()
 
 bool CPVRChannelGroupSettings::UpdateUseBackendChannelNumbers()
 {
-  const int enabledClientAmount = CServiceBroker::GetPVRManager().Clients()->EnabledClientAmount();
+  const size_t enabledClientAmount =
+      CServiceBroker::GetPVRManager().Clients()->EnabledClientAmount();
   m_bUseBackendChannelNumbers =
       m_settings.GetBoolValue(CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERS) &&
       (enabledClientAmount == 1 ||

--- a/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
+++ b/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
@@ -643,14 +643,14 @@ void CPVRRadioRDSInfoTag::SetProgramServiceText(const std::string& strPSText)
   for (size_t i = m_strProgramServiceText.MaxSize() / 2 + 1; i < m_strProgramServiceText.MaxSize();
        ++i)
   {
-    m_strProgramServiceLine0 += m_strProgramServiceText.GetLine(static_cast<unsigned int>(i));
+    m_strProgramServiceLine0 += m_strProgramServiceText.GetLine(i);
     m_strProgramServiceLine0 += ' ';
   }
 
   m_strProgramServiceLine1.erase();
   for (size_t i = 0; i < m_strProgramServiceText.MaxSize() / 2; ++i)
   {
-    m_strProgramServiceLine1 += m_strProgramServiceText.GetLine(static_cast<unsigned int>(i));
+    m_strProgramServiceLine1 += m_strProgramServiceText.GetLine(i);
     m_strProgramServiceLine1 += ' ';
   }
 }

--- a/xbmc/pvr/channels/PVRRadioRDSInfoTag.h
+++ b/xbmc/pvr/channels/PVRRadioRDSInfoTag.h
@@ -161,10 +161,7 @@ private:
     void Add(const std::string& text);
 
     const std::string& GetText() const { return m_infoText; }
-    std::string GetLine(unsigned int line) const
-    {
-      return line < m_data.size() ? m_data.at(line) : "";
-    }
+    std::string GetLine(size_t line) const { return line < m_data.size() ? m_data.at(line) : ""; }
 
   private:
     const size_t m_maxSize = 10;

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -733,7 +733,6 @@ bool CPVREpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
 
   std::vector<std::shared_ptr<CPVREpg>> invalidTables;
 
-  unsigned int iCounter = 0;
   const std::shared_ptr<CPVREpgDatabase> database = GetEpgDatabase();
 
   m_critSection.lock();
@@ -745,6 +744,7 @@ bool CPVREpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
     progressHandler = std::make_unique<CPVRGUIProgressHandler>(
         g_localizeStrings.Get(19004)); // Loading programme guide
 
+  size_t counter = 0;
   for (const auto& epgEntry : epgsToUpdate)
   {
     if (InterruptUpdate())
@@ -758,8 +758,8 @@ bool CPVREpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
       continue;
 
     if (progressHandler)
-      progressHandler->UpdateProgress(epg->GetChannelData()->ChannelName(), ++iCounter,
-                                      static_cast<unsigned int>(epgsToUpdate.size()));
+      progressHandler->UpdateProgress(epg->GetChannelData()->ChannelName(), ++counter,
+                                      epgsToUpdate.size());
 
     if ((!bOnlyPending || epg->UpdatePending()) &&
         epg->Update(start,

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -245,9 +245,9 @@ bool CPVREpgInfoTag::IsUpcoming() const
   return (m_startTime > now);
 }
 
-float CPVREpgInfoTag::ProgressPercentage() const
+double CPVREpgInfoTag::ProgressPercentage() const
 {
-  float fReturn = 0.0f;
+  double ret = 0.0;
 
   time_t currentTime, startTime, endTime;
   CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(currentTime);
@@ -256,16 +256,19 @@ float CPVREpgInfoTag::ProgressPercentage() const
 
   if (currentTime >= startTime && currentTime <= endTime)
   {
-    const std::chrono::duration<float> current{currentTime - startTime};
-    const std::chrono::duration<float> total{endTime - startTime > 0 ? endTime - startTime
-                                                                     : 3600.0f};
-    fReturn = current.count() * 100.0f / total.count();
+    const std::chrono::duration<double> total{endTime - startTime > 0 ? endTime - startTime
+                                                                      : 3600.0};
+    if (total.count())
+    {
+      const std::chrono::duration<double> current{currentTime - startTime};
+      ret = current.count() * 100.0 / total.count();
+    }
   }
   else if (currentTime > endTime)
   {
-    fReturn = 100.0f;
+    ret = 100.0;
   }
-  return fReturn;
+  return ret;
 }
 
 unsigned int CPVREpgInfoTag::Progress() const

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -103,7 +103,7 @@ public:
    * @brief Get the progress of this tag in percent.
    * @return The current progress of this tag.
    */
-  float ProgressPercentage() const;
+  double ProgressPercentage() const;
 
   /*!
    * @brief Get the progress of this tag in seconds.

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -194,9 +194,8 @@ void CGUIEPGGridContainer::Process(unsigned int currentTime, CDirtyRegionList& d
   {
     int iItem =
         (m_orientation == VERTICAL)
-            ? MathUtils::round_int(static_cast<double>(m_channelScrollOffset / m_channelHeight))
-            : MathUtils::round_int(
-                  static_cast<double>(m_programmeScrollOffset / (m_gridHeight / m_blocksPerPage)));
+            ? MathUtils::round_int(m_channelScrollOffset / m_channelHeight)
+            : MathUtils::round_int(m_programmeScrollOffset / (m_gridHeight / m_blocksPerPage));
 
     CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), m_pageControl, iItem);
     SendWindowMessage(msg);
@@ -838,8 +837,7 @@ float CGUIEPGGridContainer::GetProgrammeScrollOffsetPos() const
 int CGUIEPGGridContainer::GetChannelScrollOffset(CGUIListItemLayout* layout) const
 {
   if (m_bEnableChannelScrolling)
-    return MathUtils::round_int(
-        static_cast<double>(m_channelScrollOffset / layout->Size(m_orientation)));
+    return MathUtils::round_int(m_channelScrollOffset / layout->Size(m_orientation));
   else
     return m_channelOffset;
 }
@@ -847,7 +845,7 @@ int CGUIEPGGridContainer::GetChannelScrollOffset(CGUIListItemLayout* layout) con
 int CGUIEPGGridContainer::GetProgrammeScrollOffset() const
 {
   if (m_bEnableProgrammeScrolling)
-    return MathUtils::round_int(static_cast<double>(m_programmeScrollOffset / m_blockSize));
+    return MathUtils::round_int(m_programmeScrollOffset / m_blockSize);
   else
     return m_blockOffset;
 }
@@ -1262,11 +1260,10 @@ EVENT_RESULT CGUIEPGGridContainer::OnMouseEvent(const CPoint& point,
       // we're done with exclusive access
       CGUIMessage msg(GUI_MSG_EXCLUSIVE_MOUSE, 0, GetParentID());
       SendWindowMessage(msg);
-      ScrollToChannelOffset(MathUtils::round_int(
-          static_cast<double>(m_channelScrollOffset / m_channelLayout->Size(m_orientation))));
+      ScrollToChannelOffset(
+          MathUtils::round_int(m_channelScrollOffset / m_channelLayout->Size(m_orientation)));
       SetChannel(m_channelCursor);
-      ScrollToBlockOffset(
-          MathUtils::round_int(static_cast<double>(m_programmeScrollOffset / m_blockSize)));
+      ScrollToBlockOffset(MathUtils::round_int(m_programmeScrollOffset / m_blockSize));
       SetBlock(m_blockCursor);
       return EVENT_RESULT_HANDLED;
     }
@@ -1278,10 +1275,9 @@ EVENT_RESULT CGUIEPGGridContainer::OnMouseEvent(const CPoint& point,
       {
         std::unique_lock<CCriticalSection> lock(m_critSection);
 
-        m_channelOffset = MathUtils::round_int(
-            static_cast<double>(m_channelScrollOffset / m_channelLayout->Size(m_orientation)));
-        m_blockOffset =
-            MathUtils::round_int(static_cast<double>(m_programmeScrollOffset / m_blockSize));
+        m_channelOffset =
+            MathUtils::round_int(m_channelScrollOffset / m_channelLayout->Size(m_orientation));
+        m_blockOffset = MathUtils::round_int(m_programmeScrollOffset / m_blockSize);
         ValidateOffset();
       }
       return EVENT_RESULT_HANDLED;
@@ -2556,8 +2552,8 @@ void CGUIEPGGridContainer::HandleProgrammeGrid(bool bRender,
         // increment our X position
         posA2 += m_gridModel->GetGridItemWidth(
             channel, block); // assumes focused & unfocused layouts have equal length
-        block += MathUtils::round_int(
-            static_cast<double>(m_gridModel->GetGridItemOriginWidth(channel, block) / m_blockSize));
+        block +=
+            MathUtils::round_int(m_gridModel->GetGridItemOriginWidth(channel, block) / m_blockSize);
       }
     }
 

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
@@ -516,7 +516,7 @@ bool CPVRGUIActionsTimers::SetRecordingOnChannel(const std::shared_ptr<CPVRChann
               selector.AddAction(RECORD_NEXT_SHOW, nextTitle);
 
               // be smart. if current show is almost over, preselect next show.
-              if (epgTag->ProgressPercentage() > 90.0f)
+              if (epgTag->ProgressPercentage() > 90.0)
                 ePreselect = RECORD_NEXT_SHOW;
             }
           }

--- a/xbmc/pvr/guilib/PVRGUIChannelIconUpdater.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelIconUpdater.cpp
@@ -65,13 +65,12 @@ void CPVRGUIChannelIconUpdater::SearchAndUpdateMissingChannelIcons() const
   for (const auto& group : m_groups)
   {
     const std::vector<std::shared_ptr<CPVRChannelGroupMember>> members = group->GetMembers();
-    int channelIndex = 0;
+    size_t channelIndex = 0;
     for (const auto& member : members)
     {
       const std::shared_ptr<CPVRChannel> channel = member->Channel();
 
-      progressHandler->UpdateProgress(channel->ChannelName(), channelIndex++,
-                                      static_cast<unsigned int>(members.size()));
+      progressHandler->UpdateProgress(channel->ChannelName(), channelIndex++, members.size());
 
       // skip if an icon is already set and exists
       if (CFileUtils::Exists(channel->IconPath()))

--- a/xbmc/pvr/guilib/PVRGUIProgressHandler.cpp
+++ b/xbmc/pvr/guilib/PVRGUIProgressHandler.cpp
@@ -43,15 +43,15 @@ void CPVRGUIProgressHandler::UpdateProgress(const std::string& strText, float fP
   }
 }
 
-void CPVRGUIProgressHandler::UpdateProgress(const std::string& strText,
-                                            unsigned int iCurrent,
-                                            unsigned int iMax)
+void CPVRGUIProgressHandler::UpdateProgress(const std::string& text,
+                                            size_t currentValue,
+                                            size_t maxValue)
 {
-  float fPercentage = (iCurrent * 100.0f) / iMax;
-  if (!std::isnan(fPercentage))
-    fPercentage = std::min(100.0f, fPercentage);
+  float percentage = (currentValue * 100.0f) / maxValue;
+  if (!std::isnan(percentage))
+    percentage = std::min(100.0f, percentage);
 
-  UpdateProgress(strText, fPercentage);
+  UpdateProgress(text, percentage);
 }
 
 void CPVRGUIProgressHandler::Process()

--- a/xbmc/pvr/guilib/PVRGUIProgressHandler.h
+++ b/xbmc/pvr/guilib/PVRGUIProgressHandler.h
@@ -37,11 +37,11 @@ namespace PVR
 
     /*!
      * @brief Update the progress dialogs's content.
-     * @param strText The new progress text.
-     * @param iCurrent The new current progress value, must be less or equal iMax.
-     * @param iMax The new maximum progress value, must be greater or equal iCurrent.
+     * @param text The new progress text.
+     * @param currentValue The new current progress value, must be less or equal iMax.
+     * @param maxValue The new maximum progress value, must be greater or equal iCurrent.
      */
-    void UpdateProgress(const std::string& strText, unsigned int iCurrent, unsigned int iMax);
+    void UpdateProgress(const std::string& text, size_t currentValue, size_t maxValue);
 
   protected:
     // CThread implementation

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -1482,7 +1482,7 @@ bool CPVRGUIInfo::GetPVRInt(const CFileItem* item, const CGUIInfo& info, int& iV
         iValue = 0xFF;
       return true;
     case PVR_CLIENT_COUNT:
-      iValue = CServiceBroker::GetPVRManager().Clients()->EnabledClientAmount();
+      iValue = static_cast<int>(CServiceBroker::GetPVRManager().Clients()->EnabledClientAmount());
       return true;
   }
   return false;

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -46,6 +46,7 @@
 #include "settings/SettingsComponent.h"
 #include "threads/SingleLock.h"
 #include "threads/SystemClock.h"
+#include "utils/MathUtils.h"
 #include "utils/StringUtils.h"
 
 #include <cmath>
@@ -1468,17 +1469,15 @@ bool CPVRGUIInfo::GetPVRInt(const CFileItem* item, const CGUIInfo& info, int& iV
       iValue = GetTimeShiftSeekPercent();
       return true;
     case PVR_ACTUAL_STREAM_SIG_PROGR:
-      iValue =
-          static_cast<int>(std::lrintf(static_cast<float>(m_qualityInfo.Signal()) / 0xFFFF * 100));
+      iValue = MathUtils::round_int(static_cast<double>(m_qualityInfo.Signal()) / 0xFFFF * 100.0);
       return true;
     case PVR_ACTUAL_STREAM_SNR_PROGR:
-      iValue =
-          static_cast<int>(std::lrintf(static_cast<float>(m_qualityInfo.SNR()) / 0xFFFF * 100));
+      iValue = MathUtils::round_int(static_cast<double>(m_qualityInfo.SNR()) / 0xFFFF * 100.0);
       return true;
     case PVR_BACKEND_DISKSPACE_PROGR:
       if (m_iBackendDiskTotal > 0)
-        iValue = static_cast<int>(
-            std::lrintf(static_cast<float>(m_iBackendDiskUsed) / m_iBackendDiskTotal * 100));
+        iValue = MathUtils::round_int(static_cast<double>(m_iBackendDiskUsed) /
+                                      m_iBackendDiskTotal * 100.0);
       else
         iValue = 0xFF;
       return true;
@@ -2206,14 +2205,14 @@ int CPVRGUIInfo::GetTimeShiftSeekPercent() const
   {
     int total = m_timesInfo.GetTimeshiftProgressDuration();
 
-    float totalTime = static_cast<float>(total);
-    if (totalTime == 0.0f)
+    const double totalTime = static_cast<double>(total);
+    if (totalTime == 0.0)
       return 0;
 
-    float percentPerSecond = 100.0f / totalTime;
-    float percent = progress + percentPerSecond * seekSize;
-    percent = std::max(0.0f, std::min(percent, 100.0f));
-    return static_cast<int>(std::lrintf(percent));
+    const double percentPerSecond = 100.0 / totalTime;
+    double percent = progress + percentPerSecond * seekSize;
+    percent = std::max(0.0, std::min(percent, 100.0));
+    return MathUtils::round_int(percent);
   }
   return progress;
 }

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -1281,43 +1281,43 @@ bool CPVRGUIInfo::GetRadioRDSLabel(const CFileItem* item,
         strValue = tag->GetInfoStock();
         return true;
       case RDS_INFO_STOCK_SIZE:
-        strValue = std::to_string(static_cast<int>(tag->GetInfoStock().size()));
+        strValue = std::to_string(tag->GetInfoStock().size());
         return true;
       case RDS_INFO_SPORT:
         strValue = tag->GetInfoSport();
         return true;
       case RDS_INFO_SPORT_SIZE:
-        strValue = std::to_string(static_cast<int>(tag->GetInfoSport().size()));
+        strValue = std::to_string(tag->GetInfoSport().size());
         return true;
       case RDS_INFO_LOTTERY:
         strValue = tag->GetInfoLottery();
         return true;
       case RDS_INFO_LOTTERY_SIZE:
-        strValue = std::to_string(static_cast<int>(tag->GetInfoLottery().size()));
+        strValue = std::to_string(tag->GetInfoLottery().size());
         return true;
       case RDS_INFO_WEATHER:
         strValue = tag->GetInfoWeather();
         return true;
       case RDS_INFO_WEATHER_SIZE:
-        strValue = std::to_string(static_cast<int>(tag->GetInfoWeather().size()));
+        strValue = std::to_string(tag->GetInfoWeather().size());
         return true;
       case RDS_INFO_HOROSCOPE:
         strValue = tag->GetInfoHoroscope();
         return true;
       case RDS_INFO_HOROSCOPE_SIZE:
-        strValue = std::to_string(static_cast<int>(tag->GetInfoHoroscope().size()));
+        strValue = std::to_string(tag->GetInfoHoroscope().size());
         return true;
       case RDS_INFO_CINEMA:
         strValue = tag->GetInfoCinema();
         return true;
       case RDS_INFO_CINEMA_SIZE:
-        strValue = std::to_string(static_cast<int>(tag->GetInfoCinema().size()));
+        strValue = std::to_string(tag->GetInfoCinema().size());
         return true;
       case RDS_INFO_OTHER:
         strValue = tag->GetInfoOther();
         return true;
       case RDS_INFO_OTHER_SIZE:
-        strValue = std::to_string(static_cast<int>(tag->GetInfoOther().size()));
+        strValue = std::to_string(tag->GetInfoOther().size());
         return true;
       case RDS_PROG_HOST:
         strValue = tag->GetProgHost();

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -23,6 +23,7 @@
 #include "pvr/timers/PVRTimers.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/MathUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
@@ -336,7 +337,7 @@ bool CPVRRecording::SetResumePoint(const CBookmark& resumePoint)
   if (client && client->GetClientCapabilities().SupportsRecordingsLastPlayedPosition())
   {
     if (client->SetRecordingLastPlayedPosition(
-            *this, static_cast<int>(std::lrint(resumePoint.timeInSeconds))) != PVR_ERROR_NO_ERROR)
+            *this, MathUtils::round_int(resumePoint.timeInSeconds)) != PVR_ERROR_NO_ERROR)
       return false;
   }
 
@@ -350,8 +351,8 @@ bool CPVRRecording::SetResumePoint(double timeInSeconds,
   const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
   if (client && client->GetClientCapabilities().SupportsRecordingsLastPlayedPosition())
   {
-    if (client->SetRecordingLastPlayedPosition(
-            *this, static_cast<int>(std::lrint(timeInSeconds))) != PVR_ERROR_NO_ERROR)
+    if (client->SetRecordingLastPlayedPosition(*this, MathUtils::round_int(timeInSeconds)) !=
+        PVR_ERROR_NO_ERROR)
       return false;
   }
 

--- a/xbmc/pvr/settings/PVRSettings.cpp
+++ b/xbmc/pvr/settings/PVRSettings.cpp
@@ -198,7 +198,8 @@ bool CPVRSettings::IsSettingVisible(const std::string& condition,
     // Setting is only visible if exactly one PVR client is enabled or
     // the expert setting to always use backend numbers is enabled
     const auto& settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-    int enabledClientAmount = CServiceBroker::GetPVRManager().Clients()->EnabledClientAmount();
+    const size_t enabledClientAmount =
+        CServiceBroker::GetPVRManager().Clients()->EnabledClientAmount();
 
     return enabledClientAmount == 1 ||
            (settings->GetBool(CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERSALWAYS) &&

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1118,7 +1118,8 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetInt(pPVR, "infotoggleinterval", m_iPVRInfoToggleInterval, 0, 30000);
     XMLUtils::GetBoolean(pPVR, "channeliconsautoscan", m_bPVRChannelIconsAutoScan);
     XMLUtils::GetBoolean(pPVR, "autoscaniconsuserset", m_bPVRAutoScanIconsUserSet);
-    XMLUtils::GetInt(pPVR, "numericchannelswitchtimeout", m_iPVRNumericChannelSwitchTimeout, 50, 60000);
+    XMLUtils::GetUInt(pPVR, "numericchannelswitchtimeout", m_iPVRNumericChannelSwitchTimeout, 50,
+                      60000);
     XMLUtils::GetInt(pPVR, "timeshiftthreshold", m_iPVRTimeshiftThreshold, 0, 60);
     XMLUtils::GetBoolean(pPVR, "timeshiftsimpleosd", m_bPVRTimeshiftSimpleOSD);
     TiXmlElement* pSortDecription = pPVR->FirstChildElement("pvrrecordings");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -319,7 +319,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_iPVRInfoToggleInterval; /*!< @brief if there are more than 1 pvr gui info item available (e.g. multiple recordings active at the same time), use this toggle delay in milliseconds. defaults to 3000. */
     bool m_bPVRChannelIconsAutoScan; /*!< @brief automatically scan user defined folder for channel icons when loading internal channel groups */
     bool m_bPVRAutoScanIconsUserSet; /*!< @brief mark channel icons populated by auto scan as "user set" */
-    int m_iPVRNumericChannelSwitchTimeout; /*!< @brief time in msecs after that a channel switch occurs after entering a channel number, if confirmchannelswitch is disabled */
+    uint32_t
+        m_iPVRNumericChannelSwitchTimeout; /*!< @brief time in msecs after that a channel switch occurs after entering a channel number, if confirmchannelswitch is disabled */
     int m_iPVRTimeshiftThreshold; /*!< @brief time diff between current playing time and timeshift buffer end, in seconds, before a playing stream is displayed as timeshifting. */
     bool m_bPVRTimeshiftSimpleOSD; /*!< @brief use simple timeshift OSD (with progress only for the playing event instead of progress for the whole ts buffer). */
     SortDescription m_PVRDefaultSortOrder; /*!< @brief SortDecription used to store default recording sort type and sort order */

--- a/xbmc/utils/MathUtils.h
+++ b/xbmc/utils/MathUtils.h
@@ -152,6 +152,14 @@ namespace MathUtils
 #endif
   }
 
+  /*! \brief Round to nearest integer.
+   \sa truncate_int, test
+  */
+  inline int round_int(float x)
+  {
+    return round_int(static_cast<double>(x));
+  }
+
   /*! \brief Truncate to nearest integer.
    This routine does fast truncation to an integer.
    It should simply drop the fractional portion of the floating point number.


### PR DESCRIPTION
This PR reduces the number of narrowing casts used in the PVR component. Where possible, appropriate data types (e.g. `size_t` as replacement of `int`) were introduced so that no narrowing of values is needed anymore.

Runtime-tested on Android and macOS, latest Kodi master.

@phunkyfish could you please review, best commit by commit. I tried to separate changes into small logical chunks.