### PR TITLE
[addons][PVR] Fix PVR_TIMER_TYPE::iPreventDuplicateEpisodesDefault and…

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_timers.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_timers.h
@@ -391,11 +391,11 @@ extern "C"
 
     unsigned int iPreventDuplicateEpisodesSize;
     struct PVR_ATTRIBUTE_INT_VALUE* preventDuplicateEpisodes;
-    unsigned int iPreventDuplicateEpisodesDefault;
+    int iPreventDuplicateEpisodesDefault;
 
     unsigned int iRecordingGroupSize;
     struct PVR_ATTRIBUTE_INT_VALUE* recordingGroup;
-    unsigned int iRecordingGroupDefault;
+    int iRecordingGroupDefault;
 
     unsigned int iMaxRecordingsSize;
     struct PVR_ATTRIBUTE_INT_VALUE* maxRecordings;

--- a/xbmc/pvr/settings/PVRIntSettingValues.cpp
+++ b/xbmc/pvr/settings/PVRIntSettingValues.cpp
@@ -48,15 +48,6 @@ CPVRIntSettingValues::CPVRIntSettingValues(int defaultValue) : m_defaultValue(de
 {
 }
 
-CPVRIntSettingValues::CPVRIntSettingValues(struct PVR_ATTRIBUTE_INT_VALUE* values,
-                                           unsigned int valuesSize,
-                                           unsigned int defaultValue,
-                                           int defaultDescriptionResourceId /* = 0 */)
-  : CPVRIntSettingValues(
-        values, valuesSize, static_cast<int>(defaultValue), defaultDescriptionResourceId)
-{
-}
-
 CPVRIntSettingValues::CPVRIntSettingValues(const std::vector<SettingIntValue>& values,
                                            int defaultValue)
   : m_values(values), m_defaultValue(defaultValue)

--- a/xbmc/pvr/settings/PVRIntSettingValues.h
+++ b/xbmc/pvr/settings/PVRIntSettingValues.h
@@ -27,10 +27,6 @@ public:
                        unsigned int valuesSize,
                        int defaultValue,
                        int defaultDescriptionResourceId = 0);
-  CPVRIntSettingValues(struct PVR_ATTRIBUTE_INT_VALUE* values,
-                       unsigned int valuesSize,
-                       unsigned int defaultValue,
-                       int defaultDescriptionResourceId = 0);
   CPVRIntSettingValues(const std::vector<SettingIntValue>& values, int defaultValue);
 
   virtual ~CPVRIntSettingValues() = default;


### PR DESCRIPTION
… PVR_TIMER_TYPE::iRecordingGroupDefault type (signed/unsigned mismatch).

The mismatch is actually between the C API defining the struct members as an `unsigned int` and the C++ wrapper providing it as an `int`. Although `unsigned` seems semantically more correct, because all timer type default value definitions are `int` I decided for consistency across all the definitions.

The change is ABI compatible, because the member's size does not change.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish could you please review.