### PR TITLE
[VideoInfoScanner] Avoid duplicate calls to scraper to get season art

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -682,7 +682,8 @@ CVideoInfoScanner::CVideoInfoScanner()
 
         if (fetchEpisodes)
         {
-          InfoRet ret = RetrieveInfoForEpisodes(pItem, lResult, info2, useLocal, pDlgProgress);
+          InfoRet ret =
+              RetrieveInfoForEpisodes(pItem, lResult, info2, useLocal, pDlgProgress, true);
           if (ret == InfoRet::ADDED)
           {
             m_database.SetPathHash(pItem->GetPath(), pItem->GetProperty("hash").asString());
@@ -712,7 +713,7 @@ CVideoInfoScanner::CVideoInfoScanner()
     }
     if (fetchEpisodes)
     {
-      InfoRet ret = RetrieveInfoForEpisodes(pItem, lResult, info2, useLocal, pDlgProgress);
+      InfoRet ret = RetrieveInfoForEpisodes(pItem, lResult, info2, useLocal, pDlgProgress, true);
       if (ret == InfoRet::ADDED)
         m_database.SetPathHash(pItem->GetPath(), pItem->GetProperty("hash").asString());
     }
@@ -904,7 +905,8 @@ CVideoInfoScanner::CVideoInfoScanner()
                                                                    long showID,
                                                                    const ADDON::ScraperPtr& scraper,
                                                                    bool useLocal,
-                                                                   CGUIDialogProgress* progress)
+                                                                   CGUIDialogProgress* progress,
+                                                                   bool alreadyHasArt /* = false */)
   {
     // enumerate episodes
     EPISODELIST files;
@@ -925,19 +927,12 @@ CVideoInfoScanner::CVideoInfoScanner()
       std::map<int, std::map<std::string, std::string>> seasonArt;
       m_database.GetTvShowSeasonArt(showID, seasonArt);
 
-      bool updateSeasonArt = false;
-      for (std::map<int, std::map<std::string, std::string>>::const_iterator i = seasonArt.begin(); i != seasonArt.end(); ++i)
-      {
-        if (i->second.empty())
-        {
-          updateSeasonArt = true;
-          break;
-        }
-      }
-
+      const bool updateSeasonArt{
+          alreadyHasArt ||
+          std::ranges::any_of(seasonArt, [](const auto& i) { return i.second.empty(); })};
       if (updateSeasonArt)
       {
-        if (!item->IsPlugin() || scraper->ID() != "metadata.local")
+        if (!alreadyHasArt && !item->IsPlugin() && scraper->ID() != "metadata.local")
         {
           CVideoInfoDownloader loader(scraper);
           loader.GetArtwork(showInfo);

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -133,7 +133,8 @@ namespace KODI::VIDEO
                                     long showID,
                                     const ADDON::ScraperPtr& scraper,
                                     bool useLocal,
-                                    CGUIDialogProgress* progress = nullptr);
+                                    CGUIDialogProgress* progress = nullptr,
+                                    bool alreadyHasArt = false);
 
     /*! \brief Update the progress bar with the heading and line and check for cancellation
      \param progress CGUIDialogProgress bar


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Whilst looking at a related issue I noticed that in the following block of code in `RetrieveInfoForEpisodes()` the season art is already in the database, and retrieved by `GetTvShowSeasonArt()`

![image](https://github.com/user-attachments/assets/104e45af-24ca-4c2b-8338-a3d4ed74b6ab)

The test looking at `SeasonArt` to set the `updateSeasonArt` flag nearly always fails as there is often no season 0 (specials) art and/or season -1 (all seasons) art.

![image](https://github.com/user-attachments/assets/5a24993f-c06d-49eb-aa3e-90cda6c099bf)

Looking further there are 4 instances where `RetrieveInfoForEpisodes()` is called, before 2 of them `GetDetails()` is called before `RetrieveInfoForEpisodes()` so the `VideoInfoTag()` is already populated with season art from scraper which is written to the database by `AddVideo()`.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The additional call to `loader.GetArtwork()` above is unneeded and wastes time.

I've added a flag to show that art has already been scraped.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Running (in debug mode in visual studio) with and without the flag there are 729 entries in the `art` table in each case.

Before - From the logs (for 3 runs starting with a blank database)
```
2025-01-08 00:48:15.739 T:14900    info <general>: VideoInfoScanner: Finished scan. Scanning for video info took 147844 ms
2025-01-08 00:53:33.770 T:23712    info <general>: VideoInfoScanner: Finished scan. Scanning for video info took 150676 ms
2025-01-08 00:59:19.378 T:39720    info <general>: VideoInfoScanner: Finished scan. Scanning for video info took 205548 ms
```

After
```
2025-01-08 00:34:58.194 T:41644    info <general>: VideoInfoScanner: Finished scan. Scanning for video info took 138886 ms
2025-01-08 00:39:00.671 T:22176    info <general>: VideoInfoScanner: Finished scan. Scanning for video info took 96909 ms
2025-01-08 00:43:15.235 T:6396     info <general>: VideoInfoScanner: Finished scan. Scanning for video info took 117653 ms
```

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Faster library scans.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
