### PR TITLE
[Estuary] Make path info a metadata item that can open text viewer

### DIFF
--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -274,7 +274,12 @@ msgctxt "#31048"
 msgid "Available"
 msgstr ""
 
-#empty strings from id 31049 to 31051
+#empty strings from id 31049 to 31050
+
+#: /xml/DialogVideoInfo.xml
+msgctxt "#31051"
+msgid "Press OK to see path"
+msgstr ""
 
 #: /xml/Includes.xml
 msgctxt "#31052"

--- a/addons/skin.estuary/xml/Custom_1102_TextViewer.xml
+++ b/addons/skin.estuary/xml/Custom_1102_TextViewer.xml
@@ -4,6 +4,7 @@
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
 		<control type="group">
+			<visible>!String.IsEqual(window(home).Property(TextViewer_Header),$LOCALIZE[15311])</visible>
 			<left>13%</left>
 			<centertop>50%</centertop>
 			<height>770</height>
@@ -22,6 +23,34 @@
 				<pagecontrol>3000</pagecontrol>
 				<font>font37</font>
 				<label>$INFO[Window(home).Property(TextViewer_Text)]</label>
+			</control>
+			<control type="scrollbar" id="3000">
+				<include>HiddenObject</include>
+				<ondown>3000</ondown>
+				<onup>3000</onup>
+			</control>
+		</control>
+		<control type="group">
+			<visible>String.IsEqual(window(home).Property(TextViewer_Header),$LOCALIZE[15311])</visible>
+			<left>13%</left>
+			<centertop>50%</centertop>
+			<height>255</height>
+			<include content="DialogBackgroundCommons">
+				<param name="width" value="84%" />
+				<param name="height" value="255" />
+				<param name="header_label" value="$INFO[Window(home).Property(TextViewer_Header)]" />
+				<param name="header_id" value="1" />
+			</include>
+			<control type="textbox" id="2000">
+				<left>1%</left>
+				<top>85</top>
+				<width>82%</width>
+				<height>170</height>
+				<shadowcolor>black</shadowcolor>
+				<pagecontrol>3000</pagecontrol>
+				<font>font13</font>
+				<label>$INFO[Window(home).Property(TextViewer_Text)]</label>
+				<autoscroll delay="2000" time="5000">true</autoscroll>
 			</control>
 			<control type="scrollbar" id="3000">
 				<include>HiddenObject</include>

--- a/addons/skin.estuary/xml/DialogVideoInfo.xml
+++ b/addons/skin.estuary/xml/DialogVideoInfo.xml
@@ -245,8 +245,15 @@
 						<param name="altlabel" value="$LOCALIZE[126]: $INFO[ListItem.Status]" />
 						<param name="visible" value="!String.IsEmpty(ListItem.Status)" />
 					</include>
-					<include content="InfoDialogMetadata">
+					<include content="InfoDialogMetaTextViewer">
 						<param name="control_id" value="161" />
+						<param name="label" value="[COLOR button_focus]$LOCALIZE[15311] [/COLOR]$INFO[ListItem.DecodedFileNameAndPath]" />
+						<param name="altlabel" value="$LOCALIZE[15311] $INFO[ListItem.DecodedFileNameAndPath]" />
+						<param name="text_viewer_header" value="$LOCALIZE[15311]" />
+						<param name="text_viewer_info" value="$INFO[ListItem.DecodedFileNameAndPath]" />
+					</include>
+					<include content="InfoDialogMetadata">
+						<param name="control_id" value="162" />
 						<param name="label" value="[COLOR button_focus]$LOCALIZE[570]: [/COLOR]$INFO[ListItem.DateAdded]" />
 						<param name="altlabel" value="$LOCALIZE[570]: $INFO[ListItem.DateAdded]" />
 						<param name="visible" value="!String.IsEmpty(ListItem.DateAdded) + [String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,musicvideo) | String.IsEqual(ListItem.DBType,video)]" />
@@ -671,22 +678,6 @@
 					<param name="visible" value="true" />
 				</include>
 			</control>
-			<control type="label">
-				<right>80</right>
-				<top>970</top>
-				<align>right</align>
-				<width>1194</width>
-				<height>44</height>
-				<font>font20_title</font>
-				<textcolor>99FFFFFF</textcolor>
-				<shadowcolor>text_shadow</shadowcolor>
-				<scroll>true</scroll>
-				<label>$INFO[ListItem.DecodedFileNameAndPath]</label>
-				<animation effect="fade" start="0" end="100" time="300" delay="300">WindowOpen</animation>
-				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
-				<animation effect="fade" start="0" end="100" time="300">Visible</animation>
-				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
-			</control>
 			<include content="InfoDialogTopBarInfo">
 				<param name="main_label" value="$VAR[VideoInfoMainLabelVar]" />
 				<param name="sub_label" value="$VAR[VideoInfoSubLabelVar]" />
@@ -702,43 +693,33 @@
 			<height>40</height>
 			<include>MediaFlags</include>
 			<control type="group">
-				<visible>Control.HasFocus(50) + !String.IsEqual(ListItem.DBType,set)</visible>
+				<visible>Control.HasFocus(50) + !String.IsEqual(ListItem.DBType,set) | Control.HasFocus(138) | Control.HasFocus(139) | Control.HasFocus(161)</visible>
 				<animation effect="fade" time="200">VisibleChange</animation>
-				<top>10</top>
-				<left>0</left>
-				<control type="image">
-					<left>21</left>
-					<width>36</width>
-					<height>36</height>
-					<animation effect="rotate" end="-90" center="36,19" time="0" condition="true">Conditional</animation>
-					<texture colordiffuse="grey">frame/menu-nofo.png</texture>
-				</control>
-				<control type="label">
-					<left>74</left>
-					<width>500</width>
-					<height>44</height>
-					<shadowcolor>text_shadow</shadowcolor>
-					<label>$LOCALIZE[31125]</label>
-				</control>
-			</control>
-			<control type="group">
-				<visible>Control.HasFocus(138)</visible>
-				<animation effect="fade" time="200">VisibleChange</animation>
-				<top>10</top>
+				<top>5</top>
 				<left>0</left>
 				<control type="image">
 					<top>4</top>
 					<left>17</left>
 					<width>36</width>
 					<height>36</height>
+					<animation effect="rotate" end="-90" center="36,19" time="0" condition="true">Conditional</animation>
+					<texture colordiffuse="grey">frame/menu-nofo.png</texture>
+					<visible>Control.HasFocus(50) + !String.IsEqual(ListItem.DBType,set)</visible>
+				</control>
+				<control type="image">
+					<top>4</top>
+					<left>17</left>
+					<width>36</width>
+					<height>36</height>
 					<texture colordiffuse="grey">lists/played-total.png</texture>
+					<visible>Control.HasFocus(138) | Control.HasFocus(139) | Control.HasFocus(161)</visible>
 				</control>
 				<control type="label">
 					<left>74</left>
 					<width>800</width>
 					<height>44</height>
 					<shadowcolor>text_shadow</shadowcolor>
-					<label>$LOCALIZE[31126]</label>
+					<label>$VAR[DialogVideoInfoHelpVar]</label>
 				</control>
 			</control>
 		</control>

--- a/addons/skin.estuary/xml/Includes_Buttons.xml
+++ b/addons/skin.estuary/xml/Includes_Buttons.xml
@@ -45,6 +45,27 @@
 			</control>
 		</definition>
 	</include>
+	<include name="InfoDialogMetaTextViewer">
+		<param name="visible">true</param>
+		<definition>
+			<control type="togglebutton" id="$PARAM[control_id]">
+				<width>472</width>
+				<height>49</height>
+				<textoffsetx>16</textoffsetx>
+				<aligny>center</aligny>
+				<font>font12</font>
+				<texturefocus colordiffuse="button_focus">lists/focus.png</texturefocus>
+				<alttexturefocus colordiffuse="button_focus">lists/focus.png</alttexturefocus>
+				<onclick>SetProperty(TextViewer_Header,$PARAM[text_viewer_header],home)</onclick>
+				<onclick>SetProperty(TextViewer_Text,$PARAM[text_viewer_info],home)</onclick>
+				<onclick>ActivateWindow(1102)</onclick>
+				<label>$PARAM[label]</label>
+				<altlabel>$PARAM[altlabel]</altlabel>
+				<usealttexture>Control.HasFocus($PARAM[control_id])</usealttexture>
+				<visible>$PARAM[visible]</visible>
+			</control>
+		</definition>
+	</include>
 	<include name="DefaultSettingButton">
 		<param name="height">70</param>
 		<param name="textoffsetx">40</param>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -941,4 +941,9 @@
 		<value condition="String.IsEqual(ListItem.Property(stream.isforced),true)">$LOCALIZE[39106]</value>
 		<value condition="String.IsEqual(ListItem.Property(stream.isoriginal),true)">$LOCALIZE[39111]</value>
 	</variable>
+	<variable name="DialogVideoInfoHelpVar">
+		<value condition="Control.HasFocus(50) + !String.IsEqual(ListItem.DBType,set)">$LOCALIZE[31125]</value>
+		<value condition="Control.HasFocus(138) | Control.HasFocus(139)">$LOCALIZE[31126]</value>
+		<value condition="Control.HasFocus(161)">$LOCALIZE[31051]</value>
+	</variable>
 </includes>


### PR DESCRIPTION
## Description
Follow up to https://github.com/xbmc/xbmc/pull/26544

Move path info to metadata grouplist so it's not always displayed between dialog buttons and media flags.

## Motivation and context
I feel it's unnecessary to always have the path displayed at the bottom. However rather than go back and only display the path when `Refresh` button is highlighted, I've instead moved it to the metadata grouplist so it's more easily discoverable there. Due to width of grouplist it's likely paths will have to scroll, so in order to more easily see the full path I've create a new button `InfoDialogMetaTextViewer` that can invoke the text viewer to display the path.  To let users know it's a button that can be pressed I've added a help prompt in the style of the already existing for ones Plot and Actor info.

## Screenshots (if appropriate):
After https://github.com/xbmc/xbmc/pull/26544
![image](https://github.com/user-attachments/assets/fd8d128d-5eac-4e5a-a129-cad7e793f0a5)

With this PR
![image](https://github.com/user-attachments/assets/c3d59e1c-e40c-4695-a047-fde3eb3be3a5)
![image](https://github.com/user-attachments/assets/71dab8af-63de-4287-9feb-a7d6761215b2)
![image](https://github.com/user-attachments/assets/ab3a4843-63fa-476f-965c-0087051e005b)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
