### PR TITLE
File: fix CFileStreamBuffer conditions after e13c564

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -48,6 +48,8 @@ bool CDVDInputStreamFile::Open()
   // If this file is audio and/or video (= not a subtitle) flag to caller
   if (!VIDEO::IsSubtitle(m_item))
     flags |= READ_AUDIO_VIDEO;
+  else
+    flags |= READ_NO_BUFFER; // disable CFileStreamBuffer for subtitles
 
   std::string content = m_item.GetMimeType();
 

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -391,7 +391,7 @@ bool CFile::ShouldUseStreamBuffer(const CURL& url)
   if (m_flags & READ_NO_BUFFER)
     return false;
 
-  if (m_flags & READ_AUDIO_VIDEO)
+  if (m_flags & READ_AUDIO_VIDEO || m_pFile->GetChunkSize() > 0)
     return true;
 
   // file size > 200 MB but not in optical disk


### PR DESCRIPTION
## Description
File: fix CFileStreamBuffer conditions after e13c564

Fix: https://forum.kodi.tv/showthread.php?tid=380052

## Motivation and context
Logic `m_pFile->GetChunkSize() > 0` removed by accident in https://github.com/xbmc/xbmc/pull/25158

Note that SMB always make use of chunk size 64 KB, 128 KB, etc. even for directory listings and any file type. In this case was affecting slow list contents although in other systems went unnoticed.

This logic has always been present e.g. Nexus:

https://github.com/xbmc/xbmc/blob/4b95737efaddf7c869736e539318f18433413ff1/xbmc/filesystem/File.cpp#L363-L367

Then there should be no problem adding it again.

## How has this been tested?
User has confirmed in forum it works:

> Yeah I can confirm kodi-20250108-f934761e-fix-chunk-armeabi-v7a also fixes the issue.

https://forum.kodi.tv/showthread.php?tid=380052&pid=3221455#pid3221455

The other issues (connection to other host / HP Deskjet on port 3911) seems unrelated and unknown at this time...

In any case what this PR fixes is "slow SMB directory listings".


## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
