### PR TITLE
[PVR] PVRGUIInfo: Fix support for ListItem.TitleExtraInfo for PVR timers

### DIFF
--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -437,6 +437,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
       case LISTITEM_PARENTAL_RATING_ICON:
       case LISTITEM_PARENTAL_RATING_SOURCE:
       case LISTITEM_MEDIAPROVIDERS:
+      case LISTITEM_TITLE_EXTRAINFO:
         break; // obtain value from channel/epg
       default:
         return false;


### PR DESCRIPTION
A one-liner. ListItem.TitleExtraInfo did not work for PVR timers.

Before:

<img width="1710" alt="Screenshot_2025-01-26_at_22_27_55" src="https://github.com/user-attachments/assets/2ccb8653-a55e-4101-a2be-a5ece4340948" />

After:

<img width="1710" alt="Screenshot_2025-01-26_at_22_26_47" src="https://github.com/user-attachments/assets/a194884a-3535-4ab7-9765-45620832abe7" />

@phunkyfish could you please approve?