### PR TITLE
Remove IVECFILEITEM type def

### DIFF
--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -622,12 +622,6 @@ typedef std::shared_ptr<CFileItem> CFileItemPtr;
 typedef std::vector< CFileItemPtr > VECFILEITEMS;
 
 /*!
-  \brief Iterator for VECFILEITEMS
-  \sa CFileItemList
-  */
-typedef std::vector< CFileItemPtr >::iterator IVECFILEITEMS;
-
-/*!
   \brief A map of pointers to CFileItem
   \sa CFileItem
   */

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -190,18 +190,15 @@ void CFileItemList::AddFront(const CFileItemPtr& pItem, int itemPosition)
 void CFileItemList::Remove(CFileItem* pItem)
 {
   std::unique_lock<CCriticalSection> lock(m_lock);
-
-  for (IVECFILEITEMS it = m_items.begin(); it != m_items.end(); ++it)
+  const auto it =
+      std::ranges::find_if(m_items, [pItem](const auto& item) { return item.get() == pItem; });
+  if (it != m_items.end())
   {
-    if (pItem == it->get())
+    m_items.erase(it);
+    if (m_fastLookup)
     {
-      m_items.erase(it);
-      if (m_fastLookup)
-      {
-        m_map.erase(m_ignoreURLOptions ? CURL(pItem->GetPath()).GetWithoutOptions()
-                                       : pItem->GetPath());
-      }
-      break;
+      m_map.erase(m_ignoreURLOptions ? CURL(pItem->GetPath()).GetWithoutOptions()
+                                     : pItem->GetPath());
     }
   }
 }


### PR DESCRIPTION
## Description
Remove a shout'y and barely used typedef.

## Motivation and context
Typedefs for iterators are mostly unnecessary these days with ranged loops and auto.
Let's drop it.

## How has this been tested?
It builds

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
