### PR TITLE
[Video] make use of internal FFmpeg CPU capabilities detection for video post-processing

### DIFF
--- a/xbmc/cores/FFmpeg.h
+++ b/xbmc/cores/FFmpeg.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "ServiceBroker.h"
-#include "utils/CPUInfo.h"
 #include "utils/StringUtils.h"
 
 extern "C" {
@@ -41,23 +40,6 @@ struct FFMpegException : public std::exception
 std::string FFMpegErrorToString(int err);
 
 } // namespace FFMPEG_HELP_TOOLS
-
-inline int PPCPUFlags()
-{
-  unsigned int cpuFeatures = CServiceBroker::GetCPUInfo()->GetCPUFeatures();
-  int flags = 0;
-
-  if (cpuFeatures & CPU_FEATURE_MMX)
-    flags |= PP_CPU_CAPS_MMX;
-  if (cpuFeatures & CPU_FEATURE_MMX2)
-    flags |= PP_CPU_CAPS_MMX2;
-  if (cpuFeatures & CPU_FEATURE_3DNOW)
-    flags |= PP_CPU_CAPS_3DNOW;
-  if (cpuFeatures & CPU_FEATURE_ALTIVEC)
-    flags |= PP_CPU_CAPS_ALTIVEC;
-
-  return flags;
-}
 
 // callback used for logging
 void ff_avutil_log(void* ptr, int level, const char* format, va_list va);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoPPFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoPPFFmpeg.cpp
@@ -54,7 +54,7 @@ bool CDVDVideoPPFFmpeg::CheckInit(int iWidth, int iHeight)
       Dispose();
     }
 
-    m_pContext = pp_get_context(iWidth, iHeight, PPCPUFlags() | PP_FORMAT_420);
+    m_pContext = pp_get_context(iWidth, iHeight, PP_CPU_CAPS_AUTO | PP_FORMAT_420);
 
     m_iInitWidth = iWidth;
     m_iInitHeight = iHeight;


### PR DESCRIPTION
## Description
[Video] make use of internal FFmpeg CPU capabilities detection for video post-processing

## Motivation and context
This removes dependence of `GetCPUInfo()->GetCPUFeatures()` for FFmpeg and use more modern and built-in detection included in FFmpeg https://ffmpeg.org/doxygen/3.2/cpu_8c_source.html#l00076

Related to: https://github.com/xbmc/xbmc/pull/26463 to continue use optimized FFmpeg video post-processing also for Windows ARM64.

This is only relevant for FFmpeg software video decoding and enabling video post-processing (in video settings).

Maybe also on other platforms this enables use more advanced CPU instructions (if FFmpeg implements it).


## How has this been tested?
Windows x64

## What is the effect on users?
none

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
