### PR TITLE
[Settings] Revert shutdown function timer back to spinner control

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3656,11 +3656,11 @@
           <level>2</level>
           <default>0</default>
           <constraints>
-            <minimum>0</minimum>
+            <minimum label="351">0</minimum>
             <step>15</step>
             <maximum>1440</maximum>
           </constraints>
-          <control type="slider" format="integer">
+          <control type="spinner" format="string">
             <formatlabel>14044</formatlabel>
           </control>
         </setting>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Revert shutdown function timer setting back to spinner control

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In my PR https://github.com/xbmc/xbmc/pull/23299 to increase the shutdown timeout, it was suggested to change from a spinner to a slider control and the PR was merged with that suggestion.

However after using it I dislike the slider. A slider doesn't match to similar surrounding spinner controls, it only states "0" rather than "Off" (or local equivalent) and as a slider the range shown for shutdown is not actually useful.

Ergo revert back to original spinner.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by applying patch to an installed Kodi settings.xml file by hand.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
None. Slider was only in unreleased git.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
