### PR TITLE
[FileSystem][POSIX] Fix SMB passwordless access (POSIX client - Windows server)

### DIFF
--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -259,11 +259,22 @@ int CSMBDirectory::Open(const CURL &url)
 int CSMBDirectory::OpenDir(const CURL& url, std::string& strAuth)
 {
   int fd = -1;
+  bool guest = false;
 
   /* make a writeable copy */
   CURL urlIn = CSMB::GetResolvedUrl(url);
 
   CPasswordManager::GetInstance().AuthenticateURL(urlIn);
+
+  // set the username to "guest" when not provided username
+  // which is required for passwordless or everyone access
+  if (urlIn.GetUserName().empty())
+  {
+    urlIn.SetUserName("guest");
+    urlIn.SetPassword(" ");
+    guest = true;
+  }
+
   strAuth = smb.URLEncode(urlIn);
 
   // remove the / or \ at the end. the samba library does not strip them off
@@ -292,7 +303,14 @@ int CSMBDirectory::OpenDir(const CURL& url, std::string& strAuth)
     if (errno == EACCES || errno == EPERM || errno == EAGAIN || errno == EINVAL)
     {
       if (m_flags & DIR_FLAG_ALLOW_PROMPT)
+      {
+        if (guest) // clean user/pass if tried guest access and failed
+        {
+          urlIn.SetUserName("");
+          urlIn.SetPassword("");
+        }
         RequireAuthentication(urlIn);
+      }
       break;
     }
 


### PR DESCRIPTION
## Description
Fix passwordless access (POSIX client - Windows server)

Fix https://github.com/xbmc/xbmc/issues/18832

## Motivation and context
SMB passwordless still (semi-broken) in some cases:

|  Client (Kodi) | Server   |  current state
|---|---|:---:|
|  Windows  | Windows  |  works |  
| Windows  |  Linux based |  works |
|  Android  |  Linux based |  works  |
|  Android  |  Windows |  semi-broken  |

* semi-broken = access is possible but user needs enter guest/1234

This PR fixes Android/Windows case.

NOTE: this PR is similar to https://github.com/xbmc/xbmc/pull/19599 which fixed the same thing for Windows only.
 
## How has this been tested?
- Tested in Shield with Windows 11 24H2 as SMB server.
- Tested also on Windows 10 22H2 based server.
- Tested on Synology NAS server to test no regressions in other cases.

Before --> prompts for user/password
After --> direct access without prompt and no needed store passwords in `passwords.xml`


## What is the effect on users?
Allow access to SMB share without prompt for user/password (only if Windows server is properly configured).

This works on Windows 11 **24H2** using SMBv3.

Is need turn Off "Password protected sharing" in Advanced network settings > Advanced sharing settings > All networks:

![Screenshot 2025-01-18 091442](https://github.com/user-attachments/assets/dad91196-a6a7-4919-9d8c-9249e359063b)

And in a shared folders Add "guest" or "everyone" user permissions.


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
