### PR TITLE
Fix typos in xbmc/interfaces/legacy

### DIFF
--- a/xbmc/interfaces/legacy/CallbackHandler.cpp
+++ b/xbmc/interfaces/legacy/CallbackHandler.cpp
@@ -113,7 +113,7 @@ namespace XBMCAddon
 
         // since the state of the iterator may have been corrupted by
         //  the changing state of the list from another thread during
-        //  the releasing fo the lock in the immediately preceeding
+        //  the releasing of the lock in the immediately preceding
         //  codeblock, we need to reset it before continuing the loop
         iter = g_callQueue.begin();
       }

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -1502,7 +1502,7 @@ namespace XBMCAddon
       /// @brief \python_func{ getItemHeight() }
       /// Returns the control's current item height as an integer.
       ///
-      /// @return                       Current item heigh
+      /// @return                       Current item height
       ///
       ///
       ///--------------------------------------------------------------------------

--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -108,7 +108,7 @@ constexpr int ALPHANUM_HIDE_INPUT{2};
       /// **Yes / no / custom dialog**
       ///
       /// The YesNoCustom dialog can be used to inform the user about questions and
-      /// get the answer. The dialog provides a third button appart from yes and no.
+      /// get the answer. The dialog provides a third button apart from yes and no.
       /// Button labels are fully customizable.
       ///
       /// @param heading        string or unicode - dialog heading.

--- a/xbmc/interfaces/legacy/InfoTagGame.h
+++ b/xbmc/interfaces/legacy/InfoTagGame.h
@@ -74,7 +74,7 @@ public:
   ///                                          performance).
   ///                                          Note however, that if you are creating listitems
   ///                                          and managing the container itself (e.g using
-  ///                                          WindowXML or WindowXMLDialog classes) subsquent
+  ///                                          WindowXML or WindowXMLDialog classes) subsequent
   ///                                          modifications to the item will require locking.
   ///                                          Thus, in such cases, use the default value (`False`).
   ///

--- a/xbmc/interfaces/legacy/InfoTagMusic.h
+++ b/xbmc/interfaces/legacy/InfoTagMusic.h
@@ -73,7 +73,7 @@ namespace XBMCAddon
       ///                                          performance).
       ///                                          Note however, that if you are creating listitems
       ///                                          and managing the container itself (e.g using
-      ///                                          WindowXML or WindowXMLDialog classes) subsquent
+      ///                                          WindowXML or WindowXMLDialog classes) subsequent
       ///                                          modifications to the item will require locking.
       ///                                          Thus, in such cases, use the default value (`False`).
       ///

--- a/xbmc/interfaces/legacy/InfoTagPicture.h
+++ b/xbmc/interfaces/legacy/InfoTagPicture.h
@@ -69,7 +69,7 @@ public:
   ///                                          performance).
   ///                                          Note however, that if you are creating listitems
   ///                                          and managing the container itself (e.g using
-  ///                                          WindowXML or WindowXMLDialog classes) subsquent
+  ///                                          WindowXML or WindowXMLDialog classes) subsequent
   ///                                          modifications to the item will require locking.
   ///                                          Thus, in such cases, use the default value (`False`).
   ///

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -884,7 +884,7 @@ namespace XBMCAddon
       ///                                          performance).
       ///                                          Note however, that if you are creating listitems
       ///                                          and managing the container itself (e.g using
-      ///                                          WindowXML or WindowXMLDialog classes) subsquent
+      ///                                          WindowXML or WindowXMLDialog classes) subsequent
       ///                                          modifications to the item will require locking.
       ///                                          Thus, in such cases, use the default value (`False`).
       ///

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -59,45 +59,45 @@ namespace XBMCAddon
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
-    ///
-    /// \ingroup python_xbmcgui_listitem
-    /// @brief Selectable window list item.
-    ///
-    /// The list item control is used for creating item lists in Kodi
-    ///
-    /// \python_class{ ListItem([label, label2, path, offscreen]) }
-    ///
-    /// @param label                [opt] string (default `""`) - the label to display on the item
-    /// @param label2               [opt] string (default `""`) - the label2 of the item
-    /// @param path                 [opt] string (default `""`) - the path for the item
-    /// @param offscreen            [opt] bool (default `False`) - if GUI based locks should be
-    ///                                          avoided. Most of the times listitems are created
-    ///                                          offscreen and added later to a container
-    ///                                          for display (e.g. plugins) or they are not
-    ///                                          even displayed (e.g. python scrapers).
-    ///                                          In such cases, there is no need to lock the
-    ///                                          GUI when creating the items (increasing your addon
-    ///                                          performance).
-    ///                                          Note however, that if you are creating listitems
-    ///                                          and managing the container itself (e.g using
-    ///                                          WindowXML or WindowXMLDialog classes) subsquent
-    ///                                          modifications to the item will require locking.
-    ///                                          Thus, in such cases, use the default value (`False`).
-    ///
-    ///
-    ///-----------------------------------------------------------------------
-    /// @python_v16 **iconImage** and **thumbnailImage** are deprecated. Use **setArt()**.
-    /// @python_v18 Added **offscreen** argument.
-    /// @python_v19 Removed **iconImage** and **thumbnailImage**. Use **setArt()**.
-    ///
-    /// **Example:**
-    /// ~~~~~~~~~~~~~{.py}
-    /// ...
-    /// listitem = xbmcgui.ListItem('Casino Royale')
-    /// ...
-    /// ~~~~~~~~~~~~~
-    ///
-    ListItem([label, label2, path, offscreen]);
+      ///
+      /// \ingroup python_xbmcgui_listitem
+      /// @brief Selectable window list item.
+      ///
+      /// The list item control is used for creating item lists in Kodi
+      ///
+      /// \python_class{ ListItem([label, label2, path, offscreen]) }
+      ///
+      /// @param label                [opt] string (default `""`) - the label to display on the item
+      /// @param label2               [opt] string (default `""`) - the label2 of the item
+      /// @param path                 [opt] string (default `""`) - the path for the item
+      /// @param offscreen            [opt] bool (default `False`) - if GUI based locks should be
+      ///                                          avoided. Most of the times listitems are created
+      ///                                          offscreen and added later to a container
+      ///                                          for display (e.g. plugins) or they are not
+      ///                                          even displayed (e.g. python scrapers).
+      ///                                          In such cases, there is no need to lock the
+      ///                                          GUI when creating the items (increasing your addon
+      ///                                          performance).
+      ///                                          Note however, that if you are creating listitems
+      ///                                          and managing the container itself (e.g using
+      ///                                          WindowXML or WindowXMLDialog classes) subsequent
+      ///                                          modifications to the item will require locking.
+      ///                                          Thus, in such cases, use the default value (`False`).
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v16 **iconImage** and **thumbnailImage** are deprecated. Use **setArt()**.
+      /// @python_v18 Added **offscreen** argument.
+      /// @python_v19 Removed **iconImage** and **thumbnailImage**. Use **setArt()**.
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ...
+      /// listitem = xbmcgui.ListItem('Casino Royale')
+      /// ...
+      /// ~~~~~~~~~~~~~
+      ///
+      ListItem([ label, label2, path, offscreen ]);
 #else
     ListItem(const String& label = emptyString,
              const String& label2 = emptyString,

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -217,7 +217,7 @@ namespace XBMCAddon
     /// @throws PyExc_TypeError     If time is not an integer.
     ///
     /// @warning This is useful if you need to sleep for a small amount of time
-    /// (milisecond range) somewhere in your addon logic. Please note that Kodi
+    /// (millisecond range) somewhere in your addon logic. Please note that Kodi
     /// will attempt to stop any running scripts when signaled to exit and wait for a maximum
     /// of 5 seconds before trying to force stop your script. If your addon makes use
     /// of \ref xbmc_Sleep "xbmc.sleep()" incorrectly (long periods of time, e.g. that exceed

--- a/xbmc/interfaces/legacy/ModuleXbmcvfs.h
+++ b/xbmc/interfaces/legacy/ModuleXbmcvfs.h
@@ -30,103 +30,103 @@ namespace XBMCAddon
     //
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
-    ///
-    /// \ingroup python_xbmcvfs
-    /// @brief \python_func{ xbmcvfs.copy(source, destination) }
-    /// Copy file to destination, returns true/false.
-    ///
-    /// @param source                file to copy.
-    /// @param destination           destination file
-    /// @return                      True if successed
-    ///
-    ///
-    /// ------------------------------------------------------------------------
-    ///
-    /// **Example:**
-    /// ~~~~~~~~~~~~~{.py}
-    /// ..
-    /// success = xbmcvfs.copy(source, destination)
-    /// ..
-    /// ~~~~~~~~~~~~~
-    ///
-    copy(...);
+  ///
+  /// \ingroup python_xbmcvfs
+  /// @brief \python_func{ xbmcvfs.copy(source, destination) }
+  /// Copy file to destination, returns true/false.
+  ///
+  /// @param source                file to copy.
+  /// @param destination           destination file
+  /// @return                      True if successful
+  ///
+  ///
+  /// ------------------------------------------------------------------------
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// success = xbmcvfs.copy(source, destination)
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  copy(...);
 #else
     bool copy(const String& strSource, const String& strDestination);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
-    ///
-    /// \ingroup python_xbmcvfs
-    /// @brief \python_func{ xbmcvfs.delete(file) }
-    /// Delete a file
-    ///
-    /// @param file                  File to delete
-    /// @return                      True if successed
-    ///
-    ///
-    /// ------------------------------------------------------------------------
-    ///
-    /// **Example:**
-    /// ~~~~~~~~~~~~~{.py}
-    /// ..
-    /// xbmcvfs.delete(file)
-    /// ..
-    /// ~~~~~~~~~~~~~
-    ///
-    delete(...);
+  ///
+  /// \ingroup python_xbmcvfs
+  /// @brief \python_func{ xbmcvfs.delete(file) }
+  /// Delete a file
+  ///
+  /// @param file                  File to delete
+  /// @return                      True if successful
+  ///
+  ///
+  /// ------------------------------------------------------------------------
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// xbmcvfs.delete(file)
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  delete (...);
 #else
     bool deleteFile(const String& file);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
-    ///
-    /// \ingroup python_xbmcvfs
-    /// @brief \python_func{ xbmcvfs.rename(file, newFileName) }
-    /// Rename a file
-    ///
-    /// @param file                  File to rename
-    /// @param newFileName           New filename, including the full path
-    /// @return                      True if successed
-    ///
-    /// @note Moving files between different filesystem (eg. local to nfs://) is not possible on
-    ///       all platforms. You may have to do it manually by using the copy and deleteFile functions.
-    ///
-    ///
-    /// ------------------------------------------------------------------------
-    ///
-    /// **Example:**
-    /// ~~~~~~~~~~~~~{.py}
-    /// ..
-    /// success = xbmcvfs.rename(file,newFileName)
-    /// ..
-    /// ~~~~~~~~~~~~~
-    ///
-    rename(...);
+  ///
+  /// \ingroup python_xbmcvfs
+  /// @brief \python_func{ xbmcvfs.rename(file, newFileName) }
+  /// Rename a file
+  ///
+  /// @param file                  File to rename
+  /// @param newFileName           New filename, including the full path
+  /// @return                      True if successful
+  ///
+  /// @note Moving files between different filesystem (eg. local to nfs://) is not possible on
+  ///       all platforms. You may have to do it manually by using the copy and deleteFile functions.
+  ///
+  ///
+  /// ------------------------------------------------------------------------
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// success = xbmcvfs.rename(file,newFileName)
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  rename(...);
 #else
     bool rename(const String& file, const String& newFile);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
-    ///
-    /// \ingroup python_xbmcvfs
-    /// @brief \python_func{ xbmcvfs.exists(path) }
-    /// Check for a file or folder existence
-    ///
-    /// @param path                  File or folder (folder must end with
-    ///                              slash or backslash)
-    /// @return                      True if successed
-    ///
-    ///
-    /// ------------------------------------------------------------------------
-    ///
-    /// **Example:**
-    /// ~~~~~~~~~~~~~{.py}
-    /// ..
-    /// success = xbmcvfs.exists(path)
-    /// ..
-    /// ~~~~~~~~~~~~~
-    ///
-    exists(...);
+  ///
+  /// \ingroup python_xbmcvfs
+  /// @brief \python_func{ xbmcvfs.exists(path) }
+  /// Check for a file or folder existence
+  ///
+  /// @param path                  File or folder (folder must end with
+  ///                              slash or backslash)
+  /// @return                      True if successful
+  ///
+  ///
+  /// ------------------------------------------------------------------------
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// success = xbmcvfs.exists(path)
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  exists(...);
 #else
     bool exists(const String& path);
 #endif
@@ -206,7 +206,7 @@ namespace XBMCAddon
     /// @return            Validated path
     ///
     /// @note The result is platform-specific. Only useful if you are coding
-    ///       for multiple platfforms for fixing slash problems
+    ///       for multiple platforms for fixing slash problems
     ///         (e.g. Corrects 'Z://something' -> 'Z:\something').
     ///
     ///
@@ -232,7 +232,7 @@ namespace XBMCAddon
     /// Create a folder.
     ///
     /// @param path                  Folder to create
-    /// @return                      True if successed
+    /// @return                      True if successful
     ///
     ///
     /// ------------------------------------------------------------------------
@@ -258,7 +258,7 @@ namespace XBMCAddon
     /// Create folder(s) - it will create all folders in the path.
     ///
     /// @param path                  Folders to create
-    /// @return                      True if successed
+    /// @return                      True if successful
     ///
     ///
     /// ------------------------------------------------------------------------

--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -518,7 +518,7 @@ namespace XBMCAddon
       int iControlId = ref(window)->GetFocusedControlID();
       if(iControlId == -1)
         throw WindowException("No control in this window has focus");
-      // Sine I'm already holding the lock theres no reason to give it to GetFocusedControlID
+      // Since I'm already holding the lock there's no reason to give it to GetFocusedControlID
       return GetControlById(iControlId,NULL);
     }
 

--- a/xbmc/interfaces/legacy/Window.h
+++ b/xbmc/interfaces/legacy/Window.h
@@ -514,7 +514,7 @@ namespace XBMCAddon
       /// @brief \python_func{ show() }
       /// Show this window.
       ///
-      /// Shows this window by activating it, calling close() after it wil
+      /// Shows this window by activating it, calling close() afterwards will
       /// activate the current window again.
       ///
       /// @note If your script ends this window will be closed to. To show it

--- a/xbmc/interfaces/legacy/wsgi/WsgiInputStream.h
+++ b/xbmc/interfaces/legacy/wsgi/WsgiInputStream.h
@@ -33,7 +33,7 @@ namespace XBMCAddon
       /// Read a maximum of `<size>` bytes from the wsgi.input stream.
       ///
       /// @param size         [opt] bytes to read
-      /// @return             Returns the readed string
+      /// @return             Returns the read string
       ///
       read(...);
 #else
@@ -48,7 +48,7 @@ namespace XBMCAddon
       /// stream.
       ///
       /// @param size         [opt] bytes to read
-      /// @return             Returns the readed string line
+      /// @return             Returns the read string line
       ///
       read(...);
 #else
@@ -63,7 +63,7 @@ namespace XBMCAddon
       /// wsgi.input stream and return them as a list.
       ///
       /// @param sizehint      [opt] bytes to read
-      /// @return              Returns a list readed string lines
+      /// @return              Returns a list read string lines
       ///
       read(...);
 #else


### PR DESCRIPTION
## Description
Fixed typos in comments and doxygen within xbmc/interfaces/legacy and its sub-directories.

Found using codespell

## Motivation and context

Accuracy of documentation and code.

## How has this been tested?
n/a

## What is the effect on users?
no negative impacts

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
