### PR TITLE
[Games] Fix handling of zip files in My Games window if vfs.libarchive is installed

### DIFF
--- a/xbmc/games/GameUtils.h
+++ b/xbmc/games/GameUtils.h
@@ -110,6 +110,11 @@ private:
   static bool Enable(const std::string& gameClient);
 
   /*!
+   * \brief Load and cache installable game add-ons
+   */
+  static void LoadInstallableAddons();
+
+  /*!
    * \brief Cache of installable game add-ons used to compute the list of
    * known game file extensions
    */

--- a/xbmc/games/windows/GUIWindowGames.h
+++ b/xbmc/games/windows/GUIWindowGames.h
@@ -41,6 +41,7 @@ protected:
   bool OnClickMsg(int controlId, int actionId);
   void OnItemInfo(int itemNumber);
   bool PlayGame(const CFileItem& item);
+  bool CanPlay(const CFileItem& item) const;
 
   CGUIDialogProgress* m_dlgProgress = nullptr;
 };


### PR DESCRIPTION
## Description

Currently, browsing into zips is broken in the My Games window. Clicking on a zip does nothing. The only way to play a zip is to open the context menu and press "Play". And this only works for cores that support zip files. Files inside the zip can't be played.

The root cause is handling of so-called "file folders", which are zip files that appear as directories. Normally, Kodi treats these as directories. However, this doesn't work for games, because Kodi doesn't show directories that don't contain the appropriate media type (based on file extensions). Take for example MAME; a zip file won't have any files with recognizable game extensions, but we still want the zip to appear so that it can be played.

Therefore, because zips don't show up when processing directory retrieval with file folders, we need to disable the file folder behavior by default. When I built the My Games window, I added some additional processing to handle file folders. However, this processing wasn't sufficient. The goal of this PR is to enhance this processing, allowing zips to be both played (if they don't contain game extensions like MAME roms) and browsed into (if they contain files with game extensions).

## Motivation and context

Reported in the forum here: https://forum.kodi.tv/showthread.php?tid=379996

My first attempt to fix this bug is here: https://github.com/xbmc/xbmc/pull/26224, but I deemed it too intrusive. This PR only affects the My Games window.

## How has this been tested?

Included in my latest round of test builds: https://github.com/garbear/xbmc/releases/tag/retroplayer-21.1-20250104

Tested with:

* zip file containing one game (correctly collapsed down to its inner file)
* zip file containing a non-game (movie) file (correctly shown as a zip file to be played, e.g. a MAME rom)
* zip file containing multiple games (correctly able to browse into, as well as play via context menu)

Tested all zip types both locally and on a samba share.

## What is the effect on users?

* Fixed playing roms from within zip files

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
