### PR TITLE
[FileSystem][POSIX] Fix prompt for credentials when browsing SMB files

### DIFF
--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -289,7 +289,7 @@ int CSMBDirectory::OpenDir(const CURL& url, std::string& strAuth)
   {
     std::string cError;
 
-    if (errno == EACCES)
+    if (errno == EACCES || errno == EPERM || errno == EAGAIN || errno == EINVAL)
     {
       if (m_flags & DIR_FLAG_ALLOW_PROMPT)
         RequireAuthentication(urlIn);


### PR DESCRIPTION
## Description
[FileSystem] Fix prompt for credentials when browsing SMB files

## Motivation and context
When browsing for SMB location from "File Manager > Add source > Browse for new share" is not possible enter credentials because only returns an error. Typically "Operation not permitted" or "Invalid argument".

This works fine in Windows but not on Android or other posix systems.

The workaround is use "Add network location..." dialog but most users are stuck and don't come here unless they find help.

This happens because modern systems may return additional error codes besides `EACCES`:

```
EPERM    1  Operation not permitted
EAGAIN  11  Resource temporarily unavailable
EACCES  13  Permission denied
EINVAL  22  Invalid argument
```
But calling `RequireAuthentication()` that displays GUI dialog to allow enter credentials fix the issue 🙂

**NOTE:**
What modern SMB does not allow is browsing the _servers_, but this was implemented via WS-Discovery (https://github.com/xbmc/xbmc/pull/19532 and https://github.com/xbmc/xbmc/pull/19971). Browsing the directory structure should always be possible (if credentials are provided).

## How has this been tested?
Tested in Android (Shield) accessing SMB shares from: 
- Windows 11 24H2 (SMB v3)
- Synology NAS (SMB v2.1 / SMB v3)
- Asus router RT-AX88U (SMB v1 / SMB v2)

All works as expected.

## What is the effect on users?
Restore the ability to browse SMB shares on Android / others posix systems.


## Screenshots (if appropriate):
**Before**
![before_1](https://github.com/user-attachments/assets/8eed694e-dfe6-494f-811c-4a26592889ad)

![before_2](https://github.com/user-attachments/assets/30e30969-586e-431d-ae03-a1d7bbd8073f)

**After**
![after_1](https://github.com/user-attachments/assets/5354ff8d-30b5-4f83-853f-17119a4b1147)

![after_2](https://github.com/user-attachments/assets/5adbc636-4d7f-4b19-8ad2-9e1b0bad0c03)

![after_3](https://github.com/user-attachments/assets/5bfde9ae-e86d-430d-86dd-6624ec2673e2)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
