### PR TITLE
Fix build with taglib2

### DIFF
--- a/xbmc/music/tags/TagLibVFSStream.cpp
+++ b/xbmc/music/tags/TagLibVFSStream.cpp
@@ -9,7 +9,7 @@
 
 #include "filesystem/File.h"
 
-#include <limits.h>
+#include <limits>
 
 #include <taglib/taglib.h>
 #include <taglib/tiostream.h>
@@ -59,7 +59,7 @@ FileName TagLibVFSStream::name() const
  * Reads a block of size \a length at the current get pointer.
  */
 #if (TAGLIB_MAJOR_VERSION >= 2)
-ByteVector TagLibVFSStream::readBlock(unsigned long length)
+ByteVector TagLibVFSStream::readBlock(size_t length)
 #else
 ByteVector TagLibVFSStream::readBlock(TagLib::ulong length)
 #endif
@@ -282,7 +282,11 @@ bool TagLibVFSStream::isOpen() const
  *
  * \see Position
  */
+#if (TAGLIB_MAJOR_VERSION >= 2)
+void TagLibVFSStream::seek(TagLib::offset_t offset, Position p)
+#else
 void TagLibVFSStream::seek(long offset, Position p)
+#endif
 {
   const long fileLen = length();
   if (m_bIsReadOnly && fileLen > 0)
@@ -340,27 +344,49 @@ void TagLibVFSStream::clear()
 /*!
  * Returns the current offset within the file.
  */
+#if (TAGLIB_MAJOR_VERSION >= 2)
+TagLib::offset_t TagLibVFSStream::tell() const
+{
+  int64_t pos = m_file.GetPosition();
+  if (pos > std::numeric_limits<TagLib::offset_t>::max())
+    return -1;
+  else
+    return static_cast<TagLib::offset_t>(pos);
+}
+#else
 long TagLibVFSStream::tell() const
 {
   int64_t pos = m_file.GetPosition();
-  if(pos > LONG_MAX)
+  if (pos > std::numeric_limits<long>::max())
     return -1;
   else
-    return (long)pos;
+    return static_cast<long>(pos);
 }
+#endif
 
 /*!
  * Returns the length of the file.
  */
+#if (TAGLIB_MAJOR_VERSION >= 2)
+TagLib::offset_t TagLibVFSStream::length()
+{
+  return static_cast<TagLib::offset_t>(m_file.GetLength());
+}
+#else
 long TagLibVFSStream::length()
 {
-  return (long)m_file.GetLength();
+  return static_cast<long>(m_file.GetLength());
 }
+#endif
 
 /*!
  * Truncates the file to a \a length.
  */
+#if (TAGLIB_MAJOR_VERSION >= 2)
+void TagLibVFSStream::truncate(TagLib::offset_t length)
+#else
 void TagLibVFSStream::truncate(long length)
+#endif
 {
   m_file.Truncate(length);
 }

--- a/xbmc/music/tags/TagLibVFSStream.h
+++ b/xbmc/music/tags/TagLibVFSStream.h
@@ -38,7 +38,7 @@ namespace MUSIC_INFO
      * Reads a block of size \a length at the current get pointer.
      */
 #if (TAGLIB_MAJOR_VERSION >= 2)
-    TagLib::ByteVector readBlock(unsigned long length) override;
+    TagLib::ByteVector readBlock(size_t length) override;
 #else
     TagLib::ByteVector readBlock(TagLib::ulong length) override;
 #endif
@@ -99,7 +99,11 @@ namespace MUSIC_INFO
      *
      * \see Position
      */
+#if (TAGLIB_MAJOR_VERSION >= 2)
+    void seek(TagLib::offset_t offset, TagLib::IOStream::Position p = Beginning) override;
+#else
     void seek(long offset, TagLib::IOStream::Position p = Beginning) override;
+#endif
 
     /*!
      * Reset the end-of-file and error flags on the file.
@@ -109,17 +113,29 @@ namespace MUSIC_INFO
     /*!
      * Returns the current offset within the file.
      */
+#if (TAGLIB_MAJOR_VERSION >= 2)
+    TagLib::offset_t tell() const override;
+#else
     long tell() const override;
+#endif
 
     /*!
      * Returns the length of the file.
      */
+#if (TAGLIB_MAJOR_VERSION >= 2)
+    TagLib::offset_t length() override;
+#else
     long length() override;
+#endif
 
     /*!
      * Truncates the file to a \a length.
      */
+#if (TAGLIB_MAJOR_VERSION >= 2)
+    void truncate(TagLib::offset_t length) override;
+#else
     void truncate(long length) override;
+#endif
 
   protected:
     /*!


### PR DESCRIPTION
## Description

Fix build failure on 32-bit architectures with taglib2 in Debian

## Motivation and context

Debian sid now has only taglib2 and existing PRs were not enough to address `off_t` and `size_t` differences across architectures

## How has this been tested?

Build and runtime test on Debian sid

## What is the effect on users?

Debian users get new Kodi? :)

## Screenshots (if appropriate):

## Types of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:

- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
