### PR TITLE
Backport: Fix peripheral settings

### DIFF
--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -509,7 +509,7 @@ bool CPeripheral::SetSetting(const std::string& strKey, const std::string& strVa
     else if ((*it).second.m_setting->GetType() == SettingType::Number)
       bChanged = SetSetting(strKey, (float)(strValue.empty() ? 0 : atof(strValue.c_str())));
     else if ((*it).second.m_setting->GetType() == SettingType::Boolean)
-      bChanged = SetSetting(strKey, strValue == "1");
+      bChanged = SetSetting(strKey, strValue == "1" || StringUtils::EqualsNoCase(strValue, "true"));
   }
   return bChanged;
 }

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -122,6 +122,8 @@ void CGUIDialogPeripheralSettings::OnSettingChanged(const std::shared_ptr<const 
     if (controller)
       peripheral->SetControllerProfile(controller);
   }
+
+  peripheral->OnSettingChanged(settingId);
 }
 
 bool CGUIDialogPeripheralSettings::Save()


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Backport of #26605

* "Set boolean" right now do check only for "1".
* Adapter OnSettingChanged is not called.
Commit is based on patch used since 2021:
https://github.com/CoreELEC/CoreELEC/blob/coreelec-21/projects/Amlogic-ce/devices/Amlogic-ne/patches/kodi/kodi-temp-03-TEMP-fix-OnSettingChanged-signal.patch

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
