### PR TITLE
[Peripherals] Persist peripheral settings when changed

### DIFF
--- a/xbmc/peripherals/bus/PeripheralBus.h
+++ b/xbmc/peripherals/bus/PeripheralBus.h
@@ -77,6 +77,11 @@ public:
   }
 
   /*!
+   * \brief Get the appearance of a peripheral, if known
+   */
+  virtual std::string GetAppearance(const CPeripheral& peripheral) const { return ""; }
+
+  /*!
    * @brief Get the instance of the peripheral at the given location.
    * @param strLocation The location.
    * @return The peripheral or NULL if it wasn't found.

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -208,6 +208,8 @@ public:
   virtual float GetSettingFloat(const std::string& strKey) const;
   virtual bool SetSetting(const std::string& strKey, float fValue);
 
+  virtual void SetAddonSetting(const std::string& strKey, const std::string& addonId);
+
   virtual void PersistSettings(bool bExiting = false);
   virtual void LoadPersistedSettings(void);
   virtual void ResetDefaultSettings(void);
@@ -276,10 +278,7 @@ public:
    *
    * \param controller The new controller profile
    */
-  virtual void SetControllerProfile(const KODI::GAME::ControllerPtr& controller)
-  {
-    m_controllerProfile = controller;
-  }
+  virtual void SetControllerProfile(const KODI::GAME::ControllerPtr& controller);
 
 protected:
   virtual void ClearSettings(void);

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -220,6 +220,18 @@ void CPeripheralJoystick::PowerOff()
   m_bus->PowerOff(m_strLocation);
 }
 
+void CPeripheralJoystick::ResetDefaultSettings()
+{
+  CPeripheral::ResetDefaultSettings();
+
+  // Reset the appearance from the peripheral bus
+  if (m_buttonMap)
+  {
+    m_buttonMap->SetAppearance(m_bus->GetAppearance(*this));
+    m_buttonMap->SaveButtonMap();
+  }
+}
+
 void CPeripheralJoystick::RegisterJoystickDriverHandler(IDriverHandler* handler, bool bPromiscuous)
 {
   std::unique_lock<CCriticalSection> lock(m_handlerMutex);

--- a/xbmc/peripherals/devices/PeripheralJoystick.h
+++ b/xbmc/peripherals/devices/PeripheralJoystick.h
@@ -59,6 +59,7 @@ public:
   bool InitialiseFeature(const PeripheralFeature feature) override;
   void OnUserNotification() override;
   bool TestFeature(PeripheralFeature feature) override;
+  void ResetDefaultSettings() override;
   void RegisterJoystickDriverHandler(KODI::JOYSTICK::IDriverHandler* handler,
                                      bool bPromiscuous) override;
   void UnregisterJoystickDriverHandler(KODI::JOYSTICK::IDriverHandler* handler) override;

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -28,9 +28,6 @@
 using namespace KODI;
 using namespace PERIPHERALS;
 
-// Settings for peripherals
-constexpr std::string_view SETTING_APPEARANCE = "appearance";
-
 CGUIDialogPeripheralSettings::CGUIDialogPeripheralSettings()
   : CGUIDialogSettingsManualBase(WINDOW_DIALOG_PERIPHERAL_SETTINGS, "DialogSettings.xml"),
     m_item(NULL)
@@ -104,24 +101,10 @@ void CGUIDialogPeripheralSettings::OnSettingChanged(const std::shared_ptr<const 
   if (!peripheral)
     return;
 
-  if (settingId == SETTING_APPEARANCE)
-  {
-    // Get the controller profile of the new appearance
-    GAME::ControllerPtr controller;
+  peripheral->SetSetting(settingId, setting->ToString());
 
-    if (setting->GetType() == SettingType::String)
-    {
-      std::shared_ptr<const CSettingString> settingString =
-          std::static_pointer_cast<const CSettingString>(setting);
-      const std::string& addonId = settingString->GetValue();
-
-      if (m_manager != nullptr)
-        controller = m_manager->GetControllerProfiles().GetController(addonId);
-    }
-
-    if (controller)
-      peripheral->SetControllerProfile(controller);
-  }
+  // Persist settings so that the new setting takes effect immediately
+  Save();
 }
 
 bool CGUIDialogPeripheralSettings::Save()
@@ -155,6 +138,9 @@ void CGUIDialogPeripheralSettings::OnResetSettings()
 
   // re-create all settings and their controls
   SetupView();
+
+  // Persist settings so that resetting takes effect immediately
+  Save();
 }
 
 void CGUIDialogPeripheralSettings::SetupView()

--- a/xbmc/platform/android/peripherals/AndroidJoystickState.h
+++ b/xbmc/platform/android/peripherals/AndroidJoystickState.h
@@ -60,6 +60,11 @@ public:
   bool InitializeButtonMap(KODI::JOYSTICK::IButtonMap& buttonMap) const;
 
   /*!
+   * \brief Get the joystick appearance, if known
+   */
+  std::string GetAppearance() const;
+
+  /*!
    * \brief Deinitialize the joystick object
    *
    * GetEvents() will not be called after deinitialization.

--- a/xbmc/platform/android/peripherals/PeripheralBusAndroid.cpp
+++ b/xbmc/platform/android/peripherals/PeripheralBusAndroid.cpp
@@ -169,6 +169,22 @@ bool CPeripheralBusAndroid::InitializeButtonMap(const CPeripheral& peripheral,
   return true;
 }
 
+std::string CPeripheralBusAndroid::GetAppearance(const CPeripheral& peripheral) const
+{
+  int deviceId;
+  if (!GetDeviceId(peripheral.Location(), deviceId))
+    return "";
+
+  std::unique_lock<CCriticalSection> lock(m_critSectionStates);
+
+  auto it = m_joystickStates.find(deviceId);
+  if (it == m_joystickStates.end())
+    return "";
+
+  const CAndroidJoystickState& joystick = it->second;
+  return joystick.GetAppearance();
+}
+
 void CPeripheralBusAndroid::Initialise(void)
 {
   CPeripheralBus::Initialise();

--- a/xbmc/platform/android/peripherals/PeripheralBusAndroid.h
+++ b/xbmc/platform/android/peripherals/PeripheralBusAndroid.h
@@ -37,6 +37,7 @@ public:
   bool InitializeProperties(CPeripheral& peripheral) override;
   bool InitializeButtonMap(const CPeripheral& peripheral,
                            KODI::JOYSTICK::IButtonMap& buttonMap) const override;
+  std::string GetAppearance(const CPeripheral& peripheral) const override;
   void Initialise(void) override;
   void ProcessEvents() override;
 


### PR DESCRIPTION
## Description

As title says, this will persist peripheral settings when changed. It has the side effect of settings taking effect immediately, without needing to restart Kodi, fixing https://github.com/xbmc/xbmc/issues/19207. It also fixes the "Appearance" setting for controllers not resetting when the user clicks "Defaults".

This PR also refactors the saving of controller appearance added in https://github.com/xbmc/xbmc/pull/22856. It has been moved to where peripheral settings are saved, cleaning up the dialog a bit and ensuring the appearance is saved when modified outside of the Peripherals Dialog.

Buttonmap appearances are set after peripheral settings are loaded, so if they disagree, buttonmaps take precedence.

If either setting is set to a controller profile that isn't installed, it will be installed on startup.

Fixes https://github.com/xbmc/xbmc/issues/19207.

Requires https://github.com/xbmc/peripheral.joystick/pull/322 to fix resetting empty configs

## Motivation and context

I was looking in my `peripheral_data/` folder in userdata, and noticed that the appearance setting wasn't used:

```xml
<settings>
    <setting id="appearance" value=""/>
    <setting id="left_stick_deadzone" value="0.20"/>
    <setting id="right_stick_deadzone" value="0.20"/>
</settings>
```

Not a problem, appearance is stored in peripheral.joystick's buttonmaps.

But after the Android debacle missing peripheral.joystick since moving to aab packaging, I'd like to start doing more controller stuff in core, reducing reliance on the add-on, and maybe someday not even need peripheral.joystick.

So, now appearance is saved/loaded in `peripheral_data/` too:

```xml
<settings>
    <setting id="appearance" value="game.controller.default"/>
    <setting id="left_stick_deadzone" value="0.20"/>
    <setting id="right_stick_deadzone" value="0.20"/>
</settings>
```

As I was working on this PR, I remembered https://github.com/xbmc/xbmc/issues/19207, and realized that it would be fixed as a nice side effect.

## How has this been tested?

Tested on my retroplayer branch. Tested by modifying both buttonmaps and peripheral settings, clearing both, clearing each, making them agree, making them disagree, using invalid controller profiles, using uninstalled controller profiles.

Currently, controllers won't even show up in the Peripherals Dialog if peripheral.joystick isn't installed, because unmapped buttons aren't very useful. But I modified this so that unmapped controllers show up, and verified that the appearance could still be changed and persisted without peripheral.joystick installed.

Tested resetting peripheral settings, with and without peripheral.joystick installed (via the before-mentioned modification).

## What is the effect on users?

* Fixed disabling CEC not taking effect until Kodi is restarted

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
