### PR TITLE
[guilib/listproviders] Improvements and Fixes

### DIFF
--- a/xbmc/guilib/listproviders/DirectoryProvider.cpp
+++ b/xbmc/guilib/listproviders/DirectoryProvider.cpp
@@ -66,13 +66,14 @@ public:
       m_limit(limit),
       m_browse(browse),
       m_parentID(parentID)
-  { }
+  {
+  }
   ~CDirectoryJob() override = default;
 
   const char* GetType() const override { return "directory"; }
-  bool operator==(const CJob *job) const override
+  bool operator==(const CJob* job) const override
   {
-    if (strcmp(job->GetType(),GetType()) == 0)
+    if (strcmp(job->GetType(), GetType()) == 0)
     {
       const CDirectoryJob* dirJob = dynamic_cast<const CDirectoryJob*>(job);
       if (dirJob && dirJob->m_url == m_url)
@@ -170,15 +171,16 @@ public:
     }
   }
 
-  const std::vector<CGUIStaticItemPtr> &GetItems() const { return m_items; }
-  const std::string &GetTarget() const { return m_target; }
-  std::vector<InfoTagType> GetItemTypes(std::vector<InfoTagType> &itemTypes) const
+  const std::vector<CGUIStaticItemPtr>& GetItems() const { return m_items; }
+  const std::string& GetTarget() const { return m_target; }
+  std::vector<InfoTagType> GetItemTypes(std::vector<InfoTagType>& itemTypes) const
   {
     itemTypes.clear();
     for (const auto& i : m_thumbloaders)
       itemTypes.push_back(i.first);
     return itemTypes;
   }
+
 private:
   std::string m_url;
   std::string m_target;
@@ -187,7 +189,7 @@ private:
   CDirectoryProvider::BrowseMode m_browse{CDirectoryProvider::BrowseMode::AUTO};
   int m_parentID;
   std::vector<CGUIStaticItemPtr> m_items;
-  std::map<InfoTagType, std::shared_ptr<CThumbLoader> > m_thumbloaders;
+  std::map<InfoTagType, std::shared_ptr<CThumbLoader>> m_thumbloaders;
 };
 
 CDirectoryProvider::CDirectoryProvider(const TiXmlElement* element, int parentID)
@@ -196,19 +198,19 @@ CDirectoryProvider::CDirectoryProvider(const TiXmlElement* element, int parentID
   assert(element);
   if (!element->NoChildren())
   {
-    const char *target = element->Attribute("target");
+    const char* target = element->Attribute("target");
     if (target)
       m_target.SetLabel(target, "", parentID);
 
-    const char *sortMethod = element->Attribute("sortby");
+    const char* sortMethod = element->Attribute("sortby");
     if (sortMethod)
       m_sortMethod.SetLabel(sortMethod, "", parentID);
 
-    const char *sortOrder = element->Attribute("sortorder");
+    const char* sortOrder = element->Attribute("sortorder");
     if (sortOrder)
       m_sortOrder.SetLabel(sortOrder, "", parentID);
 
-    const char *limit = element->Attribute("limit");
+    const char* limit = element->Attribute("limit");
     if (limit)
       m_limit.SetLabel(limit, "", parentID);
 
@@ -297,9 +299,11 @@ void CDirectoryProvider::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
     // we don't need to refresh anything if there are no fitting
     // items in this list provider for the announcement flag
     if (((flag & ANNOUNCEMENT::VideoLibrary) &&
-         (std::find(m_itemTypes.begin(), m_itemTypes.end(), InfoTagType::VIDEO) == m_itemTypes.end())) ||
+         (std::find(m_itemTypes.begin(), m_itemTypes.end(), InfoTagType::VIDEO) ==
+          m_itemTypes.end())) ||
         ((flag & ANNOUNCEMENT::AudioLibrary) &&
-         (std::find(m_itemTypes.begin(), m_itemTypes.end(), InfoTagType::AUDIO) == m_itemTypes.end())))
+         (std::find(m_itemTypes.begin(), m_itemTypes.end(), InfoTagType::AUDIO) ==
+          m_itemTypes.end())))
       return;
 
     if (flag & ANNOUNCEMENT::Player)
@@ -355,7 +359,8 @@ void CDirectoryProvider::OnAddonEvent(const ADDON::AddonEvent& event)
   }
 }
 
-void CDirectoryProvider::OnAddonRepositoryEvent(const ADDON::CRepositoryUpdater::RepositoryUpdated& event)
+void CDirectoryProvider::OnAddonRepositoryEvent(
+    const ADDON::CRepositoryUpdater::RepositoryUpdated& event)
 {
   std::unique_lock<CCriticalSection> lock(m_section);
   if (URIUtils::IsProtocol(m_currentUrl, "addons"))
@@ -424,7 +429,7 @@ void CDirectoryProvider::FreeResources(bool immediately)
     item->FreeMemory(immediately);
 }
 
-void CDirectoryProvider::OnJobComplete(unsigned int jobID, bool success, CJob *job)
+void CDirectoryProvider::OnJobComplete(unsigned int jobID, bool success, CJob* job)
 {
   std::unique_lock<CCriticalSection> lock(m_section);
   if (success)
@@ -568,9 +573,12 @@ bool CDirectoryProvider::UpdateURL()
         this, ANNOUNCEMENT::VideoLibrary | ANNOUNCEMENT::AudioLibrary | ANNOUNCEMENT::Player |
                   ANNOUNCEMENT::GUI);
     CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CDirectoryProvider::OnAddonEvent);
-    CServiceBroker::GetRepositoryUpdater().Events().Subscribe(this, &CDirectoryProvider::OnAddonRepositoryEvent);
-    CServiceBroker::GetPVRManager().Events().Subscribe(this, &CDirectoryProvider::OnPVRManagerEvent);
-    CServiceBroker::GetFavouritesService().Events().Subscribe(this, &CDirectoryProvider::OnFavouritesEvent);
+    CServiceBroker::GetRepositoryUpdater().Events().Subscribe(
+        this, &CDirectoryProvider::OnAddonRepositoryEvent);
+    CServiceBroker::GetPVRManager().Events().Subscribe(this,
+                                                       &CDirectoryProvider::OnPVRManagerEvent);
+    CServiceBroker::GetFavouritesService().Events().Subscribe(
+        this, &CDirectoryProvider::OnFavouritesEvent);
   }
   return true;
 }
@@ -621,8 +629,10 @@ bool CDirectoryProvider::UpdateSort()
   m_currentSort.sortOrder = sortOrder;
   m_currentSort.sortAttributes = SortAttributeIgnoreFolders;
 
-  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING))
-    m_currentSort.sortAttributes = static_cast<SortAttribute>(m_currentSort.sortAttributes | SortAttributeIgnoreArticle);
+  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING))
+    m_currentSort.sortAttributes =
+        static_cast<SortAttribute>(m_currentSort.sortAttributes | SortAttributeIgnoreArticle);
 
   return true;
 }

--- a/xbmc/guilib/listproviders/DirectoryProvider.cpp
+++ b/xbmc/guilib/listproviders/DirectoryProvider.cpp
@@ -11,11 +11,14 @@
 #include "ContextMenuManager.h"
 #include "FileItem.h"
 #include "ServiceBroker.h"
+#include "addons/AddonEvents.h"
 #include "addons/AddonManager.h"
+#include "addons/RepositoryUpdater.h"
 #include "favourites/FavouritesService.h"
 #include "filesystem/Directory.h"
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
+#include "interfaces/IAnnouncer.h"
 #include "music/MusicFileItemClassify.h"
 #include "music/MusicThumbLoader.h"
 #include "pictures/PictureThumbLoader.h"
@@ -50,6 +53,156 @@ using namespace KODI;
 using namespace KODI::MESSAGING;
 using namespace KODI::UTILS::GUILIB;
 using namespace PVR;
+
+class CDirectoryProvider::CSubscriber : public ANNOUNCEMENT::IAnnouncer
+{
+public:
+  explicit CSubscriber(ISubscriberCallback& invalidate) : m_callback(invalidate)
+  {
+    CServiceBroker::GetAnnouncementManager()->AddAnnouncer(
+        this, ANNOUNCEMENT::VideoLibrary | ANNOUNCEMENT::AudioLibrary | ANNOUNCEMENT::Player |
+                  ANNOUNCEMENT::GUI);
+  }
+  virtual ~CSubscriber() { CServiceBroker::GetAnnouncementManager()->RemoveAnnouncer(this); }
+
+protected:
+  bool OnEventPublished(Topic topic = Topic::UNSPECIFIED)
+  {
+    return m_callback.OnEventPublished(topic);
+  }
+
+private:
+  CSubscriber() = delete;
+
+  // IAnnouncer implementation
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                const std::string& sender,
+                const std::string& message,
+                const CVariant& data) override
+  {
+    if (flag & ANNOUNCEMENT::VideoLibrary && OnEventPublished(Topic::VIDEO_LIBRARY))
+      return;
+
+    if (flag & ANNOUNCEMENT::AudioLibrary && OnEventPublished(Topic::AUDIO_LIBRARY))
+      return;
+
+    if (flag & ANNOUNCEMENT::Player)
+    {
+      if (message == "OnPlay" || message == "OnResume" || message == "OnStop")
+        OnEventPublished(Topic::PLAYER);
+    }
+    else
+    {
+      // if we're in a database transaction, don't bother doing anything just yet
+      if (data.isMember("transaction") && data["transaction"].asBoolean())
+        return;
+
+      // if there was a database update, we set the update state
+      // to PENDING to fire off a new job in the next update
+      if (message == "OnScanFinished" || message == "OnCleanFinished" || message == "OnUpdate" ||
+          message == "OnRemove" || message == "OnRefresh")
+        OnEventPublished();
+    }
+  }
+
+  CCriticalSection m_critSection;
+  ISubscriberCallback& m_callback;
+};
+
+namespace
+{
+class CAddonsSubscriber : public CDirectoryProvider::CSubscriber
+{
+public:
+  explicit CAddonsSubscriber(ISubscriberCallback& invalidate)
+    : CDirectoryProvider::CSubscriber(invalidate)
+  {
+    CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CAddonsSubscriber::OnAddonEvent);
+    CServiceBroker::GetRepositoryUpdater().Events().Subscribe(
+        this, &CAddonsSubscriber::OnAddonRepositoryEvent);
+  }
+  ~CAddonsSubscriber() override
+  {
+    CServiceBroker::GetRepositoryUpdater().Events().Unsubscribe(this);
+    CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
+  }
+
+private:
+  void OnAddonEvent(const ADDON::AddonEvent& event)
+  {
+    if (typeid(event) == typeid(ADDON::AddonEvents::Enabled) ||
+        typeid(event) == typeid(ADDON::AddonEvents::Disabled) ||
+        typeid(event) == typeid(ADDON::AddonEvents::ReInstalled) ||
+        typeid(event) == typeid(ADDON::AddonEvents::UnInstalled) ||
+        typeid(event) == typeid(ADDON::AddonEvents::MetadataChanged) ||
+        typeid(event) == typeid(ADDON::AddonEvents::AutoUpdateStateChanged))
+    {
+      OnEventPublished();
+    }
+  }
+
+  void OnAddonRepositoryEvent(const ADDON::CRepositoryUpdater::RepositoryUpdated& event)
+  {
+    OnEventPublished();
+  }
+};
+
+class CPVRSubscriber : public CDirectoryProvider::CSubscriber
+{
+public:
+  explicit CPVRSubscriber(ISubscriberCallback& invalidate)
+    : CDirectoryProvider::CSubscriber(invalidate)
+  {
+    CServiceBroker::GetPVRManager().Events().Subscribe(this, &CPVRSubscriber::OnPVRManagerEvent);
+  }
+  ~CPVRSubscriber() override { CServiceBroker::GetPVRManager().Events().Unsubscribe(this); }
+
+private:
+  void OnPVRManagerEvent(const PVR::PVREvent& event)
+  {
+    if (event == PVR::PVREvent::ManagerStarted || event == PVR::PVREvent::ManagerStopped ||
+        event == PVR::PVREvent::RecordingsInvalidated ||
+        event == PVR::PVREvent::TimersInvalidated ||
+        event == PVR::PVREvent::ChannelGroupsInvalidated ||
+        event == PVR::PVREvent::SavedSearchesInvalidated ||
+        event == PVR::PVREvent::ClientsInvalidated ||
+        event == PVR::PVREvent::ClientsPrioritiesInvalidated)
+    {
+      OnEventPublished();
+    }
+  }
+};
+
+class CFavouritesSubscriber : public CDirectoryProvider::CSubscriber
+{
+public:
+  explicit CFavouritesSubscriber(ISubscriberCallback& invalidate)
+    : CDirectoryProvider::CSubscriber(invalidate)
+  {
+    CServiceBroker::GetFavouritesService().Events().Subscribe(
+        this, &CFavouritesSubscriber::OnFavouritesEvent);
+  }
+  ~CFavouritesSubscriber() override
+  {
+    CServiceBroker::GetFavouritesService().Events().Unsubscribe(this);
+  }
+
+private:
+  void OnFavouritesEvent(const CFavouritesService::FavouritesUpdated& event) { OnEventPublished(); }
+};
+
+std::unique_ptr<CDirectoryProvider::CSubscriber> GetSubscriber(const std::string& url,
+                                                               ISubscriberCallback& invalidate)
+{
+  if (URIUtils::IsProtocol(url, "addons"))
+    return std::make_unique<CAddonsSubscriber>(invalidate);
+  else if (URIUtils::IsProtocol(url, "pvr"))
+    return std::make_unique<CPVRSubscriber>(invalidate);
+  else if (URIUtils::IsProtocol(url, "favourites"))
+    return std::make_unique<CFavouritesSubscriber>(invalidate);
+  else
+    return std::make_unique<CDirectoryProvider::CSubscriber>(invalidate);
+}
 
 class CDirectoryJob : public CJob
 {
@@ -191,6 +344,7 @@ private:
   std::vector<CGUIStaticItemPtr> m_items;
   std::map<InfoTagType, std::shared_ptr<CThumbLoader>> m_thumbloaders;
 };
+} // unnamed namespace
 
 CDirectoryProvider::CDirectoryProvider(const TiXmlElement* element, int parentID)
   : IListProvider(parentID), m_nextJobTimer(this)
@@ -318,50 +472,6 @@ bool CDirectoryProvider::Update(bool forceRefresh)
   return changed; //! @todo Also returned changed if properties are changed (if so, need to update scroll to letter).
 }
 
-void CDirectoryProvider::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
-                                  const std::string& sender,
-                                  const std::string& message,
-                                  const CVariant& data)
-{
-  {
-    std::unique_lock<CCriticalSection> lock(m_section);
-    // we don't need to refresh anything if there are no fitting
-    // items in this list provider for the announcement flag
-    if (((flag & ANNOUNCEMENT::VideoLibrary) &&
-         (std::find(m_itemTypes.begin(), m_itemTypes.end(), InfoTagType::VIDEO) ==
-          m_itemTypes.end())) ||
-        ((flag & ANNOUNCEMENT::AudioLibrary) &&
-         (std::find(m_itemTypes.begin(), m_itemTypes.end(), InfoTagType::AUDIO) ==
-          m_itemTypes.end())))
-      return;
-
-    if (flag & ANNOUNCEMENT::Player)
-    {
-      if (message == "OnPlay" || message == "OnResume" || message == "OnStop")
-      {
-        if (m_currentSort.sortBy ==
-                SortByNone || // not nice, but many directories that need to be refreshed on start/stop have no special sort order (e.g. in progress movies)
-            m_currentSort.sortBy == SortByLastPlayed ||
-            m_currentSort.sortBy == SortByDateAdded || m_currentSort.sortBy == SortByPlaycount ||
-            m_currentSort.sortBy == SortByLastUsed)
-          m_updateState = INVALIDATED;
-      }
-    }
-    else
-    {
-      // if we're in a database transaction, don't bother doing anything just yet
-      if (data.isMember("transaction") && data["transaction"].asBoolean())
-        return;
-
-      // if there was a database update, we set the update state
-      // to PENDING to fire off a new job in the next update
-      if (message == "OnScanFinished" || message == "OnCleanFinished" || message == "OnUpdate" ||
-          message == "OnRemove" || message == "OnRefresh")
-        m_updateState = INVALIDATED;
-    }
-  }
-}
-
 void CDirectoryProvider::Fetch(std::vector<std::shared_ptr<CGUIListItem>>& items)
 {
   std::unique_lock<CCriticalSection> lock(m_section);
@@ -371,54 +481,6 @@ void CDirectoryProvider::Fetch(std::vector<std::shared_ptr<CGUIListItem>>& items
     if (i->IsVisible())
       items.push_back(i);
   }
-}
-
-void CDirectoryProvider::OnAddonEvent(const ADDON::AddonEvent& event)
-{
-  std::unique_lock<CCriticalSection> lock(m_section);
-  if (URIUtils::IsProtocol(m_currentUrl, "addons"))
-  {
-    if (typeid(event) == typeid(ADDON::AddonEvents::Enabled) ||
-        typeid(event) == typeid(ADDON::AddonEvents::Disabled) ||
-        typeid(event) == typeid(ADDON::AddonEvents::ReInstalled) ||
-        typeid(event) == typeid(ADDON::AddonEvents::UnInstalled) ||
-        typeid(event) == typeid(ADDON::AddonEvents::MetadataChanged) ||
-        typeid(event) == typeid(ADDON::AddonEvents::AutoUpdateStateChanged))
-      m_updateState = INVALIDATED;
-  }
-}
-
-void CDirectoryProvider::OnAddonRepositoryEvent(
-    const ADDON::CRepositoryUpdater::RepositoryUpdated& event)
-{
-  std::unique_lock<CCriticalSection> lock(m_section);
-  if (URIUtils::IsProtocol(m_currentUrl, "addons"))
-  {
-    m_updateState = INVALIDATED;
-  }
-}
-
-void CDirectoryProvider::OnPVRManagerEvent(const PVR::PVREvent& event)
-{
-  std::unique_lock<CCriticalSection> lock(m_section);
-  if (URIUtils::IsProtocol(m_currentUrl, "pvr"))
-  {
-    if (event == PVR::PVREvent::ManagerStarted || event == PVR::PVREvent::ManagerStopped ||
-        event == PVR::PVREvent::RecordingsInvalidated ||
-        event == PVR::PVREvent::TimersInvalidated ||
-        event == PVR::PVREvent::ChannelGroupsInvalidated ||
-        event == PVR::PVREvent::SavedSearchesInvalidated ||
-        event == PVR::PVREvent::ClientsInvalidated ||
-        event == PVR::PVREvent::ClientsPrioritiesInvalidated)
-      m_updateState = INVALIDATED;
-  }
-}
-
-void CDirectoryProvider::OnFavouritesEvent(const CFavouritesService::FavouritesUpdated& event)
-{
-  std::unique_lock<CCriticalSection> lock(m_section);
-  if (URIUtils::IsProtocol(m_currentUrl, "favourites"))
-    m_updateState = INVALIDATED;
 }
 
 void CDirectoryProvider::Reset()
@@ -442,15 +504,9 @@ void CDirectoryProvider::Reset()
     m_updateState = OK;
   }
 
-  std::unique_lock<CCriticalSection> subscriptionLock(m_subscriptionSection);
-  if (m_isSubscribed)
   {
-    m_isSubscribed = false;
-    CServiceBroker::GetAnnouncementManager()->RemoveAnnouncer(this);
-    CServiceBroker::GetFavouritesService().Events().Unsubscribe(this);
-    CServiceBroker::GetRepositoryUpdater().Events().Unsubscribe(this);
-    CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
-    CServiceBroker::GetPVRManager().Events().Unsubscribe(this);
+    std::unique_lock<CCriticalSection> subscriptionLock(m_subscriptionSection);
+    m_subscriber.reset();
   }
 }
 
@@ -506,6 +562,32 @@ void CDirectoryProvider::OnTimeout()
     // Start a new update job.
     StartDirectoryJob();
   }
+}
+
+bool CDirectoryProvider::OnEventPublished(Topic topic /*= Topic::UNSPECIFIED*/)
+{
+  std::unique_lock<CCriticalSection> lock(m_section);
+  switch (topic)
+  {
+    case Topic::UNSPECIFIED:
+      // Always invalidate.
+      break;
+    case Topic::PLAYER:
+      // We don't need to do anything if there is no matching sort method.
+      if (m_currentSort.sortBy != SortByNone && m_currentSort.sortBy != SortByLastPlayed &&
+          m_currentSort.sortBy != SortByDateAdded && m_currentSort.sortBy != SortByPlaycount &&
+          m_currentSort.sortBy != SortByLastUsed)
+        return false;
+      break;
+    case Topic::VIDEO_LIBRARY:
+      // We don't need to do anything if there are no fitting items.
+      return std::ranges::find(m_itemTypes, InfoTagType::VIDEO) == m_itemTypes.cend();
+    case Topic::AUDIO_LIBRARY:
+      // We don't need to do anything if there are no fitting items.
+      return std::ranges::find(m_itemTypes, InfoTagType::AUDIO) == m_itemTypes.cend();
+  }
+  m_updateState = INVALIDATED;
+  return true;
 }
 
 std::string CDirectoryProvider::GetTarget(const CFileItem& item) const
@@ -621,9 +703,10 @@ bool CDirectoryProvider::IsUpdating() const
 
 bool CDirectoryProvider::UpdateURL()
 {
+  std::string value;
   {
     std::unique_lock<CCriticalSection> lock(m_section);
-    std::string value(m_url.GetLabel(m_parentID, false));
+    value = m_url.GetLabel(m_parentID, false);
     if (value == m_currentUrl)
       return false;
 
@@ -631,20 +714,7 @@ bool CDirectoryProvider::UpdateURL()
   }
 
   std::unique_lock<CCriticalSection> subscriptionLock(m_subscriptionSection);
-  if (!m_isSubscribed)
-  {
-    m_isSubscribed = true;
-    CServiceBroker::GetAnnouncementManager()->AddAnnouncer(
-        this, ANNOUNCEMENT::VideoLibrary | ANNOUNCEMENT::AudioLibrary | ANNOUNCEMENT::Player |
-                  ANNOUNCEMENT::GUI);
-    CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CDirectoryProvider::OnAddonEvent);
-    CServiceBroker::GetRepositoryUpdater().Events().Subscribe(
-        this, &CDirectoryProvider::OnAddonRepositoryEvent);
-    CServiceBroker::GetPVRManager().Events().Subscribe(this,
-                                                       &CDirectoryProvider::OnPVRManagerEvent);
-    CServiceBroker::GetFavouritesService().Events().Subscribe(
-        this, &CDirectoryProvider::OnFavouritesEvent);
-  }
+  m_subscriber = GetSubscriber(value, *this);
   return true;
 }
 
@@ -656,7 +726,6 @@ bool CDirectoryProvider::UpdateLimit()
     return false;
 
   m_currentLimit = value;
-
   return true;
 }
 

--- a/xbmc/guilib/listproviders/DirectoryProvider.h
+++ b/xbmc/guilib/listproviders/DirectoryProvider.h
@@ -15,8 +15,10 @@
 #include "guilib/GUIStaticItem.h"
 #include "interfaces/IAnnouncer.h"
 #include "threads/CriticalSection.h"
+#include "threads/Timer.h"
 #include "utils/Job.h"
 
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -40,7 +42,8 @@ enum class InfoTagType
 
 class CDirectoryProvider : public IListProvider,
                            public IJobCallback,
-                           public ANNOUNCEMENT::IAnnouncer
+                           public ANNOUNCEMENT::IAnnouncer,
+                           private ITimerCallback
 {
 public:
   typedef enum
@@ -81,8 +84,17 @@ public:
   void OnJobComplete(unsigned int jobID, bool success, CJob* job) override;
 
 private:
+  void StartDirectoryJob();
+
+  // ITimerCallback implementation
+  void OnTimeout() override;
+
   UpdateState m_updateState = OK;
   unsigned int m_jobID = 0;
+  bool m_jobPending{false};
+  std::chrono::time_point<std::chrono::system_clock> m_lastJobStartedAt;
+  CTimer m_nextJobTimer;
+
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_url;
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_target;
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_sortMethod;

--- a/xbmc/guilib/listproviders/DirectoryProvider.h
+++ b/xbmc/guilib/listproviders/DirectoryProvider.h
@@ -26,7 +26,7 @@ class CVariant;
 
 namespace PVR
 {
-  enum class PVREvent;
+enum class PVREvent;
 }
 
 enum class InfoTagType
@@ -38,10 +38,9 @@ enum class InfoTagType
   PVR,
 };
 
-class CDirectoryProvider :
-  public IListProvider,
-  public IJobCallback,
-  public ANNOUNCEMENT::IAnnouncer
+class CDirectoryProvider : public IListProvider,
+                           public IJobCallback,
+                           public ANNOUNCEMENT::IAnnouncer
 {
 public:
   typedef enum
@@ -58,7 +57,7 @@ public:
     ALWAYS
   };
 
-  CDirectoryProvider(const TiXmlElement *element, int parentID);
+  CDirectoryProvider(const TiXmlElement* element, int parentID);
   explicit CDirectoryProvider(const CDirectoryProvider& other);
   ~CDirectoryProvider() override;
 
@@ -79,7 +78,8 @@ public:
   void FreeResources(bool immediately) override;
 
   // callback from directory job
-  void OnJobComplete(unsigned int jobID, bool success, CJob *job) override;
+  void OnJobComplete(unsigned int jobID, bool success, CJob* job) override;
+
 private:
   UpdateState m_updateState = OK;
   unsigned int m_jobID = 0;
@@ -89,9 +89,9 @@ private:
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_sortOrder;
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_limit;
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_browse;
-  std::string      m_currentUrl;
-  std::string      m_currentTarget;   ///< \brief node.target property on the list as a whole
-  SortDescription  m_currentSort;
+  std::string m_currentUrl;
+  std::string m_currentTarget; ///< \brief node.target property on the list as a whole
+  SortDescription m_currentSort;
   unsigned int m_currentLimit{0};
   BrowseMode m_currentBrowse{BrowseMode::AUTO};
   std::vector<CGUIStaticItemPtr> m_items;


### PR DESCRIPTION
**First commit** is only clang-format.

**Second commit** fixes a crash caused by two `CDirectoryJob` instances running concurrently for the same `CDirectoryProvider`, sharing and concurrently reading from/writing to the same `CVideoInfoTag` instance. The two concurrent jobs happen because the (as I read the original code) intention to ensure only one job at a time running for a `CDirectoryProvider` instance does not work. To check whether a job was already started, and in case to use `CJobManger::CancelJob`to stop this job, then immediately to start a new job does not actually work. `CJobMananger::CancelJob` will not stop execution of the job to cancel if it is already running! In fact the existing job runs to an end in one worker thread, and in parallel the second job runs in another worker thread!

<img width="1710" alt="Screenshot 2025-03-28 at 17 44 45" src="https://github.com/user-attachments/assets/66712ec3-cb93-4721-9458-2358362b9de7" />
<img width="1710" alt="Screenshot 2025-03-28 at 17 44 59" src="https://github.com/user-attachments/assets/3f9b6eb1-4367-4a36-bd07-84adbd050d76" />

I fixed the concurrency issue by postponing update requests arriving while another update job is running until that job ended, and in case more than one update request comes in while another job is running, all requests except one will be ignored.

Third commit refactors and optimizes the subscription/unsubscription code so that no longer every provider instance subscribes to every `topic`and on arrival filters messages by its URL pattern, but to only subscribe to the topics based on own URL pattern. This avoid lots (!) of unneeded subscriber notification calls.

Runtime-tested for quite some time on Android and macOS, latest Kodi master.

Not sure who could review this, maybe @enen92 ? Best reviewed commit by commit, ignoring commit 1 (clang-format only).
