### PR TITLE
[video] Refactor video play processors 'play part' functionality. …

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -13639,7 +13639,7 @@ msgid "Movie plot"
 msgstr ""
 
 #. Label for context menu entry to start playback of a part of a video stack
-#: xbmc/video/guilib/VideoSelectActionProcessor.cpp
+#: xbmc/video/guilib/VideoPlayActionProcessor.cpp
 #: xbmc/video/windows/GUIWindowVideoBase.cpp
 msgctxt "#20324"
 msgid "Play part..."
@@ -15797,8 +15797,8 @@ msgid "Activate teletext"
 msgstr ""
 
 #. Label for disc stack part and number
-#: xbmc/video/guilib/VideoSelectActionProcessor.cpp
-#: xbmc/video/VideoUtils.cpp
+#: xbmc/video/guilib/VideoPlayActionProcessor.cpp
+#: xbmc/video/gui/VideoGUIUtils.cpp
 msgctxt "#23051"
 msgid "Part {0:d}"
 msgstr ""

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2680,6 +2680,7 @@ void CVideoPlayer::OnExit()
   }
   bookmark.player = m_name;
   bookmark.playerState = GetPlayerState();
+  bookmark.partNumber = fileItem.m_lStartPartNumber;
   m_outboundEvents->Submit([=]() {
     cb->OnPlayerCloseFile(fileItem, bookmark);
   });
@@ -2743,6 +2744,7 @@ void CVideoPlayer::HandleMessages()
       }
       bookmark.player = m_name;
       bookmark.playerState = GetPlayerState();
+      bookmark.partNumber = fileItem.m_lStartPartNumber;
       m_outboundEvents->Submit([=]() {
         cb->OnPlayerCloseFile(fileItem, bookmark);
       });

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -252,12 +252,6 @@ public:
   }
 
 protected:
-  bool OnPlayPartSelected(unsigned int part) override
-  {
-    //! @todo pvr recordings do not support video stacking (yet).
-    return false;
-  }
-
   bool OnChooseSelected() override
   {
     m_window.OnPopupMenu(m_itemIndex);

--- a/xbmc/utils/guilib/GUIBuiltinsUtils.cpp
+++ b/xbmc/utils/guilib/GUIBuiltinsUtils.cpp
@@ -14,7 +14,6 @@
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
 #include "utils/ExecString.h"
-#include "utils/StringUtils.h"
 
 #include <string>
 
@@ -53,13 +52,6 @@ bool CGUIBuiltinsUtils::ExecutePlayMediaNoResume(const std::shared_ptr<CFileItem
 bool CGUIBuiltinsUtils::ExecutePlayMediaAskResume(const std::shared_ptr<CFileItem>& item)
 {
   return ExecuteAction({"PlayMedia", *item, ""}, item);
-}
-
-bool CGUIBuiltinsUtils::ExecutePlayMediaPart(const std::shared_ptr<CFileItem>& item,
-                                             unsigned int part)
-{
-  // part numbers are 1-based
-  return ExecuteAction({"PlayMedia", *item, StringUtils::Format("playoffset={}", part - 1)}, item);
 }
 
 bool CGUIBuiltinsUtils::ExecuteQueueMedia(const std::shared_ptr<CFileItem>& item)

--- a/xbmc/utils/guilib/GUIBuiltinsUtils.h
+++ b/xbmc/utils/guilib/GUIBuiltinsUtils.h
@@ -50,12 +50,6 @@ public:
    */
   static bool ExecutePlayMediaAskResume(const std::shared_ptr<CFileItem>& item);
 
-  /*! \brief Execute "PlayMedia" for the given item and given part (for multipart-media).
-   \param item The item asociated with the action to execute
-   \return True on success, false otherwise
-   */
-  static bool ExecutePlayMediaPart(const std::shared_ptr<CFileItem>& item, unsigned int part);
-
   /*! \brief Execute "QueueMedia" for the given item.
    \param item The item asociated with the action to execute
    \return True on success, false otherwise

--- a/xbmc/video/VideoUtils.h
+++ b/xbmc/video/VideoUtils.h
@@ -10,6 +10,7 @@
 
 #include <memory>
 #include <string>
+#include <tuple>
 
 class CFileItem;
 
@@ -43,6 +44,29 @@ bool IsAutoPlayNextItem(const CFileItem& item);
   */
 bool IsAutoPlayNextItem(const std::string& content);
 
+/*!
+ \brief Get the resume offset and part number for the given stack item.
+ \param item The stack item to retrieve the offset for
+ \return The offset or -1 if not found and the part number or 0 if not available
+ */
+std::tuple<int64_t, unsigned int> GetStackResumeOffsetAndPartNumber(const CFileItem& item);
+
+/*!
+ \brief Get the resume offset for a part of a stack item.
+ \param item The stack item to retrieve the offset for
+ \param partNumber The number of the part (1-based)
+ \return The offset or -1 if not found
+ */
+int64_t GetStackPartResumeOffset(const CFileItem& item, unsigned int partNumber);
+
+/*!
+ \brief Get the start offset for a part of a stack item.
+ \param item The stack item to retrieve the offset for
+ \param partNumber The number of the part (1-based)
+ \return The offset or -1 if not found
+ */
+int64_t GetStackPartStartOffset(const CFileItem& item, unsigned int partNumber);
+
 struct ResumeInformation
 {
   bool isResumable{false}; // the playback of the item can be resumed
@@ -56,14 +80,6 @@ struct ResumeInformation
  \return The resume information.
  */
 ResumeInformation GetItemResumeInformation(const CFileItem& item);
-
-/*!
- \brief Get resume information for a part of a stack item.
- \param item The stack item to retrieve information for
- \param partNumber The number of the part
- \return The resume information.
- */
-ResumeInformation GetStackPartResumeInformation(const CFileItem& item, unsigned int partNumber);
 
 /*!
  \brief For a given non-library folder containing video files, load info from the video database.

--- a/xbmc/video/guilib/VideoAction.h
+++ b/xbmc/video/guilib/VideoAction.h
@@ -20,7 +20,7 @@ enum Action
   ACTION_INFO = 3,
   // 4 unused
   ACTION_PLAY_FROM_BEGINNING = 5, // play from beginning, also if resume would be possible
-  ACTION_PLAYPART = 6,
+  // 6 unused
   ACTION_QUEUE = 7,
 };
 } // namespace KODI::VIDEO::GUILIB

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -361,8 +361,10 @@ void AddItemToPlayListAndPlay(const std::shared_ptr<CFileItem>& itemToQueue,
     for (const std::shared_ptr<CFileItem>& queuedItem : queuedItems)
     {
       if (queuedItem->IsSamePath(itemToPlay.get()))
+      {
+        queuedItem->m_lStartPartNumber = itemToPlay->m_lStartPartNumber;
         break;
-
+      }
       pos++;
     }
   }
@@ -634,27 +636,34 @@ std::string GetResumeString(const CFileItem& item)
   const ResumeInformation resumeInfo = GetItemResumeInformation(item);
   if (resumeInfo.isResumable)
   {
-    if (resumeInfo.startOffset > 0)
-    {
-      std::string resumeString = StringUtils::Format(
-          g_localizeStrings.Get(12022),
-          StringUtils::SecondsToTimeString(
-              static_cast<long>(CUtil::ConvertMilliSecsToSecsInt(resumeInfo.startOffset)),
-              TIME_FORMAT_HH_MM_SS));
-      if (resumeInfo.partNumber > 0)
-      {
-        const std::string partString =
-            StringUtils::Format(g_localizeStrings.Get(23051), resumeInfo.partNumber);
-        resumeString += " (" + partString + ")";
-      }
-      return resumeString;
-    }
-    else
-    {
-      return g_localizeStrings.Get(13362); // Continue watching
-    }
+    return GetResumeString(resumeInfo.startOffset, resumeInfo.partNumber);
   }
-  return {};
+  else
+  {
+    return {};
+  }
+}
+
+std::string GetResumeString(int64_t startOffset, unsigned int partNumber)
+{
+  if (startOffset > 0)
+  {
+    std::string resumeString{
+        StringUtils::Format(g_localizeStrings.Get(12022),
+                            StringUtils::SecondsToTimeString(
+                                static_cast<long>(CUtil::ConvertMilliSecsToSecsInt(startOffset)),
+                                TIME_FORMAT_HH_MM_SS))};
+    if (partNumber > 0)
+    {
+      const std::string partString{StringUtils::Format(g_localizeStrings.Get(23051), partNumber)};
+      resumeString += " (" + partString + ")";
+    }
+    return resumeString;
+  }
+  else
+  {
+    return g_localizeStrings.Get(13362); // Continue watching
+  }
 }
 
 } // namespace KODI::VIDEO::UTILS

--- a/xbmc/video/guilib/VideoGUIUtils.h
+++ b/xbmc/video/guilib/VideoGUIUtils.h
@@ -72,4 +72,12 @@ bool HasItemVideoDbInformation(const CFileItem& item);
  */
 std::string GetResumeString(const CFileItem& item);
 
+/*!
+ \brief Get a localized resume string for the given start offset.
+ \param startOffset The Start offset to get the resume string for
+ \param partNumber The part number if available (1-based), 0 otherwise
+ \return The resume string.
+ */
+std::string GetResumeString(int64_t startOffset, unsigned int partNumber);
+
 } // namespace KODI::VIDEO::UTILS

--- a/xbmc/video/guilib/VideoPlayActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.cpp
@@ -9,15 +9,25 @@
 #include "VideoPlayActionProcessor.h"
 
 #include "FileItem.h"
+#include "FileItemList.h"
 #include "ServiceBroker.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
 #include "dialogs/GUIDialogContextMenu.h"
+#include "dialogs/GUIDialogSelect.h"
+#include "filesystem/Directory.h"
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIWindowManager.h"
+#include "guilib/LocalizeStrings.h"
 #include "playlists/PlayListTypes.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/PlayerUtils.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "utils/Variant.h"
+#include "utils/log.h"
 #include "video/VideoFileItemClassify.h"
+#include "video/VideoUtils.h"
 #include "video/guilib/VideoGUIUtils.h"
 #include "video/guilib/VideoVersionHelper.h"
 
@@ -48,6 +58,22 @@ bool CVideoPlayActionProcessor::ProcessAction(Action action)
     return true; // User cancelled the select menu. We're done.
   }
 
+  if (m_chooseStackPart)
+  {
+    if (!URIUtils::IsStack(m_item->GetDynPath()))
+    {
+      CLog::LogF(LOGERROR, "Invalid item (not a stack)!");
+      return true; // done
+    }
+
+    m_chosenStackPart = ChooseStackPart();
+    if (m_chosenStackPart < 1)
+    {
+      m_userCancelled = true;
+      return true; // User cancelled the select menu. We're done.
+    }
+  }
+
   return Process(action);
 }
 
@@ -57,7 +83,7 @@ bool CVideoPlayActionProcessor::Process(Action action)
   {
     case ACTION_PLAY_OR_RESUME:
     {
-      const Action selectedAction = ChoosePlayOrResume(*m_item);
+      const Action selectedAction = ChoosePlayOrResume();
       if (selectedAction < 0)
       {
         m_userCancelled = true;
@@ -68,12 +94,16 @@ bool CVideoPlayActionProcessor::Process(Action action)
     }
 
     case ACTION_RESUME:
-      m_item->SetStartOffset(STARTOFFSET_RESUME);
+    {
+      SetResumeData();
       return OnResumeSelected();
+    }
 
     case ACTION_PLAY_FROM_BEGINNING:
-      m_item->SetStartOffset(0);
+    {
+      SetStartData();
       return OnPlaySelected();
+    }
 
     default:
       break;
@@ -81,11 +111,34 @@ bool CVideoPlayActionProcessor::Process(Action action)
   return false; // We did not handle the action.
 }
 
-Action CVideoPlayActionProcessor::ChoosePlayOrResume(const CFileItem& item)
+Action CVideoPlayActionProcessor::ChoosePlayOrResume() const
+{
+  if (m_chosenStackPart)
+  {
+    const int64_t offset{VIDEO::UTILS::GetStackPartResumeOffset(*m_item, m_chosenStackPart)};
+    if (offset > 0)
+      return ChoosePlayOrResume(VIDEO::UTILS::GetResumeString(offset, m_chosenStackPart));
+  }
+  else if (URIUtils::IsStack(m_item->GetDynPath()))
+  {
+    const auto [offset, partNumber] = VIDEO::UTILS::GetStackResumeOffsetAndPartNumber(*m_item);
+    if (offset > 0)
+      return ChoosePlayOrResume(VIDEO::UTILS::GetResumeString(offset, partNumber));
+  }
+  else
+  {
+    const VIDEO::UTILS::ResumeInformation resumeInfo{
+        VIDEO::UTILS::GetItemResumeInformation(*m_item)};
+    if (resumeInfo.isResumable)
+      return ChoosePlayOrResume(
+          VIDEO::UTILS::GetResumeString(resumeInfo.startOffset, resumeInfo.partNumber));
+  }
+  return ACTION_PLAY_FROM_BEGINNING;
+}
+
+Action CVideoPlayActionProcessor::ChoosePlayOrResume(const std::string& resumeString)
 {
   Action action = ACTION_PLAY_FROM_BEGINNING;
-
-  const std::string resumeString = VIDEO::UTILS::GetResumeString(item);
   if (!resumeString.empty())
   {
     CContextButtons choices;
@@ -95,8 +148,70 @@ Action CVideoPlayActionProcessor::ChoosePlayOrResume(const CFileItem& item)
 
     action = static_cast<Action>(CGUIDialogContextMenu::ShowAndGetChoice(choices));
   }
-
   return action;
+}
+
+Action CVideoPlayActionProcessor::ChoosePlayOrResume(const CFileItem& item)
+{
+  return ChoosePlayOrResume(VIDEO::UTILS::GetResumeString(item));
+}
+
+unsigned int CVideoPlayActionProcessor::ChooseStackPart() const
+{
+  CFileItemList parts;
+  XFILE::CDirectory::GetDirectory(m_item->GetDynPath(), parts, "", XFILE::DIR_FLAG_DEFAULTS);
+
+  if (parts.IsEmpty())
+  {
+    CLog::LogF(LOGERROR, "Invalid item (empty stack)!");
+    return 0; // done
+  }
+
+  for (int i = 0; i < parts.Size(); ++i)
+  {
+    parts[i]->SetLabel(StringUtils::Format(g_localizeStrings.Get(23051), i + 1)); // Part #
+  }
+
+  CGUIDialogSelect* dialog{CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(
+      WINDOW_DIALOG_SELECT)};
+
+  dialog->Reset();
+  dialog->SetHeading(CVariant{20324}); // Play part...
+  dialog->SetItems(parts);
+  dialog->Open();
+
+  if (!dialog->IsConfirmed())
+    return 0; // User cancelled the dialog.
+
+  return dialog->GetSelectedItem() + 1; // part numbers are 1-based
+}
+
+void CVideoPlayActionProcessor::SetResumeData()
+{
+  if (m_chosenStackPart)
+  {
+    m_item->m_lStartPartNumber = m_chosenStackPart;
+    m_item->SetStartOffset(VIDEO::UTILS::GetStackPartResumeOffset(*m_item, m_chosenStackPart));
+  }
+  else
+  {
+    m_item->m_lStartPartNumber = 1;
+    m_item->SetStartOffset(STARTOFFSET_RESUME);
+  }
+}
+
+void CVideoPlayActionProcessor::SetStartData()
+{
+  if (m_chosenStackPart)
+  {
+    m_item->m_lStartPartNumber = m_chosenStackPart;
+    m_item->SetStartOffset(VIDEO::UTILS::GetStackPartStartOffset(*m_item, m_chosenStackPart));
+  }
+  else
+  {
+    m_item->m_lStartPartNumber = 1;
+    m_item->SetStartOffset(0);
+  }
 }
 
 bool CVideoPlayActionProcessor::OnResumeSelected()

--- a/xbmc/video/guilib/VideoPlayActionProcessor.h
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.h
@@ -26,6 +26,7 @@ public:
   bool ProcessAction(Action action);
 
   void SetChoosePlayer() { m_choosePlayer = true; }
+  void SetChooseStackPart() { m_chooseStackPart = true; }
 
   bool UserCancelled() const { return m_userCancelled; }
 
@@ -43,8 +44,15 @@ protected:
   std::shared_ptr<CFileItem> m_item;
   bool m_userCancelled{false};
   bool m_choosePlayer{false};
+  bool m_chooseStackPart{false};
+  unsigned int m_chosenStackPart{0};
 
 private:
   CVideoPlayActionProcessor() = delete;
+  unsigned int ChooseStackPart() const;
+  Action ChoosePlayOrResume() const;
+  static Action ChoosePlayOrResume(const std::string& resumeString);
+  void SetResumeData();
+  void SetStartData();
 };
 } // namespace KODI::VIDEO::GUILIB

--- a/xbmc/video/guilib/VideoSelectActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoSelectActionProcessor.cpp
@@ -10,18 +10,10 @@
 
 #include "ContextMenuManager.h"
 #include "FileItem.h"
-#include "FileItemList.h"
 #include "ServiceBroker.h"
-#include "dialogs/GUIDialogSelect.h"
-#include "filesystem/Directory.h"
-#include "guilib/GUIComponent.h"
-#include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "utils/StringUtils.h"
 #include "utils/Variant.h"
-#include "utils/guilib/GUIBuiltinsUtils.h"
 #include "utils/guilib/GUIContentUtils.h"
 #include "video/VideoFileItemClassify.h"
 #include "video/guilib/VideoGUIUtils.h"
@@ -50,15 +42,6 @@ bool CVideoSelectActionProcessor::Process(Action action)
     case ACTION_CHOOSE:
       return OnChooseSelected();
 
-    case ACTION_PLAYPART:
-    {
-      const unsigned int part = ChooseStackItemPartNumber();
-      if (part < 1) // part numbers are 1-based
-        return false;
-
-      return OnPlayPartSelected(part);
-    }
-
     case ACTION_QUEUE:
       return OnQueueSelected();
 
@@ -81,13 +64,6 @@ bool CVideoSelectActionProcessor::Process(Action action)
   return false; // We did not handle the action.
 }
 
-bool CVideoSelectActionProcessor::OnPlayPartSelected(unsigned int part)
-{
-  //! @todo implement different (not using builtins function)
-  KODI::UTILS::GUILIB::CGUIBuiltinsUtils::ExecutePlayMediaPart(m_item, part);
-  return true;
-}
-
 bool CVideoSelectActionProcessor::OnQueueSelected()
 {
   VIDEO::UTILS::QueueItem(m_item, VIDEO::UTILS::QueuePosition::POSITION_END);
@@ -103,29 +79,6 @@ bool CVideoSelectActionProcessor::OnChooseSelected()
 {
   CONTEXTMENU::ShowFor(m_item, CContextMenuManager::MAIN);
   return true;
-}
-
-unsigned int CVideoSelectActionProcessor::ChooseStackItemPartNumber() const
-{
-  CFileItemList parts;
-  XFILE::CDirectory::GetDirectory(m_item->GetDynPath(), parts, "", XFILE::DIR_FLAG_DEFAULTS);
-
-  for (int i = 0; i < parts.Size(); ++i)
-    parts[i]->SetLabel(StringUtils::Format(g_localizeStrings.Get(23051), i + 1)); // Part #
-
-  CGUIDialogSelect* dialog =
-      CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(
-          WINDOW_DIALOG_SELECT);
-
-  dialog->Reset();
-  dialog->SetHeading(CVariant{20324}); // Play part...
-  dialog->SetItems(parts);
-  dialog->Open();
-
-  if (!dialog->IsConfirmed())
-    return 0; // User cancelled the dialog.
-
-  return dialog->GetSelectedItem() + 1; // part numbers are 1-based
 }
 
 } // namespace KODI::VIDEO::GUILIB

--- a/xbmc/video/guilib/VideoSelectActionProcessor.h
+++ b/xbmc/video/guilib/VideoSelectActionProcessor.h
@@ -32,13 +32,11 @@ protected:
   Action GetDefaultAction() override;
   bool Process(Action action) override;
 
-  virtual bool OnPlayPartSelected(unsigned int part);
   virtual bool OnQueueSelected();
   virtual bool OnInfoSelected();
   virtual bool OnChooseSelected();
 
 private:
   CVideoSelectActionProcessor() = delete;
-  unsigned int ChooseStackItemPartNumber() const;
 };
 } // namespace KODI::VIDEO::GUILIB

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -59,7 +59,6 @@ public:
                             bool allowReplaceLabels = true);
 
   bool PlayItem(const std::shared_ptr<CFileItem>& item, const std::string& player);
-  bool OnPlayStackPart(const std::shared_ptr<CFileItem>& item, unsigned int partNumber);
   void OnQueueItem(const std::shared_ptr<CFileItem>& item, int iItem, bool first = false);
 
 protected:
@@ -86,13 +85,6 @@ protected:
    \return true if the action is performed, false otherwise
    */
   bool OnItemInfo(int item);
-  /*! \brief perform a given action on a file
-   \param item the selected item
-   \param action the action to perform
-   \return true if the action is performed, false otherwise
-   */
-  bool OnFileAction(int item, KODI::VIDEO::GUILIB::Action action, const std::string& player);
-
   void OnRestartItem(int iItem, const std::string &player = "");
   bool OnPlayOrResumeItem(int iItem, const std::string& player = "");
   bool OnPlayMedia(int iItem, const std::string &player = "") override;


### PR DESCRIPTION
This PR completes the refactoring for our play/select action processors started with https://github.com/xbmc/xbmc/pull/26216

* Refactor 'play part' play action processor code
* Provide default implementation for 'play part'
* Change existing implementations to use the new default implementation. 
* Improve/fix resume point handling for stacks. Respect setting value for default play action on 'play part' etc.

Sorry, only one bigger commit this time, thought about how to split into logical thunks, with no real success.

I carefully runtime-tested the change with both disc image stacks and video file stacks, on macOS and Android, latest master.

@enen92 I guess you would be the best fit to review this PR. 
