### PR TITLE
[VideoInfoScanner] Skip scan of sub directories of missing/offline sources and directories

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1287,9 +1287,9 @@ bool URIUtils::IsSmb(const std::string& strFile)
   return IsProtocol(strFile, "smb");
 }
 
-bool URIUtils::IsURL(const std::string& strFile)
+bool URIUtils::IsURL(std::string_view file)
 {
-  return strFile.find("://") != std::string::npos;
+  return file.find("://") != std::string::npos;
 }
 
 bool URIUtils::IsFTP(const std::string& strFile)
@@ -1640,17 +1640,19 @@ void URIUtils::AddSlashAtEnd(std::string& strFolder)
   }
 }
 
-bool URIUtils::HasSlashAtEnd(const std::string& strFile, bool checkURL /* = false */)
+bool URIUtils::HasSlashAtEnd(std::string_view file, bool checkURL /* = false */)
 {
-  if (strFile.empty()) return false;
-  if (checkURL && IsURL(strFile))
-  {
-    CURL url(strFile);
-    const std::string& file = url.GetFileName();
-    return file.empty() || HasSlashAtEnd(file, false);
-  }
-  char kar = strFile.c_str()[strFile.size() - 1];
+  if (file.empty())
+    return false;
 
+  if (checkURL && IsURL(file))
+  {
+    CURL url(std::string{file});
+    const std::string& filename = url.GetFileName();
+    return filename.empty() || HasSlashAtEnd(filename, false);
+  }
+
+  const char kar = file.back();
   if (kar == '/' || kar == '\\')
     return true;
 

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -292,7 +292,7 @@ public:
   static bool IsStack(const std::string& strFile);
   static bool IsFavourite(const std::string& strFile);
   static bool IsUPnP(const std::string& strFile);
-  static bool IsURL(const std::string& strFile);
+  static bool IsURL(std::string_view file);
   static bool IsVideoDb(const std::string& strFile);
   static bool IsAPK(const std::string& strFile);
   static bool IsZIP(const std::string& strFile);
@@ -322,7 +322,7 @@ public:
 
   static std::string AppendSlash(std::string strFolder);
   static void AddSlashAtEnd(std::string& strFolder);
-  static bool HasSlashAtEnd(const std::string& strFile, bool checkURL = false);
+  static bool HasSlashAtEnd(std::string_view file, bool checkURL = false);
   static void RemoveSlashAtEnd(std::string& strFolder);
   static bool CompareWithoutSlashAtEnd(const std::string& strPath1, const std::string& strPath2);
   static std::string FixSlashesAndDups(const std::string& path, const char slashCharacter = '/', const size_t startFrom = 0);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -383,9 +383,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
      * the check for file or folder exclusion to prevent an infinite while loop
      * in Process().
      */
-    std::set<std::string>::iterator it = m_pathsToScan.find(strDirectory);
-    if (it != m_pathsToScan.end())
-      m_pathsToScan.erase(it);
+    m_pathsToScan.erase(strDirectory);
 
     // load subfolder
     CFileItemList items;
@@ -1335,9 +1333,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
        * Remove this path from the list we're processing in order to avoid hitting
        * it twice in the main loop.
        */
-      std::set<std::string>::iterator it = m_pathsToScan.find(item->GetPath());
-      if (it != m_pathsToScan.end())
-        m_pathsToScan.erase(it);
+      m_pathsToScan.erase(item->GetPath());
 
       if (HasNoMedia(item->GetPath()))
         return true;

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -166,7 +166,6 @@ void OnDirectoryScanned(const std::string& strDirectory)
   msg.SetStringParam(strDirectory);
   CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
 }
-
 } // namespace
 
 namespace KODI::VIDEO
@@ -256,17 +255,39 @@ CVideoInfoScanner::~CVideoInfoScanner()
         else if (!CDirectory::Exists(directory))
         {
           /*
-           * Note that this will skip clean (if m_bClean is enabled) if the directory really
-           * doesn't exist rather than a NAS being switched off.  A manual clean from settings
-           * will still pick up and remove it though.
+           * Note that this will skip clean (if m_bClean is enabled) for the directory and its
+           * sub-directories if the directory really doesn't exist rather than a NAS being switched
+           * off. A manual clean from settings will still pick up and remove it though.
            */
-          CLog::Log(LOGWARNING, "{} directory '{}' does not exist - skipping scan{}.", __FUNCTION__,
-                    CURL::GetRedacted(directory), m_bClean ? " and clean" : "");
-          m_pathsToScan.erase(m_pathsToScan.begin());
+          CLog::LogF(LOGWARNING, "directory '{}' does not exist - skipping scan{}.",
+                     CURL::GetRedacted(directory), m_bClean ? " and clean" : "");
+          m_pathsToScan.erase(directory);
+
+          SkipRelatedDirectories(directory);
         }
-        else if ([[maybe_unused]] const auto [scanComplete, foundContent] = DoScan(directory);
-                 scanComplete == ScanComplete::Stopped)
-          bCancelled = true;
+        else
+        {
+          if ([[maybe_unused]] const auto [scanComplete, foundContent] = DoScan(directory);
+              scanComplete == ScanComplete::Stopped)
+          {
+            bCancelled = true;
+          }
+          else
+          {
+            // The remaining sub directories under the path to scan were not found on disk, skip
+            // the individual scans.
+            // Happens mostly for TV Shows that are in the library and were deleted from a sub
+            // directory of a defined source.
+            std::function<void(const std::string&)> f;
+            if (m_bClean)
+              f = [this](const std::string& dir)
+              { m_pathsToClean.insert(m_database.GetPathId(dir)); };
+
+            if (auto count = RemoveSubDirectories(m_pathsToScan, directory, f))
+              CLog::Log(LOGDEBUG, "VideoInfoScanner: Skipped {} missing sub directories of {}.",
+                        count, directory);
+          }
+        }
       }
 
       if (!bCancelled)
@@ -2759,4 +2780,56 @@ CVideoInfoScanner::~CVideoInfoScanner()
   {
     return CGUIDialogVideoManagerVersions::ProcessVideoVersion(itemType, dbId);
   }
-}
+
+  void CVideoInfoScanner::SkipRelatedDirectories(std::string_view originalDirectory)
+  {
+    std::string directory{originalDirectory};
+
+    // Look for an existing parent directory
+    std::string parentDir = URIUtils::GetParentPath(directory);
+    while (!parentDir.empty() && parentDir != directory && !CDirectory::Exists(parentDir))
+    {
+      directory = parentDir;
+      parentDir = URIUtils::GetParentPath(directory);
+    }
+
+    if (directory != originalDirectory)
+    {
+      const std::string& parentMsg =
+          parentDir.empty()
+              ? "no existing root parent directory found"
+              : StringUtils::Format("first existing parent directory is '{}'", parentDir);
+
+      CLog::LogF(LOGWARNING, "{}, skipping '{}' and its sub directories", parentMsg, directory);
+    }
+
+    if (auto count = RemoveSubDirectories(m_pathsToScan, directory, nullptr))
+      CLog::LogF(LOGWARNING, "skipped {} sub directories.", count);
+  }
+
+  size_t CVideoInfoScanner::RemoveSubDirectories(std::set<std::string, std::less<>>& directories,
+                                                 std::string_view directory,
+                                                 std::function<void(const std::string&)> f)
+  {
+    size_t count{0};
+
+    if (!URIUtils::HasSlashAtEnd(directory))
+    {
+      CLog::LogF(LOGWARNING, "The parameter '{}' doesn't end with a path separator. Skipping...",
+                 directory);
+      return count;
+    }
+
+    auto it{directories.lower_bound(directory)};
+
+    while (it != directories.end() && (*it).starts_with(directory))
+    {
+      if (f)
+        f(*it);
+
+      it = directories.erase(it);
+      ++count;
+    }
+    return count;
+  }
+  } // namespace KODI::VIDEO

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -15,8 +15,10 @@
 #include "utils/Artwork.h"
 #include "utils/RegExp.h"
 
+#include <functional>
 #include <set>
 #include <string>
+#include <string_view>
 #include <vector>
 
 class CAdvancedSettings;
@@ -332,6 +334,27 @@ namespace KODI::VIDEO
     std::set<int> m_pathsToClean;
     std::shared_ptr<CAdvancedSettings> m_advancedSettings;
     CVideoDatabase::ScraperCache m_scraperCache;
+
+  private:
+    /*!
+     * \brief Remove paths that share missing ancestors with \p directory from the list of paths
+     *        to scan
+     * \param[in] directory The non-existent directory
+     */
+    void SkipRelatedDirectories(std::string_view directory);
+
+    /*!
+     * \brief Removes the directory and sub directories of \p directory from the paths to be
+     *        scanned. Paths must end with a directory separator.
+     * \param[in] directories List of paths
+     * \param[in] directory Path of the directory to remove
+     * \param[in] f function to execute before the removal of a path
+     * \return number of elements removed
+     */
+    static size_t RemoveSubDirectories(std::set<std::string, std::less<>>& directories,
+                                       std::string_view directory,
+                                       std::function<void(const std::string&)> f);
+
     mutable KODI::REGEXP::RegExpCache m_regexpCache;
   };
   } // namespace KODI::VIDEO


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Modified the videoinfoscanner main loop in two places to remove paths from the m_pathToScan list:
- top level Process() function: preemptively remove sub-directories of directories that don't exist so they won't be tested for existence. Try to identify the first existing parent dir to widen the scope of the removal.
- at the end of top-level DoScan. For each directory, after all subdirectories enumerated from disc have been processed and removed from the list to scan, the remaining subdirectories in the to scan list must be missing sub directories. They would have been enumerated one by one and found not to exist otherwise.

Possible concern: is it always safe to assume that for a path A/, A/xxx/ is a subdirectory that cannot possibly exist if A/ doesn't exist? I couldn't come up with examples with the usual filesystems, but don't know the quirks of all protocols.
If that cannot be assumed, then the code would have to use GetParent() to establish the relation (or lack of) but that would be significantly slower - though maybe still faster than i/o (at least network i/o)
edit: the manipulated directories will only be of types supported as sources, all hierarchical so there is no issue.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The scanner spends time testing the existence of all sources and known children paths even after determining that a parent path does not exist (ex. can't access the root of an offline disk)
This is wasteful, especially if testing the paths requires network i/o.

Probably the issue reported in the forum https://forum.kodi.tv/showthread.php?tid=380114&pid=3221897#pid3221897

The gains depend on the amount of offline directories and on the efficiency and warmth of the os and fs library caches.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

smb, nfs, Windows local files.
with some source folders present, some missing.
some movies and tv shows in the library were deleted to be seen as missing.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Faster library scan for libraries with a significant amount of offline data.

## Screenshots
before 
```
2025-01-13 00:05:05.725 T:32820   debug <general>: VideoInfoScanner: Skipping dir 'Y:\TV\Why Women Kill\' due to no change
2025-01-13 00:05:05.837 T:32820   debug <general>: VideoInfoScanner: Skipping dir 'Y:\TV\Workaholics\' due to no change
2025-01-13 00:05:06.086 T:32820 warning <general>: KODI::VIDEO::CVideoInfoScanner::Process directory 'Y:\TV\2 Broke Girls\' does not exist - skipping scan.
2025-01-13 00:05:06.086 T:32820 warning <general>: KODI::VIDEO::CVideoInfoScanner::Process directory 'Y:\TV\86 - Eighty Six\' does not exist - skipping scan.
... etc
```

after

```
...
2025-01-12 23:58:28.123 T:16864   debug <general>: VideoInfoScanner: Skipping dir 'Y:\TV\Why Women Kill\' due to no change
2025-01-12 23:58:28.258 T:16864   debug <general>: VideoInfoScanner: Skipping dir 'Y:\TV\Workaholics\' due to no change
2025-01-12 23:58:28.382 T:16864   debug <general>: VideoInfoScanner: Skipped 744 missing sub directories of Y:\TV\.
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
