### PR TITLE
[Estuary] Fix #26530 stream info for Video Stream Dialog

### DIFF
--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -284,7 +284,7 @@
 						<right>50</right>
 						<height>30</height>
 						<aligny>center</aligny>
-						<label>$VAR[VideoCodecVar]$VAR[VideoHDRTypeVar, | ]$INFO[ListItem.Property(stream.resolution), | ]$VAR[StreamBitrateVar, | , kbps]$INFO[ListItem.Property(stream.fps), | , fps]$VAR[VideoStreamDialogItemLabelVar, - [LIGHT],[/LIGHT]]</label>
+						<label>$VAR[StreamCodecVar]$VAR[StreamHDRTypeVar, | ]$INFO[ListItem.Property(stream.resolution), | ]$VAR[StreamBitrateVar, | , kbps]$INFO[ListItem.Property(stream.fps), | , fps]$VAR[VideoStreamDialogItemLabelVar, - [LIGHT],[/LIGHT]]</label>
 					</control>
 					<control type="label">
 						<left>50</left>
@@ -333,7 +333,7 @@
 						<height>30</height>
 						<aligny>center</aligny>
 						<scroll>true</scroll>
-						<label>$VAR[VideoCodecVar]$VAR[VideoHDRTypeVar, | ]$INFO[ListItem.Property(stream.resolution), | ]$VAR[StreamBitrateVar, | , kbps]$INFO[ListItem.Property(stream.fps), | , fps]$VAR[VideoStreamDialogItemLabelVar, - [LIGHT],[/LIGHT]]</label>
+						<label>$VAR[StreamCodecVar]$VAR[StreamHDRTypeVar, | ]$INFO[ListItem.Property(stream.resolution), | ]$VAR[StreamBitrateVar, | , kbps]$INFO[ListItem.Property(stream.fps), | , fps]$VAR[VideoStreamDialogItemLabelVar, - [LIGHT],[/LIGHT]]</label>
 					</control>
 					<control type="label">
 						<left>50</left>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -716,9 +716,6 @@
 		<value condition="!String.IsEmpty(VideoPlayer.AudioLanguage)">[UPPERCASE]$INFO[VideoPlayer.AudioLanguage][/UPPERCASE]</value>
 		<value condition="String.IsEmpty(VideoPlayer.AudioLanguage)">$LOCALIZE[13205]</value>
 	</variable>
-	<variable name="StreamBitrateVar">
-		<value condition="!String.IsEqual(ListItem.Property(stream.bitrate),0)">$INFO[ListItem.Property(stream.bitrate)]</value>
-	</variable>
 	<variable name="VideoListPosterVar">
 		<value condition="!String.IsEmpty(Container(6).ListItem.Art(poster))">$INFO[Container(6).ListItem.Art(poster)]</value>
 		<value condition="!String.IsEmpty(Container(6).ListItem.Art(thumb))">$INFO[Container(6).ListItem.Art(thumb)]</value>
@@ -910,6 +907,15 @@
 		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),truehd_atmos)">Dolby TrueHD Atmos</value>
 		<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),truehd)">Dolby TrueHD</value>
 		<value>$INFO[ListItem.Property(stream.codec)]</value>
+	</variable>
+	<variable name="StreamHDRTypeVar">
+		<value condition="String.IsEqual(ListItem.Property(stream.hdrtype),dolbyvision)">Dolby Vision</value>
+		<value condition="String.IsEqual(ListItem.Property(stream.hdrtype),hdr10)">HDR10</value>
+		<value condition="String.IsEqual(ListItem.Property(stream.hdrtype),hlg)">HLG</value>
+		<value>$INFO[ListItem.Property(stream.hdrtype)]</value>
+	</variable>
+	<variable name="StreamBitrateVar">
+		<value condition="!String.IsEqual(ListItem.Property(stream.bitrate),0)">$INFO[ListItem.Property(stream.bitrate)]</value>
 	</variable>
 	<variable name="MediaInfoListLabelVar">
 		<value condition="Window.IsVisible(selectvideoversion)">$INFO[ListItem.VideoVersionName]</value>


### PR DESCRIPTION
## Description

Fix https://github.com/xbmc/xbmc/issues/26564

## Motivation and context
Wrong Variable being used in Video Stream Dialog for video codec info changed from incorrect `$VAR[VideoCodecVar]` to correct `$VAR[StreamCodecVar]`

In addition I noticed `$VAR[VideoHDRTypeVar]` is not correct for streams in Video Stream Dialog so was also fixed by adding `$VAR[StreamHDRTypeVar]`

## How has this been tested?
Tested with STRM suggest by @CastagnaIT 
```
#KODIPROP:mimetype=application/dash+xml
#KODIPROP:inputstream=inputstream.adaptive
https://ftp.itec.aau.at/datasets/mmsys18/testing/Beauty_4sec/multi-codec.mpd
```
Before
![image](https://github.com/user-attachments/assets/bffbf53a-74d8-4a6b-9926-1e8fc6d4d640)

After
![image](https://github.com/user-attachments/assets/689ea29a-e399-461a-b729-6319bd787b77)
