### PR TITLE
[database] Fix 'endless' waiting on splash screen when connect to remote database(s) fails.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16843,7 +16843,19 @@ msgctxt "#24185"
 msgid "Minimum: {0:s} / Not available{3:s}"
 msgstr ""
 
-#empty strings from id 24186 to 24990
+#. Progress text on splash screen
+#: xbmc/Application.cpp
+msgctxt "#24186"
+msgid "Connecting to database - please wait"
+msgstr ""
+
+#. Error text on splash screen
+#: xbmc/Application.cpp
+msgctxt "#24187"
+msgid "Failed to initialise databases - exiting in {} seconds."
+msgstr ""
+
+#empty strings from id 24188 to 24990
 
 #. Used as error message in add-on browser when add-on repository data could not be downloaded
 #: xbmc/filesystem/AddonsDirectory.cpp

--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -20,6 +20,7 @@
 #include "video/VideoDatabase.h"
 #include "view/ViewDatabase.h"
 
+#include <algorithm>
 #include <mutex>
 
 using namespace PVR;
@@ -34,7 +35,7 @@ CDatabaseManager::CDatabaseManager() :
 
 CDatabaseManager::~CDatabaseManager() = default;
 
-void CDatabaseManager::Initialize()
+bool CDatabaseManager::Initialize()
 {
   std::unique_lock<CCriticalSection> lock(m_section);
 
@@ -60,6 +61,9 @@ void CDatabaseManager::Initialize()
   CLog::Log(LOGDEBUG, "{}, updating databases... DONE", __FUNCTION__);
 
   m_bIsUpgrading = false;
+
+  return std::ranges::all_of(m_dbStatus,
+                             [](const auto& db) { return db.second == DBStatus::READY; });
 }
 
 bool CDatabaseManager::CanOpen(const std::string &name)
@@ -96,7 +100,13 @@ bool CDatabaseManager::Update(CDatabase &db, const DatabaseSettings &settings)
     if (version)
       dbName += std::to_string(version);
 
-    if (db.Connect(dbName, dbSettings, false))
+    const CDatabase::ConnectionState connectionState{db.Connect(dbName, dbSettings, false)};
+
+    if (connectionState == CDatabase::ConnectionState::STATE_ERROR)
+    {
+      return false; // unable to connect
+    }
+    else if (connectionState == CDatabase::ConnectionState::STATE_CONNECTED)
     {
       // Database exists, take a copy for our current version (if needed) and reopen that one
       if (version < db.GetSchemaVersion())
@@ -122,7 +132,7 @@ bool CDatabaseManager::Update(CDatabase &db, const DatabaseSettings &settings)
         if (copy_fail)
           return false;
 
-        if (!db.Connect(latestDb, dbSettings, false))
+        if (db.Connect(latestDb, dbSettings, false) != CDatabase::ConnectionState::STATE_CONNECTED)
         {
           CLog::Log(LOGERROR, "Unable to open freshly copied database {}", latestDb);
           return false;
@@ -141,7 +151,7 @@ bool CDatabaseManager::Update(CDatabase &db, const DatabaseSettings &settings)
     version--;
   }
   // try creating a new one
-  if (db.Connect(latestDb, dbSettings, true))
+  if (db.Connect(latestDb, dbSettings, true) == CDatabase::ConnectionState::STATE_CONNECTED)
     return true;
 
   // failed to update or open the database

--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -61,6 +61,7 @@ bool CDatabaseManager::Initialize()
   CLog::Log(LOGDEBUG, "{}, updating databases... DONE", __FUNCTION__);
 
   m_bIsUpgrading = false;
+  m_connecting = false;
 
   return std::ranges::all_of(m_dbStatus,
                              [](const auto& db) { return db.second == DBStatus::READY; });
@@ -100,7 +101,9 @@ bool CDatabaseManager::Update(CDatabase &db, const DatabaseSettings &settings)
     if (version)
       dbName += std::to_string(version);
 
+    m_connecting = true;
     const CDatabase::ConnectionState connectionState{db.Connect(dbName, dbSettings, false)};
+    m_connecting = false;
 
     if (connectionState == CDatabase::ConnectionState::STATE_ERROR)
     {

--- a/xbmc/DatabaseManager.h
+++ b/xbmc/DatabaseManager.h
@@ -50,12 +50,21 @@ public:
    */
   bool CanOpen(const std::string &name);
 
+  /*! \brief Check whether manager is connecting to the databases currently.
+   \return true if connecting, false otherwise.
+   */
+  bool IsConnecting() const { return m_connecting; }
+
+  /*! \brief Check whether manager is upgrading the databases currently.
+   \return true if upgrading, false otherwise.
+   */
   bool IsUpgrading() const { return m_bIsUpgrading; }
 
   void LocalizationChanged();
 
 private:
   std::atomic<bool> m_bIsUpgrading;
+  std::atomic<bool> m_connecting{false};
 
   enum class DBStatus
   {

--- a/xbmc/DatabaseManager.h
+++ b/xbmc/DatabaseManager.h
@@ -35,8 +35,9 @@ public:
 
   /*! \brief Initialize the database manager
    Checks that all databases are up to date, otherwise updates them.
+   \return true if all databases are initialized successfully, false otherwise.
    */
-  void Initialize();
+  bool Initialize();
 
   /*! \brief Check whether we can open a database.
 

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -586,12 +586,14 @@ bool CApplication::Initialize()
         event.Set();
       });
 
-  std::string localizedStr = g_localizeStrings.Get(24150);
+  const std::string connecting{g_localizeStrings.Get(24186)};
+  const std::string updating{g_localizeStrings.Get(24150)};
   int iDots = 1;
   while (!event.Wait(1000ms))
   {
-    if (databaseManager.IsUpgrading())
-      CServiceBroker::GetRenderSystem()->ShowSplash(std::string(iDots, ' ') + localizedStr + std::string(iDots, '.'));
+    CServiceBroker::GetRenderSystem()->ShowSplash(
+        std::string(iDots, ' ') + (databaseManager.IsConnecting() ? connecting : updating) +
+        std::string(iDots, '.'));
 
     if (iDots == 3)
       iDots = 1;
@@ -604,6 +606,17 @@ bool CApplication::Initialize()
   {
     // Bail out if any of the databases failed to initialize properly.
     CLog::Log(LOGFATAL, "Failed to initialize databases");
+
+    const std::string dbInitFailedExiting{g_localizeStrings.Get(24187)};
+
+    unsigned int secondsLeftUntilExit{10};
+    while (secondsLeftUntilExit)
+    {
+      CServiceBroker::GetRenderSystem()->ShowSplash(
+          StringUtils::Format(dbInitFailedExiting, secondsLeftUntilExit));
+      KODI::TIME::Sleep(1s);
+      secondsLeftUntilExit--;
+    }
     return false;
   }
 
@@ -615,7 +628,8 @@ bool CApplication::Initialize()
     guiFontManager.Initialize();
     event.Set();
   });
-  localizedStr = g_localizeStrings.Get(39175);
+
+  std::string localizedStr{g_localizeStrings.Get(39175)};
   iDots = 1;
   while (!event.Wait(1000ms))
   {

--- a/xbmc/application/ApplicationSkinHandling.cpp
+++ b/xbmc/application/ApplicationSkinHandling.cpp
@@ -237,7 +237,10 @@ void CApplicationSkinHandling::UnloadSkin()
     gui->GetAudioManager().Enable(false);
 
     gui->GetWindowManager().DeInitialize();
-    CServiceBroker::GetTextureCache()->Deinitialize();
+
+    const std::shared_ptr<CTextureCache> textureCache{CServiceBroker::GetTextureCache()};
+    if (textureCache)
+      textureCache->Deinitialize();
 
     // remove the skin-dependent window
     gui->GetWindowManager().Delete(WINDOW_DIALOG_FULLSCREEN_INFO);

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -255,7 +255,14 @@ public:
                         CDbUrl& dbUrl,
                         SortDescription& sorting);
 
-  bool Connect(const std::string& dbName, const DatabaseSettings& db, bool create);
+  enum class ConnectionState
+  {
+    STATE_ERROR,
+    STATE_DATABASE_NOT_FOUND,
+    STATE_CONNECTED,
+  };
+
+  ConnectionState Connect(const std::string& dbName, const DatabaseSettings& db, bool create);
 
 protected:
   friend class CDatabaseManager;

--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -29,9 +29,9 @@ class Dataset; // forward declaration of class Dataset
 
 #define DB_BUFF_MAX 8 * 1024 // Maximum buffer's capacity
 
-#define DB_CONNECTION_NONE 0
-#define DB_CONNECTION_OK 1
-#define DB_CONNECTION_BAD 2
+constexpr unsigned int DB_CONNECTION_NONE = 0;
+constexpr unsigned int DB_CONNECTION_OK = 1;
+constexpr unsigned int DB_CONNECTION_DATABASE_NOT_FOUND = 2;
 
 #define DB_COMMAND_OK 0 // OK - command executed
 #define DB_EMPTY_QUERY 1 // Query didn't return tuples

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -254,14 +254,16 @@ int MysqlDatabase::connect(bool create_new)
     }
 
     // if we failed above, either credentials were incorrect or the database didn't exist
-    if (mysql_errno(conn) == ER_BAD_DB_ERROR && create_new)
+    if (mysql_errno(conn) == ER_BAD_DB_ERROR)
     {
-
-      if (create() == MYSQL_OK)
+      if (create_new && create() == MYSQL_OK)
       {
         active = true;
-
         return DB_CONNECTION_OK;
+      }
+      else
+      {
+        return DB_CONNECTION_DATABASE_NOT_FOUND; // we're connected, but database does not exist
       }
     }
 

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -322,10 +322,17 @@ int SqliteDatabase::connect(bool create)
     if (create)
       flags |= SQLITE_OPEN_CREATE;
     int errorCode = sqlite3_open_v2(db_fullpath.c_str(), &conn, flags, NULL);
-    if (create && errorCode == SQLITE_CANTOPEN)
+    if (errorCode == SQLITE_CANTOPEN)
     {
-      CLog::Log(LOGFATAL, "SqliteDatabase: can't open {}", db_fullpath);
-      throw std::runtime_error("SqliteDatabase: can't open " + db_fullpath);
+      if (create)
+      {
+        CLog::Log(LOGFATAL, "SqliteDatabase: can't open {}", db_fullpath);
+        throw std::runtime_error("SqliteDatabase: can't open " + db_fullpath);
+      }
+      else
+      {
+        return DB_CONNECTION_DATABASE_NOT_FOUND; // database file does not exist
+      }
     }
     else if (errorCode == SQLITE_OK)
     {

--- a/xbmc/platform/darwin/ios/IOSEAGLView.mm
+++ b/xbmc/platform/darwin/ios/IOSEAGLView.mm
@@ -368,12 +368,16 @@
     {
       readyToRun = false;
       ELOG(@"%sUnable to create GUI", __PRETTY_FUNCTION__);
+      if (g_application.Stop(EXITCODE_QUIT))
+        g_application.Cleanup();
     }
 
     if (!g_application.Initialize())
     {
       readyToRun = false;
       ELOG(@"%sUnable to initialize application", __PRETTY_FUNCTION__);
+      if (g_application.Stop(EXITCODE_QUIT))
+        g_application.Cleanup();
     }
 
     if (readyToRun)

--- a/xbmc/platform/darwin/tvos/XBMCController.mm
+++ b/xbmc/platform/darwin/tvos/XBMCController.mm
@@ -423,11 +423,15 @@ int KODI_Run(bool renderGUI)
   if (renderGUI && !g_application.CreateGUI())
   {
     CLog::Log(LOGERROR, "ERROR: Unable to create GUI. Exiting");
+    if (g_application.Stop(EXITCODE_QUIT))
+      g_application.Cleanup();
     return status;
   }
   if (!g_application.Initialize())
   {
     CLog::Log(LOGERROR, "ERROR: Unable to Initialize. Exiting");
+    if (g_application.Stop(EXITCODE_QUIT))
+      g_application.Cleanup();
     return status;
   }
 

--- a/xbmc/platform/xbmc.cpp
+++ b/xbmc/platform/xbmc.cpp
@@ -43,6 +43,8 @@ extern "C" int XBMC_Run(bool renderGUI)
   if (!g_application.Initialize())
   {
     CMessagePrinter::DisplayError("ERROR: Unable to Initialize. Exiting");
+    if (g_application.Stop(EXITCODE_QUIT))
+      g_application.Cleanup();
     return status;
   }
 


### PR DESCRIPTION
Fixes #25262

Changed: Instead of trying again and again to connect to a non accessible database, now, whenever during Kodi startup connect to a remote database fails, Kodi startup will immediately stopped, an error message will be displayed on splash screen for 10 secs, then Kodi exits.

![Screenshot 2025-04-18 at 13 14 38](https://github.com/user-attachments/assets/8cc75908-5f1a-46df-8cf8-318ae8bd8686)
![Screenshot 2025-04-18 at 13 07 35](https://github.com/user-attachments/assets/3c49cdbc-3547-4642-a28e-9fc486b2b9fb)

Runtime-tested on macOS and Android.

@enen92 if you are around, could you have alook?  