### PR TITLE
[VideoPlayer][EDL] Fix issues when playing file with chapters along with an EDL

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4933,7 +4933,10 @@ void CVideoPlayer::UpdatePlayState(double timeout)
       {
         std::string name;
         m_pDemuxer->GetChapterName(name, i + 1);
-        state.chapters.emplace_back(name, m_pDemuxer->GetChapterPos(i + 1));
+        std::chrono::milliseconds position{m_pDemuxer->GetChapterPos(i + 1) * 1000};
+        state.chapters.emplace_back(
+            name,
+            std::chrono::round<std::chrono::seconds>(m_Edl.GetTimeWithoutCuts(position)).count());
       }
     }
     CServiceBroker::GetDataCacheCore().SetChapters(state.chapters);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2878,12 +2878,40 @@ void CVideoPlayer::HandleMessages()
       int offset = 0;
 
       // This should always be the case.
-      if(m_pDemuxer && m_pDemuxer->SeekChapter(msg.GetChapter(), &start))
+      if (m_pDemuxer)
       {
-        FlushBuffers(start, true, true);
-        int64_t beforeSeek = GetTime();
-        offset = DVD_TIME_TO_MSEC(start) - static_cast<int>(beforeSeek);
-        m_callback.OnPlayBackSeekChapter(msg.GetChapter());
+        // SeekChapter does not know about EDL cuts as demuxers are EDL agnostic
+        // So get and adjust chapter time
+        const std::chrono::milliseconds position{m_pDemuxer->GetChapterPos(msg.GetChapter()) *
+                                                 1000};
+        const auto hasEdit{m_Edl.InEdit(position)};
+        double time{static_cast<double>(position.count())};
+        if (hasEdit)
+        {
+          const auto& edit{hasEdit.value()};
+          if (edit->action == EDL::Action::CUT)
+          {
+            // Ensure moving backward/forward doesn't take us past the beginning/end point (which may be cut)
+            const bool forward{msg.GetChapter() > GetChapter()};
+            const std::chrono::milliseconds absoluteTime{forward ? edit->start : edit->end};
+            const std::chrono::milliseconds adjustedTime{m_Edl.GetTimeWithoutCuts(absoluteTime)};
+            const auto endTime{std::chrono::duration<double, std::milli>(m_State.timeMax)};
+            if (adjustedTime + 50ms > endTime)
+              // If close to end then use end of stream otherwise adjustedTime can be a few ms over the end
+              // and still cause the video to freeze
+              time = m_pDemuxer->GetStreamLength();
+            else
+              time = static_cast<double>(absoluteTime.count());
+          }
+        }
+
+        if (m_pDemuxer->SeekTime(time, true, &start))
+        {
+          FlushBuffers(start, true, true);
+          int64_t beforeSeek = GetTime();
+          offset = DVD_TIME_TO_MSEC(start) - static_cast<int>(beforeSeek);
+          m_callback.OnPlayBackSeekChapter(msg.GetChapter());
+        }
       }
       else if (m_pInputStream)
       {

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2498,7 +2498,7 @@ bool CVideoPlayer::CheckSceneSkip(const CCurrentStream& current)
     return false;
 
   const auto hasEdit =
-      m_Edl.InEdit(std::chrono::milliseconds(std::lround(current.dts + m_offset_pts)));
+      m_Edl.InEdit(std::chrono::milliseconds(DVD_TIME_TO_MSEC(current.dts + m_offset_pts)));
   return hasEdit && hasEdit.value()->action == EDL::Action::CUT;
 }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

When experimenting with EDLs as a means to play single bluray chapters I discovered that EDLs and chapters don't work together well. This is true in MKVs as well as bluray streams.

Example - find a MKV file > 35min in length that has chapters.
Generate an EDL file (as per the Wiki) that cuts some time off the beginning and the end.

In this case I'm using a MKV from 28 Weeks Later and the following EDL.

```
0   300    0
5000 6007  0
```

The MKV is 6007 seconds long. The EDL removes the first 5 minutes and then the end of the file from 5000 seconds.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Bug 1**

Chapter marks are not adjusted to account for cuts at the beginning of the file.

This is what the progress bar looks like without an EDL - the first chapter is at 5m 34sec.
![image](https://github.com/user-attachments/assets/78653010-e960-487c-b280-e7f262e0af99)

Without commit 1 the chapter mark is not adjusted - if you cut the first 5min you would expect the chapter mark to be at 34sec on the progress bar:
![image](https://github.com/user-attachments/assets/d9c08d00-c6e8-4055-81db-bd3fadbac7fb)

**Bug 2**

With an EDL in place, if you attempt to move past 35 minutes the playback freezes. This is beacuse dts time is in microseconds and this is not adjusted to milliseconds and there is overflow of signed 32bit integer - 35 min * 60 sec * 1000ms * 1000us = approx 2^15.

DVD_TIME_TO_MSEC is needed -> commit 2.

**Bug 3**

If you try to seek (using the chapter seek buttons on the progress bar or remote) to a chapter beyond the cut beginning/end playback hangs (beginning of chapter 1 is always absolute 0ms).

Fixed in commit 3.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
