### PR TITLE
[Docs] Unescaped commas in ListItems & VideoPlayer

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4019,7 +4019,7 @@ const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
 ///   \table_row3{   <b>`VideoPlayer.TitleExtraInfo`</b>,
 ///                  \anchor VideoPlayer_TitleExtraInfo
 ///                  _string_,
-///     @return string containing extra information, enriching the title of the currently playing media, if any.
+///     @return string containing extra information\, enriching the title of the currently playing media\, if any.
 ///     <p><hr>
 ///     @skinning_v22 **[New Infolabel]** \link VideoPlayer_TitleExtraInfo `VideoPlayer.TitleExtraInfo`\endlink
 ///     <p>
@@ -7105,7 +7105,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///   \table_row3{   <b>`ListItem.PVRGroupOrigin`</b>,
 ///                  \anchor ListItem_PVRGroupOrigin
 ///                  _string_,
-///     @return If selected item is of type PVR channel group, the creator (user, system, client) of
+///     @return If selected item is of type PVR channel group\, the creator (user\, system\, client) of
 ///     the group.
 ///     <p><hr>
 ///     @skinning_v22 **[New Infolabel]** \link ListItem_PVRGroupOrigin `ListItem.PVRGroupOrigin`\endlink
@@ -7130,7 +7130,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///   \table_row3{   <b>`ListItem.TitleExtraInfo`</b>,
 ///                  \anchor ListItem_TitleExtraInfo
 ///                  _string_,
-///     @return string containing extra information, enriching the title of the item.
+///     @return string containing extra information\, enriching the title of the item.
 ///     <p><hr>
 ///     @skinning_v22 **[New Infolabel]** \link ListItem_TitleExtraInfo `ListItem.TitleExtraInfo`\endlink
 ///     <p>


### PR DESCRIPTION
## Description
Addressed unescaped commas in the documentation.

- ListItem.PVRGroupOrigin
- ListItem.TitleExtraInfo
- VideoPlayer.TitleExtraInfo

## Motivation and context
Updated documentation

## How has this been tested?
Rebuild documentation locally.

## What is the effect on users?
None, developers only.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/67fe67d9-356c-4143-ba51-30aaaf386a26)

![image](https://github.com/user-attachments/assets/7f719f09-6cff-4e65-84c8-5ba42b904501)

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
