### PR TITLE
[DllLoader] Define _PATH_MOUNTED and _PATH_MNTTAB if not already

### DIFF
--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -72,6 +72,15 @@
 #include "platform/win32/CharsetConverter.h"
 #endif
 
+#ifdef TARGET_LINUX
+#ifndef _PATH_MOUNTED
+#define _PATH_MOUNTED "/proc/mounts"
+#endif
+#ifndef _PATH_MNTTAB
+#define _PATH_MNTTAB "/etc/fstab"
+#endif
+#endif
+
 using namespace XFILE;
 
 struct SDirData


### PR DESCRIPTION
## Description
Those are glibc quirks and are not available on other libcs like musl libc.

There is no portable way to detected these paths in POSIX, so just force the value on libcs where it is not explictly specified.

## Motivation and context
To fix musl compat in Alpine.

## How has this been tested?
Built with musl and glibc.

## What is the effect on users?
none

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
