### PR TITLE
[Windows] Allow use Video Super Resolution with 10-bit intermediate target

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -488,11 +488,9 @@ ProcessorConversion CRendererDXVA::ChooseConversion(const ProcessorConversions& 
 {
   assert(conversions.size() > 0);
 
-  // Try HQ except when:
-  // - trying VSR scaling, which requires RGB8 processor output format
-  // - the user opted out of high quality and the swap chain is 8 bits.
-  if (!m_tryVSR && (DX::Windowing()->IsHighPrecisionProcessingSettingEnabled() ||
-                    DX::Windowing()->GetBackBuffer().GetFormat() == DXGI_FORMAT_R10G10B10A2_UNORM))
+  // Try HQ except when the user opted out of high quality and the swap chain is 8 bits.
+  if (DX::Windowing()->IsHighPrecisionProcessingSettingEnabled() ||
+      DX::Windowing()->GetBackBuffer().GetFormat() == DXGI_FORMAT_R10G10B10A2_UNORM)
   {
     const auto it =
         std::find_if(conversions.cbegin(), conversions.cend(), [](const ProcessorConversion& c) {


### PR DESCRIPTION
## Description
[Windows] Allow use Video Super Resolution with 10-bit intermediate target

Setting "Use high precision processing" enabled
and "Allow use DXVA Video Super Resolution" enabled at same time.

## Motivation and context
In early iterations VSR only support 8-bit video but currently is also supported 10-bit both Intel and NVIDIA.

So the limitation of having to prevent 10-bit video processing to enable VSR no longer exists. In fact, it's contradictory because if someone wants to improve video quality with VSR, they'll also want to improve video with 10-bit processing (reduce banding, improve the limit to full-range conversion, etc.).

## How has this been tested?
Tested on NUC 14 Pro (NUC14RVK) which has Intel Arc graphics (https://www.intel.com/content/www/us/en/products/sku/236848/intel-core-ultra-5-processor-125h-18m-cache-up-to-4-50-ghz/specifications.html) 

For NVIDIA this change already tested on https://github.com/xbmc/xbmc/pull/26398 as NVIDIA even support HDR10 in VSR.

NOTE: Changes for NVIDIA and HDR10 will be made in a separate PR to avoid confusion. This PR is only for things that are full supported by Intel and NVIDIA and do not need different implementations.


## What is the effect on users?
When "Use high precision processing" is enabled it continues to be used together with Video Super Resolution.

## Screenshots (if appropriate):
**1080p SDR video to 4K display - Intel Arc with VSR enabled and 10-bit intermediate target**
![Intel_Arc_10-bit_VSR_ON](https://github.com/user-attachments/assets/f1a22a1e-430d-4e03-b25c-2dd5ffe0a4eb)

**1080p SDR video to 4K display - Intel Arc with VSR disabled**
![Intel_Arc_10-bit_VSR_OFF](https://github.com/user-attachments/assets/72f00f94-041b-4167-a1ce-2459f5495fd8)

Power usage, frequency difference and video compute load demonstrate that VSR is working on Intel Arc with 10-bit video.  


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
