### PR TITLE
[PVR][Estuary] Increase resolution of Estuary Guide Window

### DIFF
--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -602,7 +602,8 @@
 				<orientation>$PARAM[control_orientation]</orientation>
 				<pagecontrol>60</pagecontrol>
 				<scrolltime tween="quadratic" easing="out">300</scrolltime>
-				<timeblocks>34</timeblocks>
+				<timeblocks>170</timeblocks>
+				<minspertimeblock>1</minspertimeblock>
 				<rulerunit>6</rulerunit>
 				<onleft>9000</onleft>
 				<onright>60</onright>

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -902,6 +902,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
   int focusPosition = 0;
   int scrollTime = 200;
   int timeBlocks = 36;
+  unsigned int minutesPerTimeBlock{CGUIEPGGridContainer::DEFAULT_MINUTES_PER_BLOCK};
   int rulerUnit = 12;
   bool useControlCoords = false;
   bool renderFocusedLast = false;
@@ -1133,6 +1134,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
 
   XMLUtils::GetBoolean(pControlNode, "pulseonselect", bPulse);
   XMLUtils::GetInt(pControlNode, "timeblocks", timeBlocks);
+  XMLUtils::GetUInt(pControlNode, "minspertimeblock", minutesPerTimeBlock);
   XMLUtils::GetInt(pControlNode, "rulerunit", rulerUnit);
   GetTexture(pControlNode, "progresstexture", textureProgressIndicator);
 
@@ -1551,9 +1553,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
     }
     case CGUIControl::GUICONTAINER_EPGGRID:
     {
-      CGUIEPGGridContainer* epgGridContainer =
-          new CGUIEPGGridContainer(parentID, id, posX, posY, width, height, orientation, scrollTime,
-                                   preloadItems, timeBlocks, rulerUnit, textureProgressIndicator);
+      CGUIEPGGridContainer* epgGridContainer = new CGUIEPGGridContainer(
+          parentID, id, posX, posY, width, height, orientation, scrollTime, preloadItems,
+          timeBlocks, minutesPerTimeBlock, rulerUnit, textureProgressIndicator);
       control = epgGridContainer;
       epgGridContainer->LoadLayout(pControlNode);
       epgGridContainer->SetRenderOffset(offset);

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -39,8 +39,10 @@
 using namespace KODI;
 using namespace PVR;
 
-#define BLOCKJUMP    4 // how many blocks are jumped with each analogue scroll action
-static const int BLOCK_SCROLL_OFFSET = 60 / CGUIEPGGridContainerModel::MINSPERBLOCK; // how many blocks are jumped if we are at left/right edge of grid
+#define BLOCKJUMP 4 // how many blocks are jumped with each analogue scroll action
+static const int BLOCK_SCROLL_OFFSET =
+    60 / CGUIEPGGridContainerModel::
+             MINSPERBLOCK; // how many blocks are jumped if we are at left/right edge of grid
 
 CGUIEPGGridContainer::CGUIEPGGridContainer(int parentID,
                                            int controlID,
@@ -240,7 +242,8 @@ void CGUIEPGGridContainer::RenderChannels()
   HandleChannels(true, dummyTime, dummyRegions);
 }
 
-void CGUIEPGGridContainer::ProcessRulerDate(unsigned int currentTime, CDirtyRegionList& dirtyregions)
+void CGUIEPGGridContainer::ProcessRulerDate(unsigned int currentTime,
+                                            CDirtyRegionList& dirtyregions)
 {
   HandleRulerDate(false, currentTime, dirtyregions);
 }
@@ -266,7 +269,8 @@ void CGUIEPGGridContainer::RenderRuler()
   HandleRuler(true, dummyTime, dummyRegions);
 }
 
-void CGUIEPGGridContainer::ProcessProgrammeGrid(unsigned int currentTime, CDirtyRegionList& dirtyregions)
+void CGUIEPGGridContainer::ProcessProgrammeGrid(unsigned int currentTime,
+                                                CDirtyRegionList& dirtyregions)
 {
   HandleProgrammeGrid(false, currentTime, dirtyregions);
 }
@@ -298,10 +302,12 @@ float CGUIEPGGridContainer::GetProgressIndicatorWidth() const
 
 float CGUIEPGGridContainer::GetProgressIndicatorHeight() const
 {
-  return (m_orientation == VERTICAL) ? m_rulerHeight + m_gridHeight : GetCurrentTimePositionOnPage();
+  return (m_orientation == VERTICAL) ? m_rulerHeight + m_gridHeight
+                                     : GetCurrentTimePositionOnPage();
 }
 
-void CGUIEPGGridContainer::ProcessProgressIndicator(unsigned int currentTime, CDirtyRegionList& dirtyregions)
+void CGUIEPGGridContainer::ProcessProgressIndicator(unsigned int currentTime,
+                                                    CDirtyRegionList& dirtyregions)
 {
   float width = GetProgressIndicatorWidth();
   float height = GetProgressIndicatorHeight();
@@ -324,7 +330,8 @@ void CGUIEPGGridContainer::ProcessProgressIndicator(unsigned int currentTime, CD
 
 void CGUIEPGGridContainer::RenderProgressIndicator()
 {
-  if (CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_rulerPosX, m_rulerPosY, GetProgressIndicatorWidth(), GetProgressIndicatorHeight()))
+  if (CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(
+          m_rulerPosX, m_rulerPosY, GetProgressIndicatorWidth(), GetProgressIndicatorHeight()))
   {
     m_guiProgressIndicatorTexture->SetDiffuseColor(m_diffuseColor);
     m_guiProgressIndicatorTexture->Render(0, m_guiProgressIndicatorTextureDepth);
@@ -332,9 +339,16 @@ void CGUIEPGGridContainer::RenderProgressIndicator()
   }
 }
 
-void CGUIEPGGridContainer::ProcessItem(float posX, float posY, const CFileItemPtr& item, CFileItemPtr& lastitem,
-  bool focused, CGUIListItemLayout* normallayout, CGUIListItemLayout* focusedlayout,
-  unsigned int currentTime, CDirtyRegionList& dirtyregions, float resize /* = -1.0f */)
+void CGUIEPGGridContainer::ProcessItem(float posX,
+                                       float posY,
+                                       const CFileItemPtr& item,
+                                       CFileItemPtr& lastitem,
+                                       bool focused,
+                                       CGUIListItemLayout* normallayout,
+                                       CGUIListItemLayout* focusedlayout,
+                                       unsigned int currentTime,
+                                       CDirtyRegionList& dirtyregions,
+                                       float resize /* = -1.0f */)
 {
   if (!normallayout || !focusedlayout)
     return;
@@ -437,7 +451,7 @@ bool CGUIEPGGridContainer::OnAction(const CAction& action)
 
     case ACTION_NEXT_ITEM:
       // skip +12h
-      ScrollToBlockOffset(m_blockOffset + (12 * 60  / CGUIEPGGridContainerModel::MINSPERBLOCK));
+      ScrollToBlockOffset(m_blockOffset + (12 * 60 / CGUIEPGGridContainerModel::MINSPERBLOCK));
       SetBlock(m_blockCursor);
       return true;
 
@@ -518,7 +532,8 @@ bool CGUIEPGGridContainer::OnAction(const CAction& action)
     case ACTION_SCROLL_UP: // left horizontal scrolling
       if (m_orientation == VERTICAL)
       {
-        int blocksToJump = action.GetID() == ACTION_TELETEXT_RED ? m_blocksPerPage / 2 : m_blocksPerPage / 4;
+        int blocksToJump =
+            action.GetID() == ACTION_TELETEXT_RED ? m_blocksPerPage / 2 : m_blocksPerPage / 4;
 
         m_analogScrollCount += action.GetAmount() * action.GetAmount();
         bool handled = false;
@@ -537,7 +552,8 @@ bool CGUIEPGGridContainer::OnAction(const CAction& action)
       }
       else
       {
-        int channelsToJump = action.GetID() == ACTION_TELETEXT_RED ? m_channelsPerPage / 2 : m_channelsPerPage / 4;
+        int channelsToJump =
+            action.GetID() == ACTION_TELETEXT_RED ? m_channelsPerPage / 2 : m_channelsPerPage / 4;
 
         m_analogScrollCount += action.GetAmount() * action.GetAmount();
         bool handled = false;
@@ -561,7 +577,8 @@ bool CGUIEPGGridContainer::OnAction(const CAction& action)
     case ACTION_SCROLL_DOWN: // right horizontal scrolling
       if (m_orientation == VERTICAL)
       {
-        int blocksToJump = action.GetID() == ACTION_TELETEXT_BLUE ? m_blocksPerPage / 2 : m_blocksPerPage / 4;
+        int blocksToJump =
+            action.GetID() == ACTION_TELETEXT_BLUE ? m_blocksPerPage / 2 : m_blocksPerPage / 4;
 
         m_analogScrollCount += action.GetAmount() * action.GetAmount();
         bool handled = false;
@@ -582,7 +599,8 @@ bool CGUIEPGGridContainer::OnAction(const CAction& action)
       }
       else
       {
-        int channelsToJump = action.GetID() == ACTION_TELETEXT_BLUE ? m_channelsPerPage / 2 : m_channelsPerPage / 4;
+        int channelsToJump =
+            action.GetID() == ACTION_TELETEXT_BLUE ? m_channelsPerPage / 2 : m_channelsPerPage / 4;
 
         m_analogScrollCount += action.GetAmount() * action.GetAmount();
         bool handled = false;
@@ -592,9 +610,12 @@ bool CGUIEPGGridContainer::OnAction(const CAction& action)
           handled = true;
           m_analogScrollCount -= 0.4f;
 
-          if (m_channelOffset + m_channelsPerPage < m_gridModel->ChannelItemsSize() && m_channelCursor >= m_channelsPerPage / 2)
+          if (m_channelOffset + m_channelsPerPage < m_gridModel->ChannelItemsSize() &&
+              m_channelCursor >= m_channelsPerPage / 2)
             ChannelScroll(channelsToJump);
-          else if (m_channelCursor < m_channelsPerPage - channelsToJump && m_channelOffset + m_channelCursor < m_gridModel->ChannelItemsSize() - channelsToJump)
+          else if (m_channelCursor < m_channelsPerPage - channelsToJump &&
+                   m_channelOffset + m_channelCursor <
+                       m_gridModel->ChannelItemsSize() - channelsToJump)
             SetChannel(m_channelCursor + channelsToJump);
         }
         return handled;
@@ -754,7 +775,8 @@ void CGUIEPGGridContainer::UpdateItems()
     {
       int iChannelIndex = CGUIEPGGridContainerModel::INVALID_INDEX;
       int iBlockIndex = CGUIEPGGridContainerModel::INVALID_INDEX;
-      m_gridModel->FindChannelAndBlockIndex(channelUid, broadcastUid, eventOffset, iChannelIndex, iBlockIndex);
+      m_gridModel->FindChannelAndBlockIndex(channelUid, broadcastUid, eventOffset, iChannelIndex,
+                                            iBlockIndex);
 
       if (iBlockIndex != CGUIEPGGridContainerModel::INVALID_INDEX)
       {
@@ -777,8 +799,12 @@ void CGUIEPGGridContainer::UpdateItems()
         newChannelIndex = iChannelIndex;
       }
       else if (newChannelIndex >= m_gridModel->ChannelItemsSize() ||
-               (m_gridModel->GetGridItem(newChannelIndex, newBlockIndex)->GetEPGInfoTag()->UniqueChannelID() != prevSelectedEpgTag->UniqueChannelID() &&
-                m_gridModel->GetGridItem(newChannelIndex, newBlockIndex)->GetEPGInfoTag()->ClientID() != prevSelectedEpgTag->ClientID()))
+               (m_gridModel->GetGridItem(newChannelIndex, newBlockIndex)
+                        ->GetEPGInfoTag()
+                        ->UniqueChannelID() != prevSelectedEpgTag->UniqueChannelID() &&
+                m_gridModel->GetGridItem(newChannelIndex, newBlockIndex)
+                        ->GetEPGInfoTag()
+                        ->ClientID() != prevSelectedEpgTag->ClientID()))
       {
         // default to first channel
         newChannelIndex = 0;
@@ -889,7 +915,8 @@ void CGUIEPGGridContainer::OnUp()
       ScrollToChannelOffset(m_channelOffset - 1);
       SetChannel(0);
     }
-    else if (action.GetNavigation() == GetID() || !action.HasActionsMeetingCondition()) // wrap around
+    else if (action.GetNavigation() == GetID() ||
+             !action.HasActionsMeetingCondition()) // wrap around
     {
       int offset = m_gridModel->ChannelItemsSize() - m_channelsPerPage;
 
@@ -944,7 +971,8 @@ void CGUIEPGGridContainer::OnDown()
         SetChannel(m_channelsPerPage - 1);
       }
     }
-    else if (action.GetNavigation() == GetID() || !action.HasActionsMeetingCondition()) // wrap around
+    else if (action.GetNavigation() == GetID() ||
+             !action.HasActionsMeetingCondition()) // wrap around
     {
       ScrollToChannelOffset(0);
       SetChannel(0);
@@ -1014,7 +1042,8 @@ void CGUIEPGGridContainer::OnLeft()
       ScrollToChannelOffset(m_channelOffset - 1);
       SetChannel(0);
     }
-    else if (action.GetNavigation() == GetID() || !action.HasActionsMeetingCondition()) // wrap around
+    else if (action.GetNavigation() == GetID() ||
+             !action.HasActionsMeetingCondition()) // wrap around
     {
       int offset = m_gridModel->ChannelItemsSize() - m_channelsPerPage;
 
@@ -1072,7 +1101,8 @@ void CGUIEPGGridContainer::OnRight()
         SetChannel(m_channelsPerPage - 1);
       }
     }
-    else if (action.GetNavigation() == GetID() || !action.HasActionsMeetingCondition()) // wrap around
+    else if (action.GetNavigation() == GetID() ||
+             !action.HasActionsMeetingCondition()) // wrap around
     {
       SetChannel(0);
       ScrollToChannelOffset(0);
@@ -1100,7 +1130,8 @@ bool CGUIEPGGridContainer::SetChannel(const std::shared_ptr<CPVRChannel>& channe
 {
   for (int iIndex = 0; iIndex < m_gridModel->ChannelItemsSize(); iIndex++)
   {
-    int iChannelId = static_cast<int>(m_gridModel->GetChannelItem(iIndex)->GetProperty("channelid").asInteger(-1));
+    int iChannelId = static_cast<int>(
+        m_gridModel->GetChannelItem(iIndex)->GetProperty("channelid").asInteger(-1));
     if (iChannelId == channel->ChannelID())
     {
       GoToChannel(iIndex);
@@ -1232,30 +1263,30 @@ EVENT_RESULT CGUIEPGGridContainer::OnMouseEvent(const CPoint& point,
 {
   switch (event.m_id)
   {
-  case ACTION_MOUSE_LEFT_CLICK:
-    OnMouseClick(0, point);
-    return EVENT_RESULT_HANDLED;
-  case ACTION_MOUSE_RIGHT_CLICK:
-    OnMouseClick(1, point);
-    return EVENT_RESULT_HANDLED;
-  case ACTION_MOUSE_DOUBLE_CLICK:
-    OnMouseDoubleClick(0, point);
-    return EVENT_RESULT_HANDLED;
-  case ACTION_MOUSE_WHEEL_UP:
-    OnMouseWheel(-1, point);
-    return EVENT_RESULT_HANDLED;
-  case ACTION_MOUSE_WHEEL_DOWN:
-    OnMouseWheel(1, point);
-    return EVENT_RESULT_HANDLED;
-  case ACTION_GESTURE_BEGIN:
+    case ACTION_MOUSE_LEFT_CLICK:
+      OnMouseClick(0, point);
+      return EVENT_RESULT_HANDLED;
+    case ACTION_MOUSE_RIGHT_CLICK:
+      OnMouseClick(1, point);
+      return EVENT_RESULT_HANDLED;
+    case ACTION_MOUSE_DOUBLE_CLICK:
+      OnMouseDoubleClick(0, point);
+      return EVENT_RESULT_HANDLED;
+    case ACTION_MOUSE_WHEEL_UP:
+      OnMouseWheel(-1, point);
+      return EVENT_RESULT_HANDLED;
+    case ACTION_MOUSE_WHEEL_DOWN:
+      OnMouseWheel(1, point);
+      return EVENT_RESULT_HANDLED;
+    case ACTION_GESTURE_BEGIN:
     {
       // we want exclusive access
       CGUIMessage msg(GUI_MSG_EXCLUSIVE_MOUSE, GetID(), GetParentID());
       SendWindowMessage(msg);
       return EVENT_RESULT_HANDLED;
     }
-  case ACTION_GESTURE_END:
-  case ACTION_GESTURE_ABORT:
+    case ACTION_GESTURE_END:
+    case ACTION_GESTURE_ABORT:
     {
       // we're done with exclusive access
       CGUIMessage msg(GUI_MSG_EXCLUSIVE_MOUSE, 0, GetParentID());
@@ -1267,7 +1298,7 @@ EVENT_RESULT CGUIEPGGridContainer::OnMouseEvent(const CPoint& point,
       SetBlock(m_blockCursor);
       return EVENT_RESULT_HANDLED;
     }
-  case ACTION_GESTURE_PAN:
+    case ACTION_GESTURE_PAN:
     {
       m_programmeScrollOffset -= event.m_offsetX;
       m_channelScrollOffset -= event.m_offsetY;
@@ -1282,8 +1313,8 @@ EVENT_RESULT CGUIEPGGridContainer::OnMouseEvent(const CPoint& point,
       }
       return EVENT_RESULT_HANDLED;
     }
-  default:
-    return EVENT_RESULT_UNHANDLED;
+    default:
+      return EVENT_RESULT_UNHANDLED;
   }
 }
 
@@ -1367,7 +1398,8 @@ CFileItemPtr CGUIEPGGridContainer::GetSelectedGridItem(int offset /*= 0*/) const
 
   if (m_channelCursor + m_channelOffset + offset < m_gridModel->ChannelItemsSize() &&
       m_blockCursor + m_blockOffset < m_gridModel->GridItemsSize())
-    item = m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, m_blockCursor + m_blockOffset);
+    item =
+        m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, m_blockCursor + m_blockOffset);
 
   return item;
 }
@@ -1402,26 +1434,26 @@ std::string CGUIEPGGridContainer::GetLabel(int info) const
   std::string label;
   switch (info)
   {
-  case CONTAINER_NUM_PAGES:
-    if (m_channelsPerPage > 0)
-      label = std::to_string((m_gridModel->ChannelItemsSize() + m_channelsPerPage - 1) /
-                             m_channelsPerPage);
-    else
-      label = std::to_string(0);
-    break;
-  case CONTAINER_CURRENT_PAGE:
-    if (m_channelsPerPage > 0)
-      label = std::to_string(1 + (m_channelCursor + m_channelOffset) / m_channelsPerPage);
-    else
-      label = std::to_string(1);
-    break;
-  case CONTAINER_POSITION:
-    label = std::to_string(1 + m_channelCursor + m_channelOffset);
-    break;
-  case CONTAINER_NUM_ITEMS:
-    label = std::to_string(m_gridModel->ChannelItemsSize());
-    break;
-  default:
+    case CONTAINER_NUM_PAGES:
+      if (m_channelsPerPage > 0)
+        label = std::to_string((m_gridModel->ChannelItemsSize() + m_channelsPerPage - 1) /
+                               m_channelsPerPage);
+      else
+        label = std::to_string(0);
+      break;
+    case CONTAINER_CURRENT_PAGE:
+      if (m_channelsPerPage > 0)
+        label = std::to_string(1 + (m_channelCursor + m_channelOffset) / m_channelsPerPage);
+      else
+        label = std::to_string(1);
+      break;
+    case CONTAINER_POSITION:
+      label = std::to_string(1 + m_channelCursor + m_channelOffset);
+      break;
+    case CONTAINER_NUM_ITEMS:
+      label = std::to_string(m_gridModel->ChannelItemsSize());
+      break;
+    default:
       break;
   }
   return label;
@@ -1539,13 +1571,15 @@ void CGUIEPGGridContainer::ScrollToBlockOffset(int offset)
   if (range <= 0)
     range = 1;
 
-  if (offset * size < m_programmeScrollOffset && m_programmeScrollOffset - offset * size > size * range)
+  if (offset * size < m_programmeScrollOffset &&
+      m_programmeScrollOffset - offset * size > size * range)
   {
     // scrolling left, and we're jumping more than 0.5 of a screen
     m_programmeScrollOffset = (offset + range) * size;
   }
 
-  if (offset * size > m_programmeScrollOffset && offset * size - m_programmeScrollOffset > size * range)
+  if (offset * size > m_programmeScrollOffset &&
+      offset * size - m_programmeScrollOffset > size * range)
   {
     // scrolling right, and we're jumping more than 0.5 of a screen
     m_programmeScrollOffset = (offset - range) * size;
@@ -1617,7 +1651,8 @@ void CGUIEPGGridContainer::LoadLayout(TiXmlElement* layout)
   while (itemElement)
   {
     m_focusedProgrammeLayouts.emplace_back();
-    m_focusedProgrammeLayouts.back().LoadLayout(itemElement, GetParentID(), true, m_width, m_height);
+    m_focusedProgrammeLayouts.back().LoadLayout(itemElement, GetParentID(), true, m_width,
+                                                m_height);
     itemElement = itemElement->NextSiblingElement("focusedlayout");
   }
   itemElement = layout->FirstChildElement("itemlayout");
@@ -1878,12 +1913,14 @@ void CGUIEPGGridContainer::UpdateLayout()
   GetCurrentLayouts();
 
   // Note: m_rulerDateLayout is optional
-  if (!m_focusedProgrammeLayout || !m_programmeLayout || !m_focusedChannelLayout || !m_channelLayout || !m_rulerLayout)
+  if (!m_focusedProgrammeLayout || !m_programmeLayout || !m_focusedChannelLayout ||
+      !m_channelLayout || !m_rulerLayout)
     return;
 
   if (oldChannelLayout == m_channelLayout && oldFocusedChannelLayout == m_focusedChannelLayout &&
-      oldProgrammeLayout == m_programmeLayout && oldFocusedProgrammeLayout == m_focusedProgrammeLayout &&
-      oldRulerLayout == m_rulerLayout && oldRulerDateLayout == m_rulerDateLayout)
+      oldProgrammeLayout == m_programmeLayout &&
+      oldFocusedProgrammeLayout == m_focusedProgrammeLayout && oldRulerLayout == m_rulerLayout &&
+      oldRulerDateLayout == m_rulerDateLayout)
     return; // nothing has changed, so don't update stuff
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
@@ -1944,8 +1981,10 @@ void CGUIEPGGridContainer::UpdateScrollOffset(unsigned int currentTime)
     return;
 
   m_channelScrollOffset += m_channelScrollSpeed * (currentTime - m_channelScrollLastTime);
-  if ((m_channelScrollSpeed < 0 && m_channelScrollOffset < m_channelOffset * m_programmeLayout->Size(m_orientation)) ||
-      (m_channelScrollSpeed > 0 && m_channelScrollOffset > m_channelOffset * m_programmeLayout->Size(m_orientation)))
+  if ((m_channelScrollSpeed < 0 &&
+       m_channelScrollOffset < m_channelOffset * m_programmeLayout->Size(m_orientation)) ||
+      (m_channelScrollSpeed > 0 &&
+       m_channelScrollOffset > m_channelOffset * m_programmeLayout->Size(m_orientation)))
   {
     m_channelScrollOffset = m_channelOffset * m_programmeLayout->Size(m_orientation);
     m_channelScrollSpeed = 0;
@@ -2114,14 +2153,17 @@ void CGUIEPGGridContainer::HandleChannels(bool bRender,
   if (bRender)
   {
     if (m_orientation == VERTICAL)
-      CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_channelPosX, m_channelPosY, m_channelWidth, m_gridHeight);
+      CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_channelPosX, m_channelPosY,
+                                                                    m_channelWidth, m_gridHeight);
     else
-      CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_channelPosX, m_channelPosY, m_gridWidth, m_channelHeight);
+      CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_channelPosX, m_channelPosY,
+                                                                    m_gridWidth, m_channelHeight);
   }
   else
   {
     // Free memory not used on screen
-    if (m_gridModel->ChannelItemsSize() > m_channelsPerPage + cacheBeforeChannel + cacheAfterChannel)
+    if (m_gridModel->ChannelItemsSize() >
+        m_channelsPerPage + cacheBeforeChannel + cacheAfterChannel)
       m_gridModel->FreeChannelMemory(chanOffset - cacheBeforeChannel,
                                      chanOffset + m_channelsPerPage - 1 + cacheAfterChannel);
   }
@@ -2146,7 +2188,8 @@ void CGUIEPGGridContainer::HandleChannels(bool bRender,
   float drawOffset = (chanOffset - cacheBeforeChannel) * m_channelLayout->Size(m_orientation) -
                      GetChannelScrollOffsetPos();
   if (m_channelOffset + m_channelCursor < chanOffset)
-    drawOffset += m_focusedChannelLayout->Size(m_orientation) - m_channelLayout->Size(m_orientation);
+    drawOffset +=
+        m_focusedChannelLayout->Size(m_orientation) - m_channelLayout->Size(m_orientation);
 
   pos += drawOffset;
   end += cacheAfterChannel * m_channelLayout->Size(m_orientation);
@@ -2193,13 +2236,16 @@ void CGUIEPGGridContainer::HandleChannels(bool bRender,
       {
         // process our item
         if (m_orientation == VERTICAL)
-          ProcessItem(originChannel.x, pos, item, m_lastItem, focused, m_channelLayout, m_focusedChannelLayout, currentTime, dirtyregions);
+          ProcessItem(originChannel.x, pos, item, m_lastItem, focused, m_channelLayout,
+                      m_focusedChannelLayout, currentTime, dirtyregions);
         else
-          ProcessItem(pos, originChannel.y, item, m_lastItem, focused, m_channelLayout, m_focusedChannelLayout, currentTime, dirtyregions);
+          ProcessItem(pos, originChannel.y, item, m_lastItem, focused, m_channelLayout,
+                      m_focusedChannelLayout, currentTime, dirtyregions);
       }
     }
     // increment our position
-    pos += focused ? m_focusedChannelLayout->Size(m_orientation) : m_channelLayout->Size(m_orientation);
+    pos += focused ? m_focusedChannelLayout->Size(m_orientation)
+                   : m_channelLayout->Size(m_orientation);
     current++;
   }
 
@@ -2235,7 +2281,8 @@ void CGUIEPGGridContainer::HandleRulerDate(bool bRender,
   if (bRender)
   {
     // Render single ruler item with date of selected programme
-    CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_posX, m_posY, m_rulerDateWidth, m_rulerDateHeight);
+    CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_posX, m_posY, m_rulerDateWidth,
+                                                                  m_rulerDateHeight);
     RenderItem(m_posX, m_posY, item.get(), false);
     CServiceBroker::GetWinSystem()->GetGfxContext().RestoreClipRegion();
   }
@@ -2249,7 +2296,8 @@ void CGUIEPGGridContainer::HandleRulerDate(bool bRender,
     item->SetLabel(m_gridModel->GetRulerItem(rulerOffset / m_rulerUnit + 1)->GetLabel2());
 
     CFileItemPtr lastitem;
-    ProcessItem(m_posX, m_posY, item, lastitem, false, m_rulerDateLayout, m_rulerDateLayout, currentTime, dirtyregions);
+    ProcessItem(m_posX, m_posY, item, lastitem, false, m_rulerDateLayout, m_rulerDateLayout,
+                currentTime, dirtyregions);
   }
 }
 
@@ -2272,7 +2320,8 @@ void CGUIEPGGridContainer::HandleRuler(bool bRender,
     if (!m_rulerDateLayout)
     {
       // Render single ruler item with date of selected programme
-      CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_posX, m_posY, m_width, m_height);
+      CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_posX, m_posY, m_width,
+                                                                    m_height);
       RenderItem(m_posX, m_posY, item.get(), false);
       CServiceBroker::GetWinSystem()->GetGfxContext().RestoreClipRegion();
     }
@@ -2281,9 +2330,11 @@ void CGUIEPGGridContainer::HandleRuler(bool bRender,
     GetProgrammeCacheOffsets(cacheBeforeRuler, cacheAfterRuler);
 
     if (m_orientation == VERTICAL)
-      CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_rulerPosX, m_rulerPosY, m_gridWidth, m_rulerHeight);
+      CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_rulerPosX, m_rulerPosY,
+                                                                    m_gridWidth, m_rulerHeight);
     else
-      CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_rulerPosX, m_rulerPosY, m_rulerWidth, m_gridHeight);
+      CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_rulerPosX, m_rulerPosY,
+                                                                    m_rulerWidth, m_gridHeight);
   }
   else if (bAssignDepth)
   {
@@ -2296,7 +2347,8 @@ void CGUIEPGGridContainer::HandleRuler(bool bRender,
     if (!m_rulerDateLayout)
     {
       item->SetLabel(m_gridModel->GetRulerItem(rulerOffset / m_rulerUnit + 1)->GetLabel2());
-      ProcessItem(m_posX, m_posY, item, lastitem, false, m_rulerLayout, m_rulerLayout, currentTime, dirtyregions, m_channelWidth);
+      ProcessItem(m_posX, m_posY, item, lastitem, false, m_rulerLayout, m_rulerLayout, currentTime,
+                  dirtyregions, m_channelWidth);
     }
 
     GetProgrammeCacheOffsets(cacheBeforeRuler, cacheAfterRuler);
@@ -2352,7 +2404,8 @@ void CGUIEPGGridContainer::HandleRuler(bool bRender,
       else if (bAssignDepth)
         AssignItemDepth(item.get(), false);
       else
-        ProcessItem(pos, originRuler.y, item, lastitem, false, m_rulerLayout, m_rulerLayout, currentTime, dirtyregions, m_rulerWidth);
+        ProcessItem(pos, originRuler.y, item, lastitem, false, m_rulerLayout, m_rulerLayout,
+                    currentTime, dirtyregions, m_rulerWidth);
 
       pos += m_rulerWidth;
     }
@@ -2363,7 +2416,8 @@ void CGUIEPGGridContainer::HandleRuler(bool bRender,
       else if (bAssignDepth)
         AssignItemDepth(item.get(), false);
       else
-        ProcessItem(originRuler.x, pos, item, lastitem, false, m_rulerLayout, m_rulerLayout, currentTime, dirtyregions, m_rulerHeight);
+        ProcessItem(originRuler.x, pos, item, lastitem, false, m_rulerLayout, m_rulerLayout,
+                    currentTime, dirtyregions, m_rulerHeight);
 
       pos += m_rulerHeight;
     }
@@ -2380,7 +2434,8 @@ void CGUIEPGGridContainer::HandleProgrammeGrid(bool bRender,
                                                CDirtyRegionList& dirtyregions,
                                                bool bAssignDepth)
 {
-  if (!m_focusedProgrammeLayout || !m_programmeLayout || m_gridModel->RulerItemsSize() <= 1 || m_gridModel->IsZeroGridDuration())
+  if (!m_focusedProgrammeLayout || !m_programmeLayout || m_gridModel->RulerItemsSize() <= 1 ||
+      m_gridModel->IsZeroGridDuration())
     return;
 
   const int blockOffset = GetProgrammeScrollOffset();
@@ -2391,7 +2446,8 @@ void CGUIEPGGridContainer::HandleProgrammeGrid(bool bRender,
 
   if (bRender)
   {
-    CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_gridPosX, m_gridPosY, m_gridWidth, m_gridHeight);
+    CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_gridPosX, m_gridPosY,
+                                                                  m_gridWidth, m_gridHeight);
   }
   else if (!bAssignDepth)
   {
@@ -2415,8 +2471,8 @@ void CGUIEPGGridContainer::HandleProgrammeGrid(bool bRender,
     if (m_gridModel->FreeProgrammeMemory(firstChannel, lastChannel, firstBlock, lastBlock))
     {
       // announce changed viewport
-      const CGUIMessage msg(
-          GUI_MSG_REFRESH_LIST, GetParentID(), GetID(), static_cast<int>(PVREvent::Epg));
+      const CGUIMessage msg(GUI_MSG_REFRESH_LIST, GetParentID(), GetID(),
+                            static_cast<int>(PVREvent::Epg));
       CServiceBroker::GetAppMessenger()->SendGUIMessage(msg);
     }
   }

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -56,7 +56,7 @@ CGUIEPGGridContainer::CGUIEPGGridContainer(int parentID,
                                            const CTextureInfo& progressIndicatorTexture)
   : IGUIContainer(parentID, controlID, posX, posY, width, height),
     m_orientation(orientation),
-    m_rulerUnit(rulerUnit),
+    m_rulerUnit(rulerUnit * MINUTES_PER_RULER_UNIT / minutesPerTimeBlock),
     m_blocksPerPage(timeBlocks),
     m_minutesPerBlock(minutesPerTimeBlock),
     m_cacheChannelItems(preloadItems),

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.dox
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.dox
@@ -224,6 +224,7 @@ important, as `xml` tags are case-sensitive.
 | Tag                   | Description                                                   |
 |----------------------:|:--------------------------------------------------------------|
 | timeblocks            | The number of timeframes on the ruler.
+| minspertimeblock      | The number of minutes a timeblock represents.
 | rulerunit             | Timeframe of each unit on ruler. 1 unit equals 5 minutes.
 | rulerdatelayout       | The layout of a ruler date item (usually used to display the start date of current epg page).
 | rulerlayout           | The layout of a ruler item.

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.h
@@ -40,6 +40,7 @@ class CGUIEPGGridContainer : public IGUIContainer
 {
 public:
   static constexpr unsigned int DEFAULT_MINUTES_PER_BLOCK{5};
+  static constexpr unsigned int MINUTES_PER_RULER_UNIT{5};
 
   CGUIEPGGridContainer(int parentID,
                        int controlID,

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.h
@@ -30,263 +30,281 @@ class TiXmlElement;
 
 namespace PVR
 {
-  class CPVRChannel;
-  class CPVRChannelGroupMember;
-  class CPVRChannelNumber;
+class CPVRChannel;
+class CPVRChannelGroupMember;
+class CPVRChannelNumber;
 
-  class CGUIEPGGridContainerModel;
+class CGUIEPGGridContainerModel;
 
-  class CGUIEPGGridContainer : public IGUIContainer
-  {
-  public:
-    CGUIEPGGridContainer(int parentID, int controlID, float posX, float posY, float width, float height,
-                         ORIENTATION orientation, int scrollTime, int preloadItems, int minutesPerPage,
-                         int rulerUnit, const CTextureInfo& progressIndicatorTexture);
-    CGUIEPGGridContainer(const CGUIEPGGridContainer& other);
+class CGUIEPGGridContainer : public IGUIContainer
+{
+public:
+  CGUIEPGGridContainer(int parentID,
+                       int controlID,
+                       float posX,
+                       float posY,
+                       float width,
+                       float height,
+                       ORIENTATION orientation,
+                       int scrollTime,
+                       int preloadItems,
+                       int minutesPerPage,
+                       int rulerUnit,
+                       const CTextureInfo& progressIndicatorTexture);
+  CGUIEPGGridContainer(const CGUIEPGGridContainer& other);
 
-    CGUIEPGGridContainer* Clone() const override { return new CGUIEPGGridContainer(*this); }
+  CGUIEPGGridContainer* Clone() const override { return new CGUIEPGGridContainer(*this); }
 
-    /*!
-     * @brief Check whether the control currently holds data.
-     * @return true if the control has data, false otherwise.
-     */
-    bool HasData() const;
+  /*!
+   * @brief Check whether the control currently holds data.
+   * @return true if the control has data, false otherwise.
+   */
+  bool HasData() const;
 
-    void AllocResources() override;
-    void FreeResources(bool immediately) override;
+  void AllocResources() override;
+  void FreeResources(bool immediately) override;
 
-    bool OnAction(const CAction& action) override;
-    void OnDown() override;
-    void OnUp() override;
-    void OnLeft() override;
-    void OnRight() override;
-    bool OnMouseOver(const CPoint& point) override;
-    bool OnMessage(CGUIMessage& message) override;
-    void SetFocus(bool focus) override;
-    std::string GetDescription() const override;
-    EVENT_RESULT OnMouseEvent(const CPoint& point, const KODI::MOUSE::CMouseEvent& event) override;
+  bool OnAction(const CAction& action) override;
+  void OnDown() override;
+  void OnUp() override;
+  void OnLeft() override;
+  void OnRight() override;
+  bool OnMouseOver(const CPoint& point) override;
+  bool OnMessage(CGUIMessage& message) override;
+  void SetFocus(bool focus) override;
+  std::string GetDescription() const override;
+  EVENT_RESULT OnMouseEvent(const CPoint& point, const KODI::MOUSE::CMouseEvent& event) override;
 
-    void Process(unsigned int currentTime, CDirtyRegionList& dirtyregions) override;
-    void Render() override;
+  void Process(unsigned int currentTime, CDirtyRegionList& dirtyregions) override;
+  void Render() override;
 
-    std::shared_ptr<CGUIListItem> GetListItem(int offset, unsigned int flag = 0) const override;
-    std::string GetLabel(int info) const override;
+  std::shared_ptr<CGUIListItem> GetListItem(int offset, unsigned int flag = 0) const override;
+  std::string GetLabel(int info) const override;
 
-    std::shared_ptr<CFileItem> GetSelectedGridItem(int offset = 0) const;
-    std::shared_ptr<CPVRChannelGroupMember> GetSelectedChannelGroupMember() const;
-    CDateTime GetSelectedDate() const;
+  std::shared_ptr<CFileItem> GetSelectedGridItem(int offset = 0) const;
+  std::shared_ptr<CPVRChannelGroupMember> GetSelectedChannelGroupMember() const;
+  CDateTime GetSelectedDate() const;
 
-    void LoadLayout(TiXmlElement* layout);
-    void SetPageControl(int id);
+  void LoadLayout(TiXmlElement* layout);
+  void SetPageControl(int id);
 
-    /*! \brief Set the offset of the first item in the container from the container's position
-     Useful for lists/panels where the focused item may be larger than the non-focused items and thus
-     normally cut off from the clipping window defined by the container's position + size.
-     \param offset CPoint holding the offset in skin coordinates.
-     */
-    void SetRenderOffset(const CPoint& offset);
+  /*! \brief Set the offset of the first item in the container from the container's position
+   Useful for lists/panels where the focused item may be larger than the non-focused items and thus
+   normally cut off from the clipping window defined by the container's position + size.
+   \param offset CPoint holding the offset in skin coordinates.
+   */
+  void SetRenderOffset(const CPoint& offset);
 
-    void JumpToNow();
-    void JumpToDate(const CDateTime& date);
+  void JumpToNow();
+  void JumpToDate(const CDateTime& date);
 
-    void GoToBegin();
-    void GoToEnd();
-    void GoToNow();
-    void GoToDate(const CDateTime& date);
+  void GoToBegin();
+  void GoToEnd();
+  void GoToNow();
+  void GoToDate(const CDateTime& date);
 
-    void GoToFirstChannel();
-    void GoToLastChannel();
+  void GoToFirstChannel();
+  void GoToLastChannel();
 
-    void GoToTop();
-    void GoToBottom();
-    void GoToMostLeft();
-    void GoToMostRight();
+  void GoToTop();
+  void GoToBottom();
+  void GoToMostLeft();
+  void GoToMostRight();
 
-    void SetTimelineItems(const std::unique_ptr<CFileItemList>& items,
-                          const CDateTime& gridStart,
-                          const CDateTime& gridEnd);
+  void SetTimelineItems(const std::unique_ptr<CFileItemList>& items,
+                        const CDateTime& gridStart,
+                        const CDateTime& gridEnd);
 
-    std::unique_ptr<CFileItemList> GetCurrentTimeLineItems() const;
+  std::unique_ptr<CFileItemList> GetCurrentTimeLineItems() const;
 
-    /*!
-     * @brief Set the control's selection to the given channel and set the control's view port to show the channel.
-     * @param channel the channel.
-     * @return true if the selection was set to the given channel, false otherwise.
-     */
-    bool SetChannel(const std::shared_ptr<CPVRChannel>& channel);
+  /*!
+   * @brief Set the control's selection to the given channel and set the control's view port to show the channel.
+   * @param channel the channel.
+   * @return true if the selection was set to the given channel, false otherwise.
+   */
+  bool SetChannel(const std::shared_ptr<CPVRChannel>& channel);
 
-    /*!
-     * @brief Set the control's selection to the given channel and set the control's view port to show the channel.
-     * @param channel the channel's path.
-     * @return true if the selection was set to the given channel, false otherwise.
-     */
-    bool SetChannel(const std::string& channel);
+  /*!
+   * @brief Set the control's selection to the given channel and set the control's view port to show the channel.
+   * @param channel the channel's path.
+   * @return true if the selection was set to the given channel, false otherwise.
+   */
+  bool SetChannel(const std::string& channel);
 
-    /*!
-     * @brief Set the control's selection to the given channel and set the control's view port to show the channel.
-     * @param channelNumber the channel's number.
-     * @return true if the selection was set to the given channel, false otherwise.
-     */
-    bool SetChannel(const CPVRChannelNumber& channelNumber);
+  /*!
+   * @brief Set the control's selection to the given channel and set the control's view port to show the channel.
+   * @param channelNumber the channel's number.
+   * @return true if the selection was set to the given channel, false otherwise.
+   */
+  bool SetChannel(const CPVRChannelNumber& channelNumber);
 
-    virtual void AssignDepth() override;
+  virtual void AssignDepth() override;
 
-    void AssignItemDepth(CGUIListItem* item, bool focused);
+  void AssignItemDepth(CGUIListItem* item, bool focused);
 
-  private:
-    bool OnClick(int actionID);
-    bool SelectItemFromPoint(const CPoint& point, bool justGrid = true);
+private:
+  bool OnClick(int actionID);
+  bool SelectItemFromPoint(const CPoint& point, bool justGrid = true);
 
-    void SetChannel(int channel);
+  void SetChannel(int channel);
 
-    void SetBlock(int block, bool bUpdateBlockTravelAxis = true);
-    void UpdateBlock(bool bUpdateBlockTravelAxis = true);
+  void SetBlock(int block, bool bUpdateBlockTravelAxis = true);
+  void UpdateBlock(bool bUpdateBlockTravelAxis = true);
 
-    void ChannelScroll(int amount);
-    void ProgrammesScroll(int amount);
-    void ValidateOffset();
-    void UpdateLayout();
+  void ChannelScroll(int amount);
+  void ProgrammesScroll(int amount);
+  void ValidateOffset();
+  void UpdateLayout();
 
-    void SetItem(const std::pair<std::shared_ptr<CFileItem>, int>& itemInfo);
-    bool SetItem(const std::shared_ptr<CFileItem>& item, int channelIndex, int blockIndex);
-    std::shared_ptr<CFileItem> GetItem() const;
-    std::pair<std::shared_ptr<CFileItem>, int> GetNextItem() const;
-    std::pair<std::shared_ptr<CFileItem>, int> GetPrevItem() const;
-    void UpdateItem();
+  void SetItem(const std::pair<std::shared_ptr<CFileItem>, int>& itemInfo);
+  bool SetItem(const std::shared_ptr<CFileItem>& item, int channelIndex, int blockIndex);
+  std::shared_ptr<CFileItem> GetItem() const;
+  std::pair<std::shared_ptr<CFileItem>, int> GetNextItem() const;
+  std::pair<std::shared_ptr<CFileItem>, int> GetPrevItem() const;
+  void UpdateItem();
 
-    void MoveToRow(int row);
+  void MoveToRow(int row);
 
-    CGUIListItemLayout* GetFocusedLayout() const;
+  CGUIListItemLayout* GetFocusedLayout() const;
 
-    void ScrollToBlockOffset(int offset);
-    void ScrollToChannelOffset(int offset);
-    void GoToBlock(int blockIndex);
-    void GoToChannel(int channelIndex);
-    void UpdateScrollOffset(unsigned int currentTime);
-    void ProcessItem(float posX, float posY, const std::shared_ptr<CFileItem>& item, std::shared_ptr<CFileItem>& lastitem, bool focused, CGUIListItemLayout* normallayout, CGUIListItemLayout* focusedlayout, unsigned int currentTime, CDirtyRegionList& dirtyregions, float resize = -1.0f);
-    void RenderItem(float posX, float posY, CGUIListItem* item, bool focused);
-    void GetCurrentLayouts();
+  void ScrollToBlockOffset(int offset);
+  void ScrollToChannelOffset(int offset);
+  void GoToBlock(int blockIndex);
+  void GoToChannel(int channelIndex);
+  void UpdateScrollOffset(unsigned int currentTime);
+  void ProcessItem(float posX,
+                   float posY,
+                   const std::shared_ptr<CFileItem>& item,
+                   std::shared_ptr<CFileItem>& lastitem,
+                   bool focused,
+                   CGUIListItemLayout* normallayout,
+                   CGUIListItemLayout* focusedlayout,
+                   unsigned int currentTime,
+                   CDirtyRegionList& dirtyregions,
+                   float resize = -1.0f);
+  void RenderItem(float posX, float posY, CGUIListItem* item, bool focused);
+  void GetCurrentLayouts();
 
-    void ProcessChannels(unsigned int currentTime, CDirtyRegionList& dirtyregions);
-    void ProcessRuler(unsigned int currentTime, CDirtyRegionList& dirtyregions);
-    void ProcessRulerDate(unsigned int currentTime, CDirtyRegionList& dirtyregions);
-    void ProcessProgrammeGrid(unsigned int currentTime, CDirtyRegionList& dirtyregions);
-    void ProcessProgressIndicator(unsigned int currentTime, CDirtyRegionList& dirtyregions);
-    void RenderChannels();
-    void RenderRulerDate();
-    void RenderRuler();
-    void RenderProgrammeGrid();
-    void RenderProgressIndicator();
+  void ProcessChannels(unsigned int currentTime, CDirtyRegionList& dirtyregions);
+  void ProcessRuler(unsigned int currentTime, CDirtyRegionList& dirtyregions);
+  void ProcessRulerDate(unsigned int currentTime, CDirtyRegionList& dirtyregions);
+  void ProcessProgrammeGrid(unsigned int currentTime, CDirtyRegionList& dirtyregions);
+  void ProcessProgressIndicator(unsigned int currentTime, CDirtyRegionList& dirtyregions);
+  void RenderChannels();
+  void RenderRulerDate();
+  void RenderRuler();
+  void RenderProgrammeGrid();
+  void RenderProgressIndicator();
 
-    CPoint m_renderOffset; ///< \brief render offset of the first item in the list \sa SetRenderOffset
+  CPoint m_renderOffset; ///< \brief render offset of the first item in the list \sa SetRenderOffset
 
-    ORIENTATION m_orientation;
+  ORIENTATION m_orientation;
 
-    std::vector<CGUIListItemLayout> m_channelLayouts;
-    std::vector<CGUIListItemLayout> m_focusedChannelLayouts;
-    std::vector<CGUIListItemLayout> m_focusedProgrammeLayouts;
-    std::vector<CGUIListItemLayout> m_programmeLayouts;
-    std::vector<CGUIListItemLayout> m_rulerLayouts;
-    std::vector<CGUIListItemLayout> m_rulerDateLayouts;
+  std::vector<CGUIListItemLayout> m_channelLayouts;
+  std::vector<CGUIListItemLayout> m_focusedChannelLayouts;
+  std::vector<CGUIListItemLayout> m_focusedProgrammeLayouts;
+  std::vector<CGUIListItemLayout> m_programmeLayouts;
+  std::vector<CGUIListItemLayout> m_rulerLayouts;
+  std::vector<CGUIListItemLayout> m_rulerDateLayouts;
 
-    CGUIListItemLayout* m_channelLayout = nullptr;
-    CGUIListItemLayout* m_focusedChannelLayout = nullptr;
-    CGUIListItemLayout* m_programmeLayout = nullptr;
-    CGUIListItemLayout* m_focusedProgrammeLayout = nullptr;
-    CGUIListItemLayout* m_rulerLayout = nullptr;
-    CGUIListItemLayout* m_rulerDateLayout = nullptr;
+  CGUIListItemLayout* m_channelLayout = nullptr;
+  CGUIListItemLayout* m_focusedChannelLayout = nullptr;
+  CGUIListItemLayout* m_programmeLayout = nullptr;
+  CGUIListItemLayout* m_focusedProgrammeLayout = nullptr;
+  CGUIListItemLayout* m_rulerLayout = nullptr;
+  CGUIListItemLayout* m_rulerDateLayout = nullptr;
 
-    int m_pageControl = 0;
+  int m_pageControl = 0;
 
-    void GetChannelCacheOffsets(int& cacheBefore, int& cacheAfter);
-    void GetProgrammeCacheOffsets(int& cacheBefore, int& cacheAfter);
+  void GetChannelCacheOffsets(int& cacheBefore, int& cacheAfter);
+  void GetProgrammeCacheOffsets(int& cacheBefore, int& cacheAfter);
 
-  private:
-    bool OnMouseClick(int dwButton, const CPoint& point);
-    bool OnMouseDoubleClick(int dwButton, const CPoint& point);
-    bool OnMouseWheel(char wheel, const CPoint& point);
+private:
+  bool OnMouseClick(int dwButton, const CPoint& point);
+  bool OnMouseDoubleClick(int dwButton, const CPoint& point);
+  bool OnMouseWheel(char wheel, const CPoint& point);
 
-    void HandleChannels(bool bRender,
-                        unsigned int currentTime,
-                        CDirtyRegionList& dirtyregions,
-                        bool bAssignDepth = false);
-    void HandleRuler(bool bRender,
-                     unsigned int currentTime,
-                     CDirtyRegionList& dirtyregions,
-                     bool bAssignDepth = false);
-    void HandleRulerDate(bool bRender,
-                         unsigned int currentTime,
-                         CDirtyRegionList& dirtyregions,
-                         bool bAssignDepth = false);
-    void HandleProgrammeGrid(bool bRender,
-                             unsigned int currentTime,
-                             CDirtyRegionList& dirtyregions,
-                             bool bAssignDepth = false);
+  void HandleChannels(bool bRender,
+                      unsigned int currentTime,
+                      CDirtyRegionList& dirtyregions,
+                      bool bAssignDepth = false);
+  void HandleRuler(bool bRender,
+                   unsigned int currentTime,
+                   CDirtyRegionList& dirtyregions,
+                   bool bAssignDepth = false);
+  void HandleRulerDate(bool bRender,
+                       unsigned int currentTime,
+                       CDirtyRegionList& dirtyregions,
+                       bool bAssignDepth = false);
+  void HandleProgrammeGrid(bool bRender,
+                           unsigned int currentTime,
+                           CDirtyRegionList& dirtyregions,
+                           bool bAssignDepth = false);
 
-    float GetCurrentTimePositionOnPage() const;
-    float GetProgressIndicatorWidth() const;
-    float GetProgressIndicatorHeight() const;
+  float GetCurrentTimePositionOnPage() const;
+  float GetProgressIndicatorWidth() const;
+  float GetProgressIndicatorHeight() const;
 
-    void UpdateItems();
+  void UpdateItems();
 
-    float GetChannelScrollOffsetPos() const;
-    float GetProgrammeScrollOffsetPos() const;
-    int GetChannelScrollOffset(CGUIListItemLayout* layout) const;
-    int GetProgrammeScrollOffset() const;
+  float GetChannelScrollOffsetPos() const;
+  float GetProgrammeScrollOffsetPos() const;
+  int GetChannelScrollOffset(CGUIListItemLayout* layout) const;
+  int GetProgrammeScrollOffset() const;
 
-    int m_rulerUnit; //! number of blocks that makes up one element of the ruler
-    int m_channelsPerPage = 0;
-    int m_programmesPerPage = 0;
-    int m_channelCursor = 0;
-    int m_channelOffset = 0;
-    int m_blocksPerPage;
-    int m_blockCursor = 0;
-    int m_blockOffset = 0;
-    int m_blockTravelAxis = 0;
-    int m_cacheChannelItems;
-    int m_cacheProgrammeItems;
-    int m_cacheRulerItems;
+  int m_rulerUnit; //! number of blocks that makes up one element of the ruler
+  int m_channelsPerPage = 0;
+  int m_programmesPerPage = 0;
+  int m_channelCursor = 0;
+  int m_channelOffset = 0;
+  int m_blocksPerPage;
+  int m_blockCursor = 0;
+  int m_blockOffset = 0;
+  int m_blockTravelAxis = 0;
+  int m_cacheChannelItems;
+  int m_cacheProgrammeItems;
+  int m_cacheRulerItems;
 
-    float m_rulerDateHeight = 0; //! height of ruler date item
-    float m_rulerDateWidth = 0; //! width of ruler date item
-    float m_rulerPosX = 0; //! X position of first ruler item
-    float m_rulerPosY = 0; //! Y position of first ruler item
-    float m_rulerHeight = 0; //! height of the scrolling timeline above the ruler items
-    float m_rulerWidth = 0; //! width of each element of the ruler
-    float m_channelPosX = 0; //! X position of first channel row
-    float m_channelPosY = 0; //! Y position of first channel row
-    float m_channelHeight = 0; //! height of the channel item
-    float m_channelWidth = 0; //! width of the channel item
-    float m_gridPosX = 0; //! X position of first grid item
-    float m_gridPosY = 0; //! Y position of first grid item
-    float m_gridWidth = 0; //! width of the epg grid control
-    float m_gridHeight = 0; //! height of the epg grid control
-    float m_blockSize = 0; //! a block's width in pixels
-    float m_analogScrollCount = 0;
+  float m_rulerDateHeight = 0; //! height of ruler date item
+  float m_rulerDateWidth = 0; //! width of ruler date item
+  float m_rulerPosX = 0; //! X position of first ruler item
+  float m_rulerPosY = 0; //! Y position of first ruler item
+  float m_rulerHeight = 0; //! height of the scrolling timeline above the ruler items
+  float m_rulerWidth = 0; //! width of each element of the ruler
+  float m_channelPosX = 0; //! X position of first channel row
+  float m_channelPosY = 0; //! Y position of first channel row
+  float m_channelHeight = 0; //! height of the channel item
+  float m_channelWidth = 0; //! width of the channel item
+  float m_gridPosX = 0; //! X position of first grid item
+  float m_gridPosY = 0; //! Y position of first grid item
+  float m_gridWidth = 0; //! width of the epg grid control
+  float m_gridHeight = 0; //! height of the epg grid control
+  float m_blockSize = 0; //! a block's width in pixels
+  float m_analogScrollCount = 0;
 
-    std::unique_ptr<CGUITexture> m_guiProgressIndicatorTexture;
-    uint32_t m_guiProgressIndicatorTextureDepth{0};
+  std::unique_ptr<CGUITexture> m_guiProgressIndicatorTexture;
+  uint32_t m_guiProgressIndicatorTextureDepth{0};
 
-    std::shared_ptr<CFileItem> m_lastItem;
-    std::shared_ptr<CFileItem> m_lastChannel;
+  std::shared_ptr<CFileItem> m_lastItem;
+  std::shared_ptr<CFileItem> m_lastChannel;
 
-    bool m_bEnableProgrammeScrolling = true;
-    bool m_bEnableChannelScrolling = true;
+  bool m_bEnableProgrammeScrolling = true;
+  bool m_bEnableChannelScrolling = true;
 
-    int m_scrollTime;
+  int m_scrollTime;
 
-    int m_programmeScrollLastTime = 0;
-    float m_programmeScrollSpeed = 0;
-    float m_programmeScrollOffset = 0;
+  int m_programmeScrollLastTime = 0;
+  float m_programmeScrollSpeed = 0;
+  float m_programmeScrollOffset = 0;
 
-    int m_channelScrollLastTime = 0;
-    float m_channelScrollSpeed = 0;
-    float m_channelScrollOffset = 0;
+  int m_channelScrollLastTime = 0;
+  float m_channelScrollSpeed = 0;
+  float m_channelScrollOffset = 0;
 
-    mutable CCriticalSection m_critSection;
-    std::unique_ptr<CGUIEPGGridContainerModel> m_gridModel;
-    std::unique_ptr<CGUIEPGGridContainerModel> m_updatedGridModel;
+  mutable CCriticalSection m_critSection;
+  std::unique_ptr<CGUIEPGGridContainerModel> m_gridModel;
+  std::unique_ptr<CGUIEPGGridContainerModel> m_updatedGridModel;
 
-    int m_itemStartBlock = 0;
-  };
-}
+  int m_itemStartBlock = 0;
+};
+} // namespace PVR

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.h
@@ -258,7 +258,7 @@ private:
 
   int GetBlockScrollOffset() const;
 
-  int m_rulerUnit; //! number of blocks that makes up one element of the ruler
+  int m_blocksPerRulerItem; //! number of blocks that makes up one element of the ruler
   int m_channelsPerPage = 0;
   int m_programmesPerPage = 0;
   int m_channelCursor = 0;

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.h
@@ -39,6 +39,8 @@ class CGUIEPGGridContainerModel;
 class CGUIEPGGridContainer : public IGUIContainer
 {
 public:
+  static constexpr unsigned int DEFAULT_MINUTES_PER_BLOCK{5};
+
   CGUIEPGGridContainer(int parentID,
                        int controlID,
                        float posX,
@@ -48,7 +50,8 @@ public:
                        ORIENTATION orientation,
                        int scrollTime,
                        int preloadItems,
-                       int minutesPerPage,
+                       int timeBlocks,
+                       unsigned int minutesPerTimeBlock,
                        int rulerUnit,
                        const CTextureInfo& progressIndicatorTexture);
   CGUIEPGGridContainer(const CGUIEPGGridContainer& other);
@@ -252,12 +255,15 @@ private:
   int GetChannelScrollOffset(CGUIListItemLayout* layout) const;
   int GetProgrammeScrollOffset() const;
 
+  int GetBlockScrollOffset() const;
+
   int m_rulerUnit; //! number of blocks that makes up one element of the ruler
   int m_channelsPerPage = 0;
   int m_programmesPerPage = 0;
   int m_channelCursor = 0;
   int m_channelOffset = 0;
   int m_blocksPerPage;
+  unsigned int m_minutesPerBlock{DEFAULT_MINUTES_PER_BLOCK};
   int m_blockCursor = 0;
   int m_blockOffset = 0;
   int m_blockTravelAxis = 0;

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
@@ -73,7 +73,7 @@ void CGUIEPGGridContainerModel::Initialize(const std::unique_ptr<CFileItemList>&
                                            int iFirstBlock,
                                            int iBlocksPerPage,
                                            unsigned int minutesPerBlock,
-                                           int iRulerUnit,
+                                           int blocksPerRulerItem,
                                            float fBlockSize)
 {
   if (!m_channelItems.empty())
@@ -134,7 +134,7 @@ void CGUIEPGGridContainerModel::Initialize(const std::unique_ptr<CFileItemList>&
   rulerItem->SetProperty("DateLabel", true);
   m_rulerItems.emplace_back(rulerItem);
 
-  const CDateTimeSpan unit(0, 0, iRulerUnit * minutesPerBlock, 0);
+  const CDateTimeSpan unit(0, 0, blocksPerRulerItem * minutesPerBlock, 0);
   for (; ruler < rulerEnd; ruler += unit)
   {
     rulerItem = std::make_shared<CFileItem>(ruler.GetAsLocalizedTime("", false));

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
@@ -51,8 +51,9 @@ std::shared_ptr<CFileItem> CGUIEPGGridContainerModel::CreateGapItem(int iChannel
 std::vector<std::shared_ptr<CPVREpgInfoTag>> CGUIEPGGridContainerModel::GetEPGTimeline(
     int iChannel, const CDateTime& minEventEnd, const CDateTime& maxEventStart) const
 {
-  CDateTime min = minEventEnd - CDateTimeSpan(0, 0, MINSPERBLOCK, 0) + CDateTimeSpan(0, 0, 0, 1);
-  CDateTime max = maxEventStart + CDateTimeSpan(0, 0, MINSPERBLOCK, 0);
+  CDateTime min =
+      minEventEnd - CDateTimeSpan(0, 0, m_minutesPerBlock, 0) + CDateTimeSpan(0, 0, 0, 1);
+  CDateTime max = maxEventStart + CDateTimeSpan(0, 0, m_minutesPerBlock, 0);
 
   if (min < m_gridStart)
     min = m_gridStart;
@@ -71,6 +72,7 @@ void CGUIEPGGridContainerModel::Initialize(const std::unique_ptr<CFileItemList>&
                                            int iChannelsPerPage,
                                            int iFirstBlock,
                                            int iBlocksPerPage,
+                                           unsigned int minutesPerBlock,
                                            int iRulerUnit,
                                            float fBlockSize)
 {
@@ -81,6 +83,7 @@ void CGUIEPGGridContainerModel::Initialize(const std::unique_ptr<CFileItemList>&
   }
 
   m_fBlockSize = fBlockSize;
+  m_minutesPerBlock = minutesPerBlock;
 
   ////////////////////////////////////////////////////////////////////////
   // Create channel items
@@ -91,7 +94,7 @@ void CGUIEPGGridContainerModel::Initialize(const std::unique_ptr<CFileItemList>&
   {
     // default to start "now minus GRID_START_PADDING minutes" and end "start plus one page".
     m_gridStart = CDateTime::GetUTCDateTime() - CDateTimeSpan(0, 0, GetGridStartPadding(), 0);
-    m_gridEnd = m_gridStart + CDateTimeSpan(0, 0, iBlocksPerPage * MINSPERBLOCK, 0);
+    m_gridEnd = m_gridStart + CDateTimeSpan(0, 0, iBlocksPerPage * minutesPerBlock, 0);
   }
   else if (gridStart >
            (CDateTime::GetUTCDateTime() - CDateTimeSpan(0, 0, GetGridStartPadding(), 0)))
@@ -117,7 +120,7 @@ void CGUIEPGGridContainerModel::Initialize(const std::unique_ptr<CFileItemList>&
   const int iBlocksLastPage = m_blocks % iBlocksPerPage;
   if (iBlocksLastPage > 0)
   {
-    m_gridEnd += CDateTimeSpan(0, 0, (iBlocksPerPage - iBlocksLastPage) * MINSPERBLOCK, 0);
+    m_gridEnd += CDateTimeSpan(0, 0, (iBlocksPerPage - iBlocksLastPage) * minutesPerBlock, 0);
     m_blocks += (iBlocksPerPage - iBlocksLastPage);
   }
 
@@ -131,7 +134,7 @@ void CGUIEPGGridContainerModel::Initialize(const std::unique_ptr<CFileItemList>&
   rulerItem->SetProperty("DateLabel", true);
   m_rulerItems.emplace_back(rulerItem);
 
-  const CDateTimeSpan unit(0, 0, iRulerUnit * MINSPERBLOCK, 0);
+  const CDateTimeSpan unit(0, 0, iRulerUnit * minutesPerBlock, 0);
   for (; ruler < rulerEnd; ruler += unit)
   {
     rulerItem = std::make_shared<CFileItem>(ruler.GetAsLocalizedTime("", false));
@@ -603,7 +606,8 @@ void CGUIEPGGridContainerModel::FreeRulerMemory(int keepStart, int keepEnd)
 
 unsigned int CGUIEPGGridContainerModel::GetPageNowOffset() const
 {
-  return GetGridStartPadding() / MINSPERBLOCK; // this is the 'now' block relative to page start
+  return GetGridStartPadding() /
+         m_minutesPerBlock; // this is the 'now' block relative to page start
 }
 
 CDateTime CGUIEPGGridContainerModel::GetStartTimeForBlock(int block) const
@@ -613,7 +617,7 @@ CDateTime CGUIEPGGridContainerModel::GetStartTimeForBlock(int block) const
   else if (block >= GridItemsSize())
     block = GetLastBlock();
 
-  return m_gridStart + CDateTimeSpan(0, 0, block * MINSPERBLOCK, 0);
+  return m_gridStart + CDateTimeSpan(0, 0, block * m_minutesPerBlock, 0);
 }
 
 int CGUIEPGGridContainerModel::GetBlock(const CDateTime& datetime) const
@@ -632,9 +636,9 @@ int CGUIEPGGridContainerModel::GetBlock(const CDateTime& datetime) const
   //       an event starting at 5:00:00 shall be mapped to block 10, not both at block 10.
   //       Only exception is grid end, because there is no successor.
   if (datetime >= m_gridEnd)
-    return diff / 60 / MINSPERBLOCK; // block is equal or after grid end
+    return diff / 60 / m_minutesPerBlock; // block is equal or after grid end
   else
-    return (diff - 1) / 60 / MINSPERBLOCK;
+    return (diff - 1) / 60 / m_minutesPerBlock;
 }
 
 int CGUIEPGGridContainerModel::GetNowBlock() const
@@ -656,7 +660,7 @@ int CGUIEPGGridContainerModel::GetFirstEventBlock(
     diff = (eventStart - m_gridStart).GetSecondsTotal();
 
   // First block of a tag is always the block calculated using event's start time, rounded up.
-  float fBlockIndex = diff / 60.0f / MINSPERBLOCK;
+  float fBlockIndex = diff / 60.0f / m_minutesPerBlock;
   return static_cast<int>(std::ceil(fBlockIndex));
 }
 

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
@@ -46,8 +46,6 @@ class CPVREpgInfoTag;
 class CGUIEPGGridContainerModel
 {
 public:
-  static constexpr int MINSPERBLOCK = 5; // minutes
-
   CGUIEPGGridContainerModel() = default;
   virtual ~CGUIEPGGridContainerModel() = default;
 
@@ -58,6 +56,7 @@ public:
                   int iChannelsPerPage,
                   int iFirstBlock,
                   int iBlocksPerPage,
+                  unsigned int minutesPerBlock,
                   int iRulerUnit,
                   float fBlockSize);
   void SetInvalid();
@@ -168,6 +167,7 @@ private:
   mutable std::unordered_map<GridCoordinates, GridItem, GridCoordinatesHash> m_gridIndex;
 
   int m_blocks = 0;
+  unsigned int m_minutesPerBlock{0};
   float m_fBlockSize = 0.0f;
 
   int m_firstActiveChannel = 0;

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
@@ -57,7 +57,7 @@ public:
                   int iFirstBlock,
                   int iBlocksPerPage,
                   unsigned int minutesPerBlock,
-                  int iRulerUnit,
+                  int blocksPerRulerItem,
                   float fBlockSize);
   void SetInvalid();
 


### PR DESCRIPTION
This PR extends EPG grid GUI control to handle flexible resolutions for the EPG grid. Highest resolution possible now is 1 minute. Formerly, the grid's resolution was hard-coded to 5 minutes, which means all events shorter than 5 minutes were not displayed in the grid.

Also included here is increasing the resolution to 1 minute for Estuary.

<img width="1710" alt="Screenshot 2025-04-11 at 15 12 32" src="https://github.com/user-attachments/assets/5b1738b4-5ef8-413d-9350-97f0ce698541" />

Runtime-tested for quite some time on macOS and Android (NVidia Shield Pro 2019).

@phunkyfish something for you to review? Best reviewed commit by commit, ignoring the purely clang-format commit