### PR TITLE
CDisplayInfo: downgrade EDID parsing errors to warnings

### DIFF
--- a/xbmc/utils/DisplayInfo.cpp
+++ b/xbmc/utils/DisplayInfo.cpp
@@ -54,17 +54,17 @@ bool CDisplayInfo::IsValid() const
   const char* error = di_info_get_failure_msg(m_info.get());
   if (error)
   {
-    CLog::Log(LOGERROR, "[display-info] Error parsing EDID:");
-    CLog::Log(LOGERROR, "[display-info] ----------------------------------------------");
+    CLog::Log(LOGWARNING, "[display-info] EDID parser warnings:");
+    CLog::Log(LOGWARNING, "[display-info] ----------------------------------------------");
 
     std::vector<std::string> lines = StringUtils::Split(error, "\n");
 
     for (const auto& line : lines)
     {
-      CLog::Log(LOGERROR, "[display-info] {}", line);
+      CLog::Log(LOGWARNING, "[display-info] {}", line);
     }
 
-    CLog::Log(LOGERROR, "[display-info] ----------------------------------------------");
+    CLog::Log(LOGWARNING, "[display-info] ----------------------------------------------");
   }
 
   return true;


### PR DESCRIPTION
## Description
As practically all EDID errors are harmless (except a truly broken EDID which results in no 'display-info' output at all) flag them as warnings not errors.

## Motivation and context
EDID extension block specifications are historically loose and open to vendor interpretation; which ensures most if not all TV's will fail to parse at least one element and generate an error message. These errors are often and wrongly flagged by users with some kind of monitor issue and LibreELEC users notably see 'EDID' and run our EDID capture script which can compound and confuse further troubleshooting.

## How has this been tested?
Build tested with an RPi5 and current LE master image.

## What is the effect on users?
Hopefully fewer users wrongly flagging EDID errors in logs.

## Screenshots (if appropriate):
Before (an older Panasonic TV):

```
2025-03-14 11:25:06.602 T:1120    error <general>: [display-info] Error parsing EDID:
2025-03-14 11:25:06.602 T:1120    error <general>: [display-info] ----------------------------------------------
2025-03-14 11:25:06.602 T:1120    error <general>: [display-info] Block 1, CTA-861 Extension Block:
2025-03-14 11:25:06.602 T:1120    error <general>: [display-info]   Speaker Allocation Data Block: Deprecated bit F16 must be 0.
2025-03-14 11:25:06.602 T:1120    error <general>: [display-info]   Colorimetry Data Block: Reserved bits MD0-MD3 must be 0.
2025-03-14 11:25:06.602 T:1120    error <general>: [display-info]   Video Capability Data Block: Set Selectable RGB Quantization to avoid interop issues.
2025-03-14 11:25:06.602 T:1120    error <general>: [display-info]
2025-03-14 11:25:06.602 T:1120    error <general>: [display-info] ----------------------------------------------
2025-03-14 11:25:06.602 T:1120     info <general>: [display-info] make: 'DENON, Ltd.' model: 'DENON-AVR'
2025-03-14 11:25:06.602 T:1120     info <general>: [display-info] supports hdr static metadata type1: true
2025-03-14 11:25:06.602 T:1120     info <general>: [display-info] supported eotf:
2025-03-14 11:25:06.602 T:1120     info <general>: [display-info]   traditional sdr: true
2025-03-14 11:25:06.602 T:1120     info <general>: [display-info]   traditional hdr: false
2025-03-14 11:25:06.602 T:1120     info <general>: [display-info]   pq:              true
2025-03-14 11:25:06.602 T:1120     info <general>: [display-info]   hlg:             true
2025-03-14 11:25:06.602 T:1120     info <general>: [display-info] luma min: '0' avg: '0' max: '0'
2025-03-14 11:25:06.602 T:1120     info <general>: [display-info] supported colorimetry:
2025-03-14 11:25:06.602 T:1120     info <general>: [display-info]   xvycc_601:   true
2025-03-14 11:25:06.602 T:1120     info <general>: [display-info]   xvycc_709:   true
2025-03-14 11:25:06.602 T:1120     info <general>: [display-info]   sycc_601:    false
2025-03-14 11:25:06.602 T:1120     info <general>: [display-info]   opycc_601:   false
2025-03-14 11:25:06.602 T:1120     info <general>: [display-info]   oprgb:       false
2025-03-14 11:25:06.602 T:1120     info <general>: [display-info]   bt2020_cycc: false
2025-03-14 11:25:06.602 T:1120     info <general>: [display-info]   bt2020_ycc:  true
2025-03-14 11:25:06.602 T:1120     info <general>: [display-info]   bt2020_rgb:  true
2025-03-14 11:25:06.602 T:1120     info <general>: [display-info]   st2113_rgb:  false
2025-03-14 11:25:06.602 T:1120     info <general>: [display-info]   ictcp:       false
```

After (a newer LG TV):

```
2025-03-14 18:04:12.554 T:1170  warning <general>: [display-info] EDID parser warnings:
2025-03-14 18:04:12.554 T:1170  warning <general>: [display-info] ----------------------------------------------
2025-03-14 18:04:12.554 T:1170  warning <general>: [display-info] Block 1, CTA-861 Extension Block:
2025-03-14 18:04:12.554 T:1170  warning <general>: [display-info]   Speaker Allocation Data Block: Deprecated bit F16 must be 0.
2025-03-14 18:04:12.554 T:1170  warning <general>: [display-info]
2025-03-14 18:04:12.554 T:1170  warning <general>: [display-info] ----------------------------------------------
2025-03-14 18:04:12.554 T:1170     info <general>: [display-info] make: 'MARANTZ JAPAN, INC.' model: 'marantz-AVR'
2025-03-14 18:04:12.554 T:1170     info <general>: [display-info] supports hdr static metadata type1: true
2025-03-14 18:04:12.554 T:1170     info <general>: [display-info] supported eotf:
2025-03-14 18:04:12.554 T:1170     info <general>: [display-info]   traditional sdr: true
2025-03-14 18:04:12.554 T:1170     info <general>: [display-info]   traditional hdr: false
2025-03-14 18:04:12.554 T:1170     info <general>: [display-info]   pq:              true
2025-03-14 18:04:12.554 T:1170     info <general>: [display-info]   hlg:             true
2025-03-14 18:04:12.554 T:1170     info <general>: [display-info] luma min: '0' avg: '0' max: '0'
2025-03-14 18:04:12.554 T:1170     info <general>: [display-info] supported colorimetry:
2025-03-14 18:04:12.554 T:1170     info <general>: [display-info]   xvycc_601:   false
2025-03-14 18:04:12.554 T:1170     info <general>: [display-info]   xvycc_709:   false
2025-03-14 18:04:12.554 T:1170     info <general>: [display-info]   sycc_601:    false
2025-03-14 18:04:12.554 T:1170     info <general>: [display-info]   opycc_601:   false
2025-03-14 18:04:12.554 T:1170     info <general>: [display-info]   oprgb:       false
2025-03-14 18:04:12.554 T:1170     info <general>: [display-info]   bt2020_cycc: false
2025-03-14 18:04:12.554 T:1170     info <general>: [display-info]   bt2020_ycc:  true
2025-03-14 18:04:12.554 T:1170     info <general>: [display-info]   bt2020_rgb:  true
2025-03-14 18:04:12.554 T:1170     info <general>: [display-info]   st2113_rgb:  false
2025-03-14 18:04:12.554 T:1170     info <general>: [display-info]   ictcp:       false
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
