### PR TITLE
[Windows] Allow use Video Super Resolution on videos up to 1440p

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24215,7 +24215,7 @@ msgstr ""
 #. Help text of setting "Allow use DXVA Video Super Resolution" with label #13417
 #: system/settings/settings.xml
 msgctxt "#39194"
-msgid "Enables advanced DXVA upscaler using NVIDIA \"RTX Video Super Resolution\" or \"Intel Video Super Resolution\".[CR]Used when the video source is 1920x1080 or less and the source resolution is lower than the display resolution.[CR]Only available on specific hardware: NVIDIA RTX 20xx, 30xx, 40xx and above, Intel Arc A770, A750."
+msgid "Enables advanced DXVA upscaler using NVIDIA \"RTX Video Super Resolution\" or \"Intel Video Super Resolution\".[CR]Used when the video source is 2560x1440 or less and the source resolution is lower than the display resolution.[CR]Only available on specific hardware: NVIDIA RTX and Intel Arc."
 msgstr ""
 
 #. Description of setting with label #13418 "Use high precision processing"

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -529,7 +529,8 @@ bool CProcessorHD::Render(CRect src, CRect dst, ID3D11Resource* target, CRenderB
 
 bool CProcessorHD::IsSuperResolutionSuitable(const VideoPicture& picture)
 {
-  if (picture.iWidth > 1920)
+  // both Intel and NVIDIA support VSR in videos up to 1440p
+  if (picture.iWidth > 2560)
     return false;
 
   const UINT outputWidth = DX::Windowing()->GetBackBuffer().GetWidth();


### PR DESCRIPTION
## Description
[Windows] Allow use Video Super Resolution on videos up to 1440p

## Motivation and context
Both intel and NVIDIA support use VSR in videos up to 1440p.

For NVIDIA is explicit mentioned here:

> Q: What video will RTX Video Super Resolution enhance?
> 
> A: Most video played in supported browsers can be enhanced by RTX Video Super Resolution. RTX Video Super Resolution supports video input resolutions from 360p to 1440p.  Video we have identified as not supported includes some DRM protected content and YouTube shorts.   

https://nvidia.custhelp.com/app/answers/detail/a_id/5448/~/rtx-video-faq

For Intel tested on NUC 14 pro (NUC14RVK).


## How has this been tested?
Tested on NVIDIA RTX 4070 and NUC14RVK:

![Intel_Arc_VSR_1440p](https://github.com/user-attachments/assets/bbc8b256-0426-4082-8924-55dc7875c646)



## What is the effect on users?
Extends Video Super Resolution use cases to videos > 1080p and <= 1440p

Updated strings.po description and removed specific denominations of graphics cards models (for NVIDIA now exist 50xx and Intel integrated graphics has "Intel Arc" denomination).



## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
