### PR TITLE
[Estuary] Add mediaflags for new types of audio

### DIFF
--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -337,7 +337,7 @@
 		</control>
 	</include>
 	<include name="MediaFlag">
-		<param name="width">115</param>
+		<param name="width">155</param>
 		<param name="height">60</param>
 		<param name="flag_visible">true</param>
 		<param name="texture">colors/white.png</param>
@@ -350,7 +350,7 @@
 					<fadetime>0</fadetime>
 					<top>13</top>
 					<left>5</left>
-					<width>105</width>
+					<width>145</width>
 					<height>34</height>
 					<texture border="2" infill="false" colordiffuse="white">$PARAM[texture]</texture>
 				</control>
@@ -373,7 +373,7 @@
 				<bottom>0</bottom>
 				<height>60</height>
 				<align>right</align>
-				<itemgap>10</itemgap>
+				<itemgap>2</itemgap>
 				<width>1900</width>
 				<usecontrolcoords>true</usecontrolcoords>
 				<control type="group">

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -813,13 +813,13 @@
 		<value>$INFO[VideoPlayer.VideoCodec]</value>
 	</variable>
 	<variable name="VideoListHDRVar">
-		<value condition="String.IsEqual(ListItem.HdrType,dolbyvision)">DoVi</value>
+		<value condition="String.IsEqual(ListItem.HdrType,dolbyvision)">Dolby Vision</value>
 		<value condition="String.IsEqual(ListItem.HdrType,hdr10)">HDR10</value>
 		<value condition="String.IsEqual(ListItem.HdrType,hlg)">HLG</value>
 		<value>$INFO[ListItem.HdrType]</value>
 	</variable>
 	<variable name="VideoPlayerHDRVar">
-		<value condition="String.IsEqual(VideoPlayer.HdrType,dolbyvision)">DoVi</value>
+		<value condition="String.IsEqual(VideoPlayer.HdrType,dolbyvision)">Dolby Vision</value>
 		<value condition="String.IsEqual(VideoPlayer.HdrType,hdr10)">HDR10</value>
 		<value condition="String.IsEqual(VideoPlayer.HdrType,hlg)">HLG</value>
 		<value>$INFO[VideoPlayer.HdrType]</value>
@@ -838,10 +838,13 @@
 		<value condition="String.IsEqual(ListItem.AudioCodec,dca)">DTS</value>
 		<value condition="String.IsEqual(ListItem.AudioCodec,dolbydigital)">Dolby D</value>
 		<value condition="String.IsEqual(ListItem.AudioCodec,dts)">DTS</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,dtshd_hra)">DTSHD-HRA</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,dtshd_ma)">DTSHD-MA</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,dtsma)">DTSHD-MA</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,dtshd_hra)">DTS-HD HRA</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,dtshd_ma)">DTS-HD MA</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,dtshd_ma_x)">DTS:X MA</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,dtshd_ma_x_imax)">DTS:X + IMAX</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,dtsma)">DTS-HD MA</value>
 		<value condition="String.IsEqual(ListItem.AudioCodec,eac3)">Dolby D+</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,eac3_ddp_atmos)">DD+ Atmos</value>
 		<value condition="String.IsEqual(ListItem.AudioCodec,flac)">FLAC</value>
 		<value condition="String.IsEqual(ListItem.AudioCodec,mp1)">MP1</value>
 		<value condition="String.IsEqual(ListItem.AudioCodec,mp3)">MP3</value>
@@ -853,6 +856,7 @@
 		<value condition="String.IsEqual(ListItem.AudioCodec,pcm_s16le)">PCM</value>
 		<value condition="String.IsEqual(ListItem.AudioCodec,pcm_s24le)">PCM</value>
 		<value condition="String.IsEqual(ListItem.AudioCodec,truehd)">TrueHD</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,truehd_atmos)">Dolby Atmos</value>
 		<value condition="String.IsEqual(ListItem.AudioCodec,vorbis)">Vorbis</value>
 		<value condition="String.IsEqual(ListItem.AudioCodec,wav)">WAV</value>
 		<value condition="String.IsEqual(ListItem.AudioCodec,wavpack)">WAVP</value>
@@ -874,10 +878,13 @@
 		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dca)">DTS</value>
 		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dolbydigital)">Dolby D</value>
 		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dts)">DTS</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dtshd_hra)">DTSHD-HRA</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dtshd_ma)">DTSHD-MA</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dtsma)">DTSHD-MA</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dtshd_hra)">DTS-HD HRA</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dtshd_ma)">DTS-HD MA</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dtshd_ma_x)">DTS:X MA</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dtshd_ma_x_imax)">DTS:X + IMAX</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dtsma)">DTS-HD MA</value>
 		<value condition="String.IsEqual(VideoPlayer.AudioCodec,eac3)">Dolby D+</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,eac3_ddp_atmos)">DD+ Atmos</value>
 		<value condition="String.IsEqual(VideoPlayer.AudioCodec,flac)">FLAC</value>
 		<value condition="String.IsEqual(VideoPlayer.AudioCodec,mp1)">MP1</value>
 		<value condition="String.IsEqual(VideoPlayer.AudioCodec,mp3)">MP3</value>
@@ -889,6 +896,7 @@
 		<value condition="String.IsEqual(VideoPlayer.AudioCodec,pcm_s16le)">PCM</value>
 		<value condition="String.IsEqual(VideoPlayer.AudioCodec,pcm_s24le)">PCM</value>
 		<value condition="String.IsEqual(VideoPlayer.AudioCodec,truehd)">TrueHD</value>
+		<value condition="String.IsEqual(VideoPlayer.AudioCodec,truehd_atmos)">Dolby Atmos</value>
 		<value condition="String.IsEqual(VideoPlayer.AudioCodec,vorbis)">Vorbis</value>
 		<value condition="String.IsEqual(VideoPlayer.AudioCodec,wav)">WAV</value>
 		<value condition="String.IsEqual(VideoPlayer.AudioCodec,wavpack)">WAVP</value>
@@ -926,20 +934,23 @@
 		<value condition="String.IsEqual(MusicPlayer.Codec,aac)">AAC</value>
 		<value condition="String.IsEqual(MusicPlayer.Codec,aac_latm)">AAC</value>
 		<value condition="String.IsEqual(MusicPlayer.Codec,ac3)">Dolby D</value>
-		<value condition="String.IsEqual(LMusicPlayer.Codec,aif)">AIFF</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,aif)">AIFF</value>
 		<value condition="String.IsEqual(MusicPlayer.Codec,aifc)">AIFF</value>
 		<value condition="String.IsEqual(MusicPlayer.Codec,aiff)">AIFF</value>
 		<value condition="String.IsEqual(MusicPlayer.Codec,alac)">ALAC</value>
-		<value condition="String.IsEqual(LMusicPlayer.Codec,ape)">APE</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,ape)">APE</value>
 		<value condition="String.IsEqual(MusicPlayer.Codec,avc)">AVC</value>
 		<value condition="String.IsEqual(MusicPlayer.Codec,cdda)">CDDA</value>
 		<value condition="String.IsEqual(MusicPlayer.Codec,dca)">DTS</value>
 		<value condition="String.IsEqual(MusicPlayer.Codec,dolbydigital)">Dolby D</value>
 		<value condition="String.IsEqual(MusicPlayer.Codec,dts)">DTS</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,dtshd_hra)">DTSHD-HRA</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,dtshd_ma)">DTSHD-MA</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,dtsma)">DTSHD-MA</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,dtshd_hra)">DTS-HD HRA</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,dtshd_ma)">DTS-HD MA</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,dtshd_ma_x)">DTS:X MA</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,dtshd_ma_x_imax)">DTS:X + IMAX</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,dtsma)">DTS-HD MA</value>
 		<value condition="String.IsEqual(MusicPlayer.Codec,eac3)">Dolby D+</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,eac3_ddp_atmos)">DD+ Atmos</value>
 		<value condition="String.IsEqual(MusicPlayer.Codec,flac)">FLAC</value>
 		<value condition="String.IsEqual(MusicPlayer.Codec,mp1)">MP1</value>
 		<value condition="String.IsEqual(MusicPlayer.Codec,mp3)">MP3</value>
@@ -951,6 +962,7 @@
 		<value condition="String.IsEqual(MusicPlayer.Codec,pcm_s16le)">PCM</value>
 		<value condition="String.IsEqual(MusicPlayer.Codec,pcm_s24le)">PCM</value>
 		<value condition="String.IsEqual(MusicPlayer.Codec,truehd)">TrueHD</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,truehd_atmos)">Dolby Atmos</value>
 		<value condition="String.IsEqual(MusicPlayer.Codec,vorbis)">Vorbis</value>
 		<value condition="String.IsEqual(MusicPlayer.Codec,wav)">WAV</value>
 		<value condition="String.IsEqual(MusicPlayer.Codec,wavpack)">WAVP</value>


### PR DESCRIPTION
## Description
[Estuary] Add mediaflags for new types of audio



## Screenshots (if appropriate):
**Before**
![before1](https://github.com/user-attachments/assets/21bd4825-f934-4b36-8ffa-abbcfa3980cd)

![before2](https://github.com/user-attachments/assets/bb637834-3d66-4104-a4df-9c4ce77fe08b)

**After**
![new1](https://github.com/user-attachments/assets/bb345d4a-f29a-4b21-a9b5-dd69a45a173e)

![new2](https://github.com/user-attachments/assets/f65540a4-b2a0-48ac-afb9-1427d7f3ba1f)

![new3](https://github.com/user-attachments/assets/5e1adba0-366c-40d7-a835-fe0d211dc35c)

![new4](https://github.com/user-attachments/assets/e34bd621-2c04-42ed-85be-1092bc05fc6c)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
