### PR TITLE
Fix video info dialog scroll buttons

### DIFF
--- a/addons/skin.estuary/xml/DialogPVRInfo.xml
+++ b/addons/skin.estuary/xml/DialogPVRInfo.xml
@@ -103,7 +103,7 @@
 					</control>
 					<control type="image">
 						<left>755</left>
-						<width>512</width>
+						<width>509</width>
 						<height>718</height>
 						<aligny>bottom</aligny>
 						<texture border="21">dialogs/dialog-bg.png</texture>

--- a/addons/skin.estuary/xml/DialogVideoInfo.xml
+++ b/addons/skin.estuary/xml/DialogVideoInfo.xml
@@ -596,7 +596,15 @@
 							<top>0</top>
 							<width>264</width>
 							<height>142</height>
+							<texture border="21" colordiffuse="button_focus">buttons/button-nofo.png</texture>
+							<visible>!Control.HasFocus(5000)</visible>
+						</control>
+						<control type="image">
+							<top>0</top>
+							<width>264</width>
+							<height>142</height>
 							<texture border="21" colordiffuse="button_focus">buttons/button-fo.png</texture>
+							<visible>Control.HasFocus(5000)</visible>
 						</control>
 						<control type="image">
 							<top>30</top>

--- a/addons/skin.estuary/xml/DialogVideoInfo.xml
+++ b/addons/skin.estuary/xml/DialogVideoInfo.xml
@@ -1,9 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<defaultcontrol always="true">8</defaultcontrol>
+	<onload>SetFocus(5000,0,absolute)</onload>
 	<onload>SetProperty(infobackground,$ESCINFO[ListItem.Art(fanart)],home)</onload>
 	<onunload>ClearProperty(infobackground,home)</onunload>
 	<controls>
+		<control type="button" id="6">
+			<include>HiddenObject</include>
+		</control>
+		<control type="button" id="7">
+			<enable>String.IsEmpty(Container.PluginName) + !Container.Content(Sets)</enable>
+			<include>HiddenObject</include>
+		</control>
+		<control type="togglebutton" id="8">
+			<include>HiddenObject</include>
+		</control>
+		<control type="button" id="10">
+			<include>HiddenObject</include>
+		</control>
+		<control type="button" id="11">
+			<include>HiddenObject</include>
+		</control>
+		<control type="button" id="13">
+			<include>HiddenObject</include>
+		</control>
+		<control type="button" id="14">
+			<include>HiddenObject</include>
+		</control>
+		<control type="button" id="15">
+			<include>HiddenObject</include>
+		</control>
 		<control type="group">
 			<centertop>50%</centertop>
 			<height>1080</height>
@@ -101,7 +126,7 @@
 					</control>
 					<control type="image">
 						<left>735</left>
-						<width>512</width>
+						<width>509</width>
 						<height>418</height>
 						<aligny>bottom</aligny>
 						<texture border="21">dialogs/dialog-bg.png</texture>
@@ -518,143 +543,187 @@
 						</control>
 					</focusedlayout>
 				</control>
-				<control type="grouplist" id="5000">
+				<control type="list" id="5000">
 					<left>0</left>
 					<top>864</top>
-					<width>1246</width>
+					<width>1235</width>
 					<height>400</height>
 					<onleft>5000</onleft>
 					<onright>5000</onright>
 					<onup>140</onup>
 					<ondown condition="!Integer.IsGreater(Container(5000).Position,4)">SetFocus(50,$INFO[Container(5000).Position])</ondown>
 					<ondown condition="Integer.IsGreater(Container(5000).Position,4)">SetFocus(50,4)</ondown>
-					<itemgap>-18</itemgap>
 					<align>center</align>
 					<orientation>horizontal</orientation>
 					<scrolltime tween="quadratic">200</scrolltime>
-					<include content="InfoDialogToggleButton">
-						<param name="id" value="8" />
-						<param name="icon_on" value="icons/filemanager.png" />
-						<param name="icon_off" value="icons/infodialogs/play.png" />
-						<param name="selected" value="String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,season) | String.IsEqual(ListItem.DBType,set)" />
-						<param name="label" value="$VAR[VideoInfoPlayButtonLabelVar]" />
-					</include>
-					<include content="InfoDialogButton">
-						<param name="id" value="11" />
-						<param name="icon" value="icons/infodialogs/trailer.png" />
-						<param name="label" value="$LOCALIZE[20410]" />
-						<param name="visible" value="!String.IsEmpty(ListItem.Trailer) + ![String.StartsWith(Container.FolderPath,plugin://) + String.Contains(Container.FolderPath,trailer)]" />
-					</include>
-					<include content="InfoDialogButton">
-						<param name="id" value="441" />
-						<param name="icon" value="icons/infodialogs/cinema.png" />
-						<param name="onclick_1" value="Dialog.Close(MovieInformation)" />
-						<param name="onclick_2" value="RunScript(script.cinemavision,experience)" />
-						<param name="label" value="$LOCALIZE[31003]" />
-						<param name="visible" value="System.AddonIsEnabled(script.cinemavision) + [String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,season) | String.IsEqual(ListItem.DBType,episode)]" />
-					</include>
-					<control type="group" id="400">
-						<width>264</width>
-						<visible>Control.IsEnabled(7) | !String.IsEmpty(ListItem.UserRating)</visible>
-						<control type="button" id="7">
-							<include content="VideoInfoButtonsCommon">
-								<param name="icon" value="" />
-							</include>
-							<label>$LOCALIZE[31033]</label>
-							<onleft>441</onleft>
-							<onright>101</onright>
-							<onup>140</onup>
-							<enable>String.IsEmpty(Container.PluginName) + !Container.Content(Sets)</enable>
-							<ondown condition="Integer.IsEqual(Container(5000).CurrentItem,1)">SetFocus(50,0)</ondown>
-							<ondown condition="Integer.IsEqual(Container(5000).CurrentItem,2)">SetFocus(50,1)</ondown>
-							<ondown condition="Integer.IsEqual(Container(5000).CurrentItem,3)">SetFocus(50,2)</ondown>
-							<ondown condition="Integer.IsEqual(Container(5000).CurrentItem,4)">SetFocus(50,3)</ondown>
-							<ondown condition="Integer.IsEqual(Container(5000).CurrentItem,5)">SetFocus(50,4)</ondown>
-						</control>
-						<control type="label">
-							<label>$INFO[ListItem.UserRating]</label>
-							<font>font45_title</font>
-							<left>0</left>
-							<top>24</top>
+					<itemlayout height="142" width="245">
+						<control type="image">
+							<top>0</top>
 							<width>264</width>
-							<align>center</align>
+							<height>142</height>
+							<texture border="21" colordiffuse="button_focus">buttons/button-nofo.png</texture>
 						</control>
 						<control type="image">
-							<texture>icons/infodialogs/rating.png</texture>
-							<left>108</left>
 							<top>30</top>
+							<left>108</left>
 							<width>48</width>
 							<height>48</height>
-							<align>center</align>
-							<visible>String.IsEmpty(ListItem.UserRating)</visible>
+							<texture>$INFO[ListItem.Icon]</texture>
 						</control>
-					</control>
-					<include content="InfoDialogButton">
-						<param name="id" value="101" />
-						<param name="icon" value="icons/infodialogs/info.png" />
-						<param name="label" value="$LOCALIZE[31034]" />
-						<param name="onclick_1_condition" value="!String.IsEmpty(ListItem.DBID) + String.IsEqual(ListItem.DBType,movie)" />
-						<param name="onclick_1" value="RunScript(script.embuary.info,call=movie,dbid=$INFO[ListItem.DBID])" />
-						<param name="onclick_2_condition" value="!String.IsEmpty(ListItem.DBID) + String.IsEqual(ListItem.DBType,tvshow)" />
-						<param name="onclick_2" value="RunScript(script.embuary.info,call=tv,dbid=$INFO[ListItem.DBID])" />
-						<param name="onclick_3_condition" value="!String.IsEmpty(ListItem.DBID) + String.IsEqual(ListItem.DBType,episode)" />
-						<param name="onclick_3" value="RunScript(script.embuary.info,call=tv,query='$ESCINFO[ListItem.TVShowTitle]',year=$INFO[ListItem.Year])" />
-						<param name="visible" value="System.AddonIsEnabled(script.embuary.info) + !String.IsEmpty(ListItem.DBID) + [String.IsEqual(ListItem.DbType,movie) | String.IsEqual(ListItem.DbType,tvshow) | String.IsEqual(ListItem.DbType,episode)]" />
-					</include>
-					<include content="InfoDialogButton">
-						<param name="id" value="102" />
-						<param name="icon" value="icons/infodialogs/image.png" />
-						<param name="label" value="$LOCALIZE[31028]" />
-						<param name="onclick_1" value="SetProperty(fanart,$ESCINFO[ListItem.Art(fanart)],home)" />
-						<param name="onclick_2" value="ActivateWindow(1104)" />
-						<param name="visible" value="!String.IsEmpty(ListItem.Art(fanart))" />
-					</include>
-					<include content="InfoDialogButton">
-						<param name="id" value="13" />
-						<param name="icon" value="icons/infodialogs/director.png" />
-						<param name="label" value="$LOCALIZE[31123]" />
-						<param name="visible" value="!String.IsEmpty(ListItem.Director)" />
-					</include>
-					<include content="InfoDialogButton">
-						<param name="id" value="999" />
-						<param name="icon" value="DefaultMusicAlbums.png" />
-						<param name="onclick_1" value="Dialog.Close(all,true)" />
-						<param name="onclick_2" value="ActivateWindow(Music,musicdb://albums/?artist=$INFO[ListItem.Artist]&amp;albumartistonly=true&amp;compilation=false)" />
-						<param name="label" value="$LOCALIZE[132]" />
-						<param name="visible" value="String.IsEqual(ListItem.DBType,musicvideo)" />
-					</include>
-					<include content="InfoDialogButton">
-						<param name="id" value="14" />
-						<param name="icon" value="icons/infodialogs/versions.png" />
-						<param name="label" value="$LOCALIZE[40000]" />
-						<param name="visible" value="String.IsEqual(ListItem.DBType,movie)" />
-					</include>
-					<include content="InfoDialogButton">
-						<param name="id" value="15" />
-						<param name="icon" value="icons/infodialogs/extras.png" />
-						<param name="label" value="$LOCALIZE[40211]" />
-						<param name="visible" value="String.IsEqual(ListItem.DBType,movie)" />
-					</include>
-					<include content="InfoDialogButton">
-						<param name="id" value="443" />
-						<param name="icon" value="icons/infodialogs/set.png" />
-						<param name="label" value="$LOCALIZE[20457]" />
-						<param name="onclick_1" value="Dialog.Close(all,true)" />
-						<param name="onclick_2" value="ActivateWindow(Videos,videodb://movies/sets/$INFO[ListItem.SetId]/?setid=$INFO[ListItem.SetId])" />
-						<param name="visible" value="!String.IsEmpty(ListItem.SetID)" />
-					</include>
-					<include content="InfoDialogButton">
-						<param name="id" value="10" />
-						<param name="icon" value="icons/infodialogs/choose_image.png" />
-						<param name="label" value="$LOCALIZE[13511]" />
-						<param name="visible" value="Control.IsEnabled(10)" />
-					</include>
-					<include content="InfoDialogButton">
-						<param name="id" value="6" />
-						<param name="icon" value="icons/infodialogs/update.png" />
-						<param name="label" value="$LOCALIZE[184]" />
-						<param name="visible" value="Control.IsEnabled(6)" />
-					</include>
+						<control type="label">
+							<top>63</top>
+							<left>23</left>
+							<width>214</width>
+							<height>67</height>
+							<align>center</align>
+							<aligny>center</aligny>
+							<font>font12</font>
+							<label>$INFO[ListItem.Label]</label>
+						</control>
+						<control type="label">
+							<top>24</top>
+							<left>23</left>
+							<width>214</width>
+							<height>67</height>
+							<align>center</align>
+							<aligny>center</aligny>
+							<font>font45_title</font>
+							<label>$INFO[ListItem.Label2]</label>
+						</control>
+					</itemlayout>
+					<focusedlayout height="142" width="245">
+						<control type="image">
+							<top>0</top>
+							<width>264</width>
+							<height>142</height>
+							<texture border="21" colordiffuse="button_focus">buttons/button-fo.png</texture>
+						</control>
+						<control type="image">
+							<top>30</top>
+							<left>108</left>
+							<width>48</width>
+							<height>48</height>
+							<texture>$INFO[ListItem.Icon]</texture>
+						</control>
+						<control type="label">
+							<top>63</top>
+							<left>23</left>
+							<width>214</width>
+							<height>67</height>
+							<align>center</align>
+							<aligny>center</aligny>
+							<font>font12</font>
+							<label>$INFO[ListItem.Label]</label>
+						</control>
+						<control type="label">
+							<top>24</top>
+							<left>23</left>
+							<width>214</width>
+							<height>67</height>
+							<align>center</align>
+							<aligny>center</aligny>
+							<font>font45_title</font>
+							<label>$INFO[ListItem.Label2]</label>
+						</control>
+					</focusedlayout>
+					<content>
+						<item>
+							<label>$VAR[VideoInfoPlayButtonLabelVar]</label>
+							<icon>icons/infodialogs/play.png</icon>
+							<onclick>SendClick(8)</onclick>
+							<visible>![String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,season) | String.IsEqual(ListItem.DBType,set)]</visible>
+						</item>
+						<item>
+							<label>$VAR[VideoInfoPlayButtonLabelVar]</label>
+							<icon>icons/filemanager.png</icon>
+							<onclick>SendClick(8)</onclick>
+							<visible>String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,season) | String.IsEqual(ListItem.DBType,set)</visible>
+						</item>
+						<item>
+							<label>$LOCALIZE[20410]</label>
+							<icon>icons/infodialogs/trailer.png</icon>
+							<onclick>SendClick(11)</onclick>
+							<visible>!String.IsEmpty(ListItem.Trailer) + ![String.StartsWith(Container.FolderPath,plugin://) + String.Contains(Container.FolderPath,trailer)]</visible>
+						</item>
+						<item>
+							<label>$LOCALIZE[31003]</label>
+							<icon>icons/infodialogs/cinema.png</icon>
+							<onclick>Dialog.Close(MovieInformation)</onclick>
+							<onclick>RunScript(script.cinemavision,experience)</onclick>
+							<visible>System.AddonIsEnabled(script.cinemavision) + [String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,season) | String.IsEqual(ListItem.DBType,episode)]</visible>
+						</item>
+						<item>
+							<label>$LOCALIZE[31033]</label>
+							<icon>icons/infodialogs/rating.png</icon>
+							<onclick>SendClick(7)</onclick>
+							<visible>Control.IsEnabled(7) + String.IsEmpty(ListItem.UserRating)</visible>
+						</item>
+						<item>
+							<label>$LOCALIZE[31033]</label>
+							<label2>$INFO[ListItem.UserRating]</label2>
+							<onclick>SendClick(7)</onclick>
+							<visible>Control.IsEnabled(7) + !String.IsEmpty(ListItem.UserRating)</visible>
+						</item>
+						<item>
+							<label>$LOCALIZE[31034]</label>
+							<icon>icons/infodialogs/info.png</icon>
+							<onclick condition="!String.IsEmpty(ListItem.DBID) + String.IsEqual(ListItem.DBType,movie)">RunScript(script.embuary.info,call=movie,dbid=$INFO[ListItem.DBID])</onclick>
+							<onclick condition="!String.IsEmpty(ListItem.DBID) + String.IsEqual(ListItem.DBType,tvshow)">RunScript(script.embuary.info,call=tv,dbid=$INFO[ListItem.DBID])</onclick>
+							<onclick condition="!String.IsEmpty(ListItem.DBID) + String.IsEqual(ListItem.DBType,episode)">RunScript(script.embuary.info,call=tv,query='$ESCINFO[ListItem.TVShowTitle]',year=$INFO[ListItem.Year])</onclick>
+							<visible>System.AddonIsEnabled(script.embuary.info) + !String.IsEmpty(ListItem.DBID) + [String.IsEqual(ListItem.DbType,movie) | String.IsEqual(ListItem.DbType,tvshow) | String.IsEqual(ListItem.DbType,episode)]</visible>
+						</item>
+						<item>
+							<label>$LOCALIZE[31028]</label>
+							<icon>icons/infodialogs/image.png</icon>
+							<onclick>SetProperty(fanart,$ESCINFO[ListItem.Art(fanart)],home)</onclick>
+							<onclick>ActivateWindow(1104)</onclick>
+							<visible>!String.IsEmpty(ListItem.Art(fanart))</visible>
+						</item>
+						<item>
+							<label>$LOCALIZE[31123]</label>
+							<icon>icons/infodialogs/director.png</icon>
+							<onclick>SendClick(13)</onclick>
+							<visible>!String.IsEmpty(ListItem.Director)</visible>
+						</item>
+						<item>
+							<label>$LOCALIZE[132]</label>
+							<icon>DefaultMusicAlbums.png</icon>
+							<onclick>Dialog.Close(all,true)</onclick>
+							<onclick>ActivateWindow(Music,musicdb://albums/?artist=$INFO[ListItem.Artist]&amp;albumartistonly=true&amp;compilation=false)</onclick>
+							<visible>String.IsEqual(ListItem.DBType,musicvideo)</visible>
+						</item>
+						<item>
+							<label>$LOCALIZE[40000]</label>
+							<icon>icons/infodialogs/versions.png</icon>
+							<onclick>SendClick(14)</onclick>
+							<visible>String.IsEqual(ListItem.DBType,movie)</visible>
+						</item>
+						<item>
+							<label>$LOCALIZE[40211]</label>
+							<icon>icons/infodialogs/extras.png</icon>
+							<onclick>SendClick(15)</onclick>
+							<visible>String.IsEqual(ListItem.DBType,movie)</visible>
+						</item>
+						<item>
+							<label>$LOCALIZE[20457]</label>
+							<icon>icons/infodialogs/set.png</icon>
+							<onclick>Dialog.Close(all,true)</onclick>
+							<onclick>ActivateWindow(Videos,videodb://movies/sets/$INFO[ListItem.SetId]/?setid=$INFO[ListItem.SetId])</onclick>
+							<visible>!String.IsEmpty(ListItem.SetID)</visible>
+						</item>
+						<item>
+							<label>$LOCALIZE[13511]</label>
+							<icon>icons/infodialogs/choose_image.png</icon>
+							<onclick>SendClick(10)</onclick>
+							<visible>Control.IsEnabled(10)</visible>
+						</item>
+						<item>
+							<label>$LOCALIZE[184]</label>
+							<icon>icons/infodialogs/update.png</icon>
+							<onclick>SendClick(6)</onclick>
+							<visible>Control.IsEnabled(6)</visible>
+						</item>
+					</content>
 				</control>
 				<include content="LeftRightArrows">
 					<param name="list_id" value="5000" />
@@ -682,7 +751,7 @@
 				<shadowcolor>text_shadow</shadowcolor>
 				<scroll>true</scroll>
 				<label>$INFO[ListItem.DecodedFileNameAndPath]</label>
-				<visible>Control.HasFocus(6)</visible>
+				<visible>String.IsEqual(Container(5000).ListItem.Label,$LOCALIZE[184])</visible>
 				<animation effect="fade" start="0" end="100" time="300" delay="300">WindowOpen</animation>
 				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
 				<animation effect="fade" start="0" end="100" time="300">Visible</animation>

--- a/addons/skin.estuary/xml/Includes_Buttons.xml
+++ b/addons/skin.estuary/xml/Includes_Buttons.xml
@@ -25,7 +25,7 @@
 		<param name="altclick">noop</param>
 		<definition>
 			<control type="togglebutton" id="$PARAM[control_id]">
-				<width>472</width>
+				<width>469</width>
 				<height>49</height>
 				<textoffsetx>16</textoffsetx>
 				<aligny>center</aligny>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Change from using a grouplist to a list so the left/right scroll buttons function correctly.
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The left/right scroll buttons don't work for grouplists.
Reported on the forum [here](https://forum.kodi.tv/showthread.php?tid=379328&pid=3214475#pid3214475) and discussed with @KarellenX on Slack.

![scrollarrows](https://github.com/user-attachments/assets/0f813613-78d9-4a6b-93e9-131f5361e484)

Also, fixes the issue when moving down from the buttons (once the group has scrolled to the right) where it would focus on the  4th cast member instead of the 5th.
  
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.
## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Correct functioning of scroll buttons when using mouse/touch.
## Screenshots (if appropriate):
Also shortened the width of the info area so all elements align correctly along the right side.

![Untitled](https://github.com/user-attachments/assets/7fc6deb0-c932-45d2-9034-29c5f8415360)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
