### PR TITLE
[Peripherals] Improvements for the Peripherals Dialog

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6749,7 +6749,6 @@ msgstr ""
 #: xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
 #: xbmc/music/MusicDatabase.cpp
 #: xbmc/peripherals/bus/PeripheralBus.cpp
-#: xbmc/peripherals/devices/Peripheral.cpp
 #: xbmc/platform/win32/WIN32Util.cpp
 #: xbmc/pvr/addons/PVRClients.cpp
 #: xbmc/pvr/channels/PVRChannel.cpp

--- a/addons/skin.estuary/xml/DialogSettings.xml
+++ b/addons/skin.estuary/xml/DialogSettings.xml
@@ -96,6 +96,12 @@
 				<animation effect="fade" start="0" end="100" delay="300" time="320">WindowOpen</animation>
 				<animation effect="fade" start="100" end="0" time="150">WindowClose</animation>
 			</control>
+			<control type="gamecontroller" id="100">
+				<top>550</top>
+				<right>20</right>
+				<height>290</height>
+				<width>290</width>
+			</control>
 		</control>
 	</controls>
 </window>

--- a/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
@@ -527,7 +527,11 @@ int CGUIWindowAddonBrowser::SelectAddonID(const std::vector<AddonType>& types,
   for (const auto& addon : addons)
   {
     const CFileItemPtr item(CAddonsDirectory::FileItemFromAddon(addon, addon->ID()));
-    item->SetLabel2(addon->Summary());
+
+    // Game controllers don't have specific summaries
+    if (addon->Type() != AddonType::GAME_CONTROLLER)
+      item->SetLabel2(addon->Summary());
+
     if (!items.Contains(item->GetPath()))
     {
       items.Add(item);

--- a/xbmc/games/controllers/ControllerIDs.h
+++ b/xbmc/games/controllers/ControllerIDs.h
@@ -8,16 +8,16 @@
 
 #pragma once
 
-// Default controller IDs
-#define DEFAULT_CONTROLLER_ID "game.controller.default"
-#define DEFAULT_KEYBOARD_ID "game.controller.keyboard"
-#define DEFAULT_MOUSE_ID "game.controller.mouse"
-#define DEFAULT_REMOTE_ID "game.controller.remote"
-
 namespace KODI
 {
 namespace GAME
 {
+
+// Default controller IDs
+constexpr const char* DEFAULT_CONTROLLER_ID = "game.controller.default";
+constexpr const char* DEFAULT_KEYBOARD_ID = "game.controller.keyboard";
+constexpr const char* DEFAULT_MOUSE_ID = "game.controller.mouse";
+constexpr const char* DEFAULT_REMOTE_ID = "game.controller.remote";
 
 // Used to set the appearance of PlayStation controllers
 constexpr const char* CONTROLLER_ID_PLAYSTATION = "game.controller.ps.dualanalog";

--- a/xbmc/input/joysticks/DeadzoneFilter.cpp
+++ b/xbmc/input/joysticks/DeadzoneFilter.cpp
@@ -31,7 +31,7 @@ using namespace JOYSTICK;
 CDeadzoneFilter::CDeadzoneFilter(IButtonMap* buttonMap, PERIPHERALS::CPeripheral* peripheral)
   : m_buttonMap(buttonMap), m_peripheral(peripheral)
 {
-  if (m_buttonMap->ControllerID() != DEFAULT_CONTROLLER_ID)
+  if (m_buttonMap->ControllerID() != GAME::DEFAULT_CONTROLLER_ID)
     CLog::Log(LOGERROR, "ERROR: Must use default controller profile instead of {}",
               m_buttonMap->ControllerID());
 }

--- a/xbmc/input/joysticks/DeadzoneFilter.cpp
+++ b/xbmc/input/joysticks/DeadzoneFilter.cpp
@@ -25,8 +25,8 @@ using namespace JOYSTICK;
 #define AXIS_EPSILON 0.01f
 
 // Settings for analog sticks
-#define SETTING_LEFT_STICK_DEADZONE "left_stick_deadzone"
-#define SETTING_RIGHT_STICK_DEADZONE "right_stick_deadzone"
+const char* CDeadzoneFilter::SETTING_LEFT_STICK_DEADZONE = "left_stick_deadzone";
+const char* CDeadzoneFilter::SETTING_RIGHT_STICK_DEADZONE = "right_stick_deadzone";
 
 CDeadzoneFilter::CDeadzoneFilter(IButtonMap* buttonMap, PERIPHERALS::CPeripheral* peripheral)
   : m_buttonMap(buttonMap), m_peripheral(peripheral)

--- a/xbmc/input/joysticks/DeadzoneFilter.h
+++ b/xbmc/input/joysticks/DeadzoneFilter.h
@@ -53,6 +53,10 @@ public:
    */
   float FilterAxis(unsigned int axisIndex, float axisValue);
 
+  // Settings for analog sticks
+  static const char* SETTING_LEFT_STICK_DEADZONE;
+  static const char* SETTING_RIGHT_STICK_DEADZONE;
+
 private:
   /*!
    * \brief Get the deadzone value from the peripheral's settings

--- a/xbmc/input/joysticks/JoystickEasterEgg.cpp
+++ b/xbmc/input/joysticks/JoystickEasterEgg.cpp
@@ -21,7 +21,7 @@ using namespace JOYSTICK;
 
 const std::map<std::string, std::vector<FeatureName>> CJoystickEasterEgg::m_sequence = {
     {
-        DEFAULT_CONTROLLER_ID,
+        GAME::DEFAULT_CONTROLLER_ID,
         {
             GAME::CDefaultController::FEATURE_UP,
             GAME::CDefaultController::FEATURE_UP,
@@ -36,7 +36,7 @@ const std::map<std::string, std::vector<FeatureName>> CJoystickEasterEgg::m_sequ
         },
     },
     {
-        DEFAULT_REMOTE_ID,
+        GAME::DEFAULT_REMOTE_ID,
         {
             "up",
             "up",

--- a/xbmc/input/joysticks/JoystickMonitor.cpp
+++ b/xbmc/input/joysticks/JoystickMonitor.cpp
@@ -23,7 +23,7 @@ using namespace JOYSTICK;
 
 std::string CJoystickMonitor::ControllerID() const
 {
-  return DEFAULT_CONTROLLER_ID;
+  return GAME::DEFAULT_CONTROLLER_ID;
 }
 
 bool CJoystickMonitor::AcceptsInput(const FeatureName& feature) const

--- a/xbmc/input/joysticks/RumbleGenerator.cpp
+++ b/xbmc/input/joysticks/RumbleGenerator.cpp
@@ -37,7 +37,7 @@ CRumbleGenerator::CRumbleGenerator()
 
 std::string CRumbleGenerator::ControllerID() const
 {
-  return DEFAULT_CONTROLLER_ID;
+  return GAME::DEFAULT_CONTROLLER_ID;
 }
 
 void CRumbleGenerator::NotifyUser(IInputReceiver* receiver)

--- a/xbmc/input/keyboard/test/TestKeyboardTranslator.cpp
+++ b/xbmc/input/keyboard/test/TestKeyboardTranslator.cpp
@@ -25,13 +25,14 @@ TEST(TestKeyboardTranslator, TranslateKeys)
 
   // Load add-on info
   ADDON::AddonPtr addon;
-  EXPECT_TRUE(addonManager.GetAddon(DEFAULT_KEYBOARD_ID, addon, ADDON::AddonType::GAME_CONTROLLER,
+  EXPECT_TRUE(addonManager.GetAddon(GAME::DEFAULT_KEYBOARD_ID, addon,
+                                    ADDON::AddonType::GAME_CONTROLLER,
                                     ADDON::OnlyEnabled::CHOICE_YES));
 
   // Convert to game controller
   GAME::ControllerPtr controller = std::static_pointer_cast<GAME::CController>(addon);
   ASSERT_NE(controller.get(), nullptr);
-  EXPECT_EQ(controller->ID(), DEFAULT_KEYBOARD_ID);
+  EXPECT_EQ(controller->ID(), GAME::DEFAULT_KEYBOARD_ID);
 
   // Load controller profile
   EXPECT_TRUE(controller->LoadLayout());

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -312,13 +312,19 @@ void CPeripheralBus::GetDirectory(const std::string& strPath, CFileItemList& ite
                                 PeripheralTypeTranslator::TypeToString(peripheral->Type()));
 
     std::string strVersion(peripheral->GetVersionInfo());
-    if (strVersion.empty())
-      strVersion = g_localizeStrings.Get(13205);
 
-    std::string strDetails = StringUtils::Format("{} {}", g_localizeStrings.Get(24051), strVersion);
+    std::string strDetails;
+
     if (peripheral->GetBusType() == PERIPHERAL_BUS_CEC && !peripheral->GetSettingBool("enabled"))
       strDetails =
           StringUtils::Format("{}: {}", g_localizeStrings.Get(126), g_localizeStrings.Get(13106));
+
+    if (strDetails.empty())
+    {
+      std::string strVersion(peripheral->GetVersionInfo());
+      if (!strVersion.empty())
+        strDetails = StringUtils::Format("{} {}", g_localizeStrings.Get(24051), strVersion);
+    }
 
     peripheralFile->SetProperty("version", strVersion);
     peripheralFile->SetLabel2(strDetails);

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -63,7 +63,6 @@ CPeripheral::CPeripheral(CPeripherals& manager,
     m_strDeviceName(scanResult.m_strDeviceName),
     m_iVendorId(scanResult.m_iVendorId),
     m_iProductId(scanResult.m_iProductId),
-    m_strVersionInfo(g_localizeStrings.Get(13205)), // "unknown"
     m_bus(bus)
 {
   PeripheralTypeTranslator::FormatHexString(scanResult.m_iVendorId, m_strVendorId);

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -93,7 +93,7 @@ bool CPeripheralJoystick::InitialiseFeature(const PeripheralFeature feature)
       if (bSuccess)
       {
         m_buttonMap =
-            std::make_unique<CAddonButtonMap>(this, addon, DEFAULT_CONTROLLER_ID, m_manager);
+            std::make_unique<CAddonButtonMap>(this, addon, GAME::DEFAULT_CONTROLLER_ID, m_manager);
         if (m_buttonMap->Load())
         {
           InitializeDeadzoneFiltering(*m_buttonMap);

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -15,7 +15,9 @@
 #include "games/GameServices.h"
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerIDs.h"
+#include "games/controllers/ControllerLayout.h"
 #include "games/controllers/ControllerManager.h"
+#include "games/controllers/input/PhysicalTopology.h"
 #include "input/InputManager.h"
 #include "input/joysticks/DeadzoneFilter.h"
 #include "input/joysticks/JoystickMonitor.h"
@@ -26,6 +28,7 @@
 #include "peripherals/Peripherals.h"
 #include "peripherals/addons/AddonButtonMap.h"
 #include "peripherals/bus/virtual/PeripheralBusAddon.h"
+#include "settings/lib/Setting.h"
 #include "utils/log.h"
 
 #include <algorithm>
@@ -281,11 +284,32 @@ void CPeripheralJoystick::SetControllerProfile(const KODI::GAME::ControllerPtr& 
 {
   CPeripheral::SetControllerProfile(controller);
 
+  const std::string controllerId = controller ? controller->ID() : "";
+  const bool providesInput = controller ? controller->Layout().Topology().ProvidesInput() : true;
+
   // Save preference to buttonmap
   if (m_buttonMap)
   {
-    if (m_buttonMap->SetAppearance(controller->ID()))
+    if (m_buttonMap->SetAppearance(controllerId))
       m_buttonMap->SaveButtonMap();
+  }
+
+  // Update settings
+  for (const auto& it : m_settings)
+  {
+    std::shared_ptr<CSetting> setting = it.second.m_setting;
+    if (!setting)
+      continue;
+
+    if (setting->GetId() == CDeadzoneFilter::SETTING_LEFT_STICK_DEADZONE ||
+        setting->GetId() == CDeadzoneFilter::SETTING_RIGHT_STICK_DEADZONE)
+    {
+      if (controllerId == GAME::DEFAULT_KEYBOARD_ID || controllerId == GAME::DEFAULT_MOUSE_ID ||
+          controllerId == GAME::DEFAULT_REMOTE_ID || !providesInput)
+        setting->SetVisible(false);
+      else
+        setting->SetVisible(true);
+    }
   }
 }
 

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -13,7 +13,9 @@
 #include "addons/Skin.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "games/controllers/Controller.h"
+#include "games/controllers/ControllerLayout.h"
 #include "games/controllers/ControllerManager.h"
+#include "games/controllers/guicontrols/GUIGameController.h"
 #include "guilib/GUIMessage.h"
 #include "peripherals/Peripherals.h"
 #include "settings/SettingAddon.h"
@@ -27,6 +29,11 @@
 
 using namespace KODI;
 using namespace PERIPHERALS;
+
+namespace
+{
+constexpr const int CONTROL_ID_PERIPHERAL_ICON = 100;
+} // namespace
 
 CGUIDialogPeripheralSettings::CGUIDialogPeripheralSettings()
   : CGUIDialogSettingsManualBase(WINDOW_DIALOG_PERIPHERAL_SETTINGS, "DialogSettings.xml"),
@@ -151,6 +158,24 @@ void CGUIDialogPeripheralSettings::SetupView()
   SET_CONTROL_LABEL(CONTROL_SETTINGS_OKAY_BUTTON, 186);
   SET_CONTROL_LABEL(CONTROL_SETTINGS_CANCEL_BUTTON, 222);
   SET_CONTROL_LABEL(CONTROL_SETTINGS_CUSTOM_BUTTON, 409);
+
+  // Set peripheral icon
+  GAME::ControllerPtr controller;
+
+  if (m_item != nullptr)
+  {
+    PeripheralPtr peripheral = CServiceBroker::GetPeripherals().GetByPath(m_item->GetPath());
+    if (peripheral)
+      controller = peripheral->ControllerProfile();
+  }
+
+  if (controller)
+  {
+    GAME::CGUIGameController* control =
+        dynamic_cast<GAME::CGUIGameController*>(GetControl(CONTROL_ID_PERIPHERAL_ICON));
+    if (control != nullptr)
+      control->SetFileName(controller->Layout().ImagePath());
+  }
 }
 
 void CGUIDialogPeripheralSettings::InitializeSettings()

--- a/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
@@ -184,13 +184,4 @@ void CGUIDialogPeripherals::UpdatePeripheralsSync()
   m_peripherals.Clear();
   m_manager->GetDirectory("peripherals://all/", m_peripherals);
   SetItems(m_peripherals);
-
-  if (selectedItem)
-  {
-    for (int i = 0; i < m_peripherals.Size(); i++)
-    {
-      if (m_peripherals[i]->GetPath() == selectedItem->GetPath())
-        SetSelected(i);
-    }
-  }
 }

--- a/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
@@ -96,7 +96,7 @@ void CGUIDialogPeripherals::Show(CPeripherals& manager)
 
       // Show an error if the peripheral doesn't have any settings
       PeripheralPtr peripheral = manager.GetByPath(pItem->GetPath());
-      if (!peripheral || peripheral->GetSettings().empty())
+      if (!peripheral || !peripheral->HasConfigurableSettings())
       {
         MESSAGING::HELPERS::ShowOKDialogText(CVariant{35000}, CVariant{35004});
         continue;
@@ -133,8 +133,10 @@ bool CGUIDialogPeripherals::OnMessage(CGUIMessage& message)
     case GUI_MSG_REFRESH_LIST:
     {
       if (m_manager && message.GetControlId() == -1)
+      {
         UpdatePeripheralsSync();
-      return true;
+        return true;
+      }
     }
     default:
       break;

--- a/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
+++ b/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
@@ -258,7 +258,7 @@ void CAndroidJoystickState::Deinitialize(void)
 bool CAndroidJoystickState::InitializeButtonMap(JOYSTICK::IButtonMap& buttonMap) const
 {
   // We only map the default controller
-  if (buttonMap.ControllerID() != DEFAULT_CONTROLLER_ID)
+  if (buttonMap.ControllerID() != GAME::DEFAULT_CONTROLLER_ID)
     return false;
 
   bool success = false;


### PR DESCRIPTION
## Description

This PR contains improvements for the Peripherals Dialog:

* Clean up the dialogs, remove unneeded/duplicated text
* Added mouse and keyboard peripherals, shown only if a mouse click or keyboard key has been pressed
* Added realtime highlighting of all input

### 2. Remove "Unknown" versions

Before:

<img width="1277" alt="Screenshot 2025-01-13 at 5 19 13 AM" src="https://github.com/user-attachments/assets/2e1b48af-28b7-434e-8e6e-2566c250c11e" />

After:

<img width="1271" alt="Screenshot 2025-01-13 at 5 20 59 AM" src="https://github.com/user-attachments/assets/bfc90811-dae3-4dd7-92d0-64a44ede43ff" />

### 3. Duplicate labels

Before:

<img width="1274" alt="Screenshot 2025-01-13 at 5 23 46 AM" src="https://github.com/user-attachments/assets/7b88f326-bb2f-4609-af61-41ca14a083b2" />

After:

<img width="1272" alt="Screenshot 2025-01-13 at 5 26 29 AM" src="https://github.com/user-attachments/assets/19f348ab-9c89-4323-941d-4a954e662762" />

### 4. Hide deadzone settings for mice, keyboards, remotes and hubs

Before:

<img width="1275" alt="Screenshot 2025-01-13 at 5 28 22 AM" src="https://github.com/user-attachments/assets/6caad3a2-d36a-4d2f-b24f-52bad74f1e96" />

After:

<img width="1269" alt="Screenshot 2025-01-13 at 5 29 25 AM" src="https://github.com/user-attachments/assets/d5a0fa1d-0daa-49a3-bae2-020b828c4190" />

### 5. Show peripheral icon

Before:

<img width="1275" alt="Screenshot 2025-01-13 at 5 32 53 AM" src="https://github.com/user-attachments/assets/47add530-a09b-434c-a68d-95b7586cc7c8" />

After:

<img width="1275" alt="Screenshot 2025-01-13 at 5 31 41 AM" src="https://github.com/user-attachments/assets/78f4208c-3d5b-491b-a9f8-f33052dc81ed" />

## Motivation and context

Minor quality-of-life improvements.

## How has this been tested?

See screenshots.

## What is the effect on users?

* Enhanced the Peripheral Dialog with realtime input highlighting

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
