### PR TITLE
[cores/VideoPlayer][VideoRenderers] windows/RendererShaders.cpp: Do not include gpu_memcpy_sse4.h for ARM64.

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.cpp
@@ -11,8 +11,8 @@
 #include "DVDCodecs/Video/DXVA.h"
 #include "rendering/dx/RenderContext.h"
 #include "utils/CPUInfo.h"
-#ifndef _M_ARM
-  #include "utils/gpu_memcpy_sse4.h"
+#if !defined(_M_ARM) && !defined(_M_ARM64)
+#include "utils/gpu_memcpy_sse4.h"
 #endif
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"

--- a/xbmc/platform/win32/utils/CMakeLists.txt
+++ b/xbmc/platform/win32/utils/CMakeLists.txt
@@ -1,7 +1,11 @@
 set(SOURCES Win32InterfaceForCLog.cpp)
 
-set(HEADERS gpu_memcpy_sse4.h
-            memcpy_sse2.h
-            Win32InterfaceForCLog.h)
+set(HEADERS Win32InterfaceForCLog.h)
+
+# Do not add SSE headers for ARM64
+if(NOT CMAKE_GENERATOR_PLATFORM STREQUAL arm64)
+  list(APPEND HEADERS gpu_memcpy_sse4.h
+                      memcpy_sse2.h)
+endif()
 
 core_add_library(platform_win32_utils)


### PR DESCRIPTION
## Description
Do not include gpu_memcpy_sse4.h in RendererShaders.cpp for ARM64.
This is the sixth PR from my Windows ARM64 fork here: https://github.com/ddscentral/xbmc-win-arm64

## Motivation and context
Support for Windows ARM64

## How has this been tested?
Will fix build error when building for Windows ARM64 due to inclusion of an x86 specific header.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed