### PR TITLE
[video][music] Fix playback of PVR recordings provided by add-ons implementing URL-based playback.

### DIFF
--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -644,18 +644,7 @@ int PlayOrQueueMedia(const std::vector<std::string>& params,
 
   if (forcePlay)
   {
-    if ((MUSIC::IsAudio(item) || VIDEO::IsVideo(item)) && !PLAYLIST::IsSmartPlayList(item) &&
-        !item.IsPVR())
-    {
-      if (!item.HasProperty("playlist_type_hint"))
-        item.SetProperty("playlist_type_hint", static_cast<int>(GetPlayListId(item)));
-
-      CServiceBroker::GetPlaylistPlayer().Play(std::make_shared<CFileItem>(item), "");
-    }
-    else
-    {
-      g_application.PlayMedia(item, "", GetPlayListId(item));
-    }
+    CPlayerUtils::PlayMedia(std::make_shared<CFileItem>(item), "", GetPlayListId(item));
   }
   else
   {

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -763,10 +763,20 @@ void PlayItem(const std::shared_ptr<CFileItem>& itemIn,
     else // mode == PlayMode::PLAY_ONLY_THIS
     {
       // song, so just play it
-      auto& playlistPlayer = CServiceBroker::GetPlaylistPlayer();
-      playlistPlayer.Reset();
-      playlistPlayer.SetCurrentPlaylist(PLAYLIST::Id::TYPE_NONE);
-      playlistPlayer.Play(item, player);
+
+      //! @todo get rid of special treatment for some media
+      //! logic "borrowed" from PlayerBuiltins.cpp -> PlayOrQueueMedia()
+      if (item->IsPVR() || PLAYLIST::IsSmartPlayList(*item))
+      {
+        g_application.PlayMedia(*item, player, PLAYLIST::Id::TYPE_NONE);
+      }
+      else
+      {
+        auto& playlistPlayer = CServiceBroker::GetPlaylistPlayer();
+        playlistPlayer.Reset();
+        playlistPlayer.SetCurrentPlaylist(PLAYLIST::Id::TYPE_NONE);
+        playlistPlayer.Play(item, player);
+      }
     }
   }
 }

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -42,6 +42,7 @@
 #include "threads/IRunnable.h"
 #include "utils/FileUtils.h"
 #include "utils/JobManager.h"
+#include "utils/PlayerUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -763,20 +764,7 @@ void PlayItem(const std::shared_ptr<CFileItem>& itemIn,
     else // mode == PlayMode::PLAY_ONLY_THIS
     {
       // song, so just play it
-
-      //! @todo get rid of special treatment for some media
-      //! logic "borrowed" from PlayerBuiltins.cpp -> PlayOrQueueMedia()
-      if (item->IsPVR() || PLAYLIST::IsSmartPlayList(*item))
-      {
-        g_application.PlayMedia(*item, player, PLAYLIST::Id::TYPE_NONE);
-      }
-      else
-      {
-        auto& playlistPlayer = CServiceBroker::GetPlaylistPlayer();
-        playlistPlayer.Reset();
-        playlistPlayer.SetCurrentPlaylist(PLAYLIST::Id::TYPE_NONE);
-        playlistPlayer.Play(item, player);
-      }
+      CPlayerUtils::PlayMedia(item, player, PLAYLIST::Id::TYPE_NONE);
     }
   }
 }

--- a/xbmc/utils/PlayerUtils.cpp
+++ b/xbmc/utils/PlayerUtils.cpp
@@ -9,10 +9,14 @@
 #include "PlayerUtils.h"
 
 #include "FileItem.h"
+#include "PlayListPlayer.h"
 #include "ServiceBroker.h"
+#include "application/Application.h"
 #include "application/ApplicationPlayer.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/MusicUtils.h"
+#include "playlists/PlayListFileItemClassify.h"
 #include "utils/Variant.h"
 #include "video/VideoFileItemClassify.h"
 #include "video/guilib/VideoGUIUtils.h"
@@ -83,4 +87,28 @@ std::vector<std::string> CPlayerUtils::GetPlayersForItem(const CFileItem& item)
 bool CPlayerUtils::HasItemMultiplePlayers(const CFileItem& item)
 {
   return GetPlayersForItem(item).size() > 1;
+}
+
+bool CPlayerUtils::PlayMedia(const std::shared_ptr<CFileItem>& item,
+                             const std::string& player,
+                             KODI::PLAYLIST::Id playlistId)
+{
+  //! @todo get rid of special treatment for some media
+
+  if ((MUSIC::IsAudio(*item) || VIDEO::IsVideo(*item)) && !PLAYLIST::IsSmartPlayList(*item) &&
+      !item->IsPVR())
+  {
+    if (!item->HasProperty("playlist_type_hint"))
+      item->SetProperty("playlist_type_hint", static_cast<int>(playlistId));
+
+    PLAYLIST::CPlayListPlayer& playlistPlayer{CServiceBroker::GetPlaylistPlayer()};
+    playlistPlayer.Reset();
+    playlistPlayer.SetCurrentPlaylist(playlistId);
+    playlistPlayer.Play(item, player);
+  }
+  else
+  {
+    g_application.PlayMedia(*item, player, playlistId);
+  }
+  return true;
 }

--- a/xbmc/utils/PlayerUtils.h
+++ b/xbmc/utils/PlayerUtils.h
@@ -15,6 +15,12 @@
 class CApplicationPlayer;
 class CFileItem;
 
+namespace KODI::PLAYLIST
+{
+enum class Id;
+
+} // namespace KODI::PLAYLIST
+
 enum class TempoStepChange
 {
   INCREASE,
@@ -37,8 +43,19 @@ public:
 
   /*!
    \brief Check whether multiple players are available for the given item.
-   \param item The ite.
+   \param item The item
    \return True if multiple players are available, false otherwise
    */
   static bool HasItemMultiplePlayers(const CFileItem& item);
+
+  /*!
+   \brief Play the media represented by the given item.
+   \param item The item
+   \param player The player to use or empty string for default player
+   \param playlistId The id of the playlist to add the item to.
+   \return True on success, false otherwise
+   */
+  static bool PlayMedia(const std::shared_ptr<CFileItem>& item,
+                        const std::string& player,
+                        KODI::PLAYLIST::Id playlistId);
 };

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -15,7 +15,6 @@
 #include "PlayListPlayer.h"
 #include "ServiceBroker.h"
 #include "Util.h"
-#include "application/Application.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
 #include "dialogs/GUIDialogBusy.h"
@@ -37,6 +36,7 @@
 #include "settings/SettingsComponent.h"
 #include "threads/IRunnable.h"
 #include "utils/FileUtils.h"
+#include "utils/PlayerUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -438,20 +438,7 @@ void PlayItem(
     else // mode == PlayMode::PLAY_ONLY_THIS
     {
       // single item, play it
-
-      //! @todo get rid of special treatment for some media
-      //! logic "borrowed" from PlayerBuiltins.cpp -> PlayOrQueueMedia()
-      if (item->IsPVR() || PLAYLIST::IsSmartPlayList(*item))
-      {
-        g_application.PlayMedia(*item, player, PLAYLIST::Id::TYPE_NONE);
-      }
-      else
-      {
-        auto& playlistPlayer = CServiceBroker::GetPlaylistPlayer();
-        playlistPlayer.Reset();
-        playlistPlayer.SetCurrentPlaylist(PLAYLIST::Id::TYPE_NONE);
-        playlistPlayer.Play(item, player);
-      }
+      CPlayerUtils::PlayMedia(item, player, PLAYLIST::Id::TYPE_NONE);
     }
   }
 }

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -15,6 +15,7 @@
 #include "PlayListPlayer.h"
 #include "ServiceBroker.h"
 #include "Util.h"
+#include "application/Application.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
 #include "dialogs/GUIDialogBusy.h"
@@ -437,10 +438,20 @@ void PlayItem(
     else // mode == PlayMode::PLAY_ONLY_THIS
     {
       // single item, play it
-      auto& playlistPlayer = CServiceBroker::GetPlaylistPlayer();
-      playlistPlayer.Reset();
-      playlistPlayer.SetCurrentPlaylist(PLAYLIST::Id::TYPE_NONE);
-      playlistPlayer.Play(item, player);
+
+      //! @todo get rid of special treatment for some media
+      //! logic "borrowed" from PlayerBuiltins.cpp -> PlayOrQueueMedia()
+      if (item->IsPVR() || PLAYLIST::IsSmartPlayList(*item))
+      {
+        g_application.PlayMedia(*item, player, PLAYLIST::Id::TYPE_NONE);
+      }
+      else
+      {
+        auto& playlistPlayer = CServiceBroker::GetPlaylistPlayer();
+        playlistPlayer.Reset();
+        playlistPlayer.SetCurrentPlaylist(PLAYLIST::Id::TYPE_NONE);
+        playlistPlayer.Play(item, player);
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes a recently regression introduced with https://github.com/xbmc/xbmc/pull/26216 that was reported on the Forum: https://forum.kodi.tv/showthread.php?tid=380163

Runtime.tested on macOS, latest Kodi master

@enen92 maybe something you can have a look at?