### PR TITLE
[Backport][FileSystem][POSIX] Fix prompt for credentials when browsing SMB files

### DIFF
--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -288,7 +288,7 @@ int CSMBDirectory::OpenDir(const CURL& url, std::string& strAuth)
   {
     std::string cError;
 
-    if (errno == EACCES)
+    if (errno == EACCES || errno == EPERM || errno == EAGAIN || errno == EINVAL)
     {
       if (m_flags & DIR_FLAG_ALLOW_PROMPT)
         RequireAuthentication(urlIn);


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/26165


## What is the effect on users?
Improves usability and user experience.


## Screenshots (if appropriate):
**Before**
![398217662-30e30969-586e-431d-ae03-a1d7bbd8073f](https://github.com/user-attachments/assets/f64d2ebd-5653-4c71-a823-8aaecbfc84d4)

**After**
![screenshot00001](https://github.com/user-attachments/assets/db80aca8-2496-4021-a5f5-d7f5dbb61a4a)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
