### PR TITLE
[Pictures] fix typo in variable name

### DIFF
--- a/xbmc/pictures/metadata/ImageMetadataParser.cpp
+++ b/xbmc/pictures/metadata/ImageMetadataParser.cpp
@@ -30,11 +30,11 @@ namespace
 {
 std::string GetGPSString(const Exiv2::Value& value)
 {
-  const Exiv2::Rational degress = value.toRational(0);
+  const Exiv2::Rational degrees = value.toRational(0);
   const Exiv2::Rational minutes = value.toRational(1);
   Exiv2::Rational seconds = value.toRational(2);
 
-  const int32_t dd = degress.first;
+  const int32_t dd = degrees.first;
   int32_t mm{0};
   float ss{0.0};
   if (minutes.second > 0)


### PR DESCRIPTION
## Description
Fixes source typo in `xbmc/pictures/metadata/ImageMetadataParser.cpp` that appears to be 'degrees'

Found using codespell

## Motivation and context

Accuracy of documentation and code.

## How has this been tested?
n/a

## What is the effect on users?
no negative impacts

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
