### PR TITLE
[macOS] Fix disconnected controller not updating in game

### DIFF
--- a/xbmc/games/agents/input/AgentInput.cpp
+++ b/xbmc/games/agents/input/AgentInput.cpp
@@ -323,7 +323,7 @@ void CAgentInput::ProcessJoysticks(PERIPHERALS::EventLockHandlePtr& inputHandlin
       joysticks.end());
 
   // Update agent controllers
-  ProcessAgentControllers(joysticks, inputHandlingLock);
+  ProcessAgentControllers(joysticks, inputHandlingLock, true);
 
   if (!m_gameClient)
     return;
@@ -363,7 +363,7 @@ void CAgentInput::ProcessKeyboard()
   {
     // Update agent controllers
     PERIPHERALS::EventLockHandlePtr inputHandlingLock;
-    ProcessAgentControllers(keyboards, inputHandlingLock);
+    ProcessAgentControllers(keyboards, inputHandlingLock, false);
 
     // Process keyboard input
     if (m_gameClient && m_gameClient->Input().SupportsKeyboard() &&
@@ -397,7 +397,7 @@ void CAgentInput::ProcessMouse()
   {
     // Update agent controllers
     PERIPHERALS::EventLockHandlePtr inputHandlingLock;
-    ProcessAgentControllers(mice, inputHandlingLock);
+    ProcessAgentControllers(mice, inputHandlingLock, false);
 
     // Process mouse input
     if (m_gameClient && m_gameClient->Input().SupportsMouse() &&
@@ -423,7 +423,8 @@ void CAgentInput::ProcessMouse()
 }
 
 void CAgentInput::ProcessAgentControllers(const PERIPHERALS::PeripheralVector& peripherals,
-                                          PERIPHERALS::EventLockHandlePtr& inputHandlingLock)
+                                          PERIPHERALS::EventLockHandlePtr& inputHandlingLock,
+                                          bool updateJoysticks)
 {
   std::lock_guard<std::mutex> lock(m_controllerMutex);
 
@@ -472,9 +473,7 @@ void CAgentInput::ProcessAgentControllers(const PERIPHERALS::PeripheralVector& p
   }
 
   // If we're processing joysticks, remove expired joysticks
-  if (std::any_of(peripherals.begin(), peripherals.end(),
-                  [](const PERIPHERALS::PeripheralPtr& peripheral)
-                  { return peripheral->Type() == PERIPHERALS::PERIPHERAL_JOYSTICK; }))
+  if (updateJoysticks)
   {
     std::vector<std::string> expiredJoysticks;
     for (const auto& agentController : m_controllers)

--- a/xbmc/games/agents/input/AgentInput.h
+++ b/xbmc/games/agents/input/AgentInput.h
@@ -117,8 +117,9 @@ private:
   void ProcessMouse();
 
   // Internal helpers
-  void ProcessAgentControllers(const PERIPHERALS::PeripheralVector& joysticks,
-                               PERIPHERALS::EventLockHandlePtr& inputHandlingLock);
+  void ProcessAgentControllers(const PERIPHERALS::PeripheralVector& peripherals,
+                               PERIPHERALS::EventLockHandlePtr& inputHandlingLock,
+                               bool updateJoysticks);
   void UpdateExpiredJoysticks(const PERIPHERALS::PeripheralVector& joysticks,
                               PERIPHERALS::EventLockHandlePtr& inputHandlingLock);
   void UpdateConnectedJoysticks(const PERIPHERALS::PeripheralVector& joysticks,

--- a/xbmc/platform/darwin/peripherals/PeripheralBusGCControllerManager.mm
+++ b/xbmc/platform/darwin/peripherals/PeripheralBusGCControllerManager.mm
@@ -47,8 +47,8 @@
 
 - (void)DeviceRemoved:(int)deviceID
 {
-  parentClass->callOnDeviceRemoved([self GetDeviceLocation:deviceID]);
   parentClass->SetScanResults([self GetInputDevices]);
+  parentClass->callOnDeviceRemoved([self GetDeviceLocation:deviceID]);
 }
 
 #pragma mark - init


### PR DESCRIPTION
## Description

This PR fixes controllers disconnecting on macOS with the GCController joystick driver. The problem is that notifications are sent before state is updated, resulting in no notifications (as state update isn't detected). By setting state before invoking the callback, the state update is correctly detected, and controller disconnection events are successfully sent, resulting in game input and UI updates.

However, fixing this uncovered another small bug in the Player Viewer. When controllers are disconnected, game input is updated, and the user's controller is shown as having no game input. But the controller is disconnected, so it shouldn't be shown at all! To fix this, the flaky check was replaced by a bool set explicitly to the correct value by the callers.

## Motivation and context

My main dev PC is in pieces on the floor, so I'm taking this time to polish Kodi on my macbook.

## How has this been tested?

### Test setup

Connected a controller on macOS, launched Opera (3DO emulator), opened Player Viewer, verified controller is shown:

<img width="1277" alt="Screenshot 2024-12-30 at 11 23 43 AM" src="https://github.com/user-attachments/assets/2b25fb8f-22e9-47a9-8a7a-5052434eb88a" />

### Testing first patch

Disconnected controller. Verified that game input was disconnected, but the Player Viewer isn't removing the disconnected controller:

<img width="1273" alt="Screenshot 2024-12-30 at 11 31 17 AM" src="https://github.com/user-attachments/assets/1bd34151-f802-415f-b2b0-f7277580cf7f" />

### Testing second patch

Disconnected controller. Verified that it is no longer shown in the Player Viewer:

<img width="1274" alt="Screenshot 2024-12-30 at 11 25 33 AM" src="https://github.com/user-attachments/assets/bef763ff-2c2a-4a1a-9b3a-b84a80b6b8d9" />

Tested this second patch on both macOS and Windows ARM (x64 emulation), verified fixed on both platforms.

## What is the effect on users?

* Fixed disconnecting controllers on macOS not updating in-game

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
