### PR TITLE
[swig][cmake] Swig TARGET and updated dep tracking

### DIFF
--- a/cmake/modules/buildtools/FindSWIG.cmake
+++ b/cmake/modules/buildtools/FindSWIG.cmake
@@ -3,28 +3,36 @@
 # --------
 # Finds the SWIG executable
 #
-# This will define the following variables::
+# This will define the following TARGET:
 #
-# SWIG_FOUND - system has SWIG
-# SWIG_EXECUTABLE - the SWIG executable
+# SWIG::SWIG - the SWIG executable
 
-find_program(SWIG_EXECUTABLE NAMES swig4.0 swig3.0 swig2.0 swig
-                             PATH_SUFFIXES swig
-                             HINTS ${NATIVEPREFIX}/bin)
-if(SWIG_EXECUTABLE)
-  execute_process(COMMAND ${SWIG_EXECUTABLE} -swiglib
-    OUTPUT_VARIABLE SWIG_DIR
-    ERROR_VARIABLE SWIG_swiglib_error
-    RESULT_VARIABLE SWIG_swiglib_result)
-  execute_process(COMMAND ${SWIG_EXECUTABLE} -version
-    OUTPUT_VARIABLE SWIG_version_output
-    ERROR_VARIABLE SWIG_version_output
-    RESULT_VARIABLE SWIG_version_result)
-    string(REGEX REPLACE ".*SWIG Version[^0-9.]*\([0-9.]+\).*" "\\1"
-           SWIG_VERSION "${SWIG_version_output}")
+if(NOT TARGET SWIG::SWIG)
+  find_program(SWIG_EXECUTABLE NAMES swig4.0 swig3.0 swig2.0 swig
+                               NO_CACHE
+                               PATH_SUFFIXES swig
+                               HINTS ${NATIVEPREFIX}/bin)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(SWIG
+                                    REQUIRED_VARS SWIG_EXECUTABLE
+                                    VERSION_VAR SWIG_VERSION)
+
+  if(SWIG_FOUND)
+    execute_process(COMMAND ${SWIG_EXECUTABLE} -version
+      OUTPUT_VARIABLE SWIG_version_output
+      ERROR_VARIABLE SWIG_version_output
+      RESULT_VARIABLE SWIG_version_result)
+      string(REGEX REPLACE ".*SWIG Version[^0-9.]*\([0-9.]+\).*" "\\1"
+             SWIG_VERSION "${SWIG_version_output}")
+
+    add_executable(SWIG::SWIG IMPORTED GLOBAL)
+    set_target_properties(SWIG::SWIG PROPERTIES
+                                     IMPORTED_LOCATION "${SWIG_EXECUTABLE}"
+                                     VERSION "${SWIG_VERSION}")
+  else()
+    if(SWIG_FIND_REQUIRED)
+      message(FATAL_ERROR "Swig executable was not found.")
+    endif()
+  endif()
 endif()
-
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(SWIG
-                                  REQUIRED_VARS SWIG_EXECUTABLE SWIG_DIR
-                                  VERSION_VAR SWIG_VERSION)

--- a/xbmc/interfaces/swig/CMakeLists.txt
+++ b/xbmc/interfaces/swig/CMakeLists.txt
@@ -20,13 +20,37 @@ function(generate_file file)
     set(JAVA_OPEN_OPTS --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.regex=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED  --add-opens java.base/java.net=ALL-UNNAMED)
   endif()
 
+  # Args used for swig execution
+  set(SWIG_ARGS -w401 -c++ -o ${file}.xml -xml -I${CMAKE_SOURCE_DIR}/xbmc ${CMAKE_CURRENT_SOURCE_DIR}/../swig/${file})
+
+  # This generates a file that has the dependencies the preprocessed swig template finds
+  # execute_process needs explicit use of explicit swig executable location. it is not TARGET aware
+  # retrieve location property from TARGET
+  get_target_property(_swig_exe SWIG::SWIG IMPORTED_LOCATION)
+  execute_process(COMMAND ${_swig_exe} -MM -MF build/swig/${file}.dep ${SWIG_ARGS})
+  file(READ ${CMAKE_BINARY_DIR}/build/swig/${file}.dep swig_deps)
+
+  # Match all lines except the first one until " \"
+  string(REGEX MATCHALL "\n  [^ ]+" temp ${swig_deps})
+  set(swig_deps)
+  foreach(t ${temp})
+    string(STRIP "${t}" t)
+    set(swig_deps ${swig_deps} "${t}")
+  endforeach()
+
+  # We set this to allow cmake to detect if changes in the headers/template files are made
+  # and to force a cmake reconfigure to detect new dependencies that may have been added.
+  set_property(DIRECTORY ${CMAKE_SOURCE_DIR} APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${swig_deps})
+
   add_custom_command(OUTPUT ${CPP_FILE}
                      COMMAND SWIG::SWIG
-                     ARGS -w401 -c++ -o ${file}.xml -xml -I${CMAKE_SOURCE_DIR}/xbmc ${CMAKE_CURRENT_SOURCE_DIR}/../swig/${file}
+                     ARGS ${SWIG_ARGS}
                      COMMAND ${Java_JAVA_EXECUTABLE}
                      ARGS ${JAVA_OPEN_OPTS} -cp "${classpath}" groovy.ui.GroovyMain ${CMAKE_SOURCE_DIR}/tools/codegenerator/Generator.groovy ${file}.xml ${CMAKE_CURRENT_SOURCE_DIR}/../python/PythonSwig.cpp.template ${file}.cpp > ${devnull}
                      ${CLANG_FORMAT_COMMAND}
-                     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../swig/${file} ${CMAKE_CURRENT_SOURCE_DIR}/../python/PythonSwig.cpp.template)
+                     DEPENDS SWIG::SWIG ${swig_deps} ${CMAKE_CURRENT_SOURCE_DIR}/../python/PythonSwig.cpp.template
+                     BYPRODUCTS build/swig/${CPP_FILE} build/swig/${file}.xml)
+
   set(SOURCES ${SOURCES} "${CPP_FILE}" PARENT_SCOPE)
 endfunction()
 

--- a/xbmc/interfaces/swig/CMakeLists.txt
+++ b/xbmc/interfaces/swig/CMakeLists.txt
@@ -21,7 +21,7 @@ function(generate_file file)
   endif()
 
   add_custom_command(OUTPUT ${CPP_FILE}
-                     COMMAND ${SWIG_EXECUTABLE}
+                     COMMAND SWIG::SWIG
                      ARGS -w401 -c++ -o ${file}.xml -xml -I${CMAKE_SOURCE_DIR}/xbmc ${CMAKE_CURRENT_SOURCE_DIR}/../swig/${file}
                      COMMAND ${Java_JAVA_EXECUTABLE}
                      ARGS ${JAVA_OPEN_OPTS} -cp "${classpath}" groovy.ui.GroovyMain ${CMAKE_SOURCE_DIR}/tools/codegenerator/Generator.groovy ${file}.xml ${CMAKE_CURRENT_SOURCE_DIR}/../python/PythonSwig.cpp.template ${file}.cpp > ${devnull}


### PR DESCRIPTION
## Description
Implement TARGET usage for swig tool and update swig dependency tracking
    
## Motivation and context
Saw a comment in slack by @notspiff responding to an issue @DaVukovic had after #26191 

Our swig generation was only tracking the explicit swig template and the input template file
This was discovered due to changes in https://github.com/xbmc/xbmc/pull/26191 that did not
change the swig templates, but did change headers that the swig templates included.

This now adds dependency tracking to any files included as part of the swig template, and
also adds cmake reconfiguration tracking on those files to regenerate the cmake project if
one is changes for any possible non-existing input data for swig (ie a new include in a
template or included header)

## How has this been tested?
Manually altering headers and templates and testing output and rebuilds are done.

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
