### PR TITLE
[Videoversions] Extend video version functionality to allow the selection of multiple versions (playlists) in the same Blu-ray ISO/folder - and add support for import/export of (multi) movie versions.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24563,7 +24563,11 @@ msgctxt "#40032"
 msgid "No similar movies were found in the library."
 msgstr ""
 
-#empty string id 40033
+#. Add version: Add another version from this disc - for Blurays
+#: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+msgctxt "#40033"
+msgid "Add another version from this disc?"
+msgstr ""
 
 #. Addition of new extra: a movie with multiple versions cannot be turned into an extra of another movie.
 #: xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -24607,7 +24611,13 @@ msgctxt "#40040"
 msgid "Are you sure to remove the extra \"{0:s}\"?"
 msgstr ""
 
-#empty strings with id 40041 to 40201
+#. Prompt to assign playlist to current movie version
+#: xbmc/video/dialogs/GUIDialogVideoManager.cpp
+msgctxt "#40041"
+msgid "Assign playlist to current movie version?"
+msgstr ""
+
+#empty strings with id 40042 to 40201
 
 #. Ignore different video versions settting
 #: system/settings/settings.xml

--- a/addons/skin.estuary/xml/DialogVideoManager.xml
+++ b/addons/skin.estuary/xml/DialogVideoManager.xml
@@ -31,7 +31,8 @@
 				<align>right</align>
 				<aligny>bottom</aligny>
 				<textcolor>grey</textcolor>
-				<label>$INFO[Container(50).ListItem.FileNameAndPath]</label>
+				<scroll>true</scroll>
+				<label>$INFO[Container(50).ListItem.DecodedFileNameAndPath]</label>
 			</control>
 			<control type="label">
 				<right>20</right>

--- a/xbmc/NfoFile.h
+++ b/xbmc/NfoFile.h
@@ -30,7 +30,7 @@ class CNfoFile
 public:
   virtual ~CNfoFile() { Close(); }
 
-  CInfoScanner::InfoType Create(const std::string&, const ADDON::ScraperPtr&, int episode = -1);
+  CInfoScanner::InfoType Create(const std::string&, const ADDON::ScraperPtr&, int index = 1);
 
   template<class T>
   bool GetDetails(T& details, const char* document = nullptr, bool prioritise = false)
@@ -51,8 +51,7 @@ public:
   ADDON::ScraperPtr GetScraperInfo() { return m_info; }
   const CScraperUrl &ScraperUrl() const { return m_scurl; }
 
-  static int Scrape(ADDON::ScraperPtr& scraper, CScraperUrl& url,
-                    const std::string& content);
+  static int Scrape(const ADDON::ScraperPtr& scraper, CScraperUrl& url, const std::string& content);
 
   static std::vector<ADDON::ScraperPtr> GetScrapers(ADDON::AddonType type,
                                                     const ADDON::ScraperPtr& selectedScraper);

--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -44,6 +44,7 @@ using ScraperPtr = std::shared_ptr<CScraper>;
 enum class ContentType
 {
   MOVIES,
+  MOVIE_VERSIONS,
   TVSHOWS,
   MUSICVIDEOS,
   ALBUMS,
@@ -214,6 +215,8 @@ private:
 
       case MOVIES:
         return "movies"sv;
+      case MOVIE_VERSIONS:
+        return "movie versions"sv;
       case TVSHOWS:
         return "TV shows"sv;
       case MUSICVIDEOS:

--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -59,15 +59,16 @@ void CApplicationPlayerCallback::OnPlayBackStarted(const CFileItem& file)
   std::shared_ptr<CFileItem> itemCurrentFile;
 
   // check if VideoPlayer should set file item stream details from its current streams
-  const bool isBlu_dvd_image_or_stream = URIUtils::IsBlurayPath(file.GetPath()) ||
-                                         VIDEO::IsDVDFile(file) || file.IsDiscImage() ||
-                                         NETWORK::IsInternetStream(file);
+  const bool isBlu_dvd_image_or_stream = VIDEO::IsBDFile(file) || VIDEO::IsDVDFile(file) ||
+                                         file.IsDiscImage() || NETWORK::IsInternetStream(file);
 
   const bool hasNoStreamDetails =
       (!file.HasVideoInfoTag() || !file.GetVideoInfoTag()->HasStreamDetails());
 
+  // Always update streamdetails for bluray:// paths as existing details may be been taken from BLURAY_TITLE_INFO
   if (file.GetProperty("get_stream_details_from_player").asBoolean() ||
-      (hasNoStreamDetails && isBlu_dvd_image_or_stream))
+      (hasNoStreamDetails && isBlu_dvd_image_or_stream) ||
+      URIUtils::IsBlurayPath(file.GetDynPath()))
   {
     auto& components = CServiceBroker::GetAppComponents();
     const auto appPlayer = components.GetComponent<CApplicationPlayer>();

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -165,6 +165,9 @@ bool CGUIDialogSimpleMenu::ShowPlaylistSelection(CFileItem& item)
       }
 
       item.SetDynPath(item_new->GetDynPath());
+      item.GetVideoInfoTag()->m_streamDetails =
+          item_new->GetVideoInfoTag()
+              ->m_streamDetails; // Basic stream details from BLURAY_TITLE INFO
       item.SetProperty("get_stream_details_from_player", true); // Overwrite when played
       item.SetProperty("original_listitem_url", originalDynPath);
       return true;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -321,6 +321,8 @@ void CAdvancedSettings::Initialize()
   m_disableEpisodeRanges = false;
 
   m_caseSensitiveLocalArtMatch = true; // case sensitive local art matching
+  m_bNoRemoteArtWithLocalScraper =
+      false; // If local nfo file refers to online art, it will be retrieved
 
   m_iEpgUpdateCheckInterval = 300; /* Check every X seconds, if EPG data need to be updated. This does not mean that
                                       every X seconds an EPG update is actually triggered, it's just the interval how
@@ -826,6 +828,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetBoolean(pElement, "casesensitivelocalartmatch", m_caseSensitiveLocalArtMatch);
     XMLUtils::GetInt(pElement, "minimumepisodeplaylistduration", m_minimumEpisodePlaylistDuration);
     XMLUtils::GetBoolean(pElement, "disableepisoderanges", m_disableEpisodeRanges);
+    XMLUtils::GetBoolean(pElement, "noremoteartwithlocalscraper", m_bNoRemoteArtWithLocalScraper);
   }
 
   pElement = pRootElement->FirstChildElement("videoscanner");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -275,6 +275,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_caseSensitiveLocalArtMatch{true};
     int m_minimumEpisodePlaylistDuration; // seconds
     bool m_disableEpisodeRanges{false};
+    bool m_bNoRemoteArtWithLocalScraper{false};
 
     CLangInfo::Tokens m_vecTokens;
 

--- a/xbmc/utils/ArtUtils.h
+++ b/xbmc/utils/ArtUtils.h
@@ -15,10 +15,11 @@ class CFileItem;
 namespace KODI::ART
 {
 
-enum class UseSeasonAndEpisode : bool
+enum class AdditionalIdentifiers : uint8_t
 {
-  NO,
-  YES
+  NONE,
+  SEASON_AND_EPISODE, // Append SxxEyy to the file name
+  PLAYLIST, // Append playlist number to the file name
 };
 
 //! \brief Set default icon for item.
@@ -36,27 +37,29 @@ std::string GetFolderThumb(const CFileItem& item, const std::string& folderJPG =
            No file existence check is typically performed.
  \param artFile the art file to search for.
  \param useFolder whether to look in the folder for the art file. Defaults to false.
- \param useSeasonAndEpisode for multi-episode files. Append SxxEyy to the file name. Defaults to no.
+ \param additionalIdentifiers for multi-episode/multi-movie files. Append SxxEyy or playlist number to the file name.
+                              Defaults to none.
  \return the path to the local artwork.
  \sa FindLocalArt
  */
 std::string GetLocalArt(const CFileItem& item,
                         const std::string& artFile,
                         bool useFolder = false,
-                        UseSeasonAndEpisode useSeasonAndEpisode = UseSeasonAndEpisode::NO);
+                        AdditionalIdentifiers useSeasonAndEpisode = AdditionalIdentifiers::NONE);
 
 /*!
  \brief Assemble the base filename of local artwork for an item,
  accounting for archives, stacks and multi-paths, and BDMV/VIDEO_TS folders.
  \param useFolder whether to look in the folder for the art file. Defaults to false.
- \param useSeasonAndEpisode for multi-episode files. Append SxxEyy to the file name. Defaults to no.
+ \param additionalIdentifiers for multi-episode/multi-movie files. Append SxxEyy or playlist number to the file name.
+                              Defaults to none.
  \return the path to the base filename for artwork lookup.
  \sa GetLocalArt
  */
 std::string GetLocalArtBaseFilename(
     const CFileItem& item,
     bool& useFolder,
-    UseSeasonAndEpisode useSeasonAndEpisode = UseSeasonAndEpisode::NO);
+    AdditionalIdentifiers additionalIdentifiers = AdditionalIdentifiers::NONE);
 
 /*!
  \brief Get the local fanart for item if it exists

--- a/xbmc/utils/DiscsUtils.cpp
+++ b/xbmc/utils/DiscsUtils.cpp
@@ -9,6 +9,7 @@
 #include "DiscsUtils.h"
 
 #include "FileItem.h"
+#include "URIUtils.h"
 #include "URL.h"
 
 //! @todo it's wrong to include videoplayer scoped files, refactor
@@ -78,7 +79,12 @@ UTILS::DISCS::DiscInfo UTILS::DISCS::ProbeBlurayDiscInfo(const std::string& medi
 
 bool UTILS::DISCS::IsBlurayDiscImage(const CFileItem& item)
 {
-  if (!item.IsDiscImage())
+  return IsBlurayDiscImage(item.GetDynPath());
+}
+
+bool UTILS::DISCS::IsBlurayDiscImage(const std::string& path)
+{
+  if (!URIUtils::IsDiscImage(path))
     return false;
 
   static constexpr std::array<std::string_view, 4> blurayFiles = {
@@ -88,7 +94,7 @@ bool UTILS::DISCS::IsBlurayDiscImage(const CFileItem& item)
       "BDMV/INDEX.BDM",
   };
   CURL url("udf://");
-  url.SetHostName(item.GetDynPath());
+  url.SetHostName(path);
 
   return std::ranges::any_of(blurayFiles,
                              [&url](std::string_view file)

--- a/xbmc/utils/DiscsUtils.h
+++ b/xbmc/utils/DiscsUtils.h
@@ -77,5 +77,11 @@ DiscInfo ProbeBlurayDiscInfo(const std::string& mediaPath);
 */
 bool IsBlurayDiscImage(const CFileItem& item);
 
+/*! \brief Probe a FileItem to see it is a bluray disc image
+    \param path The path to probe
+    \return true if the item is a bluray disc image, false otherwise
+*/
+bool IsBlurayDiscImage(const std::string& path);
+
 } // namespace DISCS
 } // namespace UTILS

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -12286,12 +12286,13 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
         if (lastTitle == currentTitle && item.HasVideoVersions())
         {
           item.SetProperty("idMovie", lastMovieId);
-          scanner.AddVideo(&item, ContentType::MOVIE_VERSIONS, useFolders, true, nullptr, true);
+          scanner.AddVideo(&item, nullptr, useFolders, true, nullptr, true,
+                           ContentType::MOVIE_VERSIONS);
         }
         else
         {
-          lastMovieId =
-              scanner.AddVideo(&item, ContentType::MOVIES, useFolders, true, nullptr, true);
+          lastMovieId = scanner.AddVideo(&item, nullptr, useFolders, true, nullptr, true,
+                                         ContentType::MOVIES);
           lastTitle = currentTitle;
         }
         if (item.HasVideoVersions())
@@ -12304,7 +12305,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
           if (tag->IsDefaultVideoVersion())
             SetDefaultVideoVersion(VideoDbContentType::MOVIES, lastMovieId, tag->m_iFileId);
         }
-        scanner.AddVideo(&item, ContentType::MOVIES, useFolders, true, nullptr, true);
+        scanner.AddVideo(&item, nullptr, useFolders, true, nullptr, true, ContentType::MOVIES);
         current++;
       }
       else if (StringUtils::CompareNoCase(movie->Value(), MediaTypeMusicVideo, 10) == 0)
@@ -12322,7 +12323,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
         artItem.SetPath(GetSafeFile(musicvideosDir, filename) + ".avi");
         scanner.GetArtwork(&artItem, ContentType::MUSICVIDEOS, useFolders, true, actorsDir);
         item.SetArt(artItem.GetArt());
-        scanner.AddVideo(&item, ContentType::MUSICVIDEOS, useFolders, true, nullptr, true);
+        scanner.AddVideo(&item, nullptr, useFolders, true, nullptr, true, ContentType::MUSICVIDEOS);
         current++;
       }
       else if (StringUtils::CompareNoCase(movie->Value(), MediaTypeTvShow, 6) == 0)
@@ -12342,8 +12343,8 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
         artItem.SetPath(artPath);
         scanner.GetArtwork(&artItem, ContentType::TVSHOWS, useFolders, true, actorsDir);
         showItem.SetArt(artItem.GetArt());
-        const auto showID = static_cast<int>(
-            scanner.AddVideo(&showItem, ContentType::TVSHOWS, useFolders, true, nullptr, true));
+        const int showID = scanner.AddVideo(&showItem, nullptr, useFolders, true, nullptr, true,
+                                            ContentType::TVSHOWS);
         // season artwork
         KODI::ART::SeasonsArtwork seasonArt;
         artItem.GetVideoInfoTag()->m_strPath = artPath;
@@ -12369,8 +12370,8 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
           artItem2.SetPath(GetSafeFile(artPath, filename));
           scanner.GetArtwork(&artItem2, ContentType::TVSHOWS, useFolders, true, actorsDir);
           item.SetArt(artItem2.GetArt());
-          scanner.AddVideo(&item, ContentType::TVSHOWS, false, false, showItem.GetVideoInfoTag(),
-                           true);
+          scanner.AddVideo(&item, nullptr, false, false, showItem.GetVideoInfoTag(), true,
+                           ContentType::TVSHOWS);
           episode = episode->NextSiblingElement("episodedetails");
         }
       }

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -494,6 +494,12 @@ enum class DeleteMovieHashAction
 #define COMPARE_PERCENTAGE     0.90f // 90%
 #define COMPARE_PERCENTAGE_MIN 0.50f // 50%
 
+enum class AllowNonFileNameMatch : bool
+{
+  NO_MATCH,
+  YES_MATCH
+};
+
 struct EpisodeInformation
 {
   int index{0};
@@ -715,6 +721,9 @@ public:
                               int idMVideo = -1);
   bool SetStreamDetailsForFile(const CStreamDetails& details,
                                const std::string& strFileNameAndPath);
+
+  int AddMovieVersion(CFileItem& item, int idMovie, const KODI::ART::Artwork& art);
+
   /*!
    * \brief Clear any existing stream details and add the new provided details to a file.
    * \param[in] details New stream details
@@ -1259,13 +1268,12 @@ public:
    *        (used to preserve streamdetails for bluray playlists)
    * \return true for success, false otherwise
    */
-  bool ConvertVideoToVersion(
-      VideoDbContentType itemType,
-      int dbIdSource,
-      int dbIdTarget,
-      int idVideoVersion,
-      VideoAssetType assetType,
-      DeleteMovieCascadeAction cascadeAction = DeleteMovieCascadeAction::ALL_ASSETS);
+  bool ConvertVideoToVersion(VideoDbContentType itemType,
+                             int dbIdSource,
+                             int dbIdTarget,
+                             int idVideoVersion,
+                             VideoAssetType assetType,
+                             DeleteMovieCascadeAction cascadeAction);
 
   /*!
    * \brief Adds a version of an existing movie to the database
@@ -1316,8 +1324,10 @@ public:
   VideoAssetInfo GetVideoVersionInfo(const std::string& filenameAndPath);
   bool UpdateAssetsOwner(const std::string& mediaType, int dbIdSource, int dbIdTarget);
 
-  int GetMovieId(const std::string& strFilenameAndPath);
+  int GetMovieId(const std::string& strFilenameAndPath,
+                 AllowNonFileNameMatch allowNonFileNameMatch = AllowNonFileNameMatch::NO_MATCH);
   std::string GetMovieTitle(int idMovie);
+  int GetMovieIdByTitle(const std::string& title);
   void GetSameVideoItems(const CFileItem& item, CFileItemList& items);
   int GetFileIdByMovie(int idMovie);
   int GetFileIdByFile(const std::string& fullpath);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -481,7 +481,8 @@ enum class ArtFallbackOptions
 enum class DeleteMovieCascadeAction
 {
   DEFAULT_VERSION,
-  ALL_ASSETS
+  ALL_ASSETS,
+  ALL_ASSETS_NOT_STREAMDETAILS
 };
 
 enum class DeleteMovieHashAction
@@ -1246,13 +1247,32 @@ public:
    * \param dbIdTarget id that the video will be attached to
    * \param idVideoVersion new versiontype of the default version of the video
    * \param assetType new asset type of the default version of the video
+   * \param cascadeAction action to take on the assets of the video being converted
+   *        (used to preserve streamdetails for bluray playlists)
    * \return true for success, false otherwise
    */
-  bool ConvertVideoToVersion(VideoDbContentType itemType,
-                             int dbIdSource,
-                             int dbIdTarget,
-                             int idVideoVersion,
-                             VideoAssetType assetType);
+  bool ConvertVideoToVersion(
+      VideoDbContentType itemType,
+      int dbIdSource,
+      int dbIdTarget,
+      int idVideoVersion,
+      VideoAssetType assetType,
+      DeleteMovieCascadeAction cascadeAction = DeleteMovieCascadeAction::ALL_ASSETS);
+
+  /*!
+   * \brief Adds a version of an existing movie to the database
+   * \param itemType type of the video being converted
+   * \param dbIdSource id of the video being converted
+   * \param idVideoVersion new versiontype of the default version of the video
+   * \param assetType new asset type of the default version of the video
+   * \return dbId in the videoversion table, -1 if failure
+   */
+  int AddVideoVersion(VideoDbContentType itemType,
+                      int dbIdSource,
+                      int idFile,
+                      int idVideoVersion,
+                      VideoAssetType assetType);
+
   void SetDefaultVideoVersion(VideoDbContentType itemType, int dbId, int idFile);
   void SetVideoVersion(int idFile, int idVideoVersion);
   int AddVideoVersionType(const std::string& typeVideoVersion,

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -505,6 +505,14 @@ using EpisodeFileMapEntry = std::pair<std::string, EpisodeInformation>;
 
 class CVideoDatabase : public CDatabase
 {
+  struct FileInformation
+  {
+    std::string path;
+    int fileId{0};
+    int vvId{0};
+    std::string hash;
+  };
+
 public:
 
   class CActor    // used for actor retrieval for non-master users

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -49,6 +49,13 @@ namespace KODI::VIDEO
 
   class CVideoInfoScanner : public CInfoScanner
   {
+
+    enum class UseRemoteArtWithLocalScraper : bool
+    {
+      NO,
+      YES
+    };
+
   public:
     CVideoInfoScanner();
     ~CVideoInfoScanner() override;
@@ -68,19 +75,21 @@ namespace KODI::VIDEO
 
     /*! \brief Add an item to the database.
      \param pItem item to add to the database.
-     \param content content type of the item.
+     \param scraper scraper used for the lookup.
      \param videoFolder whether the video is represented by a folder (single movie per folder). Defaults to false.
      \param useLocal whether to use local information for artwork etc.
      \param showInfo pointer to CVideoInfoTag details for the show if this is an episode. Defaults to nullptr.
      \param libraryImport Whether this call belongs to a full library import or not. Defaults to false.
+     \param contentOverride content type of the item. Defaults to CONTENT_NONE (which is ignored).
      \return database id of the added item, or -1 on failure.
      */
     long AddVideo(CFileItem* pItem,
-                  ADDON::ContentType content,
+                  const ADDON::ScraperPtr& scraper,
                   bool videoFolder = false,
                   bool useLocal = true,
                   const CVideoInfoTag* showInfo = nullptr,
-                  bool libraryImport = false);
+                  bool libraryImport = false,
+                  ADDON::ContentType contentOverride = ADDON::ContentType::NONE);
 
     /*! \brief Retrieve information for a list of items and add them to the database.
      \param items list of items to retrieve info for.
@@ -115,23 +124,28 @@ namespace KODI::VIDEO
      \param bApplyToDir whether we should apply any thumbs to a folder.  Defaults to false.
      \param useLocal whether we should use local thumbs. Defaults to true.
      \param actorArtPath the path to search for actor thumbs. Defaults to empty.
+     \param useRemoteArt use remote art if also using local scraper. Defaults to yes.
      */
     void GetArtwork(CFileItem* pItem,
                     ADDON::ContentType content,
                     bool bApplyToDir = false,
                     bool useLocal = true,
-                    const std::string& actorArtPath = "");
+                    const std::string& actorArtPath = "",
+                    UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES);
 
     /*! \brief Get season thumbs for a tvshow.
      All seasons (regardless of whether the user has episodes) are added to the art map.
      \param show     tvshow info tag
      \param art      artwork map to which season thumbs are added.
      \param useLocal whether to use local thumbs, defaults to true
+     \param useRemoteArt use remote art if also using local scraper. Defaults to yes.
      */
-    static void GetSeasonThumbs(const CVideoInfoTag& show,
-                                KODI::ART::SeasonsArtwork& art,
-                                const std::vector<std::string>& artTypes,
-                                bool useLocal = true);
+    static void GetSeasonThumbs(
+        const CVideoInfoTag& show,
+        KODI::ART::SeasonsArtwork& art,
+        const std::vector<std::string>& artTypes,
+        bool useLocal = true,
+        UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES);
     static std::string GetImage(const CScraperUrl::SUrlEntry &image, const std::string& itemPath);
 
     bool EnumerateEpisodeItem(const CFileItem *item, EPISODELIST& episodeList);
@@ -238,8 +252,12 @@ namespace KODI::VIDEO
      Updates each actor with their thumb (local or online)
      \param actors - vector of SActorInfo
      \param strPath - path on filesystem to look for local thumbs
+     \param useRemoteArt - use remote art (ie. http://) even if derived from local .nfo file. Defaults to yes.
      */
-    void FetchActorThumbs(std::vector<SActorInfo>& actors, const std::string& strPath);
+    void FetchActorThumbs(
+        std::vector<SActorInfo>& actors,
+        const std::string& strPath,
+        UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES);
 
     static int GetPathHash(const CFileItemList &items, std::string &hash);
 

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1147,6 +1147,8 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
   if (XMLUtils::GetString(movie, "filenameandpath", value))
     SetFileNameAndPath(value);
   XMLUtils::GetInt(movie, "playlist", m_iTrack);
+  XMLUtils::GetBoolean(movie, "hasvideoversions", m_hasVideoVersions);
+  XMLUtils::GetBoolean(movie, "isdefaultvideoversion", m_isDefaultVideoVersion);
 
   if (XMLUtils::GetDate(movie, "premiered", m_premiered))
   {
@@ -1873,6 +1875,7 @@ void CVideoInfoTag::CAssetInfo::ParseNative(const TiXmlElement* movie)
   if (XMLUtils::GetString(movie, "videoassettitle", value))
     m_title = value;
 
+  m_id = VIDEO_VERSION_ID_BEGIN;
   XMLUtils::GetInt(movie, "videoassetid", m_id);
 
   int assetType{-1};

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -221,7 +221,6 @@ void CGUIDialogVideoManager::Refresh()
 
   for (auto& item : *m_videoAssetsList)
   {
-    item->SetProperty("noartfallbacktoowner", true);
     loader.LoadItem(item.get());
   }
 

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -296,6 +296,10 @@ void CGUIDialogVideoManager::Remove()
 
   m_database.DeleteVideoAsset(m_selectedVideoAsset->GetVideoInfoTag()->m_iDbId);
 
+  // If a version of a bluray then remove the idFile as well
+  if (URIUtils::IsBlurayPath(m_selectedVideoAsset->GetDynPath()))
+    m_database.DeleteFile(m_selectedVideoAsset->GetVideoInfoTag()->m_iFileId);
+
   // refresh data and controls
   Refresh();
   RefreshSelectedVideoAsset();

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -214,7 +214,8 @@ bool CGUIDialogVideoManagerExtras::AddVideoExtra()
           return false;
 
         return m_database.ConvertVideoToVersion(itemType, newAsset.m_idMedia, dbId,
-                                                idNewVideoVersion, VideoAssetType::EXTRA);
+                                                idNewVideoVersion, VideoAssetType::EXTRA,
+                                                DeleteMovieCascadeAction::ALL_ASSETS);
       }
     }
 

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -347,8 +347,22 @@ bool CGUIDialogVideoManagerVersions::ChoosePlaylist(const std::shared_ptr<CFileI
       bool videoDbSuccess{false};
       m_database.BeginTransaction();
       if (replaceExistingFile == ReplaceExistingFile::YES)
+      {
         videoDbSuccess = m_database.SetFileForMedia(item->GetDynPath(), item->GetVideoContentType(),
                                                     idMovie, item->GetVideoInfoTag()->m_iFileId);
+        if (videoDbSuccess)
+        {
+          m_database.SetStreamDetailsForFile(item->GetVideoInfoTag()->m_streamDetails,
+                                             item->GetDynPath());
+
+          // Notify all windows to update the file item
+          std::shared_ptr<CFileItem> oldItem{item};
+          oldItem->SetPath(oldPath);
+          CGUIMessage msg{GUI_MSG_NOTIFY_ALL,        0,      0, GUI_MSG_UPDATE_ITEM,
+                          GUI_MSG_FLAG_FORCE_UPDATE, oldItem};
+          CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
+        }
+      }
       else
       {
         // Choose a video version for the video
@@ -360,6 +374,7 @@ bool CGUIDialogVideoManagerVersions::ChoosePlaylist(const std::shared_ptr<CFileI
         if (idFile > 0)
         {
           videoDbSuccess = true;
+          m_database.SetStreamDetailsForFileId(item->GetVideoInfoTag()->m_streamDetails, idFile);
           if (m_database.AddVideoVersion(item->GetVideoContentType(), idMovie, idFile,
                                          idVideoVersion, VideoAssetType::VERSION) < 0)
             return false;

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -17,6 +17,7 @@
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogSelect.h"
+#include "dialogs/GUIDialogSimpleMenu.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
@@ -27,6 +28,7 @@
 #include "storage/MediaManager.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "video/VideoManagerTypes.h"
 #include "video/VideoThumbLoader.h"
@@ -206,6 +208,23 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersion()
     return false;
   }
 
+  if (m_selectedVideoAsset && m_selectedVideoAsset->IsBluray())
+  {
+    // First see if the existing video asset has a playlist
+    if (!URIUtils::IsBlurayPath(m_selectedVideoAsset->GetDynPath()))
+    {
+      const int dlgResult{CGUIDialogYesNo::ShowAndGetInput(CVariant{40030}, CVariant{40041})};
+      if (dlgResult == CGUIDialogYesNo::DIALOG_RESULT_YES)
+        if (!ChoosePlaylist(m_selectedVideoAsset, ReplaceExistingFile::YES))
+          return false;
+    }
+
+    // Now ask if the user wants to add another playlist as a version
+    const int dlgResult{CGUIDialogYesNo::ShowAndGetInput(CVariant{40030}, CVariant{40033})};
+    if (dlgResult == CGUIDialogYesNo::DIALOG_RESULT_YES)
+      return ChoosePlaylist(m_selectedVideoAsset, ReplaceExistingFile::NO);
+  }
+
   CVideoDatabase videoDb;
   if (!videoDb.Open())
   {
@@ -302,6 +321,65 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersion()
                                                tag->m_type, tag->m_iDbId, videoDb,
                                                MediaRole::Parent);
   }
+  return false;
+}
+
+bool CGUIDialogVideoManagerVersions::ChoosePlaylist(const std::shared_ptr<CFileItem>& item,
+                                                    ReplaceExistingFile replaceExistingFile)
+{
+  // Open database
+  if (!m_database.IsOpen() && !m_database.Open())
+  {
+    CLog::LogF(LOGERROR, "Failed to open video database!");
+    return false;
+  }
+
+  // Select the playlist using the simple menu
+  const std::string oldPath{item->GetDynPath()};
+  item->SetProperty("force_playlist_selection", true);
+  const int idMovie{m_database.GetMovieId(oldPath)};
+
+  if (CGUIDialogSimpleMenu::ShowPlaylistSelection(*item))
+  {
+    if (oldPath != item->GetDynPath())
+    {
+      // Add playlist file as bluray://
+      bool videoDbSuccess{false};
+      m_database.BeginTransaction();
+      if (replaceExistingFile == ReplaceExistingFile::YES)
+        videoDbSuccess = m_database.SetFileForMedia(item->GetDynPath(), item->GetVideoContentType(),
+                                                    idMovie, item->GetVideoInfoTag()->m_iFileId);
+      else
+      {
+        // Choose a video version for the video
+        const int idVideoVersion{ChooseVideoAsset(item, VideoAssetType::VERSION, "")};
+        if (idVideoVersion < 0)
+          return false;
+
+        const int idFile{m_database.AddFile(item->GetDynPath())};
+        if (idFile > 0)
+        {
+          videoDbSuccess = true;
+          if (m_database.AddVideoVersion(item->GetVideoContentType(), idMovie, idFile,
+                                         idVideoVersion, VideoAssetType::VERSION) < 0)
+            return false;
+        }
+      }
+
+      if (videoDbSuccess)
+        m_database.CommitTransaction();
+      else
+        m_database.RollbackTransaction();
+
+      // refresh data and controls
+      Refresh();
+      UpdateControls();
+      m_hasUpdatedItems = true;
+
+      return videoDbSuccess;
+    }
+  }
+
   return false;
 }
 
@@ -640,6 +718,15 @@ bool CGUIDialogVideoManagerVersions::AddSimilarMovieAsVersion(
     return false;
   }
 
+  // Choose playlist for blurays
+  DeleteMovieCascadeAction cascadeAction{DeleteMovieCascadeAction::ALL_ASSETS};
+  if (itemMovie->IsBluray())
+  {
+    if (!ChoosePlaylist(itemMovie, ReplaceExistingFile::YES))
+      return false;
+    cascadeAction = DeleteMovieCascadeAction::ALL_ASSETS_NOT_STREAMDETAILS;
+  }
+
   // choose a video version type for the video
   const int idVideoVersion{ChooseVideoAsset(itemMovie, VideoAssetType::VERSION, "")};
   if (idVideoVersion < 0)
@@ -655,7 +742,7 @@ bool CGUIDialogVideoManagerVersions::AddSimilarMovieAsVersion(
   const int sourceDbId{itemMovie->GetVideoInfoTag()->m_iDbId};
   const int targetDbId{m_videoAsset->GetVideoInfoTag()->m_iDbId};
   return videoDb.ConvertVideoToVersion(VideoDbContentType::MOVIES, sourceDbId, targetDbId,
-                                       idVideoVersion, VideoAssetType::VERSION);
+                                       idVideoVersion, VideoAssetType::VERSION, cascadeAction);
 }
 
 bool CGUIDialogVideoManagerVersions::PostProcessList(CFileItemList& list, int dbId)

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -488,7 +488,8 @@ bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
   }
 
   return videoDb.ConvertVideoToVersion(itemType, sourceDbId, targetDbId, idVideoVersion,
-                                       VideoAssetType::VERSION);
+                                       VideoAssetType::VERSION,
+                                       DeleteMovieCascadeAction::ALL_ASSETS);
 }
 
 bool CGUIDialogVideoManagerVersions::GetAllOtherMovies(const std::shared_ptr<CFileItem>& item,
@@ -671,7 +672,8 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
         if (idNewVideoVersion != -1)
         {
           return m_database.ConvertVideoToVersion(itemType, newAsset.m_idMedia, dbId,
-                                                  idNewVideoVersion, VideoAssetType::VERSION);
+                                                  idNewVideoVersion, VideoAssetType::VERSION,
+                                                  DeleteMovieCascadeAction::ALL_ASSETS);
         }
         else
         {

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
@@ -12,7 +12,6 @@
 
 #include <memory>
 #include <string>
-#include <tuple>
 
 class CFileItem;
 
@@ -49,6 +48,12 @@ protected:
   void Remove() override;
 
 private:
+  enum class ReplaceExistingFile : bool
+  {
+    NO,
+    YES
+  };
+
   void SetDefaultVideoVersion(const CFileItem& version);
   /*!
    * \brief Prompt the user to select a file / movie to add as version
@@ -122,6 +127,15 @@ private:
    * \return True for success, false otherwise.
    */
   static bool PostProcessList(CFileItemList& list, int dbId);
+
+  /*!
+   * \brief Prompts the user to choose a playlist from the current disc
+   * \param item the current CFileItem
+   * \param replaceExistingFile whether to replace the existing playlist in the database
+   * \return true for success, false otherwise.
+   */
+  bool ChoosePlaylist(const std::shared_ptr<CFileItem>& item,
+                      ReplaceExistingFile replaceExistingFile);
 
   std::shared_ptr<CFileItem> m_defaultVideoVersion;
 };

--- a/xbmc/video/tags/VideoTagLoaderNFO.cpp
+++ b/xbmc/video/tags/VideoTagLoaderNFO.cpp
@@ -47,10 +47,16 @@ CInfoScanner::InfoType CVideoTagLoaderNFO::Load(CVideoInfoTag& tag,
 {
   CNfoFile nfoReader;
   CInfoScanner::InfoType result = CInfoScanner::InfoType::NONE;
-  if (m_info && m_info->Content() == ADDON::ContentType::TVSHOWS && !m_item.IsFolder())
-    result = nfoReader.Create(m_path, m_info, m_item.GetVideoInfoTag()->m_iEpisode);
-  else if (m_info)
-    result = nfoReader.Create(m_path, m_info);
+  if (m_info)
+  {
+    if (m_info->Content() == ADDON::ContentType::MOVIES && !m_item.IsFolder() &&
+        m_item.HasProperty("nfo_index"))
+      result = nfoReader.Create(
+          m_path, m_info,
+          m_item.GetProperty("nfo_index").asInteger32(1)); // multiple versions (playlists) in nfo
+    else
+      result = nfoReader.Create(m_path, m_info);
+  }
 
   if (result == CInfoScanner::InfoType::FULL || result == CInfoScanner::InfoType::COMBINED ||
       result == CInfoScanner::InfoType::OVERRIDE)

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -819,8 +819,11 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
       }
       if (PLAYLIST::IsSmartPlayList(*item) || PLAYLIST::IsSmartPlayList(*m_vecItems))
         buttons.Add(CONTEXT_BUTTON_EDIT_SMART_PLAYLIST, 586);
-      if (URIUtils::IsBlurayPath(item->GetDynPath()))
+
+      if (URIUtils::IsBlurayPath(item->GetDynPath()) && !item->IsFolder())
+      {
         buttons.Add(CONTEXT_BUTTON_CHOOSE_PLAYLIST, 13424);
+      }
     }
   }
   CGUIMediaWindow::GetContextButtons(itemNumber, buttons);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Now that bluray:// file paths are implemented to point to individual playlists this PR extends the video version functionality to allow the selection of multiple playlsits on the same disc and assign each a version.

This also extends import/export functionality to support multi-movie files (ie. blurays in the case) - but could be easily extended to include mkv files with more than one movie in the future. It also fixes some existing bugs regarding movie versions import/export.

For multiple movies in a file (ie bluray), multiple `<movie>` entries are created in the .nfo - all encapsulated in a root <movies> to ensure xml compliance - one for each movie version. This because there is only one base file (.ISO or index.bdmv) and the playlist information is stored in the nfo itself - and the interaction between VideoInfoScanner and the NFO classes makes it difficult to scan all nfo files and communicate back (the nfo file is 'found' in the NFO classes not in VideoInfoScanner).

How to use:
When the version dialog detects that you are managing versions on a bluray it asks first if you want to assign a playlist to the default version (if not played already) then if you want to add an additional version/playlsit on the disc. If yes, then the simple menu dialog is used to select a playlist. If no, then the usual library/browse options are presented.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently you cannot select multiple video versions within the same file, so for blurays where you have multiple versions (eg. Terminator 2 - Theatrical version, Special Edition and Extended Edition) on the same disc you cannot use this feature.

**Failure to import movie versions**

Firstly create two versions of a movie with media files.

![image](https://github.com/user-attachments/assets/36b05b72-261d-4477-a310-da47890a6c77)

Export -> Separate -> Yes to art -> Overwrite
Delete database
Set content Movies -> Local Scraper -> Individual folders

![image](https://github.com/user-attachments/assets/07adfa50-f51f-4678-801e-323f8b97bf05)

Note versions are not created.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/a39d23f8-a70b-453d-b092-68b64f0d7ca7)

![image](https://github.com/user-attachments/assets/eb2e9a1a-463b-4be1-b6cd-0c550865d1af)

![image](https://github.com/user-attachments/assets/b2034dad-6daa-4fbd-90b0-49b00500dd6b)

More complex test:

```
+---Aliens (1986)
    ¦   Aliens - The Cocoon Cut-poster.png
    ¦   Aliens - The Cocoon Cut.mp4
    ¦   Aliens - The Cocoon Cut.nfo
    ¦   
    +---Disc 1
    ¦       ALIENS.dvd
    ¦       ALIENS.iso
    ¦       ALIENS.md5
    ¦       
    +---Disc 2
        ¦   disc.inf
        ¦   
        +---BDMV
        ¦   ¦   index.bdmv
        ¦   ¦   MovieObject.bdmv
 ```

The Bluray discs are taken from the UHD release. Disc 1 is 4K - containing both the theatrical and special editions. Disc 2 is bluray - again containing both editions. The Cocoon cut is a fan edit.

Adding the source using the TMDB scraper:
![image](https://github.com/user-attachments/assets/81fd1065-41f4-4f24-b0d4-8c21cee8b5cd)

On Aliens (Disc 1) -> Context menu -> Manage.. -> Manage versions
Add version
Yes to assign playlist to current movie version -> 800
Yes to add another version from this disc -> 801 -> Special Edition
Add version
No to add another version from this disc
Select Aliens (Disc 2) from the dialog
Select title 800 -> Standard edition

![image](https://github.com/user-attachments/assets/7eb5f11d-b34e-40ab-b3d0-1f8559919a1c)

Now left click/select the bottom Standard edition (on Disc 2) entry

NB - this is how add version knows which disc to look for a version on.

![image](https://github.com/user-attachments/assets/9b2517ef-a60e-4528-b040-498357035cf5)

Add version
Yes to add another version from this disc -> 801 -> Special Edition

![image](https://github.com/user-attachments/assets/1fa72e93-1220-48cb-8dc3-48aed0077ea3)

Add version
No to add another version from this disc
Browse Library
Select Aliens – The Cocoon Cut -> Fan edit

Now the versions manager looks like:

![image](https://github.com/user-attachments/assets/2b37a050-5398-4a66-96ba-94035e3b5154)

Now the library looks like:

![image](https://github.com/user-attachments/assets/81c562aa-276a-4f01-bcd8-625167c3d003)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
