### PR TITLE
[Addons] Add missing error logging when no supported platforms are provided

### DIFF
--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -224,6 +224,9 @@ AddonInfoPtr CAddonInfoBuilder::Generate(const std::string& addonPath, bool plat
   if (!platformCheck || PlatformSupportsAddon(addon))
     return addon;
 
+  CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: No platform for add-on {} (supported platforms: {})",
+            __FUNCTION__, addon->ID(), StringUtils::Join(addon->m_platforms, ", "));
+
   return nullptr;
 }
 


### PR DESCRIPTION
## Description

When we moved to aab packaging for the Play Store in v21, both armv7 and arm64 libraries went into the package, but asset files were architecture-independent. This caused peripheral.joystick to break, because arm64 got the armv7 addon.xml. The `<platform>` tag was wrong for arm64, causing the add-on to be skipped.

We solved this with our aab packaging code by stripping out the `<platform>` tag from addon.xml.

However, debugging this issue was complicated, because if Kodi doesn't match a platform in the `<platform>` tag, it silently fails instead of logging an error.

So, this PR adds the missing error log.

## Motivation and context

This change will help debug errors like https://github.com/xbmc/xbmc/issues/26055 in the future.

## How has this been tested?

### Before

Currently, on Android arm64 installed from the Play Store (which uses aab packaging), peripheral.joystick's addon.xml is found:

```
debug <general>: CAddonInfoBuilder::ParseXMLTypes: Binary addon found: peripheral.joystick
```

But the `<platform>` tag is `<platform>android-armv7</platform>`, and the add-on is silently skipped:

```
info <general>: CAddonMgr::FindAddons: metadata.tvshows.themoviedb.org.python v1.7.2 installed
info <general>: CAddonMgr::FindAddons: repository.xbmc.org v3.4.0 installed
```

If Kodi is installed from an APK (bypassing aab packaging), then it gets the correct `<platform>` tag (`<platform>android-aarch64</platform>`), and is discovered when enumerating add-ons:

```
info <general>: CAddonMgr::FindAddons: metadata.tvshows.themoviedb.org.python v1.7.2 installed
info <general>: CAddonMgr::FindAddons: peripheral.joystick v21.1.18 installed
info <general>: CAddonMgr::FindAddons: repository.xbmc.org v3.4.0 installed
```

### After

Tested this change on my macbook M2. Modifying the `<platform>` tag to x86_64 (`<platform>osx-x86_64</platform>`) correctly logs the error:

```
debug <general>: CAddonInfoBuilder::ParseXMLTypes: Binary addon found: peripheral.joystick
error <general>: CAddonInfoBuilder::Generate: No platform for add-on peripheral.joystick (supported platforms: osx-x86_64)
```

When I modify `<platform>` to include both arm and intel (`<platform>osx-arm64 osx-x86_64</platform>`), the error goes away:

```
debug <general>: CAddonInfoBuilder::ParseXMLTypes: Binary addon found: peripheral.joystick
 info <general>: CAddonMgr::FindAddons: peripheral.joystick v21.1.18 installed
```

## What is the effect on users?

* None

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
