### PR TITLE
[input/remote] Add buttons "favorites" and "last"

### DIFF
--- a/system/Lircmap.xml
+++ b/system/Lircmap.xml
@@ -600,6 +600,8 @@
 		<blue>KEY_BLUE</blue>
 		<recordedtv>KEY_PVR</recordedtv>
 		<liveradio>KEY_RADIO</liveradio>
+		<favorites>KEY_FAVORITES</favorites>
+		<last>KEY_LAST</last>
 	</remote>
 
 	<remote device="devinput-32">
@@ -660,6 +662,8 @@
 		<blue>KEY_BLUE</blue>
 		<recordedtv>KEY_PVR</recordedtv>
 		<liveradio>KEY_RADIO</liveradio>
+		<favorites>KEY_FAVORITES</favorites>
+		<last>KEY_LAST</last>
 	</remote>
 
 	<remote device="devinput-64">
@@ -720,5 +724,7 @@
 		<blue>KEY_BLUE</blue>
 		<recordedtv>KEY_PVR</recordedtv>
 		<liveradio>KEY_RADIO</liveradio>
+		<favorites>KEY_FAVORITES</favorites>
+		<last>KEY_LAST</last>
 	</remote>
 </lircmap>

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -75,6 +75,7 @@
       <eight>JumpSMS8</eight>
       <nine>JumpSMS9</nine>
       <print>Screenshot</print>
+      <favorites>ActivateWindow(FavouritesBrowser)</favorites>
     </remote>
   </global>
   <Home>
@@ -712,4 +713,9 @@
       <title>PlayerProcessInfo</title>
     </remote>
   </PlayerProcessInfo>
+  <FullScreenLiveTV>
+    <remote>
+      <last>Number0</last>
+    </remote>
+  </FullScreenLiveTV>
 </keymap>

--- a/xbmc/input/keymaps/remote/IRTranslator.cpp
+++ b/xbmc/input/keymaps/remote/IRTranslator.cpp
@@ -299,6 +299,10 @@ uint32_t CIRTranslator::TranslateString(std::string strButton)
     buttonCode = XINPUT_IR_REMOTE_DVD_MENU;
   else if (strButton == "print")
     buttonCode = XINPUT_IR_REMOTE_PRINT;
+  else if (strButton == "favorites")
+    buttonCode = XINPUT_IR_REMOTE_FAVORITE_MENU;
+  else if (strButton == "last")
+    buttonCode = XINPUT_IR_REMOTE_LAST;
   else
     CLog::Log(LOGERROR, "Remote Translator: Can't find button {}", strButton);
   return buttonCode;

--- a/xbmc/input/remote/IRRemote.h
+++ b/xbmc/input/remote/IRRemote.h
@@ -86,6 +86,9 @@
 
 #define XINPUT_IR_REMOTE_PRINT 240
 
+#define XINPUT_IR_REMOTE_FAVORITE_MENU 241
+#define XINPUT_IR_REMOTE_LAST 242
+
 // Reserved 256 -> ...
 // Key.h
 // KEY_BUTTON_*

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -926,7 +926,7 @@ void CPeripheralCecAdapter::PushCecKeypress(const cec_keypress& key)
       PushCecKeypress(xbmcKey);
       break;
     case CEC_USER_CONTROL_CODE_FAVORITE_MENU:
-      xbmcKey.iButton = XINPUT_IR_REMOTE_MENU;
+      xbmcKey.iButton = XINPUT_IR_REMOTE_FAVORITE_MENU;
       PushCecKeypress(xbmcKey);
       break;
     case CEC_USER_CONTROL_CODE_EXIT:
@@ -946,7 +946,7 @@ void CPeripheralCecAdapter::PushCecKeypress(const cec_keypress& key)
       PushCecKeypress(xbmcKey);
       break;
     case CEC_USER_CONTROL_CODE_PREVIOUS_CHANNEL:
-      xbmcKey.iButton = XINPUT_IR_REMOTE_TELETEXT;
+      xbmcKey.iButton = XINPUT_IR_REMOTE_LAST;
       PushCecKeypress(xbmcKey);
       break;
     case CEC_USER_CONTROL_CODE_SOUND_SELECT:


### PR DESCRIPTION
## Description
Two buttons from CEC are mapped to other existing buttons: "favorites" to "menu" and "last channel" to "teletext".  Plumb them into the xbmc/input/remote translations, so that they can be given their own meaning in the keymaps, and add the same buttons to the LIRC map for non-CEC remotes.

## Motivation and context
This provides easier access to the favorites menu, and also a more intuitive way than "0" to switch to the previous channel.

## How has this been tested?
I have tested with a custom CoreELEC build, since that's the only way I have to place Kodi on a computer with an IR receiver.

## What is the effect on users?
Some buttons on the users' CEC remote will start working as intended. Some buttons on the users' LIRC remote were not working at all and will start working now.

The previous replaced functionality of the buttons on CEC remotes is changed as follows:
* The "favorites menu" button will no longer bring up the menu. This is not a problem because the "menu" button is almost always present and is a more intuitive way to obtain the same effect.
* Likewise, the "last channel" button will not bring up teletext anymore. This may have been intentional, I don't know. My TV remote has a teletext button but other equipment that supports CEC might not.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
