### PR TITLE
[video] Fix mark watched/unwatched missing in certain context menus.

### DIFF
--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -20,6 +20,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/PlayerUtils.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
@@ -96,10 +97,21 @@ bool CVideoMarkWatched::IsVisible(const CFileItem& item) const
   if (item.m_bIsFolder && item.IsPlugin()) // we cannot manage plugin folder's watched state
     return false;
 
-  if (item.m_bIsFolder) // Only allow video db content, video and recording folders to be updated recursively
+  if (item.m_bIsFolder)
   {
-    if (item.HasVideoInfoTag())
-      return VIDEO::IsVideoDb(item);
+    if (item.HasProperty("watchedepisodes") && item.HasProperty("totalepisodes"))
+    {
+      return item.GetProperty("watchedepisodes").asInteger() <
+             item.GetProperty("totalepisodes").asInteger();
+    }
+    else if (item.HasProperty("watched") && item.HasProperty("total"))
+    {
+      return item.GetProperty("watched").asInteger() < item.GetProperty("total").asInteger();
+    }
+    else if (VIDEO::IsVideoDb(item))
+      return true;
+    else if (StringUtils::StartsWithNoCase(item.GetPath(), "library://video/"))
+      return true;
     else if (item.GetProperty("IsVideoFolder").asBoolean())
       return true;
     else
@@ -125,10 +137,20 @@ bool CVideoMarkUnWatched::IsVisible(const CFileItem& item) const
   if (item.m_bIsFolder && item.IsPlugin()) // we cannot manage plugin folder's watched state
     return false;
 
-  if (item.m_bIsFolder) // Only allow video db content, video and recording folders to be updated recursively
+  if (item.m_bIsFolder)
   {
-    if (item.HasVideoInfoTag())
-      return VIDEO::IsVideoDb(item);
+    if (item.HasProperty("watchedepisodes"))
+    {
+      return item.GetProperty("watchedepisodes").asInteger() > 0;
+    }
+    else if (item.HasProperty("watched"))
+    {
+      return item.GetProperty("watched").asInteger() > 0;
+    }
+    else if (VIDEO::IsVideoDb(item))
+      return true;
+    else if (StringUtils::StartsWithNoCase(item.GetPath(), "library://video/"))
+      return true;
     else if (item.GetProperty("IsVideoFolder").asBoolean())
       return true;
     else


### PR DESCRIPTION
Fixes https://github.com/xbmc/xbmc/issues/26276

Before (Movies/TV shows top level nodes missing mark watched/unwatched context menu items):

<img width="1710" alt="Screenshot 2025-01-13 at 08 31 28" src="https://github.com/user-attachments/assets/35e6da59-ce46-481a-888c-a19932bdcda0" />

After:

<img width="1710" alt="Screenshot 2025-01-13 at 08 29 11" src="https://github.com/user-attachments/assets/8d314f57-fc7d-4ba3-b85b-5da0acee9cdb" />

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 if you are around, could you please review.