### PR TITLE
[Omega][video] Fix default select action 'show info' processing for PVR items.

### DIFF
--- a/xbmc/video/guilib/VideoSelectActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoSelectActionProcessor.cpp
@@ -59,7 +59,8 @@ bool CVideoSelectActionProcessorBase::Process(Action action)
     case ACTION_INFO:
     {
       if (GetDefaultAction() == ACTION_INFO && !m_item->IsVideoDb() && !m_item->IsPlugin() &&
-          !m_item->IsScript() && !VIDEO_UTILS::HasItemVideoDbInformation(*m_item))
+          !m_item->IsScript() && !m_item->IsPVR() &&
+          !VIDEO_UTILS::HasItemVideoDbInformation(*m_item))
       {
         // for items without info fall back to default play action
         return Process(CVideoPlayActionProcessorBase::GetDefaultAction());


### PR DESCRIPTION
Fixes a regression reported in the forum: https://forum.kodi.tv/showthread.php?tid=379822

Runtime-tested at macOS, latest Kodi Omega branch.

@enen92 Could you please review.

Needs backport.