### PR TITLE
PipeWire: stop log spam from RequestProcess events

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -607,7 +607,8 @@ unsigned int CAESinkPipewire::AddPackets(uint8_t** data, unsigned int frames, un
 
   } while (true);
 
-  m_stream->TriggerProcess();
+  if (m_stream->IsDriving())
+    m_stream->TriggerProcess();
 
   return frames;
 }

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
@@ -73,6 +73,11 @@ void CPipewireStream::QueueBuffer(pw_buffer* buffer)
   pw_stream_queue_buffer(m_stream.get(), buffer);
 }
 
+bool CPipewireStream::IsDriving() const
+{
+  return pw_stream_is_driving(m_stream.get());
+}
+
 bool CPipewireStream::TriggerProcess() const
 {
   int ret = pw_stream_trigger_process(m_stream.get());

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
@@ -43,6 +43,8 @@ public:
   pw_buffer* DequeueBuffer();
   void QueueBuffer(pw_buffer* buffer);
 
+  bool IsDriving() const;
+
   bool TriggerProcess() const;
 
   void Flush(bool drain);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

This PR fixes an issue where PipeWire error logs are continuously created whenever there is audio playing or if the "keep audio device alive" setting is enabled.

This issue has appeared ever since PipeWire [v1.2.4](https://gitlab.freedesktop.org/pipewire/pipewire/-/compare/1.2.3...1.2.4) introduced a [change](https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/c6ae68b9326f235aa6ee11b62b8e6a9126bb2e22) that forwards RequestProcess events.

These events are emitted whenever [`pw_stream_trigger_process()`](https://github.com/xbmc/xbmc/blob/b794e3660961ad23246035ddd78eabd607581615/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp#L78) is called, which then tries to send RequestProcess commands (`command 10`) to a driver that fails with the error.

Since the stream is a driver, as set by [`PW_STREAM_FLAG_DRIVER`](https://github.com/xbmc/xbmc/blob/b794e3660961ad23246035ddd78eabd607581615/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp#L463), we should only call `pw_stream_trigger_process()` when the stream is driving by checking [`pw_stream_is_driving()`](https://docs.pipewire.org/group__pw__stream.html#ga3ddd332c45aa95250d3d1d26cf01452a). This allows [`do_trigger_driver()`](https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/e4ff13a75d7acf170f6094db148dc77f380d505a/src/pipewire/stream.c#L2598) to be called while not allowing RequestProcess events to be emitted when the stream is not driving.

The [`(impl->trigger)` condition](https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/e4ff13a75d7acf170f6094db148dc77f380d505a/src/pipewire/stream.c#L2594) only applies when the stream has `PW_STREAM_FLAG_TRIGGER` set, which is not the case [here](https://github.com/xbmc/xbmc/blob/b794e3660961ad23246035ddd78eabd607581615/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp#L461).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR fixes #26122.

Other users have also reported the same [issue](https://forum.endeavouros.com/t/thousands-of-pipewire-errors/61069/8).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have tested this fix to be working on Arch (PipeWire v1.2.7) and Ubuntu 24.10 (PipeWire v1.2.4).

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

This change will stop logging errors continuously whenever there is audio playback.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

