### PR TITLE
[Estuary] Refactor media flags + add Atmos/DTS:X flags

### DIFF
--- a/addons/skin.estuary/xml/DialogMusicInfo.xml
+++ b/addons/skin.estuary/xml/DialogMusicInfo.xml
@@ -530,8 +530,8 @@
 		<control type="group">
 			<centerleft>50%</centerleft>
 			<width>1920</width>
-			<bottom>0</bottom>
-			<height>70</height>
+			<bottom>10</bottom>
+			<height>40</height>
 			<include>MediaFlags</include>
 		</control>
 		<include condition="Skin.HasSetting(touchmode)">TouchBackButton</include>

--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -50,7 +50,7 @@
 					</control>
 				</control>
 				<control type="group">
-					<top>195</top>
+					<top>205</top>
 					<include condition="!Skin.HasSetting(hide_mediaflags)">MediaFlags</include>
 				</control>
 			</control>

--- a/addons/skin.estuary/xml/DialogVideoInfo.xml
+++ b/addons/skin.estuary/xml/DialogVideoInfo.xml
@@ -699,8 +699,8 @@
 			<animation effect="fade" start="100" end="0" time="200" tween="sine" condition="Window.IsVisible(script-embuary-video.xml) | Window.IsVisible(script-embuary-person.xml) | Window.IsVisible(script-embuary-image.xml)">Conditional</animation>
 			<centerleft>50%</centerleft>
 			<width>1920</width>
-			<bottom>0</bottom>
-			<height>70</height>
+			<bottom>10</bottom>
+			<height>40</height>
 			<include>MediaFlags</include>
 			<control type="group">
 				<visible>Control.HasFocus(50) + !String.IsEqual(ListItem.DBType,set)</visible>

--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -1116,8 +1116,8 @@
 			<include>BottomBar</include>
 			<control type="group">
 				<depth>DepthBars</depth>
-				<bottom>0</bottom>
-				<height>70</height>
+				<bottom>10</bottom>
+				<height>40</height>
 				<animation effect="fade" start="0" end="100" time="300" delay="300">WindowOpen</animation>
 				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
 				<include condition="!Skin.HasSetting(hide_mediaflags)">MediaFlags</include>

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -40,6 +40,7 @@
 	<constant name="list_item_height">75</constant>
 	<expression name="infodialog_active">Window.IsActive(musicinformation) | Window.IsActive(songinformation) | Window.IsActive(movieinformation) | Window.IsActive(addoninformation) | Window.IsActive(pvrguideinfo) | Window.IsActive(pvrrecordinginfo) | Window.IsActive(pictureinfo) | Window.IsVisible(script-embuary-video.xml) | Window.IsVisible(script-embuary-person.xml) | Window.IsVisible(script-embuary-image.xml)</expression>
 	<expression name="sidebar_visible">ControlGroup(9000).HasFocus | Control.HasFocus(6130) | Control.HasFocus(6131)</expression>
+	<expression name="object_audio_true">[String.Contains(ListItem.AudioCodec,atmos) | String.Contains(ListItem.AudioCodec,dtshd_ma_x)] | [Window.IsActive(fullscreenvideo) + [String.Contains(VideoPlayer.AudioCodec,atmos) | String.Contains(VideoPlayer.AudioCodec,dtshd_ma_x)]] | [Window.IsActive(visualisation) + [String.Contains(MusicPlayer.AudioCodec,atmos) | String.Contains(MusicPlayer.AudioCodec,dtshd_ma_x)]]</expression>
 	<include name="CommonScrollbars">
 		<param name="bottom_offset">list_bottom_offset</param>
 		<definition>
@@ -317,49 +318,39 @@
 	</include>
 	<include name="InfoFlag">
 		<control type="group">
-			<width>180</width>
+			<width>114</width>
 			<visible>$PARAM[visible]</visible>
 			<control type="image">
 				<top>-3</top>
 				<left>0</left>
-				<width>40</width>
-				<height>40</height>
+				<width>33</width>
+				<height>33</height>
 				<texture colordiffuse="white">$PARAM[icon]</texture>
 			</control>
 			<control type="label">
-				<left>50</left>
-				<width>180</width>
-				<height>35</height>
+				<left>40</left>
+				<width>114</width>
+				<height>36</height>
 				<aligny>center</aligny>
-				<font>font12</font>
+				<font>font_flag</font>
 				<label>$PARAM[label]</label>
 			</control>
 		</control>
 	</include>
 	<include name="MediaFlag">
-		<param name="width">115</param>
-		<param name="height">60</param>
-		<param name="flag_visible">true</param>
 		<param name="texture">colors/white.png</param>
+		<param name="flag_visible">true</param>
 		<definition>
-			<control type="group">
-				<width>$PARAM[width]</width>
-				<height>$PARAM[height]</height>
+			<control type="button">
+				<width>auto</width>
+				<height>33</height>
+				<align>center</align>
+				<aligny>center</aligny>
+				<font>font_flag</font>
+				<label>$PARAM[flag_label]</label>
+				<texturefocus border="2" infill="false" colordiffuse="white">$PARAM[texture]</texturefocus>
+				<texturenofocus border="2" infill="false" colordiffuse="white">$PARAM[texture]</texturenofocus>
 				<visible>$PARAM[flag_visible]</visible>
-				<control type="image">
-					<fadetime>0</fadetime>
-					<top>13</top>
-					<left>5</left>
-					<width>105</width>
-					<height>34</height>
-					<texture border="2" infill="false" colordiffuse="white">$PARAM[texture]</texture>
-				</control>
-				<control type="label">
-					<align>center</align>
-					<aligny>center</aligny>
-					<label>$PARAM[flag_label]</label>
-					<font>font_flag</font>
-				</control>
 			</control>
 		</definition>
 	</include>
@@ -370,22 +361,21 @@
 				<visible>Window.IsActive(Home) | Window.IsActive(10025) | Window.IsActive(TVRecordings) | Window.IsActive(RadioRecordings)</visible>
 				<orientation>horizontal</orientation>
 				<right>20</right>
-				<bottom>0</bottom>
-				<height>60</height>
+				<height>40</height>
 				<align>right</align>
-				<itemgap>10</itemgap>
+				<itemgap>9</itemgap>
 				<width>1900</width>
 				<usecontrolcoords>true</usecontrolcoords>
-				<control type="group">
-					<width>150</width>
-					<visible>System.AddonIsEnabled(resource.images.studios.white) + !String.IsEmpty(ListItem.Studio)</visible>
-					<include content="MediaFlag">
-						<param name="texture" value="$INFO[ListItem.Studio,resource://resource.images.studios.white/,.png]" />
-					</include>
+				<control type="image">
+					<width>114</width>
+					<height>36</height>
+					<fadetime>0</fadetime>
+					<aspectratio align="center" aligny="center">keep</aspectratio>
+					<texture>$INFO[ListItem.Studio,resource://resource.images.studios.white/,.png]</texture>
+					<visible>System.AddonIsEnabled(resource.images.studios.white) + !String.IsEmpty($PARAM[infolabel_prefix]ListItem.Studio)</visible>
 				</control>
 				<control type="group">
-					<top>10</top>
-					<width>200</width>
+					<width>144</width>
 					<visible>!String.IsEmpty($PARAM[infolabel_prefix]ListItem.Premiered)</visible>
 					<include content="InfoFlag">
 						<param name="icon" value="lists/year.png" />
@@ -402,15 +392,15 @@
 				</include>
 				<include content="MediaFlag">
 					<param name="flag_visible" value="!String.IsEmpty(ListItem.VideoCodec)" />
-					<param name="flag_label" value="$VAR[VideoListCodecVar]" />
+					<param name="flag_label" value="$VAR[VideoCodecVar]" />
 				</include>
 				<include content="MediaFlag">
 					<param name="flag_visible" value="!String.IsEmpty(ListItem.VideoResolution)" />
-					<param name="flag_label" value="$INFO[ListItem.VideoResolution]$VAR[VideoListResolutionTypeVar, ]" />
+					<param name="flag_label" value="$INFO[ListItem.VideoResolution]$VAR[VideoResolutionTypeVar, ]" />
 				</include>
 				<include content="MediaFlag">
 					<param name="flag_visible" value="!String.IsEmpty(ListItem.HdrType)" />
-					<param name="flag_label" value="$VAR[VideoListHDRVar]" />
+					<param name="flag_label" value="$VAR[VideoHDRTypeVar]" />
 				</include>
 				<include content="MediaFlag">
 					<param name="flag_visible" value="!String.IsEmpty(ListItem.VideoAspect)" />
@@ -418,11 +408,15 @@
 				</include>
 				<include content="MediaFlag">
 					<param name="flag_visible" value="!String.IsEmpty(ListItem.AudioCodec)" />
-					<param name="flag_label" value="$VAR[AudioListCodecVar]" />
+					<param name="flag_label" value="$VAR[AudioCodecVar]" />
+				</include>
+				<include content="MediaFlag">
+					<param name="flag_visible" value="$EXP[object_audio_true]" />
+					<param name="flag_label" value="$VAR[ObjectAudioTypeVar]" />
 				</include>
 				<include content="MediaFlag">
 					<param name="flag_visible" value="!String.IsEmpty(ListItem.AudioChannels)" />
-					<param name="flag_label" value="$VAR[AudioListChannelsVar]" />
+					<param name="flag_label" value="$VAR[AudioChannelsVar]" />
 				</include>
 			</control>
 			<control type="grouplist">
@@ -432,7 +426,7 @@
 				<bottom>0</bottom>
 				<height>60</height>
 				<align>right</align>
-				<itemgap>10</itemgap>
+				<itemgap>9</itemgap>
 				<width>1900</width>
 				<usecontrolcoords>true</usecontrolcoords>
 				<include content="MediaFlag">
@@ -441,15 +435,15 @@
 				</include>
 				<include content="MediaFlag">
 					<param name="flag_visible" value="!String.IsEmpty(VideoPlayer.VideoCodec)" />
-					<param name="flag_label" value="$VAR[VideoPlayerCodecVar]" />
+					<param name="flag_label" value="$VAR[VideoCodecVar]" />
 				</include>
 				<include content="MediaFlag">
 					<param name="flag_visible" value="!String.IsEmpty(VideoPlayer.VideoResolution)" />
-					<param name="flag_label" value="$INFO[VideoPlayer.VideoResolution]$VAR[VideoPlayerResolutionTypeVar, ]" />
+					<param name="flag_label" value="$INFO[VideoPlayer.VideoResolution]$VAR[VideoResolutionTypeVar, ]" />
 				</include>
 				<include content="MediaFlag">
 					<param name="flag_visible" value="!String.IsEmpty(VideoPlayer.HdrType)" />
-					<param name="flag_label" value="$VAR[VideoPlayerHDRVar]" />
+					<param name="flag_label" value="$VAR[VideoHDRTypeVar]" />
 				</include>
 				<include content="MediaFlag">
 					<param name="flag_visible" value="!String.IsEmpty(VideoPlayer.VideoAspect)" />
@@ -457,11 +451,15 @@
 				</include>
 				<include content="MediaFlag">
 					<param name="flag_visible" value="!String.IsEmpty(VideoPlayer.AudioCodec)" />
-					<param name="flag_label" value="$VAR[VideoPlayerAudioCodecVar]" />
+					<param name="flag_label" value="$VAR[AudioCodecVar]" />
+				</include>
+				<include content="MediaFlag">
+					<param name="flag_visible" value="$EXP[object_audio_true]" />
+					<param name="flag_label" value="$VAR[ObjectAudioTypeVar]" />
 				</include>
 				<include content="MediaFlag">
 					<param name="flag_visible" value="!String.IsEmpty(VideoPlayer.AudioChannels)" />
-					<param name="flag_label" value="$VAR[VideoPlayerAudioChannelsVar]" />
+					<param name="flag_label" value="$VAR[AudioChannelsVar]" />
 				</include>
 			</control>
 			<control type="grouplist">
@@ -471,7 +469,7 @@
 				<bottom>10</bottom>
 				<height>60</height>
 				<align>right</align>
-				<itemgap>10</itemgap>
+				<itemgap>9</itemgap>
 				<width>1900</width>
 				<usecontrolcoords>true</usecontrolcoords>
 				<include content="MediaFlag">
@@ -484,7 +482,7 @@
 				</include>
 				<include content="MediaFlag">
 					<param name="flag_visible" value="!String.IsEmpty(ListItem.MusicChannels)" />
-					<param name="flag_label" value="$VAR[MusicListChannelsVar]" />
+					<param name="flag_label" value="$VAR[AudioChannelsVar]" />
 				</include>
 				<include content="MediaFlag">
 					<param name="flag_visible" value="!String.IsEmpty(ListItem.Samplerate)" />
@@ -507,10 +505,10 @@
 				<visible>Player.ShowInfo + !Player.ChannelPreviewActive + Window.IsActive(visualisation)</visible>)
 				<orientation>horizontal</orientation>
 				<right>20</right>
-				<bottom>10</bottom>
+				<bottom>9</bottom>
 				<height>60</height>
 				<align>right</align>
-				<itemgap>10</itemgap>
+				<itemgap>9</itemgap>
 				<width>1900</width>
 				<usecontrolcoords>true</usecontrolcoords>
 				<include content="MediaFlag">
@@ -519,11 +517,15 @@
 				</include>
 				<include content="MediaFlag">
 					<param name="flag_visible" value="!String.IsEmpty(MusicPlayer.Codec)" />
-					<param name="flag_label" value="$VAR[MusicPlayerCodecVar]" />
+					<param name="flag_label" value="$VAR[AudioCodecVar]" />
+				</include>
+				<include content="MediaFlag">
+					<param name="flag_visible" value="$EXP[object_audio_true]" />
+					<param name="flag_label" value="$VAR[ObjectAudioTypeVar]" />
 				</include>
 				<include content="MediaFlag">
 					<param name="flag_visible" value="!String.IsEmpty(MusicPlayer.Channels)" />
-					<param name="flag_label" value="$VAR[MusicPlayerAudioChannelsVar]" />
+					<param name="flag_label" value="$VAR[AudioChannelsVar]" />
 				</include>
 				<include content="MediaFlag">
 					<param name="flag_visible" value="!String.IsEmpty(MusicPlayer.SampleRate)" />
@@ -1726,7 +1728,6 @@
 					<top>0</top>
 					<right>20</right>
 					<height>60</height>
-					<font>font14</font>
 					<aligny>center</aligny>
 					<textcolor>grey</textcolor>
 					<label>$VAR[MediaInfoListLabelVar]</label>
@@ -1736,7 +1737,7 @@
 					<top>50</top>
 					<right>20</right>
 					<height>65</height>
-					<font>font12</font>
+					<font>font10</font>
 					<aligny>center</aligny>
 					<textcolor>grey</textcolor>
 					<label>$VAR[MediaInfoListLabel2Var]</label>
@@ -1766,7 +1767,6 @@
 					<height>60</height>
 					<aligny>center</aligny>
 					<scroll>true</scroll>
-					<font>font14</font>
 					<label>$VAR[MediaInfoListLabelVar]</label>
 				</control>
 				<control type="label">
@@ -1774,7 +1774,7 @@
 					<top>50</top>
 					<right>20</right>
 					<height>65</height>
-					<font>font12</font>
+					<font>font10</font>
 					<aligny>center</aligny>
 					<label>$VAR[MediaInfoListLabel2Var]</label>
 				</control>

--- a/addons/skin.estuary/xml/Includes_SettingsDialog.xml
+++ b/addons/skin.estuary/xml/Includes_SettingsDialog.xml
@@ -14,14 +14,14 @@
 		<control type="button" id="22105">
 			<include>DialogSettingButton</include>
 			<label>$LOCALIZE[31112]</label>
-			<label2>[B]$VAR[ActiveVideoPlayerAudioLanguage]$VAR[VideoPlayerAudioCodecVar, - ]$VAR[VideoPlayerAudioChannelsVar, ][/B]</label2>
+			<label2>[B]$VAR[ActiveVideoPlayerAudioLanguage]$VAR[AudioCodecVar, - ]$VAR[AudioChannelsVar, ][/B]</label2>
 			<onclick>DialogSelectAudio</onclick>
 			<enable>Integer.IsGreater(VideoPlayer.AudioStreamCount,1)</enable>
 		</control>
 		<control type="button" id="22110">
 			<include>DialogSettingButton</include>
 			<label>$LOCALIZE[31109]</label>
-			<label2>[B]$INFO[VideoPlayer.VideoCodec]$INFO[Player.Process(videowidth), - ]$INFO[Player.Process(videoheight),x]$INFO[Player.Process(videoscantype)][/B]</label2>
+			<label2>[B]$INFO[VideoCodecVar]$INFO[Player.Process(videowidth), - ]$INFO[Player.Process(videoheight),x]$INFO[Player.Process(videoscantype)][/B]</label2>
 			<onclick>DialogSelectVideo</onclick>
 			<enable>Integer.IsGreater(VideoPlayer.VideoStreamCount,1)</enable>
 		</control>

--- a/addons/skin.estuary/xml/MyMusicNav.xml
+++ b/addons/skin.estuary/xml/MyMusicNav.xml
@@ -29,8 +29,8 @@
 			</include>
 			<control type="group">
 				<depth>DepthBars</depth>
-				<bottom>0</bottom>
-				<height>70</height>
+				<bottom>10</bottom>
+				<height>40</height>
 				<animation effect="fade" start="0" end="100" time="300" delay="300">WindowOpen</animation>
 				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
 				<include condition="!Skin.HasSetting(hide_mediaflags) + ![Window.IsVisible(songinformation) | Window.IsVisible(musicinformation)]">MediaFlags</include>

--- a/addons/skin.estuary/xml/MyPVRRecordings.xml
+++ b/addons/skin.estuary/xml/MyPVRRecordings.xml
@@ -73,8 +73,8 @@
 				<param name="info_visible" value="true" />
 			</include>
 			<control type="group">
-				<bottom>0</bottom>
-				<height>70</height>
+				<bottom>10</bottom>
+				<height>40</height>
 				<animation effect="fade" start="0" end="100" time="300" delay="300">WindowOpen</animation>
 				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
 				<include condition="!Skin.HasSetting(hide_mediaflags)">MediaFlags</include>

--- a/addons/skin.estuary/xml/MyPlaylist.xml
+++ b/addons/skin.estuary/xml/MyPlaylist.xml
@@ -30,8 +30,8 @@
 			<control type="group">
 				<visible>!Container.Content(songs)</visible>
 				<depth>DepthBars</depth>
-				<bottom>0</bottom>
-				<height>70</height>
+				<bottom>10</bottom>
+				<height>40</height>
 				<animation effect="fade" start="0" end="100" time="300" delay="300">WindowOpen</animation>
 				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
 				<include condition="!Skin.HasSetting(hide_mediaflags)">MediaFlags</include>

--- a/addons/skin.estuary/xml/MyVideoNav.xml
+++ b/addons/skin.estuary/xml/MyVideoNav.xml
@@ -86,8 +86,8 @@
 			</include>
 			<control type="group">
 				<depth>DepthBars</depth>
-				<bottom>0</bottom>
-				<height>70</height>
+				<bottom>10</bottom>
+				<height>40</height>
 				<animation effect="fade" start="0" end="100" time="300" delay="300">WindowOpen</animation>
 				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
 				<include condition="!Skin.HasSetting(hide_mediaflags)">MediaFlags</include>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -738,259 +738,124 @@
 		<value condition="!String.IsEmpty(Container(50).ListItem.Art(thumb))">$INFO[Container(50).ListItem.Art(thumb)]</value>
 		<value>$INFO[ListItem.Art(thumb)]</value>
 	</variable>
-	<variable name="VideoListResolutionTypeVar">
-		<value condition="String.IsEqual(ListItem.VideoResolution,480)">SD</value>
-		<value condition="String.IsEqual(ListItem.VideoResolution,540)">SD</value>
-		<value condition="String.IsEqual(ListItem.VideoResolution,576)">SD</value>
-		<value condition="String.IsEqual(ListItem.VideoResolution,720)">HD</value>
-		<value condition="String.IsEqual(ListItem.VideoResolution,1080)">HD</value>
-		<value condition="String.IsEqual(ListItem.VideoResolution,4K)">UHD</value>
-		<value condition="String.IsEqual(ListItem.VideoResolution,8K)">UHD</value>
-		<value>$INFO[ListItem.VideoResolution]</value>
-	</variable>
-	<variable name="VideoPlayerResolutionTypeVar">
-		<value condition="String.IsEqual(VideoPlayer.VideoResolution,480)">SD</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoResolution,540)">SD</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoResolution,576)">SD</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoResolution,720)">HD</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoResolution,1080)">HD</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoResolution,4K)">UHD</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoResolution,8K)">UHD</value>
-		<value>$INFO[VideoPlayer.VideoResolution]</value>
-	</variable>
-	<variable name="VideoListCodecVar">
-		<value condition="String.IsEqual(ListItem.VideoCodec,av1)">AV1</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,avc1)">AVC-1</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,div3)">DivX</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,divx)">DivX</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,dx50)">DivX</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,flv)">FLV</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,h264)">H.264</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,hev1)">H.265</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,hevc)">H.265</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,hvc1)">H.265</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,mpeg1)">MPEG-1</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,mpeg2)">MPEG-2</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,mpeg2video)">MPEG-2</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,mp4v)">MPEG-4</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,mpeg4)">MPEG-4</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,theora)">Theora</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,vc1)">VC-1</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,vc-1)">VC-1</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,vp8)">VP8</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,vp9)">VP9</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,wmv)">WMV</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,wmv3)">WMV</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,wvc1)">VC-1</value>
-		<value condition="String.IsEqual(ListItem.VideoCodec,xvid)">XviD</value>
+	<variable name="VideoCodecVar">
+		<value condition="String.IsEqual(ListItem.VideoCodec,av1) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,av1)]">AV1</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,avc1) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,avc1)]">AVC-1</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,div3) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,div3)]">DivX</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,divx) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,divx)]">DivX</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,dx50) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,dx50)]">DivX</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,flv) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,flv)]">FLV</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,h264) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,h264)]">H.264</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,hev1) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,hev1)]">H.265</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,hevc) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,hevc)]">H.265</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,hvc1) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,hvc1)]">H.265</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,mpeg1) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,mpeg1)]">MPEG-1</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,mpeg2) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,mpeg2)]">MPEG-2</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,mpeg2video) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,mpeg2video)]">MPEG-2</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,mp4v) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,mp4v)]">MPEG-4</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,mpeg4) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,mpeg4)]">MPEG-4</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,theora) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,theora)]">Theora</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,vc1) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,vc1)]">VC-1</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,vc-1) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,vc-1)]">VC-1</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,vp8) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,vp8)]">VP8</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,vp9) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,vp9)]">VP9</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,wmv) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,wmv)]">WMV</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,wmv3) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,wmv3)]">WMV</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,wvc1) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,wvc1)]">VC-1</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,xvid) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoCodec,xvid)]">XviD</value>
+		<value condition="Window.IsActive(fullscreenvideo)">$INFO[VideoPlayer.VideoCodec]</value>
 		<value>$INFO[ListItem.VideoCodec]</value>
 	</variable>
-	<variable name="VideoPlayerCodecVar">
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,av1)">AV1</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,avc1)">AVC-1</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,div3)">DivX</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,divx)">DivX</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,dx50)">DivX</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,flv)">FLV</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,h264)">H.264</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,hev1)">H.265</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,hevc)">H.265</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,hvc1)">H.265</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,mpeg1)">MPEG-1</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,mpeg2)">MPEG-2</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,mpeg2video)">MPEG-2</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,mp4v)">MPEG-4</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,mpeg4)">MPEG-4</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,theora)">Theora</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,vc1)">VC-1</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,vc-1)">VC-1</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,vp8)">VP8</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,vp9)">VP9</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,wmv)">WMV</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,wmv3)">WMV</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,wvc1)">VC-1</value>
-		<value condition="String.IsEqual(VideoPlayer.VideoCodec,xvid)">XviD</value>
-		<value>$INFO[VideoPlayer.VideoCodec]</value>
+	<variable name="VideoResolutionTypeVar">
+		<value condition="String.IsEqual(ListItem.VideoResolution,480) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoResolution,480)]">SD</value>
+		<value condition="String.IsEqual(ListItem.VideoResolution,540) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoResolution,540)]">SD</value>
+		<value condition="String.IsEqual(ListItem.VideoResolution,576) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoResolution,576)]">SD</value>
+		<value condition="String.IsEqual(ListItem.VideoResolution,720) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoResolution,720)]">HD</value>
+		<value condition="String.IsEqual(ListItem.VideoResolution,1080) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoResolution,1080)]">HD</value>
+		<value condition="String.IsEqual(ListItem.VideoResolution,4K) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoResolution,4K)]">UHD</value>
+		<value condition="String.IsEqual(ListItem.VideoResolution,8K) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.VideoResolution,8K)]">UHD</value>
+		<value condition="Window.IsActive(fullscreenvideo)">$INFO[VideoPlayer.VideoResolution]</value>
+		<value>$INFO[ListItem.VideoResolution]</value>
 	</variable>
-	<variable name="VideoListHDRVar">
-		<value condition="String.IsEqual(ListItem.HdrType,dolbyvision)">DoVi</value>
-		<value condition="String.IsEqual(ListItem.HdrType,hdr10)">HDR10</value>
-		<value condition="String.IsEqual(ListItem.HdrType,hlg)">HLG</value>
+	<variable name="VideoHDRTypeVar">
+		<value condition="String.IsEqual(ListItem.HdrType,dolbyvision) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.HdrType,dolbyvision)]">Dolby Vision</value>
+		<value condition="String.IsEqual(ListItem.HdrType,hdr10) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.HdrType,hdr10)]">HDR10</value>
+		<value condition="String.IsEqual(ListItem.HdrType,hlg) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.HdrType,hlg)]">HLG</value>
+		<value condition="Window.IsActive(fullscreenvideo)">$INFO[VideoPlayer.HdrType]</value>
 		<value>$INFO[ListItem.HdrType]</value>
 	</variable>
-	<variable name="VideoPlayerHDRVar">
-		<value condition="String.IsEqual(VideoPlayer.HdrType,dolbyvision)">DoVi</value>
-		<value condition="String.IsEqual(VideoPlayer.HdrType,hdr10)">HDR10</value>
-		<value condition="String.IsEqual(VideoPlayer.HdrType,hlg)">HLG</value>
-		<value>$INFO[VideoPlayer.HdrType]</value>
-	</variable>
-	<variable name="AudioListCodecVar">
-		<value condition="String.IsEqual(ListItem.AudioCodec,aac)">AAC</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,aac_latm)">AAC</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,ac3)">Dolby D</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,aif)">AIFF</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,aifc)">AIFF</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,aiff)">AIFF</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,alac)">ALAC</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,ape)">APE</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,avc)">AVC</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,cdda)">CDDA</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,dca)">DTS</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,dolbydigital)">Dolby D</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,dts)">DTS</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,dtshd_hra)">DTSHD-HRA</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,dtshd_ma)">DTSHD-MA</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,dtsma)">DTSHD-MA</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,eac3)">Dolby D+</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,flac)">FLAC</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,mp1)">MP1</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,mp3)">MP3</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,mp3float)">MP3</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,ogg)">OGG</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,opus)">OPUS</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,pcm)">PCM</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,pcm_bluray)">PCM</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,pcm_s16le)">PCM</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,pcm_s24le)">PCM</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,truehd)">TrueHD</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,vorbis)">Vorbis</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,wav)">WAV</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,wavpack)">WAVP</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,wmapro)">WMA-PRO</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,wmav2)">WMA</value>
+	<variable name="AudioCodecVar">
+		<value condition="String.IsEqual(ListItem.AudioCodec,aac) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,aac)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,aac)]">AAC</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,aac_latm) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,aac_latm)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,aac_latm)]">AAC</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,ac3) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,ac3)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,ac3)]">Dolby Digital</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,aif) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,aif)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,aif)]">AIFF</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,aifc) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,aifc)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,aifc)]">AIFF</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,aiff) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,aiff)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,aiff)]">AIFF</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,alac) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,alac)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,alac)]">ALAC</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,ape) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,ape)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,ape)]">APE</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,avc) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,avc)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,avc)]">AVC</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,cdda) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,cdda)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,cdda)]">CDDA</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,dca) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,dca)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,dca)]">DTS</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,dolbydigital) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,dolbydigital)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,dolbydigital)]">Dolby Digital</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,dts) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,dts)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,dts)]">DTS</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,dtshd_hra) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,dtshd_hra)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,dtshd_hra)]">DTS-HD HRA</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,dtshd_ma) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,dtshd_ma)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,dtshd_ma)]">DTS-HD MA</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,dtsma) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,dtsma)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,dtsma)]">DTS-HD MA</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,dtshd_ma_x) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,dtshd_ma_x)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,dtshd_ma_x)]">DTS-HD MA</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,dtshd_ma_x_imax) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,dtshd_ma_x_imax)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,dtshd_ma_x_imax)]">DTS-HD MA</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,eac3) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,eac3)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,eac3)]">Dolby Digital+</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,eac3_ddp_atmos) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,eac3_ddp_atmos)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,eac3_ddp_atmos)]">Dolby Digital+</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,flac) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,flac)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,flac)]">FLAC</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,mp1) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,mp1)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,mp1)]">MP1</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,mp3) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,mp3)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,mp3)]">MP3</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,mp3float) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,mp3float)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,mp3float)]">MP3</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,ogg) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,ogg)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,ogg)]">OGG</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,opus) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,opus)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,opus)]">OPUS</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,pcm) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,pcm)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,pcm)]">PCM</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,pcm_bluray) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,pcm_bluray)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,pcm_bluray)]">PCM</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,pcm_s16le) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,pcm_s16le)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,pcm_s16le)]">PCM</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,pcm_s24le) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,pcm_s24le)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,pcm_s24le)]">PCM</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,truehd) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,truehd)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,truehd)]">Dolby TrueHD</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,truehd_atmos) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,truehd_atmos)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,truehd_atmos)]">Dolby TrueHD</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,vorbis) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,vorbis)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,vorbis)]">Vorbis</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,wav) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,wav)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,wav)]">WAV</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,wavpack) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,wavpack)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,wavpack)]">">WAVP</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,wmapro) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,wmapro)] | [Window.IsActive(visualisation) + String.IsEqual(VideoPlayer.AudioCodec,wmapro)]">WMA-PRO</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,wmav2) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,wmav2)] | [Window.IsActive(visualisation) + String.IsEqual(VideoPlayer.AudioCodec,wmav2)]">WMA</value>
+		<value condition="Window.IsActive(fullscreenvideo)">$INFO[VideoPlayer.AudioCodec]</value>
+		<value condition="Window.IsActive(visualisation)">$INFO[MusicPlayer.Codec]</value>
 		<value>$INFO[ListItem.AudioCodec]</value>
 	</variable>
-	<variable name="VideoPlayerAudioCodecVar">
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,aac)">AAC</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,aac_latm)">AAC</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,ac3)">Dolby D</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,aif)">AIFF</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,aifc)">AIFF</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,aiff)">AIFF</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,alac)">ALAC</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,ape)">APE</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,avc)">AVC</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,cdda)">CDDA</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dca)">DTS</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dolbydigital)">Dolby D</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dts)">DTS</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dtshd_hra)">DTSHD-HRA</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dtshd_ma)">DTSHD-MA</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,dtsma)">DTSHD-MA</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,eac3)">Dolby D+</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,flac)">FLAC</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,mp1)">MP1</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,mp3)">MP3</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,mp3float)">MP3</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,ogg)">OGG</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,opus)">OPUS</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,pcm)">PCM</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,pcm_bluray)">PCM</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,pcm_s16le)">PCM</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,pcm_s24le)">PCM</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,truehd)">TrueHD</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,vorbis)">Vorbis</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,wav)">WAV</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,wavpack)">WAVP</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,wmapro)">WMA-PRO</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioCodec,wmav2)">WMA</value>
-		<value>$INFO[VideoPlayer.AudioCodec]</value>
+	<variable name="ObjectAudioTypeVar">
+		<value condition="String.IsEqual(ListItem.AudioCodec,eac3_ddp_atmos) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,eac3_ddp_atmos)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,eac3_ddp_atmos)]">Dolby Atmos</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,truehd_atmos) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,truehd_atmos)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,truehd_atmos)]">Dolby Atmos</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,dtshd_ma_x) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,dtshd_ma_x)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,dtshd_ma_x)]">DTS:X</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,dtshd_ma_x_imax) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,dtshd_ma_x_imax)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,dtshd_ma_x_imax)]">DTS:X IMAX</value>
+<!--		<value>EMPTY</value> -->
 	</variable>
-	<variable name="AudioListChannelsVar">
-		<value condition="String.IsEqual(ListItem.AudioChannels,0)">0.0</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,1)">1.0</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,2)">2.0</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,3)">2.1</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,4)">4.0</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,5)">4.1</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,6)">5.1</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,7)">6.1</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,8)">7.1</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,10)">9.1</value>
+	<variable name="AudioChannelsVar">
+		<value condition="String.IsEqual(ListItem.AudioChannels,0) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,0)] | String.IsEqual(ListItem.MusicChannels,0) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,0)]">0.0</value>
+		<value condition="String.IsEqual(ListItem.AudioChannels,1) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,1)] | String.IsEqual(ListItem.MusicChannels,1) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,1)]">1.0</value>
+		<value condition="String.IsEqual(ListItem.AudioChannels,2) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,2)] | String.IsEqual(ListItem.MusicChannels,2) | [Window.IsActive(visualisation)+ String.IsEqual(MusicPlayer.Channels,2)]">2.0</value>
+		<value condition="String.IsEqual(ListItem.AudioChannels,3) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,3)] | String.IsEqual(ListItem.MusicChannels,3) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,3)]">2.1</value>
+		<value condition="String.IsEqual(ListItem.AudioChannels,4) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,4)] | String.IsEqual(ListItem.MusicChannels,4) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,4)]">4.0</value>
+		<value condition="String.IsEqual(ListItem.AudioChannels,5) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,5)] | String.IsEqual(ListItem.MusicChannels,5) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,5)]">4.1</value>
+		<value condition="String.IsEqual(ListItem.AudioChannels,6) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,6)] | String.IsEqual(ListItem.MusicChannels,6) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,6)]">5.1</value>
+		<value condition="String.IsEqual(ListItem.AudioChannels,7) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,7)] | String.IsEqual(ListItem.MusicChannels,7) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,7)]">6.1</value>
+		<value condition="String.IsEqual(ListItem.AudioChannels,8) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,8)] | String.IsEqual(ListItem.MusicChannels,8) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,8)]">7.1</value>
+		<value condition="String.IsEqual(ListItem.AudioChannels,10) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,10)] | String.IsEqual(ListItem.MusicChannels,10) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,10)]">9.1</value>
+		<value condition="Window.IsActive(fullscreenvideo)">$INFO[VideoPlayer.AudioChannels]</value>
+		<value condition="Window.IsActive(visualisation)">$INFO[MusicPlayer.Channels]</value>
+		<value condition="Container.Content(albums) | Window.IsActive(10502)">$INFO[ListItem.MusicChannels]</value>
 		<value>$INFO[ListItem.AudioChannels]</value>
-	</variable>
-	<variable name="VideoPlayerAudioChannelsVar">
-		<value condition="String.IsEqual(VideoPlayer.AudioChannels,0)">0.0</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioChannels,1)">1.0</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioChannels,2)">2.0</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioChannels,3)">2.1</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioChannels,4)">4.0</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioChannels,5)">4.1</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioChannels,6)">5.1</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioChannels,7)">6.1</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioChannels,8)">7.1</value>
-		<value condition="String.IsEqual(VideoPlayer.AudioChannels,10)">9.1</value>
-		<value>$INFO[VideoPlayer.AudioChannels]</value>
-	</variable>
-	<variable name="MusicPlayerCodecVar">
-		<value condition="String.IsEqual(MusicPlayer.Codec,aac)">AAC</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,aac_latm)">AAC</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,ac3)">Dolby D</value>
-		<value condition="String.IsEqual(LMusicPlayer.Codec,aif)">AIFF</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,aifc)">AIFF</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,aiff)">AIFF</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,alac)">ALAC</value>
-		<value condition="String.IsEqual(LMusicPlayer.Codec,ape)">APE</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,avc)">AVC</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,cdda)">CDDA</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,dca)">DTS</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,dolbydigital)">Dolby D</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,dts)">DTS</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,dtshd_hra)">DTSHD-HRA</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,dtshd_ma)">DTSHD-MA</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,dtsma)">DTSHD-MA</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,eac3)">Dolby D+</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,flac)">FLAC</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,mp1)">MP1</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,mp3)">MP3</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,mp3float)">MP3</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,ogg)">OGG</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,opus)">OPUS</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,pcm)">PCM</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,pcm_bluray)">PCM</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,pcm_s16le)">PCM</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,pcm_s24le)">PCM</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,truehd)">TrueHD</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,vorbis)">Vorbis</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,wav)">WAV</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,wavpack)">WAVP</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,wmapro)">WMA-PRO</value>
-		<value condition="String.IsEqual(MusicPlayer.Codec,wmav2)">WMA</value>
-		<value>$INFO[MusicPlayer.Codec]</value>
-	</variable>
-	<variable name="MusicListChannelsVar">
-		<value condition="String.IsEqual(ListItem.MusicChannels,0)">0.0</value>
-		<value condition="String.IsEqual(ListItem.MusicChannels,1)">1.0</value>
-		<value condition="String.IsEqual(ListItem.MusicChannels,2)">2.0</value>
-		<value condition="String.IsEqual(ListItem.MusicChannels,3)">2.1</value>
-		<value condition="String.IsEqual(ListItem.MusicChannels,4)">4.0</value>
-		<value condition="String.IsEqual(ListItem.MusicChannels,5)">4.1</value>
-		<value condition="String.IsEqual(ListItem.MusicChannels,6)">5.1</value>
-		<value condition="String.IsEqual(ListItem.MusicChannels,7)">6.1</value>
-		<value condition="String.IsEqual(ListItem.MusicChannels,8)">7.1</value>
-		<value condition="String.IsEqual(ListItem.MusicChannels,10)">9.1</value>
-		<value>$INFO[ListItem.MusicChannels]</value>
-	</variable>
-	<variable name="MusicPlayerAudioChannelsVar">
-		<value condition="String.IsEqual(MusicPlayer.Channels,0)">0.0</value>
-		<value condition="String.IsEqual(MusicPlayer.Channels,1)">1.0</value>
-		<value condition="String.IsEqual(MusicPlayer.Channels,2)">2.0</value>
-		<value condition="String.IsEqual(MusicPlayer.Channels,3)">2.1</value>
-		<value condition="String.IsEqual(MusicPlayer.Channels,4)">4.0</value>
-		<value condition="String.IsEqual(MusicPlayer.Channels,5)">4.1</value>
-		<value condition="String.IsEqual(MusicPlayer.Channels,6)">5.1</value>
-		<value condition="String.IsEqual(MusicPlayer.Channels,7)">6.1</value>
-		<value condition="String.IsEqual(MusicPlayer.Channels,8)">7.1</value>
-		<value condition="String.IsEqual(MusicPlayer.Channels,10)">9.1</value>
-		<value>$INFO[MusicPlayer.Channels]</value>
 	</variable>
 	<variable name="MediaInfoListLabelVar">
 		<value condition="Window.IsVisible(selectvideoversion)">$INFO[ListItem.VideoVersionName]</value>
 		<value>$INFO[ListItem.Label]</value>
 	</variable>
 	<variable name="MediaInfoListLabel2Var">
-		<value condition="ListItem.IsStereoscopic">$INFO[ListItem.Duration,$LOCALIZE[180]: ][CR]3D | $VAR[VideoListCodecVar]$INFO[ListItem.VideoResolution, | ]$VAR[VideoListResolutionTypeVar, ]$VAR[VideoListHDRVar, | ]$VAR[VideoListAspectVar, | ]$VAR[AudioListCodecVar, | ]$VAR[AudioListChannelsVar, ]</value>
-		<value>$INFO[ListItem.Duration,$LOCALIZE[180]: ][CR]$VAR[VideoListCodecVar]$INFO[ListItem.VideoResolution, | ]$VAR[VideoListResolutionTypeVar, ]$VAR[VideoListHDRVar, | ]$VAR[VideoListAspectVar, | ]$VAR[AudioListCodecVar, | ]$VAR[AudioListChannelsVar, ]</value>
+		<value condition="ListItem.IsStereoscopic">$INFO[ListItem.Duration,$LOCALIZE[180]: ][CR]3D | $VAR[VideoCodecVar]$INFO[ListItem.VideoResolution, | ]$VAR[VideoResolutionTypeVar, ]$VAR[VideoHDRTypeVar, | ]$INFO[ListItem.VideoAspect, | ,:1]$VAR[AudioListCodecVar, | ]$VAR[AudioChannelsVar, ]</value>
+		<value>$INFO[ListItem.Duration,$LOCALIZE[180]: ][CR]$VAR[VideoCodecVar]$INFO[ListItem.VideoResolution, | ]$VAR[VideoResolutionTypeVar, ]$VAR[VideoHDRTypeVar, | ]$INFO[ListItem.VideoAspect, | ,:1]$VAR[AudioCodecVar, | ]$VAR[AudioChannelsVar, ]</value>
 	</variable>
 	<variable name="PVRInstanceName">
 		<value condition="Integer.IsGreater(PVR.ClientCount,1)">$INFO[ListItem.PVRClientName,[COLOR grey]$LOCALIZE[31137]:[/COLOR] ,]$INFO[ListItem.PVRInstanceName, (,)]</value>


### PR DESCRIPTION
## Description
After https://github.com/xbmc/xbmc/pull/24972 and https://github.com/xbmc/xbmc/pull/26073 we now have the ability to add media flags for object audio.

This prompted me to review the existing media flag code commited in https://github.com/xbmc/xbmc/pull/25689
as there was scope for code optimisation a refactor of code was done. 

1. The seperate variables for listitems and player items have been consolidated.
2.  To make most efficient use of space the flags now use an autofit width button.

The PR has been split into 2 commits:

Refactor code - for changes to the existing code
Add object audio flagging - adds the changes required soley for the object audio flags

## Motivation and context
Optimise code and add flags for object audio.

## How has this been tested?
Tested locally with a variety of media files covering all the audio codec types.

## Screenshots (if appropriate):

Dolby Digital+ Atmos
![image](https://github.com/user-attachments/assets/7d93f3fd-016c-45b0-8deb-7f2a6c26b263)

Dolby TrueHD Atmos
![image](https://github.com/user-attachments/assets/4f7c5c1d-d8bd-471f-9792-54230105c0d3)

DTSHD-MA DTS:X
![image](https://github.com/user-attachments/assets/ed341e76-3be1-4f32-850a-e13c251b003c)

DTSHD-MA DTS:X IMAX
![image](https://github.com/user-attachments/assets/441b9a97-794e-49da-b159-a9a8c192d69e)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
