### PR TITLE
[Addons][VFS] Fix browsing archives on the VFS

### DIFF
--- a/xbmc/addons/VFSEntry.h
+++ b/xbmc/addons/VFSEntry.h
@@ -9,6 +9,7 @@
 
 #include "FileItem.h"
 #include "FileItemList.h"
+#include "URL.h"
 #include "addons/binary-addons/AddonDll.h"
 #include "addons/binary-addons/AddonInstanceHandler.h"
 #include "addons/kodi-dev-kit/include/kodi/addon-instance/VFS.h"
@@ -282,6 +283,14 @@ protected:
     //! \return True if listing succeeded, false otherwise.
     bool GetDirectory(const CURL& url, CFileItemList& items) override
     {
+      // Check for cached items
+      const CURL cachedItemsUrl{m_items.GetPath()};
+      if (cachedItemsUrl.GetHostName() == url.GetWithoutUserDetails())
+      {
+        items.Assign(m_items);
+        return true;
+      }
+
       return CVFSEntryIDirectoryWrapper::GetDirectory(url, items);
     }
 

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -121,11 +121,8 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
               pItem->SetPath(wrap->m_items.GetPath());
             }
 
-            // Check for folder, if yes return also wrap.
-            // Needed to fix for e.g. RAR files with only one file inside
-            pItem->m_bIsFolder = URIUtils::HasSlashAtEnd(pItem->GetPath());
-            if (pItem->m_bIsFolder)
-              return wrap;
+            // Return wrap so that its item cache can be used
+            return wrap;
           }
           else
           {


### PR DESCRIPTION
## Description

### Problem

Situation: I have a single SNES game in a zip file on a samba share. vfs.libarchive is installed. When I visit My Games and click on the zip file, instead of browsing into it, nothing happens. If vfs.libarchive is uninstalled, browsing into the zip works correctly.

The problem appears to be in the file directory factory, here: https://github.com/xbmc/xbmc/blob/fe42fddc653f76d4f19784e3b28e56c7a75bb4b1/xbmc/filesystem/FileDirectoryFactory.cpp#L101

When the zip extension matches vfs.libarchive, it calls:

```c++
if (wrap->ContainsFiles(url))
```

This succeeds. vfs.libarchive correctly uses an SMBFile to read the zip, and `wrap` has cached the contents. In the log, I see:

```
debug <general>: CSMBFile::Open - opened smb://USERNAME:PASSWORD@192.168.0.10/Media2/Games/ROMs/Super Nintendo/Misc/game.sfc.zip, fd=10000
debug <general>: CSMBFile::Close closing fd 10000
```

However, here's the problem: This check fails, as the zip URL doesn't end in a slash:

```c++
// Check for folder, if yes return also wrap.
// Needed to fix for e.g. RAR files with only one file inside
pItem->m_bIsFolder = URIUtils::HasSlashAtEnd(pItem->GetPath());
if (pItem->m_bIsFolder)
  return wrap;
```

So `wrap` is deleted and the add-on isn't used anymore. Kodi falls back to using SMBFile, which fails, as the zip file isn't a directory:

```
error <general>: SMBDirectory->GetDirectory: Unable to open directory : 'smb://USERNAME:PASSWORD@192.168.0.10/Media2/Games/ROMs/Super%20Nintendo/Misc/game.sfc.zip'
                 unix_err:'14' error : 'Not a directory'
error <general>: GetDirectory - Error getting smb://192.168.0.10/Media2/Games/ROMs/Super Nintendo/Misc/game.sfc.zip
```

### Possible Solution

The add-on *knows* the archive contents when `ContainsFiles()` succeeds. They are cached in `wrap`. So we should return `wrap` to use its cached items:

```c++
// Return wrap so that its item cache can be used
return wrap;
```

By returning `wrap`, the add-on is then used to list the contents, instead of falling back to SMBFile. And because `wrap` cached the contents, we can simply use the cache when the directory is listed:

```c++
// Check for cached items
const CURL cachedItemsUrl{m_items.GetPath()};
if (cachedItemsUrl.GetHostName() == url.GetWithoutUserDetails())
{
  items.Assign(m_items);
  return true;
}
```

### Concerns

This problematic behavior was in the original VFS add-on implementation 9 years ago. I'm not sure what was intended by it. And I'm not sure if this change will break anything else. Hopefully someone familiar with VFS add-ons can take a look.

## Motivation and context

Reported in the forum here: https://forum.kodi.tv/showthread.php?tid=379996

## How has this been tested?

After applying this patch, I can successfully browse into the zip, and launch the SNES game inside.

## What is the effect on users?

* Fixed browsing into zip files on Samba shares

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
