### PR TITLE
Media Source Dialog - change string for new path from <None> to Enter path...

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1092,7 +1092,6 @@ msgstr ""
 #. Name of an action to perform on a specific event, like changing the CEC source away from Kodi
 #: system/peripherals.xml
 #: xbmc/addons/GUIViewStateAddonBrowser.cpp
-#: xbmc/dialogs/GUIDialogMediaSource.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
 #: system/settings/settings.xml
 #: xbmc/LangInfo.cpp
@@ -4163,7 +4162,11 @@ msgctxt "#1019"
 msgid "Enter the username"
 msgstr ""
 
-#empty string with id 1020
+#. Label for button to enter path in the Add video/music/picture/file source dialogs
+#: xbmc/dialogs/GUIDialogMediaSource.cpp
+msgctxt "#1020"
+msgid "Enter path..."
+msgstr ""
 
 #: xbmc/dialogs/GUIDialogMediaSource.cpp
 #: addons/skin.estuary/xml/DialogMediaSource.xml

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -487,7 +487,8 @@ void CGUIDialogMediaSource::UpdateButtons()
     std::string path;
     CURL url(item->GetPath());
     path = url.GetWithoutUserDetails();
-    if (path.empty()) path = "<" + g_localizeStrings.Get(231) + ">"; // <None>
+    if (path.empty())
+      path = g_localizeStrings.Get(1020); // "Enter path..."
     item->SetLabel(path);
   }
   CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), CONTROL_PATH, 0, 0, m_paths);


### PR DESCRIPTION
## Description

Change the label for the button to add a new path in the source selection dialog.

## Motivation and context
Inspired by https://github.com/xbmc/xbmc/issues/24547

It's not something I've ever viewed personally as a problem, however it seems there a number of users not realising that `<None>` is a button that you can select to input a path for a source.

The change to `Enter path...` aims to bring consistancy with other areas of Kodi where a button with 3 dots is used to signify button is used to open a dialog.

## Screenshots (if appropriate):

Before change

![image](https://github.com/user-attachments/assets/59a2ef21-e90c-4dd7-9078-ce5bbd601807)

After change

![image](https://github.com/user-attachments/assets/0b50a780-10b8-4cd9-9ec0-92a310044290)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
