### PR TITLE
[Windows] Clean dependencies path to prevent Debug vs Release conflicts

### DIFF
--- a/tools/buildsteps/windows/download-dependencies.bat
+++ b/tools/buildsteps/windows/download-dependencies.bat
@@ -29,6 +29,9 @@ SET APP_PATH=%WORKSPACE%\project\BuildDependencies\%TARGETPLATFORM%
 SET NATIVE_PATH=%WORKSPACE%\project\BuildDependencies\%HOST_BUILDTOOLS%
 SET TMP_PATH=%BUILD_DEPS_PATH%\scripts\tmp
 
+REM Clean dependencies path (install path) to avoid Debug vs Release conflicts
+IF EXIST %APP_PATH% rmdir %APP_PATH% /S /Q
+
 REM Change to the BuildDependencies directory, if we're not there already
 PUSHD %BUILD_DEPS_PATH%
 


### PR DESCRIPTION
## Description
`project\BuildDependencies\%TARGETPLATFORM%` contains both download pre-build dependencies and also locally build dependencies. Is also the "install path" of the build dependencies. It needs to be cleaned so as not to conflict with previous builds or may even contain other versions.

Download script only overwrites but not removes different files names.

## Motivation and context
Helps with https://github.com/xbmc/xbmc/issues/26437

Now to build Debug and after Release you should manual clean `project\BuildDependencies\x64` (for x64). 

This PR does the same every time is executed `download-dependencies.bat`

## How has this been tested?
Tested build Windows x64

## What is the effect on users?
Prevents conflicts at build Debug and Release in an interleaved manner.

This sequence not works before and works after:
```
download-dependencies.bat
mkdir kodi-build
cd kodi-build
cmake -G "Visual Studio 17 2022" -A x64 -T host=x64 %kodi%
cmake --build . --config "Debug"

download-dependencies.bat
mkdir kodi-build
cd kodi-build
cmake -G "Visual Studio 17 2022" -A x64 -T host=x64 %kodi%
cmake --build . --config "Release"
```

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
