### PR TITLE
[video] Fix hang when deleting a PVR recording automatically after watching.

### DIFF
--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -431,7 +431,11 @@ void CPVRRecording::UpdateMetadata(CVideoDatabase& db, const CPVRClient& client)
 
 void CPVRRecording::DeleteMetadata(CVideoDatabase& db)
 {
-  db.EraseAllForFile(m_strFileNameAndPath);
+  db.BeginTransaction();
+  if (db.EraseAllForFile(m_strFileNameAndPath))
+    db.CommitTransaction();
+  else
+    db.RollbackTransaction();
 }
 
 std::vector<EDL::Edit> CPVRRecording::GetEdl() const

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -12231,16 +12231,8 @@ void CVideoDatabase::EraseAllForFile(const std::string& fileNameAndPath)
     const int fileId{GetFileId(fileNameAndPath)};
     if (fileId != -1)
     {
-      std::string sql = PrepareSQL("DELETE FROM settings WHERE idFile = %i", fileId);
-      m_pDS->exec(sql);
-
-      sql = PrepareSQL("DELETE FROM bookmark WHERE idFile = %i", fileId);
-      m_pDS->exec(sql);
-
-      sql = PrepareSQL("DELETE FROM streamdetails WHERE idFile = %i", fileId);
-      m_pDS->exec(sql);
-
-      sql = PrepareSQL("DELETE FROM files WHERE idFile = %i", fileId);
+      // Note: Associated bookmarks, streamdetails, ... are deleted by trigger delete_file.
+      std::string sql{PrepareSQL("DELETE FROM files WHERE idFile = %i", fileId)};
       m_pDS->exec(sql);
 
       std::string path;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3587,17 +3587,19 @@ void CVideoDatabase::GetEpisodesByFile(const std::string& strFilenameAndPath, st
 }
 
 //********************************************************************************************************************************
-void CVideoDatabase::AddBookMarkToFile(const std::string& strFilenameAndPath, const CBookmark &bookmark, CBookmark::EType type /*= CBookmark::STANDARD*/)
+bool CVideoDatabase::AddBookMarkToFile(const std::string& strFilenameAndPath,
+                                       const CBookmark& bookmark,
+                                       CBookmark::EType type /*= CBookmark::STANDARD*/)
 {
   try
   {
     int idFile = AddFile(strFilenameAndPath);
     if (idFile < 0)
-      return;
+      return false;
     if (nullptr == m_pDB)
-      return;
+      return false;
     if (nullptr == m_pDS)
-      return;
+      return false;
 
     std::string strSQL;
     int idBookmark=-1;
@@ -3632,7 +3634,9 @@ void CVideoDatabase::AddBookMarkToFile(const std::string& strFilenameAndPath, co
   catch (...)
   {
     CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strFilenameAndPath);
+    return false;
   }
+  return true;
 }
 
 void CVideoDatabase::ClearBookMarkOfFile(const std::string& strFilenameAndPath,
@@ -3676,24 +3680,28 @@ void CVideoDatabase::ClearBookMarkOfFile(const std::string& strFilenameAndPath,
 }
 
 //********************************************************************************************************************************
-void CVideoDatabase::ClearBookMarksOfFile(const std::string& strFilenameAndPath, CBookmark::EType type /*= CBookmark::STANDARD*/)
+bool CVideoDatabase::ClearBookMarksOfFile(const std::string& strFilenameAndPath,
+                                          CBookmark::EType type /*= CBookmark::STANDARD*/)
 {
   int idFile = GetFileId(strFilenameAndPath);
-  if (idFile >= 0)
-    return ClearBookMarksOfFile(idFile, type);
+  if (idFile < 0)
+    return false;
+
+  return ClearBookMarksOfFile(idFile, type);
 }
 
-void CVideoDatabase::ClearBookMarksOfFile(int idFile, CBookmark::EType type /*= CBookmark::STANDARD*/)
+bool CVideoDatabase::ClearBookMarksOfFile(int idFile,
+                                          CBookmark::EType type /*= CBookmark::STANDARD*/)
 {
   if (idFile < 0)
-    return;
+    return false;
 
   try
   {
     if (nullptr == m_pDB)
-      return;
+      return false;
     if (nullptr == m_pDS)
-      return;
+      return false;
 
     std::string strSQL=PrepareSQL("delete from bookmark where idFile=%i and type=%i", idFile, (int)type);
     m_pDS->exec(strSQL);
@@ -3706,7 +3714,9 @@ void CVideoDatabase::ClearBookMarksOfFile(int idFile, CBookmark::EType type /*= 
   catch (...)
   {
     CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idFile);
+    return false;
   }
+  return true;
 }
 
 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -708,14 +708,17 @@ public:
   void SetStackTimes(const std::string &filePath, const std::vector<uint64_t> &times);
 
   void GetBookMarksForFile(const std::string& strFilenameAndPath, VECBOOKMARKS& bookmarks, CBookmark::EType type = CBookmark::STANDARD, bool bAppend=false, long partNumber=0);
-  void AddBookMarkToFile(const std::string& strFilenameAndPath, const CBookmark &bookmark, CBookmark::EType type = CBookmark::STANDARD);
+  bool AddBookMarkToFile(const std::string& strFilenameAndPath,
+                         const CBookmark& bookmark,
+                         CBookmark::EType type = CBookmark::STANDARD);
   bool GetResumeBookMark(const std::string& strFilenameAndPath, CBookmark &bookmark);
   void DeleteResumeBookMark(const CFileItem& item);
   void ClearBookMarkOfFile(const std::string& strFilenameAndPath,
                            const CBookmark& bookmark,
                            CBookmark::EType type = CBookmark::STANDARD);
-  void ClearBookMarksOfFile(const std::string& strFilenameAndPath, CBookmark::EType type = CBookmark::STANDARD);
-  void ClearBookMarksOfFile(int idFile, CBookmark::EType type = CBookmark::STANDARD);
+  bool ClearBookMarksOfFile(const std::string& strFilenameAndPath,
+                            CBookmark::EType type = CBookmark::STANDARD);
+  bool ClearBookMarksOfFile(int idFile, CBookmark::EType type = CBookmark::STANDARD);
   bool GetBookMarkForEpisode(const CVideoInfoTag& tag, CBookmark& bookmark);
   void AddBookMarkForEpisode(const CVideoInfoTag& tag, const CBookmark& bookmark);
   void DeleteBookMarkForEpisode(const CVideoInfoTag& tag);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -698,11 +698,11 @@ public:
    */
   void EraseAllForPath(const std::string& path);
 
-  /**
-   * Erases all entries for the given file, including path entry if no longer used
-   * @param fileNameAndPath The name and path of the file to erase db entries for
+  /*! \brief Erases all entries for the given file, including path entry if no longer used.
+   \param fileNameAndPath The name and path of the file to erase db entries for.
+   \return True on success, false otherwise.
    */
-  void EraseAllForFile(const std::string& fileNameAndPath);
+  bool EraseAllForFile(const std::string& fileNameAndPath);
 
   bool GetStackTimes(const std::string &filePath, std::vector<uint64_t> &times);
   void SetStackTimes(const std::string &filePath, const std::vector<uint64_t> &times);


### PR DESCRIPTION
Fixes #26450, following the advice from @CrystalP to rework `CSaveFileState::DoWork` transaction handling.

Runtime-tested on macOS and Android, latest Kodi master.

@CrystalP can you please review.