### PR TITLE
[VideoInfoScanner] Reduce Scraper Cache Clearing to Speedup Library Update

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -495,7 +495,9 @@ CVideoInfoScanner::CVideoInfoScanner()
       }
 
       // clear our scraper cache
-      info2->ClearCache();
+      // @todo: move to a dedicated housekeeping task
+      if (auto p = m_clearedScrapers.emplace(info2->ID()); p.second)
+        info2->ClearCache();
 
       InfoRet ret = InfoRet::CANCELLED;
       if (info2->Content() == CONTENT_TVSHOWS)

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -292,5 +292,6 @@ namespace KODI::VIDEO
              is at least 1:4, "thumb" otherwise.
      */
     static std::string GetArtTypeFromSize(unsigned int width, unsigned int height);
+    std::set<std::string> m_clearedScrapers;
   };
   } // namespace KODI::VIDEO


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Clear the scraper cache only once per library update and per scraper addon.
Cache clearing can be useful to clear old files but it is surprisingly expensive and doesn't have to be done before each movie or tv series.  No change for information dialog > refresh.

risk: maybe some scrapers rely on previous behavior and expect an empty cache folder but that would be a bug.
metadata.tvshows.themoviedb.org.python stores .pickle files and doesn't seem to have trouble. It happily overwrites them with each scrape.

future PR: it would be nicer to move the cache clearing to a generic housekeeping mechanism on a fixed schedule, or maybe to schedule it after the completion of a scan. I don't know if there is an existing framework for those things.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Noticed while profiling library update performance. ClearCache takes a significant amount of time, even with a SSD.

![image](https://github.com/user-attachments/assets/dbddfa9b-5b26-432d-a7c4-78a00dbce8ca)
(in this example, 7.44% of cpu time for a library scan that took 39.58% of cpu. That means 18% of the cpu used by a library scan)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

tested with both tmdb scrapers and metadata.local.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Faster library update.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
