### PR TITLE
[utils] MathUtils.h: define DISABLE_MATHUTILS_ASM_ROUND_INT for Windows ARM64.

### DIFF
--- a/xbmc/utils/MathUtils.h
+++ b/xbmc/utils/MathUtils.h
@@ -29,6 +29,7 @@
     defined(__arm__) || \
     defined(__loongarch__) || \
     defined(_M_ARM) || \
+    defined(_M_ARM64) || \
     defined(__mips__) || \
     defined(__or1k__) || \
     defined(__powerpc__) || \


### PR DESCRIPTION

## Description
Another small PR from my Windows ARM64 fork here: https://github.com/ddscentral/xbmc-win-arm64
This PR adds Windows ARM64 to MathUtils.h list of platforms for which to define DISABLE_MATHUTILS_ASM_ROUND_INT.
This is the fifth from my series of PRs with the goal to upstream changes from my fork.

## Motivation and context
Support Windows ARM64

## How has this been tested?
MathUtils.h should no longer try to use x86 assembly on ARM64

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
