### PR TITLE
RetroPlayer: Split DMA renderer into separate GL/GLES renderers

### DIFF
--- a/xbmc/cores/RetroPlayer/buffers/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/buffers/CMakeLists.txt
@@ -10,18 +10,18 @@ set(HEADERS BaseRenderBuffer.h
             RenderBufferManager.h
 )
 
-if(TARGET ${APP_NAME_LC}::OpenGl OR TARGET ${APP_NAME_LC}::OpenGLES)
-  list(APPEND SOURCES RenderBufferOpenGLES.cpp
-                      RenderBufferPoolOpenGLES.cpp)
-  list(APPEND HEADERS RenderBufferOpenGLES.h
-                      RenderBufferPoolOpenGLES.h)
-endif()
-
 if(TARGET ${APP_NAME_LC}::OpenGl)
   list(APPEND SOURCES RenderBufferOpenGL.cpp
                       RenderBufferPoolOpenGL.cpp)
   list(APPEND HEADERS RenderBufferOpenGL.h
                       RenderBufferPoolOpenGL.h)
+endif()
+
+if(TARGET ${APP_NAME_LC}::OpenGLES)
+  list(APPEND SOURCES RenderBufferOpenGLES.cpp
+                      RenderBufferPoolOpenGLES.cpp)
+  list(APPEND HEADERS RenderBufferOpenGLES.h
+                      RenderBufferPoolOpenGLES.h)
 endif()
 
 if(("gbm" IN_LIST CORE_PLATFORM_NAME_LC OR "wayland" IN_LIST CORE_PLATFORM_NAME_LC) AND TARGET ${APP_NAME_LC}::EGL)

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolDMA.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolDMA.cpp
@@ -9,7 +9,8 @@
 #include "RenderBufferPoolDMA.h"
 
 #include "RenderBufferDMA.h"
-#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMA.h"
+#include "cores/RetroPlayer/rendering/RenderVideoSettings.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAUtils.h"
 
 #include <drm_fourcc.h>
 
@@ -22,7 +23,7 @@ CRenderBufferPoolDMA::CRenderBufferPoolDMA(CRenderContext& context) : m_context(
 
 bool CRenderBufferPoolDMA::IsCompatible(const CRenderVideoSettings& renderSettings) const
 {
-  if (!CRPRendererDMA::SupportsScalingMethod(renderSettings.GetScalingMethod()))
+  if (!CRPRendererDMAUtils::SupportsScalingMethod(renderSettings.GetScalingMethod()))
     return false;
 
   return true;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/CMakeLists.txt
@@ -8,19 +8,29 @@ if(CORE_SYSTEM_NAME STREQUAL windows)
   list(APPEND HEADERS RPWinRenderer.h)
 endif()
 
-if(TARGET ${APP_NAME_LC}::OpenGl OR TARGET ${APP_NAME_LC}::OpenGLES)
-  list(APPEND SOURCES RPRendererOpenGLES.cpp)
-  list(APPEND HEADERS RPRendererOpenGLES.h)
-endif()
-
 if(TARGET ${APP_NAME_LC}::OpenGl)
   list(APPEND SOURCES RPRendererOpenGL.cpp)
   list(APPEND HEADERS RPRendererOpenGL.h)
 endif()
 
+if(TARGET ${APP_NAME_LC}::OpenGLES)
+  list(APPEND SOURCES RPRendererOpenGLES.cpp)
+  list(APPEND HEADERS RPRendererOpenGLES.h)
+endif()
+
 if(("gbm" IN_LIST CORE_PLATFORM_NAME_LC OR "wayland" IN_LIST CORE_PLATFORM_NAME_LC) AND TARGET ${APP_NAME_LC}::EGL)
-  list(APPEND SOURCES RPRendererDMA.cpp)
-  list(APPEND HEADERS RPRendererDMA.h)
+  list(APPEND SOURCES RPRendererDMAUtils.cpp)
+  list(APPEND HEADERS RPRendererDMAUtils.h)
+
+  if(TARGET ${APP_NAME_LC}::OpenGl)
+    list(APPEND SOURCES RPRendererDMAOpenGL.cpp)
+    list(APPEND HEADERS RPRendererDMAOpenGL.h)
+  endif()
+
+  if(TARGET ${APP_NAME_LC}::OpenGLES)
+    list(APPEND SOURCES RPRendererDMAOpenGLES.cpp)
+    list(APPEND HEADERS RPRendererDMAOpenGLES.h)
+  endif()
 endif()
 
 core_add_library(rp-videorenderers)

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
@@ -1,0 +1,137 @@
+/*
+ *  Copyright (C) 2017-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "RPRendererDMAOpenGL.h"
+
+#include "cores/RetroPlayer/buffers/RenderBufferDMA.h"
+#include "cores/RetroPlayer/buffers/RenderBufferPoolDMA.h"
+#include "cores/RetroPlayer/rendering/RenderContext.h"
+#include "cores/RetroPlayer/rendering/RenderVideoSettings.h"
+#include "utils/BufferObjectFactory.h"
+#include "utils/GLUtils.h"
+
+#include <cassert>
+#include <cstddef>
+
+using namespace KODI;
+using namespace RETRO;
+
+std::string CRendererFactoryDMAOpenGL::RenderSystemName() const
+{
+  return "DMA-GL";
+}
+
+CRPBaseRenderer* CRendererFactoryDMAOpenGL::CreateRenderer(
+    const CRenderSettings& settings,
+    CRenderContext& context,
+    std::shared_ptr<IRenderBufferPool> bufferPool)
+{
+  return new CRPRendererDMAOpenGL(settings, context, std::move(bufferPool));
+}
+
+RenderBufferPoolVector CRendererFactoryDMAOpenGL::CreateBufferPools(CRenderContext& context)
+{
+  if (!CBufferObjectFactory::CreateBufferObject(false))
+    return {};
+
+  return {std::make_shared<CRenderBufferPoolDMA>(context)};
+}
+
+CRPRendererDMAOpenGL::CRPRendererDMAOpenGL(const CRenderSettings& renderSettings,
+                                           CRenderContext& context,
+                                           std::shared_ptr<IRenderBufferPool> bufferPool)
+  : CRPRendererOpenGL(renderSettings, context, std::move(bufferPool))
+{
+}
+
+void CRPRendererDMAOpenGL::Render(uint8_t alpha)
+{
+  auto renderBuffer = static_cast<CRenderBufferDMA*>(m_renderBuffer);
+  assert(renderBuffer != nullptr);
+
+  CRect rect = m_sourceRect;
+
+  rect.x1 /= renderBuffer->GetWidth();
+  rect.x2 /= renderBuffer->GetWidth();
+  rect.y1 /= renderBuffer->GetHeight();
+  rect.y2 /= renderBuffer->GetHeight();
+
+  const uint32_t color = (alpha << 24) | 0xFFFFFF;
+
+  glBindTexture(m_textureTarget, renderBuffer->TextureID());
+
+  GLint filter = GL_NEAREST;
+  if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
+    filter = GL_LINEAR;
+  glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+  m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE);
+
+  GLubyte colour[4];
+  GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
+  struct PackedVertex
+  {
+    float x, y, z;
+    float u1, v1;
+  } vertex[4];
+
+  GLint vertLoc = m_context.GUIShaderGetPos();
+  GLint loc = m_context.GUIShaderGetCoord0();
+  GLint uniColLoc = m_context.GUIShaderGetUniCol();
+  GLint depthLoc = m_context.GUIShaderGetDepth();
+
+  // Setup color values
+  colour[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
+  colour[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
+  colour[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
+  colour[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
+
+  for (unsigned int i = 0; i < 4; i++)
+  {
+    // Setup vertex position values
+    vertex[i].x = m_rotatedDestCoords[i].x;
+    vertex[i].y = m_rotatedDestCoords[i].y;
+    vertex[i].z = 0.0f;
+  }
+
+  // Setup texture coordinates
+  vertex[0].u1 = vertex[3].u1 = rect.x1;
+  vertex[0].v1 = vertex[1].v1 = rect.y1;
+  vertex[1].u1 = vertex[2].u1 = rect.x2;
+  vertex[2].v1 = vertex[3].v1 = rect.y2;
+
+  glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_STATIC_DRAW);
+
+  glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex),
+                        reinterpret_cast<const GLuint*>(offsetof(PackedVertex, x)));
+  glVertexAttribPointer(loc, 2, GL_FLOAT, 0, sizeof(PackedVertex),
+                        reinterpret_cast<const GLuint*>(offsetof(PackedVertex, u1)));
+
+  glEnableVertexAttribArray(vertLoc);
+  glEnableVertexAttribArray(loc);
+
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_mainIndexVBO);
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * 4, idx, GL_STATIC_DRAW);
+
+  glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f),
+              (colour[3] / 255.0f));
+  glUniform1f(depthLoc, -1.0f);
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+
+  glDisableVertexAttribArray(vertLoc);
+  glDisableVertexAttribArray(loc);
+
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+
+  m_context.DisableGUIShader();
+}

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017-2018 Team Kodi
+ *  Copyright (C) 2017-2025 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "RPRendererOpenGLES.h"
+#include "RPRendererOpenGL.h"
 
 #include <memory>
 
@@ -16,10 +16,10 @@ namespace KODI
 {
 namespace RETRO
 {
-class CRendererFactoryDMA : public IRendererFactory
+class CRendererFactoryDMAOpenGL : public IRendererFactory
 {
 public:
-  ~CRendererFactoryDMA() override = default;
+  ~CRendererFactoryDMAOpenGL() override = default;
 
   // implementation of IRendererFactory
   std::string RenderSystemName() const override;
@@ -35,18 +35,17 @@ public:
  *        CRenderBufferPoolDMA and CRenderBufferDMA. A windowing system
  *        must register use of this renderer and register at least one
  *        CBufferObject types.
- *
  */
-class CRPRendererDMA : public CRPRendererOpenGLES
+class CRPRendererDMAOpenGL : public CRPRendererOpenGL
 {
 public:
-  CRPRendererDMA(const CRenderSettings& renderSettings,
-                 CRenderContext& context,
-                 std::shared_ptr<IRenderBufferPool> bufferPool);
-  ~CRPRendererDMA() override = default;
+  CRPRendererDMAOpenGL(const CRenderSettings& renderSettings,
+                       CRenderContext& context,
+                       std::shared_ptr<IRenderBufferPool> bufferPool);
+  ~CRPRendererDMAOpenGL() override = default;
 
 protected:
-  // implementation of CRPRendererOpenGLES
+  // Implementation of CRPRendererOpenGLES
   void Render(uint8_t alpha) override;
 };
 } // namespace RETRO

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
@@ -6,7 +6,7 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include "RPRendererDMA.h"
+#include "RPRendererDMAOpenGLES.h"
 
 #include "cores/RetroPlayer/buffers/RenderBufferDMA.h"
 #include "cores/RetroPlayer/buffers/RenderBufferPoolDMA.h"
@@ -21,19 +21,20 @@
 using namespace KODI;
 using namespace RETRO;
 
-std::string CRendererFactoryDMA::RenderSystemName() const
+std::string CRendererFactoryDMAOpenGLES::RenderSystemName() const
 {
-  return "DMA";
+  return "DMA-GLES";
 }
 
-CRPBaseRenderer* CRendererFactoryDMA::CreateRenderer(const CRenderSettings& settings,
-                                                     CRenderContext& context,
-                                                     std::shared_ptr<IRenderBufferPool> bufferPool)
+CRPBaseRenderer* CRendererFactoryDMAOpenGLES::CreateRenderer(
+    const CRenderSettings& settings,
+    CRenderContext& context,
+    std::shared_ptr<IRenderBufferPool> bufferPool)
 {
-  return new CRPRendererDMA(settings, context, std::move(bufferPool));
+  return new CRPRendererDMAOpenGLES(settings, context, std::move(bufferPool));
 }
 
-RenderBufferPoolVector CRendererFactoryDMA::CreateBufferPools(CRenderContext& context)
+RenderBufferPoolVector CRendererFactoryDMAOpenGLES::CreateBufferPools(CRenderContext& context)
 {
   if (!CBufferObjectFactory::CreateBufferObject(false))
     return {};
@@ -41,14 +42,14 @@ RenderBufferPoolVector CRendererFactoryDMA::CreateBufferPools(CRenderContext& co
   return {std::make_shared<CRenderBufferPoolDMA>(context)};
 }
 
-CRPRendererDMA::CRPRendererDMA(const CRenderSettings& renderSettings,
-                               CRenderContext& context,
-                               std::shared_ptr<IRenderBufferPool> bufferPool)
+CRPRendererDMAOpenGLES::CRPRendererDMAOpenGLES(const CRenderSettings& renderSettings,
+                                               CRenderContext& context,
+                                               std::shared_ptr<IRenderBufferPool> bufferPool)
   : CRPRendererOpenGLES(renderSettings, context, std::move(bufferPool))
 {
 }
 
-void CRPRendererDMA::Render(uint8_t alpha)
+void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
 {
   auto renderBuffer = static_cast<CRenderBufferDMA*>(m_renderBuffer);
   assert(renderBuffer != nullptr);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.h
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (C) 2017-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "RPRendererOpenGLES.h"
+
+#include <memory>
+
+namespace KODI
+{
+namespace RETRO
+{
+class CRendererFactoryDMAOpenGLES : public IRendererFactory
+{
+public:
+  ~CRendererFactoryDMAOpenGLES() override = default;
+
+  // implementation of IRendererFactory
+  std::string RenderSystemName() const override;
+  CRPBaseRenderer* CreateRenderer(const CRenderSettings& settings,
+                                  CRenderContext& context,
+                                  std::shared_ptr<IRenderBufferPool> bufferPool) override;
+  RenderBufferPoolVector CreateBufferPools(CRenderContext& context) override;
+};
+
+/**
+ * @brief Special CRPBaseRenderer implementation to handle Direct Memory
+ *        Access (DMA) buffer types. For specific use with
+ *        CRenderBufferPoolDMA and CRenderBufferDMA. A windowing system
+ *        must register use of this renderer and register at least one
+ *        CBufferObject types.
+ */
+class CRPRendererDMAOpenGLES : public CRPRendererOpenGLES
+{
+public:
+  CRPRendererDMAOpenGLES(const CRenderSettings& renderSettings,
+                         CRenderContext& context,
+                         std::shared_ptr<IRenderBufferPool> bufferPool);
+  ~CRPRendererDMAOpenGLES() override = default;
+
+protected:
+  // Implementation of CRPRendererOpenGLES
+  void Render(uint8_t alpha) override;
+};
+} // namespace RETRO
+} // namespace KODI

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAUtils.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAUtils.cpp
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (C) 2017-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "RPRendererDMAUtils.h"
+
+#if !defined(HAS_GLES)
+#include "RPRendererDMAOpenGL.h"
+#else
+#include "RPRendererDMAOpenGLES.h"
+#endif
+
+using namespace KODI;
+using namespace RETRO;
+
+bool CRPRendererDMAUtils::SupportsScalingMethod(SCALINGMETHOD method)
+{
+#if !defined(HAS_GLES)
+  return CRPRendererDMAOpenGL::SupportsScalingMethod(method);
+#else
+  return CRPRendererDMAOpenGLES::SupportsScalingMethod(method);
+#endif
+}

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAUtils.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAUtils.h
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (C) 2017-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "cores/GameSettings.h"
+
+namespace KODI
+{
+namespace RETRO
+{
+class CRPRendererDMAUtils
+{
+public:
+  /*!
+   * \brief Check if the DMA renderer supports the specified scaling method
+   *
+   * Note how the graphics API (OpenGL vs. OpenGLES) is abstracted here. The
+   * reason is because this interface is exposed to the DMA buffer code, which
+   * is currently independent of graphics API (i.e. no use of `HAS_GLES` in
+   * the DMA buffer code).
+   */
+  static bool SupportsScalingMethod(SCALINGMETHOD method);
+};
+} // namespace RETRO
+} // namespace KODI

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -10,7 +10,7 @@
 
 #include "OptionalsReg.h"
 #include "cores/RetroPlayer/process/gbm/RPProcessInfoGbm.h"
-#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMA.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.h"
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h"
@@ -53,7 +53,7 @@ bool CWinSystemGbmGLContext::InitWindowSystem()
   CDVDFactoryCodec::ClearHWAccels();
   CLinuxRendererGL::Register();
   RETRO::CRPProcessInfoGbm::Register();
-  RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryDMA);
+  RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryDMAOpenGL);
   RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGL);
 
   if (!CWinSystemGbmEGLContext::InitWindowSystemEGL(EGL_OPENGL_BIT, EGL_OPENGL_API))

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -10,7 +10,7 @@
 
 #include "OptionalsReg.h"
 #include "cores/RetroPlayer/process/gbm/RPProcessInfoGbm.h"
-#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMA.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.h"
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
 #include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h"
@@ -57,7 +57,7 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
   CDVDFactoryCodec::ClearHWAccels();
   CLinuxRendererGLES::Register();
   RETRO::CRPProcessInfoGbm::Register();
-  RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryDMA);
+  RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryDMAOpenGLES);
   RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGLES);
 
   if (!CWinSystemGbmEGLContext::InitWindowSystemEGL(EGL_OPENGL_ES2_BIT, EGL_OPENGL_ES_API))

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
@@ -10,7 +10,7 @@
 
 #include "OptionalsReg.h"
 #include "cores/RetroPlayer/process/RPProcessInfo.h"
-#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMA.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.h"
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h"
 #include "rendering/gl/ScreenshotSurfaceGL.h"
@@ -42,7 +42,7 @@ bool CWinSystemWaylandEGLContextGL::InitWindowSystem()
   }
 
   CLinuxRendererGL::Register();
-  RETRO::CRPProcessInfo::RegisterRendererFactory(new RETRO::CRendererFactoryDMA);
+  RETRO::CRPProcessInfo::RegisterRendererFactory(new RETRO::CRendererFactoryDMAOpenGL);
   RETRO::CRPProcessInfo::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGL);
 
   bool general, deepColor;

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp
@@ -10,7 +10,7 @@
 
 #include "OptionalsReg.h"
 #include "cores/RetroPlayer/process/RPProcessInfo.h"
-#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMA.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.h"
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h"
 #include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h"
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h"
@@ -47,7 +47,7 @@ bool CWinSystemWaylandEGLContextGLES::InitWindowSystem()
   CDVDVideoCodecDRMPRIME::Register();
   CRendererDRMPRIMEGLES::Register();
 
-  RETRO::CRPProcessInfo::RegisterRendererFactory(new RETRO::CRendererFactoryDMA);
+  RETRO::CRPProcessInfo::RegisterRendererFactory(new RETRO::CRendererFactoryDMAOpenGLES);
   RETRO::CRPProcessInfo::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGLES);
 
   bool general, deepColor;


### PR DESCRIPTION
## Description

As title says, this PR refactors the RetroPlayer DMA renderer into separate classes for GL and GLES.

As a result, we no longer pull the GLES renderer into GL code, like we were doing here:

```cmake
if(TARGET ${APP_NAME_LC}::OpenGl OR TARGET ${APP_NAME_LC}::OpenGLES)
  list(APPEND SOURCES RPRendererOpenGLES.cpp)
  list(APPEND HEADERS RPRendererOpenGLES.h)
endif()
```


## Motivation and context

Needed for shaders (ssshh, the PR is close!)

## How has this been tested?

Included in latest round of test builds: https://github.com/garbear/xbmc/releases/tag/retroplayer-21.2-20250129

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
