### PR TITLE
[Windows] check SHA512 at build FFmpeg to recover from corrupted downloads

### DIFF
--- a/tools/buildsteps/windows/buildhelpers.sh
+++ b/tools/buildsteps/windows/buildhelpers.sh
@@ -114,6 +114,15 @@ do_clean() {
 
 do_download() {
   if [ ! -d "$LOCALSRCDIR" ]; then
+    if [ -f /downloads/$ARCHIVE ]; then
+      HASH_SUM=$(sha512sum /downloads/$ARCHIVE | cut -f 1 -d " ")
+      if [ "$HASH_SUM" != "$SHA512" ]; then
+        echo "Hash of file '${ARCHIVE}' not match!"
+        echo "Expected: ${SHA512}"
+        echo "Found: ${HASH_SUM}"
+        rm /downloads/$ARCHIVE
+      fi
+    fi
     if [ ! -f /downloads/$ARCHIVE ]; then
       do_print_status "$LIBNAME-$VERSION" "$orange_color" "Downloading"
       do_wget $BASE_URL/$ARCHIVE $ARCHIVE
@@ -137,6 +146,7 @@ do_loaddeps() {
   local file="$1"
   LIBNAME=$(grep "LIBNAME=" $file | sed 's/LIBNAME=//g;s/#.*$//g;/^$/d')
   VERSION=$(grep "VERSION=" $file | sed 's/VERSION=//g;s/#.*$//g;/^$/d')
+  SHA512=$(grep "SHA512=" $file | sed 's/SHA512=//g;s/#.*$//g;/^$/d')
   ARCHIVE=$LIBNAME-$VERSION.tar.gz
 
   BASE_URL=$(grep "BASE_URL=" $file | sed 's/BASE_URL=//g;s/#.*$//g;/^$/d')


### PR DESCRIPTION
## Description
[Windows] check SHA512 at build FFmpeg to recover from corrupted downloads.

## Motivation and context
Currently if a file with same name already exists, FFmpeg source code file never is download again. This is very easy to happen if for any reason the first time download is corrupted (it will never be recovered).

This happens even if the file does not exist on the mirrors, as a small file is saved containing the server error "404 file not found", etc. And when the file is available, it is not downloaded unless someone deletes it manually.

The PR removes the existent file if SHA512 hash not match (and force the download again).

## How has this been tested?
Simulated file corrupted replacing by other file, etc.

## What is the effect on users?
It will avoid possible Jenkins breakage when updating FFmpeg version.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
