### PR TITLE
[PVR] Fix divide by zero errors due to CGUIEPGGridContainerModel::m_minutesPerBlock being initialized to late.

### DIFF
--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -58,14 +58,14 @@ CGUIEPGGridContainer::CGUIEPGGridContainer(int parentID,
     m_orientation(orientation),
     m_blocksPerRulerItem(rulerUnit * MINUTES_PER_RULER_UNIT / minutesPerTimeBlock),
     m_blocksPerPage(timeBlocks),
-    m_minutesPerBlock(minutesPerTimeBlock),
+    m_minutesPerBlock(minutesPerTimeBlock > 0 ? minutesPerTimeBlock : DEFAULT_MINUTES_PER_BLOCK),
     m_cacheChannelItems(preloadItems),
     m_cacheProgrammeItems(preloadItems),
     m_cacheRulerItems(preloadItems),
     m_guiProgressIndicatorTexture(
         CGUITexture::CreateTexture(posX, posY, width, height, progressIndicatorTexture)),
     m_scrollTime(scrollTime ? scrollTime : 1),
-    m_gridModel(new CGUIEPGGridContainerModel)
+    m_gridModel(new CGUIEPGGridContainerModel(m_minutesPerBlock))
 {
   ControlType = GUICONTAINER_EPGGRID;
 }
@@ -88,12 +88,12 @@ CGUIEPGGridContainer::CGUIEPGGridContainer(const CGUIEPGGridContainer& other)
     m_rulerDateLayout(other.m_rulerDateLayout),
     m_pageControl(other.m_pageControl),
     m_blocksPerRulerItem(other.m_blocksPerRulerItem),
+    m_blocksPerPage(other.m_blocksPerPage),
+    m_minutesPerBlock(other.m_minutesPerBlock),
     m_channelsPerPage(other.m_channelsPerPage),
     m_programmesPerPage(other.m_programmesPerPage),
     m_channelCursor(other.m_channelCursor),
     m_channelOffset(other.m_channelOffset),
-    m_blocksPerPage(other.m_blocksPerPage),
-    m_minutesPerBlock(other.m_minutesPerBlock),
     m_blockCursor(other.m_blockCursor),
     m_blockOffset(other.m_blockOffset),
     m_blockTravelAxis(other.m_blockTravelAxis),
@@ -1830,11 +1830,11 @@ void CGUIEPGGridContainer::SetTimelineItems(const std::unique_ptr<CFileItemList>
                                             const CDateTime& gridStart,
                                             const CDateTime& gridEnd)
 {
-  int blocksPerRulerItem{MINUTES_PER_RULER_UNIT};
+  int blocksPerRulerItem;
   int iFirstChannel;
   int iChannelsPerPage;
   int iBlocksPerPage;
-  unsigned int minutesPerBlock{DEFAULT_MINUTES_PER_BLOCK};
+  unsigned int minutesPerBlock;
   int iFirstBlock;
   float fBlockSize;
   {
@@ -1850,11 +1850,10 @@ void CGUIEPGGridContainer::SetTimelineItems(const std::unique_ptr<CFileItemList>
   }
 
   std::unique_ptr<CGUIEPGGridContainerModel> oldUpdatedGridModel;
-  std::unique_ptr<CGUIEPGGridContainerModel> newUpdatedGridModel(new CGUIEPGGridContainerModel);
+  auto newUpdatedGridModel{std::make_unique<CGUIEPGGridContainerModel>(minutesPerBlock)};
 
   newUpdatedGridModel->Initialize(items, gridStart, gridEnd, iFirstChannel, iChannelsPerPage,
-                                  iFirstBlock, iBlocksPerPage, minutesPerBlock, blocksPerRulerItem,
-                                  fBlockSize);
+                                  iFirstBlock, iBlocksPerPage, blocksPerRulerItem, fBlockSize);
   {
     std::unique_lock<CCriticalSection> lock(m_critSection);
 

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.h
@@ -258,13 +258,14 @@ private:
 
   int GetBlockScrollOffset() const;
 
-  int m_blocksPerRulerItem; //! number of blocks that makes up one element of the ruler
+  const int m_blocksPerRulerItem{0}; //! number of blocks that make up one element of the ruler
+  const int m_blocksPerPage{0};
+  const unsigned int m_minutesPerBlock{DEFAULT_MINUTES_PER_BLOCK};
+
   int m_channelsPerPage = 0;
   int m_programmesPerPage = 0;
   int m_channelCursor = 0;
   int m_channelOffset = 0;
-  int m_blocksPerPage;
-  unsigned int m_minutesPerBlock{DEFAULT_MINUTES_PER_BLOCK};
   int m_blockCursor = 0;
   int m_blockOffset = 0;
   int m_blockTravelAxis = 0;

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
@@ -30,6 +30,11 @@ using namespace PVR;
 
 static const unsigned int GRID_START_PADDING = 30; // minutes
 
+CGUIEPGGridContainerModel::CGUIEPGGridContainerModel(unsigned int minutesPerBlock)
+  : m_minutesPerBlock(minutesPerBlock)
+{
+}
+
 void CGUIEPGGridContainerModel::SetInvalid()
 {
   for (const auto& gridItem : m_gridIndex)
@@ -72,7 +77,6 @@ void CGUIEPGGridContainerModel::Initialize(const std::unique_ptr<CFileItemList>&
                                            int iChannelsPerPage,
                                            int iFirstBlock,
                                            int iBlocksPerPage,
-                                           unsigned int minutesPerBlock,
                                            int blocksPerRulerItem,
                                            float fBlockSize)
 {
@@ -83,7 +87,6 @@ void CGUIEPGGridContainerModel::Initialize(const std::unique_ptr<CFileItemList>&
   }
 
   m_fBlockSize = fBlockSize;
-  m_minutesPerBlock = minutesPerBlock;
 
   ////////////////////////////////////////////////////////////////////////
   // Create channel items
@@ -94,7 +97,7 @@ void CGUIEPGGridContainerModel::Initialize(const std::unique_ptr<CFileItemList>&
   {
     // default to start "now minus GRID_START_PADDING minutes" and end "start plus one page".
     m_gridStart = CDateTime::GetUTCDateTime() - CDateTimeSpan(0, 0, GetGridStartPadding(), 0);
-    m_gridEnd = m_gridStart + CDateTimeSpan(0, 0, iBlocksPerPage * minutesPerBlock, 0);
+    m_gridEnd = m_gridStart + CDateTimeSpan(0, 0, iBlocksPerPage * m_minutesPerBlock, 0);
   }
   else if (gridStart >
            (CDateTime::GetUTCDateTime() - CDateTimeSpan(0, 0, GetGridStartPadding(), 0)))
@@ -120,7 +123,7 @@ void CGUIEPGGridContainerModel::Initialize(const std::unique_ptr<CFileItemList>&
   const int iBlocksLastPage = m_blocks % iBlocksPerPage;
   if (iBlocksLastPage > 0)
   {
-    m_gridEnd += CDateTimeSpan(0, 0, (iBlocksPerPage - iBlocksLastPage) * minutesPerBlock, 0);
+    m_gridEnd += CDateTimeSpan(0, 0, (iBlocksPerPage - iBlocksLastPage) * m_minutesPerBlock, 0);
     m_blocks += (iBlocksPerPage - iBlocksLastPage);
   }
 
@@ -134,7 +137,7 @@ void CGUIEPGGridContainerModel::Initialize(const std::unique_ptr<CFileItemList>&
   rulerItem->SetProperty("DateLabel", true);
   m_rulerItems.emplace_back(rulerItem);
 
-  const CDateTimeSpan unit(0, 0, blocksPerRulerItem * minutesPerBlock, 0);
+  const CDateTimeSpan unit(0, 0, blocksPerRulerItem * m_minutesPerBlock, 0);
   for (; ruler < rulerEnd; ruler += unit)
   {
     rulerItem = std::make_shared<CFileItem>(ruler.GetAsLocalizedTime("", false));

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
@@ -46,7 +46,7 @@ class CPVREpgInfoTag;
 class CGUIEPGGridContainerModel
 {
 public:
-  CGUIEPGGridContainerModel() = default;
+  explicit CGUIEPGGridContainerModel(unsigned int minutesPerBlock);
   virtual ~CGUIEPGGridContainerModel() = default;
 
   void Initialize(const std::unique_ptr<CFileItemList>& items,
@@ -56,7 +56,6 @@ public:
                   int iChannelsPerPage,
                   int iFirstBlock,
                   int iBlocksPerPage,
-                  unsigned int minutesPerBlock,
                   int blocksPerRulerItem,
                   float fBlockSize);
   void SetInvalid();
@@ -111,6 +110,8 @@ public:
   std::unique_ptr<CFileItemList> GetCurrentTimeLineItems(int firstChannel, int numChannels) const;
 
 private:
+  CGUIEPGGridContainerModel() = delete;
+
   GridItem* GetGridItemPtr(int iChannel, int iBlock) const;
   std::shared_ptr<CFileItem> CreateGapItem(int iChannel) const;
   std::shared_ptr<CFileItem> GetItem(int iChannel, int iBlock) const;
@@ -167,7 +168,7 @@ private:
   mutable std::unordered_map<GridCoordinates, GridItem, GridCoordinatesHash> m_gridIndex;
 
   int m_blocks = 0;
-  unsigned int m_minutesPerBlock{0};
+  const unsigned int m_minutesPerBlock{0};
   float m_fBlockSize = 0.0f;
 
   int m_firstActiveChannel = 0;


### PR DESCRIPTION
Fixes #26643 

Fallout from #26630, sorry for that. :-/

Runtime-tested by me on macOS, Android and and by @emveepee on Windows.

@phunkyfish can you please review. Problem was that some `CGUIEPGGridContainerModel` methods were accessing `m_minutesPerBlock` before it was initialized. Fix is to initialize it earlier (in the ctor). Also included safety net to ensure that `CGUIEPGGridContainer` will prevent 0 minutesPerBlock value.
