### PR TITLE
[Video] Various fixes for bluray:// paths (menu and information related) and associated code refactoring (2/4).

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1360,7 +1360,7 @@ bool CFileItem::IsSamePath(const CFileItem *item) const
     if (item->HasProperty("item_start") || HasProperty("item_start"))
       return (item->GetProperty("item_start") == GetProperty("item_start"));
     // See if we have associated a bluray playlist
-    if (VIDEO::IsBlurayPlaylist(*this) || VIDEO::IsBlurayPlaylist(*item))
+    if (URIUtils::IsBlurayPath(GetDynPath()) || URIUtils::IsBlurayPath(item->GetDynPath()))
       return (GetDynPath() == item->GetDynPath());
     return true;
   }
@@ -1984,8 +1984,9 @@ std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
     return GetLocalMetadataPath();
 
   if (bUseFolderNames &&
-     (!m_bIsFolder || URIUtils::IsInArchive(m_strPath) ||
-     (HasVideoInfoTag() && GetVideoInfoTag()->m_iDbId > 0 && !CMediaTypes::IsContainer(GetVideoInfoTag()->m_type))))
+      (!m_bIsFolder || URIUtils::IsInArchive(m_strPath) || URIUtils::IsBlurayPath(m_strPath) ||
+       (HasVideoInfoTag() && GetVideoInfoTag()->m_iDbId > 0 &&
+        !CMediaTypes::IsContainer(GetVideoInfoTag()->m_type))))
   {
     std::string name2(strMovieName);
     URIUtils::GetParentPath(name2,strMovieName);

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2443,7 +2443,7 @@ bool CApplication::PlayFile(CFileItem item,
   // a disc image might be Blu-Ray disc
   if (!(options.startpercent > 0.0 || options.starttime > 0.0) &&
       (VIDEO::IsBDFile(item) || item.IsDiscImage() ||
-       (forceSelection && VIDEO::IsBlurayPlaylist(item))))
+       (forceSelection && URIUtils::IsBlurayPath(item.GetDynPath()))))
   {
     // No video selection when using external or remote players (they handle it if supported)
     const bool isSimpleMenuAllowed = [&]()

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -150,7 +150,8 @@ bool CDVDInputStreamBluray::Open()
     openDisc = VIDEO::IsProtectedBlurayDisc(base);
 
     // check for a menu call for an image file
-    if (StringUtils::EqualsNoCase(filename, "menu"))
+    if (StringUtils::EqualsNoCase(filename, "menu") &&
+        !(m_item.GetStartOffset() == STARTOFFSET_RESUME && m_item.IsResumable()))
     {
       //get rid of the udf:// protocol
       CURL url2(root);

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -57,7 +57,7 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item, bool forceSelectio
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_DISC_PLAYBACK) != BD_PLAYBACK_SIMPLE_MENU)
     return true;
 
-  if (forceSelection && VIDEO::IsBlurayPlaylist(item))
+  if (forceSelection && URIUtils::IsBlurayPath(item.GetDynPath()))
   {
     item.SetProperty("save_dyn_path", item.GetDynPath()); // save for screen refresh later
     item.SetDynPath(URIUtils::GetBlurayFile(item.GetDynPath()));

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -235,6 +235,22 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     hints.flags = m_flags;
     if (!CDirectory::GetDirectory(url2, items, hints))
       return false;
+
+    // Found items will have underlying protocol (eg. udf:// or smb://)
+    // in path so add back bluray://
+    // (so properly recognised in cache as bluray:// files for CFile:Exists() etc..)
+    CURL url3{url};
+    for (const auto& item : items)
+    {
+      const CURL url4{item->GetPath()};
+      url3.SetFileName(url4.GetFileName());
+      item->SetPath(url3.Get());
+    }
+
+    url3.SetFileName("menu");
+    const std::shared_ptr<CFileItem> item{std::make_shared<CFileItem>()};
+    item->SetPath(url3.Get());
+    items.Add(item);
   }
 
   items.AddSortMethod(SortByTrackNumber,  554, LABEL_MASKS("%L", "%D", "%L", ""));    // FileName, Duration | Foldername, empty

--- a/xbmc/filesystem/BlurayFile.cpp
+++ b/xbmc/filesystem/BlurayFile.cpp
@@ -12,24 +12,30 @@
 
 #include <assert.h>
 
-namespace XFILE
+using namespace XFILE;
+
+CBlurayFile::CBlurayFile(void) : COverrideFile(false)
 {
+}
 
-  CBlurayFile::CBlurayFile(void)
-    : COverrideFile(false)
-  { }
+CBlurayFile::~CBlurayFile(void) = default;
 
-  CBlurayFile::~CBlurayFile(void) = default;
+std::string CBlurayFile::TranslatePath(const CURL& url)
+{
+  assert(url.IsProtocol("bluray"));
 
-  std::string CBlurayFile::TranslatePath(const CURL& url)
-  {
-    assert(url.IsProtocol("bluray"));
+  std::string host = url.GetHostName();
+  const std::string& filename = url.GetFileName();
+  if (host.empty() || filename.empty())
+    return "";
 
-    std::string host = url.GetHostName();
-    const std::string& filename = url.GetFileName();
-    if (host.empty() || filename.empty())
-      return "";
+  return host.append(filename);
+}
 
-    return host.append(filename);
-  }
-} /* namespace XFILE */
+bool CBlurayFile::Exists(const CURL& url)
+{
+  const CURL baseUrl{TranslatePath(url)};
+  if (baseUrl.GetFileName() == "menu")
+    return true;
+  return CFile::Exists(baseUrl);
+}

--- a/xbmc/filesystem/BlurayFile.h
+++ b/xbmc/filesystem/BlurayFile.h
@@ -19,6 +19,8 @@ namespace XFILE
     CBlurayFile();
     ~CBlurayFile() override;
 
+    bool Exists(const CURL& url) override;
+
   protected:
     std::string TranslatePath(const CURL& url) override;
   };

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -46,8 +46,9 @@ void CSaveFileState::DoWork(CFileItem& item,
     progressTrackingFile =
         item.GetVideoInfoTag()
             ->m_strFileNameAndPath; // this variable contains removable:// suffixed by disc label+uniqueid or is empty if label not uniquely identified
-  else if (IsBlurayPlaylist(item) && (item.GetVideoContentType() == VideoDbContentType::MOVIES ||
-                                      item.GetVideoContentType() == VideoDbContentType::EPISODES))
+  else if (URIUtils::IsBlurayPath(item.GetDynPath()) &&
+           (item.GetVideoContentType() == VideoDbContentType::MOVIES ||
+            item.GetVideoContentType() == VideoDbContentType::EPISODES))
     progressTrackingFile = item.GetDynPath();
   else if (item.HasVideoInfoTag() && IsVideoDb(item))
     progressTrackingFile =

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -330,6 +330,17 @@ bool URIUtils::GetParentPath(const std::string& strPath, std::string& strParent)
     strFile = url.GetHostName();
     return GetParentPath(strFile, strParent);
   }
+  else if (url.IsProtocol("bluray"))
+  {
+    const CURL url2(url.GetHostName()); // strip bluray://
+    if (url2.IsProtocol("udf"))
+    {
+      strFile = url2.GetHostName(); // strip udf://
+      return GetParentPath(strFile, strParent);
+    }
+    strParent = url2.Get();
+    return true;
+  }
   else if (url.IsProtocol("stack"))
   {
     CStackDirectory dir;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -6704,10 +6704,9 @@ int CVideoDatabase::GetPlayCount(const std::string& strFilenameAndPath)
 
 int CVideoDatabase::GetPlayCount(const CFileItem &item)
 {
-  if (IsBlurayPlaylist(item))
+  if (URIUtils::IsBlurayPath(item.GetDynPath()))
     return GetPlayCount(GetFileId(item.GetDynPath()));
-  else
-    return GetPlayCount(GetFileId(item));
+  return GetPlayCount(GetFileId(item));
 }
 
 CDateTime CVideoDatabase::GetLastPlayed(int iFileId)
@@ -6778,7 +6777,7 @@ void CVideoDatabase::UpdateFanart(const CFileItem& item, VideoDbContentType type
 CDateTime CVideoDatabase::SetPlayCount(const CFileItem& item, int count, const CDateTime& date)
 {
   int id{-1};
-  if (IsBlurayPlaylist(item))
+  if (URIUtils::IsBlurayPath(item.GetDynPath()))
     id = AddFile(item.GetDynPath());
   else if (item.HasProperty("original_listitem_url") &&
            URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))

--- a/xbmc/video/VideoFileItemClassify.cpp
+++ b/xbmc/video/VideoFileItemClassify.cpp
@@ -72,11 +72,6 @@ bool IsProtectedBlurayDisc(const CFileItem& item)
   return CFileUtils::Exists(path);
 }
 
-bool IsBlurayPlaylist(const CFileItem& item)
-{
-  return StringUtils::EqualsNoCase(URIUtils::GetExtension(item.GetDynPath()), ".mpls");
-}
-
 bool IsSubtitle(const CFileItem& item)
 {
   return URIUtils::HasExtension(item.GetPath(),

--- a/xbmc/video/VideoFileItemClassify.h
+++ b/xbmc/video/VideoFileItemClassify.h
@@ -25,9 +25,6 @@ bool IsDVDFile(const CFileItem& item, bool bVobs = true, bool bIfos = true);
 //! \brief Checks whether item points to a protected blu-ray disc.
 bool IsProtectedBlurayDisc(const CFileItem& item);
 
-//! \brief Checks whether item points to a blu-ray playlist (.mpls)
-bool IsBlurayPlaylist(const CFileItem& item);
-
 //! \brief Check whether an item is a subtitle file.
 bool IsSubtitle(const CFileItem& item);
 

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -827,7 +827,7 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
       }
       if (PLAYLIST::IsSmartPlayList(*item) || PLAYLIST::IsSmartPlayList(*m_vecItems))
         buttons.Add(CONTEXT_BUTTON_EDIT_SMART_PLAYLIST, 586);
-      if (VIDEO::IsBlurayPlaylist(*item))
+      if (URIUtils::IsBlurayPath(item->GetDynPath()))
         buttons.Add(CONTEXT_BUTTON_CHOOSE_PLAYLIST, 13424);
     }
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Second of four commits fixing bugs related to bluray:// paths.

Fixes:
- If a bluray was played through the menu then resuming play returned to the menu rather than the playlist last played
- If a bluray was played through the menu then the Choose Playlist context menu item was missing
- The movie could not be updated through the refresh option in the Information dialog

Review note:
- First two commits are taken from #26233.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Bug fixes

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
