### PR TITLE
[DVDInputStreamBluray] fix multithreading issue in read_blocks callback

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -45,17 +45,10 @@ using namespace std::chrono_literals;
 
 static int read_blocks(void* handle, void* buf, int lba, int num_blocks)
 {
-  int result = -1;
-  CDVDInputStreamFile* lpstream = reinterpret_cast<CDVDInputStreamFile*>(handle);
-  int64_t offset = static_cast<int64_t>(lba) * 2048;
-  if (lpstream->Seek(offset, SEEK_SET) >= 0)
-  {
-    int64_t size = static_cast<int64_t>(num_blocks) * 2048;
-    if (size <= std::numeric_limits<int>::max())
-      result = lpstream->Read(reinterpret_cast<uint8_t*>(buf), static_cast<int>(size)) / 2048;
-  }
-
-  return result;
+  CDVDInputStreamBluray* blurayStream = reinterpret_cast<CDVDInputStreamBluray*>(handle);
+  if (!blurayStream)
+    return -1;
+  return blurayStream->ReadBlocks(reinterpret_cast<uint8_t*>(buf), lba, num_blocks);
 }
 
 static void bluray_overlay_cb(void *this_gen, const BD_OVERLAY * ov)
@@ -230,7 +223,7 @@ bool CDVDInputStreamBluray::Open()
 
   if (openStream)
   {
-    if (!bd_open_stream(m_bd, m_pstream.get(), read_blocks))
+    if (!bd_open_stream(m_bd, this, read_blocks))
     {
       CLog::Log(LOGERROR, "CDVDInputStreamBluray::Open - failed to open {} in stream mode",
                 CURL::GetRedacted(root));
@@ -692,6 +685,23 @@ int CDVDInputStreamBluray::Read(uint8_t* buf, int buf_size)
     result = bd_read(m_bd, buf, buf_size);
     while (bd_get_event(m_bd, &m_event))
       ProcessEvent();
+  }
+  return result;
+}
+
+int CDVDInputStreamBluray::ReadBlocks(uint8_t* buf, int lba, int num_blocks)
+{
+  CDVDInputStreamFile* lpstream = m_pstream.get();
+  if (!lpstream)
+    return -1;
+  int result = -1;
+  int64_t offset = static_cast<int64_t>(lba) * 2048;
+  std::unique_lock<CCriticalSection> lock(m_readBlocksLock);
+  if (lpstream->Seek(offset, SEEK_SET) >= 0)
+  {
+    int64_t size = static_cast<int64_t>(num_blocks) * 2048;
+    if (size <= std::numeric_limits<int>::max())
+      result = lpstream->Read(buf, static_cast<int>(size)) / 2048;
   }
   return result;
 }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -57,6 +57,7 @@ public:
   bool Open() override;
   void Close() override;
   int Read(uint8_t* buf, int buf_size) override;
+  int ReadBlocks(uint8_t* buf, int lba, int num_blocks);
   int64_t Seek(int64_t offset, int whence) override;
   void Abort() override;
   bool IsEOF() override;
@@ -189,4 +190,7 @@ protected:
 
     /*! Bluray state serializer handler */
     CBlurayStateSerializer m_blurayStateSerializer;
+
+    /* used during bd_open_stream read block*/
+    CCriticalSection m_readBlocksLock;
 };


### PR DESCRIPTION
## Description
Fix multithreading issue in read_blocks callback when using bd_open_stream.

When I play bluray iso files in BD-J mode and enter the menu for the first time, the menu items often cannot be displayed. I think there may be a problem with I/O reading. 

I added some test code to print the hash of the current thread id in the read_blocks callback method, and found that there are indeed hashes of multiple threads. I compared it with the source code of VLC : [vlc code](https://github.com/videolan/vlc/blob/a39444d484b07fdd22b4583986fe3097854e3043/modules/access/bluray.c#L664) found that a mutex lock is required here to ensure multi-thread synchronization.

test code  print thread hash added in read_blocks：
```
static int read_blocks(void* handle, void* buf, int lba, int num_blocks)
{
  //test code start
  std::thread::id tid = std::this_thread::get_id();
  std::hash<std::thread::id> hasher;
  int thread_id = hasher(tid);
  CLog::Log(LOGDEBUG, "read_blocks thread: {}", thread_id);
  //test code end

  int result = -1;
  CDVDInputStreamFile* lpstream = reinterpret_cast<CDVDInputStreamFile*>(handle);
  int64_t offset = static_cast<int64_t>(lba) * 2048;
  if (lpstream->Seek(offset, SEEK_SET) >= 0)
  {
    int64_t size = static_cast<int64_t>(num_blocks) * 2048;
    if (size <= std::numeric_limits<int>::max())
      result = lpstream->Read(reinterpret_cast<uint8_t*>(buf), static_cast<int>(size)) / 2048;
  }

  return result;
}
```
the test code print multi hashes:
```
2025-01-08 09:23:27.487 14838-15095/org.xbmc.kodi D/Kodi: 2025-01-08 09:23:27.487 T:15095   debug <general>: read_blocks thread: -1701330496
2025-01-08 09:23:27.512 14838-15095/org.xbmc.kodi D/Kodi: 2025-01-08 09:23:27.512 T:15095   debug <general>: read_blocks thread: -1701330496
2025-01-08 09:23:27.513 14838-15095/org.xbmc.kodi D/Kodi: 2025-01-08 09:23:27.513 T:15095   debug <general>: read_blocks thread: -1701330496
2025-01-08 09:23:27.513 14838-15095/org.xbmc.kodi D/Kodi: 2025-01-08 09:23:27.513 T:15095   debug <general>: read_blocks thread: -1701330496
2025-01-08 09:23:27.515 14838-15095/org.xbmc.kodi D/Kodi: 2025-01-08 09:23:27.515 T:15095   debug <general>: read_blocks thread: -1701330496
2025-01-08 09:23:27.515 14838-15095/org.xbmc.kodi D/Kodi: 2025-01-08 09:23:27.515 T:15095   debug <general>: read_blocks thread: -1701330496
2025-01-08 09:23:27.537 14838-15100/org.xbmc.kodi D/Kodi: 2025-01-08 09:23:27.537 T:15100   debug <general>: read_blocks thread: -1708408384
2025-01-08 09:23:27.537 14838-15100/org.xbmc.kodi D/Kodi: 2025-01-08 09:23:27.537 T:15100   debug <general>: read_blocks thread: -1708408384
2025-01-08 09:23:27.539 14838-15100/org.xbmc.kodi D/Kodi: 2025-01-08 09:23:27.538 T:15100   debug <general>: read_blocks thread: -1708408384
2025-01-08 09:23:27.539 14838-15100/org.xbmc.kodi D/Kodi: 2025-01-08 09:23:27.539 T:15100   debug <general>: read_blocks thread: -1708408384
2025-01-08 09:23:27.540 14838-15100/org.xbmc.kodi D/Kodi: 2025-01-08 09:23:27.540 T:15100   debug <general>: read_blocks thread: -1708408384
2025-01-08 09:23:28.381 14838-14952/org.xbmc.kodi D/Kodi: 2025-01-08 09:23:28.381 T:14952   debug <general>: read_blocks thread: -1274003008
2025-01-08 09:23:28.382 14838-14952/org.xbmc.kodi D/Kodi: 2025-01-08 09:23:28.382 T:14952   debug <general>: read_blocks thread: -1274003008
```

## Motivation and context
Fix this multithread synchronization issue to ensure BD-J menus can be displayed correctly.

## How has this been tested?
Can be tested in Android App，play bluray iso in BD-J mode and enter the menu .

It is easy for menu items to not be displayed when first time enter the menu.

## What is the effect on users?
Ensure that users can see the menu items normally when playing Blu-Ray ISO

## Screenshots (if appropriate):
menu issue video:

https://github.com/user-attachments/assets/4050a5c6-3bff-46b2-8bb0-bb805b273764

after fix the result video:

https://github.com/user-attachments/assets/8e4291d8-f313-4e8e-affd-038f28e3e89f



## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [ ] All new and existing tests passed
