### PR TITLE
[VideoDatabase] Fix clean database deletes archive:// paths and refactor for bluray:// paths

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1241,6 +1241,10 @@ int CUtil::GetMatchingSource(const std::string& strPath1,
   if (checkURL.IsProtocol("stack"))
     strPath.erase(0, 8); // remove the stack protocol
 
+  // bluray://
+  if (checkURL.IsProtocol("bluray"))
+    strPath = URIUtils::GetDiscBase(checkURL.Get()); // get the actual path on disc
+
   if (checkURL.IsProtocol("shout"))
     strPath = checkURL.GetHostName();
 

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1251,6 +1251,21 @@ int CUtil::GetMatchingSource(const std::string& strPath1,
   if (checkURL.IsProtocol("multipath"))
     strPath = CMultiPathDirectory::GetFirstPath(strPath);
 
+  // Check to see if protocol is VFS addon (eg. archive://)
+  if (!checkURL.GetProtocol().empty() && CServiceBroker::IsAddonInterfaceUp())
+  {
+    for (const auto& vfsAddon : CServiceBroker::GetVFSAddonCache().GetAddonInstances())
+    {
+      auto prots = StringUtils::Split(vfsAddon->GetProtocols(), "|");
+      if (vfsAddon->HasDirectories() &&
+          std::ranges::find(prots, checkURL.GetProtocol()) != prots.end())
+      {
+        strPath = checkURL.GetHostName(); // resolve host (eg. actual .zip file)
+        break;
+      }
+    }
+  }
+
   bIsSourceName = false;
   int iIndex = -1;
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -10523,10 +10523,6 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
         if (URIUtils::IsInArchive(fullPath))
           fullPath = CURL(fullPath).GetHostName();
 
-        // if bluray:// get actual path
-        if (URIUtils::IsBlurayPath(fullPath))
-          fullPath = URIUtils::GetBlurayFile(fullPath);
-
         bool del = true;
         if (URIUtils::IsPlugin(fullPath))
         {


### PR DESCRIPTION
Problem: Running a database clean deletes archive:// entries even though the actual archive is still present
Fix: archive:// paths need to be resolved to the actual archive file on disk.

Also, as part of investigating the above, I've properly implemented the same for bluray:// paths.

@garbear - should be straightforward. This was something I identified in #25140.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
