### PR TITLE
[PVR] Clean data: Fix 'datetime first channels added' not deleted whe…

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -789,6 +789,11 @@ bool CPVRDatabase::DeleteChannels()
   CLog::LogFC(LOGDEBUG, LOGPVR, "Deleting all channels from the database");
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
+  // Reset datetime first channels added for all clients.
+  if (!ExecuteQuery("UPDATE clients SET sDateTimeFirstChannelsAdded = ''"))
+    return false;
+
+  // Delete all channels data.
   return DeleteValues("channels");
 }
 

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -477,6 +477,7 @@ void CPVRClient::ResetProperties()
   m_prevConnectionState = PVR_CONNECTION_STATE_UNKNOWN;
   m_ignoreClient = false;
   m_priority.reset();
+  m_firstChannelsAdded.reset();
   m_strBackendVersion = DEFAULT_INFO_STRING_VALUE;
   m_strConnectionString = DEFAULT_INFO_STRING_VALUE;
   m_strBackendName = DEFAULT_INFO_STRING_VALUE;
@@ -572,6 +573,7 @@ void CPVRClient::Stop()
 {
   m_bBlockAddonCalls = true;
   m_priority.reset();
+  m_firstChannelsAdded.reset();
 }
 
 void CPVRClient::Continue()


### PR DESCRIPTION
…n deleting channels from PVR database.

I recently cleared my PVR database using Kodi user interface (Settings->PVR->General->Clear data) and immediately after doing that I noticed that the Estuary "Recently added channels" widget now listed all (!) channels as new. Correct behavior is not to show any channels after very first channel load for a client, which logically is the case after removing all channels from the PVR database.

Reason for the issue was that the "sDateTimeFirstChannelsAdded" field values were not reset in the "clients" table of the PVR database when deleting all channels data.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish could you please review?