### PR TITLE
[Video] Import/export improvements and fixes - including multi-episode file support (including blurays).

### DIFF
--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -38,6 +38,7 @@ CInfoScanner::InfoType CNfoFile::Create(const std::string& strPath,
 
   CFileItemList items;
   bool bNfo=false;
+  bool overrideNfo{false};
 
   if (m_type == AddonType::SCRAPER_ALBUMS)
   {
@@ -54,6 +55,7 @@ CInfoScanner::InfoType CNfoFile::Create(const std::string& strPath,
   {
     CVideoInfoTag details;
     bNfo = GetDetails(details);
+    overrideNfo = details.GetOverride();
   }
 
   std::vector<ScraperPtr> vecScrapers = GetScrapers(m_type, m_info);
@@ -70,7 +72,7 @@ CInfoScanner::InfoType CNfoFile::Create(const std::string& strPath,
   {
     if (!m_scurl.HasUrls())
     {
-      if (m_doc.find("[scrape url]") != std::string::npos)
+      if (overrideNfo || m_doc.find("[scrape url]") != std::string::npos)
         return CInfoScanner::InfoType::OVERRIDE;
       else
         return CInfoScanner::InfoType::FULL;

--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -52,30 +52,8 @@ CInfoScanner::InfoType CNfoFile::Create(const std::string& strPath,
   else if (m_type == AddonType::SCRAPER_TVSHOWS || m_type == AddonType::SCRAPER_MOVIES ||
            m_type == AddonType::SCRAPER_MUSICVIDEOS)
   {
-    // first check if it's an XML file with the info we need
     CVideoInfoTag details;
     bNfo = GetDetails(details);
-    if (episode > -1 && bNfo && m_type == AddonType::SCRAPER_TVSHOWS)
-    {
-      int infos=0;
-      while (m_headPos != std::string::npos && details.m_iEpisode != episode)
-      {
-        m_headPos = m_doc.find("<episodedetails", m_headPos + 1);
-        if (m_headPos == std::string::npos)
-          break;
-
-        bNfo  = GetDetails(details);
-        infos++;
-      }
-      if (details.m_iEpisode != episode)
-      {
-        bNfo = false;
-        details.Reset();
-        m_headPos = 0;
-        if (infos == 1) // still allow differing nfo/file numbers for single ep nfo's
-          bNfo = GetDetails(details);
-      }
-    }
   }
 
   std::vector<ScraperPtr> vecScrapers = GetScrapers(m_type, m_info);

--- a/xbmc/utils/ArtUtils.h
+++ b/xbmc/utils/ArtUtils.h
@@ -15,6 +15,12 @@ class CFileItem;
 namespace KODI::ART
 {
 
+enum class UseSeasonAndEpisode : bool
+{
+  NO,
+  YES
+};
+
 //! \brief Set default icon for item.
 void FillInDefaultIcon(CFileItem& item);
 
@@ -30,19 +36,27 @@ std::string GetFolderThumb(const CFileItem& item, const std::string& folderJPG =
            No file existence check is typically performed.
  \param artFile the art file to search for.
  \param useFolder whether to look in the folder for the art file. Defaults to false.
+ \param useSeasonAndEpisode for multi-episode files. Append SxxEyy to the file name. Defaults to no.
  \return the path to the local artwork.
  \sa FindLocalArt
  */
-std::string GetLocalArt(const CFileItem& item, const std::string& artFile, bool useFolder = false);
+std::string GetLocalArt(const CFileItem& item,
+                        const std::string& artFile,
+                        bool useFolder = false,
+                        UseSeasonAndEpisode useSeasonAndEpisode = UseSeasonAndEpisode::NO);
 
 /*!
  \brief Assemble the base filename of local artwork for an item,
  accounting for archives, stacks and multi-paths, and BDMV/VIDEO_TS folders.
  \param useFolder whether to look in the folder for the art file. Defaults to false.
+ \param useSeasonAndEpisode for multi-episode files. Append SxxEyy to the file name. Defaults to no.
  \return the path to the base filename for artwork lookup.
  \sa GetLocalArt
  */
-std::string GetLocalArtBaseFilename(const CFileItem& item, bool& useFolder);
+std::string GetLocalArtBaseFilename(
+    const CFileItem& item,
+    bool& useFolder,
+    UseSeasonAndEpisode useSeasonAndEpisode = UseSeasonAndEpisode::NO);
 
 /*!
  \brief Get the local fanart for item if it exists
@@ -52,11 +66,11 @@ std::string GetLocalArtBaseFilename(const CFileItem& item, bool& useFolder);
 std::string GetLocalFanart(const CFileItem& item);
 
 /*! \brief Get the .tbn file associated with an item.
- Note this is used to derive the .nfo path in CVideoDatabase::ExportToXML() and for
- bluray/dvd this is not the same as the thumbnail/art directory.
  \param item CFileItem containing the item path.
+ \param season For multi-episode files. Append SxxEyy to the file name.
+ \param episode For multi-episode files. Append SxxEyy to the file name.
  \return the path to the .tbn file
 */
-std::string GetTBNFile(const CFileItem& item);
+std::string GetTBNFile(const CFileItem& item, int season = -1, int episode = -1);
 
 } // namespace KODI::ART

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3809,52 +3809,20 @@ void CVideoDatabase::GetEpisodesByFileId(int idFile, std::vector<CVideoInfoTag>&
 
   try
   {
-    const std::string sql{PrepareSQL(
-        "select episode_view.*, streamdetails.iVideoDuration as duration from "
-        "episode_view left join streamdetails on episode_view.idFile = streamdetails.idFile "
-        "and streamdetails.iStreamType = %i "
-        "where episode_view.idShow = (select idShow from episode where idFile = %i limit 1) "
-        "order by cast(episode_view.c%02d as integer), cast(episode_view.c%02d as integer)",
-        CStreamDetail::VIDEO, idFile, VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_EPISODE_EPISODE)};
-    m_pDS->query(sql);
+    const int idShow{GetSingleValueInt(
+        PrepareSQL("SELECT idShow FROM episode WHERE idFile=%i", idFile), *m_pDS)};
 
     // Generate map of episodes in each file (finding base file for bluray://) of show
-    std::multimap<std::string, int, std::less<>> fileMap;
-    int index{1};
-    std::string episodeFile;
-    while (!m_pDS->eof())
-    {
-      std::string file{URIUtils::AddFileToFolder(m_pDS->fv("strPath").get_asString(),
-                                                 m_pDS->fv("strFileName").get_asString())};
-      if (URIUtils::IsBlurayPath(file))
-        file = URIUtils::GetDiscFile(file);
-      fileMap.insert({file, index});
-      if (episodeFile.empty() && m_pDS->fv("idFile").get_asInt() == idFile)
-        episodeFile = file;
-      m_pDS->next();
-      index++;
-    }
-
-    // Remove episodes not from the base file/path
-    std::erase_if(fileMap,
-                  [&episodeFile](const auto& it)
-                  {
-                    auto const& [file, _] = it;
-                    return file != episodeFile;
-                  });
+    EpisodeFileMap fileMap;
+    if (!GetEpisodeMap(idShow, fileMap, m_pDS, idFile))
+      return;
 
     // Get episode details
-    for (int i : fileMap | std::views::values)
+    for (const auto& episode : fileMap | std::views::values)
     {
-      m_pDS->goto_rec(i);
+      m_pDS->goto_rec(episode.index);
       CVideoInfoTag tag{GetDetailsForEpisode(*m_pDS)};
-
-      // Different scrapers put duration in different places
-      const unsigned int episodeViewDuration{
-          m_pDS->fv(StringUtils::Format("c{:02}", VIDEODB_ID_EPISODE_RUNTIME).c_str())
-              .get_asUInt()};
-      const unsigned int streamDetailsDuration{m_pDS->fv("duration").get_asUInt()};
-      tag.m_duration = episodeViewDuration > 0 ? episodeViewDuration : streamDetailsDuration;
+      tag.m_duration = episode.duration;
       episodes.emplace_back(tag);
     }
     m_pDS->close();
@@ -3863,6 +3831,65 @@ void CVideoDatabase::GetEpisodesByFileId(int idFile, std::vector<CVideoInfoTag>&
   {
     CLog::LogF(LOGERROR, "File Id {} failed", idFile);
   }
+}
+
+bool CVideoDatabase::GetEpisodeMap(int idShow,
+                                   EpisodeFileMap& fileMap,
+                                   std::unique_ptr<Dataset>& pDS,
+                                   int idFile /* = -1 */)
+{
+  try
+  {
+    const std::string sql{PrepareSQL(
+        "select episode_view.*, streamdetails.iVideoDuration as duration from "
+        "episode_view left join streamdetails on episode_view.idFile = streamdetails.idFile "
+        "and streamdetails.iStreamType = %i "
+        "where episode_view.idShow = %i "
+        "order by cast(episode_view.c%02d as integer), cast(episode_view.c%02d as integer)",
+        CStreamDetail::VIDEO, idShow, VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_EPISODE_EPISODE)};
+    pDS->query(sql);
+
+    // Generate map of episodes in each file (finding base file for bluray://) of show
+    int index{1};
+    std::string episodeFile{};
+    while (!pDS->eof())
+    {
+      EpisodeInformation episodeInformation;
+      const std::string file{URIUtils::AddFileToFolder(pDS->fv("strPath").get_asString(),
+                                                       pDS->fv("strFileName").get_asString())};
+      const std::string baseFile{URIUtils::IsBlurayPath(file) ? URIUtils::GetDiscFile(file) : file};
+      // Different scrapers put duration in different places
+      const unsigned int streamDetailsDuration{pDS->fv("duration").get_asUInt()};
+      const unsigned int episodeViewDuration{
+          pDS->fv(StringUtils::Format("c{:02}", VIDEODB_ID_EPISODE_RUNTIME).c_str()).get_asUInt()};
+      episodeInformation.duration =
+          episodeViewDuration > 0 ? episodeViewDuration : streamDetailsDuration;
+      episodeInformation.index = index;
+
+      fileMap.insert({baseFile, episodeInformation});
+      if (idFile > 0 && episodeFile.empty() && pDS->fv("idFile").get_asInt() == idFile)
+        episodeFile = baseFile;
+
+      pDS->next();
+      index++;
+    }
+
+    // Remove episodes not from the base file/path
+    if (!episodeFile.empty())
+      std::erase_if(fileMap,
+                    [&episodeFile](const EpisodeFileMapEntry& it)
+                    {
+                      const auto& [file, episodeInfo] = it;
+                      return file != episodeFile;
+                    });
+
+    return true;
+  }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Failed to fetch episodes for idShow: {}, idFile: {}", idShow, idFile);
+  }
+  return false;
 }
 
 //********************************************************************************************************************************
@@ -11396,6 +11423,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
       }
 
       CFileItem item(movie.m_strFileNameAndPath,false);
+      std::string singlePath;
       if (!singleFile && CUtil::SupportsWriteFileOperations(movie.m_strFileNameAndPath))
       {
         if (!item.Exists(false))
@@ -11406,14 +11434,9 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
         }
         else
         {
-          std::string nfoFile(URIUtils::ReplaceExtension(ART::GetTBNFile(item), ".nfo"));
-
-          if (item.IsOpticalMediaFile())
-          {
-            nfoFile = URIUtils::AddFileToFolder(
-                                    URIUtils::GetParentPath(nfoFile),
-                                    URIUtils::GetFileName(nfoFile));
-          }
+          std::string nfoFile{URIUtils::ReplaceExtension(ART::GetTBNFile(item), ".nfo")};
+          singlePath = item.IsOpticalMediaFile() ? URIUtils::GetBasePath(item.GetDynPath())
+                                                 : URIUtils::GetDirectory(nfoFile);
 
           if (overwrite || !CFile::Exists(nfoFile, false))
           {
@@ -11426,6 +11449,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
               iFailCount++;
             }
           }
+          singlePath = URIUtils::GetDirectory(nfoFile);
         }
       }
       if (!singleFile)
@@ -11450,7 +11474,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
           CServiceBroker::GetTextureCache()->Export(url, savedThumb, overwrite);
         }
         if (actorThumbs)
-          ExportActorThumbs(actorsDir, movie, !singleFile, overwrite);
+          ExportActorThumbs(actorsDir, singlePath, movie, !singleFile, overwrite);
       }
       m_pDS->next();
       current++;
@@ -11633,14 +11657,14 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
 
     // repeat for all tvshows
     sql = "SELECT * FROM tvshow_view";
-    m_pDS->query(sql);
+    pDS2->query(sql);
 
-    total = m_pDS->num_rows();
+    total = pDS2->num_rows();
     current = 0;
 
-    while (!m_pDS->eof())
+    while (!pDS2->eof())
     {
-      CVideoInfoTag tvshow = GetDetailsForTvShow(*m_pDS, VideoDbDetailsAll);
+      CVideoInfoTag tvshow = GetDetailsForTvShow(*pDS2, VideoDbDetailsAll);
       GetTvShowNamedSeasons(tvshow.m_iDbId, tvshow.m_namedSeasons);
 
       KODI::ART::SeasonsArtwork seasonArt;
@@ -11650,8 +11674,8 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
       if (GetArtForItem(tvshow.m_iDbId, tvshow.m_type, artwork) && !artwork.empty() && singleFile)
       {
         TiXmlElement additionalNode("art");
-        for (const auto &i : artwork)
-          XMLUtils::SetString(&additionalNode, i.first.c_str(), i.second);
+        for (const auto& [type, url] : artwork)
+          XMLUtils::SetString(&additionalNode, type.c_str(), url);
         for (const auto& [seasonNumber, art] : seasonArt)
         {
           TiXmlElement seasonNode("season");
@@ -11676,12 +11700,13 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
         if (progress->IsCanceled())
         {
           progress->Close();
-          m_pDS->close();
+          pDS2->close();
           return;
         }
       }
 
       CFileItem item(tvshow.m_strPath, true);
+      std::string singlePath;
       if (!singleFile && CUtil::SupportsWriteFileOperations(tvshow.m_strPath))
       {
         if (!item.Exists(false))
@@ -11695,7 +11720,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
 
           if (overwrite || !CFile::Exists(nfoFile, false))
           {
-            if(!xmlDoc.SaveFile(nfoFile))
+            if (!xmlDoc.SaveFile(nfoFile))
             {
               CLog::LogF(LOGERROR, "TVShow nfo export failed! ('{}')", nfoFile);
               CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
@@ -11704,6 +11729,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
               iFailCount++;
             }
           }
+          singlePath = URIUtils::GetDirectory(nfoFile);
         }
       }
       if (!singleFile)
@@ -11726,7 +11752,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
 
         tvshowDir = tvshow.m_strPath;
         if (actorThumbs)
-          ExportActorThumbs(actorsDir, tvshow, !singleFile, overwrite);
+          ExportActorThumbs(actorsDir, singlePath, tvshow, !singleFile, overwrite);
 
         // export season thumbs
         for (const auto& [seasonNumber, art] : seasonArt)
@@ -11747,95 +11773,102 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
         }
       }
 
-      // now save the episodes from this show
-      sql = PrepareSQL("select * from episode_view where idShow=%i order by strFileName, idEpisode",tvshow.m_iDbId);
-      pDS->query(sql);
+      // Now save the episodes from this show
       std::string showDir(item.GetPath());
 
-      while (!pDS->eof())
+      // Generate map of episodes in each file (finding base file for bluray://)
+      EpisodeFileMap fileMap;
+      if (!GetEpisodeMap(tvshow.m_iDbId, fileMap, pDS))
       {
-        CVideoInfoTag episode = GetDetailsForEpisode(*pDS, VideoDbDetailsAll);
-        KODI::ART::Artwork artwork2;
-        if (GetArtForItem(episode.m_iDbId, MediaTypeEpisode, artwork2) && !artwork2.empty() &&
-            singleFile)
-        {
-          TiXmlElement additionalNode("art");
-          for (const auto& [type, url] : artwork2)
-            XMLUtils::SetString(&additionalNode, type.c_str(), url);
-          episode.Save(pMain->LastChild(), "episodedetails", true, &additionalNode);
-        }
-        else if (singleFile)
-          episode.Save(pMain->LastChild(), "episodedetails", singleFile);
-        else
-          episode.Save(pMain, "episodedetails", singleFile);
-        pDS->next();
-        // multi-episode files need dumping to the same XML
-        while (!singleFile && !pDS->eof() &&
-               episode.m_iFileId == pDS->fv("idFile").get_asInt())
-        {
-          episode = GetDetailsForEpisode(*pDS, VideoDbDetailsAll);
-          episode.Save(pMain, "episodedetails", singleFile);
-          pDS->next();
-        }
+        CLog::LogF(LOGERROR, "Failed to generate episode map for TV show ID {}", tvshow.m_iDbId);
+        continue; // Skip processing for this TV show
+      }
 
-        // reset old skip state
-        bSkip = false;
+      for (const auto& [file, episodeInformation] : fileMap)
+      {
+        pDS->goto_rec(episodeInformation.index);
+        CFileItem item(file, false);
 
-        CFileItem item2(episode.m_strFileNameAndPath, false);
-        if (!singleFile && CUtil::SupportsWriteFileOperations(episode.m_strFileNameAndPath))
-        {
-          if (!item2.Exists(false))
-          {
-            CLog::Log(LOGINFO, "Not exporting item {} as it does not exist",
-                      episode.m_strFileNameAndPath);
-            bSkip = true;
-          }
-          else
-          {
-            std::string nfoFile(URIUtils::ReplaceExtension(ART::GetTBNFile(item2), ".nfo"));
+        if (!singleFile && (!CUtil::SupportsWriteFileOperations(file) || !item.Exists(false)))
+          break;
 
-            if (overwrite || !CFile::Exists(nfoFile, false))
-            {
-              if(!xmlDoc.SaveFile(nfoFile))
-              {
-                CLog::LogF(LOGERROR, "Episode nfo export failed! ('{}')", nfoFile);
-                CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
-                                                      g_localizeStrings.Get(20302),
-                                                      CURL::GetRedacted(nfoFile));
-                iFailCount++;
-              }
-            }
-          }
-        }
+        CVideoInfoTag episode{GetDetailsForEpisode(*pDS, VideoDbDetailsAll)};
+        ART::Artwork artwork;
+        GetArtForItem(episode.m_iDbId, MediaTypeEpisode, artwork);
+
         if (!singleFile)
         {
+          // Separate files
+          // Save details in XML
+          episode.Save(pMain, "episodedetails", singleFile);
+
+          std::string nfoFile;
+          if (const bool multipleEpisodes{fileMap.count(file) > 1}; multipleEpisodes)
+          {
+            // If multiple episode file then nfo and art will have SxxEyy appended
+            nfoFile = URIUtils::ReplaceExtension(
+                ART::GetTBNFile(item, episode.m_iSeason, episode.m_iEpisode), ".nfo");
+            item.SetDynPath(nfoFile);
+
+            // Art name is derived in GetLocalArt() which in turn calls GetTBNFile()
+            // Need to set season/episode in VideoInfoTag
+            item.SetProperty("is_multi_episode", true);
+            CVideoInfoTag* tag{item.GetVideoInfoTag()};
+            tag->m_iSeason = episode.m_iSeason;
+            tag->m_iEpisode = episode.m_iEpisode;
+          }
+          else
+            nfoFile = URIUtils::ReplaceExtension(ART::GetTBNFile(item), ".nfo");
+
+          if (overwrite || !CFile::Exists(nfoFile, false))
+          {
+            // Save NFO file
+            if (!xmlDoc.SaveFile(nfoFile))
+            {
+              CLog::LogF(LOGERROR, "Episode nfo export failed! ('{}')", nfoFile);
+              CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
+                                                    g_localizeStrings.Get(20302),
+                                                    CURL::GetRedacted(nfoFile));
+              iFailCount++;
+            }
+          }
+          singlePath = URIUtils::GetDirectory(nfoFile);
+
+          // Reset XML for next episode
           xmlDoc.Clear();
           TiXmlDeclaration decl2("1.0", "UTF-8", "yes");
           xmlDoc.InsertEndChild(decl2);
         }
-
-        if (images && !bSkip)
+        else
         {
-          if (singleFile)
+          // Single XML
+          // Include art (if present) in XML and save
+          if (!artwork.empty())
           {
-            std::string epName =
-                StringUtils::Format("s{:02}e{:02}.avi", episode.m_iSeason, episode.m_iEpisode);
-            item2.SetPath(URIUtils::AddFileToFolder(showDir, epName));
+            TiXmlElement additionalNode("art");
+            for (const auto& [artType, artPath] : artwork)
+              XMLUtils::SetString(&additionalNode, artType.c_str(), artPath);
+            episode.Save(pMain->LastChild(), "episodedetails", true, &additionalNode);
           }
-          for (const auto& [type, url] : artwork2)
-          {
-            const std::string savedThumb = ART::GetLocalArt(item2, type, false);
-            CServiceBroker::GetTextureCache()->Export(url, savedThumb, overwrite);
-          }
-          if (actorThumbs)
-            ExportActorThumbs(actorsDir, episode, !singleFile, overwrite, tvshowDir);
+          else
+            episode.Save(pMain->LastChild(), "episodedetails", singleFile);
+
+          // Arbitrary name for art
+          const std::string epName{
+              StringUtils::Format("s{:02}e{:02}.avi", episode.m_iSeason, episode.m_iEpisode)};
+          item.SetPath(URIUtils::AddFileToFolder(showDir, epName));
         }
+
+        // Write art/actor images
+        ExportArt(item, artwork, overwrite);
+        if (actorThumbs)
+          ExportActorThumbs(actorsDir, singlePath, episode, !singleFile, overwrite, tvshowDir);
       }
       pDS->close();
-      m_pDS->next();
+      pDS2->next();
       current++;
     }
-    m_pDS->close();
+    pDS2->close();
 
     if (!singleFile && progress)
     {
@@ -11893,19 +11926,31 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
         CVariant{647}, CVariant{StringUtils::Format(g_localizeStrings.Get(15011), iFailCount)});
 }
 
-void CVideoDatabase::ExportActorThumbs(const std::string& strDir,
+void CVideoDatabase::ExportArt(const CFileItem& item, const ART::Artwork& artwork, bool overwrite)
+{
+  for (const auto& [artType, artPath] : artwork)
+  {
+    const std::string savedThumb{ART::GetLocalArt(
+        item, artType, false,
+        item.GetProperty("is_multi_episode").asBoolean(false) ? ART::UseSeasonAndEpisode::YES
+                                                              : ART::UseSeasonAndEpisode::NO)};
+    CServiceBroker::GetTextureCache()->Export(artPath, savedThumb, overwrite);
+  }
+}
+
+void CVideoDatabase::ExportActorThumbs(const std::string& path,
+                                       const std::string& singlePath,
                                        const CVideoInfoTag& tag,
                                        bool singleFiles,
                                        bool overwrite /* =false */,
                                        const std::string& tvshowDir /* ="" */) const
 {
-  std::string strPath(strDir);
+  std::string strPath{path};
   if (singleFiles)
   {
 
     strPath = URIUtils::AddFileToFolder(
-        tag.m_type == MediaTypeEpisode && !tvshowDir.empty() ? tvshowDir : tag.m_strPath,
-        ".actors");
+        tag.m_type == MediaTypeEpisode && !tvshowDir.empty() ? tvshowDir : singlePath, ".actors");
     if (!CDirectory::Exists(strPath))
     {
       CDirectory::Create(strPath);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -491,6 +491,15 @@ enum class DeleteMovieHashAction
 #define COMPARE_PERCENTAGE     0.90f // 90%
 #define COMPARE_PERCENTAGE_MIN 0.50f // 50%
 
+struct EpisodeInformation
+{
+  int index{0};
+  unsigned int duration{0};
+};
+
+using EpisodeFileMap = std::multimap<std::string, EpisodeInformation>;
+using EpisodeFileMapEntry = std::pair<std::string, EpisodeInformation>;
+
 class CVideoDatabase : public CDatabase
 {
 public:
@@ -641,6 +650,10 @@ public:
   void GetEpisodesByBlurayPath(const std::string& path, std::vector<CVideoInfoTag>& episodes);
   void GetEpisodesByFile(const std::string& strFilenameAndPath, std::vector<CVideoInfoTag>& episodes);
   void GetEpisodesByFileId(int idFile, std::vector<CVideoInfoTag>& episodes);
+  bool GetEpisodeMap(int idShow,
+                     EpisodeFileMap& fileMap,
+                     std::unique_ptr<dbiplus::Dataset>& pDS,
+                     int idFile = -1 /* = -1 */);
 
   int SetDetailsForItem(CVideoInfoTag& details, const KODI::ART::Artwork& artwork);
   int SetDetailsForItem(int id,
@@ -1076,7 +1089,9 @@ public:
   void UpdateFileDateAdded(CVideoInfoTag& details);
 
   void ExportToXML(const std::string &path, bool singleFile = true, bool images=false, bool actorThumbs=false, bool overwrite=false);
+  void ExportArt(const CFileItem& item, const KODI::ART::Artwork& artwork, bool overwrite);
   void ExportActorThumbs(const std::string& path,
+                         const std::string& singlePath,
                          const CVideoInfoTag& tag,
                          bool singleFiles,
                          bool overwrite = false,

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2365,7 +2365,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
                                     pDlgProgress))
           return InfoRet::NOT_FOUND; //! @todo should we just skip to the next episode?
 
-        if (result == InfoType::COMBINED)
+        if (result == InfoType::COMBINED || result == InfoType::OVERRIDE)
           scraperItem.GetVideoInfoTag()->Merge(*item.GetVideoInfoTag());
 
         // Only set season/epnum from filename when it is not already set by a scraper

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -127,7 +127,7 @@ void AddLocalItemArtwork(KODI::ART::Artwork& itemArt,
                            CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(),
                            DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
 
-  std::string baseFilename = URIUtils::GetFileName(itemPath);
+  std::string baseFilename{URIUtils::GetFileName(itemPath)};
   if (!baseFilename.empty())
   {
     URIUtils::RemoveExtension(baseFilename);
@@ -140,10 +140,10 @@ void AddLocalItemArtwork(KODI::ART::Artwork& itemArt,
   for (const auto& artFile : availableArtFiles)
   {
     std::string candidate{URIUtils::GetFileName(artFile->GetPath())};
-    const bool matchesFilename{!baseFilename.empty() &&
-                               (caseSensitive
-                                    ? StringUtils::StartsWith(candidate, baseFilename)
-                                    : StringUtils::StartsWithNoCase(candidate, baseFilename))};
+
+    bool matchesFilename{!baseFilename.empty() &&
+                         (caseSensitive ? StringUtils::StartsWith(candidate, baseFilename)
+                                        : StringUtils::StartsWithNoCase(candidate, baseFilename))};
 
     if (!baseFilename.empty() && !matchesFilename)
       continue;
@@ -1752,12 +1752,28 @@ CVideoInfoScanner::~CVideoInfoScanner()
     CVideoInfoTag &movieDetails = *pItem->GetVideoInfoTag();
     if (movieDetails.m_basePath.empty())
       movieDetails.m_basePath = pItem->GetBaseMoviePath(videoFolder);
-    movieDetails.m_parentPathID = m_database.AddPath(URIUtils::GetParentPath(movieDetails.m_basePath));
+    if (movieDetails.m_iTrack > -1)
+    {
+      // Relative path (eg. bluray://) with playlist/title
+      const std::string fileandpath{
+          URIUtils::GetBlurayPlaylistPath(pItem->GetPath(), movieDetails.m_iTrack)};
+      const std::string path{URIUtils::GetDirectory(fileandpath)};
 
-    movieDetails.m_strFileNameAndPath = pItem->GetPath();
+      movieDetails.m_parentPathID = m_database.AddPath(path);
+      movieDetails.m_strPath = path;
+      movieDetails.m_strFileNameAndPath = fileandpath;
+      pItem->SetDynPath(fileandpath); // Needed for SetPlayCount() later
+    }
+    else
+    {
+      movieDetails.m_parentPathID =
+          m_database.AddPath(URIUtils::GetParentPath(movieDetails.m_basePath));
 
-    if (pItem->IsFolder())
-      movieDetails.m_strPath = pItem->GetPath();
+      movieDetails.m_strFileNameAndPath = pItem->GetPath();
+
+      if (pItem->IsFolder())
+        movieDetails.m_strPath = pItem->GetPath();
+    }
 
     std::string strTitle(movieDetails.m_strTitle);
 
@@ -1897,7 +1913,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
       if ((libraryImport || m_advancedSettings->m_bVideoLibraryImportResumePoint) &&
           movieDetails.GetResumePoint().IsSet())
-        m_database.AddBookMarkToFile(pItem->GetPath(), movieDetails.GetResumePoint(), CBookmark::RESUME);
+        m_database.AddBookMarkToFile(pItem->GetVideoInfoTag()->m_strFileNameAndPath,
+                                     movieDetails.GetResumePoint(), CBookmark::RESUME);
     }
 
     m_database.Close();
@@ -2035,8 +2052,10 @@ CVideoInfoScanner::~CVideoInfoScanner()
         // the previous call.
         useFolder = false;
 
-        AddLocalItemArtwork(art, artTypes, ART::GetLocalArtBaseFilename(*pItem, useFolder), addAll,
-                            exactName);
+        AddLocalItemArtwork(
+            art, artTypes,
+            ART::GetLocalArtBaseFilename(*pItem, useFolder, ART::UseSeasonAndEpisode::YES), addAll,
+            exactName);
       }
 
       if (moviePartOfSet)
@@ -2183,6 +2202,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       else
       {
         item.SetPath(file->strPath);
+        item.GetVideoInfoTag()->m_iSeason = file->iSeason;
         item.GetVideoInfoTag()->m_iEpisode = file->iEpisode;
       }
 
@@ -2339,18 +2359,22 @@ CVideoInfoScanner::~CVideoInfoScanner()
       if (bFound)
       {
         CVideoInfoDownloader imdb(scraper);
-        CFileItem item;
-        item.SetPath(file->strPath);
-        if (!imdb.GetEpisodeDetails(guide->cScraperUrl, *item.GetVideoInfoTag(), pDlgProgress))
+        CFileItem scraperItem;
+        scraperItem.SetPath(file->strPath);
+        if (!imdb.GetEpisodeDetails(guide->cScraperUrl, *scraperItem.GetVideoInfoTag(),
+                                    pDlgProgress))
           return InfoRet::NOT_FOUND; //! @todo should we just skip to the next episode?
 
-        // Only set season/epnum from filename when it is not already set by a scraper
-        if (item.GetVideoInfoTag()->m_iSeason == -1)
-          item.GetVideoInfoTag()->m_iSeason = guide->iSeason;
-        if (item.GetVideoInfoTag()->m_iEpisode == -1)
-          item.GetVideoInfoTag()->m_iEpisode = guide->iEpisode;
+        if (result == InfoType::COMBINED)
+          scraperItem.GetVideoInfoTag()->Merge(*item.GetVideoInfoTag());
 
-        if (AddVideo(&item, ContentType::TVSHOWS, file->isFolder, useLocal, &showInfo) < 0)
+        // Only set season/epnum from filename when it is not already set by a scraper
+        if (scraperItem.GetVideoInfoTag()->m_iSeason == -1)
+          scraperItem.GetVideoInfoTag()->m_iSeason = guide->iSeason;
+        if (scraperItem.GetVideoInfoTag()->m_iEpisode == -1)
+          scraperItem.GetVideoInfoTag()->m_iEpisode = guide->iEpisode;
+
+        if (AddVideo(&scraperItem, ContentType::TVSHOWS, file->isFolder, useLocal, &showInfo) < 0)
           return InfoRet::INFO_ERROR;
       }
       else

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1143,6 +1143,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
 
   if (XMLUtils::GetString(movie, "filenameandpath", value))
     SetFileNameAndPath(value);
+  XMLUtils::GetInt(movie, "playlist", m_iTrack);
 
   if (XMLUtils::GetDate(movie, "premiered", m_premiered))
   {

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -15,6 +15,7 @@
 #include "settings/SettingsComponent.h"
 #include "utils/Archive.h"
 #include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
@@ -192,6 +193,12 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const std::string &tag, bool savePathI
     XMLUtils::SetString(movie, "path", m_strPath);
     XMLUtils::SetString(movie, "filenameandpath", m_strFileNameAndPath);
     XMLUtils::SetString(movie, "basepath", m_basePath);
+  }
+  if (URIUtils::IsBlurayPath(m_strFileNameAndPath))
+  {
+    const int playlist{URIUtils::GetBlurayPlaylistFromPath(m_strFileNameAndPath)};
+    if (playlist != -1)
+      XMLUtils::SetInt(movie, "playlist", playlist);
   }
   if (!m_strEpisodeGuide.empty())
   {

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1004,6 +1004,9 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
   std::string value;
   float fValue;
 
+  if (StringUtils::ToLower(XMLUtils::GetAttribute(movie, "override")) == "true")
+    SetOverride(true);
+
   if (XMLUtils::GetString(movie, "title", value))
     SetTitle(value);
 

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -170,6 +170,9 @@ public:
   void SetNamedSeasons(std::map<int, std::string> namedSeasons);
   void SetUserrating(int userrating);
 
+  void SetOverride(bool override) { m_override = override; }
+  bool GetOverride() const { return m_override; }
+
   /*!
    * @brief Get this videos's play count.
    * @return the play count.
@@ -441,4 +444,5 @@ private:
   bool m_isDefaultVideoVersion{false};
 
   bool m_updateSetOverview{true};
+  bool m_override{false};
 };

--- a/xbmc/video/tags/VideoTagLoaderNFO.cpp
+++ b/xbmc/video/tags/VideoTagLoaderNFO.cpp
@@ -20,6 +20,7 @@
 #include "utils/log.h"
 #include "video/VideoInfoTag.h"
 
+#include <ranges>
 #include <utility>
 
 using namespace XFILE;
@@ -142,7 +143,23 @@ std::string CVideoTagLoaderNFO::FindNFO(const CFileItem& item,
         nfoFile = item.GetPath();
       // no, create .nfo file
       else
+      {
         nfoFile = URIUtils::ReplaceExtension(item.GetPath(), ".nfo");
+
+        // Look for specific SxxEyy nfo and use this if present
+        if (item.HasVideoInfoTag())
+        {
+          const CVideoInfoTag* tag{item.GetVideoInfoTag()};
+          if (tag->m_iSeason >= 0 && tag->m_iEpisode >= 0)
+          {
+            std::string file{item.GetPath()};
+            URIUtils::RemoveExtension(file);
+            file = fmt::format("{}-S{:02}E{:02}.nfo", file, tag->m_iSeason, tag->m_iEpisode);
+            if (CFileUtils::Exists(file))
+              nfoFile = file;
+          }
+        }
+      }
     }
 
     // test file existence
@@ -167,36 +184,39 @@ std::string CVideoTagLoaderNFO::FindNFO(const CFileItem& item,
       nfoFile = FindNFO(parentDirectory, true);
     }
   }
+
   // folders (or stacked dvds) can take any nfo file if there's a unique one
-  if (item.IsFolder() || item.IsOpticalMediaFile() || (movieFolder && nfoFile.empty()))
+  if (nfoFile.empty() && (item.IsFolder() || item.IsOpticalMediaFile() || movieFolder))
   {
     // see if there is a unique nfo file in this folder, and if so, use that
+    // if we are looking for a specific episode nfo the file name must end with SxxEyy
+    // (otherwise it could match the wrong episode nfo)
+    const std::string strPath{item.IsFolder() ? item.GetPath()
+                                              : URIUtils::GetDirectory(item.GetPath())};
     CFileItemList items;
-    CDirectory dir;
-    std::string strPath;
-    if (item.IsFolder())
-      strPath = item.GetPath();
-    else
-      strPath = URIUtils::GetDirectory(item.GetPath());
-
-    if (dir.GetDirectory(strPath, items, ".nfo", DIR_FLAG_DEFAULTS) && items.Size())
+    if (CDirectory::GetDirectory(strPath, items, ".nfo", DIR_FLAG_DEFAULTS) && items.Size() > 0)
     {
-      int numNFO = -1;
-      for (int i = 0; i < items.Size(); i++)
-      {
-        if (items[i]->IsNFO())
-        {
-          if (numNFO == -1)
-            numNFO = i;
-          else
-          {
-            numNFO = -1;
-            break;
-          }
-        }
-      }
-      if (numNFO > -1)
-        return items[numNFO]->GetPath();
+      const CVideoInfoTag* tag{item.GetVideoInfoTag()};
+      auto nfoItems{items | std::views::filter(
+                                [&tag](const auto& nfoItem)
+                                {
+                                  if (!nfoItem->IsNFO())
+                                    return false;
+
+                                  if (tag && tag->m_iSeason >= 0 && tag->m_iEpisode >= 0)
+                                  {
+                                    std::string path{nfoItem->GetPath()};
+                                    const std::string extension{URIUtils::GetExtension(path)};
+                                    if (!extension.empty())
+                                      path.erase(path.size() - extension.size());
+                                    return path.ends_with(fmt::format(
+                                        "S{:02}E{:02}", tag->m_iSeason, tag->m_iEpisode));
+                                  }
+
+                                  return true;
+                                })};
+      if (std::ranges::distance(nfoItems) == 1)
+        return (*nfoItems.begin())->GetPath();
     }
   }
 

--- a/xbmc/video/tags/VideoTagLoaderNFO.cpp
+++ b/xbmc/video/tags/VideoTagLoaderNFO.cpp
@@ -52,7 +52,8 @@ CInfoScanner::InfoType CVideoTagLoaderNFO::Load(CVideoInfoTag& tag,
   else if (m_info)
     result = nfoReader.Create(m_path, m_info);
 
-  if (result == CInfoScanner::InfoType::FULL || result == CInfoScanner::InfoType::COMBINED)
+  if (result == CInfoScanner::InfoType::FULL || result == CInfoScanner::InfoType::COMBINED ||
+      result == CInfoScanner::InfoType::OVERRIDE)
     nfoReader.GetDetails(tag, nullptr, prioritise);
 
   if (result == CInfoScanner::InfoType::URL || result == CInfoScanner::InfoType::COMBINED)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Allows the import/export of multi-episode files (which includes blurays).
Allows nfos to be override nfos.

Main changes

- For multi-episode files (media or bluray) this PR appends -SxxEyy to the filename and an .nfo is created for each episode. For bluray files these files are created in the BDMV directory eg. index-S01E01.nfo

NB art is placed there as well (with the same name and art type appended - eg. `index-SxxEyy-thumb.jpg`) - this is in contrast to other art that is placed in the basepath for blurays. For multi-episode media files the nfo files and art are all in the same directory (as currently). This fixes the art issue below and also ensures the XMLs are compliant as they only contain one `<episodedetails>` tag.

- Also introduces an override tag for nfos - so for example, if  you scrape a directory using an online scraper but want to specify a playlist then create an nfo named (for example) index-S01E01.nfo containing:
```
<episodedetails override="true">
  <playlist>140</playlist>
</episodedetails>
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Whilst adding bluray support I found a few issues with current implementation. The movie related ones have now moved to the bluray version PR.

**Failure to save/import art for multi-episode media files and non-compliant XML**

Create a multi-episode file

![image](https://github.com/user-attachments/assets/103da866-3ad5-448c-abd8-745ba414cb86)

![image](https://github.com/user-attachments/assets/50162436-5724-4776-a5c1-ce69f660d34c)

Set content TV Shows -> Local scraper
XML not compliant (as multiple `<episodedetails>`)

![image](https://github.com/user-attachments/assets/da5d3a6b-ec68-4695-8612-b32a6e2edde4)

The issue is art is only saved for one episode.

Set content TV Shows-> Local Scraper

![image](https://github.com/user-attachments/assets/2f872f25-d9c1-41e5-9477-f3ce7199d150)

Note the thumb is the same.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Creating a sample source containing a mixture of media files, a DVD VIDEO_TS, a bluray ISO and BDMV.
Export, delete database and add source.
Examine the movie, paths, files and versions tables.

Note the movie fixes (other than images being written in the wrong directory and export not completing) have moved into another PR.

Episodes

![image](https://github.com/user-attachments/assets/1d8f8437-c31c-4cc1-b5a5-8559091f619b)

![image](https://github.com/user-attachments/assets/a6cc5a8a-9db5-4b5c-b7fd-3eb8354c1c61)

![image](https://github.com/user-attachments/assets/41fe2486-fb29-4d03-8e7b-d5311c979643)

After Export -> Delete -> Add Source

![image](https://github.com/user-attachments/assets/d7e42d5b-7c69-4cc9-adcf-55c93338bc93)

![image](https://github.com/user-attachments/assets/1d002c58-0b09-4d78-afdc-30f84e474674)

![image](https://github.com/user-attachments/assets/66a22dda-6750-4741-a2c5-7950bcdf3bf9)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
