### PR TITLE
[Cmake] Find module fixes for brotli and nghttp2

### DIFF
--- a/cmake/modules/FindBrotli.cmake
+++ b/cmake/modules/FindBrotli.cmake
@@ -34,9 +34,11 @@ if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
       set(_PREFIX "lib")
     endif()
 
-    set(BROTLICOMMON_LIBRARY "${DEP_LOCATION}/lib/${_PREFIX}brotlicommon.${_LIBEXT}")
+    set(BROTLICOMMON_LIBRARY_RELEASE "${DEP_LOCATION}/lib/${_PREFIX}brotlicommon.${_LIBEXT}")
+    set(BROTLIDEC_LIBRARY_RELEASE "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY}")
 
-    set(BROTLIDEC_LIBRARY "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY}")
+    # Todo: debug postfix libs for windows
+    #       Will require patching nghttp2, as they do not use debug postfix for differentiation
 
   endmacro()
 
@@ -52,7 +54,7 @@ if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
                       ${${CORE_PLATFORM_NAME_LC}_SEARCH_CONFIG})
 
   # Check for existing Brotli. If version >= BROTLI-VERSION file version, dont build
-  if(brotli2_VERSION VERSION_LESS ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VER} AND Brotli_FIND_REQUIRED)
+  if(brotli_VERSION VERSION_LESS ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VER} AND Brotli_FIND_REQUIRED)
     # Build lib
     buildbrotli()
   else()
@@ -62,7 +64,9 @@ if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
       # convert this back to either DEBUG/RELEASE or just RELEASE
       # we only do this because we use find_package_handle_standard_args for config time output
       # and it isnt capable of handling TARGETS, so we have to extract the info
-      foreach(_target "brotli::brotlicommon;brotli::brotlidec")
+      set(brotli_targets brotli::brotlicommon
+                         brotli::brotlidec)
+      foreach(_target ${brotli_targets})
 
         string(REPLACE "brotli::" "" _target_name ${_target})
         string(TOUPPER ${_target_name} _target_name_UPPER)
@@ -102,8 +106,12 @@ if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
   endif()
 
   include(SelectLibraryConfigurations)
-  select_library_configurations(BROTLI)
-  unset(BROTLI_LIBRARIES)
+  select_library_configurations(BROTLIDEC)
+  unset(BROTLIDEC_LIBRARIES)
+
+  include(SelectLibraryConfigurations)
+  select_library_configurations(BROTLICOMMON)
+  unset(BROTLICOMMON_LIBRARIES)
 
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(Brotli

--- a/cmake/modules/FindNGHttp2.cmake
+++ b/cmake/modules/FindNGHttp2.cmake
@@ -11,6 +11,10 @@
 if(NOT TARGET LIBRARY::NGHttp2)
 
   macro(buildlibnghttp2)
+
+    set(patches "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/01-all-cmake-version.patch")
+    generate_patchcommand("${patches}")
+
     set(CMAKE_ARGS -DENABLE_DEBUG=OFF
                    -DENABLE_FAILMALLOC=OFF
                    -DENABLE_LIB_ONLY=ON

--- a/cmake/modules/FindOpenSSL.cmake
+++ b/cmake/modules/FindOpenSSL.cmake
@@ -36,6 +36,10 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     # Add Crypto as a link library to easily propagate both targets to our custom target
     set_target_properties(OpenSSL::SSL PROPERTIES
                                        INTERFACE_LINK_LIBRARIES "OpenSSL::Crypto")
+
+    # Required for external searches. Not used internally
+    set(OpenSSL_FOUND ON CACHE BOOL "OpenSSL found")
+    mark_as_advanced(OpenSSL_FOUND)
   else()
     if(OpenSSL_FIND_REQUIRED)
       message(FATAL_ERROR "OpenSSL libraries were not found.")

--- a/cmake/modules/FindZlib.cmake
+++ b/cmake/modules/FindZlib.cmake
@@ -38,6 +38,10 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
   if(ZLIB_FOUND)
     add_library(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} ALIAS ZLIB::ZLIB)
+
+    # Required for external searches. Not used internally
+    set(ZLIB_FOUND ON CACHE BOOL "ZLIB found")
+    mark_as_advanced(ZLIB_FOUND)
   else()
     if(ZLIB_FIND_REQUIRED)
       message(FATAL_ERROR "Zlib libraries were not found.")


### PR DESCRIPTION
## Description
Fix wrong variable name for brotli, and fix using existing cmake config for brotlicommon and brotlidec

apply patch to cmake internal build for nghttp2 to allow versioning of the lib to be tested.

## Motivation and context
Noticed some libs always rebuilding. Fix the issues with brotli and nghttp2.

## How has this been tested?
Win arm64 full build, clean build folder and rebuilt with known libs built from previous build

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
