### PR TITLE
[platform/win32] threads/Win32Exception.cpp: Add support for Windows ARM64

### DIFF
--- a/xbmc/platform/win32/threads/Win32Exception.cpp
+++ b/xbmc/platform/win32/threads/Win32Exception.cpp
@@ -210,6 +210,10 @@ bool win32_exception::write_stacktrace(EXCEPTION_POINTERS* pEp)
   frame.AddrPC.Offset = pEp->ContextRecord->Eip; // Current location in program
   frame.AddrStack.Offset = pEp->ContextRecord->Esp; // Stack pointers current value
   frame.AddrFrame.Offset = pEp->ContextRecord->Ebp; // Value of register used to access local function variables.
+#elif defined(_M_ARM64)
+  frame.AddrPC.Offset = pEp->ContextRecord->Pc; // Current location in program
+  frame.AddrStack.Offset = pEp->ContextRecord->Sp; // Stack pointers current value
+  frame.AddrFrame.Offset = pEp->ContextRecord->Fp; // Value of register used to access local function variables.
 #else
   frame.AddrPC.Offset = pEp->ContextRecord->Rip; // Current location in program
   frame.AddrStack.Offset = pEp->ContextRecord->Rsp; // Stack pointers current value


### PR DESCRIPTION
## Description
Add ARM64 case to write_stacktrace() function. 
This is the seventh of series of PRs to upstream changes from my Windows ARM64 fork here: https://github.com/ddscentral/xbmc-win-arm64/
write_stacktrace() uses processor registers which are architecure specific. This PR adds registers for ARM64. I chose registers based on descriptions for  _ARM64_NT_CONTEXT and _ARM64EC_NT_CONTEXT structs in winnt.h.

In my fork, I have simply stubbed-out the write_stacktrace, however when I had a closer look at the code, it seems the only thing architecture specific are the registers used to fill a STACKFRAME64 struct.

## Motivation and context
Add support for Windows ARM64

## How has this been tested?
Build will no longer fail on Windows ARM64 due to use of x86 specific registers.
Stacktraces can be written on Windows ARM64

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

My knowledge of low-level ARM64 code is limited. Suggestions/fixes are welcome.