### PR TITLE
Fix typos in xbmc/platform directory

### DIFF
--- a/xbmc/platform/darwin/tvos/TVOSDisplayManager.mm
+++ b/xbmc/platform/darwin/tvos/TVOSDisplayManager.mm
@@ -179,7 +179,7 @@
       m_winSystem->AnnounceOnLostDevice();
       // displayLinkTick is tracking actual refresh duration.
       // when isDisplayModeSwitchInProgress == NO, we have switched
-      // and stablized. We might have switched to some other
+      // and stabilized. We might have switched to some other
       // rate than what we requested. setting preferredDisplayCriteria is
       // only a request. For example, 30Hz might only be available in HDR
       // and asking for 30Hz/SDR might result in 60Hz/SDR and

--- a/xbmc/platform/darwin/tvos/XBMCController.mm
+++ b/xbmc/platform/darwin/tvos/XBMCController.mm
@@ -465,7 +465,7 @@ int KODI_Run(bool renderGUI)
 
 #pragma mark - remoteControlReceivedWithEvent forwarder
 //  remoteControlReceived requires subclassing of UIViewController
-//  Just implement as a forwarding class to CLibRemote so it doesnt need to subclass
+//  Just implement as a forwarding class to CLibRemote so it doesn't need to subclass
 - (void)remoteControlReceivedWithEvent:(UIEvent*)receivedEvent
 {
   if (receivedEvent.type == UIEventTypeRemoteControl)

--- a/xbmc/platform/linux/AppParamParserLinux.cpp
+++ b/xbmc/platform/linux/AppParamParserLinux.cpp
@@ -33,7 +33,7 @@ Selected window system not available: {}
 constexpr const char* loggingText =
     R"""(
 Selected logging target not available: {}
-    Available log targest: {}
+    Available log targets: {}
 )""";
 
 constexpr const char* audioBackendsText =

--- a/xbmc/platform/linux/DBusMessage.h
+++ b/xbmc/platform/linux/DBusMessage.h
@@ -132,7 +132,7 @@ private:
       return false;
     }
     // Ignore return value, if we try to read past the end of the message this
-    // will be catched by the type check (past-end type is DBUS_TYPE_INVALID)
+    // will be caught by the type check (past-end type is DBUS_TYPE_INVALID)
     dbus_message_iter_next(iter);
     return GetReplyArgumentsWithIter(iter, args...);
   }

--- a/xbmc/platform/linux/network/zeroconf/ZeroconfAvahi.h
+++ b/xbmc/platform/linux/network/zeroconf/ZeroconfAvahi.h
@@ -61,7 +61,7 @@ private:
   struct ServiceInfo;
   typedef std::map<std::string, std::shared_ptr<ServiceInfo> > tServiceMap;
 
-  //goes through a list of todos and publishs them (takes the client a param, as it might be called from
+  //goes through a list of todos and publishes them (takes the client a param, as it might be called from
   // from the callbacks)
   void updateServices(AvahiClient* fp_client);
   //helper that actually does the work of publishing

--- a/xbmc/platform/posix/filesystem/SMBWSDiscovery.h
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscovery.h
@@ -93,7 +93,7 @@ private:
    * January 1, 1970 
    *
    * Our implementation will only set this on creation of the class
-   * We arent providing services to clients, so this should be ok.
+   * We aren't providing services to clients, so this should be ok.
    */
   long long wsd_instance_id;
 

--- a/xbmc/platform/posix/storage/discs/DiscDriveHandlerPosix.h
+++ b/xbmc/platform/posix/storage/discs/DiscDriveHandlerPosix.h
@@ -41,7 +41,7 @@ public:
   void EjectDriveTray(const std::string& devicePath) override;
 
   /*! \brief Close the provided drive device
-  * \note Some drives support closing appart from opening/eject
+  * \note Some drives support closing apart from opening/eject
   * \param devicePath the path for the device drive (e.g. /dev/sr0)
   */
   void CloseDriveTray(const std::string& devicePath) override;

--- a/xbmc/platform/win32/dxerr.cpp
+++ b/xbmc/platform/win32/dxerr.cpp
@@ -3477,7 +3477,7 @@ void WINAPI DXGetErrorDescriptionW( _In_ HRESULT hr, _Out_cap_(count) WCHAR* des
 //        CHK_ERR(DDERR_OUTOFMEMORY, "DDERR_OUTOFMEMORY")
 //        CHK_ERR(DDERR_OUTOFVIDEOMEMORY, "DDERR_OUTOFVIDEOMEMORY")
         CHK_ERR(DDERR_OVERLAYCANTCLIP, "hardware does not support clipped overlays")
-        CHK_ERR(DDERR_OVERLAYCOLORKEYONLYONEACTIVE, "Can only have ony color key active at one time for overlays")
+        CHK_ERR(DDERR_OVERLAYCOLORKEYONLYONEACTIVE, "Can only have one color key active at one time for overlays")
         CHK_ERR(DDERR_PALETTEBUSY, "Access to this palette is being refused because the palette is already locked by another thread.")
         CHK_ERR(DDERR_COLORKEYNOTSET, "No src color key specified for this operation.")
         CHK_ERR(DDERR_SURFACEALREADYATTACHED, "This surface is already attached to the surface it is being attached to.")
@@ -3515,8 +3515,8 @@ void WINAPI DXGetErrorDescriptionW( _In_ HRESULT hr, _Out_cap_(count) WCHAR* des
         CHK_ERR(DDERR_NOBLTHW, "No blter.")
         CHK_ERR(DDERR_NODDROPSHW, "No DirectDraw ROP hardware.")
         CHK_ERR(DDERR_OVERLAYNOTVISIBLE, "returned when GetOverlayPosition is called on a hidden overlay")
-        CHK_ERR(DDERR_NOOVERLAYDEST, "returned when GetOverlayPosition is called on a overlay that UpdateOverlay has never been called on to establish a destionation.")
-        CHK_ERR(DDERR_INVALIDPOSITION, "returned when the position of the overlay on the destionation is no longer legal for that destionation.")
+        CHK_ERR(DDERR_NOOVERLAYDEST, "returned when GetOverlayPosition is called on a overlay that UpdateOverlay has never been called on to establish a destination.")
+        CHK_ERR(DDERR_INVALIDPOSITION, "returned when the position of the overlay on the destination is no longer legal for that destination.")
         CHK_ERR(DDERR_NOTAOVERLAYSURFACE, "returned when an overlay member is called for a non-overlay surface")
         CHK_ERR(DDERR_EXCLUSIVEMODEALREADYSET, "An attempt was made to set the cooperative level when it was already set to exclusive.")
         CHK_ERR(DDERR_NOTFLIPPABLE, "An attempt has been made to flip a surface that is not flippable.")
@@ -3627,7 +3627,7 @@ void WINAPI DXGetErrorDescriptionW( _In_ HRESULT hr, _Out_cap_(count) WCHAR* des
 // -------------------------------------------------------------
 // D2DERR_UNSUPPORTED_PIXEL_FORMAT is not defined for UWP. WINCODEC_ERR_UNSUPPORTEDPIXELFORMAT is and has the same value.
 //        CHK_ERR(D2DERR_UNSUPPORTED_PIXEL_FORMAT, "The pixel format is not supported.")
-//        CHK_ERR(D2DERR_INSUFFICIENT_BUFFER, "The supplied buffer was too small to accomodate the data.")
+//        CHK_ERR(D2DERR_INSUFFICIENT_BUFFER, "The supplied buffer was too small to accommodate the data.")
         CHK_ERR(D2DERR_WRONG_STATE, "The object was not in the correct state to process the method.")
         CHK_ERR(D2DERR_NOT_INITIALIZED, "The object has not yet been initialized.")
         CHK_ERR(D2DERR_UNSUPPORTED_OPERATION, "The requested operation is not supported.")

--- a/xbmc/platform/win32/storage/discs/Win32DiscDriveHandler.h
+++ b/xbmc/platform/win32/storage/discs/Win32DiscDriveHandler.h
@@ -41,7 +41,7 @@ public:
   void EjectDriveTray(const std::string& devicePath) override;
 
   /*! \brief Close the provided drive device
-  * \note Some drives support closing appart from opening/eject
+  * \note Some drives support closing apart from opening/eject
   * \param devicePath the path for the device drive (e.g. D\://)
   */
   void CloseDriveTray(const std::string& devicePath) override;


### PR DESCRIPTION
## Description
Fixed typos in xbmc/platform comments and doxygen

Found using codespell

## Motivation and context

Accuracy of documentation and code.

## How has this been tested?
n/a

## What is the effect on users?
no negative impacts

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
