### PR TITLE
[StreamUtils] Common place to get codec name

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -12,6 +12,7 @@
 #include "DVDInputStreams/DVDInputStream.h"
 #include "cores/FFmpeg.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
+#include "utils/StreamUtils.h"
 #include "utils/log.h"
 
 #include <memory>
@@ -662,34 +663,12 @@ std::string CDVDDemuxClient::GetFileName()
 
 std::string CDVDDemuxClient::GetStreamCodecName(int iStreamId)
 {
-  CDemuxStream *stream = GetStream(iStreamId);
-  std::string strName;
+  CDemuxStream* stream = GetStream(iStreamId);
   if (stream)
   {
-    if (stream->codec == AV_CODEC_ID_AC3)
-      strName = "ac3";
-    else if (stream->codec == AV_CODEC_ID_MP2)
-      strName = "mp2";
-    else if (stream->codec == AV_CODEC_ID_AAC)
-      strName = "aac";
-    else if (stream->codec == AV_CODEC_ID_DTS)
-      strName = "dca";
-    else if (stream->codec == AV_CODEC_ID_MPEG2VIDEO)
-      strName = "mpeg2video";
-    else if (stream->codec == AV_CODEC_ID_H264)
-      strName = "h264";
-    else if (stream->codec == AV_CODEC_ID_EAC3)
-      strName = "eac3";
-    else if (stream->codec == AV_CODEC_ID_VP8)
-      strName = "vp8";
-    else if (stream->codec == AV_CODEC_ID_VP9)
-      strName = "vp9";
-    else if (stream->codec == AV_CODEC_ID_HEVC)
-      strName = "hevc";
-    else if (stream->codec == AV_CODEC_ID_AV1)
-      strName = "av1";
+    return StreamUtils::GetCodecName(stream->codec, stream->profile);
   }
-  return strName;
+  return {};
 }
 
 bool CDVDDemuxClient::SeekTime(double timems, bool backwards, double *startpts)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -30,6 +30,7 @@
 #include "threads/SystemClock.h"
 #include "utils/FontUtils.h"
 #include "utils/LangCodeExpander.h"
+#include "utils/StreamUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XTimeUtils.h"
@@ -2067,37 +2068,11 @@ bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)
 std::string CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId)
 {
   CDemuxStream* stream = GetStream(iStreamId);
-  std::string strName;
   if (stream)
   {
-    /* use profile to determine the DTS type */
-    if (stream->codec == AV_CODEC_ID_DTS)
-    {
-      if (stream->profile == FF_PROFILE_DTS_HD_MA)
-        strName = "dtshd_ma";
-      else if (stream->profile == FF_PROFILE_DTS_HD_MA_X)
-        strName = "dtshd_ma_x";
-      else if (stream->profile == FF_PROFILE_DTS_HD_MA_X_IMAX)
-        strName = "dtshd_ma_x_imax";
-      else if (stream->profile == FF_PROFILE_DTS_HD_HRA)
-        strName = "dtshd_hra";
-      else
-        strName = "dca";
-
-      return strName;
-    }
-
-    if (stream->codec == AV_CODEC_ID_EAC3 && stream->profile == AV_PROFILE_EAC3_DDP_ATMOS)
-      return "eac3_ddp_atmos";
-
-    if (stream->codec == AV_CODEC_ID_TRUEHD && stream->profile == AV_PROFILE_TRUEHD_ATMOS)
-      return "truehd_atmos";
-
-    const AVCodec* codec = avcodec_find_decoder(stream->codec);
-    if (codec)
-      strName = avcodec_get_name(codec->id);
+    return StreamUtils::GetCodecName(stream->codec, stream->profile);
   }
-  return strName;
+  return {};
 }
 
 bool CDVDDemuxFFmpeg::IsProgramChange()

--- a/xbmc/utils/StreamUtils.cpp
+++ b/xbmc/utils/StreamUtils.cpp
@@ -8,6 +8,12 @@
 
 #include "StreamUtils.h"
 
+extern "C"
+{
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+}
+
 int StreamUtils::GetCodecPriority(const std::string &codec)
 {
   /*
@@ -29,4 +35,37 @@ int StreamUtils::GetCodecPriority(const std::string &codec)
   if (codec == "ac3") // Dolby Digital
     return 1;
   return 0;
+}
+
+std::string StreamUtils::GetCodecName(int codecId, int profile)
+{
+  std::string codecName;
+
+  if (codecId == AV_CODEC_ID_DTS)
+  {
+    if (profile == FF_PROFILE_DTS_HD_MA)
+      codecName = "dtshd_ma";
+    else if (profile == FF_PROFILE_DTS_HD_MA_X)
+      codecName = "dtshd_ma_x";
+    else if (profile == FF_PROFILE_DTS_HD_MA_X_IMAX)
+      codecName = "dtshd_ma_x_imax";
+    else if (profile == FF_PROFILE_DTS_HD_HRA)
+      codecName = "dtshd_hra";
+    else
+      codecName = "dca";
+
+    return codecName;
+  }
+
+  if (codecId == AV_CODEC_ID_EAC3 && profile == AV_PROFILE_EAC3_DDP_ATMOS)
+    return "eac3_ddp_atmos";
+
+  if (codecId == AV_CODEC_ID_TRUEHD && profile == AV_PROFILE_TRUEHD_ATMOS)
+    return "truehd_atmos";
+
+  const AVCodec* codec = avcodec_find_decoder(static_cast<AVCodecID>(codecId));
+  if (codec)
+    codecName = avcodec_get_name(codec->id);
+
+  return codecName;
 }

--- a/xbmc/utils/StreamUtils.h
+++ b/xbmc/utils/StreamUtils.h
@@ -31,4 +31,12 @@ public:
     return ((static_cast<uint32_t>(c1) << 24) | (static_cast<uint32_t>(c2) << 16) |
             (static_cast<uint32_t>(c3) << 8) | (static_cast<uint32_t>(c4)));
   }
+
+  /*!
+   * \brief Get the codec name translated from ffmpeg codec id and profile
+   * \param codecId The ffmpeg codec id
+   * \param profile The ffmpeg codec profile
+   * \return The codec name
+   */
+  static std::string GetCodecName(int codecId, int profile);
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fix problem of inconsistent codec names due to missing custom translations

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
By using inputstream adaptive i have seen that "atmos" codec name was not shown on GUI
the problem is that kodi make use also of custom codec name
but this is fragmented on source code that lead to easy forgetfulness of maintenance

an example is  `eac3_ddp_atmos` present on ffmpeg but missing on inputstream interface
this move related code to a common place in StreamUtils header that already list these custom codec names

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
play this STRM
```
#KODIPROP:mimetype=application/vnd.apple.mpegurl
#KODIPROP:inputstream=inputstream.adaptive
https://devstreaming-cdn.apple.com/videos/streaming/examples/adv_dv_atmos/main.m3u8
```
and ATMOS must be shown on Audio stream selection GUI dialog

for completeness i tested also streams with HEVC and AV1 and codec name is correct

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
show appropriate codec on GUI

## Screenshots (if appropriate):
before
![429366740-e657f4f6-cbdb-47e4-960d-c6e50f518c4c](https://github.com/user-attachments/assets/c81c3768-b4fd-4279-9e6a-e7526df5369f)
after
![immagine](https://github.com/user-attachments/assets/5b162387-777a-4377-9b82-cb05b3d19ada)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
