### PR TITLE
AESinkAudioTrack: Backport fixes from Piers

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -1207,12 +1207,7 @@ void CActiveAESink::SetSilenceTimer()
     m_extSilenceTimeout = XbmcThreads::EndTime<decltype(m_extSilenceTimeout)>::Max();
   else if (m_extAppFocused) // handles no playback/GUI and playback in pause and seek
   {
-    // only true with AudioTrack RAW + passthrough + TrueHD
-    const bool noSilenceOnPause =
-        !m_needIecPack && m_requestedFormat.m_dataFormat == AE_FMT_RAW &&
-        m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD;
-
-    m_extSilenceTimeout = (noSilenceOnPause) ? 0ms : m_silenceTimeOut;
+    m_extSilenceTimeout = m_silenceTimeOut;
   }
   else
   {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -811,23 +811,34 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
   if (!IsInitialized())
     return INT_MAX;
 
-  // If the sink did not move twice the buffer size in time it was opened
+  // If the sink did not move twice the buffer size at least 400 ms in time it was opened
   // take action. Some sinks open with e.g. 128 ms nicely but under the
   // hood need a bit more samples to start moving on sink start.
-  // Simple equation: N x stime packages in ms > 2 configured audiotrack_buffer in ms
+  // Simple equation: N x stime packages in ms > 400 ms or 2 buffer sizes in ms
   // will result in the error condition triggering.
 
   const bool isRawPt = m_passthrough && !m_info.m_wantsIECPassthrough;
+  bool forceBlock = false;
   if (!isRawPt)
   {
-    const double max_stuck_delay_ms = m_audiotrackbuffer_sec_orig * 2000.0;
+    const double max_stuck_delay_ms = std::max((m_audiotrackbuffer_sec_orig * 2000.0), 400.0);
     const double stime_ms = 1000.0 * frames / m_format.m_sampleRate;
 
-    if (m_superviseAudioDelay && (m_stuckCounter * stime_ms > max_stuck_delay_ms))
+    if (m_superviseAudioDelay)
     {
-      CLog::Log(LOGERROR, "Sink got stuck with {:f} ms - ask AE for reopening", max_stuck_delay_ms);
-      usleep(max_stuck_delay_ms * 1000);
-      return INT_MAX;
+      if (m_stuckCounter * stime_ms > max_stuck_delay_ms)
+      {
+        CLog::Log(LOGERROR, "Sink got stuck with {:f} ms - ask AE for reopening",
+                  max_stuck_delay_ms);
+        usleep(max_stuck_delay_ms * 1000);
+        return INT_MAX;
+      }
+      else if (m_stuckCounter * stime_ms >= m_audiotrackbuffer_sec_orig * 1000.0)
+      {
+        CLog::LogF(LOGDEBUG, "Sink filling too fast - throttleing - Fillstate: {} ms!",
+                   (m_stuckCounter * stime_ms));
+        forceBlock = true;
+      }
     }
   }
 
@@ -938,6 +949,16 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
         extra_sleep_ms = 0.0;
         CLog::Log(LOGDEBUG, "Resetting pause bursts as buffer level was reached! (1)");
       }
+    }
+  }
+  if (forceBlock)
+  {
+    // Sink consumes too fast - block the frames minus they needed to add
+    double extra_sleep_ms = (1000.0 * frames / m_format.m_sampleRate) - time_to_add_ms;
+    if (extra_sleep_ms > 0.0)
+    {
+      CLog::LogF(LOGDEBUG, "Extra Sleeping for {:f}", extra_sleep_ms);
+      usleep(extra_sleep_ms * 1000);
     }
   }
   return written_frames;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -940,18 +940,6 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
       }
     }
   }
-  else
-  {
-    // waiting should only be done if sink is not run dry
-    double period_time = m_format.m_frames / static_cast<double>(m_sink_sampleRate);
-    if (m_delay >= (m_audiotrackbuffer_sec - period_time))
-    {
-      double time_should_ms = 1000.0 * written_frames / m_format.m_sampleRate;
-      double time_off = time_should_ms - time_to_add_ms;
-      if (time_off > 0)
-        usleep(time_off * 500); // sleep half the error on average away
-    }
-  }
   return written_frames;
 }
 


### PR DESCRIPTION
Backport tested Audiotrack changes from Piers.

Fixes DTS-HD-MA resume on RAW
Removes wrong sleeping as AudioHAL does not block depending on periods
Extendes the advancedsettings use-case for superviseaudiodelay