### PR TITLE
[pvr][video] Fix PVR recordings URL encoding bug (needs video database schema bump).

### DIFF
--- a/xbmc/pvr/recordings/PVRRecordingsPath.cpp
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.cpp
@@ -92,7 +92,14 @@ CPVRRecordingsPath::CPVRRecordingsPath(bool bDeleted,
 {
   std::string strDirectoryN(TrimSlashes(strDirectory));
   if (!strDirectoryN.empty())
+  {
+    std::vector<std::string> segments{StringUtils::Split(strDirectoryN, "/")};
+    for (auto& segment : segments)
+      segment = CURL::Encode(segment);
+
+    strDirectoryN = StringUtils::Join(segments, "/");
     strDirectoryN = StringUtils::Format("{}/", strDirectoryN);
+  }
 
   std::string strTitleN(strTitle);
   strTitleN = CURL::Encode(strTitleN);


### PR DESCRIPTION
Fixes directory path segments not being encoded in PVR recordings URLs. As these URLs end up in the video database to track play count, last played, play position, stream details, we need to fix the broken URLs in the database, thus videodb schema bump is needed.

Effect for users was play count etc. not tracked properly for recordings URLs containing directory path segments with special (reserved) characters, like `?`.

Carefully runtime-tested on macOS, latest Kodi master, esp. proper database migration.

@phunkyfish can you please review?