### PR TITLE
Run SonarQube on master

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,39 @@
+name: SonarQube
+# Only run after push to master - PR analysis is very unhelpful since we cannot tune the
+# ruleset, quality gate etc.
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    name: SonarQube
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Install Build Wrapper
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v4
+      - name: Install dependencies
+        # See docs/README.Ubuntu.md
+        run: |
+          sudo apt update
+          sudo apt install -y debhelper autoconf automake autopoint gettext autotools-dev cmake curl default-jre doxygen gawk gcc gdc gperf libasound2-dev libass-dev libavahi-client-dev libavahi-common-dev libbluetooth-dev libbluray-dev libbz2-dev libcdio-dev libp8-platform-dev libcrossguid-dev libcurl4-openssl-dev libcwiid-dev libdbus-1-dev libdrm-dev libegl1-mesa-dev libenca-dev libexiv2-dev libflac-dev libfmt-dev libfontconfig-dev libfreetype6-dev libfribidi-dev libfstrcmp-dev libgcrypt-dev libgif-dev libgles2-mesa-dev libgl1-mesa-dev libglu1-mesa-dev libgnutls28-dev libgpg-error-dev libgtest-dev libiso9660-dev libjpeg-dev liblcms2-dev libltdl-dev liblzo2-dev libmicrohttpd-dev libmysqlclient-dev libnfs-dev libogg-dev libpcre2-dev libplist-dev libpng-dev libpulse-dev libshairplay-dev libsmbclient-dev libspdlog-dev libsqlite3-dev libssl-dev libtag1-dev libtiff5-dev libtinyxml-dev libtinyxml2-dev libtool libudev-dev libunistring-dev libva-dev libvdpau-dev libvorbis-dev libxmu-dev libxrandr-dev libxslt1-dev libxt-dev lsb-release meson nasm ninja-build python3-dev python3-pil python3-pip rapidjson-dev swig unzip uuid-dev zip zlib1g-dev
+          sudo apt install -y libcec-dev libfmt-dev liblirc-dev
+          sudo apt install -y libflatbuffers-dev
+          sudo apt install -y libglew-dev libwayland-dev libxkbcommon-dev waylandpp-dev wayland-protocols
+          sudo apt install -y libgbm-dev libinput-dev libxkbcommon-dev
+          sudo apt install -y doxygen libcap-dev libsndio-dev libmariadbd-dev
+          sudo apt install -y libdisplay-info-dev
+      - name: Run Build Wrapper
+        run: |
+          mkdir build
+          cmake -S . -B build -D APP_RENDER_SYSTEM=gl -D CMAKE_EXPORT_COMPILE_COMMANDS=ON
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v4
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            --define sonar.cfamily.compile-commands="build/compile_commands.json"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,58 @@
+## -----------------------------------------------------------------------------
+## Project Identification
+## -----------------------------------------------------------------------------
+
+# sonar.projectKey: Unique identifier for this project in SonarCloud.
+#   Format: <organization>_<repository>
+#   e.g. teamkodi_xbmc
+sonar.projectKey=xbmc_xbmc
+
+# sonar.organization: Your SonarCloud organization key.
+#   Find it on https://sonarcloud.io/organizations
+sonar.organization=teamkodi
+
+## -----------------------------------------------------------------------------
+## Metadata (display purposes only)
+## -----------------------------------------------------------------------------
+
+# sonar.projectName: Display name in SonarCloud UI.
+#   Default: repository name
+#   You can override if you want a friendlier name, e.g. "Kodi Media Center"
+# sonar.projectName=xbmc
+
+# sonar.projectVersion: Project version shown in UI.
+#   e.g. 1.0, 22.0-alpha1
+# sonar.projectVersion=1.0
+
+## -----------------------------------------------------------------------------
+## Source Directories
+## -----------------------------------------------------------------------------
+
+# sonar.sources: Comma-separated list of directories to analyze.
+#   Default: current directory (.)
+#   Example: src,lib,components
+# sonar.sources=.
+
+## -----------------------------------------------------------------------------
+## Exclusions
+## -----------------------------------------------------------------------------
+
+# sonar.exclusions: File patterns to exclude from analysis (supports ** and wildcards).
+#   Common use: third‑party code, build artifacts, heavy external tools.
+# We exclude embedded libs and Java files (which cannot be analyzed without special setup)
+sonar.exclusions=lib/**,tools/depends/**,**/*.java
+
+## -----------------------------------------------------------------------------
+## Language Settings
+## -----------------------------------------------------------------------------
+
+# sonar.python.version: Supported Python versions for analysis.
+#   Comma‑separated list.
+#   e.g. 3.7,3.8,…,3.13
+sonar.python.version=3.7,3.8,3.9,3.10,3.11,3.12,3.13
+
+# sonar.sourceEncoding: Encoding of source files.
+#   Default: system encoding (usually UTF‑8).
+#   e.g. UTF-8, ISO-8859-1
+# sonar.sourceEncoding=UTF-8
+


### PR DESCRIPTION
Set up a GitHub actions workflow to automatically run SonarQube.

Since we cannot tune the ruleset on the free plan, we do not enable PR analysis. Just run it on master after every push.