### PR TITLE
platform/win32/CPUInfoWin32.cpp: Disable use of __cpuid for ARM64.

### DIFF
--- a/xbmc/platform/win32/CPUInfoWin32.cpp
+++ b/xbmc/platform/win32/CPUInfoWin32.cpp
@@ -124,6 +124,7 @@ CCPUInfoWin32::CCPUInfoWin32()
   else
     m_cpuQueryLoad = nullptr;
 
+#ifndef _M_ARM64
   int CPUInfo[4] = {}; // receives EAX, EBX, ECD and EDX in that order
 
   __cpuid(CPUInfo, 0);
@@ -166,6 +167,7 @@ CCPUInfoWin32::CCPUInfoWin32()
   // Set MMX2 when SSE is present as SSE is a superset of MMX2 and Intel doesn't set the MMX2 cap
   if (m_cpuFeatures & CPU_FEATURE_SSE)
     m_cpuFeatures |= CPU_FEATURE_MMX2;
+#endif
 }
 
 CCPUInfoWin32::~CCPUInfoWin32()


### PR DESCRIPTION
## Description
This small PR disables the use of "__cpuid" in CPUInfoWin32.cpp when building for Windows ARM64 as this intrinsic does not exist on ARM64.
This is the fourth from my series of PRs with the goal to upstream my Windows ARM64 fork here: https://github.com/ddscentral/xbmc-win-arm64/

## Motivation and context
Add support for Windows ARM64

## How has this been tested?
Will no longer get an error when compiling CPUInfoWin32.cpp when building for Windows ARM64.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
