### PR TITLE
[powermanagement] Improve Behavior when System is in "Suspend" State, part 2

### DIFF
--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -433,10 +433,17 @@ bool CTextureCache::CleanAllUnusedImagesJob(CGUIDialogProgress* progress)
 
 void CTextureCache::CleanTimer()
 {
+  if (IsSleeping())
+  {
+    CLog::LogF(LOGDEBUG, "Texture cleanup postponed. System is sleeping.");
+    m_cleanTimer.Start(1h);
+    return;
+  }
+
   CServiceBroker::GetJobManager()->Submit(
       [this]()
       {
-        auto next = m_cleaningInProgress.test_and_set() ? std::chrono::hours(1) : ScanOldestCache();
+        auto next = m_cleaningInProgress.test_and_set() ? 1h : ScanOldestCache();
         m_cleaningInProgress.clear();
         m_cleanTimer.Start(next);
       },

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -11,6 +11,7 @@
 #include "TextureCacheJob.h"
 #include "TextureDatabase.h"
 #include "guilib/AspectRatio.h"
+#include "powermanagement/PowerState.h"
 #include "threads/CriticalSection.h"
 #include "threads/Event.h"
 #include "threads/Timer.h"
@@ -38,7 +39,7 @@ class CTexture;
  unused for a set period of time.
 
  */
-class CTextureCache : public CJobQueue
+class CTextureCache : public CJobQueue, public CPowerState
 {
 public:
   CTextureCache();

--- a/xbmc/addons/RepositoryUpdater.cpp
+++ b/xbmc/addons/RepositoryUpdater.cpp
@@ -227,6 +227,12 @@ static void SetProgressIndicator(CRepositoryUpdateJob* job)
 void CRepositoryUpdater::CheckForUpdates(const ADDON::RepositoryPtr& repo, bool showProgress)
 {
   std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  if (IsSleeping())
+  {
+    CLog::LogF(LOGDEBUG, "Repository update check postponed. System is sleeping.");
+    return;
+  }
+
   auto job = std::find_if(m_jobs.begin(), m_jobs.end(),
       [&](CRepositoryUpdateJob* job){ return job->GetAddon()->ID() == repo->ID(); });
 

--- a/xbmc/addons/RepositoryUpdater.h
+++ b/xbmc/addons/RepositoryUpdater.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "powermanagement/PowerState.h"
 #include "settings/lib/ISettingCallback.h"
 #include "threads/CriticalSection.h"
 #include "threads/Timer.h"
@@ -31,7 +32,10 @@ class CRepositoryUpdateJob;
 
 struct AddonEvent;
 
-class CRepositoryUpdater : private ITimerCallback, private IJobCallback, public ISettingCallback
+class CRepositoryUpdater : private ITimerCallback,
+                           private IJobCallback,
+                           public ISettingCallback,
+                           public CPowerState
 {
 public:
   explicit CRepositoryUpdater(CAddonMgr& addonMgr);

--- a/xbmc/powermanagement/CMakeLists.txt
+++ b/xbmc/powermanagement/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES DPMSSupport.cpp
 set(HEADERS DPMSSupport.h
             IPowerSyscall.h
             PowerManager.h
+            PowerState.h
             PowerTypes.h)
 
 if(CORE_SYSTEM_NAME MATCHES windows)

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -11,6 +11,7 @@
 #include "FileItem.h"
 #include "PowerTypes.h"
 #include "ServiceBroker.h"
+#include "addons/RepositoryUpdater.h"
 #include "application/AppParams.h"
 #include "application/Application.h"
 #include "application/ApplicationComponents.h"
@@ -198,6 +199,7 @@ void CPowerManager::OnSleep()
 
   g_application.StopPlaying();
   CServiceBroker::GetPVRManager().OnSleep();
+  CServiceBroker::GetRepositoryUpdater().OnSleep();
   auto& components = CServiceBroker::GetAppComponents();
   const auto appPower = components.GetComponent<CApplicationPowerHandling>();
   appPower->StopShutdownTimer();
@@ -237,6 +239,7 @@ void CPowerManager::OnWake()
   CServiceBroker::GetActiveAE()->Resume();
   g_application.UpdateLibraries();
   CServiceBroker::GetWeatherManager().Refresh();
+  CServiceBroker::GetRepositoryUpdater().OnWake();
   CServiceBroker::GetPVRManager().OnWake();
   RestorePlayerState();
 

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -11,6 +11,7 @@
 #include "FileItem.h"
 #include "PowerTypes.h"
 #include "ServiceBroker.h"
+#include "TextureCache.h"
 #include "addons/RepositoryUpdater.h"
 #include "application/AppParams.h"
 #include "application/Application.h"
@@ -200,6 +201,7 @@ void CPowerManager::OnSleep()
   g_application.StopPlaying();
   CServiceBroker::GetPVRManager().OnSleep();
   CServiceBroker::GetRepositoryUpdater().OnSleep();
+  CServiceBroker::GetTextureCache()->OnSleep();
   auto& components = CServiceBroker::GetAppComponents();
   const auto appPower = components.GetComponent<CApplicationPowerHandling>();
   appPower->StopShutdownTimer();
@@ -239,6 +241,7 @@ void CPowerManager::OnWake()
   CServiceBroker::GetActiveAE()->Resume();
   g_application.UpdateLibraries();
   CServiceBroker::GetWeatherManager().Refresh();
+  CServiceBroker::GetTextureCache()->OnWake();
   CServiceBroker::GetRepositoryUpdater().OnWake();
   CServiceBroker::GetPVRManager().OnWake();
   RestorePlayerState();

--- a/xbmc/powermanagement/PowerState.h
+++ b/xbmc/powermanagement/PowerState.h
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <atomic>
+
+class CPowerState
+{
+public:
+  CPowerState() = default;
+  virtual ~CPowerState() = default;
+
+  /**
+   * Called when system is going to sleep.
+   */
+  virtual void OnSleep() { m_sleeping.test_and_set(); }
+
+  /**
+   * Called when system is awakened from sleep.
+   */
+  virtual void OnWake() { m_sleeping.clear(); }
+
+  /**
+   * Test whether system is sleeping.
+   */
+  bool IsSleeping() const { return m_sleeping.test(); }
+
+  /**
+   * Test whether system is awakened from sleep.
+   */
+  bool IsAwake() const { return !IsSleeping(); }
+
+private:
+  std::atomic_flag m_sleeping{};
+};

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -528,7 +528,7 @@ void CPVRManager::Process()
 
   while (IsStarted() && m_addons->HasCreatedClients() && !bRestart)
   {
-    if (m_suspended)
+    if (IsSleeping())
     {
       CThread::Sleep(1s);
       continue;
@@ -640,18 +640,18 @@ void CPVRManager::OnSleep()
 
   SetWakeupCommand();
 
-  m_epgContainer->OnSystemSleep();
-  m_timers->OnSystemSleep();
-  m_addons->OnSystemSleep();
-  m_suspended = true;
+  m_epgContainer->OnSleep();
+  m_timers->OnSleep();
+  m_addons->OnSleep();
+  CPowerState::OnSleep();
 }
 
 void CPVRManager::OnWake()
 {
-  m_suspended = false;
-  m_addons->OnSystemWake();
-  m_timers->OnSystemWake();
-  m_epgContainer->OnSystemWake();
+  CPowerState::OnWake();
+  m_addons->OnWake();
+  m_timers->OnWake();
+  m_epgContainer->OnWake();
 
   PublishEvent(PVREvent::SystemWake);
 

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -640,18 +640,18 @@ void CPVRManager::OnSleep()
 
   SetWakeupCommand();
 
+  CPowerState::OnSleep();
   m_epgContainer->OnSleep();
   m_timers->OnSleep();
   m_addons->OnSleep();
-  CPowerState::OnSleep();
 }
 
 void CPVRManager::OnWake()
 {
-  CPowerState::OnWake();
   m_addons->OnWake();
   m_timers->OnWake();
   m_epgContainer->OnWake();
+  CPowerState::OnWake();
 
   PublishEvent(PVREvent::SystemWake);
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -10,6 +10,7 @@
 
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h"
 #include "interfaces/IAnnouncer.h"
+#include "powermanagement/PowerState.h"
 #include "pvr/PVRComponentRegistration.h"
 #include "pvr/guilib/PVRGUIActionListener.h"
 #include "pvr/settings/PVRSettings.h"
@@ -18,7 +19,6 @@
 #include "threads/Thread.h"
 #include "utils/EventStream.h"
 
-#include <atomic>
 #include <memory>
 #include <string>
 #include <vector>
@@ -94,7 +94,7 @@ enum class PVREvent
   SystemWake,
 };
 
-class CPVRManager : private CThread, public ANNOUNCEMENT::IAnnouncer
+class CPVRManager : private CThread, public ANNOUNCEMENT::IAnnouncer, public CPowerState
 {
 public:
   /*!
@@ -206,12 +206,12 @@ public:
   /*!
    * @brief Propagate event on system sleep
    */
-  void OnSleep();
+  void OnSleep() override;
 
   /*!
    * @brief Propagate event on system wake
    */
-  void OnWake();
+  void OnWake() override;
 
   /*!
    * @brief Get the TV database.
@@ -452,7 +452,6 @@ private:
   mutable CCriticalSection
       m_critSection; /*!< critical section for all changes to this class, except for changes to triggers */
   bool m_bFirstStart = true; /*!< true when the PVR manager was started first, false otherwise */
-  std::atomic<bool> m_suspended{false}; /*!< whether the system is in suspended state */
 
   mutable CCriticalSection m_managerStateMutex;
   ManagerState m_managerState = ManagerState::STATE_STOPPED;

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -810,16 +810,18 @@ bool CPVRClients::AnyClientSupportingRecordingsDelete() const
   });
 }
 
-void CPVRClients::OnSystemSleep()
+void CPVRClients::OnSleep()
 {
   ForCreatedClients(__FUNCTION__, [](const std::shared_ptr<CPVRClient>& client) {
     client->OnSystemSleep();
     return PVR_ERROR_NO_ERROR;
   });
+  CPowerState::OnSleep();
 }
 
-void CPVRClients::OnSystemWake()
+void CPVRClients::OnWake()
 {
+  CPowerState::OnWake();
   ForCreatedClients(__FUNCTION__, [](const std::shared_ptr<CPVRClient>& client) {
     client->OnSystemWake();
     return PVR_ERROR_NO_ERROR;

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -10,6 +10,7 @@
 
 #include "addons/IAddonManagerCallback.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h"
+#include "powermanagement/PowerState.h"
 #include "threads/CriticalSection.h"
 
 #include <functional>
@@ -62,7 +63,7 @@ struct SBackend
   uint64_t diskTotal = 0;
 };
 
-class CPVRClients : public ADDON::IAddonMgrCallback
+class CPVRClients : public ADDON::IAddonMgrCallback, public CPowerState
 {
 public:
   CPVRClients();
@@ -384,12 +385,12 @@ public:
   /*!
    * @brief Propagate "system sleep" event to clients
    */
-  void OnSystemSleep();
+  void OnSleep() override;
 
   /*!
    * @brief Propagate "system wakeup" event to clients
    */
-  void OnSystemWake();
+  void OnWake() override;
 
   /*!
    * @brief Propagate "power saving activated" event to clients

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -22,9 +22,10 @@ class CVariant;
 
 namespace ADDON
 {
-  struct AddonEvent;
-  class CAddonInfo;
-}
+struct AddonEvent;
+class CAddonInfo;
+
+} // namespace ADDON
 
 namespace PVR
 {
@@ -41,9 +42,9 @@ class CPVRTimersContainer;
 
 typedef std::map<int, std::shared_ptr<CPVRClient>> CPVRClientMap;
 
-/**
-   * Holds generic data about a backend (number of channels etc.)
-   */
+/*!
+ * @brief Holds generic data about a backend (number of channels etc.)
+ */
 struct SBackend
 {
   std::string clientname;
@@ -61,434 +62,432 @@ struct SBackend
   uint64_t diskTotal = 0;
 };
 
-  class CPVRClients : public ADDON::IAddonMgrCallback
-  {
-  public:
-    CPVRClients();
-    ~CPVRClients() override;
+class CPVRClients : public ADDON::IAddonMgrCallback
+{
+public:
+  CPVRClients();
+  ~CPVRClients() override;
 
-    /*!
-     * @brief Start all clients.
-     */
-    void Start();
+  /*!
+   * @brief Start all clients.
+   */
+  void Start();
 
-    /*!
-     * @brief Stop all clients.
-     */
-    void Stop();
+  /*!
+   * @brief Stop all clients.
+   */
+  void Stop();
 
-    /*!
-     * @brief Continue all clients.
-     */
-    void Continue();
+  /*!
+   * @brief Continue all clients.
+   */
+  void Continue();
 
-    /*!
-     * @brief Update all clients, sync with Addon Manager state (start, restart, shutdown clients).
-     * @param changedAddonId The id of the changed addon, empty string denotes 'any addon'.
-     * @param changedInstanceId The Identifier of the changed add-on instance
-     */
-    void UpdateClients(
-        const std::string& changedAddonId = "",
-        ADDON::AddonInstanceId changedInstanceId = ADDON::ADDON_SINGLETON_INSTANCE_ID);
+  /*!
+   * @brief Update all clients, sync with Addon Manager state (start, restart, shutdown clients).
+   * @param changedAddonId The id of the changed addon, empty string denotes 'any addon'.
+   * @param changedInstanceId The Identifier of the changed add-on instance
+   */
+  void UpdateClients(const std::string& changedAddonId = "",
+                     ADDON::AddonInstanceId changedInstanceId = ADDON::ADDON_SINGLETON_INSTANCE_ID);
 
-    /*!
-     * @brief Restart a single client add-on.
-     * @param addonId The add-on to restart.
-     * @param instanceId Instance identifier to use
-     * @param bDataChanged True if the client's data changed, false otherwise (unused).
-     * @return True if the client was found and restarted, false otherwise.
-     */
-    bool RequestRestart(const std::string& addonId,
-                        ADDON::AddonInstanceId instanceId,
-                        bool bDataChanged) override;
+  /*!
+   * @brief Restart a single client add-on.
+   * @param addonId The add-on to restart.
+   * @param instanceId Instance identifier to use
+   * @param bDataChanged True if the client's data changed, false otherwise (unused).
+   * @return True if the client was found and restarted, false otherwise.
+   */
+  bool RequestRestart(const std::string& addonId,
+                      ADDON::AddonInstanceId instanceId,
+                      bool bDataChanged) override;
 
-    /*!
-     * @brief Stop a client.
-     * @param clientId The id of the client to stop.
-     * @param restart If true, restart the client.
-     * @return True if the client was found, false otherwise.
-     */
-    bool StopClient(int clientId, bool restart);
+  /*!
+   * @brief Stop a client.
+   * @param clientId The id of the client to stop.
+   * @param restart If true, restart the client.
+   * @return True if the client was found, false otherwise.
+   */
+  bool StopClient(int clientId, bool restart);
 
-    /*!
-     * @brief Handle addon events (enable, disable, ...).
-     * @param event The addon event.
-     */
-    void OnAddonEvent(const ADDON::AddonEvent& event);
+  /*!
+   * @brief Handle addon events (enable, disable, ...).
+   * @param event The addon event.
+   */
+  void OnAddonEvent(const ADDON::AddonEvent& event);
 
-    /*!
-     * @brief Get the number of created clients.
-     * @return The amount of created clients.
-     */
-    size_t CreatedClientAmount() const;
+  /*!
+   * @brief Get the number of created clients.
+   * @return The amount of created clients.
+   */
+  size_t CreatedClientAmount() const;
 
-    /*!
-     * @brief Check whether there are any created clients.
-     * @return True if at least one client is created.
-     */
-    bool HasCreatedClients() const;
+  /*!
+   * @brief Check whether there are any created clients.
+   * @return True if at least one client is created.
+   */
+  bool HasCreatedClients() const;
 
-    /*!
-     * @brief Check whether a given client ID points to a created client.
-     * @param iClientId The client ID.
-     * @return True if the the client ID represents a created client, false otherwise.
-     */
-    bool IsCreatedClient(int iClientId) const;
+  /*!
+   * @brief Check whether a given client ID points to a created client.
+   * @param iClientId The client ID.
+   * @return True if the the client ID represents a created client, false otherwise.
+   */
+  bool IsCreatedClient(int iClientId) const;
 
-    /*!
-     * @brief Get the the client for the given client id, if it is created.
-     * @param clientId The ID of the client to get.
-     * @return The client if found, nullptr otherwise.
-     */
-    std::shared_ptr<CPVRClient> GetCreatedClient(int clientId) const;
+  /*!
+   * @brief Get the the client for the given client id, if it is created.
+   * @param clientId The ID of the client to get.
+   * @return The client if found, nullptr otherwise.
+   */
+  std::shared_ptr<CPVRClient> GetCreatedClient(int clientId) const;
 
-    /*!
-     * @brief Get all created clients.
-     * @return All created clients.
-     */
-    CPVRClientMap GetCreatedClients() const;
+  /*!
+   * @brief Get all created clients.
+   * @return All created clients.
+   */
+  CPVRClientMap GetCreatedClients() const;
 
-    /*!
-     * @brief Get the ID of the first created client.
-     * @return the ID or PVR_CLIENT_INVALID_UID if no clients are created;
-     */
-    int GetFirstCreatedClientID() const;
+  /*!
+   * @brief Get the ID of the first created client.
+   * @return the ID or PVR_CLIENT_INVALID_UID if no clients are created;
+   */
+  int GetFirstCreatedClientID() const;
 
-    /*!
-     * @brief Check whether there are any created, but not (yet) connected clients.
-     * @return True if at least one client is ignored.
-     */
-    bool HasIgnoredClients() const;
+  /*!
+   * @brief Check whether there are any created, but not (yet) connected clients.
+   * @return True if at least one client is ignored.
+   */
+  bool HasIgnoredClients() const;
 
-    /*!
-     * @brief Get the number of enabled clients.
-     * @return The amount of enabled clients.
-     */
-    size_t EnabledClientAmount() const;
+  /*!
+   * @brief Get the number of enabled clients.
+   * @return The amount of enabled clients.
+   */
+  size_t EnabledClientAmount() const;
 
-    /*!
-     * @brief Check whether a given client ID points to an enabled client.
-     * @param clientId The client ID.
-     * @return True if the the client ID represents an enabled client, false otherwise.
-     */
-    bool IsEnabledClient(int clientId) const;
+  /*!
+   * @brief Check whether a given client ID points to an enabled client.
+   * @param clientId The client ID.
+   * @return True if the the client ID represents an enabled client, false otherwise.
+   */
+  bool IsEnabledClient(int clientId) const;
 
-    /*!
-     * @brief Get a list of the enabled client infos.
-     * @return A list of enabled client infos.
-     */
-    std::vector<CVariant> GetEnabledClientInfos() const;
+  /*!
+   * @brief Get a list of the enabled client infos.
+   * @return A list of enabled client infos.
+   */
+  std::vector<CVariant> GetEnabledClientInfos() const;
 
-    /*!
-     * @brief Get info required for providers. Include both enabled and disabled PVR add-ons
-     * @return A list containing the information required to create client providers.
-     */
-    std::vector<CVariant> GetClientProviderInfos() const;
+  /*!
+   * @brief Get info required for providers. Include both enabled and disabled PVR add-ons
+   * @return A list containing the information required to create client providers.
+   */
+  std::vector<CVariant> GetClientProviderInfos() const;
 
-    //@}
+  //@}
 
-    /*! @name general methods */
-    //@{
+  /*! @name general methods */
+  //@{
 
-    /*!
-     * @brief Returns properties about all created clients
-     * @return the properties
-     */
-    std::vector<SBackend> GetBackendProperties() const;
+  /*!
+   * @brief Returns properties about all created clients
+   * @return the properties
+   */
+  std::vector<SBackend> GetBackendProperties() const;
 
-    //@}
+  //@}
 
-    /*! @name Timer methods */
-    //@{
+  /*! @name Timer methods */
+  //@{
 
-    /*!
-     * @brief Get all timers from the given clients
-     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
-     * @param timers Store the timers in this container.
-     * @param failedClients in case of errors will contain the ids of the clients for which the timers could not be obtained.
-     * @return true on success for all clients, false in case of error for at least one client.
-     */
-    bool GetTimers(const std::vector<std::shared_ptr<CPVRClient>>& clients,
-                   CPVRTimersContainer* timers,
-                   std::vector<int>& failedClients) const;
+  /*!
+   * @brief Get all timers from the given clients
+   * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
+   * @param timers Store the timers in this container.
+   * @param failedClients in case of errors will contain the ids of the clients for which the timers could not be obtained.
+   * @return true on success for all clients, false in case of error for at least one client.
+   */
+  bool GetTimers(const std::vector<std::shared_ptr<CPVRClient>>& clients,
+                 CPVRTimersContainer* timers,
+                 std::vector<int>& failedClients) const;
 
-    /*!
-     * @brief Update all timer types from the given clients
-     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
-     * @param failedClients in case of errors will contain the ids of the clients for which the timer types could not be obtained.
-     * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
-     */
-    PVR_ERROR UpdateTimerTypes(const std::vector<std::shared_ptr<CPVRClient>>& clients,
-                               std::vector<int>& failedClients);
+  /*!
+   * @brief Update all timer types from the given clients
+   * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
+   * @param failedClients in case of errors will contain the ids of the clients for which the timer types could not be obtained.
+   * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
+   */
+  PVR_ERROR UpdateTimerTypes(const std::vector<std::shared_ptr<CPVRClient>>& clients,
+                             std::vector<int>& failedClients);
 
-    /*!
-     * @brief Get all timer types supported by the backends, without updating them from the backends.
-     * @return the types.
-     */
-    const std::vector<std::shared_ptr<CPVRTimerType>> GetTimerTypes() const;
+  /*!
+   * @brief Get all timer types supported by the backends, without updating them from the backends.
+   * @return the types.
+   */
+  const std::vector<std::shared_ptr<CPVRTimerType>> GetTimerTypes() const;
 
-    //@}
+  //@}
 
-    /*! @name Recording methods */
-    //@{
+  /*! @name Recording methods */
+  //@{
 
-    /*!
-     * @brief Get all recordings from the given clients
-     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
-     * @param recordings Store the recordings in this container.
-     * @param deleted If true, return deleted recordings, return not deleted recordings otherwise.
-     * @param failedClients in case of errors will contain the ids of the clients for which the recordings could not be obtained.
-     * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
-     */
-    PVR_ERROR GetRecordings(const std::vector<std::shared_ptr<CPVRClient>>& clients,
-                            CPVRRecordings* recordings,
-                            bool deleted,
-                            std::vector<int>& failedClients) const;
-
-    /*!
-     * @brief Delete all "soft" deleted recordings permanently on the backend.
-     * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
-     */
-    PVR_ERROR DeleteAllRecordingsFromTrash();
-
-    //@}
-
-    /*! @name EPG methods */
-    //@{
-
-    /*!
-     * @brief Tell all clients the past time frame to use when notifying epg events back to Kodi.
-     *
-     * The clients might push epg events asynchronously to Kodi using the callback function
-     * EpgEventStateChange. To be able to only push events that are actually of interest for Kodi,
-     * clients need to know about the future epg time frame Kodi uses.
-     *
-     * @param[in] iPastDays number of days before "now".
-     *                        @ref EPG_TIMEFRAME_UNLIMITED means that Kodi is interested in all
-     *                        epg events, regardless of event times.
-     * @return @ref PVR_ERROR_NO_ERROR if the operation succeeded, the respective @ref PVR_ERROR
-     *         value otherwise.
-     */
-    PVR_ERROR SetEPGMaxPastDays(int iPastDays);
-
-    /*!
-     * @brief Tell all clients the future time frame to use when notifying epg events back to Kodi.
-     *
-     * The clients might push epg events asynchronously to Kodi using the callback function
-     * EpgEventStateChange. To be able to only push events that are actually of interest for Kodi,
-     * clients need to know about the future epg time frame Kodi uses.
-     *
-     * @param[in] iFutureDays number of days from "now".
-     *                        @ref EPG_TIMEFRAME_UNLIMITED means that Kodi is interested in all
-     *                        epg events, regardless of event times.
-     * @return @ref PVR_ERROR_NO_ERROR if the operation succeeded, the respective @ref PVR_ERROR
-     *         value otherwise.
-     */
-    PVR_ERROR SetEPGMaxFutureDays(int iFutureDays);
-
-    //@}
-
-    /*! @name Channel methods */
-    //@{
-
-    /*!
-     * @brief Get all channels from the given clients.
-     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
-     * @param bRadio Whether to fetch radio or TV channels.
-     * @param channels The container to store the channels.
-     * @param failedClients in case of errors will contain the ids of the clients for which the channels could not be obtained.
-     * @return PVR_ERROR_NO_ERROR if the channels were fetched successfully, last error otherwise.
-     */
-    PVR_ERROR GetChannels(const std::vector<std::shared_ptr<CPVRClient>>& clients,
-                          bool bRadio,
-                          std::vector<std::shared_ptr<CPVRChannel>>& channels,
+  /*!
+   * @brief Get all recordings from the given clients
+   * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
+   * @param recordings Store the recordings in this container.
+   * @param deleted If true, return deleted recordings, return not deleted recordings otherwise.
+   * @param failedClients in case of errors will contain the ids of the clients for which the recordings could not be obtained.
+   * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
+   */
+  PVR_ERROR GetRecordings(const std::vector<std::shared_ptr<CPVRClient>>& clients,
+                          CPVRRecordings* recordings,
+                          bool deleted,
                           std::vector<int>& failedClients) const;
 
-    /*!
-     * @brief Get all providers from backends.
-     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
-     * @param group The container to store the providers in.
-     * @param failedClients in case of errors will contain the ids of the clients for which the providers could not be obtained.
-     * @return PVR_ERROR_NO_ERROR if the providers were fetched successfully, last error otherwise.
-     */
-    PVR_ERROR GetProviders(const std::vector<std::shared_ptr<CPVRClient>>& clients,
-                           CPVRProvidersContainer* providers,
-                           std::vector<int>& failedClients) const;
+  /*!
+   * @brief Delete all "soft" deleted recordings permanently on the backend.
+   * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
+   */
+  PVR_ERROR DeleteAllRecordingsFromTrash();
 
-    /*!
-     * @brief Get all channel groups from the given clients.
-     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
-     * @param groups Store the channel groups in this container.
-     * @param failedClients in case of errors will contain the ids of the clients for which the channel groups could not be obtained.
-     * @return PVR_ERROR_NO_ERROR if the channel groups were fetched successfully, last error otherwise.
-     */
-    PVR_ERROR GetChannelGroups(const std::vector<std::shared_ptr<CPVRClient>>& clients,
-                               CPVRChannelGroups* groups,
-                               std::vector<int>& failedClients) const;
+  //@}
 
-    /*!
-     * @brief Get all group members of a channel group from the given clients.
-     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
-     * @param group The group to get the member for.
-     * @param groupMembers The container for the group members.
-     * @param failedClients in case of errors will contain the ids of the clients for which the channel group members could not be obtained.
-     * @return PVR_ERROR_NO_ERROR if the channel group members were fetched successfully, last error otherwise.
-     */
-    PVR_ERROR GetChannelGroupMembers(
-        const std::vector<std::shared_ptr<CPVRClient>>& clients,
-        CPVRChannelGroup* group,
-        std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers,
-        std::vector<int>& failedClients) const;
+  /*! @name EPG methods */
+  //@{
 
-    /*!
-     * @brief Get a list of clients providing a channel scan dialog.
-     * @return All clients supporting channel scan.
-     */
-    std::vector<std::shared_ptr<CPVRClient>> GetClientsSupportingChannelScan() const;
+  /*!
+   * @brief Tell all clients the past time frame to use when notifying epg events back to Kodi.
+   *
+   * The clients might push epg events asynchronously to Kodi using the callback function
+   * EpgEventStateChange. To be able to only push events that are actually of interest for Kodi,
+   * clients need to know about the future epg time frame Kodi uses.
+   *
+   * @param[in] iPastDays number of days before "now".
+   *                        @ref EPG_TIMEFRAME_UNLIMITED means that Kodi is interested in all
+   *                        epg events, regardless of event times.
+   * @return @ref PVR_ERROR_NO_ERROR if the operation succeeded, the respective @ref PVR_ERROR
+   *         value otherwise.
+   */
+  PVR_ERROR SetEPGMaxPastDays(int iPastDays);
 
-    /*!
-     * @brief Get a list of clients providing a channel settings dialog.
-     * @return All clients supporting channel settings.
-     */
-    std::vector<std::shared_ptr<CPVRClient>> GetClientsSupportingChannelSettings(bool bRadio) const;
+  /*!
+   * @brief Tell all clients the future time frame to use when notifying epg events back to Kodi.
+   *
+   * The clients might push epg events asynchronously to Kodi using the callback function
+   * EpgEventStateChange. To be able to only push events that are actually of interest for Kodi,
+   * clients need to know about the future epg time frame Kodi uses.
+   *
+   * @param[in] iFutureDays number of days from "now".
+   *                        @ref EPG_TIMEFRAME_UNLIMITED means that Kodi is interested in all
+   *                        epg events, regardless of event times.
+   * @return @ref PVR_ERROR_NO_ERROR if the operation succeeded, the respective @ref PVR_ERROR
+   *         value otherwise.
+   */
+  PVR_ERROR SetEPGMaxFutureDays(int iFutureDays);
 
-    /*!
-     * @brief Get whether or not any client supports recording size.
-     * @return True if any client supports recording size.
-     */
-    bool AnyClientSupportingRecordingsSize() const;
+  //@}
 
-    /*!
-     * @brief Get whether or not any client supports EPG.
-     * @return True if any client supports EPG.
-     */
-    bool AnyClientSupportingEPG() const;
+  /*! @name Channel methods */
+  //@{
 
-    /*!
-     * @brief Get whether or not any client supports recordings.
-     * @return True if any client supports recordings.
-     */
-    bool AnyClientSupportingRecordings() const;
-    //@}
+  /*!
+   * @brief Get all channels from the given clients.
+   * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
+   * @param bRadio Whether to fetch radio or TV channels.
+   * @param channels The container to store the channels.
+   * @param failedClients in case of errors will contain the ids of the clients for which the channels could not be obtained.
+   * @return PVR_ERROR_NO_ERROR if the channels were fetched successfully, last error otherwise.
+   */
+  PVR_ERROR GetChannels(const std::vector<std::shared_ptr<CPVRClient>>& clients,
+                        bool bRadio,
+                        std::vector<std::shared_ptr<CPVRChannel>>& channels,
+                        std::vector<int>& failedClients) const;
 
-    /*!
-     * @brief Get whether or not any client supports recordings delete.
-     * @return True if any client supports recordings delete.
-     */
-    bool AnyClientSupportingRecordingsDelete() const;
-    //@}
-
-    /*! @name Power management methods */
-    //@{
-
-    /*!
-     * @brief Propagate "system sleep" event to clients
-     */
-    void OnSystemSleep();
-
-    /*!
-     * @brief Propagate "system wakeup" event to clients
-     */
-    void OnSystemWake();
-
-    /*!
-     * @brief Propagate "power saving activated" event to clients
-     */
-    void OnPowerSavingActivated();
-
-    /*!
-     * @brief Propagate "power saving deactivated" event to clients
-     */
-    void OnPowerSavingDeactivated();
-
-    //@}
-
-    /*!
-     * @brief Notify a change of an addon connection state.
-     * @param client The changed client.
-     * @param strConnectionString A human-readable string providing additional information.
-     * @param newState The new connection state.
-     * @param strMessage A human readable string replacing default state message.
-     */
-    void ConnectionStateChange(CPVRClient* client,
-                               const std::string& strConnectionString,
-                               PVR_CONNECTION_STATE newState,
-                               const std::string& strMessage);
-
-  private:
-    /*!
-     * @brief Get the known instance ids for a given addon id.
-     * @param addonID The addon id.
-     * @return The list of known instance ids.
-     */
-    std::vector<ADDON::AddonInstanceId> GetKnownInstanceIds(const std::string& addonID) const;
-
-    bool GetAddonsWithStatus(
-        const std::string& changedAddonId,
-        std::vector<std::pair<std::shared_ptr<ADDON::CAddonInfo>, bool>>& addonsWithStatus) const;
-
-    std::vector<std::pair<ADDON::AddonInstanceId, bool>> GetInstanceIdsWithStatus(
-        const std::shared_ptr<ADDON::CAddonInfo>& addon, bool addonIsEnabled) const;
-
-    /*!
-     * @brief Get the client instance for a given client id.
-     * @param clientId The id of the client to get.
-     * @return The client if found, nullptr otherwise.
-     */
-    std::shared_ptr<CPVRClient> GetClient(int clientId) const;
-
-    /*!
-     * @brief Check whether a client is known.
-     * @param iClientId The id of the client to check.
-     * @return True if this client is known, false otherwise.
-     */
-    bool IsKnownClient(int iClientId) const;
-
-    /*!
-     * @brief Get all created clients and clients not (yet) ready to use.
-     * @param clientsReady Store the created clients in this map.
-     * @param clientsNotReady Store the the ids of the not (yet) ready clients in this list.
-     * @return PVR_ERROR_NO_ERROR in case all clients are ready, PVR_ERROR_SERVER_ERROR otherwise.
-     */
-    PVR_ERROR GetCallableClients(CPVRClientMap& clientsReady,
-                                 std::vector<int>& clientsNotReady) const;
-
-    typedef std::function<PVR_ERROR(const std::shared_ptr<CPVRClient>&)> PVRClientFunction;
-
-    /*!
-     * @brief Wraps calls to the given clients in order to do common pre and post function invocation actions.
-     * @param strFunctionName The function name, for logging purposes.
-     * @param clients The clients to wrap.
-     * @param function The function to wrap. It has to have return type PVR_ERROR and must take a const reference to a std::shared_ptr<CPVRClient> as parameter.
-     * @param failedClients Contains a list of the ids of clients for that the call failed, if any.
-     * @return PVR_ERROR_NO_ERROR on success, any other PVR_ERROR_* value otherwise.
-     */
-    PVR_ERROR ForClients(const char* strFunctionName,
-                         const std::vector<std::shared_ptr<CPVRClient>>& clients,
-                         const PVRClientFunction& function,
+  /*!
+   * @brief Get all providers from backends.
+   * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
+   * @param group The container to store the providers in.
+   * @param failedClients in case of errors will contain the ids of the clients for which the providers could not be obtained.
+   * @return PVR_ERROR_NO_ERROR if the providers were fetched successfully, last error otherwise.
+   */
+  PVR_ERROR GetProviders(const std::vector<std::shared_ptr<CPVRClient>>& clients,
+                         CPVRProvidersContainer* providers,
                          std::vector<int>& failedClients) const;
 
-    /*!
-     * @brief Wraps calls to all created clients in order to do common pre and post function invocation actions.
-     * @param strFunctionName The function name, for logging purposes.
-     * @param function The function to wrap. It has to have return type PVR_ERROR and must take a const reference to a std::shared_ptr<CPVRClient> as parameter.
-     * @return PVR_ERROR_NO_ERROR on success, any other PVR_ERROR_* value otherwise.
-     */
-    PVR_ERROR ForCreatedClients(const char* strFunctionName,
-                                const PVRClientFunction& function) const;
+  /*!
+   * @brief Get all channel groups from the given clients.
+   * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
+   * @param groups Store the channel groups in this container.
+   * @param failedClients in case of errors will contain the ids of the clients for which the channel groups could not be obtained.
+   * @return PVR_ERROR_NO_ERROR if the channel groups were fetched successfully, last error otherwise.
+   */
+  PVR_ERROR GetChannelGroups(const std::vector<std::shared_ptr<CPVRClient>>& clients,
+                             CPVRChannelGroups* groups,
+                             std::vector<int>& failedClients) const;
 
-    /*!
-     * @brief Wraps calls to all created clients in order to do common pre and post function invocation actions.
-     * @param strFunctionName The function name, for logging purposes.
-     * @param function The function to wrap. It has to have return type PVR_ERROR and must take a const reference to a std::shared_ptr<CPVRClient> as parameter.
-     * @param failedClients Contains a list of the ids of clients for that the call failed, if any.
-     * @return PVR_ERROR_NO_ERROR on success, any other PVR_ERROR_* value otherwise.
-     */
-    PVR_ERROR ForCreatedClients(const char* strFunctionName,
-                                const PVRClientFunction& function,
-                                std::vector<int>& failedClients) const;
+  /*!
+   * @brief Get all group members of a channel group from the given clients.
+   * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
+   * @param group The group to get the member for.
+   * @param groupMembers The container for the group members.
+   * @param failedClients in case of errors will contain the ids of the clients for which the channel group members could not be obtained.
+   * @return PVR_ERROR_NO_ERROR if the channel group members were fetched successfully, last error otherwise.
+   */
+  PVR_ERROR GetChannelGroupMembers(
+      const std::vector<std::shared_ptr<CPVRClient>>& clients,
+      CPVRChannelGroup* group,
+      std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers,
+      std::vector<int>& failedClients) const;
 
-    mutable CCriticalSection m_critSection;
-    CPVRClientMap m_clientMap;
-  };
-}
+  /*!
+   * @brief Get a list of clients providing a channel scan dialog.
+   * @return All clients supporting channel scan.
+   */
+  std::vector<std::shared_ptr<CPVRClient>> GetClientsSupportingChannelScan() const;
+
+  /*!
+   * @brief Get a list of clients providing a channel settings dialog.
+   * @return All clients supporting channel settings.
+   */
+  std::vector<std::shared_ptr<CPVRClient>> GetClientsSupportingChannelSettings(bool bRadio) const;
+
+  /*!
+   * @brief Get whether or not any client supports recording size.
+   * @return True if any client supports recording size.
+   */
+  bool AnyClientSupportingRecordingsSize() const;
+
+  /*!
+   * @brief Get whether or not any client supports EPG.
+   * @return True if any client supports EPG.
+   */
+  bool AnyClientSupportingEPG() const;
+
+  /*!
+   * @brief Get whether or not any client supports recordings.
+   * @return True if any client supports recordings.
+   */
+  bool AnyClientSupportingRecordings() const;
+  //@}
+
+  /*!
+   * @brief Get whether or not any client supports recordings delete.
+   * @return True if any client supports recordings delete.
+   */
+  bool AnyClientSupportingRecordingsDelete() const;
+  //@}
+
+  /*! @name Power management methods */
+  //@{
+
+  /*!
+   * @brief Propagate "system sleep" event to clients
+   */
+  void OnSystemSleep();
+
+  /*!
+   * @brief Propagate "system wakeup" event to clients
+   */
+  void OnSystemWake();
+
+  /*!
+   * @brief Propagate "power saving activated" event to clients
+   */
+  void OnPowerSavingActivated();
+
+  /*!
+   * @brief Propagate "power saving deactivated" event to clients
+   */
+  void OnPowerSavingDeactivated();
+
+  //@}
+
+  /*!
+   * @brief Notify a change of an addon connection state.
+   * @param client The changed client.
+   * @param strConnectionString A human-readable string providing additional information.
+   * @param newState The new connection state.
+   * @param strMessage A human readable string replacing default state message.
+   */
+  void ConnectionStateChange(CPVRClient* client,
+                             const std::string& strConnectionString,
+                             PVR_CONNECTION_STATE newState,
+                             const std::string& strMessage);
+
+private:
+  /*!
+   * @brief Get the known instance ids for a given addon id.
+   * @param addonID The addon id.
+   * @return The list of known instance ids.
+   */
+  std::vector<ADDON::AddonInstanceId> GetKnownInstanceIds(const std::string& addonID) const;
+
+  bool GetAddonsWithStatus(
+      const std::string& changedAddonId,
+      std::vector<std::pair<std::shared_ptr<ADDON::CAddonInfo>, bool>>& addonsWithStatus) const;
+
+  std::vector<std::pair<ADDON::AddonInstanceId, bool>> GetInstanceIdsWithStatus(
+      const std::shared_ptr<ADDON::CAddonInfo>& addon, bool addonIsEnabled) const;
+
+  /*!
+   * @brief Get the client instance for a given client id.
+   * @param clientId The id of the client to get.
+   * @return The client if found, nullptr otherwise.
+   */
+  std::shared_ptr<CPVRClient> GetClient(int clientId) const;
+
+  /*!
+   * @brief Check whether a client is known.
+   * @param iClientId The id of the client to check.
+   * @return True if this client is known, false otherwise.
+   */
+  bool IsKnownClient(int iClientId) const;
+
+  /*!
+   * @brief Get all created clients and clients not (yet) ready to use.
+   * @param clientsReady Store the created clients in this map.
+   * @param clientsNotReady Store the the ids of the not (yet) ready clients in this list.
+   * @return PVR_ERROR_NO_ERROR in case all clients are ready, PVR_ERROR_SERVER_ERROR otherwise.
+   */
+  PVR_ERROR GetCallableClients(CPVRClientMap& clientsReady,
+                               std::vector<int>& clientsNotReady) const;
+
+  typedef std::function<PVR_ERROR(const std::shared_ptr<CPVRClient>&)> PVRClientFunction;
+
+  /*!
+   * @brief Wraps calls to the given clients in order to do common pre and post function invocation actions.
+   * @param strFunctionName The function name, for logging purposes.
+   * @param clients The clients to wrap.
+   * @param function The function to wrap. It has to have return type PVR_ERROR and must take a const reference to a std::shared_ptr<CPVRClient> as parameter.
+   * @param failedClients Contains a list of the ids of clients for that the call failed, if any.
+   * @return PVR_ERROR_NO_ERROR on success, any other PVR_ERROR_* value otherwise.
+   */
+  PVR_ERROR ForClients(const char* strFunctionName,
+                       const std::vector<std::shared_ptr<CPVRClient>>& clients,
+                       const PVRClientFunction& function,
+                       std::vector<int>& failedClients) const;
+
+  /*!
+   * @brief Wraps calls to all created clients in order to do common pre and post function invocation actions.
+   * @param strFunctionName The function name, for logging purposes.
+   * @param function The function to wrap. It has to have return type PVR_ERROR and must take a const reference to a std::shared_ptr<CPVRClient> as parameter.
+   * @return PVR_ERROR_NO_ERROR on success, any other PVR_ERROR_* value otherwise.
+   */
+  PVR_ERROR ForCreatedClients(const char* strFunctionName, const PVRClientFunction& function) const;
+
+  /*!
+   * @brief Wraps calls to all created clients in order to do common pre and post function invocation actions.
+   * @param strFunctionName The function name, for logging purposes.
+   * @param function The function to wrap. It has to have return type PVR_ERROR and must take a const reference to a std::shared_ptr<CPVRClient> as parameter.
+   * @param failedClients Contains a list of the ids of clients for that the call failed, if any.
+   * @return PVR_ERROR_NO_ERROR on success, any other PVR_ERROR_* value otherwise.
+   */
+  PVR_ERROR ForCreatedClients(const char* strFunctionName,
+                              const PVRClientFunction& function,
+                              std::vector<int>& failedClients) const;
+
+  mutable CCriticalSection m_critSection;
+  CPVRClientMap m_clientMap;
+};
+} // namespace PVR

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -318,7 +318,7 @@ void CPVREpgContainer::Process()
     CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(iNow);
     {
       std::unique_lock<CCriticalSection> lock(m_critSection);
-      bUpdateEpg = (iNow >= m_iNextEpgUpdate) && !m_bSuspended;
+      bUpdateEpg = (iNow >= m_iNextEpgUpdate) && IsAwake();
       iLastEpgCleanup = m_iLastEpgCleanup;
     }
 
@@ -327,7 +327,7 @@ void CPVREpgContainer::Process()
       m_bIsInitialising = false;
 
     /* clean up old entries */
-    if (!m_bStop && !m_bSuspended &&
+    if (!m_bStop && IsAwake() &&
         iNow >= iLastEpgCleanup + CServiceBroker::GetSettingsComponent()
                                       ->GetAdvancedSettings()
                                       ->m_iEpgCleanupInterval)
@@ -335,7 +335,7 @@ void CPVREpgContainer::Process()
 
     /* check for pending manual EPG updates */
 
-    while (!m_bStop && !m_bSuspended)
+    while (!m_bStop && IsAwake())
     {
       CEpgUpdateRequest request;
       std::shared_ptr<CPVREpg> epg;
@@ -362,7 +362,7 @@ void CPVREpgContainer::Process()
 
     /* check for pending EPG tag changes */
 
-    if (!m_bStop && !m_bSuspended)
+    if (!m_bStop && IsAwake())
     {
       unsigned int iProcessed = 0;
       XbmcThreads::EndTime<> processTimeslice(
@@ -401,7 +401,7 @@ void CPVREpgContainer::Process()
       }
     }
 
-    if (!m_bStop && !m_bSuspended)
+    if (!m_bStop && IsAwake())
     {
       bool bHasPendingUpdates = false;
 
@@ -921,16 +921,6 @@ void CPVREpgContainer::OnPlaybackStopped()
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   m_bPlaying = false;
-}
-
-void CPVREpgContainer::OnSystemSleep()
-{
-  m_bSuspended = true;
-}
-
-void CPVREpgContainer::OnSystemWake()
-{
-  m_bSuspended = false;
 }
 
 int CPVREpgContainer::CleanupCachedImages()

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_epg.h"
+#include "powermanagement/PowerState.h"
 #include "pvr/settings/PVRSettings.h"
 #include "threads/CriticalSection.h"
 #include "threads/Event.h"
@@ -39,7 +40,7 @@ enum class PVREvent;
 
 struct PVREpgSearchData;
 
-class CPVREpgContainer : private CThread
+class CPVREpgContainer : private CThread, public CPowerState
 {
   friend class CPVREpgDatabase;
 
@@ -206,16 +207,6 @@ public:
   void OnPlaybackStopped();
 
   /*!
-   * @brief Inform the epg container that the system is going to sleep
-   */
-  void OnSystemSleep();
-
-  /*!
-   * @brief Inform the epg container that the system gets awake from sleep
-   */
-  void OnSystemWake();
-
-  /*!
    * @brief Erase stale texture db entries and image files.
    * @return number of cleaned up images.
    */
@@ -362,7 +353,5 @@ private:
       false; /*!< true while an epg updated notification to observers is pending. */
   CPVRSettings m_settings;
   CEventSource<PVREvent>& m_events;
-
-  std::atomic<bool> m_bSuspended = {false};
 };
 } // namespace PVR

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -27,335 +27,342 @@ class CDateTime;
 
 namespace PVR
 {
-  class CEpgUpdateRequest;
-  class CEpgTagStateChange;
-  class CPVREpg;
-  class CPVREpgChannelData;
-  class CPVREpgDatabase;
-  class CPVREpgInfoTag;
-  class CPVREpgSearchFilter;
+class CEpgUpdateRequest;
+class CEpgTagStateChange;
+class CPVREpg;
+class CPVREpgChannelData;
+class CPVREpgDatabase;
+class CPVREpgInfoTag;
+class CPVREpgSearchFilter;
 
-  enum class PVREvent;
+enum class PVREvent;
 
-  struct PVREpgSearchData;
+struct PVREpgSearchData;
 
-  class CPVREpgContainer : private CThread
-  {
-    friend class CPVREpgDatabase;
+class CPVREpgContainer : private CThread
+{
+  friend class CPVREpgDatabase;
 
-  public:
-    CPVREpgContainer() = delete;
+public:
+  CPVREpgContainer() = delete;
 
-    /*!
-     * @brief Create a new EPG table container.
-     */
-    explicit CPVREpgContainer(CEventSource<PVREvent>& eventSource);
+  /*!
+   * @brief Create a new EPG table container.
+   */
+  explicit CPVREpgContainer(CEventSource<PVREvent>& eventSource);
 
-    /*!
-     * @brief Destroy this instance.
-     */
-    ~CPVREpgContainer() override;
+  /*!
+   * @brief Destroy this instance.
+   */
+  ~CPVREpgContainer() override;
 
-    /*!
-     * @brief Get a pointer to the database instance.
-     * @return A pointer to the database instance.
-     */
-    std::shared_ptr<CPVREpgDatabase> GetEpgDatabase() const;
+  /*!
+   * @brief Get a pointer to the database instance.
+   * @return A pointer to the database instance.
+   */
+  std::shared_ptr<CPVREpgDatabase> GetEpgDatabase() const;
 
-    /*!
-     * @brief Start the EPG update thread.
-     */
-    void Start();
+  /*!
+   * @brief Start the EPG update thread.
+   */
+  void Start();
 
-    /*!
-     * @brief Stop the EPG update thread.
-     */
-    void Stop();
+  /*!
+   * @brief Stop the EPG update thread.
+   */
+  void Stop();
 
-    /**
-     * @brief (re)load EPG data.
-     * @return True if loaded successfully, false otherwise.
-     */
-    bool Load();
+  /**
+   * @brief (re)load EPG data.
+   * @return True if loaded successfully, false otherwise.
+   */
+  bool Load();
 
-    /**
-     * @brief unload all EPG data.
-     */
-    void Unload();
+  /**
+   * @brief unload all EPG data.
+   */
+  void Unload();
 
-    /*!
-     * @brief Check whether the EpgContainer has fully started.
-     * @return True if started, false otherwise.
-     */
-    bool IsStarted() const;
+  /*!
+   * @brief Check whether the EpgContainer has fully started.
+   * @return True if started, false otherwise.
+   */
+  bool IsStarted() const;
 
-    /*!
-     * @brief Queue the deletion of the given EPG tables from this container.
-     * @param epg The tables to delete.
-     * @return True on success, false otherwise.
-     */
-    bool QueueDeleteEpgs(const std::vector<std::shared_ptr<CPVREpg>>& epgs);
+  /*!
+   * @brief Queue the deletion of the given EPG tables from this container.
+   * @param epg The tables to delete.
+   * @return True on success, false otherwise.
+   */
+  bool QueueDeleteEpgs(const std::vector<std::shared_ptr<CPVREpg>>& epgs);
 
-    /*!
-     * @brief CEventStream callback for PVR events.
-     * @param event The event.
-     */
-    void Notify(const PVREvent& event);
+  /*!
+   * @brief CEventStream callback for PVR events.
+   * @param event The event.
+   */
+  void Notify(const PVREvent& event);
 
-    /*!
-     * @brief Create the EPg for a given channel.
-     * @param iEpgId The EPG id.
-     * @param strScraperName The scraper name.
-     * @param channelData The channel data.
-     * @return the created EPG
-     */
-    std::shared_ptr<CPVREpg> CreateChannelEpg(int iEpgId, const std::string& strScraperName, const std::shared_ptr<CPVREpgChannelData>& channelData);
+  /*!
+   * @brief Create the EPg for a given channel.
+   * @param iEpgId The EPG id.
+   * @param strScraperName The scraper name.
+   * @param channelData The channel data.
+   * @return the created EPG
+   */
+  std::shared_ptr<CPVREpg> CreateChannelEpg(int iEpgId,
+                                            const std::string& strScraperName,
+                                            const std::shared_ptr<CPVREpgChannelData>& channelData);
 
-    /*!
-     * @brief Get the start and end time across all EPGs.
-     * @return The times; first: start time, second: end time.
-     */
-    std::pair<CDateTime, CDateTime> GetFirstAndLastEPGDate() const;
+  /*!
+   * @brief Get the start and end time across all EPGs.
+   * @return The times; first: start time, second: end time.
+   */
+  std::pair<CDateTime, CDateTime> GetFirstAndLastEPGDate() const;
 
-    /*!
-     * @brief Get all EPGs.
-     * @return The EPGs.
-     */
-    std::vector<std::shared_ptr<CPVREpg>> GetAllEpgs() const;
+  /*!
+   * @brief Get all EPGs.
+   * @return The EPGs.
+   */
+  std::vector<std::shared_ptr<CPVREpg>> GetAllEpgs() const;
 
-    /*!
-     * @brief Get an EPG given its ID.
-     * @param iEpgId The database ID of the table.
-     * @return The EPG or nullptr if it wasn't found.
-     */
-    std::shared_ptr<CPVREpg> GetById(int iEpgId) const;
+  /*!
+   * @brief Get an EPG given its ID.
+   * @param iEpgId The database ID of the table.
+   * @return The EPG or nullptr if it wasn't found.
+   */
+  std::shared_ptr<CPVREpg> GetById(int iEpgId) const;
 
-    /*!
-     * @brief Get an EPG given its client id and channel uid.
-     * @param iClientId the id of the pvr client providing the EPG
-     * @param iChannelUid the uid of the channel for the EPG
-     * @return The EPG or nullptr if it wasn't found.
-     */
-    std::shared_ptr<CPVREpg> GetByChannelUid(int iClientId, int iChannelUid) const;
+  /*!
+   * @brief Get an EPG given its client id and channel uid.
+   * @param iClientId the id of the pvr client providing the EPG
+   * @param iChannelUid the uid of the channel for the EPG
+   * @return The EPG or nullptr if it wasn't found.
+   */
+  std::shared_ptr<CPVREpg> GetByChannelUid(int iClientId, int iChannelUid) const;
 
-    /*!
-     * @brief Get the EPG event with the given event id
-     * @param epg The epg to lookup the event.
-     * @param iBroadcastId The event id to lookup.
-     * @return The requested event, or an empty tag when not found
-     */
-    std::shared_ptr<CPVREpgInfoTag> GetTagById(const std::shared_ptr<const CPVREpg>& epg,
-                                               unsigned int iBroadcastId) const;
+  /*!
+   * @brief Get the EPG event with the given event id
+   * @param epg The epg to lookup the event.
+   * @param iBroadcastId The event id to lookup.
+   * @return The requested event, or an empty tag when not found
+   */
+  std::shared_ptr<CPVREpgInfoTag> GetTagById(const std::shared_ptr<const CPVREpg>& epg,
+                                             unsigned int iBroadcastId) const;
 
-    /*!
-     * @brief Get the EPG event with the given database id
-     * @param iDatabaseId The id to lookup.
-     * @return The requested event, or an empty tag when not found
-     */
-    std::shared_ptr<CPVREpgInfoTag> GetTagByDatabaseId(int iDatabaseId) const;
+  /*!
+   * @brief Get the EPG event with the given database id
+   * @param iDatabaseId The id to lookup.
+   * @return The requested event, or an empty tag when not found
+   */
+  std::shared_ptr<CPVREpgInfoTag> GetTagByDatabaseId(int iDatabaseId) const;
 
-    /*!
-     * @brief Get all EPG tags matching the given search criteria.
-     * @param searchData The search criteria.
-     * @return The matching tags.
-     */
-    std::vector<std::shared_ptr<CPVREpgInfoTag>> GetTags(const PVREpgSearchData& searchData) const;
+  /*!
+   * @brief Get all EPG tags matching the given search criteria.
+   * @param searchData The search criteria.
+   * @return The matching tags.
+   */
+  std::vector<std::shared_ptr<CPVREpgInfoTag>> GetTags(const PVREpgSearchData& searchData) const;
 
-    /*!
-     * @brief Notify EPG container that there are pending manual EPG updates
-     * @param bHasPendingUpdates The new value
-     */
-    void SetHasPendingUpdates(bool bHasPendingUpdates = true);
+  /*!
+   * @brief Notify EPG container that there are pending manual EPG updates
+   * @param bHasPendingUpdates The new value
+   */
+  void SetHasPendingUpdates(bool bHasPendingUpdates = true);
 
-    /*!
-     * @brief A client triggered an epg update request for a channel
-     * @param iClientID The id of the client which triggered the update request
-     * @param iUniqueChannelID The uid of the channel for which the epg shall be updated
-     */
-    void UpdateRequest(int iClientID, int iUniqueChannelID);
+  /*!
+   * @brief A client triggered an epg update request for a channel
+   * @param iClientID The id of the client which triggered the update request
+   * @param iUniqueChannelID The uid of the channel for which the epg shall be updated
+   */
+  void UpdateRequest(int iClientID, int iUniqueChannelID);
 
-    /*!
-     * @brief A client announced an updated epg tag for a channel
-     * @param tag The epg tag containing the updated data
-     * @param eNewState The kind of change (CREATED, UPDATED, DELETED)
-     */
-    void UpdateFromClient(const std::shared_ptr<CPVREpgInfoTag>& tag, EPG_EVENT_STATE eNewState);
+  /*!
+   * @brief A client announced an updated epg tag for a channel
+   * @param tag The epg tag containing the updated data
+   * @param eNewState The kind of change (CREATED, UPDATED, DELETED)
+   */
+  void UpdateFromClient(const std::shared_ptr<CPVREpgInfoTag>& tag, EPG_EVENT_STATE eNewState);
 
-    /*!
-     * @brief Get the number of past days to show in the guide and to import from backends.
-     * @return the number of past epg days.
-     */
-    int GetPastDaysToDisplay() const;
+  /*!
+   * @brief Get the number of past days to show in the guide and to import from backends.
+   * @return the number of past epg days.
+   */
+  int GetPastDaysToDisplay() const;
 
-    /*!
-     * @brief Get the number of future days to show in the guide and to import from backends.
-     * @return the number of future epg days.
-     */
-    int GetFutureDaysToDisplay() const;
+  /*!
+   * @brief Get the number of future days to show in the guide and to import from backends.
+   * @return the number of future epg days.
+   */
+  int GetFutureDaysToDisplay() const;
 
-    /*!
-     * @brief Inform the epg container that playback of an item just started.
-     */
-    void OnPlaybackStarted();
+  /*!
+   * @brief Inform the epg container that playback of an item just started.
+   */
+  void OnPlaybackStarted();
 
-    /*!
-     * @brief Inform the epg container that playback of an item was stopped due to user interaction.
-     */
-    void OnPlaybackStopped();
+  /*!
+   * @brief Inform the epg container that playback of an item was stopped due to user interaction.
+   */
+  void OnPlaybackStopped();
 
-    /*!
-     * @brief Inform the epg container that the system is going to sleep
-     */
-    void OnSystemSleep();
+  /*!
+   * @brief Inform the epg container that the system is going to sleep
+   */
+  void OnSystemSleep();
 
-    /*!
-     * @brief Inform the epg container that the system gets awake from sleep
-     */
-    void OnSystemWake();
+  /*!
+   * @brief Inform the epg container that the system gets awake from sleep
+   */
+  void OnSystemWake();
 
-    /*!
-     * @brief Erase stale texture db entries and image files.
-     * @return number of cleaned up images.
-     */
-    int CleanupCachedImages();
+  /*!
+   * @brief Erase stale texture db entries and image files.
+   * @return number of cleaned up images.
+   */
+  int CleanupCachedImages();
 
-    /*!
-     * @brief Get all saved searches from the database.
-     * @param bRadio Whether to fetch saved searches for radio or TV.
-     * @return The searches.
-     */
-    std::vector<std::shared_ptr<CPVREpgSearchFilter>> GetSavedSearches(bool bRadio) const;
+  /*!
+   * @brief Get all saved searches from the database.
+   * @param bRadio Whether to fetch saved searches for radio or TV.
+   * @return The searches.
+   */
+  std::vector<std::shared_ptr<CPVREpgSearchFilter>> GetSavedSearches(bool bRadio) const;
 
-    /*!
-     * @brief Get the saved search matching the given id.
-     * @param bRadio Whether to fetch a TV or radio saved search.
-     * @param iId The id.
-     * @return The saved search or nullptr if not found.
-     */
-    std::shared_ptr<CPVREpgSearchFilter> GetSavedSearchById(bool bRadio, int iId) const;
+  /*!
+   * @brief Get the saved search matching the given id.
+   * @param bRadio Whether to fetch a TV or radio saved search.
+   * @param iId The id.
+   * @return The saved search or nullptr if not found.
+   */
+  std::shared_ptr<CPVREpgSearchFilter> GetSavedSearchById(bool bRadio, int iId) const;
 
-    /*!
-     * @brief Persist a saved search in the database.
-     * @param search The saved search.
-     * @return True on success, false otherwise.
-     */
-    bool PersistSavedSearch(CPVREpgSearchFilter& search);
+  /*!
+   * @brief Persist a saved search in the database.
+   * @param search The saved search.
+   * @return True on success, false otherwise.
+   */
+  bool PersistSavedSearch(CPVREpgSearchFilter& search);
 
-    /*!
-     * @brief Update time last executed for the given search.
-     * @param epgSearch The search.
-     * @return True on success, false otherwise.
-     */
-    bool UpdateSavedSearchLastExecuted(const CPVREpgSearchFilter& epgSearch);
+  /*!
+   * @brief Update time last executed for the given search.
+   * @param epgSearch The search.
+   * @return True on success, false otherwise.
+   */
+  bool UpdateSavedSearchLastExecuted(const CPVREpgSearchFilter& epgSearch);
 
-    /*!
-     * @brief Delete a saved search from the database.
-     * @param search The saved search.
-     * @return True on success, false otherwise.
-     */
-    bool DeleteSavedSearch(const CPVREpgSearchFilter& search);
+  /*!
+   * @brief Delete a saved search from the database.
+   * @param search The saved search.
+   * @return True on success, false otherwise.
+   */
+  bool DeleteSavedSearch(const CPVREpgSearchFilter& search);
 
-  private:
-    /*!
-     * @brief Notify EPG table observers when the currently active tag changed.
-     * @return True if the check was done, false if it was not the right time to check
-     */
-    bool CheckPlayingEvents();
+private:
+  /*!
+   * @brief Notify EPG table observers when the currently active tag changed.
+   * @return True if the check was done, false if it was not the right time to check
+   */
+  bool CheckPlayingEvents();
 
-    /*!
-     * @brief The next EPG ID to be given to a table when the db isn't being used.
-     * @return The next ID.
-     */
-    int NextEpgId();
+  /*!
+   * @brief The next EPG ID to be given to a table when the db isn't being used.
+   * @return The next ID.
+   */
+  int NextEpgId();
 
-    /*!
-     * @brief Wait for an EPG update to finish.
-     */
-    void WaitForUpdateFinish();
+  /*!
+   * @brief Wait for an EPG update to finish.
+   */
+  void WaitForUpdateFinish();
 
-    /*!
-     * @brief Call Persist() on each table
-     * @param iMaxTimeslice time in milliseconds for max processing. Return after this time
-     *        even if not all data was persisted, unless value is -1
-     * @return True when they all were persisted, false otherwise.
-     */
-    bool PersistAll(unsigned int iMaxTimeslice) const;
+  /*!
+   * @brief Call Persist() on each table
+   * @param iMaxTimeslice time in milliseconds for max processing. Return after this time
+   *        even if not all data was persisted, unless value is -1
+   * @return True when they all were persisted, false otherwise.
+   */
+  bool PersistAll(unsigned int iMaxTimeslice) const;
 
-    /*!
-     * @brief Remove old EPG entries.
-     * @return True if the old entries were removed successfully, false otherwise.
-     */
-    bool RemoveOldEntries();
+  /*!
+   * @brief Remove old EPG entries.
+   * @return True if the old entries were removed successfully, false otherwise.
+   */
+  bool RemoveOldEntries();
 
-    /*!
-     * @brief Load and update the EPG data.
-     * @param bOnlyPending Only check and update EPG tables with pending manual updates
-     * @return True if the update has not been interrupted, false otherwise.
-     */
-    bool UpdateEPG(bool bOnlyPending = false);
+  /*!
+   * @brief Load and update the EPG data.
+   * @param bOnlyPending Only check and update EPG tables with pending manual updates
+   * @return True if the update has not been interrupted, false otherwise.
+   */
+  bool UpdateEPG(bool bOnlyPending = false);
 
-    /*!
-     * @brief Check whether a running update should be interrupted.
-     * @return True if a running update should be interrupted, false otherwise.
-     */
-    bool InterruptUpdate() const;
+  /*!
+   * @brief Check whether a running update should be interrupted.
+   * @return True if a running update should be interrupted, false otherwise.
+   */
+  bool InterruptUpdate() const;
 
-    /*!
-     * @brief EPG update thread
-     */
-    void Process() override;
+  /*!
+   * @brief EPG update thread
+   */
+  void Process() override;
 
-    /*!
-     * @brief Load all tables from the database
-     */
-    void LoadFromDatabase();
+  /*!
+   * @brief Load all tables from the database
+   */
+  void LoadFromDatabase();
 
-    /*!
-     * @brief Insert data from database
-     * @param newEpg the EPG containing the updated data.
-     */
-    void InsertFromDB(const std::shared_ptr<CPVREpg>& newEpg);
+  /*!
+   * @brief Insert data from database
+   * @param newEpg the EPG containing the updated data.
+   */
+  void InsertFromDB(const std::shared_ptr<CPVREpg>& newEpg);
 
-    /*!
-     * @brief Queue the deletion of an EPG table from this container.
-     * @param epg The table to delete.
-     * @param database The database containing the epg data.
-     * @return True on success, false otherwise.
-     */
-    bool QueueDeleteEpg(const std::shared_ptr<const CPVREpg>& epg,
-                        const std::shared_ptr<CPVREpgDatabase>& database);
+  /*!
+   * @brief Queue the deletion of an EPG table from this container.
+   * @param epg The table to delete.
+   * @param database The database containing the epg data.
+   * @return True on success, false otherwise.
+   */
+  bool QueueDeleteEpg(const std::shared_ptr<const CPVREpg>& epg,
+                      const std::shared_ptr<CPVREpgDatabase>& database);
 
-    std::shared_ptr<CPVREpgDatabase> m_database; /*!< the EPG database */
+  std::shared_ptr<CPVREpgDatabase> m_database; /*!< the EPG database */
 
-    bool m_bIsUpdating = false; /*!< true while an update is running */
-    std::atomic<bool> m_bIsInitialising = {
-        true}; /*!< true while the epg manager hasn't loaded all tables */
-    bool m_bStarted = false; /*!< true if EpgContainer has fully started */
-    bool m_bLoaded = false; /*!< true after epg data is initially loaded from the database */
-    bool m_bPreventUpdates = false; /*!< true to prevent EPG updates */
-    bool m_bPlaying = false; /*!< true if Kodi is currently playing something */
-    int m_pendingUpdates = 0; /*!< count of pending manual updates */
-    time_t m_iLastEpgCleanup = 0; /*!< the time the EPG was cleaned up */
-    time_t m_iNextEpgUpdate = 0; /*!< the time the EPG will be updated */
-    time_t m_iNextEpgActiveTagCheck = 0; /*!< the time the EPG will be checked for active tag updates */
-    int m_iNextEpgId = 0; /*!< the next epg ID that will be given to a new table when the db isn't being used */
+  bool m_bIsUpdating = false; /*!< true while an update is running */
+  std::atomic<bool> m_bIsInitialising = {
+      true}; /*!< true while the epg manager hasn't loaded all tables */
+  bool m_bStarted = false; /*!< true if EpgContainer has fully started */
+  bool m_bLoaded = false; /*!< true after epg data is initially loaded from the database */
+  bool m_bPreventUpdates = false; /*!< true to prevent EPG updates */
+  bool m_bPlaying = false; /*!< true if Kodi is currently playing something */
+  int m_pendingUpdates = 0; /*!< count of pending manual updates */
+  time_t m_iLastEpgCleanup = 0; /*!< the time the EPG was cleaned up */
+  time_t m_iNextEpgUpdate = 0; /*!< the time the EPG will be updated */
+  time_t m_iNextEpgActiveTagCheck =
+      0; /*!< the time the EPG will be checked for active tag updates */
+  int m_iNextEpgId =
+      0; /*!< the next epg ID that will be given to a new table when the db isn't being used */
 
-    std::map<int, std::shared_ptr<CPVREpg>> m_epgIdToEpgMap; /*!< the EPGs in this container. maps epg ids to epgs */
-    std::map<std::pair<int, int>, std::shared_ptr<CPVREpg>> m_channelUidToEpgMap; /*!< the EPGs in this container. maps channel uids to epgs */
+  std::map<int, std::shared_ptr<CPVREpg>>
+      m_epgIdToEpgMap; /*!< the EPGs in this container. maps epg ids to epgs */
+  std::map<std::pair<int, int>, std::shared_ptr<CPVREpg>>
+      m_channelUidToEpgMap; /*!< the EPGs in this container. maps channel uids to epgs */
 
-    mutable CCriticalSection m_critSection; /*!< a critical section for changes to this container */
-    CEvent m_updateEvent; /*!< trigger when an update finishes */
+  mutable CCriticalSection m_critSection; /*!< a critical section for changes to this container */
+  CEvent m_updateEvent; /*!< trigger when an update finishes */
 
-    std::list<CEpgUpdateRequest> m_updateRequests; /*!< list of update requests triggered by addon */
-    CCriticalSection m_updateRequestsLock; /*!< protect update requests */
+  std::list<CEpgUpdateRequest> m_updateRequests; /*!< list of update requests triggered by addon */
+  CCriticalSection m_updateRequestsLock; /*!< protect update requests */
 
-    std::list<CEpgTagStateChange> m_epgTagChanges; /*!< list of updated epg tags announced by addon */
-    CCriticalSection m_epgTagChangesLock; /*!< protect changed epg tags list */
+  std::list<CEpgTagStateChange> m_epgTagChanges; /*!< list of updated epg tags announced by addon */
+  CCriticalSection m_epgTagChangesLock; /*!< protect changed epg tags list */
 
-    bool m_bUpdateNotificationPending = false; /*!< true while an epg updated notification to observers is pending. */
-    CPVRSettings m_settings;
-    CEventSource<PVREvent>& m_events;
+  bool m_bUpdateNotificationPending =
+      false; /*!< true while an epg updated notification to observers is pending. */
+  CPVRSettings m_settings;
+  CEventSource<PVREvent>& m_events;
 
-    std::atomic<bool> m_bSuspended = {false};
-  };
-}
+  std::atomic<bool> m_bSuspended = {false};
+};
+} // namespace PVR

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -150,16 +150,6 @@ void CPVRTimers::Stop()
   CServiceBroker::GetPVRManager().Events().Unsubscribe(this);
 }
 
-void CPVRTimers::OnSystemSleep()
-{
-  m_suspended = true;
-}
-
-void CPVRTimers::OnSystemWake()
-{
-  m_suspended = false;
-}
-
 bool CPVRTimers::UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients)
 {
   {
@@ -183,7 +173,7 @@ void CPVRTimers::Process()
 {
   while (!m_bStop)
   {
-    if (m_suspended)
+    if (IsSleeping())
     {
       CThread::Sleep(10s);
       continue;

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -8,10 +8,10 @@
 
 #pragma once
 
+#include "powermanagement/PowerState.h"
 #include "pvr/settings/PVRSettings.h"
 #include "threads/Thread.h"
 
-#include <atomic>
 #include <map>
 #include <memory>
 #include <queue>
@@ -66,7 +66,7 @@ protected:
   MapTags m_tags;
 };
 
-class CPVRTimers : public CPVRTimersContainer, private CThread
+class CPVRTimers : public CPVRTimersContainer, private CThread, public CPowerState
 {
 public:
   CPVRTimers();
@@ -81,16 +81,6 @@ public:
      * @brief stop the timer update thread.
      */
   void Stop();
-
-  /*!
-   * @brief Inform the epg container that the system is going to sleep
-   */
-  void OnSystemSleep();
-
-  /*!
-   * @brief Inform the epg container that the system gets awake from sleep
-   */
-  void OnSystemWake();
 
   /*!
    * @brief Update all timers from PVR database and from given clients.
@@ -337,7 +327,6 @@ private:
   CPVRSettings m_settings;
   std::queue<std::shared_ptr<CPVRTimerInfoTag>> m_remindersToAnnounce;
   bool m_bReminderRulesUpdatePending = false;
-  std::atomic<bool> m_suspended{false};
 
   bool m_bFirstUpdate = true;
   std::vector<int> m_failedClients;


### PR DESCRIPTION
Follow-up to #26580

* Introduce a reusable power state class, refactor PVR components to use it
* Prevent addons repository updates while system is sleeping (involves network access, which is not guaranteed to work in suspend state)
* Prevent texture cache cleanup while system is sleeping (could involve network access to shared databases, which is not guaranteed to work in suspend state)

Runtime-tested an macOS and Android, latest Kodi master

@phunkyfish , @rmrector @howie-f when you find some time for a review... best reviewed commit by commit, ignoring the two clang-format commits.

BTW: There may be more of these scheduled activities that should be prevented while system is sleeping, but this is what I found so far by examining the logs Kodi has written "over night", while my Android Shield TV is in "suspend" mode.