### PR TITLE
[Backport] macOS-inspired controller fixes

### DIFF
--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -400,15 +400,32 @@ bool CGameClientInput::ConnectController(const std::string& portAddress,
 
 bool CGameClientInput::DisconnectController(const std::string& portAddress)
 {
-  PERIPHERALS::EventLockHandlePtr inputHandlingLock;
-
   std::lock_guard<std::recursive_mutex> lock(m_portMutex);
+
+  if (!DisconnectControllerRecursive(portAddress))
+    return false;
+
+  // Update port state
+  m_portManager->ConnectController(portAddress, false);
+  SetChanged();
+
+  return true;
+}
+
+bool CGameClientInput::DisconnectControllerRecursive(const std::string& portAddress)
+{
+  PERIPHERALS::EventLockHandlePtr inputHandlingLock;
 
   // If port is a multitap, we need to deactivate its children
   const CPortNode& currentPort = m_portManager->GetControllerTree().GetPort(portAddress);
+  const PortVec& childPorts = currentPort.GetActiveController().GetHub().GetPorts();
+  for (const CPortNode& childPort : childPorts)
+    DisconnectControllerRecursive(childPort.GetAddress());
+
+  // Update agent input
   CloseJoysticks(currentPort, inputHandlingLock);
 
-  // If a port was closed, then destroying the lock will block until all
+  // If a port was closed, then destroying the last lock will block until all
   // peripheral input handling is complete to avoid invalidating the port's
   // input handler
   inputHandlingLock.reset();
@@ -430,10 +447,6 @@ bool CGameClientInput::DisconnectController(const std::string& portAddress)
       return false;
     }
   }
-
-  // Update port state
-  m_portManager->ConnectController(portAddress, false);
-  SetChanged();
 
   // Update agent input
   CloseJoystick(portAddress, inputHandlingLock);

--- a/xbmc/games/addons/input/GameClientInput.h
+++ b/xbmc/games/addons/input/GameClientInput.h
@@ -103,9 +103,12 @@ public:
   bool ReceiveInputEvent(const game_input_event& eventStruct);
 
 private:
-  // Private input helpers
+  // Private topology helpers
   void LoadTopology();
   void SetControllerLayouts(const ControllerVector& controllers);
+  bool DisconnectControllerRecursive(const std::string& portAddress);
+
+  // Private input helpers
   bool OpenJoystick(const std::string& portAddress, const ControllerPtr& controller);
   void CloseJoysticks(const CPortNode& port, PERIPHERALS::EventLockHandlePtr& inputHandlingLock);
   void CloseJoystick(const std::string& portAddress,

--- a/xbmc/games/agents/input/AgentInput.cpp
+++ b/xbmc/games/agents/input/AgentInput.cpp
@@ -323,7 +323,7 @@ void CAgentInput::ProcessJoysticks(PERIPHERALS::EventLockHandlePtr& inputHandlin
       joysticks.end());
 
   // Update agent controllers
-  ProcessAgentControllers(joysticks, inputHandlingLock);
+  ProcessAgentControllers(joysticks, inputHandlingLock, true);
 
   if (!m_gameClient)
     return;
@@ -363,7 +363,7 @@ void CAgentInput::ProcessKeyboard()
   {
     // Update agent controllers
     PERIPHERALS::EventLockHandlePtr inputHandlingLock;
-    ProcessAgentControllers(keyboards, inputHandlingLock);
+    ProcessAgentControllers(keyboards, inputHandlingLock, false);
 
     // Process keyboard input
     if (m_gameClient && m_gameClient->Input().SupportsKeyboard() &&
@@ -397,7 +397,7 @@ void CAgentInput::ProcessMouse()
   {
     // Update agent controllers
     PERIPHERALS::EventLockHandlePtr inputHandlingLock;
-    ProcessAgentControllers(mice, inputHandlingLock);
+    ProcessAgentControllers(mice, inputHandlingLock, false);
 
     // Process mouse input
     if (m_gameClient && m_gameClient->Input().SupportsMouse() &&
@@ -423,7 +423,8 @@ void CAgentInput::ProcessMouse()
 }
 
 void CAgentInput::ProcessAgentControllers(const PERIPHERALS::PeripheralVector& peripherals,
-                                          PERIPHERALS::EventLockHandlePtr& inputHandlingLock)
+                                          PERIPHERALS::EventLockHandlePtr& inputHandlingLock,
+                                          bool updateJoysticks)
 {
   std::lock_guard<std::mutex> lock(m_controllerMutex);
 
@@ -472,9 +473,7 @@ void CAgentInput::ProcessAgentControllers(const PERIPHERALS::PeripheralVector& p
   }
 
   // If we're processing joysticks, remove expired joysticks
-  if (std::any_of(peripherals.begin(), peripherals.end(),
-                  [](const PERIPHERALS::PeripheralPtr& peripheral)
-                  { return peripheral->Type() == PERIPHERALS::PERIPHERAL_JOYSTICK; }))
+  if (updateJoysticks)
   {
     std::vector<std::string> expiredJoysticks;
     for (const auto& agentController : m_controllers)

--- a/xbmc/games/agents/input/AgentInput.h
+++ b/xbmc/games/agents/input/AgentInput.h
@@ -117,8 +117,9 @@ private:
   void ProcessMouse();
 
   // Internal helpers
-  void ProcessAgentControllers(const PERIPHERALS::PeripheralVector& joysticks,
-                               PERIPHERALS::EventLockHandlePtr& inputHandlingLock);
+  void ProcessAgentControllers(const PERIPHERALS::PeripheralVector& peripherals,
+                               PERIPHERALS::EventLockHandlePtr& inputHandlingLock,
+                               bool updateJoysticks);
   void UpdateExpiredJoysticks(const PERIPHERALS::PeripheralVector& joysticks,
                               PERIPHERALS::EventLockHandlePtr& inputHandlingLock);
   void UpdateConnectedJoysticks(const PERIPHERALS::PeripheralVector& joysticks,

--- a/xbmc/platform/darwin/peripherals/PeripheralBusGCControllerManager.mm
+++ b/xbmc/platform/darwin/peripherals/PeripheralBusGCControllerManager.mm
@@ -47,8 +47,8 @@
 
 - (void)DeviceRemoved:(int)deviceID
 {
-  parentClass->callOnDeviceRemoved([self GetDeviceLocation:deviceID]);
   parentClass->SetScanResults([self GetInputDevices]);
+  parentClass->callOnDeviceRemoved([self GetDeviceLocation:deviceID]);
 }
 
 #pragma mark - init


### PR DESCRIPTION
## Description

Backport of:

* https://github.com/xbmc/xbmc/pull/26183 (*partial backport*)
* https://github.com/xbmc/xbmc/pull/26194
* https://github.com/xbmc/xbmc/pull/26195

Contains:

* 2 macOS fixes
  - Fixed broken re-mapping of analog sticks
  - Fixed broken disconnecting of physical controllers
* 2 minor generic fixes
  - Fixed disconnecting emulated daisy-chained controllers
  - Fixed physical controller not disappearing when disconnected

## Motivation and context

I'm grouping the backports here because all PRs involve minor controller bugs.

## How has this been tested?

Tested on macOS over the last few days. Controllers are working much better on macOS. Also tested the "physical controller not disappearing when disconnected" fix on Windows x64-on-ARM in Parallels, confirmed fixed.

## What is the effect on users?

* Improved controller handling on macOS
* Minor in-game controller fixes

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
