### PR TITLE
[Estuary] Fix music video media flags

### DIFF
--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -448,7 +448,7 @@
 				</include>
 			</control>
 			<control type="grouplist">
-				<visible>Container.Content(albums) | Window.IsActive(10502)</visible>
+				<visible>!String.IsEqual(ListItem.DbType,musicvideo) + [Container.Content(albums) | Window.IsActive(music)]</visible>
 				<orientation>horizontal</orientation>
 				<right>20</right>
 				<bottom>10</bottom>


### PR DESCRIPTION
## Description
As a result of introducing music media flags within https://github.com/xbmc/xbmc/pull/24162 this had the unintended consquence of music videos showing both music flags and video flags for anything with Content type Album.

## Motivation and context
Raised on Slack by @the-black-eagle 

Navigate to Artists node

![image](https://github.com/user-attachments/assets/93678d90-0a90-48a8-bce5-b4702b7dab82)

Select an Artist

![image](https://github.com/user-attachments/assets/1a76aa21-affe-4fce-a7c0-e83f3ce701ee)

Both Music & Video flags are shown

![image](https://github.com/user-attachments/assets/b4d2a0dc-4d4d-4076-a008-dc9ef10dd90b)

This is a consequence of **Content** type being set to **Albums** within this path. When adding music flags I hadn't considered that you could have music video albums.

There was a bit of a debate on Slack as whether the **Content** type should be **Albums** here, and conclusion seemed to be that it was correct.


## How has this been tested?
After replicating the issue after the report from @the-black-eagle I established an easy fix as music videos always return a `ListItem.DbType` of `musicvideo` so simply fix is to use this to exclude the music flags.

Also took the opportunity to change Window.IsActive(10502) to the correct window name of Window.IsActive(music) for that id

Been tested navigating the various music and music video nodes to make sure there are no unintended consequences.

## What is the effect on users?
Prevent the wrong type of media flags appearing.

## Screenshots (if appropriate):

With fix

![image](https://github.com/user-attachments/assets/062bd772-b915-446a-81d8-840def49fff0)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
