### PR TITLE
DNSNameCache: Add a Time To Live for cached names

### DIFF
--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -443,3 +443,18 @@ std::shared_ptr<speech::ISpeechRecognition> CServiceBroker::GetSpeechRecognition
 {
   return g_serviceBroker.m_speechRecognition;
 }
+
+void CServiceBroker::RegisterDNSNameCache(std::shared_ptr<CDNSNameCache> cache)
+{
+  g_serviceBroker.m_dnsNameCache = std::move(cache);
+}
+
+void CServiceBroker::UnregisterDNSNameCache()
+{
+  g_serviceBroker.m_dnsNameCache.reset();
+}
+
+std::shared_ptr<CDNSNameCache> CServiceBroker::GetDNSNameCache()
+{
+  return g_serviceBroker.m_dnsNameCache;
+}

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -80,6 +80,7 @@ class CPlatform;
 class CTextureCache;
 class CJobManager;
 class CSlideShowDelegator;
+class CDNSNameCache;
 
 namespace WSDiscovery
 {
@@ -225,6 +226,10 @@ public:
   static void UnregisterSpeechRecognition();
   static std::shared_ptr<speech::ISpeechRecognition> GetSpeechRecognition();
 
+  static void RegisterDNSNameCache(std::shared_ptr<CDNSNameCache> cache);
+  static void UnregisterDNSNameCache();
+  static std::shared_ptr<CDNSNameCache> GetDNSNameCache();
+
 private:
   std::shared_ptr<CAppParams> m_appParams;
   std::unique_ptr<CLog> m_logging;
@@ -242,6 +247,7 @@ private:
   std::shared_ptr<KODI::KEYBOARD::CKeyboardLayoutManager> m_keyboardLayoutManager;
   std::shared_ptr<speech::ISpeechRecognition> m_speechRecognition;
   std::shared_ptr<CSlideShowDelegator> m_slideshowDelegator;
+  std::shared_ptr<CDNSNameCache> m_dnsNameCache;
 };
 
 XBMC_GLOBAL_REF(CServiceBroker, g_serviceBroker);

--- a/xbmc/addons/interfaces/Network.cpp
+++ b/xbmc/addons/interfaces/Network.cpp
@@ -156,7 +156,7 @@ char* Interface_Network::dns_lookup(void* kodiBase, const char* url, bool* ret)
   }
 
   std::string string;
-  *ret = CDNSNameCache::Lookup(url, string);
+  *ret = CServiceBroker::GetDNSNameCache()->Lookup(url, string);
   char* buffer = nullptr;
   if (!string.empty())
     buffer = strdup(string.c_str());

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -62,6 +62,7 @@
 #include "filesystem/DllLibCurl.h"
 #include "filesystem/File.h"
 #include "music/MusicFileItemClassify.h"
+#include "network/DNSNameCache.h"
 #include "network/NetworkFileItemClassify.h"
 #include "playlists/PlayListFileItemClassify.h"
 #include "video/VideoFileItemClassify.h"
@@ -275,6 +276,8 @@ bool CApplication::Create()
 
   const auto keyboardLayoutManager = std::make_shared<KEYBOARD::CKeyboardLayoutManager>();
   CServiceBroker::RegisterKeyboardLayoutManager(keyboardLayoutManager);
+
+  CServiceBroker::RegisterDNSNameCache(std::make_shared<CDNSNameCache>());
 
   m_ServiceManager = std::make_unique<CServiceManager>();
 
@@ -1983,6 +1986,8 @@ bool CApplication::Cleanup()
       m_ServiceManager->DeinitStageOne();
       m_ServiceManager.reset();
     }
+
+    CServiceBroker::UnregisterDNSNameCache();
 
     CServiceBroker::UnregisterKeyboardLayoutManager();
 

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -8,6 +8,7 @@
 
 #include "mysqldataset.h"
 
+#include "ServiceBroker.h"
 #include "Util.h"
 #include "network/DNSNameCache.h"
 #include "network/WakeOnAccess.h"
@@ -159,7 +160,8 @@ int MysqlDatabase::connect(bool create_new)
     return DB_CONNECTION_NONE;
 
   std::string resolvedHost;
-  if (!StringUtils::EqualsNoCase(host, "localhost") && CDNSNameCache::Lookup(host, resolvedHost))
+  if (!StringUtils::EqualsNoCase(host, "localhost") &&
+      CServiceBroker::GetDNSNameCache()->Lookup(host, resolvedHost))
   {
     if (host != resolvedHost)
       CLog::LogF(LOGDEBUG, "Replacing configured host {} with resolved host {}", host,

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -741,7 +741,7 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
 
   // lookup host in DNS cache
   std::string resolvedHost;
-  if (CDNSNameCache::GetCached(url2.GetHostName(), resolvedHost))
+  if (CServiceBroker::GetDNSNameCache()->GetCached(url2.GetHostName(), resolvedHost))
   {
     struct curl_slist* tempCache;
     int entryPort = url2.GetPort();

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -76,7 +76,7 @@ CNfsConnection::~CNfsConnection()
 void CNfsConnection::resolveHost(const CURL& url)
 {
   // resolve if hostname has changed
-  CDNSNameCache::Lookup(url.GetHostName(), m_resolvedHostName);
+  CServiceBroker::GetDNSNameCache()->Lookup(url.GetHostName(), m_resolvedHostName);
 }
 
 std::list<std::string> CNfsConnection::GetExportList(const CURL& url)

--- a/xbmc/filesystem/test/TestHTTPDirectory.cpp
+++ b/xbmc/filesystem/test/TestHTTPDirectory.cpp
@@ -8,9 +8,11 @@
 
 #include "FileItem.h"
 #include "FileItemList.h"
+#include "ServiceBroker.h"
 #include "URL.h"
 #include "filesystem/CurlFile.h"
 #include "filesystem/HTTPDirectory.h"
+#include "network/DNSNameCache.h"
 #include "network/WebServer.h"
 #include "network/httprequesthandler/HTTPVfsHandler.h"
 #include "settings/MediaSourceSettings.h"
@@ -81,6 +83,8 @@ protected:
 protected:
   void SetUp() override
   {
+    CServiceBroker::RegisterDNSNameCache(std::make_shared<CDNSNameCache>());
+
     SetupMediaSources();
 
     m_webServer.Start(m_webServerPort, "", "");
@@ -95,6 +99,8 @@ protected:
     m_webServer.UnregisterRequestHandler(&m_vfsHandler);
 
     TearDownMediaSources();
+
+    CServiceBroker::UnregisterDNSNameCache();
   }
 
   void SetupMediaSources()

--- a/xbmc/network/DNSNameCache.cpp
+++ b/xbmc/network/DNSNameCache.cpp
@@ -70,7 +70,7 @@ bool CDNSNameCache::Lookup(const std::string& strHostName, std::string& strIpAdd
   return false;
 }
 
-bool CDNSNameCache::GetCached(const std::string& strHostName, std::string& strIpAddress)
+bool CDNSNameCache::GetCached(const std::string& strHostName, std::string& strIpAddress) const
 {
   std::lock_guard lock(m_critical);
 

--- a/xbmc/network/DNSNameCache.h
+++ b/xbmc/network/DNSNameCache.h
@@ -40,7 +40,7 @@ public:
    *
    * \return true if the IP is cached
    */
-  bool GetCached(const std::string& strHostName, std::string& strIpAddress);
+  bool GetCached(const std::string& strHostName, std::string& strIpAddress) const;
   /*!
    * \brief Get the IP for the hostname from the cache or query it form the DNS
    *
@@ -64,6 +64,6 @@ private:
     std::optional<std::chrono::steady_clock::time_point> m_expirationTime;
   };
 
-  CCriticalSection m_critical;
-  std::unordered_map<std::string, CacheEntry> m_hostToIp;
+  mutable CCriticalSection m_critical;
+  mutable std::unordered_map<std::string, CacheEntry> m_hostToIp;
 };

--- a/xbmc/network/DNSNameCache.h
+++ b/xbmc/network/DNSNameCache.h
@@ -8,26 +8,27 @@
 
 #pragma once
 
+#include "threads/CriticalSection.h"
+
 #include <chrono>
 #include <optional>
 #include <string>
 #include <unordered_map>
 
-class CCriticalSection;
-
-class CDNSNameCache
+class CDNSNameCache final
 {
 public:
-  CDNSNameCache(void);
-  virtual ~CDNSNameCache(void);
   static void Add(const std::string& strHostName, const std::string& strIpAddress);
   static void AddPermanent(const std::string& strHostName, const std::string& strIpAddress);
   static bool GetCached(const std::string& strHostName, std::string& strIpAddress);
   static bool Lookup(const std::string& strHostName, std::string& strIpAddress);
 
-protected:
-  static CCriticalSection m_critical;
+private:
+  CDNSNameCache() = default;
+
   static constexpr std::chrono::seconds TTL{60};
+  static CDNSNameCache ms_instance;
+
   struct CacheEntry
   {
     CacheEntry(std::string ip, std::optional<std::chrono::steady_clock::time_point> expirationTime);
@@ -35,5 +36,7 @@ protected:
     std::string m_ip;
     std::optional<std::chrono::steady_clock::time_point> m_expirationTime;
   };
+
+  CCriticalSection m_critical;
   std::unordered_map<std::string, CacheEntry> m_hostToIp;
 };

--- a/xbmc/network/DNSNameCache.h
+++ b/xbmc/network/DNSNameCache.h
@@ -18,9 +18,39 @@
 class CDNSNameCache final
 {
 public:
+  /*!
+   * \brief Add the IP for a hostname to the cache. From the time of adding it stays in the cache for \ref TTL
+   *
+   * \param strHostName The hostname
+   * \param strIpAddress The IP for that hostname. Can be IPv4 or IPv6
+   */
   static void Add(const std::string& strHostName, const std::string& strIpAddress);
+  /*!
+   * \brief Add the IP for a hostname to the cache indefinitely
+   *
+   * \param strHostName The hostname
+   * \param strIpAddress The IP for that hostname. Can be IPv4 or IPv6
+   */
   static void AddPermanent(const std::string& strHostName, const std::string& strIpAddress);
+  /*!
+   * \brief Get an IP for a hostname from the cache
+   *
+   * \param strHostName The hostname to look up
+   * \param[out] strIpAddress Contains the IP for the hostname if the info is in the cache, otherwise unchanged
+   *
+   * \return true if the IP is cached
+   */
   static bool GetCached(const std::string& strHostName, std::string& strIpAddress);
+  /*!
+   * \brief Get the IP for the hostname from the cache or query it form the DNS
+   *
+   * If a successful DNS query was performed the result is added to the cache for the duration of \ref TTL
+   *
+   * \param strHostName The hostname to look up
+   * \param[out] strIpAddress Contains the IP for the hostname if the info can be provided, otherwise unchanged
+   *
+   * \return true if the IP is cached or the DNS query was successful
+   */
   static bool Lookup(const std::string& strHostName, std::string& strIpAddress);
 
 private:

--- a/xbmc/network/DNSNameCache.h
+++ b/xbmc/network/DNSNameCache.h
@@ -9,19 +9,13 @@
 #pragma once
 
 #include <string>
-#include <vector>
+#include <unordered_map>
 
 class CCriticalSection;
 
 class CDNSNameCache
 {
 public:
-  class CDNSName
-  {
-  public:
-    std::string m_strHostName;
-    std::string m_strIpAddress;
-  };
   CDNSNameCache(void);
   virtual ~CDNSNameCache(void);
   static void Add(const std::string& strHostName, const std::string& strIpAddress);
@@ -30,5 +24,5 @@ public:
 
 protected:
   static CCriticalSection m_critical;
-  std::vector<CDNSName> m_vecDNSNames;
+  std::unordered_map<std::string, std::string> m_hostToIp;
 };

--- a/xbmc/network/DNSNameCache.h
+++ b/xbmc/network/DNSNameCache.h
@@ -24,14 +24,14 @@ public:
    * \param strHostName The hostname
    * \param strIpAddress The IP for that hostname. Can be IPv4 or IPv6
    */
-  static void Add(const std::string& strHostName, const std::string& strIpAddress);
+  void Add(const std::string& strHostName, const std::string& strIpAddress);
   /*!
    * \brief Add the IP for a hostname to the cache indefinitely
    *
    * \param strHostName The hostname
    * \param strIpAddress The IP for that hostname. Can be IPv4 or IPv6
    */
-  static void AddPermanent(const std::string& strHostName, const std::string& strIpAddress);
+  void AddPermanent(const std::string& strHostName, const std::string& strIpAddress);
   /*!
    * \brief Get an IP for a hostname from the cache
    *
@@ -40,7 +40,7 @@ public:
    *
    * \return true if the IP is cached
    */
-  static bool GetCached(const std::string& strHostName, std::string& strIpAddress);
+  bool GetCached(const std::string& strHostName, std::string& strIpAddress);
   /*!
    * \brief Get the IP for the hostname from the cache or query it form the DNS
    *
@@ -51,13 +51,10 @@ public:
    *
    * \return true if the IP is cached or the DNS query was successful
    */
-  static bool Lookup(const std::string& strHostName, std::string& strIpAddress);
+  bool Lookup(const std::string& strHostName, std::string& strIpAddress);
 
 private:
-  CDNSNameCache() = default;
-
   static constexpr std::chrono::seconds TTL{60};
-  static CDNSNameCache ms_instance;
 
   struct CacheEntry
   {

--- a/xbmc/network/DNSNameCache.h
+++ b/xbmc/network/DNSNameCache.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <chrono>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -19,10 +21,19 @@ public:
   CDNSNameCache(void);
   virtual ~CDNSNameCache(void);
   static void Add(const std::string& strHostName, const std::string& strIpAddress);
+  static void AddPermanent(const std::string& strHostName, const std::string& strIpAddress);
   static bool GetCached(const std::string& strHostName, std::string& strIpAddress);
   static bool Lookup(const std::string& strHostName, std::string& strIpAddress);
 
 protected:
   static CCriticalSection m_critical;
-  std::unordered_map<std::string, std::string> m_hostToIp;
+  static constexpr std::chrono::seconds TTL{60};
+  struct CacheEntry
+  {
+    CacheEntry(std::string ip, std::optional<std::chrono::steady_clock::time_point> expirationTime);
+
+    std::string m_ip;
+    std::optional<std::chrono::steady_clock::time_point> m_expirationTime;
+  };
+  std::unordered_map<std::string, CacheEntry> m_hostToIp;
 };

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -68,7 +68,7 @@ static int GetTotalSeconds(const CDateTimeSpan& ts)
 static unsigned long HostToIP(const std::string& host)
 {
   std::string ip;
-  CDNSNameCache::Lookup(host, ip);
+  CServiceBroker::GetDNSNameCache()->Lookup(host, ip);
   return inet_addr(ip.c_str());
 }
 

--- a/xbmc/network/mdns/ZeroconfBrowserMDNS.cpp
+++ b/xbmc/network/mdns/ZeroconfBrowserMDNS.cpp
@@ -398,7 +398,7 @@ bool CZeroconfBrowserMDNS::doResolveService(CZeroconfBrowser::ZeroconfService& f
       CLog::Log(LOGWARNING,
                 "ZeroconfBrowserMDNS: Could not resolve hostname {} falling back to CDNSNameCache",
                 fr_service.GetHostname());
-      if (CDNSNameCache::Lookup(fr_service.GetHostname(), strIP))
+      if (CServiceBroker::GetDNSNameCache()->Lookup(fr_service.GetHostname(), strIP))
         fr_service.SetIP(strIP);
       else
         CLog::Log(LOGERROR, "ZeroconfBrowserMDNS: Could not resolve hostname {}",

--- a/xbmc/network/test/TestWebServer.cpp
+++ b/xbmc/network/test/TestWebServer.cpp
@@ -10,17 +10,15 @@
 #  include <windows.h>
 #endif
 
-#include <errno.h>
-#include <stdlib.h>
-
-#include <gtest/gtest.h>
+#include "ServiceBroker.h"
 #include "URL.h"
 #include "filesystem/CurlFile.h"
 #include "filesystem/File.h"
 #include "interfaces/json-rpc/JSONRPC.h"
+#include "network/DNSNameCache.h"
 #include "network/WebServer.h"
-#include "network/httprequesthandler/HTTPVfsHandler.h"
 #include "network/httprequesthandler/HTTPJsonRpcHandler.h"
+#include "network/httprequesthandler/HTTPVfsHandler.h"
 #include "settings/MediaSourceSettings.h"
 #include "test/TestUtils.h"
 #include "utils/JSONVariantParser.h"
@@ -28,7 +26,11 @@
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 
+#include <errno.h>
 #include <random>
+#include <stdlib.h>
+
+#include <gtest/gtest.h>
 
 using namespace XFILE;
 
@@ -64,6 +66,8 @@ protected:
 protected:
   void SetUp() override
   {
+    CServiceBroker::RegisterDNSNameCache(std::make_shared<CDNSNameCache>());
+
     SetupMediaSources();
 
     webserver.Start(webserverPort, "", "");
@@ -80,6 +84,8 @@ protected:
     webserver.UnregisterRequestHandler(&m_jsonRpcHandler);
 
     TearDownMediaSources();
+
+    CServiceBroker::UnregisterDNSNameCache();
   }
 
   void SetupMediaSources()

--- a/xbmc/platform/posix/filesystem/SMBFile.cpp
+++ b/xbmc/platform/posix/filesystem/SMBFile.cpp
@@ -373,7 +373,7 @@ CURL CSMB::GetResolvedUrl(const CURL& url)
   CURL tmpUrl(url);
   std::string resolvedHostName;
 
-  if (CDNSNameCache::Lookup(tmpUrl.GetHostName(), resolvedHostName))
+  if (CServiceBroker::GetDNSNameCache()->Lookup(tmpUrl.GetHostName(), resolvedHostName))
     tmpUrl.SetHostName(resolvedHostName);
 
   return tmpUrl;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1107,7 +1107,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
         std::string name  = XMLUtils::GetAttribute(element, "name");
         std::string value = element->FirstChild()->ValueStr();
         if (!name.empty())
-          CDNSNameCache::Add(name, value);
+          CDNSNameCache::AddPermanent(name, value);
       }
       element = element->NextSiblingElement("entry");
     }

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1107,7 +1107,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
         std::string name  = XMLUtils::GetAttribute(element, "name");
         std::string value = element->FirstChild()->ValueStr();
         if (!name.empty())
-          CDNSNameCache::AddPermanent(name, value);
+          CServiceBroker::GetDNSNameCache()->AddPermanent(name, value);
       }
       element = element->NextSiblingElement("entry");
     }

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -823,7 +823,7 @@ bool URIUtils::IsHostOnLAN(const std::string& host, LanCheckMode lanCheckMode)
   if(address == INADDR_NONE)
   {
     std::string ip;
-    if(CDNSNameCache::Lookup(host, ip))
+    if (CServiceBroker::GetDNSNameCache()->Lookup(host, ip))
       address = ntohl(inet_addr(ip.c_str()));
   }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

So far the IP of the first successful lookup has been used indefinitely. This PR adds a TTL of 60 seconds for dynamically looked up hostnames and an infinity TTL for static names from the advancedsettings.xml. 60 seconds has been choosen as Firefox uses the same value for its DNS cache.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #26487.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified the behavior with a debugger for dynamic and permanent cache entries.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Kodi uses the correct IPs if the IP for a host changes.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
