### PR TITLE
[xbmc] Fix missing include cstdint

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/BlurayStateSerializer.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/BlurayStateSerializer.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 /*! \brief Pod structure which represents the current Bluray state */

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -15,6 +15,7 @@
 #include "utils/BitstreamStats.h"
 #include "utils/Geometry.h"
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDStateSerializer.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDStateSerializer.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace tinyxml2

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -11,6 +11,7 @@
 #include "cores/Direction.h"
 #include "cores/EdlEdit.h"
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>

--- a/xbmc/filesystem/ZipManager.h
+++ b/xbmc/filesystem/ZipManager.h
@@ -19,6 +19,7 @@
 #define CHDR_SIZE 46
 #define ECDREC_SIZE 22
 
+#include <cstdint>
 #include <cstring>
 #include <map>
 #include <string>


### PR DESCRIPTION
## Description
since gcc13, on musl the compiler fails because of missing imports of e.g. int32_t which are provided by cstdint

## Motivation and context
In Alpine Linux, we ship this patch since we build our packages with gcc 13+ where the fail was discovered

## How has this been tested?
it fixes the build with musl + gcc 13/14.

## What is the effect on users?
none

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
