### PR TITLE
[Estuary] Align media properties for flags/streams/versions

### DIFF
--- a/addons/skin.estuary/xml/Custom_1101_SettingsDialog.xml
+++ b/addons/skin.estuary/xml/Custom_1101_SettingsDialog.xml
@@ -6,41 +6,14 @@
 	<onunload>ClearProperty(settingsdialog_content,Home)</onunload>
 	<controls>
 		<control type="group">
-			<centerleft>50%</centerleft>
-			<height>700</height>
-			<centertop>50%</centertop>
-			<width>700</width>
-			<include condition="String.IsEqual(window(home).Property(settingsdialog_content),osd) | String.IsEqual(window(home).Property(settingsdialog_content),3d) | String.IsEqual(window(home).Property(settingsdialog_content),games)">SettingsDialogOSDVisible</include>
-			<animation effect="fade" time="200">VisibleChange</animation>
-			<include content="DialogBackgroundCommons">
-				<param name="width" value="700" />
-				<param name="height" value="80" />
-				<param name="header_label" value="$INFO[Window(home).Property(settingsdialog_header)]" />
-				<param name="header_id" value="1" />
+			<visible>!String.IsEqual(window(home).Property(settingsdialog_content),streamselection)</visible>
+			<include>SettingsDialogLayout</include>
+		</control>
+		<control type="group">
+			<visible>String.IsEqual(window(home).Property(settingsdialog_content),streamselection)</visible>
+			<include content="SettingsDialogLayout">
+				<param name="width" value="1000" />
 			</include>
-			<control type="group" id="11000">
-				<left>0</left>
-				<top>80</top>
-				<control type="grouplist" id="11100">
-					<width>700</width>
-					<height>700</height>
-					<itemgap>0</itemgap>
-					<onup>11100</onup>
-					<ondown>11100</ondown>
-					<orientation>vertical</orientation>
-					<include condition="String.IsEqual(window(home).Property(settingsdialog_content),streamselection)">SettingsDialogStreamSelectionContent</include>
-					<include condition="String.IsEqual(window(home).Property(settingsdialog_content),videosettings)">SettingsDialogVideoSettingsContent</include>
-					<include condition="String.IsEqual(window(home).Property(settingsdialog_content),3d)">SettingsDialog3DContent</include>
-					<include condition="String.IsEqual(window(home).Property(settingsdialog_content),games)">SettingsDialogGameContent</include>
-					<include condition="String.IsEqual(window(home).Property(settingsdialog_content),musicsettings)">SettingsDialogMusicSettingsContent</include>
-					<include condition="String.IsEqual(window(home).Property(settingsdialog_content),moviewidgets)">SettingsDialogMovieWidgetsContent</include>
-					<include condition="String.IsEqual(window(home).Property(settingsdialog_content),tvshowwidgets)">SettingsDialogTVShowWidgetsContent</include>
-					<include condition="String.IsEqual(window(home).Property(settingsdialog_content),musicwidgets)">SettingsDialogMusicWidgetsContent</include>
-					<include condition="String.IsEqual(window(home).Property(settingsdialog_content),musicvideowidgets)">SettingsDialogMusicVideoWidgetsContent</include>
-					<include condition="String.IsEqual(window(home).Property(settingsdialog_content),tvwidgets)">SettingsDialogTVWidgetsContent</include>
-					<include condition="String.IsEqual(window(home).Property(settingsdialog_content),radiowidgets)">SettingsDialogRadioWidgetsContent</include>
-				</control>
-			</control>
 		</control>
 	</controls>
 </window>

--- a/addons/skin.estuary/xml/DialogVideoManager.xml
+++ b/addons/skin.estuary/xml/DialogVideoManager.xml
@@ -5,11 +5,11 @@
 		<control type="group">
 			<centertop>50%</centertop>
 			<centerleft>50%</centerleft>
-			<width>1640</width>
+			<width>1760</width>
 			<height>780</height>
 			<include>Animation_DialogPopupVisible</include>
 			<include content="DialogBackgroundCommons">
-				<param name="width" value="1640" />
+				<param name="width" value="1760" />
 				<param name="height" value="780" />
 				<param name="header_id" value="2" />
 			</include>
@@ -25,7 +25,7 @@
 				<description>Path label</description>
 				<left>20</left>
 				<bottom>10</bottom>
-				<width>1300</width>
+				<width>1420</width>
 				<height>30</height>
 				<font>font12</font>
 				<align>right</align>
@@ -50,7 +50,7 @@
 				<control type="image">
 					<left>0</left>
 					<top>0</top>
-					<width>920</width>
+					<width>1040</width>
 					<height>665</height>
 					<texture border="40">buttons/dialogbutton-nofo.png</texture>
 				</control>
@@ -68,7 +68,7 @@
 					<include>MediaInfoListLayout</include>
 				</control>
 				<control type="scrollbar" id="60">
-					<left>900</left>
+					<left>1020</left>
 					<top>20</top>
 					<width>12</width>
 					<height>625</height>
@@ -78,7 +78,7 @@
 				</control>
 			</control>
 			<control type="grouplist" id="101">
-				<left>1340</left>
+				<left>1460</left>
 				<top>80</top>
 				<width>300</width>
 				<height>565</height>

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -1696,7 +1696,7 @@
 	</include>
 	<include name="MediaInfoListLayout">
 		<param name="height">125</param>
-		<param name="width">880</param>
+		<param name="width">1000</param>
 		<param name="fontcolor">grey</param>
 		<definition>
 			<itemlayout height="$PARAM[height]" width="$PARAM[width]">

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -284,7 +284,7 @@
 						<right>50</right>
 						<height>30</height>
 						<aligny>center</aligny>
-						<label>$INFO[ListItem.Property(stream.codec)]$INFO[ListItem.Property(stream.hdrtype),$COMMA ]$INFO[ListItem.Property(stream.resolution),$COMMA ]$VAR[StreamBitrateVar,$COMMA , kbps]$INFO[ListItem.Property(stream.fps),$COMMA , fps]$VAR[VideoStreamDialogItemLabelVar, - [LIGHT],[/LIGHT]]</label>
+						<label>$VAR[VideoCodecVar]$VAR[VideoHDRTypeVar, | ]$INFO[ListItem.Property(stream.resolution), | ]$VAR[StreamBitrateVar, | , kbps]$INFO[ListItem.Property(stream.fps), | , fps]$VAR[VideoStreamDialogItemLabelVar, - [LIGHT],[/LIGHT]]</label>
 					</control>
 					<control type="label">
 						<left>50</left>
@@ -333,7 +333,7 @@
 						<height>30</height>
 						<aligny>center</aligny>
 						<scroll>true</scroll>
-						<label>$INFO[ListItem.Property(stream.codec)]$INFO[ListItem.Property(stream.hdrtype),$COMMA ]$INFO[ListItem.Property(stream.resolution),$COMMA ]$VAR[StreamBitrateVar,$COMMA , kbps]$INFO[ListItem.Property(stream.fps),$COMMA , fps]$VAR[VideoStreamDialogItemLabelVar, - [LIGHT],[/LIGHT]]</label>
+						<label>$VAR[VideoCodecVar]$VAR[VideoHDRTypeVar, | ]$INFO[ListItem.Property(stream.resolution), | ]$VAR[StreamBitrateVar, | , kbps]$INFO[ListItem.Property(stream.fps), | , fps]$VAR[VideoStreamDialogItemLabelVar, - [LIGHT],[/LIGHT]]</label>
 					</control>
 					<control type="label">
 						<left>50</left>
@@ -359,7 +359,7 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="61">
-				<left>960</left>
+				<left>950</left>
 				<top>100</top>
 				<width>12</width>
 				<bottom>20</bottom>
@@ -404,7 +404,7 @@
 	Available ListItem audio stream properties:
 	stream.description, stream.codec, stream.codecdesc, stream.channels,
 	stream.isdefault, stream.isforced, stream.isoriginal, stream.ishearingimpaired, stream.isvisualimpaired
-	-->
+	-->
 		<control type="group">
 			<centertop>50%</centertop>
 			<centerleft>50%</centerleft>
@@ -461,7 +461,7 @@
 						<texture>icons/menumarks/tick.png</texture>
 						<visible>ListItem.IsSelected</visible>
 					</control>
--					<control type="label">
+					<control type="label">
 						<left>50</left>
 						<top>5</top>
 						<right>50</right>
@@ -476,7 +476,7 @@
 						<height>20</height>
 						<font>font10</font>
 						<aligny>center</aligny>
-						<label>$INFO[ListItem.Property(stream.codecdesc)]$INFO[ListItem.Property(stream.channels), - , $LOCALIZE[31612]]$INFO[ListItem.Property(stream.description), - ]</label>
+						<label>$VAR[StreamCodecVar]$VAR[AudioChannelsVar, ]$INFO[ListItem.Property(stream.description), | ]</label>
 						<textcolor>grey</textcolor>
 					</control>
 					<control type="image">
@@ -526,7 +526,7 @@
 						<font>font10</font>
 						<aligny>center</aligny>
 						<scroll>true</scroll>
-						<label>$INFO[ListItem.Property(stream.codecdesc)]$INFO[ListItem.Property(stream.channels), - , $LOCALIZE[31612]]$INFO[ListItem.Property(stream.description), - ]</label>
+						<label>$VAR[StreamCodecVar]$VAR[AudioChannelsVar, ]$INFO[ListItem.Property(stream.description), | ]</label>
 					</control>
 					<control type="image">
 						<right>10</right>
@@ -541,7 +541,7 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="61">
-				<left>960</left>
+				<left>950</left>
 				<top>100</top>
 				<width>12</width>
 				<bottom>20</bottom>
@@ -586,7 +586,7 @@
 	Available ListItem subtitle stream properties:
 	stream.description, stream.codec, stream.isdefault, stream.isforced, stream.isoriginal,
 	stream.ishearingimpaired, stream.isvisualimpaired, stream.isexternal
-	-->
+	-->
 		<control type="group">
 			<centertop>50%</centertop>
 			<centerleft>50%</centerleft>
@@ -723,7 +723,7 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="61">
-				<left>910</left>
+				<left>900</left>
 				<top>100</top>
 				<width>12</width>
 				<bottom>20</bottom>
@@ -1272,9 +1272,9 @@
 			<centertop>50%</centertop>
 			<centerleft>50%</centerleft>
 			<height>750</height>
-			<width>1640</width>
+			<width>1760</width>
 			<include content="DialogBackgroundCommons">
-				<param name="width" value="1640" />
+				<param name="width" value="1760" />
 				<param name="height" value="750" />
 				<param name="header_id" value="1" />
 			</include>
@@ -1289,7 +1289,7 @@
 			<control type="image">
 				<left>420</left>
 				<top>80</top>
-				<width>920</width>
+				<width>1040</width>
 				<height>665</height>
 				<texture border="40">buttons/dialogbutton-nofo.png</texture>
 			</control>
@@ -1298,7 +1298,7 @@
 			<control type="list" id="6">
 				<left>440</left>
 				<top>100</top>
-				<width>920</width>
+				<width>1040</width>
 				<height>625</height>
 				<onup>6</onup>
 				<ondown>6</ondown>
@@ -1309,7 +1309,7 @@
 				<include>MediaInfoListLayout</include>
 			</control>
 			<control type="scrollbar" id="61">
-				<left>1320</left>
+				<left>1440</left>
 				<top>100</top>
 				<width>12</width>
 				<bottom>20</bottom>
@@ -1318,7 +1318,7 @@
 				<orientation>vertical</orientation>
 			</control>
 			<control type="grouplist" id="9001">
-				<left>1340</left>
+				<left>1460</left>
 				<top>80</top>
 				<onleft>61</onleft>
 				<itemgap>dialogbuttons_itemgap</itemgap>

--- a/addons/skin.estuary/xml/Includes_SettingsDialog.xml
+++ b/addons/skin.estuary/xml/Includes_SettingsDialog.xml
@@ -3,25 +3,74 @@
 	<include name="SettingsDialogOSDVisible">
 		<visible>!Window.IsActive(DialogSettings.xml) + !Window.IsActive(DialogSlider.xml) + !Window.IsActive(GameVideoFilter) + !Window.IsActive(GameStretchMode) + !Window.IsActive(GameControllers) + !Window.IsActive(GameVideoRotation)</visible>
 	</include>
+	<include name="SettingsDialogLayout">
+		<param name="height">700</param>
+		<param name="width">700</param>
+		<definition>
+			<control type="group">
+				<centerleft>50%</centerleft>
+				<height>$PARAM[height]</height>
+				<centertop>50%</centertop>
+				<width>$PARAM[width]</width>
+				<include condition="String.IsEqual(window(home).Property(settingsdialog_content),osd) | String.IsEqual(window(home).Property(settingsdialog_content),3d) | String.IsEqual(window(home).Property(settingsdialog_content),games)">SettingsDialogOSDVisible</include>
+				<animation effect="fade" time="200">VisibleChange</animation>
+				<include content="DialogBackgroundCommons">
+					<param name="width" value="$PARAM[width]" />
+					<param name="height" value="80" />
+					<param name="header_label" value="$INFO[Window(home).Property(settingsdialog_header)]" />
+					<param name="header_id" value="1" />
+				</include>
+				<control type="group" id="11000">
+					<left>0</left>
+					<top>80</top>
+					<control type="grouplist" id="11100">
+						<width>$PARAM[width]</width>
+						<height>$PARAM[height]</height>
+						<itemgap>0</itemgap>
+						<onup>11100</onup>
+						<ondown>11100</ondown>
+						<orientation>vertical</orientation>
+						<include condition="String.IsEqual(window(home).Property(settingsdialog_content),streamselection)">SettingsDialogStreamSelectionContent</include>
+						<include condition="String.IsEqual(window(home).Property(settingsdialog_content),videosettings)">SettingsDialogVideoSettingsContent</include>
+						<include condition="String.IsEqual(window(home).Property(settingsdialog_content),3d)">SettingsDialog3DContent</include>
+						<include condition="String.IsEqual(window(home).Property(settingsdialog_content),games)">SettingsDialogGameContent</include>
+						<include condition="String.IsEqual(window(home).Property(settingsdialog_content),musicsettings)">SettingsDialogMusicSettingsContent</include>
+						<include condition="String.IsEqual(window(home).Property(settingsdialog_content),moviewidgets)">SettingsDialogMovieWidgetsContent</include>
+						<include condition="String.IsEqual(window(home).Property(settingsdialog_content),tvshowwidgets)">SettingsDialogTVShowWidgetsContent</include>
+						<include condition="String.IsEqual(window(home).Property(settingsdialog_content),musicwidgets)">SettingsDialogMusicWidgetsContent</include>
+						<include condition="String.IsEqual(window(home).Property(settingsdialog_content),musicvideowidgets)">SettingsDialogMusicVideoWidgetsContent</include>
+						<include condition="String.IsEqual(window(home).Property(settingsdialog_content),tvwidgets)">SettingsDialogTVWidgetsContent</include>
+						<include condition="String.IsEqual(window(home).Property(settingsdialog_content),radiowidgets)">SettingsDialogRadioWidgetsContent</include>
+					</control>
+				</control>
+			</control>
+		</definition>
+	</include>
 	<include name="SettingsDialogStreamSelectionContent">
 		<control type="button" id="22106">
-			<include>DialogSettingButton</include>
+			<include content="DialogSettingButton">
+				<param name="width" value="1000" />
+			</include>
 			<label>$LOCALIZE[31115]</label>
-			<label2>$VAR[ActiveVideoPlayerSubtitleLanguage]</label2>
+			<label2>[B]$VAR[ActiveVideoPlayerSubtitleLanguage][/B]</label2>
 			<onclick>DialogSelectSubtitle</onclick>
 			<enable>VideoPlayer.HasSubtitles</enable>
 		</control>
 		<control type="button" id="22105">
-			<include>DialogSettingButton</include>
+			<include content="DialogSettingButton">
+				<param name="width" value="1000" />
+			</include>
 			<label>$LOCALIZE[31112]</label>
-			<label2>[B]$VAR[ActiveVideoPlayerAudioLanguage]$VAR[AudioCodecVar, - ]$VAR[AudioChannelsVar, ][/B]</label2>
+			<label2>[B]$VAR[ActiveVideoPlayerAudioLanguage]$VAR[AudioCodecVar, | ]$VAR[ObjectAudioTypeVar, / ]$VAR[AudioChannelsVar, ][/B]</label2>
 			<onclick>DialogSelectAudio</onclick>
 			<enable>Integer.IsGreater(VideoPlayer.AudioStreamCount,1)</enable>
 		</control>
 		<control type="button" id="22110">
-			<include>DialogSettingButton</include>
+			<include content="DialogSettingButton">
+				<param name="width" value="1000" />
+			</include>
 			<label>$LOCALIZE[31109]</label>
-			<label2>[B]$INFO[VideoCodecVar]$INFO[Player.Process(videowidth), - ]$INFO[Player.Process(videoheight),x]$INFO[Player.Process(videoscantype)][/B]</label2>
+			<label2>[B]$VAR[VideoCodecVar]$VAR[VideoHDRTypeVar, | ]$INFO[VideoPlayer.VideoResolution, | ]$VAR[VideoResolutionTypeVar, ][/B]</label2>
 			<onclick>DialogSelectVideo</onclick>
 			<enable>Integer.IsGreater(VideoPlayer.VideoStreamCount,1)</enable>
 		</control>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -708,13 +708,13 @@
 		<value>$INFO[ListItem.Icon]</value>
 	</variable>
 	<variable name="ActiveVideoPlayerSubtitleLanguage">
-		<value condition="!VideoPlayer.HasSubtitles">[B]$LOCALIZE[36623][/B]</value>
-		<value condition="VideoPlayer.HasSubtitles + !VideoPlayer.SubtitlesEnabled">[B]$LOCALIZE[1223][/B]</value>
-		<value condition="VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled + !String.IsEmpty(VideoPlayer.SubtitlesLanguage)">[B]$INFO[VideoPlayer.SubtitlesLanguage][/B]</value>
-		<value condition="VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled + String.IsEmpty(VideoPlayer.SubtitlesLanguage)">[B]$LOCALIZE[13205][/B]</value>
+		<value condition="!VideoPlayer.HasSubtitles">$LOCALIZE[36623]</value>
+		<value condition="VideoPlayer.HasSubtitles + !VideoPlayer.SubtitlesEnabled">$LOCALIZE[1223]</value>
+		<value condition="VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled + !String.IsEmpty(VideoPlayer.SubtitlesLanguage)">[UPPERCASE]$INFO[VideoPlayer.SubtitlesLanguage][/UPPERCASE]</value>
+		<value condition="VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled + String.IsEmpty(VideoPlayer.SubtitlesLanguage)">$LOCALIZE[13205]</value>
 	</variable>
 	<variable name="ActiveVideoPlayerAudioLanguage">
-		<value condition="!String.IsEmpty(VideoPlayer.AudioLanguage)">$INFO[VideoPlayer.AudioLanguage]</value>
+		<value condition="!String.IsEmpty(VideoPlayer.AudioLanguage)">[UPPERCASE]$INFO[VideoPlayer.AudioLanguage][/UPPERCASE]</value>
 		<value condition="String.IsEmpty(VideoPlayer.AudioLanguage)">$LOCALIZE[13205]</value>
 	</variable>
 	<variable name="StreamBitrateVar">
@@ -831,31 +831,94 @@
 		<value condition="String.IsEqual(ListItem.AudioCodec,truehd_atmos) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,truehd_atmos)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,truehd_atmos)]">Dolby Atmos</value>
 		<value condition="String.IsEqual(ListItem.AudioCodec,dtshd_ma_x) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,dtshd_ma_x)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,dtshd_ma_x)]">DTS:X</value>
 		<value condition="String.IsEqual(ListItem.AudioCodec,dtshd_ma_x_imax) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,dtshd_ma_x_imax)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.AudioCodec,dtshd_ma_x_imax)]">DTS:X IMAX</value>
-<!--		<value>EMPTY</value> -->
 	</variable>
 	<variable name="AudioChannelsVar">
-		<value condition="String.IsEqual(ListItem.AudioChannels,0) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,0)] | String.IsEqual(ListItem.MusicChannels,0) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,0)]">0.0</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,1) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,1)] | String.IsEqual(ListItem.MusicChannels,1) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,1)]">1.0</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,2) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,2)] | String.IsEqual(ListItem.MusicChannels,2) | [Window.IsActive(visualisation)+ String.IsEqual(MusicPlayer.Channels,2)]">2.0</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,3) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,3)] | String.IsEqual(ListItem.MusicChannels,3) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,3)]">2.1</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,4) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,4)] | String.IsEqual(ListItem.MusicChannels,4) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,4)]">4.0</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,5) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,5)] | String.IsEqual(ListItem.MusicChannels,5) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,5)]">4.1</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,6) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,6)] | String.IsEqual(ListItem.MusicChannels,6) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,6)]">5.1</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,7) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,7)] | String.IsEqual(ListItem.MusicChannels,7) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,7)]">6.1</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,8) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,8)] | String.IsEqual(ListItem.MusicChannels,8) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,8)]">7.1</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,10) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,10)] | String.IsEqual(ListItem.MusicChannels,10) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,10)]">9.1</value>
+		<value condition="String.IsEqual(ListItem.AudioChannels,0) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,0)] | String.IsEqual(ListItem.MusicChannels,0) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,0)] | String.Contains(ListItem.Property(stream.channels),0)">0.0</value>
+		<value condition="String.IsEqual(ListItem.AudioChannels,1) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,1)] | String.IsEqual(ListItem.MusicChannels,1) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,1)] | String.Contains(ListItem.Property(stream.channels),1)">1.0</value>
+		<value condition="String.IsEqual(ListItem.AudioChannels,2) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,2)] | String.IsEqual(ListItem.MusicChannels,2) | [Window.IsActive(visualisation)+ String.IsEqual(MusicPlayer.Channels,2)] | String.Contains(ListItem.Property(stream.channels),2)">2.0</value>
+		<value condition="String.IsEqual(ListItem.AudioChannels,3) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,3)] | String.IsEqual(ListItem.MusicChannels,3) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,3)] | String.Contains(ListItem.Property(stream.channels),3)">2.1</value>
+		<value condition="String.IsEqual(ListItem.AudioChannels,4) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,4)] | String.IsEqual(ListItem.MusicChannels,4) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,4)] | String.Contains(ListItem.Property(stream.channels),4)">4.0</value>
+		<value condition="String.IsEqual(ListItem.AudioChannels,5) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,5)] | String.IsEqual(ListItem.MusicChannels,5) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,5)] | String.Contains(ListItem.Property(stream.channels),5)">4.1</value>
+		<value condition="String.IsEqual(ListItem.AudioChannels,6) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,6)] | String.IsEqual(ListItem.MusicChannels,6) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,6)] | String.Contains(ListItem.Property(stream.channels),6)">5.1</value>
+		<value condition="String.IsEqual(ListItem.AudioChannels,7) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,7)] | String.IsEqual(ListItem.MusicChannels,7) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,7)] | String.Contains(ListItem.Property(stream.channels),7)">6.1</value>
+		<value condition="String.IsEqual(ListItem.AudioChannels,8) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,8)] | String.IsEqual(ListItem.MusicChannels,8) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,8)] | String.Contains(ListItem.Property(stream.channels),8)">7.1</value>
+		<value condition="String.IsEqual(ListItem.AudioChannels,10) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,10)] | String.IsEqual(ListItem.MusicChannels,10) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,10)] | String.Contains(ListItem.Property(stream.channels),10)">9.1</value>
 		<value condition="Window.IsActive(fullscreenvideo)">$INFO[VideoPlayer.AudioChannels]</value>
 		<value condition="Window.IsActive(visualisation)">$INFO[MusicPlayer.Channels]</value>
 		<value condition="Container.Content(albums) | Window.IsActive(10502)">$INFO[ListItem.MusicChannels]</value>
 		<value>$INFO[ListItem.AudioChannels]</value>
+	</variable>
+	<variable name="StreamCodecVar">
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),av1)">AV1</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),avc1)">AVC-1</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),div3)">DivX</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),divx)">DivX</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),dx50)">DivX</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),flv)">FLV</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),h264)">H.264</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),hev1)">H.265</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),hevc)">H.265</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),hvc1)">H.265</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),mpeg1)">MPEG-1</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),mpeg2)">MPEG-2</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),mpeg2video)">MPEG-2</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),mp4v)">MPEG-4</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),mpeg4)">MPEG-4</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),theora)">Theora</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),vc1)">VC-1</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),vc-1)">VC-1</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),vp8)">VP8</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),vp9)">VP9</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),wmv)">WMV</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),wmv3)">WMV</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),wvc1)">VC-1</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),xvid)">XviD</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),aac)">AAC</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),aac_latm)">AAC</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),aif)">AIFF</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),aifc)">AIFF</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),aiff)">AIFF</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),alac)">ALAC</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),ape)">APE</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),avc)">AVC</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),cdda)">CDDA</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),flac)">FLAC</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),mp1)">MP1</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),mp3)">MP3</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),mp3float)">MP3</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),ogg)">OGG</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),opus)">OPUS</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),pcm)">PCM</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),pcm_bluray)">PCM</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),pcm_s16le)">PCM</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),pcm_s24le)">PCM</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),vorbis)">Vorbis</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),wav)">WAV</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),wavpack)">">WAVP</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),wmapro)">WMA-PRO</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),wmav2)">WMA</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),dtshd_hra)">DTS-HD HRA</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),dtsma)">DTS-HD MA</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),dtshd_ma_x_imax)">DTS-HD MA / DTS:X IMAX</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),dtshd_ma_x)">DTS-HD MA / DTS:X</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),dtshd_ma)">DTS-HD MA</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),dca)">DTS</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),dts)">DTS</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),eac3_ddp_atmos)">Dolby Digital+ Atmos</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),eac3)">Dolby Digital+</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),dolbydigital)">Dolby Digital</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),ac3)">Dolby Digital</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),truehd_atmos)">Dolby TrueHD Atmos</value>
+		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),truehd)">Dolby TrueHD</value>
+		<value>$INFO[ListItem.Property(stream.codec)]</value>
 	</variable>
 	<variable name="MediaInfoListLabelVar">
 		<value condition="Window.IsVisible(selectvideoversion)">$INFO[ListItem.VideoVersionName]</value>
 		<value>$INFO[ListItem.Label]</value>
 	</variable>
 	<variable name="MediaInfoListLabel2Var">
-		<value condition="ListItem.IsStereoscopic">$INFO[ListItem.Duration,$LOCALIZE[180]: ][CR]3D | $VAR[VideoCodecVar]$INFO[ListItem.VideoResolution, | ]$VAR[VideoResolutionTypeVar, ]$VAR[VideoHDRTypeVar, | ]$INFO[ListItem.VideoAspect, | ,:1]$VAR[AudioListCodecVar, | ]$VAR[AudioChannelsVar, ]</value>
-		<value>$INFO[ListItem.Duration,$LOCALIZE[180]: ][CR]$VAR[VideoCodecVar]$INFO[ListItem.VideoResolution, | ]$VAR[VideoResolutionTypeVar, ]$VAR[VideoHDRTypeVar, | ]$INFO[ListItem.VideoAspect, | ,:1]$VAR[AudioCodecVar, | ]$VAR[AudioChannelsVar, ]</value>
+		<value condition="ListItem.IsStereoscopic">$INFO[ListItem.Duration,$LOCALIZE[180]: ][CR]3D$VAR[VideoCodecVar, | ]$INFO[ListItem.VideoResolution, | ]$VAR[VideoResolutionTypeVar, ]$VAR[VideoHDRTypeVar, | ]$INFO[ListItem.VideoAspect, | ,:1]$VAR[AudioCodecVar, | ]$VAR[ObjectAudioTypeVar, / ]$VAR[AudioChannelsVar, ]</value>
+		<value>$INFO[ListItem.Duration,$LOCALIZE[180]: ][CR]$VAR[VideoCodecVar]$INFO[ListItem.VideoResolution, | ]$VAR[VideoResolutionTypeVar, ]$VAR[VideoHDRTypeVar, | ]$INFO[ListItem.VideoAspect, | ,:1]$VAR[AudioCodecVar, | ]$VAR[ObjectAudioTypeVar, / ]$VAR[AudioChannelsVar, ]</value>
 	</variable>
 	<variable name="PVRInstanceName">
 		<value condition="Integer.IsGreater(PVR.ClientCount,1)">$INFO[ListItem.PVRClientName,[COLOR grey]$LOCALIZE[31137]:[/COLOR] ,]$INFO[ListItem.PVRInstanceName, (,)]</value>


### PR DESCRIPTION
## Description
Align media properties for flags, streams and versions

## Motivation and context
The stream selection dialog currently use the ffmpeg provided codecs names, this aligns the naming the the media flags.
The version selection dialog was missing the object audio info (Atmos/DTS:X)

## How has this been tested?
Been testing with a variety of SDR & HDR files.

## What is the effect on users?
Improve consistency of the media property info reported in the GUI.

## Screenshots (if appropriate):

### Stream Selection menu

**Before**

![image](https://github.com/user-attachments/assets/ef5fd85e-e3d6-445d-a09e-cdc32e8df93f)

**After**

- Capitlise the Subtitle/Audio language as all lower case looked odd to me
- Use the same variables for audio/video streams that are used for media flags.

![image](https://github.com/user-attachments/assets/0180e388-1105-48a0-969f-e9273bacb103)

### Audio stream dialog

**Before**

![image](https://github.com/user-attachments/assets/0362dcaa-e878-4ee3-9235-51dd1153eb57)

**After**

- Use Variable to display formatted codec names to match the names used in media flags instead of the ffmpeg codec names.
- The number of channels could appear a maximum 3 times as it's incliude in` (ListItem.Property(stream.codec)`, `(ListItem.Property(stream.channels)` and sometimes in `ListItem.Property(stream.description)` so the new use of variables cuts this to a maximum of 2 times, and once only if there's no channels info in `ListItem.Property(stream.description)`.

![image](https://github.com/user-attachments/assets/697c03bf-6564-4e7f-8b4c-60d537068342)

### Video stream dialog

**Before**

- **Note:** wrong variable name was used after recent changes to variables as part of the media flag refactor.

![image](https://github.com/user-attachments/assets/cd136b41-a05d-4e5c-8866-1f94e9f66c9f)

**After**
- Use Variable to display formatted codec names to match the names used in media flags instead of the ffmpeg codec names. **_Fixes the issue noted in the before comment._**
- Use Variable to disaply formatted HDR type names to match the names used in media flags instead of the ffmpeg codec names.

![image](https://github.com/user-attachments/assets/758bce2b-6f5c-4e49-9ebe-bfc879ac3187)

### Choose Version / Manage Version dialogs

**Before**

![image](https://github.com/user-attachments/assets/ff68abb1-fb9b-4070-a862-8fc98f8b757f)

**After**

- Hadn't been updated to include the object audio info e.g. Atmos

![image](https://github.com/user-attachments/assets/b726b442-81d3-47b5-9779-793e1e7c36d4)

![image](https://github.com/user-attachments/assets/9bc6218e-e59e-44b2-b5d9-8fd6796ffa10)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
