### PR TITLE
rendering_gl: Simplify max texture size query

### DIFF
--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -460,31 +460,13 @@ void CRenderSystemGL::Project(float &x, float &y, float &z)
 
 void CRenderSystemGL::CalculateMaxTexturesize()
 {
-  GLint width = 256;
-
-  // reset any previous GL errors
-  ResetGLErrors();
-
-  // max out at 2^(8+8)
-  for (int i = 0 ; i<8 ; i++)
+  GLint width;
+  glGetIntegerv(GL_MAX_TEXTURE_SIZE, &width);
+  m_maxTextureSize = width;
+  if (width > 65536) // have an upper limit in case driver acts stupid
   {
-    glTexImage2D(GL_PROXY_TEXTURE_2D, 0, GL_RGBA, width, width, 0, GL_BGRA,
-                 GL_UNSIGNED_BYTE, NULL);
-    glGetTexLevelParameteriv(GL_PROXY_TEXTURE_2D, 0, GL_TEXTURE_WIDTH,
-                             &width);
-
-    // GMA950 on OS X sets error instead
-    if (width == 0 || (glGetError() != GL_NO_ERROR) )
-      break;
-
-    m_maxTextureSize = width;
-    width *= 2;
-    if (width > 65536) // have an upper limit in case driver acts stupid
-    {
-      CLog::Log(LOGERROR, "GL: Could not determine maximum texture width, falling back to 2048");
-      m_maxTextureSize = 2048;
-      break;
-    }
+    CLog::Log(LOGERROR, "GL: Could not determine maximum texture width, falling back to 2048");
+    m_maxTextureSize = 2048;
   }
 
   CLog::Log(LOGINFO, "GL: Maximum texture width: {}", m_maxTextureSize);


### PR DESCRIPTION
## Description
Instead of having a loop of proxy texture creations, simply query the value from the driver

## Motivation and context
Trying to cleanup and modernize parts of the GL backend

## How has this been tested?
Log reports the same maximum texture size as before this change
info <general>: GL: Maximum texture width: 16384

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
