### PR TITLE
[cmake] Texturepacker src and internal texturepacker build changes

### DIFF
--- a/tools/depends/native/TexturePacker/src/CMakeLists.txt
+++ b/tools/depends/native/TexturePacker/src/CMakeLists.txt
@@ -1,7 +1,13 @@
 cmake_minimum_required(VERSION 3.15)
 project(TexturePacker)
 
-list(APPEND CMAKE_MODULE_PATH ${KODI_SOURCE_DIR}/cmake/modules)
+# If we are building inside the Kodi project, add its Find module paths
+# otherwise point to TexturePacker's source for the Find modules
+if(${KODI_SOURCE_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
+  list(APPEND CMAKE_MODULE_PATH ${KODI_SOURCE_DIR}/cmake/modules)
+else()
+  list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR})
+endif()
 
 if(NATIVEPREFIX)
   set(CMAKE_FIND_ROOT_PATH ${NATIVEPREFIX})

--- a/tools/depends/native/TexturePacker/src/FindLzo2.cmake
+++ b/tools/depends/native/TexturePacker/src/FindLzo2.cmake
@@ -1,0 +1,35 @@
+#.rst:
+# FindLzo2
+# --------
+# Finds the Lzo2 library
+#
+# This will define the following target:
+#
+#   ${APP_NAME_LC}::Lzo2   - The Lzo2 library
+
+if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
+
+  find_path(LZO2_INCLUDE_DIR NAMES lzo1x.h
+                             PATH_SUFFIXES lzo
+                             HINTS ${DEPENDS_PATH}/include
+                             ${${CORE_PLATFORM_NAME_LC}_SEARCH_CONFIG})
+
+  find_library(LZO2_LIBRARY NAMES lzo2 liblzo2
+                            HINTS ${DEPENDS_PATH}/lib
+                            ${${CORE_PLATFORM_NAME_LC}_SEARCH_CONFIG})
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Lzo2
+                                    REQUIRED_VARS LZO2_LIBRARY LZO2_INCLUDE_DIR)
+
+  if(LZO2_FOUND)
+    add_library(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} UNKNOWN IMPORTED)
+    set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
+                                                                     IMPORTED_LOCATION "${LZO2_LIBRARY}"
+                                                                     INTERFACE_INCLUDE_DIRECTORIES "${LZO2_INCLUDE_DIR}")
+  else()
+    if(LibLzo2_FIND_REQUIRED)
+      message(FATAL_ERROR "Lzo2 library was not found.")
+    endif()
+  endif()
+endif()


### PR DESCRIPTION
## Description
Introduce its own FindLzo2.cmake for TexturePacker src tree
Change the linux cmake paths regarding INTERNAL_TEXTUREPACKER_EXECUTABLE and INTERNAL_TEXTUREPACKER_INSTALLABLE to build TexturePacker using externalproject_add to more clearly add separation between Kodi and TexturePacker

Do note, TexturePacker will now require system libs to be available. Lzo2, PNG, GIF, JPEG libs.
The use of any future ENABLE_INTERNAL_LZO2 will NOT make available an internal build of the lib intended for Kodi for its use.
TexturePacker will fail with something similar to the following. As it now uses externalproject_add, such a failure will not be made until actual build is attempted rather than configure time.

```
-- Check for working CXX compiler: /usr/lib64/ccache/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find Lzo2 (missing: LZO2_LIBRARY LZO2_INCLUDE_DIR)
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:603 (_FPHSA_FAILURE_MESSAGE)
  FindLzo2.cmake:22 (find_package_handle_standard_args)
  CMakeLists.txt:24 (find_package)


-- Configuring incomplete, errors occurred!

```

## Motivation and context
Looking to allow building Lzo2 internally for all platforms (previous attempt #21473) . @wsnipex pointed out the failures due to a combination of internal lzo2 and texturepacker being built.

This more clearly splits the texturepacker build into its own build. Any information required has to be passed through, rather than implicitly available with add_directory method.

## How has this been tested?
Fedora 41 build and install Kodi using combinations of ENABLE_INTERNAL_LZO2 on and off, using both Make and Ninja.
TexturePacker is installed (and renamed as per existing install commands in Linux platform install.cmake)

Using another branch that introduces building lzo2 for all platforms, Kodi can use the internal build of lzo2, with TexturePacker using system Lzo2.

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
