### PR TITLE
[utils] SystemInfo.cpp: correctly detect Windows ARM64 as being 64-bit and ARM

### DIFF
--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -1023,7 +1023,8 @@ int CSysInfo::GetKernelBitness(void)
     GetNativeSystemInfo(&si);
     if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_INTEL || si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM)
       kernelBitness = 32;
-    else if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64)
+    else if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64 ||
+             si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM64)
       kernelBitness = 64;
     else
     {
@@ -1067,7 +1068,8 @@ const std::string& CSysInfo::GetKernelCpuFamily(void)
     if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_INTEL ||
         si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64)
         kernelCpuFamily = "x86";
-    else if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM)
+    else if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM ||
+             si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM64)
       kernelCpuFamily = "ARM";
 #elif defined(TARGET_DARWIN)
     const NXArchInfo* archInfo = NXGetLocalArchInfo();
@@ -1476,7 +1478,7 @@ std::string CSysInfo::GetBuildTargetCpuFamily(void)
 {
 #if defined(__thumb__) || defined(_M_ARMT)
   return "ARM (Thumb)";
-#elif defined(__arm__) || defined(_M_ARM) || defined (__aarch64__)
+#elif defined(__arm__) || defined(_M_ARM) || defined(__aarch64__) || defined(_M_ARM64)
   return "ARM";
 #elif defined(__loongarch__)
   return "LoongArch";


### PR DESCRIPTION
## Description
Correctly detect the CPU on Windows ARM64 as being 64-bit and belonging to ARM family.
This is the tenth PR from my series of PRs with the goal to upstream my Kodi Windows ARM64 fork here: https://github.com/ddscentral/xbmc-win-arm64/
This PR allows the CPU on Windows ARM64 to be correctly detected as being 64-bit and belonging to the ARM family.
Without this change, the CPU would be detected as "unknown CPU family 0-bit".

## Motivation and context
Add support for Windows ARM64

## How has this been tested?
CPU is correctly shown as ARM and 64-bit. Without this change, CPU is detected as unknown and 0-bit.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
