### PR TITLE
[Backport][Windows] Fix conditions to trigger FFmpeg rebuild

### DIFF
--- a/tools/buildsteps/windows/buildhelpers.sh
+++ b/tools/buildsteps/windows/buildhelpers.sh
@@ -163,10 +163,11 @@ PATH_CHANGE_REV_FILENAME=".last_success_revision"
 #params paths to be hashed
 function getBuildHash ()
 {
-  local version="$(extractVersion $3)"
+  local package="$(extractPackage $3)"
+  local version="$(extractVersion $4)"
   local hashStr
   hashStr="$(git rev-list HEAD --max-count=1  -- $@)"
-  hashStr="$hashStr $@ $version"
+  hashStr="$hashStr $@ $version $package"
   echo $hashStr
 }
 
@@ -215,4 +216,13 @@ function extractVersion()
   local ver=$(grep "VERSION=" $file | sed 's/VERSION=//g;s/#.*$//g;/^$/d')
 
   echo $ver
+}
+
+function extractPackage()
+{
+  local path="$1"
+  local file="$path/0_package.target-$TRIPLET.list"
+  local package=$(grep '^dav1d-' $file)
+
+  echo $package
 }

--- a/tools/buildsteps/windows/buildhelpers.sh
+++ b/tools/buildsteps/windows/buildhelpers.sh
@@ -159,13 +159,14 @@ do_clean_get() {
 
 PATH_CHANGE_REV_FILENAME=".last_success_revision"
 
-#hash a dir based on the git revision and $TRIPLET
+#hash a dir based on the git revision and $version
 #params paths to be hashed
 function getBuildHash ()
 {
+  local version="$(extractVersion $3)"
   local hashStr
   hashStr="$(git rev-list HEAD --max-count=1  -- $@)"
-  hashStr="$hashStr $@ $TRIPLET"
+  hashStr="$hashStr $@ $version"
   echo $hashStr
 }
 
@@ -206,4 +207,12 @@ function tagSuccessFulBuild ()
   # tag last successful build with revisions of the given dir
   # needs to match the checks in function getBuildHash
   echo "$(getBuildHash $pathToTag $@)" > $pathToTag/$PATH_CHANGE_REV_FILENAME
+}
+
+function extractVersion()
+{
+  local file="$1"
+  local ver=$(grep "VERSION=" $file | sed 's/VERSION=//g;s/#.*$//g;/^$/d')
+
+  echo $ver
 }

--- a/tools/buildsteps/windows/make-mingwlibs.sh
+++ b/tools/buildsteps/windows/make-mingwlibs.sh
@@ -73,7 +73,7 @@ checkfiles() {
 
 buildProcess() {
 export PREFIX=/xbmc/project/BuildDependencies/mingwlibs/$TRIPLET
-if [ "$(pathChanged $PREFIX /xbmc/tools/buildsteps/windows /xbmc/tools/depends/target/ffmpeg/FFMPEG-VERSION)" == "0" ]; then
+if [ "$(pathChanged $PREFIX /xbmc/tools/buildsteps/windows /xbmc/project/BuildDependencies/scripts /xbmc/tools/depends/target/ffmpeg/FFMPEG-VERSION)" == "0" ]; then
   return
 fi
 
@@ -106,7 +106,7 @@ echo "--------------------------------------------------------------------------
 echo " compile mingw libs $TRIPLET done..."
 echo "-------------------------------------------------------------------------------"
 
-tagSuccessFulBuild $PREFIX /xbmc/tools/buildsteps/windows /xbmc/tools/depends/target/ffmpeg/FFMPEG-VERSION
+tagSuccessFulBuild $PREFIX /xbmc/tools/buildsteps/windows /xbmc/project/BuildDependencies/scripts /xbmc/tools/depends/target/ffmpeg/FFMPEG-VERSION
 }
 
 run_builds() {


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/26061 and https://github.com/xbmc/xbmc/pull/26158



## What is the effect on users?
- Triggers rebuild of FFmpeg when apply changes locally (.diff) without merge.
- Make sure FFmpeg is rebuild when dav1d changes. This also may fix some inconsistencies in Jenkins as now Omega / master has different workspace, FFmpeg is not rebuild frequently. In the extreme case, some nightly/release build may contain an invalid or inconsistent FFmpeg compilation.



## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
