### PR TITLE
[MUISIC]]MKA FILES] Use ffmpeg to read more tags from mka files

### DIFF
--- a/xbmc/filesystem/AudioBookFileDirectory.cpp
+++ b/xbmc/filesystem/AudioBookFileDirectory.cpp
@@ -15,10 +15,12 @@
 #include "filesystem/File.h"
 #include "guilib/LocalizeStrings.h"
 #include "imagefiles/ImageFileURL.h"
-#include "music/tags/MusicInfoTag.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
 
 using namespace XFILE;
+using namespace MUSIC_INFO;
 
 static int cfile_file_read(void *h, uint8_t* buf, int size)
 {
@@ -55,20 +57,108 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
   std::string title;
   std::string author;
   std::string album;
+  std::string desc;
+  std::vector<std::string> artistsort;
+  std::vector<std::string> tagdata;
+  std::vector<std::string> separators{" feat. ", " ft. ", " Feat. ", " Ft. ",  ";", ":",
+                                      "|",       "#",     "/",       " with ", "&"};
+  const std::string musicsep =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator;
+  if (musicsep.find_first_of(";/,&|#") == std::string::npos)
+    separators.push_back(musicsep); // add custom music separator from as.xml
 
   const int end_time_m4b_file =
       m_fctx->streams[0]->duration * av_q2d(m_fctx->streams[0]->time_base);
   const int end_time_mka_file = m_fctx->duration * av_q2d(av_get_time_base_q());
+  const bool isAudioBook = url.IsFileType("m4b");
+  // Some tags are relevant to the whole album - these are read first
+  CMusicInfoTag albumtag;
 
   AVDictionaryEntry* tag=nullptr;
   while ((tag = av_dict_get(m_fctx->metadata, "", tag, AV_DICT_IGNORE_SUFFIX)))
   {
-    if (StringUtils::CompareNoCase(tag->key, "title") == 0)
-      title = tag->value;
-    else if (StringUtils::CompareNoCase(tag->key, "album") == 0)
-      album = tag->value;
-    else if (StringUtils::CompareNoCase(tag->key, "artist") == 0)
-      author = tag->value;
+    if (isAudioBook)
+    {
+      if (StringUtils::CompareNoCase(tag->key, "title") == 0)
+        title = tag->value;
+      else if (StringUtils::CompareNoCase(tag->key, "album") == 0)
+        album = tag->value;
+      else if (StringUtils::CompareNoCase(tag->key, "artist") == 0)
+        author = tag->value;
+      else if (StringUtils::CompareNoCase(tag->key, "description") == 0)
+        desc = tag->value;
+    }
+    else
+    {
+      std::string key = StringUtils::ToUpper(tag->key);
+      // track is matroska's discnumber when at level 50 (these tags) as set by mp3tag
+      // part_number is the matroska spec key
+      if (key == "TRACK" || key == "PART_NUMBER")
+        albumtag.SetDiscNumber(std::stoi(tag->value));
+      else if (key == "SUBTITLE" || key == "SETSUBTITLE")
+        albumtag.SetDiscSubtitle(tag->value);
+      else if (key == "TITLE")
+        albumtag.SetAlbum(tag->value);
+      else if (key == "ALBUM")
+        albumtag.SetAlbum(tag->value);
+      else if (key == "ARTIST")
+        albumtag.SetArtist(tag->value);
+      else if (key == "ARTISTSORT" || key == "ARTIST SORT")
+        albumtag.SetArtistSort(
+            StringUtils::Join(StringUtils::Split(tag->value, separators), musicsep));
+      else if (key == "ALBUMARTIST" || key == "ALBUM ARTIST")
+        albumtag.SetAlbumArtist(
+            StringUtils::Join(StringUtils::Split(tag->value, separators), musicsep));
+      else if (key == "ALBUMARTSTS" || key == "ALBUM ARTISTS")
+        albumtag.SetAlbumArtist(StringUtils::Split(tag->value, separators));
+      else if (key == "ALBUMARTISTSORT" || key == "ALBUM ARTIST SORT")
+        albumtag.SetAlbumArtistSort(
+            StringUtils::Join(StringUtils::Split(tag->value, separators), musicsep));
+      else if (key == "MUSICBRAINZ_ARTISTID")
+        albumtag.SetMusicBrainzArtistID(StringUtils::Split(tag->value, separators));
+      else if (key == "MUSICBRAINZ_ALBUMARTISTID")
+        albumtag.SetMusicBrainzAlbumArtistID(StringUtils::Split(tag->value, separators));
+      else if (key == "MUSICBRAINZ_ALBUMARTIST")
+        albumtag.SetAlbumArtist(tag->value);
+      else if (key == "MUSICBRAINZ_ALBUMID")
+        albumtag.SetMusicBrainzAlbumID(tag->value);
+      else if (key == "MUSICBRAINZ_RELEASEGROUPID")
+        albumtag.SetMusicBrainzReleaseGroupID(tag->value);
+      else if (key == "MUSICBRAINZ_ALBUMSTATUS")
+        albumtag.SetAlbumReleaseStatus(tag->value);
+      else if (key == "MUSICBRAINZ_ALBUMTYPE")
+        albumtag.SetMusicBrainzReleaseType(tag->value);
+      else if (key == "PUBLISHER")
+        albumtag.SetRecordLabel(tag->value);
+      // mp3tag info shows year but the value is stored in date_recorded
+      // equates to TDRC in id3v2.4 ISO 8601 yyyy-mm-dd or part thereof
+      else if (key == "YEAR" || key == "DATE_RECORDED")
+        albumtag.SetReleaseDate(tag->value);
+      else if (key == "ORIGYEAR") // ISO 8601 as above. Equates to TDOR in id3v2.4 (set by mp3tag)
+        albumtag.SetOriginalDate(tag->value);
+      else if (key == "MOOD")
+        albumtag.SetMood(tag->value);
+      // genre could be comma delimited or not. Temporarily add the comma just in case.  true trims
+      // any whitespace around the genre(s)
+      else if (key == "GENRE")
+      {
+        separators.push_back(",");
+        albumtag.SetGenre(StringUtils::Split(tag->value, separators), true);
+        separators.pop_back();
+      }
+      // comma separated list of role, person
+      else if (key == "INVOLVEDPEOPLE")
+      {
+        tagdata = StringUtils::Split(tag->value, ",");
+        AddCommaDelimitedString(tagdata, separators, albumtag);
+      }
+      else if (key == "SUBTITLE" || key == "SETSUBTITLE")
+        albumtag.SetDiscSubtitle(tag->value);
+      else if (key == "REMIXED_BY")
+        albumtag.AddArtistRole("Remixer", tag->value);
+      else if (key == "COMMENT")
+        albumtag.SetComment(tag->value);
+    }
   }
 
   std::string thumb;
@@ -81,29 +171,101 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
     std::string chaptitle = StringUtils::Format(g_localizeStrings.Get(25010), i + 1);
     std::string chapauthor;
     std::string chapalbum;
+
+    std::shared_ptr<CFileItem> item(new CFileItem(url.Get(), false));
+    *item->GetMusicInfoTag() = albumtag;
+
+    auto addRole = [&](const std::string& role, const std::string& value)
+    {
+      if (!value.empty())
+        item->GetMusicInfoTag()->AddArtistRole(role, StringUtils::Split(value, separators));
+    };
+
     while ((tag=av_dict_get(m_fctx->chapters[i]->metadata, "", tag, AV_DICT_IGNORE_SUFFIX)))
     {
-      if (StringUtils::CompareNoCase(tag->key, "title") == 0)
-        chaptitle = tag->value;
-      else if (StringUtils::CompareNoCase(tag->key, "artist") == 0)
-        chapauthor = tag->value;
-      else if (StringUtils::CompareNoCase(tag->key, "album") == 0)
-        chapalbum = tag->value;
+      if (isAudioBook)
+      {
+        if (StringUtils::CompareNoCase(tag->key, "title") == 0)
+          chaptitle = tag->value;
+        else if (StringUtils::CompareNoCase(tag->key, "artist") == 0)
+          chapauthor = tag->value;
+        else if (StringUtils::CompareNoCase(tag->key, "album") == 0)
+          chapalbum = tag->value;
+      }
+      else
+      {
+        std::string key = StringUtils::ToUpper(tag->key);
+        if (key == "TITLE")
+          item->GetMusicInfoTag()->SetTitle(tag->value);
+        else if (key == "ARTIST")
+          item->GetMusicInfoTag()->SetArtist(tag->value);
+        else if (key == "MUSICBRAINZ_TRACKID")
+          item->GetMusicInfoTag()->SetMusicBrainzTrackID(tag->value);
+        else if (key == "COMPOSER")
+          addRole("Composer", tag->value);
+        else if (key == "LYRICIST")
+          addRole("Lyricist", tag->value);
+        else if (key == "CONDUCTOR")
+          addRole("Conductor", tag->value);
+        else if (key == "WRITER")
+          addRole("Writer", tag->value);
+        else if (key == "ARRANGER")
+          addRole("Arranger", tag->value);
+        else if (key == "BAND")
+          addRole("Band", tag->value);
+        else if (key == "ENGINEER")
+          addRole("Engineer", tag->value);
+        else if (key == "PRODUCER")
+          addRole("Producer", tag->value);
+        else if (key == "REMIXED_BY")
+          addRole("Remixer", tag->value);
+        else if (key == "YEAR" || key == "DATE_RECORDED")
+          item->GetMusicInfoTag()->SetReleaseDate(tag->value);
+        else if (key == "ORIGYEAR")
+          item->GetMusicInfoTag()->SetOriginalDate(tag->value);
+        else if (key == "SUBTITLE" || key == "SETSUBTITLE")
+          item->GetMusicInfoTag()->SetDiscSubtitle(tag->value);
+        else if (key == "COMMENT")
+          item->GetMusicInfoTag()->SetComment(tag->value);
+        else if (key == "MOOD")
+          item->GetMusicInfoTag()->SetMood(tag->value);
+        else if (key == "GENRE")
+        {
+          separators.push_back(",");
+          item->GetMusicInfoTag()->SetGenre(StringUtils::Split(tag->value, separators), true);
+          separators.pop_back();
+        }
+        // comma separated list of instrument, person
+        else if (key == "INSTRUMENTS")
+        {
+          tagdata = StringUtils::Split(tag->value, ",");
+          AddCommaDelimitedString(tagdata, separators, *item->GetMusicInfoTag());
+        }
+        // comma separated list of role, person
+        else if (key == "INVOLVEDPEOPLE")
+        {
+          tagdata = StringUtils::Split(tag->value, ",");
+          AddCommaDelimitedString(tagdata, separators, *item->GetMusicInfoTag());
+        }
+      }
+      /* The comma separated lists are outside the Matroska spec
+         (see https://www.matroska.org/technical/tagging.html) as it states to use multiple simple
+         tags for eg 2 or more composers.  However, ffmpeg returns just the last tag and drops the
+         rest (https://trac.ffmpeg.org/ticket/9641).  Therefore until (if) it gets fixed, this is
+         the best solution.
+       */
     }
-    CFileItemPtr item(new CFileItem(url.Get(),false));
+    if (isAudioBook)
+    {
+      item->GetMusicInfoTag()->SetTitle(chaptitle);
+      item->GetMusicInfoTag()->SetAlbum(chapalbum.empty() ? album.empty() ? title : album
+                                                          : chapalbum);
+      item->GetMusicInfoTag()->SetArtist(chapauthor.empty() ? author : chapauthor);
+      if (!desc.empty())
+        item->GetMusicInfoTag()->SetComment(desc);
+    }
     item->GetMusicInfoTag()->SetTrackNumber(i+1);
     item->GetMusicInfoTag()->SetLoaded(true);
-    item->GetMusicInfoTag()->SetTitle(chaptitle);
-    if (album.empty())
-      item->GetMusicInfoTag()->SetAlbum(title);
-    else if (chapalbum.empty())
-      item->GetMusicInfoTag()->SetAlbum(album);
-    else
-      item->GetMusicInfoTag()->SetAlbum(chapalbum);
-    if (chapauthor.empty())
-      item->GetMusicInfoTag()->SetArtist(author);
-    else
-      item->GetMusicInfoTag()->SetArtist(chapauthor);
 
     item->SetLabel(StringUtils::Format("{0:02}. {1} - {2}", i + 1,
                                        item->GetMusicInfoTag()->GetAlbum(),
@@ -135,6 +297,25 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
   }
 
   return true;
+}
+
+void CAudioBookFileDirectory::AddCommaDelimitedString(const std::vector<std::string>& data,
+                                                      const std::vector<std::string>& separators,
+                                                      MUSIC_INFO::CMusicInfoTag& musictag)
+{
+  if (!data.empty())
+  {
+    for (size_t i = 0; i + 1 < data.size(); i += 2)
+    {
+      std::vector<std::string> roles = StringUtils::Split(data[i], separators);
+      for (auto& role : roles)
+      {
+        StringUtils::Trim(role);
+        StringUtils::ToCapitalize(role);
+        musictag.AddArtistRole(role, StringUtils::Split(data[i + 1], ","));
+      }
+    }
+  }
 }
 
 bool CAudioBookFileDirectory::Exists(const CURL& url)

--- a/xbmc/filesystem/AudioBookFileDirectory.h
+++ b/xbmc/filesystem/AudioBookFileDirectory.h
@@ -8,10 +8,13 @@
 #pragma once
 
 #include "IFileDirectory.h"
+#include "music/tags/MusicInfoTag.h"
+
+#include <memory>
+
 extern "C" {
 #include <libavformat/avformat.h>
 }
-
 namespace XFILE
 {
   class CAudioBookFileDirectory : public IFileDirectory
@@ -24,6 +27,9 @@ namespace XFILE
       bool IsAllowed(const CURL& url) const override { return true; }
 
     protected:
+      void AddCommaDelimitedString(const std::vector<std::string>& data,
+                                   const std::vector<std::string>& separators,
+                                   MUSIC_INFO::CMusicInfoTag& musictag);
       AVIOContext* m_ioctx = nullptr;
       AVFormatContext* m_fctx = nullptr;
   };


### PR DESCRIPTION
## Description
This PR adds the ability to read multiple tags from MKA files (which are often used to store high end audio tracks).  This enables Kodi to add these MKA albums to it's music library and scrape, display and evaluate these albums in the same way as mp3 or flac albums.

This PR follows the matroska tagging guidelines to a certain extent.  The first set of tags read (album stuff) are tagtypevalue 50.  The track info is tagtypevalue 30.  The deviation occurs because ffmpeg returns just the last value of a multiple tag entry.  Given 3 composers, the composer tag should be returned 3 times, each with a different value.  However, ffmpeg just returns the last value.  There is a comment in the code to this effect, and a link to the bugtracker.

In short, this PR allows the reading of the most common music tags, similar to the tags of mp3 or flac files from mka files.  This then allows smartplaylists etc to use that data in the same way as other common music file formats.

Assuming this gets merged, the wiki will document the `involved people` and `instruments` tag layouts.

## Motivation and context
This allows the scanning and retaining of more metadata for mka albums.  This includes, but is not limited to, musicbrainz artist, album and track ID's, artist sort info, album artists, publisher etc etc
## How has this been tested?
Tested locally by scanning in mka files tagged with metadata.

## What is the effect on users?
mka albums can be scanned in and played back like mp3 / ape / flac albums.  Much more info will be stored in the music database.
## Screenshots (if appropriate):

info dialog on MKA album before this PR

![before_improved_handling](https://github.com/user-attachments/assets/ac0fe8a2-bb33-44f1-8e0e-146ba4823723)

info dialog on MKA album _after_ PR

![after_this_pr](https://github.com/user-attachments/assets/76880631-601b-4a87-81e9-f48a9fb0e0de)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
