### PR TITLE
Port Dialog: Fix disconnecting daisy chained controllers

### DIFF
--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -400,15 +400,32 @@ bool CGameClientInput::ConnectController(const std::string& portAddress,
 
 bool CGameClientInput::DisconnectController(const std::string& portAddress)
 {
-  PERIPHERALS::EventLockHandlePtr inputHandlingLock;
-
   std::lock_guard<std::recursive_mutex> lock(m_portMutex);
+
+  if (!DisconnectControllerRecursive(portAddress))
+    return false;
+
+  // Update port state
+  m_portManager->ConnectController(portAddress, false);
+  SetChanged();
+
+  return true;
+}
+
+bool CGameClientInput::DisconnectControllerRecursive(const std::string& portAddress)
+{
+  PERIPHERALS::EventLockHandlePtr inputHandlingLock;
 
   // If port is a multitap, we need to deactivate its children
   const CPortNode& currentPort = m_portManager->GetControllerTree().GetPort(portAddress);
+  const PortVec& childPorts = currentPort.GetActiveController().GetHub().GetPorts();
+  for (const CPortNode& childPort : childPorts)
+    DisconnectControllerRecursive(childPort.GetAddress());
+
+  // Update agent input
   CloseJoysticks(currentPort, inputHandlingLock);
 
-  // If a port was closed, then destroying the lock will block until all
+  // If a port was closed, then destroying the last lock will block until all
   // peripheral input handling is complete to avoid invalidating the port's
   // input handler
   inputHandlingLock.reset();
@@ -430,10 +447,6 @@ bool CGameClientInput::DisconnectController(const std::string& portAddress)
       return false;
     }
   }
-
-  // Update port state
-  m_portManager->ConnectController(portAddress, false);
-  SetChanged();
 
   // Update agent input
   CloseJoystick(portAddress, inputHandlingLock);

--- a/xbmc/games/addons/input/GameClientInput.h
+++ b/xbmc/games/addons/input/GameClientInput.h
@@ -103,9 +103,12 @@ public:
   bool ReceiveInputEvent(const game_input_event& eventStruct);
 
 private:
-  // Private input helpers
+  // Private topology helpers
   void LoadTopology();
   void SetControllerLayouts(const ControllerVector& controllers);
+  bool DisconnectControllerRecursive(const std::string& portAddress);
+
+  // Private input helpers
   bool OpenJoystick(const std::string& portAddress, const ControllerPtr& controller);
   void CloseJoysticks(const CPortNode& port, PERIPHERALS::EventLockHandlePtr& inputHandlingLock);
   void CloseJoystick(const std::string& portAddress,


### PR DESCRIPTION
## Description

This PR fixes a bug when disconnecting daisy chained controllers due to a missing recursive call.

The problem appears when a parent controller is disconnected. It is removed from the libretro mapping, but child controllers are not.

The fix is to add the missing recursive call. Minor refactoring was done to keep the port state update out of the recursion so that the state of child ports is not overwritten.

## Motivation and context

Discovered when trying to get 3DO games working with Opera. I also made the following fixes for Opera:

* https://github.com/xbmc/xbmc/pull/26097
* https://github.com/kodi-game/game.libretro.opera/pull/11

## How has this been tested?

### Setup

When starting Opera, all daisy chained controllers are connected:

```
...
8th controller connected:
AddOnLog: game.libretro.opera: Setting port "/1/game.controller.3do/1/game.controller.3do/1/game.controller.3do/1/game.controller.3do/1/game.controller.3do/1/game.controller.3do/1/game.controller.3do/1" (libretro port 7) to controller "game.controller.3do" (libretro device ID 1)
AddOnLog: game.libretro.opera: Libretro input bindings:
AddOnLog: game.libretro.opera: ------------------------------------------------------------
AddOnLog: game.libretro.opera: Port: 0
AddOnLog: game.libretro.opera: Port: 1
AddOnLog: game.libretro.opera: Port: 2
AddOnLog: game.libretro.opera: Port: 3
AddOnLog: game.libretro.opera: Port: 4
AddOnLog: game.libretro.opera: Port: 5
AddOnLog: game.libretro.opera: Port: 6
AddOnLog: game.libretro.opera: Port: 7
AddOnLog: game.libretro.opera: ------------------------------------------------------------
```

### Before

Before, when first controller is disconnected, only it is updated:


```
AddOnLog: game.libretro.opera: Setting port "/1" (libretro port 0) to controller "" (libretro device ID 0)
AddOnLog: game.libretro.opera: Libretro input bindings:
AddOnLog: game.libretro.opera: ------------------------------------------------------------
AddOnLog: game.libretro.opera: Port: 1
AddOnLog: game.libretro.opera: Port: 2
AddOnLog: game.libretro.opera: Port: 3
AddOnLog: game.libretro.opera: Port: 4
AddOnLog: game.libretro.opera: Port: 5
AddOnLog: game.libretro.opera: Port: 6
AddOnLog: game.libretro.opera: Port: 7
AddOnLog: game.libretro.opera: ------------------------------------------------------------
```

### After

After, when fist controller is disconnected, all controllers are updated:

```
AddOnLog: game.libretro.opera: Setting port "/1" (libretro port 0) to controller "" (libretro device ID 0)
AddOnLog: game.libretro.opera: Libretro input bindings:
AddOnLog: game.libretro.opera: ------------------------------------------------------------
AddOnLog: game.libretro.opera: ------------------------------------------------------------
```

Now, when first controller is reconnected, the state off all child ports is remembered, and as a result all controllers are reconnected:

```
...
8th controller connected:
AddOnLog: game.libretro.opera: Setting port "/1/game.controller.3do/1/game.controller.3do/1/game.controller.3do/1/game.controller.3do/1/game.controller.3do/1/game.controller.3do/1/game.controller.3do/1" (libretro port 7) to controller "game.controller.3do" (libretro device ID 1)
AddOnLog: game.libretro.opera: Libretro input bindings:
AddOnLog: game.libretro.opera: ------------------------------------------------------------
AddOnLog: game.libretro.opera: Port: 0
AddOnLog: game.libretro.opera: Port: 1
AddOnLog: game.libretro.opera: Port: 2
AddOnLog: game.libretro.opera: Port: 3
AddOnLog: game.libretro.opera: Port: 4
AddOnLog: game.libretro.opera: Port: 5
AddOnLog: game.libretro.opera: Port: 6
AddOnLog: game.libretro.opera: Port: 7
AddOnLog: game.libretro.opera: ------------------------------------------------------------
```

### Validating port state

To test which ports are "remembered", I disconnected controller 7, then controller 2:

```
<ports>
<port id="1" address="/1" connected="true" controller="game.controller.3do"/>
<port id="1" address="/1/.../1" connected="true" controller="game.controller.3do"/>
<port id="1" address="/1/.../1/.../1" connected="false"/>
<port id="1" address="/1/.../1/.../1/.../1" connected="true" controller="game.controller.3do"/>
<port id="1" address="/1/.../1/.../1/.../1/.../1" connected="true" controller="game.controller.3do"/>
<port id="1" address="/1/.../1/.../1/.../1/.../1/.../1" connected="true" controller="game.controller.3do"/>
<port id="1" address="/1/.../1/.../1/.../1/.../1/.../1/.../1" connected="false"/>
<port id="1" address="/1/.../1/.../1/.../1/.../1/.../1/.../1/.../1" connected="true" controller="game.controller.3do"/>
</ports>
```

Reconnected controller 2, and controllers 3-6 were connected, with controller 7 successfully remembering its state.

## What is the effect on users?

* Fixed disconnecting daisy chained controllers (used in Opera)

## Screenshots (if appropriate):

### Setup

All 8 controllers are connected by default:

<img width="1275" alt="Screenshot 2024-12-30 at 8 22 02 AM" src="https://github.com/user-attachments/assets/433ef6c3-5456-46e8-84fe-e1a0978ab517" />

### Test procedure

The root controller was disconnected:

<img width="1274" alt="Screenshot 2024-12-30 at 8 22 21 AM" src="https://github.com/user-attachments/assets/58bdb7ee-ea30-4c70-8cd9-1e900b159924" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
