### PR TITLE
Fix issue in chorus web interface for video playlists not displayed

### DIFF
--- a/addons/webinterface.default/js/kodi-webinterface.js
+++ b/addons/webinterface.default/js/kodi-webinterface.js
@@ -3214,8 +3214,10 @@ this.Kodi.module("KodiEntities", function(KodiEntities, App, Backbone, Marionett
           model.end = helpers.global.dateStringToObj(model.endtime);
         }
         if (type === 'movie' || type === 'tvshow' || type === 'season') {
-          model.fanart = 'fanart' in model.art ? model.art.fanart : void 0;
-          model.thumbnail = 'poster' in model.art ? model.art.poster : 'thumb' in model.art ? model.art.thumb : void 0;
+          model.fanart = 'art' in model && 'fanart' in model.art ? model.art.fanart : void 0;
+          if (!('thumbnail' in model)) {
+            model.thumbnail = 'art' in model ? ('poster' in model.art ? model.art.poster : 'thumb' in model.art ? model.art.thumb : void 0) : void 0;
+          }
         }
         if (type === 'tvshow' || type === 'season') {
           model.progress = helpers.global.round((model.watchedepisodes / model.episode) * 100, 2);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
Fix issue in chorus web interface for video playlists not displayed

<!--- Describe your change in detail here. -->
Chorus playlists video may not be displayed due to the webinterface trying to look for attributes not existing. This create a js error and leave the playlist empty.
This PR simply makes sure the fields exists or return an empty field.

In details
- `model.art`  may not exist for videos adn shows, so update the code to verify it exists, or return the default value
- `model.thumbnail` may already be returned with the thumbnail path, so if it exists, use it.


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
I was tired of not being able to see and control the queued videos in the interface. This solves it and queued videos are now displayed even if no fanart is returned.

<!--- If it fixes an open issue, please link to the issue here. -->
n/a

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
changed it on my linux install, then in mac os install.

<!--- Include details of your testing environment, and the tests you ran to -->
webinterface ran with normal use cases, both on linux ubuntu and macos

<!--- see how your change affects other areas of the code, etc. -->
n/a

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
just makes video in playlists showing properly

<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
