### PR TITLE
Fix Wrong Info Dialog for Versions of Same Name

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2107,8 +2107,9 @@ bool CFileItem::LoadDetails()
     bool ret{false};
     auto tag{std::make_unique<CVideoInfoTag>()};
     if (params.GetMovieId() >= 0)
-      ret = db.GetMovieInfo({}, *tag, static_cast<int>(params.GetMovieId()),
-                            static_cast<int>(params.GetVideoVersionId()));
+      ret = db.GetMovieInfo(
+          {}, *tag, static_cast<int>(params.GetMovieId()),
+          static_cast<int>(params.GetVideoVersionId())); //! @todo add support for asset id
     else if (params.GetMVideoId() >= 0)
       ret = db.GetMusicVideoInfo({}, *tag, static_cast<int>(params.GetMVideoId()));
     else if (params.GetEpisodeId() >= 0)

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -228,7 +228,8 @@ JSONRPC_STATUS CPlayerOperations::GetItem(const std::string &method, ITransportL
             case VideoDbContentType::MOVIES:
               videodatabase.GetMovieInfo("", *(fileItem->GetVideoInfoTag()),
                                          fileItem->GetVideoInfoTag()->m_iDbId,
-                                         fileItem->GetVideoInfoTag()->GetAssetInfo().GetId());
+                                         fileItem->GetVideoInfoTag()->GetAssetInfo().GetId(),
+                                         fileItem->GetVideoInfoTag()->m_iFileId);
               break;
 
             case VideoDbContentType::MUSICVIDEOS:

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -401,7 +401,8 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
 
           if (params.GetMovieId() >= 0)
             db.GetMovieInfo(static_cast<const char*>(path), *item->GetVideoInfoTag(),
-                            params.GetMovieId(), params.GetVideoVersionId());
+                            params.GetMovieId(),
+                            params.GetVideoVersionId()); //! @todo add support for asset id
           else if (params.GetMVideoId() >= 0)
             db.GetMusicVideoInfo((const char*)path, *item->GetVideoInfoTag(), params.GetMVideoId());
           else if (params.GetEpisodeId() >= 0)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2184,6 +2184,7 @@ bool CVideoDatabase::GetMovieInfo(const std::string& strFilenameAndPath,
                                   CVideoInfoTag& details,
                                   int idMovie /* = -1 */,
                                   int idVersion /* = -1 */,
+                                  int idFile /* = -1 */,
                                   int getDetails /* = VideoDbDetailsAll */)
 {
   try
@@ -2198,7 +2199,12 @@ bool CVideoDatabase::GetMovieInfo(const std::string& strFilenameAndPath,
       return false;
 
     std::string sql;
-    if (idVersion >= 0)
+    if (idFile >= 0)
+    {
+      sql = PrepareSQL("SELECT * FROM movie_view WHERE idMovie = %i AND videoVersionIdFile = %i",
+                       idMovie, idFile);
+    }
+    else if (idVersion >= 0)
     {
       //! @todo get rid of "videos with versions as folder" hack!
       if (idVersion != VIDEO_VERSION_ID_ALL)
@@ -2207,7 +2213,7 @@ bool CVideoDatabase::GetMovieInfo(const std::string& strFilenameAndPath,
     }
     else if (!strFilenameAndPath.empty())
     {
-      const int idFile{GetFileId(strFilenameAndPath)};
+      idFile = GetFileId(strFilenameAndPath);
       if (idFile != -1)
         sql = PrepareSQL("SELECT * FROM movie_view WHERE idMovie = %i AND videoVersionIdFile = %i",
                          idMovie, idFile);
@@ -2225,7 +2231,7 @@ bool CVideoDatabase::GetMovieInfo(const std::string& strFilenameAndPath,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strFilenameAndPath);
+    CLog::LogF(LOGERROR, "{} {} {} failed", strFilenameAndPath, idMovie, idFile);
   }
   return false;
 }

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -587,6 +587,7 @@ public:
                     CVideoInfoTag& details,
                     int idMovie = -1,
                     int idVersion = -1,
+                    int idFile = -1,
                     int getDetails = VideoDbDetailsAll);
   bool GetTvShowInfo(const std::string& strPath, CVideoInfoTag& details, int idTvShow = -1, CFileItem* item = NULL, int getDetails = VideoDbDetailsAll);
   bool GetSeasonInfo(const std::string& path, int season, CVideoInfoTag& details, CFileItem* item);

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -691,7 +691,8 @@ void CGUIDialogVideoInfo::OnSearchItemFound(const CFileItem* pItem)
   CVideoInfoTag movieDetails;
   if (type == VideoDbContentType::MOVIES)
     db.GetMovieInfo(pItem->GetPath(), movieDetails, pItem->GetVideoInfoTag()->m_iDbId,
-                    pItem->GetVideoInfoTag()->GetAssetInfo().GetId());
+                    pItem->GetVideoInfoTag()->GetAssetInfo().GetId(),
+                    pItem->GetVideoInfoTag()->m_iFileId);
   if (type == VideoDbContentType::EPISODES)
     db.GetEpisodeInfo(pItem->GetPath(), movieDetails, pItem->GetVideoInfoTag()->m_iDbId);
   if (type == VideoDbContentType::TVSHOWS)
@@ -1223,7 +1224,7 @@ bool CGUIDialogVideoInfo::UpdateVideoItemTitle(const std::shared_ptr<CFileItem>&
   if (mediaType == MediaTypeMovie)
   {
     database.GetMovieInfo("", detail, iDbId, pItem->GetVideoInfoTag()->GetAssetInfo().GetId(),
-                          VideoDbDetailsNone);
+                          pItem->GetVideoInfoTag()->m_iFileId, VideoDbDetailsNone);
     title = detail.m_strTitle;
   }
   else if (mediaType == MediaTypeVideoCollection)
@@ -2007,7 +2008,7 @@ bool CGUIDialogVideoInfo::UpdateVideoItemSortTitle(const std::shared_ptr<CFileIt
   VideoDbContentType iType = pItem->GetVideoContentType();
   if (iType == VideoDbContentType::MOVIES)
     database.GetMovieInfo("", detail, iDbId, pItem->GetVideoInfoTag()->GetAssetInfo().GetId(),
-                          VideoDbDetailsNone);
+                          pItem->GetVideoInfoTag()->m_iFileId, VideoDbDetailsNone);
   else if (iType == VideoDbContentType::TVSHOWS)
     database.GetTvShowInfo(pItem->GetVideoInfoTag()->m_strFileNameAndPath, detail, iDbId, 0, VideoDbDetailsNone);
 

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -375,12 +375,13 @@ bool CGUIWindowVideoBase::ShowInfo(const CFileItemPtr& item2, const ScraperPtr& 
   {
     m_database.Open(); // since we can be called from the music library
 
-    int dbId = item->HasVideoInfoTag() ? item->GetVideoInfoTag()->m_iDbId : -1;
+    const int dbId{item->HasVideoInfoTag() ? item->GetVideoInfoTag()->m_iDbId : -1};
     if (info->Content() == CONTENT_MOVIES)
     {
       const int versionId{item->HasVideoInfoTag() ? item->GetVideoInfoTag()->GetAssetInfo().GetId()
                                                   : -1};
-      bHasInfo = m_database.GetMovieInfo(item->GetPath(), movieDetails, dbId, versionId);
+      const int fileId{item->HasVideoInfoTag() ? item->GetVideoInfoTag()->m_iFileId : -1};
+      bHasInfo = m_database.GetMovieInfo(item->GetPath(), movieDetails, dbId, versionId, fileId);
     }
     if (info->Content() == CONTENT_TVSHOWS)
     {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

When opening the info dialog and the item has scraper info, there is an attempt to read the video info tag from the db and to ignore the tag already attached to the item provided to the dialog.

However the same tag is read for multiple version of the same name of the same movie because CVideoDatabase::GetMovieInfo() takes dbid/idMovie and versionId paramaters which doesn't allow the disambiguation.

Issue fixed by adding a fileId parameter to GetMovieInfo().

In GetMovieInfo, fileId (when provided) is used in priority, then, as current master code the versionId followed by the filename.

Notes on the callers of GetMovieInfo:
- CFileItem::LoadDetails(), CUPnPServer::Build() do not have enough information available to address the same issue faced by the info dialog as individual versions cannot be represented as videodb url. Will be possible with the rewrite of #26301. @todo added by the PR
- a couple other callers don't specify the versionId parameter today so they were considered out of scope for the PR, but should be reviewed as they may have an issue as well.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Forum thread https://forum.kodi.tv/showthread.php?tid=381310

The media flags displayed in the library views are correct but under some circumstances, the media flags in the info dialog are incorrect for movies that have multiple versions of same name.

Steps to reproduce:
- Add one version of the movie to the library (version type is "Standard Edition" by default)
- Add another version with different media flags (ex. resolution, a/r, codecs, duration) of the same movie to the library as a separate library entry
- Add the first version of the movie as a version of the library entry of the second video, keep the "Standard Edition" name
- Navigate to the movie in the library
- Press i to bring up the info dialog > shows media info of the video added first, instead of the second (the default version)
- Enable "show videos with multiple versions as folder" setting
- Navigate into the movie virtual folder
- The info dialog brings up for both versions the media flags of the video first added to the library

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

navigation from Versions top level node
info on movie folder item in library
info on versions inside the virtual movie versions folders in library
info on movies without versions in library
info in Videos

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Display correct media flags in info dialog for same name multiple versions of a movie

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
