### PR TITLE
[pvr] Channel group selection dialog: Fix initial selection not set to currently active group.

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -410,24 +410,17 @@ bool CGUIWindowPVRBase::OpenChannelGroupSelectionDialog()
   dialog->Reset();
   dialog->SetHeading(CVariant{g_localizeStrings.Get(19146)});
   dialog->SetMultiSelection(false);
+  dialog->SetItems(options);
 
   auto& pvrMgr = CServiceBroker::GetPVRManager();
   const bool useDetails = pvrMgr.Clients()->CreatedClientAmount() > 1;
   dialog->SetUseDetails(useDetails);
   if (useDetails)
   {
-    std::string selectedName;
-    std::string selectedClient;
-
+    std::string selectedGroup;
     const std::shared_ptr<const CPVRChannelGroup> channelGroup = GetChannelGroup();
     if (channelGroup)
-    {
-      selectedName = channelGroup->GroupName();
-
-      auto client = pvrMgr.GetClient(channelGroup->GetClientID());
-      if (client)
-        selectedClient = client->GetFullClientName();
-    }
+      selectedGroup = channelGroup->GetPath();
 
     CPVRThumbLoader loader;
     int idx = 0;
@@ -444,7 +437,7 @@ bool CGUIWindowPVRBase::OpenChannelGroupSelectionDialog()
       // if not yet done, find and select currently active channel group
       if (idx >= 0)
       {
-        if (group->GetLabel() == selectedName && group->GetLabel2() == selectedClient)
+        if (group->GetPath() == selectedGroup)
         {
           dialog->SetSelected(idx);
           idx = -1; // done
@@ -462,11 +455,11 @@ bool CGUIWindowPVRBase::OpenChannelGroupSelectionDialog()
     if (channelGroup)
     {
       int idx = -1;
-      const std::string selectedName = channelGroup->GroupName();
+      const std::string selectedGroup{channelGroup->GetPath()};
       for (auto& group : options)
       {
         // select currently active channel group
-        if (group->GetLabel() == selectedName)
+        if (group->GetPath() == selectedGroup)
         {
           dialog->SetSelected(idx);
           break;
@@ -475,8 +468,6 @@ bool CGUIWindowPVRBase::OpenChannelGroupSelectionDialog()
       }
     }
   }
-
-  dialog->SetItems(options);
 
   dialog->Open();
 


### PR DESCRIPTION
Fixes #26269 

Runtime-tested on macOS, latest Kodi master.

@phunkyfish could you please review.