### PR TITLE
[Backport] LinuxRendererGL/GLES: improve conditions to enable HDR to SDR tone mapping

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -2716,7 +2716,7 @@ void CLinuxRendererGL::DeleteCLUT()
 void CLinuxRendererGL::CheckVideoParameters(int index)
 {
   const CPictureBuffer& buf = m_buffers[index];
-  ETONEMAPMETHOD method = m_videoSettings.m_ToneMapMethod;
+  const ETONEMAPMETHOD& toneMapMethod = m_videoSettings.m_ToneMapMethod;
 
   if (buf.m_srcPrimaries != m_srcPrimaries)
   {
@@ -2725,20 +2725,20 @@ void CLinuxRendererGL::CheckVideoParameters(int index)
   }
 
   bool toneMap = false;
-  if (method != VS_TONEMAPMETHOD_OFF)
+  const bool streamIsHDRPQ =
+      (buf.m_srcColTransfer == AVCOL_TRC_SMPTE2084 && buf.m_srcPrimaries == AVCOL_PRI_BT2020);
+
+  if (streamIsHDRPQ && toneMapMethod != VS_TONEMAPMETHOD_OFF)
   {
-    if (buf.hasLightMetadata || (buf.hasDisplayMetadata && buf.displayMetadata.has_luminance))
-    {
-      toneMap = true;
-    }
+    toneMap = true;
   }
 
-  if (toneMap != m_toneMap || (m_toneMapMethod != method))
+  if (toneMap != m_toneMap || toneMapMethod != m_toneMapMethod)
   {
     m_reloadShaders = true;
+    m_toneMap = toneMap;
+    m_toneMapMethod = toneMapMethod;
   }
-  m_toneMap = toneMap;
-  m_toneMapMethod = method;
 }
 
 CRenderCapture* CLinuxRendererGL::GetRenderCapture()

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -278,6 +278,7 @@ void CLinuxRendererGL::AddVideoPicture(const VideoPicture &picture, int index)
   buf.loaded = false;
   buf.m_srcPrimaries = picture.color_primaries;
   buf.m_srcColSpace = picture.color_space;
+  buf.m_srcColTransfer = picture.color_transfer;
   buf.m_srcFullRange = picture.color_range == 1;
   buf.m_srcBits = picture.colorBits;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -188,6 +188,8 @@ protected:
 
     AVColorPrimaries m_srcPrimaries;
     AVColorSpace m_srcColSpace;
+    AVColorTransferCharacteristic m_srcColTransfer;
+
     int m_srcBits = 8;
     int m_srcTextureBits = 8;
     bool m_srcFullRange;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -170,6 +170,7 @@ void CLinuxRendererGLES::AddVideoPicture(const VideoPicture &picture, int index)
   buf.loaded = false;
   buf.m_srcPrimaries = picture.color_primaries;
   buf.m_srcColSpace = picture.color_space;
+  buf.m_srcColTransfer = picture.color_transfer;
   buf.m_srcFullRange = picture.color_range == 1;
   buf.m_srcBits = picture.colorBits;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -1728,13 +1728,12 @@ void CLinuxRendererGLES::CheckVideoParameters(int index)
   }
 
   bool toneMap = false;
+  const bool streamIsHDRPQ =
+      (buf.m_srcColTransfer == AVCOL_TRC_SMPTE2084 && buf.m_srcPrimaries == AVCOL_PRI_BT2020);
 
-  if (!m_passthroughHDR && toneMapMethod != VS_TONEMAPMETHOD_OFF)
+  if (streamIsHDRPQ && !m_passthroughHDR && toneMapMethod != VS_TONEMAPMETHOD_OFF)
   {
-    if (buf.hasLightMetadata || (buf.hasDisplayMetadata && buf.displayMetadata.has_luminance))
-    {
-      toneMap = true;
-    }
+    toneMap = true;
   }
 
   if (toneMap != m_toneMap || toneMapMethod != m_toneMapMethod)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -842,30 +842,7 @@ void CLinuxRendererGLES::RenderSinglePass(int index, int field)
   CPictureBuffer &buf = m_buffers[index];
   CYuvPlane (&planes)[YuvImage::MAX_PLANES] = m_buffers[index].fields[field];
 
-  if (buf.m_srcPrimaries != m_srcPrimaries)
-  {
-    m_srcPrimaries = buf.m_srcPrimaries;
-    m_reloadShaders = true;
-  }
-
-  bool toneMap = false;
-  ETONEMAPMETHOD toneMapMethod = m_videoSettings.m_ToneMapMethod;
-
-  if (!m_passthroughHDR && toneMapMethod != VS_TONEMAPMETHOD_OFF)
-  {
-    if (buf.hasLightMetadata || (buf.hasDisplayMetadata && buf.displayMetadata.has_luminance))
-    {
-      toneMap = true;
-    }
-  }
-
-  if (toneMap != m_toneMap || toneMapMethod != m_toneMapMethod)
-  {
-    m_reloadShaders = true;
-  }
-
-  m_toneMap = toneMap;
-  m_toneMapMethod = toneMapMethod;
+  CheckVideoParameters(index);
 
   if (m_reloadShaders)
   {
@@ -976,30 +953,7 @@ void CLinuxRendererGLES::RenderToFBO(int index, int field)
   CPictureBuffer &buf = m_buffers[index];
   CYuvPlane (&planes)[YuvImage::MAX_PLANES] = m_buffers[index].fields[field];
 
-  if (buf.m_srcPrimaries != m_srcPrimaries)
-  {
-    m_srcPrimaries = buf.m_srcPrimaries;
-    m_reloadShaders = true;
-  }
-
-  bool toneMap = false;
-  ETONEMAPMETHOD toneMapMethod = m_videoSettings.m_ToneMapMethod;
-
-  if (toneMapMethod != VS_TONEMAPMETHOD_OFF)
-  {
-    if (buf.hasLightMetadata || (buf.hasDisplayMetadata && buf.displayMetadata.has_luminance))
-    {
-      toneMap = true;
-    }
-  }
-
-  if (toneMap != m_toneMap || m_toneMapMethod != toneMapMethod)
-  {
-    m_reloadShaders = true;
-  }
-
-  m_toneMap = toneMap;
-  m_toneMapMethod = toneMapMethod;
+  CheckVideoParameters(index);
 
   if (m_reloadShaders)
   {
@@ -1760,4 +1714,33 @@ bool CLinuxRendererGLES::IsGuiLayer()
 CRenderCapture* CLinuxRendererGLES::GetRenderCapture()
 {
   return new CRenderCaptureGLES;
+}
+
+void CLinuxRendererGLES::CheckVideoParameters(int index)
+{
+  const CPictureBuffer& buf = m_buffers[index];
+  const ETONEMAPMETHOD& toneMapMethod = m_videoSettings.m_ToneMapMethod;
+
+  if (buf.m_srcPrimaries != m_srcPrimaries)
+  {
+    m_srcPrimaries = buf.m_srcPrimaries;
+    m_reloadShaders = true;
+  }
+
+  bool toneMap = false;
+
+  if (!m_passthroughHDR && toneMapMethod != VS_TONEMAPMETHOD_OFF)
+  {
+    if (buf.hasLightMetadata || (buf.hasDisplayMetadata && buf.displayMetadata.has_luminance))
+    {
+      toneMap = true;
+    }
+  }
+
+  if (toneMap != m_toneMap || toneMapMethod != m_toneMapMethod)
+  {
+    m_reloadShaders = true;
+    m_toneMap = toneMap;
+    m_toneMapMethod = toneMapMethod;
+  }
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -176,6 +176,8 @@ protected:
 
     AVColorPrimaries m_srcPrimaries;
     AVColorSpace m_srcColSpace;
+    AVColorTransferCharacteristic m_srcColTransfer;
+
     int m_srcBits{8};
     int m_srcTextureBits{8};
     bool m_srcFullRange;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -100,6 +100,7 @@ protected:
   virtual void ReleaseShaders();
   void SetTextureFilter(GLenum method);
   void UpdateVideoFilter();
+  void CheckVideoParameters(int index);
   AVColorPrimaries GetSrcPrimaries(AVColorPrimaries srcPrimaries, unsigned int width, unsigned int height);
 
   // textures


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/26052



## What is the effect on users?
Enable/fix HDR to SDR tone mapping on video sources with partial or missing display metadata.



## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
