### PR TITLE
[video] CONTEXTMENU::CVideoMarkWatched::IsVisible: Add support for items with no or empty video info tag.

### DIFF
--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -120,10 +120,10 @@ bool CVideoMarkWatched::IsVisible(const CFileItem& item) const
     else
       return !item.IsParentFolder() && URIUtils::IsPVRRecordingFileOrFolder(item.GetPath());
   }
-  else if (!item.HasVideoInfoTag())
-    return false;
-
-  return item.GetVideoInfoTag()->GetPlayCount() == 0;
+  else if (item.HasVideoInfoTag())
+    return item.GetVideoInfoTag()->GetPlayCount() <= 0;
+  else
+    return VIDEO::IsVideo(item);
 }
 
 bool CVideoMarkWatched::Execute(const std::shared_ptr<CFileItem>& item) const
@@ -159,10 +159,10 @@ bool CVideoMarkUnWatched::IsVisible(const CFileItem& item) const
     else
       return !item.IsParentFolder() && URIUtils::IsPVRRecordingFileOrFolder(item.GetPath());
   }
-  else if (!item.HasVideoInfoTag())
+  else if (item.HasVideoInfoTag())
+    return item.GetVideoInfoTag()->GetPlayCount() > 0;
+  else
     return false;
-
-  return item.GetVideoInfoTag()->GetPlayCount() > 0;
 }
 
 bool CVideoMarkUnWatched::Execute(const std::shared_ptr<CFileItem>& item) const


### PR DESCRIPTION
Fixes #26484 

Runtime-tested on macOS and Android, latest Kodi master.

@arnova could you review and runtime-test?