### PR TITLE
Scoped enum VideoContentType is not formattable

### DIFF
--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -17,8 +17,12 @@
 
 #include <memory>
 #include <set>
+#include <stdexcept>
+#include <string_view>
 #include <utility>
 #include <vector>
+
+#include <fmt/format.h>
 
 class CFileItem;
 class CFileItemList;
@@ -178,6 +182,40 @@ enum class VideoDbContentType
   EPISODES = 4,
   MOVIE_SETS = 5,
   MUSICALBUMS = 6
+};
+
+template<>
+struct fmt::formatter<VideoDbContentType> : fmt::formatter<std::string_view>
+{
+  template<typename FormatContext>
+  constexpr auto format(const VideoDbContentType& type, FormatContext& ctx)
+  {
+    return fmt::formatter<std::string_view>::format(enumToSV(type), ctx);
+  }
+
+private:
+  static constexpr std::string_view enumToSV(VideoDbContentType type)
+  {
+    using namespace std::literals::string_view_literals;
+    switch (type)
+    {
+      case VideoDbContentType::UNKNOWN:
+        return "unknown"sv;
+      case VideoDbContentType::MOVIES:
+        return "movies"sv;
+      case VideoDbContentType::TVSHOWS:
+        return "TV shows"sv;
+      case VideoDbContentType::MUSICVIDEOS:
+        return "music videos"sv;
+      case VideoDbContentType::EPISODES:
+        return "episodes"sv;
+      case VideoDbContentType::MOVIE_SETS:
+        return "movie sets"sv;
+      case VideoDbContentType::MUSICALBUMS:
+        return "music albums"sv;
+    };
+    throw std::invalid_argument("no videodb content string found");
+  }
 };
 
 typedef enum // this enum MUST match the offset struct further down!! and make sure to keep min and max at -1 and sizeof(offsets)


### PR DESCRIPTION
Cast to int the scoped enum VideoContentType to be formattable, and fix the build with g++ 13.3.0 on Ubuntu 24.04 x86-64.

/usr/include/fmt/core.h:1757:7: error: static assertion failed: Cannot format an argument. To make type T formattable provide a formatter<T> specialization

## Description
Fix compile error with g++ 13.3.0 on Ubuntu 24.04 x86_64

## Motivation and context
Build of Kodi cannot be achieved with g++ 13.3.0 (Ubuntu 24.04)

## How has this been tested?
No change

## What is the effect on users?
No change

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
