### PR TITLE
[Windows] Fix logic for rebuild FFmpeg

### DIFF
--- a/tools/buildsteps/windows/buildffmpeg.sh
+++ b/tools/buildsteps/windows/buildffmpeg.sh
@@ -116,6 +116,8 @@ cd $LOCALBUILDDIR
 
 do_clean_get $1
 [ -f config.mak ] && make distclean
+cleanLastSuccess $FFMPEGDESTDIR
+
 do_print_status "$LIBNAME-$VERSION (${TRIPLET})" "$blue_color" "Configuring"
 
 [[ -z "$extra_cflags" ]] && extra_cflags=-DPTW32_STATIC_LIB

--- a/tools/buildsteps/windows/buildhelpers.sh
+++ b/tools/buildsteps/windows/buildhelpers.sh
@@ -226,3 +226,12 @@ function extractPackage()
 
   echo $package
 }
+
+function cleanLastSuccess()
+{
+  local path="$1"
+  local file="$path/$PATH_CHANGE_REV_FILENAME"
+  if [[ -f $file ]]; then
+    rm $file
+  fi
+}


### PR DESCRIPTION
## Description
Fix logic for rebuild FFmpeg

## Motivation and context
This fixes a gap in the logic for rebuild FFmpeg when a build process is interrupted:

Rebuild or not depends on if state stored on file `.last_success_revision` (git hashes, FFmpeg version, dav1d version, etc. ) is consistent with current working dir contents and current git state.

But if `.last_success_revision` contents is valid and match current git BUT FFmpeg build is interrupted before finishing, FFmpeg libs not exist anymore because are cleaned before build start. `.last_success_revision` is created when build finalizes but may already exist from previous build...

The fix is remove `.last_success_revision` file when build starts, in this way if is interrupted is signaled that build is not valid, However, if it ends the file is recreated and is signaled that last build is OK.

## How has this been tested?
Tested locally:

Before --> is observed that `.last_success_revision` file is not removed (only is overwrite every time that FFmpeg build finishes).
After --> `.last_success_revision` is removed before start FFmpeg compilation and is recreated when build finalize OK.

## What is the effect on users?
Fixes that it is not possible to compile FFmpeg again when the build process is interrupted (unless manually clean up the folders).

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
