### PR TITLE
[MUSIC][AUDIOBOOKS] Fix some mka albums not showing correct length for last …

### DIFF
--- a/xbmc/filesystem/AudioBookFileDirectory.cpp
+++ b/xbmc/filesystem/AudioBookFileDirectory.cpp
@@ -56,6 +56,10 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
   std::string author;
   std::string album;
 
+  const int end_time_m4b_file =
+      m_fctx->streams[0]->duration * av_q2d(m_fctx->streams[0]->time_base);
+  const int end_time_mka_file = m_fctx->duration * av_q2d(av_get_time_base_q());
+
   AVDictionaryEntry* tag=nullptr;
   while ((tag = av_dict_get(m_fctx->metadata, "", tag, AV_DICT_IGNORE_SUFFIX)))
   {
@@ -108,7 +112,6 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
                                                        av_q2d(m_fctx->chapters[i]->time_base)));
     item->SetEndOffset(CUtil::ConvertSecsToMilliSecs(m_fctx->chapters[i]->end *
                                                      av_q2d(m_fctx->chapters[i]->time_base)));
-    int compare = m_fctx->streams[0]->duration * av_q2d(m_fctx->streams[0]->time_base);
     if (item->GetEndOffset() < 0 ||
         item->GetEndOffset() > CUtil::ConvertMilliSecsToSecs(m_fctx->duration))
     {
@@ -117,9 +120,9 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
             m_fctx->chapters[i + 1]->start * av_q2d(m_fctx->chapters[i + 1]->time_base)));
       else
       {
-        item->SetEndOffset(m_fctx->duration); // mka file
+        item->SetEndOffset(CUtil::ConvertSecsToMilliSecs(end_time_mka_file)); // mka file
         if (item->GetEndOffset() < 0)
-          item->SetEndOffset(CUtil::ConvertSecsToMilliSecs(compare)); // m4b file
+          item->SetEndOffset(CUtil::ConvertSecsToMilliSecs(end_time_m4b_file)); // m4b file
       }
     }
     item->GetMusicInfoTag()->SetDuration(


### PR DESCRIPTION
…track

## Description
This fixes an issue with some mka files where the ending time of each chapter is not stored in the chapter info.  Kodi already calculates the correct end time by using the start time of the next chapter, however it didn't correctly calculate the end time for the last chapter.

For mka files where the chapter info includes both start and end times, this wasn't an issue.

I also took the opportunity to move the variables out of the for loop and make them `const`.  Only need to calculate the correct length once.

## Motivation and context
Brought to my attention by @HomerJau [here](https://github.com/xbmc/xbmc/pull/26143#issuecomment-2567210993)
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Tested locally with mka files that do and don't contain chapter end time info

<ins>mka file with chapter end times</ins>

<sub>Chapter 0: Start time 0 : End time 663663000000
Chapter 6: Start time 2947569625000 : End time 3426690000000
end_time_m4b_file -2147483648 
end_time_mka_file 3426</sub>

<ins>mka file without chapter end times</ins>

<sub>Chapter 0: Start time 0 : End time -9223372036854775808
Chapter 4: Start time 2417415000000 : End time -9223372036854775808
end_time_m4b_file -2147483648 
end_time_mka_file 2511</sub>

<ins>m4b files not affected</ins>

<sub>Chapter 0: Start time 0 : End time 97816575
end_time_m4b_file 59482 
end_time_mka_file -2147483648</sub>
## What is the effect on users?
Fixes an issue with mka albums where the length of the last track was not calculated correctly in some circumstances.
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

Before

![before](https://github.com/user-attachments/assets/546c11ee-c0fa-4d4b-b64b-8736d90a3e02)

After

![after](https://github.com/user-attachments/assets/886b259e-bcca-4426-9cc3-04888f406952)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
