### PR TITLE
Add Flirc appearance to peripherals.xml

### DIFF
--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -62,6 +62,10 @@
      <setting key="keymap" value="osmcv3" label="35007" configurable="1"/>
   </peripheral>
 
+  <peripheral vendor_product="20A0:0001" bus="usb" name="Flirc" mapTo="hid">
+    <setting key="appearance" type="addon" addontype="kodi.game.controller" value="game.controller.flirc" configurable="0"/>
+  </peripheral>
+
   <peripheral class="joystick" name="joystick" mapTo="joystick">
     <setting key="appearance" type="addon" addontype="kodi.game.controller" value="game.controller.default" label="480" order="1"/>
     <setting key="last_active" type="string" value="" configurable="0"/>


### PR DESCRIPTION
## Description

This PR adds the Flirc to peripherals.xml, causing it to show up in the Peripherals Dialog.

Requires:

* https://github.com/kodi-game/controller-topology-project/pull/349
* https://github.com/xbmc/repo-resources/pull/503

## Motivation and context

It doesn't have any settings, so clicking on it is anticlimactic. But it's useful for debugging, because you can see whether Kodi identifies your Flirc.

## How has this been tested?

Tested on macOS ARM64.

## What is the effect on users?

* Show the Flirc in the Peripherals Dialog

## Screenshots (if appropriate):

<img width="1278" alt="Screenshot 2025-01-30 at 9 34 08 PM" src="https://github.com/user-attachments/assets/ac6e3eb2-0965-4240-a8da-ae70af770f66" />

<img width="1275" alt="Screenshot 2025-01-30 at 7 41 10 PM" src="https://github.com/user-attachments/assets/08296b1f-227d-4175-b954-be6f6b4550e5" />

<img width="1276" alt="Screenshot 2025-01-30 at 7 41 28 PM" src="https://github.com/user-attachments/assets/1bad8cf1-8c4d-4847-b2fb-08b4a9d804f0" />

<img width="1277" alt="Screenshot 2025-01-30 at 7 45 49 PM" src="https://github.com/user-attachments/assets/5165ffd3-d9bd-411a-9a8b-ca8dd0b76973" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
