### PR TITLE
[PVR] CPVRClient: Block add-on calls when system goes to sleep; unblock on wake.

### DIFF
--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -1987,12 +1987,15 @@ PVR_ERROR CPVRClient::IsRealTimeStream(bool& bRealTime) const
 
 PVR_ERROR CPVRClient::OnSystemSleep()
 {
-  return DoAddonCall(__func__, [](const AddonInstance* addon)
-                     { return addon->toAddon->OnSystemSleep(addon); });
+  const PVR_ERROR ret = DoAddonCall(__func__, [](const AddonInstance* addon)
+                                    { return addon->toAddon->OnSystemSleep(addon); });
+  m_bBlockAddonCalls = true;
+  return ret;
 }
 
 PVR_ERROR CPVRClient::OnSystemWake()
 {
+  m_bBlockAddonCalls = false;
   return DoAddonCall(__func__, [](const AddonInstance* addon)
                      { return addon->toAddon->OnSystemWake(addon); });
 }


### PR DESCRIPTION
Calling add-ons when system is in suspended state can lead to all kind of weird behavior, especially for "special" suspend modes like we have on Android, which are technically not suspend to RAM or disk, but more keeping the system running with limited resource access (e.g. network not being available, which is a problem for most if not even all of the PVR add-ons). 

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish please review.