### PR TITLE
[addons] CAddonInfo::GetKnownInstanceIds(): Fix SonarQube issue…

### DIFF
--- a/xbmc/addons/addoninfo/AddonInfo.cpp
+++ b/xbmc/addons/addoninfo/AddonInfo.cpp
@@ -301,7 +301,7 @@ std::vector<AddonInstanceId> CAddonInfo::GetKnownInstanceIds() const
       {
         URIUtils::RemoveExtension(filename);
         const std::string_view uid(filename.data() + startName.length());
-        if (!uid.empty() && StringUtils::IsInteger(uid.data()))
+        if (!uid.empty() && StringUtils::IsInteger(uid))
           ret.emplace_back(std::atoi(uid.data()));
       }
     }


### PR DESCRIPTION
'Remove this call to data() to properly handle non null-terminated string_views.' Must have slipped through while changing the implementation to use `string_view`.

@neo1973 could you have a look please.