### PR TITLE
[UDMABufferObject] Use sysconf(_SC_PAGESIZE) to retrieve page size

### DIFF
--- a/xbmc/utils/UDMABufferObject.cpp
+++ b/xbmc/utils/UDMABufferObject.cpp
@@ -23,8 +23,6 @@
 namespace
 {
 
-const auto PAGESIZE = getpagesize();
-
 int RoundUp(int num, int factor)
 {
   return num + factor - 1 - (num - 1) % factor;
@@ -93,7 +91,7 @@ bool CUDMABufferObject::CreateBufferObject(uint32_t format, uint32_t width, uint
 bool CUDMABufferObject::CreateBufferObject(uint64_t size)
 {
   // Must be rounded to the system page size
-  m_size = RoundUp(size, PAGESIZE);
+  m_size = RoundUp(size, sysconf(_SC_PAGESIZE));
 
   m_memfd = memfd_create("kodi", MFD_CLOEXEC | MFD_ALLOW_SEALING);
   if (m_memfd < 0)


### PR DESCRIPTION
## Description
getpagesize() is deprecated and legacy since POSIX.1-2001 and is not available on architectures where PAGESIZE is not defined. Instead query the current page size at runtime.

## Motivation and context
Various target ABIs dont define PAGESIZE and therefore can query the page size at build time. Instead query the page size at runtime.

## How has this been tested?
Built using musl libc on armv7, ppc64le, riscv64, s390x, x86, x86_64.

## What is the effect on users?
None

## Screenshots (if appropriate):
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
