### PR TITLE
[Estuary] Skin adjustments after changes for videoassets

### DIFF
--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -336,7 +336,7 @@
 					<width>114</width>
 					<height>36</height>
 					<fadetime>0</fadetime>
-					<aspectratio align="center" aligny="center">keep</aspectratio>
+					<aspectratio align="right" aligny="center">keep</aspectratio>
 					<texture>$INFO[ListItem.Studio,resource://resource.images.studios.white/,.png]</texture>
 					<visible>System.AddonIsEnabled(resource.images.studios.white) + !String.IsEmpty($PARAM[infolabel_prefix]ListItem.Studio)</visible>
 				</control>

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -303,28 +303,6 @@
 			</focusedlayout>
 		</definition>
 	</include>
-	<include name="InfoFlag">
-		<control type="group">
-			<width>150</width>
-			<visible>$PARAM[visible]</visible>
-			<control type="image">
-				<top>-3</top>
-				<left>0</left>
-				<width>33</width>
-				<height>33</height>
-				<aspectratio aligny="center">keep</aspectratio>
-				<texture colordiffuse="white">$PARAM[icon]</texture>
-			</control>
-			<control type="label">
-				<left>40</left>
-				<width>110</width>
-				<height>36</height>
-				<aligny>center</aligny>
-				<font>font_flag</font>
-				<label>$PARAM[label]</label>
-			</control>
-		</control>
-	</include>
 	<include name="MediaFlag">
 		<param name="texture">colors/white.png</param>
 		<param name="flag_visible">true</param>
@@ -362,13 +340,21 @@
 					<texture>$INFO[ListItem.Studio,resource://resource.images.studios.white/,.png]</texture>
 					<visible>System.AddonIsEnabled(resource.images.studios.white) + !String.IsEmpty($PARAM[infolabel_prefix]ListItem.Studio)</visible>
 				</control>
-				<control type="group">
-					<width>150</width>
-					<visible>!String.IsEmpty($PARAM[infolabel_prefix]ListItem.Premiered)</visible>
-					<include content="InfoFlag">
-						<param name="icon" value="lists/year.png" />
-						<param name="label" value="$INFO[ListItem.Premiered]" />
-					</include>
+				<control type="image">
+					<visible>!String.IsEmpty(ListItem.Premiered))</visible>
+					<top>-2</top>
+					<width>32</width>
+					<height>32</height>
+					<aspectratio align="right" aligny="center">keep</aspectratio>
+					<texture colordiffuse="white">lists/year.png</texture>
+				</control>
+				<control type="label">
+					<visible>!String.IsEmpty(ListItem.Premiered)</visible>
+					<width>auto</width>
+					<height>33</height>
+					<aligny>center</aligny>
+					<font>font_flag</font>
+					<label>$INFO[ListItem.Premiered]</label>
 				</control>
 				<include content="MediaFlag">
 					<param name="flag_visible" value="!String.IsEmpty(ListItem.Duration) + !Control.IsVisible(504)" />

--- a/addons/skin.estuary/xml/MyVideoNav.xml
+++ b/addons/skin.estuary/xml/MyVideoNav.xml
@@ -2,7 +2,7 @@
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
 	<backgroundcolor>background</backgroundcolor>
-	<views>50,51,52,53,54,55,500,501,502,504</views>
+	<views>504,50,51,52,53,54,55,500,501,502</views>
 	<menucontrol>9000</menucontrol>
 	<controls>
 		<include>DefaultBackground</include>


### PR DESCRIPTION
## Description

**Commit 1  -** Make MediaList 504 the default view for videoassets

**Commit 2 -** Adjust Premiered date flag as when the other media flags are being hidden in the new MediaList 504 view, this has exposed an issue when different resoltuion from 1080p are used.

**Commit 3 -** Adjust Studio flag x axis alignment to right to minimise gap to Premiered date flag.

## How has this been tested?

**Commit 1 -** Closing Kodi, renaming/deleting guisettings.xml, and opening Kodi again so a new guisettings.xml is created, then selecting a version.

**Commit 2/3 -** Used 720p anf 1050p resolution where issues had been reported on Slack.

