### PR TITLE
[VideoInfoScanner] Allow scraper to correctly process episodes in files named with the format SxxExx-Eyy and add further tests.

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -318,6 +318,7 @@ void CAdvancedSettings::Initialize()
   m_bVideoScannerIgnoreErrors = false;
   m_iVideoLibraryDateAdded = 1; // prefer mtime over ctime and current time
   m_minimumEpisodePlaylistDuration = 5 * 60; // 5 minutes
+  m_disableEpisodeRanges = false;
 
   m_caseSensitiveLocalArtMatch = true; // case sensitive local art matching
 
@@ -824,6 +825,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetInt(pElement, "dateadded", m_iVideoLibraryDateAdded);
     XMLUtils::GetBoolean(pElement, "casesensitivelocalartmatch", m_caseSensitiveLocalArtMatch);
     XMLUtils::GetInt(pElement, "minimumepisodeplaylistduration", m_minimumEpisodePlaylistDuration);
+    XMLUtils::GetBoolean(pElement, "disableepisoderanges", m_disableEpisodeRanges);
   }
 
   pElement = pRootElement->FirstChildElement("videoscanner");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -274,6 +274,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     bool m_caseSensitiveLocalArtMatch{true};
     int m_minimumEpisodePlaylistDuration; // seconds
+    bool m_disableEpisodeRanges{false};
 
     CLangInfo::Tokens m_vecTokens;
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1352,6 +1352,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
       // add what we found by now
       episodeList.push_back(episode);
 
+      const bool disableEpisodeRanges{m_advancedSettings->m_disableEpisodeRanges};
+
       CRegExp reg2(true, CRegExp::autoUtf8);
       // check the remainder of the string for any further episodes.
       if (!byDate && reg2.RegComp(m_advancedSettings->m_tvshowMultiPartEnumRegExp))
@@ -1372,7 +1374,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
             {
               // Already added SxxEyy now loop (if needed) to SxxEzz
               const int last{episode.iEpisode};
-              const int next{!remainder.starts_with("-") ? last : currentEpisode + 1};
+              const int next{
+                  disableEpisodeRanges || !remainder.starts_with("-") ? last : currentEpisode + 1};
 
               ProcessEpisodeRange(next, last, episode, episodeList,
                                   m_advancedSettings->m_tvshowMultiPartEnumRegExp);
@@ -1418,7 +1421,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
                    (regexp2pos >= 0 && regexppos == -1))
           {
             const int last{std::stoi(reg2.GetMatch(1))};
-            const int next{currentEpisode + 1};
+            const int next{remainder.starts_with("-") && !disableEpisodeRanges ? currentEpisode + 1
+                                                                               : last};
 
             ProcessEpisodeRange(next, last, episode, episodeList,
                                 m_advancedSettings->m_tvshowMultiPartEnumRegExp);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -66,6 +66,35 @@ using namespace KODI;
 using KODI::MESSAGING::HELPERS::DialogResponse;
 using KODI::UTILITY::CDigest;
 
+namespace
+{
+void ProcessEpisodeRange(int first,
+                         int last,
+                         VIDEO::EPISODE& episode,
+                         VIDEO::EPISODELIST& episodeList,
+                         const std::string& regex)
+{
+  if (first <= last)
+  {
+    for (int e = first; e <= last; ++e)
+    {
+      episode.iEpisode = e;
+      CLog::LogF(LOGDEBUG, "VideoInfoScanner: Adding multipart episode {} [{}]", episode.iEpisode,
+                 regex);
+      episodeList.push_back(episode);
+    }
+  }
+  else if (!episodeList.empty())
+  {
+    // SxxEaa-SxxEbb or Eaa-Ebb is backwards - bb<aa
+    CLog::LogF(LOGDEBUG,
+               "VideoInfoScanner: Removing season {}, episode {} as range {}-{} is backwards",
+               episode.iSeason, episode.iEpisode, episodeList.back().iEpisode, last);
+    episodeList.pop_back();
+  }
+}
+} // namespace
+
 namespace KODI::VIDEO
 {
 
@@ -1327,32 +1356,74 @@ CVideoInfoScanner::~CVideoInfoScanner()
       // check the remainder of the string for any further episodes.
       if (!byDate && reg2.RegComp(m_advancedSettings->m_tvshowMultiPartEnumRegExp))
       {
-        int offset = 0;
+        int offset{0};
+        int currentSeason{episode.iSeason};
+        int currentEpisode{episode.iEpisode};
 
         // we want "long circuit" OR below so that both offsets are evaluated
         while (static_cast<int>((regexp2pos = reg2.RegFind(remainder.c_str() + offset)) > -1) |
                static_cast<int>((regexppos = reg.RegFind(remainder.c_str() + offset)) > -1))
         {
-          if (((regexppos <= regexp2pos) && regexppos != -1) ||
-             (regexppos >= 0 && regexp2pos == -1))
+          if ((regexppos <= regexp2pos && regexppos != -1) || // season (or 'ep') match
+              (regexppos >= 0 && regexp2pos == -1))
           {
             GetEpisodeAndSeasonFromRegExp(reg, episode, defaultSeason);
+            if (currentSeason == episode.iSeason)
+            {
+              // Already added SxxEyy now loop (if needed) to SxxEzz
+              const int last{episode.iEpisode};
+              const int next{!remainder.starts_with("-") ? last : currentEpisode + 1};
 
-            CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding new season {}, multipart episode {} [{}]",
-                      episode.iSeason, episode.iEpisode,
-                      m_advancedSettings->m_tvshowMultiPartEnumRegExp);
+              ProcessEpisodeRange(next, last, episode, episodeList,
+                                  m_advancedSettings->m_tvshowMultiPartEnumRegExp);
 
-            episodeList.push_back(episode);
-            remainder = reg.GetMatch(3);
+              currentEpisode = episode.iEpisode;
+              remainder = reg.GetMatch(3);
+            }
+            else
+            {
+              // Two possible scenarios here:
+              if (remainder.substr(offset, 1) != "-" || disableEpisodeRanges)
+              {
+                // (Sxx)Eyy has already been added and we now in a new range (eg. S00E01S01E01....)
+                // Add first episode here
+                currentSeason = episode.iSeason;
+                currentEpisode = episode.iEpisode;
+                episodeList.push_back(episode);
+                remainder = reg.GetMatch(3);
+              }
+              else
+              {
+                // (Sxx)Eyy has already been added as start of range and we now have SaaEbb (eg. S01E01-S02E05)
+                //   this is not allowed as scanner cannot determine how many episodes in a season
+                if (offset == 0)
+                {
+                  // Already added first episode of invalid range so remove it
+                  episodeList.pop_back();
+                  remainder = reg.GetMatch(3);
+                  CLog::LogF(
+                      LOGDEBUG,
+                      "VideoInfoScanner: Removing season {}, episode {} as part of invalid range",
+                      episode.iSeason, episode.iEpisode);
+                }
+                else
+                {
+                  remainder = remainder.substr(offset);
+                }
+              }
+            }
             offset = 0;
           }
-          else if (((regexp2pos < regexppos) && regexp2pos != -1) ||
+          else if ((regexp2pos < regexppos && regexp2pos != -1) || // episode match
                    (regexp2pos >= 0 && regexppos == -1))
           {
-            episode.iEpisode = atoi(reg2.GetMatch(1).c_str());
-            CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding multipart episode {} [{}]",
-                      episode.iEpisode, m_advancedSettings->m_tvshowMultiPartEnumRegExp);
-            episodeList.push_back(episode);
+            const int last{std::stoi(reg2.GetMatch(1))};
+            const int next{currentEpisode + 1};
+
+            ProcessEpisodeRange(next, last, episode, episodeList,
+                                m_advancedSettings->m_tvshowMultiPartEnumRegExp);
+
+            currentEpisode = episode.iEpisode;
             offset += regexp2pos + reg2.GetFindLen();
           }
         }

--- a/xbmc/video/test/TestVideoInfoScanner.cpp
+++ b/xbmc/video/test/TestVideoInfoScanner.cpp
@@ -7,6 +7,9 @@
  */
 
 #include "FileItem.h"
+#include "ServiceBroker.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
 #include "video/VideoInfoScanner.h"
 
 #include <gtest/gtest.h>
@@ -16,29 +19,70 @@ using ::testing::Test;
 using ::testing::WithParamInterface;
 using ::testing::ValuesIn;
 
-typedef struct
+struct TestEntry
 {
   const char* path;
-  int season;
-  int episode[4]; // for multi-episodes
-} TestEntry;
+  std::vector<VIDEO::EPISODE> ranges;
+  std::vector<VIDEO::EPISODE> noranges;
+};
 
 static const TestEntry TestData[] = {
-  //season+episode
-  {"foo.S02E03.mkv",   2, {3} },
-  {"foo.203.mkv",      2, {3} },
-  //episode only
-  {"foo.Ep03.mkv",     1, {3} },
-  {"foo.Ep_03.mkv",    1, {3} },
-  {"foo.Part.III.mkv", 1, {3} },
-  {"foo.Part.3.mkv",   1, {3} },
-  {"foo.E03.mkv",      1, {3} },
-  {"foo.2009.E03.mkv", 1, {3} },
-  // multi-episode
-  {"The Legend of Korra - S01E01-02 - Welcome to Republic City & A Leaf in the Wind.mkv", 1, { 1, 2 } },
-  {"foo.S01E01E02.mkv", 1, {1,2} },
-  {"foo.S01E03E04E05.mkv", 1, {3,4,5} }
-};
+    //season+episode
+    {"foo.S02E03.mkv", {{2, 3}}, {{2, 3}}},
+    {"foo.203.mkv", {{2, 3}}, {{2, 3}}},
+    //episode only
+    {"foo.Ep03.mkv", {{1, 3}}, {{1, 3}}},
+    {"foo.Ep_03.mkv", {{1, 3}}, {{1, 3}}},
+    {"foo.Part.III.mkv", {{1, 3}}, {{1, 3}}},
+    {"foo.Part.3.mkv", {{1, 3}}, {{1, 3}}},
+    {"foo.E03.mkv", {{1, 3}}, {{1, 3}}},
+    {"foo.2009.E03.mkv", {{1, 3}}, {{1, 3}}},
+    // multi-episode
+    {"The Legend of Korra - S01E01-02 - Welcome to Republic City & A Leaf in the Wind.mkv",
+     {{1, 1}, {1, 2}},
+     {{1, 1}, {1, 2}}},
+    {"foo.S01E01E02.mkv", {{1, 1}, {1, 2}}, {{1, 1}, {1, 2}}},
+    {"foo.S01E03E04E05.mkv", {{1, 3}, {1, 4}, {1, 5}}, {{1, 3}, {1, 4}, {1, 5}}},
+    {"foo.S02E01-S02E02.mkv", {{2, 1}, {2, 2}}, {{2, 1}, {2, 2}}},
+    {"foo S02E01-bar-S02E02-bar.mkv", {{2, 1}, {2, 2}}, {{2, 1}, {2, 2}}},
+    {"foo S02E01-S02E02-S02E03.mkv", {{2, 1}, {2, 2}, {2, 3}}, {{2, 1}, {2, 2}, {2, 3}}},
+    {"foo 2x01-2x02.mkv", {{2, 1}, {2, 2}}, {{2, 1}, {2, 2}}},
+    {"foo ep01-ep02.mkv", {{1, 1}, {1, 2}}, {{1, 1}, {1, 2}}},
+    {"foo S02E01-02-03.mkv", {{2, 1}, {2, 2}, {2, 3}}, {{2, 1}, {2, 2}, {2, 3}}},
+    {"foo 2x01x02.mkv", {{2, 1}, {2, 2}}, {{2, 1}, {2, 2}}},
+    {"foo ep01-02.mkv", {{1, 1}, {1, 2}}, {{1, 1}, {1, 2}}},
+    {"foo.S02E01S02E03.mkv", {{2, 1}, {2, 3}}, {{2, 1}, {2, 3}}},
+    // spanning episodes
+    {"foo.E03-05.mkv", {{1, 3}, {1, 4}, {1, 5}}, {{1, 3}, {1, 5}}},
+    {"foo.ep03-05.mkv", {{1, 3}, {1, 4}, {1, 5}}, {{1, 3}, {1, 5}}},
+    {"foo.ep03-ep05.mkv", {{1, 3}, {1, 4}, {1, 5}}, {{1, 3}, {1, 5}}},
+    {"foo.5x03-5x05.mkv", {{5, 3}, {5, 4}, {5, 5}}, {{5, 3}, {5, 5}}},
+    {"foo.S05E03-05.mkv", {{5, 3}, {5, 4}, {5, 5}}, {{5, 3}, {5, 5}}},
+    {"foo.S05E03-E05.mkv", {{5, 3}, {5, 4}, {5, 5}}, {{5, 3}, {5, 5}}},
+    {"foo.S05E03-S05E05.mkv", {{5, 3}, {5, 4}, {5, 5}}, {{5, 3}, {5, 5}}},
+    {"foo.S05E01-E03-E05.mkv", {{5, 1}, {5, 2}, {5, 3}, {5, 4}, {5, 5}}, {{5, 1}, {5, 3}, {5, 5}}},
+    {"foo.S05E01-S05E03-S05E05.mkv",
+     {{5, 1}, {5, 2}, {5, 3}, {5, 4}, {5, 5}},
+     {{5, 1}, {5, 3}, {5, 5}}},
+    // multi-season
+    {"foo.S00E100S05E03E04E05.mkv",
+     {{0, 100}, {5, 3}, {5, 4}, {5, 5}},
+     {{0, 100}, {5, 3}, {5, 4}, {5, 5}}},
+    {"foo.S01E01E02S02E01.mkv", {{1, 1}, {1, 2}, {2, 1}}, {{1, 1}, {1, 2}, {2, 1}}},
+    {"foo.S00E01-04S05E03-E06.mkv",
+     {{0, 1}, {0, 2}, {0, 3}, {0, 4}, {5, 3}, {5, 4}, {5, 5}, {5, 6}},
+     {{0, 1}, {0, 4}, {5, 3}, {5, 6}}},
+    // expected (partial) failure
+    {"foo.S01E01-S02E03.mkv", {}, {{1, 1}, {2, 3}}}, // cannot determine number of episodes in S01
+    {"foo.S01E03-S01E01.mkv", {}, {{1, 3}, {1, 1}}}, // range backwards
+    {"foo.S01E03-E01.mkv", {}, {{1, 3}, {1, 1}}}, // range backwards
+    {"foo S00E01E03-S01E01.mkv", {{0, 1}}, {{0, 1}, {0, 3}, {1, 1}}}, // invalid range
+    {"foo.S00E01-04S01E01-S02E03.mkv",
+     {{0, 1}, {0, 2}, {0, 3}, {0, 4}},
+     {{0, 1}, {0, 4}, {1, 1}, {2, 3}}}, // second range invalid
+    {"foo.S01E03-S02E02S03E01-E04.mkv",
+     {{3, 1}, {3, 2}, {3, 3}, {3, 4}},
+     {{1, 3}, {2, 2}, {3, 1}, {3, 4}}}}; // first range invalid
 
 class TestVideoInfoScanner : public Test,
                              public WithParamInterface<TestEntry>
@@ -47,18 +91,22 @@ class TestVideoInfoScanner : public Test,
 
 TEST_P(TestVideoInfoScanner, EnumerateEpisodeItem)
 {
+  const std::shared_ptr<CAdvancedSettings> advancedSettings =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
   const TestEntry& entry = GetParam();
-  VIDEO::CVideoInfoScanner scanner;
-  CFileItem item(entry.path, false);
-  VIDEO::EPISODELIST expected;
-  for (int i = 0; i < 3 && entry.episode[i]; i++)
-    expected.emplace_back(entry.season, entry.episode[i], 0, false);
 
+  CFileItem item(entry.path, false);
+  VIDEO::CVideoInfoScanner scanner;
   VIDEO::EPISODELIST result;
+
+  advancedSettings->m_disableEpisodeRanges = false;
   ASSERT_TRUE(scanner.EnumerateEpisodeItem(&item, result));
-  EXPECT_EQ(expected.size(), result.size());
-  for (size_t i = 0; i < expected.size(); i++)
-    EXPECT_EQ(expected[i], result[i]);
+  EXPECT_EQ(entry.ranges, result);
+
+  advancedSettings->m_disableEpisodeRanges = true;
+  result.clear();
+  ASSERT_TRUE(scanner.EnumerateEpisodeItem(&item, result));
+  EXPECT_EQ(entry.noranges, result);
 }
 
 INSTANTIATE_TEST_SUITE_P(VideoInfoScanner, TestVideoInfoScanner, ValuesIn(TestData));


### PR DESCRIPTION
Found during bluray feature testing.

```
Folder PATH listing for volume Tests
Volume serial number is 6722-DF41
\\mediamaster\tests.
└───Obi-Wan Kenobi (2022)
    └───Season 1
            OBI_WAN_KENOBI_COMPLETE_DISC_1 S01E01-E03.iso
            OBI_WAN_KENOBI_COMPLETE_DISC_1.dvd
            OBI_WAN_KENOBI_COMPLETE_DISC_1.md5
            OBI_WAN_KENOBI_COMPLETE_DISC_2 S01E04E05E06.iso
            OBI_WAN_KENOBI_COMPLETE_DISC_2.dvd
            OBI_WAN_KENOBI_COMPLETE_DISC_2.md5
```

Before:
![image](https://github.com/user-attachments/assets/9c97e3cb-90a3-4355-97ca-3a871c7820b8)

After
![image](https://github.com/user-attachments/assets/fd13ac3a-e2a8-46ad-ba27-f7db38cf3662)

## Description

As above.

## Motivation and context

Episodes can be missed if the SxxExx-Eyy format is used.
The wiki isn't entirely clear if this is allowed or not (https://kodi.wiki/view/Naming_video_files/Episodes) but the regex for multiple episodes allows it in code (but just doesn't process it properly it seems).

## How has this been tested?

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

As above.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
