### PR TITLE
[Android] Increase compatibility as an external player for more apps

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -72,6 +72,7 @@
                 <data android:mimeType="audio/*" />
                 <data android:mimeType="image/*" />
 
+                <data android:scheme="" />
                 <data android:scheme="file" />
                 <data android:scheme="content" />
                 <data android:scheme="http" />


### PR DESCRIPTION
## Description
Enables Kodi to be used as an external player for almost every app, mimics the fix applied here https://github.com/nova-video-player/aos-Video/pull/117 to make Nova work as an external player for Kodi (even though Kodi is migrating to FileProvider in the future).

## Motivation and context
Applies the fix for playing local files on external players found here https://github.com/nova-video-player/aos-AVP/issues/340 

Right now if Kodi wants to play a local file using an external player the command will be (the example is for Nova player but it works the same way with VLC and any other app)
```Shell
am start -a android.intent.action.VIEW -t 'video/*' -p org.courville.nova -d '/storage/emulated/0/video.mp4'
```

In Kodi, this is changing with https://github.com/xbmc/xbmc/pull/26051 AFAIK, but there still might be some legacy apps that do not work the same way and end up sending a link with empty scheme, this change will enable such apps to invoke Kodi as an external player. Some other apps that support empty schemes are VLC, Google Photos, Nova (thanks to the changes mentioned above), Android's native Gallery App (at least on Samsung) among many others

## What is the effect on users?
Enables Kodi to be used as an external player for more apps

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
