### PR TITLE
[video][music] Fix missing context menu entries for plugin-provided items.

### DIFF
--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -86,6 +86,7 @@ void CContextMenuManager::Init()
       std::make_shared<CONTEXTMENU::CMovieSetInfo>(),
       std::make_shared<CONTEXTMENU::CMusicVideoInfo>(),
       std::make_shared<CONTEXTMENU::CTVShowInfo>(),
+      std::make_shared<CONTEXTMENU::CMusicInfo>(),
       std::make_shared<CONTEXTMENU::CSeasonInfo>(),
       std::make_shared<CONTEXTMENU::CAlbumInfo>(),
       std::make_shared<CONTEXTMENU::CArtistInfo>(),

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -80,6 +80,7 @@ void CContextMenuManager::Init()
       std::make_shared<CONTEXTMENU::CDisableAddon>(),
       std::make_shared<CONTEXTMENU::CAddonSettings>(),
       std::make_shared<CONTEXTMENU::CCheckForUpdates>(),
+      std::make_shared<CONTEXTMENU::CVideoInfo>(),
       std::make_shared<CONTEXTMENU::CEpisodeInfo>(),
       std::make_shared<CONTEXTMENU::CMovieInfo>(),
       std::make_shared<CONTEXTMENU::CMovieSetInfo>(),

--- a/xbmc/music/ContextMenus.cpp
+++ b/xbmc/music/ContextMenus.cpp
@@ -14,6 +14,7 @@
 #include "cores/playercorefactory/PlayerCoreFactory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/MusicUtils.h"
 #include "music/dialogs/GUIDialogMusicInfo.h"
 #include "playlists/PlayListTypes.h"
@@ -44,6 +45,18 @@ bool CMusicInfoBase::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   CGUIDialogMusicInfo::ShowFor(item.get());
   return true;
+}
+
+bool CMusicInfo::IsVisible(const CFileItem& item) const
+{
+  if (CMusicInfoBase::IsVisible(item))
+    return true;
+
+  if (item.m_bIsFolder)
+    return false;
+
+  const auto* tag{item.GetMusicInfoTag()};
+  return tag && tag->GetType() == MediaTypeNone && !tag->GetTitle().empty() && MUSIC::IsAudio(item);
 }
 
 bool CMusicBrowse::IsVisible(const CFileItem& item) const

--- a/xbmc/music/ContextMenus.cpp
+++ b/xbmc/music/ContextMenus.cpp
@@ -26,12 +26,12 @@
 using namespace CONTEXTMENU;
 using namespace KODI;
 
-CMusicInfo::CMusicInfo(MediaType mediaType)
+CMusicInfoBase::CMusicInfoBase(MediaType mediaType)
   : CStaticContextMenuAction(19033), m_mediaType(std::move(mediaType))
 {
 }
 
-bool CMusicInfo::IsVisible(const CFileItem& item) const
+bool CMusicInfoBase::IsVisible(const CFileItem& item) const
 {
   return (item.HasMusicInfoTag() && item.GetMusicInfoTag()->GetType() == m_mediaType) ||
          (m_mediaType == MediaTypeArtist && VIDEO::IsVideoDb(item) &&
@@ -40,7 +40,7 @@ bool CMusicInfo::IsVisible(const CFileItem& item) const
           item.HasProperty("album_musicid"));
 }
 
-bool CMusicInfo::Execute(const std::shared_ptr<CFileItem>& item) const
+bool CMusicInfoBase::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   CGUIDialogMusicInfo::ShowFor(item.get());
   return true;

--- a/xbmc/music/ContextMenus.h
+++ b/xbmc/music/ContextMenus.h
@@ -28,6 +28,12 @@ private:
   const MediaType m_mediaType;
 };
 
+struct CMusicInfo : CMusicInfoBase
+{
+  CMusicInfo() : CMusicInfoBase(MediaTypeMusic) {}
+  bool IsVisible(const CFileItem& item) const override;
+};
+
 struct CAlbumInfo : CMusicInfoBase
 {
   CAlbumInfo() : CMusicInfoBase(MediaTypeAlbum) {}

--- a/xbmc/music/ContextMenus.h
+++ b/xbmc/music/ContextMenus.h
@@ -18,9 +18,9 @@ class CFileItem;
 namespace CONTEXTMENU
 {
 
-struct CMusicInfo : CStaticContextMenuAction
+struct CMusicInfoBase : CStaticContextMenuAction
 {
-  explicit CMusicInfo(MediaType mediaType);
+  explicit CMusicInfoBase(MediaType mediaType);
   bool IsVisible(const CFileItem& item) const override;
   bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 
@@ -28,19 +28,19 @@ private:
   const MediaType m_mediaType;
 };
 
-struct CAlbumInfo : CMusicInfo
+struct CAlbumInfo : CMusicInfoBase
 {
-  CAlbumInfo() : CMusicInfo(MediaTypeAlbum) {}
+  CAlbumInfo() : CMusicInfoBase(MediaTypeAlbum) {}
 };
 
-struct CArtistInfo : CMusicInfo
+struct CArtistInfo : CMusicInfoBase
 {
-  CArtistInfo() : CMusicInfo(MediaTypeArtist) {}
+  CArtistInfo() : CMusicInfoBase(MediaTypeArtist) {}
 };
 
-struct CSongInfo : CMusicInfo
+struct CSongInfo : CMusicInfoBase
 {
-  CSongInfo() : CMusicInfo(MediaTypeSong) {}
+  CSongInfo() : CMusicInfoBase(MediaTypeSong) {}
 };
 
 struct CMusicBrowse : CStaticContextMenuAction

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -872,6 +872,13 @@ bool IsNonExistingUserPartyModePlaylist(const CFileItem& item)
   const auto profileManager{CServiceBroker::GetSettingsComponent()->GetProfileManager()};
   return ((profileManager->GetUserDataItem("PartyMode.xsp") == path) && !CFileUtils::Exists(path));
 }
+
+bool IsEmptyMusicItem(const CFileItem& item)
+{
+  //! @todo Poor man's way to detect empty music info tags (inspired by CVideoInfoTag::IsEmpty())
+  return item.HasMusicInfoTag() && item.GetMusicInfoTag()->GetTitle().empty();
+}
+
 } // unnamed namespace
 
 bool IsItemPlayable(const CFileItem& item)
@@ -885,7 +892,7 @@ bool IsItemPlayable(const CFileItem& item)
     return false;
 
   // Exclude other components
-  if (item.IsPVR() || item.IsPlugin() || item.IsScript() || item.IsAddonsPath())
+  if (item.IsPVR() || item.IsAddonsPath())
     return false;
 
   // Exclude special items
@@ -931,11 +938,20 @@ bool IsItemPlayable(const CFileItem& item)
     return true;
   }
 
-  if (item.HasMusicInfoTag() && item.CanQueue())
+  if (item.IsPlugin() && MUSIC::IsAudio(item) && !IsEmptyMusicItem(item) &&
+      item.GetProperty("isplayable").asBoolean(false))
+  {
     return true;
-  else if (!item.m_bIsFolder && MUSIC::IsAudio(item))
+  }
+  else if (item.HasMusicInfoTag() && item.CanQueue() && !item.IsPlugin() && !item.IsScript())
+  {
     return true;
-  else if (item.m_bIsFolder)
+  }
+  else if (!item.m_bIsFolder && MUSIC::IsAudio(item) && !IsEmptyMusicItem(item))
+  {
+    return true;
+  }
+  else if (item.m_bIsFolder && !item.IsPlugin() && !item.IsScript())
   {
     // Not a music-specific folder (just file:// or nfs://). Allow play if context is Music window.
     if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_MUSIC_NAV &&

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -64,6 +64,18 @@ bool CVideoInfoBase::Execute(const std::shared_ptr<CFileItem>& item) const
   return true;
 }
 
+bool CVideoInfo::IsVisible(const CFileItem& item) const
+{
+  if (CVideoInfoBase::IsVisible(item))
+    return true;
+
+  if (item.m_bIsFolder)
+    return false;
+
+  const auto* tag{item.GetVideoInfoTag()};
+  return tag && tag->m_type == MediaTypeNone && !tag->IsEmpty() && VIDEO::IsVideo(item);
+}
+
 bool CVideoRemoveResumePoint::IsVisible(const CFileItem& itemIn) const
 {
   CFileItem item(itemIn.GetItemToPlay());

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -42,12 +42,12 @@ using namespace KODI;
 namespace CONTEXTMENU
 {
 
-CVideoInfo::CVideoInfo(MediaType mediaType)
+CVideoInfoBase::CVideoInfoBase(MediaType mediaType)
   : CStaticContextMenuAction(19033), m_mediaType(std::move(mediaType))
 {
 }
 
-bool CVideoInfo::IsVisible(const CFileItem& item) const
+bool CVideoInfoBase::IsVisible(const CFileItem& item) const
 {
   if (!item.HasVideoInfoTag())
     return false;
@@ -58,7 +58,7 @@ bool CVideoInfo::IsVisible(const CFileItem& item) const
   return item.GetVideoInfoTag()->m_type == m_mediaType;
 }
 
-bool CVideoInfo::Execute(const std::shared_ptr<CFileItem>& item) const
+bool CVideoInfoBase::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   CGUIDialogVideoInfo::ShowFor(*item);
   return true;

--- a/xbmc/video/ContextMenus.h
+++ b/xbmc/video/ContextMenus.h
@@ -28,6 +28,12 @@ private:
   const MediaType m_mediaType;
 };
 
+struct CVideoInfo : CVideoInfoBase
+{
+  CVideoInfo() : CVideoInfoBase(MediaTypeVideo) {}
+  bool IsVisible(const CFileItem& item) const override;
+};
+
 struct CTVShowInfo : CVideoInfoBase
 {
   CTVShowInfo() : CVideoInfoBase(MediaTypeTvShow) {}

--- a/xbmc/video/ContextMenus.h
+++ b/xbmc/video/ContextMenus.h
@@ -17,10 +17,10 @@
 namespace CONTEXTMENU
 {
 
-class CVideoInfo : public CStaticContextMenuAction
+class CVideoInfoBase : public CStaticContextMenuAction
 {
 public:
-  explicit CVideoInfo(MediaType mediaType);
+  explicit CVideoInfoBase(MediaType mediaType);
   bool IsVisible(const CFileItem& item) const override;
   bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 
@@ -28,34 +28,34 @@ private:
   const MediaType m_mediaType;
 };
 
-struct CTVShowInfo : CVideoInfo
+struct CTVShowInfo : CVideoInfoBase
 {
-  CTVShowInfo() : CVideoInfo(MediaTypeTvShow) {}
+  CTVShowInfo() : CVideoInfoBase(MediaTypeTvShow) {}
 };
 
-struct CSeasonInfo : CVideoInfo
+struct CSeasonInfo : CVideoInfoBase
 {
-  CSeasonInfo() : CVideoInfo(MediaTypeSeason) {}
+  CSeasonInfo() : CVideoInfoBase(MediaTypeSeason) {}
 };
 
-struct CEpisodeInfo : CVideoInfo
+struct CEpisodeInfo : CVideoInfoBase
 {
-  CEpisodeInfo() : CVideoInfo(MediaTypeEpisode) {}
+  CEpisodeInfo() : CVideoInfoBase(MediaTypeEpisode) {}
 };
 
-struct CMusicVideoInfo : CVideoInfo
+struct CMusicVideoInfo : CVideoInfoBase
 {
-  CMusicVideoInfo() : CVideoInfo(MediaTypeMusicVideo) {}
+  CMusicVideoInfo() : CVideoInfoBase(MediaTypeMusicVideo) {}
 };
 
-struct CMovieInfo : CVideoInfo
+struct CMovieInfo : CVideoInfoBase
 {
-  CMovieInfo() : CVideoInfo(MediaTypeMovie) {}
+  CMovieInfo() : CVideoInfoBase(MediaTypeMovie) {}
 };
 
-struct CMovieSetInfo : CVideoInfo
+struct CMovieSetInfo : CVideoInfoBase
 {
-  CMovieSetInfo() : CVideoInfo(MediaTypeVideoCollection) {}
+  CMovieSetInfo() : CVideoInfoBase(MediaTypeVideoCollection) {}
 };
 
 struct CVideoRemoveResumePoint : CStaticContextMenuAction


### PR DESCRIPTION
Fixes missing Play/Resume/Information context menu entries for items provided by plugins. Problem was brought uo and discussed here: https://github.com/xbmc/xbmc/pull/25592#issuecomment-2558261944 ff

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 could you please review whenever you find some time.

Should be backported.