### PR TITLE
[cmake] Quiet Pkgconfig searches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,7 +172,7 @@ if (NOT PLATFORMDEFS_DIR STREQUAL "")
   list(APPEND INCLUDES ${CMAKE_SOURCE_DIR}/xbmc/${PLATFORMDEFS_DIR})
 endif()
 
-find_package(PkgConfig)
+find_package(PkgConfig QUIET)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED QUIET)
 list(APPEND DEPLIBS ${CMAKE_THREAD_LIBS_INIT})

--- a/cmake/modules/FindAcbAPI.cmake
+++ b/cmake/modules/FindAcbAPI.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::AcbAPI   - The acbAPI library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_ACBAPI libAcbAPI QUIET)
   endif()

--- a/cmake/modules/FindAlsa.cmake
+++ b/cmake/modules/FindAlsa.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::Alsa   - The Alsa library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
 
   if(Alsa_FIND_VERSION)
     if(Alsa_FIND_VERSION_EXACT)

--- a/cmake/modules/FindAvahi.cmake
+++ b/cmake/modules/FindAvahi.cmake
@@ -9,7 +9,7 @@
 #   ${APP_NAME_LC}::AvahiCommon - The avahi common library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_AVAHI avahi-client QUIET)
   endif()

--- a/cmake/modules/FindBluetooth.cmake
+++ b/cmake/modules/FindBluetooth.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::Bluetooth   - The Bluetooth library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_BLUETOOTH bluez bluetooth QUIET)
   endif()

--- a/cmake/modules/FindBluray.cmake
+++ b/cmake/modules/FindBluray.cmake
@@ -9,7 +9,7 @@
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
 
   # We only rely on pkgconfig for non windows platforms
   if(PKG_CONFIG_FOUND AND NOT (WIN32 OR WINDOWS_STORE))

--- a/cmake/modules/FindBrotli.cmake
+++ b/cmake/modules/FindBrotli.cmake
@@ -14,7 +14,7 @@
 #
 
 if(NOT TARGET Brotli::Brotli)
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND AND NOT (WIN32 OR WINDOWSSTORE))
     pkg_check_modules(BROTLICOMMON libbrotlicommon QUIET)
     # First item is the full path of the library file found

--- a/cmake/modules/FindCAP.cmake
+++ b/cmake/modules/FindCAP.cmake
@@ -8,7 +8,7 @@
 # ${APP_NAME_LC}::CAP - The LibCap library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_CAP libcap QUIET)
   endif()

--- a/cmake/modules/FindCEC.cmake
+++ b/cmake/modules/FindCEC.cmake
@@ -89,7 +89,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
                                 ${${CORE_PLATFORM_LC}_SEARCH_CONFIG})
       set(CEC_VERSION ${libcec_VERSION})
     else()
-      find_package(PkgConfig)
+      find_package(PkgConfig QUIET)
       # Fallback to pkg-config and individual lib/include file search
       if(PKG_CONFIG_FOUND)
         pkg_check_modules(PC_CEC libcec QUIET)

--- a/cmake/modules/FindCdio.cmake
+++ b/cmake/modules/FindCdio.cmake
@@ -9,7 +9,7 @@
 #
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
 
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_CDIO libcdio>=0.80 QUIET)

--- a/cmake/modules/FindCrossGUID.cmake
+++ b/cmake/modules/FindCrossGUID.cmake
@@ -38,7 +38,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
   if(ENABLE_INTERNAL_CROSSGUID)
     buildCrossGUID()
   else()
-    find_package(PkgConfig)
+    find_package(PkgConfig QUIET)
     # Do not use pkgconfig on windows
     if(PKG_CONFIG_FOUND AND NOT WIN32)
       pkg_check_modules(PC_CROSSGUID crossguid QUIET)

--- a/cmake/modules/FindCurl.cmake
+++ b/cmake/modules/FindCurl.cmake
@@ -83,7 +83,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
   else()
     # Maybe need to look explicitly for CURL::libcurl_static/shared?
     if(NOT TARGET CURL::libcurl)
-      find_package(PkgConfig)
+      find_package(PkgConfig QUIET)
 
       # We only rely on pkgconfig for non windows platforms
       if(PKG_CONFIG_FOUND AND NOT (WIN32 OR WINDOWS_STORE))

--- a/cmake/modules/FindDBus.cmake
+++ b/cmake/modules/FindDBus.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::DBus   - The DBUS library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_DBUS dbus-1 QUIET)
   endif()

--- a/cmake/modules/FindDav1d.cmake
+++ b/cmake/modules/FindDav1d.cmake
@@ -35,7 +35,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
     BUILD_DEP_TARGET()
   else()
-    find_package(PkgConfig)
+    find_package(PkgConfig QUIET)
     # Do not use pkgconfig on windows
     if(PKG_CONFIG_FOUND AND NOT WIN32)
       pkg_check_modules(PC_DAV1D dav1d QUIET)

--- a/cmake/modules/FindEGL.cmake
+++ b/cmake/modules/FindEGL.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::EGL   - The EGL library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_EGL egl QUIET)
   endif()

--- a/cmake/modules/FindEpollShim.cmake
+++ b/cmake/modules/FindEpollShim.cmake
@@ -7,7 +7,7 @@
 #   ${APP_NAME_LC}::EpollShim   - The epoll-shim library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
 
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_EPOLLSHIM epoll-shim QUIET)

--- a/cmake/modules/FindExiv2.cmake
+++ b/cmake/modules/FindExiv2.cmake
@@ -98,7 +98,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
       get_target_property(EXIV2_INCLUDE_DIR ${_exiv_target_name} INTERFACE_INCLUDE_DIRECTORIES)
     else()
-      find_package(PkgConfig)
+      find_package(PkgConfig QUIET)
       # Fallback to pkg-config and individual lib/include file search
       if(PKG_CONFIG_FOUND)
         pkg_check_modules(PC_EXIV2 exiv2 QUIET)

--- a/cmake/modules/FindFreeType.cmake
+++ b/cmake/modules/FindFreeType.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::FreeType   - The FreeType library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   # Do not use pkgconfig on windows
   if(PKG_CONFIG_FOUND AND NOT (WIN32 OR WINDOWS_STORE))
     pkg_check_modules(PC_FREETYPE freetype2 QUIET)

--- a/cmake/modules/FindFriBidi.cmake
+++ b/cmake/modules/FindFriBidi.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::FriBidi   - The FriBidi library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
 
   if(PKG_CONFIG_FOUND AND NOT (WIN32 OR WINDOWS_STORE))
     pkg_check_modules(FRIBIDI fribidi IMPORTED_TARGET GLOBAL QUIET)

--- a/cmake/modules/FindFstrcmp.cmake
+++ b/cmake/modules/FindFstrcmp.cmake
@@ -27,7 +27,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
     BUILD_DEP_TARGET()
   else()
-    find_package(PkgConfig)
+    find_package(PkgConfig QUIET)
     if(PKG_CONFIG_FOUND AND NOT (WIN32 OR WINDOWS_STORE))
       pkg_check_modules(PC_FSTRCMP fstrcmp QUIET)
     endif()

--- a/cmake/modules/FindGBM.cmake
+++ b/cmake/modules/FindGBM.cmake
@@ -7,7 +7,7 @@
 #   ${APP_NAME_LC}::GBM   - The GBM library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_GBM gbm QUIET)
   endif()

--- a/cmake/modules/FindGLU.cmake
+++ b/cmake/modules/FindGLU.cmake
@@ -9,7 +9,7 @@
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
 
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_GLU glu QUIET)

--- a/cmake/modules/FindGLX.cmake
+++ b/cmake/modules/FindGLX.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::GLX    - The GLX library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
 
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_GLX glx QUIET)

--- a/cmake/modules/FindHarfBuzz.cmake
+++ b/cmake/modules/FindHarfBuzz.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::HarfBuzz   - The HarfBuzz library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND AND NOT (WIN32 OR WINDOWS_STORE))
     pkg_check_modules(PC_HARFBUZZ harfbuzz QUIET)
   endif()

--- a/cmake/modules/FindIso9660pp.cmake
+++ b/cmake/modules/FindIso9660pp.cmake
@@ -11,7 +11,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
   find_package(Cdio)
 
   if(Cdio_FOUND)
-    find_package(PkgConfig)
+    find_package(PkgConfig QUIET)
     if(PKG_CONFIG_FOUND AND NOT (WIN32 OR WINDOWS_STORE))
       if(Iso9660pp_FIND_VERSION)
         if(Iso9660pp_FIND_VERSION_EXACT)

--- a/cmake/modules/FindLCMS2.cmake
+++ b/cmake/modules/FindLCMS2.cmake
@@ -16,7 +16,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     endif()
   endif()
 
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND AND NOT (WIN32 OR WINDOWS_STORE))
     pkg_check_modules(PC_LCMS2 lcms2${LCMS2_FIND_SPEC} QUIET)
   endif()

--- a/cmake/modules/FindLibDRM.cmake
+++ b/cmake/modules/FindLibDRM.cmake
@@ -16,7 +16,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     endif()
   endif()
 
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_LIBDRM libdrm${LibDRM_FIND_SPEC} QUIET)
   endif()

--- a/cmake/modules/FindLibDisplayInfo.cmake
+++ b/cmake/modules/FindLibDisplayInfo.cmake
@@ -9,7 +9,7 @@
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
 
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_LIBDISPLAYINFO libdisplay-info QUIET)

--- a/cmake/modules/FindLibDovi.cmake
+++ b/cmake/modules/FindLibDovi.cmake
@@ -8,7 +8,7 @@
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
 
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_LIBDOVI libdovi QUIET)

--- a/cmake/modules/FindLibInput.cmake
+++ b/cmake/modules/FindLibInput.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::LibInput   - The LibInput library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
 
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_LIBINPUT libinput QUIET)

--- a/cmake/modules/FindLibUSB.cmake
+++ b/cmake/modules/FindLibUSB.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::LibUSB   - The USB library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
 
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_LIBUSB libusb QUIET)

--- a/cmake/modules/FindLircClient.cmake
+++ b/cmake/modules/FindLircClient.cmake
@@ -7,7 +7,7 @@
 #   ${APP_NAME_LC}::LircClient - The lirc library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_LIRC lirc QUIET)
   endif()

--- a/cmake/modules/FindMariaDBClient.cmake
+++ b/cmake/modules/FindMariaDBClient.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::MariaDBClient   - The MariaDBClient library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
 
   if(PKG_CONFIG_FOUND)
     pkg_search_module(PC_MARIADBCLIENT libmariadb mariadb QUIET)

--- a/cmake/modules/FindMicroHttpd.cmake
+++ b/cmake/modules/FindMicroHttpd.cmake
@@ -9,7 +9,7 @@
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
 
   if(PKG_CONFIG_FOUND AND NOT (WIN32 OR WINDOWS_STORE))
     if(MicroHttpd_FIND_VERSION)

--- a/cmake/modules/FindNFS.cmake
+++ b/cmake/modules/FindNFS.cmake
@@ -67,7 +67,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
                                    HINTS ${DEPENDS_PATH}/include
                                    ${${CORE_PLATFORM_LC}_SEARCH_CONFIG})
     else()
-      find_package(PkgConfig)
+      find_package(PkgConfig QUIET)
       # Try pkgconfig based search as last resort
       if(PKG_CONFIG_FOUND AND NOT (WIN32 OR WINDOWS_STORE))
         if(NFS_FIND_VERSION)

--- a/cmake/modules/FindNGHttp2.cmake
+++ b/cmake/modules/FindNGHttp2.cmake
@@ -8,7 +8,7 @@
 #   NGHttp2::NGHttp2   - The NGHttp2 library
 
 if(NOT TARGET NGHttp2::NGHttp2)
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND AND NOT (WIN32 OR WINDOWSSTORE))
     pkg_check_modules(NGHTTP2 libnghttp2 QUIET)
 

--- a/cmake/modules/FindOpenGLES.cmake
+++ b/cmake/modules/FindOpenGLES.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::OpenGLES - The OpenGLES IMPORTED library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_OPENGLES glesv2 QUIET)
   endif()

--- a/cmake/modules/FindOpenGl.cmake
+++ b/cmake/modules/FindOpenGl.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::OpenGl - The OpenGL library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_OPENGL gl QUIET)
   endif()

--- a/cmake/modules/FindP8Platform.cmake
+++ b/cmake/modules/FindP8Platform.cmake
@@ -46,7 +46,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} OR P8Platform_FIND_REQU
   else()
     # p8-platform cmake config is terrible for modern cmake. For now just use pkgconfig
     # and manual find_* 
-    find_package(PkgConfig)
+    find_package(PkgConfig QUIET)
     # Do not use pkgconfig on windows
     if(PKG_CONFIG_FOUND AND NOT WIN32)
       pkg_check_modules(PC_P8PLATFORM p8-platform QUIET)

--- a/cmake/modules/FindPCRE2.cmake
+++ b/cmake/modules/FindPCRE2.cmake
@@ -81,7 +81,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
       get_target_property(PCRE2_INCLUDE_DIR PCRE2::8BIT INTERFACE_INCLUDE_DIRECTORIES)
     else()
       # ToDo: use pkgconfig data imported and drop manual find_path/find_library
-      find_package(PkgConfig)
+      find_package(PkgConfig QUIET)
       if(PKG_CONFIG_FOUND)
         pkg_check_modules(PC_PCRE2 libpcre2-8 QUIET)
       endif()

--- a/cmake/modules/FindPipewire.cmake
+++ b/cmake/modules/FindPipewire.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::Pipewire    - The pipewire library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     if(Pipewire_FIND_VERSION)
       if(Pipewire_FIND_VERSION_EXACT)

--- a/cmake/modules/FindPlayerAPIs.cmake
+++ b/cmake/modules/FindPlayerAPIs.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::PlayerAPIs   - The playerAPIs library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     if(PlayerAPIs_FIND_VERSION)
       if(PlayerAPIs_FIND_VERSION_EXACT)

--- a/cmake/modules/FindPlayerFactory.cmake
+++ b/cmake/modules/FindPlayerFactory.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::PlayerFactory   - The PlayerFactory library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     if(PlayerFactory_FIND_VERSION)
       if(PlayerFactory_FIND_VERSION_EXACT)

--- a/cmake/modules/FindPlist.cmake
+++ b/cmake/modules/FindPlist.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::Plist - The Plist library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND AND NOT (WIN32 OR WINDOWS_STORE))
     pkg_search_module(PC_PLIST libplist-2.0 libplist QUIET)
   endif()

--- a/cmake/modules/FindPulseAudio.cmake
+++ b/cmake/modules/FindPulseAudio.cmake
@@ -11,7 +11,7 @@
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     if(PulseAudio_FIND_VERSION)
       if(PulseAudio_FIND_VERSION_EXACT)

--- a/cmake/modules/FindRapidJSON.cmake
+++ b/cmake/modules/FindRapidJSON.cmake
@@ -61,7 +61,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     # If RAPIDJSON_INCLUDE_DIRS exists, then the find_package command found a config
     # and suitable version. If its not, we fall back to a pkgconfig/manual search
     if(NOT DEFINED RAPIDJSON_INCLUDE_DIRS)
-      find_package(PkgConfig)
+      find_package(PkgConfig QUIET)
       # Fallback to pkg-config and individual lib/include file search
       # Do not use pkgconfig on windows
       if(PKG_CONFIG_FOUND AND NOT WIN32)

--- a/cmake/modules/FindSmbClient.cmake
+++ b/cmake/modules/FindSmbClient.cmake
@@ -18,7 +18,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     endif()
   else()
 
-    find_package(PkgConfig)
+    find_package(PkgConfig QUIET)
 
     if(PKG_CONFIG_FOUND)
       pkg_check_modules(SMBCLIENT smbclient QUIET)

--- a/cmake/modules/FindSpdlog.cmake
+++ b/cmake/modules/FindSpdlog.cmake
@@ -95,7 +95,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
       get_target_property(SPDLOG_INCLUDE_DIR spdlog::spdlog INTERFACE_INCLUDE_DIRECTORIES)
     else()
-      find_package(PkgConfig)
+      find_package(PkgConfig QUIET)
       # Fallback to pkg-config and individual lib/include file search
       if(PKG_CONFIG_FOUND)
         pkg_check_modules(PC_SPDLOG spdlog QUIET)

--- a/cmake/modules/FindSqlite3.cmake
+++ b/cmake/modules/FindSqlite3.cmake
@@ -9,7 +9,7 @@
 #
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND AND NOT (WIN32 OR WINDOWS_STORE))
     pkg_check_modules(PC_SQLITE3 sqlite3 QUIET)
 

--- a/cmake/modules/FindTagLib.cmake
+++ b/cmake/modules/FindTagLib.cmake
@@ -72,7 +72,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     # Build Taglib
     buildTagLib()
   else()
-    find_package(PkgConfig)
+    find_package(PkgConfig QUIET)
     if(PKG_CONFIG_FOUND AND NOT (WIN32 OR WINDOWS_STORE))
       if(TagLib_FIND_VERSION)
         if(TagLib_FIND_VERSION_EXACT)

--- a/cmake/modules/FindTinyXML.cmake
+++ b/cmake/modules/FindTinyXML.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::TinyXML   - The TinyXML library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
 
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_TINYXML tinyxml QUIET)

--- a/cmake/modules/FindUDEV.cmake
+++ b/cmake/modules/FindUDEV.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::UDEV   - The UDEV library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_UDEV libudev QUIET)
   endif()

--- a/cmake/modules/FindUUID.cmake
+++ b/cmake/modules/FindUUID.cmake
@@ -9,7 +9,7 @@
 #
 
 if(NOT TARGET UUID::UUID)
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_UUID uuid QUIET)
   endif()

--- a/cmake/modules/FindUdfread.cmake
+++ b/cmake/modules/FindUdfread.cmake
@@ -41,7 +41,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
       unset(UDFREAD_LIBRARIES)
     endif()
   else()
-    find_package(PkgConfig)
+    find_package(PkgConfig QUIET)
     pkg_check_modules(libudfread libudfread IMPORTED_TARGET GLOBAL QUIET)
 
     include(cmake/scripts/common/ModuleHelpers.cmake)

--- a/cmake/modules/FindVAAPI.cmake
+++ b/cmake/modules/FindVAAPI.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::VAAPI   - The VAAPI library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
 
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_VAAPI libva libva-drm libva-wayland libva-x11 QUIET)

--- a/cmake/modules/FindVDPAU.cmake
+++ b/cmake/modules/FindVDPAU.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::VDPAU   - The VDPAU library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_VDPAU vdpau QUIET)
   endif()

--- a/cmake/modules/FindWaylandProtocols.cmake
+++ b/cmake/modules/FindWaylandProtocols.cmake
@@ -7,7 +7,7 @@
 # WAYLAND_PROTOCOLS_DIR - directory containing the additional Wayland protocols
 #                         from the wayland-protocols package
 
-find_package(PkgConfig)
+find_package(PkgConfig QUIET)
 pkg_check_modules(PC_WAYLAND_PROTOCOLS wayland-protocols)
 if(PC_WAYLAND_PROTOCOLS_FOUND)
   pkg_get_variable(WAYLAND_PROTOCOLS_DIR wayland-protocols pkgdatadir)

--- a/cmake/modules/FindWaylandpp.cmake
+++ b/cmake/modules/FindWaylandpp.cmake
@@ -7,7 +7,7 @@
 #   ${APP_NAME_LC}::Waylandpp   - The waylandpp library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   pkg_check_modules(PC_WAYLANDPP wayland-client++ wayland-egl++ wayland-cursor++ QUIET)
 
   if(PC_WAYLANDPP_FOUND)

--- a/cmake/modules/FindWebOSHelpers.cmake
+++ b/cmake/modules/FindWebOSHelpers.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::WebOSHelpers   - The webOS helpers library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     if(WebOSHelpers_FIND_VERSION)
       if(WebOSHelpers_FIND_VERSION_EXACT)

--- a/cmake/modules/FindX.cmake
+++ b/cmake/modules/FindX.cmake
@@ -9,7 +9,7 @@
 #   ${APP_NAME_LC}::Xext - The X11 extension library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_X x11 xext QUIET)
   endif()

--- a/cmake/modules/FindXRandR.cmake
+++ b/cmake/modules/FindXRandR.cmake
@@ -8,7 +8,7 @@
 #   ${APP_NAME_LC}::XRandR   - The XRANDR library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
 
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_XRANDR xrandr QUIET)

--- a/cmake/modules/FindXSLT.cmake
+++ b/cmake/modules/FindXSLT.cmake
@@ -10,7 +10,7 @@
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
   find_package(LibXml2 REQUIRED)
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
 
   if(PKG_CONFIG_FOUND AND NOT (WIN32 OR WINDOWS_STORE))
     pkg_check_modules(PC_XSLT libxslt QUIET)

--- a/cmake/modules/FindXkbcommon.cmake
+++ b/cmake/modules/FindXkbcommon.cmake
@@ -7,7 +7,7 @@
 #   ${APP_NAME_LC}::Xkbcommon   - The libxkbcommon library
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_XKBCOMMON xkbcommon QUIET)
   endif()

--- a/cmake/modules/buildtools/FindGtest.cmake
+++ b/cmake/modules/buildtools/FindGtest.cmake
@@ -41,7 +41,7 @@ else()
     endif()
   endif()
 
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_GTEST gtest${Gtest_FIND_SPEC} QUIET)
     set(GTEST_VERSION ${PC_GTEST_VERSION})

--- a/cmake/modules/buildtools/FindWaylandPPScanner.cmake
+++ b/cmake/modules/buildtools/FindWaylandPPScanner.cmake
@@ -8,7 +8,7 @@
 
 if(NOT wayland::waylandppscanner)
 
-  find_package(PkgConfig)
+  find_package(PkgConfig QUIET)
   pkg_check_modules(PC_WAYLANDPP_SCANNER wayland-scanner++ QUIET)
 
   if(PC_WAYLANDPP_SCANNER_FOUND)


### PR DESCRIPTION
## Description
Quiet pkg-config searches

## Motivation and context
A newer cmake seems to be more verbosely outputting find_package searches

```
-- Found JsonSchemaBuilder: C:/Users/source/repos/xbmc/project/BuildDependencies/tools/bin/JsonSchemaBuilder.exe
-- External TexturePacker for WIN32 will be executed during build: C:/Users/source/repos/xbmc/project/BuildDependencies/tools/tools/TexturePacker/TexturePacker.exe
-- Found DX Effects Compiler Tool (FXC): C:/Program Files (x86)/Windows Kits/10/bin/10.0.26100.0/x64/fxc.exe
-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
-- Could NOT find Alsa (missing: ALSA_LIBRARY ALSA_INCLUDE_DIR) (Required is at least version "1.0.27")
-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
-- Could NOT find Avahi (missing: AVAHI_CLIENT_LIBRARY AVAHI_COMMON_LIBRARY AVAHI_CLIENT_INCLUDE_DIR AVAHI_COMMON_INCLUDE_DIR)
-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
-- Could NOT find Bluetooth (missing: BLUETOOTH_LIBRARY BLUETOOTH_INCLUDE_DIR)
-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
-- Found Bluray: C:/Users/source/repos/xbmc/project/BuildDependencies/x64/lib/libbluray.lib (found suitable version "1.3.4", minimum required is "0.9.3")
-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
-- Could NOT find CAP (missing: CAP_LIBRARY CAP_INCLUDE_DIR)
-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
```

Unnecessary and doesnt really help anything, so lets just quiet it down for any non required searches

```
-- Found JsonSchemaBuilder: C:/Users/source/repos/xbmc/project/BuildDependencies/tools/bin/JsonSchemaBuilder.exe
-- External TexturePacker for WIN32 will be executed during build: C:/Users/source/repos/xbmc/project/BuildDependencies/tools/tools/TexturePacker/TexturePacker.exe
-- Found DX Effects Compiler Tool (FXC): C:/Program Files (x86)/Windows Kits/10/bin/10.0.26100.0/x64/fxc.exe
-- Could NOT find Alsa (missing: ALSA_LIBRARY ALSA_INCLUDE_DIR) (Required is at least version "1.0.27")
-- Could NOT find Avahi (missing: AVAHI_CLIENT_LIBRARY AVAHI_COMMON_LIBRARY AVAHI_CLIENT_INCLUDE_DIR AVAHI_COMMON_INCLUDE_DIR)
-- Could NOT find Bluetooth (missing: BLUETOOTH_LIBRARY BLUETOOTH_INCLUDE_DIR)
-- Found Bluray: C:/Users/source/repos/xbmc/project/BuildDependencies/x64/lib/libbluray.lib (found suitable version "1.3.4", minimum required is "0.9.3")
-- Could NOT find CAP (missing: CAP_LIBRARY CAP_INCLUDE_DIR)
-- Found Patch: C:/Program Files (x86)/Git/usr/bin/patch.exe (found version "2.7.6")
-- Found CEC: C:/Users/source/repos/xbmc/project/BuildDependencies/x64/bin/cec.dll (found suitable version "4.0.7", minimum required is "4.0.0")
```

## How has this been tested?
Windows using cmake 

```
>cmake --version
cmake version 3.31.3

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
