### PR TITLE
[utils/guilib] Refactor actions executed via exec strings.

### DIFF
--- a/xbmc/favourites/ContextMenus.cpp
+++ b/xbmc/favourites/ContextMenus.cpp
@@ -17,12 +17,14 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
+#include "utils/guilib/GUIBuiltinsUtils.h"
 #include "utils/guilib/GUIContentUtils.h"
 #include "video/VideoUtils.h"
 #include "video/guilib/VideoGUIUtils.h"
 
 using namespace CONTEXTMENU;
 using namespace KODI;
+using namespace KODI::UTILS::GUILIB;
 
 bool CFavouriteContextMenuAction::IsVisible(const CFileItem& item) const
 {
@@ -150,7 +152,7 @@ bool CFavouritesTargetResume::Execute(const std::shared_ptr<CFileItem>& item) co
 {
   const std::shared_ptr<CFileItem> targetItem{ResolveFavouriteItem(*item)};
   if (targetItem)
-    return FAVOURITES_UTILS::ExecuteAction({"PlayMedia", *targetItem, "resume"}, targetItem);
+    return CGUIBuiltinsUtils::ExecutePlayMediaTryResume(targetItem);
 
   return false;
 }
@@ -173,7 +175,7 @@ bool CFavouritesTargetPlay::Execute(const std::shared_ptr<CFileItem>& item) cons
 {
   const std::shared_ptr<CFileItem> targetItem{ResolveFavouriteItem(*item)};
   if (targetItem)
-    return FAVOURITES_UTILS::ExecuteAction({"PlayMedia", *targetItem, "noresume"}, targetItem);
+    return CGUIBuiltinsUtils::ExecutePlayMediaNoResume(targetItem);
 
   return false;
 }

--- a/xbmc/favourites/FavouritesUtils.cpp
+++ b/xbmc/favourites/FavouritesUtils.cpp
@@ -15,15 +15,16 @@
 #include "favourites/GUIWindowFavourites.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
-#include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "storage/MediaManager.h"
-#include "utils/ExecString.h"
 #include "utils/Variant.h"
+#include "utils/guilib/GUIBuiltinsUtils.h"
 #include "view/GUIViewState.h"
 
 #include <string>
+
+using namespace KODI::UTILS::GUILIB;
 
 namespace FAVOURITES_UTILS
 {
@@ -125,30 +126,10 @@ bool ShouldEnableMoveItems()
   return true;
 }
 
-namespace
-{
-bool ExecuteAction(const std::string& execString, const std::shared_ptr<CFileItem>& item)
-{
-  if (!execString.empty())
-  {
-    CGUIMessage message(GUI_MSG_EXECUTE, 0, 0, 0, 0, item);
-    message.SetStringParam(execString);
-    CServiceBroker::GetGUI()->GetWindowManager().SendMessage(message);
-    return true;
-  }
-  return false;
-}
-} // unnamed namespace
-
-bool ExecuteAction(const CExecString& execString, const std::shared_ptr<CFileItem>& item)
-{
-  return ExecuteAction(execString.GetExecString(), item);
-}
-
 bool ExecuteAction(const CFavouritesURL& favURL, const std::shared_ptr<CFileItem>& item)
 {
   if (favURL.IsValid())
-    return ExecuteAction(favURL.GetExecString(), item);
+    return CGUIBuiltinsUtils::ExecuteAction(favURL.GetExecString(), item);
 
   return false;
 }

--- a/xbmc/favourites/FavouritesUtils.h
+++ b/xbmc/favourites/FavouritesUtils.h
@@ -10,7 +10,6 @@
 
 #include <memory>
 
-class CExecString;
 class CFavouritesURL;
 class CFileItem;
 class CFileItemList;
@@ -23,7 +22,6 @@ bool MoveItem(CFileItemList& items, const std::shared_ptr<CFileItem>& item, int 
 bool RemoveItem(CFileItemList& items, const std::shared_ptr<CFileItem>& item);
 bool ShouldEnableMoveItems();
 
-bool ExecuteAction(const CExecString& execString, const std::shared_ptr<CFileItem>& item);
 bool ExecuteAction(const CFavouritesURL& favURL, const std::shared_ptr<CFileItem>& item);
 
 } // namespace FAVOURITES_UTILS

--- a/xbmc/favourites/GUIWindowFavourites.cpp
+++ b/xbmc/favourites/GUIWindowFavourites.cpp
@@ -10,17 +10,15 @@
 
 #include "ContextMenuManager.h"
 #include "FileItem.h"
-#include "ServiceBroker.h"
 #include "favourites/FavouritesURL.h"
 #include "favourites/FavouritesUtils.h"
-#include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
-#include "guilib/GUIWindowManager.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/ApplicationMessenger.h"
 #include "utils/PlayerUtils.h"
 #include "utils/StringUtils.h"
+#include "utils/guilib/GUIBuiltinsUtils.h"
 #include "utils/guilib/GUIContentUtils.h"
 #include "video/VideoUtils.h"
 #include "video/guilib/VideoGUIUtils.h"
@@ -28,6 +26,7 @@
 #include "video/guilib/VideoSelectActionProcessor.h"
 
 using namespace KODI;
+using namespace KODI::UTILS::GUILIB;
 
 CGUIWindowFavourites::CGUIWindowFavourites()
   : CGUIMediaWindow(WINDOW_FAVOURITES, "MyFavourites.xml")
@@ -61,27 +60,25 @@ public:
 protected:
   bool OnPlayPartSelected(unsigned int part) override
   {
-    // part numbers are 1-based
-    FAVOURITES_UTILS::ExecuteAction(
-        {"PlayMedia", *m_item, StringUtils::Format("playoffset={}", part - 1)}, m_item);
+    CGUIBuiltinsUtils::ExecutePlayMediaPart(m_item, part);
     return true;
   }
 
   bool OnResumeSelected() override
   {
-    FAVOURITES_UTILS::ExecuteAction({"PlayMedia", *m_item, "resume"}, m_item);
+    CGUIBuiltinsUtils::ExecutePlayMediaTryResume(m_item);
     return true;
   }
 
   bool OnPlaySelected() override
   {
-    FAVOURITES_UTILS::ExecuteAction({"PlayMedia", *m_item, "noresume"}, m_item);
+    CGUIBuiltinsUtils::ExecutePlayMediaNoResume(m_item);
     return true;
   }
 
   bool OnQueueSelected() override
   {
-    FAVOURITES_UTILS::ExecuteAction({"QueueMedia", *m_item, ""}, m_item);
+    CGUIBuiltinsUtils::ExecuteQueueMedia(m_item);
     return true;
   }
 
@@ -108,13 +105,13 @@ public:
 protected:
   bool OnResumeSelected() override
   {
-    FAVOURITES_UTILS::ExecuteAction({"PlayMedia", *m_item, "resume"}, m_item);
+    CGUIBuiltinsUtils::ExecutePlayMediaTryResume(m_item);
     return true;
   }
 
   bool OnPlaySelected() override
   {
-    FAVOURITES_UTILS::ExecuteAction({"PlayMedia", *m_item, "noresume"}, m_item);
+    CGUIBuiltinsUtils::ExecutePlayMediaNoResume(m_item);
     return true;
   }
 };

--- a/xbmc/utils/guilib/CMakeLists.txt
+++ b/xbmc/utils/guilib/CMakeLists.txt
@@ -1,5 +1,7 @@
-set(SOURCES GUIContentUtils.cpp)
+set(SOURCES GUIBuiltinsUtils.cpp
+            GUIContentUtils.cpp)
 
-set(HEADERS GUIContentUtils.h)
+set(HEADERS GUIBuiltinsUtils.h
+            GUIContentUtils.h)
 
 core_add_library(utils_guilib)

--- a/xbmc/utils/guilib/GUIBuiltinsUtils.cpp
+++ b/xbmc/utils/guilib/GUIBuiltinsUtils.cpp
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GUIBuiltinsUtils.h"
+
+#include "FileItem.h"
+#include "ServiceBroker.h"
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIMessage.h"
+#include "guilib/GUIWindowManager.h"
+#include "utils/ExecString.h"
+#include "utils/StringUtils.h"
+
+#include <string>
+
+namespace KODI::UTILS::GUILIB
+{
+bool CGUIBuiltinsUtils::ExecuteAction(const CExecString& execute,
+                                      const std::shared_ptr<CFileItem>& item)
+{
+  return ExecuteAction(execute.GetExecString(), item);
+}
+
+bool CGUIBuiltinsUtils::ExecuteAction(const std::string& execute,
+                                      const std::shared_ptr<CFileItem>& item)
+{
+  if (!execute.empty())
+  {
+    CGUIMessage message(GUI_MSG_EXECUTE, 0, 0);
+    message.SetStringParam(execute);
+    message.SetItem(item);
+    CServiceBroker::GetGUI()->GetWindowManager().SendMessage(message);
+    return true;
+  }
+  return false;
+}
+
+bool CGUIBuiltinsUtils::ExecutePlayMediaTryResume(const std::shared_ptr<CFileItem>& item)
+{
+  return ExecuteAction({"PlayMedia", *item, "resume"}, item);
+}
+
+bool CGUIBuiltinsUtils::ExecutePlayMediaNoResume(const std::shared_ptr<CFileItem>& item)
+{
+  return ExecuteAction({"PlayMedia", *item, "noresume"}, item);
+}
+
+bool CGUIBuiltinsUtils::ExecutePlayMediaAskResume(const std::shared_ptr<CFileItem>& item)
+{
+  return ExecuteAction({"PlayMedia", *item, ""}, item);
+}
+
+bool CGUIBuiltinsUtils::ExecutePlayMediaPart(const std::shared_ptr<CFileItem>& item,
+                                             unsigned int part)
+{
+  // part numbers are 1-based
+  return ExecuteAction({"PlayMedia", *item, StringUtils::Format("playoffset={}", part - 1)}, item);
+}
+
+bool CGUIBuiltinsUtils::ExecuteQueueMedia(const std::shared_ptr<CFileItem>& item)
+{
+  return ExecuteAction({"QueueMedia", *item, ""}, item);
+}
+} // namespace KODI::UTILS::GUILIB

--- a/xbmc/utils/guilib/GUIBuiltinsUtils.h
+++ b/xbmc/utils/guilib/GUIBuiltinsUtils.h
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <memory>
+
+class CExecString;
+class CFileItem;
+
+namespace KODI::UTILS::GUILIB
+{
+class CGUIBuiltinsUtils
+{
+public:
+  /*! \brief Execute the action given by exec string and item.
+   \param execute The action to execute
+   \param item The item asociated with the action to execute
+   \return True on success, false otherwise
+   */
+  static bool ExecuteAction(const CExecString& execute, const std::shared_ptr<CFileItem>& item);
+
+  /*! \brief Execute the action given by exec string and item.
+   \param execute The action to execute
+   \param item The item asociated with the action to execute
+   \return True on success, false otherwise
+   */
+  static bool ExecuteAction(const std::string& execute, const std::shared_ptr<CFileItem>& item);
+
+  /*! \brief Execute "PlayMedia" for the given item, resume of possible, else play from beginning.
+   \param item The item asociated with the action to execute
+   \return True on success, false otherwise
+   */
+  static bool ExecutePlayMediaTryResume(const std::shared_ptr<CFileItem>& item);
+
+  /*! \brief Execute "PlayMedia" for the given item, force playback from the beginning.
+   \param item The item asociated with the action to execute
+   \return True on success, false otherwise
+   */
+  static bool ExecutePlayMediaNoResume(const std::shared_ptr<CFileItem>& item);
+
+  /*! \brief Execute "PlayMedia" for the given item, ask whether to resume if possible, else play from beginning.
+   \param item The item asociated with the action to execute
+   \return True on success, false otherwise
+   */
+  static bool ExecutePlayMediaAskResume(const std::shared_ptr<CFileItem>& item);
+
+  /*! \brief Execute "PlayMedia" for the given item and given part (for multipart-media).
+   \param item The item asociated with the action to execute
+   \return True on success, false otherwise
+   */
+  static bool ExecutePlayMediaPart(const std::shared_ptr<CFileItem>& item, unsigned int part);
+
+  /*! \brief Execute "QueueMedia" for the given item.
+   \param item The item asociated with the action to execute
+   \return True on success, false otherwise
+   */
+  static bool ExecuteQueueMedia(const std::shared_ptr<CFileItem>& item);
+};
+} // namespace KODI::UTILS::GUILIB

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -22,9 +22,8 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/ContentUtils.h"
-#include "utils/ExecString.h"
-#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/guilib/GUIBuiltinsUtils.h"
 #include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
 #include "video/VideoManagerTypes.h"
@@ -38,6 +37,7 @@
 #include <utility>
 
 using namespace KODI;
+using namespace KODI::UTILS::GUILIB;
 
 namespace CONTEXTMENU
 {
@@ -187,19 +187,6 @@ bool CVideoBrowse::Execute(const std::shared_ptr<CFileItem>& item) const
 
 namespace
 {
-bool ExecuteAction(const CExecString& execute, const std::shared_ptr<CFileItem>& item)
-{
-  const std::string& execStr{execute.GetExecString()};
-  if (!execStr.empty())
-  {
-    CGUIMessage message(GUI_MSG_EXECUTE, 0, 0, 0, 0, item);
-    message.SetStringParam(execStr);
-    CServiceBroker::GetGUI()->GetWindowManager().SendMessage(message);
-    return true;
-  }
-  return false;
-}
-
 class CVideoSelectActionProcessor : public VIDEO::GUILIB::CVideoSelectActionProcessorBase
 {
 public:
@@ -211,26 +198,25 @@ public:
 protected:
   bool OnPlayPartSelected(unsigned int part) override
   {
-    // part numbers are 1-based
-    ExecuteAction({"PlayMedia", *m_item, StringUtils::Format("playoffset={}", part - 1)}, m_item);
+    CGUIBuiltinsUtils::ExecutePlayMediaPart(m_item, part);
     return true;
   }
 
   bool OnResumeSelected() override
   {
-    ExecuteAction({"PlayMedia", *m_item, "resume"}, m_item);
+    CGUIBuiltinsUtils::ExecutePlayMediaTryResume(m_item);
     return true;
   }
 
   bool OnPlaySelected() override
   {
-    ExecuteAction({"PlayMedia", *m_item, "noresume"}, m_item);
+    CGUIBuiltinsUtils::ExecutePlayMediaNoResume(m_item);
     return true;
   }
 
   bool OnQueueSelected() override
   {
-    ExecuteAction({"QueueMedia", *m_item, ""}, m_item);
+    CGUIBuiltinsUtils::ExecuteQueueMedia(m_item);
     return true;
   }
 


### PR DESCRIPTION
Just cleanup, no functional changes. Introduce `CGUIBuiltinsUtils` to get rid of duplicated code and string "magic".

Runtime-tested on macOS and Android, latest Kodi master.

@neo1973 could you have a look? 