### PR TITLE
[cmake] Modulehelper dont append DEP_BUILDENV when _LIB_TYPE native

### DIFF
--- a/cmake/scripts/common/ModuleHelpers.cmake
+++ b/cmake/scripts/common/ModuleHelpers.cmake
@@ -320,7 +320,10 @@ macro(BUILD_DEP_TARGET)
   endif()
 
   if(CONFIGURE_COMMAND)
-    if(NOT CMAKE_ARGS AND DEP_BUILDENV)
+    # DEP_BUILDENV is potentially populated in a toolchain file. We dont want to use it
+    # for host tool builds, so make sure to check _LIB_TYPE
+    if(NOT CMAKE_ARGS AND
+      (DEP_BUILDENV AND NOT ${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}_LIB_TYPE STREQUAL "native"))
       # DEP_BUILDENV only used for non cmake externalproject_add builds
       # iterate through CONFIGURE_COMMAND looking for multiple COMMAND, we need to
       # add DEP_BUILDENV for each distinct COMMAND


### PR DESCRIPTION
## Description
Minor fixup for the case of host build tools being built internally that arent cmake based.


## Motivation and context
Work on building swig if needed for all platforms to allow updating swig globally for all platforms including windows

This allows a host tool dependency that uses autoconf to not automatically append target platform flags to its build

## How has this been tested?
Swig build that uses a host pcre2 lib that is created by the cmake project

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
