### PR TITLE
Remove MAPFILEITEMPAIR type def

### DIFF
--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -633,11 +633,5 @@ typedef std::vector< CFileItemPtr >::iterator IVECFILEITEMS;
   */
 typedef std::map<std::string, CFileItemPtr > MAPFILEITEMS;
 
-/*!
-  \brief Pair for MAPFILEITEMS
-  \sa MAPFILEITEMS
-  */
-typedef std::pair<std::string, CFileItemPtr > MAPFILEITEMSPAIR;
-
 typedef bool (*FILEITEMLISTCOMPARISONFUNC) (const CFileItemPtr &pItem1, const CFileItemPtr &pItem2);
 typedef void (*FILEITEMFILLFUNC)(CFileItemPtr& item);

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -92,9 +92,9 @@ void CFileItemList::SetFastLookup(bool fastLookup)
     for (unsigned int i = 0; i < m_items.size(); i++)
     {
       CFileItemPtr pItem = m_items[i];
-      m_map.insert(MAPFILEITEMSPAIR(m_ignoreURLOptions ? CURL(pItem->GetPath()).GetWithoutOptions()
-                                                       : pItem->GetPath(),
-                                    pItem));
+      m_map.emplace(m_ignoreURLOptions ? CURL(pItem->GetPath()).GetWithoutOptions()
+                                       : pItem->GetPath(),
+                    pItem);
     }
   }
   if (!fastLookup && m_fastLookup)
@@ -153,8 +153,8 @@ void CFileItemList::Add(CFileItemPtr pItem)
 {
   std::unique_lock<CCriticalSection> lock(m_lock);
   if (m_fastLookup)
-    m_map.insert(MAPFILEITEMSPAIR(
-        m_ignoreURLOptions ? CURL(pItem->GetPath()).GetWithoutOptions() : pItem->GetPath(), pItem));
+    m_map.emplace(
+        m_ignoreURLOptions ? CURL(pItem->GetPath()).GetWithoutOptions() : pItem->GetPath(), pItem);
   m_items.emplace_back(std::move(pItem));
 }
 
@@ -163,8 +163,8 @@ void CFileItemList::Add(CFileItem&& item)
   std::unique_lock<CCriticalSection> lock(m_lock);
   auto ptr = std::make_shared<CFileItem>(std::move(item));
   if (m_fastLookup)
-    m_map.insert(MAPFILEITEMSPAIR(
-        m_ignoreURLOptions ? CURL(ptr->GetPath()).GetWithoutOptions() : ptr->GetPath(), ptr));
+    m_map.emplace(m_ignoreURLOptions ? CURL(ptr->GetPath()).GetWithoutOptions() : ptr->GetPath(),
+                  ptr);
   m_items.emplace_back(std::move(ptr));
 }
 
@@ -182,8 +182,8 @@ void CFileItemList::AddFront(const CFileItemPtr& pItem, int itemPosition)
   }
   if (m_fastLookup)
   {
-    m_map.insert(MAPFILEITEMSPAIR(
-        m_ignoreURLOptions ? CURL(pItem->GetPath()).GetWithoutOptions() : pItem->GetPath(), pItem));
+    m_map.emplace(
+        m_ignoreURLOptions ? CURL(pItem->GetPath()).GetWithoutOptions() : pItem->GetPath(), pItem);
   }
 }
 


### PR DESCRIPTION
## Description
Remove a shout'y typedef

## Motivation and context
Typedef was only used to do suboptimal map insertions. Improve those,
and remove the typedef.

## How has this been tested?
It builds

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
