### PR TITLE
Fix: only require Java if SWIG_GENERATE_JAVA is enabled

### DIFF
--- a/xbmc/interfaces/swig/CMakeLists.txt
+++ b/xbmc/interfaces/swig/CMakeLists.txt
@@ -54,7 +54,10 @@ function(generate_file file)
   set(SOURCES ${SOURCES} "${CPP_FILE}" PARENT_SCOPE)
 endfunction()
 
-find_package(Java COMPONENTS Runtime REQUIRED)
+if(SWIG_GENERATE_JAVA)
+  find_package(Java COMPONENTS Runtime REQUIRED)
+endif()
+
 find_package(SWIG REQUIRED)
 
 # Default URL/Versions/Hashes to use unless *_SOURCE_DIR are set for the relevant binary


### PR DESCRIPTION
Prevents unnecessary build failures on systems not using Java bindings. Wraps the find_package(Java REQUIRED) call in a conditional based on the SWIG_GENERATE_JAVA flag.