### PR TITLE
[bluray] gate includes based on HAVE_LIBBLURAY

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -56,7 +56,9 @@
 #include "events/EventLog.h"
 #include "events/NotificationEvent.h"
 #include "favourites/FavouritesService.h"
+#ifdef HAVE_LIBBLURAY
 #include "filesystem/BlurayDiscCache.h"
+#endif
 #include "filesystem/Directory.h"
 #include "filesystem/DirectoryCache.h"
 #include "filesystem/DirectoryFactory.h"

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -35,7 +35,9 @@
 #include "addons/VFSEntry.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogPlayEject.h"
+#ifdef HAVE_LIBBLURAY
 #include "filesystem/BlurayDiscCache.h"
+#endif
 #include "messaging/helpers/DialogOKHelper.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"


### PR DESCRIPTION
## Description
Only add bluray includes if bluray enabled

## Motivation and context
Someone in one of the kodi chat channels said using ``-DENABLE_BLURAY=OFF`` with master no longer built.

```
In file included from /xbmc/storage/MediaManager.cpp:38:
In file included from/xbmc/filesystem/BlurayDiscCache.h:11:
/xbmc/filesystem/BlurayDirectory.h:18:10: fatal error: 'libbluray/bluray.h' file not found
   18 | #include <libbluray/bluray.h>
      |          ^~~~~~~~~~~~~~~~~~~~
```

```
In file included from /xbmc/application/Application.cpp:59:
In file included from /xbmc/filesystem/BlurayDiscCache.h:11:
/xbmc/filesystem/BlurayDirectory.h:18:10: fatal error: 'libbluray/bluray.h' file not found
   18 | #include <libbluray/bluray.h>
      |          ^~~~~~~~~~~~~~~~~~~~
```

## How has this been tested?
Build master with ``-DENABLE_BLURAY=OFF``

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
