### PR TITLE
[FileItem] Fix missing dynpath in fileitems restored from disc cache.

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -630,6 +630,7 @@ void CFileItem::Archive(CArchive& ar)
     ar << m_bIsParentFolder;
     ar << m_bLabelPreformatted;
     ar << m_strPath;
+    ar << m_strDynPath;
     ar << m_bIsShareOrDrive;
     ar << static_cast<int>(m_iDriveType);
     ar << m_dateTime;
@@ -685,6 +686,7 @@ void CFileItem::Archive(CArchive& ar)
     ar >> m_bIsParentFolder;
     ar >> m_bLabelPreformatted;
     ar >> m_strPath;
+    ar >> m_strDynPath;
     ar >> m_bIsShareOrDrive;
     int dtype;
     ar >> dtype;


### PR DESCRIPTION
This fixes a long-standing bug I discovered while working on something else.

`CMediaWindow` uses `CArchive`  to write the list of items its to a cache file and to restore that list under certain circumstances from that file. I discovered, that `CFileItem::m_dynPath` member is neither written to that cache file nor restored from it.

Visual effect for users can be several glitches, one thing I noted was missing "Play part" context menu item for stack video library items after playing any video from Movies media window. When opening the media window, the cache file gets written to disk and after playback of a video from the window ended, the media window file item list gets restored from the cache file. And because then dynpath member is missing for any file item contained in the list, everything that relies on presence of dynpath does not work, for example, determining whether abovementioned context menu item shall be displayed (because `CFileItem::IsStack` checks item's dynpath protocol).

Runtime-tested on macOS and Android, latest Kodi master.

@neo1973 can you please review.