### PR TITLE
[Estuary] Player Process Info dialog update

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9363,6 +9363,7 @@ msgid "Deinterlace video"
 msgstr ""
 
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+#: addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
 msgctxt "#16038"
 msgid "Deinterlace method"
 msgstr ""
@@ -9775,6 +9776,7 @@ msgstr ""
 
 #. label for PVR backend name in system information's PVR section
 #: xbmc/windows/GUIWindowSystemInfo.cpp
+#: addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
 msgctxt "#19012"
 msgid "PVR backend"
 msgstr ""
@@ -14412,6 +14414,7 @@ msgstr ""
 
 #. Used in smart playlists to select items based on the HDR type (HDR10, HLG, Dolbyvision)
 #: xbmc/playlists/SmartPlayList.cpp
+#: addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
 msgctxt "#20474"
 msgid "HDR type"
 msgstr ""
@@ -14926,6 +14929,7 @@ msgid "Audio codec"
 msgstr ""
 
 #: xbmc/playlists/SmartPlaylist.cpp
+#: addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
 msgctxt "#21447"
 msgid "Audio language"
 msgstr ""
@@ -15656,6 +15660,7 @@ msgid "GPU temperature:"
 msgstr ""
 
 #: xbmc/windows/GUIWindowSystemInfo.cpp
+#: addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
 msgctxt "#22011"
 msgid "CPU temperature:"
 msgstr ""

--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -856,7 +856,25 @@ msgctxt "#31176"
 msgid "Default select action for movie sets on the home screen"
 msgstr ""
 
-#empty strings from id 31177 to 31599
+#empty strings from id 31177 to 31596
+
+#: /xml/Includes_SettingsDialog.xml
+#. Button to select Player Process Info window
+msgctxt "#31597"
+msgid "Player info"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show player cache
+msgctxt "#31598"
+msgid "Player cache"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the video codec name
+msgctxt "#31599"
+msgid "Audio decoder"
+msgstr ""
 
 #: /xml/DialogPlayerProcessInfo.xml
 #. Label to show the video codec name

--- a/addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
+++ b/addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
@@ -11,9 +11,9 @@
 			<height>250</height>
 			<animation effect="slide" end="0,-20" time="150" condition="VideoPlayer.Content(LiveTV)">conditional</animation>
 			<control type="image">
-				<left>30</left>
+				<left>0</left>
+				<width>100%</width>
 				<top>-220</top>
-				<right>30</right>
 				<height>330</height>
 				<texture border="40">dialogs/dialog-bg-nobo.png</texture>
 			</control>
@@ -22,7 +22,7 @@
 				<top>-204</top>
 				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5551)</visible>
 				<control type="label">
-					<width>1200</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[PVR.ActStreamServiceName,[COLOR button_focus]$LOCALIZE[19099]:[/COLOR] ]</label>
@@ -30,7 +30,7 @@
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="label">
-					<width>1200</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[PVR.ActStreamProviderName,[COLOR button_focus]$LOCALIZE[19101]:[/COLOR] ]</label>
@@ -38,7 +38,7 @@
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="label">
-					<width>1200</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[PVR.ActStreamClient,[COLOR button_focus]$LOCALIZE[19012]:[/COLOR] ]</label>
@@ -46,7 +46,7 @@
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="label">
-					<width>1200</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[PVR.ActStreamDevice,[COLOR button_focus]$LOCALIZE[19006]:[/COLOR] ]</label>
@@ -54,7 +54,7 @@
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="label">
-					<width>1200</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[PVR.ActStreamStatus,[COLOR button_focus]$LOCALIZE[19007]:[/COLOR] ]</label>
@@ -62,7 +62,7 @@
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="label">
-					<width>1200</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[PVR.ActStreamEncryptionName,[COLOR button_focus]$LOCALIZE[19015]:[/COLOR] ]</label>
@@ -71,12 +71,12 @@
 				</control>
 			</control>
 			<control type="grouplist">
-				<left>1250</left>
+				<left>985</left>
 				<top>-204</top>
 				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5551)</visible>
 				<usecontrolcoords>true</usecontrolcoords>
 				<control type="label">
-					<width>600</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[PVR.ActStreamBer,[COLOR button_focus]$LOCALIZE[19010]:[/COLOR] ]</label>
@@ -84,7 +84,7 @@
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="label">
-					<width>600</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[PVR.ActStreamUnc,[COLOR button_focus]$LOCALIZE[19011]:[/COLOR] ]</label>
@@ -92,7 +92,7 @@
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="label">
-					<width>600</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[PVR.ActStreamMux,[COLOR button_focus]$LOCALIZE[19100]:[/COLOR] ]</label>
@@ -100,7 +100,7 @@
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="label">
-					<width>600</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[PVR.ActStreamSignal,[COLOR button_focus]$LOCALIZE[19008]:[/COLOR] ]</label>
@@ -109,13 +109,13 @@
 				</control>
 				<control type="progress">
 					<top>5</top>
-					<width>600</width>
+					<width>885</width>
 					<height>18</height>
 					<info>PVR.ActStreamProgrSignal</info>
 				</control>
 				<control type="label">
 					<top>5</top>
-					<width>1600</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[PVR.ActStreamSNR,[COLOR button_focus]$LOCALIZE[19009]:[/COLOR] ]</label>
@@ -124,7 +124,7 @@
 				</control>
 				<control type="progress">
 					<top>0</top>
-					<width>600</width>
+					<width>885</width>
 					<height>18</height>
 					<info>PVR.ActStreamProgrSNR</info>
 				</control>
@@ -134,72 +134,88 @@
 				<top>-204</top>
 				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5552)</visible>
 				<control type="label">
-					<width>830</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[VideoPlayer.VideoCodec,[COLOR button_focus]$LOCALIZE[31600]:[/COLOR] ]</label>
 					<font>font14</font>
 					<shadowcolor>black</shadowcolor>
-					<visible>Player.HasVideo</visible>
+					<visible>!String.IsEmpty(VideoPlayer.VideoCodec)</visible>
 				</control>
 				<control type="label">
-					<width>830</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[VideoPlayer.VideoResolution,[COLOR button_focus]$LOCALIZE[31601]:[/COLOR] ]</label>
 					<font>font14</font>
 					<shadowcolor>black</shadowcolor>
-					<visible>Player.HasVideo</visible>
+					<visible>!String.IsEmpty(VideoPlayer.VideoResolution)</visible>
 				</control>
 				<control type="label">
-					<width>830</width>
+					<width>885</width>
+					<height>50</height>
+					<label>$INFO[VideoPlayer.HdrType,[COLOR button_focus]$LOCALIZE[20474]:[/COLOR] ]</label>
+					<font>font14</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(VideoPlayer.HdrType)</visible>
+				</control>
+				<control type="label">
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[VideoPlayer.VideoAspect,[COLOR button_focus]$LOCALIZE[31602]:[/COLOR] ]</label>
 					<font>font14</font>
 					<shadowcolor>black</shadowcolor>
-					<visible>Player.HasVideo</visible>
+					<visible>!String.IsEmpty(VideoPlayer.VideoAspect)</visible>
 				</control>
 				<control type="label">
-					<width>830</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[VideoPlayer.VideoBitrate,[COLOR button_focus]$LOCALIZE[31603]:[/COLOR] , kb/s]</label>
 					<font>font14</font>
 					<shadowcolor>black</shadowcolor>
-					<visible>Player.HasVideo</visible>
+					<visible>!String.IsEmpty(VideoPlayer.VideoBitrate)</visible>
 				</control>
 			</control>
 			<control type="grouplist">
-				<left>1010</left>
+				<left>985</left>
 				<top>-204</top>
 				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5552)</visible>
 				<control type="label">
-					<width>830</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[VideoPlayer.AudioCodec,[COLOR button_focus]$LOCALIZE[31604]:[/COLOR] ]</label>
 					<font>font14</font>
 					<shadowcolor>black</shadowcolor>
-					<visible>Player.HasVideo</visible>
+					<visible>!String.IsEmpty(VideoPlayer.AudioCodec)</visible>
 				</control>
 				<control type="label">
-					<width>830</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[VideoPlayer.AudioChannels,[COLOR button_focus]$LOCALIZE[31605]:[/COLOR] ]</label>
 					<font>font14</font>
 					<shadowcolor>black</shadowcolor>
-					<visible>Player.HasVideo</visible>
+					<visible>!String.IsEmpty(VideoPlayer.AudioChannels)</visible>
 				</control>
 				<control type="label">
-					<width>830</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[VideoPlayer.AudioBitrate,[COLOR button_focus]$LOCALIZE[31606]:[/COLOR] , kb/s]</label>
 					<font>font14</font>
 					<shadowcolor>black</shadowcolor>
-					<visible>Player.HasVideo</visible>
+					<visible>!String.IsEmpty(VideoPlayer.AudioBitrate)</visible>
+				</control>
+				<control type="label">
+					<width>880</width>
+					<height>38</height>
+					<label>$INFO[VideoPlayer.AudioLanguage,[COLOR button_focus]$LOCALIZE[21447]:[/COLOR] ]</label>
+					<font>font14</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(VideoPlayer.AudioLanguage)</visible>
 				</control>
 			</control>
 			<control type="grouplist">
@@ -207,48 +223,80 @@
 				<top>-204</top>
 				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5553)</visible>
 				<control type="label">
-					<width>1600</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[Player.Process(videodecoder),[COLOR button_focus]$LOCALIZE[31139]:[/COLOR] ]$VAR[VideoHWDecoder, (,)]</label>
 					<font>font14</font>
 					<shadowcolor>black</shadowcolor>
-					<visible>Player.HasVideo</visible>
+					<visible>!String.IsEmpty(Player.Process(videodecoder))</visible>
 				</control>
 				<control type="label">
-					<width>1600</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[Player.Process(pixformat),[COLOR button_focus]$LOCALIZE[31140]:[/COLOR] ]</label>
 					<font>font14</font>
 					<shadowcolor>black</shadowcolor>
-					<visible>Player.HasVideo</visible>
+					<visible>!String.IsEmpty(Player.Process(pixformat))</visible>
 				</control>
 				<control type="label">
-					<width>1600</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[Player.Process(deintmethod),[COLOR button_focus]$LOCALIZE[16038]:[/COLOR] ]</label>
 					<font>font14</font>
 					<shadowcolor>black</shadowcolor>
-					<visible>Player.HasVideo</visible>
+					<visible>!String.IsEmpty(Player.Process(deintmethod))</visible>
 				</control>
 				<control type="label">
-					<width>1600</width>
+					<width>885</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[Player.Process(videowidth),[COLOR button_focus]$LOCALIZE[38031]:[/COLOR] ,x]$INFO[Player.Process(videoheight)]$INFO[Player.Process(videoscantype)]$INFO[Player.Process(videodar),$COMMA , AR]$INFO[Player.Process(videofps),$COMMA , FPS]</label>
 					<font>font14</font>
 					<shadowcolor>black</shadowcolor>
-					<visible>Player.HasVideo</visible>
+					<visible>!String.IsEmpty(Player.Process(videowidth))</visible>
 				</control>
 				<control type="label">
-					<width>1600</width>
+					<width>885</width>
 					<height>50</height>
-					<aligny>bottom</aligny>
-					<label>[COLOR button_focus]$LOCALIZE[460]:[/COLOR] $INFO[Player.Process(audiochannels),,$COMMA ]$INFO[Player.Process(audiodecoder)]$INFO[Player.Process(audiobitspersample),$COMMA , bits]$INFO[Player.Process(audiosamplerate),$COMMA , Hz]</label>
+					<label>$INFO[Player.CacheLevel,[COLOR button_focus]$LOCALIZE[31598]:[/COLOR] ,%]</label>
 					<font>font14</font>
 					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(Player.CacheLevel)</visible>
+				</control>
+			</control>
+			<control type="grouplist">
+				<left>985</left>
+				<top>-204</top>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5553)</visible>
+				<control type="label">
+					<width>885</width>
+					<height>50</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[Player.Process(audiodecoder),[COLOR button_focus]$LOCALIZE[31599]:[/COLOR] ]</label>
+					<font>font14</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(Player.Process(audiodecoder))</visible>
+				</control>
+				<control type="label">
+					<width>885</width>
+					<height>50</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[Player.Process(audiochannels),[COLOR button_focus]$LOCALIZE[31605]:[/COLOR] ]</label>
+					<font>font14</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(Player.Process(audiochannels))</visible>
+				</control>
+				<control type="label">
+					<width>885</width>
+					<height>50</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[Player.Process(audiobitspersample),[COLOR button_focus]$LOCALIZE[460]:[/COLOR] , bits]$INFO[Player.Process(audiosamplerate),$COMMA , Hz]</label>
+					<font>font14</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(Player.Process(audiobitspersample))</visible>
 				</control>
 			</control>
 			<control type="grouplist">
@@ -256,23 +304,25 @@
 				<top>-204</top>
 				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5554)</visible>
 				<control type="label">
-					<width>1600</width>
+					<width>1820</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[System.ScreenResolution,[COLOR button_focus]$LOCALIZE[31607]:[/COLOR] ]</label>
 					<font>font14</font>
 					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(System.ScreenResolution)</visible>
 				</control>
 				<control type="label">
-					<width>1600</width>
+					<width>1820</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[System.FPS,[COLOR button_focus]$LOCALIZE[31608]:[/COLOR] , fps]</label>
 					<font>font14</font>
 					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(System.FPS)</visible>
 				</control>
 				<control type="label">
-					<width>1600</width>
+					<width>1820</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[System.Memory(used.percent),[COLOR button_focus]$LOCALIZE[31030]:[/COLOR] ]</label>
@@ -281,7 +331,7 @@
 					<visible>System.SupportsCPUUsage</visible>
 				</control>
 				<control type="label">
-					<width>1600</width>
+					<width>1820</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[System.CpuUsage,[COLOR button_focus]$LOCALIZE[31609]:[/COLOR] ]</label>
@@ -290,7 +340,7 @@
 					<visible>System.SupportsCPUUsage</visible>
 				</control>
 				<control type="label">
-					<width>1600</width>
+					<width>1820</width>
 					<height>50</height>
 					<aligny>bottom</aligny>
 					<label>$INFO[System.Memory(used.percent),[COLOR button_focus]$LOCALIZE[31030]:[/COLOR] ]</label>
@@ -298,9 +348,17 @@
 					<shadowcolor>black</shadowcolor>
 					<visible>!System.SupportsCPUUsage</visible>
 				</control>
+				<control type="label">
+					<width>1820</width>
+					<height>50</height>
+					<label>$INFO[System.CPUTemperature,[COLOR button_focus]$LOCALIZE[22011][/COLOR] ]</label>
+					<font>font14</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!String.IsEmpty(System.CPUTemperature)</visible>
+				</control>
 			</control>
 			<control type="grouplist" id="5550">
-				<right>15</right>
+				<right>20</right>
 				<top>-310</top>
 				<width>1000</width>
 				<height>100</height>

--- a/addons/skin.estuary/xml/Includes_SettingsDialog.xml
+++ b/addons/skin.estuary/xml/Includes_SettingsDialog.xml
@@ -67,6 +67,12 @@
 			<onclick>ActivateWindow(1110)</onclick>
 			<visible>Player.TempoEnabled</visible>
 		</control>
+		<control type="button" id="22110">
+			<include>DialogSettingButton</include>
+			<label>$LOCALIZE[31597]</label>
+			<onclick>Dialog.Close(1101)</onclick>
+			<onclick>ActivateWindow(playerprocessinfo)</onclick>
+		</control>
 	</include>
 	<include name="SettingsDialog3DContent">
 		<control type="radiobutton" id="22101">


### PR DESCRIPTION
## Description
Update to Player Process Info dialog to include additional infolabels and to do some minor re-arrangments.

## Motivation and context
Recently refactored Player Process Info dialog for Confluence so decided to review the dialog for Estuary as well.

## Screenshots (if appropriate):

Add button to OSD Settings to access Player Process Info dialog. This allows easy access on limited button remotes & touch devices.

**Before**

![image](https://github.com/user-attachments/assets/d1d5e692-f047-4fec-a3f6-dd5daad776e0)

**After**

![image](https://github.com/user-attachments/assets/8ea24db7-9128-49e5-b3bc-bdd13d564866)

**Media - Before**

![image](https://github.com/user-attachments/assets/7e1eb158-433e-4eab-bd16-e443e041b4f5)

**Media - After**

Add `HDR Type` and `Audio Language`

![image](https://github.com/user-attachments/assets/f55ccff1-b1f8-4ed5-9988-0243b2cb4a28)

**Player - Before**

![image](https://github.com/user-attachments/assets/1f437cf4-5206-4994-89c2-6eb034030060)

**Player - After**

Re-arrangement of video properties to left and audio to the right. Add `Player cache` and split previous `Audio stream` details into `Audio decoder`, `Audio channels` and `Audio Stream`.

![image](https://github.com/user-attachments/assets/d8e07617-4cc7-405e-abf3-7064a84f64e8)

**PVR - Before**

![image](https://github.com/user-attachments/assets/3a9428c8-8dc1-4886-b7ed-98379e5406d2)

**PVR - After**
Change of dimensions only to fit with the dimensions changes done for Media/Player to establish a common center point to the dialog.

![image](https://github.com/user-attachments/assets/07c34f7f-d927-4eaa-8e13-ffb2af389d63)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
