### PR TITLE
[PVR] Delete recording context menu item: Fix label for recordings folders.

### DIFF
--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -384,14 +384,13 @@ bool EditRecording::Execute(const CFileItemPtr& item) const
 
 std::string DeleteRecording::GetLabel(const CFileItem& item) const
 {
-  const std::shared_ptr<const CPVRRecording> recording(item.GetPVRRecordingInfoTag());
-  if (recording)
-  {
-    if (recording->IsDeleted())
-      return g_localizeStrings.Get(19291); // Delete permanently
-    else
-      return g_localizeStrings.Get(117); // Delete
-  }
+  const std::shared_ptr<const CPVRRecording> recording{item.GetPVRRecordingInfoTag()};
+  if (recording && recording->IsDeleted())
+    return g_localizeStrings.Get(19291); // Delete permanently
+
+  if (recording || item.m_bIsFolder)
+    return g_localizeStrings.Get(117); // Delete
+
   return g_localizeStrings.Get(19357); // Delete recording
 }
 


### PR DESCRIPTION
Fixes a small regression introduced with https://github.com/xbmc/xbmc/pull/26513 - recording folders had context menu entry "Delete recording" instead of just "Delete" as it was before above mentioned PR. 

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish can you please review.