### PR TITLE
Fix typos in xbmc/filesystem

### DIFF
--- a/xbmc/filesystem/DirectoryFactory.h
+++ b/xbmc/filesystem/DirectoryFactory.h
@@ -19,7 +19,7 @@ namespace XFILE
  \brief Get access to a directory of a file system.
 
  The Factory can be used to create a directory object
- for every file system accessable. \n
+ for every file system accessible. \n
  \n
  Example:
 

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -776,7 +776,7 @@ bool XFILE::CFile::ReadLine(std::string& line)
 
   try
   {
-    // Read by buffer chuncks until to EOL or EOF
+    // Read by buffer chunks until to EOL or EOF
     while (true)
     {
       char bufferLine[1025];

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -102,7 +102,7 @@ bool CFileCache::Open(const CURL& url)
   CLog::Log(LOGDEBUG, "CFileCache::{} - <{}> opening", __FUNCTION__, m_sourcePath);
 
   // Opening the source file.
-  // The READ_NO_CACHE and READ_NO_BUFFER flags are required to avoid create other intances of
+  // The READ_NO_CACHE and READ_NO_BUFFER flags are required to avoid create other instances of
   // FileCache or StreamBuffer since CFile::Open is called again in loop
   if (!m_source.Open(url.Get(), READ_NO_CACHE | READ_TRUNCATED | READ_NO_BUFFER))
   {

--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -251,7 +251,7 @@ bool CNFSDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     bool bIsDir = false;
     int64_t lTimeDate = 0;
 
-    //reslove symlinks
+    //resolve symlinks
     if(tmpDirent.type == NF3LNK)
     {
       CURL linkUrl;

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -541,7 +541,7 @@ static void ParseItem(CFileItem* item, tinyxml2::XMLElement* root, const std::st
     if(best->duration)
       item->SetProperty("duration", StringUtils::SecondsToTimeString(best->duration));
 
-    /* handling of mimetypes fo directories are sub optimal at best */
+    /* handling of mimetypes for directories are sub optimal at best */
     if(best->mime == "application/rss+xml" && StringUtils::StartsWithNoCase(item->GetPath(), "http://"))
       item->SetPath("rss://" + item->GetPath().substr(7));
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.h
@@ -26,7 +26,7 @@ namespace XFILE
 
     private:
       /*!
-       * \brief Get the title of choosen season.
+       * \brief Get the title of chosen season.
        * \return The season title.
        */
       std::string GetSeasonTitle() const;


### PR DESCRIPTION
## Description
Fixed typos in xbmc/filesystem comments and doxygen

Found using codespell

## Motivation and context

Accuracy of documentation and code.

## How has this been tested?
n/a

## What is the effect on users?
no negative impacts

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
