### PR TITLE
[Android] Keep the use of getPath() method on devices with API level before 30

### DIFF
--- a/xbmc/platform/android/storage/AndroidStorageProvider.cpp
+++ b/xbmc/platform/android/storage/AndroidStorageProvider.cpp
@@ -198,7 +198,10 @@ void CAndroidStorageProvider::GetRemovableDrives(std::vector<CMediaSource>& remo
         {
           CMediaSource share;
 
-          share.strPath = vol.getDirectory().getAbsolutePath();
+          if (CJNIBase::GetSDKVersion() >= 30)
+            share.strPath = vol.getDirectory().getAbsolutePath();
+          else
+            share.strPath = vol.getPath();
           if (xbmc_jnienv()->ExceptionCheck())
           {
             xbmc_jnienv()->ExceptionDescribe();


### PR DESCRIPTION
The getDirectory() method was added at API level 30. Keep getPath() method in previous versions.

Related to #26250

Fix #26421

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
