### PR TITLE
AESinkAudioTrack: Superviseaudiodelay increase success probability

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -815,23 +815,34 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
   if (!IsInitialized())
     return INT_MAX;
 
-  // If the sink did not move twice the buffer size in time it was opened
+  // If the sink did not move twice the buffer size at least 400 ms in time it was opened
   // take action. Some sinks open with e.g. 128 ms nicely but under the
   // hood need a bit more samples to start moving on sink start.
-  // Simple equation: N x stime packages in ms > 2 configured audiotrack_buffer in ms
+  // Simple equation: N x stime packages in ms > 400 ms or 2 buffer sizes in ms
   // will result in the error condition triggering.
 
   const bool isRawPt = m_passthrough && !m_info.m_wantsIECPassthrough;
+  bool forceBlock = false;
   if (!isRawPt)
   {
-    const double max_stuck_delay_ms = m_audiotrackbuffer_sec_orig * 2000.0;
+    const double max_stuck_delay_ms = std::max((m_audiotrackbuffer_sec_orig * 2000.0), 400.0);
     const double stime_ms = 1000.0 * frames / m_format.m_sampleRate;
 
-    if (m_superviseAudioDelay && (m_stuckCounter * stime_ms > max_stuck_delay_ms))
+    if (m_superviseAudioDelay)
     {
-      CLog::Log(LOGERROR, "Sink got stuck with {:f} ms - ask AE for reopening", max_stuck_delay_ms);
-      usleep(max_stuck_delay_ms * 1000);
-      return INT_MAX;
+      if (m_stuckCounter * stime_ms > max_stuck_delay_ms)
+      {
+        CLog::Log(LOGERROR, "Sink got stuck with {:f} ms - ask AE for reopening",
+                  max_stuck_delay_ms);
+        usleep(max_stuck_delay_ms * 1000);
+        return INT_MAX;
+      }
+      else if (m_stuckCounter * stime_ms >= m_audiotrackbuffer_sec_orig * 1000.0)
+      {
+        CLog::LogF(LOGDEBUG, "Sink filling too fast - throttleing - Fillstate: {} ms!",
+                   (m_stuckCounter * stime_ms));
+        forceBlock = true;
+      }
     }
   }
 
@@ -942,6 +953,16 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
         extra_sleep_ms = 0.0;
         CLog::Log(LOGDEBUG, "Resetting pause bursts as buffer level was reached! (1)");
       }
+    }
+  }
+  if (forceBlock)
+  {
+    // Sink consumes too fast - block the frames minus they needed to add
+    double extra_sleep_ms = (1000.0 * frames / m_format.m_sampleRate) - time_to_add_ms;
+    if (extra_sleep_ms > 0.0)
+    {
+      CLog::LogF(LOGDEBUG, "Extra Sleeping for {:f}", extra_sleep_ms);
+      usleep(extra_sleep_ms * 1000);
     }
   }
   return written_frames;


### PR DESCRIPTION
It seems on startup kodi is a bit too fast adding packets. Therefore throttle when we reach the configured buffer length to give the underlaying framework a chance to do its setup job. Allow up to 400 ms offset for the time being as it was seen on the FireTV that the probability of the sink surviving its opening highly increases as the delay settles at around this value later anyways.

Mitigates: https://forum.kodi.tv/showthread.php?tid=371883&pid=3219529 further

This code is only active with the usual superviseaudiodelay advanced setting, see also the forum documentation, here: https://forum.kodi.tv/showthread.php?tid=376161