### PR TITLE
StringUtils: Fix MSVC iterator assertion

### DIFF
--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1054,26 +1054,22 @@ static wchar_t GetCollationWeight(const wchar_t& r)
 // See also the equivalent StringUtils::AlphaNumericCollation() for UFT8 data
 int64_t StringUtils::AlphaNumericCompare(std::wstring_view left, std::wstring_view right) noexcept
 {
-  auto l = left.begin();
-  auto r = right.begin();
-  std::wstring_view::const_iterator ld, rd;
-  wchar_t lc, rc;
-  int64_t lnum, rnum;
-  bool lsym, rsym;
+  auto l{left.cbegin()};
+  auto r{right.cbegin()};
   while (l != left.end() && r != right.end())
   {
     // check if we have a numerical value
     if (*l >= L'0' && *l <= L'9' && *r >= L'0' && *r <= L'9')
     {
-      ld = l;
-      lnum = *ld++ - L'0';
+      auto ld = l;
+      int64_t lnum{*ld++ - L'0'};
       while (ld != left.end() && *ld >= L'0' && *ld <= L'9' && std::distance(l, ld) < 15)
       { // compare only up to 15 digits
         lnum *= 10;
         lnum += *ld++ - L'0';
       }
-      rd = r;
-      rnum = *rd++ - L'0';
+      auto rd = r;
+      int64_t rnum{*rd++ - L'0'};
       while (rd != right.end() && *rd >= L'0' && *rd <= L'9' && std::distance(r, rd) < 15)
       { // compare only up to 15 digits
         rnum *= 10;
@@ -1089,16 +1085,16 @@ int64_t StringUtils::AlphaNumericCompare(std::wstring_view left, std::wstring_vi
       continue;
     }
 
-    lc = *l;
-    rc = *r;
+    wchar_t lc{*l};
+    wchar_t rc{*r};
     // Put ascii punctuation and symbols e.g. !#$&()*+,-./:;<=>?@[\]^_ `{|}~ above the other
     // alphanumeric ascii, rather than some being mixed between the numbers and letters, and
     // above all other unicode letters, symbols and punctuation.
     // (Locale collation of these chars varies across platforms)
-    lsym = (lc >= 32 && lc < L'0') || (lc > L'9' && lc < L'A') || (lc > L'Z' && lc < L'a') ||
-           (lc > L'z' && lc < 128);
-    rsym = (rc >= 32 && rc < L'0') || (rc > L'9' && rc < L'A') || (rc > L'Z' && rc < L'a') ||
-           (rc > L'z' && rc < 128);
+    const bool lsym{(lc >= 32 && lc < L'0') || (lc > L'9' && lc < L'A') ||
+                    (lc > L'Z' && lc < L'a') || (lc > L'z' && lc < 128)};
+    const bool rsym{(rc >= 32 && rc < L'0') || (rc > L'9' && rc < L'A') ||
+                    (rc > L'Z' && rc < L'a') || (rc > L'z' && rc < 128)};
     if (lsym && !rsym)
       return -1;
     if (!lsym && rsym)

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -17,6 +17,7 @@
 //------------------------------------------------------------------------
 
 #include <charconv>
+#include <iterator>
 #ifdef HAVE_NEW_CROSSGUID
 #include <crossguid/guid.hpp>
 #else
@@ -1066,14 +1067,14 @@ int64_t StringUtils::AlphaNumericCompare(std::wstring_view left, std::wstring_vi
     {
       ld = l;
       lnum = *ld++ - L'0';
-      while (ld != left.end() && *ld >= L'0' && *ld <= L'9' && ld < l + 15)
+      while (ld != left.end() && *ld >= L'0' && *ld <= L'9' && std::distance(l, ld) < 15)
       { // compare only up to 15 digits
         lnum *= 10;
         lnum += *ld++ - L'0';
       }
       rd = r;
       rnum = *rd++ - L'0';
-      while (rd != right.end() && *rd >= L'0' && *rd <= L'9' && rd < r + 15)
+      while (rd != right.end() && *rd >= L'0' && *rd <= L'9' && std::distance(r, rd) < 15)
       { // compare only up to 15 digits
         rnum *= 10;
         rnum += *rd++ - L'0';

--- a/xbmc/utils/test/TestStringUtils.cpp
+++ b/xbmc/utils/test/TestStringUtils.cpp
@@ -408,11 +408,27 @@ TEST(TestStringUtils, FindNumber)
 
 TEST(TestStringUtils, AlphaNumericCompare)
 {
-  int64_t ref, var;
+  // less than
+  EXPECT_LT(StringUtils::AlphaNumericCompare(L"123abc", L"abc123"), 0);
+  EXPECT_LT(StringUtils::AlphaNumericCompare(L"123abc", L"124abc"), 0);
+  EXPECT_LT(StringUtils::AlphaNumericCompare(L"123abc", L"123bbc"), 0);
+  EXPECT_LT(StringUtils::AlphaNumericCompare(L"abc123", L"abc124"), 0);
+  EXPECT_LT(StringUtils::AlphaNumericCompare(L"abc123", L"bbc123"), 0);
+  EXPECT_LT(StringUtils::AlphaNumericCompare(L"2", L"12"), 0);
 
-  ref = 0;
-  var = StringUtils::AlphaNumericCompare(L"123abc", L"abc123");
-  EXPECT_LT(var, ref);
+  // equals
+  EXPECT_EQ(StringUtils::AlphaNumericCompare(L"123abc", L"123abc"), 0);
+
+  // greater than (same as less than but reversed arguments)
+  EXPECT_GT(StringUtils::AlphaNumericCompare(L"abc123", L"123abc"), 0);
+  EXPECT_GT(StringUtils::AlphaNumericCompare(L"124abc", L"123abc"), 0);
+  EXPECT_GT(StringUtils::AlphaNumericCompare(L"123bbc", L"123abc"), 0);
+  EXPECT_GT(StringUtils::AlphaNumericCompare(L"abc124", L"abc123"), 0);
+  EXPECT_GT(StringUtils::AlphaNumericCompare(L"bbc123", L"abc123"), 0);
+  EXPECT_GT(StringUtils::AlphaNumericCompare(L"12", L"2"), 0);
+
+  // test that long numbers are treated correctly
+  EXPECT_EQ(StringUtils::AlphaNumericCompare(L"12345678901234567890", L"12345678901234567890"), 0);
 }
 
 TEST(TestStringUtils, TimeStringToSeconds)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

MSVC is very defensive in debug mode and doesn't allow interators past `end()` even if they are not dereferenced. Fixes this error:

"cannot seek string_view iterator after end", comparison of left=30 with right=60.

Reported by @CrystalP in https://github.com/xbmc/xbmc/pull/25642#discussion_r2051349560

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Be able to run Kodi when build with a MSVC debug build. 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

No change on Linux, needs confirmation from a Windows dev.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
