### PR TITLE
[VAAPI] Initialize all members of `CVaapiBufferStats`

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -59,14 +59,14 @@ class CDecoder;
 class CVaapiBufferStats
 {
 public:
-  uint16_t decodedPics;
-  uint16_t processedPics;
-  uint16_t renderPics;
-  uint64_t latency;         // time decoder has waited for a frame, ideally there is no latency
-  int codecFlags;
-  bool canSkipDeint;
-  int processCmd;
-  bool isVpp;
+  uint16_t decodedPics{};
+  uint16_t processedPics{};
+  uint16_t renderPics{};
+  uint64_t latency{}; // time decoder has waited for a frame, ideally there is no latency
+  int codecFlags{};
+  bool canSkipDeint{};
+  int processCmd{};
+  bool isVpp{};
 
   void IncDecoded()
   {
@@ -105,6 +105,9 @@ public:
     processedPics = 0;
     renderPics = 0;
     latency = 0;
+    codecFlags = 0;
+    canSkipDeint = false;
+    processCmd = 0;
     isVpp = false;
   }
   void Get(uint16_t& decoded, uint16_t& processed, uint16_t& render, bool& vpp)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Fixes the following Valgrind warning:

```
Thread 67 Vaapi-Output:
Conditional jump or move depends on uninitialised value(s)
   at 0x14DF1F0: VAAPI::COutput::InitCycle() (VAAPI.cpp:2055)
   by 0x14E367E: VAAPI::COutput::StateMachine(int, Actor::Protocol*, Actor::Message*) (VAAPI.cpp:1719)
   by 0x14E3860: VAAPI::COutput::Process() (VAAPI.cpp:1897)
   by 0x19A7F24: CThread::Action() (Thread.cpp:283)
   by 0x19A9207: operator() (Thread.cpp:152)
   by 0x19A9207: __invoke_impl<void, CThread::Create(bool)::<lambda(CThread*, std::promise<bool>)>, CThread*, std::promise<bool> > (invoke.h:61)
   by 0x19A9207: __invoke<CThread::Create(bool)::<lambda(CThread*, std::promise<bool>)>, CThread*, std::promise<bool> > (invoke.h:96)
   by 0x19A9207: _M_invoke<0, 1, 2> (std_thread.h:301)
   by 0x19A9207: operator() (std_thread.h:308)
   by 0x19A9207: std::thread::_State_impl<std::thread::_Invoker<std::tuple<CThread::Create(bool)::{lambda(CThread*, std::promise<bool>)#1}, CThread*, std::promise<bool> > > >::_M_run() (std_thread.h:253)
   by 0x882DC33: execute_native_thread_routine (thread.cc:104)
   by 0x8A9639C: start_thread (pthread_create.c:447)
   by 0x8B1B2A3: clone (clone.S:100)
 Uninitialised value was created by a heap allocation
   at 0x5CA1F93: operator new(unsigned long) (vg_replace_malloc.c:487)
   by 0x14E1496: VAAPI::CDecoder::Create(CDVDStreamInfo&, CProcessInfo&, AVPixelFormat) (VAAPI.cpp:1256)
   by 0x15052EA: operator() (std_function.h:591)
   by 0x15052EA: CDVDFactoryCodec::CreateVideoCodecHWAccel(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CDVDStreamInfo&, CProcessInfo&, AVPixelFormat) (DVDFactoryCodec.cpp:118)
   by 0x14CDC06: CDVDVideoCodecFFmpeg::GetFormat(AVCodecContext*, AVPixelFormat const*) (DVDVideoCodecFFmpeg.cpp:287)
   by 0x2DC40F5: ff_get_format (in kodi.bin)
   by 0x2EF4379: get_pixel_format (in kodi.bin)
   by 0x2EF6345: h264_init_ps (in kodi.bin)
   by 0x2EF945E: ff_h264_queue_decode_slice (in kodi.bin)
   by 0x2EFF8DB: h264_decode_frame (in kodi.bin)
   by 0x2DC2A0B: ff_decode_receive_frame_internal (in kodi.bin)
   by 0x2DC2F54: decode_receive_frame_internal (in kodi.bin)
   by 0x2DC31FB: avcodec_send_packet (in kodi.bin)
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prevent undefined behavior.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Valgrind is now happy.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Probably none.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
