### PR TITLE
CCurlFile: fix http2 retry

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1769,6 +1769,7 @@ int8_t CCurlFile::CReadState::FillBuffer(unsigned int want)
             if ( (msg->data.result == CURLE_OPERATION_TIMEDOUT ||
                   msg->data.result == CURLE_PARTIAL_FILE       ||
                   msg->data.result == CURLE_COULDNT_CONNECT    ||
+                  msg->data.result == CURLE_HTTP2_STREAM       ||
                   msg->data.result == CURLE_RECV_ERROR)        &&
                   !m_bFirstLoop)
             {


### PR DESCRIPTION
When a download is interrupted, curl returns a different error for http1 (18, CURLE_PARTIAL_FILE) compared to http2 (92, CURLE_HTTP2_STREAM). This can happen due to network or server issues.

Add CURLE_HTTP2_STREAM to the list of curl errors that trigger a retry. Likely fixes #17047 and #19838.

Without this retry fails as in this log snippet:
```
18:19:18.906 Curl::Debug - TEXT: HTTP/2 stream 3 was not closed cleanly: CANCEL (err 8)
18:19:18.906 Curl::Debug - TEXT: Connection #0 to host example.com left intact
18:19:18.906 CCurlFile::CReadState::FillBuffer - (0x7fff3804e8d0) Failed: Stream error in the HTTP/2 framing layer(92)
18:19:18.906 CFileCache::Process - <https://example.com/file> source read returned -1! Will retry
18:19:20.906 CFileCache::Process - <https://example.com/file> source read returned 0! Will retry
18:19:22.906 CFileCache::Process - <https://example.com/file> source read returned 0! Will retry
18:19:24.906 CFileCache::Process - <https://example.com/file> source read returned 0! Will retry
18:19:26.907 CFileCache::Process - <https://example.com/file> source read returned 0! Will retry
18:19:28.907 CFileCache::Process - <https://example.com/file> source read returned 0! Will retry
18:19:30.907 CFileCache::Process - <https://example.com/file> source read returned 0! Will retry
18:19:32.907 CFileCache::Process - <https://example.com/file> source read returned 0! Will retry
18:19:34.907 CFileCache::Process - <https://example.com/file> source read returned 0! Will retry
18:19:36.907 CFileCache::Process - <https://example.com/file> source read returned 0! Will retry
18:19:38.907 CFileCache::Process - <https://example.com/file> source read didn't return any data before eof!
```

Comparing to HTTP1, we get curl returning 18 (CURLE_PARTIAL_FILE):
```
18:26:23.412 CCurlFile::CReadState::FillBuffer:1774 - (0x7fff3804e040) Failed: Transferred a partial file(18)
18:26:23.412 CCurlFile::CReadState::FillBuffer - (0x7fff3804e040) Reconnect, (re)try 1
```

After this change we can see http2 succesfully retries just like http1:
```
18:37:28.067 CCurlFile::CReadState::FillBuffer:1774 - (0x7fff3804e2d0) Failed: Stream error in the HTTP/2 framing layer(92)
18:37:28.067 CCurlFile::CReadState::FillBuffer - (0x7fff3804e2d0) Reconnect, (re)try 1
```

My method for reproducing this is to play a file behind a reverse proxy (kodi <-> haproxy <-> jellyfin):
- Step 1, start kodi from the commandline with a URL as the argument (e.g. jellyfin.example.com/Video/...)
- Step 2, pause video immediately
- Step 3, wait for reverse proxy tcp connection to jellyfin to be closed (about 60 seconds for me)
- Step 4, resume video

I'm sure there are simpler ways to reproduce, for example:
- play a file directly from an http2 file server
- pause in kodi
- kill and restart http2 file server (causing the existing TCP connection to be nuked)
- resume playback in kodi
