### PR TITLE
[GUI] Bump xbmc.gui to 5.18.0 for Piers

### DIFF
--- a/addons/skin.estuary/addon.xml
+++ b/addons/skin.estuary/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="skin.estuary" version="4.0.0" name="Estuary" provider-name="phil65, Ichabod Fletchman">
+<addon id="skin.estuary" version="4.1.0" name="Estuary" provider-name="phil65, Ichabod Fletchman">
 	<requires>
-		<import addon="xbmc.gui" version="5.17.0"/>
+		<import addon="xbmc.gui" version="5.18.0"/>
 	</requires>
 	<extension point="xbmc.gui.skin" debugging="false">
 		<res width="1920" height="1440" aspect="4:3" default="false" folder="xml" />

--- a/addons/xbmc.gui/addon.xml
+++ b/addons/xbmc.gui/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.gui" version="5.17.0" provider-name="Team Kodi">
+<addon id="xbmc.gui" version="5.18.0" provider-name="Team Kodi">
   <backwards-compatibility abi="5.17.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>


### PR DESCRIPTION
After a discussion on the Slack Skinning channel that it was felt it was about time to bump xmc.gui for skins.

It has been 9 months since release of Omega and Piers cycle started, so it felt it was time to start allowing Piers only skins. Also last bump was Oct 2023 during Omega cycle, and since then there's been several new dialogs for video versions and stream selection (for video, audio & subtitles) added.

This include the associated version bumps for Estuary.



