### PR TITLE
[video] Fix CGUIWindowVideoBase::ShowInfoAndRefresh return value. …

### DIFF
--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -2,7 +2,7 @@
 <window>
 	<visible>Window.IsActive(fullscreenvideo) | Window.IsActive(visualisation)</visible>
 	<visible>![Window.IsActive(sliderdialog) | Window.IsActive(pvrosdchannels) | Window.IsActive(pvrchannelguide) | Window.IsActive(pvrguideinfo) | Window.IsActive(1110)]</visible>
-	<visible>Player.Seeking | Player.HasPerformedSeek(3) | [Player.Paused + !Player.Caching] | Player.Forwarding | Player.Rewinding | [Player.ShowInfo + Window.IsActive(visualisation)] | Window.IsActive(fullscreeninfo) | Player.ShowTime | Window.IsActive(videoosd) | Window.IsActive(musicosd) | Window.IsActive(playerprocessinfo) | !String.IsEmpty(Player.SeekNumeric) | !String.IsEmpty(PVR.ChannelNumberInput)</visible>
+	<visible>Player.Seeking | Player.HasPerformedSeek(3) | [Player.Paused + !Player.Caching] | Player.Forwarding | Player.Rewinding | Player.ShowInfo | Window.IsActive(fullscreeninfo) | Player.ShowTime | Window.IsActive(videoosd) | Window.IsActive(musicosd) | Window.IsActive(playerprocessinfo) | !String.IsEmpty(Player.SeekNumeric) | !String.IsEmpty(PVR.ChannelNumberInput)</visible>
 	<include>Animation_BottomSlide</include>
 	<depth>DepthOSD</depth>
 	<zorder>0</zorder>

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -169,7 +169,8 @@ bool CGUIWindowVideoBase::OnMessage(CGUIMessage& message)
         }
         else if (iAction == ACTION_SHOW_INFO)
         {
-          return OnItemInfo(iItem);
+          OnItemInfo(iItem);
+          return true;
         }
         else if (iAction == ACTION_PLAYER_PLAY)
         {

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -122,11 +122,19 @@ protected:
   bool m_stackingAvailable;
 
 private:
+  enum class ShowInfoResult
+  {
+    RESULT_ERROR, // some error occured
+    RESULT_OK_UPDATED, // no error, data updated
+    RESULT_OK_NOT_UPDATED, // no error, data not updated
+  };
+
   /*!
    \brief Lookup the information of an item and display an Info dialog
    \param item the item to lookup
    \param content
-   \return true: the information of the item was modified. false: no change.
+   \return the result.
    */
-  bool ShowInfo(const CFileItemPtr& item, const ADDON::ScraperPtr& content);
+  ShowInfoResult ShowInfo(const std::shared_ptr<CFileItem>& item,
+                          const std::shared_ptr<ADDON::CScraper>& content);
 };


### PR DESCRIPTION
`CGUIWindowVideoBase::ShowInfoAndRefresh` must return "success" not "needsrefresh". Otherwise certain actions could be handled multiple times, e.g. `ACTION_SHOW_INFO`, with undefined behavior.

Fixes a problem @CrystalP reported on Slack.

>  Play a movie from the library. TAB to go back to menu, press i to show info dialog, press TAB > returns to fullscreen movie, with info OSD but it can't be toggled off with i. Only way out I found is to tab out/back in again.

Reverts #26702 (wrong fix approach, nothing for the skin can fix).

Runtime-tested on macOS, latest Kodi master.

@CrystalP can you please review.