### PR TITLE
[GUI] Always Sort the Specials Season at the Bottom

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -13928,6 +13928,7 @@ msgstr ""
 
 #: xbmc/media/MediaTypes.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
+#: xbmc/video/GUIViewStateVideo.cpp
 #: addons/skin.estuary/xml/DialogFullScreenInfo.xml
 #: addons/skin.estuary/xml/Variables.xml
 msgctxt "#20373"

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -17,6 +17,7 @@
 #include "utils/Variant.h"
 
 #include <algorithm>
+#include <limits>
 
 std::string ArrayToString(SortAttribute attributes, const CVariant &variant, const std::string &separator = " / ")
 {
@@ -356,10 +357,14 @@ std::string ByEpisodeNumber(SortAttribute attributes, const SortItem &values)
 
 std::string BySeason(SortAttribute attributes, const SortItem &values)
 {
-  int season = (int)values.at(FieldSeason).asInteger();
+  int season = static_cast<int>(values.at(FieldSeason).asInteger());
+
+  if (season == 0)
+    season = std::numeric_limits<int>::max();
+
   const CVariant &specialSeason = values.at(FieldSeasonSpecialSort);
   if (!specialSeason.isNull() && specialSeason.asInteger() > 0)
-    season = (int)specialSeason.asInteger();
+    season = static_cast<int>(specialSeason.asInteger());
 
   return StringUtils::Format("{} {}", season, ByLabel(attributes, values));
 }

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -358,7 +358,7 @@ std::string BySeason(SortAttribute attributes, const SortItem &values)
 {
   int season = (int)values.at(FieldSeason).asInteger();
   const CVariant &specialSeason = values.at(FieldSeasonSpecialSort);
-  if (!specialSeason.isNull())
+  if (!specialSeason.isNull() && specialSeason.asInteger() > 0)
     season = (int)specialSeason.asInteger();
 
   return StringUtils::Format("{} {}", season, ByLabel(attributes, values));

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -121,8 +121,9 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
       break;
       case NodeType::SEASONS:
       {
-        AddSortMethod(SortBySortTitle, 556, LABEL_MASKS("%L", "","%L",""));  // Label, empty | Label, empty
-        SetSortMethod(SortBySortTitle);
+        AddSortMethod(SortBySeason, 20373,
+                      LABEL_MASKS("%L", "", "%L", "")); // Label, empty | Label, empty
+        SetSortMethod(SortBySeason);
 
         const CViewState *viewState = CViewStateSettings::GetInstance().Get("videonavseasons");
         SetViewAsControl(viewState->m_viewMode);

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -846,21 +846,12 @@ void CVideoInfoTag::ToSortable(SortItem& sortable, Field field) const
   }
   case FieldSortTitle:
   {
-    // seasons with a custom name/title need special handling as they should be sorted by season number
-    if (m_type == MediaTypeSeason && !m_strSortTitle.empty())
-      sortable[FieldSortTitle] = StringUtils::Format(g_localizeStrings.Get(20358), m_iSeason);
-    else
-      sortable[FieldSortTitle] = m_strSortTitle;
+    sortable[FieldSortTitle] = m_strSortTitle;
     break;
   }
   case FieldOriginalTitle:
   {
-    // seasons with a custom name/title need special handling as they should be sorted by season number
-    if (m_type == MediaTypeSeason && !m_strOriginalTitle.empty())
-      sortable[FieldOriginalTitle] =
-          StringUtils::Format(g_localizeStrings.Get(20358).c_str(), m_iSeason);
-    else
-      sortable[FieldOriginalTitle] = m_strOriginalTitle;
+    sortable[FieldOriginalTitle] = m_strOriginalTitle;
     break;
   }
   case FieldTvShowStatus:             sortable[FieldTvShowStatus] = m_strStatus; break;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

### Current
The sort order of seasons is currently a strange exception grafted on the alphabetical  sort by title and sometimes use the season numbers (named seasons), and other times not.

With the English language, this is the usual situation (specials season of most tv shows are unnamed):
| Label | Sort Label |
|:---|:---|
| Season 1 | Season 1 |
| Specials | Specials |

(specials season at the bottom)

but with a named specials season:

| Label | Sort Label |
|:---|:---|
| Specialzzz | Season 0 |
| Season 1 | Season 1 |

(specials season at the top)

A similar thing happens when changing languages and disturbs the position of the specials season.

### With the PR

The PR removes those inconsistencies by fixing up the BySeason sort order that wasn't used until now for some reason.
It is now the sort order of seasons and systematically sorts by season number. The specials season number is set to maxint during the sort to be sure it will always be at the end of the list.
At the same time the exception in the ByTitle sort order was removed.

New sorting:
| Label | Sort Label |
|:---|:---|
| Season 1 | 1 |
| Named or Unnamed Specials Season | MAX_INT |

(specials season at the bottom)

There is a minor impact on linked movies with the PR as it currently is. They will appear after seasons and specials (unless their title starts with a digit). This could be changed, if requested.
The wiki says that the sort order of linked movies cannot be controlled, so no official behavior is broken either way.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Reported in the forums https://forum.kodi.tv/showthread.php?tid=380356
and closes #26651.

Issue observed in German and also for some series in English.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Series with named seasons and specials season, series with unnamed seasons and specials season and combinations of both.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Consistent place of the Specials season in shows' seasons listing.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
