### PR TITLE
Fix typos in xbmc/(utils|video|windowing) directories

### DIFF
--- a/xbmc/utils/DiscsUtils.h
+++ b/xbmc/utils/DiscsUtils.h
@@ -53,7 +53,7 @@ struct DiscInfo
 /*! \brief Try to obtain the disc info (type, name, serial) of a given media path
     \param[in, out] info The disc info struct
     \param mediaPath The disc mediapath (e.g. /dev/cdrom, D\://, etc)
-    \return true if getting the disc info was successfull
+    \return true if getting the disc info was successful
 */
 bool GetDiscInfo(DiscInfo& info, const std::string& mediaPath);
 

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -163,7 +163,7 @@ public:
 
    \param input Input string to be split
    \param delimiter Delimiter to be used to split the input string
-   \param iMaxStrings (optional) Maximum number of splitted strings
+   \param iMaxStrings (optional) Maximum number of split strings
    */
   static std::vector<std::string> Split(const std::string& input, const std::string& delimiter, unsigned int iMaxStrings = 0);
   static std::vector<std::string> Split(const std::string& input, const char delimiter, size_t iMaxStrings = 0);
@@ -175,7 +175,7 @@ public:
    \param d_first the beginning of the destination range
    \param input Input string to be split
    \param delimiter Delimiter to be used to split the input string
-   \param iMaxStrings (optional) Maximum number of splitted strings
+   \param iMaxStrings (optional) Maximum number of split strings
    \return output iterator to the element in the destination range, one past the last element
    *       that was put there
    */

--- a/xbmc/utils/guilib/GUIBuiltinsUtils.h
+++ b/xbmc/utils/guilib/GUIBuiltinsUtils.h
@@ -20,38 +20,38 @@ class CGUIBuiltinsUtils
 public:
   /*! \brief Execute the action given by exec string and item.
    \param execute The action to execute
-   \param item The item asociated with the action to execute
+   \param item The item associated with the action to execute
    \return True on success, false otherwise
    */
   static bool ExecuteAction(const CExecString& execute, const std::shared_ptr<CFileItem>& item);
 
   /*! \brief Execute the action given by exec string and item.
    \param execute The action to execute
-   \param item The item asociated with the action to execute
+   \param item The item associated with the action to execute
    \return True on success, false otherwise
    */
   static bool ExecuteAction(const std::string& execute, const std::shared_ptr<CFileItem>& item);
 
   /*! \brief Execute "PlayMedia" for the given item, resume of possible, else play from beginning.
-   \param item The item asociated with the action to execute
+   \param item The item associated with the action to execute
    \return True on success, false otherwise
    */
   static bool ExecutePlayMediaTryResume(const std::shared_ptr<CFileItem>& item);
 
   /*! \brief Execute "PlayMedia" for the given item, force playback from the beginning.
-   \param item The item asociated with the action to execute
+   \param item The item associated with the action to execute
    \return True on success, false otherwise
    */
   static bool ExecutePlayMediaNoResume(const std::shared_ptr<CFileItem>& item);
 
   /*! \brief Execute "PlayMedia" for the given item, ask whether to resume if possible, else play from beginning.
-   \param item The item asociated with the action to execute
+   \param item The item associated with the action to execute
    \return True on success, false otherwise
    */
   static bool ExecutePlayMediaAskResume(const std::shared_ptr<CFileItem>& item);
 
   /*! \brief Execute "QueueMedia" for the given item.
-   \param item The item asociated with the action to execute
+   \param item The item associated with the action to execute
    \return True on success, false otherwise
    */
   static bool ExecuteQueueMedia(const std::shared_ptr<CFileItem>& item);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2449,7 +2449,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
   {
     int dbId = -1;
 
-    // get the library item which was added previously with the specified conent type
+    // get the library item which was added previously with the specified content type
     for (const auto& item : items)
     {
       if (content == CONTENT_MOVIES && !item->m_bIsFolder)

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
@@ -68,7 +68,7 @@ private:
    * to if role is Parent
    * \param[in] videoDb Database connection
    * \param[in] role NewVersion: dbId will be converted to a version of the movie chosen by
-   * the user from the whole libray.
+   * the user from the whole library.
    * Parent: dbId will have another movie chosen by the user from the whole library as a new version.
    *
    * \return True: success, a version was created and attached, false otherwise.
@@ -100,12 +100,12 @@ private:
   /*!
    * \brief Convert the movie into a version
    * \param itemMovie Movie to convert
-   * \return True for success, false otherwse
+   * \return True for success, false otherwise
    */
   bool AddSimilarMovieAsVersion(const std::shared_ptr<CFileItem>& itemMovie);
 
   /*!
-   * \brief Populates a list with all movies of the libray, excluding the item provided as parameter.
+   * \brief Populates a list with all movies of the library, excluding the item provided as parameter.
    * \param[in] item The item that will be excluded from the list
    * \param[out] list List to populate
    * \param[in] videoDb Database connection

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -93,7 +93,7 @@ SortDescription GetSortDescription(const CGUIViewState& state, const CFileItemLi
       {
         if (item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_iEpisode > 0)
         {
-          // first choice for folders containig episodes
+          // first choice for folders containing episodes
           sortDescription.sortOrder = SortOrderAscending;
           return sortDescription;
         }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -479,7 +479,7 @@ bool CGUIWindowVideoBase::ShowInfo(const CFileItemPtr& item2, const ScraperPtr& 
   do
   {
     // reload images
-    //! !todo we need this to update images in video info dialog immediatly after refresh, but why?
+    //! @todo we need this to update images in video info dialog immediately after refresh, but why?
     CGUIMessage reload(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REFRESH_THUMBS);
     OnMessage(reload);
 

--- a/xbmc/windowing/GraphicContext.h
+++ b/xbmc/windowing/GraphicContext.h
@@ -130,7 +130,7 @@ public:
   void ResetDepth() { m_layer = 2; }
   /*! \brief Reserve layers for the caller to use
    \param addLayers number of layers needed
-   \returns uint32_t returns the absolute layer hight
+   \returns uint32_t returns the absolute layer height
    */
   uint32_t GetDepth(uint32_t addLayers = 2);
 

--- a/xbmc/windowing/ios/WinSystemIOS.mm
+++ b/xbmc/windowing/ios/WinSystemIOS.mm
@@ -247,7 +247,7 @@ bool CWinSystemIOS::GetScreenResolution(int* w, int* h, double* fps, int screenI
   }
 
   // for mainscreen use the eagl bounds from xbmcController
-  // because mainscreen is might be 90° rotate dependend on
+  // because mainscreen is might be 90° rotate dependent on
   // the device and eagl gives the correct values in all cases.
   if(screenIdx == 0)
   {

--- a/xbmc/windowing/osx/WinEventsOSXImpl.mm
+++ b/xbmc/windowing/osx/WinEventsOSXImpl.mm
@@ -308,7 +308,7 @@
     case NSEventTypeScrollWheel:
     {
       // very strange, real scrolls have non-zero deltaY followed by same number of events
-      // with a zero deltaY. This reverses our scroll which is WTF? anoying. Trap them out here.
+      // with a zero deltaY. This reverses our scroll which is WTF? annoying. Trap them out here.
       if (nsEvent.deltaY != 0.0)
       {
         auto button = nsEvent.scrollingDeltaY > 0 ? XBMC_BUTTON_WHEELUP : XBMC_BUTTON_WHEELDOWN;
@@ -317,7 +317,7 @@
                             mouseEventType:XBMC_MOUSEBUTTONDOWN
                                 buttonCode:button])
         {
-          // scrollwhell need a subsquent button press with no button code
+          // scrollwhell need a subsequent button press with no button code
           [self SendXBMCMouseButtonEvent:nsEvent
                                xbmcEvent:newEvent
                           mouseEventType:XBMC_MOUSEBUTTONUP

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -785,7 +785,7 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
 
 bool CWinSystemOSX::DestroyWindowInternal()
 {
-  // set this 1st, we should really mutex protext m_appWindow in this class
+  // set this 1st, we should really mutex protect m_appWindow in this class
   m_bWindowCreated = false;
   if (m_appWindow)
   {

--- a/xbmc/windowing/wayland/WinEventsWayland.cpp
+++ b/xbmc/windowing/wayland/WinEventsWayland.cpp
@@ -180,7 +180,7 @@ private:
         if (cancelPoll.revents & POLLIN)
         {
           // Read away the char so we don't get another notification
-          // Indepentent from m_roundtripQueue so there are no races
+          // Independent from m_roundtripQueue so there are no races
           char c;
           if (read(m_pipeRead, &c, 1) != 1)
             throw std::runtime_error("Error reading from wayland message pipe");


### PR DESCRIPTION
## Description
Fixed typos in xbmc/(utils|video|windowing) directory comments and doxygen

Found using codespell

## Motivation and context

Accuracy of documentation and code.

## How has this been tested?
n/a

## What is the effect on users?
no negative impacts

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
