### PR TITLE
[Android] Replace the use of the hidden method getPath() with the pub…

### DIFF
--- a/xbmc/platform/android/storage/AndroidStorageProvider.cpp
+++ b/xbmc/platform/android/storage/AndroidStorageProvider.cpp
@@ -174,7 +174,7 @@ void CAndroidStorageProvider::GetRemovableDrives(std::vector<CMediaSource>& remo
       for (int i = 0; i < vols.size(); ++i)
       {
         CJNIStorageVolume vol = vols.get(i);
-        // CLog::Log(LOGDEBUG, "-- Volume: {}({}) -- {}", vol.getPath(), vol.getUserLabel(), vol.getState());
+        // CLog::Log(LOGDEBUG, "-- Volume: {}({}) -- {}", vol.getDirectory().getAbsolutePath(), vol.getUserLabel(), vol.getState());
 
         bool removable = vol.isRemovable();
         if (xbmc_jnienv()->ExceptionCheck())
@@ -198,7 +198,7 @@ void CAndroidStorageProvider::GetRemovableDrives(std::vector<CMediaSource>& remo
         {
           CMediaSource share;
 
-          share.strPath = vol.getPath();
+          share.strPath = vol.getDirectory().getAbsolutePath();
           if (xbmc_jnienv()->ExceptionCheck())
           {
             xbmc_jnienv()->ExceptionDescribe();


### PR DESCRIPTION
…lic alternative method getDirectory()

See warning message on logcat:
```
W org.xbmc.kodi: Accessing hidden method Landroid/os/storage/StorageVolume;->getPath()Ljava/lang/String; (max-target-q,test-api, JNI, denied)
W org.xbmc.kodi: If this is a platform test consider enabling VMRuntime.ALLOW_TEST_API_ACCESS change id for this package.
W System.err: java.lang.NoSuchMethodError: no non-static method "Landroid/os/storage/StorageVolume;.getPath()Ljava/lang/String;"
...
```

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
