### PR TITLE
CVariant: Fix `swap()` so it doesn't change a `VariantTypeConstNull` variant

### DIFF
--- a/xbmc/utils/Variant.cpp
+++ b/xbmc/utils/Variant.cpp
@@ -599,7 +599,10 @@ const char *CVariant::c_str() const
 
 void CVariant::swap(CVariant& rhs) noexcept
 {
-  std::swap(m_data, rhs.m_data);
+  if (type() == VariantTypeConstNull)
+    rhs = VariantTypeConstNull;
+  else
+    std::swap(m_data, rhs.m_data);
 }
 
 CVariant::iterator_array CVariant::begin_array()

--- a/xbmc/utils/test/TestVariant.cpp
+++ b/xbmc/utils/test/TestVariant.cpp
@@ -396,3 +396,22 @@ TEST(TestVariant, asBoolean)
   EXPECT_FALSE(CVariant(CVariant::VariantTypeArray).asBoolean());
   EXPECT_FALSE(CVariant(CVariant::VariantTypeObject).asBoolean());
 }
+
+TEST(TestVariant, ConstNullVariant_cant_be_changed)
+{
+  CVariant c1 = CVariant::ConstNullVariant;
+  EXPECT_EQ(CVariant::VariantTypeConstNull, CVariant::ConstNullVariant.type());
+
+  CVariant c2 = std::move(CVariant::ConstNullVariant);
+  EXPECT_EQ(CVariant::VariantTypeConstNull, CVariant::ConstNullVariant.type());
+
+  CVariant c3(CVariant::VariantTypeInteger);
+  CVariant::ConstNullVariant = c3;
+  EXPECT_EQ(CVariant::VariantTypeConstNull, CVariant::ConstNullVariant.type());
+  CVariant::ConstNullVariant = std::move(c3);
+  EXPECT_EQ(CVariant::VariantTypeConstNull, CVariant::ConstNullVariant.type());
+
+  CVariant::ConstNullVariant.swap(c3);
+  EXPECT_EQ(CVariant::VariantTypeConstNull, CVariant::ConstNullVariant.type());
+  EXPECT_EQ(CVariant::VariantTypeConstNull, c3.type());
+}


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

See title.

> [!NOTE]
> I modeled the behavior of `swap` after `operator=` which means that if a `CVariant` is swapped with `CVariant::ConstNullVariant` (or any `VariantTypeConstNull` variant) it becomes a `VariantTypeConstNull` as well and can never be changed again. Same as when we assign a `VariantTypeConstNull` to a variant.
>
> I'm not sure this is a good design for either `swap` or `operator=`. I think it would be better if in such case the non `VariantTypeConstNull` would become `VariantTypeNull` instead.
>
> This is just food for thoughts and not in scope of this PR. Maybe something to discuss during Devcon?

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before that, it was possible to alter the `CVariant::ConstNullVariant` via `swap()` which is bad :(
This may fixes the crash in xbmc/inputstream.ffmpegdirect#319.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With the new unit test.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

The fixed problem could have caused crashes, logical inconsistencies, etc.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
