### PR TITLE
[PVR] Reduce number of published events

### DIFF
--- a/xbmc/guilib/listproviders/DirectoryProvider.cpp
+++ b/xbmc/guilib/listproviders/DirectoryProvider.cpp
@@ -370,7 +370,6 @@ void CDirectoryProvider::OnPVRManagerEvent(const PVR::PVREvent& event)
   if (URIUtils::IsProtocol(m_currentUrl, "pvr"))
   {
     if (event == PVR::PVREvent::ManagerStarted || event == PVR::PVREvent::ManagerStopped ||
-        event == PVR::PVREvent::ManagerError || event == PVR::PVREvent::ManagerInterrupted ||
         event == PVR::PVREvent::RecordingsInvalidated ||
         event == PVR::PVREvent::TimersInvalidated ||
         event == PVR::PVREvent::ChannelGroupsInvalidated ||

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -451,9 +451,6 @@ void CPVRManager::SetState(CPVRManager::ManagerState state)
   PVREvent event;
   switch (state)
   {
-    case ManagerState::STATE_ERROR:
-      event = PVREvent::ManagerError;
-      break;
     case ManagerState::STATE_STOPPED:
       event = PVREvent::ManagerStopped;
       break;
@@ -462,9 +459,6 @@ void CPVRManager::SetState(CPVRManager::ManagerState state)
       break;
     case ManagerState::STATE_STOPPING:
       event = PVREvent::ManagerStopped;
-      break;
-    case ManagerState::STATE_INTERRUPTED:
-      event = PVREvent::ManagerInterrupted;
       break;
     case ManagerState::STATE_STARTED:
       event = PVREvent::ManagerStarted;
@@ -592,8 +586,6 @@ void CPVRManager::Process()
   m_timers->Stop();
   m_epgContainer->Stop();
   m_guiInfo->Stop();
-
-  SetState(ManagerState::STATE_INTERRUPTED);
 
   UnloadComponents();
   m_database->Close();

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -48,11 +48,9 @@ class CPVREpgInfoTag;
 enum class PVREvent
 {
   // PVR Manager states
-  ManagerError = 0,
   ManagerStopped,
   ManagerStarting,
   ManagerStopping,
-  ManagerInterrupted,
   ManagerStarted,
 
   // Channel events
@@ -356,11 +354,9 @@ private:
 
   enum class ManagerState
   {
-    STATE_ERROR = 0,
     STATE_STOPPED,
     STATE_STARTING,
     STATE_STOPPING,
-    STATE_INTERRUPTED,
     STATE_STARTED
   };
 

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -403,9 +403,10 @@ void CPVRChannelGroups::UpdateSystemChannelGroups()
   }
 
   if (!newGroups.empty())
+  {
     m_groups.insert(m_groups.end(), newGroups.cbegin(), newGroups.cend());
-
-  SortGroups();
+    SortGroups();
+  }
 }
 
 bool CPVRChannelGroups::UpdateChannelNumbersFromAllChannelsGroup()

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -176,8 +176,6 @@ int CPVRChannelGroups::GetGroupClientPriority(
 
 void CPVRChannelGroups::SortGroupsByBackendOrder()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
-
   const auto& gF = GetGroupFactory();
 
   // sort by group type, then by client priority, then by position, last by name
@@ -202,8 +200,6 @@ void CPVRChannelGroups::SortGroupsByBackendOrder()
 
 void CPVRChannelGroups::SortGroupsByLocalOrder()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
-
   // sort by group's local position
   std::sort(m_groups.begin(), m_groups.end(), [](const auto& group1, const auto& group2) {
     return group1->GetPosition() < group2->GetPosition();
@@ -212,15 +208,24 @@ void CPVRChannelGroups::SortGroupsByLocalOrder()
 
 void CPVRChannelGroups::SortGroups()
 {
-  const bool backendOrderSort =
-      m_settings.GetBoolValue(CSettings::SETTING_PVRMANAGER_BACKENDCHANNELGROUPSORDER);
+  bool orderChanged{false};
+  {
+    std::unique_lock<CCriticalSection> lock(m_critSection);
 
-  if (backendOrderSort)
-    SortGroupsByBackendOrder();
-  else
-    SortGroupsByLocalOrder();
+    const bool backendOrderSort{
+        m_settings.GetBoolValue(CSettings::SETTING_PVRMANAGER_BACKENDCHANNELGROUPSORDER)};
 
-  CServiceBroker::GetPVRManager().PublishEvent(PVREvent::ChannelGroupsInvalidated);
+    const std::vector<std::shared_ptr<CPVRChannelGroup>> groupsInOldOrder{m_groups};
+
+    if (backendOrderSort)
+      SortGroupsByBackendOrder();
+    else
+      SortGroupsByLocalOrder();
+
+    orderChanged = m_groups != groupsInOldOrder;
+  }
+  if (orderChanged)
+    CServiceBroker::GetPVRManager().PublishEvent(PVREvent::ChannelGroupsInvalidated);
 }
 
 std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroups::GetChannelGroupMemberByPath(


### PR DESCRIPTION
PVR produces lots of messages, especially during PVR startup. This PR is a first step to reduce the amount of those messages to what is actually consumed by event subscribers.

BTW: Checking whether a group actually got re-sorted needs some CPU cycles, but is definitely better than blindly pushing messages (as there are plenty of subscribers actually).

Runtime-tested on macOS and Android, latest kodi master.

@phunkyfish could you please review.