### PR TITLE
[webOS] Remove setrlimit condition

### DIFF
--- a/xbmc/platform/linux/PlatformWebOS.cpp
+++ b/xbmc/platform/linux/PlatformWebOS.cpp
@@ -39,12 +39,9 @@ bool CPlatformWebOS::InitStageOne()
 
 bool CPlatformWebOS::InitStageTwo()
 {
-  if (CServiceBroker::GetLogging().GetLogLevel() > LOG_LEVEL_DEBUG)
-  {
-    constexpr rlimit limit{0, 0};
-    if (setrlimit(RLIMIT_CORE, &limit) != 0)
-      CLog::Log(LOGERROR, "Failed to disable core dumps");
-  }
+  constexpr rlimit limit{0, 0};
+  if (setrlimit(RLIMIT_CORE, &limit) != 0)
+    CLog::Log(LOGERROR, "Failed to disable core dumps");
 
   return CPlatformLinux::InitStageTwo();
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Supersedes #26622

Removes the conditional check which was wrong. `LOG_LEVEL_DEBUG = -1` but `LOG_LEVEL_NORMAL = 0` which essentially only disabled this for `LOG_LEVEL_DEBUG_FREEMEM = 2`. I don't think there's much benefit in enabling coredumps for webOS at all, so remove the check here and call `setrlimit` always.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Removes core dumps on webOS because they can fill up space quickly.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS 24

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
