### PR TITLE
[PVR] Improve Behavior when System is "Suspend" State

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -528,6 +528,12 @@ void CPVRManager::Process()
 
   while (IsStarted() && m_addons->HasCreatedClients() && !bRestart)
   {
+    if (m_suspended)
+    {
+      CThread::Sleep(1s);
+      continue;
+    }
+
     // In case any new client connected, load from db and fetch data update from new client(s)
     UpdateComponents(ManagerState::STATE_STARTED);
 
@@ -636,10 +642,12 @@ void CPVRManager::OnSleep()
 
   m_epgContainer->OnSystemSleep();
   m_addons->OnSystemSleep();
+  m_suspended = true;
 }
 
 void CPVRManager::OnWake()
 {
+  m_suspended = false;
   m_addons->OnSystemWake();
   m_epgContainer->OnSystemWake();
 

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -641,6 +641,7 @@ void CPVRManager::OnSleep()
   SetWakeupCommand();
 
   m_epgContainer->OnSystemSleep();
+  m_timers->OnSystemSleep();
   m_addons->OnSystemSleep();
   m_suspended = true;
 }
@@ -649,6 +650,7 @@ void CPVRManager::OnWake()
 {
   m_suspended = false;
   m_addons->OnSystemWake();
+  m_timers->OnSystemWake();
   m_epgContainer->OnSystemWake();
 
   PublishEvent(PVREvent::SystemWake);

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -18,6 +18,7 @@
 #include "threads/Thread.h"
 #include "utils/EventStream.h"
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <vector>
@@ -451,6 +452,7 @@ private:
   mutable CCriticalSection
       m_critSection; /*!< critical section for all changes to this class, except for changes to triggers */
   bool m_bFirstStart = true; /*!< true when the PVR manager was started first, false otherwise */
+  std::atomic<bool> m_suspended{false}; /*!< whether the system is in suspended state */
 
   mutable CCriticalSection m_managerStateMutex;
   ManagerState m_managerState = ManagerState::STATE_STOPPED;

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -150,6 +150,16 @@ void CPVRTimers::Stop()
   CServiceBroker::GetPVRManager().Events().Unsubscribe(this);
 }
 
+void CPVRTimers::OnSystemSleep()
+{
+  m_suspended = true;
+}
+
+void CPVRTimers::OnSystemWake()
+{
+  m_suspended = false;
+}
+
 bool CPVRTimers::UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients)
 {
   {
@@ -173,6 +183,12 @@ void CPVRTimers::Process()
 {
   while (!m_bStop)
   {
+    if (m_suspended)
+    {
+      CThread::Sleep(10s);
+      continue;
+    }
+
     // update all timers not owned by a client (e.g. reminders)
     UpdateEntries(MAX_NOTIFICATION_DELAY.count());
 

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -11,6 +11,7 @@
 #include "pvr/settings/PVRSettings.h"
 #include "threads/Thread.h"
 
+#include <atomic>
 #include <map>
 #include <memory>
 #include <queue>
@@ -80,6 +81,16 @@ public:
      * @brief stop the timer update thread.
      */
   void Stop();
+
+  /*!
+   * @brief Inform the epg container that the system is going to sleep
+   */
+  void OnSystemSleep();
+
+  /*!
+   * @brief Inform the epg container that the system gets awake from sleep
+   */
+  void OnSystemWake();
 
   /*!
    * @brief Update all timers from PVR database and from given clients.
@@ -326,6 +337,7 @@ private:
   CPVRSettings m_settings;
   std::queue<std::shared_ptr<CPVRTimerInfoTag>> m_remindersToAnnounce;
   bool m_bReminderRulesUpdatePending = false;
+  std::atomic<bool> m_suspended{false};
 
   bool m_bFirstUpdate = true;
   std::vector<int> m_failedClients;


### PR DESCRIPTION
One more PR to support the special "suspend" system state of Android (maybe also other OS?) better.

I'm not an expert here, but to my understanding the Android suspend system state is no a suspend to disk/RAM where the machine state gets saved and CPU etc. is halted. It is more a "system continues to run almost normally, but the OS kindly asks the running apps not to do any resource consuming activities". Certain resources can also be not available when in this state (e.g. no network access possible).

This PR suppresses any activities normally done from inside the PVR Manager and PVR Timers threads, to save computing resources and to avoid (most probably not working) add-on calls which always could lead to (non working) network activities for example.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish can you please review.

BTW: This problems are not only of relevance for PVR, there are other activities Kodu currentyl tries to run while in suspended mode. For example, I spotted failing addon repository update checks done while system is suspended. Fix to come with another PR.