### PR TITLE
[Backport] Fix segfault on exit if Peripherals dialog is loaded

### DIFF
--- a/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
@@ -143,6 +143,16 @@ bool CGUIDialogPeripherals::OnMessage(CGUIMessage& message)
   return CGUIDialogSelect::OnMessage(message);
 }
 
+void CGUIDialogPeripherals::FreeResources(bool immediately /* = false */)
+{
+  // Free GUI resources
+  for (auto it = m_peripherals.begin(); it != m_peripherals.end(); ++it)
+    (*it)->FreeMemory();
+
+  // Free ancestor resources
+  CGUIDialogSelect::FreeResources(immediately);
+}
+
 void CGUIDialogPeripherals::Notify(const Observable& obs, const ObservableMessage msg)
 {
   switch (msg)

--- a/xbmc/peripherals/dialogs/GUIDialogPeripherals.h
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripherals.h
@@ -35,6 +35,7 @@ public:
 
   // implementation of CGUIControl via CGUIDialogSelect
   bool OnMessage(CGUIMessage& message) override;
+  void FreeResources(bool immediately = false) override;
 
   // implementation of Observer
   void Notify(const Observable& obs, const ObservableMessage msg) override;


### PR DESCRIPTION
## Description

Backport of https://github.com/xbmc/xbmc/pull/26185

## Motivation and context

Relatively safe backport of a bug I came across while testing controllers on macOS.

## How has this been tested?

Tested by plugging/unplugging controllers in the dialog, opening and closing it many times, and exiting Kodi when its open and from the home screen after opening. Observed no more crashes.

## What is the effect on users?

* Fixed possible crash on exit if the Peripherals dialog is open with at least one peripheral.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
