### PR TITLE
[Backport][Peripherals] Backport fixes for Peripheral Dialog

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6643,7 +6643,6 @@ msgstr ""
 #: xbmc/addons/gui/GUIDialogAddonSettings.cpp
 #: xbmc/music/MusicDatabase.cpp
 #: xbmc/peripherals/bus/PeripheralBus.cpp
-#: xbmc/peripherals/devices/Peripheral.cpp
 #: xbmc/platform/win32/WIN32Util.cpp
 #: xbmc/pvr/addons/PVRClients.cpp
 #: xbmc/pvr/channels/PVRChannel.cpp

--- a/addons/skin.estuary/xml/DialogSettings.xml
+++ b/addons/skin.estuary/xml/DialogSettings.xml
@@ -68,7 +68,7 @@
 				<top>92</top>
 				<orientation>vertical</orientation>
 				<width>300</width>
-				<height>250</height>
+				<height>280</height>
 				<itemgap>-10</itemgap>
 				<onleft>5</onleft>
 				<onright>5</onright>

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -64,8 +64,17 @@
 
   <peripheral class="joystick" name="joystick" mapTo="joystick">
     <setting key="appearance" type="addon" addontype="kodi.game.controller" label="480" order="1"/>
+    <setting key="last_active" type="string" value="" configurable="0"/>
     <setting key="left_stick_deadzone" type="float" label="35078" order="2" value="0.2" min="0.0" step="0.05" max="1.0" />
     <setting key="right_stick_deadzone" type="float" label="35079" order="3" value="0.2" min="0.0" step="0.05" max="1.0" />
+  </peripheral>
+
+  <peripheral class="keyboard" name="keyboard" mapTo="keyboard">
+    <setting key="last_active" type="string" value="" configurable="0"/>
+  </peripheral>
+
+  <peripheral class="mouse" name="mouse" mapTo="mouse">
+    <setting key="last_active" type="string" value="" configurable="0"/>
   </peripheral>
 
 </peripherals>

--- a/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
@@ -526,7 +526,11 @@ int CGUIWindowAddonBrowser::SelectAddonID(const std::vector<AddonType>& types,
   for (const auto& addon : addons)
   {
     const CFileItemPtr item(CAddonsDirectory::FileItemFromAddon(addon, addon->ID()));
-    item->SetLabel2(addon->Summary());
+
+    // Game controllers don't have specific summaries
+    if (addon->Type() != AddonType::GAME_CONTROLLER)
+      item->SetLabel2(addon->Summary());
+
     if (!items.Contains(item->GetPath()))
     {
       items.Add(item);

--- a/xbmc/games/agents/input/AgentInput.cpp
+++ b/xbmc/games/agents/input/AgentInput.cpp
@@ -105,13 +105,11 @@ void CAgentInput::Refresh()
 {
   if (m_gameClient)
   {
-    // Open keyboard
-    if (m_bHasKeyboard)
-      ProcessKeyboard();
+    // Process keyboard
+    ProcessKeyboard();
 
-    // Open mouse
-    if (m_bHasMouse)
-      ProcessMouse();
+    // Process mouse
+    ProcessMouse();
 
     // Open/close joysticks
     PERIPHERALS::EventLockHandlePtr inputHandlingLock;
@@ -431,6 +429,10 @@ void CAgentInput::ProcessAgentControllers(const PERIPHERALS::PeripheralVector& p
   // Handle new and existing controllers
   for (const auto& peripheral : peripherals)
   {
+    // Skip peripherals that have never been active
+    if (!peripheral->LastActive().IsValid())
+      continue;
+
     // Check if controller already exists
     auto it = std::find_if(m_controllers.begin(), m_controllers.end(),
                            [&peripheral](const std::shared_ptr<CAgentController>& controller) {

--- a/xbmc/games/agents/windows/GUIAgentControllerList.cpp
+++ b/xbmc/games/agents/windows/GUIAgentControllerList.cpp
@@ -269,7 +269,7 @@ void CGUIAgentControllerList::OnControllerSelect(const CFileItem& selectedAgentI
     PERIPHERALS::PeripheralPtr peripheral = agentController->GetPeripheral();
     if (peripheral && peripheral->Location() == selectedAgentItem.GetPath())
     {
-      if (peripheral->GetSettings().empty())
+      if (!peripheral->HasConfigurableSettings())
       {
         // Show an error if the peripheral doesn't have any settings
         CLog::Log(LOGERROR, "Peripheral has no settings");

--- a/xbmc/games/controllers/Controller.cpp
+++ b/xbmc/games/controllers/Controller.cpp
@@ -132,8 +132,7 @@ bool CController::LoadLayout(void)
     }
 
     auto* pRootElement = xmlDoc.RootElement();
-    if (pRootElement == nullptr || pRootElement->NoChildren() ||
-        std::strcmp(pRootElement->Value(), LAYOUT_XML_ROOT) != 0)
+    if (pRootElement == nullptr || std::strcmp(pRootElement->Value(), LAYOUT_XML_ROOT) != 0)
     {
       CLog::Log(LOGERROR, "Can't find root <{}> tag", LAYOUT_XML_ROOT);
       return false;

--- a/xbmc/games/controllers/ControllerManager.cpp
+++ b/xbmc/games/controllers/ControllerManager.cpp
@@ -35,6 +35,9 @@ ControllerPtr CControllerManager::GetController(const std::string& controllerId)
 {
   using namespace ADDON;
 
+  if (controllerId.empty())
+    return {};
+
   std::lock_guard<CCriticalSection> lock(m_mutex);
 
   ControllerPtr& cachedController = m_cache[controllerId];

--- a/xbmc/games/controllers/guicontrols/GUIGameController.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.cpp
@@ -16,6 +16,7 @@
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerLayout.h"
 #include "guilib/GUIListItem.h"
+#include "guilib/GUITexture.h"
 #include "utils/log.h"
 
 #include <algorithm>
@@ -36,6 +37,9 @@ CGUIGameController::CGUIGameController(int parentID,
 {
   // Initialize CGUIControl
   ControlType = GUICONTROL_GAMECONTROLLER;
+
+  // Initialize CGUIImage
+  SetAspectRatio(CAspectRatio::AR_KEEP);
 }
 
 CGUIGameController::CGUIGameController(const CGUIGameController& from)
@@ -51,6 +55,9 @@ CGUIGameController::CGUIGameController(const CGUIGameController& from)
 {
   // Initialize CGUIControl
   ControlType = GUICONTROL_GAMECONTROLLER;
+
+  // Initialize CGUIImage
+  SetAspectRatio(CAspectRatio::AR_KEEP);
 }
 
 CGUIGameController* CGUIGameController::Clone(void) const

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -311,13 +311,19 @@ void CPeripheralBus::GetDirectory(const std::string& strPath, CFileItemList& ite
                                 PeripheralTypeTranslator::TypeToString(peripheral->Type()));
 
     std::string strVersion(peripheral->GetVersionInfo());
-    if (strVersion.empty())
-      strVersion = g_localizeStrings.Get(13205);
 
-    std::string strDetails = StringUtils::Format("{} {}", g_localizeStrings.Get(24051), strVersion);
+    std::string strDetails;
+
     if (peripheral->GetBusType() == PERIPHERAL_BUS_CEC && !peripheral->GetSettingBool("enabled"))
       strDetails =
           StringUtils::Format("{}: {}", g_localizeStrings.Get(126), g_localizeStrings.Get(13106));
+
+    if (strDetails.empty())
+    {
+      std::string strVersion(peripheral->GetVersionInfo());
+      if (!strVersion.empty())
+        strDetails = StringUtils::Format("{} {}", g_localizeStrings.Get(24051), strVersion);
+    }
 
     peripheralFile->SetProperty("version", strVersion);
     peripheralFile->SetLabel2(strDetails);

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -42,6 +42,7 @@ namespace
 {
 // Settings for peripherals
 constexpr std::string_view SETTING_APPEARANCE = "appearance";
+constexpr std::string_view SETTING_LAST_ACTIVE = "last_active";
 
 struct SortBySettingsOrder
 {
@@ -176,8 +177,10 @@ bool CPeripheral::Initialise(void)
           CUtil::MakeLegalFileName(std::move(safeDeviceName), LEGAL_WIN32_COMPAT));
   }
 
+  // Load settings and initialize state
   LoadPersistedSettings();
 
+  // Initialize features
   for (unsigned int iFeaturePtr = 0; iFeaturePtr < m_features.size(); iFeaturePtr++)
   {
     PeripheralFeature feature = m_features.at(iFeaturePtr);
@@ -492,6 +495,13 @@ bool CPeripheral::SetSetting(const std::string& strKey, const std::string& strVa
         stringSetting->SetValue(strValue);
         if (bChanged && m_bInitialised)
           m_changedSettings.insert(strKey);
+
+        if (strKey == SETTING_LAST_ACTIVE && !strValue.empty())
+        {
+          CDateTime lastActive;
+          lastActive.SetFromW3CDateTime(strValue, false);
+          SetLastActive(lastActive);
+        }
       }
     }
     else if ((*it).second.m_setting->GetType() == SettingType::Integer)
@@ -817,5 +827,33 @@ bool CPeripheral::operator!=(const PeripheralScanResult& right) const
 
 CDateTime CPeripheral::LastActive() const
 {
-  return CDateTime();
+  // By default, peripherals are fully-activated
+  return CDateTime::GetCurrentDateTime();
+}
+
+void CPeripheral::SetLastActive(const CDateTime& lastActive)
+{
+  // Update last active setting
+  const std::string strKey{SETTING_LAST_ACTIVE};
+
+  auto it = m_settings.find(strKey);
+  if (it != m_settings.end() && it->second.m_setting->GetType() == SettingType::String)
+  {
+    std::shared_ptr<CSettingString> stringSetting =
+        std::static_pointer_cast<CSettingString>(it->second.m_setting);
+
+    const bool wasActive = !stringSetting->GetValue().empty();
+
+    const std::string lastActiveStr = lastActive.IsValid() ? lastActive.GetAsW3CDateTime() : "";
+
+    stringSetting->SetValue(lastActiveStr);
+
+    // Notify listeners if a peripheral was activated for the first time
+    if (!wasActive & lastActive.IsValid())
+    {
+      m_manager.SetChanged(true);
+      m_manager.NotifyObservers(ObservableMessagePeripheralsChanged);
+      PersistSettings();
+    }
+  }
 }

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -63,7 +63,6 @@ CPeripheral::CPeripheral(CPeripherals& manager,
     m_strDeviceName(scanResult.m_strDeviceName),
     m_iVendorId(scanResult.m_iVendorId),
     m_iProductId(scanResult.m_iProductId),
-    m_strVersionInfo(g_localizeStrings.Get(13205)), // "unknown"
     m_bus(bus)
 {
   PeripheralTypeTranslator::FormatHexString(scanResult.m_iVendorId, m_strVendorId);

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -265,6 +265,13 @@ public:
   virtual CDateTime LastActive() const;
 
   /*!
+   * \brief Set the last time this peripheral was active
+   *
+   * \param lastActive The time of last activation, or invalid if unknown/never active
+   */
+  virtual void SetLastActive(const CDateTime& lastActive);
+
+  /*!
    * \brief Get the controller profile that best represents this peripheral
    *
    * \return The controller profile, or empty if unknown

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -272,7 +272,9 @@ void CPeripheralJoystick::SetControllerProfile(const KODI::GAME::ControllerPtr& 
   // Save preference to buttonmap
   if (m_buttonMap)
   {
-    if (m_buttonMap->SetAppearance(controller->ID()))
+    const std::string controllerId = controller ? controller->ID() : "";
+
+    if (m_buttonMap->SetAppearance(controllerId))
       m_buttonMap->SaveButtonMap();
   }
 }

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -243,6 +243,15 @@ KEYMAP::IKeymap* CPeripheralJoystick::GetKeymap(const std::string& controllerId)
   return m_appInput->GetKeymap(controllerId);
 }
 
+void CPeripheralJoystick::SetLastActive(const CDateTime& lastActive)
+{
+  // Update state
+  m_lastActive = lastActive;
+
+  // Update ancestor
+  CPeripheral::SetLastActive(lastActive);
+}
+
 GAME::ControllerPtr CPeripheralJoystick::ControllerProfile() const
 {
   // Button map has the freshest state
@@ -292,9 +301,10 @@ bool CPeripheralJoystick::OnButtonMotion(unsigned int buttonIndex, bool bPressed
   if (bPressed && !g_application.IsAppFocused())
     return false;
 
-  m_lastActive = CDateTime::GetCurrentDateTime();
-
   std::unique_lock<CCriticalSection> lock(m_handlerMutex);
+
+  // Update state
+  SetLastActive(CDateTime::GetCurrentDateTime());
 
   // Check GUI setting and send button release if controllers are disabled
   if (!m_manager.GetInputManager().IsControllerEnabled())
@@ -348,7 +358,8 @@ bool CPeripheralJoystick::OnHatMotion(unsigned int hatIndex, HAT_STATE state)
   if (state != HAT_STATE::NONE && !g_application.IsAppFocused())
     return false;
 
-  m_lastActive = CDateTime::GetCurrentDateTime();
+  // Update state
+  SetLastActive(CDateTime::GetCurrentDateTime());
 
   std::unique_lock<CCriticalSection> lock(m_handlerMutex);
 
@@ -445,8 +456,9 @@ bool CPeripheralJoystick::OnAxisMotion(unsigned int axisIndex, float position)
     }
   }
 
+  // Update state
   if (bHandled)
-    m_lastActive = CDateTime::GetCurrentDateTime();
+    SetLastActive(CDateTime::GetCurrentDateTime());
 
   return bHandled;
 }

--- a/xbmc/peripherals/devices/PeripheralJoystick.h
+++ b/xbmc/peripherals/devices/PeripheralJoystick.h
@@ -65,6 +65,7 @@ public:
   KODI::JOYSTICK::IDriverReceiver* GetDriverReceiver() override { return this; }
   KODI::KEYMAP::IKeymap* GetKeymap(const std::string& controllerId) override;
   CDateTime LastActive() const override { return m_lastActive; }
+  void SetLastActive(const CDateTime& lastActive) override;
   KODI::GAME::ControllerPtr ControllerProfile() const override;
   void SetControllerProfile(const KODI::GAME::ControllerPtr& controller) override;
 

--- a/xbmc/peripherals/devices/PeripheralKeyboard.cpp
+++ b/xbmc/peripherals/devices/PeripheralKeyboard.cpp
@@ -79,6 +79,15 @@ void CPeripheralKeyboard::UnregisterKeyboardDriverHandler(
     m_keyboardHandlers.erase(it);
 }
 
+void CPeripheralKeyboard::SetLastActive(const CDateTime& lastActive)
+{
+  // Update state
+  m_lastActive = lastActive;
+
+  // Update ancestor
+  CPeripheral::SetLastActive(lastActive);
+}
+
 GAME::ControllerPtr CPeripheralKeyboard::ControllerProfile() const
 {
   if (m_controllerProfile)
@@ -89,9 +98,10 @@ GAME::ControllerPtr CPeripheralKeyboard::ControllerProfile() const
 
 bool CPeripheralKeyboard::OnKeyPress(const CKey& key)
 {
-  m_lastActive = CDateTime::GetCurrentDateTime();
-
   std::unique_lock<CCriticalSection> lock(m_mutex);
+
+  // Update state
+  SetLastActive(CDateTime::GetCurrentDateTime());
 
   bool bHandled = false;
 

--- a/xbmc/peripherals/devices/PeripheralKeyboard.h
+++ b/xbmc/peripherals/devices/PeripheralKeyboard.h
@@ -35,6 +35,7 @@ public:
                                      bool bPromiscuous) override;
   void UnregisterKeyboardDriverHandler(KODI::KEYBOARD::IKeyboardDriverHandler* handler) override;
   CDateTime LastActive() const override { return m_lastActive; }
+  void SetLastActive(const CDateTime& lastActive) override;
   KODI::GAME::ControllerPtr ControllerProfile() const override;
 
   // implementation of IKeyboardDriverHandler

--- a/xbmc/peripherals/devices/PeripheralMouse.cpp
+++ b/xbmc/peripherals/devices/PeripheralMouse.cpp
@@ -72,6 +72,15 @@ void CPeripheralMouse::UnregisterMouseDriverHandler(MOUSE::IMouseDriverHandler* 
     m_mouseHandlers.erase(it);
 }
 
+void CPeripheralMouse::SetLastActive(const CDateTime& lastActive)
+{
+  // Update state
+  m_lastActive = lastActive;
+
+  // Update ancestor
+  CPeripheral::SetLastActive(lastActive);
+}
+
 GAME::ControllerPtr CPeripheralMouse::ControllerProfile() const
 {
   if (m_controllerProfile)
@@ -104,17 +113,19 @@ bool CPeripheralMouse::OnPosition(int x, int y)
     }
   }
 
+  // Update state
   if (bHandled)
-    m_lastActive = CDateTime::GetCurrentDateTime();
+    SetLastActive(CDateTime::GetCurrentDateTime());
 
   return bHandled;
 }
 
 bool CPeripheralMouse::OnButtonPress(MOUSE::BUTTON_ID button)
 {
-  m_lastActive = CDateTime::GetCurrentDateTime();
-
   std::unique_lock<CCriticalSection> lock(m_mutex);
+
+  // Update state
+  SetLastActive(CDateTime::GetCurrentDateTime());
 
   bool bHandled = false;
 

--- a/xbmc/peripherals/devices/PeripheralMouse.h
+++ b/xbmc/peripherals/devices/PeripheralMouse.h
@@ -35,6 +35,7 @@ public:
                                   bool bPromiscuous) override;
   void UnregisterMouseDriverHandler(KODI::MOUSE::IMouseDriverHandler* handler) override;
   CDateTime LastActive() const override { return m_lastActive; }
+  void SetLastActive(const CDateTime& lastActive) override;
   KODI::GAME::ControllerPtr ControllerProfile() const override;
 
   // implementation of IMouseDriverHandler

--- a/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
@@ -184,13 +184,4 @@ void CGUIDialogPeripherals::UpdatePeripheralsSync()
   m_peripherals.Clear();
   m_manager->GetDirectory("peripherals://all/", m_peripherals);
   SetItems(m_peripherals);
-
-  if (selectedItem)
-  {
-    for (int i = 0; i < m_peripherals.Size(); i++)
-    {
-      if (m_peripherals[i]->GetPath() == selectedItem->GetPath())
-        SetSelected(i);
-    }
-  }
 }

--- a/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
@@ -96,7 +96,7 @@ void CGUIDialogPeripherals::Show(CPeripherals& manager)
 
       // Show an error if the peripheral doesn't have any settings
       PeripheralPtr peripheral = manager.GetByPath(pItem->GetPath());
-      if (!peripheral || peripheral->GetSettings().empty())
+      if (!peripheral || !peripheral->HasConfigurableSettings())
       {
         MESSAGING::HELPERS::ShowOKDialogText(CVariant{35000}, CVariant{35004});
         continue;
@@ -133,8 +133,10 @@ bool CGUIDialogPeripherals::OnMessage(CGUIMessage& message)
     case GUI_MSG_REFRESH_LIST:
     {
       if (m_manager && message.GetControlId() == -1)
+      {
         UpdatePeripheralsSync();
-      return true;
+        return true;
+      }
     }
     default:
       break;


### PR DESCRIPTION
## Description

This PR contains only the fixes from the upstream Peripheral Dialog PRs:

* https://github.com/xbmc/xbmc/pull/26290
* https://github.com/xbmc/xbmc/pull/26315
* https://github.com/xbmc/xbmc/pull/26323

## Motivation and context

These fixes should be harmless for Omega. If there is a problem, we'll catch it early.

Not backported is the fix from https://github.com/xbmc/xbmc/pull/26286, because it involves some non-fix additions. However, if a dialog fix is introduced with rebase conflicts due to https://github.com/xbmc/xbmc/pull/26286, then it might be appropriate to backport.

## How has this been tested?

Fixes are included in latest round of RetroPlayer test builds: https://github.com/garbear/xbmc/releases

## What is the effect on users?

* Minor fixes for Peripherals Dialog

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
