### PR TITLE
[FileSystem][Settings] SMB settings improvements

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22163,7 +22163,7 @@ msgstr ""
 #. Description of setting with label #36628 "Minimum protocol version"
 #: system/settings/settings.xml
 msgctxt "#36629"
-msgid "Set the minimum SMB protocol version to negotiate when making connections. Forcing SMBv2 may be required to prevent SMBv1 use on some OS."
+msgid "Set the minimum SMB protocol version to negotiate when making connections. Forcing SMBv2 may be required to prevent SMBv1 use on some systems. Only SMBv2.1 and SMBv3 support Large MTU (chunk size > 64 KB)."
 msgstr ""
 
 #. Label of a setting, sets additional config required for some proprietary SMBv1 implementations (mostly routers)
@@ -22208,7 +22208,11 @@ msgctxt "#36636"
 msgid "You must first enter a password before web server authentication can be enabled."
 msgstr ""
 
-#empty string with id 36637
+#. Values for setting with label #36621 and #36628 "Minimum/Maximum protocol version"
+#: system/settings/settings.xml
+msgctxt "#36637"
+msgid "SMBv2 and Large MTU"
+msgstr ""
 
 #. Menuitem at "Settings -> System -> Add-ons"
 #: ./system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2525,14 +2525,9 @@
         </setting>
         <setting id="smb.minprotocol" type="integer" label="36628" help="36629">
           <level>2</level>
-          <default>0</default>
+          <default>21</default>
           <constraints>
-            <options>
-              <option label="36623">0</option>
-              <option label="36624">1</option>
-              <option label="36625">2</option>
-              <option label="36626">3</option>
-            </options>
+            <options>smbversions</options>
           </constraints>
           <control type="list" format="integer" />
         </setting>
@@ -2540,12 +2535,7 @@
           <level>2</level>
           <default>3</default>
           <constraints>
-            <options>
-              <option label="36623">0</option>
-              <option label="36624">1</option>
-              <option label="36625">2</option>
-              <option label="36626">3</option>
-            </options>
+            <options>smbversions</options>
           </constraints>
           <control type="list" format="integer" />
         </setting>
@@ -2574,6 +2564,14 @@
           <constraints>
             <options>filechunksizes</options>
           </constraints>
+          <dependencies>
+            <dependency type="enable">
+              <or>
+                <condition setting="smb.minprotocol" operator="is">21</condition>
+                <condition setting="smb.minprotocol" operator="is">3</condition>
+              </or>
+            </dependency>
+          </dependencies>
           <control type="list" format="string" />
         </setting>
       </group>

--- a/xbmc/platform/posix/filesystem/SMBFile.cpp
+++ b/xbmc/platform/posix/filesystem/SMBFile.cpp
@@ -133,21 +133,43 @@ void CSMB::Init()
         fprintf(f, "\tlock directory = %s/.smb/\n", home.c_str());
 
         // set minimum smbclient protocol version
-        if (settings->GetInt(CSettings::SETTING_SMB_MINPROTOCOL) > 0)
+        switch (settings->GetInt(CSettings::SETTING_SMB_MINPROTOCOL))
         {
-          if (settings->GetInt(CSettings::SETTING_SMB_MINPROTOCOL) == 1)
+          case 0:
+          default:
+            break;
+          case 1:
             fprintf(f, "\tclient min protocol = NT1\n");
-          else
-            fprintf(f, "\tclient min protocol = SMB%d\n", settings->GetInt(CSettings::SETTING_SMB_MINPROTOCOL));
+            break;
+          case 2:
+            fprintf(f, "\tclient min protocol = SMB2_02\n");
+            break;
+          case 21:
+            fprintf(f, "\tclient min protocol = SMB2_10\n");
+            break;
+          case 3:
+            fprintf(f, "\tclient min protocol = SMB3\n");
+            break;
         }
 
         // set maximum smbclient protocol version
-        if (settings->GetInt(CSettings::SETTING_SMB_MAXPROTOCOL) > 0)
+        switch (settings->GetInt(CSettings::SETTING_SMB_MAXPROTOCOL))
         {
-          if (settings->GetInt(CSettings::SETTING_SMB_MAXPROTOCOL) == 1)
+          case 0:
+          default:
+            break;
+          case 1:
             fprintf(f, "\tclient max protocol = NT1\n");
-          else
-            fprintf(f, "\tclient max protocol = SMB%d\n", settings->GetInt(CSettings::SETTING_SMB_MAXPROTOCOL));
+            break;
+          case 2:
+            fprintf(f, "\tclient max protocol = SMB2_02\n");
+            break;
+          case 21:
+            fprintf(f, "\tclient max protocol = SMB2_10\n");
+            break;
+          case 3:
+            fprintf(f, "\tclient max protocol = SMB3\n");
+            break;
         }
 
         // set legacy security options
@@ -749,14 +771,11 @@ int CSMBFile::GetChunkSize()
   if (!settings)
     return (64 * 1024);
 
-  int chunkSize = settings->GetInt(CSettings::SETTING_SMB_CHUNKSIZE) * 1024;
-
-  if (settings->GetInt(CSettings::SETTING_SMB_MINPROTOCOL) == 1 &&
-      settings->GetInt(CSettings::SETTING_SMB_MAXPROTOCOL) == 1)
+  // Only SMBv2.1 and SMBv3 supports large MTU
+  if (settings->GetInt(CSettings::SETTING_SMB_MINPROTOCOL) > 2)
   {
-    if (chunkSize > 64 * 1024)
-      chunkSize = 64 * 1024;
+    return (settings->GetInt(CSettings::SETTING_SMB_CHUNKSIZE) * 1024);
   }
 
-  return chunkSize;
+  return (64 * 1024);
 }

--- a/xbmc/settings/ServicesSettings.cpp
+++ b/xbmc/settings/ServicesSettings.cpp
@@ -114,3 +114,15 @@ void CServicesSettings::SettingOptionsCacheChunkSizesFiller(const SettingConstPt
   list.emplace_back(StringUtils::Format(kb, 512), 512 * 1024);
   list.emplace_back(StringUtils::Format(mb, 1), 1024 * 1024);
 }
+
+void CServicesSettings::SettingOptionsSmbVersionsFiller(const SettingConstPtr& setting,
+                                                        std::vector<IntegerSettingOption>& list,
+                                                        int& current,
+                                                        void* data)
+{
+  list.emplace_back(g_localizeStrings.Get(36623), 0);
+  list.emplace_back(g_localizeStrings.Get(36624), 1);
+  list.emplace_back(g_localizeStrings.Get(36625), 2);
+  list.emplace_back(g_localizeStrings.Get(36637), 21);
+  list.emplace_back(g_localizeStrings.Get(36626), 3);
+}

--- a/xbmc/settings/ServicesSettings.h
+++ b/xbmc/settings/ServicesSettings.h
@@ -36,4 +36,8 @@ public:
                                                   std::vector<IntegerSettingOption>& list,
                                                   int& current,
                                                   void* data);
+  static void SettingOptionsSmbVersionsFiller(const SettingConstPtr& setting,
+                                              std::vector<IntegerSettingOption>& list,
+                                              int& current,
+                                              void* data);
 };

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -411,6 +411,8 @@ void CSettings::InitializeOptionFillers()
   GetSettingsManager()->RegisterSettingOptionsFiller(
       "keyboardlayouts", KEYBOARD::CKeyboardLayoutManager::SettingOptionsKeyboardLayoutsFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller(
+      "smbversions", CServicesSettings::SettingOptionsSmbVersionsFiller);
+  GetSettingsManager()->RegisterSettingOptionsFiller(
       "filechunksizes", CServicesSettings::SettingOptionsChunkSizesFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller(
       "filecachebuffermodes", CServicesSettings::SettingOptionsBufferModesFiller);
@@ -470,6 +472,7 @@ void CSettings::UninitializeOptionFillers()
 #endif // defined(TARGET_LINUX)
   GetSettingsManager()->UnregisterSettingOptionsFiller("verticalsyncs");
   GetSettingsManager()->UnregisterSettingOptionsFiller("keyboardlayouts");
+  GetSettingsManager()->UnregisterSettingOptionsFiller("smbversions");
   GetSettingsManager()->UnregisterSettingOptionsFiller("filechunksizes");
   GetSettingsManager()->UnregisterSettingOptionsFiller("filecachebuffermodes");
   GetSettingsManager()->UnregisterSettingOptionsFiller("filecachememorysizes");


### PR DESCRIPTION
## Description
SMB settings improvements

## Motivation and context
There are currently significant limitations in SMB settings (even bugs):

Not exist distinction between SMBv2 and SMBv2.1. This is important due "Large MTU" only is supported from v2.1 (not in v2.0). Some very popular devices like Asus routers only supports SMBv2 (talking about the built-in USB drive sharing functionality only). ---> can not be used default 128 KB chunk size. 

Things are even worse: If user decides set min SMB protocol to SMBv2 and max to SMBv3 this is expected work because router supports SMBv2 but not works because Kodi try negotiate SMBv2.1 !!!

The background of this is:
https://unix.stackexchange.com/questions/458203/available-min-max-values-for-smb-protocol

> By default SMB2 selects the SMB2_10 variant. (v2.1)

Example of this:
https://forum.kodi.tv/showthread.php?tid=380007&pid=3220941#pid3220941
https://forum.kodi.tv/showthread.php?tid=380007&pid=3220948#pid3220948

Even with "safe" settings min = v1 / max = v2, default 128 KB chunk size may cause issues in some devices that only supports SMBv2.

This PR does several things:

- Add new setting value `SMBv2.1` to explicit request this level.
- Remaps current setting value `SMBv2` to true v2 level.
- Makes SMB chunk size setting only applies if SMB min protocol version > v2  (SMBv2.1 and SMBv3).
- Disables the SMB chunk size setting in GUI to denote not in use when not supported.
- Changes default min SMB to SMBv2.1 --> because SMBv1 is deprecated and 2.0 not supports Large MTU (take steps to move forward).

Some more info as reference:
https://forum.kodi.tv/showthread.php?tid=377708&pid=3199560#pid3199560
https://forum.kodi.tv/showthread.php?tid=377708&pid=3199562#pid3199562


## How has this been tested?
Tested on Shield with share on Asus Router (RT-AX88U) configured as SMBv2

Before --> Is not possible access the share with setting SMB min protocol to SMBv2
After --> Share works fine with setting SMB min protocol to SMBv2

Before --> with Kodi default settings works but 128 KB chunk size is used when shouldn't.
After -->  with Kodi min SMBv2 setting works and is used proper 64 K chunk size.
After -->  with Kodi min SMBv2.1 setting NOT works as device only supports v2.0.

Note: 
Due new default min SMB to SMBv2.1 it's expected that users encounter issues on devices that only supports SMBv2... but these will now be "all or nothing connection issues" instead of random errors due the chunk size, meaning you will now have to tweak Kodi settings in "obsolete" devices (min SMB protocol).

The advantage of change the default min SMB to v2.1 is that enforces to move away from using SMBv1 and use newer, more secure and performant versions (assuming the server has all versions enabled). 

Anyway if the server only supports lower versions, the user will be aware of this and will be forced to change Kodi settings to work.

Change minimum default to v2.1 is also good to fix issues on some devices like:
https://forum.kodi.tv/showthread.php?tid=379682&pid=3218458#pid3218458

This is because even server supports e.g. (1 to 2.1) if Kodi is configured (0 to 3), Large MTU is not negotiated properly unless is forced minimum to 2.1.

From settings strings:
`Forcing SMBv2 may be required to prevent SMBv1 use on some systems.`


## What is the effect on users?
- Allows use SMBv2 on devices that supports v2 but not SMBv2.1 and prevents SMBv1 being used unintentionally.
- Prevents Chunk Size > 64 KB used on systems that not supports SMBv2.1 / Large MTU.


## Screenshots (if appropriate):

![screenshot00001](https://github.com/user-attachments/assets/9044c455-e8a0-492d-9475-5a0679070625)



## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
