### PR TITLE
[application] Fix stack part number handling on start/stop of playback.

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2678,7 +2678,6 @@ void CVideoPlayer::OnExit()
   }
   bookmark.player = m_name;
   bookmark.playerState = GetPlayerState();
-  bookmark.partNumber = fileItem.m_lStartPartNumber;
   m_outboundEvents->Submit([=]() {
     cb->OnPlayerCloseFile(fileItem, bookmark);
   });
@@ -2742,7 +2741,6 @@ void CVideoPlayer::HandleMessages()
       }
       bookmark.player = m_name;
       bookmark.playerState = GetPlayerState();
-      bookmark.partNumber = fileItem.m_lStartPartNumber;
       m_outboundEvents->Submit([=]() {
         cb->OnPlayerCloseFile(fileItem, bookmark);
       });


### PR DESCRIPTION
Fixes an issue with resume labels, as reported on the forum: https://forum.kodi.tv/showthread.php?tid=381238

The two lines removed in `CVideoPlayer` are actually not needed. I introduced them recently, but misunderstood the concept for part numbers at that time. In fact due to this wrong part number was set at items at end of playback, explaining the bug that the wrong resume label only appeared after the video was played, then stopped.

The other change is basically a bug fix where the fact that `CBookmark::partNumber` is not zero based was not handled properly.

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 could you have a look?