### PR TITLE
[Addons] fix doxygen typos and grammar

### DIFF
--- a/xbmc/addons/kodi-dev-kit/doxygen/Skin/skin.dox
+++ b/xbmc/addons/kodi-dev-kit/doxygen/Skin/skin.dox
@@ -21,7 +21,7 @@ or two by adding a button, or altering the textures or layout.
 
 - \subpage skin_controls - Controls are the substance of your skin.
 - \subpage window_ids - List of available window names, definitions, IDs and the matching XML-file
-- \subpage Skin_Timers - Programatic time-based objects for Skins
+- \subpage Skin_Timers - Programmatic time-based objects for Skins
 
 */
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/Filesystem.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/Filesystem.h
@@ -568,8 +568,8 @@ public:
   //----------------------------------------------------------------------------
 
   //============================================================================
-  // @note Not for addon development itself needed, thats why below is
-  // disabled for doxygen!
+  // @note Not necessary for addon development, therefore it's 
+  // disabled for doxygen below!
   //
   // @ingroup cpp_kodi_vfs_CDirEntry
   // @brief Constructor to create own copy
@@ -1148,7 +1148,7 @@ inline std::string ATTR_DLL_LOCAL GetFileMD5(const std::string& path)
 /// std::string thumb;
 /// std::string filename;
 /// if (kodi::gui::DialogFileBrowser::ShowAndGetFile("local", "*.avi|*.mpg|*.mp4",
-///                                                "Test File selection to get Thumnail",
+///                                                "Test File selection to get Thumbnail",
 ///                                                filename))
 /// {
 ///   thumb = kodi::vfs::GetCacheThumbName(filename);

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Game.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Game.h
@@ -1020,7 +1020,7 @@ public:
   /// @brief Resets the runtime. Must be called each time a new rom is starting
   ///        and when the savestate is changed
   ///
-  /// @return the error, or GAME_ERROR_NO_ERROR if the runtim was reseted
+  /// @return the error, or GAME_ERROR_NO_ERROR if the runtime was reset
   ///         successfully
   ///
   virtual GAME_ERROR RCResetRuntime() { return GAME_ERROR_NOT_IMPLEMENTED; }

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/General.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/General.h
@@ -316,7 +316,7 @@ public:
   ///
   /// @param[in] settingValues possible setting values
   /// @param[in] defaultValue default setting value
-  /// @param[in] minValue minimim setting value
+  /// @param[in] minValue minimum setting value
   /// @param[in] step amount to change values from min to max
   /// @param[in] maxValue maximum setting value
   PVRIntSettingDefinition(const std::vector<PVRTypeIntValue>& settingValues,

--- a/xbmc/addons/kodi-dev-kit/include/kodi/gui/controls/SettingsSlider.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/gui/controls/SettingsSlider.h
@@ -183,7 +183,7 @@ public:
   /// becomes changed with this function will a step of the user with the
   /// value fixed here be executed.
   ///
-  /// @param[in] interval Intervall step to set.
+  /// @param[in] interval interval step to set.
   ///
   /// @note Percent, floating point or integer are alone possible. Combining
   /// these different values can be not together and can, therefore, only
@@ -293,7 +293,7 @@ public:
   /// becomes changed with this function will a step of the user with the
   /// value fixed here be executed.
   ///
-  /// @param[in] interval Intervall step to set.
+  /// @param[in] interval interval step to set.
   ///
   /// @note Percent, floating point or integer are alone possible. Combining
   /// these different values can be not together and can, therefore, only

--- a/xbmc/addons/kodi-dev-kit/include/kodi/gui/controls/Slider.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/gui/controls/Slider.h
@@ -195,7 +195,7 @@ public:
   /// becomes changed with this function will a step of the user with the
   /// value fixed here be executed.
   ///
-  /// @param[in] interval Intervall step to set.
+  /// @param[in] interval interval step to set.
   ///
   /// @note Percent, floating point or integer are alone possible. Combining
   /// these different values can be not together and can, therefore, only one
@@ -305,7 +305,7 @@ public:
   /// becomes changed with this function will a step of the user with the
   /// value fixed here be executed.
   ///
-  /// @param[in] interval Intervall step to set.
+  /// @param[in] interval interval step to set.
   ///
   /// @note Percent, floating point or integer are alone possible. Combining
   /// these different values can be not together and can, therefore, only

--- a/xbmc/addons/kodi-dev-kit/include/kodi/gui/controls/Spin.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/gui/controls/Spin.h
@@ -394,7 +394,7 @@ public:
   /// becomes changed with this function will a step of the user with the
   /// value fixed here be executed.
   ///
-  /// @param[in] interval Intervall step to set.
+  /// @param[in] interval interval step to set.
   ///
   /// @note Percent, floating point or integer are alone possible. Combining
   /// these different values can be not together and can, therefore, only

--- a/xbmc/addons/kodi-dev-kit/include/kodi/gui/dialogs/Select.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/gui/dialogs/Select.h
@@ -40,7 +40,7 @@ typedef struct SSelectionEntry
   SSelectionEntry() = default;
   /*! \endcond */
 
-  /// Entry identfication string
+  /// Entry identification string
   std::string id;
 
   /// Entry name to show on GUI dialog


### PR DESCRIPTION
## Description
Typo fixes for code documentation like doxygen. Also includes a grammatical fix.

## Motivation and context
Improve documentation quality

## How has this been tested?
n/a

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
