### PR TITLE
RetroPlayer: Fix black screen in DMA OpenGL

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
@@ -23,7 +23,7 @@ using namespace RETRO;
 
 std::string CRendererFactoryDMAOpenGL::RenderSystemName() const
 {
-  return "DMA-GL";
+  return "DMAOpenGL";
 }
 
 CRPBaseRenderer* CRendererFactoryDMAOpenGL::CreateRenderer(

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
@@ -77,11 +77,7 @@ void CRPRendererDMAOpenGL::Render(uint8_t alpha)
 
   GLubyte colour[4];
   GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
-  struct PackedVertex
-  {
-    float x, y, z;
-    float u1, v1;
-  } vertex[4];
+  PackedVertex vertex[4];
 
   GLint vertLoc = m_context.GUIShaderGetPos();
   GLint loc = m_context.GUIShaderGetCoord0();

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
@@ -79,8 +79,6 @@ void CRPRendererDMAOpenGL::Render(uint8_t alpha)
   GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
   PackedVertex vertex[4];
 
-  GLint vertLoc = m_context.GUIShaderGetPos();
-  GLint loc = m_context.GUIShaderGetCoord0();
   GLint uniColLoc = m_context.GUIShaderGetUniCol();
   GLint depthLoc = m_context.GUIShaderGetDepth();
 
@@ -104,30 +102,23 @@ void CRPRendererDMAOpenGL::Render(uint8_t alpha)
   vertex[1].u1 = vertex[2].u1 = rect.x2;
   vertex[2].v1 = vertex[3].v1 = rect.y2;
 
+  glBindVertexArray(m_mainVAO);
+
   glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
   glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_STATIC_DRAW);
 
-  glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex),
-                        reinterpret_cast<const GLuint*>(offsetof(PackedVertex, x)));
-  glVertexAttribPointer(loc, 2, GL_FLOAT, 0, sizeof(PackedVertex),
-                        reinterpret_cast<const GLuint*>(offsetof(PackedVertex, u1)));
-
-  glEnableVertexAttribArray(vertLoc);
-  glEnableVertexAttribArray(loc);
-
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_mainIndexVBO);
+  // No need to bind the index VBO, it's part of VAO state
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * 4, idx, GL_STATIC_DRAW);
 
   glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f),
               (colour[3] / 255.0f));
   glUniform1f(depthLoc, -1.0f);
+
   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
 
-  glDisableVertexAttribArray(vertLoc);
-  glDisableVertexAttribArray(loc);
-
+  // Unbind VAO/VBO just to be safe
+  glBindVertexArray(0);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
   m_context.DisableGUIShader();
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.h
@@ -45,7 +45,7 @@ public:
   ~CRPRendererDMAOpenGL() override = default;
 
 protected:
-  // Implementation of CRPRendererOpenGLES
+  // Implementation of CRPRendererOpenGL
   void Render(uint8_t alpha) override;
 };
 } // namespace RETRO

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
@@ -77,11 +77,7 @@ void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
 
   GLubyte colour[4];
   GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
-  struct PackedVertex
-  {
-    float x, y, z;
-    float u1, v1;
-  } vertex[4];
+  PackedVertex vertex[4];
 
   GLint vertLoc = m_context.GUIShaderGetPos();
   GLint loc = m_context.GUIShaderGetCoord0();

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
@@ -23,7 +23,7 @@ using namespace RETRO;
 
 std::string CRendererFactoryDMAOpenGLES::RenderSystemName() const
 {
-  return "DMA-GLES";
+  return "DMAOpenGLES";
 }
 
 CRPBaseRenderer* CRendererFactoryDMAOpenGLES::CreateRenderer(

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -261,11 +261,7 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
 
   GLubyte colour[4];
   GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
-  struct PackedVertex
-  {
-    float x, y, z;
-    float u1, v1;
-  } vertex[4];
+  PackedVertex vertex[4];
 
   GLint vertLoc = m_context.GUIShaderGetPos();
   GLint loc = m_context.GUIShaderGetCoord0();

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
@@ -52,6 +52,12 @@ public:
   static bool SupportsScalingMethod(SCALINGMETHOD method);
 
 protected:
+  struct PackedVertex
+  {
+    float x, y, z;
+    float u1, v1;
+  };
+
   // implementation of CRPBaseRenderer
   void RenderInternal(bool clear, uint8_t alpha) override;
   void FlushInternal() override;


### PR DESCRIPTION
## Description

This PR fixes an error introduced in https://github.com/xbmc/xbmc/pull/26351.

Prior to splitting the DMA renderer into separate OpenGL and OpenGL ES classes, the DMA renderer inherited its rendering path from the GLES renderer—even when running on a full OpenGL context. That worked fine because GLES is a subset of GL.

After the split, CRPRendererDMAOpenGL inherited the OpenGL setup but still used the old DMA/GLES Render() method. This mismatch caused the black‐screen issue, because the leftover GLES‐style attribute setup clashed with the OpenGL vertex array object (VAO) usage.

To fix this, we replaced the DMAOpenGL Render() method with the proper OpenGL renderer code (including matching structs and attribute handling). Now the DMAOpenGL renderer consistently uses the full desktop GL pipeline, which resolves the black‐screen problem on GBM/GL systems.

## Motivation and context

When manually calling `glVertexAttribPointer()` and related functions post‐VAO binding, it could leave the VAO in an inconsistent state. This caused black screens or invisible rendering for some Linux/GBM setups. Removing these calls ensures a stable, consistent state across different OpenGL drivers.

Thanks to @KOPRajs for catching the error and providing the fix.

## How has this been tested?

**Platform**: Linux (GBM/GL)

**Result**: The black screen issue is gone, and nearest/bilinear GUI “shaders” now render correctly.

## What is the effect on users?

Users on affected GBM/GL builds will no longer experience black screens when playing games with RetroPlayer’s DMA OpenGL renderer.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
