### PR TITLE
[interfaces/builtins] If available, pass item instance to 'PlayerControl.(Play|Queue)Media' builtin function

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -3056,7 +3056,7 @@ bool CApplication::ExecuteXBMCAction(std::string actionStr,
   {
     if (!CBuiltins::GetInstance().IsSystemPowerdownCommand(actionStr) ||
         CServiceBroker::GetPVRManager().Get<PVR::GUI::PowerManagement>().CanSystemPowerdown())
-      CBuiltins::GetInstance().Execute(actionStr);
+      CBuiltins::GetInstance().Execute(actionStr, item);
   }
   else
   {

--- a/xbmc/favourites/ContextMenus.cpp
+++ b/xbmc/favourites/ContextMenus.cpp
@@ -123,7 +123,7 @@ bool CFavouritesTargetBrowse::IsVisible(const CFileItem& item) const
 
 bool CFavouritesTargetBrowse::Execute(const std::shared_ptr<CFileItem>& item) const
 {
-  return FAVOURITES_UTILS::ExecuteAction({*item, -1});
+  return FAVOURITES_UTILS::ExecuteAction({*item, -1}, item);
 }
 
 std::string CFavouritesTargetResume::GetLabel(const CFileItem& item) const
@@ -150,7 +150,7 @@ bool CFavouritesTargetResume::Execute(const std::shared_ptr<CFileItem>& item) co
 {
   const std::shared_ptr<CFileItem> targetItem{ResolveFavouriteItem(*item)};
   if (targetItem)
-    return FAVOURITES_UTILS::ExecuteAction({"PlayMedia", *targetItem, "resume"});
+    return FAVOURITES_UTILS::ExecuteAction({"PlayMedia", *targetItem, "resume"}, targetItem);
 
   return false;
 }
@@ -173,7 +173,7 @@ bool CFavouritesTargetPlay::Execute(const std::shared_ptr<CFileItem>& item) cons
 {
   const std::shared_ptr<CFileItem> targetItem{ResolveFavouriteItem(*item)};
   if (targetItem)
-    return FAVOURITES_UTILS::ExecuteAction({"PlayMedia", *targetItem, "noresume"});
+    return FAVOURITES_UTILS::ExecuteAction({"PlayMedia", *targetItem, "noresume"}, targetItem);
 
   return false;
 }

--- a/xbmc/favourites/FavouritesUtils.cpp
+++ b/xbmc/favourites/FavouritesUtils.cpp
@@ -127,11 +127,11 @@ bool ShouldEnableMoveItems()
 
 namespace
 {
-bool ExecuteAction(const std::string& execString)
+bool ExecuteAction(const std::string& execString, const std::shared_ptr<CFileItem>& item)
 {
   if (!execString.empty())
   {
-    CGUIMessage message(GUI_MSG_EXECUTE, 0, 0);
+    CGUIMessage message(GUI_MSG_EXECUTE, 0, 0, 0, 0, item);
     message.SetStringParam(execString);
     CServiceBroker::GetGUI()->GetWindowManager().SendMessage(message);
     return true;
@@ -140,15 +140,15 @@ bool ExecuteAction(const std::string& execString)
 }
 } // unnamed namespace
 
-bool ExecuteAction(const CExecString& execString)
+bool ExecuteAction(const CExecString& execString, const std::shared_ptr<CFileItem>& item)
 {
-  return ExecuteAction(execString.GetExecString());
+  return ExecuteAction(execString.GetExecString(), item);
 }
 
-bool ExecuteAction(const CFavouritesURL& favURL)
+bool ExecuteAction(const CFavouritesURL& favURL, const std::shared_ptr<CFileItem>& item)
 {
   if (favURL.IsValid())
-    return ExecuteAction(favURL.GetExecString());
+    return ExecuteAction(favURL.GetExecString(), item);
 
   return false;
 }

--- a/xbmc/favourites/FavouritesUtils.h
+++ b/xbmc/favourites/FavouritesUtils.h
@@ -23,7 +23,7 @@ bool MoveItem(CFileItemList& items, const std::shared_ptr<CFileItem>& item, int 
 bool RemoveItem(CFileItemList& items, const std::shared_ptr<CFileItem>& item);
 bool ShouldEnableMoveItems();
 
-bool ExecuteAction(const CExecString& execString);
-bool ExecuteAction(const CFavouritesURL& favURL);
+bool ExecuteAction(const CExecString& execString, const std::shared_ptr<CFileItem>& item);
+bool ExecuteAction(const CFavouritesURL& favURL, const std::shared_ptr<CFileItem>& item);
 
 } // namespace FAVOURITES_UTILS

--- a/xbmc/interfaces/builtins/Builtins.cpp
+++ b/xbmc/interfaces/builtins/Builtins.cpp
@@ -142,7 +142,8 @@ void CBuiltins::GetHelp(std::string &help)
   }
 }
 
-int CBuiltins::Execute(const std::string& execString)
+int CBuiltins::Execute(const std::string& execString,
+                       const std::shared_ptr<CGUIListItem>& item /*= nullptr*/)
 {
   const CExecString exec(execString);
   if (!exec.IsValid())
@@ -155,7 +156,12 @@ int CBuiltins::Execute(const std::string& execString)
   if (it != m_command.end())
   {
     if (it->second.parameters == 0 || params.size() >= it->second.parameters)
-      return it->second.Execute(params);
+    {
+      if (item && it->second.ExecuteEx)
+        return it->second.ExecuteEx(params, item);
+      else
+        return it->second.Execute(params);
+    }
     else
     {
       CLog::Log(LOGERROR, "{0} called with invalid number of parameters (should be: {1}, is {2})",

--- a/xbmc/interfaces/builtins/Builtins.h
+++ b/xbmc/interfaces/builtins/Builtins.h
@@ -9,8 +9,11 @@
 #pragma once
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
+
+class CGUIListItem;
 
 class CBuiltins
 {
@@ -19,8 +22,11 @@ public:
   struct BUILT_IN
   {
     std::string description; //!< Description of command (help string)
-    size_t parameters;       //!< Number of required parameters (can be 0)
-    int (*Execute)(const std::vector<std::string>& params); //!< Function to handle command
+    size_t parameters{0}; //!< Number of required parameters (can be 0)
+    int (*Execute)(const std::vector<std::string>& params){nullptr}; //!< Function to handle command
+    int (*ExecuteEx)(const std::vector<std::string>& params,
+                     const std::shared_ptr<CGUIListItem>& item){
+        nullptr}; //!< Function to handle command
   };
 
   //! \brief A map of commands
@@ -31,7 +37,7 @@ public:
   bool HasCommand(const std::string& execString);
   bool IsSystemPowerdownCommand(const std::string& execString);
   void GetHelp(std::string &help);
-  int Execute(const std::string& execString);
+  int Execute(const std::string& execString, const std::shared_ptr<CGUIListItem>& item = nullptr);
 
 protected:
   CBuiltins();

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -505,11 +505,8 @@ int PlayOrQueueMedia(const std::vector<std::string>& params,
       CMediaSettings::GetInstance().SetMediaStartWindowed(true);
     else if (StringUtils::EqualsNoCase(params[i], "resume"))
     {
-      // Force the item to resume (if applicable).
-      // If item is provided by a plugin, we don't know if this can be resumed or not at this point,
-      // that information was lost when the item was turned into a string but we were told to resume
-      // so we will try to do that.
-      if (item.IsPlugin() || VIDEO::UTILS::GetItemResumeInformation(item).isResumable)
+      // force the item to resume (if applicable)
+      if (VIDEO::UTILS::GetItemResumeInformation(item).isResumable)
         item.SetStartOffset(STARTOFFSET_RESUME);
       else
         item.SetStartOffset(0);

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -453,7 +453,9 @@ PLAYLIST::Id GetPlayListId(const CFileItem& item)
   return playlistId;
 }
 
-int PlayOrQueueMedia(const std::vector<std::string>& params, bool forcePlay)
+int PlayOrQueueMedia(const std::vector<std::string>& params,
+                     bool forcePlay,
+                     const std::shared_ptr<CGUIListItem>& itemIn)
 {
   // restore to previous window if needed
   if( CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_SLIDESHOW ||
@@ -468,11 +470,19 @@ int PlayOrQueueMedia(const std::vector<std::string>& params, bool forcePlay)
   appPower->ResetScreenSaver();
   appPower->WakeUpScreenSaverAndDPMS();
 
-  CFileItem item(params[0], URIUtils::HasSlashAtEnd(params[0], true));
+  CFileItem item;
+  if (itemIn && itemIn->IsFileItem())
+  {
+    item = *std::static_pointer_cast<CFileItem>(itemIn);
+  }
+  else
+  {
+    item = {params[0], URIUtils::HasSlashAtEnd(params[0], true)};
 
-  // at this point the item instance has only the path and the folder flag set. We
-  // need some extended item properties to process resume successfully. Load them.
-  item.LoadDetails();
+    // at this point the item instance has only the path and the folder flag set. We
+    // need some extended item properties to process resume successfully. Load them.
+    item.LoadDetails();
+  }
 
   if ((VIDEO::IsVideo(item) && !g_passwordManager.IsVideoUnlocked()) ||
       (MUSIC::IsAudio(item) && !g_passwordManager.IsMusicUnlocked()))
@@ -671,7 +681,12 @@ int PlayOrQueueMedia(const std::vector<std::string>& params, bool forcePlay)
  */
 int PlayMedia(const std::vector<std::string>& params)
 {
-  return PlayOrQueueMedia(params, true);
+  return PlayOrQueueMedia(params, true, nullptr);
+}
+
+int PlayMediaEx(const std::vector<std::string>& params, const std::shared_ptr<CGUIListItem>& item)
+{
+  return PlayOrQueueMedia(params, true, item);
 }
 
 /*! \brief Queue media in the video or music playlist, according to type of media items. If both audio and video items are contained, queue to video
@@ -690,7 +705,12 @@ int PlayMedia(const std::vector<std::string>& params)
  */
 int QueueMedia(const std::vector<std::string>& params)
 {
-  return PlayOrQueueMedia(params, false);
+  return PlayOrQueueMedia(params, false, nullptr);
+}
+
+int QueueMediaEx(const std::vector<std::string>& params, const std::shared_ptr<CGUIListItem>& item)
+{
+  return PlayOrQueueMedia(params, false, item);
 }
 
 } // unnamed namespace
@@ -878,8 +898,8 @@ CBuiltins::CommandMap CPlayerBuiltins::GetOperations() const
            {"playlist.clear",      {"Clear the current playlist", 0, ClearPlaylist}},
            {"playlist.playoffset", {"Start playing from a particular offset in the playlist", 1, PlayOffset}},
            {"playercontrol",       {"Control the music or video player", 1, PlayerControl}},
-           {"playmedia",           {"Play the specified media file (or playlist)", 1, PlayMedia}},
-           {"queuemedia",          {"Queue the specified media in video or music playlist", 1, QueueMedia}},
+           {"playmedia",           {"Play the specified media file (or playlist)", 1, PlayMedia, PlayMediaEx}},
+           {"queuemedia",          {"Queue the specified media in video or music playlist", 1, QueueMedia, QueueMediaEx}},
            {"playwith",            {"Play the selected item with the specified core", 1, PlayWith}},
            {"seek",                {"Performs a seek in seconds on the current playing media file", 1, Seek}},
            {"subtitleshiftup",     {"Shift up the subtitle position", 0, SubtitleShiftUp}},

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -175,12 +175,12 @@ bool CVideoBrowse::Execute(const std::shared_ptr<CFileItem>& item) const
 
 namespace
 {
-bool ExecuteAction(const CExecString& execute)
+bool ExecuteAction(const CExecString& execute, const std::shared_ptr<CFileItem>& item)
 {
   const std::string& execStr{execute.GetExecString()};
   if (!execStr.empty())
   {
-    CGUIMessage message(GUI_MSG_EXECUTE, 0, 0);
+    CGUIMessage message(GUI_MSG_EXECUTE, 0, 0, 0, 0, item);
     message.SetStringParam(execStr);
     CServiceBroker::GetGUI()->GetWindowManager().SendMessage(message);
     return true;
@@ -200,25 +200,25 @@ protected:
   bool OnPlayPartSelected(unsigned int part) override
   {
     // part numbers are 1-based
-    ExecuteAction({"PlayMedia", *m_item, StringUtils::Format("playoffset={}", part - 1)});
+    ExecuteAction({"PlayMedia", *m_item, StringUtils::Format("playoffset={}", part - 1)}, m_item);
     return true;
   }
 
   bool OnResumeSelected() override
   {
-    ExecuteAction({"PlayMedia", *m_item, "resume"});
+    ExecuteAction({"PlayMedia", *m_item, "resume"}, m_item);
     return true;
   }
 
   bool OnPlaySelected() override
   {
-    ExecuteAction({"PlayMedia", *m_item, "noresume"});
+    ExecuteAction({"PlayMedia", *m_item, "noresume"}, m_item);
     return true;
   }
 
   bool OnQueueSelected() override
   {
-    ExecuteAction({"QueueMedia", *m_item, ""});
+    ExecuteAction({"QueueMedia", *m_item, ""}, m_item);
     return true;
   }
 


### PR DESCRIPTION
So no information gets lost due to reconstruction of the item with only its path being available.

Fixes the root cause for the work around provided with https://github.com/xbmc/xbmc/pull/26109, making the workaround obsolete.

Runtime-tested with the test scenario provided by @felizk

The interesting part is the change in function `PlayOrQueueMedia`, where the original item instance is used instead of recreating it from the given path. The rest is just passing the item around via new method params etc.
 
BTW: I spotted lots of more or less duplicate code while working on this PR and will come up with a larger refactoring PR for that soon.

@enen92 could you please review.