### PR TITLE
[guilib] Fix GUI rendering on Windows ARM64.

### DIFF
--- a/xbmc/guilib/GUIShaderDX.cpp
+++ b/xbmc/guilib/GUIShaderDX.cpp
@@ -283,6 +283,8 @@ void CGUIShaderDX::Project(float &x, float &y, float &z)
 {
 #if defined(_XM_SSE_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
   XMVECTOR vLocation = { x, y, z };
+#elif defined(_M_ARM64) && defined(_XM_ARM_NEON_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
+  XMVECTOR vLocation = {.n128_f32{x, y, z}};
 #elif defined(_XM_ARM_NEON_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
   XMVECTOR vLocation = { x, y };
 #endif


### PR DESCRIPTION
## Description
Fix GUI rendering on Windows ARM64.
This is the eleventh PR from my series of PRs with the goal to upstream my Windows ARM64 fork here: https://github.com/ddscentral/xbmc-win-arm64
This PR fixes GUI not rendering on Windows ARM64 due to incorrect initialization of "vLocation" vector in CGUIShaderDX::Project(). MSVC declares the XMVECTOR structure identically on both ARM and ARM64. However, when building existing code for Windows ARM64, compiler gives warnings
```
C:\Build\xbmc-win-arm64\xbmc\guilib\GUIShaderDX.cpp(287,26): warning C4838: conversion from 'float' to 'unsigned __int64' requires a narrowing conversion [C:\Build\xbmc-win-arm64\kodi-build.arm64\libkodi.vcxproj]
  (compiling source file '../xbmc/guilib/GUIShaderDX.cpp')
  
C:\Build\xbmc-win-arm64\xbmc\guilib\GUIShaderDX.cpp(287,29): warning C4838: conversion from 'float' to 'unsigned __int64' requires a narrowing conversion [C:\Build\xbmc-win-arm64\kodi-build.arm64\libkodi.vcxproj]
  (compiling source file '../xbmc/guilib/GUIShaderDX.cpp')
```

It seems these conversions somehow mess-up things on Windows ARM64, causing the CGUIShaderDX::Project() to fail silently. The result is that the UI is not rendered at all, even though the inputs and video playback do work correctly.

To fix this, I wrote my own initializer function, inspired by code I found in OpenAL-soft's repository, which initializes XMVECTOR using 4 floats using "vsetq_lane_f32" ARM (NEON) intrinsic.

Initializing XMVECTOR with this function seems to make XMVector3Project() happy and the UI is rendered correctly.

## Motivation and context
Add support for Windows ARM64

## How has this been tested?
Without this change, Kodi appears to "freeze" at startup, even though you still hear sound effects if you press the Enter key or arrow keys. Video playback works by dropping a file to Kodi.exe, but no controls are displayed.
With this change, UI is rendered correctly and controls are visible during playback.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

I am aware that the initializer function looks out of place, but I'm not sure where it would be best to put it. I need help from developers here on this, I will be happy to update the PR with any changes required.
