### PR TITLE
[guilib/listproviders] CDirectoryProvider: Ignore PVR events until PVR manager is fully initalized.

### DIFF
--- a/xbmc/guilib/listproviders/DirectoryProvider.h
+++ b/xbmc/guilib/listproviders/DirectoryProvider.h
@@ -125,6 +125,6 @@ private:
 
   std::string GetTarget(const CFileItem& item) const;
 
-  CCriticalSection m_subscriptionSection;
+  mutable CCriticalSection m_subscriptionSection;
   std::unique_ptr<CSubscriber> m_subscriber;
 };


### PR DESCRIPTION
PVR component is sending lots of events while initializing, which leads to frequent updates at the respective widgets at Estuary PVR home screen for example (same for other skins with PVR home screen widget support). These updates manifest in frequent "flickering" of the widgets.

This PR defers directory updates until PVR is fully initialized, effectively reducing the "flickering" a lot.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish although no pvr source code changed, I think this is something you could review. 

