### PR TITLE
[Peripherals] Wait for GUI before installing controllers

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1690,6 +1690,12 @@ void CGUIWindowManager::AddMsgTarget(IMsgTargetCallback* pMsgTarget)
   m_vecMsgTargets.emplace_back(pMsgTarget);
 }
 
+void CGUIWindowManager::RemoveMsgTarget(IMsgTargetCallback* pMsgTarget)
+{
+  m_vecMsgTargets.erase(std::remove(m_vecMsgTargets.begin(), m_vecMsgTargets.end(), pMsgTarget),
+                        m_vecMsgTargets.end());
+}
+
 int CGUIWindowManager::GetActiveWindow() const
 {
   if (!m_windowHistory.empty())

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -198,6 +198,7 @@ public:
   // pMessageIDList: point to first integer of a 0 ends integer array.
   int RemoveThreadMessageByMessageIds(int *pMessageIDList);
   void AddMsgTarget( IMsgTargetCallback* pMsgTarget );
+  void RemoveMsgTarget(IMsgTargetCallback* pMsgTarget);
   int GetActiveWindow() const;
   int GetActiveWindowOrDialog() const;
   bool HasModalDialog(bool ignoreClosing) const;

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -79,7 +79,8 @@ CPeripherals::CPeripherals(CInputManager& inputManager,
                            GAME::CControllerManager& controllerProfiles)
   : m_inputManager(inputManager),
     m_controllerProfiles(controllerProfiles),
-    m_eventScanner(new CEventScanner(*this))
+    m_eventScanner(new CEventScanner(*this)),
+    m_guiReadyEvent(std::make_unique<CEvent>())
 {
   // Register settings
   std::set<std::string> settingSet;
@@ -93,6 +94,13 @@ CPeripherals::CPeripherals(CInputManager& inputManager,
 
 CPeripherals::~CPeripherals()
 {
+  // Unregister with GUI messenger
+  CGUIComponent* gui = CServiceBroker::GetGUI();
+  if (gui != nullptr)
+    gui->GetWindowManager().RemoveMsgTarget(this);
+
+  m_guiReadyEvent->Set();
+
   // Unregister settings
   CServiceBroker::GetSettingsComponent()->GetSettings()->UnregisterCallback(this);
 
@@ -137,6 +145,11 @@ void CPeripherals::Initialise()
 
   CServiceBroker::GetAppMessenger()->RegisterReceiver(this);
   CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this, ANNOUNCEMENT::Player);
+
+  // Register for GUI messages
+  CGUIComponent* gui = CServiceBroker::GetGUI();
+  if (gui != nullptr)
+    gui->GetWindowManager().AddMsgTarget(this);
 }
 
 void CPeripherals::Clear()
@@ -735,6 +748,32 @@ bool CPeripherals::OnAction(const CAction& action)
   }
 
   return false;
+}
+
+bool CPeripherals::OnMessage(CGUIMessage& message)
+{
+  switch (message.GetMessage())
+  {
+    case GUI_MSG_NOTIFY_ALL:
+    {
+      if (message.GetParam1() == GUI_MSG_UI_READY)
+      {
+        m_guiReady = true;
+        m_guiReadyEvent->Set();
+      }
+      break;
+    }
+    default:
+      break;
+  }
+
+  return false;
+}
+
+bool CPeripherals::WaitForGUI()
+{
+  m_guiReadyEvent->Wait();
+  return m_guiReady;
 }
 
 bool CPeripherals::IsMuted()

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -10,6 +10,7 @@
 
 #include "bus/PeripheralBus.h"
 #include "devices/Peripheral.h"
+#include "guilib/IMsgTargetCallback.h"
 #include "interfaces/IAnnouncer.h"
 #include "messaging/IMessageTarget.h"
 #include "peripherals/events/interfaces/IEventScannerCallback.h"
@@ -18,6 +19,7 @@
 #include "threads/Thread.h"
 #include "utils/Observer.h"
 
+#include <atomic>
 #include <memory>
 #include <vector>
 
@@ -27,6 +29,7 @@ class CSetting;
 class CSettingsCategory;
 class CAction;
 class CKey;
+class CEvent;
 
 namespace tinyxml2
 {
@@ -57,7 +60,8 @@ class CPeripherals : public ISettingCallback,
                      public Observable,
                      public KODI::MESSAGING::IMessageTarget,
                      public IEventScannerCallback,
-                     public ANNOUNCEMENT::IAnnouncer
+                     public ANNOUNCEMENT::IAnnouncer,
+                     public IMsgTargetCallback
 {
 public:
   explicit CPeripherals(CInputManager& inputManager,
@@ -338,6 +342,9 @@ public:
                 const std::string& message,
                 const CVariant& data) override;
 
+  // Implementation of IMsgTargetCallback
+  bool OnMessage(CGUIMessage& message) override;
+
   /*!
    * \brief Access the input manager passed to the constructor
    */
@@ -371,6 +378,9 @@ public:
    */
   float GetPeripheralActivation(const std::string& peripheralPath) const;
 
+  // GUI functions
+  bool WaitForGUI();
+
 private:
   bool LoadMappings();
   bool GetMappingForDevice(const CPeripheralBus& bus, PeripheralScanResult& result) const;
@@ -392,5 +402,7 @@ private:
   mutable CCriticalSection m_critSectionBusses;
   mutable CCriticalSection m_critSectionMappings;
   CCriticalSection m_addonInstallMutex;
+  std::atomic<bool> m_guiReady{false};
+  std::unique_ptr<CEvent> m_guiReadyEvent;
 };
 } // namespace PERIPHERALS

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -983,6 +983,10 @@ void CPeripheral::InstallController(
 
 GAME::ControllerPtr CPeripheral::InstallAsync(const std::string& controllerId)
 {
+  // Installing controllers calls into the GUI, so wait for it to be ready
+  if (!m_manager.WaitForGUI())
+    return {};
+
   GAME::ControllerPtr controller;
 
   // Only 1 install at a time. Remaining installs will wake when this one


### PR DESCRIPTION
## Description

This PR fixes a potential 2-year-old race condition on startup introduced in https://github.com/xbmc/xbmc/pull/22856. Controller profiles are read from peripherals.xml in Stage Three. Installing an add-on calls into the GUI. If the add-on is installed fast enough, the GUI might not fully be ready.

To solve this, we block for the "GUI ready" signal before installing any add-ons.

## Motivation and context

I observed a crash on first run, and unreproducible after that. I went bug hunting and discovered a possible race condition that could cause this single crash.

The code is almost 2 years old (https://github.com/xbmc/xbmc/pull/22856) and never crashed before. Still, better safe than sorry.

## How has this been tested?

I can't reproduce the crash on first startup, so it may not have been caused by this race condition.

With the patch, I set breakpoints and verified that before the patch, add-on installation starts during stage 3, and after the patch, it blocks until CApplication is initialized.

## What is the effect on users?

* Possibly fixes crash in splash screen on first startup

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
