### PR TITLE
[video] Fix duplicate 'Information' context menu entries for PVR recordings.

### DIFF
--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -69,6 +69,9 @@ bool CVideoInfo::IsVisible(const CFileItem& item) const
   if (item.m_bIsFolder)
     return false;
 
+  if (item.IsPVRRecording())
+    return false; // pvr recordings have its own implementation for this
+
   const auto* tag{item.GetVideoInfoTag()};
   return tag && tag->m_type == MediaTypeNone && !tag->IsEmpty() && VIDEO::IsVideo(item);
 }


### PR DESCRIPTION
Fixes a small regression introduced with https://github.com/xbmc/xbmc/pull/26166 - two 'Information' context menu entries for PVR recordings, where one obviously is sufficient. ;-)

<img width="1710" alt="Screenshot_2025-01-19_at_13_37_11" src="https://github.com/user-attachments/assets/3739b1d1-446e-4006-9acc-694917cf6946" />

Fix runtime-tested on macOS and Android, latest master.

@phunkyfish please review, thanks. 

 