### PR TITLE
[guiinfo][Estuary] Redesign of PVR info dialog (align it with video info dialog).

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -800,6 +800,7 @@ msgstr ""
 #: xbmc/pvr/windows/GUIViewStatePVR.cpp
 #: addons/skin.estuary/xml/Variables.xml
 #: addons/skin.estuary/xml/View_51_Poster.xml
+#: addons/skin.estuary/xml/DialogPVRInfo.xml
 #: addons/skin.estuary/xml/DialogVideoInfo.xml
 msgctxt "#180"
 msgid "Duration"
@@ -1259,6 +1260,7 @@ msgstr ""
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
 #: xbmc/pvr/windows/GUIWIndowPVRGuide.cpp
 #: xbmc/pvr/PVRContextMenus.cpp
+#: addons/skin.estuary/xml/DialogPVRInfo.xml
 #: addons/skin.estuary/xml/Variables.xml
 msgctxt "#264"
 msgid "Record"
@@ -2593,6 +2595,7 @@ msgid "Name"
 msgstr ""
 
 #. generic "date" label used in different places
+#: addons/skin.estuary/xml/DialogPVRInfo.xml
 #: addons/skin.estuary/xml/Variables.xml
 #: xbmc/pvr/windows/GUIViewStatePVR.cpp
 msgctxt "#552"
@@ -2671,6 +2674,7 @@ msgstr ""
 #: xbmc/playlists/SmartPlaylist.cpp
 #: xbmc/music/MusicUtils.cpp
 #: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+#: addons/skin.estuary/xml/DialogPVRInfo.xml
 #: addons/skin.estuary/xml/DialogVideoInfo.xml
 #: addons/skin.estuary/xml/DialogFullScreenInfo.xml
 msgctxt "#563"
@@ -2703,6 +2707,7 @@ msgstr ""
 
 #. generic "last played" label used in different places
 #: addons/skin.estuary/xml/Includes_MusicInfo.xml
+#: addons/skin.estuary/xml/DialogPVRInfo.xml
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
 #: xbmc/pvr/windows/GUIViewStatePVR.cpp
@@ -2752,6 +2757,7 @@ msgctxt "#575"
 msgid "In progress"
 msgstr ""
 
+#: addons/skin.estuary/xml/DialogPVRInfo.xml
 msgctxt "#576"
 msgid "Times played"
 msgstr ""
@@ -9721,6 +9727,7 @@ msgid "or use phrases to find an exact match, like \"The wizard of Oz\"."
 msgstr ""
 
 #. Label of a context menu entry to find similar programs (matching a given epg event)
+#: addons/skin.estuary/xml/DialogPVRInfo.xml
 #: xbmc/pvr/PVRContextMenuItem.cpp
 msgctxt "#19003"
 msgid "Find similar"
@@ -9898,6 +9905,7 @@ msgstr ""
 
 #. generic 'channel' label used in different places
 #: addons/skin.estuary/xml/DialogFullScreenInfo.xml
+#: addons/skin.estuary/xml/DialogPVRInfo.xml
 #: xbmc/filesystem/PluginDirectory.cpp
 #: xbmc/pvr/channels/PVRChannel.cpp
 #: xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
@@ -12495,6 +12503,7 @@ msgid "Channel guide"
 msgstr ""
 
 #. Label for context menu entries, dialog heading, button to start playing a recording
+#: addons/skin.estuary/xml/DialogPVRInfo.xml
 #: xbmc/pvr/PVRContextMenus.cpp
 #: xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
 msgctxt "#19687"
@@ -15726,6 +15735,7 @@ msgctxt "#22030"
 msgid "Font"
 msgstr ""
 
+#: addons/skin.estuary/xml/DialogPVRInfo.xml
 #: system/settings/settings.xml
 msgctxt "#22031"
 msgid "Size"

--- a/addons/skin.estuary/xml/DialogPVRInfo.xml
+++ b/addons/skin.estuary/xml/DialogPVRInfo.xml
@@ -1,125 +1,371 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<defaultcontrol always="true">9000</defaultcontrol>
+	<defaultcontrol always="true">5000</defaultcontrol>
 	<onload>SetProperty(infobackground,$ESCINFO[ListItem.Art(fanart)],home)</onload>
 	<onunload>ClearProperty(infobackground,home)</onunload>
 	<controls>
-		<control type="group">
-			<animation effect="fade" start="0" end="100" time="100">WindowOpen</animation>
-			<animation effect="fade" start="100" end="0" time="100">WindowClose</animation>
-			<animation effect="fade" start="100" end="75" time="0" condition="true">Conditional</animation>
-			<visible>Window.isActive(fullscreenvideo)</visible>
-			<include>ColoredBackgroundImages</include>
-		</control>
 		<control type="group">
 			<centertop>50%</centertop>
 			<height>1080</height>
 			<centerleft>50%</centerleft>
 			<width>1920</width>
-			<control type="image">
+			<control type="group">
+				<top>150</top>
+				<left>66</left>
 				<include>OpenClose_Left</include>
-				<left>114</left>
-				<top>236</top>
-				<width>461</width>
-				<height>461</height>
-				<aspectratio>keep</aspectratio>
-				<texture fallback="DefaultTVShows.png">$INFO[ListItem.Icon]</texture>
+				<control type="group">
+					<control type="image">
+						<top>-16</top>
+						<left>-16</left>
+						<width>566</width>
+						<height>718</height>
+						<aspectratio>stretch</aspectratio>
+						<texture border="21">dialogs/dialog-bg.png</texture>
+					</control>
+					<control type="image">
+						<left>14</left>
+						<width>505</width>
+						<height>655</height>
+						<aligny>center</aligny>
+						<aspectratio>keep</aspectratio>
+						<texture fallback="DefaultTVShows.png">$INFO[ListItem.ChannelLogo]</texture>
+						<visible>!String.IsEmpty(ListItem.ChannelLogo) + String.IsEmpty(ListItem.Art(thumb)) + String.IsEmpty(ListItem.EpgEventIcon)</visible>
+					</control>
+					<control type="image">
+						<left>14</left>
+						<width>505</width>
+						<height>655</height>
+						<aligny>center</aligny>
+						<aspectratio>keep</aspectratio>
+						<texture fallback="DefaultMovies.png">$INFO[ListItem.EpgEventIcon]</texture>
+						<visible>String.IsEmpty(ListItem.ChannelLogo) + String.IsEmpty(ListItem.Art(thumb)) + !String.IsEmpty(ListItem.EpgEventIcon)</visible>
+					</control>
+					<control type="image">
+						<left>14</left>
+						<width>505</width>
+						<height>655</height>
+						<aspectratio>keep</aspectratio>
+						<aligny>center</aligny>
+						<texture fallback="DefaultMovies.png">$INFO[ListItem.Art(thumb)]</texture>
+						<visible>String.IsEmpty(ListItem.ChannelLogo) + !String.IsEmpty(ListItem.Art(thumb)) + String.IsEmpty(ListItem.EpgEventIcon)</visible>
+					</control>
+					<control type="image">
+						<left>14</left>
+						<top>14</top>
+						<width>505</width>
+						<height>315</height>
+						<aspectratio>keep</aspectratio>
+						<texture fallback="DefaultTVShows.png">$INFO[ListItem.ChannelLogo]</texture>
+						<visible>!String.IsEmpty(ListItem.ChannelLogo) + [!String.IsEmpty(ListItem.Art(thumb)) | !String.IsEmpty(ListItem.EpgEventIcon)]</visible>
+					</control>
+					<control type="image">
+						<left>14</left>
+						<top>360</top>
+						<width>505</width>
+						<height>315</height>
+						<aspectratio>keep</aspectratio>
+						<texture fallback="DefaultMovies.png">$INFO[ListItem.EpgEventIcon]</texture>
+						<visible>!String.IsEmpty(ListItem.ChannelLogo) + String.IsEmpty(ListItem.Art(thumb)) + !String.IsEmpty(ListItem.EpgEventIcon)</visible>
+					</control>
+					<control type="image">
+						<left>14</left>
+						<top>360</top>
+						<width>505</width>
+						<height>315</height>
+						<aspectratio>keep</aspectratio>
+						<texture fallback="DefaultMovies.png">$INFO[ListItem.Art(thumb)]</texture>
+						<visible>!String.IsEmpty(ListItem.ChannelLogo) + !String.IsEmpty(ListItem.Art(thumb)) + String.IsEmpty(ListItem.EpgEventIcon)</visible>
+					</control>
+				</control>
 			</control>
 			<control type="group">
-				<top>230</top>
-				<left>50</left>
 				<include>OpenClose_Right</include>
-				<control type="button" id="61">
-					<left>600</left>
-					<top>-18</top>
-					<width>1170</width>
-					<height>509</height>
-					<font></font>
-					<onleft>61</onleft>
-					<onright>61</onright>
-					<ondown>9000</ondown>
-					<onup>9000</onup>
-					<onclick>SetProperty(TextViewer_Header,$LOCALIZE[207],home)</onclick>
-					<onclick>SetProperty(TextViewer_Text,$ESCINFO[ListItem.Plot],home)</onclick>
-					<onclick>ActivateWindow(1102)</onclick>
+				<left>600</left>
+				<top>-30</top>
+				<control type="group" id="140">
+					<top>164</top>
+					<control type="button" id="138">
+						<width>774</width>
+						<height>718</height>
+						<textoffsetx>40</textoffsetx>
+						<textoffsety>20</textoffsety>
+						<aligny>bottom</aligny>
+						<label></label>
+						<onclick condition="!String.IsEmpty(ListItem.Plot)">SetProperty(TextViewer_Header,$LOCALIZE[207],home)</onclick>
+						<onclick condition="!String.IsEmpty(ListItem.Plot)">SetProperty(TextViewer_Text,$ESCINFO[ListItem.Plot],home)</onclick>
+						<onclick condition="!String.IsEmpty(ListItem.Plot)">ActivateWindow(1102)</onclick>
+						<onup>5000</onup>
+						<onleft>4000</onleft>
+						<onright>4000</onright>
+						<ondown>5000</ondown>
+						<texturenofocus border="21">dialogs/dialog-bg.png</texturenofocus>
+						<visible>Integer.IsGreater(Container(4000).NumItems,0)</visible>
+					</control>
+					<control type="image">
+						<left>755</left>
+						<width>512</width>
+						<height>718</height>
+						<aligny>bottom</aligny>
+						<texture border="21">dialogs/dialog-bg.png</texture>
+						<visible>Integer.IsGreater(Container(4000).NumItems,0)</visible>
+					</control>
+					<control type="button" id="139">
+						<width>1265</width>
+						<height>718</height>
+						<textoffsetx>40</textoffsetx>
+						<textoffsety>20</textoffsety>
+						<aligny>bottom</aligny>
+						<label></label>
+						<onclick condition="!String.IsEmpty(ListItem.Plot)">SetProperty(TextViewer_Header,$LOCALIZE[207],home)</onclick>
+						<onclick condition="!String.IsEmpty(ListItem.Plot)">SetProperty(TextViewer_Text,$ESCINFO[ListItem.Plot],home)</onclick>
+						<onclick condition="!String.IsEmpty(ListItem.Plot)">ActivateWindow(1102)</onclick>
+						<onup>50</onup>
+						<onleft>4000</onleft>
+						<onright>4000</onright>
+						<ondown>5000</ondown>
+						<texturenofocus border="21">dialogs/dialog-bg.png</texturenofocus>
+						<visible>!Integer.IsGreater(Container(4000).NumItems,0)</visible>
+					</control>
+					<control type="textbox">
+						<left>40</left>
+						<top>25</top>
+						<width>690</width>
+						<height>660</height>
+						<label fallback="19055">$INFO[ListItem.Plot]</label>
+						<autoscroll delay="10000" time="5000" repeat="10000">Skin.HasSetting(AutoScroll)</autoscroll>
+						<visible>Integer.IsGreater(Container(4000).NumItems,0)</visible>
+					</control>
+					<control type="textbox">
+						<left>40</left>
+						<top>25</top>
+						<width>1185</width>
+						<height>660</height>
+						<label fallback="19055">$INFO[ListItem.Plot]</label>
+						<autoscroll delay="10000" time="5000" repeat="10000">Skin.HasSetting(AutoScroll)</autoscroll>
+						<visible>!Integer.IsGreater(Container(4000).NumItems,0)</visible>
+					</control>
 				</control>
-				<control type="textbox" id="400">
-					<left>660</left>
-					<top>20</top>
-					<width>1050</width>
-					<height>425</height>
-					<align>justify</align>
-					<label>$INFO[ListItem.ChannelName,[B],[/B][CR]]$INFO[ListItem.Date,[COLOR grey]$LOCALIZE[552]:[/COLOR] ,[CR]]$INFO[ListItem.Duration,[COLOR grey]$LOCALIZE[180]:[/COLOR] ,[CR]]$VAR[RecordingSizeLabel]$VAR[PremieredLabel]$INFO[ListItem.Rating,[COLOR grey]$LOCALIZE[563]:[/COLOR] ,[CR]]$VAR[ExpirationDateTimeLabel]$VAR[PVRInstanceName,,[CR]]$INFO[ListItem.MediaProviders,[COLOR grey]$LOCALIZE[19334]:[/COLOR] ,[CR]]$INFO[ListItem.Genre,[COLOR grey]$LOCALIZE[515]: [/COLOR]][CR]$INFO[ListItem.ParentalRatingCode,[COLOR grey]$LOCALIZE[31017]: [/COLOR],[CR]]$INFO[ListItem.Writer,[COLOR grey]$LOCALIZE[20417]:[/COLOR] ,[CR]]$INFO[ListItem.Director,[COLOR grey]$LOCALIZE[20339]:[/COLOR] ,[CR]]$INFO[ListItem.Cast,[COLOR grey]$LOCALIZE[206]:[/COLOR] ,[CR]][CR]$INFO[ListItem.Plot]</label>
-					<autoscroll time="3000" delay="4000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+				<control type="grouplist" id="4000">
+					<orientation>vertical</orientation>
+					<left>775</left>
+					<top>185</top>
+					<height>677</height>
+					<itemgap>-8</itemgap>
+					<ondown>5000</ondown>
+					<onup>5000</onup>
+					<onright>140</onright>
+					<onleft>140</onleft>
+					<include content="InfoDialogMetadata">
+						<param name="control_id" value="150" />
+						<param name="label" value="[COLOR button_focus]$LOCALIZE[19029]: [/COLOR]$INFO[ListItem.ChannelNumberLabel,(,) ]$INFO[ListItem.ChannelName]" />
+						<param name="altlabel" value="$LOCALIZE[19029]: $INFO[ListItem.ChannelNumberLabel,(,) ]$INFO[ListItem.ChannelName]" />
+						<param name="visible" value="!String.IsEmpty(ListItem.ChannelNumberLabel) | !String.IsEmpty(ListItem.ChannelName)" />
+					</include>
+					<include content="InfoDialogMetadata">
+						<param name="control_id" value="151" />
+						<param name="label" value="[COLOR button_focus]$LOCALIZE[31137]: [/COLOR]$INFO[ListItem.PVRClientName] $INFO[ListItem.PVRInstanceName, (,)]" />
+						<param name="altlabel" value="$LOCALIZE[31137]: $INFO[ListItem.PVRClientName] $INFO[ListItem.PVRInstanceName, (,)]" />
+						<param name="visible" value="!String.IsEmpty(ListItem.PVRClientName)" />
+					</include>
+					<include content="InfoDialogMetadata">
+						<param name="control_id" value="152" />
+						<param name="label" value="[COLOR button_focus]$LOCALIZE[19334]: [/COLOR]$INFO[ListItem.MediaProviders]" />
+						<param name="altlabel" value="$LOCALIZE[19334]: $INFO[ListItem.MediaProviders]" />
+						<param name="visible" value="!String.IsEmpty(ListItem.MediaProviders)" />
+					</include>
+					<include content="InfoDialogMetadata">
+						<param name="control_id" value="153" />
+						<param name="label" value="[COLOR button_focus]$LOCALIZE[515]: [/COLOR]$INFO[ListItem.Genre]" />
+						<param name="altlabel" value="$LOCALIZE[515]: $INFO[ListItem.Genre]" />
+						<param name="visible" value="!String.IsEmpty(ListItem.Genre)" />
+					</include>
+					<include content="InfoDialogMetadata">
+						<param name="control_id" value="154" />
+						<param name="label" value="[COLOR button_focus]$LOCALIZE[206]: [/COLOR]$INFO[ListItem.Cast(pipe)]" />
+						<param name="altlabel" value="$LOCALIZE[206]: $INFO[ListItem.Cast(pipe)]" />
+						<param name="visible" value="!String.IsEmpty(ListItem.Cast(pipe))" />
+					</include>
+					<include content="InfoDialogMetadata">
+						<param name="control_id" value="155" />
+						<param name="label" value="[COLOR button_focus]$LOCALIZE[20339]: [/COLOR]$INFO[ListItem.Director(pipe)]" />
+						<param name="altlabel" value="$LOCALIZE[20339]: $INFO[ListItem.Director(pipe)]" />
+						<param name="visible" value="!String.IsEmpty(ListItem.Director(pipe))" />
+					</include>
+					<include content="InfoDialogMetadata">
+						<param name="control_id" value="156" />
+						<param name="label" value="[COLOR button_focus]$LOCALIZE[20417]: [/COLOR]$INFO[ListItem.Writer(pipe)]" />
+						<param name="altlabel" value="$LOCALIZE[20417]: $INFO[ListItem.Writer(pipe)]" />
+						<param name="visible" value="!String.IsEmpty(ListItem.Writer(pipe))" />
+					</include>
+					<include content="InfoDialogMetadata">
+						<param name="control_id" value="157" />
+						<param name="label" value="[COLOR button_focus]$VAR[FirstAiredLabel]: [/COLOR]$INFO[ListItem.Premiered]" />
+						<param name="altlabel" value="$VAR[FirstAiredLabel]: $INFO[ListItem.Premiered]" />
+						<param name="visible" value="!String.IsEmpty(ListItem.Premiered)" />
+					</include>
+					<include content="InfoDialogMetadata">
+						<param name="control_id" value="158" />
+						<param name="label" value="[COLOR button_focus]$LOCALIZE[552]: [/COLOR]$INFO[ListItem.Date]" />
+						<param name="altlabel" value="$LOCALIZE[552]: $INFO[ListItem.Date]" />
+						<param name="visible" value="!String.IsEmpty(ListItem.Date)" />
+					</include>
+					<include content="InfoDialogMetadata">
+						<param name="control_id" value="159" />
+						<param name="label" value="[COLOR button_focus]$LOCALIZE[180]: [/COLOR]$INFO[ListItem.Duration]" />
+						<param name="altlabel" value="$LOCALIZE[180]: $INFO[ListItem.Duration]" />
+						<param name="visible" value="!String.IsEmpty(ListItem.Duration)" />
+					</include>
+					<include content="InfoDialogMetadata">
+						<param name="control_id" value="160" />
+						<param name="label" value="[COLOR button_focus]$LOCALIZE[22031]: [/COLOR]$INFO[ListItem.Size]" />
+						<param name="altlabel" value="$LOCALIZE[22031]: $INFO[ListItem.Size]" />
+						<param name="visible" value="!String.IsEmpty(ListItem.Size) + !String.IsEqual(ListItem.Size,0.00 B)" />
+					</include>
+					<include content="InfoDialogMetadata">
+						<param name="control_id" value="161" />
+						<param name="label" value="[COLOR button_focus]$LOCALIZE[576]: [/COLOR]$INFO[ListItem.PlayCount]" />
+						<param name="altlabel" value="$LOCALIZE[576]: $INFO[ListItem.PlayCount]" />
+						<param name="visible" value="!String.IsEmpty(ListItem.PlayCount)" />
+					</include>
+					<include content="InfoDialogMetadata">
+						<param name="control_id" value="162" />
+						<param name="label" value="[COLOR button_focus]$LOCALIZE[568]: [/COLOR]$INFO[ListItem.LastPlayed]" />
+						<param name="altlabel" value="$LOCALIZE[568]: $INFO[ListItem.LastPlayed]" />
+						<param name="visible" value="!String.IsEmpty(ListItem.LastPlayed)" />
+					</include>
+					<include content="InfoDialogMetadata">
+						<param name="control_id" value="163" />
+						<param name="label" value="[COLOR button_focus]$LOCALIZE[19299]: [/COLOR]$INFO[ListItem.ExpirationDate] $INFO[ListItem.ExpirationTime]" />
+						<param name="altlabel" value="$LOCALIZE[19299]: $INFO[ListItem.ExpirationDate] $INFO[ListItem.ExpirationTime]" />
+						<param name="visible" value="!String.IsEmpty(ListItem.ExpirationDate) + !String.IsEmpty(ListItem.ExpirationTime) " />
+					</include>
+					<include content="InfoDialogMetadata">
+						<param name="control_id" value="164" />
+						<param name="label" value="[COLOR button_focus]$LOCALIZE[563]: [/COLOR]$INFO[ListItem.Rating]" />
+						<param name="altlabel" value="$LOCALIZE[563]: $INFO[ListItem.Rating]" />
+						<param name="visible" value="!String.IsEmpty(ListItem.Rating)" />
+					</include>
+					<include content="InfoDialogMetadata">
+						<param name="control_id" value="165" />
+						<param name="label" value="[COLOR button_focus]$LOCALIZE[31017]: [/COLOR]$INFO[ListItem.ParentalRatingCode]" />
+						<param name="altlabel" value="$LOCALIZE[31017]: $INFO[ListItem.ParentalRatingCode]" />
+						<param name="visible" value="!String.IsEmpty(ListItem.ParentalRatingCode)" />
+					</include>
 				</control>
-				<control type="grouplist" id="9000">
-					<left>150</left>
-					<top>600</top>
-					<width>1520</width>
-					<height>160</height>
-					<itemgap>10</itemgap>
+			</control>
+			<control type="group">
+				<include>OpenClose_Right</include>
+				<left>90</left>
+				<top>864</top>
+				<width>1740</width>
+				<height>400</height>
+				<control type="grouplist" id="5000">
+					<onleft>5000</onleft>
+					<onright>5000</onright>
+					<onup>140</onup>
+					<ondown>140</ondown>
+					<itemgap>-18</itemgap>
 					<align>center</align>
 					<orientation>horizontal</orientation>
-					<defaultcontrol always="true">5</defaultcontrol>
-					<onleft>9000</onleft>
-					<onright>9000</onright>
-					<onup>61</onup>
-					<ondown>61</ondown>
+					<scrolltime tween="quadratic">200</scrolltime>
 					<include content="InfoDialogButton">
-						<param name="width" value="275" />
 						<param name="id" value="5" />
 						<param name="icon" value="icons/infodialogs/launch.png" />
 						<param name="label" value="$LOCALIZE[19165]" />
 						<param name="visible" value="Window.IsActive(PVRGuideInfo)" />
 					</include>
 					<include content="InfoDialogButton">
-						<param name="width" value="275" />
 						<param name="id" value="10" />
 						<param name="icon" value="icons/infodialogs/cinema.png" />
 						<param name="label" value="$LOCALIZE[19190]" />
 						<param name="visible" value="Window.IsActive(PVRGuideInfo)" />
 					</include>
 					<include content="InfoDialogButton">
-						<param name="width" value="275" />
 						<param name="id" value="8" />
 						<param name="icon" value="icons/infodialogs/play_record.png" />
 						<param name="label" value="$LOCALIZE[19687]" />
 						<param name="visible" value="Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRecordingInfo)" />
 					</include>
 					<include content="InfoDialogButton">
-						<param name="width" value="275" />
 						<param name="id" value="6" />
 						<param name="icon" value="icons/infodialogs/record.png" />
+						<param name="label" value="$LOCALIZE[264]" />
 						<param name="visible" value="Window.IsActive(PVRGuideInfo)" />
 					</include>
 					<include content="InfoDialogButton">
-						<param name="width" value="275" />
 						<param name="id" value="9" />
 						<param name="icon" value="icons/infodialogs/timer.png" />
 						<param name="label" value="$LOCALIZE[19061]" />
 						<param name="visible" value="Window.IsActive(PVRGuideInfo)" />
 					</include>
 					<include content="InfoDialogButton">
-						<param name="width" value="275" />
 						<param name="id" value="11" />
 						<param name="icon" value="icons/infodialogs/bell.png" />
 						<param name="label" value="$LOCALIZE[826]" />
 						<param name="visible" value="Window.IsActive(PVRGuideInfo)" />
 					</include>
 					<include content="InfoDialogButton">
-						<param name="width" value="275" />
 						<param name="id" value="4" />
 						<param name="icon" value="icons/infodialogs/similar.png" />
 						<param name="label" value="$LOCALIZE[19003]" />
 						<param name="visible" value="Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRecordingInfo)" />
 					</include>
+					<include content="InfoDialogButton">
+						<param name="id" value="102" />
+						<param name="icon" value="icons/infodialogs/image.png" />
+						<param name="label" value="$LOCALIZE[31028]" />
+						<param name="onclick_1" value="SetProperty(fanart,$ESCINFO[ListItem.Art(fanart)],home)" />
+						<param name="onclick_2" value="ActivateWindow(1104)" />
+						<param name="visible" value="!String.IsEmpty(ListItem.Art(fanart))" />
+					</include>
+					<include content="InfoDialogButton">
+						<param name="id" value="13" />
+						<param name="icon" value="icons/infodialogs/director.png" />
+						<param name="label" value="$LOCALIZE[31123]" />
+						<param name="visible" value="!String.IsEmpty(ListItem.Director)" />
+					</include>
 				</control>
+				<include content="LeftRightArrows">
+					<param name="list_id" value="5000" />
+					<param name="left_posx" value="-15" />
+					<param name="right_posx" value="1730" />
+					<param name="posy" value="60" />
+					<param name="visible" value="true" />
+				</include>
 			</control>
 			<include content="InfoDialogTopBarInfo">
 				<param name="main_label" value="$INFO[ListItem.Title] $INFO[ListItem.Year,([COLOR grey],[/COLOR])]" />
 				<param name="sub_label" value="$VAR[FlagDashLabel]$VAR[SeasonEpisodeAndNameLabel]" />
-				<param name="posy" value="40" />
 			</include>
+		</control>
+		<control type="group">
+			<animation effect="fade" start="0" end="100" time="300" delay="300">WindowOpen</animation>
+			<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
+			<centerleft>50%</centerleft>
+			<width>1920</width>
+			<bottom>0</bottom>
+			<height>70</height>
+			<include>MediaFlags</include>
+			<control type="group">
+				<visible>Control.HasFocus(138)</visible>
+				<animation effect="fade" time="200">VisibleChange</animation>
+				<top>10</top>
+				<left>0</left>
+				<control type="image">
+					<top>4</top>
+					<left>17</left>
+					<width>36</width>
+					<height>36</height>
+					<texture colordiffuse="grey">lists/played-total.png</texture>
+				</control>
+				<control type="label">
+					<left>74</left>
+					<width>800</width>
+					<height>44</height>
+					<shadowcolor>text_shadow</shadowcolor>
+					<label>$LOCALIZE[31126]</label>
+				</control>
+			</control>
 		</control>
 		<include condition="Skin.HasSetting(touchmode)">TouchBackButton</include>
 	</controls>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -2493,6 +2493,16 @@ const infomap musicpartymode[] = {{ "enabled",           MUSICPM_ENABLED },
 ///     @return The genre(s) of current song.
 ///     <p>
 ///   }
+///   \table_row3{   <b>`MusicPlayer.Genre(separator)`</b>,
+///                  \anchor MusicPlayer_Genre_separator
+///                  _string_,
+///     @return A list of genres of current song\, separated by given separator\, or if no
+///     separator was given separated by the advanced settings value \“itemseparator\” for music.
+///     Possible values for separator: comma\, pipe\, slash\, cr\, dash\, colon\, semicolon\, fullstop
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link MusicPlayer_Genre_separator `MusicPlayer.Genre(separator)`\endlink
+///     <p>
+///   }
 ///   \table_row3{   <b>`MusicPlayer.offset(number).Genre`</b>,
 ///                  \anchor MusicPlayer_OffSet_Genre
 ///                  _string_,
@@ -3162,6 +3172,16 @@ const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
 ///     @return The genre(s) of current movie\, if it's in the database.
 ///     <p>
 ///   }
+///   \table_row3{   <b>`VideoPlayer.Genre(separator)`</b>,
+///                  \anchor VideoPlayer_Genre_separator
+///                  _string_,
+///     @return A list of genres of current movie\, separated by given separator\, or if no
+///     separator was given separated by the advanced settings value \“itemseparator\” for videos.
+///     Possible values for separator: comma\, pipe\, slash\, cr\, dash\, colon\, semicolon\, fullstop
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link VideoPlayer_Genre_separator `VideoPlayer.Genre(separator)`\endlink
+///     <p>
+///   }
 ///   \table_row3{   <b>`VideoPlayer.offset(number).Genre`</b>,
 ///                  \anchor VideoPlayer_Offset_Genre
 ///                  _string_,
@@ -3185,6 +3205,17 @@ const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
 ///     <p><hr>
 ///     @skinning_v15 **[Infolabel Updated]** \link VideoPlayer_Director `VideoPlayer.Director`\endlink
 ///     also supports EPG.
+///     <p>
+///   }
+///   \table_row3{   <b>`VideoPlayer.Director(separator)`</b>,
+///                  \anchor VideoPlayer_Director_separator
+///                  _string_,
+///     @return A list of directors of the currently playing video\, separated by given separator\,
+///     or if no separator was given separated by the advanced settings value \“itemseparator\” for
+///     video items.
+///     Possible values for separator: comma\, pipe\, slash\, cr\, dash\, colon\, semicolon\, fullstop
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link VideoPlayer_Director_separator `VideoPlayer.Director(separator)`\endlink
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`VideoPlayer.offset(number).Director`</b>,
@@ -3488,11 +3519,31 @@ const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
 ///     also supports EPG.
 ///     <p>
 ///   }
+///   \table_row3{   <b>`VideoPlayer.Cast(separator)`</b>,
+///                  \anchor VideoPlayer_Cast_separator
+///                  _string_,
+///     @return A list of cast members of the currently playing video\, separated by given
+///     separator\, or if no separator was given separated by carriage returns.
+///     Possible values for separator: comma\, pipe\, slash\, cr\, dash\, colon\, semicolon\, fullstop
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link VideoPlayer_Cast_separator `VideoPlayer.Cast(separator)`\endlink
+///     <p>
+///   }
 ///   \table_row3{   <b>`VideoPlayer.CastAndRole`</b>,
 ///                  \anchor VideoPlayer_CastAndRole
 ///                  _string_,
 ///     @return A list of cast members and roles\, separated by carriage
 ///     returns. Every cast/role combination is formatted 'cast' as 'role' where 'as' is localised.
+///     <p>
+///   }
+///   \table_row3{   <b>`VideoPlayer.CastAndRole(separator)`</b>,
+///                  \anchor VideoPlayer_CastAndRole_separator
+///                  _string_,
+///     @return A list of cast members and roles of the currently playing video\, pairs separated by
+///     given separator\, or if no separator was given separated by carriage returns.
+///     Possible values for separator: comma\, pipe\, slash\, cr\, dash\, colon\, semicolon\, fullstop
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link VideoPlayer_CastAndRole_separator `VideoPlayer.CastAndRole(separator)`\endlink
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`VideoPlayer.Album`</b>,
@@ -3568,6 +3619,17 @@ const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
 ///     <p><hr>
 ///     @skinning_v15 **[Infolabel Updated]** \link VideoPlayer_Writer `VideoPlayer.Writer`\endlink
 ///     also supports EPG.
+///     <p>
+///   }
+///   \table_row3{   <b>`VideoPlayer.Writer(separator)`</b>,
+///                  \anchor VideoPlayer_Writer_separator
+///                  _string_,
+///     @return A list of writers of the currently playing video\, separated by given separator\,
+///     or if no separator was given separated by the advanced settings value \“itemseparator\” for
+///     video items.
+///     Possible values for separator: comma\, pipe\, slash\, cr\, dash\, colon\, semicolon\, fullstop
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link VideoPlayer_Writer_separator `VideoPlayer.Writer(separator)`\endlink
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`VideoPlayer.offset(number).Writer`</b>,
@@ -3833,6 +3895,17 @@ const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
 ///                  \anchor VideoPlayer_NextGenre
 ///                  _string_,
 ///     @return The genre of the programme that will be played next (PVR).
+///     <p>
+///   }
+///   \table_row3{   <b>`VideoPlayer.NextGenre(separator)`</b>,
+///                  \anchor VideoPlayer_NextGenre_separator
+///                  _string_,
+///     @return A list of genres of the programme that will be played next (PVR)\, separated by
+///     given separator\, or if no separator was given separated by the advanced settings value
+///     \“itemseparator\” for videos.
+///     Possible values for separator: comma\, pipe\, slash\, cr\, dash\, colon\, semicolon\, fullstop
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link VideoPlayer_NextGenre_separator `VideoPlayer.NextGenre(separator)`\endlink
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`VideoPlayer.NextPlot`</b>,
@@ -5107,6 +5180,16 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     container.
 ///     <p>
 ///   }
+///   \table_row3{   <b>`ListItem.Genre(separator)`</b>,
+///                  \anchor ListItem_Genre_separator
+///                  _string_,
+///     @return A list of genres\, separated by given separator\, or if no separator was given
+///     separated by the advanced settings value \“itemseparator\” for videos or music.
+///     Possible values for separator: comma\, pipe\, slash\, cr\, dash\, colon\, semicolon\, fullstop
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link ListItem_Genre_separator `ListItem.Genre(separator)`\endlink
+///     <p>
+///   }
 ///   \table_row3{   <b>`ListItem.Contributors`</b>,
 ///                  \anchor ListItem_Contributors
 ///                  _string_,
@@ -5130,6 +5213,16 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     <p><hr>
 ///     @skinning_v15 **[Infolabel Updated]** \link ListItem_Director `ListItem.Director`\endlink
 ///     also supports EPG.
+///     <p>
+///   }
+///   \table_row3{   <b>`ListItem.Director(separator)`</b>,
+///                  \anchor ListItem_Director_separator
+///                  _string_,
+///     @return A list of directors\, separated by given separator\, or if no separator was given
+///     separated by the advanced settings value \“itemseparator\” for video items.
+///     Possible values for separator: comma\, pipe\, slash\, cr\, dash\, colon\, semicolon\, fullstop
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link ListItem_Director_separator `ListItem.Director(separator)`\endlink
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Country`</b>,
@@ -5967,11 +6060,31 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     also supports EPG.
 ///     <p>
 ///   }
+///   \table_row3{   <b>`ListItem.Cast(separator)`</b>,
+///                  \anchor ListItem_Cast_separator
+///                  _string_,
+///     @return A list of cast members\, separated by given separator\, or if no separator was
+///     given separated by carriage returns.
+///     Possible values for separator: comma\, pipe\, slash\, cr\, dash\, colon\, semicolon\, fullstop
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link ListItem_Cast_separator `ListItem.Cast(separator)`\endlink
+///     <p>
+///   }
 ///   \table_row3{   <b>`ListItem.CastAndRole`</b>,
 ///                  \anchor ListItem_CastAndRole
 ///                  _string_,
 ///     @return A list of cast members and roles\, separated by carriage
 ///     returns. Every cast/role combination is formatted 'cast' as 'role' where 'as' is localised.
+///     <p>
+///   }
+///   \table_row3{   <b>`ListItem.CastAndRole(separator)`</b>,
+///                  \anchor ListItem_CastAndRole_separator
+///                  _string_,
+///     @return A list of cast members and roles\, separated by given separator\, or if no separator
+///     was given separated by carriage returns.
+///     Possible values for separator: comma\, pipe\, slash\, cr\, dash\, colon\, semicolon\, fullstop
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link ListItem_CastAndRole_separator `ListItem.CastAndRole(separator)`\endlink
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Studio`</b>,
@@ -6001,6 +6114,16 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     <p><hr>
 ///     @skinning_v15 **[Infolabel Updated]** \link ListItem_Writer `ListItem.Writer`\endlink
 ///     also supports EPG.
+///     <p>
+///   }
+///   \table_row3{   <b>`ListItem.Writer(separator)`</b>,
+///                  \anchor ListItem_Writer_separator
+///                  _string_,
+///     @return A list of writers\, separated by given separator\, or if no separator was given
+///     separated by the advanced settings value \“itemseparator\” for video items.
+///     Possible values for separator: comma\, pipe\, slash\, cr\, dash\, colon\, semicolon\, fullstop
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link ListItem_Writer_separator `ListItem.Writer(separator)`\endlink
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Tag`</b>,
@@ -6314,6 +6437,17 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///                  \anchor ListItem_NextGenre
 ///                  _string_,
 ///     @return The genre of the next item (PVR).
+///     <p>
+///   }
+///   \table_row3{   <b>`ListItem.NextGenre(separator)`</b>,
+///                  \anchor ListItem_NextGenre_separator
+///                  _string_,
+///     @return A list of genres of the the next item (PVR)\, separated by given separator\, or if
+///     no separator was given separated by the advanced settings value \“itemseparator\” for
+///     videos.
+///     Possible values for separator: comma\, pipe\, slash\, cr\, dash\, colon\, semicolon\, fullstop
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link ListItem_NextGenre_separator `ListItem.NextGenre(separator)`\endlink
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.NextPlot`</b>,
@@ -10220,6 +10354,34 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition)
   return TranslateSingleString(strCondition, listItemDependent);
 }
 
+namespace
+{
+std::string TranslateListSeparator(const std::string& param)
+{
+  if (StringUtils::EqualsNoCase(param, "comma"))
+    return ",";
+  else if (StringUtils::EqualsNoCase(param, "pipe"))
+    return "|";
+  else if (StringUtils::EqualsNoCase(param, "slash"))
+    return "/";
+  else if (StringUtils::EqualsNoCase(param, "cr"))
+    return "\n";
+  else if (StringUtils::EqualsNoCase(param, "dash"))
+    return "-";
+  else if (StringUtils::EqualsNoCase(param, "colon"))
+    return ":";
+  else if (StringUtils::EqualsNoCase(param, "semicolon"))
+    return ";";
+  else if (StringUtils::EqualsNoCase(param, "fullstop"))
+    return ".";
+  else
+  {
+    CLog::Log(LOGERROR, "unhandled separator param {}", param);
+    return {};
+  }
+}
+} // unnamed namespace
+
 int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool &listItemDependent)
 {
   /* We need to disable caching in INFO::InfoBool::Get if either of the following are true:
@@ -10525,7 +10687,13 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
           return AddMultiInfo(CGUIInfo(player_time.val, TranslateTimeFormat(prop.param())));
       }
       if (prop.name == "content" && prop.num_params())
+      {
         return AddMultiInfo(CGUIInfo(MUSICPLAYER_CONTENT, prop.param(), 0));
+      }
+      else if (prop.name == "genre" && prop.num_params() > 0)
+      {
+        return AddMultiInfo(CGUIInfo(MUSICPLAYER_GENRE, TranslateListSeparator(prop.param()), 0));
+      }
       else if (prop.name == "property")
       {
         if (StringUtils::EqualsNoCase(prop.param(), "fanart_image"))
@@ -10556,6 +10724,33 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
       if (prop.name == "art" && prop.num_params() > 0)
       {
         return AddMultiInfo(CGUIInfo(VIDEOPLAYER_ART, prop.param(), 0));
+      }
+      if (prop.name == "cast" && prop.num_params() > 0)
+      {
+        return AddMultiInfo(CGUIInfo(VIDEOPLAYER_CAST, TranslateListSeparator(prop.param()), 0));
+      }
+      if (prop.name == "castandrole" && prop.num_params() > 0)
+      {
+        return AddMultiInfo(
+            CGUIInfo(VIDEOPLAYER_CAST_AND_ROLE, TranslateListSeparator(prop.param()), 0));
+      }
+      if (prop.name == "writer" && prop.num_params() > 0)
+      {
+        return AddMultiInfo(CGUIInfo(VIDEOPLAYER_WRITER, TranslateListSeparator(prop.param()), 0));
+      }
+      if (prop.name == "director" && prop.num_params() > 0)
+      {
+        return AddMultiInfo(
+            CGUIInfo(VIDEOPLAYER_DIRECTOR, TranslateListSeparator(prop.param()), 0));
+      }
+      if (prop.name == "genre" && prop.num_params() > 0)
+      {
+        return AddMultiInfo(CGUIInfo(VIDEOPLAYER_GENRE, TranslateListSeparator(prop.param()), 0));
+      }
+      if (prop.name == "nextgenre" && prop.num_params() > 0)
+      {
+        return AddMultiInfo(
+            CGUIInfo(VIDEOPLAYER_NEXT_GENRE, TranslateListSeparator(prop.param()), 0));
       }
       return TranslateVideoPlayerString(prop.name);
     }
@@ -10884,6 +11079,11 @@ int CGUIInfoManager::TranslateListItem(const Property& cat, const Property& prop
              prop.name == "uniqueid")
     {
       data3 = prop.param();
+    }
+    else if (prop.name == "cast" || prop.name == "castandrole" || prop.name == "director" ||
+             prop.name == "writer" || prop.name == "genre" || prop.name == "nextgenre")
+    {
+      data3 = TranslateListSeparator(prop.param());
     }
     else if (prop.name == "duration" || prop.name == "nextduration")
     {

--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -188,8 +188,14 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         return true;
       case MUSICPLAYER_GENRE:
       case LISTITEM_GENRE:
-        value =  StringUtils::Join(tag->GetGenre(), CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);
+      {
+        const std::string sep{info.GetData3().empty() ? CServiceBroker::GetSettingsComponent()
+                                                            ->GetAdvancedSettings()
+                                                            ->m_musicItemSeparator
+                                                      : info.GetData3()};
+        value = StringUtils::Join(tag->GetGenre(), sep);
         return true;
+      }
       case MUSICPLAYER_LYRICS:
         value = tag->GetLyrics();
         return true;

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -143,12 +143,24 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         return true;
       case VIDEOPLAYER_GENRE:
       case LISTITEM_GENRE:
-        value = StringUtils::Join(tag->m_genre, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
+      {
+        const std::string sep{info.GetData3().empty() ? CServiceBroker::GetSettingsComponent()
+                                                            ->GetAdvancedSettings()
+                                                            ->m_videoItemSeparator
+                                                      : info.GetData3()};
+        value = StringUtils::Join(tag->m_genre, sep);
         return true;
+      }
       case VIDEOPLAYER_DIRECTOR:
       case LISTITEM_DIRECTOR:
-        value = StringUtils::Join(tag->m_director, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
+      {
+        const std::string sep{info.GetData3().empty() ? CServiceBroker::GetSettingsComponent()
+                                                            ->GetAdvancedSettings()
+                                                            ->m_videoItemSeparator
+                                                      : info.GetData3()};
+        value = StringUtils::Join(tag->m_director, sep);
         return true;
+      }
       case VIDEOPLAYER_IMDBNUMBER:
       case LISTITEM_IMDBNUMBER:
         value = tag->GetUniqueID();
@@ -300,11 +312,11 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         break;
       case VIDEOPLAYER_CAST:
       case LISTITEM_CAST:
-        value = tag->GetCast();
+        value = tag->GetCast(info.GetData3());
         return true;
       case VIDEOPLAYER_CAST_AND_ROLE:
       case LISTITEM_CAST_AND_ROLE:
-        value = tag->GetCast(true);
+        value = tag->GetCast(info.GetData3(), true);
         return true;
       case VIDEOPLAYER_ARTIST:
       case LISTITEM_ARTIST:
@@ -316,8 +328,14 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         return true;
       case VIDEOPLAYER_WRITER:
       case LISTITEM_WRITER:
-        value = StringUtils::Join(tag->m_writingCredits, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
+      {
+        const std::string sep{info.GetData3().empty() ? CServiceBroker::GetSettingsComponent()
+                                                            ->GetAdvancedSettings()
+                                                            ->m_videoItemSeparator
+                                                      : info.GetData3()};
+        value = StringUtils::Join(tag->m_writingCredits, sep);
         return true;
+      }
       case VIDEOPLAYER_TAGLINE:
       case LISTITEM_TAGLINE:
         value = tag->m_strTagLine;

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -219,7 +219,7 @@ namespace XBMCAddon
 
     String InfoTagVideo::getCast()
     {
-      return infoTag->GetCast(true);
+      return infoTag->GetCast("\n", true);
     }
 
     std::vector<Actor*> InfoTagVideo::getActors()

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -361,34 +361,38 @@ unsigned int CPVREpgInfoTag::GetDuration() const
   }
 }
 
-const std::string CPVREpgInfoTag::GetCastLabel() const
+const std::string CPVREpgInfoTag::GetCastLabel(const std::string& separator) const
 {
   // Note: see CVideoInfoTag::GetCast for reference implementation.
-  std::string strLabel;
-  for (const auto& castEntry : m_cast)
-    strLabel += StringUtils::Format("{}\n", castEntry);
-
-  return StringUtils::TrimRight(strLabel, "\n");
+  const std::string sep{separator.empty() ? "\n" : separator};
+  return StringUtils::Join(m_cast, sep);
 }
 
-const std::string CPVREpgInfoTag::GetDirectorsLabel() const
+const std::string CPVREpgInfoTag::GetDirectorsLabel(const std::string& separator) const
 {
-  return StringUtils::Join(
-      m_directors,
-      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
+  const std::string sep{
+      separator.empty()
+          ? CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator
+          : separator};
+  return StringUtils::Join(m_directors, sep);
 }
 
-const std::string CPVREpgInfoTag::GetWritersLabel() const
+const std::string CPVREpgInfoTag::GetWritersLabel(const std::string& separator) const
 {
-  return StringUtils::Join(
-      m_writers,
-      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
+  const std::string sep{
+      separator.empty()
+          ? CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator
+          : separator};
+  return StringUtils::Join(m_writers, sep);
 }
 
-const std::string CPVREpgInfoTag::GetGenresLabel() const
+const std::string CPVREpgInfoTag::GetGenresLabel(const std::string& separator) const
 {
-  return StringUtils::Join(
-      Genre(), CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
+  const std::string sep{
+      separator.empty()
+          ? CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator
+          : separator};
+  return StringUtils::Join(Genre(), sep);
 }
 
 int CPVREpgInfoTag::Year() const

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -238,28 +238,32 @@ public:
   const std::vector<std::string>& Writers() const { return m_writers; }
 
   /*!
-   * @brief Get the cast of this event as formatted string.
+   * @brief Get the cast members of this event as formatted string.
+   * @param separator The separator for the different cast members, default value if empty.
    * @return The cast label.
    */
-  const std::string GetCastLabel() const;
+  const std::string GetCastLabel(const std::string& separator) const;
 
   /*!
    * @brief Get the director(s) of this event as formatted string.
+   * @param separator The separator for the different directors, default value if empty.
    * @return The directors label.
    */
-  const std::string GetDirectorsLabel() const;
+  const std::string GetDirectorsLabel(const std::string& separator) const;
 
   /*!
    * @brief Get the writer(s) of this event as formatted string.
+   * @param separator The separator for the different writers, default value if empty.
    * @return The writers label.
    */
-  const std::string GetWritersLabel() const;
+  const std::string GetWritersLabel(const std::string& separator) const;
 
   /*!
    * @brief Get the genre(s) of this event as formatted string.
+   * @param separator The separator for the different genres, default value if empty.
    * @return The genres label.
    */
-  const std::string GetGenresLabel() const;
+  const std::string GetGenresLabel(const std::string& separator) const;
 
   /*!
    * @brief Get the year of this event.

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -736,7 +736,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
       case LISTITEM_GENRE:
       case VIDEOPLAYER_NEXT_GENRE:
       case LISTITEM_NEXT_GENRE:
-        strValue = epgTag->GetGenresLabel();
+        strValue = epgTag->GetGenresLabel(info.GetData3());
         return true;
       case VIDEOPLAYER_PLOT:
       case LISTITEM_PLOT:
@@ -831,15 +831,15 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
         return true;
       case VIDEOPLAYER_CAST:
       case LISTITEM_CAST:
-        strValue = epgTag->GetCastLabel();
+        strValue = epgTag->GetCastLabel(info.GetData3());
         return true;
       case VIDEOPLAYER_DIRECTOR:
       case LISTITEM_DIRECTOR:
-        strValue = epgTag->GetDirectorsLabel();
+        strValue = epgTag->GetDirectorsLabel(info.GetData3());
         return true;
       case VIDEOPLAYER_WRITER:
       case LISTITEM_WRITER:
-        strValue = epgTag->GetWritersLabel();
+        strValue = epgTag->GetWritersLabel(info.GetData3());
         return true;
       case LISTITEM_EPG_EVENT_ICON:
         strValue = epgTag->IconPath();

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -982,20 +982,22 @@ bool CVideoInfoTag::HasUniqueID() const
   return !m_uniqueIDs.empty();
 }
 
-const std::string CVideoInfoTag::GetCast(bool bIncludeRole /*= false*/) const
+const std::string CVideoInfoTag::GetCast(const std::string& separator,
+                                         bool bIncludeRole /*= false*/) const
 {
+  const std::string sep{separator.empty() ? "\n" : separator};
   std::string strLabel;
   for (iCast it = m_cast.begin(); it != m_cast.end(); ++it)
   {
     std::string character;
     if (it->strRole.empty() || !bIncludeRole)
-      character = StringUtils::Format("{}\n", it->strName);
+      character = StringUtils::Format("{}{}", it->strName, sep);
     else
-      character =
-          StringUtils::Format("{} {} {}\n", it->strName, g_localizeStrings.Get(20347), it->strRole);
+      character = StringUtils::Format("{} {} {}{}", it->strName, g_localizeStrings.Get(20347),
+                                      it->strRole, sep);
     strLabel += character;
   }
-  return StringUtils::TrimRight(strLabel, "\n");
+  return StringUtils::TrimRight(strLabel, sep.c_str());
 }
 
 void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -88,7 +88,7 @@ public:
   bool HasPremiered() const;
   const CDateTime& GetPremiered() const;
   const CDateTime& GetFirstAired() const;
-  const std::string GetCast(bool bIncludeRole = false) const;
+  const std::string GetCast(const std::string& separator, bool bIncludeRole = false) const;
   bool HasStreamDetails() const;
   bool IsEmpty() const;
 


### PR DESCRIPTION
What subject says. Rework layout of the PVR info dialog so it is visually more close to the video info dialog.

With only channel logo being available:

<img width="1710" alt="Screenshot 2025-01-29 at 17 34 09" src="https://github.com/user-attachments/assets/272ea8df-e7ad-470b-b4f4-63707a8b5359" />

With both channel logo and thumbnail being available:

<img width="1710" alt="Screenshot 2025-01-29 at 17 36 41" src="https://github.com/user-attachments/assets/4fa6f065-64c4-44a6-8960-3947ce5e1b2b" />

With square channel logo:

<img width="1710" alt="Screenshot 2025-01-29 at 19 12 10" src="https://github.com/user-attachments/assets/70db0842-373b-4f3d-b715-05f42820075e" />


**Skinning engine changes:**

Introduces parameter 'separator' to several existing guiinfo labels which return a list of items, to make the separator used for the list customizable.

Possible values for the parameter: comma pipe slash cr dash colon semicolon fullstop

If the param is omitted, these labels work as before.

Following labels now support the new parameter:

* ListItem.Cast
* ListItem.CastAndRole
* ListItem.Writer
* ListItem.Director
* ListItem.Genre
* ListItem.NextGenre
* MusicPlayer.Genre
* VideoPlayer.Cast
* VideoPlayer.CastAndRole
* VideoPlayer.Writer
* VideoPlayer.Director
* VideoPlayer.Genre
* VideoPlayer.NextGenre
 

@jjd-uk as discussed internally, maybe you can check the skin code changes.
@neo1973 could you have a look at the code changes, mostly documentation. Code changes itself are trivial.