### PR TITLE
[cmake] FindIconv propogate FOUND variable for external searches

### DIFF
--- a/cmake/modules/FindIconv.cmake
+++ b/cmake/modules/FindIconv.cmake
@@ -29,6 +29,10 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     # for integration into our core dep packaging
     add_library(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} ALIAS Iconv::Iconv)
     add_library(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} ALIAS Iconv::Iconv)
+
+    # Required for external searches. Not used internally
+    set(Iconv_FOUND ON CACHE BOOL "Iconv found")
+    mark_as_advanced(Iconv_FOUND)
   else()
     if(Iconv_FIND_REQUIRED)
       message(FATAL_ERROR "Iconv libraries were not found.")


### PR DESCRIPTION
## Description
Set ``Iconv_FOUND`` variable as a cache variable in FindIconv

## Motivation and context
Some config files depend on Iconv_FOUND variable, and not the target name (eg exiv2), propagate the variable to allow their dependency checks to succeed

## How has this been tested?
Windows building.

```
CMake Error at C:/Program Files/CMake/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find Exiv2 (missing: EXIV2_LIBRARY EXIV2_INCLUDE_DIR) (found
  version "0.28.5")
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:603 (_FPHSA_FAILURE_MESSAGE)
  cmake/modules/FindExiv2.cmake:148 (find_package_handle_standard_args)
  cmake/scripts/common/Macros.cmake:378 (find_package)
  cmake/scripts/common/Macros.cmake:390 (find_package_with_ver)
  CMakeLists.txt:287 (core_require_dep)

```
The snippet with --trace where Iconv_FOUND is checked and fails

```
C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeFindDependencyMacro.cmake(76):  find_package(Iconv REQUIRED ${cmake_fd_quiet_arg} ${cmake_fd_required_arg} )
C:/xbmc/cmake/modules/FindIconv.cmake(12):  if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} )
C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeFindDependencyMacro.cmake(80):  list(POP_BACK _CMAKE_Iconv_HASH_STACK cmake_fd_call_hash )
C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeFindDependencyMacro.cmake(81):  set(_CMAKE_Iconv_${cmake_fd_call_hash}_FOUND ${Iconv_FOUND} )
C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeFindDependencyMacro.cmake(83):  if(NOT DEFINED cmake_fd_alreadyTransitive OR cmake_fd_alreadyTransitive )
C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeFindDependencyMacro.cmake(87):  unset(cmake_fd_alreadyTransitive )
C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeFindDependencyMacro.cmake(88):  unset(cmake_fd_call_hash )
C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeFindDependencyMacro.cmake(89):  unset(cmake_fd_quiet_arg )
C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeFindDependencyMacro.cmake(90):  unset(cmake_fd_required_arg )
C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeFindDependencyMacro.cmake(91):  if(NOT Iconv_FOUND )
C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeFindDependencyMacro.cmake(92):  set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE ${CMAKE_FIND_PACKAGE_NAME} could not be found because dependency Iconv could not be found. )
C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeFindDependencyMacro.cmake(93):  set(${CMAKE_FIND_PACKAGE_NAME}_FOUND False )
C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeFindDependencyMacro.cmake(94):  return()
```

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
