### PR TITLE
[Peripherals] Fix shortened peripheral locations

### DIFF
--- a/xbmc/games/addons/input/GameClientJoystick.cpp
+++ b/xbmc/games/addons/input/GameClientJoystick.cpp
@@ -179,7 +179,7 @@ std::string CGameClientJoystick::GetControllerAddress() const
 std::string CGameClientJoystick::GetSourceLocation() const
 {
   if (m_sourcePeripheral)
-    return m_sourcePeripheral->Location();
+    return m_sourcePeripheral->FileLocation();
 
   return "";
 }

--- a/xbmc/games/agents/input/AgentController.cpp
+++ b/xbmc/games/agents/input/AgentController.cpp
@@ -87,7 +87,7 @@ std::string CAgentController::GetPeripheralName() const
 
 const std::string& CAgentController::GetPeripheralLocation() const
 {
-  return m_peripheral->Location();
+  return m_peripheral->FileLocation();
 }
 
 ControllerPtr CAgentController::GetController() const

--- a/xbmc/games/agents/input/AgentInput.cpp
+++ b/xbmc/games/agents/input/AgentInput.cpp
@@ -432,10 +432,10 @@ void CAgentInput::ProcessAgentControllers(const PERIPHERALS::PeripheralVector& p
   for (const auto& peripheral : peripherals)
   {
     // Check if controller already exists
-    auto it = std::find_if(m_controllers.begin(), m_controllers.end(),
-                           [&peripheral](const std::shared_ptr<CAgentController>& controller) {
-                             return controller->GetPeripheralLocation() == peripheral->Location();
-                           });
+    auto it =
+        std::find_if(m_controllers.begin(), m_controllers.end(),
+                     [&peripheral](const std::shared_ptr<CAgentController>& controller)
+                     { return controller->GetPeripheralLocation() == peripheral->FileLocation(); });
 
     if (it == m_controllers.end())
     {
@@ -481,11 +481,10 @@ void CAgentInput::ProcessAgentControllers(const PERIPHERALS::PeripheralVector& p
       if (agentController->GetPeripheral()->Type() != PERIPHERALS::PERIPHERAL_JOYSTICK)
         continue;
 
-      auto it =
-          std::find_if(peripherals.begin(), peripherals.end(),
-                       [&agentController](const PERIPHERALS::PeripheralPtr& peripheral) {
-                         return agentController->GetPeripheralLocation() == peripheral->Location();
-                       });
+      auto it = std::find_if(
+          peripherals.begin(), peripherals.end(),
+          [&agentController](const PERIPHERALS::PeripheralPtr& peripheral)
+          { return agentController->GetPeripheralLocation() == peripheral->FileLocation(); });
 
       if (it == peripherals.end())
         expiredJoysticks.emplace_back(agentController->GetPeripheralLocation());
@@ -822,7 +821,7 @@ void CAgentInput::LogPeripheralMap(
       if (line != 0)
         CLog::Log(LOGDEBUG, "");
       CLog::Log(LOGDEBUG, "{}:", controllerAddress);
-      CLog::Log(LOGDEBUG, "    {} [{}]", peripheral->Location(), peripheral->DeviceName());
+      CLog::Log(LOGDEBUG, "    {} [{}]", peripheral->FileLocation(), peripheral->DeviceName());
 
       ++line;
     }
@@ -837,7 +836,7 @@ void CAgentInput::LogPeripheralMap(
     // Sort by peripheral location
     std::map<std::string, std::string> disconnectedPeripheralMap;
     for (const auto& peripheral : disconnectedPeripherals)
-      disconnectedPeripheralMap[peripheral->Location()] = peripheral->DeviceName();
+      disconnectedPeripheralMap[peripheral->FileLocation()] = peripheral->DeviceName();
 
     // Log location and device name for disconnected peripherals
     for (const auto& [location, deviceName] : disconnectedPeripheralMap)

--- a/xbmc/games/agents/input/AgentInput.h
+++ b/xbmc/games/agents/input/AgentInput.h
@@ -104,7 +104,7 @@ private:
   using JoystickMap = std::map<PortAddress, std::shared_ptr<CGameClientJoystick>>;
   using PortMap = std::map<JOYSTICK::IInputProvider*, std::shared_ptr<CGameClientJoystick>>;
 
-  using PeripheralLocation = std::string;
+  using PeripheralLocation = std::string; // peripherals:// protocol URI
   using CurrentPortMap = std::map<PortAddress, PeripheralLocation>;
   using CurrentPeripheralMap = std::map<PeripheralLocation, PortAddress>;
 

--- a/xbmc/games/agents/windows/GUIAgentControllerList.cpp
+++ b/xbmc/games/agents/windows/GUIAgentControllerList.cpp
@@ -268,7 +268,7 @@ void CGUIAgentControllerList::OnControllerSelect(const CFileItem& selectedAgentI
   for (const std::shared_ptr<const CAgentController>& agentController : agentControllers)
   {
     PERIPHERALS::PeripheralPtr peripheral = agentController->GetPeripheral();
-    if (peripheral && peripheral->Location() == selectedAgentItem.GetPath())
+    if (peripheral && peripheral->FileLocation() == selectedAgentItem.GetPath())
     {
       if (peripheral->GetSettings().empty())
       {
@@ -307,7 +307,7 @@ void CGUIAgentControllerList::ShowControllerDialog(const CAgentController& agent
   CServiceBroker::GetPeripherals().GetDirectory("peripherals://all/", peripherals);
   for (int i = 0; i < peripherals.Size(); ++i)
   {
-    if (peripherals[i]->GetProperty("location").asString() == peripheral->Location())
+    if (peripherals[i]->GetPath() == peripheral->FileLocation())
     {
       peripheralItem = peripherals[i];
       break;
@@ -316,15 +316,14 @@ void CGUIAgentControllerList::ShowControllerDialog(const CAgentController& agent
 
   if (!peripheralItem)
   {
-    CLog::Log(LOGERROR, "Failed to get peripheral for location {}", peripheral->Location());
+    CLog::Log(LOGERROR, "Failed to get peripheral for location {}", peripheral->FileLocation());
     if (peripherals.IsEmpty())
       CLog::Log(LOGERROR, "No peripherals available");
     else
     {
       CLog::Log(LOGERROR, "Available peripherals are:");
       for (int i = 0; i < peripherals.Size(); ++i)
-        CLog::Log(LOGERROR, "  - \"{}\" ({})", peripherals[i]->GetProperty("location").asString(),
-                  peripherals[i]->GetPath());
+        CLog::Log(LOGERROR, "  - \"{}\"", peripherals[i]->GetPath());
     }
     return;
   }

--- a/xbmc/games/controllers/guicontrols/GUIGameController.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.cpp
@@ -17,6 +17,7 @@
 #include "games/controllers/ControllerLayout.h"
 #include "guilib/GUIListItem.h"
 #include "guilib/GUITexture.h"
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include <algorithm>
@@ -84,7 +85,7 @@ void CGUIGameController::DoProcess(unsigned int currentTime, CDirtyRegionList& d
   if (!portAddress.empty())
     activation = agentInput.GetGamePortActivation(portAddress);
 
-  if (!peripheralLocation.empty())
+  if (StringUtils::StartsWith(peripheralLocation, "peripherals://"))
     activation = std::max(agentInput.GetPeripheralActivation(peripheralLocation), activation);
 
   SetActivation(activation);

--- a/xbmc/games/controllers/guicontrols/GUIGameController.dox
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.dox
@@ -74,9 +74,9 @@ A SNES controller connected to port 1 on a multitap would then have the address
 --------------------------------------------------------------------------------
 \section Game_Controller_sect4 Peripheral location
 
-Peripherals are located by their driver and peripheral index. For example, the
-first controller connected via the peripheral.joystick add-on (<b>`joystick`</b>
-driver) would be <b>`/joystick/0`</b>.
+Peripherals are located by a <b>`peripherals://`</b> URI containing their
+peripheral bus as a hostname and a path to the peripheral. For example,
+keyboards have the location <b>`peripherals://application/keyboard.dev`</b>.
 
 
 --------------------------------------------------------------------------------

--- a/xbmc/games/controllers/guicontrols/GUIGameControllerList.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIGameControllerList.cpp
@@ -187,7 +187,7 @@ void CGUIGameControllerList::UpdatePortIndex(const PERIPHERALS::PeripheralPtr& a
 
 void CGUIGameControllerList::UpdatePeripheral(const PERIPHERALS::PeripheralPtr& agentPeripheral)
 {
-  m_peripheralLocation = agentPeripheral->Location();
+  m_peripheralLocation = agentPeripheral->FileLocation();
 }
 
 std::string CGUIGameControllerList::GetPortAddress(

--- a/xbmc/games/controllers/input/DefaultButtonMap.cpp
+++ b/xbmc/games/controllers/input/DefaultButtonMap.cpp
@@ -28,7 +28,7 @@ CDefaultButtonMap::~CDefaultButtonMap() = default;
 
 std::string CDefaultButtonMap::Location() const
 {
-  return m_device->Location();
+  return m_device->FileLocation();
 }
 
 bool CDefaultButtonMap::Load()
@@ -53,7 +53,7 @@ bool CDefaultButtonMap::Load()
   }
 
   CLog::Log(LOGDEBUG, "Failed to load default button map for \"{}\" with profile {}",
-            m_device->Location(), m_strControllerId);
+            m_device->FileLocation(), m_strControllerId);
   return false;
 }
 

--- a/xbmc/input/joysticks/mapping/ButtonMapping.cpp
+++ b/xbmc/input/joysticks/mapping/ButtonMapping.cpp
@@ -263,8 +263,7 @@ CAxisDetector& CButtonMapping::GetAxis(
 
     PERIPHERALS::CPeripherals& peripheralManager = CServiceBroker::GetPeripherals();
 
-    const PERIPHERALS::PeripheralPtr peripheral =
-        peripheralManager.GetPeripheralAtLocation(peripheralLocation);
+    const PERIPHERALS::PeripheralPtr peripheral = peripheralManager.GetByPath(peripheralLocation);
 
     if (peripheral &&
         peripheral->GetBusType() == PERIPHERALS::PeripheralBusType::PERIPHERAL_BUS_GCCONTROLLER)

--- a/xbmc/peripherals/addons/AddonButtonMap.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMap.cpp
@@ -43,7 +43,7 @@ CAddonButtonMap::~CAddonButtonMap(void)
 
 std::string CAddonButtonMap::Location(void) const
 {
-  return m_device->Location();
+  return m_device->FileLocation();
 }
 
 bool CAddonButtonMap::Load(void)

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -230,9 +230,9 @@ void CPeripheralAddon::UnregisterRemovedDevices(const PeripheralScanResults& res
   {
     auto it = m_peripherals.find(index);
     const PeripheralPtr& peripheral = it->second;
-    CLog::Log(LOGINFO, "{} - device removed from {}/{}: {} ({}:{})", __FUNCTION__,
-              PeripheralTypeTranslator::TypeToString(peripheral->Type()), peripheral->Location(),
-              peripheral->DeviceName(), peripheral->VendorIdAsString(),
+    CLog::Log(LOGINFO, "{} - {} device removed from {}: {} ({}:{})", __FUNCTION__,
+              PeripheralTypeTranslator::TypeToString(peripheral->Type()),
+              peripheral->FileLocation(), peripheral->DeviceName(), peripheral->VendorIdAsString(),
               peripheral->ProductIdAsString());
     UnregisterButtonMap(peripheral.get());
     peripheral->OnDeviceRemoved();

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -100,10 +100,10 @@ void CPeripheralBus::UnregisterRemovedDevices(const PeripheralScanResults& resul
         features.size() > 1 || (features.size() == 1 && features.at(0) != FEATURE_UNKNOWN);
     if (peripheral->Type() != PERIPHERAL_UNKNOWN || peripheralHasFeatures)
     {
-      CLog::Log(LOGINFO, "{} - device removed from {}/{}: {} ({}:{})", __FUNCTION__,
-                PeripheralTypeTranslator::TypeToString(peripheral->Type()), peripheral->Location(),
-                peripheral->DeviceName(), peripheral->VendorIdAsString(),
-                peripheral->ProductIdAsString());
+      CLog::Log(LOGINFO, "{} - {} device removed from {}: {} ({}:{})", __FUNCTION__,
+                PeripheralTypeTranslator::TypeToString(peripheral->Type()),
+                peripheral->FileLocation(), peripheral->DeviceName(),
+                peripheral->VendorIdAsString(), peripheral->ProductIdAsString());
       peripheral->OnDeviceRemoved();
     }
 


### PR DESCRIPTION
## Description

This PR changes the short "peripheral location" via `Location()` used in various places into the longer "peripheral path" via `FileLocation()`.

File location is given by:

`peripherals://<bus>/<location>.dev`

### macOS controller example

Before:

`darwin/inputdevice/0`

After:

`peripherals://darwin_gccontroller/darwin/inputdevice/0.dev`

### Keyboard example

Before:

`keyboard`

After:

`peripherals://application/keyboard.dev`

## Motivation and context

Broken out from https://github.com/xbmc/xbmc/pull/26290 for easier review, as this is an independent change.

While location was unique enough for all purposes so far, there could be clashes in the future, so better to use the full path.

## How has this been tested?

Included in latest test builds: https://github.com/garbear/xbmc/releases

## What is the effect on users?

* None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
