### PR TITLE
[PVR] Use default play action processor to trigger playback of recordings.

### DIFF
--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -555,7 +555,6 @@ int PlayOrQueueMedia(const std::vector<std::string>& params,
       return false;
     }
   }
-  item.SetProperty("check_resume", false);
 
   if (!forcePlay /* queue */ || item.m_bIsFolder || PLAYLIST::IsPlayList(item))
   {

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -939,7 +939,7 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
 
     CFileItem recItem{recording};
     HandleResumeOption(optionResume, recItem);
-    if (!CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayRecording(recItem, false))
+    if (!CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayMedia(recItem))
       return FailedToExecute;
 
     return ACK;
@@ -992,8 +992,7 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
 
         CFileItem recItem{recording};
         HandleResumeOption(optionResume, recItem);
-        if (!CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayRecording(recItem,
-                                                                                     false))
+        if (!CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayMedia(recItem))
           return FailedToExecute;
       }
       else

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -33,6 +33,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/URIUtils.h"
+#include "video/guilib/VideoPlayActionProcessor.h"
 
 #include <memory>
 #include <string>
@@ -178,8 +179,13 @@ bool PlayRecording::IsVisible(const CFileItem& item) const
 
 bool PlayRecording::Execute(const CFileItemPtr& item) const
 {
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayRecording(
-      *item, true /* bCheckResume */);
+  const std::shared_ptr<CPVRRecording> recording{
+      CServiceBroker::GetPVRManager().Recordings()->GetRecordingForEpgTag(item->GetEPGInfoTag())};
+  if (!recording)
+    return false;
+
+  KODI::VIDEO::GUILIB::CVideoPlayActionProcessor proc{std::make_shared<CFileItem>(recording)};
+  return proc.ProcessDefaultAction();
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -251,8 +251,7 @@ void CGUIDialogPVRChannelsOSD::GotoChannel(int iItem)
           CSettings::SETTING_PVRMENU_CLOSECHANNELOSDONSWITCH))
     Close();
 
-  CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
-      *item, true /* bCheckResume */);
+  CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(*item);
 }
 
 void CGUIDialogPVRChannelsOSD::Notify(const PVREvent& event)

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -154,8 +154,7 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonPlay(const CGUIMessage& message)
       }
       else
       {
-        CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
-            *m_progItem, true /* bCheckResume */);
+        CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(*m_progItem);
       }
       bReturn = true;
     }

--- a/xbmc/pvr/guilib/PVRGUIActionListener.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionListener.cpp
@@ -294,7 +294,7 @@ bool CPVRGUIActionListener::OnAction(const CAction& action)
         return false;
 
       CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
-          CFileItem(groupMember), false);
+          CFileItem(groupMember));
       return true;
     }
 

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.h
@@ -34,10 +34,9 @@ public:
   /*!
    * @brief Play recording.
    * @param item containing a recording or an epg tag.
-   * @param bCheckResume controls resume check.
    * @return true on success, false otherwise.
    */
-  bool PlayRecording(const CFileItem& item, bool bCheckResume) const;
+  bool PlayRecording(const CFileItem& item) const;
 
   /*!
    * @brief Play EPG tag.
@@ -52,11 +51,9 @@ public:
   /*!
    * @brief Switch channel.
    * @param item containing a channel or an epg tag.
-   * @param bCheckResume controls resume check in case a recording for the current epg event is
-   * present.
    * @return true on success, false otherwise.
    */
-  bool SwitchToChannel(const CFileItem& item, bool bCheckResume) const;
+  bool SwitchToChannel(const CFileItem& item) const;
 
   /*!
    * @brief Playback the given file item.
@@ -98,14 +95,6 @@ public:
 private:
   CPVRGUIActionsPlayback(const CPVRGUIActionsPlayback&) = delete;
   CPVRGUIActionsPlayback const& operator=(CPVRGUIActionsPlayback const&) = delete;
-
-  /*!
-   * @brief Check whether resume play is possible for a given item, display "resume from ..."/"play
-   * from start" context menu in case.
-   * @param item containing a recording or an epg tag.
-   * @return true, to play/resume the item, false otherwise.
-   */
-  bool CheckResumeRecording(const CFileItem& item) const;
 
   /*!
    * @brief Check "play minimized" settings value and switch to fullscreen if not set.

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
@@ -1034,7 +1034,7 @@ void CPVRGUIActionsTimers::AnnounceReminder(const std::shared_ptr<CPVRTimerInfoT
     if (groupMember)
     {
       CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
-          CFileItem(groupMember), false);
+          CFileItem(groupMember));
 
       if (bAutoClosed)
       {

--- a/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
@@ -246,7 +246,7 @@ void CPVRGUIChannelNavigator::SwitchToCurrentChannel()
     item = std::make_unique<CFileItem>(m_currentChannel);
   }
 
-  CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(*item, false);
+  CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(*item);
 }
 
 bool CPVRGUIChannelNavigator::IsPreview() const

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -219,7 +219,7 @@ bool CGUIWindowPVRChannelsBase::OnMessage(CGUIMessage& message)
             case ACTION_MOUSE_LEFT_CLICK:
             case ACTION_PLAYER_PLAY:
               CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
-                  *(m_vecItems->Get(iItem)), true);
+                  *(m_vecItems->Get(iItem)));
               break;
             case ACTION_SHOW_INFO:
               CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -252,8 +252,6 @@ enum class PlayMode
 
 void SetPathAndPlay(const std::shared_ptr<CFileItem>& item, PlayMode mode)
 {
-  item->SetProperty("check_resume", false);
-
   if (item->IsLiveTV()) // pvr tv or pvr radio?
   {
     g_application.PlayMedia(*item, "", PLAYLIST::Id::TYPE_VIDEO);


### PR DESCRIPTION
Fixes default play action setting not respected for some use cases. Also makes an item property hack ("check_resume") obsolete.

Runtime-tested on macOS and Android, latest master.

@phunkyfish could you have a look please.