### PR TITLE
[video] Cleanup settings 'default select action' and 'default play action' logics.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5927,6 +5927,7 @@ msgstr ""
 #. Label of various controls for starting playback from the beginning
 #: addons/skin.estuary/xml/SkinSettings.xml
 #: addons/skin.estuary/xml/Variables.xml
+#: system/settings/settings.xml
 #: xbmc/Autorun.cpp
 #: xbmc/favourites/ContextMenus.cpp
 #: xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
@@ -7359,7 +7360,8 @@ msgctxt "#13403"
 msgid "Clear default"
 msgstr ""
 
-#: system/settings/settings.xml
+#. Button label used in play disc ask resume dialog
+#: xbmc/Autorun.cpp
 msgctxt "#13404"
 msgid "Resume"
 msgstr ""
@@ -19968,7 +19970,7 @@ msgstr ""
 #. Description of setting with label #22079 "Default select action"
 #: system/settings/settings.xml
 msgctxt "#36177"
-msgid "Toggle between [Choose], [Play] (default), [Resume], [Show information] and [Queue item].[CR][Choose] will open a context menu to select an item, e.g. show information.[CR][Play] will automatically play videos from the beginning or if a resume point is present ask whether to play from beginning or to resume.[CR][Resume] Will automatically resume videos from the last position that you were viewing them.[CR][Show information] will open the video's information dialog.[CR][Queue item] will append the video to the video playlist."
+msgid "Toggle between [Choose], [Play] (default), [Show information] and [Queue item].[CR][Choose] will open a context menu to select an item, e.g. show information.[CR][Play] will play videos as defined by the setting 'Default play action'.[CR][Show information] will open the video's information dialog.[CR][Queue item] will append the video to the video playlist."
 msgstr ""
 
 #. Description of setting with label #20433 "Extract thumbnails and video information"
@@ -20122,7 +20124,7 @@ msgstr ""
 #. Description of setting with label #22076 "Default play action"
 #: system/settings/settings.xml
 msgctxt "#36204"
-msgid "Toggle between [Ask if resumable] (default) and [Resume].[CR][Ask if resumable] will ask whether to play from beginning or to resume (if a resume point is present).[CR][Resume] will automatically resume videos from the last position that you were viewing them.[CR]If no resume point is set, playback will automatically start from the beginning."
+msgid "Toggle between [Ask if resumable] (default), [Resume] and [Play from beginning].[CR][Ask if resumable] will ask whether to play from beginning or to resume (if a resume point is present).[CR][Resume] will automatically resume playback from the last position that you were viewing them. If no resume point is set, playback will automatically start from the beginning.[CR][Play from beginning] will automatically start playback from beginning, ignoring any existing resume positions."
 msgstr ""
 
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1112,12 +1112,11 @@
       <group id="1" label="593">
         <setting id="myvideos.selectaction" type="integer" label="22079" help="36177">
           <level>0</level>
-          <default>1</default> <!-- ACTION_PLAY_OR_RESUME -->
+          <default>8</default> <!-- ACTION_PLAY -->
           <constraints>
             <options>
               <option label="22080">0</option> <!-- ACTION_CHOOSE -->
-              <option label="208">1</option> <!-- ACTION_PLAY_OR_RESUME -->
-              <option label="13404">2</option> <!-- ACTION_RESUME -->
+              <option label="208">8</option> <!-- ACTION_PLAY -->
               <option label="22081">3</option> <!-- ACTION_INFO -->
               <option label="13347">7</option> <!-- ACTION_QUEUE -->
             </options>
@@ -1136,6 +1135,7 @@
             <options>
               <option label="22077">1</option> <!-- ACTION_PLAY_OR_RESUME -->
               <option label="22078">2</option> <!-- ACTION_RESUME -->
+              <option label="12021">4</option> <!-- ACTION_PLAY_FROM_BEGINNING -->
             </options>
           </constraints>
           <control type="list" format="string" />

--- a/xbmc/video/guilib/CMakeLists.txt
+++ b/xbmc/video/guilib/CMakeLists.txt
@@ -1,10 +1,12 @@
-set(SOURCES VideoGUIUtils.cpp
+set(SOURCES VideoActionProcessorBase.cpp
+            VideoGUIUtils.cpp
             VideoPlayActionProcessor.cpp
             VideoSelectActionProcessor.cpp
             VideoStreamSelectHelper.cpp
             VideoVersionHelper.cpp)
 
 set(HEADERS VideoAction.h
+            VideoActionProcessorBase.h
             VideoGUIUtils.h
             VideoPlayActionProcessor.h
             VideoSelectActionProcessor.h

--- a/xbmc/video/guilib/VideoAction.h
+++ b/xbmc/video/guilib/VideoAction.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2023 Team Kodi
+ *  Copyright (C) 2023-2025 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -14,13 +14,14 @@ namespace KODI::VIDEO::GUILIB
 //       the integer settings SETTING_MYVIDEOS_SELECTACTION and SETTING_MYVIDEOS_PLAYACTION.
 enum Action
 {
-  ACTION_CHOOSE = 0,
+  ACTION_CHOOSE = 0, // open context menu to pick an action
   ACTION_PLAY_OR_RESUME = 1, // if resume is possible, ask user. play from beginning otherwise
   ACTION_RESUME = 2, // resume if possibly, play from beginning otherwise
-  ACTION_INFO = 3,
+  ACTION_INFO = 3, // show info dialog
   // 4 unused
   ACTION_PLAY_FROM_BEGINNING = 5, // play from beginning, also if resume would be possible
   // 6 unused
-  ACTION_QUEUE = 7,
+  ACTION_QUEUE = 7, // add item to the video playlist
+  ACTION_PLAY = 8, // play according to SETTING_MYVIDEOS_PLAYACTION value
 };
 } // namespace KODI::VIDEO::GUILIB

--- a/xbmc/video/guilib/VideoActionProcessorBase.cpp
+++ b/xbmc/video/guilib/VideoActionProcessorBase.cpp
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "VideoActionProcessorBase.h"
+
+#include "video/guilib/VideoVersionHelper.h"
+
+namespace KODI::VIDEO::GUILIB
+{
+
+bool CVideoActionProcessorBase::ProcessDefaultAction()
+{
+  return ProcessAction(GetDefaultAction());
+}
+
+bool CVideoActionProcessorBase::ProcessAction(Action action)
+{
+  m_userCancelled = false;
+
+  const auto movie{CVideoVersionHelper::ChooseVideoFromAssets(m_item)};
+  if (movie)
+  {
+    m_item = movie;
+  }
+  else
+  {
+    m_userCancelled = true;
+    return true; // User cancelled the select menu. We're done.
+  }
+
+  return Process(action);
+}
+
+} // namespace KODI::VIDEO::GUILIB

--- a/xbmc/video/guilib/VideoActionProcessorBase.h
+++ b/xbmc/video/guilib/VideoActionProcessorBase.h
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "video/guilib/VideoAction.h"
+
+#include <memory>
+
+class CFileItem;
+
+namespace KODI::VIDEO::GUILIB
+{
+class CVideoActionProcessorBase
+{
+public:
+  explicit CVideoActionProcessorBase(const std::shared_ptr<CFileItem>& item) : m_item(item) {}
+  virtual ~CVideoActionProcessorBase() = default;
+
+  bool ProcessDefaultAction();
+  bool ProcessAction(Action action);
+
+  bool UserCancelled() const { return m_userCancelled; }
+
+protected:
+  virtual Action GetDefaultAction() = 0;
+  virtual bool Process(Action action) = 0;
+
+  std::shared_ptr<CFileItem> m_item;
+  bool m_userCancelled{false};
+
+private:
+  CVideoActionProcessorBase() = delete;
+};
+} // namespace KODI::VIDEO::GUILIB

--- a/xbmc/video/guilib/VideoPlayActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2023 Team Kodi
+ *  Copyright (C) 2023-2025 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -26,10 +26,8 @@
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
-#include "video/VideoFileItemClassify.h"
 #include "video/VideoUtils.h"
 #include "video/guilib/VideoGUIUtils.h"
-#include "video/guilib/VideoVersionHelper.h"
 
 namespace KODI::VIDEO::GUILIB
 {
@@ -47,25 +45,9 @@ Action CVideoPlayActionProcessor::GetDefaultAction()
   return GetDefaultPlayAction();
 }
 
-bool CVideoPlayActionProcessor::ProcessDefaultAction()
+bool CVideoPlayActionProcessor::Process(Action action)
 {
-  return ProcessAction(GetDefaultAction());
-}
-
-bool CVideoPlayActionProcessor::ProcessAction(Action action)
-{
-  m_userCancelled = false;
-
-  const auto movie{CVideoVersionHelper::ChooseVideoFromAssets(m_item)};
-  if (movie)
-    m_item = movie;
-  else
-  {
-    m_userCancelled = true;
-    return true; // User cancelled the select menu. We're done.
-  }
-
-  if (m_chooseStackPart)
+  if (m_chooseStackPart && m_chosenStackPart == 0)
   {
     if (!URIUtils::IsStack(m_item->GetDynPath()))
     {
@@ -81,11 +63,6 @@ bool CVideoPlayActionProcessor::ProcessAction(Action action)
     }
   }
 
-  return Process(action);
-}
-
-bool CVideoPlayActionProcessor::Process(Action action)
-{
   switch (action)
   {
     case ACTION_PLAY_OR_RESUME:

--- a/xbmc/video/guilib/VideoPlayActionProcessor.h
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2023 Team Kodi
+ *  Copyright (C) 2023-2025 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "video/guilib/VideoAction.h"
+#include "video/guilib/VideoActionProcessorBase.h"
 
 #include <memory>
 
@@ -16,36 +16,26 @@ class CFileItem;
 
 namespace KODI::VIDEO::GUILIB
 {
-class CVideoPlayActionProcessor
+class CVideoPlayActionProcessor : public CVideoActionProcessorBase
 {
 public:
-  explicit CVideoPlayActionProcessor(const std::shared_ptr<CFileItem>& item) : m_item(item) {}
+  explicit CVideoPlayActionProcessor(const std::shared_ptr<CFileItem>& item)
+    : CVideoActionProcessorBase(item)
+  {
+  }
   virtual ~CVideoPlayActionProcessor() = default;
-
-  bool ProcessDefaultAction();
-  bool ProcessAction(Action action);
 
   void SetChoosePlayer() { m_choosePlayer = true; }
   void SetChooseStackPart() { m_chooseStackPart = true; }
 
-  bool UserCancelled() const { return m_userCancelled; }
-
   static Action ChoosePlayOrResume(const CFileItem& item);
 
 protected:
-  virtual Action GetDefaultAction();
-  virtual bool Process(Action action);
+  Action GetDefaultAction() override;
+  bool Process(Action action) override;
 
   virtual bool OnResumeSelected();
   virtual bool OnPlaySelected();
-
-  void Play(const std::string& player);
-
-  std::shared_ptr<CFileItem> m_item;
-  bool m_userCancelled{false};
-  bool m_choosePlayer{false};
-  bool m_chooseStackPart{false};
-  unsigned int m_chosenStackPart{0};
 
 private:
   CVideoPlayActionProcessor() = delete;
@@ -54,5 +44,10 @@ private:
   static Action ChoosePlayOrResume(const std::string& resumeString);
   void SetResumeData();
   void SetStartData();
+  void Play(const std::string& player);
+
+  bool m_chooseStackPart{false};
+  bool m_choosePlayer{false};
+  unsigned int m_chosenStackPart{0};
 };
 } // namespace KODI::VIDEO::GUILIB

--- a/xbmc/video/guilib/VideoSelectActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoSelectActionProcessor.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2023 Team Kodi
+ *  Copyright (C) 2023-2025 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -17,28 +17,33 @@
 #include "utils/guilib/GUIContentUtils.h"
 #include "video/VideoFileItemClassify.h"
 #include "video/guilib/VideoGUIUtils.h"
+#include "video/guilib/VideoPlayActionProcessor.h"
 
 namespace KODI::VIDEO::GUILIB
 {
 
-Action CVideoSelectActionProcessor::GetDefaultSelectAction()
-{
-  return static_cast<Action>(CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
-      CSettings::SETTING_MYVIDEOS_SELECTACTION));
-}
-
 Action CVideoSelectActionProcessor::GetDefaultAction()
 {
-  return GetDefaultSelectAction();
+  auto settings{CServiceBroker::GetSettingsComponent()->GetSettings()};
+  Action action{static_cast<Action>(settings->GetInt(CSettings::SETTING_MYVIDEOS_SELECTACTION))};
+  if (action == ACTION_PLAY_OR_RESUME || action == ACTION_RESUME)
+  {
+    // Compat: The former settings value ACTION_PLAY_OR_RESUME and ACTION_RESUME are no longer
+    // valid for SETTING_MYVIDEOS_SELECTACTION. Migrate it to the new default setting value.
+    action = ACTION_PLAY;
+    settings->SetInt(CSettings::SETTING_MYVIDEOS_SELECTACTION, action);
+    settings->Save();
+  }
+  return action;
 }
 
 bool CVideoSelectActionProcessor::Process(Action action)
 {
-  if (CVideoPlayActionProcessor::Process(action))
-    return true;
-
   switch (action)
   {
+    case ACTION_PLAY:
+      return OnPlaySelected();
+
     case ACTION_CHOOSE:
       return OnChooseSelected();
 
@@ -51,8 +56,8 @@ bool CVideoSelectActionProcessor::Process(Action action)
           !m_item->IsPlugin() && !m_item->IsScript() && !m_item->IsPVR() &&
           !KODI::VIDEO::UTILS::HasItemVideoDbInformation(*m_item))
       {
-        // for items without info fall back to default play action
-        return Process(CVideoPlayActionProcessor::GetDefaultAction());
+        // For items without info fall back to default play action.
+        return Process(ACTION_PLAY);
       }
 
       return OnInfoSelected();
@@ -62,6 +67,16 @@ bool CVideoSelectActionProcessor::Process(Action action)
       break;
   }
   return false; // We did not handle the action.
+}
+
+bool CVideoSelectActionProcessor::OnPlaySelected()
+{
+  // Play the current video version, even if multiple versions are available.
+  m_item->SetProperty("has_resolved_video_asset", true);
+
+  // Execute default play action.
+  CVideoPlayActionProcessor proc(m_item);
+  return proc.ProcessDefaultAction();
 }
 
 bool CVideoSelectActionProcessor::OnQueueSelected()

--- a/xbmc/video/guilib/VideoSelectActionProcessor.h
+++ b/xbmc/video/guilib/VideoSelectActionProcessor.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2023 Team Kodi
+ *  Copyright (C) 2023-2025 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "video/guilib/VideoPlayActionProcessor.h"
+#include "video/guilib/VideoActionProcessorBase.h"
 
 #include <memory>
 
@@ -16,22 +16,21 @@ class CFileItem;
 
 namespace KODI::VIDEO::GUILIB
 {
-class CVideoSelectActionProcessor : public CVideoPlayActionProcessor
+class CVideoSelectActionProcessor : public CVideoActionProcessorBase
 {
 public:
   explicit CVideoSelectActionProcessor(const std::shared_ptr<CFileItem>& item)
-    : CVideoPlayActionProcessor(item)
+    : CVideoActionProcessorBase(item)
   {
   }
 
   ~CVideoSelectActionProcessor() override = default;
 
-  static Action GetDefaultSelectAction();
-
 protected:
   Action GetDefaultAction() override;
   bool Process(Action action) override;
 
+  virtual bool OnPlaySelected();
   virtual bool OnQueueSelected();
   virtual bool OnInfoSelected();
   virtual bool OnChooseSelected();


### PR DESCRIPTION
This PR reworks some details how the two settings Media->Videos `Default select action` and `Default play action` work.

**Default select action:** 
* Kicks in whenever some video/video folder is selected in a list, either in video window or in a home screen widget

**Default play action:** 
* Kicks in whenever some video/video folder is about to be played, by hitting the play button on keyboard/remote or via builtin `PlayMedia`, by selecting a deticated play button in a dialog etc.

**Current behavior**
* Both settings have values to control what happens when video playback is triggered. Whether to automatically resume if possible, to ask whether to start from beginning or resume. Can lead to select asking for resume, play button not asking - play behavior depends on the context that triggered the play action. This is confusing and inconsistent. See also: https://github.com/xbmc/xbmc/issues/26503

**New behavior**
* `Default select action` defines only that a play action shall be triggered on select, but not any longer what exactly is supposed to happen (resume if possible, to ask whether to start from beginning or resume). The latter is controlled solely now via `Default play action`, no matter what the context was that triggered the play action. This guarantees consistent play action behavior across the whole application.
* As a consequence. `Resume` was removed from possible `Default select action` values, behavior of `Play`was changed to always trigger the play behavior as configured using `Default play action` setting.
* For even more consistency, `Start from the beginning` was added as an option for setting `Default play action`.

<img width="1710" alt="Screenshot 2025-03-12 at 08 26 26" src="https://github.com/user-attachments/assets/eea614d0-52fd-4cce-93be-8e3d72c02f37" />

<img width="1710" alt="Screenshot 2025-03-12 at 08 29 29" src="https://github.com/user-attachments/assets/ae8b4a0f-3401-4308-acca-0e9c9022994b" />

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 you reviewed PRs targeting this code area before, so maybe you are the bast candidate to review this PR as well.

@jurialmunkey fyi