### PR TITLE
[MUSIC] Extend embedded art support to mka/m4b files

### DIFF
--- a/xbmc/filesystem/AudioBookFileDirectory.cpp
+++ b/xbmc/filesystem/AudioBookFileDirectory.cpp
@@ -15,6 +15,7 @@
 #include "filesystem/File.h"
 #include "guilib/LocalizeStrings.h"
 #include "imagefiles/ImageFileURL.h"
+#include "music/MusicEmbeddedCoverLoaderFFmpeg.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -164,6 +165,9 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
   std::string thumb;
   if (m_fctx->nb_chapters > 1)
     thumb = IMAGE_FILES::URLFromFile(url.Get(), "music");
+
+  // Look for any embedded cover art
+  CMusicEmbeddedCoverLoaderFFmpeg::GetEmbeddedCover(m_fctx, albumtag);
 
   for (size_t i=0;i<m_fctx->nb_chapters;++i)
   {

--- a/xbmc/music/CMakeLists.txt
+++ b/xbmc/music/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES Album.cpp
             GUIViewStateMusic.cpp
             MusicDatabase.cpp
             MusicDbUrl.cpp
+            MusicEmbeddedCoverLoaderFFmpeg.cpp
             MusicEmbeddedImageFileLoader.cpp
             MusicFileItemClassify.cpp
             MusicInfoLoader.cpp
@@ -18,6 +19,7 @@ set(HEADERS Album.h
             GUIViewStateMusic.h
             MusicDatabase.h
             MusicDbUrl.h
+            MusicEmbeddedCoverLoaderFFmpeg.h
             MusicEmbeddedImageFileLoader.h
             MusicFileItemClassify.h
             MusicInfoLoader.h

--- a/xbmc/music/MusicEmbeddedCoverLoaderFFmpeg.cpp
+++ b/xbmc/music/MusicEmbeddedCoverLoaderFFmpeg.cpp
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (C) 2005-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "MusicEmbeddedCoverLoaderFFmpeg.h"
+
+#include "cores/FFmpeg.h"
+#include "tags/MusicInfoTag.h"
+#include "utils/EmbeddedArt.h"
+
+using namespace MUSIC_INFO;
+
+void CMusicEmbeddedCoverLoaderFFmpeg::GetEmbeddedCover(AVFormatContext* fctx,
+                                                       CMusicInfoTag& tag,
+                                                       EmbeddedArt* art /* nullptr */)
+{
+  for (size_t i = 0; i < fctx->nb_streams; ++i)
+  {
+    const AVStream* fctx_pic = fctx->streams[i];
+    if ((fctx_pic->disposition & AV_DISPOSITION_ATTACHED_PIC) == 0)
+      continue;
+
+    AVCodecID pic_id = fctx_pic->codecpar->codec_id;
+    const std::unordered_map<AVCodecID, std::string> mime_map = {{AV_CODEC_ID_MJPEG, "image/jpeg"},
+                                                                 {AV_CODEC_ID_PNG, "image/png"},
+                                                                 {AV_CODEC_ID_BMP, "image/bmp"}};
+
+    auto it = mime_map.find(pic_id);
+    if (it != mime_map.end())
+    {
+      const auto& mimetype = it->second;
+      size_t pic_size = fctx_pic->attached_pic.size;
+      uint8_t* pic = fctx_pic->attached_pic.data;
+
+      tag.SetCoverArtInfo(pic_size, mimetype);
+      if (art)
+        art->Set(pic, pic_size, mimetype, "thumb");
+      break; // just need one cover
+    }
+  }
+}

--- a/xbmc/music/MusicEmbeddedCoverLoaderFFmpeg.h
+++ b/xbmc/music/MusicEmbeddedCoverLoaderFFmpeg.h
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2005-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+struct AVFormatContext;
+class EmbeddedArt;
+
+namespace MUSIC_INFO
+{
+class CMusicInfoTag;
+
+class CMusicEmbeddedCoverLoaderFFmpeg
+{
+public:
+  /*!
+ * \brief Searches the supplied AVFormatContext for the first stream containing a supported embedded
+ *  picture.
+ *  This function is called by CMusicInfoTagLoaderFFmpeg when browsing mka music in files view, and
+ *   by CAudioBookFileDirectory when scanning mka files into the music library.
+ *
+ *  If art is found, it is added to CMusicInfoTag and EmbeddedArt (if available).
+ *
+ *  If there is no embedded picture or it is not of type jpg/png/bmp then no art is set.
+ *
+ * \param fctx An AVFormatContext containing one or more streams, one of which may contain art
+ * \param tag MusicInfoTag holding information about the current music track to which found art is
+ *  added
+ * \param art Class containing embedded art details (if available)
+ */
+  static void GetEmbeddedCover(AVFormatContext* fctx,
+                               CMusicInfoTag& tag,
+                               EmbeddedArt* art = nullptr);
+};
+} // namespace MUSIC_INFO

--- a/xbmc/music/tags/MusicInfoTagLoaderFFmpeg.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderFFmpeg.cpp
@@ -11,6 +11,7 @@
 #include "MusicInfoTag.h"
 #include "cores/FFmpeg.h"
 #include "filesystem/File.h"
+#include "music/MusicEmbeddedCoverLoaderFFmpeg.h"
 #include "utils/StringUtils.h"
 
 using namespace MUSIC_INFO;
@@ -156,6 +157,9 @@ bool CMusicInfoTagLoaderFFmpeg::Load(const std::string& strFileName, CMusicInfoT
   if (st)
     while ((avtag = av_dict_get(st->metadata, "", avtag, AV_DICT_IGNORE_SUFFIX)))
       ParseTag(avtag);
+
+  // Look for any embedded cover art
+  CMusicEmbeddedCoverLoaderFFmpeg::GetEmbeddedCover(fctx, tag, art);
 
   if (!tag.GetTitle().empty())
     tag.SetLoaded(true);


### PR DESCRIPTION
## Description
This PR extends embedded art handling to allow it to be extracted from mka /m4b files.  The PR is split into two commits, the first extends the ffmpegtagloader.  This allows embedded art to be displayed when navigating in the file explorer.
The second commit extends `CAudioBookFileDirectory` to look for and set any embedded art found.  If there are no tags in the file that describe the mimetype (I have files that do, as well as files that don't) then the code attempts to deduce the mimetype from the magic numbers for bmp, png and jpeg.

Note that this will conflict with my PR https://github.com/xbmc/xbmc/pull/26293 so will need rebasing if that one gets merged.
## Motivation and context
Embedded art doesn't currently work at all with mka files and is hit & miss with m4b files.
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally with multiple mka and m4b files that do and don't contain embedded art.

## What is the effect on users?
Allows users with embedded art in m4b & mka files to actually see the art.

## Screenshots (if appropriate):
Navigating an album in the file brwser before this PR

![before_no_art](https://github.com/user-attachments/assets/46ebc224-a55c-4edc-97a4-fc8eba95780b)

and after 

![after_extension](https://github.com/user-attachments/assets/fa41c711-5326-4ec8-8329-caee762fdfef)

Scanned in some files.  All of the art here is embedded in either mka or m4b files.

![all_this_art_is_embedded](https://github.com/user-attachments/assets/25926d20-824a-4d21-8fc9-8e087120c4e2)



## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
