### PR TITLE
[Android] Extending the use of Fileprovider to removable storage

### DIFF
--- a/tools/android/packaging/xbmc/res/xml/file_paths.xml
+++ b/tools/android/packaging/xbmc/res/xml/file_paths.xml
@@ -1,3 +1,4 @@
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
    <external-path name="external" path="/"/>
+   <root-path name="storage-path" path="/storage/"/>
 </paths>

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1036,11 +1036,7 @@ bool CXBMCApp::StartActivity(const std::string& package,
     // decoded path or null if this is not a hierarchical URI
     const std::string pathname = jniURI.getPath();
 
-    // path to shared/external storage volume
-    std::string extpath;
-
-    if (!pathname.empty() && CAndroidStorageProvider::GetExternalStorage(extpath) &&
-        !extpath.empty() && StringUtils::StartsWith(pathname, extpath))
+    if (!pathname.empty() && StringUtils::StartsWith(pathname, "/storage/"))
     {
       // generate a content URI
       jniURI = CJNIFileProvider::getUriForFile(CXBMCApp::Get(), "org.xbmc.kodi.fileprovider",


### PR DESCRIPTION
## Description
According to the Fileprovider documentation it's only possible to use it with files stored on primary storage volume (path: `/storage/emulated/0/`).

Using the undocumented `<root-path>` element, it's possible to extend its use to directories in other storage areas.

This PR extends the use of Fileprovider to files on external secondary volumes (path: `/storage/`). 

## Motivation and context
Add more use cases to https://github.com/xbmc/xbmc/pull/26051

## How has this been tested?
Tested playing the video `/storage/1F02-0F18/sample.mp4` with an external player. 
The generated URI is `content://org.xbmc.kodi.fileprovider/storage-path/1F02-0F18/sample.mp4`

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
