### PR TITLE
[Android] Remove media button handling using a BroadcastReceiver

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -114,7 +114,6 @@
             <intent-filter>
                 <action android:name="android.intent.action.DREAMING_STOPPED" />
                 <action android:name="android.bluetooth.a2dp.profile.action.CONNECTION_STATE_CHANGED" />
-                <action android:name="android.intent.action.MEDIA_BUTTON" />
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>

--- a/tools/android/packaging/xbmc/src/Main.java.in
+++ b/tools/android/packaging/xbmc/src/Main.java.in
@@ -5,7 +5,6 @@ import @APP_PACKAGE@.channels.util.TvUtil;
 import static android.content.pm.PackageManager.FEATURE_LEANBACK;
 
 import android.app.NativeActivity;
-import android.content.ComponentName;
 import android.content.Intent;
 import android.content.pm.ResolveInfo;
 import android.graphics.Rect;
@@ -101,18 +100,6 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
     }
 
     return ret;
-  }
-
-  public void registerMediaButtonEventReceiver()
-  {
-    AudioManager manager = (AudioManager) getSystemService(AUDIO_SERVICE);
-    manager.registerMediaButtonEventReceiver(new ComponentName(getPackageName(), XBMCBroadcastReceiver.class.getName()));
-  }
-
-  public void unregisterMediaButtonEventReceiver()
-  {
-    AudioManager manager = (AudioManager) getSystemService(AUDIO_SERVICE);
-    manager.unregisterMediaButtonEventReceiver(new ComponentName(getPackageName(), XBMCBroadcastReceiver.class.getName()));
   }
 
   @Override

--- a/xbmc/platform/android/activity/JNIMainActivity.cpp
+++ b/xbmc/platform/android/activity/JNIMainActivity.cpp
@@ -161,15 +161,3 @@ CJNIRect CJNIMainActivity::getDisplayRect()
   return call_method<jhobject>(m_context,
                                "getDisplayRect", "()Landroid/graphics/Rect;");
 }
-
-void CJNIMainActivity::registerMediaButtonEventReceiver()
-{
-  call_method<void>(m_context,
-                    "registerMediaButtonEventReceiver", "()V");
-}
-
-void CJNIMainActivity::unregisterMediaButtonEventReceiver()
-{
-  call_method<void>(m_context,
-                    "unregisterMediaButtonEventReceiver", "()V");
-}

--- a/xbmc/platform/android/activity/JNIMainActivity.h
+++ b/xbmc/platform/android/activity/JNIMainActivity.h
@@ -36,8 +36,6 @@ public:
 
   static void _callNative(JNIEnv *env, jobject context, jlong funcAddr, jlong variantAddr);
   static void runNativeOnUiThread(void (*callback)(void*), void* variant);
-  static void registerMediaButtonEventReceiver();
-  static void unregisterMediaButtonEventReceiver();
 
   CJNIRect getDisplayRect();
 


### PR DESCRIPTION
## Description
On Android 5.0 and higher, Android automatically dispatches media button events to the active `MediaSession`.

This PR removes unused code that handled media button events received via an intent with the  `ACTION_MEDIA_BUTTON` action.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
