### PR TITLE
[Video] Add refresh set functionality, set.nfo support and improve add/update set consistency with Movie Set Information Folder. 

### DIFF
--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -414,12 +414,12 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         value = StringUtils::Join(tag->m_tags, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
         return true;
       case LISTITEM_SET:
-        value = tag->m_set.title;
+        value = tag->m_set.GetTitle();
         return true;
       case LISTITEM_SETID:
-        if (tag->m_set.id > 0)
+        if (tag->m_set.GetID() > 0)
         {
-          value = std::to_string(tag->m_set.id);
+          value = std::to_string(tag->m_set.GetID());
           return true;
         }
         break;

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -806,7 +806,7 @@ namespace XBMCAddon
 
     void InfoTagVideo::setSetIdRaw(CVideoInfoTag* infoTag, int setId)
     {
-      infoTag->m_set.id = setId;
+      infoTag->m_set.SetID(setId);
     }
 
     void InfoTagVideo::setTrackNumberRaw(CVideoInfoTag* infoTag, int trackNumber)

--- a/xbmc/utils/GroupUtils.cpp
+++ b/xbmc/utils/GroupUtils.cpp
@@ -46,11 +46,11 @@ bool GroupUtils::Group(GroupBy groupBy, const std::string &baseDir, const CFileI
     const CFileItemPtr item = items.Get(index);
 
     // group by sets
-    if ((groupBy & GroupBySet) &&
-      item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_set.id > 0)
+    if ((groupBy & GroupBySet) && item->HasVideoInfoTag() &&
+        item->GetVideoInfoTag()->m_set.GetID() > 0)
     {
       ungrouped = false;
-      setMap[item->GetVideoInfoTag()->m_set.id].insert(item);
+      setMap[item->GetVideoInfoTag()->m_set.GetID()].insert(item);
     }
 
     if (ungrouped)
@@ -72,7 +72,8 @@ bool GroupUtils::Group(GroupBy groupBy, const std::string &baseDir, const CFileI
         continue;
       }
 
-      CFileItemPtr pItem(new CFileItem((*set->second.begin())->GetVideoInfoTag()->m_set.title));
+      CFileItemPtr pItem(
+          new CFileItem((*set->second.begin())->GetVideoInfoTag()->m_set.GetTitle()));
       pItem->GetVideoInfoTag()->m_iDbId = set->first;
       pItem->GetVideoInfoTag()->m_type = MediaTypeVideoCollection;
 
@@ -90,7 +91,7 @@ bool GroupUtils::Group(GroupBy groupBy, const std::string &baseDir, const CFileI
       CVideoInfoTag* setInfo = pItem->GetVideoInfoTag();
       setInfo->m_strPath = pItem->GetPath();
       setInfo->m_strTitle = pItem->GetLabel();
-      setInfo->m_strPlot = (*set->second.begin())->GetVideoInfoTag()->m_set.overview;
+      setInfo->m_strPlot = (*set->second.begin())->GetVideoInfoTag()->m_set.GetOverview();
 
       int ratings = 0;
       float totalRatings = 0;

--- a/xbmc/video/CMakeLists.txt
+++ b/xbmc/video/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES Bookmark.cpp
             ContextMenus.cpp
             GUIViewStateVideo.cpp
             PlayerController.cpp
+            SetInfoTag.cpp
             Teletext.cpp
             VideoDatabase.cpp
             VideoDbUrl.cpp
@@ -22,6 +23,7 @@ set(HEADERS Bookmark.h
             Episode.h
             GUIViewStateVideo.h
             PlayerController.h
+            SetInfoTag.h
             Teletext.h
             TeletextDefines.h
             VideoDatabase.h

--- a/xbmc/video/SetInfoTag.cpp
+++ b/xbmc/video/SetInfoTag.cpp
@@ -1,0 +1,170 @@
+/*
+ *  Copyright (C) 2024-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SetInfoTag.h"
+
+#include "VideoThumbLoader.h"
+#include "utils/Archive.h"
+#include "utils/StringUtils.h"
+#include "utils/Variant.h"
+#include "utils/XMLUtils.h"
+
+void CSetInfoTag::Reset()
+{
+  m_title.clear();
+  m_id = -1;
+  m_overview.clear();
+  m_updateSetOverview = false;
+  m_art.clear();
+}
+
+bool CSetInfoTag::Load(const TiXmlElement* element, bool append, bool prioritise)
+{
+  if (!element)
+    return false;
+  if (!append)
+    Reset();
+  ParseNative(element, prioritise);
+  return true;
+}
+
+void CSetInfoTag::ParseNative(const TiXmlElement* set, bool prioritise)
+{
+  std::string value;
+
+  if (XMLUtils::GetString(set, "title", value))
+    SetTitle(value);
+  if (XMLUtils::GetString(set, "originaltitle", value))
+    SetOriginalTitle(value);
+  if (XMLUtils::GetString(set, "overview", value))
+    SetOverview(value);
+
+  const TiXmlElement* art{set->FirstChildElement("art")};
+  if (art)
+    for (const TiXmlElement* picture = art->FirstChildElement(); picture;
+         picture = picture->NextSiblingElement())
+    {
+      std::string type{picture->ValueStr()};
+      std::string url{picture->GetText()};
+      if (!type.empty() && !url.empty())
+        m_art.insert({type, url});
+    }
+}
+
+void CSetInfoTag::SetOverview(const std::string& overview)
+{
+  m_overview = overview;
+  m_overview = StringUtils::Trim(m_overview);
+  m_updateSetOverview = true;
+}
+
+void CSetInfoTag::SetTitle(const std::string& title)
+{
+  m_title = title;
+  m_title = StringUtils::Trim(m_title);
+}
+
+void CSetInfoTag::SetOriginalTitle(const std::string& title)
+{
+  m_originalTitle = title;
+}
+
+void CSetInfoTag::SetArt(const KODI::ART::Artwork& art)
+{
+  m_art = art;
+}
+
+void CSetInfoTag::Merge(const CSetInfoTag& other)
+{
+  if (other.GetID())
+    m_id = other.GetID();
+  if (other.HasTitle())
+    m_title = other.GetTitle();
+  if (other.HasOriginalTitle())
+    m_originalTitle = other.GetOriginalTitle();
+  if (other.HasOverview())
+    m_overview = other.GetOverview();
+  if (!other.m_art.empty())
+    m_art = other.m_art;
+}
+
+void CSetInfoTag::Copy(const CSetInfoTag& other)
+{
+  m_id = other.GetID();
+  m_title = other.GetTitle();
+  m_originalTitle = other.GetOriginalTitle();
+  m_overview = other.GetOverview();
+  m_art = other.m_art;
+}
+
+bool CSetInfoTag::Save(TiXmlNode* node,
+                       const std::string& tag,
+                       bool savePathInfo,
+                       const TiXmlElement* additionalNode /* =nullptr */)
+{
+  if (!node)
+    return false;
+
+  // we start with a <tag> tag
+  TiXmlElement setElement(tag.c_str());
+  TiXmlNode* set = node->InsertEndChild(setElement);
+  if (!set)
+    return false;
+
+  XMLUtils::SetString(set, "title", m_title);
+  if (!m_originalTitle.empty())
+    XMLUtils::SetString(set, "originaltitle", m_originalTitle);
+  if (!m_overview.empty())
+    XMLUtils::SetString(set, "overview", m_overview);
+
+  if (HasArt())
+  {
+    TiXmlElement art("art");
+    for (auto& [type, url] : m_art)
+    {
+      XMLUtils::SetString(&art, type.c_str(), url);
+    }
+    set->InsertEndChild(art);
+  }
+
+  if (additionalNode)
+    set->InsertEndChild(*additionalNode);
+
+  return true;
+}
+
+void CSetInfoTag::Archive(CArchive& ar)
+{
+  if (ar.IsStoring())
+  {
+    ar << m_title;
+    ar << m_id;
+    ar << m_overview;
+    ar << m_originalTitle;
+  }
+  else
+  {
+    ar >> m_title;
+    ar >> m_id;
+    ar >> m_overview;
+    ar >> m_originalTitle;
+  }
+}
+
+void CSetInfoTag::Serialize(CVariant& value) const
+{
+  value["set"] = m_title;
+  value["setid"] = m_id;
+  value["setoverview"] = m_overview;
+  value["originalset"] = m_originalTitle;
+}
+
+bool CSetInfoTag::IsEmpty() const
+{
+  return (m_title.empty() && m_id == -1 && m_overview.empty());
+}

--- a/xbmc/video/SetInfoTag.h
+++ b/xbmc/video/SetInfoTag.h
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (C) 2024-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "VideoThumbLoader.h"
+
+#include <string>
+
+class TiXmlNode;
+class TiXmlElement;
+
+class CSetInfoTag : public IArchivable, public ISerializable
+{
+public:
+  CSetInfoTag() { Reset(); }
+  void Reset();
+  /* \brief Load information to a setinfotag from an XML element
+
+   \param element    the root XML element to parse.
+   \param append     whether information should be added to the existing tag, or whether it should be reset first.
+   \param prioritise if appending, whether additive tags should be prioritised (i.e. replace or prepend) over existing values. Defaults to false.
+
+   \sa ParseNative
+   */
+  bool Load(const TiXmlElement* element, bool append = false, bool prioritise = false);
+  bool IsEmpty() const;
+
+  int GetID() const { return m_id; }
+  void SetID(int id) { m_id = id; }
+
+  void SetOverview(const std::string& overview);
+  bool HasOverview() const { return !m_overview.empty(); }
+  std::string GetOverview() const { return m_overview; }
+  bool GetUpdateSetOverview() const { return m_updateSetOverview; }
+
+  void SetTitle(const std::string& title);
+  bool HasTitle() const { return !m_title.empty(); }
+  std::string GetTitle() const { return m_title; }
+
+  void SetOriginalTitle(const std::string& title);
+  bool HasOriginalTitle() const { return !m_originalTitle.empty(); }
+  std::string GetOriginalTitle() const { return m_originalTitle; }
+
+  void SetArt(const KODI::ART::Artwork& art);
+  bool HasArt() const { return !m_art.empty(); }
+  KODI::ART::Artwork GetArt() const { return m_art; }
+
+  void Merge(const CSetInfoTag& other);
+  void Copy(const CSetInfoTag& other);
+  bool Save(TiXmlNode* node,
+            const std::string& tag,
+            bool savePathInfo = true,
+            const TiXmlElement* additionalNode = nullptr);
+  void Archive(CArchive& ar) override;
+  void Serialize(CVariant& value) const override;
+
+  std::string m_title; // Title of the movie set
+  std::string m_originalTitle; // Original title of movie set (from scraper)
+  std::string m_overview; // Overview/description of the movie set
+  KODI::ART::Artwork m_art; // Art information
+  int m_id{-1}; // ID of movie set in database
+
+private:
+  bool m_updateSetOverview{false}; // If overview has been set
+
+  /* \brief Parse our native XML format for video info.
+   See Load for a description of the available tag types.
+
+   \param element    the root XML element to parse.
+   \param prioritise whether additive tags should be replaced (or prepended) by the content of the tags, or appended to.
+   \sa Load
+   */
+  void ParseNative(const TiXmlElement* set, bool prioritise);
+};

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -189,7 +189,8 @@ void CVideoDatabase::CreateTables()
     "strHdrType text)");
 
   CLog::Log(LOGINFO, "create sets table");
-  m_pDS->exec("CREATE TABLE sets ( idSet integer primary key, strSet text, strOverview text)");
+  m_pDS->exec("CREATE TABLE sets ( idSet integer primary key, strSet text, strOverview text, "
+              "strOriginalSet text)");
 
   CLog::Log(LOGINFO, "create seasons table");
   m_pDS->exec("CREATE TABLE seasons ( idSeason integer primary key, idShow integer, season integer, name text, userrating integer)");
@@ -567,6 +568,7 @@ void CVideoDatabase::CreateViews()
       "  movie.*,"
       "  sets.strSet AS strSet,"
       "  sets.strOverview AS strSetOverview,"
+      "  sets.strOriginalSet as strOriginalSet,"
       "  files.strFileName AS strFileName,"
       "  path.strPath AS strPath,"
       "  files.playCount AS playCount,"
@@ -1833,6 +1835,7 @@ int CVideoDatabase::AddUniqueIDs(int mediaId, const char *mediaType, const CVide
 
 int CVideoDatabase::AddSet(const std::string& strSet,
                            const std::string& strOverview /* = "" */,
+                           const std::string& strOriginalSet /* = "" */,
                            const bool updateOverview /* = true */)
 {
   if (strSet.empty())
@@ -1843,27 +1846,33 @@ int CVideoDatabase::AddSet(const std::string& strSet,
     if (m_pDB == nullptr || m_pDS == nullptr)
       return -1;
 
-    std::string strSQL = PrepareSQL("SELECT idSet FROM sets WHERE strSet LIKE '%s'", strSet.c_str());
+    std::string strSQL =
+        PrepareSQL("SELECT idSet FROM sets WHERE strOriginalSet='%s'",
+                   strOriginalSet.empty() ? strSet.c_str() : strOriginalSet.c_str());
     m_pDS->query(strSQL);
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
-      strSQL = PrepareSQL("INSERT INTO sets (idSet, strSet, strOverview) VALUES(NULL, '%s', '%s')", strSet.c_str(), strOverview.c_str());
+      strSQL = PrepareSQL("INSERT INTO sets (idSet, strSet, strOverview, strOriginalSet) "
+                          "VALUES(NULL, '%s', '%s', '%s')",
+                          strSet.c_str(), strOverview.c_str(),
+                          strOriginalSet.empty() ? strSet.c_str() : strOriginalSet.c_str());
       m_pDS->exec(strSQL);
       return static_cast<int>(m_pDS->lastinsertid());
     }
     else
     {
-      int id = m_pDS->fv("idSet").get_asInt();
+      const int id = m_pDS->fv("idSet").get_asInt();
       m_pDS->close();
 
       // update set data
       if (updateOverview)
-      {
-        strSQL = PrepareSQL("UPDATE sets SET strOverview = '%s' WHERE idSet = %i",
-                            strOverview.c_str(), id);
-        m_pDS->exec(strSQL);
-      }
+        strSQL = PrepareSQL("UPDATE sets SET strSet = '%s', strOverview = '%s' WHERE idSet = %i",
+                            strSet.c_str(), strOverview.c_str(), id);
+      else
+        strSQL = PrepareSQL("UPDATE sets SET strSet = '%s' WHERE idSet = %i", strSet.c_str(), id);
+
+      m_pDS->exec(strSQL);
 
       return id;
     }
@@ -2757,7 +2766,8 @@ int CVideoDatabase::SetDetailsForMovie(CVideoInfoTag& details,
     if (details.m_set.HasTitle())
     {
       idSet = AddSet(details.m_set.GetTitle(), details.m_set.GetOverview(),
-                     details.GetUpdateSetOverview());
+                     details.m_set.GetOriginalTitle(), details.GetUpdateSetOverview());
+      details.m_set.SetID(idSet);
       // add art if not available
       if (!HasArtForItem(idSet, MediaTypeVideoCollection))
       {
@@ -4794,6 +4804,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMovie(const dbiplus::sql_record* cons
   details.m_set.SetID(record->at(VIDEODB_DETAILS_MOVIE_SET_ID).get_asInt());
   details.m_set.SetTitle(record->at(VIDEODB_DETAILS_MOVIE_SET_NAME).get_asString());
   details.m_set.SetOverview(record->at(VIDEODB_DETAILS_MOVIE_SET_OVERVIEW).get_asString());
+  details.m_set.SetOriginalTitle(record->at(VIDEODB_DETAILS_MOVIE_SET_ORIGINALNAME).get_asString());
   details.m_iFileId = record->at(VIDEODB_DETAILS_MOVIE_VERSION_FILEID).get_asInt();
   details.m_strPath = record->at(VIDEODB_DETAILS_MOVIE_PATH).get_asString();
   std::string strFileName = record->at(VIDEODB_DETAILS_MOVIE_FILE).get_asString();
@@ -6939,11 +6950,19 @@ void CVideoDatabase::UpdateTables(int iVersion)
     }
     m_pDS->close();
   }
+
+  if (iVersion < 136)
+  {
+    m_pDS->exec("ALTER TABLE sets ADD strOriginalSet TEXT");
+
+    // Copy current set title for existing sets
+    m_pDS->exec("UPDATE sets SET strOriginalSet = strSet");
+  }
 }
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 135;
+  return 136;
 }
 
 bool CVideoDatabase::LookupByFolders(const std::string &path, bool shows)
@@ -8739,6 +8758,19 @@ bool CVideoDatabase::GetMoviesNav(const std::string& strBaseDir, CFileItemList& 
   return GetMoviesByWhere(videoUrl.ToString(), filter, items, sortDescription, getDetails);
 }
 
+bool CVideoDatabase::GetMoviesBySet(const std::string& baseDir, CFileItemList& items, int idSet)
+{
+  CVideoDbUrl videoUrl;
+  if (!videoUrl.FromString(baseDir))
+    return false;
+
+  if (idSet > 0)
+    videoUrl.AddOption("setid", idSet);
+
+  Filter filter;
+  return GetMoviesByWhere(videoUrl.ToString(), filter, items, SortDescription(), VideoDbDetailsAll);
+}
+
 bool CVideoDatabase::GetMoviesByWhere(const std::string& strBaseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription /* = SortDescription() */, int getDetails /* = VideoDbDetailsNone */)
 {
   try
@@ -9195,6 +9227,11 @@ std::string CVideoDatabase::GetCountryById(int id) const
 std::string CVideoDatabase::GetSetById(int id) const
 {
   return GetSingleValue("sets", "strSet", PrepareSQL("idSet=%i", id));
+}
+
+std::string CVideoDatabase::GetOriginalSetById(int id) const
+{
+  return GetSingleValue("sets", "strOriginalSet", PrepareSQL("idSet=%i", id));
 }
 
 std::string CVideoDatabase::GetSetByNameLike(const std::string& nameLike) const
@@ -11380,7 +11417,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
     if (images && !movieSetsDir.empty())
     {
       // find all movie sets
-      sql = "select idSet, strSet from sets";
+      sql = "select idSet, strSet, strOriginalSet from sets";
 
       m_pDS->query(sql);
 
@@ -11389,7 +11426,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
 
       while (!m_pDS->eof())
       {
-        std::string title = m_pDS->fv("strSet").get_asString();
+        std::string title = m_pDS->fv("strOriginalSet").get_asString();
 
         if (progress)
         {

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2754,9 +2754,10 @@ int CVideoDatabase::SetDetailsForMovie(CVideoInfoTag& details,
 
     // add set...
     int idSet = -1;
-    if (!details.m_set.title.empty())
+    if (details.m_set.HasTitle())
     {
-      idSet = AddSet(details.m_set.title, details.m_set.overview, details.GetUpdateSetOverview());
+      idSet = AddSet(details.m_set.GetTitle(), details.m_set.GetOverview(),
+                     details.GetUpdateSetOverview());
       // add art if not available
       if (!HasArtForItem(idSet, MediaTypeVideoCollection))
       {
@@ -2871,9 +2872,9 @@ int CVideoDatabase::UpdateDetailsForMovie(int idMovie,
     if (updatedDetails.contains("set"))
     { // set
       idSet = -1;
-      if (!details.m_set.title.empty())
+      if (details.m_set.HasTitle())
       {
-        idSet = AddSet(details.m_set.title, details.m_set.overview);
+        idSet = AddSet(details.m_set.GetTitle(), details.m_set.GetOverview());
       }
     }
 
@@ -4790,9 +4791,9 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMovie(const dbiplus::sql_record* cons
   versionInfo.SetTitle(record->at(VIDEODB_DETAILS_MOVIE_VERSION_TYPENAME).get_asString());
   versionInfo.SetType(
       static_cast<VideoAssetType>(record->at(VIDEODB_DETAILS_MOVIE_VERSION_ITEMTYPE).get_asInt()));
-  details.m_set.id = record->at(VIDEODB_DETAILS_MOVIE_SET_ID).get_asInt();
-  details.m_set.title = record->at(VIDEODB_DETAILS_MOVIE_SET_NAME).get_asString();
-  details.m_set.overview = record->at(VIDEODB_DETAILS_MOVIE_SET_OVERVIEW).get_asString();
+  details.m_set.SetID(record->at(VIDEODB_DETAILS_MOVIE_SET_ID).get_asInt());
+  details.m_set.SetTitle(record->at(VIDEODB_DETAILS_MOVIE_SET_NAME).get_asString());
+  details.m_set.SetOverview(record->at(VIDEODB_DETAILS_MOVIE_SET_OVERVIEW).get_asString());
   details.m_iFileId = record->at(VIDEODB_DETAILS_MOVIE_VERSION_FILEID).get_asInt();
   details.m_strPath = record->at(VIDEODB_DETAILS_MOVIE_PATH).get_asString();
   std::string strFileName = record->at(VIDEODB_DETAILS_MOVIE_FILE).get_asString();
@@ -11905,10 +11906,10 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
         artItem.SetPath(GetSafeFile(moviesDir, filename) + ".avi");
         scanner.GetArtwork(&artItem, ContentType::MOVIES, useFolders, true, actorsDir);
         item.SetArt(artItem.GetArt());
-        if (!item.GetVideoInfoTag()->m_set.title.empty())
+        if (item.GetVideoInfoTag()->m_set.HasTitle())
         {
           std::string setPath = URIUtils::AddFileToFolder(
-              movieSetsDir, CUtil::MakeLegalFileName(item.GetVideoInfoTag()->m_set.title,
+              movieSetsDir, CUtil::MakeLegalFileName(item.GetVideoInfoTag()->m_set.GetTitle(),
                                                      LegalPath::WIN32_COMPAT));
           if (CDirectory::Exists(setPath))
           {

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -289,6 +289,23 @@ const std::array<SDbTableOffsets, 24> DbMovieOffsets = {{
 }};
 // clang-format on
 
+enum VIDEODB_SET_IDS // this enum MUST match the offset struct further down!! and make sure to keep min and max at -1 and sizeof(offsets)
+{
+  VIDEODB_ID_SET_MIN = -1,
+  VIDEODB_ID_SET_TITLE = 0,
+  VIDEODB_ID_SET_OVERVIEW = 1,
+  VIDEODB_ID_SET_ORIGINALTITLE = 2,
+  VIDEODB_ID_SET_MAX
+};
+
+// clang-format off
+const std::array<SDbTableOffsets, 3> DbSetOffsets = {{
+    {VIDEODB_TYPE_STRING, my_offsetof(CSetInfoTag, m_title)},
+    {VIDEODB_TYPE_STRING, my_offsetof(CSetInfoTag, m_overview)},
+    {VIDEODB_TYPE_STRING, my_offsetof(CSetInfoTag, m_originalTitle)}
+}};
+// clang-format on
+
 enum VIDEODB_TV_IDS // this enum MUST match the offset struct further down!! and make sure to keep min and max at -1 and sizeof(offsets)
 {
   VIDEODB_ID_TV_MIN = -1,
@@ -1350,6 +1367,8 @@ protected:
 
   CVideoInfoTag GetDetailsForMovie(dbiplus::Dataset& pDS, int getDetails = VideoDbDetailsNone);
   CVideoInfoTag GetDetailsForMovie(const dbiplus::sql_record* const record, int getDetails = VideoDbDetailsNone);
+  CSetInfoTag GetDetailsForSet(dbiplus::Dataset& pDS);
+  CSetInfoTag GetDetailsForSet(const dbiplus::sql_record* const record);
   CVideoInfoTag GetDetailsForTvShow(dbiplus::Dataset& pDS,
                                     int getDetails = VideoDbDetailsNone,
                                     CFileItem* item = nullptr);
@@ -1386,6 +1405,13 @@ protected:
                         const T& offsets,
                         CVideoInfoTag& details,
                         int idxOffset = 2) const;
+  template<typename T>
+  void GetDetailsFromDB(const dbiplus::sql_record* const record,
+                        int min,
+                        int max,
+                        const T& offsets,
+                        CSetInfoTag& details,
+                        int idxOffset);
 
   template<typename T>
   std::string GetValueString(const CVideoInfoTag& details,

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -95,26 +95,27 @@ constexpr int VIDEODB_DETAILS_MOVIE_USER_RATING         = VIDEODB_MAX_COLUMNS + 
 constexpr int VIDEODB_DETAILS_MOVIE_PREMIERED           = VIDEODB_MAX_COLUMNS + 4;
 constexpr int VIDEODB_DETAILS_MOVIE_SET_NAME            = VIDEODB_MAX_COLUMNS + 5;
 constexpr int VIDEODB_DETAILS_MOVIE_SET_OVERVIEW        = VIDEODB_MAX_COLUMNS + 6;
-constexpr int VIDEODB_DETAILS_MOVIE_FILE                = VIDEODB_MAX_COLUMNS + 7;
-constexpr int VIDEODB_DETAILS_MOVIE_PATH                = VIDEODB_MAX_COLUMNS + 8;
-constexpr int VIDEODB_DETAILS_MOVIE_PLAYCOUNT           = VIDEODB_MAX_COLUMNS + 9;
-constexpr int VIDEODB_DETAILS_MOVIE_LASTPLAYED          = VIDEODB_MAX_COLUMNS + 10;
-constexpr int VIDEODB_DETAILS_MOVIE_DATEADDED           = VIDEODB_MAX_COLUMNS + 11;
-constexpr int VIDEODB_DETAILS_MOVIE_RESUME_TIME         = VIDEODB_MAX_COLUMNS + 12;
-constexpr int VIDEODB_DETAILS_MOVIE_TOTAL_TIME          = VIDEODB_MAX_COLUMNS + 13;
-constexpr int VIDEODB_DETAILS_MOVIE_PLAYER_STATE        = VIDEODB_MAX_COLUMNS + 14;
-constexpr int VIDEODB_DETAILS_MOVIE_RATING              = VIDEODB_MAX_COLUMNS + 15;
-constexpr int VIDEODB_DETAILS_MOVIE_VOTES               = VIDEODB_MAX_COLUMNS + 16;
-constexpr int VIDEODB_DETAILS_MOVIE_RATING_TYPE         = VIDEODB_MAX_COLUMNS + 17;
-constexpr int VIDEODB_DETAILS_MOVIE_UNIQUEID_VALUE      = VIDEODB_MAX_COLUMNS + 18;
-constexpr int VIDEODB_DETAILS_MOVIE_UNIQUEID_TYPE       = VIDEODB_MAX_COLUMNS + 19;
-constexpr int VIDEODB_DETAILS_MOVIE_HASVERSIONS         = VIDEODB_MAX_COLUMNS + 20;
-constexpr int VIDEODB_DETAILS_MOVIE_HASEXTRAS           = VIDEODB_MAX_COLUMNS + 21;
-constexpr int VIDEODB_DETAILS_MOVIE_ISDEFAULTVERSION    = VIDEODB_MAX_COLUMNS + 22;
-constexpr int VIDEODB_DETAILS_MOVIE_VERSION_FILEID      = VIDEODB_MAX_COLUMNS + 23;
-constexpr int VIDEODB_DETAILS_MOVIE_VERSION_TYPEID      = VIDEODB_MAX_COLUMNS + 24;
-constexpr int VIDEODB_DETAILS_MOVIE_VERSION_TYPENAME    = VIDEODB_MAX_COLUMNS + 25;
-constexpr int VIDEODB_DETAILS_MOVIE_VERSION_ITEMTYPE    = VIDEODB_MAX_COLUMNS + 26;
+constexpr int VIDEODB_DETAILS_MOVIE_SET_ORIGINALNAME    = VIDEODB_MAX_COLUMNS + 7;
+constexpr int VIDEODB_DETAILS_MOVIE_FILE                = VIDEODB_MAX_COLUMNS + 8;
+constexpr int VIDEODB_DETAILS_MOVIE_PATH                = VIDEODB_MAX_COLUMNS + 9;
+constexpr int VIDEODB_DETAILS_MOVIE_PLAYCOUNT           = VIDEODB_MAX_COLUMNS + 10;
+constexpr int VIDEODB_DETAILS_MOVIE_LASTPLAYED          = VIDEODB_MAX_COLUMNS + 11;
+constexpr int VIDEODB_DETAILS_MOVIE_DATEADDED           = VIDEODB_MAX_COLUMNS + 12;
+constexpr int VIDEODB_DETAILS_MOVIE_RESUME_TIME         = VIDEODB_MAX_COLUMNS + 13;
+constexpr int VIDEODB_DETAILS_MOVIE_TOTAL_TIME          = VIDEODB_MAX_COLUMNS + 14;
+constexpr int VIDEODB_DETAILS_MOVIE_PLAYER_STATE        = VIDEODB_MAX_COLUMNS + 15;
+constexpr int VIDEODB_DETAILS_MOVIE_RATING              = VIDEODB_MAX_COLUMNS + 16;
+constexpr int VIDEODB_DETAILS_MOVIE_VOTES               = VIDEODB_MAX_COLUMNS + 17;
+constexpr int VIDEODB_DETAILS_MOVIE_RATING_TYPE         = VIDEODB_MAX_COLUMNS + 18;
+constexpr int VIDEODB_DETAILS_MOVIE_UNIQUEID_VALUE      = VIDEODB_MAX_COLUMNS + 19;
+constexpr int VIDEODB_DETAILS_MOVIE_UNIQUEID_TYPE       = VIDEODB_MAX_COLUMNS + 20;
+constexpr int VIDEODB_DETAILS_MOVIE_HASVERSIONS         = VIDEODB_MAX_COLUMNS + 21;
+constexpr int VIDEODB_DETAILS_MOVIE_HASEXTRAS           = VIDEODB_MAX_COLUMNS + 22;
+constexpr int VIDEODB_DETAILS_MOVIE_ISDEFAULTVERSION    = VIDEODB_MAX_COLUMNS + 23;
+constexpr int VIDEODB_DETAILS_MOVIE_VERSION_FILEID      = VIDEODB_MAX_COLUMNS + 24;
+constexpr int VIDEODB_DETAILS_MOVIE_VERSION_TYPEID      = VIDEODB_MAX_COLUMNS + 25;
+constexpr int VIDEODB_DETAILS_MOVIE_VERSION_TYPENAME    = VIDEODB_MAX_COLUMNS + 26;
+constexpr int VIDEODB_DETAILS_MOVIE_VERSION_ITEMTYPE    = VIDEODB_MAX_COLUMNS + 27;
 
 constexpr int VIDEODB_DETAILS_EPISODE_TVSHOW_ID         = VIDEODB_MAX_COLUMNS + 2;
 constexpr int VIDEODB_DETAILS_EPISODE_USER_RATING       = VIDEODB_MAX_COLUMNS + 3;
@@ -585,6 +586,7 @@ public:
   std::string GetGenreById(int id) const;
   std::string GetCountryById(int id) const;
   std::string GetSetById(int id) const;
+  std::string GetOriginalSetById(int id) const;
   std::string GetTagById(int id) const;
   std::string GetPersonById(int id) const;
   std::string GetStudioById(int id) const;
@@ -1001,6 +1003,8 @@ public:
                                CFileItemList& items,
                                int getDetails = VideoDbDetailsNone);
 
+  bool GetMoviesBySet(const std::string& baseDir, CFileItemList& items, int idSet);
+
   bool HasContent();
   bool HasContent(VideoDbContentType type);
   bool HasSets() const;
@@ -1183,6 +1187,7 @@ public:
   int AddSeason(int showID, int season, const std::string& name = "");
   int AddSet(const std::string& strSet,
              const std::string& strOverview = "",
+             const std::string& strOriginalSet = "",
              const bool updateOverview = true);
   void ClearMovieSet(int idMovie);
   void SetMovieSet(int idMovie, int idSet);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1712,6 +1712,24 @@ CVideoInfoScanner::~CVideoInfoScanner()
     return false;
   }
 
+  bool CVideoInfoScanner::AddSet(CSetInfoTag* set)
+  {
+    // ensure our database is open (this can get called via other classes)
+    if (!m_database.Open())
+      return false;
+
+    CLog::LogF(LOGDEBUG, "Adding new set {}", set->GetTitle());
+
+    // Create set
+    const int idSet{
+        m_database.AddSet(set->GetTitle(), set->GetOverview(), set->GetOriginalTitle())};
+
+    // Assume art in set
+    if (idSet > 0)
+      return m_database.SetArtForItem(idSet, MediaTypeVideoCollection, set->GetArt());
+    return false;
+  }
+
   long CVideoInfoScanner::AddVideo(CFileItem* pItem,
                                    ContentType content,
                                    bool videoFolder /* = false */,

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1669,7 +1669,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       const std::string discNum{CUtil::GetPartNumberFromPath(movieDetails.m_strFileNameAndPath)};
       if (!discNum.empty())
       {
-        if (movieDetails.m_set.title.empty())
+        if (!movieDetails.m_set.HasTitle())
         {
           const std::string setName{m_database.GetSetByNameLike(movieDetails.m_strTitle)};
           if (!setName.empty())
@@ -1875,7 +1875,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     // get and cache thumb images
     std::string mediaType = ContentToMediaType(content, pItem->IsFolder());
     std::vector<std::string> artTypes = CVideoThumbLoader::GetArtTypes(mediaType);
-    bool moviePartOfSet = content == ContentType::MOVIES && !movieDetails.m_set.title.empty();
+    bool moviePartOfSet = content == ContentType::MOVIES && movieDetails.m_set.HasTitle();
     std::vector<std::string> movieSetArtTypes;
     if (moviePartOfSet)
     {
@@ -1909,7 +1909,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
       if (moviePartOfSet)
       {
-        std::string movieSetInfoPath = GetMovieSetInfoFolder(movieDetails.m_set.title);
+        std::string movieSetInfoPath = GetMovieSetInfoFolder(movieDetails.m_set.GetTitle());
         if (!movieSetInfoPath.empty())
         {
           KODI::ART::Artwork movieSetArt;

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -26,6 +26,7 @@ class CFileItemList;
 namespace KODI::VIDEO
 {
   class IVideoInfoTagLoader;
+  class ISetInfoTagLoader;
 
   typedef struct SScanSettings
   {
@@ -95,6 +96,12 @@ namespace KODI::VIDEO
 
     static void ApplyThumbToFolder(const std::string &folder, const std::string &imdbThumb);
     static bool DownloadFailed(CGUIDialogProgress* pDlgProgress);
+
+    /*! \brief Update the set information from a SET.NFO in the Movie Set Information Folder
+     Gets set details from the VideoInfoTag of a movie
+     \param tag     info tag
+     */
+    static bool UpdateSetInTag(CVideoInfoTag& tag);
 
     /*! \brief Retrieve any artwork associated with an item
      \param pItem item to find artwork for.
@@ -298,5 +305,7 @@ namespace KODI::VIDEO
     std::set<int> m_pathsToClean;
     std::shared_ptr<CAdvancedSettings> m_advancedSettings;
     CVideoDatabase::ScraperCache m_scraperCache;
+
+    void UpdateSet(const std::shared_ptr<CFileItem>& item);
   };
   } // namespace KODI::VIDEO

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -60,6 +60,12 @@ namespace KODI::VIDEO
     void Start(const std::string& strDirectory, bool scanAll = false);
     void Stop();
 
+    /*! \brief Add a set to the database.
+     \param set CSetInfoTag to add to the database.
+     \return true if successful, false otherwise.
+     */
+    bool AddSet(CSetInfoTag* set);
+
     /*! \brief Add an item to the database.
      \param pItem item to add to the database.
      \param content content type of the item.

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -40,9 +40,7 @@ void CVideoInfoTag::Reset()
   m_strOriginalTitle.clear();
   m_strSortTitle.clear();
   m_cast.clear();
-  m_set.title.clear();
-  m_set.id = -1;
-  m_set.overview.clear();
+  m_set.Reset();
   m_tags.clear();
   m_assetInfo.Clear();
   m_hasVideoVersions = false;
@@ -218,12 +216,12 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const std::string &tag, bool savePathI
   }
   XMLUtils::SetStringArray(movie, "genre", m_genre);
   XMLUtils::SetStringArray(movie, "country", m_country);
-  if (!m_set.title.empty())
+  if (m_set.HasTitle())
   {
     TiXmlElement set("set");
-    XMLUtils::SetString(&set, "name", m_set.title);
-    if (!m_set.overview.empty())
-      XMLUtils::SetString(&set, "overview", m_set.overview);
+    XMLUtils::SetString(&set, "name", m_set.GetOriginalTitle());
+    if (m_set.HasOverview())
+      XMLUtils::SetString(&set, "overview", m_set.GetOverview());
     movie->InsertEndChild(set);
   }
   XMLUtils::SetStringArray(movie, "tag", m_tags);
@@ -360,12 +358,8 @@ void CVideoInfoTag::Merge(CVideoInfoTag& other)
   if (!other.m_cast.empty())
     m_cast = other.m_cast;
 
-  if (!other.m_set.title.empty())
-    m_set.title = other.m_set.title;
-  if (other.m_set.id)
-    m_set.id = other.m_set.id;
-  if (!other.m_set.overview.empty())
-    m_set.overview = other.m_set.overview;
+  m_set.Merge(other.m_set);
+
   if (!other.m_tags.empty())
     m_tags = other.m_tags;
 
@@ -513,9 +507,8 @@ void CVideoInfoTag::Archive(CArchive& ar)
       ar << castEntry.thumb;
       ar << castEntry.thumbUrl.GetData();
     }
-    ar << m_set.title;
-    ar << m_set.id;
-    ar << m_set.overview;
+
+    m_set.Archive(ar);
     ar << m_tags;
     m_assetInfo.Archive(ar);
     ar << m_hasVideoVersions;
@@ -619,9 +612,8 @@ void CVideoInfoTag::Archive(CArchive& ar)
       info.thumbUrl.ParseFromData(strXml);
       m_cast.emplace_back(std::move(info));
     }
-    ar >> m_set.title;
-    ar >> m_set.id;
-    ar >> m_set.overview;
+
+    m_set.Archive(ar);
     ar >> m_tags;
     m_assetInfo.Archive(ar);
     ar >> m_hasVideoVersions;
@@ -742,9 +734,7 @@ void CVideoInfoTag::Serialize(CVariant& value) const
       actor["thumbnail"] = IMAGE_FILES::URLFromFile(person.thumb);
     value["cast"].push_back(std::move(actor));
   }
-  value["set"] = m_set.title;
-  value["setid"] = m_set.id;
-  value["setoverview"] = m_set.overview;
+  m_set.Serialize(value);
   value["tag"] = m_tags;
   m_assetInfo.Serialize(value);
   value["hasvideoversions"] = m_hasVideoVersions;
@@ -827,7 +817,9 @@ void CVideoInfoTag::ToSortable(SortItem& sortable, Field field) const
   case FieldVotes:                    sortable[FieldVotes] = GetRating().votes; break;
   case FieldStudio:                   sortable[FieldStudio] = m_studio; break;
   case FieldTrailer:                  sortable[FieldTrailer] = m_strTrailer; break;
-  case FieldSet:                      sortable[FieldSet] = m_set.title; break;
+  case FieldSet:
+    sortable[FieldSet] = m_set.GetTitle();
+    break;
   case FieldTime:                     sortable[FieldTime] = GetDuration(); break;
   case FieldFilename:                 sortable[FieldFilename] = m_strFile; break;
   case FieldMPAA:                     sortable[FieldMPAA] = m_strMPAARating; break;
@@ -1654,12 +1646,12 @@ void CVideoInfoTag::SetUniqueIDs(std::map<std::string, std::string, std::less<>>
 
 void CVideoInfoTag::SetSet(std::string set)
 {
-  m_set.title = Trim(std::move(set));
+  m_set.SetTitle(std::move(set));
 }
 
 void CVideoInfoTag::SetSetOverview(std::string setOverview)
 {
-  m_set.overview = Trim(std::move(setOverview));
+  m_set.SetOverview(std::move(setOverview));
 }
 
 void CVideoInfoTag::SetTags(std::vector<std::string> tags)

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "SetInfoTag.h"
 #include "XBDateTime.h"
 #include "utils/EmbeddedArt.h"
 #include "utils/Fanart.h"
@@ -341,6 +342,7 @@ public:
   * by a scraper the Overview will be overwritten.
   */
   bool GetUpdateSetOverview() const { return m_updateSetOverview; }
+  void SetUpdateSetOverview(const bool value) { m_updateSetOverview = value; }
 
   /*!
    * @brief Set this videos's resume point.
@@ -366,13 +368,7 @@ public:
   std::string m_strSortTitle;
   std::vector<std::string> m_artist;
   std::vector<SActorInfo> m_cast;
-  struct SetInfo //!< Struct holding information about a movie set
-  {
-    std::string title; //!< Title of the movie set
-    int id; //!< ID of movie set in database
-    std::string overview; //!< Overview/description of the movie set
-  };
-  SetInfo m_set; //!< Assigned movie set
+  CSetInfoTag m_set;
   std::vector<std::string> m_tags;
   std::string m_strFile;
   std::string m_strPath;

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -462,9 +462,10 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
           item.AppendArt(artmap, MediaTypeSeason);
       }
     }
-    else if (tag.m_type == MediaTypeMovie && tag.m_set.id >= 0 && !item.HasArt("set.fanart"))
+    else if (tag.m_type == MediaTypeMovie && tag.m_set.GetID() >= 0 && !item.HasArt("set.fanart"))
     {
-      const KODI::ART::Artwork& artmap = GetArtFromCache(MediaTypeVideoCollection, tag.m_set.id);
+      const KODI::ART::Artwork& artmap =
+          GetArtFromCache(MediaTypeVideoCollection, tag.m_set.GetID());
       if (!artmap.empty())
         item.AppendArt(artmap, MediaTypeVideoCollection);
     }

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -407,8 +407,8 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
     CVideoDatabase database;
     database.Open();
     database.GetMoviesNav(m_movieItem->GetPath(), *m_castList, -1, -1, -1, -1, -1, -1,
-                          m_movieItem->GetVideoInfoTag()->m_set.id, -1,
-                          SortDescription(), VideoDbDetailsAll);
+                          m_movieItem->GetVideoInfoTag()->m_set.GetID(), -1, SortDescription(),
+                          VideoDbDetailsAll);
     m_castList->Sort(SortBySortTitle, SortOrderDescending);
     CVideoThumbLoader loader;
     for (auto& item : *m_castList)
@@ -1558,9 +1558,9 @@ bool CGUIDialogVideoInfo::GetSetForMovie(const CFileItem* movieItem,
   int currentSetId = 0;
   std::string currentSetLabel;
 
-  if (movieItem->GetVideoInfoTag()->m_set.id > currentSetId)
+  if (movieItem->GetVideoInfoTag()->m_set.GetID() > currentSetId)
   {
-    currentSetId = movieItem->GetVideoInfoTag()->m_set.id;
+    currentSetId = movieItem->GetVideoInfoTag()->m_set.GetID();
     currentSetLabel = videodb.GetSetById(currentSetId);
   }
 

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -169,7 +169,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
       db.AddSet(tag.m_set.GetTitle(), overview, tag.m_set.GetOriginalTitle());
 
       // Update set art
-      ArtMap movieSetArt;
+      ART::Artwork movieSetArt;
       if (tag.m_set.HasArt())
         movieSetArt = tag.m_set.GetArt();
       db.SetArtForItem(dbId, MediaTypeVideoCollection, movieSetArt);

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -14,6 +14,7 @@
 #include "TextureDatabase.h"
 #include "URL.h"
 #include "Util.h"
+#include "addons/AddonManager.h"
 #include "addons/Scraper.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogYesNo.h"
@@ -35,6 +36,7 @@
 #include "video/VideoInfoScanner.h"
 #include "video/tags/IVideoInfoTagLoader.h"
 #include "video/tags/VideoInfoTagLoaderFactory.h"
+#include "video/tags/VideoTagLoaderNFO.h"
 #include "video/tags/VideoTagLoaderPlugin.h"
 
 #include <memory>
@@ -42,6 +44,8 @@
 
 using namespace KODI;
 using namespace KODI::MESSAGING;
+using namespace VIDEO;
+using namespace ADDON;
 
 CVideoLibraryRefreshingJob::CVideoLibraryRefreshingJob(std::shared_ptr<CFileItem> item,
                                                        bool forceRefresh,
@@ -77,11 +81,110 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
 
   // determine the scraper for the item's path
   VIDEO::SScanSettings scanSettings;
-  ADDON::ScraperPtr scraper = db.GetScraperForPath(m_item->GetPath(), scanSettings);
+  ScraperPtr scraper = db.GetScraperForPath(m_item->GetPath(), scanSettings);
   if (scraper == nullptr)
-    return false;
+  {
+    if (m_item->GetVideoContentType() == VideoDbContentType::MOVIE_SETS)
+    {
+      // Deal with refreshing movie set
+      // Get movies in set
+      CVideoInfoTag tag{*m_item->GetVideoInfoTag()};
+      const int dbId{tag.m_iDbId};
+      std::string setTitle{tag.GetTitle()};
+      const std::string originalSetTitle{db.GetOriginalSetById(dbId)};
+      CFileItemList movies;
+      CVideoInfoTag movieTag;
+      bool localFound{false};
+      bool onlineFound{false};
+      std::string overview{};
 
-  if (URIUtils::IsPlugin(m_item->GetPath()) && !XFILE::CPluginDirectory::IsMediaLibraryScanningAllowed(ADDON::TranslateContent(scraper->Content()), m_item->GetPath()))
+      if (db.GetMoviesBySet(m_item->GetPath(), movies, dbId))
+      {
+        // Scan each movie folder for an NFO file and get online information for a movie in the set
+        for (const auto& movie : movies)
+        {
+          // Check not plugin
+          if (!URIUtils::IsPlugin(movie->GetDynPath()))
+          {
+            // Use local scraper
+            AddonPtr addon{};
+            CServiceBroker::GetAddonMgr().GetAddon("metadata.local", addon,
+                                                   OnlyEnabled::CHOICE_YES);
+            scraper = std::dynamic_pointer_cast<CScraper>(addon);
+
+            // See if Movie NFO
+            movie->SetPath(movie->GetDynPath());
+            const auto nfo{std::make_unique<CVideoTagLoaderNFO>(*movie, scraper, true)};
+            if (nfo->HasInfo())
+            {
+              // Movie NFO found - see if it has set overview
+              nfo->Load(tag, false);
+
+              // Check set matches
+              if (tag.m_set.GetTitle() == originalSetTitle)
+              {
+                localFound = true;
+                if (tag.m_set.HasOverview())
+                  overview = tag.m_set.GetOverview();
+              }
+            }
+
+            // Get online details (only if no movie.nfo containing set details found locally)
+            if (!onlineFound && overview.empty() && !movie->GetVideoInfoTag()->GetTitle().empty())
+            {
+              scraper = db.GetScraperForPath(movie->GetDynPath(), scanSettings);
+              CVideoInfoDownloader infoDownloader{scraper};
+              MOVIELIST itemResultList;
+              infoDownloader.FindMovie(movie->GetVideoInfoTag()->GetTitle(),
+                                       movie->GetVideoInfoTag()->GetYear(), itemResultList);
+              if (!itemResultList.empty())
+              {
+                CScraper::UniqueIDs uniqueIDs;
+                if (infoDownloader.GetDetails(uniqueIDs, itemResultList.at(0), tag))
+                  if (tag.m_set.HasTitle())
+                  {
+                    onlineFound = true;
+                    if (overview.empty())
+                      overview = tag.m_set.GetOverview();
+                  }
+              }
+            }
+          }
+        }
+      }
+
+      // UpdateSetInTag will update set art using the following:
+      // 1 Local files
+      // 2 Set.nfo <art> tag
+      // 3 Online scraper (already populated above)
+      bool setUpdated{CVideoInfoScanner::UpdateSetInTag(tag)};
+
+      // Nothing found to update with
+      if (!localFound && !onlineFound && !setUpdated)
+        return false;
+
+      // tag now contains up-to-date set title
+      if (tag.m_set.HasTitle())
+        overview = tag.m_set.GetOverview();
+      db.AddSet(tag.m_set.GetTitle(), overview, tag.m_set.GetOriginalTitle());
+
+      // Update set art
+      ArtMap movieSetArt;
+      if (tag.m_set.HasArt())
+        movieSetArt = tag.m_set.GetArt();
+      db.SetArtForItem(dbId, MediaTypeVideoCollection, movieSetArt);
+
+      // Refresh (for video info dialog)
+      m_item->ClearArt();
+      db.GetSetInfo(dbId, tag);
+      m_item->SetFromVideoInfoTag(tag);
+      return true;
+    }
+  }
+
+  if (URIUtils::IsPlugin(m_item->GetPath()) &&
+      !XFILE::CPluginDirectory::IsMediaLibraryScanningAllowed(TranslateContent(scraper->Content()),
+                                                              m_item->GetPath()))
   {
     CLog::Log(LOGINFO,
               "CVideoLibraryRefreshingJob: Plugin '{}' does not support media library scanning and "
@@ -91,7 +194,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
   }
 
   // copy the scraper in case we need it again
-  ADDON::ScraperPtr originalScraper(scraper);
+  ScraperPtr originalScraper(scraper);
 
   // get the item's correct title
   std::string itemTitle = m_searchTitle;

--- a/xbmc/video/tags/CMakeLists.txt
+++ b/xbmc/video/tags/CMakeLists.txt
@@ -1,10 +1,15 @@
-set(SOURCES VideoTagExtractionHelper.cpp
+set(SOURCES SetInfoTagLoaderFactory.cpp
+            SetTagLoaderNFO.cpp
+            VideoTagExtractionHelper.cpp
             VideoInfoTagLoaderFactory.cpp
             VideoTagLoaderFFmpeg.cpp
             VideoTagLoaderNFO.cpp
             VideoTagLoaderPlugin.cpp)
 
-set(HEADERS IVideoInfoTagLoader.h
+set(HEADERS ISetInfoTagLoader.h
+            IVideoInfoTagLoader.h
+            SetInfoTagLoaderFactory.h
+            SetTagLoaderNFO.h
             VideoTagExtractionHelper.h
             VideoInfoTagLoaderFactory.h
             VideoTagLoaderFFmpeg.h

--- a/xbmc/video/tags/ISetInfoTagLoader.h
+++ b/xbmc/video/tags/ISetInfoTagLoader.h
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (C) 2024-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "InfoScanner.h"
+
+#include <string>
+
+class CFileItem;
+class CSetInfoTag;
+class EmbeddedArt;
+
+namespace KODI::VIDEO
+{
+
+//! \brief Base class for set tag loaders.
+class ISetInfoTagLoader
+{
+public:
+  //! \brief Constructor
+  //! \param title The title of the set to load info for
+  ISetInfoTagLoader(const std::string title) : m_title(title) {}
+  virtual ~ISetInfoTagLoader() = default;
+
+  //! \brief Returns true if we have info to provide.
+  virtual bool HasInfo() const = 0;
+
+  //! \brief Load tag from file.
+  //! \brief tag Tag to load info into
+  //! \brief prioritise True to prioritise data over existing data in tag
+  //! \returns True if tag was read, false otherwise
+  virtual CInfoScanner::InfoType Load(CSetInfoTag& tag, bool prioritise) = 0;
+
+protected:
+  const std::string m_title;
+};
+
+} // namespace KODI::VIDEO

--- a/xbmc/video/tags/SetInfoTagLoaderFactory.cpp
+++ b/xbmc/video/tags/SetInfoTagLoaderFactory.cpp
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2024-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SetInfoTagLoaderFactory.h"
+
+#include "SetTagLoaderNFO.h"
+
+using namespace KODI::VIDEO;
+
+std::unique_ptr<ISetInfoTagLoader> CSetInfoTagLoaderFactory::CreateLoader(const std::string& title)
+{
+  auto nfo{std::make_unique<CSetTagLoaderNFO>(title)};
+  if (nfo->HasInfo())
+    return nfo;
+
+  return nullptr;
+}

--- a/xbmc/video/tags/SetInfoTagLoaderFactory.h
+++ b/xbmc/video/tags/SetInfoTagLoaderFactory.h
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (C) 2024-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "ISetInfoTagLoader.h"
+#include "addons/Scraper.h"
+
+class CFileItem;
+
+namespace KODI::VIDEO
+{
+class CSetInfoTagLoaderFactory
+{
+public:
+  //! \brief Returns a tag loader for the given item.
+  //! \param item The title of the set to find tag loader for
+  static std::unique_ptr<ISetInfoTagLoader> CreateLoader(const std::string& title);
+
+protected:
+  // No instancing of this class
+  CSetInfoTagLoaderFactory(void) = delete;
+  virtual ~CSetInfoTagLoaderFactory() = delete;
+};
+} // namespace KODI::VIDEO

--- a/xbmc/video/tags/SetTagLoaderNFO.cpp
+++ b/xbmc/video/tags/SetTagLoaderNFO.cpp
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2024-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SetTagLoaderNFO.h"
+
+#include "NfoFile.h"
+#include "URL.h"
+#include "addons/AddonManager.h"
+#include "utils/FileUtils.h"
+#include "utils/URIUtils.h"
+#include "utils/log.h"
+#include "video/SetInfoTag.h"
+#include "video/VideoInfoScanner.h"
+
+#include <utility>
+
+#include <ServiceBroker.h>
+
+using namespace XFILE;
+using namespace ADDON;
+
+CSetTagLoaderNFO::CSetTagLoaderNFO(const std::string& title) : ISetInfoTagLoader(title)
+{
+  if (!title.empty() && !KODI::VIDEO::CVideoInfoScanner::GetMovieSetInfoFolder(title).empty())
+  {
+    const std::string msif{KODI::VIDEO::CVideoInfoScanner::GetMovieSetInfoFolder(title)};
+    m_path = URIUtils::AddFileToFolder(msif, "set.nfo");
+  }
+}
+
+bool CSetTagLoaderNFO::HasInfo() const
+{
+  return !m_path.empty() && CFileUtils::Exists(m_path);
+}
+
+CInfoScanner::InfoType CSetTagLoaderNFO::Load(CSetInfoTag& tag, const bool prioritise)
+{
+  CNfoFile nfoReader;
+  AddonPtr addon;
+  CServiceBroker::GetAddonMgr().GetAddon("metadata.local", addon, ADDON::OnlyEnabled::CHOICE_YES);
+  const ScraperPtr scraper = std::dynamic_pointer_cast<CScraper>(addon);
+  const CInfoScanner::InfoType result{nfoReader.Create(m_path, scraper)};
+
+  if (result == CInfoScanner::InfoType::FULL || result == CInfoScanner::InfoType::COMBINED)
+    nfoReader.GetDetails(tag, nullptr);
+
+  // ** Get set name from originally passed if needed
+  if (tag.GetTitle().empty())
+    tag.SetTitle(m_title);
+
+  std::string type;
+  switch (result)
+  {
+    case CInfoScanner::InfoType::COMBINED:
+      type = "mixed";
+      break;
+    case CInfoScanner::InfoType::FULL:
+      type = "full";
+      break;
+    case CInfoScanner::InfoType::URL:
+      type = "URL";
+      break;
+    case CInfoScanner::InfoType::NONE:
+      type = "";
+      break;
+    case CInfoScanner::InfoType::OVERRIDE:
+      type = "override";
+      break;
+    default:
+      type = "malformed";
+  }
+  if (result != CInfoScanner::InfoType::NONE)
+    CLog::LogF(LOGDEBUG, "Found matching {} NFO file: {}", type, CURL::GetRedacted(m_path));
+  else
+    CLog::LogF(LOGDEBUG, "No NFO file found. Using title search for '{}'",
+               CURL::GetRedacted(m_path));
+
+  return result;
+}

--- a/xbmc/video/tags/SetTagLoaderNFO.h
+++ b/xbmc/video/tags/SetTagLoaderNFO.h
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2024-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "ISetInfoTagLoader.h"
+
+#include <string>
+
+//! \brief Set tag loader using nfo files.
+class CSetTagLoaderNFO : public KODI::VIDEO::ISetInfoTagLoader
+{
+public:
+  CSetTagLoaderNFO(const std::string& title);
+
+  ~CSetTagLoaderNFO() override = default;
+
+  //! \brief Returns whether or not read has info.
+  bool HasInfo() const override;
+
+  //! \brief Load "tag" from nfo file.
+  //! \brief tag Tag to load info into
+  CInfoScanner::InfoType Load(CSetInfoTag& tag, bool prioritise = false) override;
+
+protected:
+  std::string m_path; //!< Path to nfo file
+};

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -437,7 +437,8 @@ CGUIWindowVideoBase::ShowInfoResult CGUIWindowVideoBase::ShowInfo(
   if (bHasInfo)
   {
     // @todo add support to refresh movie version information
-    if (!info || info->Content() == ContentType::NONE || VIDEO::IsVideoAssetFile(*item))
+    if ((!info || info->Content() == ContentType::NONE || VIDEO::IsVideoAssetFile(*item)) &&
+        item->GetVideoContentType() != VideoDbContentType::MOVIE_SETS)
       item->SetProperty("xxuniqueid", "xx" + movieDetails.GetUniqueID()); // disable refresh button
     item->SetProperty("CheckAutoPlayNextItem", IsActive());
     *item->GetVideoInfoTag() = movieDetails;
@@ -471,7 +472,7 @@ CGUIWindowVideoBase::ShowInfoResult CGUIWindowVideoBase::ShowInfo(
   if (!profileManager->GetCurrentProfile().canWriteDatabases() && !g_passwordManager.bMasterUser)
     return RESULT_ERROR;
 
-  if (!info)
+  if (!info && item->GetVideoContentType() != VideoDbContentType::MOVIE_SETS)
     return RESULT_ERROR;
 
   if (CVideoLibraryQueue::GetInstance().IsScanningLibrary())


### PR DESCRIPTION
## Description

Created new PR as closed old one #24557 for amendments and now git won't let me reopen!

As suggested in #24131 (now closed as this supercedes).

This compliments #24533 (which deals with set details in an NFO).

This deals with adding/refreshing sets in 3 ways as well as adding support for a SET.NFO in the Movie Set Information Folder (MSIF).

**SET.NFO**

This placed in the named subfolder of the MSIF. The name is taken either from the movie scraper or the `movie.nfo` in the movie folder.

In keeping with `movie.nfo` and `tvshow.nfo` it is structured as follows:
```
<set>
<title>new title</title>
<overview>set description</overview>
</set>
```

The `<title>` tag exists to override the deafult set name/title given by the scraper (see example below).

**Changes to adding/refreshing sets**

1) When a set is added (eg. by adding a new movie that is part of a set) the code now looks for a Movie Set Information folder and, if found, will use the `set.nfo` and any art, if present. 

2) A Refresh button is added to the video information dialog for sets.

The functionality is as follows:

For _set overview_ (in increasing order of priority):
- if **no** `movie.nfo` is found then use the movie scraper for one of the movie in the set to get the overview.
- if there is a `movie.nfo` in the folder of any of the movies in the set then the `<overview>` tag in the `<set>` tag is used.
- if a `set.nfo` is found in the MSIF then that takes priorty over both the above.

For art:
- if there is no MSIF then use the movie scraper (as above) to get set art.
- if there is art in the MSIF, if present, use the artwork from there.

3) When the library is refreshed, if there are any movie sets **without** art, **and** there is art in the MSIF - then this is used and the set art is updated (taken from #24131) automatically.

## Motivation and context

Allow set information to be refreshed.

For example:

I have placed two movies in the library
- Van Wilder
- Van Vilder 2: Rise of the Taj

Currently there is no entry in the MSIF - so they are added into the movie set named by the scraper.
![image](https://github.com/xbmc/xbmc/assets/99039295/ca719a59-380d-4613-9092-609d9a320164)

As you can see - it's actually under N - National Lampoon's Van Wilder Collection but I would like it under V, so I create the following `set.nfo` in the MSIF (in the subfolder `National Lampoon's Van Wilder Collection`)

```
<set>
<title>Van Wilder Collection</title>
</set>
```
(I also place a different `poster.jpg` in the same directory)

I then select information from the set context menu - there is now a refresh button:
![image](https://github.com/xbmc/xbmc/assets/99039295/af8499b3-356d-4723-a961-175484cee13f)

After refreshing:
![image](https://github.com/xbmc/xbmc/assets/99039295/95ecffba-0959-406e-b6f4-1c48db441afb)

If I wanted to change the description/overview as well I would have included an `<overview>` in the `set.nfo`.

If I then add the third movie - Van Wilder: Freshman Year - it will automatically go into the correct set:
![image](https://github.com/xbmc/xbmc/assets/99039295/d5a91bde-5321-4a32-85d0-4219e9f339c6)

If I delete the `set.nfo` and refresh again - the set details return to default.

## How has this been tested?

Locally with sets created by scraper and sets created locally.

## What is the effect on users?

As above.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
