### PR TITLE
[rendering/dx] DirectXHelper.h: Add Qualcomm vendor ID.

### DIFF
--- a/xbmc/rendering/dx/DirectXHelper.h
+++ b/xbmc/rendering/dx/DirectXHelper.h
@@ -22,6 +22,7 @@ enum PCI_Vendors
   PCIV_NVIDIA = 0x10DE,
   PCIV_Intel = 0x8086,
   PCIV_MICROSOFT = 0x1414,
+  PCIV_QUALCOMM = 0x4D4F4351
 };
 
 namespace DX
@@ -104,6 +105,8 @@ namespace DX
         return "NVIDIA";
       case PCIV_MICROSOFT:
         return "Microsoft";
+      case PCIV_QUALCOMM:
+        return "Qualcomm";
       default:
         return "unknown";
     }


### PR DESCRIPTION
## Description
Adds a vendor ID for Qualcomm Adreno GPUs used in Snapgragon X Plus/Elite chips which power current generation Windows ARM64 tablets. This allows Kodi to correctly detect Qualcomm GPUs and will allow behavioral changes to be implemented for these GPUs.
This is the ninth PR from my series of PRs with the goal to upstream my Kodi Windows ARM64 fork here: https://github.com/ddscentral/xbmc-win-arm64

## Motivation and context
Support for Windows ARM64

## How has this been tested?
Log file correctly displays Qualcomm Adreno GPU as "Qualcomm" instead of "unknown".

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
