### PR TITLE
[win] download-msys2.bat remove obsolete msys profile env vars

### DIFF
--- a/tools/buildsteps/windows/download-msys2.bat
+++ b/tools/buildsteps/windows/download-msys2.bat
@@ -313,10 +313,7 @@ if exist %instdir%\locals\win32\etc\profile.local GOTO writeProfile64
         echo.LDFLAGS="-L/local32/lib -mthreads -pipe"
         echo.export DXSDK_DIR ACLOCAL_PATH PKG_CONFIG_PATH PKG_CONFIG_LOCAL_PATH CPPFLAGS CFLAGS CXXFLAGS LDFLAGS MSYSTEM
         echo.
-        echo.PYTHONHOME=/usr
-        echo.PYTHONPATH="/usr/lib/python2.7:/usr/lib/python2.7/Tools/Scripts"
-        echo.
-        echo.PATH=".:/local32/bin:/mingw32/bin:${MSYS2_PATH}:${INFOPATH}:${PYTHONHOME}:${PYTHONPATH}:${PATH}"
+        echo.PATH=".:/local32/bin:/mingw32/bin:${MSYS2_PATH}:${INFOPATH}:${PATH}"
         echo.PS1='\[\033[32m\]\u@\h \[\e[33m\]\w\[\e[0m\]\n\$ '
         echo.export PATH PS1
         echo.
@@ -362,10 +359,7 @@ if exist %instdir%\locals\x64\etc\profile.local GOTO loadGasPreproc
         echo.LDFLAGS="-L/local64/lib -pipe"
         echo.export DXSDK_DIR ACLOCAL_PATH PKG_CONFIG_PATH PKG_CONFIG_LOCAL_PATH CPPFLAGS CFLAGS CXXFLAGS LDFLAGS MSYSTEM
         echo.
-        echo.PYTHONHOME=/usr
-        echo.PYTHONPATH="/usr/lib/python2.7:/usr/lib/python2.7/Tools/Scripts"
-        echo.
-        echo.PATH=".:/local64/bin:/mingw64/bin:${MSYS2_PATH}:${INFOPATH}:${PYTHONHOME}:${PYTHONPATH}:${PATH}"
+        echo.PATH=".:/local64/bin:/mingw64/bin:${MSYS2_PATH}:${INFOPATH}:${PATH}"
         echo.PS1='\[\033[32m\]\u@\h \[\e[33m\]\w\[\e[0m\]\n\$ '
         echo.export PATH PS1
         echo.


### PR DESCRIPTION
## Description
Remove obsolete data

## Motivation and context
In the current version of msys2 being used, the fixed python home and path variables are no longer correct. As this has obviously no effect on building ffmpeg for windows, just remove them from the profile env

```
user@userpc MINGW64 ~
$ uname -a
MINGW64_NT-10.0-26120 userpc 3.4.9.x86_64 2023-09-15 12:15 UTC x86_64 Msys

user@userpc MINGW64 ~
$ ls -al -d /usr/lib/python*
drwxr-xr-x 1 user None 0 Feb 16 13:58 /usr/lib/python3.11
```
## How has this been tested?
mingw64 msys2 installed from kodi build step

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
