### PR TITLE
Fix typos in various xbmc subdirectories

### DIFF
--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -1034,7 +1034,7 @@ bool CFileItemList::Save(int windowID)
   if (file.OpenForWrite(cachefile, true)) // overwrite always
   {
     // Before caching save simplified cache file name in every item so the cache file can be
-    // identifed and removed if the item is updated. List path and options (used for file
+    // identified and removed if the item is updated. List path and options (used for file
     // name when list cached) can not be accurately derived from item path.
     StringUtils::Replace(cachefile, "special://temp/archive_cache/", "");
     StringUtils::Replace(cachefile, ".fi", "");

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -800,7 +800,7 @@ const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
 ///                  _string_,
 ///     @return The editlist of the currently playing item as csv in the format start1\,end1\,start2\,end2\,...
 ///     Tokens must have values in the range from 0.0 to 100.0. end token must be less or equal than start token.
-///     @note This infolabel does not contain EDL cuts. Edits start and end times are ajusted according to cuts
+///     @note This infolabel does not contain EDL cuts. Edits start and end times are adjusted according to cuts
 ///     defined for the media item.
 ///     <p><hr>
 ///     @skinning_v20 **[New Infolabel]** \link Player_Editlist `Player.Editlist`\endlink
@@ -2897,7 +2897,7 @@ const infomap musicpartymode[] = {{ "enabled",           MUSICPM_ENABLED },
 ///   \table_row3{   <b>`MusicPlayer.MediaProviders`</b>,
 ///                  \anchor MusicPlayer_MediaProviders
 ///                  _string_,
-///     @return string containing the names of the providers of the currently playing media\, separated by commas if muliple are present.
+///     @return string containing the names of the providers of the currently playing media\, separated by commas if multiple are present.
 ///     <p><hr>
 ///     @skinning_v22 **[New Infolabel]** \link MusicPlayer_MediaProviders `MusicPlayer.MediaProviders`\endlink
 ///     <p>
@@ -4084,7 +4084,7 @@ const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
 ///   \table_row3{   <b>`VideoPlayer.MediaProviders`</b>,
 ///                  \anchor VideoPlayer_MediaProviders
 ///                  _string_,
-///     @return string containing the names of the providers of the currently playing media\, separated by commas if muliple are present.
+///     @return string containing the names of the providers of the currently playing media\, separated by commas if multiple are present.
 ///     <p><hr>
 ///     @skinning_v22 **[New Infolabel]** \link VideoPlayer_MediaProviders `VideoPlayer.MediaProviders`\endlink
 ///     <p>
@@ -7256,7 +7256,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///   \table_row3{   <b>`ListItem.MediaProviders`</b>,
 ///                  \anchor ListItem_MediaProviders
 ///                  _string_,
-///     @return string containing the names of the media providers of the item\, separated by commas if muliple are present.
+///     @return string containing the names of the media providers of the item\, separated by commas if multiple are present.
 ///     <p><hr>
 ///     @skinning_v22 **[New Infolabel]** \link ListItem_MediaProviders `ListItem.MediaProviders`\endlink
 ///     <p>

--- a/xbmc/application/AppParamParser.cpp
+++ b/xbmc/application/AppParamParser.cpp
@@ -70,7 +70,7 @@ void CAppParamParser::Parse(const char* const* argv, int nArgs)
       m_params->SetTestMode(false);
   }
 
-  // Record raw paramerters
+  // Record raw parameters
   m_params->SetRawArgs(std::move(args));
 }
 

--- a/xbmc/commons/Buffer.h
+++ b/xbmc/commons/Buffer.h
@@ -73,7 +73,7 @@ namespace XbmcCommons
    * printf("buffer contents: %d, \"%s\", %ll\n", buffer.getInt(),
    *         buffer.getCharPointerDirect(), buffer.getLongLong());
    *
-   * This would also produce erroneous results as they get's will be evaluated
+   * This would also produce erroneous results as the gets will be evaluated
    *   from right to left in the parameter list of printf.
    */
   class Buffer

--- a/xbmc/games/addons/input/GameClientInput.h
+++ b/xbmc/games/addons/input/GameClientInput.h
@@ -131,7 +131,7 @@ private:
   /*!
    * \brief Map of port address to joystick handler
    *
-   * The port address is a string that identifies the adress of the port.
+   * The port address is a string that identifies the address of the port.
    *
    * The joystick handler connects to joystick input of the game client.
    *

--- a/xbmc/games/addons/input/GameClientPort.h
+++ b/xbmc/games/addons/input/GameClientPort.h
@@ -79,7 +79,7 @@ public:
   /*!
    * \brief Get the ID of the port
    *
-   * The ID is used when creating a toplogical address for the port.
+   * The ID is used when creating a topological address for the port.
    */
   const std::string& ID() const { return m_portId; }
 

--- a/xbmc/games/controllers/guicontrols/GUIGameController.dox
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.dox
@@ -48,7 +48,7 @@ The game-specific tags added in v21 are:
 | controllerdiffuse  | A diffuse color used to highlight the controller when activity is detected on the in-game port or on the underlying peripheral held by the user.
 | controlleraddress  | The in-game "address" of the controller, e.g. <b>`/1/game.controller.snes`</b> for a SNES controller connected to console port 1. Used to highlight the controller on port activity. Overrides <b>`<controllerid>`</b> and <b>`<portaddress>`</b>.
 | portaddress        | The in-game "address" of the port the controller is connected to, e.g. <b>`/1`</b> for port 1 of a SNES emulator. Used to highlight the controller on port activity.
-| peripherallocation | The location of the underlying peripheral providing input, e.g. <b>`/joystick/0`</b> for the first physical controller held by the user. Used to hightlight the controller on peripheral activity.
+| peripherallocation | The location of the underlying peripheral providing input, e.g. <b>`/joystick/0`</b> for the first physical controller held by the user. Used to highlight the controller on peripheral activity.
 
 @skinning_v21 The control has been greatly expanded to allow for more use cases in the new Player Viewer (<b>`GameAgents`</b>) dialog.
 
@@ -82,7 +82,7 @@ keyboards have the location <b>`peripherals://application/keyboard.dev`</b>.
 --------------------------------------------------------------------------------
 \section Game_Controller_sect5 List item info
 
-List item info can be used for all tag values. For example, if the control defintion looks like:
+List item info can be used for all tag values. For example, if the control definition looks like:
 
 ~~~~~~~~~~~~~
 <itemlayout width="96" height="96">

--- a/xbmc/guilib/D3DResource.cpp
+++ b/xbmc/guilib/D3DResource.cpp
@@ -385,7 +385,7 @@ void CD3DTexture::SaveTexture()
     ComPtr<ID3D11Texture2D> texture = nullptr;
     if (textureDesc.Usage != D3D11_USAGE_STAGING || 0 == (textureDesc.CPUAccessFlags & D3D11_CPU_ACCESS_READ))
     {
-      // create texture which can be readed by CPU - D3D11_USAGE_STAGING
+      // create texture which can be read by CPU - D3D11_USAGE_STAGING
       CD3D11_TEXTURE2D_DESC stagingDesc(textureDesc);
       stagingDesc.Usage = D3D11_USAGE_STAGING;
       stagingDesc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -1213,7 +1213,7 @@ void CGUIFontTTF::RenderCharacter(CGraphicContext& context,
   const float tb = texture.y2 * m_textureScaleY;
 #else
   // when scaling by shader, we have to grow the vertex and texture coords
-  // by .5 or we would ommit pixels when animating.
+  // by .5 or we would omit pixels when animating.
   const float tl = (texture.x1 - .5f) * m_textureScaleX;
   const float tr = (texture.x2 + .5f) * m_textureScaleX;
   const float tt = (texture.y1 - .5f) * m_textureScaleY;

--- a/xbmc/guilib/GUITextLayout.h
+++ b/xbmc/guilib/GUITextLayout.h
@@ -45,7 +45,7 @@ public:
 
   std::string GetAsString() const;
 
-  // The text is UTF-16 and the data stored in a character_t hold multiple informations by bits:
+  // The text is UTF-16 and the data stored in a character_t hold multiple information by bits:
   // <16 bits: are unicode code bits
   // 16-24 bits: are color bits
   // 24-32 bits: are style bits (see FONT_STYLE_* flags)

--- a/xbmc/guilib/listproviders/DirectoryProvider.cpp
+++ b/xbmc/guilib/listproviders/DirectoryProvider.cpp
@@ -115,14 +115,14 @@ public:
           (m_browse == CDirectoryProvider::BrowseMode::AUTO && limit < items.Size()))
       {
         // Add a special item to the end of the list, which can be used to open the
-        // full listing containg all items in the given target window.
+        // full listing containing all items in the given target window.
         if (!m_target.empty())
         {
           CFileItem item(m_url, true);
           item.SetLabel(g_localizeStrings.Get(22082)); // More...
           item.SetArt("icon", "DefaultFolder.png");
           item.SetProperty("node.target", m_target);
-          item.SetProperty("node.type", "target_folder"); // make item identifyable, e.g. by skins
+          item.SetProperty("node.type", "target_folder"); // make item identifiable, e.g. by skins
 
           m_items.emplace_back(std::make_shared<CGUIStaticItem>(item));
         }

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -1379,7 +1379,7 @@ JSONRPC_STATUS CAudioLibrary::RefreshArtist(const std::string& method,
   //set the artist id on the musicdb url
   musicUrl.AddOption("artistid", artistID);
 
-  //executing the StartArtistScan for refreshing the artist scraped informations
+  //executing the StartArtistScan for refreshing the artist scraped information
   CMusicLibraryQueue::GetInstance().StartArtistScan(musicUrl.ToString(), true);
 
   return ACK;

--- a/xbmc/interfaces/json-rpc/schema/methods.json
+++ b/xbmc/interfaces/json-rpc/schema/methods.json
@@ -612,7 +612,7 @@
           {
             "type": "number",
             "description":
-                "The value should be a multiple of 0.025 in a range of +/-10 (the default range can be overriden by advancedsettings.xml).",
+                "The value should be a multiple of 0.025 in a range of +/-10 (the default range can be overridden by advancedsettings.xml).",
             "required": true
           },
           {

--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -222,7 +222,7 @@ void CAlbum::MergeScrapedAlbum(const CAlbum& source, bool override /* = true */)
    appropriate when the music files are tagged with mbids, these are taken as definative, scraped
    mbids can not be depended on in this way.
 
-   When the album is megerd in this deep way it is flagged so that the database album update is aware
+   When the album is merged in this deep way it is flagged so that the database album update is aware
    artist credits and songs need to be updated too.
   */
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5554,7 +5554,7 @@ bool CMusicDatabase::GetArtistsByWhere(
     if (!BuildSQL(strSQLExtra, extFilter, strSQLExtra))
       return false;
 
-    // Count number of artsits that satisfy selection criteria (no limit built)
+    // Count number of artists that satisfy selection criteria (no limit built)
     // Count done in full query fetch when unlimited
     if (countOnly || limitedInSQL)
     {

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -149,7 +149,7 @@ public:
       CFileItemPtr songitem = playlist[i];
       if (HasSongExtraArtChanged(songitem, type, itemID, db))
       {
-        songitem->ClearArt(); // Art gets reloaded when the current playist is shown
+        songitem->ClearArt(); // Art gets reloaded when the current playlist is shown
         clearcache = true;
       }
     }

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1229,7 +1229,7 @@ void MUSIC_INFO::CMusicInfoScanner::RetrieveLocalArt()
     has been found for an album artist, art is not searched for in other folders.
 
     It will find art for "various artists", if artwork is located above the
-    folder containing compilatons.
+    folder containing compilations.
     */
     for (auto artistCredit = album.artistCredits.begin(); artistCredit != album.artistCredits.end(); ++artistCredit)
     {
@@ -1972,7 +1972,7 @@ bool CMusicInfoScanner::AddArtistArtwork(CArtist& artist, const std::string& art
   std::map<std::string, std::string> addedart;
   std::string strArt;
 
-  // Handle thumb separately, can be from multiple confgurable file names
+  // Handle thumb separately, can be from multiple configurable file names
   if (artist.art.find("thumb") == artist.art.end())
   {
     if (!artfolder.empty())
@@ -2046,7 +2046,7 @@ bool CMusicInfoScanner::AddAlbumArtwork(CAlbum& album)
   std::string strArt;
 
   // Fetch local art from album folder
-  // Handle thumbs separately, can be from multiple confgurable file names
+  // Handle thumbs separately, can be from multiple configurable file names
   if (replaceThumb || thumb == album.art.end())
   {
     if (!album.strPath.empty())
@@ -2080,7 +2080,7 @@ bool CMusicInfoScanner::AddAlbumArtwork(CAlbum& album)
       if (discnum > 0)
       {
         // Handle thumbs separately. Get thumb for path from textures db cached during scan
-        // (could be embedded or local file from multiple confgurable file names)
+        // (could be embedded or local file from multiple configurable file names)
         CFileItem item(pathpair.first.c_str(), true);
         std::string strArtType = StringUtils::Format("{}{}", "thumb", discnum);
         strArt = loader.GetCachedImage(item, "thumb");
@@ -2197,7 +2197,7 @@ bool CMusicInfoScanner::AddLocalArtwork(std::map<std::string, std::string>& art,
       strCandidate.erase(0, mediaName.length());
     StringUtils::ToLower(strCandidate);
     // Skip files already used as "thumb"
-    // Typically folder.jpg but can be from multiple confgurable file names
+    // Typically folder.jpg but can be from multiple configurable file names
     if (std::find(thumbs.begin(), thumbs.end(), strCandidate) != thumbs.end())
       continue;
     // Grab and strip file extension

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -168,7 +168,7 @@ int CMusicInfoTag::GetYear() const
 std::string CMusicInfoTag::GetYearString() const
 {
   /* Get year as YYYY from release or original dates depending on setting
-     This is how GUI and by year sorting swiches to using original year.
+     This is how GUI and by year sorting switches to using original year.
      For ripper and non-library items (library entries have both values):
      when release date missing try to fallback to original date
      when original date missing use release date

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -285,7 +285,7 @@ bool CTagLoaderTagLib::ParseTag(ID3v2::Tag *id3v2, EmbeddedArt *art, MUSIC_INFO:
   const ID3v2::FrameListMap& frameListMap = id3v2->frameListMap();
   for (ID3v2::FrameListMap::ConstIterator it = frameListMap.begin(); it != frameListMap.end(); ++it)
   {
-    // It is possible that the taglist is empty. In that case no useable values can be extracted.
+    // It is possible that the taglist is empty. In that case no usable values can be extracted.
     // and we should skip the tag.
     if (it->second.isEmpty()) continue;
 

--- a/xbmc/network/Zeroconf.h
+++ b/xbmc/network/Zeroconf.h
@@ -82,7 +82,7 @@ public:
 
 protected:
   //methods to implement for concrete implementations
-  //publishs this service
+  //publishes this service
   virtual bool doPublishService(const std::string& fcr_identifier,
                                 const std::string& fcr_type,
                                 const std::string& fcr_name,

--- a/xbmc/network/cddb.cpp
+++ b/xbmc/network/cddb.cpp
@@ -574,7 +574,7 @@ void Xcddb::parseData(const char *buffer)
       addExtended((strKeyword + "=" + strValue).c_str());
   }
 
-  //writeLog("parseData Ende");
+  //writeLog("parseData End");
 }
 
 //-------------------------------------------------------------------------------------------------------------------

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -362,7 +362,7 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
           }
         }
 
-        // all items appart from songs (artists, albums, etc) are folders
+        // all items apart from songs (artists, albums, etc) are folders
         if (!item->HasMusicInfoTag() || item->GetMusicInfoTag()->GetType() != MediaTypeSong)
         {
           item->m_bIsFolder = true;

--- a/xbmc/peripherals/bus/virtual/PeripheralBusApplication.h
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusApplication.h
@@ -34,7 +34,7 @@ protected:
   // implementation of CPeripheralBus
   bool PerformDeviceScan(PeripheralScanResults& results) override;
 
-  // Internal helper fuction
+  // Internal helper function
   static std::string MakeLocation(PeripheralType peripheralType);
 };
 } // namespace PERIPHERALS

--- a/xbmc/pictures/ExifParse.cpp
+++ b/xbmc/pictures/ExifParse.cpp
@@ -512,7 +512,7 @@ void CExifParse::ProcessDir(const unsigned char* const DirStart,
 
       case TAG_FNUMBER:
         // Simplest way of expressing aperture, so I trust it the most.
-        // (overwrite previously computd value if there is one)
+        // (overwrite previously computed value if there is one)
         m_ExifInfo->ApertureFNumber = (float)ConvertAnyFormat(ValuePtr, Format);
       break;
 
@@ -533,7 +533,7 @@ void CExifParse::ProcessDir(const unsigned char* const DirStart,
       break;
 
       case TAG_SUBJECT_DISTANCE:
-        // Inidcates the distacne the autofocus camera is focused to.
+        // Indicates the distance the autofocus camera is focused to.
         // Tends to be less accurate as distance increases.
         {
           float distance = (float)ConvertAnyFormat(ValuePtr, Format);
@@ -543,11 +543,11 @@ void CExifParse::ProcessDir(const unsigned char* const DirStart,
 
       case TAG_EXPOSURETIME:
         {
-        // Simplest way of expressing exposure time, so I trust it most.
-        // (overwrite previously computd value if there is one)
-        float expTime = (float)ConvertAnyFormat(ValuePtr, Format);
-        if (expTime)
-          m_ExifInfo->ExposureTime = expTime;
+          // Simplest way of expressing exposure time, so I trust it most.
+          // (overwrite previously computed value if there is one)
+          float expTime = (float)ConvertAnyFormat(ValuePtr, Format);
+          if (expTime)
+            m_ExifInfo->ExposureTime = expTime;
         }
       break;
 
@@ -648,7 +648,7 @@ void CExifParse::ProcessDir(const unsigned char* const DirStart,
         const unsigned char* const SubdirStart = OffsetBase + (unsigned)Get32(ValuePtr, m_MotorolaOrder);
         if (SubdirStart < OffsetBase || SubdirStart > OffsetBase+ExifLength)
         {
-          ErrNonfatal("Illegal exif or interop ofset directory link",0,0);
+          ErrNonfatal("Illegal exif or interop offset directory link", 0, 0);
         }
         else
         {

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1169,7 +1169,7 @@ void CXBMCApp::onReceive(CJNIIntent intent)
   android_printf("CXBMCApp::onReceive - Got intent. Action: %s", action.c_str());
 
   // Most actions can be processed only after the app is fully initialized,
-  // but some actions should be processed even during initilization phase.
+  // but some actions should be processed even during initialization phase.
   if (!g_application.IsInitialized() && action != CJNIAudioManager::ACTION_HDMI_AUDIO_PLUG)
   {
     android_printf("CXBMCApp::onReceive - ignoring action %s during app initialization phase",
@@ -1667,7 +1667,7 @@ void CXBMCApp::onDisplayChanged(int displayId)
   CLog::Log(LOGDEBUG, "CXBMCApp::{}: id: {}", __FUNCTION__, displayId);
 
   if (!g_application.IsInitialized())
-    // Display mode has beed changed during app startup; we want to reset audio engine on next ACTION_HDMI_AUDIO_PLUG event
+    // Display mode has been changed during app startup; we want to reset audio engine on next ACTION_HDMI_AUDIO_PLUG event
     m_aeReset = true;
 
   // Update display modes

--- a/xbmc/playlists/test/TestPlayListXML.cpp
+++ b/xbmc/playlists/test/TestPlayListXML.cpp
@@ -34,7 +34,7 @@ TEST(TestPlayListXML, LoadData)
   // Test no name and no lang
   EXPECT_STREQ(playlist[1]->GetLabel().c_str(), "mms://video.rfn.ru/vesti_24");
 
-  // Test nane and no lang
+  // Test name and no lang
   EXPECT_STREQ(playlist[2]->GetLabel().c_str(), "Test Name");
 
   /*

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -69,7 +69,7 @@ private:
        "multi with color/alpha texture and blend color"},
       {ShaderMethodGLES::SM_MULTI_111R_111R_BLENDCOLOR,
        "multi with alpha/alpha texture and blend color"},
-      {ShaderMethodGLES::SM_TEXTURE_RGBA, "texure rgba"},
+      {ShaderMethodGLES::SM_TEXTURE_RGBA, "texture rgba"},
       {ShaderMethodGLES::SM_TEXTURE_RGBA_OES, "texture rgba OES"},
       {ShaderMethodGLES::SM_TEXTURE_RGBA_BLENDCOLOR, "texture rgba blend colour"},
       {ShaderMethodGLES::SM_TEXTURE_RGBA_BOB, "texture rgba bob"},

--- a/xbmc/settings/SubtitlesSettings.cpp
+++ b/xbmc/settings/SubtitlesSettings.cpp
@@ -189,7 +189,7 @@ void CSubtitlesSettings::SettingOptionsSubtitleFontsFiller(const SettingConstPtr
       list.emplace_back(g_localizeStrings.Get(571) + " " + familyName, FONT_DEFAULT_FAMILYNAME);
     }
   }
-  // Add additionals fonts from the user fonts folder
+  // Add additional fonts from the user fonts folder
   for (const std::string& familyName : g_fontManager.GetUserFontsFamilyNames())
   {
     list.emplace_back(familyName, familyName);

--- a/xbmc/settings/SubtitlesSettings.h
+++ b/xbmc/settings/SubtitlesSettings.h
@@ -186,13 +186,13 @@ public:
 
   /*!
    * \brief Check if font override is enabled
-   * \return True if fonts must be overriden, otherwise false
+   * \return True if fonts must be overridden, otherwise false
    */
   bool IsOverrideFonts();
 
   /*!
    * \brief Get override styles
-   * \return The styles to be overriden
+   * \return The styles to be overridden
    */
   OverrideStyles GetOverrideStyles();
 

--- a/xbmc/storage/discs/IDiscDriveHandler.h
+++ b/xbmc/storage/discs/IDiscDriveHandler.h
@@ -16,7 +16,7 @@ enum class DriveState
 {
   /*! The drive is open */
   OPEN,
-  /*! The drive is not ready (happens when openning or closing) */
+  /*! The drive is not ready (happens when opening or closing) */
   NOT_READY,
   /*! The drive is ready */
   READY,
@@ -66,7 +66,7 @@ public:
   virtual void EjectDriveTray(const std::string& devicePath) = 0;
 
   /*! \brief Close the provided drive device
-  * \note Some drives support closing appart from opening/eject
+  * \note Some drives support closing apart from opening/eject
   * \param devicePath the path for the device drive (e.g. /dev/sr0)
   */
   virtual void CloseDriveTray(const std::string& devicePath) = 0;


### PR DESCRIPTION
## Description
Fixed typos in xbmc/* subdirectory comments and doxygen

Found using codespell

## Motivation and context

Accuracy of documentation and code.

## How has this been tested?
n/a

## What is the effect on users?
no negative impacts

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
