### PR TITLE
[Android] XBMCProperties is initialized only after the properties file has been read

### DIFF
--- a/tools/android/packaging/xbmc/src/XBMCProperties.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCProperties.java.in
@@ -42,13 +42,13 @@ public class XBMCProperties
         FileInputStream xbmcenvprop = new FileInputStream(fProp);
         sysProp.load(xbmcenvprop);
         System.setProperties(sysProp);
+        System.setProperty("xbmc.proploaded", "yes");
       }
       catch (Exception e)
       {
         Log.e(TAG, "XBMCProperties: Error loading " + propfn + " (" + e.getMessage() + ")");
       }
     }
-    System.setProperty("xbmc.proploaded", "yes");
   }
 
   public static String getStringProperty(String key, String devValue)


### PR DESCRIPTION
## Description
Ensure that `XBMCProperties` is marked as initialized only when the properties have been read from the `xbmc_env.properties` file and no errors are present.

## Motivation and context
Note that this issue is only reproducible when the app is uninstalled and then reinstalled:

It's possible that during the initial startup stages, the app does not have the `MANAGE_EXTERNAL_STORAGE` permission and therefore cannot access the properties file.

```
I Kodi    : XBMCProperties: Loading /storage/emulated/0/xbmc_env.properties
E Kodi    : XBMCProperties: Error loading /storage/emulated/0/xbmc_env.properties (/storage/emulated/0/xbmc_env.properties: open failed: EACCES (Permission denied))
```

In this case, `XBMCProperties` is initialized with default values, and even if the permission is subsequently granted, the properties are not reloaded during the current session.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
