### PR TITLE
[Library] Fix #26236 - Address file name case sensitivity issues during local art scraping and export.

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -326,6 +326,8 @@ void CAdvancedSettings::Initialize()
   m_bVideoScannerIgnoreErrors = false;
   m_iVideoLibraryDateAdded = 1; // prefer mtime over ctime and current time
 
+  m_caseSensitiveLocalArtMatch = true; // case sensitive local art matching
+
   m_iEpgUpdateCheckInterval = 300; /* Check every X seconds, if EPG data need to be updated. This does not mean that
                                       every X seconds an EPG update is actually triggered, it's just the interval how
                                       often to check whether an update should be triggered. If this value is greater
@@ -825,6 +827,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetBoolean(pElement, "importwatchedstate", m_bVideoLibraryImportWatchedState);
     XMLUtils::GetBoolean(pElement, "importresumepoint", m_bVideoLibraryImportResumePoint);
     XMLUtils::GetInt(pElement, "dateadded", m_iVideoLibraryDateAdded);
+    XMLUtils::GetBoolean(pElement, "casesensitivelocalartmatch", m_caseSensitiveLocalArtMatch);
   }
 
   pElement = pRootElement->FirstChildElement("videoscanner");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -269,6 +269,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_bVideoScannerIgnoreErrors;
     int m_iVideoLibraryDateAdded;
 
+    bool m_caseSensitiveLocalArtMatch{true};
+
     std::set<std::string> m_vecTokens;
 
     int m_iEpgUpdateCheckInterval;  // seconds

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -25,6 +25,7 @@
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "filesystem/Directory.h"
+#include "filesystem/DirectoryCache.h"
 #include "filesystem/File.h"
 #include "filesystem/MultiPathDirectory.h"
 #include "filesystem/PluginDirectory.h"
@@ -10805,6 +10806,9 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
     pDS2.reset(m_pDB->CreateDataset());
     if (nullptr == pDS2)
       return;
+
+    // clear directory cache (to prevent case sensitive file name matching 'errors' on case insensitive file systems)
+    g_directoryCache.Clear();
 
     // if we're exporting to a single folder, we export thumbs as well
     std::string exportRoot = URIUtils::AddFileToFolder(path, "kodi_videodb_" + CDateTime::GetCurrentDateTime().GetAsDBDate());

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1722,12 +1722,18 @@ CVideoInfoScanner::~CVideoInfoScanner()
       baseFilename.append("-");
     }
 
+    const bool caseSensitive{CServiceBroker::GetSettingsComponent()
+                                 ->GetAdvancedSettings()
+                                 ->m_caseSensitiveLocalArtMatch};
+
     for (const auto& artFile : availableArtFiles)
     {
-      std::string candidate = URIUtils::GetFileName(artFile->GetPath());
+      std::string candidate{URIUtils::GetFileName(artFile->GetPath())};
+      const bool matchesFilename{!baseFilename.empty() &&
+                                 (caseSensitive
+                                      ? StringUtils::StartsWith(candidate, baseFilename)
+                                      : StringUtils::StartsWithNoCase(candidate, baseFilename))};
 
-      bool matchesFilename =
-        !baseFilename.empty() && StringUtils::StartsWith(candidate, baseFilename);
       if (!baseFilename.empty() && !matchesFilename)
         continue;
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Bug report #26236 from @lepetrel69

We identified two issues, each addressed here.
Both issues revolve around file name case sensitivity.

In the first issue, on an NTFS filesystem in windows (which is a case insensitive implementation even though the underlying NTFS is case sensitive) - if there is an art file name that differs in case to the media file name, it is overwritten at library export even if NO overwrite is chosen.

For example, consider:

La Planète des Singes S01E01 - L'évasion est pour demain.mkv
La Planète des singes S01E01 - L'évasion est pour demain-thumb.jpg

Note the case of the 's' in singes.

In this case, when using the local scraper, the thumb file is not imported (see issue 2) and is found online through the .nfo file (whether this should happen iwhen using the local scraper is subject to a different PR).

If you then do a library export immediately after - choosing seperate files, exporting art but NO overwrite - the art file is still overwritten.

This occurs because the folder is in the directory cache and CFile::Exists() is case sensitive when the directory cache is used - so returns false when a matching thumb file with a capital S is sought but the actual writing of the file is case insenstive so the small S file gets overwritten.

If the folder is not in the directory cache (ie. new start of kodi going straight to export) then CFile::Exists() uses the underlying file system which is case insensitive and returns true so the file is not overwritten.

Solution - clear directory cache before export.

Second issue - and this is one of user preference - the case sensitivity of art matching.

In the illustration above the art was not imported due to the small s. I assume this is by design but I've also seen it cause confusion before.

So, I've added an advancedsetting - casesensitivelocalartmatch - that when false (defaults to true - current behaviour), means art matching on library scan is case insensitive.

```
<advancedsettings>
  <videolibrary>
    <casesensitivelocalartmatch>false</casesensitivelocalartmatch>
  </videolibrary>
</advancedsettings>
```

This doesn't alter import/export - which will still use identical naming.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #26236 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally and by bug report.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

As above.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
