### PR TITLE
[FileItem] CFileItem::Archive: Remove obsolete comment.

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -620,7 +620,6 @@ void CFileItem::Reset()
   SetInvalid();
 }
 
-// do not archive dynamic path
 void CFileItem::Archive(CArchive& ar)
 {
   CGUIListItem::Archive(ar);


### PR DESCRIPTION
Oversight from #26210 

@neo1973 as discussed, please review.