### PR TITLE
[Backport][Peripherals] Wait for GUI before installing controllers

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1610,6 +1610,12 @@ void CGUIWindowManager::AddMsgTarget(IMsgTargetCallback* pMsgTarget)
   m_vecMsgTargets.emplace_back(pMsgTarget);
 }
 
+void CGUIWindowManager::RemoveMsgTarget(IMsgTargetCallback* pMsgTarget)
+{
+  m_vecMsgTargets.erase(std::remove(m_vecMsgTargets.begin(), m_vecMsgTargets.end(), pMsgTarget),
+                        m_vecMsgTargets.end());
+}
+
 int CGUIWindowManager::GetActiveWindow() const
 {
   if (!m_windowHistory.empty())

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -198,6 +198,7 @@ public:
   // pMessageIDList: point to first integer of a 0 ends integer array.
   int RemoveThreadMessageByMessageIds(int *pMessageIDList);
   void AddMsgTarget( IMsgTargetCallback* pMsgTarget );
+  void RemoveMsgTarget(IMsgTargetCallback* pMsgTarget);
   int GetActiveWindow() const;
   int GetActiveWindowOrDialog() const;
   bool HasModalDialog(bool ignoreClosing) const;

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -79,7 +79,8 @@ CPeripherals::CPeripherals(CInputManager& inputManager,
                            GAME::CControllerManager& controllerProfiles)
   : m_inputManager(inputManager),
     m_controllerProfiles(controllerProfiles),
-    m_eventScanner(new CEventScanner(*this))
+    m_eventScanner(new CEventScanner(*this)),
+    m_guiReadyEvent(std::make_unique<CEvent>())
 {
   // Register settings
   std::set<std::string> settingSet;
@@ -93,6 +94,13 @@ CPeripherals::CPeripherals(CInputManager& inputManager,
 
 CPeripherals::~CPeripherals()
 {
+  // Unregister with GUI messenger
+  CGUIComponent* gui = CServiceBroker::GetGUI();
+  if (gui != nullptr)
+    gui->GetWindowManager().RemoveMsgTarget(this);
+
+  m_guiReadyEvent->Set();
+
   // Unregister settings
   CServiceBroker::GetSettingsComponent()->GetSettings()->UnregisterCallback(this);
 
@@ -137,6 +145,11 @@ void CPeripherals::Initialise()
 
   CServiceBroker::GetAppMessenger()->RegisterReceiver(this);
   CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
+
+  // Register for GUI messages
+  CGUIComponent* gui = CServiceBroker::GetGUI();
+  if (gui != nullptr)
+    gui->GetWindowManager().AddMsgTarget(this);
 }
 
 void CPeripherals::Clear()
@@ -735,6 +748,32 @@ bool CPeripherals::OnAction(const CAction& action)
   }
 
   return false;
+}
+
+bool CPeripherals::OnMessage(CGUIMessage& message)
+{
+  switch (message.GetMessage())
+  {
+    case GUI_MSG_NOTIFY_ALL:
+    {
+      if (message.GetParam1() == GUI_MSG_UI_READY)
+      {
+        m_guiReady = true;
+        m_guiReadyEvent->Set();
+      }
+      break;
+    }
+    default:
+      break;
+  }
+
+  return false;
+}
+
+bool CPeripherals::WaitForGUI()
+{
+  m_guiReadyEvent->Wait();
+  return m_guiReady;
 }
 
 bool CPeripherals::IsMuted()

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -510,6 +510,10 @@ void CPeripheralJoystick::SetSupportsPowerOff(bool bSupportsPowerOff)
 
 GAME::ControllerPtr CPeripheralJoystick::InstallAsync(const std::string& controllerId)
 {
+  // Installing controllers calls into the GUI, so wait for it to be ready
+  if (!m_manager.WaitForGUI())
+    return {};
+
   GAME::ControllerPtr controller;
 
   // Only 1 install at a time. Remaining installs will wake when this one


### PR DESCRIPTION
## Description

Backport of https://github.com/xbmc/xbmc/pull/26387

## Motivation and context

Fixes possible crash in splash screen on first startup.

## How has this been tested?

Tested on my macbook M2.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
