### PR TITLE
[Bluray][Video] Fix unable to restart playing disc if stopped in menu.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -145,24 +145,22 @@ bool CDVDInputStreamBluray::Open()
     filename = URIUtils::GetFileName(url.GetFileName());
 
     // Check whether disc is AACS protected
-    CURL url3(root);
-    CFileItem base(url3, false);
-    openDisc = VIDEO::IsProtectedBlurayDisc(base);
+    CURL url2(root);
+    CFileItem item(url2, false);
+    openDisc = VIDEO::IsProtectedBlurayDisc(item);
 
     // check for a menu call for an image file
     if (StringUtils::EqualsNoCase(filename, "menu") &&
         !(m_item.GetStartOffset() == STARTOFFSET_RESUME && m_item.IsResumable()))
     {
-      //get rid of the udf:// protocol
-      CURL url2(root);
-      const std::string& root2 = url2.GetHostName();
-      CURL url(root2);
-      CFileItem item(url, false);
       resumable = false;
 
-      // Check whether disc is AACS protected
-      if (!openDisc)
+      // Remove udf:// if present
+      if (url2.IsProtocol("udf"))
+      {
+        item.SetPath(url2.GetHostName());
         openDisc = VIDEO::IsProtectedBlurayDisc(item);
+      }
 
       if (item.IsDiscImage())
       {

--- a/xbmc/filesystem/BlurayFile.cpp
+++ b/xbmc/filesystem/BlurayFile.cpp
@@ -9,6 +9,7 @@
 #include "BlurayFile.h"
 
 #include "URL.h"
+#include "utils/URIUtils.h"
 
 #include <assert.h>
 
@@ -34,8 +35,7 @@ std::string CBlurayFile::TranslatePath(const CURL& url)
 
 bool CBlurayFile::Exists(const CURL& url)
 {
-  const CURL baseUrl{TranslatePath(url)};
-  if (baseUrl.GetFileName() == "menu")
-    return true;
-  return CFile::Exists(baseUrl);
+  if (url.GetFileName() == "menu")
+    return CFile::Exists(URIUtils::GetBlurayFile(url.Get()));
+  return CFile::Exists(TranslatePath(url));
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

As reported by @CrystalP - thanks.

Also identified assumption in CBlurayDirectory that all bluray:// menu paths had an embedded udf:// path - this is only true for images (ie. ISOs) but not files (ie. BDMV).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Attempting to play a disc stopped in the menu (and hence having a bluray://<somepath>/menu url) gave a location can't be found error - if the underlying bluray structure was file (ie. BDMV).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
