### PR TITLE
StringUtils: Use non locale aware `toupper`/`tolower` for functions on `char` strings

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/tools/StringUtils.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/tools/StringUtils.h
@@ -1597,7 +1597,7 @@ public:
       c2 = *s2++;
       // This includes the possibility that one of the characters is the null-terminator,
       // which implies a string mismatch.
-      if (c1 != c2 && ::tolower(c1) != ::tolower(c2))
+      if (c1 != c2 && ToLowerAscii(c1) != ToLowerAscii(c2))
         return false;
     } while (c2 != '\0'); // At this point, we know c1 == c2, so there's no need to test them both.
     return true;
@@ -1647,8 +1647,8 @@ public:
       index++;
       // This includes the possibility that one of the characters is the null-terminator,
       // which implies a string mismatch.
-      if (c1 != c2 && ::tolower(c1) != ::tolower(c2))
-        return ::tolower(c1) - ::tolower(c2);
+      if (c1 != c2 && ToLowerAscii(c1) != ToLowerAscii(c2))
+        return ToLowerAscii(c1) - ToLowerAscii(c2);
     } while (c2 != '\0' &&
              index != n); // At this point, we know c1 == c2, so there's no need to test them both.
     return 0;
@@ -1782,7 +1782,7 @@ public:
   {
     while (*s2 != '\0')
     {
-      if (::tolower(*s1) != ::tolower(*s2))
+      if (ToLowerAscii(*s1) != ToLowerAscii(*s2))
         return false;
       s1++;
       s2++;
@@ -1873,7 +1873,7 @@ public:
     const char* s2 = str2.c_str();
     while (*s2 != '\0')
     {
-      if (::tolower(*s1) != ::tolower(*s2))
+      if (ToLowerAscii(*s1) != ToLowerAscii(*s2))
         return false;
       s1++;
       s2++;
@@ -1899,7 +1899,7 @@ public:
     const char* s1 = str1.c_str() + str1.size() - len2;
     while (*s2 != '\0')
     {
-      if (::tolower(*s1) != ::tolower(*s2))
+      if (ToLowerAscii(*s1) != ToLowerAscii(*s2))
         return false;
       s1++;
       s2++;
@@ -3028,6 +3028,16 @@ private:
     else if (*static_cast<const wchar_t*>(a) > *static_cast<const wchar_t*>(b))
       return 1;
     return 0;
+  }
+
+  inline static char ToLowerAscii(char c)
+  {
+    return 'A' <= c && c <= 'Z' ? c - 'A' + 'a' : c;
+  }
+
+  inline static char ToUpperAscii(char c)
+  {
+    return 'a' <= c && c <= 'z' ? c - 'a' + 'A' : c;
   }
 
   inline static wchar_t tolowerUnicode(const wchar_t& c)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

From the first commit:

```
This solves the problem that an upper case 'I' isn't converted to the lower
case 'i' with a Turkish locale. This breaks scripts etc. that rely on this
conversion, e.g. when matching labels in
`CGUIInfoManager::TranslateSingleString`.

These functions had their use back in the days when 8 bit code pages like ISO
8859-1 were used, but today `char` strings are either ASCII or UTF-8. For the
former the locale awareness is a problem, for the latter is doesn't work
anyway.
```

I think doing it this way is safe as for user visible strings we use functions operating on `wchar_t` which handle Unicode correctly. The functions operating on `char` strings are non user visible and mostly ASCII or UTF-8. For UTF-8 it's already broken and this change doesn't make worse.

If this is accepted I make a backport that excludes the dev-kit change as I don't want to change external behavior in a minor release.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes the many reports of Kodi not working on systems with a Turkish locale:

- #19883
- https://forum.kodi.tv/showthread.php?tid=380015
- https://forum.kodi.tv/showthread.php?tid=378961
- https://forum.kodi.tv/showthread.php?tid=371783

There have been previous attempts to fix this but non were merged:

- #19905
- #22802 (very ambitious and large in scope)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
