### PR TITLE
Fix typos found in xbmc/cores

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
@@ -300,7 +300,7 @@ bool CAAudioUnitSink::deactivate()
     AudioUnitReset(m_audioUnit, kAudioUnitScope_Global, 0);
 
     // this is a delayed call, the OS will block here
-    // until the autio unit actually is stopped.
+    // until the audio unit actually is stopped.
     AudioOutputUnitStop(m_audioUnit);
 
     // detach the render callback on the unit

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -302,7 +302,7 @@ unsigned int CAESinkXAudio::AddPackets(uint8_t **data, unsigned int frames, unsi
   hr = m_sourceVoice->SubmitSourceBuffer(&xbuffer);
   if (FAILED(hr))
   {
-    CLog::LogF(LOGERROR, "submiting buffer failed due to {}", CWIN32Util::FormatHRESULT(hr));
+    CLog::LogF(LOGERROR, "submitting buffer failed due to {}", CWIN32Util::FormatHRESULT(hr));
     delete xbuffer.pContext;
     return INT_MAX;
   }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.h
@@ -116,7 +116,7 @@ private:
     bool AddEndOfStreamPacket();
     /*!
      * \brief Create a XAUDIO2_BUFFER with a struct buffer_ctx in pContext member, which must
-     * be deleted either manually or by XAudio2 BufferEnd callbak to avoid memory leaks.
+     * be deleted either manually or by XAudio2 BufferEnd callback to avoid memory leaks.
      * \param data data of the frames to copy. if null, the new buffer will contain silence.
      * \param frames number of frames
      * \param offset offset from the start in the data buffer.

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -184,9 +184,9 @@ public:
   virtual void SetTime(int64_t time) { }
 
   /*!
-   \brief Set the total time  in milliseconds
+   \brief Set the total time in milliseconds
    this can be used for injecting the duration in case
-   its not available in the underlaying decoder (airtunes for example)
+   it's not available in the underlying decoder (airtunes for example)
    */
   virtual void SetTotalTime(int64_t time) { }
   virtual void SetSpeed(float speed) = 0;

--- a/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.dox
+++ b/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.dox
@@ -49,7 +49,7 @@ important, as xml tags are case-sensitive.
 --------------------------------------------------------------------------------
 \section Game_Control_sect3 List item info
 
-List item info can be used for all tag values. For example, if the control defintion looks like:
+List item info can be used for all tag values. For example, if the control definition looks like:
 
 ~~~~~~~~~~~~~
 <itemlayout width="444" height="250">

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -993,7 +993,7 @@ void CRPRenderManager::GetVideoFrame(IRenderBuffer*& readableBuffer,
                          [](const IRenderBuffer* renderBuffer)
                          { return renderBuffer->GetMemoryAccess() != DataAccess::WRITE_ONLY; });
 
-  // Aquire buffer if one was found
+  // Acquire buffer if one was found
   if (it != m_renderBuffers.end())
   {
     readableBuffer = *it;

--- a/xbmc/cores/VideoPlayer/DVDDemuxSPU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxSPU.cpp
@@ -321,7 +321,7 @@ std::shared_ptr<CDVDOverlaySpu> CDVDDemuxSPU::ParsePacket(SPUData* pSPUData)
   }
 
   // parse the rle.
-  // this should be changed so it get's converted to a yuv overlay
+  // this should be changed so it gets converted to a yuv overlay
   return ParseRLE(pSPUInfo, pUnparsedData);
 }
 

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -94,8 +94,8 @@ void CDVDSubtitlesLibass::Configure()
 
   // Libass uses system font provider (like fontconfig) by default in some
   // platforms (e.g. linux/windows), on some other systems like android the
-  // font provider is currenlty not supported, then an user can add his
-  // additionals fonts only by using the user fonts folder.
+  // font provider is currently not supported, then an user can add his
+  // additional fonts only by using the user fonts folder.
   ass_set_fonts_dir(m_library, CSpecialProtocol::TranslatePath(FONT::FONTPATH::USER).c_str());
 
   // Load additional fonts into Libass memory

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -87,7 +87,7 @@ public:
    * @brief Get the list of EDL cut markers.
    * @return The list of EDL cut markers or an empty vector if no EDL cuts exist.
    * The returned values are accurate with respect to cut durations. I.e. if the file
-   * has multiple cuts, the positions of subsquent cuts are automatically corrected by
+   * has multiple cuts, the positions of subsequent cuts are automatically corrected by
    * substracting the previous cut durations.
   */
   const std::vector<std::chrono::milliseconds> GetCutMarkers() const;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1477,7 +1477,7 @@ void CVideoPlayer::Process()
 {
   // Try to resolve the correct mime type. This can take some time, for example if a requested
   // item is located at a slow/not reachable remote source. So, do mime type detection in vp worker
-  // thread, not directly when initalizing the player to keep GUI responsible.
+  // thread, not directly when initializing the player to keep GUI responsible.
   m_item.SetMimeTypeForInternetFile();
 
   CServiceBroker::GetWinSystem()->RegisterRenderLoop(this);

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -654,7 +654,7 @@ void CDVDRadioRDSData::Flush()
 {
   if(!m_messageQueue.IsInited())
     return;
-  /* flush using message as this get's called from VideoPlayer thread */
+  /* flush using message as this gets called from VideoPlayer thread */
   /* and any demux packet that has been taken out of queue need to */
   /* be disposed of before we flush */
   m_messageQueue.Flush();

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -796,7 +796,7 @@ void CVideoPlayerVideo::SetSpeed(int speed)
 
 void CVideoPlayerVideo::Flush(bool sync)
 {
-  /* flush using message as this get's called from VideoPlayer thread */
+  /* flush using message as this gets called from VideoPlayer thread */
   /* and any demux packet that has been taken out of queue need to */
   /* be disposed of before we flush */
   SendMessage(std::make_shared<CDVDMsgBool>(CDVDMsg::GENERAL_FLUSH, sync), 1);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -214,7 +214,7 @@ public:
    * \param outputFormat the output format
    * \param outputCS the output color space
    * \return true when the conversion is supported, false when it is not
-   * or the API used to validate is not availe (Windows < 10)
+   * or the API used to validate is not available (Windows < 10)
   */
   bool CheckConversion(DXGI_FORMAT inputFormat,
                        DXGI_COLOR_SPACE_TYPE inputCS,
@@ -331,7 +331,7 @@ protected:
   ProcessorConversions LogAndListConversions(const DXGIColorSpaceArgs& inputArgs,
                                              const DXGIColorSpaceArgs& outputArgs) const;
   /*!
-   * \brief Suggest chroma siting derived from source charateristics.
+   * \brief Suggest chroma siting derived from source characteristics.
    * Has limited functionality at this time and supports values that make sense for dxgi
    * \param args description of the sourcce
    * \return suggested chroma siting.

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -124,7 +124,7 @@ protected:
   void RenderFromFBO();
   void RenderSinglePass(int index, int field); // single pass glsl renderer
 
-  // hooks for HwDec Renderered
+  // hooks for HwDec rendering
   virtual bool LoadShadersHook() { return false; }
   virtual bool RenderHook(int idx) { return false; }
   virtual void AfterRenderHook(int idx) {}

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -117,7 +117,7 @@ public:
   bool GetStats(int &lateframes, double &pts, int &queued, int &discard);
 
   /**
-   * Video player call this on flush in oder to discard any queued frames
+   * Video player call this on flush in order to discard any queued frames
    */
   void DiscardBuffer();
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -653,9 +653,9 @@ void CRendererBase::ProcessHDR(CRenderBuffer* rb)
     {
       // Switch to SDR rendering
       CLog::LogF(LOGINFO, "Switching to SDR rendering");
-      // not need set color space because is alredy set when swap chain is re-created
       if (m_AutoSwitchHDR)
       {
+        // color space already sdr or set by the swap chain re-creation
         if (DX::Windowing()->IsHDROutput())
           DX::Windowing()->ToggleHDR(); // Toggle display HDR OFF
       }


### PR DESCRIPTION
## Description
Fixed typos in source comments and doxygen

Found via `codespell -q 3 -S "*.po,./lib/libUPnP/Neptune,./addons/webinterface.default/lang" -L afile,als,bloaded,busses,inout,lod,medias,ot,parm,parms,rsource,sav,te`

## Motivation and context

Accuracy of documentation and code.

## How has this been tested?
n/a

## What is the effect on users?
no negative impacts

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
