### PR TITLE
[Peripherals] Show CEC Adapter image

### DIFF
--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -34,6 +34,7 @@
     <setting key="button_repeat_rate_ms" type="int" min="0" max="250" step="10" value="0" label="36048" order="17" />
     <setting key="button_release_delay_ms" type="int" min="0" max="500" step="50" value="0" label="36049" order="18" />
     <setting key="device_type" type="enum" value="36051" label="36013" lvalues="36051|36052|36053" order="19" />
+    <setting key="appearance" type="addon" addontype="kodi.game.controller" value="game.controller.cec.adapter" configurable="0"/>
   </peripheral>
 
   <peripheral vendor_product="2548:1001,2548:1002" bus="usb" name="Pulse-Eight CEC Adapter" mapTo="cec">


### PR DESCRIPTION
## Description

This PR shows the CEC Adapter image in the Peripherals Dialog when it's attached. Also, "Pulse-Eight" appears in the UI.

## Motivation and context

Improved Peripherals Dialog (and better Pulse-Eight brand recognition).

## Related PRs

Requires:

* https://github.com/kodi-game/controller-topology-project/pull/343
* https://github.com/xbmc/repo-resources/pull/497

## How has this been tested?

Tested in my RetroPlayer builds: Coming soon!

## What is the effect on users?

* Added CEC Adapter image to Peripherals Dialog

## Screenshots (if appropriate):

Peripherals Dialog:

<img width="1272" alt="Screenshot 2025-01-18 at 9 23 23 PM" src="https://github.com/user-attachments/assets/5ea338f8-d68e-4a9a-b22b-b165f6d9d172" />

Peripheral Settings:

<img width="1275" alt="Screenshot 2025-01-18 at 9 23 35 PM" src="https://github.com/user-attachments/assets/b5eb59bd-2d68-4efa-abe7-858abcab19aa" />

Add-on Manager:

<img width="1277" alt="Screenshot 2025-01-18 at 9 23 58 PM" src="https://github.com/user-attachments/assets/5a4bb648-dab2-4ee7-8e02-18c38ba2065c" />

Add-on Info:

<img width="1277" alt="Screenshot 2025-01-18 at 9 24 12 PM" src="https://github.com/user-attachments/assets/4a2fb4b2-9d80-48fa-8c49-8cc9c04f6348" />

Controller Configuration Utility:

<img width="1276" alt="Screenshot 2025-01-18 at 9 24 25 PM" src="https://github.com/user-attachments/assets/d1630081-32a3-4bd8-ae51-92d350024b77" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
