### PR TITLE
AESinkAudioTrack: Do not verify format

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -243,29 +243,9 @@ bool CAESinkAUDIOTRACK::VerifySinkConfiguration(int sampleRate,
   int minBufferSize = CJNIAudioTrack::getMinBufferSize(sampleRate, channelMask, encoding);
   bool supported = (minBufferSize > 0);
 
-  // make sure to have enough buffer as minimum might not be enough to open
-  if (!isRaw)
-    minBufferSize *= 2;
-
-  if (supported)
-  {
-    jni::CJNIAudioTrack* jniAt = CreateAudioTrack(CJNIAudioManager::STREAM_MUSIC, sampleRate,
-                                                  channelMask, encoding, minBufferSize);
-    supported = (jniAt && jniAt->getState() == CJNIAudioTrack::STATE_INITIALIZED);
-    if (supported)
-    {
-      jniAt->pause();
-      jniAt->flush();
-    }
-
-    if (jniAt)
-    {
-      jniAt->release();
-      delete jniAt;
-    }
-  }
   CLog::Log(LOGDEBUG, "VerifySinkConfiguration samplerate: {} mask: {} encoding: {} success: {}",
             sampleRate, channelMask, encoding, supported ? "true" : "false");
+
   return supported;
 }
 


### PR DESCRIPTION
Do not fully open a sink device for checking of the format availability.

Reason:
While some firmware lie right away, others return success, but still do not properly work. On Nvidia Shield where the firmware tried to open a format multiple times under the hood, the kodi startup time could need up to 1 minute.

What could go wrong:
Some devices might now seem to support more formats if the FW was a buggy one.