### PR TITLE
[Video] Fix retrieval of basepath (and other path related fixes for bluray://, archive://, rar:// and zip://)

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1999,17 +1999,17 @@ std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
                                (HasVideoInfoTag() && GetVideoInfoTag()->m_iDbId > 0 &&
                                 !CMediaTypes::IsContainer(GetVideoInfoTag()->m_type))))
   {
-    std::string name2{strMovieName};
-    URIUtils::GetParentPath(name2, strMovieName);
-    if (URIUtils::IsInArchive(m_strPath))
-    {
-      // Try to get archive itself, if empty take path before
-      name2 = CURL(m_strPath).GetHostName();
-      if (name2.empty())
-        name2 = strMovieName;
-
-      URIUtils::GetParentPath(name2, strMovieName);
-    }
+    const std::string name{strMovieName};
+    URIUtils::GetParentPath(name, strMovieName);
+  }
+  const CURL url{strMovieName};
+  if (URIUtils::IsInArchive(strMovieName) || URIUtils::IsArchive(url))
+  {
+    // Try to get archive itself, if empty take path before
+    std::string name{url.GetHostName()};
+    if (name.empty())
+      name = strMovieName;
+    URIUtils::GetParentPath(name, strMovieName);
   }
 
   // Remove any trailing 'Disc n' and disc path (VIDEO_TS or BDMV) to get actual movie title

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1996,7 +1996,7 @@ std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
     }
 
     // Remove trailing 'Disc n' path segment to get actual movie title
-    strMovieName = CUtil::RemoveTrailingDiscNumberSegmentFromPath(strMovieName);
+    strMovieName = CUtil::RemoveTrailingPartNumberSegmentFromPath(strMovieName);
   }
 
   return strMovieName;

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1945,6 +1945,22 @@ std::string CFileItem::GetMovieName(bool bUseFolderNames /* = false */) const
   if (IsPlugin() && HasVideoInfoTag() && !GetVideoInfoTag()->m_strTitle.empty())
     return GetVideoInfoTag()->m_strTitle;
 
+  // Deal with special case of files in a 'Disc n' folder etc..
+  if (bUseFolderNames)
+  {
+    const std::string r{URIUtils::GetTrailingPartNumberRegex()};
+    CRegExp regex{true, CRegExp::autoUtf8, r.c_str()};
+    std::string path{URIUtils::GetDirectory(
+        URIUtils::IsBDFile(GetPath()) ? URIUtils::GetDiscBase(GetPath()) : GetPath())};
+    URIUtils::RemoveSlashAtEnd(path);
+    if (regex.RegFind(path) != -1)
+    {
+      std::string moviePath{URIUtils::GetParentPath(path)};
+      URIUtils::RemoveSlashAtEnd(moviePath);
+      return URIUtils::GetFileName(moviePath);
+    }
+  }
+
   if (IsLabelPreformatted())
     return GetLabel();
 
@@ -1965,26 +1981,26 @@ std::string CFileItem::GetMovieName(bool bUseFolderNames /* = false */) const
 
   URIUtils::RemoveSlashAtEnd(strMovieName);
 
-  return CURL::Decode(URIUtils::GetFileName(strMovieName));
+  strMovieName = CURL::Decode(URIUtils::GetFileName(strMovieName));
+  URIUtils::RemoveExtension(strMovieName);
+  return strMovieName;
 }
 
 std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
 {
-  std::string strMovieName = m_strPath;
+  std::string strMovieName{m_strPath};
 
   if (IsMultiPath())
     strMovieName = CMultiPathDirectory::GetFirstPath(m_strPath);
 
-  if (IsOpticalMediaFile())
-    return GetLocalMetadataPath();
-
-  if (bUseFolderNames &&
-      (!m_bIsFolder || URIUtils::IsInArchive(m_strPath) || URIUtils::IsBlurayPath(m_strPath) ||
-       (HasVideoInfoTag() && GetVideoInfoTag()->m_iDbId > 0 &&
-        !CMediaTypes::IsContainer(GetVideoInfoTag()->m_type))))
+  if (URIUtils::IsBlurayPath(strMovieName))
+    strMovieName = URIUtils::GetDiscBasePath(strMovieName);
+  else if (bUseFolderNames && (!m_bIsFolder || URIUtils::IsInArchive(m_strPath) ||
+                               (HasVideoInfoTag() && GetVideoInfoTag()->m_iDbId > 0 &&
+                                !CMediaTypes::IsContainer(GetVideoInfoTag()->m_type))))
   {
-    std::string name2(strMovieName);
-    URIUtils::GetParentPath(name2,strMovieName);
+    std::string name2{strMovieName};
+    URIUtils::GetParentPath(name2, strMovieName);
     if (URIUtils::IsInArchive(m_strPath))
     {
       // Try to get archive itself, if empty take path before
@@ -1994,10 +2010,12 @@ std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
 
       URIUtils::GetParentPath(name2, strMovieName);
     }
-
-    // Remove trailing 'Disc n' path segment to get actual movie title
-    strMovieName = CUtil::RemoveTrailingPartNumberSegmentFromPath(strMovieName);
   }
+
+  // Remove any trailing 'Disc n' and disc path (VIDEO_TS or BDMV) to get actual movie title
+  strMovieName = CUtil::RemoveTrailingPartNumberSegmentFromPath(
+      strMovieName,
+      bUseFolderNames ? CUtil::PreserveFileName::REMOVE : CUtil::PreserveFileName::KEEP);
 
   return strMovieName;
 }

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -383,7 +383,7 @@ std::string CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false *
 
 namespace
 {
-void GetTrailingDiscNumberSegmentInfoFromPath(const std::string& pathIn,
+void GetTrailingPartNumberSegmentInfoFromPath(const std::string& pathIn,
                                               size_t& pos,
                                               std::string& number)
 {
@@ -393,53 +393,34 @@ void GetTrailingDiscNumberSegmentInfoFromPath(const std::string& pathIn,
   pos = std::string::npos;
   number.clear();
 
-  // Handle Disc, Disk and locale specific spellings
-  std::string discStr{StringUtils::Format("/{} ", g_localizeStrings.Get(427))};
-  size_t discPos = path.rfind(discStr);
-
-  if (discPos == std::string::npos)
+  const std::string r{URIUtils::GetTrailingPartNumberRegex()};
+  CRegExp regex{true, CRegExp::autoUtf8, r.c_str()};
+  if (regex.RegFind(path) != -1)
   {
-    discStr = "/Disc ";
-    discPos = path.rfind(discStr);
-  }
-
-  if (discPos == std::string::npos)
-  {
-    discStr = "/Disk ";
-    discPos = path.rfind(discStr);
-  }
-
-  if (discPos != std::string::npos)
-  {
-    // Check remainder of path is numeric (eg. Disc 1)
-    const std::string discNum{path.substr(discPos + discStr.size())};
-    if (discNum.find_first_not_of("0123456789") == std::string::npos)
-    {
-      pos = discPos;
-      number = discNum;
-    }
+    pos = regex.GetSubStart(0) + 1;
+    number = regex.GetMatch(1);
   }
 }
 } // unnamed namespace
 
-std::string CUtil::RemoveTrailingDiscNumberSegmentFromPath(std::string path)
+std::string CUtil::RemoveTrailingPartNumberSegmentFromPath(std::string path)
 {
-  size_t discPos{std::string::npos};
-  std::string discNum;
-  GetTrailingDiscNumberSegmentInfoFromPath(path, discPos, discNum);
+  size_t partPos{std::string::npos};
+  std::string partNum;
+  GetTrailingPartNumberSegmentInfoFromPath(path, partPos, partNum);
 
-  if (discPos != std::string::npos)
-    path.erase(discPos);
+  if (partPos != std::string::npos)
+    path.erase(partPos);
 
   return path;
 }
 
-std::string CUtil::GetDiscNumberFromPath(const std::string& path)
+std::string CUtil::GetPartNumberFromPath(const std::string& path)
 {
-  size_t discPos{std::string::npos};
-  std::string discNum;
-  GetTrailingDiscNumberSegmentInfoFromPath(path, discPos, discNum);
-  return discNum;
+  size_t partPos{std::string::npos};
+  std::string partNum;
+  GetTrailingPartNumberSegmentInfoFromPath(path, partPos, partNum);
+  return partNum;
 }
 
 bool CUtil::GetFilenameIdentifier(const std::string& fileName,

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -66,13 +66,21 @@ public:
    'Disc', 'Disk' and the locale specific spelling, as well as 'CD', and 'DVD'
    \return the part number as string if found, empty string otherwise.
    */
-  static std::string GetPartNumberFromPath(const std::string& path);
+  static std::string GetPartNumberFromPath(std::string path);
+
+  enum class PreserveFileName : bool
+  {
+    REMOVE,
+    KEEP
+  };
 
   /*! \brief Remove last segment of the given path if it matches with
-   'Disc', 'Disk' and the locale specific spelling, as well as 'CD', and 'DVD'
+   'Disc', 'Disk' and the locale specific spelling, as well as 'CD', and 'DVD' along with any disc folders
+   (ie. BDMV or VIDEO_TS).
    \return the given path with last segment removed if it matches, unchanged path otherwise.
    */
-  static std::string RemoveTrailingPartNumberSegmentFromPath(std::string path);
+  static std::string RemoveTrailingPartNumberSegmentFromPath(std::string path,
+                                                             PreserveFileName preserveFileName);
 
   static void GetQualifiedFilename(const std::string &strBasePath, std::string &strFilename);
   static void RunShortcut(const char* szPath);

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -62,17 +62,17 @@ public:
   static std::string GetTitleFromPath(const CURL& url, bool bIsFolder = false);
   static std::string GetTitleFromPath(const std::string& strFileNameAndPath, bool bIsFolder = false);
 
-  /*! \brief Return the disc number in case the last segment of given path ends with 'Disc n'.
-   Will look for 'Disc', 'Disk' and the locale specific spelling.
-   \return the disc number as string if found, empty string otherwise.
+  /*! \brief Return the part number in case the last segment of given path ends with
+   'Disc', 'Disk' and the locale specific spelling, as well as 'CD', and 'DVD'
+   \return the part number as string if found, empty string otherwise.
    */
-  static std::string GetDiscNumberFromPath(const std::string& path);
+  static std::string GetPartNumberFromPath(const std::string& path);
 
-  /*! \brief Remove last segment of the given path if it matches 'Disc n'.
-   Will look for 'Disc', 'Disk' and the locale specific spelling.
-   \return the given path with last segment removed if it matches 'Disc n', unchanged path otherwise.
+  /*! \brief Remove last segment of the given path if it matches with
+   'Disc', 'Disk' and the locale specific spelling, as well as 'CD', and 'DVD'
+   \return the given path with last segment removed if it matches, unchanged path otherwise.
    */
-  static std::string RemoveTrailingDiscNumberSegmentFromPath(std::string path);
+  static std::string RemoveTrailingPartNumberSegmentFromPath(std::string path);
 
   static void GetQualifiedFilename(const std::string &strBasePath, std::string &strFilename);
   static void RunShortcut(const char* szPath);

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -17,14 +17,21 @@
 #include <gtest/gtest.h>
 
 using ::testing::Test;
-using ::testing::WithParamInterface;
 using ::testing::ValuesIn;
+using ::testing::WithParamInterface;
 
 struct TestFileData
 {
-  const char *file;
+  const char* file;
   bool use_folder;
-  const char *base;
+  const char* base;
+};
+
+struct TestNameData
+{
+  const char* file;
+  bool use_folder;
+  const char* name;
 };
 
 class AdvancedSettingsResetBase : public Test
@@ -47,6 +54,50 @@ class TestFileItemBasePath : public AdvancedSettingsResetBase,
 {
 };
 
+class TestFileItemMovieName : public AdvancedSettingsResetBase,
+                              public WithParamInterface<TestNameData>
+{
+};
+
+const TestFileData BaseMovies[] = {
+    {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie/"},
+    {"c:\\dir\\filename.avi", false, "c:\\dir\\filename.avi"},
+    {"c:\\dir\\filename.avi", true, "c:\\dir\\"},
+    {"/dir/filename.avi", false, "/dir/filename.avi"},
+    {"/dir/filename.avi", true, "/dir/"},
+    {"smb://somepath/file.avi", false, "smb://somepath/file.avi"},
+    {"smb://somepath/file.avi", true, "smb://somepath/"},
+    {"stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi",
+     false,
+     "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi"},
+    {"stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi",
+     true, "/path/to/movie_name/"},
+    {"/home/user/TV Shows/Dexter/S1/1x01.avi", false, "/home/user/TV Shows/Dexter/S1/1x01.avi"},
+    {"/home/user/TV Shows/Dexter/S1/1x01.avi", true, "/home/user/TV Shows/Dexter/S1/"},
+    {"zip://g%3a%5cmultimedia%5cmovies%5cSphere%2ezip/Sphere.avi", true,
+     "g:\\multimedia\\movies\\"},
+    {"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", true, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", true, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/BDMV/index.bdmv", false, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/BDMV/index.bdmv", true, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", false, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", true, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/movie.iso", false, "/home/user/movies/movie/movie.iso"},
+    {"/home/user/movies/movie/file.iso", true, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/movie.iso", false, "/home/user/movies/movie/disc 1/movie.iso"},
+    {"/home/user/movies/movie/disc 1/file.iso", true, "/home/user/movies/movie/"},
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/00800.mpls",
+     true, "smb://somepath/"},
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fDisc%201%252fmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     true, "smb://somepath/"},
+    {"bluray://smb%3a%2f%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", true, "smb://somepath/"},
+    {"bluray://smb%3a%2f%2fsomepath%2fDisc%201%2f/BDMV/PLAYLIST/00800.mpls", true,
+     "smb://somepath/"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie.zip/BDMV/index.bdmv", true, "smb://somepath/"}};
+
 TEST_P(TestFileItemBasePath, GetBaseMoviePath)
 {
   CFileItem item;
@@ -56,20 +107,35 @@ TEST_P(TestFileItemBasePath, GetBaseMoviePath)
   EXPECT_EQ(compare, path);
 }
 
-const TestFileData BaseMovies[] = {{ "c:\\dir\\filename.avi", false, "c:\\dir\\filename.avi" },
-                                   { "c:\\dir\\filename.avi", true,  "c:\\dir\\" },
-                                   { "/dir/filename.avi", false, "/dir/filename.avi" },
-                                   { "/dir/filename.avi", true,  "/dir/" },
-                                   { "smb://somepath/file.avi", false, "smb://somepath/file.avi" },
-                                   { "smb://somepath/file.avi", true, "smb://somepath/" },
-                                   { "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi", false, "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi" },
-                                   { "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi", true,  "/path/to/movie_name/" },
-                                   { "/home/user/TV Shows/Dexter/S1/1x01.avi", false, "/home/user/TV Shows/Dexter/S1/1x01.avi" },
-                                   { "/home/user/TV Shows/Dexter/S1/1x01.avi", true, "/home/user/TV Shows/Dexter/S1/" },
-                                   { "zip://g%3a%5cmultimedia%5cmovies%5cSphere%2ezip/Sphere.avi", true, "g:\\multimedia\\movies\\" },
-                                   { "/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie_name/" },
-                                   { "/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", true, "/home/user/movies/movie_name/" },
-                                   { "/home/user/movies/movie_name/BDMV/index.bdmv", false, "/home/user/movies/movie_name/" },
-                                   { "/home/user/movies/movie_name/BDMV/index.bdmv", true, "/home/user/movies/movie_name/" }};
-
 INSTANTIATE_TEST_SUITE_P(BaseNameMovies, TestFileItemBasePath, ValuesIn(BaseMovies));
+
+const TestNameData BaseNames[] = {
+    {"c:\\dir\\movie.avi", false, "movie"},
+    {"c:\\movie\\filename.avi", true, "movie"},
+    {"/dir/movie.avi", false, "movie"},
+    {"/movie/filename.avi", true, "movie"},
+    {"smb://somepath/movie.avi", false, "movie"},
+    {"smb://somepath/movie/file.avi", true, "movie"},
+    {"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", false, "movie"},
+    {"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", true, "movie"},
+    {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", false, "movie"},
+    {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", true, "movie"},
+    {"/home/user/movies/movie/BDMV/index.bdmv", false, "movie"},
+    {"/home/user/movies/movie/BDMV/index.bdmv", true, "movie"},
+    {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", false, "movie"},
+    {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", true, "movie"},
+    {"/home/user/movies/movie.iso", false, "movie"},
+    {"/home/user/movies/movie/file.iso", true, "movie"},
+    {"/home/user/movies/disc 1/movie.iso", false, "movie"},
+    {"/home/user/movies/movie/disc 1/file.iso", true, "movie"}};
+
+TEST_P(TestFileItemMovieName, GetMovieName)
+{
+  CFileItem item;
+  item.SetPath(GetParam().file);
+  std::string path = CURL(item.GetMovieName(GetParam().use_folder)).Get();
+  std::string compare = CURL(GetParam().name).Get();
+  EXPECT_EQ(compare, path);
+}
+
+INSTANTIATE_TEST_SUITE_P(NameMovies, TestFileItemMovieName, ValuesIn(BaseNames));

--- a/xbmc/test/TestUtil.cpp
+++ b/xbmc/test/TestUtil.cpp
@@ -277,3 +277,70 @@ const TestUtilSplitParamsData valuesSplitParams[] = {
 };
 
 INSTANTIATE_TEST_SUITE_P(SP, TestUtilSplitParams, ValuesIn(valuesSplitParams));
+
+struct TestDiscData
+{
+  const char* file;
+  const char* number;
+};
+
+class TestDiscNumbers : public Test, public WithParamInterface<TestDiscData>
+{
+};
+
+const TestDiscData BaseFiles[] = {{"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", ""},
+                                  {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", "1"},
+                                  {"/home/user/movies/movie/BDMV/index.bdmv", ""},
+                                  {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", "1"},
+                                  {"/home/user/movies/movie.iso", ""},
+                                  {"/home/user/movies/movie/file.iso", ""},
+                                  {"/home/user/movies/disc 1/movie.iso", "1"},
+                                  {"/home/user/movies/movie/disc 1/file.iso", "1"},
+                                  {"/home/user/movies/movie.avi", ""},
+                                  {"/home/user/movies/movie/file.avi", ""},
+                                  {"/home/user/movies/movie/disc 1/file.avi", "1"},
+                                  {"/home/user/movies/movie/disk 1/file.avi", "1"},
+                                  {"/home/user/movies/movie/cd 1/file.avi", "1"},
+                                  {"/home/user/movies/movie/dvd 1/file.avi", "1"}};
+
+TEST_P(TestDiscNumbers, GetDiscNumbers)
+{
+  const std::string discNum = CUtil::GetPartNumberFromPath(GetParam().file);
+  const std::string compare = GetParam().number;
+  EXPECT_EQ(compare, discNum);
+}
+
+INSTANTIATE_TEST_SUITE_P(DiscNumbers, TestDiscNumbers, ValuesIn(BaseFiles));
+
+struct TestRemoveData
+{
+  const char* path;
+  const char* result;
+};
+
+class TestRemoveDiscNumbers : public Test, public WithParamInterface<TestRemoveData>
+{
+};
+
+const TestRemoveData BasePaths[] = {
+    {"/home/user/movies/movie/video_ts/", "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/video_ts/", "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/BDMV/", "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/file.iso", "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/file.iso", "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/file.avi", "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/file.avi", "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disk 1/file.avi", "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/cd 1/file.avi", "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/dvd 1/file.avi", "/home/user/movies/movie/"}};
+
+TEST_P(TestRemoveDiscNumbers, RemoveDiscNumbers)
+{
+  const std::string path = CUtil::RemoveTrailingPartNumberSegmentFromPath(
+      GetParam().path, CUtil::PreserveFileName::REMOVE);
+  const std::string compare = GetParam().result;
+  EXPECT_EQ(compare, path);
+}
+
+INSTANTIATE_TEST_SUITE_P(RemoveDiscNumbers, TestRemoveDiscNumbers, ValuesIn(BasePaths));

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -468,9 +468,18 @@ std::string URIUtils::GetBasePath(const std::string& strPath)
 
   std::string strDirectory = GetDirectory(strCheck);
 
-  strDirectory = CUtil::RemoveTrailingPartNumberSegmentFromPath(strDirectory);
+  strDirectory =
+      CUtil::RemoveTrailingPartNumberSegmentFromPath(strDirectory, CUtil::PreserveFileName::REMOVE);
 
   return strDirectory;
+}
+
+bool URIUtils::IsDiscPath(const std::string& path)
+{
+  std::string folder{path};
+  RemoveSlashAtEnd(folder);
+  folder = GetFileName(folder);
+  return StringUtils::EqualsNoCase(folder, "VIDEO_TS") || StringUtils::EqualsNoCase(folder, "BDMV");
 }
 
 std::string URIUtils::GetDiscBase(const std::string& file)

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1003,6 +1003,11 @@ bool URIUtils::IsArchive(const std::string& strFile)
   return HasExtension(strFile, ".zip|.rar|.apk|.cbz|.cbr");
 }
 
+bool URIUtils::IsArchive(const CURL& url)
+{
+  return url.IsProtocol("archive") || url.IsProtocol("zip") || url.IsProtocol("rar");
+}
+
 bool URIUtils::IsDiscImage(const std::string& file)
 {
   return HasExtension(file, ".img|.iso|.nrg|.udf");

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -16,6 +16,7 @@
 #include "filesystem/MultiPathDirectory.h"
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/StackDirectory.h"
+#include "guilib/LocalizeStrings.h"
 #include "network/DNSNameCache.h"
 #include "network/Network.h"
 #include "pvr/channels/PVRChannelsPath.h"
@@ -572,6 +573,16 @@ std::string URIUtils::GetBlurayPath(const std::string& path)
   }
 
   return newPath;
+}
+
+std::string URIUtils::GetTrailingPartNumberRegex()
+{
+  // Build regex inserting local specific spelling of disc (xxx)
+  // \/?:cd|dvd|xxx|dis[ck][ _.-]*([0-9]+)$
+  std::string localeDiscStr{StringUtils::Format("{} ", g_localizeStrings.Get(427))};
+  if (!localeDiscStr.empty())
+    localeDiscStr += "|";
+  return {R"([\\\/](?:cd|dvd|)" + localeDiscStr + R"(dis[ck])[ _.-]*(\d{1,3})$)"};
 }
 
 std::string URLEncodePath(const std::string& strPath)

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -87,6 +87,12 @@ public:
    */
   static std::string GetBasePath(const std::string& strPath);
 
+  /*! \brief Determine if a path belongs to a disc file structure (ie. VIDEO_TS or BDMV).
+   \param path the path.
+   \return true if the path is a disc file structure, false otherwise.
+   */
+  static bool IsDiscPath(const std::string& path);
+
   /*! \brief Given a bluray:// path, return the base .ISO or folder containing the bluray file structure.
    \param path bluray:// path.
    \return the base .ISO or folder containing the bluray file structure.

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -154,6 +154,11 @@ public:
    */
   static bool IsOpticalMediaFile(const std::string& file);
 
+  /*! \brief Get the regex for matching trailing part numbers.
+   \return the regex
+   */
+  static std::string GetTrailingPartNumberRegex();
+
   /* \brief Change the base path of a URL: fromPath/fromFile -> toPath/toFile
     Handles changes in path separator and filename URL encoding if necessary to derive toFile.
     \param fromPath the base path of the original URL

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -254,6 +254,7 @@ public:
   static bool IsAPK(const std::string& strFile);
   static bool IsZIP(const std::string& strFile);
   static bool IsArchive(const std::string& strFile);
+  static bool IsArchive(const CURL& url);
   static bool IsDiscImage(const std::string& file);
   static bool IsDiscImageStack(const std::string& file);
   static bool IsBlurayPath(const std::string& strFile);

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -183,6 +183,31 @@ TEST_F(TestURIUtils, GetParentPath)
   EXPECT_STREQ(ref.c_str(), var.c_str());
 }
 
+TEST_F(TestURIUtils, GetBasePath)
+{
+  std::string ref, var;
+
+  ref = "smb://somepath/path/";
+
+  var = URIUtils::GetBasePath("smb://somepath/path/movie.avi");
+  EXPECT_STREQ(ref.c_str(), var.c_str());
+
+  var = URIUtils::GetBasePath("smb://somepath/path/disc 1/movie.avi");
+  EXPECT_STREQ(ref.c_str(), var.c_str());
+
+  var = URIUtils::GetBasePath(
+      "bluray://smb%3a%2f%2fsomepath%2fpath%2fDisc%201%2f/BDMV/PLAYLIST/00800.mpls");
+  EXPECT_STREQ(ref.c_str(), var.c_str());
+
+  var = URIUtils::GetBasePath(
+      "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+      "00800.mpls");
+  EXPECT_STREQ(ref.c_str(), var.c_str());
+
+  var = URIUtils::GetBasePath("zip://smb%3a%2f%2fsomepath%2fpath%2fmovie.zip/BDMV/index.bdmv");
+  EXPECT_STREQ(ref.c_str(), var.c_str());
+}
+
 TEST_F(TestURIUtils, SubstitutePath)
 {
   std::string from, to, ref, var;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2543,6 +2543,7 @@ bool CVideoDatabase::GetFileInfo(const std::string& strFilenameAndPath, CVideoIn
     details.m_strPath = m_pDS->fv("path.strPath").get_asString();
     std::string strFileName = m_pDS->fv("files.strFilename").get_asString();
     ConstructPath(details.m_strFileNameAndPath, details.m_strPath, strFileName);
+    details.m_basePath = URIUtils::GetBasePath(details.m_strPath);
     details.SetPlayCount(std::max(details.GetPlayCount(), m_pDS->fv("files.playCount").get_asInt()));
     if (!details.m_lastPlayed.IsValid())
       details.m_lastPlayed.SetFromDBDateTime(m_pDS->fv("files.lastPlayed").get_asString());

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -11931,7 +11931,7 @@ void CVideoDatabase::ConstructPath(std::string& strDest, const std::string& strP
 
 void CVideoDatabase::SplitPath(const std::string& strFileNameAndPath, std::string& strPath, std::string& strFileName)
 {
-  if (URIUtils::IsStack(strFileNameAndPath) || StringUtils::StartsWithNoCase(strFileNameAndPath, "rar://") || StringUtils::StartsWithNoCase(strFileNameAndPath, "zip://"))
+  if (URIUtils::IsStack(strFileNameAndPath))
   {
     URIUtils::GetParentPath(strFileNameAndPath,strPath);
     strFileName = strFileNameAndPath;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4316,7 +4316,7 @@ std::string CVideoDatabase::GetFileBasePathById(int idFile)
 
     if (!m_pDS->eof())
     {
-      return m_pDS->fv("strPath").get_asString();
+      return URIUtils::GetBasePath(m_pDS->fv("strPath").get_asString());
     }
     m_pDS->close();
   }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -853,7 +853,7 @@ int CVideoDatabase::AddPath(const std::string& strPath, const std::string &paren
       return -1;
 
     std::string strPath1(strPath);
-    if (URIUtils::IsStack(strPath) || StringUtils::StartsWithNoCase(strPath, "rar://") || StringUtils::StartsWithNoCase(strPath, "zip://"))
+    if (URIUtils::IsStack(strPath))
       URIUtils::GetParentPath(strPath,strPath1);
 
     URIUtils::AddSlashAtEnd(strPath1);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1501,7 +1501,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
       // Deal with 'Disc n' subdirectories
       const std::string discNum{
-          CUtil::GetDiscNumberFromPath(URIUtils::GetParentPath(movieDetails.m_strFileNameAndPath))};
+          CUtil::GetPartNumberFromPath(URIUtils::GetParentPath(movieDetails.m_strFileNameAndPath))};
       if (!discNum.empty())
       {
         if (movieDetails.m_set.title.empty())


### PR DESCRIPTION
## Description

Fix retrieval of basepath. This in turn fixes a couple of scraping errors (see pictures).

This was a suggestion from @CrystalP in another PR. Looking to see if basepath is always correctly derived. I've looked specifically at 'special' vfs paths - bluray://, archive:// and rar://

Looking at the existing code basepath is different to the actual path of the media file, it is where the actual physical file resides (eg. for an archive:// path the basepath is the path in which the archive file itself resides not the media contained therein which the archive:// path+file points to, and for BD file structure its the movie directory not the BDMV directory with index.BDMV).

This includes fixing basePath generation and better handling of Disc 1 (etc..) subdirectories in the movie directory (this was introduced in #24076)

## Motivation and context

Fix a couple of scraping issues (around rar:// and Disc n subdirectories)

## How has this been tested?

Locally using the following directory structure

```
\\MediaMaster\Tests.
├───Battle of Britain (1969)
│   └───Disc 1
│           BATTLE_OF_BRITAIN_F1.dvd
│           BATTLE_OF_BRITAIN_F1.iso
│           BATTLE_OF_BRITAIN_F1.md5
│
├───Battle Over Britain (2023)
│       Battle Over Britain (2023).zip
│
├───John Wick 3 (2019)
│       JOHN_WICK_3_PARABELLUM.dvd
│       JOHN_WICK_3_PARABELLUM.iso
│       JOHN_WICK_3_PARABELLUM.md5
│
├───Sunshine (2007)
│       Sunshine (2007).rar
│
└───Terminator 2 (1991)
    └───Disc 1
        ├───BDMV
        │   │   index.bdmv
        │   │   MovieObject.bdmv
```

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

Before

![image](https://github.com/user-attachments/assets/38199a3a-7d2b-4583-9a26-9f1b86ee5772)
![image](https://github.com/user-attachments/assets/7987d57f-7799-4cc0-8bbd-ea3f7ba67d59)
![image](https://github.com/user-attachments/assets/e40a33b2-c407-406e-b37b-e6d3ea6d40d2)
![image](https://github.com/user-attachments/assets/03e7288a-a5cb-4faa-b689-be9401590707)

After

![image](https://github.com/user-attachments/assets/7042c7a8-d5c9-41b7-8059-02ff49770c03)
![image](https://github.com/user-attachments/assets/1ddf91f7-52a2-45e3-bc45-2548b4db6530)
![image](https://github.com/user-attachments/assets/13ae4a84-8dab-4206-96fc-3857e7e24331)
![image](https://github.com/user-attachments/assets/f3e79b36-89f0-47b4-8cb1-7340d615d4bd)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
