### PR TITLE
[cores] CRenderManager::UpdateResolution: Fix SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE implementation…

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2756,6 +2756,7 @@ void CVideoPlayer::HandleMessages()
 
       FlushBuffers(DVD_NOPTS_VALUE, true, true);
       m_renderManager.Flush(false, false);
+      m_renderManager.ReInit();
       m_pDemuxer.reset();
       m_pSubtitleDemuxer.reset();
       m_subtitleDemuxerMap.clear();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -71,6 +71,7 @@ public:
   void TriggerUpdateResolution(float fps, int width, int height, std::string &stereomode);
   void SetViewMode(int iViewMode);
   void PreInit();
+  void ReInit();
   void UnInit();
   bool Flush(bool wait, bool saveBuffers);
   bool IsConfigured() const;
@@ -144,6 +145,8 @@ protected:
   void UpdateLatencyTweak();
   void CheckEnableClockSync();
 
+  void SetFPS(float fps);
+
   CBaseRenderer *m_pRenderer = nullptr;
   OVERLAY::CRenderer m_overlays;
   CDebugRenderer m_debugRenderer;
@@ -208,7 +211,8 @@ protected:
 
   VideoPicture m_picture{};
 
-  float m_fps = 0.0;
+  float m_fps{0.0f};
+  bool m_fpsAdjusted{false};
   unsigned int m_orientation = 0;
   int m_NumberBuffers = 0;
   int m_lateframes = -1;


### PR DESCRIPTION
… to respect ADJUST_REFRESHRATE_ON_START and ADJUST_REFRESHRATE_ON_STARTSTOP values.

This PR fixes something that annoyed me for a very long time already: adjust refresh rate settings values "On start / stop" and "on start" not working as expected (at least for some use cases).

<img width="1710" alt="Screenshot 2025-02-18 at 08 40 36" src="https://github.com/user-attachments/assets/4dbf37d5-3aa7-4069-bba3-71b109d2c613" />

If any of these two values are set I expect resolution / refresh rate switch to happen at most one time after playback start. That was not the case for at least one of my Kodi uses cases, playing yt videos with the respective Kodi add-on. 

For example, for whatever reason some videos start with refresh rate of 60 fps, triggering a resolution switch of my TV, which is fine. After a second or so the video changes fps to 59,95, leading to another resolution switch of my TV, which is not supposed to happen if i have set "On start/stop" or "On start".

Idea of the fix is to remember that an fps switch already happened and to not trigger another one in case. This is the first time I'm touching this code area, so my approach might be okay, I consider it clean, but maybe there is a better way to fix this. 

Runtime-tested on macOS and Android, seems to work just fine. 

@thexai could you take a look? GitHub suggested you as an reviewer,