### PR TITLE
[Estuary] Fix PVR recording resume icons

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -496,7 +496,8 @@
 	</variable>
 	<variable name="ListPVRRecordingsIconVar">
 		<value condition="ListItem.IsRecording">windows/pvr/record.png</value>
-		<value condition="ListItem.IsResumable">overlays/watched/resume.png</value>
+		<value condition="ListItem.IsResumable + Integer.IsGreater(ListItem.Playcount,0)">overlays/watched/OverlayWatchedResume.png</value>
+		<value condition="ListItem.IsResumable">overlays/watched/OverlayResume.png</value>
 		<value condition="!String.IsEmpty(ListItem.Overlay)">$INFO[ListItem.Overlay]</value>
 		<value condition="!ListItem.IsParentFolder">OverlayUnwatched.png</value>
 	</variable>


### PR DESCRIPTION
## Description
Follow up https://github.com/xbmc/xbmc/pull/26419

The usage of `resume.png` in `ListPVRRecordingsIconVar` was missed so PR26419 broke the display of a resume icon 
## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/c998b579-b70b-4fd7-865c-b391514d7af9)



## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)


## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
