### PR TITLE
Revert "AESinkAudioTrack: Stop pseudo blocking for IEC"

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -955,6 +955,18 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
       }
     }
   }
+  else
+  {
+    // waiting should only be done if sink is not run dry
+    double period_time = m_format.m_frames / static_cast<double>(m_sink_sampleRate);
+    if (m_delay >= (m_audiotrackbuffer_sec - period_time))
+    {
+      double time_should_ms = 1000.0 * written_frames / m_format.m_sampleRate;
+      double time_off = time_should_ms - time_to_add_ms;
+      if (time_off > 0)
+        usleep(time_off * 500); // sleep half the error on average away
+    }
+  }
   if (forceBlock)
   {
     // Sink consumes too fast - block the frames minus they needed to add

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -970,6 +970,9 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
   if (forceBlock)
   {
     // Sink consumes too fast - block the frames minus they needed to add
+    // update time to add, so that above else case won't make us sleep twice the amount for the
+    // superviseaudiodelay use-case.
+    time_to_add_ms = 1000.0 * (CurrentHostCounter() - startTime) / CurrentHostFrequency();
     double extra_sleep_ms = (1000.0 * frames / m_format.m_sampleRate) - time_to_add_ms;
     if (extra_sleep_ms > 0.0)
     {


### PR DESCRIPTION
This reverts commit 2a82307451da641d32f11ce9ebe0cf277078b454.

Reasoning:
When a new sink starts, this happens when a new video file is opened or when a channel switch happens. AudioEngine fills the entire buffers as fast as it can with the AddPacket in the sink NOT YET blocking. This will cause far too much data filled into the sink before the underlaying HAL / etc. is ready. So AE runs out of buffers in livetv for audio quite naturally.

I did not get a report of this regression before. But now that I got one - things are quite clear.

I will try to generailize this code a bit more to be useful for RAW, IEC and PCM shortly.