### PR TITLE
GUIShaderDX: use platform agnostic method to initialize XMVECTOR (remove `#ifdef`)

### DIFF
--- a/xbmc/guilib/GUIShaderDX.cpp
+++ b/xbmc/guilib/GUIShaderDX.cpp
@@ -279,21 +279,17 @@ void CGUIShaderDX::SetViewPort(D3D11_VIEWPORT viewPort)
   }
 }
 
-void CGUIShaderDX::Project(float &x, float &y, float &z)
+void CGUIShaderDX::Project(float& x, float& y, float& z) const
 {
-#if defined(_XM_SSE_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
-  XMVECTOR vLocation = { x, y, z };
-#elif defined(_M_ARM64) && defined(_XM_ARM_NEON_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
-  XMVECTOR vLocation = {.n128_f32{x, y, z}};
-#elif defined(_XM_ARM_NEON_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
-  XMVECTOR vLocation = { x, y };
-#endif
-  XMVECTOR vScreenCoord = XMVector3Project(vLocation, m_cbViewPort.TopLeftX, m_cbViewPort.TopLeftY,
-                                           m_cbViewPort.Width, m_cbViewPort.Height, 0, 1,
-                                           m_cbWorldViewProj.projection, m_cbWorldViewProj.view, m_cbWorldViewProj.world);
-  x = XMVectorGetX(vScreenCoord);
-  y = XMVectorGetY(vScreenCoord);
-  z = 0;
+  const XMVECTOR V = XMVectorSet(x, y, z, .0f);
+
+  const XMVECTOR screenCoord = XMVector3Project(
+      V, m_cbViewPort.TopLeftX, m_cbViewPort.TopLeftY, m_cbViewPort.Width, m_cbViewPort.Height,
+      0.0f, 1.0f, m_cbWorldViewProj.projection, m_cbWorldViewProj.view, m_cbWorldViewProj.world);
+
+  x = XMVectorGetX(screenCoord);
+  y = XMVectorGetY(screenCoord);
+  z = .0f;
 }
 
 void XM_CALLCONV CGUIShaderDX::SetWVP(const XMMATRIX &w, const XMMATRIX &v, const XMMATRIX &p)

--- a/xbmc/guilib/GUIShaderDX.h
+++ b/xbmc/guilib/GUIShaderDX.h
@@ -61,7 +61,7 @@ public:
   void XM_CALLCONV SetWorld(const DirectX::XMMATRIX &value);
   void XM_CALLCONV SetView(const DirectX::XMMATRIX &value);
   void XM_CALLCONV SetProjection(const DirectX::XMMATRIX &value);
-  void Project(float &x, float &y, float &z);
+  void Project(float& x, float& y, float& z) const;
 
   void DrawQuad(Vertex& v1, Vertex& v2, Vertex& v3, Vertex& v4);
   void DrawIndexed(unsigned int indexCount, unsigned int startIndex, unsigned int startVertex);


### PR DESCRIPTION
## Description
GUIShaderDX: use platform agnostic method to initialize XMVECTOR (remove `#ifdef`)

The implementation of XMVECTOR is platform-dependent and opaque: data should not be manipulated directly, but rather use accessors.

## Motivation and context
Related to https://github.com/xbmc/xbmc/pull/26572

Removes need of `#ifdef` by processor ARCH.

> In the DirectXMath Library, to fully support portability and optimization, XMVECTOR is, by design, an opaque type. The actual implementation of XMVECTOR is platform dependent.
> 
> In general, code should not rely on the specifics of any given platform specific implementation of XMVECTOR. Platform-specific implementations have these characteristics:
> 
> - They are not portable.
> - They may change between releases.
>  - Injudicious use of implementation details may be suboptimal.
>
> Developers should use DirectXMath Library's [accessor](https://learn.microsoft.com/en-us/windows/win32/dxmath/ovw-xnamath-reference-functions-accessors), [load](https://learn.microsoft.com/en-us/windows/win32/dxmath/ovw-xnamath-reference-functions-load), and [store](https://learn.microsoft.com/en-us/windows/win32/dxmath/ovw-xnamath-reference-functions-storage) functions to get and set the vectors, and the [DirectXMath Library 4D Vector Functions](https://learn.microsoft.com/en-us/windows/win32/dxmath/ovw-xnamath-reference-functions-vector4) to manipulate them.
> 

https://learn.microsoft.com/en-us/windows/win32/dxmath/xmvector-data-type


## How has this been tested?
Runtime Windows x64


## What is the effect on users?
Nothing

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
