### PR TITLE
[GUIDialogLockSettings] change strings wording when is for enter url credentials

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7451,7 +7451,7 @@ msgid "Start slideshow here"
 msgstr ""
 
 msgctxt "#13423"
-msgid "Remember for this path"
+msgid "Remember credentials"
 msgstr ""
 
 #. Shown on context menu when a bluray:// or dvd:// playlist has already been saved
@@ -13174,7 +13174,7 @@ msgid "Cancel shutdown timer"
 msgstr ""
 
 msgctxt "#20152"
-msgid "Lock preferences for {0:s}"
+msgid "Enter credentials for {0:s}"
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogFileBrowser.cpp


### PR DESCRIPTION
## Description
[GUIDialogLockSettings] change strings wording when is for enter url credentials (SMB, etc.)

Fixes https://github.com/xbmc/xbmc/issues/26366

## Motivation and context
`GUIDialogLockSettings` is used also for lock and profiles and current window title "Lock preferences for..." is confusing when is used for enter SMB credentials. Also changed the string "Remember for this path" because it is also not accurate and can cause confusion:

If there is a saved password for `smb://server/myshare/movies` is also used for `smb://server/myshare/music`, this seems logical but is also used for `smb://server/othershare/secret`. 

Obviously if `othershare` has different credentials on the server it won't work but Kodi tries to use the password as fallback (if there is no better alternative). If there is an exact match in passwords.xml (same path) then the correct one is used.

Note that when dialog is used for lock and profiles other string is used:

https://github.com/xbmc/xbmc/blob/f3bfeeccca6cb388834722d4765283829f67626a/addons/resource.language.en_gb/resources/strings.po#L12815-L12817

This not changes and "remember" string is not visible in the other use case.

## How has this been tested?
Windows x64

## What is the effect on users?
Less confusion in the SMB password entry dialog.

## Screenshots (if appropriate):
**Before**
![before](https://github.com/user-attachments/assets/d648f49d-3c46-42bd-b5b0-e135685ff05e)

**After**
![after](https://github.com/user-attachments/assets/ea2c3d0e-dbc7-4df2-8d95-f2403a032ae9)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
