### PR TITLE
[MUSIC][AUDIOBOOKS] Fix last chapter duration

### DIFF
--- a/xbmc/filesystem/AudioBookFileDirectory.cpp
+++ b/xbmc/filesystem/AudioBookFileDirectory.cpp
@@ -119,7 +119,7 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
       {
         item->SetEndOffset(m_fctx->duration); // mka file
         if (item->GetEndOffset() < 0)
-          item->SetEndOffset(compare); // m4b file
+          item->SetEndOffset(CUtil::ConvertSecsToMilliSecs(compare)); // m4b file
       }
     }
     item->GetMusicInfoTag()->SetDuration(


### PR DESCRIPTION
## Description
Fixes an issue with the last chapter of m4b audiobooks where the duration is either missing or wrong.
## Motivation and context
Forgot originally to convert seconds to milliseconds for the duration of the last chapter.
## How has this been tested?
Scanned some m4b audiobooks and observed that the last chapter in all cases has the correct duration now.

## What is the effect on users?
m4b books display the correct duration for the last chapter.

## Screenshots (if appropriate):
Before : 

![Screenshot from 2024-12-21 15-14-43](https://github.com/user-attachments/assets/958f2773-38af-4229-97b5-8e5c32e113aa)

After : 
![Screenshot from 2024-12-21 14-58-22](https://github.com/user-attachments/assets/66b3f3e9-f117-48c4-b77b-b8ef16e1a95a)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
