### PR TITLE
[Windows] allow use Video Super Resolution in HDR10 videos (NVIDIA only)

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -538,9 +538,11 @@ bool CProcessorHD::IsSuperResolutionSuitable(const VideoPicture& picture)
   if (outputWidth <= picture.iWidth)
     return false;
 
-  if (picture.color_primaries == AVCOL_PRI_BT2020 ||
-      picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
-      picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
+  // At this time, Intel GPUs do not support VSR on HDR video
+  if ((picture.color_primaries == AVCOL_PRI_BT2020 ||
+       picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
+       picture.color_transfer == AVCOL_TRC_ARIB_STD_B67) &&
+      DX::DeviceResources::Get()->GetAdapterDesc().VendorId == PCIV_Intel)
     return false;
 
   return true;


### PR DESCRIPTION
## Description
[Windows] allow use Video Super Resolution in HDR10 videos (NVIDIA only)

## Motivation and context
Nvidia has updated RTX Video Super Resolution to support HDR videos:

> Q. What's new with the RTX Video Super Resolution January 2025 update?
>  
> A. In the new NVIDIA app update, VSR has been updated to a more efficient AI model, using up to 30% fewer GPU resources at its highest quality setting, allowing more GeForce RTX GPUs to enable it.
> 
> **VSR now also upscales HDR video**, so if you are watching any HDR video below your monitor’s resolution in your browser, it will automatically get upscaled to your native panel resolution.
> 
> We’ve also added a GPU Utilization feature for RTX Video when Quality is set to “Auto”. Setting your GPU Utilization to “High” will use as much GPU as needed to provide the best quality Super Resolution available on your GPU.
> 
> Setting the GPU Utilization to lower levels will reserve more GPU for games or creative apps by applying lower quality settings. Or alternatively, switch to Manual mode and set a fixed quality level to use at all times.

https://nvidia.custhelp.com/app/answers/detail/a_id/5448/~/rtx-video-faq

The change is simple: only removed HDR restrictions ~and increased max resolution up to 1440p (videos larger than 1080p are now also supported for scaling to 4K)~.

 
## How has this been tested?
Tested with Nvidia RTX 4070 and driver 572.16
Tested 1080p HDR10 video on a 4K TV

Confirmed Video Super Resolution is requested and enabled. Also confirmed GPU power consumption increases from 18 W (disabled) to 44 W (enabled) playing same video.

Tested also on Intel NUC to make sure changes not cause issues when playback 1080p HDR10 video and VSR is enabled.

## What is the effect on users?
- Allow use RTX Video Super Resolution in HDR videos (typically 1080p HDR videos upscaled to 4K).


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
