### PR TITLE
[Backport][Games] Fix handling of zip files in My Games window if vfs.libarchive is installed

### DIFF
--- a/xbmc/games/GameUtils.h
+++ b/xbmc/games/GameUtils.h
@@ -110,6 +110,11 @@ private:
   static bool Enable(const std::string& gameClient);
 
   /*!
+   * \brief Load and cache installable game add-ons
+   */
+  static void LoadInstallableAddons();
+
+  /*!
    * \brief Cache of installable game add-ons used to compute the list of
    * known game file extensions
    */

--- a/xbmc/games/windows/GUIWindowGames.cpp
+++ b/xbmc/games/windows/GUIWindowGames.cpp
@@ -18,6 +18,8 @@
 #include "dialogs/GUIDialogContextMenu.h"
 #include "dialogs/GUIDialogMediaSource.h"
 #include "dialogs/GUIDialogProgress.h"
+#include "filesystem/FileDirectoryFactory.h"
+#include "games/GameUtils.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/WindowIDs.h"
@@ -99,8 +101,11 @@ bool CGUIWindowGames::OnClickMsg(int controlId, int actionId)
     }
     case ACTION_PLAYER_PLAY:
     {
-      if (OnClick(iItem))
+      if (CanPlay(*pItem))
+      {
+        PlayGame(*pItem);
         return true;
+      }
       break;
     }
     case ACTION_SHOW_INFO:
@@ -141,23 +146,6 @@ bool CGUIWindowGames::OnClick(int iItem, const std::string& player /* = "" */)
   CFileItemPtr item = m_vecItems->Get(iItem);
   if (item)
   {
-    // Compensate for DIR_FLAG_NO_FILE_DIRS flag
-    if (URIUtils::IsArchive(item->GetPath()))
-    {
-      bool bIsGame = false;
-
-      // If zip file contains no games, assume it is a game
-      CFileItemList items;
-      if (m_rootDir.GetDirectory(CURL(item->GetPath()), items))
-      {
-        if (items.Size() == 0)
-          bIsGame = true;
-      }
-
-      if (!bIsGame)
-        item->m_bIsFolder = true;
-    }
-
     if (!item->m_bIsFolder)
     {
       PlayGame(*item);
@@ -181,7 +169,7 @@ void CGUIWindowGames::GetContextButtons(int itemNumber, CContextButtons& buttons
     }
     else
     {
-      if (item->IsGame())
+      if (CanPlay(*item))
       {
         buttons.Add(CONTEXT_BUTTON_PLAY_ITEM, 208); // Play
       }
@@ -242,6 +230,55 @@ bool CGUIWindowGames::GetDirectory(const std::string& strDirectory, CFileItemLis
 {
   if (!CGUIMediaWindow::GetDirectory(strDirectory, items))
     return false;
+
+  // Now we must account for file folders not handled by DIR_FLAG_NO_FILE_DIRS
+  for (int i = 0; i < items.Size(); ++i)
+  {
+    CFileItemPtr item = items[i];
+    if (item->m_bIsFolder || !item->IsFileFolder(EFILEFOLDER_TYPE_ALWAYS))
+      continue;
+
+    const std::string originalPath = item->GetPath();
+
+    // This will turn the item into a file folder as a side effect
+    std::unique_ptr<XFILE::IFileDirectory> pDirectory{
+        XFILE::CFileDirectoryFactory::Create(CURL{originalPath}, item.get())};
+    if (pDirectory)
+    {
+      // Check for empty file folders
+      CFileItemList fileFolderItems;
+      if (!pDirectory->GetDirectory(item->GetURL(), fileFolderItems) || fileFolderItems.IsEmpty())
+      {
+        items.Remove(i);
+        --i;
+        continue;
+      }
+
+      // Check if file folder contains games or subfolders
+      if (std::any_of(fileFolderItems.begin(), fileFolderItems.end(),
+                      [](const CFileItemPtr& fileFolderItem) {
+                        return fileFolderItem->m_bIsFolder ||
+                               CGameUtils::HasGameExtension(fileFolderItem->GetPath());
+                      }))
+      {
+        continue;
+      }
+
+      // If the file folder contains no games, turn it back into a regular file
+      item->m_bIsFolder = false;
+      item->SetPath(originalPath);
+    }
+    else
+    {
+      // File folder contains a single file and was collapsed down. Remove it
+      // if not a game.
+      if (!CGameUtils::HasGameExtension(item->GetPath()))
+      {
+        items.Remove(i);
+        --i;
+      }
+    }
+  }
 
   // Set label
   std::string label;
@@ -336,5 +373,31 @@ void CGUIWindowGames::OnItemInfo(int itemNumber)
 bool CGUIWindowGames::PlayGame(const CFileItem& item)
 {
   CFileItem itemCopy(item);
+
+  // Dereference file folders. The check here assumes all "is folder" items
+  // passed CanPlay(), e.g. are definitely file folders.
+  if (itemCopy.m_bIsFolder)
+  {
+    itemCopy.m_bIsFolder = false;
+    itemCopy.SetPath(itemCopy.GetURL().GetHostName());
+    itemCopy.GetGameInfoTag();
+  }
+
   return g_application.PlayMedia(itemCopy, "", PLAYLIST::TYPE_NONE);
+}
+
+bool CGUIWindowGames::CanPlay(const CFileItem& item) const
+{
+  if (item.IsGame())
+    return true;
+
+  if (item.m_bIsFolder)
+  {
+    // Check for file folders
+    CURL url{item.GetPath()};
+    if (url.GetFileName().empty() && URIUtils::IsZIP(url.GetHostName()))
+      return true;
+  }
+
+  return false;
 }

--- a/xbmc/games/windows/GUIWindowGames.h
+++ b/xbmc/games/windows/GUIWindowGames.h
@@ -41,6 +41,7 @@ protected:
   bool OnClickMsg(int controlId, int actionId);
   void OnItemInfo(int itemNumber);
   bool PlayGame(const CFileItem& item);
+  bool CanPlay(const CFileItem& item) const;
 
   CGUIDialogProgress* m_dlgProgress = nullptr;
 };


### PR DESCRIPTION
## Description

Backport of #26227.

## Motivation and context

Reported here: https://forum.kodi.tv/showthread.php?tid=379996

Little late for a v21.2 backport, but it only affects the My Games window.

## How has this been tested?

Included in latest round of test builds: https://github.com/garbear/xbmc/releases/tag/retroplayer-21.1-20250104

## What is the effect on users?

* Fixed playing roms from within zip files if vfs.libarchive is installed

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
