### PR TITLE
[Audio][Settings] All PT audio settings visible in standard setting level and all formats enabled by default

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3371,7 +3371,7 @@
           <control type="list" format="string" />
         </setting>
         <setting id="audiooutput.ac3passthrough" type="boolean" label="364" help="36365">
-          <level>2</level>
+          <level>1</level>
           <default>true</default>
           <dependencies>
             <dependency type="visible" on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.passthrough</dependency>
@@ -3399,8 +3399,8 @@
           <control type="toggle" />
         </setting>
         <setting id="audiooutput.eac3passthrough" type="boolean" label="448" help="37016">
-          <level>2</level>
-          <default>false</default>
+          <level>1</level>
+          <default>true</default>
           <dependencies>
             <dependency type="visible">
               <and>
@@ -3413,8 +3413,8 @@
           <control type="toggle" />
         </setting>
         <setting id="audiooutput.dtspassthrough" type="boolean" label="254" help="36366">
-          <level>2</level>
-          <default>false</default>
+          <level>1</level>
+          <default>true</default>
           <dependencies>
             <dependency type="visible">
               <and>
@@ -3427,8 +3427,8 @@
           <control type="toggle" />
         </setting>
         <setting id="audiooutput.truehdpassthrough" type="boolean" label="349" help="36369">
-          <level>2</level>
-          <default>false</default>
+          <level>1</level>
+          <default>true</default>
           <dependencies>
             <dependency type="visible">
               <and>
@@ -3441,8 +3441,8 @@
           <control type="toggle" />
         </setting>
         <setting id="audiooutput.dtshdpassthrough" type="boolean" label="347" help="36370">
-          <level>2</level>
-          <default>false</default>
+          <level>1</level>
+          <default>true</default>
           <dependencies>
             <dependency type="visible">
               <and>


### PR DESCRIPTION
## Description
- Change all PT formats visible in same setting level that main passthrough switch.
- Change all PT formats enabled by default (main switch still disabled by default).

## Motivation and context
This is an usability improvement: most users with default setting level only enables main PT switch and forgets enable individual formats... (because not visible at same setting level). To avoid this main switch and individual formats switches should be at same setting level.

As nowadays most AVR receivers supports all PT formats not make much sense only AC3 enabled by default. I think is better all default enabled and user can disable one format anyway if is not supported (or user preference).

In most cases when the user wants to enable PT audio he wants to do it on all formats.

## How has this been tested?
Windows x64

## What is the effect on users?
Easier PT audio configuration by enabling only the main switch in most cases and all switches visible at the default setting level.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
