### PR TITLE
[VideoPlayer][skin] Add AAC codec by profile, fix inputstream codec name bug

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6289,12 +6289,20 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///                  _string_,
 ///     @return The audio codec of the currently selected video. Common values:
 ///       - <b>aac</b>
+///       - <b>aac_lc</b>
+///       - <b>he_aac</b>
+///       - <b>he_aac_v2</b>
+///       - <b>aac_ssr</b>
+///       - <b>aac_ltp</b>
 ///       - <b>ac3</b>
 ///       - <b>cook</b>
 ///       - <b>dca</b>
 ///       - <b>dtshd_hra</b>
 ///       - <b>dtshd_ma</b>
+///       - <b>dtshd_ma_x</b>
+///       - <b>dtshd_ma_x_imax</b>
 ///       - <b>eac3</b>
+///       - <b>eac3_ddp_atmos</b>
 ///       - <b>mp1</b>
 ///       - <b>mp2</b>
 ///       - <b>mp3</b>
@@ -6302,6 +6310,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///       - <b>pcm_s16le</b>
 ///       - <b>pcm_u8</b>
 ///       - <b>truehd</b>
+///       - <b>truehd_atmos</b>
 ///       - <b>vorbis</b>
 ///       - <b>wmapro</b>
 ///       - <b>wmav2</b>

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -12,6 +12,7 @@
 #include "DVDInputStreams/DVDInputStream.h"
 #include "cores/FFmpeg.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
+#include "utils/StreamUtils.h"
 #include "utils/log.h"
 
 #include <memory>
@@ -662,34 +663,12 @@ std::string CDVDDemuxClient::GetFileName()
 
 std::string CDVDDemuxClient::GetStreamCodecName(int iStreamId)
 {
-  CDemuxStream *stream = GetStream(iStreamId);
-  std::string strName;
+  CDemuxStream* stream = GetStream(iStreamId);
   if (stream)
   {
-    if (stream->codec == AV_CODEC_ID_AC3)
-      strName = "ac3";
-    else if (stream->codec == AV_CODEC_ID_MP2)
-      strName = "mp2";
-    else if (stream->codec == AV_CODEC_ID_AAC)
-      strName = "aac";
-    else if (stream->codec == AV_CODEC_ID_DTS)
-      strName = "dca";
-    else if (stream->codec == AV_CODEC_ID_MPEG2VIDEO)
-      strName = "mpeg2video";
-    else if (stream->codec == AV_CODEC_ID_H264)
-      strName = "h264";
-    else if (stream->codec == AV_CODEC_ID_EAC3)
-      strName = "eac3";
-    else if (stream->codec == AV_CODEC_ID_VP8)
-      strName = "vp8";
-    else if (stream->codec == AV_CODEC_ID_VP9)
-      strName = "vp9";
-    else if (stream->codec == AV_CODEC_ID_HEVC)
-      strName = "hevc";
-    else if (stream->codec == AV_CODEC_ID_AV1)
-      strName = "av1";
+    return StreamUtils::GetCodecName(stream->codec, stream->profile);
   }
-  return strName;
+  return {};
 }
 
 bool CDVDDemuxClient::SeekTime(double timems, bool backwards, double *startpts)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -30,6 +30,7 @@
 #include "threads/SystemClock.h"
 #include "utils/FontUtils.h"
 #include "utils/LangCodeExpander.h"
+#include "utils/StreamUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XTimeUtils.h"
@@ -2067,37 +2068,11 @@ bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)
 std::string CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId)
 {
   CDemuxStream* stream = GetStream(iStreamId);
-  std::string strName;
   if (stream)
   {
-    /* use profile to determine the DTS type */
-    if (stream->codec == AV_CODEC_ID_DTS)
-    {
-      if (stream->profile == FF_PROFILE_DTS_HD_MA)
-        strName = "dtshd_ma";
-      else if (stream->profile == FF_PROFILE_DTS_HD_MA_X)
-        strName = "dtshd_ma_x";
-      else if (stream->profile == FF_PROFILE_DTS_HD_MA_X_IMAX)
-        strName = "dtshd_ma_x_imax";
-      else if (stream->profile == FF_PROFILE_DTS_HD_HRA)
-        strName = "dtshd_hra";
-      else
-        strName = "dca";
-
-      return strName;
-    }
-
-    if (stream->codec == AV_CODEC_ID_EAC3 && stream->profile == AV_PROFILE_EAC3_DDP_ATMOS)
-      return "eac3_ddp_atmos";
-
-    if (stream->codec == AV_CODEC_ID_TRUEHD && stream->profile == AV_PROFILE_TRUEHD_ATMOS)
-      return "truehd_atmos";
-
-    const AVCodec* codec = avcodec_find_decoder(stream->codec);
-    if (codec)
-      strName = avcodec_get_name(codec->id);
+    return StreamUtils::GetCodecName(stream->codec, stream->profile);
   }
-  return strName;
+  return {};
 }
 
 bool CDVDDemuxFFmpeg::IsProgramChange()

--- a/xbmc/utils/StreamUtils.cpp
+++ b/xbmc/utils/StreamUtils.cpp
@@ -57,6 +57,33 @@ std::string StreamUtils::GetCodecName(int codecId, int profile)
     return codecName;
   }
 
+  if (codecId == AV_CODEC_ID_AAC)
+  {
+    switch (profile)
+    {
+      case FF_PROFILE_AAC_LOW:
+      case FF_PROFILE_MPEG2_AAC_LOW:
+        codecName = "aac_lc";
+        break;
+      case FF_PROFILE_AAC_HE:
+      case FF_PROFILE_MPEG2_AAC_HE:
+        codecName = "he_aac";
+        break;
+      case FF_PROFILE_AAC_HE_V2:
+        codecName = "he_aac_v2";
+        break;
+      case FF_PROFILE_AAC_SSR:
+        codecName = "aac_ssr";
+        break;
+      case FF_PROFILE_AAC_LTP:
+        codecName = "aac_ltp";
+        break;
+      default:
+        codecName = "aac";
+    }
+    return codecName;
+  }
+
   if (codecId == AV_CODEC_ID_EAC3 && profile == AV_PROFILE_EAC3_DDP_ATMOS)
     return "eac3_ddp_atmos";
 

--- a/xbmc/utils/StreamUtils.cpp
+++ b/xbmc/utils/StreamUtils.cpp
@@ -8,6 +8,12 @@
 
 #include "StreamUtils.h"
 
+extern "C"
+{
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+}
+
 int StreamUtils::GetCodecPriority(const std::string &codec)
 {
   /*
@@ -29,4 +35,37 @@ int StreamUtils::GetCodecPriority(const std::string &codec)
   if (codec == "ac3") // Dolby Digital
     return 1;
   return 0;
+}
+
+std::string StreamUtils::GetCodecName(int codecId, int profile)
+{
+  std::string codecName;
+
+  if (codecId == AV_CODEC_ID_DTS)
+  {
+    if (profile == FF_PROFILE_DTS_HD_MA)
+      codecName = "dtshd_ma";
+    else if (profile == FF_PROFILE_DTS_HD_MA_X)
+      codecName = "dtshd_ma_x";
+    else if (profile == FF_PROFILE_DTS_HD_MA_X_IMAX)
+      codecName = "dtshd_ma_x_imax";
+    else if (profile == FF_PROFILE_DTS_HD_HRA)
+      codecName = "dtshd_hra";
+    else
+      codecName = "dca";
+
+    return codecName;
+  }
+
+  if (codecId == AV_CODEC_ID_EAC3 && profile == AV_PROFILE_EAC3_DDP_ATMOS)
+    return "eac3_ddp_atmos";
+
+  if (codecId == AV_CODEC_ID_TRUEHD && profile == AV_PROFILE_TRUEHD_ATMOS)
+    return "truehd_atmos";
+
+  const AVCodec* codec = avcodec_find_decoder(static_cast<AVCodecID>(codecId));
+  if (codec)
+    codecName = avcodec_get_name(codec->id);
+
+  return codecName;
 }

--- a/xbmc/utils/StreamUtils.h
+++ b/xbmc/utils/StreamUtils.h
@@ -31,4 +31,12 @@ public:
     return ((static_cast<uint32_t>(c1) << 24) | (static_cast<uint32_t>(c2) << 16) |
             (static_cast<uint32_t>(c3) << 8) | (static_cast<uint32_t>(c4)));
   }
+
+  /*!
+   * \brief Get the codec name translated from ffmpeg codec id and profile
+   * \param codecId The ffmpeg codec id
+   * \param profile The ffmpeg codec profile
+   * \return The codec name
+   */
+  static std::string GetCodecName(int codecId, int profile);
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
There are more than a couple of bugs:

### ffmpeg have custom codec names, but has been forgotten InputStream (ffmpeg) cases
if you play video with inputstream add-ons such as InputStream Adaptive, codec name such as "Atmos" is never shown on GUI correctly, this because on ffmpeg we have custom profile names, introduced recently on Piers branch (i think), but has been forgotten do the same on inputstream interface. I choose to have a common place to store custom codec names, for an easy future maintenance, this fix the problem of wrong codec names on IS addons. No inputstream API bump required because its internally.


### AAC codec profiles skin regressions
With skin changes introduced from PR #26350, AAC codec names are now wrong so lack of profiles,
this because with old skin xml code was using the codec description generated internally on kodi,
the new skin code use the codec name that dont make distincion between AAC profiles,
as already done for Atmos and DTS profiles, as solution now AAC have his custom codec names (with profiles) ~with related fixes on Skin~ skin fixes on separate PR #26626

### Skin `String.Contains` bug
~on skin varibles the uses of `String.Contains` make use of wrong priorities of the conditions, example:
before (wav is before than wavpack, this cause impossibility to catch wavpack use case):~
```
<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),wav)">WAV</value>
<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),wavpack)">WAVP</value>
```
~after fix:~
```
<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),wavpack)">WAVP</value>
<value condition="Window.IsVisible(dialogselectaudio) + String.Contains(ListItem.Property(stream.codec),wav)">WAV</value>
```
~there are more than one case fixed~  skin fixes on separate PR #26626

### Skin Media flag "channels"
~i add "channels" text on channels media flag,
this because was printed on screen only the number, it is not clearly understood that it is audio information of channels~
skin fixes on separate PR #26626

BEFORE:
![BEFORE](https://github.com/user-attachments/assets/fe987b01-1ecc-4b33-858f-8636e36e6c17)

-> TAKE A LOOK AT CODEC NAMES (REQUIRES SKIN FIXES)

AFTER:
![AFTER](https://github.com/user-attachments/assets/3018922b-43a4-4a44-b304-97125c3dcb00)


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
partial fix to #26600
due to skin regressions introduced from PR #26350

i said "partial" because i havent found a good way to fix also the "channels" skin regression
@jjd-uk can help?

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
used imputstream adaptive PR: https://github.com/xbmc/inputstream.adaptive/pull/1812

with STRM file:
```
#KODIPROP:mimetype=application/vnd.apple.mpegurl
#KODIPROP:inputstream=inputstream.adaptive
https://devstreaming-cdn.apple.com/videos/streaming/examples/adv_dv_atmos/main.m3u8
```

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Can see on GUI appropriate codec names in order to distinguish audio streams

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
