### PR TITLE
[Cmake] Findtexturepacker fixes

### DIFF
--- a/cmake/modules/buildtools/FindTexturePacker.cmake
+++ b/cmake/modules/buildtools/FindTexturePacker.cmake
@@ -97,10 +97,10 @@ if(NOT TARGET TexturePacker::TexturePacker::Executable)
                           INSTALL_BYPRODUCTS ${CMAKE_BINARY_DIR}/build/bin/TexturePacker
                           CMAKE_ARGS ${CMAKE_ARGS})
 
-      ExternalProject_Get_Property(buildtexturepacker install_dir)
+      ExternalProject_Get_Property(buildtexturepacker INSTALL_DIR)
       add_executable(TexturePacker IMPORTED)
       set_target_properties(TexturePacker PROPERTIES
-                                          IMPORTED_LOCATION "${install_dir}/bin/TexturePacker")
+                                          IMPORTED_LOCATION "${INSTALL_DIR}/bin/TexturePacker")
 
       add_dependencies(TexturePacker buildtexturepacker)
 

--- a/cmake/modules/buildtools/FindTexturePacker.cmake
+++ b/cmake/modules/buildtools/FindTexturePacker.cmake
@@ -95,7 +95,8 @@ if(NOT TARGET TexturePacker::TexturePacker::Executable)
                           LIST_SEPARATOR |
                           INSTALL_DIR ${CMAKE_BINARY_DIR}/build
                           CMAKE_ARGS ${CMAKE_ARGS}
-                          INSTALL_BYPRODUCTS ${CMAKE_BINARY_DIR}/build/bin/TexturePacker)
+                          INSTALL_BYPRODUCTS ${CMAKE_BINARY_DIR}/build/bin/TexturePacker
+                          BUILD_BYPRODUCTS ${CMAKE_BINARY_DIR}/build/bin/TexturePacker)
 
       ExternalProject_Get_Property(buildtexturepacker INSTALL_DIR)
       add_executable(TexturePacker IMPORTED)

--- a/cmake/modules/buildtools/FindTexturePacker.cmake
+++ b/cmake/modules/buildtools/FindTexturePacker.cmake
@@ -94,8 +94,8 @@ if(NOT TARGET TexturePacker::TexturePacker::Executable)
                           PREFIX ${CORE_BUILD_DIR}/build-texturepacker
                           LIST_SEPARATOR |
                           INSTALL_DIR ${CMAKE_BINARY_DIR}/build
-                          INSTALL_BYPRODUCTS ${CMAKE_BINARY_DIR}/build/bin/TexturePacker
-                          CMAKE_ARGS ${CMAKE_ARGS})
+                          CMAKE_ARGS ${CMAKE_ARGS}
+                          INSTALL_BYPRODUCTS ${CMAKE_BINARY_DIR}/build/bin/TexturePacker)
 
       ExternalProject_Get_Property(buildtexturepacker INSTALL_DIR)
       add_executable(TexturePacker IMPORTED)


### PR DESCRIPTION
## Description
Fixes building with cmake < 3.26
Fixes building using Ninja

## Motivation and context
Fixes issure raised in https://github.com/xbmc/xbmc/pull/26449#issuecomment-2746372679

core issue is explained in commit, but here it is for easier reading on github

```
    when using ExternalProject_Get_Property on a target field, if cmake does not
    recognise a known field, it looks to append any data until it finds its next
    known field.
    
    This had the effect of setting INSTALL_DIR to something like
    
    /path/to/build/bin/TexturePacker;INSTALL_BYPRODUCTS;/path/to/build/bin/TexturePacker
    
    Relocate the INSTALL_BYPRODUCTS after a known field (CMAKE_ARGS in this instance)
    to limit the returned data of INSTALL_DIR correctly. We dont retrieve any other
    target properties, so this works fine for our needs here.
```

Essentially the INSTALL_BYPRODUCTS target field isnt known prior to cmake 3.26, so its data is ingested into the property request for INSTALL_DIR

ping @howie-f 

## How has this been tested?
Build using make and ninja for Debian 12 (cmake 3.25.1)

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
