### PR TITLE
[Windows] Refactor Directsound Device Default and Enumeration

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -25,7 +25,6 @@
 #include <list>
 #include <mutex>
 
-#include <Audioclient.h>
 #include <Mmreg.h>
 #include <Rpc.h>
 #include <initguid.h>
@@ -50,17 +49,24 @@ DEFINE_GUID( _KSDATAFORMAT_SUBTYPE_DOLBY_AC3_SPDIF, WAVE_FORMAT_DOLBY_AC3_SPDIF,
     goto failed; \
   }
 
-#define DS_SPEAKER_COUNT 8
-static const unsigned int DSChannelOrder[] = {SPEAKER_FRONT_LEFT, SPEAKER_FRONT_RIGHT, SPEAKER_FRONT_CENTER, SPEAKER_LOW_FREQUENCY, SPEAKER_BACK_LEFT, SPEAKER_BACK_RIGHT, SPEAKER_SIDE_LEFT, SPEAKER_SIDE_RIGHT};
-static const enum AEChannel AEChannelNamesDS[] = {AE_CH_FL, AE_CH_FR, AE_CH_FC, AE_CH_LFE, AE_CH_BL, AE_CH_BR, AE_CH_SL, AE_CH_SR, AE_CH_NULL};
-
-using namespace Microsoft::WRL;
+namespace
+{
+constexpr unsigned int DS_SPEAKER_COUNT = 8U;
+constexpr unsigned int DSChannelOrder[] = {
+    SPEAKER_FRONT_LEFT, SPEAKER_FRONT_RIGHT, SPEAKER_FRONT_CENTER, SPEAKER_LOW_FREQUENCY,
+    SPEAKER_BACK_LEFT,  SPEAKER_BACK_RIGHT,  SPEAKER_SIDE_LEFT,    SPEAKER_SIDE_RIGHT};
+constexpr enum AEChannel AEChannelNamesDS[] = {AE_CH_FL, AE_CH_FR, AE_CH_FC, AE_CH_LFE, AE_CH_BL,
+                                               AE_CH_BR, AE_CH_SL, AE_CH_SR, AE_CH_NULL};
 
 struct DSDevice
 {
   std::string name;
-  LPGUID     lpGuid;
+  LPGUID lpGuid;
 };
+
+} // namespace
+
+using namespace Microsoft::WRL;
 
 static BOOL CALLBACK DSEnumCallback(LPGUID lpGuid, LPCTSTR lpcstrDescription, LPCTSTR lpcstrModule, LPVOID lpContext)
 {
@@ -451,122 +457,41 @@ double CAESinkDirectSound::GetCacheTotal()
 
 void CAESinkDirectSound::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool force)
 {
-  CAEDeviceInfo        deviceInfo;
+  CAEDeviceInfo deviceInfo{};
 
-  ComPtr<IMMDeviceEnumerator> pEnumerator = nullptr;
-  ComPtr<IMMDeviceCollection> pEnumDevices = nullptr;
-  UINT uiCount = 0;
-
-  HRESULT                hr;
-
-  const std::string strDD = CAESinkFactoryWin::GetDefaultDeviceId();
-
-  /* Windows Vista or later - supporting WASAPI device probing */
-  hr = CoCreateInstance(CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL, IID_IMMDeviceEnumerator, reinterpret_cast<void**>(pEnumerator.GetAddressOf()));
-  EXIT_ON_FAILURE(hr, "Could not allocate WASAPI device enumerator.")
-
-  hr = pEnumerator->EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, pEnumDevices.GetAddressOf());
-  EXIT_ON_FAILURE(hr, "Retrieval of audio endpoint enumeration failed.")
-
-  hr = pEnumDevices->GetCount(&uiCount);
-  EXIT_ON_FAILURE(hr, "Retrieval of audio endpoint count failed.")
-
-  for (UINT i = 0; i < uiCount; i++)
+  for (RendererDetail& detail : CAESinkFactoryWin::GetRendererDetails())
   {
-    ComPtr<IMMDevice> pDevice = nullptr;
-    ComPtr<IPropertyStore> pProperty = nullptr;
-    PROPVARIANT varName;
-    PropVariantInit(&varName);
-
     deviceInfo.m_channels.Reset();
     deviceInfo.m_dataFormats.clear();
     deviceInfo.m_sampleRates.clear();
+    deviceInfo.m_streamTypes.clear();
 
-    hr = pEnumDevices->Item(i, pDevice.GetAddressOf());
-    if (FAILED(hr))
+    if (detail.nChannels)
+      deviceInfo.m_channels =
+          layoutsByChCount[std::max(std::min(detail.nChannels, DS_SPEAKER_COUNT), 2U)];
+    deviceInfo.m_dataFormats.push_back(AEDataFormat(AE_FMT_FLOAT));
+    if (detail.eDeviceType != AE_DEVTYPE_PCM)
     {
-      CLog::LogF(LOGERROR, "Retrieval of DirectSound endpoint failed.");
-      goto failed;
+      deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_AC3);
+      // DTS is played with the same infrastructure as AC3
+      deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_CORE);
+      deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_1024);
+      deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_2048);
+      deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_512);
+      // signal that we can doe AE_FMT_RAW
+      deviceInfo.m_dataFormats.push_back(AE_FMT_RAW);
     }
-
-    hr = pDevice->OpenPropertyStore(STGM_READ, pProperty.GetAddressOf());
-    if (FAILED(hr))
-    {
-      CLog::LogF(LOGERROR, "Retrieval of DirectSound endpoint properties failed.");
-      goto failed;
-    }
-
-    hr = pProperty->GetValue(PKEY_Device_FriendlyName, &varName);
-    if (FAILED(hr))
-    {
-      CLog::LogF(LOGERROR, "Retrieval of DirectSound endpoint device name failed.");
-      goto failed;
-    }
-
-    std::string strFriendlyName = KODI::PLATFORM::WINDOWS::FromW(varName.pwszVal);
-    PropVariantClear(&varName);
-
-    hr = pProperty->GetValue(PKEY_AudioEndpoint_GUID, &varName);
-    if (FAILED(hr))
-    {
-      CLog::LogF(LOGERROR, "Retrieval of DirectSound endpoint GUID failed.");
-      goto failed;
-    }
-
-    std::string strDevName = KODI::PLATFORM::WINDOWS::FromW(varName.pwszVal);
-    PropVariantClear(&varName);
-
-    hr = pProperty->GetValue(PKEY_AudioEndpoint_FormFactor, &varName);
-    if (FAILED(hr))
-    {
-      CLog::LogF(LOGERROR, "Retrieval of DirectSound endpoint form factor failed.");
-      goto failed;
-    }
-    std::string strWinDevType = winEndpoints[(EndpointFormFactor)varName.uiVal].winEndpointType;
-    AEDeviceType aeDeviceType = winEndpoints[(EndpointFormFactor)varName.uiVal].aeDeviceType;
-
-    PropVariantClear(&varName);
-
-    /* In shared mode Windows tells us what format the audio must be in. */
-    ComPtr<IAudioClient> pClient;
-    hr = pDevice->Activate(IID_IAudioClient, CLSCTX_ALL, nullptr, reinterpret_cast<void**>(pClient.GetAddressOf()));
-    EXIT_ON_FAILURE(hr, "Activate device failed.")
-
-    //hr = pClient->GetMixFormat(&pwfxex);
-    hr = pProperty->GetValue(PKEY_AudioEngine_DeviceFormat, &varName);
-    if (SUCCEEDED(hr) && varName.blob.cbSize > 0)
-    {
-      WAVEFORMATEX* smpwfxex = (WAVEFORMATEX*)varName.blob.pBlobData;
-      deviceInfo.m_channels = layoutsByChCount[std::max(std::min(smpwfxex->nChannels, (WORD) DS_SPEAKER_COUNT), (WORD) 2)];
-      deviceInfo.m_dataFormats.push_back(AEDataFormat(AE_FMT_FLOAT));
-      if (aeDeviceType != AE_DEVTYPE_PCM)
-      {
-        deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_AC3);
-        // DTS is played with the same infrastructure as AC3
-        deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_CORE);
-        deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_1024);
-        deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_2048);
-        deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_512);
-        // signal that we can doe AE_FMT_RAW
-        deviceInfo.m_dataFormats.push_back(AE_FMT_RAW);
-      }
-      deviceInfo.m_sampleRates.push_back(std::min(smpwfxex->nSamplesPerSec, (DWORD) 192000));
-    }
-    else
-    {
-      CLog::LogF(LOGERROR, "Getting DeviceFormat failed ({})", CWIN32Util::FormatHRESULT(hr));
-    }
-
-    deviceInfo.m_deviceName       = strDevName;
-    deviceInfo.m_displayName      = strWinDevType.append(strFriendlyName);
-    deviceInfo.m_displayNameExtra = std::string("DIRECTSOUND: ").append(strFriendlyName);
-    deviceInfo.m_deviceType       = aeDeviceType;
-
+    if (detail.m_samplesPerSec)
+      deviceInfo.m_sampleRates.push_back(std::min(detail.m_samplesPerSec, 192000UL));
+    deviceInfo.m_deviceName = detail.strDeviceId;
+    deviceInfo.m_displayName = detail.strWinDevType.append(detail.strDescription);
+    deviceInfo.m_displayNameExtra = std::string("DIRECTSOUND: ").append(detail.strDescription);
+    deviceInfo.m_deviceType = detail.eDeviceType;
     deviceInfo.m_wantsIECPassthrough = true;
     deviceInfoList.push_back(deviceInfo);
 
     // add the default device with m_deviceName = default
-    if(strDD == strDevName)
+    if (detail.bDefault)
     {
       deviceInfo.m_deviceName = std::string("default");
       deviceInfo.m_displayName = std::string("default");
@@ -575,14 +500,6 @@ void CAESinkDirectSound::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bo
       deviceInfoList.push_back(deviceInfo);
     }
   }
-
-  return;
-
-failed:
-
-  if (FAILED(hr))
-    CLog::LogF(LOGERROR, "Failed to enumerate WASAPI endpoint devices ({}).",
-               CWIN32Util::FormatHRESULT(hr));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
@@ -38,7 +38,6 @@ public:
   virtual double GetCacheTotal();
   virtual unsigned int AddPackets(uint8_t **data, unsigned int frames, unsigned int offset);
 
-  static std::string GetDefaultDevice();
   static void EnumerateDevicesEx (AEDeviceInfoList &deviceInfoList, bool force = false);
 private:
   void          AEChannelsFromSpeakerMask(DWORD speakers);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
@@ -40,12 +40,11 @@ public:
 
   static void EnumerateDevicesEx (AEDeviceInfoList &deviceInfoList, bool force = false);
 private:
-  void          AEChannelsFromSpeakerMask(DWORD speakers);
-  DWORD         SpeakerMaskFromAEChannels(const CAEChannelInfo &channels);
-  void          CheckPlayStatus();
-  bool          UpdateCacheStatus();
-  unsigned int  GetSpace();
-  const char    *dserr2str(int err);
+  void AEChannelsFromSpeakerMask(DWORD speakers);
+  DWORD SpeakerMaskFromAEChannels(const CAEChannelInfo& channels);
+  void CheckPlayStatus();
+  bool UpdateCacheStatus();
+  unsigned int GetSpace();
 
   Microsoft::WRL::ComPtr<IDirectSoundBuffer> m_pBuffer;
   Microsoft::WRL::ComPtr<IDirectSound> m_pDSound;

--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin.h
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin.h
@@ -182,6 +182,7 @@ struct RendererDetail
   AEDeviceType eDeviceType;
   unsigned int nChannels;
   unsigned int uiChannelMask;
+  unsigned long m_samplesPerSec; //!< Sample rate of the system default format
   bool bDefault;
 };
 

--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp
@@ -110,26 +110,6 @@ std::vector<RendererDetail> CAESinkFactoryWin::GetRendererDetails()
     PropVariantClear(&varName);
 
     /* In shared mode Windows tells us what format the audio must be in. */
-
-    /* Beginning of suspicous code
-     *
-     * Is this seemingly unnecessary activation actually needed in some cases to initialize
-     * PKEY_AudioEngine_DeviceFormat? Or was it forgotten when GetMixFormat() was commented?
-     * Found a blog that indicates that GetMixFormat() can force the population. Maybe only for
-     * older Windows versions?
-     * Doesn't seem needed for Windows 8.1 and above. No mention in MS documentation.
-     * This code came from AESinkDirectSound which was created with this as is.
-     * No prior history found, the DS code prior to 2012 didn't use the MMDevice API.
-     * Kept to avoid breaking something by accident.
-     */
-    ComPtr<IAudioClient> pClient;
-    hr = pDevice->Activate(IID_IAudioClient, CLSCTX_ALL, nullptr,
-                           reinterpret_cast<void**>(pClient.GetAddressOf()));
-    EXIT_ON_FAILURE(hr, "Activate device failed.")
-
-    //hr = pClient->GetMixFormat(&pwfxex);
-    /* End of suspicious code */
-
     hr = pProperty->GetValue(PKEY_AudioEngine_DeviceFormat, &varName);
     if (SUCCEEDED(hr) && varName.blob.cbSize >= sizeof(WAVEFORMATEX))
     {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The sink factory and direct sound code was very similar for default device retrieval and device enumeration (MMDevice API).

Added the few missing pieces to CAESinkFactoryWin::GetRendererDetails() and CAESinkFactoryWin::GetDefaultDeviceId() so they can be used by DirectSound and removed the equivalent DirectSound code.

Some redundancy also found in Initialize, with a DS enumeration of the devices to find the GUID, followed by multiple MMDevices enumerations (find default + is the device USB).

There was some strange code before the retrieval of the device property PKEY_AudioEngine_DeviceFormat. It's unclear if it was left by accident or if it serves a purpose and has a side-effect of populating the data of the property on some systems.
It was created directly like that for AE in 2012, the pre-AE code didn't have anything like it and I didn't find the information in the forum AE thread.
There is no problem without on Windows 8.1 10 and 11 didn't.
Removed for now, we'll see if it causes issues and needs to be brought back.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Noticed the very similar code of the DirectSound sink and CAESinkFactoryWin.
It's beneficial to share that code with the Wasapi sink.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Windows 8.1, 10 and 11 - select specific output or default.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
