### PR TITLE
[rendering/dx] DeviceResources.cpp: Enable shared surfaces and fences for Qualcomm GPUs.

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -1176,6 +1176,7 @@ void DX::DeviceResources::CheckDXVA2SharedDecoderSurfaces()
 
   m_DXVA2SharedDecoderSurfaces =
       ad.VendorId == PCIV_Intel ||
+      (ad.VendorId == PCIV_QUALCOMM && driver.valid && driver.majorVersion >= 31) ||
       (ad.VendorId == PCIV_NVIDIA && driver.valid && driver.majorVersion >= 465) ||
       (ad.VendorId == PCIV_AMD && driver.valid && driver.majorVersion >= 30 &&
        m_d3dFeatureLevel >= D3D_FEATURE_LEVEL_12_1);
@@ -1183,9 +1184,10 @@ void DX::DeviceResources::CheckDXVA2SharedDecoderSurfaces()
   CLog::LogF(LOGINFO, "DXVA2 shared decoder surfaces is{}supported",
              m_DXVA2SharedDecoderSurfaces ? " " : " NOT ");
 
-  m_DXVA2UseFence = m_DXVA2SharedDecoderSurfaces &&
-                    (ad.VendorId == PCIV_NVIDIA || ad.VendorId == PCIV_AMD) &&
-                    CSysInfo::IsWindowsVersionAtLeast(CSysInfo::WindowsVersionWin10_1703);
+  m_DXVA2UseFence =
+      m_DXVA2SharedDecoderSurfaces &&
+      (ad.VendorId == PCIV_NVIDIA || ad.VendorId == PCIV_AMD || ad.VendorId == PCIV_QUALCOMM) &&
+      CSysInfo::IsWindowsVersionAtLeast(CSysInfo::WindowsVersionWin10_1703);
 
   if (m_DXVA2SharedDecoderSurfaces)
     CLog::LogF(LOGINFO, "DXVA2 shared decoder surfaces {} fence synchronization.",


### PR DESCRIPTION
## Description
This PR adds Qualcomm PCIV ID to detection code for shared surfaces and whether to use DXVA fence. This change enables Qualcomm GPUs to use shared surfaces.
This is twelfth and the last from my series of PRs with the goal to upstream my Kodi Windows ARM64 fork here: https://github.com/ddscentral/xbmc-win-arm64/ 
After this, the upstreaming of changes to the main application will be complete.

## Motivation and context
Add support for Windows ARM64

## How has this been tested?
Video does not flash with the wrong picture when seeking.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

I'm not sure how to test the whether DXVA2 fences part is working (and whether it's needed at all), could use an a advice here.