### PR TITLE
[strings] Fix syntax error in Kodi's strings.po.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7645,7 +7645,7 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#13459"
 msgid "Enable/Disable the filter that blocks certain Android software decoders. This filter is configurable via the [userdata]/decoderfilter.xml file."
-msgstr "
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#13460"


### PR DESCRIPTION
Fixes a syntax error in strings.po introduced by https://github.com/xbmc/xbmc/pull/25862
