### PR TITLE
[guilib] CVideoGUIInfo::GetPlaylistInfo: Do not set a default thumbnail when no real thumbnail is available.

### DIFF
--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -702,9 +702,6 @@ bool CVideoGUIInfo::GetPlaylistInfo(std::string& value, const CGUIInfo& info) co
   {
     CVideoThumbLoader loader;
     loader.LoadItem(playlistItem.get());
-    // still no thumb? then just the set the default cover
-    if (!playlistItem->HasArt("thumb"))
-      playlistItem->SetArt("thumb", "DefaultVideoCover.png");
   }
   if (info.m_info == VIDEOPLAYER_PLAYLISTPOS)
   {


### PR DESCRIPTION
Fixes a weird bug I encountered recently. After playing an in-progress PVR recording from Estuary "Recently added recordings" widget, the icon of the recording was changed from the channel logo to the video default cover image the moment I started playback of the recording:

<img width="1710" alt="Screenshot_2025-03-15_at_10_33_20" src="https://github.com/user-attachments/assets/86e8bb5b-f678-4b35-a67c-365d977e187b" />

<img width="1710" alt="Screenshot_2025-03-15_at_10_33_52" src="https://github.com/user-attachments/assets/3bbf4ec0-e0df-4b37-bf32-8d4c2752b8ea" />

Cause of the issue is logic in `CVideoGUIInfo::GetPlaylistInfo` trying to obtain a thumbnail for the item and if that fails it sets "DefaultVideoCover.png" as "thumb" art for the icon.

This fallback logic really does not belong here. This should be handled by the skin, especially as it causes a problem with the implementation of `LISTITEM_ICON`which is used by the recently added recordings widget and at many other places in the skins. Namely, `LISTITEM_ICON` implementation prefers "thumb" art if present over "icon" art, replacing the channel logo ("icon" art) with the default cover image ("thumb" art) in my case.

BTW: I think the whole image loader stuff does not belong into `CVideoGUIInfo::GetPlaylistInfo`. This should be done elsewhere, but that's for another PR.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish as my issue was with PVR, maybe you can have a look?
