### PR TITLE
[PVR] Add context menu item 'Hide channel' to channels listed in 'Rec…

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10052,7 +10052,8 @@ msgctxt "#19053"
 msgid "Recording information"
 msgstr ""
 
-#. header label for hide channel confirmation message box
+#. Header label for hide channel confirmation message box and context menu item label
+#: xbmc/pvr/PVRContextMenus.cpp
 #: xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
 msgctxt "#19054"
 msgid "Hide channel"

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -19,6 +19,7 @@
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgInfoTag.h"
+#include "pvr/guilib/PVRGUIActionsChannels.h"
 #include "pvr/guilib/PVRGUIActionsEPG.h"
 #include "pvr/guilib/PVRGUIActionsPlayback.h"
 #include "pvr/guilib/PVRGUIActionsRecordings.h"
@@ -83,6 +84,7 @@ DECL_STATICCONTEXTMENUITEM(RenameSearch);
 DECL_STATICCONTEXTMENUITEM(ChooseIconForSearch);
 DECL_STATICCONTEXTMENUITEM(DuplicateSearch);
 DECL_STATICCONTEXTMENUITEM(DeleteSearch);
+DECL_STATICCONTEXTMENUITEM(HideChannel);
 
 class PVRClientMenuHook : public IContextMenuItem
 {
@@ -767,6 +769,19 @@ bool DeleteSearch::Execute(const std::shared_ptr<CFileItem>& item) const
   return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().DeleteSavedSearch(*item);
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// Hide channel
+
+bool HideChannel::IsVisible(const CFileItem& item) const
+{
+  return item.IsPVRChannel() && item.GetProperty("hideable").asBoolean(false);
+}
+
+bool HideChannel::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().HideChannel(*item);
+}
+
 } // namespace CONTEXTMENUITEM
 
 CPVRContextMenuManager& CPVRContextMenuManager::GetInstance()
@@ -802,6 +817,7 @@ CPVRContextMenuManager::CPVRContextMenuManager()
         std::make_shared<CONTEXTMENUITEM::ChooseIconForSearch>(19284), /* Choose icon */
         std::make_shared<CONTEXTMENUITEM::DuplicateSearch>(19355), /* Duplicate */
         std::make_shared<CONTEXTMENUITEM::DeleteSearch>(117), /* Delete */
+        std::make_shared<CONTEXTMENUITEM::HideChannel>(19054), /* Hide channel */
     })
 {
 }

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -762,7 +762,11 @@ bool CPVRGUIDirectory::GetChannelsDirectory(CFileItemList& results) const
           }
         }
 
-        results.Add(std::make_shared<CFileItem>(groupMember));
+        const auto item{std::make_shared<CFileItem>(groupMember)};
+        if (dateAdded)
+          item->SetProperty("hideable", true);
+
+        results.Add(std::move(item));
       }
       return true;
     }


### PR DESCRIPTION
…ently added channels' widget.

I found it quite useful and comfortable to hide channels I do not want directly from the "Recently added channels" estuary widget - much more simple compared to use the channels manager for this.

<img width="1710" alt="Screenshot_2025-01-20_at_16_55_34" src="https://github.com/user-attachments/assets/6908c645-0b2a-491b-95d6-3011b2ccba02" />

Runtime-tested on Android and macOS, latest master.

@phunkyfish could you please review?