### PR TITLE
Fix typos in docs and cmake files

### DIFF
--- a/cmake/scripts/common/Macros.cmake
+++ b/cmake/scripts/common/Macros.cmake
@@ -234,7 +234,7 @@ function(copy_file_to_buildtree file)
   endif()
 
   if(${CORE_SYSTEM_NAME} MATCHES "windows")
-    # if DEPENDS_PATH in fille
+    # if DEPENDS_PATH in file
     if(${file} MATCHES ${DEPENDS_PATH})
       file(APPEND ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/ExportFiles.cmake
 "file(GLOB filenames ${file})

--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -13,7 +13,7 @@ xbmc/interfaces/python/test       test/python
 xbmc/music/test                   test/music
 xbmc/music/tags/test              test/music_tags
 xbmc/network/test                 test/network
-xbmc/pictures/metadata/test       test/pictures/metatada
+xbmc/pictures/metadata/test       test/pictures/metadata
 xbmc/playlists/test               test/playlists
 xbmc/pvr/channels/test            test/pvrchannels
 xbmc/settings/test                test/settings

--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -385,7 +385,7 @@ int x{3};
 int* y{nullptr};
 bool z = false;
 std::string text; // not primitive
-KindOfStruct theStruct{}; // POD structures or structures with uninitalised members must be initialised with empty brackets
+KindOfStruct theStruct{}; // POD structures or structures with uninitialised members must be initialised with empty brackets
 Log::Log("test: {}, {}, {}", x, y, z);
 ```
 
@@ -643,7 +643,7 @@ New classes and functions are expected to have Doxygen comments describing their
  * \param destination the beginning of the destination range
  * \param input input string to be split
  * \param delimiter delimiter to be used to split the input string
- * \param maxStrings (optional) maximum number of splitted strings
+ * \param maxStrings (optional) maximum number of split strings
  * \return output iterator to the element in the destination range one past the last element
  *         that was put there
  */

--- a/docs/README.webOS.md
+++ b/docs/README.webOS.md
@@ -66,7 +66,7 @@ Several different strategies are used to draw your attention to certain pieces o
 
 ## 2. Prerequisites
 * **[LG developer account](https://webostv.developer.lge.com/develop/getting-started/preparing-lg-account)**. This is required to access developer mode on the webOS device.
-* **[Actvate developer mode on your webOS device]**. Follow the instructions as per **[Installing Developer Mode app page](https://webostv.developer.lge.com/develop/getting-started/developer-mode-app#installing-developer-mode-app)**.
+* **[Activate developer mode on your webOS device]**. Follow the instructions as per **[Installing Developer Mode app page](https://webostv.developer.lge.com/develop/getting-started/developer-mode-app#installing-developer-mode-app)**.
 * **[Download ares CLI tools](https://webostv.developer.lge.com/develop/tools/cli-installation)**. These are required to package the kodi binary into a IPK format that webOS understands.
 * **[Download and setup a compatible toolchain to compile kodi]**. The toolchain which was used in this guide is **[buildroot-nc4](https://github.com/openlgtv/buildroot-nc4)**, it is an up to date buildroot configuration and comes with newer tools such as GCC 12.2.0. Other toolchains exist, such as those found on the LG OpenSource website: **https://opensource.lge.com/**. You will need to enter the model number of your TV to find the applicable toolchain.
 


### PR DESCRIPTION
## Description
Fixed typos in comments and doxygen within some CMake and docs files.

Found using codespell

## Motivation and context

Accuracy of documentation and code.

## How has this been tested?
n/a

## What is the effect on users?
no negative impacts

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
