### PR TITLE
[video] Fix default select action 'show info' processing for PVR items.

### DIFF
--- a/xbmc/video/guilib/VideoSelectActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoSelectActionProcessor.cpp
@@ -62,7 +62,7 @@ bool CVideoSelectActionProcessorBase::Process(Action action)
     case ACTION_INFO:
     {
       if (GetDefaultAction() == ACTION_INFO && !KODI::VIDEO::IsVideoDb(*m_item) &&
-          !m_item->IsPlugin() && !m_item->IsScript() &&
+          !m_item->IsPlugin() && !m_item->IsScript() && !m_item->IsPVR() &&
           !KODI::VIDEO::UTILS::HasItemVideoDbInformation(*m_item))
       {
         // for items without info fall back to default play action


### PR DESCRIPTION
Fixes a regression reported in the forum: https://forum.kodi.tv/showthread.php?tid=379822

Runtime-tested at macOS, latest Kodi master.

@enen92 Could you please review.

Needs backport.