### PR TITLE
Fix typos found in various addons directories

### DIFF
--- a/addons/metadata.generic.albums/lib/scraper.py
+++ b/addons/metadata.generic.albums/lib/scraper.py
@@ -90,7 +90,7 @@ class Scraper():
     def __init__(self, action, key, artist, album, url, nfo, settings):
         # parse path settings
         self.parse_settings(settings)
-        # this is just for backward compitability with xml based scrapers https://github.com/xbmc/xbmc/pull/11632
+        # this is just for backward compatibility with xml based scrapers https://github.com/xbmc/xbmc/pull/11632
         if action == 'resolveid':
             # return the result
             result = self.resolve_mbid(key)

--- a/addons/metadata.generic.artists/lib/scraper.py
+++ b/addons/metadata.generic.artists/lib/scraper.py
@@ -91,7 +91,7 @@ class Scraper():
     def __init__(self, action, key, artist, url, nfo, settings):
         # parse path settings
         self.parse_settings(settings)
-        # this is just for backward compitability with xml based scrapers https://github.com/xbmc/xbmc/pull/11632
+        # this is just for backward compatibility with xml based scrapers https://github.com/xbmc/xbmc/pull/11632
         if action == 'resolveid':
             # return the result
             result = self.resolve_mbid(key)

--- a/addons/skin.estuary/xml/SettingsScreenCalibration.xml
+++ b/addons/skin.estuary/xml/SettingsScreenCalibration.xml
@@ -52,7 +52,7 @@
 			<top>500</top>
 			<width>380</width>
 			<height>90</height>
-			<!-- NOTE: The image must have 40px of trasparent on top and bottom the bar -->
+			<!-- NOTE: The image must have 40px of transparent on top and bottom the bar -->
 			<texturefocus colordiffuse="button_focus">calibrate/cal_sub.png</texturefocus>
 			<texturenofocus>calibrate/cal_sub.png</texturenofocus>
 			<movingspeed acceleration="180" maxvelocity="300" resettimeout="200" delta="1">

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -394,7 +394,7 @@ protected:
    *
    * \param[in] id Instance identifier to use, use @ref ADDON_SETTINGS_ID
    *               to denote global add-on settings from settings.xml.
-   * \return true if settings initialize was successfull
+   * \return true if settings initialization was successful
    */
   virtual bool SettingsInitialized(AddonInstanceId id = ADDON_SETTINGS_ID) const;
 

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -805,7 +805,7 @@ bool CAddonInstallJob::DoWork()
   if (!Install(installFrom, m_repo))
     return false;
 
-  // Load new installed and if successed replace defined m_addon here with new one
+  // Load new installed and if succeeded replace defined m_addon here with new one
   if (!CServiceBroker::GetAddonMgr().LoadAddon(m_addon->ID(), m_addon->Origin(),
                                                m_addon->Version()) ||
       !CServiceBroker::GetAddonMgr().GetAddon(m_addon->ID(), m_addon, OnlyEnabled::CHOICE_YES))

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -454,7 +454,7 @@ public:
      * @brief Get a list of add-on's with info's for the on system available
      * ones.
      *
-     * @param[out] addonInfos list where finded addon information becomes stored
+     * @param[out] addonInfos list where found addon information becomes stored
      * @param[in] onlyEnabled If true are only enabled ones given back,
      *                        if false all on system available. Default is true.
      * @param[in] type The requested type, with "ADDON_UNKNOWN" are all add-on
@@ -472,7 +472,7 @@ public:
      * @param[in] onlyEnabled If true are only enabled ones given back,
      *                        if false all on system available. Default is true.
      * @param[in] types List about requested types.
-     * @return List where finded addon information becomes returned.
+     * @return List where found addon information becomes returned.
      *
      * @note @ref ADDON_UNKNOWN should not used for here!
      */
@@ -482,7 +482,7 @@ public:
   /*!
      * @brief Get a list of disabled add-on's with info's
      *
-     * @param[out] addonInfos list where finded addon information becomes stored
+     * @param[out] addonInfos list where found addon information becomes stored
      * @param[in] type        The requested type, with "ADDON_UNKNOWN"
      *                        are all add-on types given back who match the case
      *                        with value before.
@@ -496,7 +496,7 @@ public:
      * @brief Get a list of disabled add-on's with info's for the on system
      * available ones with a specific disabled reason.
      *
-     * @param[out] addonInfos list where finded addon information becomes stored
+     * @param[out] addonInfos list where found addon information becomes stored
      * @param[in] type        The requested type, with "ADDON_UNKNOWN"
      *                        are all add-on types given back who match the case
      *                        with value before.

--- a/xbmc/addons/VFSEntry.h
+++ b/xbmc/addons/VFSEntry.h
@@ -196,7 +196,7 @@ protected:
     VFSEntryPtr m_addon; //!< Pointer to wrapped CVFSEntry.
   };
 
-  //! \brief Wrapper equpping a CVFSEntry with an IDirectory interface.
+  //! \brief Wrapper equipping a CVFSEntry with an IDirectory interface.
   //! \details Needed as CVFSEntry implements several VFS interfaces
   //!          with overlapping methods.
   class CVFSEntryIDirectoryWrapper : public XFILE::IDirectory
@@ -252,7 +252,7 @@ protected:
     VFSEntryPtr m_addon; //!< Pointer to wrapper CVFSEntry.
   };
 
-  //! \brief Wrapper equpping a CVFSEntry with an IFileDirectory interface.
+  //! \brief Wrapper equipping a CVFSEntry with an IFileDirectory interface.
   //! \details Needed as CVFSEntry implements several VFS interfaces
   //!          with overlapping methods.
   class CVFSEntryIFileDirectoryWrapper : public XFILE::IFileDirectory,

--- a/xbmc/addons/gui/skin/SkinTimers.dox
+++ b/xbmc/addons/gui/skin/SkinTimers.dox
@@ -1,7 +1,7 @@
 /*!
 
 \page Skin_Timers Skin Timers
-\brief **Programatic time-based resources for Skins**
+\brief **Programmatic time-based resources for Skins**
 
 \tableofcontents
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
@@ -557,9 +557,6 @@ private:
  * here.
  *
  * Mainly is this currently used to identify requested instance types.
- *
- * @note This class is not need to know during add-on development thats why
- * commented with "*".
  */
 class ATTR_DLL_LOCAL IAddonInstance
 {
@@ -878,7 +875,7 @@ public:
   /// @ingroup cpp_kodi_addon_addonbase
   /// @brief Instance created
   ///
-  /// @param[in] instance Instance informations about
+  /// @param[in] instance Instance information about
   /// @param[out] hdl The pointer to instance class created in addon.
   ///                 Needed to be able to identify them on calls.
   /// @return @ref ADDON_STATUS_OK if correct, for possible errors see @ref ADDON_STATUS
@@ -935,7 +932,7 @@ public:
   /// This function is optional and intended to notify addon that the instance
   /// is terminating.
   ///
-  /// @param[in] instance Instance informations about
+  /// @param[in] instance Instance information about
   /// @param[in] hdl The pointer to instance class created in addon.
   ///
   /// @warning This call is only used to inform that the associated instance

--- a/xbmc/addons/kodi-dev-kit/include/kodi/General.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/General.h
@@ -571,7 +571,7 @@ inline void ATTR_DLL_LOCAL KodiVersion(kodi_version_t& version)
 /// @param[in] modifierKey the key to define the needed layout (uppercase, symbols...)
 /// @param[out] layout_name name of used layout
 /// @param[out] layout list of selected keyboard layout
-/// @return true if request successed
+/// @return true if request succeeded
 ///
 ///
 /// ------------------------------------------------------------------------
@@ -639,7 +639,7 @@ inline bool ATTR_DLL_LOCAL GetKeyboardLayout(int modifierKey,
 /// This is used to change the keyboard layout currently used from Kodi
 ///
 /// @param[out] layout_name new name of used layout (input string not used!)
-/// @return true if request successed
+/// @return true if request succeeded
 ///
 /// @note @ref GetKeyboardLayout must be called afterwards.
 ///

--- a/xbmc/addons/kodi-dev-kit/include/kodi/gui/Window.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/gui/Window.h
@@ -164,8 +164,7 @@ public:
   /// closed. The creation can be done before "Show" becomes called, but
   /// not delete class after them.
   ///
-  /// @return Return true if call and show is successed, if false was something
-  /// failed to get needed skin parts.
+  /// @return True on success, false otherwise.
   ///
   bool Show()
   {
@@ -198,8 +197,7 @@ public:
   /// @brief Gives the control with the supplied focus.
   ///
   /// @param[in] controlId On skin defined id of control
-  /// @return Return true if call and focus is successed, if false was something
-  /// failed to get needed skin parts
+  /// @return True on success, false otherwise.
   ///
   bool SetFocusId(int controlId)
   {

--- a/xbmc/addons/kodi-dev-kit/include/kodi/gui/controls/Rendering.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/gui/controls/Rendering.h
@@ -93,7 +93,7 @@ public:
   /// @param[in] h Height of control
   /// @param[in] device The device to use. For OpenGL is empty on Direct X is
   ///                   the needed device send.
-  /// @return Add-on needs to return true if successed, otherwise false.
+  /// @return True on success, false otherwise.
   ///
   /// @note The @ref kodi::HardwareContext is basically a simple pointer which
   /// has to be changed to the desired format at the corresponding places using

--- a/xbmc/addons/kodi-dev-kit/include/kodi/gui/gl/Shader.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/gui/gl/Shader.h
@@ -350,7 +350,7 @@ public:
   /// @param[in] fragmentExtraEnd   [opt] To additionally add fragment source
   ///                               code to the end of the loaded file
   ///                               source code
-  /// @return                       true if compile was successed
+  /// @return                       true if compile was successful
   ///
   ///
   /// @note In the case of a compile error, it will be written once into the Kodi

--- a/xbmc/addons/kodi-dev-kit/include/kodi/tools/DllHelper.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/tools/DllHelper.h
@@ -43,7 +43,7 @@ namespace tools
 /// @note To use on Windows must you also include [dlfcn-win32](https://github.com/dlfcn-win32/dlfcn-win32)
 /// on your addon!\n\n
 /// Furthermore, this allows the use of Android where the required library is
-/// copied to an EXE useable folder.
+/// copied to an EXE usable folder.
 ///
 ///
 /// ----------------------------------------------------------------------------

--- a/xbmc/addons/kodi-dev-kit/include/kodi/tools/EndTime.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/tools/EndTime.h
@@ -121,7 +121,7 @@ public:
   /// @ingroup cpp_kodi_tools_CEndTime
   /// @brief The amount of time left till this timer expires
   ///
-  /// @return 0 if the expiry amount of time has past, the numbe rof milliseconds remaining otherwise
+  /// @return 0 if the expiry amount of time has past, the number of milliseconds remaining otherwise
   ///
   inline unsigned int MillisLeft() const
   {


### PR DESCRIPTION
## Description
Fixed typos in source comments and doxygen

Found via `codespell -q 3 -S "*.po,*.patch,**/addon.xml,**/strings.xml,./lib/libUPnP,./addons/webinterface.default/lang,./addons/metadata.tvshows.themoviedb.org.python,./xbmc/utils/LangCodeExpander.cpp,./xbmc/input/InputCodingTableBasePY.cpp,./tools/EventClients" -L additionals,afile,als,archtype,archtypes,bloaded,bord,bufferin,busses,buttonn,checkin,childs,childrens,doubleclick,iinterval,indx,inout,ist,lod,medias,mis,ot,parm,parms,pevents,pixelx,rsource,sav,sectionin,ser,slanguage,slanguages,somthing,strart,streamin,te,tempdate,ue,zar`

## Motivation and context

Accuracy of documentation and code.

## How has this been tested?
n/a

## What is the effect on users?
no negative impacts

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
