### PR TITLE
[dbwrappers][settings] Make database connect timeout customizable via database advanced setting

### DIFF
--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -616,7 +616,8 @@ bool CDatabase::Connect(const std::string& dbName, const DatabaseSettings& dbSet
 
   // set configuration regardless if any are empty
   m_pDB->setConfig(dbSettings.key.c_str(), dbSettings.cert.c_str(), dbSettings.ca.c_str(),
-                   dbSettings.capath.c_str(), dbSettings.ciphers.c_str(), dbSettings.compression);
+                   dbSettings.capath.c_str(), dbSettings.ciphers.c_str(), dbSettings.connecttimeout,
+                   dbSettings.compression);
 
   // create the datasets
   m_pDS.reset(m_pDB->CreateDataset());

--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -56,6 +56,7 @@ protected:
       sequence_table, //Sequence table for nextid
       default_charset, //Default character set
       key, cert, ca, capath, ciphers; //SSL - Encryption info
+  unsigned int connect_timeout; // seconds
 
 public:
   /* constructor */
@@ -97,6 +98,7 @@ public:
                          const char* newCA,
                          const char* newCApath,
                          const char* newCiphers,
+                         unsigned int newConnectTimeout,
                          bool newCompression)
   {
     key = newKey;
@@ -104,6 +106,7 @@ public:
     ca = newCA;
     capath = newCApath;
     ciphers = newCiphers;
+    connect_timeout = newConnectTimeout;
     compression = newCompression;
   }
 

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -180,9 +180,7 @@ int MysqlDatabase::connect(bool create_new)
       mysql_ssl_set(conn, key.empty() ? NULL : key.c_str(), cert.empty() ? NULL : cert.c_str(),
                     ca.empty() ? NULL : ca.c_str(), capath.empty() ? NULL : capath.c_str(),
                     ciphers.empty() ? NULL : ciphers.c_str());
-      //! @todo make this a setting
-      static constexpr unsigned int CONNECT_TIMEOUT = 5; // secs
-      mysql_options(conn, MYSQL_OPT_CONNECT_TIMEOUT, &CONNECT_TIMEOUT);
+      mysql_options(conn, MYSQL_OPT_CONNECT_TIMEOUT, &connect_timeout);
     }
 
     if (!CWakeOnAccess::GetInstance().WakeUpHost(host, "MySQL : " + db))

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -180,6 +180,9 @@ int MysqlDatabase::connect(bool create_new)
       mysql_ssl_set(conn, key.empty() ? NULL : key.c_str(), cert.empty() ? NULL : cert.c_str(),
                     ca.empty() ? NULL : ca.c_str(), capath.empty() ? NULL : capath.c_str(),
                     ciphers.empty() ? NULL : ciphers.c_str());
+      //! @todo make this a setting
+      static constexpr unsigned int CONNECT_TIMEOUT = 5; // secs
+      mysql_options(conn, MYSQL_OPT_CONNECT_TIMEOUT, &CONNECT_TIMEOUT);
     }
 
     if (!CWakeOnAccess::GetInstance().WakeUpHost(host, "MySQL : " + db))

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1164,6 +1164,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetString(pDatabase, "ca", m_databaseVideo.ca);
     XMLUtils::GetString(pDatabase, "capath", m_databaseVideo.capath);
     XMLUtils::GetString(pDatabase, "ciphers", m_databaseVideo.ciphers);
+    XMLUtils::GetUInt(pDatabase, "connecttimeout", m_databaseVideo.connecttimeout, 1, 300);
     XMLUtils::GetBoolean(pDatabase, "compression", m_databaseVideo.compression);
   }
 
@@ -1181,6 +1182,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetString(pDatabase, "ca", m_databaseMusic.ca);
     XMLUtils::GetString(pDatabase, "capath", m_databaseMusic.capath);
     XMLUtils::GetString(pDatabase, "ciphers", m_databaseMusic.ciphers);
+    XMLUtils::GetUInt(pDatabase, "connecttimeout", m_databaseMusic.connecttimeout, 1, 300);
     XMLUtils::GetBoolean(pDatabase, "compression", m_databaseMusic.compression);
   }
 
@@ -1198,6 +1200,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetString(pDatabase, "ca", m_databaseTV.ca);
     XMLUtils::GetString(pDatabase, "capath", m_databaseTV.capath);
     XMLUtils::GetString(pDatabase, "ciphers", m_databaseTV.ciphers);
+    XMLUtils::GetUInt(pDatabase, "connecttimeout", m_databaseTV.connecttimeout, 1, 300);
     XMLUtils::GetBoolean(pDatabase, "compression", m_databaseTV.compression);
   }
 
@@ -1215,6 +1218,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetString(pDatabase, "ca", m_databaseEpg.ca);
     XMLUtils::GetString(pDatabase, "capath", m_databaseEpg.capath);
     XMLUtils::GetString(pDatabase, "ciphers", m_databaseEpg.ciphers);
+    XMLUtils::GetUInt(pDatabase, "connecttimeout", m_databaseEpg.connecttimeout, 1, 300);
     XMLUtils::GetBoolean(pDatabase, "compression", m_databaseEpg.compression);
   }
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -33,6 +33,8 @@ namespace ADDON
 class DatabaseSettings
 {
 public:
+  static constexpr unsigned int DEFAULT_CONNECT_TIMEOUT = 5; // secs
+
   DatabaseSettings() { Reset(); }
   void Reset()
   {
@@ -47,6 +49,7 @@ public:
     ca.clear();
     capath.clear();
     ciphers.clear();
+    connecttimeout = DEFAULT_CONNECT_TIMEOUT;
     compression = false;
   };
   std::string type;
@@ -60,6 +63,7 @@ public:
   std::string ca;
   std::string capath;
   std::string ciphers;
+  unsigned int connecttimeout{DEFAULT_CONNECT_TIMEOUT};
   bool compression;
 };
 


### PR DESCRIPTION
What: Added a connecttimeout field to the already existing database advanced setting
Reason: Before the connect timeout for mysql databses was set to a very high value (> 1min) and could not be changed by the user. Default value is 5 seconds.

@phunkyfish could you please have a look? Should be pretty self-explaining.