### PR TITLE
[Peripherals] Highlight active controllers in the Peripherals Dialog

### DIFF
--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -76,6 +76,17 @@
 						<texture>icons/pvr/timers/bell.png</texture>
 						<visible>ListItem.Property(PVR.IsRemindingTimer)</visible>
 					</control>
+					<control type="gamecontroller">
+						<description>The animated controller image for game controllers in the select dialog</description>
+						<left>12</left>
+						<top>7</top>
+						<width>110</width>
+						<height>110</height>
+						<texture>$INFO[ListItem.Art(icon)]</texture>
+						<peripherallocation>$INFO[ListItem.FilenameAndPath]</peripherallocation>
+						<controllerdiffuse>button_focus</controllerdiffuse>
+						<visible>String.StartsWith(ListItem.FilenameAndPath,peripherals://)</visible>
+					</control>
 					<control type="label">
 						<left>135</left>
 						<top>0</top>
@@ -132,6 +143,16 @@
 						<aligny>center</aligny>
 						<texture>icons/pvr/timers/bell.png</texture>
 						<visible>ListItem.Property(PVR.IsRemindingTimer)</visible>
+					</control>
+					<control type="gamecontroller">
+						<left>12</left>
+						<top>7</top>
+						<width>110</width>
+						<height>110</height>
+						<texture>$INFO[ListItem.Art(icon)]</texture>
+						<peripherallocation>$INFO[ListItem.FilenameAndPath]</peripherallocation>
+						<controllerdiffuse>button_focus</controllerdiffuse>
+						<visible>String.StartsWith(ListItem.FilenameAndPath,peripherals://)</visible>
 					</control>
 					<control type="label">
 						<left>135</left>

--- a/xbmc/games/controllers/guicontrols/GUIGameController.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.cpp
@@ -17,6 +17,7 @@
 #include "games/controllers/ControllerLayout.h"
 #include "guilib/GUIListItem.h"
 #include "guilib/GUITexture.h"
+#include "peripherals/Peripherals.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
@@ -78,6 +79,7 @@ void CGUIGameController::DoProcess(unsigned int currentTime, CDirtyRegionList& d
   }
 
   const GAME::CAgentInput& agentInput = CServiceBroker::GetGameServices().AgentInput();
+  const PERIPHERALS::CPeripherals& peripheralManager = CServiceBroker::GetPeripherals();
 
   // Highlight the controller if it is active
   float activation = 0.0f;
@@ -86,7 +88,10 @@ void CGUIGameController::DoProcess(unsigned int currentTime, CDirtyRegionList& d
     activation = agentInput.GetGamePortActivation(portAddress);
 
   if (StringUtils::StartsWith(peripheralLocation, "peripherals://"))
-    activation = std::max(agentInput.GetPeripheralActivation(peripheralLocation), activation);
+  {
+    activation =
+        std::max(peripheralManager.GetPeripheralActivation(peripheralLocation), activation);
+  }
 
   SetActivation(activation);
 

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -1029,3 +1029,12 @@ void CPeripherals::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
     }
   }
 }
+
+float CPeripherals::GetPeripheralActivation(const std::string& peripheralPath) const
+{
+  PeripheralPtr periphreal = GetByPath(peripheralPath);
+  if (periphreal)
+    return periphreal->GetActivation();
+
+  return 0.0f;
+}

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -362,6 +362,15 @@ public:
     return m_addonInstallMutex;
   }
 
+  /*!
+   * \brief Get the current activation of a peripheral
+   *
+   * \param peripheralPath The peripherals:// URI of the peripheral's location
+   *
+   * \return The current activation, on a scale of 0.0 to 1.0
+   */
+  float GetPeripheralActivation(const std::string& peripheralPath) const;
+
 private:
   bool LoadMappings();
   bool GetMappingForDevice(const CPeripheralBus& bus, PeripheralScanResult& result) const;

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -11,6 +11,7 @@
 #include "ServiceBroker.h"
 #include "Util.h"
 #include "XBDateTime.h"
+#include "games/agents/input/AgentController.h"
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerLayout.h"
 #include "games/controllers/ControllerManager.h"
@@ -84,6 +85,12 @@ CPeripheral::CPeripheral(CPeripherals& manager,
 
 CPeripheral::~CPeripheral(void)
 {
+  if (m_controllerInput)
+  {
+    m_controllerInput->Deinitialize();
+    m_controllerInput.reset();
+  }
+
   PersistSettings(true);
 
   m_subDevices.clear();
@@ -192,6 +199,13 @@ bool CPeripheral::Initialise(void)
     CLog::Log(LOGDEBUG, "{} - initialised peripheral on '{}' with {} features and {} sub devices",
               __FUNCTION__, m_strLocation, (int)m_features.size(), (int)m_subDevices.size());
     m_bInitialised = true;
+  }
+
+  // Initialize controller input
+  if (m_bInitialised)
+  {
+    m_controllerInput = std::make_unique<GAME::CAgentController>(shared_from_this());
+    m_controllerInput->Initialize();
   }
 
   return bReturn;
@@ -822,6 +836,14 @@ bool CPeripheral::operator!=(const PeripheralScanResult& right) const
 CDateTime CPeripheral::LastActive() const
 {
   return CDateTime();
+}
+
+float CPeripheral::GetActivation() const
+{
+  if (m_controllerInput)
+    return m_controllerInput->GetActivation();
+
+  return 0.0f;
 }
 
 void CPeripheral::SetControllerProfile(const GAME::ControllerPtr& controller)

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -15,6 +15,7 @@
 #include "peripherals/PeripheralTypes.h"
 
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
@@ -24,6 +25,11 @@ class CSetting;
 
 namespace KODI
 {
+namespace GAME
+{
+class CAgentController;
+}
+
 namespace JOYSTICK
 {
 class IButtonMapper;
@@ -70,7 +76,8 @@ typedef enum
  */
 class CPeripheral : public KODI::JOYSTICK::IInputProvider,
                     public KODI::KEYBOARD::IKeyboardInputProvider,
-                    public KODI::MOUSE::IMouseInputProvider
+                    public KODI::MOUSE::IMouseInputProvider,
+                    public std::enable_shared_from_this<CPeripheral>
 {
   friend class CGUIDialogPeripheralSettings;
 
@@ -267,6 +274,13 @@ public:
   virtual CDateTime LastActive() const;
 
   /*!
+   * \brief Return the current activity level of the peripheral
+   *
+   * \return The activity level, on a scale of 0.0 to 1.0
+   */
+  virtual float GetActivation() const;
+
+  /*!
    * \brief Get the controller profile that best represents this peripheral
    *
    * \return The controller profile, or empty if unknown
@@ -313,5 +327,6 @@ protected:
       m_mouseHandlers;
   std::map<KODI::JOYSTICK::IButtonMapper*, std::unique_ptr<CAddonButtonMapping>> m_buttonMappers;
   KODI::GAME::ControllerPtr m_controllerProfile;
+  std::unique_ptr<KODI::GAME::CAgentController> m_controllerInput;
 };
 } // namespace PERIPHERALS

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -32,7 +32,6 @@
 #include "utils/log.h"
 
 #include <algorithm>
-#include <memory>
 #include <mutex>
 
 using namespace KODI;


### PR DESCRIPTION
## Description

As title says, this applies the same highlighting as in the Player Viewer to the Peripherals Dialog.

## Motivation and context

Seeing the active input helps debug input problems.

Split out from https://github.com/xbmc/xbmc/pull/26290.

## How has this been tested?

Part of my test builds: https://github.com/garbear/xbmc/releases

## What is the effect on users?

* Adds highlighting to controllers in the Peripherals Dialog

## Screenshots (if appropriate):

Showing diffuse blue highlighted controller when a button is pressed:

<img width="1274" alt="Screenshot 2025-01-19 at 10 58 55 AM" src="https://github.com/user-attachments/assets/e502b699-1e42-4884-8b38-ab90173e992b" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
