### PR TITLE
[filesystem][CurlFile] Allow switch to HEAD request

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -642,7 +642,14 @@ void CCurlFile::SetCommonOptions(CReadState* state, bool failOnError /* = true *
       g_curlInterface.easy_setopt(h, CURLOPT_PROXYUSERPWD, userpass.c_str());
   }
   if (m_customrequest.length() > 0)
+  {
     g_curlInterface.easy_setopt(h, CURLOPT_CUSTOMREQUEST, m_customrequest.c_str());
+    if (StringUtils::CompareNoCase(m_customrequest, "HEAD") == 0)
+    {
+      // Allow libcurl to switch to a proper HEAD request
+      g_curlInterface.easy_setopt(h, CURLOPT_NOBODY, 1);
+    }
+  }
 
   if (m_connecttimeout == 0)
     m_connecttimeout = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_curlconnecttimeout;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Im testing implementing HEAD request into InputStream Adaptive and i have seen this peculiarity on libcurl
that dont allow addons to make proper HEAD request

from InputStream interface for binary addons
an HTTP request is implied to be GET, unless `postdata` is set to ADDON_CURL_OPTION_PROTOCOL and this implicitly switch to POST request

if you have to do a HEAD request you need to set `customrequest` with "HEAD" value into ADDON_CURL_OPTION_PROTOCOL
https://github.com/xbmc/xbmc/blob/e30d10f4204d8301d8d9d62730edfe6f51344e4d/xbmc/addons/kodi-dev-kit/include/kodi/c-api/filesystem.h#L132-L134

but from libcurl perspective continue to do a behavior for the GET request, this can be noticed by comparing log
**without PR:**
`2025-04-23 08:20:30.633 T:20944   debug <general>: Curl::Debug - TEXT: no chunk, no close, no size. Assume close to signal end`
**with PR:**
`2025-04-23 08:19:06.202 T:4904    debug <general>: Curl::Debug - TEXT: Connection #0 to host www.xxx.yyy left intact`

from https://curl.se/libcurl/c/CURLOPT_CUSTOMREQUEST.html
the CURLOPT_NOBODY must be used
![immagine](https://github.com/user-attachments/assets/1719767b-ae16-47e0-a46f-548de294c758)

SIDENOTE:
this problem dont affect `CCurlFile::GetMimeType` used to make mimetype HEAD request
since it use "Stat" method that already set CURLOPT_NOBODY to make HEAD request
https://github.com/xbmc/xbmc/blob/e30d10f4204d8301d8d9d62730edfe6f51344e4d/xbmc/filesystem/CurlFile.cpp#L2004 

PS:
maybe same thing should be done for GET and POST use cases, so to allow switch to appropriate methods

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
can be tested by using
CI test build from https://github.com/xbmc/inputstream.adaptive/pull/1834 
and this STRM:
```
#KODIPROP:mimetype=application/dash+xml
#KODIPROP:inputstream=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_config={"dash_utctiming": {"urn:mpeg:dash:utc:http-head:2014": "https://time.akamai.com/?iso&amp;ms"}}
https://vs-dash-ww-rd.live.cf.md.bbci.co.uk/cpl/testcard2020/ll-avc-full.mpd
```
and see on log `https://time.akamai.com/?iso&amp;ms` curl request

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
