### PR TITLE
Add OSMC Remote appearance to peripherals.xml

### DIFF
--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -54,11 +54,13 @@
   </peripheral>
 
   <peripheral vendor_product="2252:1037,2017:1688,2017:1689,2017:1690" bus="usb" name="OSMC RF Remote" mapTo="hid">
+     <setting key="appearance" type="addon" addontype="kodi.game.controller" value="game.controller.osmc.remote" configurable="0"/>
      <setting key="do_not_use_custom_keymap" type="bool" value="0" label="35009" order="1"/>
      <setting key="keymap" value="osmc" label="35007" configurable="1"/>
   </peripheral>
 
   <peripheral vendor_product="2017:1710,2017:1720" bus="usb" name="OSMC RF Remote" mapTo="hid">
+     <setting key="appearance" type="addon" addontype="kodi.game.controller" value="game.controller.osmc.remote" configurable="0"/>
      <setting key="do_not_use_custom_keymap" type="bool" value="0" label="35009" order="1"/>
      <setting key="keymap" value="osmcv3" label="35007" configurable="1"/>
   </peripheral>


### PR DESCRIPTION
## Description

As title says, this adds the OSMC remote's appearance to peripherals.xml.

Requires:

* https://github.com/kodi-game/controller-topology-project/pull/351.
* https://github.com/xbmc/repo-resources/pull/503

## Motivation and context

No changes to core.

## How has this been tested?

Tested by mocking an OSMC remote on macOS.

Will test with physical hardware when it ships.

## What is the effect on users?

* Added image for OSMC remote

## Screenshots

<img width="1337" alt="Screenshot 2025-01-31 at 2 16 01 PM" src="https://github.com/user-attachments/assets/70061d9d-394c-4dbf-a284-b37ca03ca54a" />

<img width="1335" alt="Screenshot 2025-01-31 at 2 16 16 PM" src="https://github.com/user-attachments/assets/7f6f0621-7355-415a-ba9a-851dea3767f4" />

<img width="1342" alt="Screenshot 2025-01-31 at 2 16 34 PM" src="https://github.com/user-attachments/assets/e66d7ba7-9b4a-42ea-b72b-dbb44447b020" />

<img width="1337" alt="Screenshot 2025-01-31 at 2 17 12 PM" src="https://github.com/user-attachments/assets/19b8000c-4614-4a13-8a1d-ab8d5dc1be60" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
