### PR TITLE
WinSystemWin32DX.cpp: Properly detect Windows ARM64 as 64-bit when determining which user mode video driver to hook.

### DIFF
--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -22,7 +22,7 @@
 #include "platform/win32/CharsetConverter.h"
 #include "platform/win32/WIN32Util.h"
 
-#ifndef _M_X64
+#if !defined(_M_X64) && !defined(_M_ARM64)
 #include "utils/SystemInfo.h"
 #endif
 #pragma comment(lib, "dxgi.lib")
@@ -269,7 +269,7 @@ void CWinSystemWin32DX::InitHooks(IDXGIOutput* pOutput)
   CLog::LogF(LOGDEBUG, "Hooking into UserModeDriver on device {}. ",
              FromW(displayDevice.DeviceKey));
   const wchar_t* keyName =
-#ifndef _M_X64
+#if !defined(_M_X64) && !defined(_M_ARM64)
       // on x64 system and x32 build use UserModeDriverNameWow key
       CSysInfo::GetKernelBitness() == 64 ? keyName = L"UserModeDriverNameWow" :
 #endif // !_WIN64


### PR DESCRIPTION
## Description
windowing/windows/WinSystemWin32DX.cpp: Properly detect Windows ARM64 as 64-bit when determining which user mode driver should be hooked.
This is the eighth PR from my series of PRs with the goal to upstream changes from my Windows ARM64 fork here: https://github.com/ddscentral/xbmc-win-arm64/
This PR fixes the driver hooking code in WinSystemWin32DX.cpp to correctly detect Windows ARM64 as 64-bit instead of assuming that anything not x64 is 32-bit, which would result in the driver hooking code attempting to hook the wrong user mode driver and likely failing as a result.

## Motivation and context
Add support for Windows ARM64

## How has this been tested?
This change has been tested and does work correctly in my fork - Kodi is able to successfully hook the correct user mode library.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
