### PR TITLE
[cmake] Add ApplicationEnums.h to application/CMakeLists.txt

### DIFF
--- a/xbmc/application/CMakeLists.txt
+++ b/xbmc/application/CMakeLists.txt
@@ -16,6 +16,7 @@ set(HEADERS AppEnvironment.h
             AppInboundProtocol.h
             Application.h
             ApplicationActionListeners.h
+            ApplicationEnums.h
             ApplicationPlayer.h
             ApplicationPlayerCallback.h
             ApplicationPowerHandling.h


### PR DESCRIPTION
Nobrainer. Adds a header file to CMakeLists.txt which was forgotten when it was introduced.

@notspiff please review.