### PR TITLE
[PVR] Channel Manager: Fix channel details not updated when scroll bar has focus.

### DIFF
--- a/addons/skin.estuary/xml/DialogPVRChannelManager.xml
+++ b/addons/skin.estuary/xml/DialogPVRChannelManager.xml
@@ -199,7 +199,7 @@
 					<width>70</width>
 					<height>50</height>
 					<aspectratio>keep</aspectratio>
-					<texture background="true">$INFO[Container(20).ListItem.Property(icon)]</texture>
+					<texture background="true">$INFO[ListItem.Property(icon)]</texture>
 				</control>
 				<control type="grouplist" id="9003">
 					<top>590</top>


### PR DESCRIPTION
Fixes a glitch where the channel details data was not updated when scrolling through channels using channel manager dialog's scroll bar:

<img width="1710" alt="Screenshot 2025-01-21 at 08 49 07" src="https://github.com/user-attachments/assets/ea792a15-2b98-4e42-99b5-8eafbfd0803a" />

Runtime-tested on Android and macOS, latest master.

The Estuary fix is a no brainer, just a small logical glitch that can no longer happen with the core code fix of this PR.

@phunkyfish something for you to review. The actual code change is just to also update channel selection if the channel list does not have the focus, which is the case when using the scroll bar. The rest is only indentation and some non-functional code optimizations and C++ modernizations.