### PR TITLE
[cmake] Swig, explicitly set path using CMAKE_BINARY_DIR

### DIFF
--- a/xbmc/interfaces/swig/CMakeLists.txt
+++ b/xbmc/interfaces/swig/CMakeLists.txt
@@ -27,7 +27,7 @@ function(generate_file file)
   # execute_process needs explicit use of explicit swig executable location. it is not TARGET aware
   # retrieve location property from TARGET
   get_target_property(_swig_exe SWIG::SWIG IMPORTED_LOCATION)
-  execute_process(COMMAND ${_swig_exe} -MM -MF build/swig/${file}.dep ${SWIG_ARGS})
+  execute_process(COMMAND ${_swig_exe} -MM -MF ${CMAKE_BINARY_DIR}/build/swig/${file}.dep ${SWIG_ARGS})
   file(READ ${CMAKE_BINARY_DIR}/build/swig/${file}.dep swig_deps)
 
   # Match all lines except the first one until " \"
@@ -49,7 +49,7 @@ function(generate_file file)
                      ARGS ${JAVA_OPEN_OPTS} -cp "${classpath}" groovy.ui.GroovyMain ${CMAKE_SOURCE_DIR}/tools/codegenerator/Generator.groovy ${file}.xml ${CMAKE_CURRENT_SOURCE_DIR}/../python/PythonSwig.cpp.template ${file}.cpp > ${devnull}
                      ${CLANG_FORMAT_COMMAND}
                      DEPENDS SWIG::SWIG ${swig_deps} ${CMAKE_CURRENT_SOURCE_DIR}/../python/PythonSwig.cpp.template
-                     BYPRODUCTS build/swig/${CPP_FILE} build/swig/${file}.xml)
+                     BYPRODUCTS ${CMAKE_BINARY_DIR}/build/swig/${CPP_FILE} ${CMAKE_BINARY_DIR}/build/swig/${file}.xml)
 
   set(SOURCES ${SOURCES} "${CPP_FILE}" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
## Description
Fix #26505

ping @bacon-cheeseburger for confirmation

## Motivation and context
when using ``cmake -S . -B build``, swig takes it relative to what seems to be current path command is called from, rather than from build dir.

Before
```
'/bin/swig' '-MM' '-MF' 'build/swig/AddonModuleXbmcplugin.i.dep' '-w401' '-c++' '-o' 'AddonModuleXbmcplugin.i.xml' '-xml' '-I/tmp/test/xbmc/xbmc' '/tmp/test/xbmc/xbmc/interfaces/swig/../swig/AddonModuleXbmcplugin.i'
Unable to open file build/swig/AddonModuleXbmcplugin.i.dep: No such file or directory
CMake Error at xbmc/interfaces/swig/CMakeLists.txt:31 (file):
  file failed to open for reading (No such file or directory):

    /tmp/test/xbmc/build/build/swig/AddonModuleXbmcplugin.i.dep
Call Stack (most recent call first):
  xbmc/interfaces/swig/CMakeLists.txt:136 (generate_file)

```

After
```
-- Found SWIG: /bin/swig
'/bin/swig' '-MM' '-MF' '/tmp/test/xbmc/build/build/swig/AddonModuleXbmcaddon.i.dep' '-w401' '-c++' '-o' 'AddonModuleXbmcaddon.i.xml' '-xml' '-I/tmp/test/xbmc/xbmc' '/tmp/test/xbmc/xbmc/interfaces/swig/../swig/AddonModuleXbmcaddon.i'

```

## How has this been tested?


## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
