### PR TITLE
[video] Do not attempt to set the file id of Bluray items that were not in the library

### DIFF
--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -199,10 +199,11 @@ void CSaveFileState::DoWork(CFileItem& item,
           }
         }
 
-        // See if idFile needs updating
+        // See if idFile of library item needs updating
         const CVideoInfoTag* tag{item.HasVideoInfoTag() ? item.GetVideoInfoTag() : nullptr};
 
-        if (tag && URIUtils::IsBlurayPath(item.GetDynPath()) &&
+        if (tag && tag->m_iDbId >= 0 && tag->m_iFileId >= 0 &&
+            URIUtils::IsBlurayPath(item.GetDynPath()) &&
             tag->m_strFileNameAndPath != item.GetDynPath())
         {
           videodatabase.BeginTransaction();

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3023,6 +3023,9 @@ bool CVideoDatabase::SetFileForMedia(const std::string& fileAndPath,
                                      int mediaId,
                                      int oldIdFile)
 {
+  if (mediaId < 0 || oldIdFile < 0)
+    return false;
+
   switch (type)
   {
     case VideoDbContentType::MOVIES:


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The call to SetFileForMedia in SaveFileStateJob::DoWork is meant to adjust the file id for played bluray items of the library.

Nothing should be done for items that do not belong to the library (m_iDbId and m_iFileId == -1), and SetFileForMedia should return in error.
Fortunately the bug had no impact because no database records match mediaId == -1 or idFile == 1.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Noticed the execution of SQL queries of SetFileForMedia after playing a bluray that wasn't in library from Videos (play the index.bdmv)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Played bluray from library and outside.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
none.

## Screenshots (if appropriate):
before, in log:
```
dbiplus::SqliteDataset::exec: 0 ms for query: UPDATE movie SET idFile=1526 WHERE idFile=-1 AND idMovie=-1
dbiplus::SqliteDataset::exec: 0 ms for query: UPDATE videoversion SET idFile=1526 WHERE idFile=-1 AND media_type='movie' AND idMedia=-1
dbiplus::SqliteDataset::exec: 0 ms for query: UPDATE art SET media_id=1526 WHERE media_id=-1 AND media_type='videoversion'
dbiplus::SqliteDataset::exec: 0 ms for query: UPDATE streamdetails SET idFile=1526 WHERE idFile=-1 AND NOT EXISTS (SELECT 1 FROM streamdetails WHERE idFile=1526)
dbiplus::SqliteDataset::exec: 0 ms for query: DELETE FROM files WHERE idFile = -1
```

after PR: nothing in log.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
