### PR TITLE
Bump Android NDK 28c

### DIFF
--- a/docs/README.Android.md
+++ b/docs/README.Android.md
@@ -73,8 +73,8 @@ sudo apt install autoconf bison build-essential curl default-jdk flex gawk git g
 **[back to top](#table-of-contents)**
 
 ## 3. Prerequisites
-Building Kodi for Android requires Android NDK revision 27c (27.2.12479018). For the SDK just use the latest available.
-Kodi CI/CD platforms currently use r27c for build testing and releases, so we recommend using r27c for the most tested build experience
+Building Kodi for Android requires Android NDK revision 28c (28.2.13676358). For the SDK just use the latest available.
+Kodi CI/CD platforms currently use r28c for build testing and releases, so we recommend using r28c for the most tested build experience
 
 * **[Android SDK](https://developer.android.com/studio/index.html)** (Look for `Get just the command line tools`)
 
@@ -100,7 +100,7 @@ cd $HOME/android-tools/android-sdk-linux/cmdline-tools/bin
 ./sdkmanager --sdk_root=$(pwd)/../.. platform-tools
 ./sdkmanager --sdk_root=$(pwd)/../.. "platforms;android-36"
 ./sdkmanager --sdk_root=$(pwd)/../.. "build-tools;36.0.0"
-./sdkmanager --sdk_root=$(pwd)/../.. "ndk;27.2.12479018"
+./sdkmanager --sdk_root=$(pwd)/../.. "ndk;28.2.13676358"
 ```
 
 ### 3.3. Create a key to sign debug APKs
@@ -243,7 +243,7 @@ make -j$(getconf _NPROCESSORS_ONLN)
 ```
 --with-ndk-path=<path>
 ```
-  specify path to ndk (optional for android), default is sdk_path/ndk/27.2.12479018
+  specify path to ndk (optional for android), default is sdk_path/ndk/28.2.13676358
 
 ```
 --with-sdk-path=<path>

--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -56,7 +56,7 @@ case $XBMC_PLATFORM_DIR in
     ;;
 
   android)
-    DEFAULT_NDK_VERSION="27.2.12479018" # NDK package version (newer API can be inside)
+    DEFAULT_NDK_VERSION="28.2.13676358" # NDK package version (newer API can be inside)
     DEFAULT_NDK_API="24" # Nougat API level (24) defined in package ./sysroot/usr/include/android/api-level.h
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="RelWithDebInfo"

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -77,9 +77,9 @@ AC_ARG_WITH([sdk-path],
 
 AC_ARG_WITH([ndk-path],
   [AS_HELP_STRING([--with-ndk-path],
-  [specify path to ndk (optional for android), default is sdk_path/ndk/27.2.12479018])],
+  [specify path to ndk (optional for android), default is sdk_path/ndk/28.2.13676358])],
   [use_ndk_path=$withval],
-  [use_ndk_path=$use_sdk_path/ndk/27.2.12479018])
+  [use_ndk_path=$use_sdk_path/ndk/28.2.13676358])
 
 AC_ARG_WITH([sdk],
   [AS_HELP_STRING([--with-sdk],


### PR DESCRIPTION
## Description
Update to the latest stable release.

For Jenkins: this NDK needs to be manually installed. 

## How has this been tested?
Runtime-tested on Chromecast with Google TV (Android TV 14) 

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed