### PR TITLE
[PVR] CPVRGUIDirectory::GetRecordingsDirectory: Calculate and set in-progress episodes count asynchronously.

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1607,7 +1607,7 @@ int CGUIWindowManager::GetTopmostModalDialog(bool ignoreClosing /*= false*/) con
   return GetTopmostDialog(true, ignoreClosing);
 }
 
-void CGUIWindowManager::SendThreadMessage(CGUIMessage& message, int window /*= 0*/)
+void CGUIWindowManager::SendThreadMessage(const CGUIMessage& message, int window /*= 0*/)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
 

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -192,7 +192,7 @@ public:
    */
   int GetTopmostModalDialog(bool ignoreClosing = false) const;
 
-  void SendThreadMessage(CGUIMessage& message, int window = 0);
+  void SendThreadMessage(const CGUIMessage& message, int window = 0);
   void DispatchThreadMessages();
   // method to removed queued messages with message id in the requested message id list.
   // pMessageIDList: point to first integer of a 0 ends integer array.


### PR DESCRIPTION
Fixes https://github.com/xbmc/xbmc/issues/26541

GUI manager commit is needed to compile the PVR code change. For no actual reason, `CGUIWindowManager::SendThreadMessage` was expecting a non-const `GUIMessage` reference parameter.

@flubshi fyi

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish please review.