### PR TITLE
Add Windows ARM64 platform to addons

### DIFF
--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -843,6 +843,8 @@ bool CAddonInfoBuilder::PlatformSupportsAddon(const AddonInfoPtr& addon)
     "windows-i686",
 #elif defined(_M_AMD64)
     "windows-x86_64",
+#elif defined(_M_ARM64)
+    "windows-arm64",
 #else
 #error no architecture dependant platform tag
 #endif


### PR DESCRIPTION
## Description
This small PR adds Windows ARM64 as a Windows desktop platform for addons
Not all addons build for Windows ARM64 yet even in my fork, this will be addressed later.
This is the third PR in my series of PRs with the goal to upstream my Windows ARM64 fork here: https://github.com/ddscentral/xbmc-win-arm64/

## Motivation and context
Add support for Windows ARM64

## How has this been tested?
When building addons, should no longer get "no architecture dependent platform tag" error.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
