### PR TITLE
[rendering] Increase font size for splash screen status message text.

### DIFF
--- a/xbmc/rendering/RenderSystem.cpp
+++ b/xbmc/rendering/RenderSystem.cpp
@@ -89,7 +89,8 @@ void CRenderSystemBase::ShowSplash(const std::string& message)
   {
     if (!m_splashMessageLayout)
     {
-      auto messageFont = g_fontManager.LoadTTF("__splash__", "arial.ttf", 0xFFFFFFFF, 0, 20, FONT_STYLE_NORMAL, false, 1.0f, 1.0f, &res);
+      auto messageFont = g_fontManager.LoadTTF("__splash__", "arial.ttf", 0xFFFFFFFF, 0, 40,
+                                               FONT_STYLE_NORMAL, false, 1.0f, 1.0f, &res);
       if (messageFont)
         m_splashMessageLayout = std::make_unique<CGUITextLayout>(messageFont, true, .0f);
     }


### PR DESCRIPTION
As subject says: Increase font size for splash screen status message text.
Reason: Text was tiny, barely if at all readable.

Before:

![Screenshot 2025-04-13 at 15 17 03](https://github.com/user-attachments/assets/9ffc0e62-c87c-45d7-8cbd-e6da9623a312)

After:

![Screenshot 2025-04-13 at 15 16 31](https://github.com/user-attachments/assets/113e1af0-852c-4973-9bad-c40b0374b987)

I guess everybody could review. @phunkyfish maybe?