### PR TITLE
[windows] make-mingwlibs respect BASE_URL from tools/depends ffmpeg VERSION file

### DIFF
--- a/tools/buildsteps/windows/buildhelpers.sh
+++ b/tools/buildsteps/windows/buildhelpers.sh
@@ -139,7 +139,10 @@ do_loaddeps() {
   VERSION=$(grep "VERSION=" $file | sed 's/VERSION=//g;s/#.*$//g;/^$/d')
   ARCHIVE=$LIBNAME-$VERSION.tar.gz
 
-  BASE_URL=http://mirrors.kodi.tv/build-deps/sources
+  BASE_URL=$(grep "BASE_URL=" $file | sed 's/BASE_URL=//g;s/#.*$//g;/^$/d')
+  if [ -z "$BASE_URL" ]; then
+    BASE_URL=http://mirrors.kodi.tv/build-deps/sources
+  fi
   local libsrcdir=$LIBNAME-$VERSION
 
   LOCALSRCDIR=$LOCALBUILDDIR/src/$libsrcdir


### PR DESCRIPTION
## Description
Windows ffmpeg build script recognises and accepts BASE_URL if defined in the FFMPEG-VERSION file

## Motivation and context
https://github.com/xbmc/xbmc/pull/26508#issuecomment-2709126927

## How has this been tested?
Windows build ffmpeg with an overridden BASE_URL in FFMPEG-VERSION file

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
