### PR TITLE
[Video] Fix SaveFileStateJob updatelisting logic and refactors

### DIFF
--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -203,24 +203,15 @@ void CSaveFileState::DoWork(CFileItem& item,
         videoDbSuccess = true;
 
         // See if idFile needs updating
-        if (item.HasVideoInfoTag() && URIUtils::IsBlurayPath(item.GetDynPath()))
+        const CVideoInfoTag* tag{item.HasVideoInfoTag() ? item.GetVideoInfoTag() : nullptr};
+
+        if (tag && URIUtils::IsBlurayPath(item.GetDynPath()) &&
+            tag->m_strFileNameAndPath != item.GetDynPath())
         {
-          if (item.GetVideoContentType() == VideoDbContentType::MOVIES)
-          {
-            const CVideoInfoTag* tag{item.GetVideoInfoTag()};
-            if (tag->m_strFileNameAndPath != item.GetDynPath())
-              // tag->m_iFileId contains the idFile played and may be different to the idFile in the movie table entry if it's
-              // a non-default video version
-              videoDbSuccess =
-                  videodatabase.SetFileForMovie(item.GetDynPath(), tag->m_iDbId, tag->m_iFileId);
-          }
-          else if (item.GetVideoContentType() == VideoDbContentType::EPISODES)
-          {
-            const CVideoInfoTag* tag{item.GetVideoInfoTag()};
-            if (tag->m_strFileNameAndPath != item.GetDynPath())
-              videoDbSuccess =
-                  videodatabase.SetFileForEpisode(item.GetDynPath(), tag->m_iDbId, tag->m_iFileId);
-          }
+          // tag->m_iFileId contains the idFile originally played and may be different to the idFile
+          // in the movie table entry if it's a non-default video version
+          videoDbSuccess = videodatabase.SetFileForMedia(
+              item.GetDynPath(), item.GetVideoContentType(), tag->m_iDbId, tag->m_iFileId);
         }
 
         if (videoDbSuccess)

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -191,7 +191,7 @@ void CSaveFileState::DoWork(CFileItem& item,
           {
             videoDbSuccess = videodatabase.SetStreamDetailsForFile(
                 item.GetVideoInfoTag()->m_streamDetails, progressTrackingFile);
-            updateListing = !videoDbSuccess;
+            updateListing |= videoDbSuccess;
           }
         }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3018,6 +3018,23 @@ int CVideoDatabase::SetDetailsForSeason(const CVideoInfoTag& details, const std:
   return -1;
 }
 
+bool CVideoDatabase::SetFileForMedia(const std::string& fileAndPath,
+                                     VideoDbContentType type,
+                                     int mediaId,
+                                     int oldIdFile)
+{
+  switch (type)
+  {
+    case VideoDbContentType::MOVIES:
+      return SetFileForMovie(fileAndPath, mediaId, oldIdFile);
+    case VideoDbContentType::EPISODES:
+      return SetFileForEpisode(fileAndPath, mediaId, oldIdFile);
+    default:
+      CLog::LogF(LOGDEBUG, "unsupported media type {}", type);
+      return false;
+  }
+}
+
 bool CVideoDatabase::SetFileForEpisode(const std::string& fileAndPath, int idEpisode, int oldIdFile)
 {
   assert(m_pDB->in_transaction());

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -592,8 +592,10 @@ public:
                            const std::map<std::string, std::string>& artwork,
                            int idShow,
                            int idEpisode = -1);
-  bool SetFileForEpisode(const std::string& fileAndPath, int idEpisode, int oldIdFile);
-  bool SetFileForMovie(const std::string& fileAndPath, int idMovie, int oldIdFile);
+  bool SetFileForMedia(const std::string& fileAndPath,
+                       VideoDbContentType type,
+                       int mediaId,
+                       int oldIdFile);
   int SetDetailsForMusicVideo(CVideoInfoTag& details,
                               const std::map<std::string, std::string>& artwork,
                               int idMVideo = -1);
@@ -1260,6 +1262,9 @@ protected:
   void GetDetailsFromDB(std::unique_ptr<dbiplus::Dataset> &pDS, int min, int max, const SDbTableOffsets *offsets, CVideoInfoTag &details, int idxOffset = 2);
   void GetDetailsFromDB(const dbiplus::sql_record* const record, int min, int max, const SDbTableOffsets *offsets, CVideoInfoTag &details, int idxOffset = 2);
   std::string GetValueString(const CVideoInfoTag &details, int min, int max, const SDbTableOffsets *offsets) const;
+
+  bool SetFileForEpisode(const std::string& fileAndPath, int idEpisode, int oldIdFile);
+  bool SetFileForMovie(const std::string& fileAndPath, int idMovie, int oldIdFile);
 
 private:
   void CreateTables() override;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

One commit per point below, to be squashed on merge. All on SaveFileStateJob:

- fixed updatelisting update logic error. Now set to true in case of successful update of stream details, and keep previous value in case of failure
- followed pattern of other database functions and multiplexed SetFileForEpisode and SetFileForMovie behind a master SetFileForMedia function. It will be minimal effort to add support for music videos, the last content type that would make sense to handle.
- moved begin/commit/rollback transaction statements a bit to avoid unnecessary transactions and reduce usage of local variables. Complete error handling is still WIP.

FYI @78andyp

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Let a logic error through in #26220 after file stream details update in SaveFileStateJob.
updateListing = !videoDbSuccess (actual) is not the same as updateListing |= videoDbSuccess (what it should have been)

as a consequence updateListing true value from previous blocks could be overwritten and had the opposite of the expected value, resulting in stale information displayed in file listing.

Also used the opportunity to beautify things a bit.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

"regular" videos and Bluray, with and without usage of Bluray playlist,

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Fix the on-screen refresh of stream details after stopping playback.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
