### PR TITLE
[PVR] Reminders: Show the reminder when switched to another channel w…

### DIFF
--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
@@ -982,6 +982,9 @@ void CPVRGUIActionsTimers::AnnounceReminder(const std::shared_ptr<CPVRTimerInfoT
 
   dialog->Close();
 
+  // Disable the timer. No further announcements needed.
+  timer->SetState(PVR_TIMER_STATE_DISABLED);
+
   bool bAutoClosed = (iRemaining <= 0);
   bool bSwitch = (result == 0);
   bool bRecord = (result == 1);

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -591,8 +591,8 @@ bool CPVRTimers::UpdateEntries(int iMaxNotificationDelay)
 
           if (timer->EndAsUTC() >= now)
           {
-            // disable timer until timer's end time is due
-            if (!timer->IsDisabled())
+            // Disable reminder after pre-padding time has passed to skip further announcements.
+            if (timer->IsReminder() && !timer->IsDisabled() && timer->StartAsUTC() <= now)
             {
               timer->SetState(PVR_TIMER_STATE_DISABLED);
               bChanged = true;


### PR DESCRIPTION
…hile reminder is in pre-padding phase (reminder due, but show not yet started).

I recently had the following use case: I had a reminder set for a programme on channel A starting at 20:15, reminder to go off 20:10. I was watching channel A until ~20:12, then switched to another channel to watch some other programme. Later that evening, I was asking myself why the programme that started on channel A at 20:15, for which I had set a reminder, was not reminded.

This PR implements a fix for this edge use case: When watching the channel the reminder will be due for, the reminder will now be shown when switching channel in the pre-padding phase of the reminder, where its is already due, but the actual programme has not yet started. This fixes exactly the edge use case I encountered recently. After pre-padding phase, in case I still watch the channel, no reminder will pop up when changing channel. Why? When I watch the programme in question and decide to switch to another channel, why should I be asked to switch back to the channel I just stopped watching intentionally, or to record that programme? I guess I switched channel, because I'm no longer interested in the programme after watching it for a while.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish please review.