### PR TITLE
[guilib] Fix game controller aspect ratio

### DIFF
--- a/xbmc/games/controllers/guicontrols/GUIGameController.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.cpp
@@ -16,6 +16,7 @@
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerLayout.h"
 #include "guilib/GUIListItem.h"
+#include "guilib/GUITexture.h"
 #include "utils/log.h"
 
 #include <algorithm>
@@ -36,6 +37,9 @@ CGUIGameController::CGUIGameController(int parentID,
 {
   // Initialize CGUIControl
   ControlType = GUICONTROL_GAMECONTROLLER;
+
+  // Initialize CGUIImage
+  SetAspectRatio(CAspectRatio::KEEP);
 }
 
 CGUIGameController::CGUIGameController(const CGUIGameController& from)
@@ -51,6 +55,9 @@ CGUIGameController::CGUIGameController(const CGUIGameController& from)
 {
   // Initialize CGUIControl
   ControlType = GUICONTROL_GAMECONTROLLER;
+
+  // Initialize CGUIImage
+  SetAspectRatio(CAspectRatio::KEEP);
 }
 
 CGUIGameController* CGUIGameController::Clone(void) const


### PR DESCRIPTION
## Description

Just a simple fix I found. Game controllers feature real objects that shouldn't be stretched, so we default to the "keep" aspect ratio.

## Motivation and context

I'm adding CEC Adapter artwork in https://github.com/xbmc/xbmc/pull/26316.

## How has this been tested?

Modified CEC Adapter layout image from 600x600 to 600x400.

## Screenshots

### Before

<img width="1277" alt="Screenshot 2025-01-18 at 9 41 34 PM" src="https://github.com/user-attachments/assets/d769a7bb-e558-4bd0-a849-08d59dba521c" />

### After

<img width="1277" alt="Screenshot 2025-01-18 at 9 44 00 PM" src="https://github.com/user-attachments/assets/63aa052e-9f43-4f70-bd44-711bad9e7800" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
