### PR TITLE
[PVR] Fix playback of PVR recordings provided by add-ons implementing URL-based playback.

### DIFF
--- a/xbmc/filesystem/IDirectory.h
+++ b/xbmc/filesystem/IDirectory.h
@@ -141,7 +141,7 @@ public:
   \param item The item being manipulated (which the path points to a vfs protocol implementation)
   \return true if the item was resolved, false if it failed to resolve
   */
-  virtual bool Resolve(CFileItem& item) const { return true; };
+  virtual bool Resolve(CFileItem& item) const { return true; }
 
 protected:
   /*! \brief Prompt the user for some keyboard input

--- a/xbmc/filesystem/PVRDirectory.cpp
+++ b/xbmc/filesystem/PVRDirectory.cpp
@@ -23,6 +23,11 @@ bool CPVRDirectory::Exists(const CURL& url)
   return dir.Exists();
 }
 
+bool CPVRDirectory::Resolve(CFileItem& item) const
+{
+  return CPVRGUIDirectory::Resolve(item);
+}
+
 bool CPVRDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   const CPVRGUIDirectory dir(url);

--- a/xbmc/filesystem/PVRDirectory.h
+++ b/xbmc/filesystem/PVRDirectory.h
@@ -23,6 +23,7 @@ public:
   bool AllowAll() const override { return true; }
   CacheType GetCacheType(const CURL& url) const override { return CacheType::NEVER; }
   bool Exists(const CURL& url) override;
+  bool Resolve(CFileItem& item) const override;
 
   static bool SupportsWriteFileOperations(const std::string& strPath);
 

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -643,7 +643,18 @@ int PlayOrQueueMedia(const std::vector<std::string>& params,
 
   if (forcePlay)
   {
-    CPlayerUtils::PlayMedia(std::make_shared<CFileItem>(item), "", GetPlayListId(item));
+    if ((MUSIC::IsAudio(item) || VIDEO::IsVideo(item)) && !PLAYLIST::IsSmartPlayList(item) &&
+        !item.IsPVR())
+    {
+      if (!item.HasProperty("playlist_type_hint"))
+        item.SetProperty("playlist_type_hint", static_cast<int>(GetPlayListId(item)));
+
+      CServiceBroker::GetPlaylistPlayer().Play(std::make_shared<CFileItem>(item), "");
+    }
+    else
+    {
+      g_application.PlayMedia(item, "", GetPlayListId(item));
+    }
   }
   else
   {

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -763,20 +763,10 @@ void PlayItem(const std::shared_ptr<CFileItem>& itemIn,
     else // mode == PlayMode::PLAY_ONLY_THIS
     {
       // song, so just play it
-
-      //! @todo get rid of special treatment for some media
-      //! logic "borrowed" from PlayerBuiltins.cpp -> PlayOrQueueMedia()
-      if (item->IsPVR() || PLAYLIST::IsSmartPlayList(*item))
-      {
-        g_application.PlayMedia(*item, player, PLAYLIST::Id::TYPE_NONE);
-      }
-      else
-      {
-        auto& playlistPlayer = CServiceBroker::GetPlaylistPlayer();
-        playlistPlayer.Reset();
-        playlistPlayer.SetCurrentPlaylist(PLAYLIST::Id::TYPE_NONE);
-        playlistPlayer.Play(item, player);
-      }
+      auto& playlistPlayer = CServiceBroker::GetPlaylistPlayer();
+      playlistPlayer.Reset();
+      playlistPlayer.SetCurrentPlaylist(PLAYLIST::Id::TYPE_NONE);
+      playlistPlayer.Play(item, player);
     }
   }
 }

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -42,7 +42,6 @@
 #include "threads/IRunnable.h"
 #include "utils/FileUtils.h"
 #include "utils/JobManager.h"
-#include "utils/PlayerUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -764,7 +763,20 @@ void PlayItem(const std::shared_ptr<CFileItem>& itemIn,
     else // mode == PlayMode::PLAY_ONLY_THIS
     {
       // song, so just play it
-      CPlayerUtils::PlayMedia(item, player, PLAYLIST::Id::TYPE_NONE);
+
+      //! @todo get rid of special treatment for some media
+      //! logic "borrowed" from PlayerBuiltins.cpp -> PlayOrQueueMedia()
+      if (item->IsPVR() || PLAYLIST::IsSmartPlayList(*item))
+      {
+        g_application.PlayMedia(*item, player, PLAYLIST::Id::TYPE_NONE);
+      }
+      else
+      {
+        auto& playlistPlayer = CServiceBroker::GetPlaylistPlayer();
+        playlistPlayer.Reset();
+        playlistPlayer.SetCurrentPlaylist(PLAYLIST::Id::TYPE_NONE);
+        playlistPlayer.Play(item, player);
+      }
     }
   }
 }

--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h"
 #include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "threads/CriticalSection.h"
 #include "utils/ContentUtils.h"
@@ -52,6 +51,14 @@ public:
   void ReInit();
 
   /*!
+   * @brief Inform that playback of an item is going to happen.
+   * Add any info to the item that is needed for playback, e.g. add dyn path and properties
+   * @param item The item that shall be played.
+   * @return True on success, false otherwise.
+   */
+  bool OnPreparePlayback(CFileItem& item);
+
+  /*!
    * @brief Inform that playback of an item just started.
    * @param item The item that started to play.
    */
@@ -76,9 +83,7 @@ public:
    * @param item containing a channel, a recording or an epg tag.
    * @param mode playback mode.
    */
-  void StartPlayback(std::unique_ptr<CFileItem>& item,
-                     ContentUtils::PlayMode mode,
-                     PVR_SOURCE source) const;
+  void StartPlayback(std::unique_ptr<CFileItem>& item, ContentUtils::PlayMode mode) const;
 
   /*!
    * @brief Check if a TV channel, radio channel or recording is playing.

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -16,6 +16,7 @@
 #include "input/WindowTranslator.h"
 #include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "pvr/PVRManager.h"
+#include "pvr/PVRPlaybackState.h"
 #include "pvr/addons/PVRClient.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannel.h"
@@ -65,6 +66,11 @@ bool CPVRGUIDirectory::SupportsWriteFileOperations() const
 
   const std::string filename = m_url.GetFileName();
   return URIUtils::IsPVRRecording(filename);
+}
+
+bool CPVRGUIDirectory::Resolve(CFileItem& item)
+{
+  return CServiceBroker::GetPVRManager().PlaybackState()->OnPreparePlayback(item);
 }
 
 namespace

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.h
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.h
@@ -58,6 +58,13 @@ public:
   bool SupportsWriteFileOperations() const;
 
   /*!
+   * @brief Resolves a given item to a playable item
+   * @param item The item being manipulated (which the path points to a vfs protocol implementation)
+   * @return True if the item was resolved, false if it failed to resolve
+  */
+  static bool Resolve(CFileItem& item);
+
+  /*!
    * @brief Check if any TV recordings are existing.
    * @return True if TV recordings exists, false otherwise.
    */

--- a/xbmc/utils/PlayerUtils.cpp
+++ b/xbmc/utils/PlayerUtils.cpp
@@ -9,14 +9,10 @@
 #include "PlayerUtils.h"
 
 #include "FileItem.h"
-#include "PlayListPlayer.h"
 #include "ServiceBroker.h"
-#include "application/Application.h"
 #include "application/ApplicationPlayer.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
-#include "music/MusicFileItemClassify.h"
 #include "music/MusicUtils.h"
-#include "playlists/PlayListFileItemClassify.h"
 #include "utils/Variant.h"
 #include "video/VideoFileItemClassify.h"
 #include "video/guilib/VideoGUIUtils.h"
@@ -87,28 +83,4 @@ std::vector<std::string> CPlayerUtils::GetPlayersForItem(const CFileItem& item)
 bool CPlayerUtils::HasItemMultiplePlayers(const CFileItem& item)
 {
   return GetPlayersForItem(item).size() > 1;
-}
-
-bool CPlayerUtils::PlayMedia(const std::shared_ptr<CFileItem>& item,
-                             const std::string& player,
-                             KODI::PLAYLIST::Id playlistId)
-{
-  //! @todo get rid of special treatment for some media
-
-  if ((MUSIC::IsAudio(*item) || VIDEO::IsVideo(*item)) && !PLAYLIST::IsSmartPlayList(*item) &&
-      !item->IsPVR())
-  {
-    if (!item->HasProperty("playlist_type_hint"))
-      item->SetProperty("playlist_type_hint", static_cast<int>(playlistId));
-
-    PLAYLIST::CPlayListPlayer& playlistPlayer{CServiceBroker::GetPlaylistPlayer()};
-    playlistPlayer.Reset();
-    playlistPlayer.SetCurrentPlaylist(playlistId);
-    playlistPlayer.Play(item, player);
-  }
-  else
-  {
-    g_application.PlayMedia(*item, player, playlistId);
-  }
-  return true;
 }

--- a/xbmc/utils/PlayerUtils.h
+++ b/xbmc/utils/PlayerUtils.h
@@ -15,12 +15,6 @@
 class CApplicationPlayer;
 class CFileItem;
 
-namespace KODI::PLAYLIST
-{
-enum class Id;
-
-} // namespace KODI::PLAYLIST
-
 enum class TempoStepChange
 {
   INCREASE,
@@ -43,19 +37,8 @@ public:
 
   /*!
    \brief Check whether multiple players are available for the given item.
-   \param item The item
+   \param item The ite.
    \return True if multiple players are available, false otherwise
    */
   static bool HasItemMultiplePlayers(const CFileItem& item);
-
-  /*!
-   \brief Play the media represented by the given item.
-   \param item The item
-   \param player The player to use or empty string for default player
-   \param playlistId The id of the playlist to add the item to.
-   \return True on success, false otherwise
-   */
-  static bool PlayMedia(const std::shared_ptr<CFileItem>& item,
-                        const std::string& player,
-                        KODI::PLAYLIST::Id playlistId);
 };

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -15,6 +15,7 @@
 #include "PlayListPlayer.h"
 #include "ServiceBroker.h"
 #include "Util.h"
+#include "application/Application.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
 #include "dialogs/GUIDialogBusy.h"
@@ -36,7 +37,6 @@
 #include "settings/SettingsComponent.h"
 #include "threads/IRunnable.h"
 #include "utils/FileUtils.h"
-#include "utils/PlayerUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -440,7 +440,20 @@ void PlayItem(
     else // mode == PlayMode::PLAY_ONLY_THIS
     {
       // single item, play it
-      CPlayerUtils::PlayMedia(item, player, PLAYLIST::Id::TYPE_NONE);
+
+      //! @todo get rid of special treatment for some media
+      //! logic "borrowed" from PlayerBuiltins.cpp -> PlayOrQueueMedia()
+      if (item->IsPVR() || PLAYLIST::IsSmartPlayList(*item))
+      {
+        g_application.PlayMedia(*item, player, PLAYLIST::Id::TYPE_NONE);
+      }
+      else
+      {
+        auto& playlistPlayer = CServiceBroker::GetPlaylistPlayer();
+        playlistPlayer.Reset();
+        playlistPlayer.SetCurrentPlaylist(PLAYLIST::Id::TYPE_NONE);
+        playlistPlayer.Play(item, player);
+      }
     }
   }
 }

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -15,7 +15,6 @@
 #include "PlayListPlayer.h"
 #include "ServiceBroker.h"
 #include "Util.h"
-#include "application/Application.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
 #include "dialogs/GUIDialogBusy.h"
@@ -440,20 +439,10 @@ void PlayItem(
     else // mode == PlayMode::PLAY_ONLY_THIS
     {
       // single item, play it
-
-      //! @todo get rid of special treatment for some media
-      //! logic "borrowed" from PlayerBuiltins.cpp -> PlayOrQueueMedia()
-      if (item->IsPVR() || PLAYLIST::IsSmartPlayList(*item))
-      {
-        g_application.PlayMedia(*item, player, PLAYLIST::Id::TYPE_NONE);
-      }
-      else
-      {
-        auto& playlistPlayer = CServiceBroker::GetPlaylistPlayer();
-        playlistPlayer.Reset();
-        playlistPlayer.SetCurrentPlaylist(PLAYLIST::Id::TYPE_NONE);
-        playlistPlayer.Play(item, player);
-      }
+      auto& playlistPlayer = CServiceBroker::GetPlaylistPlayer();
+      playlistPlayer.Reset();
+      playlistPlayer.SetCurrentPlaylist(PLAYLIST::Id::TYPE_NONE);
+      playlistPlayer.Play(item, player);
     }
   }
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/xbmc/xbmc/pull/26302, which only partly fixed the problem, as reported here: https://forum.kodi.tv/showthread.php?tid=380163&pid=3223159#pid3223159

The PR reverts the changes from first fix attempt. I found a more simple solution which should fix playback for all use cases.

I runtime-tested the fix on macOS with test data from issue reporter.

@phunkyfish  would be nice if you could review. Best is to only look at the third commit and to ignore the 2 reverts.