### PR TITLE
[backport][VAAPI] Initialize all members of `CVaapiBufferStats`

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -59,14 +59,14 @@ class CDecoder;
 class CVaapiBufferStats
 {
 public:
-  uint16_t decodedPics;
-  uint16_t processedPics;
-  uint16_t renderPics;
-  uint64_t latency;         // time decoder has waited for a frame, ideally there is no latency
-  int codecFlags;
-  bool canSkipDeint;
-  int processCmd;
-  bool isVpp;
+  uint16_t decodedPics{};
+  uint16_t processedPics{};
+  uint16_t renderPics{};
+  uint64_t latency{}; // time decoder has waited for a frame, ideally there is no latency
+  int codecFlags{};
+  bool canSkipDeint{};
+  int processCmd{};
+  bool isVpp{};
 
   void IncDecoded()
   {
@@ -105,6 +105,9 @@ public:
     processedPics = 0;
     renderPics = 0;
     latency = 0;
+    codecFlags = 0;
+    canSkipDeint = false;
+    processCmd = 0;
     isVpp = false;
   }
   void Get(uint16_t& decoded, uint16_t& processed, uint16_t& render, bool& vpp)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Backport of #26283.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
