### PR TITLE
[pvr] Show 'delete watched' context menu item only if recordings fold…

### DIFF
--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -432,8 +432,8 @@ bool UndeleteRecording::Execute(const CFileItemPtr& item) const
 bool DeleteWatchedRecordings::IsVisible(const CFileItem& item) const
 {
   // recordings folder?
-  if (item.m_bIsFolder && !item.IsParentFolder())
-    return CPVRRecordingsPath(item.GetPath()).IsValid();
+  if (item.m_bIsFolder && !item.IsParentFolder() && CPVRRecordingsPath(item.GetPath()).IsValid())
+    return item.GetProperty("watchedepisodes").asInteger() > 0;
 
   return false;
 }


### PR DESCRIPTION
…er contains watched recordings.

Just a small improvement to only show the 'delete watched' context menu item when there are watche drecordings inside the recordings folder.

Runtime-tested on macOS, latest master.

@phunkyfish should be easy to review I guess.