### PR TITLE
Fix segfault on exit if Peripherals dialog is loaded

### DIFF
--- a/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
@@ -143,6 +143,16 @@ bool CGUIDialogPeripherals::OnMessage(CGUIMessage& message)
   return CGUIDialogSelect::OnMessage(message);
 }
 
+void CGUIDialogPeripherals::FreeResources(bool immediately /* = false */)
+{
+  // Free GUI resources
+  for (auto it = m_peripherals.begin(); it != m_peripherals.end(); ++it)
+    (*it)->FreeMemory();
+
+  // Free ancestor resources
+  CGUIDialogSelect::FreeResources(immediately);
+}
+
 void CGUIDialogPeripherals::Notify(const Observable& obs, const ObservableMessage msg)
 {
   switch (msg)

--- a/xbmc/peripherals/dialogs/GUIDialogPeripherals.h
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripherals.h
@@ -36,6 +36,7 @@ public:
 
   // implementation of CGUIControl via CGUIDialogSelect
   bool OnMessage(CGUIMessage& message) override;
+  void FreeResources(bool immediately = false) override;
 
   // implementation of Observer
   void Notify(const Observable& obs, const ObservableMessage msg) override;


### PR DESCRIPTION
## Description

As title says, this PR fixes a segfault that can occur when Kodi exits after the Peripherals dialog has been shown with at least one peripheral connected.

The cause is too much guilib stuff done in the dialog's destructor. Specifically, clearing the peripheral fileitems calls into guilib code to perform cleanup. However, the guilib objects are being destructed, causing a segfault to occur here: https://github.com/xbmc/xbmc/blob/master/xbmc/guilib/GUIControlLookup.cpp#L107. After destruction, `m_parentControl` is uninitialized memory and Kodi crashes on that line.

The fix is to simply add a hook to clear resources that is called before destruction. Fortunately, the window manager calls such a function (https://github.com/xbmc/xbmc/blob/master/xbmc/guilib/GUIWindowManager.cpp#L499):

```c++
if (pWindow)
{
  Remove(id);
  pWindow->FreeResources(true);
  delete pWindow; // Crashes
}
```

By clearing the guilib resources in `FreeResources()`, no more guilib calls are done from the constructor, fixing the crash on exit.

## Motivation and context

Noticed when testing controllers on my Macbook M2.

## How has this been tested?

To reproduce, connect at least one controller, open the Peripherals Dialog in Settings (System -> Input -> Peripherals), close the dialog, then exit Kodi.

After applying this PR: Kodi no longer crashes on exit.

## What is the effect on users?

* Fixes crash on exit after opening the Peripherals Dialog with at least one peripheral connected

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
