### PR TITLE
[interfaces] PlayerBuiltins: PlayMedia and QueueMedia Fixes

### DIFF
--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -541,7 +541,7 @@ int PlayOrQueueMedia(const std::vector<std::string>& params,
   if (!item.m_bIsFolder && item.IsPlugin())
     item.SetProperty("IsPlayable", true);
 
-  if (askToResume)
+  if (forcePlay && askToResume)
   {
     const VIDEO::GUILIB::Action action =
         VIDEO::GUILIB::CVideoSelectActionProcessor::ChoosePlayOrResume(item);

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -44,7 +44,7 @@
 #include "video/VideoFileItemClassify.h"
 #include "video/VideoUtils.h"
 #include "video/guilib/VideoGUIUtils.h"
-#include "video/guilib/VideoSelectActionProcessor.h"
+#include "video/guilib/VideoPlayActionProcessor.h"
 
 #include <math.h>
 
@@ -544,7 +544,7 @@ int PlayOrQueueMedia(const std::vector<std::string>& params,
   if (forcePlay && askToResume)
   {
     const VIDEO::GUILIB::Action action =
-        VIDEO::GUILIB::CVideoSelectActionProcessor::ChoosePlayOrResume(item);
+        VIDEO::GUILIB::CVideoPlayActionProcessor::ChoosePlayOrResume(item);
     if (action == VIDEO::GUILIB::ACTION_RESUME)
     {
       item.SetStartOffset(STARTOFFSET_RESUME);

--- a/xbmc/video/guilib/VideoPlayActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.cpp
@@ -33,11 +33,18 @@
 
 namespace KODI::VIDEO::GUILIB
 {
-
-Action CVideoPlayActionProcessor::GetDefaultAction()
+namespace
+{
+Action GetDefaultPlayAction()
 {
   return static_cast<Action>(CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
       CSettings::SETTING_MYVIDEOS_PLAYACTION));
+}
+} // unnamed namespace
+
+Action CVideoPlayActionProcessor::GetDefaultAction()
+{
+  return GetDefaultPlayAction();
 }
 
 bool CVideoPlayActionProcessor::ProcessDefaultAction()
@@ -153,7 +160,11 @@ Action CVideoPlayActionProcessor::ChoosePlayOrResume(const std::string& resumeSt
 
 Action CVideoPlayActionProcessor::ChoosePlayOrResume(const CFileItem& item)
 {
-  return ChoosePlayOrResume(VIDEO::UTILS::GetResumeString(item));
+  const Action action{GetDefaultPlayAction()};
+  if (action == VIDEO::GUILIB::ACTION_PLAY_OR_RESUME)
+    return ChoosePlayOrResume(VIDEO::UTILS::GetResumeString(item));
+  else
+    return action;
 }
 
 unsigned int CVideoPlayActionProcessor::ChooseStackPart() const


### PR DESCRIPTION
Two fixes in this PR:

1) QueueMedia: Never ask to resume when queuing items. Asking for resume simply makes no sense for this use case. This is relevant for playback only.
2) PlayMedia: Respect 'Default Play Action' settings value when determining correct play/resume behavior. Fixes #26503

@jurialmunkey fyi

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 @neo1973 maybe one of you can review this...