### PR TITLE
PipeWire: fix thread loop unlock error

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
@@ -30,14 +30,18 @@ CPipewire::CPipewire()
 CPipewire::~CPipewire()
 {
   if (m_loop)
+    m_loop->Lock();
+
+  m_registry.reset();
+  m_core.reset();
+  m_context.reset();
+
+  if (m_loop)
   {
     m_loop->Unlock();
     m_loop->Stop();
   }
 
-  m_registry.reset();
-  m_core.reset();
-  m_context.reset();
   m_loop.reset();
 
   pw_deinit();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

This PR fixes an issue that causes PipeWire to output an error to the command line after exiting Kodi.

Error message:

```
'this->recurse > 0' failed at ../pipewire/src/pipewire/thread-loop.c:62 do_unlock()
```

Adding a counter to the track number of thread loop locks and unlocks in `CPipewireThreadLoop` indicates there is one extra unlock happening upon exiting the application. This has been traced to the destructor of the `CPipewire` class.

The number of unlocks must be equal to the number of locks to prevent an error.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Several users have reported the same issue:

- <https://forum.kodi.tv/showthread.php?tid=377144>
- <https://forum.kodi.tv/showthread.php?tid=377107>
- <https://forum.kodi.tv/showthread.php?tid=378454>

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have tested this fix to be working on Arch (PipeWire v1.2.7) and Ubuntu 24.10 (PipeWire v1.2.4).

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

The user should no longer see an error upon exit.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
