### PR TITLE
[Backport] CCurlFile: fix http2 retry

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1746,6 +1746,7 @@ int8_t CCurlFile::CReadState::FillBuffer(unsigned int want)
             if ( (msg->data.result == CURLE_OPERATION_TIMEDOUT ||
                   msg->data.result == CURLE_PARTIAL_FILE       ||
                   msg->data.result == CURLE_COULDNT_CONNECT    ||
+                  msg->data.result == CURLE_HTTP2_STREAM       ||
                   msg->data.result == CURLE_RECV_ERROR)        &&
                   !m_bFirstLoop)
             {


### PR DESCRIPTION
Backport of https://github.com/xbmc/xbmc/pull/26476 for Omega
