### PR TITLE
Faster URIUtils::HasExtension Checks

### DIFF
--- a/xbmc/utils/FileExtensionProvider.h
+++ b/xbmc/utils/FileExtensionProvider.h
@@ -10,6 +10,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -77,10 +78,12 @@ private:
   void SetAddonExtensions(ADDON::AddonType type);
 
   void OnAddonEvent(const ADDON::AddonEvent& event);
+  void OnAdvancedSettingsLoaded();
 
   // Construction properties
   std::shared_ptr<CAdvancedSettings> m_advancedSettings;
   ADDON::CAddonMgr &m_addonManager;
+  int m_callbackId;
 
   // File extension properties
   std::map<ADDON::AddonType, std::string> m_addonExtensions;
@@ -88,4 +91,12 @@ private:
 
   // Protocols from add-ons with encoded host names
   std::vector<std::string> m_encoded;
+
+  // Cached extensions lists
+  mutable std::optional<std::string> m_discStubExtensions;
+  mutable std::optional<std::string> m_musicExtensions;
+  mutable std::optional<std::string> m_pictureExtensions;
+  mutable std::optional<std::string> m_subtitlesExtensions;
+  mutable std::optional<std::string> m_videoExtensions;
+  mutable std::optional<std::string> m_fileFolderExtensions;
 };

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -432,56 +432,36 @@ void StringUtils::ToCapitalize(std::wstring &str)
   }
 }
 
-static bool EqualsNoCaseInternal(const char* s1, size_t length, const char* s2)
-{
-  size_t idx{0};
-  char c1;
-
-  while (idx < length && (c1 = s1[idx]) != '\0')
-  {
-    const auto c2{s2[idx]};
-    if (!c2)
-      return false;
-
-    if (c1 != c2 && ::tolower(c1) != ::tolower(c2))
-      return false;
-    ++idx;
-  }
-  return s2[idx] == '\0';
-}
-
 bool StringUtils::EqualsNoCase(const std::string &str1, const std::string &str2)
 {
   // before we do the char-by-char comparison, first compare sizes of both strings.
   // This led to a 33% improvement in benchmarking on average. (size() just returns a member of std::string)
-  const auto length{str1.size()};
-  if (length != str2.size())
+  if (str1.size() != str2.size())
     return false;
-  return EqualsNoCaseInternal(str1.c_str(), length, str2.c_str());
+  return EqualsNoCase(str1.c_str(), str2.c_str());
 }
 
 bool StringUtils::EqualsNoCase(const std::string &str1, const char *s2)
 {
-  return EqualsNoCaseInternal(str1.c_str(), str1.size(), s2);
+  return EqualsNoCase(str1.c_str(), s2);
 }
 
 bool StringUtils::EqualsNoCase(const char *s1, const char *s2)
 {
-  return EqualsNoCaseInternal(s1, static_cast<size_t>(-1), s2);
-}
-
-bool StringUtils::EqualsNoCase(std::string_view str1, std::string_view str2)
-{
-  const auto length{str1.size()};
-  if (length != str2.size())
-    return false;
-
-  return EqualsNoCaseInternal(str1.data(), length, str2.data());
-}
-
-bool StringUtils::EqualsNoCase(std::string_view str1, const char* s2)
-{
-  return EqualsNoCaseInternal(str1.data(), str1.size(), s2);
+  char c2; // we need only one char outside the loop
+  do
+  {
+    const char c1 = *s1++; // const local variable should help compiler to optimize
+    c2 = *s2++;
+    if (c1 != c2 && ::tolower(c1) != ::tolower(c2))
+    {
+      // This includes the possibility that one of the characters is the
+      // null-terminator, which implies a string mismatch.
+      return false;
+    }
+  } while (c2 != '\0'); // At this point, we know c1 == c2, so there's no need
+      // to test them both.
+  return true;
 }
 
 int StringUtils::CompareNoCase(const std::string& str1, const std::string& str2, size_t n /* = 0 */)
@@ -758,16 +738,36 @@ bool StringUtils::EndsWith(const std::string &str1, const char *s2)
   return str1.compare(str1.size() - len2, len2, s2) == 0;
 }
 
-bool StringUtils::EndsWithNoCase(std::string_view str1, std::string_view str2)
+bool StringUtils::EndsWithNoCase(const std::string& str1, const std::string& str2)
 {
-  const int diff = str1.size() - str2.size();
-
-  if (diff < 0)
+  if (str1.size() < str2.size())
     return false;
-  else if (diff > 0)
-    str1.remove_prefix(diff);
+  const char* s1 = str1.c_str() + str1.size() - str2.size();
+  const char* s2 = str2.c_str();
+  while (*s2 != '\0')
+  {
+    if (::tolower(*s1) != ::tolower(*s2))
+      return false;
+    s1++;
+    s2++;
+  }
+  return true;
+}
 
-  return EqualsNoCase(str1, str2);
+bool StringUtils::EndsWithNoCase(const std::string& str1, const char* s2)
+{
+  size_t len2 = strlen(s2);
+  if (str1.size() < len2)
+    return false;
+  const char* s1 = str1.c_str() + str1.size() - len2;
+  while (*s2 != '\0')
+  {
+    if (::tolower(*s1) != ::tolower(*s2))
+      return false;
+    s1++;
+    s2++;
+  }
+  return true;
 }
 
 std::vector<std::string> StringUtils::Split(const std::string& input, const std::string& delimiter, unsigned int iMaxStrings)

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -451,14 +451,16 @@ bool StringUtils::EqualsNoCase(const char *s1, const char *s2)
   char c2; // we need only one char outside the loop
   do
   {
-    const char c1 = *s1++; // const local variable should help compiler to optimize
-    c2 = *s2++;
+    const char c1 = *s1; // const local variable should help compiler to optimize
+    c2 = *s2;
     if (c1 != c2 && ::tolower(c1) != ::tolower(c2))
     {
       // This includes the possibility that one of the characters is the
       // null-terminator, which implies a string mismatch.
       return false;
     }
+    s1++;
+    s2++;
   } while (c2 != '\0'); // At this point, we know c1 == c2, so there's no need
       // to test them both.
   return true;
@@ -746,7 +748,7 @@ bool StringUtils::EndsWithNoCase(const std::string& str1, const std::string& str
   const char* s2 = str2.c_str();
   while (*s2 != '\0')
   {
-    if (::tolower(*s1) != ::tolower(*s2))
+    if (*s1 != *s2 && ::tolower(*s1) != ::tolower(*s2))
       return false;
     s1++;
     s2++;
@@ -762,7 +764,7 @@ bool StringUtils::EndsWithNoCase(const std::string& str1, const char* s2)
   const char* s1 = str1.c_str() + str1.size() - len2;
   while (*s2 != '\0')
   {
-    if (::tolower(*s1) != ::tolower(*s2))
+    if (*s1 != *s2 && ::tolower(*s1) != ::tolower(*s2))
       return false;
     s1++;
     s2++;

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -107,6 +107,8 @@ public:
   static bool EqualsNoCase(const std::string &str1, const std::string &str2);
   static bool EqualsNoCase(const std::string &str1, const char *s2);
   static bool EqualsNoCase(const char *s1, const char *s2);
+  static bool EqualsNoCase(std::string_view str1, std::string_view str2);
+  static bool EqualsNoCase(std::string_view str1, const char* str2);
   static int CompareNoCase(const std::string& str1, const std::string& str2, size_t n = 0);
   static int CompareNoCase(const char* s1, const char* s2, size_t n = 0);
   static int ReturnDigits(const std::string &str);
@@ -141,8 +143,7 @@ public:
   static bool StartsWithNoCase(const char *s1, const char *s2);
   static bool EndsWith(const std::string &str1, const std::string &str2);
   static bool EndsWith(const std::string &str1, const char *s2);
-  static bool EndsWithNoCase(const std::string &str1, const std::string &str2);
-  static bool EndsWithNoCase(const std::string &str1, const char *s2);
+  static bool EndsWithNoCase(std::string_view str1, std::string_view str2);
 
   template<typename CONTAINER>
   static std::string Join(const CONTAINER &strings, const std::string& delimiter)

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -104,11 +104,9 @@ public:
   static void ToLower(std::wstring &str);
   static void ToCapitalize(std::string &str);
   static void ToCapitalize(std::wstring &str);
-  static bool EqualsNoCase(const std::string &str1, const std::string &str2);
-  static bool EqualsNoCase(const std::string &str1, const char *s2);
-  static bool EqualsNoCase(const char *s1, const char *s2);
-  static bool EqualsNoCase(std::string_view str1, std::string_view str2);
-  static bool EqualsNoCase(std::string_view str1, const char* str2);
+  static bool EqualsNoCase(const std::string& str1, const std::string& str2);
+  static bool EqualsNoCase(const std::string& str1, const char* s2);
+  static bool EqualsNoCase(const char* s1, const char* s2);
   static int CompareNoCase(const std::string& str1, const std::string& str2, size_t n = 0);
   static int CompareNoCase(const char* s1, const char* s2, size_t n = 0);
   static int ReturnDigits(const std::string &str);
@@ -143,7 +141,8 @@ public:
   static bool StartsWithNoCase(const char *s1, const char *s2);
   static bool EndsWith(const std::string &str1, const std::string &str2);
   static bool EndsWith(const std::string &str1, const char *s2);
-  static bool EndsWithNoCase(std::string_view str1, std::string_view str2);
+  static bool EndsWithNoCase(const std::string& str1, const std::string& str2);
+  static bool EndsWithNoCase(const std::string& str1, const char* s2);
 
   template<typename CONTAINER>
   static std::string Join(const CONTAINER &strings, const std::string& delimiter)

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -38,7 +38,22 @@ public:
   static std::string GetFileName(const std::string& strFileNameAndPath);
   static std::string GetFileOrFolderName(const std::string& path);
 
+  /*!
+   * \brief Retrieve the extension of the file name.
+   * In case of multiple extensions or presence of dot characters in the file name
+   * (ex. dot.separated.filename.mkv), the last extension is returned.
+   * \param url[in] CURL of the file
+   * \return the extension. Empty for filenames without an extension.
+   */
   static std::string GetExtension(const CURL& url);
+
+  /*!
+   * \brief Retrieve the extension of the file name.
+   * In case of multiple extensions or presence of dot characters in the file name
+   * (ex. dot.separated.filename.mkv), the last extension is returned.
+   * \param url[in] filename, with or without path
+   * \return the extension. Empty for filenames without an extension.
+   */
   static std::string GetExtension(const std::string& strFileName);
 
 

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -59,16 +59,14 @@ public:
 
   /*!
    \brief Check if filename have any of the listed extensions
-   \param strFileName Path or URL to check
-   \param strExtensions List of '.' prefixed lowercase extensions separated with '|'
-   \return \e true if strFileName have any one of the extensions.
-   \note The check is case insensitive for strFileName, but requires
-         strExtensions to be lowercase. Returns false when strFileName or
-         strExtensions is empty.
+   \param fileName Path or URL to check
+   \param extensions List of '.' prefixed lowercase extensions separated with '|'
+   \return \e true if fileName has any one of the extensions.
+   \note The check is case insensitive.Returns false when fileName or extensions is empty.
    \sa GetExtension
    */
-  static bool HasExtension(const std::string& strFileName, const std::string& strExtensions);
-  static bool HasExtension(const CURL& url, const std::string& strExtensions);
+  static bool HasExtension(const std::string& fileName, std::string_view extensions);
+  static bool HasExtension(const CURL& url, std::string_view extensions);
 
   static void RemoveExtension(std::string& strFileName);
   static std::string ReplaceExtension(const std::string& strFile,

--- a/xbmc/utils/test/TestStringUtils.cpp
+++ b/xbmc/utils/test/TestStringUtils.cpp
@@ -145,6 +145,39 @@ TEST(TestStringUtils, EqualsNoCase)
   EXPECT_TRUE(StringUtils::EqualsNoCase(empStr, ""));
 }
 
+TEST(TestStringUtils, EqualsNoCaseStringViewChar)
+{
+  using namespace std::literals;
+
+  std::string_view refStr = "TeSt"sv;
+
+  EXPECT_TRUE(StringUtils::EqualsNoCase(refStr, "TeSt"));
+  EXPECT_TRUE(StringUtils::EqualsNoCase(refStr, "tEsT"));
+  EXPECT_FALSE(StringUtils::EqualsNoCase(refStr, "tEsTe"));
+  EXPECT_FALSE(StringUtils::EqualsNoCase(refStr, "tEs"));
+  EXPECT_FALSE(StringUtils::EqualsNoCase(refStr, "tEsU"));
+  EXPECT_FALSE(StringUtils::EqualsNoCase(refStr, "ta"));
+  EXPECT_FALSE(StringUtils::EqualsNoCase(refStr, ""));
+
+  std::string_view empStr;
+  EXPECT_FALSE(StringUtils::EqualsNoCase(empStr, "tEsT"));
+  EXPECT_TRUE(StringUtils::EqualsNoCase(empStr, ""));
+}
+
+TEST(TestStringUtils, EqualsNoCaseCharChar)
+{
+  EXPECT_TRUE(StringUtils::EqualsNoCase("TeSt", "TeSt"));
+  EXPECT_TRUE(StringUtils::EqualsNoCase("TeSt", "tEsT"));
+  EXPECT_FALSE(StringUtils::EqualsNoCase("TeSt", "tEsTe"));
+  EXPECT_FALSE(StringUtils::EqualsNoCase("TeSt", "tEs"));
+  EXPECT_FALSE(StringUtils::EqualsNoCase("TeSt", "tEsU"));
+  EXPECT_FALSE(StringUtils::EqualsNoCase("TeSt", "ta"));
+  EXPECT_FALSE(StringUtils::EqualsNoCase("TeSt", ""));
+
+  EXPECT_FALSE(StringUtils::EqualsNoCase("", "tEsT"));
+  EXPECT_TRUE(StringUtils::EqualsNoCase("", ""));
+}
+
 TEST(TestStringUtils, Left)
 {
   std::string refstr, varstr;

--- a/xbmc/utils/test/TestStringUtils.cpp
+++ b/xbmc/utils/test/TestStringUtils.cpp
@@ -130,10 +130,19 @@ TEST(TestStringUtils, ToCapitalize)
 
 TEST(TestStringUtils, EqualsNoCase)
 {
-  std::string refstr = "TeSt";
+  std::string refStr = "TeSt";
 
-  EXPECT_TRUE(StringUtils::EqualsNoCase(refstr, "TeSt"));
-  EXPECT_TRUE(StringUtils::EqualsNoCase(refstr, "tEsT"));
+  EXPECT_TRUE(StringUtils::EqualsNoCase(refStr, "TeSt"));
+  EXPECT_TRUE(StringUtils::EqualsNoCase(refStr, "tEsT"));
+  EXPECT_FALSE(StringUtils::EqualsNoCase(refStr, "tEsTe"));
+  EXPECT_FALSE(StringUtils::EqualsNoCase(refStr, "tEs"));
+  EXPECT_FALSE(StringUtils::EqualsNoCase(refStr, "tEsU"));
+  EXPECT_FALSE(StringUtils::EqualsNoCase(refStr, "ta"));
+  EXPECT_FALSE(StringUtils::EqualsNoCase(refStr, ""));
+
+  std::string empStr;
+  EXPECT_FALSE(StringUtils::EqualsNoCase(empStr, "tEsT"));
+  EXPECT_TRUE(StringUtils::EqualsNoCase(empStr, ""));
 }
 
 TEST(TestStringUtils, Left)
@@ -264,16 +273,46 @@ TEST(TestStringUtils, StartsWith)
 
 TEST(TestStringUtils, EndsWith)
 {
-  std::string refstr = "test";
+  std::string refStr = "test";
 
-  EXPECT_FALSE(StringUtils::EndsWithNoCase(refstr, "x"));
+  EXPECT_TRUE(StringUtils::EndsWith(refStr, ""));
 
-  EXPECT_TRUE(StringUtils::EndsWith(refstr, "st"));
-  EXPECT_TRUE(StringUtils::EndsWith(refstr, "test"));
-  EXPECT_FALSE(StringUtils::EndsWith(refstr, "sT"));
+  EXPECT_FALSE(StringUtils::EndsWith(refStr, "x"));
 
-  EXPECT_TRUE(StringUtils::EndsWithNoCase(refstr, "sT"));
-  EXPECT_TRUE(StringUtils::EndsWithNoCase(refstr, "TesT"));
+  EXPECT_TRUE(StringUtils::EndsWith(refStr, "st"));
+  EXPECT_TRUE(StringUtils::EndsWith(refStr, "test"));
+  EXPECT_FALSE(StringUtils::EndsWith(refStr, "sT"));
+  EXPECT_FALSE(StringUtils::EndsWith(refStr, "retest"));
+
+  EXPECT_FALSE(StringUtils::EndsWith("", refStr));
+
+  std::string mixedCaseRefStr = "TesT";
+
+  EXPECT_FALSE(StringUtils::EndsWith(mixedCaseRefStr, "st"));
+  EXPECT_FALSE(StringUtils::EndsWith(mixedCaseRefStr, "test"));
+  EXPECT_TRUE(StringUtils::EndsWith(mixedCaseRefStr, "sT"));
+  EXPECT_FALSE(StringUtils::EndsWith(mixedCaseRefStr, "retest"));
+}
+
+TEST(TestStringUtils, EndsWithNoCase)
+{
+  std::string refStr = "test";
+
+  EXPECT_TRUE(StringUtils::EndsWithNoCase(refStr, ""));
+
+  EXPECT_FALSE(StringUtils::EndsWithNoCase(refStr, "x"));
+
+  EXPECT_TRUE(StringUtils::EndsWithNoCase(refStr, "sT"));
+  EXPECT_TRUE(StringUtils::EndsWithNoCase(refStr, "TesT"));
+  EXPECT_FALSE(StringUtils::EndsWithNoCase(refStr, "ReTesT"));
+
+  EXPECT_FALSE(StringUtils::EndsWithNoCase("", refStr));
+
+  std::string mixedCaseRefStr = "TesT";
+
+  EXPECT_TRUE(StringUtils::EndsWithNoCase(mixedCaseRefStr, "st"));
+  EXPECT_TRUE(StringUtils::EndsWithNoCase(mixedCaseRefStr, "test"));
+  EXPECT_FALSE(StringUtils::EndsWithNoCase(mixedCaseRefStr, "retest"));
 }
 
 TEST(TestStringUtils, Join)

--- a/xbmc/utils/test/TestStringUtils.cpp
+++ b/xbmc/utils/test/TestStringUtils.cpp
@@ -145,39 +145,6 @@ TEST(TestStringUtils, EqualsNoCase)
   EXPECT_TRUE(StringUtils::EqualsNoCase(empStr, ""));
 }
 
-TEST(TestStringUtils, EqualsNoCaseStringViewChar)
-{
-  using namespace std::literals;
-
-  std::string_view refStr = "TeSt"sv;
-
-  EXPECT_TRUE(StringUtils::EqualsNoCase(refStr, "TeSt"));
-  EXPECT_TRUE(StringUtils::EqualsNoCase(refStr, "tEsT"));
-  EXPECT_FALSE(StringUtils::EqualsNoCase(refStr, "tEsTe"));
-  EXPECT_FALSE(StringUtils::EqualsNoCase(refStr, "tEs"));
-  EXPECT_FALSE(StringUtils::EqualsNoCase(refStr, "tEsU"));
-  EXPECT_FALSE(StringUtils::EqualsNoCase(refStr, "ta"));
-  EXPECT_FALSE(StringUtils::EqualsNoCase(refStr, ""));
-
-  std::string_view empStr;
-  EXPECT_FALSE(StringUtils::EqualsNoCase(empStr, "tEsT"));
-  EXPECT_TRUE(StringUtils::EqualsNoCase(empStr, ""));
-}
-
-TEST(TestStringUtils, EqualsNoCaseCharChar)
-{
-  EXPECT_TRUE(StringUtils::EqualsNoCase("TeSt", "TeSt"));
-  EXPECT_TRUE(StringUtils::EqualsNoCase("TeSt", "tEsT"));
-  EXPECT_FALSE(StringUtils::EqualsNoCase("TeSt", "tEsTe"));
-  EXPECT_FALSE(StringUtils::EqualsNoCase("TeSt", "tEs"));
-  EXPECT_FALSE(StringUtils::EqualsNoCase("TeSt", "tEsU"));
-  EXPECT_FALSE(StringUtils::EqualsNoCase("TeSt", "ta"));
-  EXPECT_FALSE(StringUtils::EqualsNoCase("TeSt", ""));
-
-  EXPECT_FALSE(StringUtils::EqualsNoCase("", "tEsT"));
-  EXPECT_TRUE(StringUtils::EqualsNoCase("", ""));
-}
-
 TEST(TestStringUtils, Left)
 {
   std::string refstr, varstr;

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -105,6 +105,10 @@ TEST_F(TestURIUtils, HasExtension)
   EXPECT_TRUE(URIUtils::HasExtension("/path/to/movie.AvI", ".avi|"));
   EXPECT_FALSE(URIUtils::HasExtension("/path/to/movie.AvI", ".mkv|"));
   EXPECT_TRUE(URIUtils::HasExtension("/path/to/movie.avi", "*.avi"));
+  // pathologic, doesn't need to be supported but happens to work
+  EXPECT_FALSE(URIUtils::HasExtension("/path/to/movie.avi", ".avi."));
+  // pathologic, known broken, not worth fixing
+  //EXPECT_FALSE(URIUtils::HasExtension("/path/to/movie.avi", "..avi"));
   EXPECT_FALSE(URIUtils::HasExtension("/path/.avi/movie", ".avi"));
   EXPECT_FALSE(URIUtils::HasExtension("", ".avi"));
 
@@ -129,6 +133,11 @@ TEST_F(TestURIUtils, HasExtension)
   EXPECT_FALSE(URIUtils::HasExtension("http://server/path/to/movie.AvI", ".mpg|.mkv|.mp4"));
   EXPECT_TRUE(URIUtils::HasExtension("http://server/path/to/movie.AvI?foo=bar", ".avi|.mkv|.mp4"));
   EXPECT_FALSE(URIUtils::HasExtension("http://server/path/to/movie?foo=bar.AvI", ".avi|.mkv|.mp4"));
+
+  EXPECT_FALSE(URIUtils::HasExtension("/home/alwin/test.bdm", ".bdmv|.m4v"));
+  EXPECT_FALSE(URIUtils::HasExtension("/home/alwin/test.bdm", ".bd|.m4v"));
+  EXPECT_FALSE(URIUtils::HasExtension("/home/alwin/test.bdm", ".bdmv"));
+  EXPECT_FALSE(URIUtils::HasExtension("/home/alwin/test.bdm", ".bd"));
 }
 
 TEST_F(TestURIUtils, GetFileName)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Replacement of  #23729 and related discussion in #23726

URIUtils::HasExtension works with lists of concatenated extensions separated by | (ex. ".mkv|.mp4|.avi|.m4v")
PR above wanted to improve performance by splitting the extensions before hand and storing them as vectors of strings, ex. { ".mkv", ".mp4", ".avi", ".m4v"}

Testing showed (see benchmarks in testing) that improved parsing of the current format of extensions lists provides performance gains similar to the use of vectors of strings, without having to change all the callers. Two parsing-improving algorithms are included in the PR.

To improve performance beyond that, std::unordered_set is needed (using hashing) but requires changes to lots of callers, all over the code base.

The current algorithm spends a lot of time lowercasing then splitting the list into a vector of strings, the new algorithms parse the string and process piece by piece.

* Two improved algorithms:
  - commit 2, straight forward, readable and C++like (2x to 20x faster than current)
  - commit 3, less readable but even faster (4x to 68x faster than current and comparable to the use of a vector of strings).
The speedup for both depends largely on the position of the matching extension in the string of extensions.

* Added many unit tests to prove the algorithms provide the same results as master, quirks included :-)

* Added a cache to the GetxxxExtensions() family of functions (ex GetVideoExtensions), which otherwise build strings to return for every call, concatenating some strings. They only need to do the concatenation once on profile load or addon addition/removal.

* Minor ~5% perf. improvement of StringUtils::EqualsNoCase / StringUtils::EndsWithNoCase if they remain (ie algo of commit 3 is chosen)

It would be possible to keep the string_view overloads of StringUtils functions added for commit 2 instead of cleaning them up.

Future: reordering the extensions in the builtin lists would provide a nice speedup as well and would allow achieving the higher range of the possible improvements for popular extensions, rather than the lower range.

copied @garbear @ksooo @howie-f as you commented on the original PR.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Noticed HasExtension() function appear in a flame graph of a library scan of movies and #23729 meant to address a similar problem with artwork.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added unit tests covering every path in the new algorithms and clarifying corner cases of the existing code.
Kodi runs fine!

### Benchmark results

short list of 4 extensions - ".mkv|.mp4|.avi|.m4v"
| algorithm / type | debug build | release build | comment |
|:---|:---|:---|:---|
| Current master | 1x | 1x | |
| Improved algorithm 1 (commit 2) | 2x-4x | 2.5x-3.2x | depends on position of matched extension |
| Improved algorithm 2 (commit 3) | 8x | 4x-6x | depends on position of matched extension |
| vector/array of strings (not in PR) | 2.2x-3.5x | 3.x-4.3x | depends on position of matched extension |
| unordered_set (not in PR) | 9x-10x | 6.3x-6.7x | hash collisions |

long list of ~90 extensions - GetFileExtensionProvider().GetVideoExtensions()
| algorithm / type | debug build | release build | comment |
|:---|:---|:---|:---|
| Current master | 1x | 1x | |
| Improved algorithm 1 (commit 2) | 2x-20x | 1.7x-15x | depends on position of matched extension |
| Improved algorithm 2 (commit 3) | 26x-68x | 3.5x-23x | depends on position of matched extension |
| vector/array of strings (not in PR) | 2.3x-29x | 2.5x-25x | depends on position of matched extension |
| unordered_set (not in PR) | 120x | 50x-58x | rather constant hash lookup time |

The cached versions of the GetxxxExtensions() family of functions (ex GetVideoExtensions) are 60% faster than the original for debug builds. I wasn't able to measure a difference in release builds, due to testing methodology maybe, or aggressive compiler inlining/optimization...

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Overall small performance improvement, likely more noticeable on slow hardware in library scans.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
