### PR TITLE
[Windows] Refactor WIN32Util HDR and related code

### DIFF
--- a/xbmc/platform/win32/CMakeLists.txt
+++ b/xbmc/platform/win32/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES CharsetConverter.cpp
             CPUInfoWin32.cpp
+            DisplayUtilsWin32.cpp
             Environment.cpp
             GPUInfoWin32.cpp
             MemUtils.cpp
@@ -15,6 +16,7 @@ set(SOURCES CharsetConverter.cpp
 set(HEADERS CharsetConverter.h
             CPUInfoWin32.h
             dirent.h
+            DisplayUtilsWin32.h
             dxerr.h
             GPUInfoWin32.h
             IMMNotificationClient.h

--- a/xbmc/platform/win32/DisplayUtilsWin32.cpp
+++ b/xbmc/platform/win32/DisplayUtilsWin32.cpp
@@ -1,0 +1,187 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "DisplayUtilsWin32.h"
+
+#include "utils/SystemInfo.h"
+
+// @todo: Remove this and "SDK_26100.h" when Windows SDK updated to 10.0.26100.0 in builders
+#ifndef NTDDI_WIN11_GE // Windows SDK 10.0.26100.0 or newer
+#include "SDK_26100.h"
+#endif
+
+extern HWND g_hWnd;
+
+std::wstring CDisplayUtilsWin32::GetCurrentDisplayName()
+{
+  MONITORINFOEXW mi{};
+  mi.cbSize = sizeof(mi);
+  if (!GetMonitorInfoW(MonitorFromWindow(g_hWnd, MONITOR_DEFAULTTOPRIMARY), &mi))
+    return {};
+  return mi.szDevice;
+}
+
+std::vector<DISPLAYCONFIG_PATH_INFO> CDisplayUtilsWin32::GetDisplayConfigPaths()
+{
+  uint32_t pathCount{0};
+  uint32_t modeCount{0};
+  std::vector<DISPLAYCONFIG_PATH_INFO> paths;
+  std::vector<DISPLAYCONFIG_MODE_INFO> modes;
+
+  constexpr uint32_t flags{QDC_ONLY_ACTIVE_PATHS};
+  LONG result{ERROR_SUCCESS};
+
+  do
+  {
+    if (GetDisplayConfigBufferSizes(flags, &pathCount, &modeCount) != ERROR_SUCCESS)
+      return {};
+
+    paths.resize(pathCount);
+    modes.resize(modeCount);
+
+    result = QueryDisplayConfig(flags, &pathCount, paths.data(), &modeCount, modes.data(), nullptr);
+  } while (result == ERROR_INSUFFICIENT_BUFFER);
+
+  if (result != ERROR_SUCCESS)
+    return {};
+
+  paths.resize(pathCount);
+  modes.resize(modeCount);
+
+  return paths;
+}
+
+std::optional<CDisplayUtilsWin32::DisplayConfigId> CDisplayUtilsWin32::GetCurrentDisplayTargetId()
+{
+  std::wstring name{GetCurrentDisplayName()};
+  if (name.empty())
+    return std::nullopt;
+
+  return GetDisplayTargetId(name);
+}
+
+std::optional<CDisplayUtilsWin32::DisplayConfigId> CDisplayUtilsWin32::GetDisplayTargetId(
+    const std::wstring& gdiDeviceName)
+{
+  DISPLAYCONFIG_SOURCE_DEVICE_NAME source{};
+  source.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME;
+  source.header.size = sizeof(source);
+
+  for (const auto& path : GetDisplayConfigPaths())
+  {
+    source.header.adapterId = path.sourceInfo.adapterId;
+    source.header.id = path.sourceInfo.id;
+
+    if (DisplayConfigGetDeviceInfo(&source.header) == ERROR_SUCCESS &&
+        gdiDeviceName == source.viewGdiDeviceName)
+      return DisplayConfigId{path.targetInfo.adapterId, path.targetInfo.id};
+  }
+  return std::nullopt;
+}
+
+HDR_STATUS CDisplayUtilsWin32::SetDisplayHDRStatus(const DisplayConfigId& identifier, bool enable)
+{
+  LONG result{ERROR_SUCCESS};
+  HDR_STATUS status{enable ? HDR_STATUS::HDR_ON : HDR_STATUS::HDR_OFF};
+
+  // Windows 11 24H2 or newer (SDK 10.0.26100.0)
+  if (CSysInfo::IsWindowsVersionAtLeast(CSysInfo::WindowsVersionWin11_24H2))
+  {
+    DISPLAYCONFIG_SET_HDR_STATE setHdrState = {};
+    setHdrState.header.type =
+        static_cast<DISPLAYCONFIG_DEVICE_INFO_TYPE>(DISPLAYCONFIG_DEVICE_INFO_SET_HDR_STATE);
+    setHdrState.header.size = sizeof(setHdrState);
+    setHdrState.header.adapterId = identifier.adapterId;
+    setHdrState.header.id = identifier.id;
+    setHdrState.enableHdr = enable ? TRUE : FALSE;
+
+    result = DisplayConfigSetDeviceInfo(&setHdrState.header);
+  }
+  else // older than Windows 11 24H2
+  {
+    DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE setColorState = {};
+    setColorState.header.type = DISPLAYCONFIG_DEVICE_INFO_SET_ADVANCED_COLOR_STATE;
+    setColorState.header.size = sizeof(setColorState);
+    setColorState.header.adapterId = identifier.adapterId;
+    setColorState.header.id = identifier.id;
+    setColorState.enableAdvancedColor = enable ? TRUE : FALSE;
+
+    result = DisplayConfigSetDeviceInfo(&setColorState.header);
+  }
+
+  if (result != ERROR_SUCCESS)
+    status = HDR_STATUS::HDR_TOGGLE_FAILED;
+
+  return status;
+}
+
+HDR_STATUS CDisplayUtilsWin32::GetDisplayHDRStatus(const DisplayConfigId& identifier)
+{
+  bool hdrSupported{false};
+  bool hdrEnabled{false};
+
+  // Windows 11 24H2 or newer (SDK 10.0.26100.0)
+  if (CSysInfo::IsWindowsVersionAtLeast(CSysInfo::WindowsVersionWin11_24H2))
+  {
+    DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO_2 getColorInfo2 = {};
+    getColorInfo2.header.type = static_cast<DISPLAYCONFIG_DEVICE_INFO_TYPE>(
+        DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO_2);
+    getColorInfo2.header.size = sizeof(getColorInfo2);
+    getColorInfo2.header.adapterId = identifier.adapterId;
+    getColorInfo2.header.id = identifier.id;
+
+    if (ERROR_SUCCESS == DisplayConfigGetDeviceInfo(&getColorInfo2.header))
+    {
+      if (getColorInfo2.activeColorMode == DISPLAYCONFIG_ADVANCED_COLOR_MODE_HDR)
+        hdrEnabled = true;
+
+      if (getColorInfo2.highDynamicRangeSupported == TRUE)
+        hdrSupported = true;
+    }
+  }
+  else // older than Windows 11 24H2
+  {
+    DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO getColorInfo = {};
+    getColorInfo.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO;
+    getColorInfo.header.size = sizeof(getColorInfo);
+    getColorInfo.header.adapterId = identifier.adapterId;
+    getColorInfo.header.id = identifier.id;
+
+    if (ERROR_SUCCESS == DisplayConfigGetDeviceInfo(&getColorInfo.header))
+    {
+      // DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO documentation is lacking and field
+      // names are confusing. Through experimentation and deductions from equivalent WinRT API:
+      //
+      // SDR screen, advanced color not supported (Win 10, Win 11 < 22H2)
+      // > advancedColorSupported = 0 and wideColorEnforced = 0
+      // SDR screen, advanced color is supported (Win 11 >= 22H2)
+      // > advancedColorSupported = 1 and wideColorEnforced = 1
+      // HDR screen
+      // > advancedColorSupported = 1 and wideColorEnforced = 0
+      //
+      // advancedColorForceDisabled: maybe equivalent of advancedColorLimitedByPolicy?
+      //
+      // advancedColorEnabled = 1:
+      // For HDR screens means HDR is on
+      // For SDR screens means ACM (Automatic Color Management, Win 11 >= 22H2) is on
+
+      if (getColorInfo.advancedColorSupported && !getColorInfo.wideColorEnforced)
+        hdrSupported = true;
+
+      if (hdrSupported && getColorInfo.advancedColorEnabled)
+        hdrEnabled = true;
+    }
+  }
+
+  HDR_STATUS status{HDR_STATUS::HDR_UNSUPPORTED};
+
+  if (hdrSupported)
+    status = hdrEnabled ? HDR_STATUS::HDR_ON : HDR_STATUS::HDR_OFF;
+
+  return status;
+}

--- a/xbmc/platform/win32/DisplayUtilsWin32.h
+++ b/xbmc/platform/win32/DisplayUtilsWin32.h
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "HDRStatus.h"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <wingdi.h>
+
+class CDisplayUtilsWin32
+{
+public:
+  CDisplayUtilsWin32() = delete;
+  ~CDisplayUtilsWin32() = delete;
+
+  struct DisplayConfigId
+  {
+    LUID adapterId;
+    UINT32 id;
+  };
+
+  static std::wstring GetCurrentDisplayName();
+  static std::vector<DISPLAYCONFIG_PATH_INFO> GetDisplayConfigPaths();
+  static std::optional<DisplayConfigId> GetCurrentDisplayTargetId();
+  static std::optional<DisplayConfigId> GetDisplayTargetId(const std::wstring& gdiDeviceName);
+  static HDR_STATUS GetDisplayHDRStatus(const DisplayConfigId& identifier);
+  static HDR_STATUS SetDisplayHDRStatus(const DisplayConfigId& identifier, bool enable);
+};

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -329,19 +329,6 @@ std::string CWIN32Util::GetResInfoString()
 #endif
 }
 
-int CWIN32Util::GetDesktopColorDepth()
-{
-#ifdef TARGET_WINDOWS_STORE
-  CLog::LogF(LOGDEBUG, "s not implemented");
-  return 32;
-#else
-  DEVMODE devmode = {};
-  devmode.dmSize = sizeof(devmode);
-  EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devmode);
-  return (int)devmode.dmBitsPerPel;
-#endif
-}
-
 size_t CWIN32Util::GetSystemMemorySize()
 {
 #ifdef TARGET_WINDOWS_STORE

--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -75,7 +75,7 @@ public:
   static bool SetThreadLocalLocale(bool enable = true);
 
   // HDR display support
-  static HDR_STATUS ToggleWindowsHDR(DXGI_MODE_DESC& modeDesc);
+  static HDR_STATUS ToggleWindowsHDR();
   static HDR_STATUS GetWindowsHDRStatus();
   static bool GetSystemSdrWhiteLevel(const std::wstring& gdiDeviceName, float* sdrWhiteLevel);
 

--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -12,9 +12,6 @@
 #include "URL.h"
 #include "utils/Geometry.h"
 
-#include <optional>
-#include <vector>
-
 #include <dxgi1_5.h>
 
 #define BONJOUR_EVENT             ( WM_USER + 0x100 )	// Message sent to the Window when a Bonjour event occurs.
@@ -110,20 +107,4 @@ public:
    * \return Formatted string
    */
   static std::string FormatHRESULT(HRESULT hr);
-
-#ifdef TARGET_WINDOWS_DESKTOP
-private:
-  struct DisplayConfigId
-  {
-    LUID adapterId;
-    UINT32 id;
-  };
-
-  static std::wstring GetCurrentDisplayName();
-  static std::vector<DISPLAYCONFIG_PATH_INFO> GetDisplayConfigPaths();
-  static std::optional<DisplayConfigId> GetCurrentDisplayTargetId();
-  static std::optional<DisplayConfigId> GetDisplayTargetId(const std::wstring& gdiDeviceName);
-  static HDR_STATUS GetDisplayHDRStatus(const DisplayConfigId& identifier);
-  static HDR_STATUS SetDisplayHDRStatus(const DisplayConfigId& identifier, bool enable);
-#endif // TARGET_WINDOWS_DESKTOP
 };

--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -114,12 +114,6 @@ public:
 
 #ifdef TARGET_WINDOWS_DESKTOP
 private:
-  struct DisplayConfigSnapshot
-  {
-    std::vector<DISPLAYCONFIG_PATH_INFO> paths;
-    std::vector<DISPLAYCONFIG_MODE_INFO> modes;
-  };
-
   struct DisplayConfigId
   {
     LUID adapterId;
@@ -127,7 +121,7 @@ private:
   };
 
   static std::wstring GetCurrentDisplayName();
-  static DisplayConfigSnapshot GetDisplayConfigSnapshot();
+  static std::vector<DISPLAYCONFIG_PATH_INFO> GetDisplayConfigPaths();
   static std::optional<DisplayConfigId> GetCurrentDisplayTargetId();
   static std::optional<DisplayConfigId> GetDisplayTargetId(const std::wstring& gdiDeviceName);
   static HDR_STATUS GetDisplayHDRStatus(const DisplayConfigId& identifier);

--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -44,7 +44,6 @@ public:
   static int GetDriveStatus(const std::string &strPath, bool bStatusEx=false);
   static bool XBMCShellExecute(const std::string &strPath, bool bWaitForScriptExit=false);
   static std::string GetResInfoString();
-  static int GetDesktopColorDepth();
   static size_t GetSystemMemorySize();
 
   static std::string GetProfilePath(const bool platformDirectories);

--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -12,6 +12,7 @@
 #include "URL.h"
 #include "utils/Geometry.h"
 
+#include <optional>
 #include <vector>
 
 #include <dxgi1_5.h>
@@ -110,4 +111,26 @@ public:
    * \return Formatted string
    */
   static std::string FormatHRESULT(HRESULT hr);
+
+#ifdef TARGET_WINDOWS_DESKTOP
+private:
+  struct DisplayConfigSnapshot
+  {
+    std::vector<DISPLAYCONFIG_PATH_INFO> paths;
+    std::vector<DISPLAYCONFIG_MODE_INFO> modes;
+  };
+
+  struct DisplayConfigId
+  {
+    LUID adapterId;
+    UINT32 id;
+  };
+
+  static std::wstring GetCurrentDisplayName();
+  static DisplayConfigSnapshot GetDisplayConfigSnapshot();
+  static std::optional<DisplayConfigId> GetCurrentDisplayTargetId();
+  static std::optional<DisplayConfigId> GetDisplayTargetId(const std::wstring& gdiDeviceName);
+  static HDR_STATUS GetDisplayHDRStatus(const DisplayConfigId& identifier);
+  static HDR_STATUS SetDisplayHDRStatus(const DisplayConfigId& identifier, bool enable);
+#endif // TARGET_WINDOWS_DESKTOP
 };

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -1359,9 +1359,6 @@ void DX::DeviceResources::SetHdrColorSpace(const DXGI_COLOR_SPACE_TYPE colorSpac
 
 HDR_STATUS DX::DeviceResources::ToggleHDR()
 {
-  DXGI_MODE_DESC md = {};
-  GetDisplayMode(&md);
-
   // Xbox uses only full screen windowed mode and not needs recreate swapchain.
   // Recreate swapchain causes native 4K resolution is lost and quality obtained
   // is equivalent to 1080p upscaled to 4K (TO DO: investigate root cause).
@@ -1371,7 +1368,7 @@ HDR_STATUS DX::DeviceResources::ToggleHDR()
   DX::Windowing()->SetAlteringWindow(true);
 
   // Toggle display HDR
-  HDR_STATUS hdrStatus = CWIN32Util::ToggleWindowsHDR(md);
+  HDR_STATUS hdrStatus = CWIN32Util::ToggleWindowsHDR();
 
   // Kill swapchain
   if (!isXbox && m_swapChain && hdrStatus != HDR_STATUS::HDR_TOGGLE_FAILED)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Refactor the code handling HDR status and other information accessed with the DisplayConfigGetDeviceInfo() API.
There was a lot of boiler-plate code duplicated, which was also obscuring the purpose of the functions.

* The changes are decomposed step by step in individual commits, which don't transform the use of the API and therefore should have identical results to the original code, except for the last one.

* The last commit uses path.targetInfo.adapterId/id instead of finding the same information in the modes array with modes.at(path.targetInfo.modeInfoIdx).adapterId/id, but in my testing the values are identical, which makes sense because they both describe the same target.

The behavior of GetWindowsHDRStatus() when starting (g_hWnd) of looking for any screen with hdr available or turned on complicates things a bit.
Is there really a benefit? Most systems have a single screen so the info would be the same as retrieving capabilities of the primary screen.
For systems with multiple screens, it can be misleading since Kodi doesn't always run on the HDR screen and we'd find other log messages about hdr support when switching screen or starting playback.

to be squashed for commit after review.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Code duplication in CWIN32Util for HDR and related code.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Windows 10 22H2 and Windows 11 23H2, with SDR and HDR screens, used the HDR manual toggle and the automatic toggle when playing a video. Checked that the display friendly name and SDR white level  were not affected.

Windows 8.1 doesn't support HDR, the display friendly name still works.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
