### PR TITLE
Fix typos in xbmc/cores directory

### DIFF
--- a/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
+++ b/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
@@ -312,7 +312,7 @@ int CAEEncoderFFmpeg::Encode(uint8_t *in, int in_size, uint8_t *out, int out_siz
     //! @TODO: This is a workaround for our current design. The caller should be made
     // aware of the potential error values to use the ffmpeg API in a proper way, which means
     // copying with EAGAIN and multiple packet output.
-    // For the current situation there is a relationship implicitely assumed of:
+    // For the current situation there is a relationship implicitly assumed of:
     // 1 frame in - 1 packet out. This holds true in practice but the API does not guarantee it.
     if (err >= 0)
     {
@@ -331,7 +331,7 @@ int CAEEncoderFFmpeg::Encode(uint8_t *in, int in_size, uint8_t *out, int out_siz
     }
     else
     {
-      CLog::LogF(LOGERROR, "Error receiving encoded paket ({})", err);
+      CLog::LogF(LOGERROR, "Error receiving encoded packet ({})", err);
     }
   }
   catch (const FFMpegException& caught)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -67,7 +67,7 @@ std::unique_ptr<CDVDVideoCodec> CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInf
     return nullptr;
   }
 
-  // platform specifig video decoders
+  // platform specific video decoders
   if (!(hint.codecOptions & CODEC_FORCE_SOFTWARE))
   {
     for (auto &codec : m_hwVideoCodecs)
@@ -183,7 +183,7 @@ std::unique_ptr<CDVDAudioCodec> CDVDFactoryCodec::CreateAudioCodec(
   if (!allowdtshddecode)
     options.m_keys.emplace_back("allowdtshddecode", "0");
 
-  // platform specifig audio decoders
+  // platform specific audio decoders
   for (auto &codec : m_hwAudioCodecs)
   {
     pCodec = CreateAudioCodecHW(codec.first, processInfo);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -797,7 +797,7 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
           else
           {
             m_mime = v;
-            CLog::Log(LOGDEBUG, "Succesfully replaced VC1 mime type to {}", m_mime);
+            CLog::Log(LOGDEBUG, "Successfully replaced VC1 mime type to {}", m_mime);
             success = true;
             break;
           }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -342,7 +342,7 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   // libdav1d av1 sw decoding is implemented as a separate decoder
   // in ffmpeg which is always found first when calling `avcodec_find_decoder`.
   // To get hwaccels we look for decoders registered for `av1` (unless sw decoding is enforced).
-  // The decoder state check is needed to succesfully fallback to sw decoding if
+  // The decoder state check is needed to successfully fallback to sw decoding if
   // necessary (on retry).
   if (hints.codec == AV_CODEC_ID_AV1 && m_decoderState != STATE_HW_FAILED &&
       !(hints.codecOptions & CODEC_FORCE_SOFTWARE))

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/BlurayStateSerializer.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/BlurayStateSerializer.h
@@ -17,7 +17,7 @@ struct BlurayState
   int32_t playlistId = -1;
 };
 
-/*! \brief Auxiliar class to serialize/deserialize the Bluray state (into/from XML)
+/*! \brief Auxiliary class to serialize/deserialize the Bluray state (into/from XML)
 */
 class CBlurayStateSerializer
 {

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -1187,7 +1187,7 @@ bool CDVDInputStreamNavigator::GetCurrentButtonInfo(CDVDOverlaySpu& pOverlayPict
 
   if (pSPU->m_bHasClut)
   {
-    // get color stored in the highlight area palete using the previously stored clut
+    // get color stored in the highlight area palette using the previously stored clut
     for (unsigned i = 0; i < 4; i++)
     {
       uint8_t* yuvColor = pSPU->m_clut[(hl.palette >> (16 + i * 4)) & 0x0f];

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDStateSerializer.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDStateSerializer.h
@@ -34,7 +34,7 @@ struct DVDState
   bool sub_enabled = false;
 };
 
-/*! \brief Auxiliar class to serialize/deserialize the dvd state (into/from XML)
+/*! \brief Auxiliary class to serialize/deserialize the dvd state (into/from XML)
 */
 class CDVDStateSerializer
 {

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/dvdnav.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/dvdnav.h
@@ -283,7 +283,7 @@ dvdnav_status_t dvdnav_stop(dvdnav_t *self);
  * Note this has no relation with the region setting of the DVD drive.
  * Old DVD drives (RPC-I) used to delegate most of the RCE handling to the CPU and
  * will actually call the virtual machine (VM) for its region setting. In those cases,
- * changing the VM region mask via dvdnav_set_region_mask() will circunvent
+ * changing the VM region mask via dvdnav_set_region_mask() will circumvent
  * the region protection scheme. This is no longer the case with more recent (RPC-II) drives
  * as RCE is handled internally by the drive firmware.
  *

--- a/xbmc/cores/VideoPlayer/Interface/DemuxCrypto.h
+++ b/xbmc/cores/VideoPlayer/Interface/DemuxCrypto.h
@@ -35,7 +35,7 @@ struct DemuxCryptoSession
     return keySystem == other.keySystem && sessionId == other.sessionId;
   };
 
-  // encryped stream infos
+  // encrypted stream infos
   std::string sessionId;
   CryptoSessionSystem keySystem;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -838,7 +838,7 @@ void CRenderManager::PresentSingle(bool clear, DWORD flags, DWORD alpha)
 }
 
 /* new simpler method of handling interlaced material, *
- * we just render the two fields right after eachother */
+ * we just render the two fields right after each other */
 void CRenderManager::PresentFields(bool clear, DWORD flags, DWORD alpha)
 {
   const SPresent& m = m_Queue[m_presentsource];


### PR DESCRIPTION
## Description
Fixed typos in source comments and doxygen

Found using codespell

## Motivation and context

Accuracy of documentation and code.

## How has this been tested?
n/a

## What is the effect on users?
no negative impacts

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
