### PR TITLE
[GUIIncludes]: Minor cleanup and performance optimizations

### DIFF
--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -18,71 +18,37 @@
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
+#include <algorithm>
+
 using namespace KODI::GUILIB;
 
-CGUIIncludes::CGUIIncludes()
-{
-  m_constantAttributes.insert("x");
-  m_constantAttributes.insert("y");
-  m_constantAttributes.insert("width");
-  m_constantAttributes.insert("height");
-  m_constantAttributes.insert("center");
-  m_constantAttributes.insert("max");
-  m_constantAttributes.insert("min");
-  m_constantAttributes.insert("w");
-  m_constantAttributes.insert("h");
-  m_constantAttributes.insert("time");
-  m_constantAttributes.insert("acceleration");
-  m_constantAttributes.insert("delay");
-  m_constantAttributes.insert("start");
-  m_constantAttributes.insert("end");
-  m_constantAttributes.insert("center");
-  m_constantAttributes.insert("border");
-  m_constantAttributes.insert("repeat");
+static constexpr std::array<std::string_view, 16> CONSTANT_ATTRIBUTES = {
+    "acceleration", "border", "center", "delay", "end", "h",     "height", "max",
+    "min",          "repeat", "start",  "time",  "w",   "width", "x",      "y",
+};
+static_assert(std::ranges::is_sorted(CONSTANT_ATTRIBUTES));
 
-  m_constantNodes.insert("posx");
-  m_constantNodes.insert("posy");
-  m_constantNodes.insert("left");
-  m_constantNodes.insert("centerleft");
-  m_constantNodes.insert("right");
-  m_constantNodes.insert("centerright");
-  m_constantNodes.insert("top");
-  m_constantNodes.insert("centertop");
-  m_constantNodes.insert("bottom");
-  m_constantNodes.insert("centerbottom");
-  m_constantNodes.insert("width");
-  m_constantNodes.insert("height");
-  m_constantNodes.insert("offsetx");
-  m_constantNodes.insert("offsety");
-  m_constantNodes.insert("textoffsetx");
-  m_constantNodes.insert("textoffsety");
-  m_constantNodes.insert("textwidth");
-  m_constantNodes.insert("spinposx");
-  m_constantNodes.insert("spinposy");
-  m_constantNodes.insert("spinwidth");
-  m_constantNodes.insert("spinheight");
-  m_constantNodes.insert("radioposx");
-  m_constantNodes.insert("radioposy");
-  m_constantNodes.insert("radiowidth");
-  m_constantNodes.insert("radioheight");
-  m_constantNodes.insert("sliderwidth");
-  m_constantNodes.insert("sliderheight");
-  m_constantNodes.insert("itemgap");
-  m_constantNodes.insert("bordersize");
-  m_constantNodes.insert("timeperimage");
-  m_constantNodes.insert("fadetime");
-  m_constantNodes.insert("pauseatend");
-  m_constantNodes.insert("depth");
-  m_constantNodes.insert("movement");
-  m_constantNodes.insert("focusposition");
+static constexpr std::array<std::string_view, 35> CONSTANT_NODES = {
+    "bordersize",  "bottom",     "centerbottom",  "centerleft", "centerright", "centertop",
+    "depth",       "fadetime",   "focusposition", "height",     "itemgap",     "left",
+    "movement",    "offsetx",    "offsety",       "pauseatend", "posx",        "posy",
+    "radioheight", "radioposx",  "radioposy",     "radiowidth", "right",       "sliderheight",
+    "sliderwidth", "spinheight", "spinposx",      "spinposy",   "spinwidth",   "textoffsetx",
+    "textoffsety", "textwidth",  "timeperimage",  "top",        "width",
+};
+static_assert(std::ranges::is_sorted(CONSTANT_NODES));
 
-  m_expressionAttributes.insert("condition");
+static constexpr std::string_view EXPRESSION_ATTRIBUTE = "condition";
 
-  m_expressionNodes.insert("visible");
-  m_expressionNodes.insert("enable");
-  m_expressionNodes.insert("usealttexture");
-  m_expressionNodes.insert("selected");
-}
+static constexpr std::array<std::string_view, 4> EXPRESSION_NODES = {
+    "enable",
+    "selected",
+    "usealttexture",
+    "visible",
+};
+static_assert(std::ranges::is_sorted(EXPRESSION_NODES));
+
+CGUIIncludes::CGUIIncludes() = default;
 
 CGUIIncludes::~CGUIIncludes() = default;
 
@@ -358,7 +324,7 @@ void CGUIIncludes::ResolveConstants(TiXmlElement *node)
 
   TiXmlNode *child = node->FirstChild();
   if (child && child->Type() == TiXmlNode::TINYXML_TEXT &&
-      m_constantNodes.contains(node->ValueStr()))
+      std::ranges::binary_search(CONSTANT_NODES, node->ValueStr()))
   {
     child->SetValue(ResolveConstant(child->ValueStr()));
   }
@@ -367,7 +333,7 @@ void CGUIIncludes::ResolveConstants(TiXmlElement *node)
     TiXmlAttribute *attribute = node->FirstAttribute();
     while (attribute)
     {
-      if (m_constantAttributes.contains(attribute->Name()))
+      if (std::ranges::binary_search(CONSTANT_ATTRIBUTES, attribute->Name()))
         attribute->SetValue(ResolveConstant(attribute->ValueStr()));
 
       attribute = attribute->Next();
@@ -382,7 +348,7 @@ void CGUIIncludes::ResolveExpressions(TiXmlElement *node)
 
   TiXmlNode *child = node->FirstChild();
   if (child && child->Type() == TiXmlNode::TINYXML_TEXT &&
-      m_expressionNodes.contains(node->ValueStr()))
+      std::ranges::binary_search(EXPRESSION_NODES, node->ValueStr()))
   {
     child->SetValue(ResolveExpressions(child->ValueStr()));
   }
@@ -391,7 +357,7 @@ void CGUIIncludes::ResolveExpressions(TiXmlElement *node)
     TiXmlAttribute *attribute = node->FirstAttribute();
     while (attribute)
     {
-      if (m_expressionAttributes.contains(attribute->Name()))
+      if (EXPRESSION_ATTRIBUTE == attribute->Name())
         attribute->SetValue(ResolveExpressions(attribute->ValueStr()));
 
       attribute = attribute->Next();

--- a/xbmc/guilib/GUIIncludes.h
+++ b/xbmc/guilib/GUIIncludes.h
@@ -124,10 +124,4 @@ private:
   std::map<std::string, TiXmlElement> m_skinvariables;
   std::map<std::string, std::string> m_constants;
   std::map<std::string, std::string> m_expressions;
-
-  std::set<std::string> m_constantAttributes;
-  std::set<std::string> m_constantNodes;
-
-  std::set<std::string> m_expressionAttributes;
-  std::set<std::string> m_expressionNodes;
 };

--- a/xbmc/guilib/GUIIncludes.h
+++ b/xbmc/guilib/GUIIncludes.h
@@ -16,8 +16,9 @@
 #include <utility>
 #include <vector>
 
+#include <tinyxml.h>
+
 // forward definitions
-class TiXmlElement;
 namespace INFO
 {
   class CSkinVariableString;

--- a/xbmc/guilib/GUIIncludes.h
+++ b/xbmc/guilib/GUIIncludes.h
@@ -11,8 +11,8 @@
 #include "interfaces/info/InfoBool.h"
 
 #include <map>
-#include <set>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -119,9 +119,9 @@ private:
   std::string ResolveExpressions(const std::string &expression) const;
 
   std::vector<std::string> m_files;
-  std::map<std::string, std::pair<TiXmlElement, Params>> m_includes;
-  std::map<std::string, TiXmlElement> m_defaults;
-  std::map<std::string, TiXmlElement> m_skinvariables;
-  std::map<std::string, std::string> m_constants;
-  std::map<std::string, std::string> m_expressions;
+  std::unordered_map<std::string, std::pair<TiXmlElement, Params>> m_includes;
+  std::unordered_map<std::string, TiXmlElement> m_defaults;
+  std::unordered_map<std::string, TiXmlElement> m_skinvariables;
+  std::unordered_map<std::string, std::string> m_constants;
+  std::unordered_map<std::string, std::string> m_expressions;
 };


### PR DESCRIPTION
## Description
Using std::set for storing allowed strings is wasteful as it will cause heap allocations both for the containers themselves and for the strings inside it, while the number of items is not enough to justify it. Using a compile time array of static strings and linear search is simpler and faster.

## Motivation and context
Code cleanup

## How has this been tested?
Tested swapping interface skins

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
