### PR TITLE
[Peripherals] Last round of enhancements to Peripherals Dialog

### DIFF
--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -63,17 +63,19 @@
   </peripheral>
 
   <peripheral class="joystick" name="joystick" mapTo="joystick">
-    <setting key="appearance" type="addon" addontype="kodi.game.controller" label="480" order="1"/>
+    <setting key="appearance" type="addon" addontype="kodi.game.controller" value="game.controller.default" label="480" order="1"/>
     <setting key="last_active" type="string" value="" configurable="0"/>
     <setting key="left_stick_deadzone" type="float" label="35078" order="2" value="0.2" min="0.0" step="0.05" max="1.0" />
     <setting key="right_stick_deadzone" type="float" label="35079" order="3" value="0.2" min="0.0" step="0.05" max="1.0" />
   </peripheral>
 
   <peripheral class="keyboard" name="keyboard" mapTo="keyboard">
+    <setting key="appearance" type="addon" addontype="kodi.game.controller" value="game.controller.keyboard" configurable="0"/>
     <setting key="last_active" type="string" value="" configurable="0"/>
   </peripheral>
 
   <peripheral class="mouse" name="mouse" mapTo="mouse">
+    <setting key="appearance" type="addon" addontype="kodi.game.controller" value="game.controller.mouse" configurable="0"/>
     <setting key="last_active" type="string" value="" configurable="0"/>
   </peripheral>
 

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -64,8 +64,17 @@
 
   <peripheral class="joystick" name="joystick" mapTo="joystick">
     <setting key="appearance" type="addon" addontype="kodi.game.controller" label="480" order="1"/>
+    <setting key="last_active" type="string" value="" configurable="0"/>
     <setting key="left_stick_deadzone" type="float" label="35078" order="2" value="0.2" min="0.0" step="0.05" max="1.0" />
     <setting key="right_stick_deadzone" type="float" label="35079" order="3" value="0.2" min="0.0" step="0.05" max="1.0" />
+  </peripheral>
+
+  <peripheral class="keyboard" name="keyboard" mapTo="keyboard">
+    <setting key="last_active" type="string" value="" configurable="0"/>
+  </peripheral>
+
+  <peripheral class="mouse" name="mouse" mapTo="mouse">
+    <setting key="last_active" type="string" value="" configurable="0"/>
   </peripheral>
 
 </peripherals>

--- a/xbmc/games/agents/input/AgentInput.cpp
+++ b/xbmc/games/agents/input/AgentInput.cpp
@@ -105,13 +105,11 @@ void CAgentInput::Refresh()
 {
   if (m_gameClient)
   {
-    // Open keyboard
-    if (m_bHasKeyboard)
-      ProcessKeyboard();
+    // Process keyboard
+    ProcessKeyboard();
 
-    // Open mouse
-    if (m_bHasMouse)
-      ProcessMouse();
+    // Process mouse
+    ProcessMouse();
 
     // Open/close joysticks
     PERIPHERALS::EventLockHandlePtr inputHandlingLock;
@@ -431,6 +429,10 @@ void CAgentInput::ProcessAgentControllers(const PERIPHERALS::PeripheralVector& p
   // Handle new and existing controllers
   for (const auto& peripheral : peripherals)
   {
+    // Skip peripherals that have never been active
+    if (!peripheral->LastActive().IsValid())
+      continue;
+
     // Check if controller already exists
     auto it =
         std::find_if(m_controllers.begin(), m_controllers.end(),

--- a/xbmc/games/agents/windows/GUIAgentControllerList.cpp
+++ b/xbmc/games/agents/windows/GUIAgentControllerList.cpp
@@ -270,7 +270,7 @@ void CGUIAgentControllerList::OnControllerSelect(const CFileItem& selectedAgentI
     PERIPHERALS::PeripheralPtr peripheral = agentController->GetPeripheral();
     if (peripheral && peripheral->FileLocation() == selectedAgentItem.GetPath())
     {
-      if (peripheral->GetSettings().empty())
+      if (!peripheral->HasConfigurableSettings())
       {
         // Show an error if the peripheral doesn't have any settings
         CLog::Log(LOGERROR, "Peripheral has no settings");

--- a/xbmc/games/controllers/Controller.cpp
+++ b/xbmc/games/controllers/Controller.cpp
@@ -132,8 +132,7 @@ bool CController::LoadLayout(void)
     }
 
     auto* pRootElement = xmlDoc.RootElement();
-    if (pRootElement == nullptr || pRootElement->NoChildren() ||
-        std::strcmp(pRootElement->Value(), LAYOUT_XML_ROOT) != 0)
+    if (pRootElement == nullptr || std::strcmp(pRootElement->Value(), LAYOUT_XML_ROOT) != 0)
     {
       CLog::Log(LOGERROR, "Can't find root <{}> tag", LAYOUT_XML_ROOT);
       return false;

--- a/xbmc/games/controllers/ControllerManager.cpp
+++ b/xbmc/games/controllers/ControllerManager.cpp
@@ -35,6 +35,9 @@ ControllerPtr CControllerManager::GetController(const std::string& controllerId)
 {
   using namespace ADDON;
 
+  if (controllerId.empty())
+    return {};
+
   std::lock_guard<CCriticalSection> lock(m_mutex);
 
   ControllerPtr& cachedController = m_cache[controllerId];

--- a/xbmc/peripherals/bus/virtual/PeripheralBusApplication.h
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusApplication.h
@@ -30,13 +30,11 @@ public:
   void Initialise(void) override;
   void GetDirectory(const std::string& strPath, CFileItemList& items) const override;
 
-  /*!
-   * \brief Get the location for the specified controller index
-   */
-  std::string MakeLocation(unsigned int controllerIndex) const;
-
 protected:
   // implementation of CPeripheralBus
   bool PerformDeviceScan(PeripheralScanResults& results) override;
+
+  // Internal helper fuction
+  static std::string MakeLocation(PeripheralType peripheralType);
 };
 } // namespace PERIPHERALS

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -298,6 +298,19 @@ void CPeripheral::AddSetting(const std::string& strKey, const SettingConstPtr& s
               std::make_shared<CSettingAddon>(strKey, *mappedSetting);
           addonSetting->SetVisible(mappedSetting->IsVisible());
           deviceSetting.m_setting = addonSetting;
+
+          // Handle default settings
+          if (strKey == SETTING_APPEARANCE)
+          {
+            const std::string& controllerId = addonSetting->GetValue();
+            if (!controllerId.empty())
+            {
+              GAME::ControllerPtr controllerProfile =
+                  CServiceBroker::GetGameControllerManager().GetController(controllerId);
+              if (controllerProfile)
+                m_controllerProfile = controllerProfile;
+            }
+          }
         }
         else
         {

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -43,7 +43,7 @@ namespace
 {
 // Settings for peripherals
 constexpr std::string_view SETTING_APPEARANCE = "appearance";
-} // namespace
+constexpr std::string_view SETTING_LAST_ACTIVE = "last_active";
 
 struct SortBySettingsOrder
 {
@@ -52,6 +52,7 @@ struct SortBySettingsOrder
     return left.m_order < right.m_order;
   }
 };
+} // namespace
 
 CPeripheral::CPeripheral(CPeripherals& manager,
                          const PeripheralScanResult& scanResult,
@@ -183,8 +184,10 @@ bool CPeripheral::Initialise(void)
           CUtil::MakeLegalFileName(std::move(safeDeviceName), LegalPath::WIN32_COMPAT));
   }
 
+  // Load settings and initialize state
   LoadPersistedSettings();
 
+  // Initialize features
   for (unsigned int iFeaturePtr = 0; iFeaturePtr < m_features.size(); iFeaturePtr++)
   {
     PeripheralFeature feature = m_features.at(iFeaturePtr);
@@ -512,6 +515,13 @@ bool CPeripheral::SetSetting(const std::string& strKey, const std::string& strVa
         stringSetting->SetValue(strValue);
         if (bChanged && m_bInitialised)
           m_changedSettings.insert(strKey);
+
+        if (strKey == SETTING_LAST_ACTIVE && !strValue.empty())
+        {
+          CDateTime lastActive;
+          lastActive.SetFromW3CDateTime(strValue, false);
+          SetLastActive(lastActive);
+        }
       }
     }
     else if ((*it).second.m_setting->GetType() == SettingType::Integer)
@@ -848,7 +858,35 @@ bool CPeripheral::operator!=(const PeripheralScanResult& right) const
 
 CDateTime CPeripheral::LastActive() const
 {
-  return CDateTime();
+  // By default, peripherals are fully-activated
+  return CDateTime::GetCurrentDateTime();
+}
+
+void CPeripheral::SetLastActive(const CDateTime& lastActive)
+{
+  // Update last active setting
+  const std::string strKey{SETTING_LAST_ACTIVE};
+
+  auto it = m_settings.find(strKey);
+  if (it != m_settings.end() && it->second.m_setting->GetType() == SettingType::String)
+  {
+    std::shared_ptr<CSettingString> stringSetting =
+        std::static_pointer_cast<CSettingString>(it->second.m_setting);
+
+    const bool wasActive = !stringSetting->GetValue().empty();
+
+    const std::string lastActiveStr = lastActive.IsValid() ? lastActive.GetAsW3CDateTime() : "";
+
+    stringSetting->SetValue(lastActiveStr);
+
+    // Notify listeners if a peripheral was activated for the first time
+    if (!wasActive & lastActive.IsValid())
+    {
+      m_manager.SetChanged(true);
+      m_manager.NotifyObservers(ObservableMessagePeripheralsChanged);
+      PersistSettings();
+    }
+  }
 }
 
 float CPeripheral::GetActivation() const

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -274,6 +274,13 @@ public:
   virtual CDateTime LastActive() const;
 
   /*!
+   * \brief Set the last time this peripheral was active
+   *
+   * \param lastActive The time of last activation, or invalid if unknown/never active
+   */
+  virtual void SetLastActive(const CDateTime& lastActive);
+
+  /*!
    * \brief Return the current activity level of the peripheral
    *
    * \return The activity level, on a scale of 0.0 to 1.0

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -14,8 +14,12 @@
 #include "input/mouse/interfaces/IMouseInputProvider.h"
 #include "peripherals/PeripheralTypes.h"
 
+#include <functional>
+#include <future>
 #include <map>
 #include <memory>
+#include <mutex>
+#include <queue>
 #include <set>
 #include <string>
 #include <vector>
@@ -304,6 +308,13 @@ public:
 protected:
   virtual void ClearSettings(void);
 
+  // Helper functions
+  void InstallController(
+      const std::string& controllerId,
+      std::function<void(const KODI::GAME::ControllerPtr& installedController)> callback);
+  KODI::GAME::ControllerPtr InstallAsync(const std::string& controllerId);
+  static bool InstallSync(const std::string& controllerId);
+
   CPeripherals& m_manager;
   PeripheralType m_type;
   PeripheralBusType m_busType;
@@ -335,5 +346,8 @@ protected:
   std::map<KODI::JOYSTICK::IButtonMapper*, std::unique_ptr<CAddonButtonMapping>> m_buttonMappers;
   KODI::GAME::ControllerPtr m_controllerProfile;
   std::unique_ptr<KODI::GAME::CAgentController> m_controllerInput;
+  std::queue<std::string> m_controllersToInstall;
+  std::vector<std::future<void>> m_installTasks;
+  std::mutex m_controllerInstallMutex;
 };
 } // namespace PERIPHERALS

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -253,6 +253,15 @@ KEYMAP::IKeymap* CPeripheralJoystick::GetKeymap(const std::string& controllerId)
   return m_appInput->GetKeymap(controllerId);
 }
 
+void CPeripheralJoystick::SetLastActive(const CDateTime& lastActive)
+{
+  // Update state
+  m_lastActive = lastActive;
+
+  // Update ancestor
+  CPeripheral::SetLastActive(lastActive);
+}
+
 GAME::ControllerPtr CPeripheralJoystick::ControllerProfile() const
 {
   // Button map has the freshest state
@@ -321,9 +330,10 @@ bool CPeripheralJoystick::OnButtonMotion(unsigned int buttonIndex, bool bPressed
   if (bPressed && !g_application.IsAppFocused())
     return false;
 
-  m_lastActive = CDateTime::GetCurrentDateTime();
-
   std::unique_lock<CCriticalSection> lock(m_handlerMutex);
+
+  // Update state
+  SetLastActive(CDateTime::GetCurrentDateTime());
 
   // Check GUI setting and send button release if controllers are disabled
   if (!m_manager.GetInputManager().IsControllerEnabled())
@@ -377,7 +387,8 @@ bool CPeripheralJoystick::OnHatMotion(unsigned int hatIndex, HAT_STATE state)
   if (state != HAT_STATE::NONE && !g_application.IsAppFocused())
     return false;
 
-  m_lastActive = CDateTime::GetCurrentDateTime();
+  // Update state
+  SetLastActive(CDateTime::GetCurrentDateTime());
 
   std::unique_lock<CCriticalSection> lock(m_handlerMutex);
 
@@ -474,8 +485,9 @@ bool CPeripheralJoystick::OnAxisMotion(unsigned int axisIndex, float position)
     }
   }
 
+  // Update state
   if (bHandled)
-    m_lastActive = CDateTime::GetCurrentDateTime();
+    SetLastActive(CDateTime::GetCurrentDateTime());
 
   return bHandled;
 }

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -288,32 +288,13 @@ void CPeripheralJoystick::SetControllerProfile(const KODI::GAME::ControllerPtr& 
 {
   CPeripheral::SetControllerProfile(controller);
 
-  const std::string controllerId = controller ? controller->ID() : "";
-  const bool providesInput = controller ? controller->Layout().Topology().ProvidesInput() : true;
-
   // Save preference to buttonmap
   if (m_buttonMap)
   {
+    const std::string controllerId = controller ? controller->ID() : "";
+
     if (m_buttonMap->SetAppearance(controllerId))
       m_buttonMap->SaveButtonMap();
-  }
-
-  // Update settings
-  for (const auto& it : m_settings)
-  {
-    std::shared_ptr<CSetting> setting = it.second.m_setting;
-    if (!setting)
-      continue;
-
-    if (setting->GetId() == CDeadzoneFilter::SETTING_LEFT_STICK_DEADZONE ||
-        setting->GetId() == CDeadzoneFilter::SETTING_RIGHT_STICK_DEADZONE)
-    {
-      if (controllerId == GAME::DEFAULT_KEYBOARD_ID || controllerId == GAME::DEFAULT_MOUSE_ID ||
-          controllerId == GAME::DEFAULT_REMOTE_ID || !providesInput)
-        setting->SetVisible(false);
-      else
-        setting->SetVisible(true);
-    }
   }
 }
 

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -78,21 +78,17 @@ bool CPeripheralJoystick::InitialiseFeature(const PeripheralFeature feature)
   {
     if (feature == FEATURE_JOYSTICK)
     {
-      // Ensure an add-on is present to translate input
+      // Log if an add-on is not present to translate input
       PeripheralAddonPtr addon = m_manager.GetAddonWithButtonMap(this);
       if (!addon)
-      {
         CLog::Log(LOGERROR, "CPeripheralJoystick: No button mapping add-on for {}", m_strLocation);
-      }
-      else
-      {
-        if (m_bus->InitializeProperties(*this))
-          bSuccess = true;
-        else
-          CLog::Log(LOGERROR, "CPeripheralJoystick: Invalid location ({})", m_strLocation);
-      }
 
-      if (bSuccess)
+      if (m_bus->InitializeProperties(*this))
+        bSuccess = true;
+      else
+        CLog::Log(LOGERROR, "CPeripheralJoystick: Invalid location ({})", m_strLocation);
+
+      if (bSuccess && addon)
       {
         m_buttonMap =
             std::make_unique<CAddonButtonMap>(this, addon, GAME::DEFAULT_CONTROLLER_ID, m_manager);

--- a/xbmc/peripherals/devices/PeripheralJoystick.h
+++ b/xbmc/peripherals/devices/PeripheralJoystick.h
@@ -66,6 +66,7 @@ public:
   KODI::JOYSTICK::IDriverReceiver* GetDriverReceiver() override { return this; }
   KODI::KEYMAP::IKeymap* GetKeymap(const std::string& controllerId) override;
   CDateTime LastActive() const override { return m_lastActive; }
+  void SetLastActive(const CDateTime& lastActive) override;
   KODI::GAME::ControllerPtr ControllerProfile() const override;
   void SetControllerProfile(const KODI::GAME::ControllerPtr& controller) override;
 

--- a/xbmc/peripherals/devices/PeripheralJoystick.h
+++ b/xbmc/peripherals/devices/PeripheralJoystick.h
@@ -17,7 +17,6 @@
 
 #include <future>
 #include <memory>
-#include <queue>
 #include <string>
 #include <vector>
 
@@ -120,10 +119,6 @@ protected:
 
   void PowerOff();
 
-  // Helper functions
-  KODI::GAME::ControllerPtr InstallAsync(const std::string& controllerId);
-  static bool InstallSync(const std::string& controllerId);
-
   struct DriverHandler
   {
     KODI::JOYSTICK::IDriverHandler* handler;
@@ -139,8 +134,6 @@ protected:
   unsigned int m_motorCount = 0;
   bool m_supportsPowerOff = false;
   CDateTime m_lastActive;
-  std::queue<std::string> m_controllersToInstall;
-  std::vector<std::future<void>> m_installTasks;
 
   // Input clients
   std::unique_ptr<KODI::KEYMAP::CKeymapHandling> m_appInput;
@@ -152,6 +145,5 @@ protected:
 
   // Synchronization parameters
   CCriticalSection m_handlerMutex;
-  CCriticalSection m_controllerInstallMutex;
 };
 } // namespace PERIPHERALS

--- a/xbmc/peripherals/devices/PeripheralKeyboard.cpp
+++ b/xbmc/peripherals/devices/PeripheralKeyboard.cpp
@@ -79,6 +79,15 @@ void CPeripheralKeyboard::UnregisterKeyboardDriverHandler(
     m_keyboardHandlers.erase(it);
 }
 
+void CPeripheralKeyboard::SetLastActive(const CDateTime& lastActive)
+{
+  // Update state
+  m_lastActive = lastActive;
+
+  // Update ancestor
+  CPeripheral::SetLastActive(lastActive);
+}
+
 GAME::ControllerPtr CPeripheralKeyboard::ControllerProfile() const
 {
   if (m_controllerProfile)
@@ -89,9 +98,10 @@ GAME::ControllerPtr CPeripheralKeyboard::ControllerProfile() const
 
 bool CPeripheralKeyboard::OnKeyPress(const CKey& key)
 {
-  m_lastActive = CDateTime::GetCurrentDateTime();
-
   std::unique_lock<CCriticalSection> lock(m_mutex);
+
+  // Update state
+  SetLastActive(CDateTime::GetCurrentDateTime());
 
   bool bHandled = false;
 

--- a/xbmc/peripherals/devices/PeripheralKeyboard.h
+++ b/xbmc/peripherals/devices/PeripheralKeyboard.h
@@ -35,6 +35,7 @@ public:
                                      bool bPromiscuous) override;
   void UnregisterKeyboardDriverHandler(KODI::KEYBOARD::IKeyboardDriverHandler* handler) override;
   CDateTime LastActive() const override { return m_lastActive; }
+  void SetLastActive(const CDateTime& lastActive) override;
   KODI::GAME::ControllerPtr ControllerProfile() const override;
 
   // implementation of IKeyboardDriverHandler

--- a/xbmc/peripherals/devices/PeripheralMouse.cpp
+++ b/xbmc/peripherals/devices/PeripheralMouse.cpp
@@ -72,6 +72,15 @@ void CPeripheralMouse::UnregisterMouseDriverHandler(MOUSE::IMouseDriverHandler* 
     m_mouseHandlers.erase(it);
 }
 
+void CPeripheralMouse::SetLastActive(const CDateTime& lastActive)
+{
+  // Update state
+  m_lastActive = lastActive;
+
+  // Update ancestor
+  CPeripheral::SetLastActive(lastActive);
+}
+
 GAME::ControllerPtr CPeripheralMouse::ControllerProfile() const
 {
   if (m_controllerProfile)
@@ -104,17 +113,19 @@ bool CPeripheralMouse::OnPosition(int x, int y)
     }
   }
 
+  // Update state
   if (bHandled)
-    m_lastActive = CDateTime::GetCurrentDateTime();
+    SetLastActive(CDateTime::GetCurrentDateTime());
 
   return bHandled;
 }
 
 bool CPeripheralMouse::OnButtonPress(MOUSE::BUTTON_ID button)
 {
-  m_lastActive = CDateTime::GetCurrentDateTime();
-
   std::unique_lock<CCriticalSection> lock(m_mutex);
+
+  // Update state
+  SetLastActive(CDateTime::GetCurrentDateTime());
 
   bool bHandled = false;
 

--- a/xbmc/peripherals/devices/PeripheralMouse.h
+++ b/xbmc/peripherals/devices/PeripheralMouse.h
@@ -35,6 +35,7 @@ public:
                                   bool bPromiscuous) override;
   void UnregisterMouseDriverHandler(KODI::MOUSE::IMouseDriverHandler* handler) override;
   CDateTime LastActive() const override { return m_lastActive; }
+  void SetLastActive(const CDateTime& lastActive) override;
   KODI::GAME::ControllerPtr ControllerProfile() const override;
 
   // implementation of IMouseDriverHandler

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -61,6 +61,12 @@ bool CGUIDialogPeripheralSettings::OnMessage(CGUIMessage& message)
   return CGUIDialogSettingsManualBase::OnMessage(message);
 }
 
+void CGUIDialogPeripheralSettings::OnDeinitWindow(int nextWindowID)
+{
+  UpdateIcon({});
+  CGUIDialogSettingsManualBase::OnDeinitWindow(nextWindowID);
+}
+
 void CGUIDialogPeripheralSettings::RegisterPeripheralManager(CPeripherals& manager)
 {
   m_manager = &manager;
@@ -110,8 +116,19 @@ void CGUIDialogPeripheralSettings::OnSettingChanged(const std::shared_ptr<const 
 
   peripheral->SetSetting(settingId, setting->ToString());
 
+  // Refresh peripheral icon
+  UpdateIcon(peripheral->ControllerProfile());
+
   // Persist settings so that the new setting takes effect immediately
   Save();
+}
+
+void CGUIDialogPeripheralSettings::UpdateIcon(const GAME::ControllerPtr& controller)
+{
+  GAME::CGUIGameController* control =
+      dynamic_cast<GAME::CGUIGameController*>(GetControl(CONTROL_ID_PERIPHERAL_ICON));
+  if (control != nullptr)
+    control->SetFileName(controller ? controller->Layout().ImagePath() : "");
 }
 
 bool CGUIDialogPeripheralSettings::Save()
@@ -169,13 +186,7 @@ void CGUIDialogPeripheralSettings::SetupView()
       controller = peripheral->ControllerProfile();
   }
 
-  if (controller)
-  {
-    GAME::CGUIGameController* control =
-        dynamic_cast<GAME::CGUIGameController*>(GetControl(CONTROL_ID_PERIPHERAL_ICON));
-    if (control != nullptr)
-      control->SetFileName(controller->Layout().ImagePath());
-  }
+  UpdateIcon(controller);
 }
 
 void CGUIDialogPeripheralSettings::InitializeSettings()

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.h
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "games/controllers/ControllerTypes.h"
 #include "settings/dialogs/GUIDialogSettingsManualBase.h"
 
 class CFileItem;
@@ -28,6 +29,9 @@ public:
   // specializations of CGUIControl
   bool OnMessage(CGUIMessage& message) override;
 
+  // Implementation of CGUIWindow
+  void OnDeinitWindow(int nextWindowID) override;
+
   void RegisterPeripheralManager(CPeripherals& manager);
   void UnregisterPeripheralManager();
 
@@ -45,6 +49,8 @@ protected:
 
   // specialization of CGUIDialogSettingsManualBase
   void InitializeSettings() override;
+
+  void UpdateIcon(const KODI::GAME::ControllerPtr& controller);
 
   // Dialog state
   CPeripherals* m_manager{nullptr};


### PR DESCRIPTION
## Description

This PR adds keyboard and mouse support in the Peripherals Dialog. They only show up after the first key or mouse button press, respectively.

It also makes the appearances changeable via peripherals.xml. For example, keyboard now looks like:

```xml
  <peripheral class="keyboard" name="keyboard" mapTo="keyboard">
    <setting key="appearance" type="addon" addontype="kodi.game.controller" value="game.controller.keyboard" configurable="0"/>
    <setting key="last_active" type="string" value="" configurable="0"/>
  </peripheral>
```

If an add-on is present in peripherals.xml (like game.controller.cec.adapter for the CEC Adapter in https://github.com/xbmc/xbmc/pull/26316) but not installed, it is installed on startup or when the peripheral is first connected.

Also, now built-in joysticks are shown in the Peripherals Dialog even if peripheral.joystick isn't present.

And some minor bug fixes.

## Motivation and context

Last round of enhancements broken out from https://github.com/xbmc/xbmc/pull/26290.

## How has this been tested?

Included in latest rounds of test builds: https://github.com/garbear/xbmc/releases

## What is the effect on users?

* Added keyboard and mouse to Peripherals Dialog

## Screenshots (if appropriate):

In all its glory:

<img width="1276" alt="Screenshot 2025-01-19 at 3 54 42 PM" src="https://github.com/user-attachments/assets/0a66ff59-29db-4c9e-9007-abcdea8f2697" />

## Types of change

<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
