### PR TITLE
Fix cropping of third button in DialogSettings.xml

### DIFF
--- a/addons/skin.estuary/xml/DialogSettings.xml
+++ b/addons/skin.estuary/xml/DialogSettings.xml
@@ -68,7 +68,7 @@
 				<top>92</top>
 				<orientation>vertical</orientation>
 				<width>300</width>
-				<height>250</height>
+				<height>280</height>
 				<itemgap>-10</itemgap>
 				<onleft>5</onleft>
 				<onright>5</onright>


### PR DESCRIPTION
## Description

As title says. Before, third button is cropped and mousing over has no effect on it:

<img width="1274" alt="Screenshot 2025-01-28 at 4 12 44 PM" src="https://github.com/user-attachments/assets/2919822c-eb03-4fcd-8c9a-685141b1771d" />

After, button isn't cropped, and mousing over correctly

<img width="1272" alt="Screenshot 2025-01-28 at 4 12 20 PM" src="https://github.com/user-attachments/assets/1406fa5e-16f2-46b0-bbfd-08e762cc9ee5" />
 focuses it:

## Motivation and context

Annoying me for a while, but a whole PR for this change? I guess it had to be done.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
