### PR TITLE
[PVR] Add 'Delete recording' context menu item for EPG items which have been recorded.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -11914,7 +11914,13 @@ msgctxt "#19356"
 msgid "Copy of '{0:s}'"
 msgstr ""
 
-#empty strings from id 19357 to 19498
+#. Label of a context menu entry to delete a recording
+#: xbmc/pvr/PVRContextMenus.cpp
+msgctxt "#19357"
+msgid "Delete recording"
+msgstr ""
+
+#empty strings from id 19358 to 19498
 
 #. label for epg genre value
 #: xbmc/pvr/epg/Epg.cpp

--- a/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
@@ -269,6 +269,15 @@ bool CPVRGUIActionsRecordings::CanEditRecording(const CFileItem& item) const
 
 bool CPVRGUIActionsRecordings::DeleteRecording(const CFileItem& item) const
 {
+  if (!item.m_bIsFolder && !item.HasPVRRecordingInfoTag())
+  {
+    const std::shared_ptr<CPVRRecording> recording{CPVRItem(item).GetRecording()};
+    if (recording)
+      return DeleteRecording(CFileItem{recording});
+    else
+      return false;
+  }
+
   if ((!item.IsPVRRecording() && !item.m_bIsFolder) || item.IsParentFolder())
     return false;
 


### PR DESCRIPTION
What subject says. Add context menu item "Delete recording" for EPG tags that have been recorded, making it possible to delete recordings directly from the Guide window.

<img width="1710" alt="Screenshot_2025-03-10_at_08_26_05" src="https://github.com/user-attachments/assets/8f14484f-7076-4062-afaf-0df0601d2648" />

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish something for you to review. :-)