### PR TITLE
[cmake] FindUdfread remove remnants of internal build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,6 @@ if(UNIX)
   option(ENABLE_INTERNAL_FSTRCMP "Enable internal fstrcmp?" OFF)
   option(ENABLE_INTERNAL_DAV1D "Enable internal dav1d?" OFF)
   option(ENABLE_INTERNAL_GTEST "Enable internal gtest?" OFF)
-  option(ENABLE_INTERNAL_UDFREAD "Enable internal udfread?" OFF)
 endif()
 
 # System options

--- a/cmake/modules/FindUdfread.cmake
+++ b/cmake/modules/FindUdfread.cmake
@@ -30,28 +30,17 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     endif()
   endif()
 
-  # Check for existing UDFREAD. If version >= UDFREAD-VERSION file version, dont build
-  # A corner case, but if a linux/freebsd user WANTS to build internal udfread, build anyway
-  if((libudfread_VERSION VERSION_LESS ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VER} AND ENABLE_INTERNAL_UDFREAD) OR
-     ((CORE_SYSTEM_NAME STREQUAL linux OR CORE_SYSTEM_NAME STREQUAL freebsd) AND ENABLE_INTERNAL_UDFREAD))
-    buildudfread()
-  else()
-    if(TARGET libudfread::libudfread)
-      get_target_property(UDFREAD_LIBRARY_RELEASE libudfread::libudfread IMPORTED_LOCATION_RELWITHDEBINFO)
-      get_target_property(UDFREAD_INCLUDE_DIR libudfread::libudfread INTERFACE_INCLUDE_DIRECTORIES)
-    elseif(TARGET PkgConfig::libudfread)
-      # First item is the full path of the library file found
-      # pkg_check_modules does not populate a variable of the found library explicitly
-      list(GET libudfread_LINK_LIBRARIES 0 UDFREAD_LIBRARY_RELEASE)
+  if(TARGET libudfread::libudfread)
+    get_target_property(UDFREAD_LIBRARY libudfread::libudfread IMPORTED_LOCATION_RELWITHDEBINFO)
+    get_target_property(UDFREAD_INCLUDE_DIR libudfread::libudfread INTERFACE_INCLUDE_DIRECTORIES)
+  elseif(TARGET PkgConfig::libudfread)
+    # First item is the full path of the library file found
+    # pkg_check_modules does not populate a variable of the found library explicitly
+    list(GET libudfread_LINK_LIBRARIES 0 UDFREAD_LIBRARY)
 
-      get_target_property(UDFREAD_INCLUDE_DIR PkgConfig::libudfread INTERFACE_INCLUDE_DIRECTORIES)
-      set(UDFREAD_VERSION ${libudfread_VERSION})
-    endif()
+    get_target_property(UDFREAD_INCLUDE_DIR PkgConfig::libudfread INTERFACE_INCLUDE_DIRECTORIES)
+    set(UDFREAD_VERSION ${libudfread_VERSION})
   endif()
-
-  include(SelectLibraryConfigurations)
-  select_library_configurations(UDFREAD)
-  unset(UDFREAD_LIBRARIES)
 
   find_package_handle_standard_args(Udfread
                                     REQUIRED_VARS UDFREAD_LIBRARY UDFREAD_INCLUDE_DIR
@@ -59,13 +48,13 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
   if(UDFREAD_FOUND)
     # windows cmake config populated target
-    if(TARGET libudfread::libudfread AND NOT TARGET udfread_build)
+    if(TARGET libudfread::libudfread)
       add_library(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} ALIAS libudfread::libudfread)
       add_library(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} ALIAS libudfread::libudfread)
       set_target_properties(libudfread::libudfread PROPERTIES
                                                    INTERFACE_COMPILE_DEFINITIONS HAS_UDFREAD)
     # pkgconfig populated target that is sufficient version
-    elseif(TARGET PkgConfig::libudfread AND NOT TARGET udfread_build)
+    elseif(TARGET PkgConfig::libudfread)
       add_library(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} ALIAS PkgConfig::libudfread)
       add_library(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} ALIAS PkgConfig::libudfread)
       set_target_properties(PkgConfig::libudfread PROPERTIES


### PR DESCRIPTION
## Description
Remove remnants of internal build for udfread.

All supported linux platform package managers supply/bundle udfread. At this time, remove the internal build implementation until an appropriate multi platform implementation is available

## Motivation and context
Fixes #26674

## How has this been tested?
N/A

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
