### PR TITLE
[pvr] fix typos

### DIFF
--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -189,7 +189,7 @@ public:
   std::string GetInstanceName() const;
 
   /*!
-   * @brief A name used to uniquely identify the client, inclusing addon name and instance
+   * @brief A name used to uniquely identify the client, including addon name and instance
    * name, if multiple instances are supported by the client implementation.
    * @return string that can be used in log messages and the GUI.
    */
@@ -1098,7 +1098,7 @@ private:
    */
   static void cb_epg_event_state_change(void* kodiInstance, EPG_TAG* tag, EPG_EVENT_STATE newState);
 
-  /*! @todo remove the use complete from them, or add as generl function?!
+  /*! @todo remove the use complete from them, or add as general function?!
    * Returns the ffmpeg codec id from given ffmpeg codec string name
    */
   static PVR_CODEC cb_get_codec_by_name(const void* kodiInstance, const char* strCodecName);

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -560,7 +560,7 @@ private:
       PVR_PROVIDER_INVALID_UID; /*!< the unique id for this provider from the client */
   int m_lastWatchedGroupId{
       -1}; /*!< the id of the channel group the channel was watched from the last time */
-  CDateTime m_dateTimeAdded; /*!< the date and time the channel was added to the TV datebase */
+  CDateTime m_dateTimeAdded; /*!< the date and time the channel was added to the TV database */
   //@}
 
   mutable CCriticalSection m_critSection;

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -380,7 +380,7 @@ public:
    * @brief Check whether at least one channel of this group is offered by the given provider.
    * @param clientId The clientId to check.
    * @param providerId The providerId to check.
-   * @return True, if the group countains at least one channel offered by the provider, false otherwise.
+   * @return True, if the group contains at least one channel offered by the provider, false otherwise.
    */
   bool HasChannelForProvider(int clientId, int providerId) const;
 

--- a/xbmc/pvr/channels/PVRChannelGroupAllChannelsSingleClient.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupAllChannelsSingleClient.cpp
@@ -53,7 +53,7 @@ std::vector<std::shared_ptr<CPVRChannelGroup>> CPVRChannelGroupAllChannelsSingle
       continue;
     }
 
-    // Create a group containg all channels for this client, if not yet existing.
+    // Create a group containing all channels for this client, if not yet existing.
     const auto it = std::find_if(allChannelGroups.cbegin(), allChannelGroups.cend(),
                                  [&client](const auto& group)
                                  {

--- a/xbmc/pvr/channels/PVRChannelGroupFactory.h
+++ b/xbmc/pvr/channels/PVRChannelGroupFactory.h
@@ -69,7 +69,7 @@ public:
       const std::shared_ptr<const CPVRChannelGroup>& allChannels);
 
   /*!
-   * @brief Get the priority (e.g. for sorting groups) for the type of the given group. Lower number means higer priority.
+   * @brief Get the priority (e.g. for sorting groups) for the type of the given group. Lower number means higher priority.
    * @param group The group.
    * @return The group's type priority.
    */

--- a/xbmc/pvr/channels/PVRChannelGroupMergedByName.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupMergedByName.cpp
@@ -88,9 +88,9 @@ std::vector<std::string> GetGroupNames(const std::vector<std::shared_ptr<CPVRCha
       {
         const auto it = knownNamesCountMap.find(groupName);
         if (it == knownNamesCountMap.end())
-          knownNamesCountMap.insert({groupName, 1}); // first occurance
+          knownNamesCountMap.insert({groupName, 1}); // first occurrence
         else if ((*it).second > 0)
-          (*it).second++; // second+ occurance
+          (*it).second++; // second+ occurrence
         break;
       }
       default:

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -225,7 +225,7 @@ namespace PVR
     bool QueueDeleteQueries(const std::shared_ptr<CPVREpgDatabase>& database);
 
     /*!
-     * @brief Get the start and end time of the last not yet commited entry in this table.
+     * @brief Get the start and end time of the last not yet committed entry in this table.
      * @return The times; first: start time, second: end time.
      */
     std::pair<CDateTime, CDateTime> GetFirstAndLastUncommitedEPGDate() const;

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -817,7 +817,7 @@ std::pair<CDateTime, CDateTime> CPVREpgContainer::GetFirstAndLastEPGDate() const
   if (database)
     dbDates = database->GetFirstAndLastEPGDate();
 
-  // Merge not yet commited changes
+  // Merge not yet committed changes
   m_critSection.lock();
   const auto epgs = m_epgIdToEpgMap;
   m_critSection.unlock();

--- a/xbmc/pvr/epg/EpgTagsContainer.h
+++ b/xbmc/pvr/epg/EpgTagsContainer.h
@@ -153,7 +153,7 @@ public:
   std::vector<std::shared_ptr<CPVREpgInfoTag>> GetAllTags() const;
 
   /*!
-   * @brief Get the start and end time of the last not yet commited entry in this EPG.
+   * @brief Get the start and end time of the last not yet committed entry in this EPG.
    * @return The times; first: start time, second: end time.
    */
   std::pair<CDateTime, CDateTime> GetFirstAndLastUncommitedEPGDate() const;

--- a/xbmc/pvr/guilib/PVRGUIActionsEPG.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsEPG.h
@@ -93,7 +93,7 @@ public:
    * @brief Get the title for the given EPG tag, taking settings and parental controls into account.
    * @param item The EPG tag.
    * @return "Parental locked" in case the access to the information is restricted by parental
-   * controls, "No information avilable" if the real EPG event title is empty and
+   * controls, "No information available" if the real EPG event title is empty and
    * SETTING_EPG_HIDENOINFOAVAILABLE is false or tag is nullptr, the real EPG event title as given
    * by the EPG data provider otherwise.
    */

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -349,7 +349,7 @@ public:
   const std::string& IconPath() const { return m_iconPath.GetLocalImage(); }
 
   /*!
-   * @brief Return the thumnail path used by Kodi.
+   * @brief Return the thumbnail path used by Kodi.
    * @return The path.
    */
   const std::string& ThumbnailPath() const { return m_thumbnailPath.GetLocalImage(); }

--- a/xbmc/pvr/settings/PVRSettings.cpp
+++ b/xbmc/pvr/settings/PVRSettings.cpp
@@ -212,7 +212,7 @@ bool CPVRSettings::IsSettingVisible(const std::string& condition,
   }
   else if (settingId == CSettings::SETTING_PVRMANAGER_CLIENTPRIORITIES)
   {
-    // Setting is only visible if more than one PVR client is enabeld.
+    // Setting is only visible if more than one PVR client is enabled.
     return CServiceBroker::GetPVRManager().Clients()->EnabledClientAmount() > 1;
   }
   else

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -259,7 +259,7 @@ public:
 
   /*!
    * @brief The index for the parent of this timer, as given by the client. Timers scheduled by a
-   * timer rule will have a parant index != PVR_TIMER_NO_PARENT.
+   * timer rule will have a parent index != PVR_TIMER_NO_PARENT.
    * @return The client index or PVR_TIMER_NO_PARENT if the timer has no parent.
    */
   int ParentClientIndex() const { return m_iParentClientIndex; }


### PR DESCRIPTION
## Description
Fixed typos in source comments and doxygen

Found via `codespell -q 3 -S "*.po,./lib/libUPnP/Neptune,./addons/webinterface.default/lang" -L als,bloaded,busses,inout,lod,medias,ot,parm,te`

## Motivation and context

Accuracy of documentation and code.

## How has this been tested?
n/a

## What is the effect on users?
no negative impacts

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
