### PR TITLE
[PipeWire] Lock `CPipewireRegistry` before accessing

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -302,6 +302,7 @@ void CAESinkPipewire::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
   list.emplace_back(defaultDevice);
 
   auto& registry = pipewire->GetRegistry();
+  std::lock_guard lg(registry);
 
   for (const auto& [id, node] : registry.GetNodes())
   {

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
@@ -43,8 +43,6 @@ void CPipewireRegistry::OnGlobalAdded(void* userdata,
                                       uint32_t version,
                                       const struct spa_dict* props)
 {
-  auto& registry = *reinterpret_cast<CPipewireRegistry*>(userdata);
-
   if (strcmp(type, PW_TYPE_INTERFACE_Node) != 0)
     return;
 
@@ -55,6 +53,8 @@ void CPipewireRegistry::OnGlobalAdded(void* userdata,
   if (strcmp(mediaClass, "Audio/Sink") != 0)
     return;
 
+  auto& registry = *reinterpret_cast<CPipewireRegistry*>(userdata);
+  std::lock_guard lg(registry);
   auto& nodes = registry.GetNodes();
 
   nodes[id] = std::make_unique<CPipewireNode>(registry, id, type);
@@ -65,6 +65,7 @@ void CPipewireRegistry::OnGlobalAdded(void* userdata,
 void CPipewireRegistry::OnGlobalRemoved(void* userdata, uint32_t id)
 {
   auto& registry = *reinterpret_cast<CPipewireRegistry*>(userdata);
+  std::lock_guard lg(registry);
   auto& nodes = registry.GetNodes();
 
   auto it = nodes.find(id);

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "threads/CriticalSection.h"
+
 #include <map>
 #include <memory>
 #include <string>
@@ -35,6 +37,10 @@ public:
 
   std::map<uint32_t, std::unique_ptr<CPipewireNode>>& GetNodes() { return m_nodes; }
 
+  // C++ BasicLockable requirements
+  void lock() { m_lock.lock(); }
+  void unlock() { m_lock.unlock(); }
+
 private:
   static void OnGlobalAdded(void* userdata,
                             uint32_t id,
@@ -59,6 +65,8 @@ private:
   std::unique_ptr<pw_registry, PipewireRegistryDeleter> m_registry;
 
   std::map<uint32_t, std::unique_ptr<CPipewireNode>> m_nodes;
+
+  CCriticalSection m_lock;
 };
 
 } // namespace PIPEWIRE


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Fixes a race condition when an audio device is added or removed while a different thread is iterating over the devices.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #26358.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I'm not able to reproduce the issue on my system (anymore), but at least I don't see any new problems when connecting/removing audio devices while Kodi is running.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Kodi doesn't crash.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
