### PR TITLE
[Backport][Windows] Add full support for HDR toggle in Windows 11 24H2

### DIFF
--- a/xbmc/platform/win32/SDK_26100.h
+++ b/xbmc/platform/win32/SDK_26100.h
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+enum
+{
+  DISPLAYCONFIG_DEVICE_INFO_SET_RESERVED1 = 14,
+  DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO_2 = 15,
+  DISPLAYCONFIG_DEVICE_INFO_SET_HDR_STATE = 16,
+  DISPLAYCONFIG_DEVICE_INFO_SET_WCG_STATE = 17,
+};
+
+typedef enum _DISPLAYCONFIG_ADVANCED_COLOR_MODE
+{
+  DISPLAYCONFIG_ADVANCED_COLOR_MODE_SDR,
+  DISPLAYCONFIG_ADVANCED_COLOR_MODE_WCG,
+  DISPLAYCONFIG_ADVANCED_COLOR_MODE_HDR
+} DISPLAYCONFIG_ADVANCED_COLOR_MODE;
+
+typedef struct _DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO_2
+{
+  DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+  union
+  {
+    struct
+    {
+      UINT32 advancedColorSupported : 1;
+      UINT32 advancedColorActive : 1;
+      UINT32 reserved1 : 1;
+      UINT32 advancedColorLimitedByPolicy : 1;
+      UINT32 highDynamicRangeSupported : 1;
+      UINT32 highDynamicRangeUserEnabled : 1;
+      UINT32 wideColorSupported : 1;
+      UINT32 wideColorUserEnabled : 1;
+      UINT32 reserved : 24;
+    };
+    UINT32 value;
+  };
+  DISPLAYCONFIG_COLOR_ENCODING colorEncoding;
+  UINT32 bitsPerColorChannel;
+  DISPLAYCONFIG_ADVANCED_COLOR_MODE activeColorMode;
+} DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO_2;
+
+typedef struct _DISPLAYCONFIG_SET_HDR_STATE
+{
+  DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+  union
+  {
+    struct
+    {
+      UINT32 enableHdr : 1;
+      UINT32 reserved : 31;
+    };
+    UINT32 value;
+  };
+} DISPLAYCONFIG_SET_HDR_STATE;

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -776,6 +776,8 @@ std::string CSysInfo::GetOsPrettyNameWithVersion(void)
       break;
     case WindowsVersionWin11_21H2:
     case WindowsVersionWin11_22H2:
+    case WindowsVersionWin11_23H2:
+    case WindowsVersionWin11_24H2:
     case WindowsVersionWin11_Future:
       osNameVer.append("11");
       appendWindows10NameVersion(osNameVer);
@@ -969,7 +971,11 @@ CSysInfo::WindowsVersion CSysInfo::GetWindowsVersion()
         m_WinVer = WindowsVersionWin11_21H2;
       else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 22621)
         m_WinVer = WindowsVersionWin11_22H2;
-      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber > 22621)
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 22631)
+        m_WinVer = WindowsVersionWin11_23H2;
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 26100)
+        m_WinVer = WindowsVersionWin11_24H2;
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber > 26100)
         m_WinVer = WindowsVersionWin11_Future;
       else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber > 19045)
         m_WinVer = WindowsVersionWin10_Future;

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -102,6 +102,8 @@ public:
     WindowsVersionWin10_Future, // Windows 10 future build
     WindowsVersionWin11_21H2,   // Windows 11 21H2 - Sun Valley
     WindowsVersionWin11_22H2,   // Windows 11 22H2 - Sun Valley 2
+    WindowsVersionWin11_23H2,   // Windows 11 23H2 - Sun Valley 3
+    WindowsVersionWin11_24H2,   // Windows 11 24H2 - Hudson Valley
     WindowsVersionWin11_Future, // Windows 11 future build
     /* Insert new Windows versions here, when they'll be known */
     WindowsVersionFuture = 100  // Future Windows version, not known to code


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/26096



## What is the effect on users?
- Fixes HDR toggle broken in Windows 11 24H2 under some circumstances.
- Fixes issues related to WCG (wide color gamut) screens (only fixed in Windows 11 24H2).



## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
