### PR TITLE
[InputStreamAddon] Implemented HDR types

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -490,6 +490,7 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
     streamVideo->colorTransferCharacteristic = source->colorTransferCharacteristic;
     streamVideo->masteringMetaData = source->masteringMetaData;
     streamVideo->contentLightMetaData = source->contentLightMetaData;
+    streamVideo->hdr_type = source->hdr_type;
 
     streamVideo->m_parser_split = true;
     streamVideo->changes++;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -444,6 +444,20 @@ KODI_HANDLE CInputStreamAddon::cb_get_stream_transfer(KODI_HANDLE handle,
     videoStream->colorTransferCharacteristic =
         static_cast<AVColorTransferCharacteristic>(stream->m_colorTransferCharacteristic);
 
+    // Determine the HDR type
+    if (videoStream->colorTransferCharacteristic == AVCOL_TRC_SMPTE2084)
+    {
+      if (stream->m_codecFourCC == MKTAG('d', 'v', 'h', '1') ||
+          stream->m_codecFourCC == MKTAG('d', 'v', 'h', 'e'))
+        videoStream->hdr_type = StreamHdrType::HDR_TYPE_DOLBYVISION;
+      else
+        videoStream->hdr_type = StreamHdrType::HDR_TYPE_HDR10;
+    }
+    else if (videoStream->colorTransferCharacteristic == AVCOL_TRC_ARIB_STD_B67)
+      videoStream->hdr_type = StreamHdrType::HDR_TYPE_HLG;
+    else
+      videoStream->hdr_type = StreamHdrType::HDR_TYPE_NONE;
+
     if (stream->m_masteringMetadata)
     {
       videoStream->masteringMetaData = std::make_shared<AVMasteringDisplayMetadata>();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The detection of HDR type has been implemented on ffmpeg demuxer
https://github.com/xbmc/xbmc/blob/0df7da31f5dfa714a276e891f9ae2072320952d3/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp#L2524-L2544

but not in the inputstream addon demuxer
this PR implement in a similar way of ffmpeg
(to take in account that when streams are added there are no yet package data, just these few properties)

there is no need of InpuStream interface version bump since its all internal code

BEFORE:
![immagine](https://github.com/user-attachments/assets/3cfdd9de-cf8e-41cc-8763-c64006ed9d48)

AFTER:
![immagine](https://github.com/user-attachments/assets/26c8bc85-1f27-4507-8690-f9af138f4ffe)


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
users have no way to distinguish streams with HDR types from GUI

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
you can test by using InputStream Adaptive PR https://github.com/xbmc/inputstream.adaptive/pull/1823
test build downloads: https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Finputstream.adaptive/detail/PR-1823/4/artifacts

with this STRM file:
```
#KODIPROP:mimetype=application/vnd.apple.mpegurl
#KODIPROP:inputstream=inputstream.adaptive
https://devstreaming-cdn.apple.com/videos/streaming/examples/adv_dv_atmos/main.m3u8
```

when in playback open GUI video streams list

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
can distinguish streams with HDR

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
