### PR TITLE
[GUI] Add Sorting Methods to the movie versions/extras folders

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -2588,6 +2588,7 @@ msgstr ""
 #. generic "name" label used in different places
 #: xbmc/addons/settings/AddonSettings.cpp
 #: xbmc/pvr/windows/GUIViewStatePVR.cpp
+#: xbmc/video/GUIViewStateVideo.cpp
 #: xbmc/view/GUIViewState.cpp
 msgctxt "#551"
 msgid "Name"
@@ -2597,11 +2598,13 @@ msgstr ""
 #: addons/skin.estuary/xml/DialogPVRInfo.xml
 #: addons/skin.estuary/xml/Variables.xml
 #: xbmc/pvr/windows/GUIViewStatePVR.cpp
+#: xbmc/video/GUIViewStateVideo.cpp
 msgctxt "#552"
 msgid "Date"
 msgstr ""
 
 #: xbmc/filesystem/BlurayDirectory.cpp
+#: xbmc/video/GUIViewStateVideo.cpp
 msgctxt "#553"
 msgid "Size"
 msgstr ""
@@ -2620,6 +2623,7 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
 #: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
+#: xbmc/video/GUIViewStateVideo.cpp
 msgctxt "#556"
 msgid "Title"
 msgstr ""
@@ -2700,6 +2704,7 @@ msgstr ""
 #: addons/skin.estuary/xml/Includes_MusicInfo.xml
 #: addons/skin.estuary/xml/Variables.xml
 #: xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
+#: xbmc/video/GUIViewStateVideo.cpp
 msgctxt "#567"
 msgid "Play count"
 msgstr ""
@@ -2710,6 +2715,7 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
 #: xbmc/pvr/windows/GUIViewStatePVR.cpp
+#: xbmc/video/GUIViewStateVideo.cpp
 msgctxt "#568"
 msgid "Last played"
 msgstr ""
@@ -2723,6 +2729,7 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
 #: xbmc/pvr/windows/GUIViewStatePVR.cpp
+#: xbmc/video/GUIViewStateVideo.cpp
 msgctxt "#570"
 msgid "Date added"
 msgstr ""
@@ -14917,6 +14924,7 @@ msgid "Episode title"
 msgstr ""
 
 #: xbmc/playlists/SmartPlaylist.cpp
+#: xbmc/video/GUIViewStateVideo.cpp
 msgctxt "#21443"
 msgid "Video resolution"
 msgstr ""
@@ -14928,11 +14936,13 @@ msgid "Audio channels"
 msgstr ""
 
 #: xbmc/playlists/SmartPlaylist.cpp
+#: xbmc/video/GUIViewStateVideo.cpp
 msgctxt "#21445"
 msgid "Video codec"
 msgstr ""
 
 #: xbmc/playlists/SmartPlaylist.cpp
+#: xbmc/video/GUIViewStateVideo.cpp
 #: addons/skin.estuary/xml/MusicVisualisation.xml
 msgctxt "#21446"
 msgid "Audio codec"

--- a/addons/skin.estuary/language/resource.language.en_us/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_us/strings.po
@@ -125,8 +125,8 @@ msgid "Sort by"
 msgstr "Sort by"
 
 msgctxt "#31023"
-msgid "Viewtype"
-msgstr "Viewtype"
+msgid "View type"
+msgstr "View type"
 
 msgctxt "#31024"
 msgid "Choose rating to display for media items"

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -96,6 +96,13 @@
 		<value condition="Container.SortMethod(7) | Container.SortMethod(29)">$INFO[ListItem.Year]</value>
 		<value condition="!String.isempty(ListItem.Appearances)">$LOCALIZE[38026]: $INFO[ListItem.Appearances]</value>
 		<value condition="Window.IsActive(musicplaylist) | Window.IsActive(videoplaylist)">$INFO[ListItem.Duration]</value>
+		<value condition="$EXP[videoasset_true] + Container.SortMethod(1)"></value>
+		<value condition="$EXP[videoasset_true] + Container.SortMethod(9) + Control.IsVisible(504)"></value>
+		<value condition="$EXP[videoasset_true] + Container.SortMethod(9) + !Control.IsVisible(504)">$INFO[ListItem.Duration]</value>
+		<value condition="$EXP[videoasset_true] + Container.SortMethod(32)">$INFO[ListItem.VideoResolution]$VAR[VideoResolutionTypeVar, ]</value>
+		<value condition="$EXP[videoasset_true] + Container.SortMethod(33)">$VAR[VideoCodecVar]</value>
+		<value condition="$EXP[videoasset_true] + Container.SortMethod(36)">$VAR[AudioCodecVar]$VAR[ObjectAudioTypeVar, / ]</value>
+		<value condition="Container.SortMethod(9)">$INFO[ListItem.Duration]</value>
 		<value>$INFO[ListItem.Label2]</value>
 	</variable>
 	<variable name="PlotTextBoxVar">

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -364,23 +364,28 @@ void CFileItemList::Sort(SortBy sortBy,
 
 void CFileItemList::Sort(SortDescription sortDescription)
 {
-  if (sortDescription.sortBy == SortByFile || sortDescription.sortBy == SortBySortTitle ||
-      sortDescription.sortBy == SortByOriginalTitle || sortDescription.sortBy == SortByDateAdded ||
-      sortDescription.sortBy == SortByRating || sortDescription.sortBy == SortByYear ||
-      sortDescription.sortBy == SortByPlaylistOrder || sortDescription.sortBy == SortByLastPlayed ||
-      sortDescription.sortBy == SortByPlaycount)
-    sortDescription.sortAttributes =
-        (SortAttribute)((int)sortDescription.sortAttributes | SortAttributeIgnoreFolders);
-
   if (sortDescription.sortBy == SortByNone ||
       (m_sortDescription.sortBy == sortDescription.sortBy &&
        m_sortDescription.sortOrder == sortDescription.sortOrder &&
        m_sortDescription.sortAttributes == sortDescription.sortAttributes))
     return;
 
-  if (m_sortIgnoreFolders)
+  if (sortDescription.sortAttributes & SortAttributeForceConsiderFolders)
+  {
     sortDescription.sortAttributes =
-        (SortAttribute)((int)sortDescription.sortAttributes | SortAttributeIgnoreFolders);
+        static_cast<SortAttribute>(sortDescription.sortAttributes & ~SortAttributeIgnoreFolders);
+  }
+  else if ((sortDescription.sortBy == SortByFile || sortDescription.sortBy == SortBySortTitle ||
+            sortDescription.sortBy == SortByOriginalTitle ||
+            sortDescription.sortBy == SortByDateAdded || sortDescription.sortBy == SortByRating ||
+            sortDescription.sortBy == SortByYear || sortDescription.sortBy == SortByPlaylistOrder ||
+            sortDescription.sortBy == SortByLastPlayed ||
+            sortDescription.sortBy == SortByPlaycount) ||
+           m_sortIgnoreFolders)
+  {
+    sortDescription.sortAttributes =
+        static_cast<SortAttribute>(sortDescription.sortAttributes | SortAttributeIgnoreFolders);
+  }
 
   const Fields fields = SortUtils::GetFieldsForSorting(sortDescription.sortBy);
   SortItems sortItems((size_t)Size());

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMovieAssets.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMovieAssets.cpp
@@ -39,9 +39,7 @@ bool CDirectoryNodeMovieAssets::GetContent(CFileItemList& items) const
   CQueryParams params;
   CollectQueryParams(params);
 
-  const int details{items.HasProperty("set_videodb_details")
-                        ? items.GetProperty("set_videodb_details").asInteger32()
-                        : VideoDbDetailsNone};
+  const int details{items.GetProperty("set_videodb_details").asInteger32(VideoDbDetailsStream)};
 
   const std::string path{BuildPath()};
 

--- a/xbmc/utils/SortUtils.h
+++ b/xbmc/utils/SortUtils.h
@@ -24,12 +24,14 @@ typedef enum {
   SortOrderDescending
 } SortOrder;
 
-typedef enum {
-  SortAttributeNone           = 0x0,
-  SortAttributeIgnoreArticle  = 0x1,
-  SortAttributeIgnoreFolders  = 0x2,
+typedef enum
+{
+  SortAttributeNone = 0x0,
+  SortAttributeIgnoreArticle = 0x1,
+  SortAttributeIgnoreFolders = 0x2,
   SortAttributeUseArtistSortName = 0x4,
-  SortAttributeIgnoreLabel = 0x8
+  SortAttributeIgnoreLabel = 0x8,
+  SortAttributeForceConsiderFolders = 0x10, // overrides SortAttributeIgnoreFolders
 } SortAttribute;
 
 typedef enum {

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -322,8 +322,55 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
         SetSortOrder(SortOrderNone);
       }
       break;
-    default:
+      case NodeType::MOVIE_ASSETS:
+      case NodeType::MOVIE_ASSETS_VERSIONS:
+      {
+        AddSortMethod(SortByLabel, sortAttributes, 551,
+                      LABEL_MASKS("%L", "", "%L", "")); // Label, empty | Label, empty
+        AddSortMethod(SortByTime, 180,
+                      LABEL_MASKS("%L", "%D", "%L", "")); // Label, Duration | Label, empty
+        AddSortMethod(SortByVideoResolution, 21443,
+                      LABEL_MASKS("%L", "", "%L", "")); // Label, empty | Label, empty
+        AddSortMethod(SortByVideoCodec, 21445,
+                      LABEL_MASKS("%L", "", "%L", "")); // Label, empty | Label, empty
+        AddSortMethod(SortByAudioCodec, 21446,
+                      LABEL_MASKS("%L", "", "%L", "")); // Label, empty | Label, empty
+        AddSortMethod(SortByDateAdded, 570,
+                      LABEL_MASKS("%L", "%a", "%L", "")); // Label, DateAdded | Label, empty
+        AddSortMethod(SortByLastPlayed, SortAttributeForceConsiderFolders, 568,
+                      LABEL_MASKS("%L", "%p", "%L", "")); // Label, #Last played | Label, empty
+        AddSortMethod(SortByPlaycount, SortAttributeForceConsiderFolders, 567,
+                      LABEL_MASKS("%L", "%V", "%L", "")); // Label, Playcount | Label, empty
+
+        const CViewState* viewState = CViewStateSettings::GetInstance().Get(
+            nodeType == NodeType::MOVIE_ASSETS ? "videonavassets" : "videonavversions");
+        SetSortMethod(viewState->m_sortDescription);
+        SetSortOrder(viewState->m_sortDescription.sortOrder);
+        SetViewAsControl(viewState->m_viewMode);
+      }
       break;
+      case NodeType::MOVIE_ASSETS_EXTRAS:
+      {
+        AddSortMethod(SortByLabel, sortAttributes, 551,
+                      LABEL_MASKS("%L", "", "%L", "")); // Label, empty | Label, empty
+        AddSortMethod(SortByTime, 180,
+                      LABEL_MASKS("%L", "%D", "%L", "")); // Label, Duration | Label, empty
+        AddSortMethod(SortByDateAdded, 570,
+                      LABEL_MASKS("%L", "%a", "%L", "")); // Label, DateAdded | Label, empty
+        AddSortMethod(SortByLastPlayed, SortAttributeForceConsiderFolders, 568,
+                      LABEL_MASKS("%L", "%p", "%L", "")); // Label, #Last played | Label, empty
+        AddSortMethod(SortByPlaycount, SortAttributeForceConsiderFolders, 567,
+                      LABEL_MASKS("%L", "%V", "%L", "")); // Label, Playcount | Label, empty
+
+        const CViewState* viewState = CViewStateSettings::GetInstance().Get("videonavextras");
+        SetSortMethod(viewState->m_sortDescription);
+        SetSortOrder(viewState->m_sortDescription.sortOrder);
+        SetViewAsControl(viewState->m_viewMode);
+      }
+      break;
+
+      default:
+        break;
     }
   }
   else
@@ -383,6 +430,18 @@ void CGUIViewStateWindowVideoNav::SaveViewState()
       case NodeType::TITLE_MUSICVIDEOS:
         SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV,
                      CViewStateSettings::GetInstance().Get("videonavmusicvideos"));
+        break;
+      case NodeType::MOVIE_ASSETS:
+        SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV,
+                     CViewStateSettings::GetInstance().Get("videonavassets"));
+        break;
+      case NodeType::MOVIE_ASSETS_VERSIONS:
+        SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV,
+                     CViewStateSettings::GetInstance().Get("videonavversions"));
+        break;
+      case NodeType::MOVIE_ASSETS_EXTRAS:
+        SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV,
+                     CViewStateSettings::GetInstance().Get("videonavextras"));
         break;
       default:
         SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8307,14 +8307,22 @@ bool CVideoDatabase::GetSortedVideos(const MediaType &mediaType, const std::stri
   if (mediaType != MediaTypeMovie && mediaType != MediaTypeTvShow && mediaType != MediaTypeEpisode && mediaType != MediaTypeMusicVideo)
     return false;
 
-  SortDescription sorting = sortDescription;
-  if (sortDescription.sortBy == SortByFile || sortDescription.sortBy == SortByTitle ||
-      sortDescription.sortBy == SortBySortTitle || sortDescription.sortBy == SortByOriginalTitle ||
-      sortDescription.sortBy == SortByLabel || sortDescription.sortBy == SortByDateAdded ||
-      sortDescription.sortBy == SortByRating || sortDescription.sortBy == SortByUserRating ||
-      sortDescription.sortBy == SortByYear || sortDescription.sortBy == SortByLastPlayed ||
-      sortDescription.sortBy == SortByPlaycount)
-    sorting.sortAttributes = (SortAttribute)(sortDescription.sortAttributes | SortAttributeIgnoreFolders);
+  SortDescription sorting{sortDescription};
+  if (sorting.sortAttributes & SortAttributeForceConsiderFolders)
+  {
+    sorting.sortAttributes =
+        static_cast<SortAttribute>(sorting.sortAttributes & ~SortAttributeIgnoreFolders);
+  }
+  else if (sortDescription.sortBy == SortByFile || sortDescription.sortBy == SortByTitle ||
+           sortDescription.sortBy == SortBySortTitle ||
+           sortDescription.sortBy == SortByOriginalTitle || sortDescription.sortBy == SortByLabel ||
+           sortDescription.sortBy == SortByDateAdded || sortDescription.sortBy == SortByRating ||
+           sortDescription.sortBy == SortByUserRating || sortDescription.sortBy == SortByYear ||
+           sortDescription.sortBy == SortByLastPlayed || sortDescription.sortBy == SortByPlaycount)
+  {
+    sorting.sortAttributes =
+        static_cast<SortAttribute>(sortDescription.sortAttributes | SortAttributeIgnoreFolders);
+  }
 
   bool success = false;
   if (mediaType == MediaTypeMovie)

--- a/xbmc/view/ViewStateSettings.cpp
+++ b/xbmc/view/ViewStateSettings.cpp
@@ -43,6 +43,9 @@ CViewStateSettings::CViewStateSettings()
   AddViewState("videonavtvshows");
   AddViewState("videonavseasons");
   AddViewState("videonavmusicvideos");
+  AddViewState("videonavassets");
+  AddViewState("videonavversions");
+  AddViewState("videonavextras");
 
   AddViewState("programs", DEFAULT_VIEW_AUTO);
   AddViewState("pictures", DEFAULT_VIEW_AUTO);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Define sorting methods for content videoassets/videoversions/videoextras. 

The following made sense for versions out of the existing sorting methods:
`label, duration, video resolution, video codec, audio codec, date added, last played, playcount`

for extras. removed video resolution, video codec, audio codec that are not useful.

Created separate "buckets" to store the view type, sort method and order independently for assets versions and extras

### Core Programming
- "last played" and "playcount" override sorting attributes in order to treat folder the same as files, which can result in folders appearing between files rather than always at the top. It could make sense for playlists, tv shows/seasons, but not for the virtual Extras subfolder I think
=> Commit 1 provides a way to bypass the override.

- "duration", "video resolution", "video codec" and "audio codec" sorting methods require the stream details to be loaded to work properly for video assets, but they're not for movies right after loading the data with GetMovieByWhere. They are loaded shortly afterwards though (as part of the background artwork loader?)
=> Commit 3 fixes by forcing the stream details retrieval as part of the item load from database (only for assets).
An alternative would a wait for the async background load to complete, but how is performance (any parallelism?)
> Opinions?

Note: both make individual stream details queries  - not optimal but OK for now with the relatively short lists of versions or extras of a single movie.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Now that versions and extras are presented as folders, let's sort them in interesting ways!

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

went through the different sorting methods for versions and extras.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Ability to sort versions and extras in different ways than the asset creation order.

## Screenshots (if appropriate):
Versions:
![image](https://github.com/user-attachments/assets/da435fc2-74aa-4b4f-bc97-22ff4695a35b)

Extras:
![image](https://github.com/user-attachments/assets/48147aa7-d13d-4344-9b40-a75ac506622f)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
