### PR TITLE
[PVR] Fix multiple reminder dialogs for same event.

### DIFF
--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
@@ -986,9 +986,6 @@ void CPVRGUIActionsTimers::AnnounceReminder(const std::shared_ptr<CPVRTimerInfoT
 
   dialog->Close();
 
-  // Disable the timer. No further announcements needed.
-  timer->SetState(PVR_TIMER_STATE_DISABLED);
-
   bool bAutoClosed = (iRemaining <= 0);
   bool bSwitch = (result == CHOICE_SWITCH);
   bool bRecord = (result == CHOICE_RECORD);
@@ -1066,9 +1063,16 @@ void CPVRGUIActionsTimers::AnnounceReminders() const
   std::shared_ptr<CPVRTimerInfoTag> timer{timers->GetNextReminderToAnnnounce()};
   while (timer)
   {
-    // No announcements for currently playing channel.
-    if (!playbackState->IsPlayingChannel(timer->Channel()))
+    if (playbackState->IsPlayingChannel(timer->Channel()))
+    {
+      // No announcements for currently playing channel, but reschedule
+      // for potential future announcement (e.g. after channel switch).
+      timer->SetState(PVR_TIMER_STATE_SCHEDULED);
+    }
+    else
+    {
       AnnounceReminder(timer);
+    }
 
     timer = timers->GetNextReminderToAnnnounce();
   }

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -591,8 +591,8 @@ bool CPVRTimers::UpdateEntries(int iMaxNotificationDelay)
 
           if (timer->EndAsUTC() >= now)
           {
-            // Disable reminder after pre-padding time has passed to skip further announcements.
-            if (timer->IsReminder() && !timer->IsDisabled() && timer->StartAsUTC() <= now)
+            // disable timer until timer's end time is due
+            if (!timer->IsDisabled())
             {
               timer->SetState(PVR_TIMER_STATE_DISABLED);
               bChanged = true;


### PR DESCRIPTION
Fixes a regression introduced with #26467 which could lead to multiple reminder dialogs being shown for the same event.

Runtime-tested on macOS and Android.

@phunkyfish can you please have a look.