### PR TITLE
Updates for CMake scripts to support Windows ARM64

### DIFF
--- a/cmake/scripts/common/PrepareEnv.cmake
+++ b/cmake/scripts/common/PrepareEnv.cmake
@@ -67,17 +67,21 @@ elseif(CORE_SYSTEM_NAME STREQUAL windows)
   include(CheckSymbolExists)
   check_symbol_exists(_X86_ "Windows.h" _X86_)
   check_symbol_exists(_AMD64_ "Windows.h" _AMD64_)
+  check_symbol_exists(_ARM64_ "Windows.h" _ARM64_)
 
   if(_X86_)
     set(PLATFORM_TAG ${PLATFORM_TAG}-i686)
   elseif(_AMD64_)
     set(PLATFORM_TAG ${PLATFORM_TAG}-x86_64)
+  elseif(_ARM64_)
+    set(PLATFORM_TAG ${PLATFORM_TAG}-arm64)  
   else()
     message(FATAL_ERROR "Unsupported architecture")
   endif()
 
   unset(_X86_)
   unset(_AMD64_)
+  unset(_ARM64_)
 endif()
 
 # generate the proper KodiConfig.cmake file

--- a/cmake/scripts/windows/ArchSetup.cmake
+++ b/cmake/scripts/windows/ArchSetup.cmake
@@ -15,14 +15,16 @@ unset(_gentoolset)
 
 # -------- Architecture settings ---------
 
-if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+if(CMAKE_GENERATOR_PLATFORM STREQUAL arm64)
+  set(ARCH arm64)
+  set(SDK_TARGET_ARCH arm64)
+elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
   set(ARCH win32)
   set(SDK_TARGET_ARCH x86)
 elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
   set(ARCH x64)
   set(SDK_TARGET_ARCH x64)
 endif()
-
 
 # -------- Paths (mainly for find_package) ---------
 
@@ -55,7 +57,13 @@ endif()
 # Allow to use UTF-8 strings in the source code, disable MSVC charset conversion
 add_options(CXX ALL_BUILDS "/utf-8")
 add_options(CXX ALL_BUILDS "/wd\"4996\"")
-set(ARCH_DEFINES -D_WINDOWS -DTARGET_WINDOWS -DTARGET_WINDOWS_DESKTOP -D__SSE__ -D__SSE2__)
+set(ARCH_DEFINES -D_WINDOWS -DTARGET_WINDOWS -DTARGET_WINDOWS_DESKTOP)
+
+# Do not add SSE flags for ARM64
+if(NOT CMAKE_GENERATOR_PLATFORM STREQUAL arm64)
+  list(APPEND ARCH_DEFINES -D__SSE__ -D__SSE2__)
+endif()
+
 set(SYSTEM_DEFINES -DWIN32_LEAN_AND_MEAN -DNOMINMAX -DHAS_DX -D__STDC_CONSTANT_MACROS
                    -DTAGLIB_STATIC -DNPT_CONFIG_ENABLE_LOGGING
                    -DPLT_HTTP_DEFAULT_USER_AGENT="UPnP/1.0 DLNADOC/1.50 Kodi"


### PR DESCRIPTION
## Description
Updates for CMake scripts to support Windows ARM64This enables CMake to configure Kodi build for Windows ARM64.
This is the second in my series of PRs with the goal to upstream my Windows ARM64 fork at https://github.com/ddscentral/xbmc-win-arm64/

My first PR has added buildsteps and dependency downloading. This small PR updates CMake scripts to support Windows ARM64. After this PR, the build system will be ready to configure builds for Windows ARM64. 
Subsequent PRs will introduce code changes required to support Windows ARM64, one subsystem at a time.

## Motivation and context
Support for Windows ARM64

## How has this been tested?
Configure phase will no longer fail with "Unsupported architecture" when running configure for Windows ARM64.

## What is the effect on users?


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
