### PR TITLE
[database] MysqlDatabase::connect : Reduce debug logspam.

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -161,8 +161,10 @@ int MysqlDatabase::connect(bool create_new)
   std::string resolvedHost;
   if (!StringUtils::EqualsNoCase(host, "localhost") && CDNSNameCache::Lookup(host, resolvedHost))
   {
-    CLog::Log(LOGDEBUG, "{} replacing configured host {} with resolved host {}", __FUNCTION__, host,
-              resolvedHost);
+    if (host != resolvedHost)
+      CLog::LogF(LOGDEBUG, "Replacing configured host {} with resolved host {}", host,
+                 resolvedHost);
+
     host = resolvedHost;
   }
 


### PR DESCRIPTION
Removes some super annoying logspam that was flooding my logs... like:

```log
2025-02-11 08:31:30.141 T:376505   debug <general>: connect replacing configured host 192.168.178.41 with resolved host 192.168.178.41
```

This was in my log many many times and imo does not add any value. 

With this PR, a log entry will only be written if resolved host is different from original host. It could be that for others the log is flooded still, because for them resolved is actually != original, but for me this is already an improvement. Adding some logics to prevent this is ofc possible but I don't need it. Could be done in another PR anytime.

@neo1973 can you have a look? Should be a no-brainer.