### PR TITLE
[VideoDatabase][VideoVersions] Various fixes for bluray:// paths (library related) and associated code refactoring (1/4).

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1151,7 +1151,7 @@ bool CFileItem::IsMultiPath() const
 
 bool CFileItem::IsBluray() const
 {
-  if (URIUtils::IsBluray(m_strPath))
+  if (URIUtils::IsBlurayPath(m_strPath))
     return true;
 
   CFileItem item = CFileItem(VIDEO::UTILS::GetOpticalMediaPath(*this), false);
@@ -2012,8 +2012,8 @@ std::string CFileItem::GetLocalMetadataPath() const
   if (m_bIsFolder && !IsFileFolder())
     return m_strPath;
 
-  if (URIUtils::IsBluray(this->GetDynPath()) || VIDEO::IsDVDFile(*this) || VIDEO::IsBDFile(*this))
-    return URIUtils::GetDiscBasePath(this->GetDynPath());
+  if (URIUtils::IsBlurayPath(GetDynPath()) || VIDEO::IsDVDFile(*this) || VIDEO::IsBDFile(*this))
+    return URIUtils::GetDiscBasePath(GetDynPath());
 
   return URIUtils::GetParentPath(m_strPath);
 }

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1778,22 +1778,6 @@ void CFileItem::SetDynPath(const std::string &path)
   m_strDynPath = path;
 }
 
-std::string CFileItem::GetBlurayPath() const
-{
-  if (VIDEO::IsBlurayPlaylist(*this))
-  {
-    CURL url(GetDynPath());
-    CURL url2(url.GetHostName()); // strip bluray://
-    if (url2.IsProtocol("udf"))
-      // ISO
-      return url2.GetHostName(); // strip udf://
-    else if (url.IsProtocol("bluray"))
-      // BDMV
-      return url2.Get() + "BDMV/index.bdmv";
-  }
-  return GetDynPath();
-}
-
 void CFileItem::SetCueDocument(const CCueDocumentPtr& cuePtr)
 {
   m_cueDocument = cuePtr;
@@ -2028,19 +2012,10 @@ std::string CFileItem::GetLocalMetadataPath() const
   if (m_bIsFolder && !IsFileFolder())
     return m_strPath;
 
-  std::string parent{};
-  if (VIDEO::IsBlurayPlaylist(*this))
-    parent = URIUtils::GetParentPath(GetBlurayPath());
-  else
-    parent = URIUtils::GetParentPath(m_strPath);
-  std::string parentFolder(parent);
-  URIUtils::RemoveSlashAtEnd(parentFolder);
-  parentFolder = URIUtils::GetFileName(parentFolder);
-  if (StringUtils::EqualsNoCase(parentFolder, "VIDEO_TS") || StringUtils::EqualsNoCase(parentFolder, "BDMV"))
-  { // go back up another one
-    parent = URIUtils::GetParentPath(parent);
-  }
-  return parent;
+  if (URIUtils::IsBluray(this->GetDynPath()) || VIDEO::IsDVDFile(*this) || VIDEO::IsBDFile(*this))
+    return URIUtils::GetDiscBasePath(this->GetDynPath());
+
+  return URIUtils::GetParentPath(m_strPath);
 }
 
 bool CFileItem::LoadMusicTag()

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -9,7 +9,6 @@
 #include "FileItem.h"
 
 #include "CueDocument.h"
-#include "FileItemList.h"
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "Util.h"

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -142,8 +142,6 @@ public:
   const std::string &GetDynPath() const;
   void SetDynPath(const std::string &path);
 
-  std::string GetBlurayPath() const;
-
   /*! \brief reset class to it's default values as per construction.
    Free's all allocated memory.
    \sa Initialize

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -72,14 +72,11 @@
 #include "settings/SettingsComponent.h"
 #include "utils/Digest.h"
 #include "utils/FileExtensionProvider.h"
-#include "utils/FontUtils.h"
 #include "utils/LangCodeExpander.h"
 #include "utils/StringUtils.h"
-#include "utils/TimeUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
-#include "video/VideoInfoTag.h"
 #ifdef HAVE_LIBCAP
   #include <sys/capability.h>
 #endif

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1907,7 +1907,7 @@ void CUtil::GetVideoBasePathAndFileName(const std::string& videoPath,
 {
   const CFileItem item(videoPath, false);
 
-  if (item.IsOpticalMediaFile() || URIUtils::IsBluray(item.GetDynPath()))
+  if (item.IsOpticalMediaFile() || URIUtils::IsBlurayPath(item.GetDynPath()))
   {
     basePath = item.GetLocalMetadataPath();
     videoFileName = URIUtils::ReplaceExtension(GetTitleFromPath(basePath), "");

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1901,30 +1901,22 @@ std::string CUtil::GetFrameworksPath(bool forPython)
   return strFrameworksPath;
 }
 
-void CUtil::GetVideoBasePathAndFileName(const std::string& videoPath, std::string& basePath, std::string& videoFileName)
+void CUtil::GetVideoBasePathAndFileName(const std::string& videoPath,
+                                        std::string& basePath,
+                                        std::string& videoFileName)
 {
-  CFileItem item(videoPath, false);
-  videoFileName = URIUtils::ReplaceExtension(URIUtils::GetFileName(videoPath), "");
+  const CFileItem item(videoPath, false);
 
-  if (item.HasVideoInfoTag())
-    basePath = item.GetVideoInfoTag()->m_basePath;
-
-  if (basePath.empty() && item.IsOpticalMediaFile())
-    basePath = item.GetLocalMetadataPath();
-
-  CURL url(videoPath);
-  if (basePath.empty() && url.IsProtocol("bluray"))
+  if (item.IsOpticalMediaFile() || URIUtils::IsBluray(item.GetDynPath()))
   {
-    basePath = url.GetHostName();
-    videoFileName = URIUtils::ReplaceExtension(GetTitleFromPath(url.GetHostName()), "");
-
-    url = CURL(url.GetHostName());
-    if (url.IsProtocol("udf"))
-      basePath = URIUtils::GetParentPath(url.GetHostName());
+    basePath = item.GetLocalMetadataPath();
+    videoFileName = URIUtils::ReplaceExtension(GetTitleFromPath(basePath), "");
   }
-
-  if (basePath.empty())
+  else
+  {
+    videoFileName = URIUtils::ReplaceExtension(URIUtils::GetFileName(videoPath), "");
     basePath = URIUtils::GetBasePath(videoPath);
+  }
 }
 
 void CUtil::GetItemsToScan(const std::string& videoPath,

--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -58,7 +58,7 @@ void CApplicationPlayerCallback::OnPlayBackStarted(const CFileItem& file)
   std::shared_ptr<CFileItem> itemCurrentFile;
 
   // check if VideoPlayer should set file item stream details from its current streams
-  const bool isBlu_dvd_image_or_stream = URIUtils::IsBluray(file.GetPath()) ||
+  const bool isBlu_dvd_image_or_stream = URIUtils::IsBlurayPath(file.GetPath()) ||
                                          VIDEO::IsDVDFile(file) || file.IsDiscImage() ||
                                          NETWORK::IsInternetStream(file);
 

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -267,7 +267,7 @@ bool CDVDFileInfo::CanExtract(const CFileItem& fileItem)
     return false;
 
   // mostly can't extract from discs and files from discs.
-  if (URIUtils::IsBluray(fileItem.GetPath()) || VIDEO::IsBDFile(fileItem) || fileItem.IsDVD() ||
+  if (URIUtils::IsBlurayPath(fileItem.GetPath()) || VIDEO::IsBDFile(fileItem) || fileItem.IsDVD() ||
       fileItem.IsDiscImage() || VIDEO::IsDVDFile(fileItem, false, true))
     return false;
 

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -60,7 +60,7 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item, bool forceSelectio
   if (forceSelection && VIDEO::IsBlurayPlaylist(item))
   {
     item.SetProperty("save_dyn_path", item.GetDynPath()); // save for screen refresh later
-    item.SetDynPath(item.GetBlurayPath());
+    item.SetDynPath(URIUtils::GetBlurayFile(item.GetDynPath()));
   }
 
   if (VIDEO::IsBDFile(item))

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -285,7 +285,7 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
     if (!(m_flags & READ_NO_CACHE))
     {
       const std::string pathToUrl(url.Get());
-      if (URIUtils::IsDVD(pathToUrl) || URIUtils::IsBluray(pathToUrl) ||
+      if (URIUtils::IsDVD(pathToUrl) || URIUtils::IsBlurayPath(pathToUrl) ||
           (m_flags & READ_AUDIO_VIDEO))
       {
         const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();

--- a/xbmc/utils/ArtUtils.cpp
+++ b/xbmc/utils/ArtUtils.cpp
@@ -279,7 +279,7 @@ std::string GetLocalFanart(const CFileItem& item)
   }
 
   // no local fanart available for these
-  if (NETWORK::IsInternetStream(item) || URIUtils::IsUPnP(file) || URIUtils::IsBluray(file) ||
+  if (NETWORK::IsInternetStream(item) || URIUtils::IsUPnP(file) || URIUtils::IsBlurayPath(file) ||
       item.IsLiveTV() || item.IsPlugin() || item.IsAddonsPath() || item.IsDVD() ||
       (URIUtils::IsFTP(file) &&
        !CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bFTPThumbs) ||

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -59,7 +59,7 @@ void CSaveFileState::DoWork(CFileItem& item,
     // only use original_listitem_url for Python, UPnP and Bluray sources
     std::string original = item.GetProperty("original_listitem_url").asString();
     if (URIUtils::IsPlugin(original) || URIUtils::IsUPnP(original) ||
-        URIUtils::IsBluray(item.GetPath()))
+        URIUtils::IsBlurayPath(item.GetPath()))
       progressTrackingFile = original;
   }
 
@@ -204,7 +204,7 @@ void CSaveFileState::DoWork(CFileItem& item,
         videoDbSuccess = true;
 
         // See if idFile needs updating
-        if (item.HasVideoInfoTag() && URIUtils::IsBluray(item.GetDynPath()))
+        if (item.HasVideoInfoTag() && URIUtils::IsBlurayPath(item.GetDynPath()))
         {
           if (item.GetVideoContentType() == VideoDbContentType::MOVIES)
           {

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -174,6 +174,13 @@ void CSaveFileState::DoWork(CFileItem& item,
           }
         }
 
+        //! @todo videoDBSuccess will always be true as not updated yet for play count and bookmark changes
+        if (videoDbSuccess)
+          videodatabase.CommitTransaction();
+        else
+          videodatabase.RollbackTransaction();
+        videodatabase.BeginTransaction();
+
         if (item.HasVideoInfoTag() && item.GetVideoInfoTag()->HasStreamDetails() &&
             !item.IsLiveTV())
         {
@@ -183,24 +190,37 @@ void CSaveFileState::DoWork(CFileItem& item,
           if (!videodatabase.GetStreamDetails(dbItem) ||
               dbItem.GetVideoInfoTag()->m_streamDetails != item.GetVideoInfoTag()->m_streamDetails)
           {
-            const int idFile = videodatabase.SetStreamDetailsForFile(
+            videoDbSuccess = videodatabase.SetStreamDetailsForFile(
                 item.GetVideoInfoTag()->m_streamDetails, progressTrackingFile);
+            updateListing = !videoDbSuccess;
+          }
+        }
 
-            if (idFile == -2)
-            {
-              videoDbSuccess = false;
-            }
-            else if (idFile > 0)
-            {
-              updateListing = true;
+        if (videoDbSuccess)
+          videodatabase.CommitTransaction();
+        else
+          videodatabase.RollbackTransaction();
+        videodatabase.BeginTransaction();
+        videoDbSuccess = true;
 
-              if (item.GetVideoContentType() == VideoDbContentType::MOVIES)
-                videoDbSuccess = videodatabase.SetFileForMovie(
-                    item.GetDynPath(), item.GetVideoInfoTag()->m_iDbId, idFile);
-              else if (item.GetVideoContentType() == VideoDbContentType::EPISODES)
-                videoDbSuccess = videodatabase.SetFileForEpisode(
-                    item.GetDynPath(), item.GetVideoInfoTag()->m_iDbId, idFile);
-            }
+        // See if idFile needs updating
+        if (item.HasVideoInfoTag() && URIUtils::IsBluray(item.GetDynPath()))
+        {
+          if (item.GetVideoContentType() == VideoDbContentType::MOVIES)
+          {
+            const CVideoInfoTag* tag{item.GetVideoInfoTag()};
+            if (tag->m_strFileNameAndPath != item.GetDynPath())
+              // tag->m_iFileId contains the idFile played and may be different to the idFile in the movie table entry if it's
+              // a non-default video version
+              videoDbSuccess =
+                  videodatabase.SetFileForMovie(item.GetDynPath(), tag->m_iDbId, tag->m_iFileId);
+          }
+          else if (item.GetVideoContentType() == VideoDbContentType::EPISODES)
+          {
+            const CVideoInfoTag* tag{item.GetVideoInfoTag()};
+            if (tag->m_strFileNameAndPath != item.GetDynPath())
+              videoDbSuccess =
+                  videodatabase.SetFileForEpisode(item.GetDynPath(), tag->m_iDbId, tag->m_iFileId);
           }
         }
 

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -15,7 +15,6 @@
 #include "URIUtils.h"
 #include "URL.h"
 #include "Util.h"
-#include "application/ApplicationComponents.h"
 #include "application/ApplicationStackHelper.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -455,6 +455,20 @@ std::string URIUtils::GetBasePath(const std::string& strPath)
   return strDirectory;
 }
 
+std::string URIUtils::GetBlurayFile(const std::string& path)
+{
+  if (IsBluray(path))
+  {
+    const CURL url(path);
+    const CURL url2(url.GetHostName()); // strip bluray://
+    if (url2.IsProtocol("udf"))
+      // ISO
+      return url2.GetHostName(); // strip udf://
+    return AddFileToFolder(url2.Get(), "BDMV", "index.bdmv"); // BDMV
+  }
+  return std::string{};
+}
+
 std::string URLEncodePath(const std::string& strPath)
 {
   std::vector<std::string> segments = StringUtils::Split(strPath, "/");

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -455,6 +455,32 @@ std::string URIUtils::GetBasePath(const std::string& strPath)
   return strDirectory;
 }
 
+std::string URIUtils::GetDiscBase(const std::string& file)
+{
+  std::string discFile;
+  if (IsBluray(file))
+    discFile = GetBlurayFile(file);
+  else
+    discFile = file;
+
+  std::string parent{GetParentPath(discFile)};
+  std::string parentFolder{parent};
+  RemoveSlashAtEnd(parentFolder);
+  parentFolder = GetFileName(parentFolder);
+  if (StringUtils::EqualsNoCase(parentFolder, "VIDEO_TS") ||
+      StringUtils::EqualsNoCase(parentFolder, "BDMV"))
+    return GetParentPath(parent); // go back up another one
+  return parent;
+}
+
+std::string URIUtils::GetDiscBasePath(const std::string& file)
+{
+  std::string base{GetDiscBase(file)};
+  if (IsDiscImage(base))
+    return GetDirectory(base);
+  return base;
+}
+
 std::string URIUtils::GetBlurayFile(const std::string& path)
 {
   if (IsBluray(path))

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -458,7 +458,7 @@ std::string URIUtils::GetBasePath(const std::string& strPath)
 std::string URIUtils::GetDiscBase(const std::string& file)
 {
   std::string discFile;
-  if (IsBluray(file))
+  if (IsBlurayPath(file))
     discFile = GetBlurayFile(file);
   else
     discFile = file;
@@ -483,7 +483,7 @@ std::string URIUtils::GetDiscBasePath(const std::string& file)
 
 std::string URIUtils::GetBlurayFile(const std::string& path)
 {
-  if (IsBluray(path))
+  if (IsBlurayPath(path))
   {
     const CURL url(path);
     const CURL url2(url.GetHostName()); // strip bluray://
@@ -1223,7 +1223,7 @@ bool URIUtils::IsVideoDb(const std::string& strFile)
   return IsProtocol(strFile, "videodb");
 }
 
-bool URIUtils::IsBluray(const std::string& strFile)
+bool URIUtils::IsBlurayPath(const std::string& strFile)
 {
   return IsProtocol(strFile, "bluray");
 }

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -87,6 +87,12 @@ public:
    */
   static std::string GetBasePath(const std::string& strPath);
 
+  /*! \brief Given a bluray:// path, return the base .ISO or index.BDMV.
+   \param path bluray:// path.
+   \return the base .ISO or index.BDMV.
+   */
+  static std::string GetBlurayFile(const std::string& path);
+
   /* \brief Change the base path of a URL: fromPath/fromFile -> toPath/toFile
     Handles changes in path separator and filename URL encoding if necessary to derive toFile.
     \param fromPath the base path of the original URL

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -87,6 +87,19 @@ public:
    */
   static std::string GetBasePath(const std::string& strPath);
 
+  /*! \brief Given a bluray:// path, return the base .ISO or folder containing the bluray file structure.
+   \param path bluray:// path.
+   \return the base .ISO or folder containing the bluray file structure.
+   \note Used to determine file/folder to delete
+   */
+  static std::string GetDiscBase(const std::string& file);
+
+  /*! \brief Given a bluray:// path, return the folder containing the .ISO or bluray file structure.
+   \param path bluray:// path.
+   \return the folder containing the .ISO or bluray file structure.
+   */
+  static std::string GetDiscBasePath(const std::string& file);
+
   /*! \brief Given a bluray:// path, return the base .ISO or index.BDMV.
    \param path bluray:// path.
    \return the base .ISO or index.BDMV.

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -197,7 +197,7 @@ public:
   static bool IsArchive(const std::string& strFile);
   static bool IsDiscImage(const std::string& file);
   static bool IsDiscImageStack(const std::string& file);
-  static bool IsBluray(const std::string& strFile);
+  static bool IsBlurayPath(const std::string& strFile);
   static bool IsAndroidApp(const std::string& strFile);
   static bool IsLibraryFolder(const std::string& strFile);
   static bool IsLibraryContent(const std::string& strFile);

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -442,9 +442,10 @@ TEST_F(TestURIUtils, IsZIP)
   EXPECT_FALSE(URIUtils::IsZIP("zip://path/to/file"));
 }
 
-TEST_F(TestURIUtils, IsBluray)
+TEST_F(TestURIUtils, IsBlurayPath)
 {
-  EXPECT_TRUE(URIUtils::IsBluray("bluray://path/to/file"));
+  EXPECT_TRUE(URIUtils::IsBlurayPath("bluray://path/to/file"));
+  EXPECT_FALSE(URIUtils::IsBlurayPath("zip://path/to/file"));
 }
 
 TEST_F(TestURIUtils, AddSlashAtEnd)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1992,6 +1992,7 @@ bool CVideoDatabase::HasMovieInfo(const std::string& strFilenameAndPath)
       return false;
     if (nullptr == m_pDS)
       return false;
+
     int idMovie = GetMovieId(strFilenameAndPath);
     return (idMovie > 0); // index of zero is also invalid
   }
@@ -3017,41 +3018,109 @@ int CVideoDatabase::SetDetailsForSeason(const CVideoInfoTag& details, const std:
   return -1;
 }
 
-bool CVideoDatabase::SetFileForEpisode(const std::string& fileAndPath, int idEpisode, int idFile)
+bool CVideoDatabase::SetFileForEpisode(const std::string& fileAndPath, int idEpisode, int oldIdFile)
 {
+  assert(m_pDB->in_transaction());
+
+  const int idFile = AddFile(fileAndPath);
+  if (idFile < 0)
+    return false;
+
   try
   {
-    std::string sql = PrepareSQL("UPDATE episode SET c18='%s', idFile=%i WHERE idEpisode=%i",
-                                 fileAndPath.c_str(), idFile, idEpisode);
-    m_pDS->exec(sql);
-
-    return true;
+    m_pDS->exec(PrepareSQL("UPDATE episode SET idFile=%i WHERE idEpisode=%i", idFile, idEpisode));
+    return DeleteFile(oldIdFile);
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idEpisode);
+    CLog::LogF(LOGERROR, " idFile {}, fileAndPath {}, idEpisode {}, oldIdFile {} - failed", idFile,
+               fileAndPath, idEpisode, oldIdFile);
   }
   return false;
 }
 
-bool CVideoDatabase::SetFileForMovie(const std::string& fileAndPath, int idMovie, int idFile)
+bool CVideoDatabase::SetFileForMovie(const std::string& fileAndPath, int idMovie, int oldIdFile)
+{
+  assert(m_pDB->in_transaction());
+
+  const int idFile{AddFile(fileAndPath)};
+  if (idFile < 0)
+    return false;
+
+  try
+  {
+    std::string sql = PrepareSQL("UPDATE movie SET idFile=%i WHERE idFile=%i AND idMovie=%i",
+                                 idFile, oldIdFile, idMovie);
+    m_pDS->exec(sql);
+
+    sql = PrepareSQL(
+        "UPDATE videoversion SET idFile=%i WHERE idFile=%i AND media_type='movie' AND idMedia=%i",
+        idFile, oldIdFile, idMovie);
+    m_pDS->exec(sql);
+
+    sql = PrepareSQL("UPDATE art SET media_id=%i WHERE media_id=%i AND media_type='videoversion'",
+                     idFile, oldIdFile);
+    m_pDS->exec(sql);
+
+    sql = PrepareSQL("UPDATE streamdetails SET idFile=%i WHERE idFile=%i AND NOT EXISTS (SELECT 1 "
+                     "FROM streamdetails WHERE idFile=%i)",
+                     idFile, oldIdFile, idFile);
+    m_pDS->exec(sql);
+
+    return DeleteFile(oldIdFile);
+  }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, " idFile {}, fileAndPath {}, idMovie {}, oldIdFile {} - failed", idFile,
+               fileAndPath, idMovie, oldIdFile);
+  }
+  return false;
+}
+
+bool CVideoDatabase::DeleteFile(int idFile)
 {
   try
   {
-    assert(m_pDB->in_transaction());
+    // First check no other references to file (eg. other episodes)
+    std::string sql{PrepareSQL("SELECT idFile FROM movie WHERE idFile = %i "
+                               "UNION SELECT idFile FROM episode WHERE idFile = %i "
+                               "UNION SELECT idFile FROM videoversion WHERE idFile = %i",
+                               idFile, idFile, idFile)};
+    m_pDS->query(sql);
+    if (m_pDS->eof())
+    {
+      // Get idPath
+      sql = PrepareSQL("SELECT path.idPath, path.strPath FROM path "
+                       "JOIN files ON path.idPath = files.idPath "
+                       "WHERE idFile = %i",
+                       idFile);
+      m_pDS->query(sql);
+      int idPath{-1};
+      std::string strPath;
+      if (!m_pDS->eof())
+      {
+        idPath = m_pDS->fv("idPath").get_asInt();
+        strPath = m_pDS->fv("strPath").get_asString();
+      }
 
-    std::string sql = PrepareSQL("UPDATE movie SET c22='%s', idFile=%i WHERE idMovie=%i",
-                                 fileAndPath.c_str(), idFile, idMovie);
-    m_pDS->exec(sql);
-    sql = PrepareSQL("UPDATE videoversion SET idFile=%i WHERE idMedia=%i AND media_type='movie'",
-                     idFile, idMovie);
-    m_pDS->exec(sql);
+      // Associated bookmarks and streamdetails deleted by delete trigger
+      sql = PrepareSQL("DELETE FROM files WHERE idFile = %i", idFile);
+      m_pDS->exec(sql);
 
+      // Delete path if orphan (and not base directory - needs to remain to prevent re-adding on library update)
+      if (idPath >= 0 && URIUtils::IsBluray(strPath))
+      {
+        sql = PrepareSQL("DELETE FROM path WHERE idPath = %i "
+                         "AND NOT EXISTS (SELECT 1 FROM files WHERE files.idPath = %i)",
+                         idPath, idPath);
+        m_pDS->exec(sql);
+      }
+    }
     return true;
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idMovie);
+    CLog::LogF(LOGERROR, "({}) failed", idFile);
   }
   return false;
 }
@@ -3245,19 +3314,14 @@ int CVideoDatabase::SetDetailsForMusicVideo(CVideoInfoTag& details,
   return -1;
 }
 
-int CVideoDatabase::SetStreamDetailsForFile(const CStreamDetails& details,
-                                            const std::string& strFileNameAndPath)
+bool CVideoDatabase::SetStreamDetailsForFile(const CStreamDetails& details,
+                                             const std::string& strFileNameAndPath)
 {
   // AddFile checks to make sure the file isn't already in the DB first
   int idFile = AddFile(strFileNameAndPath);
   if (idFile < 0)
-    return -1;
-
-  //! @todo ugly error return mechanism, fixme
-  if (SetStreamDetailsForFileId(details, idFile))
-    return idFile;
-  else
-    return -2;
+    return false;
+  return SetStreamDetailsForFileId(details, idFile);
 }
 
 bool CVideoDatabase::SetStreamDetailsForFileId(const CStreamDetails& details, int idFile)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3108,7 +3108,7 @@ bool CVideoDatabase::DeleteFile(int idFile)
       m_pDS->exec(sql);
 
       // Delete path if orphan (and not base directory - needs to remain to prevent re-adding on library update)
-      if (idPath >= 0 && URIUtils::IsBluray(strPath))
+      if (idPath >= 0 && URIUtils::IsBlurayPath(strPath))
       {
         sql = PrepareSQL("DELETE FROM path WHERE idPath = %i "
                          "AND NOT EXISTS (SELECT 1 FROM files WHERE files.idPath = %i)",
@@ -10277,7 +10277,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
           fullPath = CURL(fullPath).GetHostName();
 
         // if bluray:// get actual path
-        if (URIUtils::IsBluray(fullPath))
+        if (URIUtils::IsBlurayPath(fullPath))
           fullPath = URIUtils::GetBlurayFile(fullPath);
 
         bool del = true;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -10276,6 +10276,10 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
         if (URIUtils::IsInArchive(fullPath))
           fullPath = CURL(fullPath).GetHostName();
 
+        // if bluray:// get actual path
+        if (URIUtils::IsBluray(fullPath))
+          fullPath = URIUtils::GetBlurayFile(fullPath);
+
         bool del = true;
         if (URIUtils::IsPlugin(fullPath))
         {

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -592,12 +592,13 @@ public:
                            const std::map<std::string, std::string>& artwork,
                            int idShow,
                            int idEpisode = -1);
-  bool SetFileForEpisode(const std::string& fileAndPath, int idEpisode, int idFile);
-  bool SetFileForMovie(const std::string& fileAndPath, int idMovie, int idFile);
+  bool SetFileForEpisode(const std::string& fileAndPath, int idEpisode, int oldIdFile);
+  bool SetFileForMovie(const std::string& fileAndPath, int idMovie, int oldIdFile);
   int SetDetailsForMusicVideo(CVideoInfoTag& details,
                               const std::map<std::string, std::string>& artwork,
                               int idMVideo = -1);
-  int SetStreamDetailsForFile(const CStreamDetails& details, const std::string& strFileNameAndPath);
+  bool SetStreamDetailsForFile(const CStreamDetails& details,
+                               const std::string& strFileNameAndPath);
   /*!
    * \brief Clear any existing stream details and add the new provided details to a file.
    * \param[in] details New stream details
@@ -637,6 +638,7 @@ public:
   void UpdateFanart(const CFileItem& item, VideoDbContentType type);
   void DeleteSet(int idSet);
   void DeleteTag(int idTag, VideoDbContentType mediaType);
+  bool DeleteFile(int idFile);
 
   /*! \brief Get video settings for the specified file id
    \param idFile file id to get the settings for

--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -63,8 +63,8 @@ std::string FindTrailer(const CFileItem& item)
   }
 
   // no local trailer available for these
-  if (NETWORK::IsInternetStream(item) || URIUtils::IsUPnP(strFile) || URIUtils::IsBluray(strFile) ||
-      item.IsLiveTV() || item.IsPlugin() || item.IsDVD())
+  if (NETWORK::IsInternetStream(item) || URIUtils::IsUPnP(strFile) ||
+      URIUtils::IsBlurayPath(strFile) || item.IsLiveTV() || item.IsPlugin() || item.IsDVD())
     return "";
 
   std::string strDir = URIUtils::GetDirectory(strFile);

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -61,7 +61,6 @@
 #include "video/dialogs/GUIDialogVideoManagerExtras.h"
 #include "video/dialogs/GUIDialogVideoManagerVersions.h"
 #include "video/guilib/VideoPlayActionProcessor.h"
-#include "video/guilib/VideoVersionHelper.h"
 #include "video/windows/GUIWindowVideoNav.h"
 
 #include <algorithm>


### PR DESCRIPTION
Re-doing commits following comments in #25140.

Fixes:
- Fix bluray:// path not updated if more than one videoversion and videoversions would be readded after library scan after bluray:// path assigned
- Fix library clean coud remove bluray:// paths

Plus small code optimisations/clarifications/refactoring.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
