### PR TITLE
Declare global `std::string` constants as `inline`

### DIFF
--- a/xbmc/filesystem/ZipManager.h
+++ b/xbmc/filesystem/ZipManager.h
@@ -26,7 +26,7 @@
 
 class CURL;
 
-static const std::string PATH_TRAVERSAL(R"_((^|\/|\\)\.{2}($|\/|\\))_");
+inline const std::string PATH_TRAVERSAL(R"_((^|\/|\\)\.{2}($|\/|\\))_");
 
 struct SZipEntry {
   unsigned int header = 0;

--- a/xbmc/guilib/LocalizeStrings.h
+++ b/xbmc/guilib/LocalizeStrings.h
@@ -32,8 +32,8 @@ struct LocStr
 };
 
 // The default fallback language is fixed to be English
-const std::string LANGUAGE_DEFAULT = "resource.language.en_gb";
-const std::string LANGUAGE_OLD_DEFAULT = "English";
+inline const std::string LANGUAGE_DEFAULT = "resource.language.en_gb";
+inline const std::string LANGUAGE_OLD_DEFAULT = "English";
 
 class CLocalizeStrings : public ILocalizer
 {

--- a/xbmc/guilib/XBTF.h
+++ b/xbmc/guilib/XBTF.h
@@ -15,8 +15,8 @@
 
 #include <stdint.h>
 
-static const std::string XBTF_MAGIC = "XBTF";
-static const std::string XBTF_VERSION = "3";
+inline const std::string XBTF_MAGIC = "XBTF";
+inline const std::string XBTF_VERSION = "3";
 static const char XBTF_VERSION_MIN = '2';
 
 #include "TextureFormats.h"

--- a/xbmc/music/Artist.h
+++ b/xbmc/music/Artist.h
@@ -185,10 +185,10 @@ private:
 typedef std::vector<CArtist> VECARTISTS;
 typedef std::vector<CArtistCredit> VECARTISTCREDITS;
 
-const std::string BLANKARTIST_FAKEMUSICBRAINZID = "Artist Tag Missing";
-const std::string BLANKARTIST_NAME = "[Missing Tag]";
+inline const std::string BLANKARTIST_FAKEMUSICBRAINZID = "Artist Tag Missing";
+inline const std::string BLANKARTIST_NAME = "[Missing Tag]";
 const int BLANKARTIST_ID = 1;
-const std::string VARIOUSARTISTS_MBID = "89ad4ac3-39f7-470e-963a-56509c546377";
+inline const std::string VARIOUSARTISTS_MBID = "89ad4ac3-39f7-470e-963a-56509c546377";
 
 #define ROLE_ARTIST 1  //Default role
 

--- a/xbmc/video/VideoManagerTypes.h
+++ b/xbmc/video/VideoManagerTypes.h
@@ -35,7 +35,7 @@ static constexpr int VIDEO_VERSION_ID_BEGIN = 40400;
 static constexpr int VIDEO_VERSION_ID_END = 40800;
 static constexpr int VIDEO_VERSION_ID_DEFAULT = VIDEO_VERSION_ID_BEGIN;
 static constexpr int VIDEO_VERSION_ID_ALL = 0;
-static const std::string VIDEODB_PATH_VERSION_ID_ALL{"videodb://movies/videoversions/0"};
+inline const std::string VIDEODB_PATH_VERSION_ID_ALL{"videodb://movies/videoversions/0"};
 
 struct VideoAssetInfo
 {

--- a/xbmc/weather/WeatherManager.h
+++ b/xbmc/weather/WeatherManager.h
@@ -23,7 +23,7 @@
 #define WEATHER_LABEL_CURRENT_DEWP 27
 #define WEATHER_LABEL_CURRENT_HUMI 28
 
-static const std::string ICON_ADDON_PATH = "resource://resource.images.weathericons.default";
+inline const std::string ICON_ADDON_PATH = "resource://resource.images.weathericons.default";
 
 struct ForecastDay
 {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Declare global `std::string` constants in headers as `inline`. They are implicitly `static` and each compilation unit that includes such a header gets its own copy of the constants without `inline`.

Fixes #26046.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Saves a little Memory and space in the executable.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Compiles and `readelf` confirms the symbols exist only once.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
