### PR TITLE
[Windows] Use GetWindowsHDRStatus in ToggleWindowsHDR

### DIFF
--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -113,4 +113,5 @@ public:
 
 private:
   static HDR_STATUS GetWindowsHDRStatusWin32();
+  static HDR_STATUS SetWindowsHDRStatus(bool enable, DXGI_MODE_DESC& modeDesc);
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Split ToggleWindowsHDR in two steps, first a call to GetWindowsHDRStatus() then a call to a new SetWindowsHDRStatus function.

That way ToggleWindowsHDR benefits from the win rt api added to GetWindowsHDRStatus() and both will always see the same screen status.

Refactoring of the code using the win32 api to remove the duplication is out of the scope of this PR.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Both GetWindowsHDRStatus and ToggleWindowsHDR retrieve the HDR status of the current display and initially used the same code (duplication) but they got ouf of sync with PR #24689, which aimed to solve the incorrect handling of wcg screens with Win11 22H2 (used to be incorrectly detected as HDR).

GetWindowsHDRStatus() was fixed but ToggleWindowsHDR was not. Consequence: the wcg screen would always be seen as being in hdr mode and toggle would always attempt to disable hdr. But hdr is already off.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with HDR-capable and SDR screens > no behavior change with Windows 10 22H2 or Windows 11 23H2, as expected.
Unfortunately no wcg screen available.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
