### PR TITLE
[PVR] SonarQube finding cpp:S6012: Avoid explicitly specifying the te…

### DIFF
--- a/xbmc/pvr/PVRChannelNumberInputHandler.cpp
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.cpp
@@ -39,7 +39,7 @@ void CPVRChannelNumberInputHandler::OnTimeout()
 {
   if (m_inputBuffer.empty())
   {
-    std::unique_lock<CCriticalSection> lock(m_mutex);
+    std::unique_lock lock(m_mutex);
     SetLabel("");
   }
   else
@@ -47,7 +47,7 @@ void CPVRChannelNumberInputHandler::OnTimeout()
     // call the overridden worker method
     OnInputDone();
 
-    std::unique_lock<CCriticalSection> lock(m_mutex);
+    std::unique_lock lock(m_mutex);
 
     // erase input buffer immediately , but...
     m_inputBuffer.erase();
@@ -83,7 +83,7 @@ void CPVRChannelNumberInputHandler::AppendChannelNumberCharacter(char cCharacter
   if (cCharacter != CPVRChannelNumber::SEPARATOR && (cCharacter < '0' || cCharacter > '9'))
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   if (cCharacter == CPVRChannelNumber::SEPARATOR)
   {
@@ -144,7 +144,7 @@ CPVRChannelNumber CPVRChannelNumberInputHandler::GetChannelNumber() const
   int iChannelNumber = 0;
   int iSubChannelNumber = 0;
 
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   size_t pos = m_inputBuffer.find(CPVRChannelNumber::SEPARATOR);
   if (pos != std::string::npos)
@@ -173,13 +173,13 @@ bool CPVRChannelNumberInputHandler::HasChannelNumber() const
 
 std::string CPVRChannelNumberInputHandler::GetChannelNumberLabel() const
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
   return m_label;
 }
 
 void CPVRChannelNumberInputHandler::SetLabel(const std::string& label)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
   if (label != m_label)
   {
     m_label = label;

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -117,13 +117,13 @@ namespace
 
 bool CPVRDatabase::Open()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return CDatabase::Open(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_databaseTV);
 }
 
 void CPVRDatabase::Close()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   CDatabase::Close();
 }
 
@@ -139,7 +139,7 @@ void CPVRDatabase::Unlock()
 
 void CPVRDatabase::CreateTables()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   CLog::LogF(LOGINFO, "Creating PVR database tables");
 
@@ -214,7 +214,7 @@ void CPVRDatabase::CreateTables()
 
 void CPVRDatabase::CreateAnalytics()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   CLog::LogF(LOGINFO, "Creating PVR database indices");
   m_pDS->exec("CREATE INDEX idx_clients_idClient on clients(idClient);");
@@ -226,7 +226,7 @@ void CPVRDatabase::CreateAnalytics()
 
 void CPVRDatabase::UpdateTables(int iVersion)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (iVersion < 13)
     m_pDS->exec("ALTER TABLE channels ADD idEpg integer;");
@@ -405,7 +405,7 @@ bool CPVRDatabase::DeleteClients()
 {
   CLog::LogFC(LOGDEBUG, LOGPVR, "Deleting all clients from the database");
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return DeleteValues("clients");
 }
 
@@ -421,7 +421,7 @@ bool CPVRDatabase::Persist(const CPVRClient& client)
   if (dateTime.IsValid())
     dateTimeAdded = dateTime.GetAsDBDateTime();
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   const std::string sql{
       PrepareSQL("REPLACE INTO clients (idClient, iPriority, sAddonID, iInstanceID, "
@@ -438,7 +438,7 @@ bool CPVRDatabase::Delete(const CPVRClient& client)
 
   CLog::LogFC(LOGDEBUG, LOGPVR, "Deleting client {} from the database", client.GetID());
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   Filter filter;
   filter.AppendWhere(PrepareSQL("idClient = '%i'", client.GetID()));
@@ -453,7 +453,7 @@ int CPVRDatabase::GetPriority(const CPVRClient& client) const
 
   CLog::LogFC(LOGDEBUG, LOGPVR, "Getting priority for client {} from the database", client.GetID());
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   const std::string strWhereClause = PrepareSQL("idClient = '%i'", client.GetID());
   const std::string strValue = GetSingleValue("clients", "iPriority", strWhereClause);
@@ -473,7 +473,7 @@ CDateTime CPVRDatabase::GetDateTimeFirstChannelsAdded(const CPVRClient& client) 
               "Getting datetime first channels added for client {} from the database",
               client.GetID());
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   const std::string whereClause{PrepareSQL("idClient = %i", client.GetID())};
   const std::string value{GetSingleValue("clients", "sDateTimeFirstChannelsAdded", whereClause)};
@@ -574,7 +574,7 @@ void CPVRDatabase::FixupClientIDs()
 
 int CPVRDatabase::GetClientID(const std::string& addonID, unsigned int instanceID)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // Client id already present in clients table?
   std::string sql{PrepareSQL("sAddonID = '%s' AND iInstanceID = %i", addonID.c_str(), instanceID)};
@@ -599,7 +599,7 @@ bool CPVRDatabase::DeleteProviders()
 {
   CLog::LogFC(LOGDEBUG, LOGPVR, "Deleting all providers from the database");
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return DeleteValues("providers");
 }
 
@@ -614,7 +614,7 @@ bool CPVRDatabase::Persist(CPVRProvider& provider, bool updateRecord /* = false 
 
   std::string strQuery;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   {
     /* insert a new entry when this is a new group, or replace the existing one otherwise */
     if (!updateRecord)
@@ -653,7 +653,7 @@ bool CPVRDatabase::Delete(const CPVRProvider& provider)
   CLog::LogFC(LOGDEBUG, LOGPVR, "Deleting provider '{}' from the database",
               provider.GetName());
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   Filter filter;
   filter.AppendWhere(PrepareSQL("idProvider = '%i'", provider.GetDatabaseId()));
@@ -671,7 +671,7 @@ bool CPVRDatabase::Get(CPVRProviders& results,
   if (!clientIds.empty())
     strQuery += "WHERE " + clientIds + " OR iType = 1"; // always load addon providers
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   strQuery = PrepareSQL(strQuery);
   if (ResultQuery(strQuery))
   {
@@ -712,7 +712,7 @@ bool CPVRDatabase::Get(CPVRProviders& results,
 int CPVRDatabase::GetMaxProviderId() const
 {
   std::string strQuery = PrepareSQL("SELECT max(idProvider) as maxProviderId from providers");
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   return GetSingleValueInt(strQuery);
 }
@@ -730,7 +730,7 @@ int CPVRDatabase::Get(bool bRadio,
   if (!clientIds.empty())
     strQuery += "AND " + clientIds;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   strQuery = PrepareSQL(strQuery, bRadio);
   if (ResultQuery(strQuery))
   {
@@ -788,7 +788,7 @@ bool CPVRDatabase::DeleteChannels()
 {
   CLog::LogFC(LOGDEBUG, LOGPVR, "Deleting all channels from the database");
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   // Reset datetime first channels added for all clients.
   if (!ExecuteQuery("UPDATE clients SET sDateTimeFirstChannelsAdded = ''"))
     return false;
@@ -845,7 +845,7 @@ bool CPVRDatabase::RemoveChannelsFromGroup(const CPVRChannelGroup& group)
   Filter filter;
   filter.AppendWhere(PrepareSQL("idGroup = %i", group.GroupID()));
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return DeleteValues("map_channelgroups_channels", filter);
 }
 
@@ -853,7 +853,7 @@ bool CPVRDatabase::DeleteChannelGroups()
 {
   CLog::LogFC(LOGDEBUG, LOGPVR, "Deleting all channel groups from the database");
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return DeleteValues("channelgroups") && DeleteValues("map_channelgroups_channels");
 }
 
@@ -866,7 +866,7 @@ bool CPVRDatabase::Delete(const CPVRChannelGroup& group)
     return false;
   }
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   Filter filter;
   filter.AppendWhere(PrepareSQL("idGroup = %i", group.GroupID()));
@@ -921,7 +921,7 @@ int CPVRDatabase::GetGroups(CPVRChannelGroups& results, const std::string& query
 
 int CPVRDatabase::GetLocalGroups(CPVRChannelGroups& results) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string query = PrepareSQL(
       "SELECT * from channelgroups WHERE bIsRadio = %u AND iClientId = -1", results.IsRadio());
   return GetGroups(results, query);
@@ -937,7 +937,7 @@ int CPVRDatabase::Get(CPVRChannelGroups& results,
   if (!clientIds.empty())
     query += "AND " + clientIds;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   query = PrepareSQL(query, results.IsRadio());
   return GetGroups(results, query);
 }
@@ -970,7 +970,7 @@ std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRDatabase::Get(
     strQuery += "AND " + clientIds;
   strQuery += " ORDER BY map_channelgroups_channels.iChannelNumber";
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   strQuery = PrepareSQL(strQuery, group.GroupID());
   if (ResultQuery(strQuery))
   {
@@ -1123,7 +1123,7 @@ bool CPVRDatabase::PersistGroupMembers(const CPVRChannelGroup& group)
 
 bool CPVRDatabase::ResetEPG()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strQuery = PrepareSQL("UPDATE channels SET idEpg = 0");
   return ExecuteQuery(strQuery);
 }
@@ -1139,7 +1139,7 @@ bool CPVRDatabase::Persist(CPVRChannelGroup& group)
 
   std::string strQuery;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (group.HasChanges() || group.IsNew())
   {
@@ -1200,7 +1200,7 @@ bool CPVRDatabase::Persist(CPVRChannel& channel, bool bCommit)
   if (channel.DateTimeAdded().IsValid())
     dateTimeAdded = channel.DateTimeAdded().GetAsDBDateTime();
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // Note: Do not use channel.ChannelID value to check presence of channel in channels table. It might not yet be set correctly.
   std::string strQuery =
@@ -1259,7 +1259,7 @@ bool CPVRDatabase::Persist(CPVRChannel& channel, bool bCommit)
 
 bool CPVRDatabase::UpdateLastWatched(const CPVRChannel& channel, int groupId)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strQuery = PrepareSQL(
       "UPDATE channels SET iLastWatched = %u, iLastWatchedGroupId = %i WHERE idChannel = %i",
       static_cast<unsigned int>(channel.LastWatched()), groupId, channel.ChannelID());
@@ -1268,7 +1268,7 @@ bool CPVRDatabase::UpdateLastWatched(const CPVRChannel& channel, int groupId)
 
 bool CPVRDatabase::UpdateLastWatched(const CPVRChannelGroup& group)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strQuery =
       PrepareSQL("UPDATE channelgroups SET iLastWatched = %u WHERE idGroup = %i",
                  static_cast<unsigned int>(group.LastWatched()), group.GroupID());
@@ -1277,7 +1277,7 @@ bool CPVRDatabase::UpdateLastWatched(const CPVRChannelGroup& group)
 
 bool CPVRDatabase::UpdateLastOpened(const CPVRChannelGroup& group)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strQuery =
       PrepareSQL("UPDATE channelgroups SET iLastOpened = %llu WHERE idGroup = %i",
                  group.LastOpened(), group.GroupID());
@@ -1296,7 +1296,7 @@ std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRDatabase::GetTimers(
   if (!clientIds.empty())
     strQuery += "WHERE " + clientIds + " OR (iClientId = -1)"; // always load client agnostic timers
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   strQuery = PrepareSQL(strQuery);
   if (ResultQuery(strQuery))
   {
@@ -1349,7 +1349,7 @@ std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRDatabase::GetTimers(
 
 bool CPVRDatabase::Persist(CPVRTimerInfoTag& timer)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // insert a new entry if this is a new timer, or replace the existing one otherwise
   std::string strQuery;
@@ -1401,7 +1401,7 @@ bool CPVRDatabase::Delete(const CPVRTimerInfoTag& timer)
 
   CLog::LogFC(LOGDEBUG, LOGPVR, "Deleting timer '{}' from the database", timer.m_iClientIndex);
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   Filter filter;
   filter.AppendWhere(PrepareSQL("iClientIndex = '%i'", -timer.m_iClientIndex));
@@ -1413,6 +1413,6 @@ bool CPVRDatabase::DeleteTimers()
 {
   CLog::LogFC(LOGDEBUG, LOGPVR, "Deleting all timers from the database");
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return DeleteValues("timers");
 }

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -129,21 +129,21 @@ private:
 
 void CPVRManagerJobQueue::Start()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_bStopped = false;
   m_triggerEvent.Set();
 }
 
 void CPVRManagerJobQueue::Stop()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_bStopped = true;
   m_triggerEvent.Reset();
 }
 
 void CPVRManagerJobQueue::Clear()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (CPVRJob* updateJob : m_pendingUpdates)
     delete updateJob;
 
@@ -153,7 +153,7 @@ void CPVRManagerJobQueue::Clear()
 
 void CPVRManagerJobQueue::AppendJob(CPVRJob* job)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // check for another pending job of given type...
   if (std::any_of(m_pendingUpdates.cbegin(), m_pendingUpdates.cend(),
@@ -172,7 +172,7 @@ void CPVRManagerJobQueue::ExecutePendingJobs()
   std::vector<CPVRJob*> pendingUpdates;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     if (m_bStopped)
       return;
@@ -243,7 +243,7 @@ void CPVRManager::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
 
 std::shared_ptr<CPVRDatabase> CPVRManager::GetTVDatabase() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (!m_database || !m_database->IsOpen())
     CLog::LogF(LOGERROR, "Failed to open the PVR database");
 
@@ -252,25 +252,25 @@ std::shared_ptr<CPVRDatabase> CPVRManager::GetTVDatabase() const
 
 std::shared_ptr<CPVRProviders> CPVRManager::Providers() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_providers;
 }
 
 std::shared_ptr<CPVRChannelGroupsContainer> CPVRManager::ChannelGroups() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_channelGroups;
 }
 
 std::shared_ptr<CPVRRecordings> CPVRManager::Recordings() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_recordings;
 }
 
 std::shared_ptr<CPVRTimers> CPVRManager::Timers() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_timers;
 }
 
@@ -334,7 +334,7 @@ void CPVRManager::Clear()
   m_playbackState->Clear();
   m_pendingUpdates->Clear();
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_guiInfo.reset();
   m_timers.reset();
@@ -347,7 +347,7 @@ void CPVRManager::Clear()
 
 void CPVRManager::ResetProperties()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   Clear();
 
   m_database = std::make_shared<CPVRDatabase>();
@@ -372,7 +372,7 @@ void CPVRManager::Init()
 
 void CPVRManager::Start()
 {
-  std::unique_lock<CCriticalSection> initLock(m_startStopMutex);
+  std::unique_lock initLock(m_startStopMutex);
 
   // Prevent concurrent starts
   if (IsInitialising())
@@ -397,7 +397,7 @@ void CPVRManager::Start()
 
 void CPVRManager::Stop(bool bRestart /* = false */)
 {
-  std::unique_lock<CCriticalSection> initLock(m_startStopMutex);
+  std::unique_lock initLock(m_startStopMutex);
 
   // Prevent concurrent stops
   if (IsStopped())
@@ -434,14 +434,14 @@ void CPVRManager::Deinit()
 
 CPVRManager::ManagerState CPVRManager::GetState() const
 {
-  std::unique_lock<CCriticalSection> lock(m_managerStateMutex);
+  std::unique_lock lock(m_managerStateMutex);
   return m_managerState;
 }
 
 void CPVRManager::SetState(CPVRManager::ManagerState state)
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_managerStateMutex);
+    std::unique_lock lock(m_managerStateMutex);
     if (m_managerState == state)
       return;
 
@@ -550,7 +550,7 @@ void CPVRManager::Process()
     if (m_bFirstStart)
     {
       {
-        std::unique_lock<CCriticalSection> lock(m_critSection);
+        std::unique_lock lock(m_critSection);
         m_bFirstStart = false;
       }
 
@@ -865,7 +865,7 @@ void CPVRManager::OnPlaybackEnded(const CFileItem& item)
 
 void CPVRManager::LocalizationChanged()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (IsStarted())
   {
     static_cast<CPVRChannelGroupAllChannels*>(m_channelGroups->GetGroupAllRadio().get())

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -65,7 +65,7 @@ CPVRPlaybackState::~CPVRPlaybackState() = default;
 
 void CPVRPlaybackState::ReInit()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   Clear();
 
@@ -129,7 +129,7 @@ void CPVRPlaybackState::ClearData()
 
 void CPVRPlaybackState::Clear()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_playingChannel.reset();
   m_playingRecording.reset();
@@ -234,7 +234,7 @@ bool CPVRPlaybackState::OnPreparePlayback(CFileItem& item)
 
 void CPVRPlaybackState::OnPlaybackStarted(const CFileItem& item)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_playingChannel.reset();
   m_playingRecording.reset();
@@ -319,7 +319,7 @@ bool CPVRPlaybackState::OnPlaybackStopped(const CFileItem& item)
 {
   // Playback ended due to user interaction
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   bool bChanged = false;
 
@@ -379,7 +379,7 @@ std::unique_ptr<CFileItem> CPVRPlaybackState::GetNextAutoplayItem(const CFileIte
   if (!item.GetProperty("epg_playlist_item").asBoolean(false))
     return {};
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (item.HasEPGInfoTag() && item.GetEPGInfoTag()->ClientID() == m_playingClientId &&
       item.GetEPGInfoTag()->UniqueChannelID() == m_playingEpgTagChannelUniqueId &&
@@ -458,43 +458,43 @@ void CPVRPlaybackState::StartPlayback(std::unique_ptr<CFileItem>& item,
 
 bool CPVRPlaybackState::IsPlaying() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_playingChannel != nullptr || m_playingRecording != nullptr || m_playingEpgTag != nullptr;
 }
 
 bool CPVRPlaybackState::IsPlayingTV() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_playingChannel && !m_playingChannel->Channel()->IsRadio();
 }
 
 bool CPVRPlaybackState::IsPlayingRadio() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_playingChannel && m_playingChannel->Channel()->IsRadio();
 }
 
 bool CPVRPlaybackState::IsPlayingEncryptedChannel() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_playingChannel && m_playingChannel->Channel()->IsEncrypted();
 }
 
 bool CPVRPlaybackState::IsPlayingRecording() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_playingRecording != nullptr;
 }
 
 bool CPVRPlaybackState::IsPlayingEpgTag() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_playingEpgTag != nullptr;
 }
 
 bool CPVRPlaybackState::IsPlayingChannel(int iClientID, int iUniqueChannelID) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_playingClientId == iClientID && m_playingChannelUniqueId == iUniqueChannelID;
 }
 
@@ -541,43 +541,43 @@ bool CPVRPlaybackState::IsPlayingEpgTag(const std::shared_ptr<const CPVREpgInfoT
 
 std::shared_ptr<CPVRChannel> CPVRPlaybackState::GetPlayingChannel() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_playingChannel ? m_playingChannel->Channel() : std::shared_ptr<CPVRChannel>();
 }
 
 std::shared_ptr<CPVRChannelGroupMember> CPVRPlaybackState::GetPlayingChannelGroupMember() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_playingChannel;
 }
 
 std::shared_ptr<CPVRRecording> CPVRPlaybackState::GetPlayingRecording() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_playingRecording;
 }
 
 std::shared_ptr<CPVREpgInfoTag> CPVRPlaybackState::GetPlayingEpgTag() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_playingEpgTag;
 }
 
 int CPVRPlaybackState::GetPlayingChannelUniqueID() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_playingChannelUniqueId;
 }
 
 std::string CPVRPlaybackState::GetPlayingClientName() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strPlayingClientName;
 }
 
 int CPVRPlaybackState::GetPlayingClientID() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_playingClientId;
 }
 
@@ -726,13 +726,13 @@ void CPVRPlaybackState::UpdateLastWatched(const std::shared_ptr<CPVRChannelGroup
 std::shared_ptr<CPVRChannelGroupMember> CPVRPlaybackState::GetLastPlayedChannelGroupMember(
     bool bRadio) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return bRadio ? m_lastPlayedChannelRadio : m_lastPlayedChannelTV;
 }
 
 std::shared_ptr<CPVRChannelGroupMember> CPVRPlaybackState::
     GetPreviousToLastPlayedChannelGroupMember(bool bRadio) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return bRadio ? m_previousToLastPlayedChannelRadio : m_previousToLastPlayedChannelTV;
 }

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -464,7 +464,7 @@ void CPVRClient::OnPreUnInstall()
 
 void CPVRClient::ResetProperties()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   /* initialise members */
   m_strUserPath = CSpecialProtocol::TranslatePath(Profile());
@@ -594,7 +594,7 @@ bool CPVRClient::ReadyToUse() const
 
 PVR_CONNECTION_STATE CPVRClient::GetConnectionState() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_connectionState;
 }
 
@@ -612,7 +612,7 @@ void CPVRClient::SetConnectionState(PVR_CONNECTION_STATE state)
       CLog::LogF(LOGERROR, "Cannot read PVR client name string properties");
   }
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_prevConnectionState = m_connectionState;
   m_connectionState = state;
@@ -626,13 +626,13 @@ void CPVRClient::SetConnectionState(PVR_CONNECTION_STATE state)
 
 PVR_CONNECTION_STATE CPVRClient::GetPreviousConnectionState() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_prevConnectionState;
 }
 
 bool CPVRClient::IgnoreClient() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_ignoreClient;
 }
 
@@ -672,7 +672,7 @@ bool CPVRClient::GetAddonProperties()
 
   if (retVal == PVR_ERROR_NO_ERROR)
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     m_clientCapabilities = addonCapabilities;
   }
 
@@ -762,7 +762,7 @@ bool CPVRClient::GetAddonNameStringProperties()
     return false;
 
   /* update the members */
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strBackendName = backendName;
   m_strConnectionString = connectionString;
   m_strBackendVersion = backendVersion;
@@ -1344,7 +1344,7 @@ PVR_ERROR CPVRClient::UpdateTimer(const CPVRTimerInfoTag& timer)
 
 const std::vector<std::shared_ptr<CPVRTimerType>>& CPVRClient::GetTimerTypes() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_timertypes;
 }
 
@@ -1458,7 +1458,7 @@ PVR_ERROR CPVRClient::UpdateTimerTypes()
     std::vector<std::shared_ptr<CPVRTimerType>> newTimerTypes;
     newTimerTypes.reserve(timerTypes.size());
 
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     for (const auto& type : timerTypes)
     {
@@ -2106,7 +2106,7 @@ PVR_ERROR CPVRClient::CallSettingsMenuHook(const CPVRClientMenuHook& hook)
 
 void CPVRClient::SetPriority(int iPriority)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_priority != iPriority)
   {
     m_priority = iPriority;
@@ -2120,7 +2120,7 @@ void CPVRClient::SetPriority(int iPriority)
 
 int CPVRClient::GetPriority() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (!m_priority.has_value() && m_iClientId != PVR_CLIENT_INVALID_UID)
   {
     m_priority = CServiceBroker::GetPVRManager().GetTVDatabase()->GetPriority(*this);
@@ -2130,7 +2130,7 @@ int CPVRClient::GetPriority() const
 
 const CDateTime& CPVRClient::GetDateTimeFirstChannelsAdded() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (!m_firstChannelsAdded.has_value() && m_iClientId != PVR_CLIENT_INVALID_UID)
   {
     m_firstChannelsAdded =
@@ -2141,7 +2141,7 @@ const CDateTime& CPVRClient::GetDateTimeFirstChannelsAdded() const
 
 void CPVRClient::SetDateTimeFirstChannelsAdded(const CDateTime& dateTime)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_firstChannelsAdded != dateTime)
   {
     m_firstChannelsAdded = dateTime;

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -61,7 +61,7 @@ void CPVRClients::Start()
 
 void CPVRClients::Stop()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& client : m_clientMap)
   {
     client.second->Stop();
@@ -70,7 +70,7 @@ void CPVRClients::Stop()
 
 void CPVRClients::Continue()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& client : m_clientMap)
   {
     client.second->Continue();
@@ -90,7 +90,7 @@ void CPVRClients::UpdateClients(
   std::vector<int> clientsToDestroy; // client id
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     for (const auto& addonWithStatus : addonsWithStatus)
     {
       const AddonInfoPtr addon = addonWithStatus.first;
@@ -209,7 +209,7 @@ void CPVRClients::UpdateClients(
     if (!clientsToCreate.empty())
     {
       // update created clients map
-      std::unique_lock<CCriticalSection> lock(m_critSection);
+      std::unique_lock lock(m_critSection);
       for (const auto& client : clientsToCreate)
       {
         if (m_clientMap.find(client->GetID()) == m_clientMap.end())
@@ -240,7 +240,7 @@ bool CPVRClients::StopClient(int clientId, bool restart)
   if (CServiceBroker::GetPVRManager().PlaybackState()->IsPlaying())
     CServiceBroker::GetAppMessenger()->SendMsg(TMSG_MEDIA_STOP);
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   const std::shared_ptr<CPVRClient> client = GetClient(clientId);
   if (client)
@@ -294,7 +294,7 @@ std::shared_ptr<CPVRClient> CPVRClients::GetClient(int clientId) const
   if (clientId == PVR_CLIENT_INVALID_UID)
     return {};
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const auto it = m_clientMap.find(clientId);
   if (it != m_clientMap.end())
     return it->second;
@@ -304,21 +304,21 @@ std::shared_ptr<CPVRClient> CPVRClients::GetClient(int clientId) const
 
 size_t CPVRClients::CreatedClientAmount() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return std::count_if(m_clientMap.cbegin(), m_clientMap.cend(),
                        [](const auto& client) { return client.second->ReadyToUse(); });
 }
 
 bool CPVRClients::HasCreatedClients() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return std::any_of(m_clientMap.cbegin(), m_clientMap.cend(),
                      [](const auto& client) { return client.second->ReadyToUse(); });
 }
 
 bool CPVRClients::IsKnownClient(int clientId) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // valid client IDs start at 1
   const auto it = m_clientMap.find(clientId);
@@ -343,7 +343,7 @@ CPVRClientMap CPVRClients::GetCreatedClients() const
 {
   CPVRClientMap clients;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& client : m_clientMap)
   {
     if (client.second->ReadyToUse())
@@ -361,7 +361,7 @@ std::vector<CVariant> CPVRClients::GetClientProviderInfos() const
   // Get enabled and disabled PVR client addon infos
   CServiceBroker::GetAddonMgr().GetAddonInfos(addonInfos, false, AddonType::PVRDLL);
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   std::vector<CVariant> clientProviderInfos;
   for (const auto& addonInfo : addonInfos)
@@ -399,7 +399,7 @@ std::vector<CVariant> CPVRClients::GetClientProviderInfos() const
 
 int CPVRClients::GetFirstCreatedClientID() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const auto it = std::find_if(m_clientMap.cbegin(), m_clientMap.cend(),
                                [](const auto& client) { return client.second->ReadyToUse(); });
   return it != m_clientMap.cend() ? (*it).second->GetID() : PVR_CLIENT_INVALID_UID;
@@ -439,7 +439,7 @@ size_t CPVRClients::EnabledClientAmount() const
 {
   CPVRClientMap clientMap;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     clientMap = m_clientMap;
   }
 
@@ -461,7 +461,7 @@ std::vector<CVariant> CPVRClients::GetEnabledClientInfos() const
 
   CPVRClientMap clientMap;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     clientMap = m_clientMap;
   }
 
@@ -498,7 +498,7 @@ std::vector<CVariant> CPVRClients::GetEnabledClientInfos() const
 
 bool CPVRClients::HasIgnoredClients() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return std::any_of(m_clientMap.cbegin(), m_clientMap.cend(),
                      [](const auto& client) { return client.second->IgnoreClient(); });
 }
@@ -508,7 +508,7 @@ std::vector<ADDON::AddonInstanceId> CPVRClients::GetKnownInstanceIds(
 {
   std::vector<ADDON::AddonInstanceId> instanceIds;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& entry : m_clientMap)
   {
     if (entry.second->ID() == addonID)
@@ -635,7 +635,7 @@ const std::vector<std::shared_ptr<CPVRTimerType>> CPVRClients::GetTimerTypes() c
 {
   std::vector<std::shared_ptr<CPVRTimerType>> types;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& entry : m_clientMap)
   {
     const auto& client = entry.second;
@@ -738,7 +738,7 @@ std::vector<std::shared_ptr<CPVRClient>> CPVRClients::GetClientsSupportingChanne
 {
   std::vector<std::shared_ptr<CPVRClient>> possibleScanClients;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& entry : m_clientMap)
   {
     const auto& client = entry.second;
@@ -754,7 +754,7 @@ std::vector<std::shared_ptr<CPVRClient>> CPVRClients::GetClientsSupportingChanne
 {
   std::vector<std::shared_ptr<CPVRClient>> possibleSettingsClients;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& entry : m_clientMap)
   {
     const auto& client = entry.second;
@@ -772,7 +772,7 @@ std::vector<std::shared_ptr<CPVRClient>> CPVRClients::GetClientsSupportingChanne
 
 bool CPVRClients::AnyClientSupportingRecordingsSize() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return std::any_of(m_clientMap.cbegin(), m_clientMap.cend(), [](const auto& entry) {
     const auto& client = entry.second;
     return client->ReadyToUse() && !client->IgnoreClient() &&
@@ -782,7 +782,7 @@ bool CPVRClients::AnyClientSupportingRecordingsSize() const
 
 bool CPVRClients::AnyClientSupportingEPG() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return std::any_of(m_clientMap.cbegin(), m_clientMap.cend(), [](const auto& entry) {
     const auto& client = entry.second;
     return client->ReadyToUse() && !client->IgnoreClient() &&
@@ -792,7 +792,7 @@ bool CPVRClients::AnyClientSupportingEPG() const
 
 bool CPVRClients::AnyClientSupportingRecordings() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return std::any_of(m_clientMap.cbegin(), m_clientMap.cend(), [](const auto& entry) {
     const auto& client = entry.second;
     return client->ReadyToUse() && !client->IgnoreClient() &&
@@ -802,7 +802,7 @@ bool CPVRClients::AnyClientSupportingRecordings() const
 
 bool CPVRClients::AnyClientSupportingRecordingsDelete() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return std::any_of(m_clientMap.cbegin(), m_clientMap.cend(), [](const auto& entry) {
     const auto& client = entry.second;
     return client->ReadyToUse() && !client->IgnoreClient() &&
@@ -995,7 +995,7 @@ PVR_ERROR CPVRClients::ForClients(const char* strFunctionName,
   failedClients.clear();
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     for (const auto& entry : m_clientMap)
     {
       if (entry.second->ReadyToUse() && !entry.second->IgnoreClient() &&

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -133,7 +133,7 @@ std::shared_ptr<CPVREpg> CPVRChannel::GetEPG() const
 {
   const_cast<CPVRChannel*>(this)->CreateEPG();
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (!m_bIsHidden && m_bEPGEnabled)
     return m_epg;
 
@@ -142,7 +142,7 @@ std::shared_ptr<CPVREpg> CPVRChannel::GetEPG() const
 
 bool CPVRChannel::CreateEPG()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (!m_epg)
   {
     m_epg = CServiceBroker::GetPVRManager().EpgContainer().CreateChannelEpg(
@@ -178,7 +178,7 @@ void CPVRChannel::ResetEPG()
 {
   std::shared_ptr<CPVREpg> epgToUnsubscribe;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     if (m_epg)
     {
       epgToUnsubscribe = m_epg;
@@ -192,7 +192,7 @@ void CPVRChannel::ResetEPG()
 
 bool CPVRChannel::UpdateFromClient(const std::shared_ptr<const CPVRChannel>& channel)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   SetClientID(channel->ClientID());
   SetArchive(channel->HasArchive());
@@ -220,7 +220,7 @@ bool CPVRChannel::Persist()
 {
   {
     // not changed
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     if (!m_bChanged && m_iChannelId > 0)
       return true;
   }
@@ -232,7 +232,7 @@ bool CPVRChannel::Persist()
 
     bool bReturn = database->Persist(*this, true);
 
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     m_bChanged = !bReturn;
     return bReturn;
   }
@@ -242,7 +242,7 @@ bool CPVRChannel::Persist()
 
 bool CPVRChannel::SetChannelID(int iChannelId)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_iChannelId != iChannelId)
   {
     m_iChannelId = iChannelId;
@@ -260,7 +260,7 @@ bool CPVRChannel::SetChannelID(int iChannelId)
 
 bool CPVRChannel::SetHidden(bool bIsHidden, bool bIsUserSetHidden /*= false*/)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_bIsHidden != bIsHidden || m_bIsUserSetHidden != bIsUserSetHidden)
   {
@@ -279,7 +279,7 @@ bool CPVRChannel::SetHidden(bool bIsHidden, bool bIsUserSetHidden /*= false*/)
 
 bool CPVRChannel::SetLocked(bool bIsLocked)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_bIsLocked != bIsLocked)
   {
@@ -298,25 +298,25 @@ bool CPVRChannel::SetLocked(bool bIsLocked)
 
 std::shared_ptr<CPVRRadioRDSInfoTag> CPVRChannel::GetRadioRDSInfoTag() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_rdsTag;
 }
 
 void CPVRChannel::SetRadioRDSInfoTag(const std::shared_ptr<CPVRRadioRDSInfoTag>& tag)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_rdsTag = tag;
 }
 
 bool CPVRChannel::HasArchive() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_bHasArchive;
 }
 
 bool CPVRChannel::SetArchive(bool bHasArchive)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_bHasArchive != bHasArchive)
   {
@@ -336,7 +336,7 @@ bool CPVRChannel::SetIconPath(const std::string& strIconPath, bool bIsUserSetIco
     return false;
   }
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (ClientIconPath() == strIconPath)
     return false;
 
@@ -359,7 +359,7 @@ bool CPVRChannel::SetChannelName(const std::string& strChannelName, bool bIsUser
     strName = StringUtils::Format(g_localizeStrings.Get(19085),
                                   m_clientChannelNumber.FormattedChannelNumber());
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_strChannelName != strName || m_bIsUserSetName != bIsUserSetName)
   {
     m_strChannelName = strName;
@@ -379,7 +379,7 @@ bool CPVRChannel::SetChannelName(const std::string& strChannelName, bool bIsUser
 bool CPVRChannel::SetLastWatched(time_t lastWatched, int groupId)
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     m_iLastWatched = lastWatched;
     m_lastWatchedGroupId = groupId;
   }
@@ -393,7 +393,7 @@ bool CPVRChannel::SetLastWatched(time_t lastWatched, int groupId)
 
 bool CPVRChannel::SetDateTimeAdded(const CDateTime& dateTimeAdded)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_dateTimeAdded != dateTimeAdded)
   {
@@ -409,7 +409,7 @@ bool CPVRChannel::SetDateTimeAdded(const CDateTime& dateTimeAdded)
 
 bool CPVRChannel::SetClientID(int iClientId)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_iClientId != iClientId)
   {
@@ -512,13 +512,13 @@ std::string CPVRChannel::GetEncryptionName(int iCaid)
 
 void CPVRChannel::UpdateEncryptionName()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strClientEncryptionName = GetEncryptionName(m_iClientEncryptionSystem);
 }
 
 bool CPVRChannel::SetClientProviderUid(int iClientProviderUid)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_iClientProviderUid != iClientProviderUid)
   {
@@ -606,7 +606,7 @@ std::shared_ptr<CPVREpgInfoTag> CPVRChannel::GetEPGPrevious() const
 
 bool CPVRChannel::SetEPGEnabled(bool bEPGEnabled)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_bEPGEnabled != bEPGEnabled)
   {
@@ -631,7 +631,7 @@ bool CPVRChannel::SetEPGEnabled(bool bEPGEnabled)
 
 bool CPVRChannel::SetEPGScraper(const std::string& strScraper)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_strEPGScraper != strScraper)
   {
@@ -651,7 +651,7 @@ bool CPVRChannel::SetEPGScraper(const std::string& strScraper)
 
 void CPVRChannel::ToSortable(SortItem& sortable, Field field) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (field == FieldChannelName)
     sortable[FieldChannelName] = m_strChannelName;
   else if (field == FieldLastPlayed)
@@ -668,91 +668,91 @@ void CPVRChannel::ToSortable(SortItem& sortable, Field field) const
 
 int CPVRChannel::ChannelID() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iChannelId;
 }
 
 bool CPVRChannel::IsNew() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iChannelId <= 0;
 }
 
 bool CPVRChannel::IsHidden() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_bIsHidden;
 }
 
 bool CPVRChannel::IsLocked() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_bIsLocked;
 }
 
 std::string CPVRChannel::ClientIconPath() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iconPath.GetClientImage();
 }
 
 std::string CPVRChannel::IconPath() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iconPath.GetLocalImage();
 }
 
 bool CPVRChannel::IsUserSetIcon() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_bIsUserSetIcon;
 }
 
 bool CPVRChannel::IsUserSetName() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_bIsUserSetName;
 }
 
 bool CPVRChannel::IsUserSetHidden() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_bIsUserSetHidden;
 }
 
 int CPVRChannel::LastWatchedGroupId() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_lastWatchedGroupId;
 }
 
 std::string CPVRChannel::ChannelName() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strChannelName;
 }
 
 time_t CPVRChannel::LastWatched() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iLastWatched;
 }
 
 CDateTime CPVRChannel::DateTimeAdded() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_dateTimeAdded;
 }
 
 bool CPVRChannel::IsChanged() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_bChanged;
 }
 
 void CPVRChannel::Persisted()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_bChanged = false;
 }
 
@@ -763,61 +763,61 @@ int CPVRChannel::UniqueID() const
 
 int CPVRChannel::ClientID() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iClientId;
 }
 
 const CPVRChannelNumber& CPVRChannel::ClientChannelNumber() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_clientChannelNumber;
 }
 
 std::string CPVRChannel::ClientChannelName() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strClientChannelName;
 }
 
 std::string CPVRChannel::MimeType() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strMimeType;
 }
 
 bool CPVRChannel::IsEncrypted() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iClientEncryptionSystem > 0;
 }
 
 int CPVRChannel::EncryptionSystem() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iClientEncryptionSystem;
 }
 
 std::string CPVRChannel::EncryptionName() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strClientEncryptionName;
 }
 
 int CPVRChannel::EpgID() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iEpgId;
 }
 
 bool CPVRChannel::EPGEnabled() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_bEPGEnabled;
 }
 
 std::string CPVRChannel::EPGScraper() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strEPGScraper;
 }
 
@@ -837,7 +837,7 @@ std::shared_ptr<CPVRProvider> CPVRChannel::GetDefaultProvider() const
 
 bool CPVRChannel::HasClientProvider() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iClientProviderUid != PVR_PROVIDER_INVALID_UID;
 }
 

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -68,10 +68,10 @@ std::weak_ptr<CPVRChannelGroupSettings> CPVRChannelGroup::m_settingsSingleton;
 
 std::shared_ptr<CPVRChannelGroupSettings> CPVRChannelGroup::GetSettings() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (!m_settings)
   {
-    std::unique_lock<CCriticalSection> singletonLock(m_settingsSingletonCritSection);
+    std::unique_lock singletonLock(m_settingsSingletonCritSection);
     const std::shared_ptr<CPVRChannelGroupSettings> settings = m_settingsSingleton.lock();
     if (settings)
     {
@@ -123,7 +123,7 @@ bool CPVRChannelGroup::LoadFromDatabase(
 
 void CPVRChannelGroup::Unload()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_sortedMembers.clear();
   m_members.clear();
   m_failedClients.clear();
@@ -131,13 +131,13 @@ void CPVRChannelGroup::Unload()
 
 int CPVRChannelGroup::GetClientID() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_path.GetGroupClientID();
 }
 
 void CPVRChannelGroup::SetClientID(int clientID)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_path.GetGroupClientID() != clientID)
   {
     m_path = CPVRChannelsPath(m_path.IsRadio(), m_path.GetGroupName(), clientID);
@@ -151,13 +151,13 @@ void CPVRChannelGroup::SetClientID(int clientID)
 
 const CPVRChannelsPath& CPVRChannelGroup::GetPath() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_path;
 }
 
 void CPVRChannelGroup::SetPath(const CPVRChannelsPath& path)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_path != path)
   {
     m_path = path;
@@ -207,26 +207,26 @@ void CPVRChannelGroup::Sort()
 
 bool CPVRChannelGroup::SortAndRenumber()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   Sort();
   return Renumber();
 }
 
 void CPVRChannelGroup::SortByClientChannelNumber()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   std::sort(m_sortedMembers.begin(), m_sortedMembers.end(), sortByClientChannelNumber());
 }
 
 void CPVRChannelGroup::SortByChannelNumber()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   std::sort(m_sortedMembers.begin(), m_sortedMembers.end(), sortByChannelNumber());
 }
 
 void CPVRChannelGroup::UpdateClientPriorities()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // Update own priority value
   m_clientPriority.reset();
@@ -240,7 +240,7 @@ void CPVRChannelGroup::UpdateClientPriorities()
 bool CPVRChannelGroup::ShouldBeIgnored(
     const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // Empty group should be ignored.
   return m_members.empty();
@@ -251,7 +251,7 @@ bool CPVRChannelGroup::UpdateMembersClientPriority()
   const std::shared_ptr<const CPVRClients> clients = CServiceBroker::GetPVRManager().Clients();
   bool bChanged = false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   const bool bUseBackendChannelOrder = GetSettings()->UseBackendChannelOrder();
   for (auto& member : m_sortedMembers)
@@ -284,7 +284,7 @@ bool CPVRChannelGroup::UpdateMembersClientPriority()
 std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetByUniqueID(
     const std::pair<int, int>& id) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const auto it = m_members.find(id);
   return it != m_members.end() ? it->second : std::shared_ptr<CPVRChannelGroupMember>();
 }
@@ -299,7 +299,7 @@ std::shared_ptr<CPVRChannel> CPVRChannelGroup::GetByUniqueID(int iUniqueChannelI
 
 std::shared_ptr<CPVRChannel> CPVRChannelGroup::GetByChannelID(int iChannelID) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const auto it =
       std::find_if(m_members.cbegin(), m_members.cend(), [iChannelID](const auto& member) {
         return member.second->Channel()->ChannelID() == iChannelID;
@@ -318,7 +318,7 @@ bool MatchProvider(const std::shared_ptr<CPVRChannel>& channel, int clientId, in
 
 bool CPVRChannelGroup::HasChannelForProvider(int clientId, int providerId) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return std::any_of(m_members.cbegin(), m_members.cend(),
                      [clientId, providerId](const auto& member)
                      { return MatchProvider(member.second->Channel(), clientId, providerId); });
@@ -326,7 +326,7 @@ bool CPVRChannelGroup::HasChannelForProvider(int clientId, int providerId) const
 
 unsigned int CPVRChannelGroup::GetChannelCountByProvider(int clientId, int providerId) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   auto channels =
       std::count_if(m_members.cbegin(), m_members.cend(),
                     [clientId, providerId](const auto& member)
@@ -337,7 +337,7 @@ unsigned int CPVRChannelGroup::GetChannelCountByProvider(int clientId, int provi
 std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetLastPlayedChannelGroupMember(
     int iCurrentChannel /* = -1 */) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   std::shared_ptr<CPVRChannelGroupMember> groupMember;
   for (const auto& memberPair : m_members)
@@ -357,7 +357,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetLastPlayedChannelGr
 
 GroupMemberPair CPVRChannelGroup::GetLastAndPreviousToLastPlayedChannelGroupMember() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_sortedMembers.empty())
     return {};
 
@@ -383,7 +383,7 @@ GroupMemberPair CPVRChannelGroup::GetLastAndPreviousToLastPlayedChannelGroupMemb
 CPVRChannelNumber CPVRChannelGroup::GetChannelNumber(
     const std::shared_ptr<const CPVRChannel>& channel) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::shared_ptr<const CPVRChannelGroupMember> member = GetByUniqueID(channel->StorageId());
   return member ? member->ChannelNumber() : CPVRChannelNumber();
 }
@@ -391,7 +391,7 @@ CPVRChannelNumber CPVRChannelGroup::GetChannelNumber(
 CPVRChannelNumber CPVRChannelGroup::GetClientChannelNumber(
     const std::shared_ptr<const CPVRChannel>& channel) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::shared_ptr<const CPVRChannelGroupMember> member = GetByUniqueID(channel->StorageId());
   return member ? member->ClientChannelNumber() : CPVRChannelNumber();
 }
@@ -399,7 +399,7 @@ CPVRChannelNumber CPVRChannelGroup::GetClientChannelNumber(
 std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetByChannelNumber(
     const CPVRChannelNumber& channelNumber) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const bool bUseBackendChannelNumbers = GetSettings()->UseBackendChannelNumbers();
   for (const auto& member : m_sortedMembers)
   {
@@ -419,7 +419,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetNextChannelGroupMem
 
   if (groupMember)
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     for (auto it = m_sortedMembers.cbegin(); !nextMember && it != m_sortedMembers.cend(); ++it)
     {
       if (*it == groupMember)
@@ -447,7 +447,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetPreviousChannelGrou
 
   if (groupMember)
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     for (auto it = m_sortedMembers.crbegin(); !previousMember && it != m_sortedMembers.crend();
          ++it)
     {
@@ -471,7 +471,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetPreviousChannelGrou
 std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRChannelGroup::GetMembers(
     Include eFilter /* = Include::ALL */) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (eFilter == Include::ALL)
     return m_sortedMembers;
 
@@ -500,7 +500,7 @@ std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRChannelGroup::GetMember
 
 void CPVRChannelGroup::GetChannelNumbers(std::vector<std::string>& channelNumbers) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const bool bUseBackendChannelNumbers = GetSettings()->UseBackendChannelNumbers();
   for (const auto& member : m_sortedMembers)
   {
@@ -525,7 +525,7 @@ int CPVRChannelGroup::LoadFromDatabase(const std::vector<std::shared_ptr<CPVRCli
   {
     const std::shared_ptr<const CPVRClients> allClients = CServiceBroker::GetPVRManager().Clients();
 
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     for (const auto& member : results)
     {
       // Consistency checks.
@@ -607,7 +607,7 @@ bool CPVRChannelGroup::UpdateFromClient(const std::shared_ptr<CPVRChannelGroupMe
 {
   bool bChanged = false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   const std::shared_ptr<CPVRChannel> channel = groupMember->Channel();
   const std::shared_ptr<CPVRChannelGroupMember> existingMember =
@@ -683,7 +683,7 @@ bool CPVRChannelGroup::HasValidDataForClients(
 
 bool CPVRChannelGroup::UpdateChannelNumbersFromAllChannelsGroup()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   bool bChanged = false;
 
@@ -706,7 +706,7 @@ std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRChannelGroup::RemoveDel
 {
   std::vector<std::shared_ptr<CPVRChannelGroupMember>> membersToRemove;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // put group members into map to speedup the following lookups
   std::map<std::pair<int, int>, std::shared_ptr<CPVRChannelGroupMember>> membersMap;
@@ -767,7 +767,7 @@ bool CPVRChannelGroup::UpdateGroupEntries(
   bool bChanged = false;
   bool bRemoved = false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   bRemoved = !RemoveDeletedGroupMembers(groupMembers).empty();
   bChanged = AddAndUpdateGroupMembers(groupMembers) || bRemoved;
@@ -796,7 +796,7 @@ bool CPVRChannelGroup::RemoveFromGroup(
   bool bReturn = false;
   const auto channel = groupMember->Channel();
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (auto it = m_sortedMembers.begin(); it != m_sortedMembers.end(); ++it)
   {
@@ -825,7 +825,7 @@ bool CPVRChannelGroup::AppendToGroup(
 {
   bool bReturn = false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (!CPVRChannelGroup::IsGroupMember(groupMember))
   {
@@ -855,7 +855,7 @@ bool CPVRChannelGroup::AppendToGroup(
 bool CPVRChannelGroup::IsGroupMember(
     const std::shared_ptr<const CPVRChannelGroupMember>& groupMember) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_members.find(groupMember->Channel()->StorageId()) != m_members.end();
 }
 
@@ -864,7 +864,7 @@ bool CPVRChannelGroup::Persist()
   bool bReturn(true);
   const std::shared_ptr<CPVRDatabase> database(CServiceBroker::GetPVRManager().GetTVDatabase());
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // do not persist if the group is not fully loaded and was saved before.
   if (!m_bLoaded && m_iGroupId != INVALID_GROUP_ID)
@@ -899,7 +899,7 @@ void CPVRChannelGroup::Delete()
     return;
   }
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_iGroupId > 0)
   {
@@ -913,7 +913,7 @@ bool CPVRChannelGroup::Renumber(RenumberMode mode /* = NORMAL */)
   bool bReturn(false);
   unsigned int iChannelNumber(0);
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const bool bUseBackendChannelNumbers = GetSettings()->UseBackendChannelNumbers();
   const bool bStartGroupChannelNumbersFromOne = GetSettings()->StartGroupChannelNumbersFromOne();
 
@@ -961,26 +961,26 @@ bool CPVRChannelGroup::Renumber(RenumberMode mode /* = NORMAL */)
 
 bool CPVRChannelGroup::HasNewChannels() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return std::any_of(m_members.cbegin(), m_members.cend(),
                      [](const auto& member) { return member.second->Channel()->ChannelID() <= 0; });
 }
 
 bool CPVRChannelGroup::HasChanges() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_bChanged;
 }
 
 bool CPVRChannelGroup::IsNew() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iGroupId <= 0;
 }
 
 void CPVRChannelGroup::UseBackendChannelOrderChanged()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   UpdateMembersClientPriority();
   OnSettingChanged();
 }
@@ -1004,7 +1004,7 @@ void CPVRChannelGroup::OnSettingChanged()
     return;
   }
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   CLog::LogFC(LOGDEBUG, LOGPVR,
               "Renumbering channel group '{}' to use the backend channel order and/or numbers",
@@ -1027,7 +1027,7 @@ int CPVRChannelGroup::GroupID() const
 
 void CPVRChannelGroup::SetGroupID(int iGroupId)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (iGroupId >= 0 && m_iGroupId != iGroupId)
   {
     m_iGroupId = iGroupId;
@@ -1040,14 +1040,14 @@ void CPVRChannelGroup::SetGroupID(int iGroupId)
 
 std::string CPVRChannelGroup::GroupName() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_path.GetGroupName();
 }
 
 bool CPVRChannelGroup::SetGroupName(const std::string& strGroupName,
                                     bool isUserSetName /* = false */)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_path.GetGroupName() != strGroupName)
   {
     m_isUserSetName = isUserSetName;
@@ -1068,13 +1068,13 @@ bool CPVRChannelGroup::SetGroupName(const std::string& strGroupName,
 
 std::string CPVRChannelGroup::ClientGroupName() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_clientGroupName;
 }
 
 void CPVRChannelGroup::SetClientGroupName(const std::string& groupName)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_clientGroupName != groupName)
   {
     m_clientGroupName = groupName;
@@ -1089,13 +1089,13 @@ void CPVRChannelGroup::SetClientGroupName(const std::string& groupName)
 
 bool CPVRChannelGroup::IsRadio() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_path.IsRadio();
 }
 
 time_t CPVRChannelGroup::LastWatched() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iLastWatched;
 }
 
@@ -1103,7 +1103,7 @@ void CPVRChannelGroup::SetLastWatched(time_t iLastWatched)
 {
   const std::shared_ptr<CPVRDatabase> database(CServiceBroker::GetPVRManager().GetTVDatabase());
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_iLastWatched != iLastWatched)
   {
@@ -1115,7 +1115,7 @@ void CPVRChannelGroup::SetLastWatched(time_t iLastWatched)
 
 uint64_t CPVRChannelGroup::LastOpened() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iLastOpened;
 }
 
@@ -1123,7 +1123,7 @@ void CPVRChannelGroup::SetLastOpened(uint64_t iLastOpened)
 {
   const std::shared_ptr<CPVRDatabase> database(CServiceBroker::GetPVRManager().GetTVDatabase());
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_iLastOpened != iLastOpened)
   {
@@ -1135,26 +1135,26 @@ void CPVRChannelGroup::SetLastOpened(uint64_t iLastOpened)
 
 size_t CPVRChannelGroup::Size() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_members.size();
 }
 
 bool CPVRChannelGroup::HasChannels() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return !m_members.empty();
 }
 
 bool CPVRChannelGroup::HasHiddenChannels() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return std::any_of(m_members.cbegin(), m_members.cend(),
                      [](const auto& member) { return member.second->Channel()->IsHidden(); });
 }
 
 bool CPVRChannelGroup::SetHidden(bool bHidden)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_bHidden != bHidden)
   {
@@ -1168,19 +1168,19 @@ bool CPVRChannelGroup::SetHidden(bool bHidden)
 
 bool CPVRChannelGroup::IsHidden() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_bHidden;
 }
 
 int CPVRChannelGroup::GetPosition() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iPosition;
 }
 
 bool CPVRChannelGroup::SetPosition(int iPosition)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_iPosition != iPosition)
   {
@@ -1194,13 +1194,13 @@ bool CPVRChannelGroup::SetPosition(int iPosition)
 
 int CPVRChannelGroup::GetClientPosition() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iClientPosition;
 }
 
 void CPVRChannelGroup::SetClientPosition(int iPosition)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_iClientPosition != iPosition)
   {
@@ -1214,7 +1214,7 @@ int CPVRChannelGroup::CleanupCachedImages()
 {
   std::vector<std::string> urlsToCheck;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     std::transform(
         m_members.cbegin(), m_members.cend(), std::back_inserter(urlsToCheck),
         [](const auto& groupMember) { return groupMember.second->Channel()->ClientIconPath(); });
@@ -1230,7 +1230,7 @@ int CPVRChannelGroup::GetClientPriority() const
   if (GetClientID() == PVR_GROUP_CLIENT_ID_UNKNOWN)
     return 0; // not yet fully migrated; try later.
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (!m_clientPriority.has_value())
   {
     const auto client = CServiceBroker::GetPVRManager().GetClient(GetClientID());

--- a/xbmc/pvr/channels/PVRChannelGroupMergedByName.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupMergedByName.cpp
@@ -20,7 +20,7 @@ using namespace PVR;
 bool CPVRChannelGroupMergedByName::ShouldBeIgnored(
     const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // Ignore the group if it is empty or only members from one group are present.
 

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -70,7 +70,7 @@ void CPVRChannelGroups::OnSettingChanged(const std::shared_ptr<const CSetting>& 
 
 void CPVRChannelGroups::Unload()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& group : m_groups)
     group->Unload();
 
@@ -103,7 +103,7 @@ bool CPVRChannelGroups::Update(const std::shared_ptr<CPVRChannelGroup>& group,
 
   std::shared_ptr<CPVRChannelGroup> updateGroup;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     // There can be only one all channels group! Make sure we never push a new one!
     if (group->IsChannelsOwner())
@@ -210,7 +210,7 @@ void CPVRChannelGroups::SortGroups()
 {
   bool orderChanged{false};
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     const bool backendOrderSort{
         m_settings.GetBoolValue(CSettings::SETTING_PVRMANAGER_BACKENDCHANNELGROUPSORDER)};
@@ -250,7 +250,7 @@ std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRChannelGroups::GetMembe
 
   if (group->SupportsMemberAdd())
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     const auto allGroupMembers = GetGroupAll()->GetMembers();
     for (const auto& groupMember : allGroupMembers)
@@ -274,7 +274,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetGroupById(int groupId,
 {
   const bool excludeIgnored{exclude == Exclude::IGNORED};
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const auto it = std::find_if(m_groups.cbegin(), m_groups.cend(),
                                [groupId, excludeIgnored, this](const auto& group)
                                {
@@ -290,7 +290,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetGroupByPath(
   const CPVRChannelsPath path(strInPath);
   if (path.IsChannelGroup())
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     const auto it =
         std::find_if(m_groups.cbegin(), m_groups.cend(),
                      [&path, this](const auto& group)
@@ -313,7 +313,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetGroupByName(const std::s
 {
   const bool excludeIgnored{exclude == Exclude::IGNORED};
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const auto it = std::find_if(m_groups.cbegin(), m_groups.cend(),
                                [&name, clientID, excludeIgnored, this](const auto& group)
                                {
@@ -352,7 +352,7 @@ bool CPVRChannelGroups::UpdateFromClients(const std::vector<std::shared_ptr<CPVR
   // sync channels in groups
   std::vector<std::shared_ptr<CPVRChannelGroup>> groups;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     groups = m_groups;
   }
 
@@ -389,7 +389,7 @@ bool CPVRChannelGroups::UpdateFromClients(const std::vector<std::shared_ptr<CPVR
 
 void CPVRChannelGroups::UpdateSystemChannelGroups()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // Update existing groups
   for (const auto& group : m_groups)
@@ -416,7 +416,7 @@ void CPVRChannelGroups::UpdateSystemChannelGroups()
 
 bool CPVRChannelGroups::UpdateChannelNumbersFromAllChannelsGroup()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return std::accumulate(
       m_groups.cbegin(), m_groups.cend(), false, [](bool changed, const auto& group) {
         return group->UpdateChannelNumbersFromAllChannelsGroup() ? true : changed;
@@ -430,7 +430,7 @@ bool CPVRChannelGroups::LoadFromDatabase(const std::vector<std::shared_ptr<CPVRC
   if (!database)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // Ensure we have an all channels group. It is important that the all channels group is
   // created before loading contents from database.
@@ -484,7 +484,7 @@ bool CPVRChannelGroups::PersistAll()
 {
   CLog::LogFC(LOGDEBUG, LOGPVR, "Persisting all channel group changes");
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return std::accumulate(
       m_groups.cbegin(), m_groups.cend(), true,
       [](bool success, const auto& group) { return !group->Persist() ? false : success; });
@@ -492,13 +492,13 @@ bool CPVRChannelGroups::PersistAll()
 
 std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetGroupAll() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_allChannelsGroup;
 }
 
 std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetLastGroup() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (auto it = m_groups.crbegin(); it != m_groups.crend(); ++it)
   {
     const auto& group{*it};
@@ -510,7 +510,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetLastGroup() const
 
 GroupMemberPair CPVRChannelGroups::GetLastAndPreviousToLastPlayedChannelGroupMember() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   std::vector<std::shared_ptr<CPVRChannelGroup>> groups;
   std::copy_if(m_groups.cbegin(), m_groups.cend(), std::back_inserter(groups),
@@ -547,7 +547,7 @@ GroupMemberPair CPVRChannelGroups::GetLastAndPreviousToLastPlayedChannelGroupMem
 
 std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetLastOpenedGroup() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return std::accumulate(m_groups.cbegin(), m_groups.cend(), std::shared_ptr<CPVRChannelGroup>{},
                          [](const std::shared_ptr<CPVRChannelGroup>& last,
                             const std::shared_ptr<CPVRChannelGroup>& group) {
@@ -563,7 +563,7 @@ std::vector<std::shared_ptr<CPVRChannelGroup>> CPVRChannelGroups::GetMembers(
 {
   std::vector<std::shared_ptr<CPVRChannelGroup>> groups;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   std::copy_if(m_groups.cbegin(), m_groups.cend(), std::back_inserter(groups),
                [bExcludeHidden, this](const auto& group) {
                  return (!bExcludeHidden || !group->IsHidden()) &&
@@ -578,7 +578,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetPreviousGroup(
   {
     bool bReturnNext = false;
 
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     for (auto it = m_groups.crbegin(); it != m_groups.crend(); ++it)
     {
       const auto& currentGroup{*it};
@@ -611,7 +611,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetNextGroup(
   {
     bool bReturnNext = false;
 
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     for (auto it = m_groups.cbegin(); it != m_groups.cend(); ++it)
     {
       const auto& currentGroup{*it};
@@ -659,7 +659,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::AddGroup(const std::string&
   std::shared_ptr<CPVRChannelGroup> group;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     // check if there's another local group with the same name already
     group = GetGroupByName(strName, PVR_GROUP_CLIENT_ID_LOCAL, Exclude::NONE);
@@ -691,7 +691,7 @@ bool CPVRChannelGroups::DeleteGroup(const std::shared_ptr<CPVRChannelGroup>& gro
 
   // delete the group in this container
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     for (auto it = m_groups.begin(); it != m_groups.end(); ++it)
     {
       if (*it == group || (group->GroupID() > 0 && (*it)->GroupID() == group->GroupID()))
@@ -826,7 +826,7 @@ int CPVRChannelGroups::CleanupCachedImages()
   // cleanup groups
   std::vector<std::string> urlsToCheck;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     std::transform(m_groups.cbegin(), m_groups.cend(), std::back_inserter(urlsToCheck),
                    [](const auto& group) { return group->GetPath(); });
   }
@@ -845,7 +845,7 @@ void CPVRChannelGroups::OnPVRManagerEvent(const PVR::PVREvent& event)
     // Update group client priorities
     std::vector<std::shared_ptr<CPVRChannelGroup>> groups;
     {
-      std::unique_lock<CCriticalSection> lock(m_critSection);
+      std::unique_lock lock(m_critSection);
       groups = m_groups;
     }
 

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -64,7 +64,7 @@ public:
    */
   size_t Size() const
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     return m_groups.size();
   }
 

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -43,7 +43,7 @@ bool CPVRChannelGroupsContainer::LoadFromDatabase(
 bool CPVRChannelGroupsContainer::UpdateFromClients(
     const std::vector<std::shared_ptr<CPVRClient>>& clients, bool bChannelsOnly /* = false */)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_bIsUpdating)
     return false;
   m_bIsUpdating = true;

--- a/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
+++ b/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
@@ -32,7 +32,7 @@ CPVRRadioRDSInfoTag::CPVRRadioRDSInfoTag()
 
 void CPVRRadioRDSInfoTag::Serialize(CVariant& value) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   value["strLanguage"] = m_strLanguage;
   value["strCountry"] = m_strCountry;
@@ -59,7 +59,7 @@ void CPVRRadioRDSInfoTag::Serialize(CVariant& value) const
 
 void CPVRRadioRDSInfoTag::Archive(CArchive& ar)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (ar.IsStoring())
   {
@@ -116,7 +116,7 @@ bool CPVRRadioRDSInfoTag::operator==(const CPVRRadioRDSInfoTag& right) const
   if (this == &right)
     return true;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return (
       m_strLanguage == right.m_strLanguage && m_strCountry == right.m_strCountry &&
       m_strTitle == right.m_strTitle && m_strBand == right.m_strBand &&
@@ -152,7 +152,7 @@ bool CPVRRadioRDSInfoTag::operator !=(const CPVRRadioRDSInfoTag& right) const
 
 void CPVRRadioRDSInfoTag::Clear()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_RDS_SpeechActive = false;
 
@@ -192,7 +192,7 @@ void CPVRRadioRDSInfoTag::Clear()
 
 void CPVRRadioRDSInfoTag::ResetSongInformation()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_strTitle.erase();
   m_strBand.erase();
@@ -205,419 +205,419 @@ void CPVRRadioRDSInfoTag::ResetSongInformation()
 
 void CPVRRadioRDSInfoTag::SetSpeechActive(bool active)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_RDS_SpeechActive = active;
 }
 
 void CPVRRadioRDSInfoTag::SetLanguage(const std::string& strLanguage)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strLanguage = Trim(strLanguage);
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetLanguage() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strLanguage;
 }
 
 void CPVRRadioRDSInfoTag::SetCountry(const std::string& strCountry)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strCountry = Trim(strCountry);
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetCountry() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strCountry;
 }
 
 void CPVRRadioRDSInfoTag::SetTitle(const std::string& strTitle)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strTitle = Trim(strTitle);
 }
 
 void CPVRRadioRDSInfoTag::SetArtist(const std::string& strArtist)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strArtist = Trim(strArtist);
 }
 
 void CPVRRadioRDSInfoTag::SetBand(const std::string& strBand)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strBand = Trim(strBand);
   g_charsetConverter.unknownToUTF8(m_strBand);
 }
 
 void CPVRRadioRDSInfoTag::SetComposer(const std::string& strComposer)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strComposer = Trim(strComposer);
   g_charsetConverter.unknownToUTF8(m_strComposer);
 }
 
 void CPVRRadioRDSInfoTag::SetConductor(const std::string& strConductor)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strConductor = Trim(strConductor);
   g_charsetConverter.unknownToUTF8(m_strConductor);
 }
 
 void CPVRRadioRDSInfoTag::SetAlbum(const std::string& strAlbum)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strAlbum = Trim(strAlbum);
   g_charsetConverter.unknownToUTF8(m_strAlbum);
 }
 
 void CPVRRadioRDSInfoTag::SetAlbumTrackNumber(int track)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_iAlbumTracknumber = track;
 }
 
 void CPVRRadioRDSInfoTag::SetComment(const std::string& strComment)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strComment = Trim(strComment);
   g_charsetConverter.unknownToUTF8(m_strComment);
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetTitle() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strTitle;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetArtist() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strArtist;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetBand() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strBand;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetComposer() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strComposer;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetConductor() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strConductor;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetAlbum() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strAlbum;
 }
 
 int CPVRRadioRDSInfoTag::GetAlbumTrackNumber() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iAlbumTracknumber;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetComment() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strComment;
 }
 
 void CPVRRadioRDSInfoTag::SetInfoNews(const std::string& strNews)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strInfoNews.Add(strNews);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoNews() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strInfoNews.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoNewsLocal(const std::string& strNews)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strInfoNewsLocal.Add(strNews);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoNewsLocal() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strInfoNewsLocal.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoSport(const std::string& strSport)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strInfoSport.Add(strSport);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoSport() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strInfoSport.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoStock(const std::string& strStock)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strInfoStock.Add(strStock);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoStock() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strInfoStock.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoWeather(const std::string& strWeather)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strInfoWeather.Add(strWeather);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoWeather() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strInfoWeather.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoLottery(const std::string& strLottery)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strInfoLottery.Add(strLottery);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoLottery() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strInfoLottery.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetEditorialStaff(const std::string& strEditorialStaff)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strEditorialStaff.Add(strEditorialStaff);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetEditorialStaff() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strEditorialStaff.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoHoroscope(const std::string& strHoroscope)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strInfoHoroscope.Add(strHoroscope);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoHoroscope() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strInfoHoroscope.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoCinema(const std::string& strCinema)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strInfoCinema.Add(strCinema);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoCinema() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strInfoCinema.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoOther(const std::string& strOther)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strInfoOther.Add(strOther);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoOther() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strInfoOther.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetProgStation(const std::string& strProgStation)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strProgStation = Trim(strProgStation);
   g_charsetConverter.unknownToUTF8(m_strProgStation);
 }
 
 void CPVRRadioRDSInfoTag::SetProgHost(const std::string& strProgHost)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strProgHost = Trim(strProgHost);
   g_charsetConverter.unknownToUTF8(m_strProgHost);
 }
 
 void CPVRRadioRDSInfoTag::SetProgStyle(const std::string& strProgStyle)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strProgStyle = Trim(strProgStyle);
   g_charsetConverter.unknownToUTF8(m_strProgStyle);
 }
 
 void CPVRRadioRDSInfoTag::SetProgWebsite(const std::string& strWebsite)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strProgWebsite = Trim(strWebsite);
   g_charsetConverter.unknownToUTF8(m_strProgWebsite);
 }
 
 void CPVRRadioRDSInfoTag::SetProgNow(const std::string& strNow)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strProgNow = Trim(strNow);
   g_charsetConverter.unknownToUTF8(m_strProgNow);
 }
 
 void CPVRRadioRDSInfoTag::SetProgNext(const std::string& strNext)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strProgNext = Trim(strNext);
   g_charsetConverter.unknownToUTF8(m_strProgNext);
 }
 
 void CPVRRadioRDSInfoTag::SetPhoneHotline(const std::string& strHotline)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strPhoneHotline = Trim(strHotline);
   g_charsetConverter.unknownToUTF8(m_strPhoneHotline);
 }
 
 void CPVRRadioRDSInfoTag::SetEMailHotline(const std::string& strHotline)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strEMailHotline = Trim(strHotline);
   g_charsetConverter.unknownToUTF8(m_strEMailHotline);
 }
 
 void CPVRRadioRDSInfoTag::SetPhoneStudio(const std::string& strPhone)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strPhoneStudio = Trim(strPhone);
   g_charsetConverter.unknownToUTF8(m_strPhoneStudio);
 }
 
 void CPVRRadioRDSInfoTag::SetEMailStudio(const std::string& strEMail)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strEMailStudio = Trim(strEMail);
   g_charsetConverter.unknownToUTF8(m_strEMailStudio);
 }
 
 void CPVRRadioRDSInfoTag::SetSMSStudio(const std::string& strSMS)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strSMSStudio = Trim(strSMS);
   g_charsetConverter.unknownToUTF8(m_strSMSStudio);
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetProgStyle() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strProgStyle;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetProgHost() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strProgHost;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetProgStation() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strProgStation;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetProgWebsite() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strProgWebsite;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetProgNow() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strProgNow;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetProgNext() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strProgNext;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetPhoneHotline() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strPhoneHotline;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetEMailHotline() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strEMailHotline;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetPhoneStudio() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strPhoneStudio;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetEMailStudio() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strEMailStudio;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetSMSStudio() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strSMSStudio;
 }
 
 void CPVRRadioRDSInfoTag::SetRadioStyle(const std::string& style)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strRadioStyle = style;
 }
 
 const std::string CPVRRadioRDSInfoTag::GetRadioStyle() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strRadioStyle;
 }
 
 void CPVRRadioRDSInfoTag::SetRadioText(const std::string& strRadioText)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strRadioText.Add(strRadioText);
 }
 
 std::string CPVRRadioRDSInfoTag::GetRadioText(unsigned int line) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_strRadioText.Size() > 0)
   {
@@ -636,7 +636,7 @@ std::string CPVRRadioRDSInfoTag::GetRadioText(unsigned int line) const
 
 void CPVRRadioRDSInfoTag::SetProgramServiceText(const std::string& strPSText)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strProgramServiceText.Add(strPSText);
 
   m_strProgramServiceLine0.erase();
@@ -657,25 +657,25 @@ void CPVRRadioRDSInfoTag::SetProgramServiceText(const std::string& strPSText)
 
 void CPVRRadioRDSInfoTag::SetPlayingRadioText(bool yesNo)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_bHaveRadioText = yesNo;
 }
 
 bool CPVRRadioRDSInfoTag::IsPlayingRadioText() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_bHaveRadioText;
 }
 
 void CPVRRadioRDSInfoTag::SetPlayingRadioTextPlus(bool yesNo)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_bHaveRadioTextPlus = yesNo;
 }
 
 bool CPVRRadioRDSInfoTag::IsPlayingRadioTextPlus() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_bHaveRadioTextPlus;
 }
 

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -68,7 +68,7 @@ void CPVREpg::ForceUpdate()
 
 void CPVREpg::Clear()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_tags.Clear();
 }
 
@@ -80,31 +80,31 @@ void CPVREpg::Cleanup(int iPastDays)
 
 void CPVREpg::Cleanup(const CDateTime& time)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_tags.Cleanup(time);
 }
 
 std::shared_ptr<CPVREpgInfoTag> CPVREpg::GetTagNow() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_tags.GetActiveTag();
 }
 
 std::shared_ptr<CPVREpgInfoTag> CPVREpg::GetTagNext() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_tags.GetNextStartingTag();
 }
 
 std::shared_ptr<CPVREpgInfoTag> CPVREpg::GetTagPrevious() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_tags.GetLastEndedTag();
 }
 
 bool CPVREpg::CheckPlayingEvent()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_tags.UpdateActiveTag())
   {
     m_events.Publish(PVREvent::EpgActiveItem);
@@ -115,13 +115,13 @@ bool CPVREpg::CheckPlayingEvent()
 
 std::shared_ptr<CPVREpgInfoTag> CPVREpg::GetTagByBroadcastId(unsigned int iUniqueBroadcastId) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_tags.GetTag(iUniqueBroadcastId);
 }
 
 std::shared_ptr<CPVREpgInfoTag> CPVREpg::GetTagByDatabaseId(int iDatabaseId) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_tags.GetTagByDatabaseID(iDatabaseId);
 }
 
@@ -129,7 +129,7 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpg::GetTagBetween(const CDateTime& beginTim
 {
   std::shared_ptr<CPVREpgInfoTag> tag;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   tag = m_tags.GetTagBetween(beginTime, endTime);
 
   if (!tag && bUpdateFromClient)
@@ -158,13 +158,13 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpg::GetTimeline(
     const CDateTime& minEventEnd,
     const CDateTime& maxEventStart) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_tags.GetTimeline(timelineStart, timelineEnd, minEventEnd, maxEventStart);
 }
 
 bool CPVREpg::UpdateEntries(const CPVREpg& epg)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   /* copy over tags */
   m_tags.UpdateEntries(epg.m_tags);
@@ -210,12 +210,12 @@ bool CPVREpg::UpdateEntry(const std::shared_ptr<CPVREpgInfoTag>& tag, EPG_EVENT_
 
   if (newState == EPG_EVENT_CREATED || newState == EPG_EVENT_UPDATED)
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     bRet = !IsTagExpired(tag) && m_tags.UpdateEntry(tag);
   }
   else if (newState == EPG_EVENT_DELETED)
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     const std::shared_ptr<CPVREpgInfoTag> existingTag = m_tags.GetTag(tag->UniqueBroadcastID());
     if (!existingTag)
     {
@@ -257,7 +257,7 @@ bool CPVREpg::Update(time_t start,
   std::shared_ptr<CPVREpg> tmpEpg;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     if (!m_lastScanTime.IsValid())
     {
@@ -318,7 +318,7 @@ bool CPVREpg::Update(time_t start,
 
 std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpg::GetTags() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_tags.GetAllTags();
 }
 
@@ -363,7 +363,7 @@ bool CPVREpg::QueueDeleteQueries(const std::shared_ptr<CPVREpgDatabase>& databas
     return false;
   }
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // delete own epg db entry
   database->QueueDeleteEpgQuery(*this);
@@ -381,7 +381,7 @@ bool CPVREpg::QueueDeleteQueries(const std::shared_ptr<CPVREpgDatabase>& databas
 
 std::pair<CDateTime, CDateTime> CPVREpg::GetFirstAndLastUncommitedEPGDate() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_tags.GetFirstAndLastUncommitedEPGDate();
 }
 
@@ -484,38 +484,38 @@ const std::string& CPVREpg::ConvertGenreIdToString(int iID, int iSubID)
 
 std::shared_ptr<CPVREpgChannelData> CPVREpg::GetChannelData() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_channelData;
 }
 
 void CPVREpg::SetChannelData(const std::shared_ptr<CPVREpgChannelData>& data)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_channelData = data;
   m_tags.SetChannelData(data);
 }
 
 int CPVREpg::ChannelID() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_channelData->ChannelId();
 }
 
 const std::string& CPVREpg::ScraperName() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strScraperName;
 }
 
 const std::string& CPVREpg::Name() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strName;
 }
 
 int CPVREpg::EpgID() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iEpgID;
 }
 
@@ -526,13 +526,13 @@ bool CPVREpg::UpdatePending() const
 
 bool CPVREpg::NeedsSave() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_bChanged || m_bUpdateLastScanTime || m_tags.NeedsSave();
 }
 
 bool CPVREpg::IsValid() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (ScraperName() == "client")
     return m_channelData->ClientId() != PVR_CLIENT_INVALID_UID &&
            m_channelData->UniqueClientChannelId() != PVR_CHANNEL_INVALID_UID;

--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -29,13 +29,13 @@ using namespace PVR;
 
 bool CPVREpgDatabase::Open()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return CDatabase::Open(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_databaseEpg);
 }
 
 void CPVREpgDatabase::Close()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   CDatabase::Close();
 }
 
@@ -55,7 +55,7 @@ void CPVREpgDatabase::CreateTables()
 
   CLog::LogFC(LOGDEBUG, LOGEPG, "Creating table 'epg'");
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_pDS->exec(
       "CREATE TABLE epg ("
@@ -141,14 +141,14 @@ void CPVREpgDatabase::CreateAnalytics()
 {
   CLog::LogFC(LOGDEBUG, LOGEPG, "Creating EPG database indices");
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_pDS->exec("CREATE UNIQUE INDEX idx_epg_idEpg_iStartTime on epgtags(idEpg, iStartTime desc);");
   m_pDS->exec("CREATE INDEX idx_epg_iEndTime on epgtags(iEndTime);");
 }
 
 void CPVREpgDatabase::UpdateTables(int iVersion)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (iVersion < 5)
     m_pDS->exec("ALTER TABLE epgtags ADD sGenre varchar(128);");
 
@@ -361,7 +361,7 @@ bool CPVREpgDatabase::DeleteEpg()
   bool bReturn(false);
   CLog::LogFC(LOGDEBUG, LOGEPG, "Deleting all EPG data from the database");
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   bReturn = DeleteValues("epg") || bReturn;
   bReturn = DeleteValues("epgtags") || bReturn;
@@ -381,7 +381,7 @@ bool CPVREpgDatabase::QueueDeleteEpgQuery(const CPVREpg& table)
 
   Filter filter;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   filter.AppendWhere(PrepareSQL("idEpg = %u", table.EpgID()));
 
   std::string strQuery;
@@ -399,7 +399,7 @@ bool CPVREpgDatabase::QueueDeleteTagQuery(const CPVREpgInfoTag& tag)
 
   Filter filter;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   filter.AppendWhere(PrepareSQL("idBroadcast = %u", tag.DatabaseID()));
 
   std::string strQuery;
@@ -411,7 +411,7 @@ std::vector<std::shared_ptr<CPVREpg>> CPVREpgDatabase::GetAll()
 {
   std::vector<std::shared_ptr<CPVREpg>> result;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   std::string strQuery = PrepareSQL("SELECT idEpg, sName, sScraperName FROM epg;");
   if (ResultQuery(strQuery))
   {
@@ -495,7 +495,7 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::CreateEpgTag(
 
 bool CPVREpgDatabase::HasTags(int iEpgID) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strQuery =
       PrepareSQL("SELECT iStartTime FROM epgtags WHERE idEpg = %u LIMIT 1;", iEpgID);
   std::string strValue = GetSingleValue(strQuery);
@@ -504,7 +504,7 @@ bool CPVREpgDatabase::HasTags(int iEpgID) const
 
 CDateTime CPVREpgDatabase::GetLastEndTime(int iEpgID) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strQuery =
       PrepareSQL("SELECT MAX(iEndTime) FROM epgtags WHERE idEpg = %u;", iEpgID);
   std::string strValue = GetSingleValue(strQuery);
@@ -519,7 +519,7 @@ std::pair<CDateTime, CDateTime> CPVREpgDatabase::GetFirstAndLastEPGDate() const
   CDateTime first;
   CDateTime last;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // 1st query: get min start time
   std::string strQuery = PrepareSQL("SELECT MIN(iStartTime) FROM epgtags;");
@@ -543,7 +543,7 @@ CDateTime CPVREpgDatabase::GetMinStartTime(int iEpgID, const CDateTime& minStart
   time_t t;
   minStart.GetAsTime(t);
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strQuery = PrepareSQL("SELECT MIN(iStartTime) "
                                           "FROM epgtags "
                                           "WHERE idEpg = %u AND iStartTime > %u;",
@@ -560,7 +560,7 @@ CDateTime CPVREpgDatabase::GetMaxEndTime(int iEpgID, const CDateTime& maxEnd) co
   time_t t;
   maxEnd.GetAsTime(t);
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strQuery = PrepareSQL("SELECT MAX(iEndTime) "
                                           "FROM epgtags "
                                           "WHERE idEpg = %u AND iEndTime <= %u;",
@@ -702,7 +702,7 @@ private:
 std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetEpgTags(
     const PVREpgSearchData& searchData) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   std::string strQuery = PrepareSQL("SELECT * FROM epgtags");
 
@@ -848,7 +848,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetEpgTags(
 std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByUniqueBroadcastID(
     int iEpgID, unsigned int iUniqueBroadcastId) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strQuery = PrepareSQL("SELECT * "
                                           "FROM epgtags "
                                           "WHERE idEpg = %u AND iBroadcastUid = %u;",
@@ -875,7 +875,7 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByUniqueBroadcastID(
 std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByDatabaseID(int iEpgID,
                                                                        int iDatabaseId) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strQuery = PrepareSQL("SELECT * "
                                           "FROM epgtags "
                                           "WHERE idEpg = %u AND idBroadcast = %u;",
@@ -905,7 +905,7 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByStartTime(
   time_t start;
   startTime.GetAsTime(start);
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strQuery = PrepareSQL("SELECT * "
                                           "FROM epgtags "
                                           "WHERE idEpg = %u AND iStartTime = %u;",
@@ -935,7 +935,7 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByMinStartTime(
   time_t minStart;
   minStartTime.GetAsTime(minStart);
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strQuery =
       PrepareSQL("SELECT * "
                  "FROM epgtags "
@@ -966,7 +966,7 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByMaxEndTime(
   time_t maxEnd;
   maxEndTime.GetAsTime(maxEnd);
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strQuery =
       PrepareSQL("SELECT * "
                  "FROM epgtags "
@@ -1000,7 +1000,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetEpgTagsByMinSta
   time_t maxEnd;
   maxEndTime.GetAsTime(maxEnd);
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strQuery =
       PrepareSQL("SELECT * "
                  "FROM epgtags "
@@ -1040,7 +1040,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetEpgTagsByMinEnd
   time_t maxStart;
   maxStartTime.GetAsTime(maxStart);
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strQuery =
       PrepareSQL("SELECT * "
                  "FROM epgtags "
@@ -1083,7 +1083,7 @@ bool CPVREpgDatabase::QueueDeleteEpgTagsByMinEndMaxStartTimeQuery(int iEpgID,
 
   Filter filter;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   filter.AppendWhere(PrepareSQL("idEpg = %u AND iEndTime >= %u AND iStartTime <= %u", iEpgID,
                                 static_cast<unsigned int>(minEnd),
                                 static_cast<unsigned int>(maxStart)));
@@ -1097,7 +1097,7 @@ bool CPVREpgDatabase::QueueDeleteEpgTagsByMinEndMaxStartTimeQuery(int iEpgID,
 
 std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetAllEpgTags(int iEpgID) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strQuery =
       PrepareSQL("SELECT * FROM epgtags WHERE idEpg = %u ORDER BY iStartTime;", iEpgID);
   if (ResultQuery(strQuery))
@@ -1123,7 +1123,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetAllEpgTags(int 
 
 bool CPVREpgDatabase::GetAllIconPaths(int iEpgID, std::vector<std::string>& paths) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strQuery =
       PrepareSQL("SELECT sIconPath FROM epgtags WHERE idEpg = %u;", iEpgID);
   if (ResultQuery(strQuery))
@@ -1149,7 +1149,7 @@ bool CPVREpgDatabase::GetAllIconPaths(int iEpgID, std::vector<std::string>& path
 bool CPVREpgDatabase::GetAllParentalRatingIconPaths(int iEpgID,
                                                     std::vector<std::string>& paths) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strQuery =
       PrepareSQL("SELECT sParentalRatingIcon FROM epgtags WHERE idEpg = %u;", iEpgID);
   if (ResultQuery(strQuery))
@@ -1176,7 +1176,7 @@ bool CPVREpgDatabase::GetLastEpgScanTime(int iEpgId, CDateTime* lastScan) const
 {
   bool bReturn = false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   std::string strWhereClause = PrepareSQL("idEpg = %u", iEpgId);
   std::string strValue = GetSingleValue("lastepgscan", "sLastScan", strWhereClause);
 
@@ -1195,7 +1195,7 @@ bool CPVREpgDatabase::GetLastEpgScanTime(int iEpgId, CDateTime* lastScan) const
 
 bool CPVREpgDatabase::QueuePersistLastEpgScanTimeQuery(int iEpgId, const CDateTime& lastScanTime)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   std::string strQuery = PrepareSQL("REPLACE INTO lastepgscan(idEpg, sLastScan) VALUES (%u, '%s');",
       iEpgId, lastScanTime.GetAsDBDateTime().c_str());
 
@@ -1212,7 +1212,7 @@ bool CPVREpgDatabase::QueueDeleteLastEpgScanTimeQuery(const CPVREpg& table)
 
   Filter filter;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   filter.AppendWhere(PrepareSQL("idEpg = %u", table.EpgID()));
 
   std::string strQuery;
@@ -1227,7 +1227,7 @@ int CPVREpgDatabase::Persist(const CPVREpg& epg, bool bQueueWrite)
   int iReturn = -1;
   std::string strQuery;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (epg.EpgID() > 0)
     strQuery = PrepareSQL("REPLACE INTO epg (idEpg, sName, sScraperName) "
                           "VALUES (%u, '%s', '%s');",
@@ -1258,7 +1258,7 @@ bool CPVREpgDatabase::DeleteEpgTags(int iEpgId, const CDateTime& maxEndTime)
 
   Filter filter;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   filter.AppendWhere(
       PrepareSQL("idEpg = %u AND iEndTime < %u", iEpgId, static_cast<unsigned int>(iMaxEndTime)));
   return DeleteValues("epgtags", filter);
@@ -1268,7 +1268,7 @@ bool CPVREpgDatabase::DeleteEpgTags(int iEpgId)
 {
   Filter filter;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   filter.AppendWhere(PrepareSQL("idEpg = %u", iEpgId));
   return DeleteValues("epgtags", filter);
 }
@@ -1277,7 +1277,7 @@ bool CPVREpgDatabase::QueueDeleteEpgTags(int iEpgId)
 {
   Filter filter;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   filter.AppendWhere(PrepareSQL("idEpg = %u", iEpgId));
 
   std::string strQuery;
@@ -1304,7 +1304,7 @@ bool CPVREpgDatabase::QueuePersistQuery(const CPVREpgInfoTag& tag)
   int iBroadcastId = tag.DatabaseID();
   std::string strQuery;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (iBroadcastId < 0)
   {
@@ -1359,7 +1359,7 @@ bool CPVREpgDatabase::QueuePersistQuery(const CPVREpgInfoTag& tag)
 
 int CPVREpgDatabase::GetLastEPGId() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   std::string strQuery = PrepareSQL("SELECT MAX(idEpg) FROM epg");
   std::string strValue = GetSingleValue(strQuery);
   if (!strValue.empty())
@@ -1424,7 +1424,7 @@ std::vector<std::shared_ptr<CPVREpgSearchFilter>> CPVREpgDatabase::GetSavedSearc
 {
   std::vector<std::shared_ptr<CPVREpgSearchFilter>> result;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strQuery =
       PrepareSQL("SELECT * FROM savedsearches WHERE bIsRadio = %u", bRadio);
   if (ResultQuery(strQuery))
@@ -1448,7 +1448,7 @@ std::vector<std::shared_ptr<CPVREpgSearchFilter>> CPVREpgDatabase::GetSavedSearc
 
 std::shared_ptr<CPVREpgSearchFilter> CPVREpgDatabase::GetSavedSearchById(bool bRadio, int iId) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strQuery =
       PrepareSQL("SELECT * FROM savedsearches WHERE bIsRadio = %u AND idSearch = %u;", bRadio, iId);
 
@@ -1471,7 +1471,7 @@ std::shared_ptr<CPVREpgSearchFilter> CPVREpgDatabase::GetSavedSearchById(bool bR
 
 bool CPVREpgDatabase::Persist(CPVREpgSearchFilter& epgSearch)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // Insert a new entry if this is a new search, replace the existing otherwise
   std::string strQuery;
@@ -1557,7 +1557,7 @@ bool CPVREpgDatabase::UpdateSavedSearchLastExecuted(const CPVREpgSearchFilter& e
   if (epgSearch.GetDatabaseId() == PVR_EPG_SEARCH_INVALID_DATABASE_ID)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   const std::string strQuery = PrepareSQL(
       "UPDATE savedsearches SET sLastExecutedDateTime = '%s' WHERE idSearch = %i",
@@ -1573,7 +1573,7 @@ bool CPVREpgDatabase::Delete(const CPVREpgSearchFilter& epgSearch)
   CLog::LogFC(LOGDEBUG, LOGEPG, "Deleting saved search '{}' from the database",
               epgSearch.GetTitle());
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   Filter filter;
   filter.AppendWhere(PrepareSQL("idSearch = '%i'", epgSearch.GetDatabaseId()));
@@ -1585,6 +1585,6 @@ bool CPVREpgDatabase::DeleteSavedSearches()
 {
   CLog::LogFC(LOGDEBUG, LOGEPG, "Deleting all saved searches from the database");
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return DeleteValues("savedsearches");
 }

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -146,7 +146,7 @@ CPVREpgInfoTag::CPVREpgInfoTag(const EPG_TAG& data,
 
 void CPVREpgInfoTag::SetChannelData(const std::shared_ptr<CPVREpgChannelData>& data)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (data)
     m_channelData = data;
   else
@@ -158,7 +158,7 @@ bool CPVREpgInfoTag::operator==(const CPVREpgInfoTag& right) const
   if (this == &right)
     return true;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return (m_iUniqueBroadcastID == right.m_iUniqueBroadcastID && m_channelData &&
           right.m_channelData &&
           m_channelData->UniqueClientChannelId() == right.m_channelData->UniqueClientChannelId() &&
@@ -175,7 +175,7 @@ bool CPVREpgInfoTag::operator!=(const CPVREpgInfoTag& right) const
 
 void CPVREpgInfoTag::Serialize(CVariant& value) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   value["broadcastid"] = m_iDatabaseID; // Use DB id here as it is unique across PVR clients
   value["channeluid"] = m_channelData->UniqueClientChannelId();
   value["parentalrating"] = m_parentalRating;
@@ -217,7 +217,7 @@ void CPVREpgInfoTag::Serialize(CVariant& value) const
 
 int CPVREpgInfoTag::ClientID() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_channelData->ClientId();
 }
 
@@ -305,13 +305,13 @@ int CPVREpgInfoTag::DatabaseID() const
 
 int CPVREpgInfoTag::UniqueChannelID() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_channelData->UniqueClientChannelId();
 }
 
 std::string CPVREpgInfoTag::ChannelIconPath() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_channelData->ChannelIconPath();
 }
 
@@ -479,7 +479,7 @@ std::string CPVREpgInfoTag::Path() const
 
 bool CPVREpgInfoTag::Update(const CPVREpgInfoTag& tag, bool bUpdateBroadcastId /* = true */)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   bool bChanged =
       (m_strTitle != tag.m_strTitle || m_strPlotOutline != tag.m_strPlotOutline ||
        m_strPlot != tag.m_strPlot || m_strOriginalTitle != tag.m_strOriginalTitle ||
@@ -559,7 +559,7 @@ std::vector<EDL::Edit> CPVREpgInfoTag::GetEdl() const
 {
   std::vector<EDL::Edit> edls;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::shared_ptr<const CPVRClient> client =
       CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
 
@@ -585,7 +585,7 @@ bool CPVREpgInfoTag::IsRecordable() const
 {
   bool bIsRecordable = false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::shared_ptr<const CPVRClient> client =
       CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
   if (!client || (client->IsRecordable(shared_from_this(), bIsRecordable) != PVR_ERROR_NO_ERROR))
@@ -600,7 +600,7 @@ bool CPVREpgInfoTag::IsPlayable() const
 {
   bool bIsPlayable = false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::shared_ptr<const CPVRClient> client =
       CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
   if (!client || (client->IsPlayable(shared_from_this(), bIsPlayable) != PVR_ERROR_NO_ERROR))
@@ -622,19 +622,19 @@ bool CPVREpgInfoTag::IsSeries() const
 
 bool CPVREpgInfoTag::IsRadio() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_channelData->IsRadio();
 }
 
 bool CPVREpgInfoTag::IsParentalLocked() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_channelData->IsLocked();
 }
 
 bool CPVREpgInfoTag::IsGapTag() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_bIsGapTag;
 }
 

--- a/xbmc/pvr/epg/EpgSearch.cpp
+++ b/xbmc/pvr/epg/EpgSearch.cpp
@@ -20,7 +20,7 @@ using namespace PVR;
 
 void CPVREpgSearch::Execute()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   std::vector<std::shared_ptr<CPVREpgInfoTag>> tags{
       CServiceBroker::GetPVRManager().EpgContainer().GetTags(m_filter.GetEpgSearchData())};
@@ -46,6 +46,6 @@ void CPVREpgSearch::Execute()
 
 const std::vector<std::shared_ptr<CPVREpgInfoTag>>& CPVREpgSearch::GetResults() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_results;
 }

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -670,7 +670,7 @@ bool CGUIEPGGridContainer::OnMessage(CGUIMessage& message)
 
 void CGUIEPGGridContainer::UpdateItems()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (!m_updatedGridModel)
     return;
@@ -1162,7 +1162,7 @@ bool CGUIEPGGridContainer::SetChannel(const CPVRChannelNumber& channelNumber)
 
 void CGUIEPGGridContainer::SetChannel(int channel)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   int channelIndex = channel + m_channelOffset;
   int blockIndex = m_blockCursor + m_blockOffset;
@@ -1180,7 +1180,7 @@ void CGUIEPGGridContainer::SetChannel(int channel)
 
 void CGUIEPGGridContainer::SetBlock(int block, bool bUpdateBlockTravelAxis /* = true */)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (block < 0)
     m_blockCursor = 0;
@@ -1308,7 +1308,7 @@ EVENT_RESULT CGUIEPGGridContainer::OnMouseEvent(const CPoint& point,
       m_channelScrollOffset -= event.m_offsetY;
 
       {
-        std::unique_lock<CCriticalSection> lock(m_critSection);
+        std::unique_lock lock(m_critSection);
 
         m_channelOffset =
             MathUtils::round_int(m_channelScrollOffset / m_channelLayout->Size(m_orientation));
@@ -1380,7 +1380,7 @@ std::shared_ptr<CPVRChannelGroupMember> CGUIEPGGridContainer::GetSelectedChannel
 {
   CFileItemPtr fileItem;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     if (m_channelCursor + m_channelOffset < m_gridModel->ChannelItemsSize())
       fileItem = m_gridModel->GetChannelItem(m_channelCursor + m_channelOffset);
   }
@@ -1537,7 +1537,7 @@ void CGUIEPGGridContainer::SetFocus(bool focus)
 
 void CGUIEPGGridContainer::ScrollToChannelOffset(int offset)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   float size = m_programmeLayout->Size(m_orientation);
   int range = m_channelsPerPage / 4;
@@ -1564,7 +1564,7 @@ void CGUIEPGGridContainer::ScrollToChannelOffset(int offset)
 
 void CGUIEPGGridContainer::ScrollToBlockOffset(int offset)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // make sure offset is in valid range
   offset = std::max(0, std::min(offset, m_gridModel->GridItemsSize() - m_blocksPerPage));
@@ -1596,7 +1596,7 @@ void CGUIEPGGridContainer::ScrollToBlockOffset(int offset)
 
 void CGUIEPGGridContainer::ValidateOffset()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (!m_programmeLayout)
     return;
@@ -1690,7 +1690,7 @@ void CGUIEPGGridContainer::LoadLayout(TiXmlElement* layout)
 
 std::string CGUIEPGGridContainer::GetDescription() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   const int channelIndex = m_channelCursor + m_channelOffset;
   const int blockIndex = m_blockCursor + m_blockOffset;
@@ -1838,7 +1838,7 @@ void CGUIEPGGridContainer::SetTimelineItems(const std::unique_ptr<CFileItemList>
   int iFirstBlock;
   float fBlockSize;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     blocksPerRulerItem = m_blocksPerRulerItem;
     iFirstChannel = m_channelOffset;
@@ -1855,7 +1855,7 @@ void CGUIEPGGridContainer::SetTimelineItems(const std::unique_ptr<CFileItemList>
   newUpdatedGridModel->Initialize(items, gridStart, gridEnd, iFirstChannel, iChannelsPerPage,
                                   iFirstBlock, iBlocksPerPage, blocksPerRulerItem, fBlockSize);
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     // grid contains CFileItem instances. CFileItem dtor locks global graphics mutex.
     // by increasing its refcount make sure, old data are not deleted while we're holding own mutex.
@@ -1929,7 +1929,7 @@ void CGUIEPGGridContainer::UpdateLayout()
       oldRulerDateLayout == m_rulerDateLayout)
     return; // nothing has changed, so don't update stuff
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_channelHeight = m_channelLayout->Size(VERTICAL);
   m_channelWidth = m_channelLayout->Size(HORIZONTAL);
@@ -2597,7 +2597,7 @@ void CGUIEPGGridContainer::HandleProgrammeGrid(bool bRender,
           }
 
           {
-            std::unique_lock<CCriticalSection> lock(m_critSection);
+            std::unique_lock lock(m_critSection);
             // truncate item's width
             m_gridModel->DecreaseGridItemWidth(channel, block, truncateSize);
           }

--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
@@ -401,7 +401,7 @@ void CPVRGUIActionsChannels::OnPlaybackStopped(const CFileItem& item)
 
 void CPVRGUIActionsChannels::SetSelectedChannelPath(bool bRadio, const std::string& path)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (bRadio)
     m_selectedChannelPathRadio = path;
   else
@@ -431,6 +431,6 @@ std::string CPVRGUIActionsChannels::GetSelectedChannelPath(bool bRadio) const
     }
   }
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return bRadio ? m_selectedChannelPathRadio : m_selectedChannelPathTV;
 }

--- a/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
@@ -124,7 +124,7 @@ void CPVRGUIChannelNavigator::SubscribeToShowInfoEventStream()
 
 void CPVRGUIChannelNavigator::CheckAndPublishPreviewAndPlayerShowInfoChangedEvent()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   const bool currentValue = IsPreview() && m_playerShowInfo;
   if (m_previewAndPlayerShowInfo != currentValue)
@@ -138,7 +138,7 @@ void CPVRGUIChannelNavigator::CheckAndPublishPreviewAndPlayerShowInfoChangedEven
 
 void CPVRGUIChannelNavigator::Notify(const PlayerShowInfoChangedEvent& event)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_playerShowInfo = event.m_showInfo;
   CheckAndPublishPreviewAndPlayerShowInfoChangedEvent();
@@ -146,7 +146,7 @@ void CPVRGUIChannelNavigator::Notify(const PlayerShowInfoChangedEvent& event)
 
 void CPVRGUIChannelNavigator::SelectNextChannel(ChannelSwitchMode eSwitchMode)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (!m_playerShowInfo && eSwitchMode == ChannelSwitchMode::NO_SWITCH)
   {
@@ -162,7 +162,7 @@ void CPVRGUIChannelNavigator::SelectNextChannel(ChannelSwitchMode eSwitchMode)
 
 void CPVRGUIChannelNavigator::SelectPreviousChannel(ChannelSwitchMode eSwitchMode)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (!m_playerShowInfo && eSwitchMode == ChannelSwitchMode::NO_SWITCH)
   {
@@ -187,7 +187,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRGUIChannelNavigator::GetNextOrPrevCh
         CServiceBroker::GetPVRManager().PlaybackState()->GetActiveChannelGroup(bPlayingRadio);
     if (group)
     {
-      std::unique_lock<CCriticalSection> lock(m_critSection);
+      std::unique_lock lock(m_critSection);
       return bNext ? group->GetNextChannelGroupMember(m_currentChannel)
                    : group->GetPreviousChannelGroupMember(m_currentChannel);
     }
@@ -200,7 +200,7 @@ void CPVRGUIChannelNavigator::SelectChannel(
 {
   CServiceBroker::GetGUI()->GetInfoManager().SetCurrentItem(CFileItem(groupMember));
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_currentChannel = groupMember;
   ShowInfo(false);
@@ -235,7 +235,7 @@ void CPVRGUIChannelNavigator::SwitchToCurrentChannel()
   std::unique_ptr<CFileItem> item;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     if (m_iChannelEntryJobId >= 0)
     {
@@ -251,13 +251,13 @@ void CPVRGUIChannelNavigator::SwitchToCurrentChannel()
 
 bool CPVRGUIChannelNavigator::IsPreview() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_currentChannel != m_playingChannel;
 }
 
 bool CPVRGUIChannelNavigator::IsPreviewAndShowInfo() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_previewAndPlayerShowInfo;
 }
 
@@ -279,7 +279,7 @@ void CPVRGUIChannelNavigator::ShowInfo(bool bForce)
         .GetPlayerInfoProvider()
         .SetShowInfo(true);
 
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     if (m_iChannelInfoJobId >= 0)
     {
@@ -304,7 +304,7 @@ void CPVRGUIChannelNavigator::HideInfo()
   CFileItemPtr item;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     if (m_iChannelInfoJobId >= 0)
     {
@@ -328,7 +328,7 @@ void CPVRGUIChannelNavigator::HideInfo()
 
 void CPVRGUIChannelNavigator::ToggleInfo()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_playerShowInfo)
     HideInfo();
@@ -343,7 +343,7 @@ void CPVRGUIChannelNavigator::SetPlayingChannel(
 
   if (groupMember)
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     m_playingChannel = groupMember;
     if (m_currentChannel != m_playingChannel)
@@ -364,7 +364,7 @@ void CPVRGUIChannelNavigator::SetPlayingChannel(
 
 void CPVRGUIChannelNavigator::ClearPlayingChannel()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_playingChannel.reset();
   HideInfo();

--- a/xbmc/pvr/guilib/PVRGUIProgressHandler.cpp
+++ b/xbmc/pvr/guilib/PVRGUIProgressHandler.cpp
@@ -31,7 +31,7 @@ CPVRGUIProgressHandler::CPVRGUIProgressHandler(const std::string& strTitle)
 
 void CPVRGUIProgressHandler::UpdateProgress(const std::string& strText, float fProgress)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_bChanged = true;
   m_strText = strText;
   m_fProgress = fProgress;
@@ -73,7 +73,7 @@ void CPVRGUIProgressHandler::Process()
     bool bUpdate = false;
 
     {
-      std::unique_lock<CCriticalSection> lock(m_critSection);
+      std::unique_lock lock(m_critSection);
       if (m_bChanged)
       {
         m_bChanged = false;

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -67,7 +67,7 @@ CPVRGUIInfo::CPVRGUIInfo() : CThread("PVRGUIInfo")
 
 void CPVRGUIInfo::ResetProperties()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_anyTimersInfo.ResetProperties();
   m_tvTimersInfo.ResetProperties();
@@ -151,13 +151,13 @@ void CPVRGUIInfo::Notify(const PVREvent& event)
 
 void CPVRGUIInfo::Notify(const PVRChannelNumberInputChangedEvent& event)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_channelNumberInput = event.m_input;
 }
 
 void CPVRGUIInfo::Notify(const PVRPreviewAndPlayerShowInfoChangedEvent& event)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_previewAndPlayerShowInfo = event.m_previewAndPlayerShowInfo;
 }
 
@@ -252,7 +252,7 @@ void CPVRGUIInfo::UpdateQualityData()
       client->SignalQuality(channelUid, qualityInfo);
   }
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_qualityInfo = qualityInfo;
 }
 
@@ -276,7 +276,7 @@ void CPVRGUIInfo::UpdateDescrambleData()
       client->GetDescrambleInfo(channelUid, descrambleInfo);
   }
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_descrambleInfo = descrambleInfo;
 }
 
@@ -305,7 +305,7 @@ void CPVRGUIInfo::UpdateMisc()
   const std::string strPlayingRadioGroup =
       (bStarted && bIsPlayingRadio) ? state->GetActiveChannelGroup(true)->GroupName() : "";
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strPlayingClientName = strPlayingClientName;
   m_bHasTVRecordings = bHasTVRecordings;
   m_bHasRadioRecordings = bHasRadioRecordings;
@@ -543,7 +543,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
         return false;
       case VIDEOPLAYER_CHANNEL_GROUP:
       {
-        std::unique_lock<CCriticalSection> lock(m_critSection);
+        std::unique_lock lock(m_critSection);
         strValue = recording->IsRadio() ? m_strPlayingRadioGroup : m_strPlayingTVGroup;
         return true;
       }
@@ -951,7 +951,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
       case MUSICPLAYER_CHANNEL_GROUP:
       case VIDEOPLAYER_CHANNEL_GROUP:
       {
-        std::unique_lock<CCriticalSection> lock(m_critSection);
+        std::unique_lock lock(m_critSection);
         strValue = channel->IsRadio() ? m_strPlayingRadioGroup : m_strPlayingTVGroup;
         return true;
       }
@@ -992,7 +992,7 @@ bool CPVRGUIInfo::GetPVRLabel(const CFileItem* item,
                               const CGUIInfo& info,
                               std::string& strValue) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   switch (info.m_info)
   {
@@ -1427,7 +1427,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerInt(const CFileItem* item,
 
 bool CPVRGUIInfo::GetPVRInt(const CFileItem* item, const CGUIInfo& info, int& iValue) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   switch (info.m_info)
   {
@@ -1809,7 +1809,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
 
 bool CPVRGUIInfo::GetPVRBool(const CFileItem* item, const CGUIInfo& info, bool& bValue) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   switch (info.m_info)
   {
@@ -2104,7 +2104,7 @@ void CPVRGUIInfo::CharInfoProvider(std::string& strValue) const
 
 void CPVRGUIInfo::UpdateBackendCache()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // Update the backend information for all backends if
   // an update has been requested

--- a/xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.cpp
@@ -31,7 +31,7 @@ CPVRGUITimerInfo::CPVRGUITimerInfo()
 
 void CPVRGUITimerInfo::ResetProperties()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strActiveTimerTitle.clear();
   m_strActiveTimerChannelName.clear();
   m_strActiveTimerChannelIcon.clear();
@@ -49,7 +49,7 @@ void CPVRGUITimerInfo::ResetProperties()
 
 bool CPVRGUITimerInfo::TimerInfoToggle()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_iTimerInfoToggleStart.time_since_epoch().count() == 0)
   {
     m_iTimerInfoToggleStart = std::chrono::steady_clock::now();
@@ -103,7 +103,7 @@ void CPVRGUITimerInfo::UpdateTimersToggle()
     }
   }
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strActiveTimerTitle = strActiveTimerTitle;
   m_strActiveTimerChannelName = strActiveTimerChannelName;
   m_strActiveTimerChannelIcon = strActiveTimerChannelIcon;
@@ -116,7 +116,7 @@ void CPVRGUITimerInfo::UpdateTimersCache()
   int iRecordingTimerAmount = AmountActiveRecordings();
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     m_iTimerAmount = iTimerAmount;
     m_iRecordingTimerAmount = iRecordingTimerAmount;
     m_iTimerInfoToggleStart = {};
@@ -147,7 +147,7 @@ void CPVRGUITimerInfo::UpdateNextTimer()
                                            timer->StartAsLocalTime().GetAsLocalizedTime("", false));
   }
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strNextRecordingTitle = strNextRecordingTitle;
   m_strNextRecordingChannelName = strNextRecordingChannelName;
   m_strNextRecordingChannelIcon = strNextRecordingChannelIcon;
@@ -157,55 +157,55 @@ void CPVRGUITimerInfo::UpdateNextTimer()
 
 const std::string& CPVRGUITimerInfo::GetActiveTimerTitle() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strActiveTimerTitle;
 }
 
 const std::string& CPVRGUITimerInfo::GetActiveTimerChannelName() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strActiveTimerChannelName;
 }
 
 const std::string& CPVRGUITimerInfo::GetActiveTimerChannelIcon() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strActiveTimerChannelIcon;
 }
 
 const std::string& CPVRGUITimerInfo::GetActiveTimerDateTime() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strActiveTimerTime;
 }
 
 const std::string& CPVRGUITimerInfo::GetNextTimerTitle() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strNextRecordingTitle;
 }
 
 const std::string& CPVRGUITimerInfo::GetNextTimerChannelName() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strNextRecordingChannelName;
 }
 
 const std::string& CPVRGUITimerInfo::GetNextTimerChannelIcon() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strNextRecordingChannelIcon;
 }
 
 const std::string& CPVRGUITimerInfo::GetNextTimerDateTime() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strNextRecordingTime;
 }
 
 const std::string& CPVRGUITimerInfo::GetNextTimer() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strNextTimerInfo;
 }
 

--- a/xbmc/pvr/guilib/guiinfo/PVRGUITimesInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUITimesInfo.cpp
@@ -36,7 +36,7 @@ CPVRGUITimesInfo::CPVRGUITimesInfo()
 
 void CPVRGUITimesInfo::Reset()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_iStartTime = 0;
   m_iDuration = 0;
@@ -67,7 +67,7 @@ void CPVRGUITimesInfo::UpdatePlayingTag()
     const std::shared_ptr<const CPVRChannelGroupsContainer> groups =
         CServiceBroker::GetPVRManager().ChannelGroups();
 
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     const std::shared_ptr<const CPVRChannel> playingChannel =
         m_playingEpgTag ? groups->GetChannelForEpgTag(m_playingEpgTag) : nullptr;
@@ -100,7 +100,7 @@ void CPVRGUITimesInfo::UpdatePlayingTag()
         CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingRecording();
     if (recording)
     {
-      std::unique_lock<CCriticalSection> lock(m_critSection);
+      std::unique_lock lock(m_critSection);
       m_playingEpgTag.reset();
       m_iDuration = recording->GetDuration();
     }
@@ -124,7 +124,7 @@ void CPVRGUITimesInfo::UpdateTimeshiftData()
   const std::shared_ptr<const CPVRChannel> playingChannel =
       CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (playingChannel != m_playingChannel)
   {
@@ -182,7 +182,7 @@ void CPVRGUITimesInfo::UpdateTimeshiftProgressData()
   //       In simple timeshift mode (settings value), progress start is always the start time of
   //       playing epg event and progress end is always the end time of playing epg event.
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   //////////////////////////////////////////////////////////////////////////////////////
   // start time
@@ -253,50 +253,50 @@ std::string CPVRGUITimesInfo::TimeToTimeString(time_t datetime, TIME_FORMAT form
 
 std::string CPVRGUITimesInfo::GetTimeshiftStartTime(TIME_FORMAT format) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return TimeToTimeString(m_iTimeshiftStartTime, format, false);
 }
 
 std::string CPVRGUITimesInfo::GetTimeshiftEndTime(TIME_FORMAT format) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return TimeToTimeString(m_iTimeshiftEndTime, format, false);
 }
 
 std::string CPVRGUITimesInfo::GetTimeshiftPlayTime(TIME_FORMAT format) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return TimeToTimeString(m_iTimeshiftPlayTime, format, true);
 }
 
 std::string CPVRGUITimesInfo::GetTimeshiftOffset(TIME_FORMAT format) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return StringUtils::SecondsToTimeString(m_iTimeshiftOffset, format);
 }
 
 std::string CPVRGUITimesInfo::GetTimeshiftProgressDuration(TIME_FORMAT format) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return StringUtils::SecondsToTimeString(m_iTimeshiftProgressDuration, format);
 }
 
 std::string CPVRGUITimesInfo::GetTimeshiftProgressStartTime(TIME_FORMAT format) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return TimeToTimeString(m_iTimeshiftProgressStartTime, format, false);
 }
 
 std::string CPVRGUITimesInfo::GetTimeshiftProgressEndTime(TIME_FORMAT format) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return TimeToTimeString(m_iTimeshiftProgressEndTime, format, false);
 }
 
 std::string CPVRGUITimesInfo::GetEpgEventDuration(
     const std::shared_ptr<const CPVREpgInfoTag>& epgTag, TIME_FORMAT format) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return StringUtils::SecondsToTimeString(GetEpgEventDuration(epgTag), format);
 }
 
@@ -304,7 +304,7 @@ std::string CPVRGUITimesInfo::GetEpgEventElapsedTime(
     const std::shared_ptr<const CPVREpgInfoTag>& epgTag, TIME_FORMAT format) const
 {
   int iElapsed = 0;
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (epgTag && m_playingEpgTag && *epgTag != *m_playingEpgTag)
     iElapsed = epgTag->Progress();
   else
@@ -316,7 +316,7 @@ std::string CPVRGUITimesInfo::GetEpgEventElapsedTime(
 std::string CPVRGUITimesInfo::GetEpgEventRemainingTime(
     const std::shared_ptr<const CPVREpgInfoTag>& epgTag, TIME_FORMAT format) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return StringUtils::SecondsToTimeString(GetRemainingTime(epgTag), format);
 }
 
@@ -335,7 +335,7 @@ std::string CPVRGUITimesInfo::GetEpgEventSeekTime(int iSeekSize, TIME_FORMAT for
 
 int CPVRGUITimesInfo::GetElapsedTime() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_playingEpgTag || m_iTimeshiftStartTime)
   {
     CDateTime current(m_iTimeshiftPlayTime);
@@ -351,7 +351,7 @@ int CPVRGUITimesInfo::GetElapsedTime() const
 
 int CPVRGUITimesInfo::GetRemainingTime(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (epgTag && m_playingEpgTag && *epgTag != *m_playingEpgTag)
     return epgTag->GetDuration() - epgTag->Progress();
   else
@@ -360,7 +360,7 @@ int CPVRGUITimesInfo::GetRemainingTime(const std::shared_ptr<const CPVREpgInfoTa
 
 int CPVRGUITimesInfo::GetTimeshiftProgress() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::chrono::duration<double> total{m_iTimeshiftEndTime - m_iTimeshiftStartTime};
   if (total.count())
   {
@@ -372,13 +372,13 @@ int CPVRGUITimesInfo::GetTimeshiftProgress() const
 
 int CPVRGUITimesInfo::GetTimeshiftProgressDuration() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return static_cast<int>(m_iTimeshiftProgressDuration);
 }
 
 int CPVRGUITimesInfo::GetTimeshiftProgressPlayPosition() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_iTimeshiftProgressDuration)
   {
     const std::chrono::duration<double> duration{m_iTimeshiftPlayTime -
@@ -390,7 +390,7 @@ int CPVRGUITimesInfo::GetTimeshiftProgressPlayPosition() const
 
 int CPVRGUITimesInfo::GetTimeshiftProgressEpgStart() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_playingEpgTag && m_iTimeshiftProgressDuration)
   {
     time_t epgStart = 0;
@@ -403,7 +403,7 @@ int CPVRGUITimesInfo::GetTimeshiftProgressEpgStart() const
 
 int CPVRGUITimesInfo::GetTimeshiftProgressEpgEnd() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_playingEpgTag && m_iTimeshiftProgressDuration)
   {
     time_t epgEnd = 0;
@@ -416,7 +416,7 @@ int CPVRGUITimesInfo::GetTimeshiftProgressEpgEnd() const
 
 int CPVRGUITimesInfo::GetTimeshiftProgressBufferStart() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_iTimeshiftProgressDuration)
   {
     const std::chrono::duration<double> duration{m_iTimeshiftStartTime -
@@ -428,7 +428,7 @@ int CPVRGUITimesInfo::GetTimeshiftProgressBufferStart() const
 
 int CPVRGUITimesInfo::GetTimeshiftProgressBufferEnd() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_iTimeshiftProgressDuration)
   {
     const std::chrono::duration<double> duration{m_iTimeshiftEndTime -
@@ -440,7 +440,7 @@ int CPVRGUITimesInfo::GetTimeshiftProgressBufferEnd() const
 
 int CPVRGUITimesInfo::GetEpgEventDuration(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (epgTag && m_playingEpgTag && *epgTag != *m_playingEpgTag)
     return epgTag->GetDuration();
   else
@@ -449,7 +449,7 @@ int CPVRGUITimesInfo::GetEpgEventDuration(const std::shared_ptr<const CPVREpgInf
 
 int CPVRGUITimesInfo::GetEpgEventProgress(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (epgTag && m_playingEpgTag && *epgTag != *m_playingEpgTag)
     return MathUtils::round_int(epgTag->ProgressPercentage());
   else if (m_iDuration)
@@ -460,6 +460,6 @@ int CPVRGUITimesInfo::GetEpgEventProgress(const std::shared_ptr<const CPVREpgInf
 
 bool CPVRGUITimesInfo::IsTimeshifting() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return (m_iTimeshiftOffset > static_cast<unsigned int>(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeshiftThreshold));
 }

--- a/xbmc/pvr/providers/PVRProvider.cpp
+++ b/xbmc/pvr/providers/PVRProvider.cpp
@@ -106,13 +106,13 @@ void CPVRProvider::Serialize(CVariant& value) const
 
 int CPVRProvider::GetDatabaseId() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iDatabaseId;
 }
 
 bool CPVRProvider::SetDatabaseId(int iDatabaseId)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_iDatabaseId != iDatabaseId)
   {
@@ -125,25 +125,25 @@ bool CPVRProvider::SetDatabaseId(int iDatabaseId)
 
 int CPVRProvider::GetUniqueId() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iUniqueId;
 }
 
 int CPVRProvider::GetClientId() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iClientId;
 }
 
 std::string CPVRProvider::GetName() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strName;
 }
 
 bool CPVRProvider::SetName(const std::string& strName)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_strName != strName)
   {
     m_strName = strName;
@@ -155,13 +155,13 @@ bool CPVRProvider::SetName(const std::string& strName)
 
 PVR_PROVIDER_TYPE CPVRProvider::GetType() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_type;
 }
 
 bool CPVRProvider::SetType(PVR_PROVIDER_TYPE type)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_type != type)
   {
     m_type = type;
@@ -173,19 +173,19 @@ bool CPVRProvider::SetType(PVR_PROVIDER_TYPE type)
 
 std::string CPVRProvider::GetClientIconPath() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iconPath.GetClientImage();
 }
 
 std::string CPVRProvider::GetIconPath() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iconPath.GetLocalImage();
 }
 
 bool CPVRProvider::SetIconPath(const std::string& strIconPath)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (GetClientIconPath() != strIconPath)
   {
     m_iconPath.SetClientImage(strIconPath);
@@ -212,14 +212,14 @@ const std::string DeTokenize(const std::vector<std::string>& tokens)
 
 std::vector<std::string> CPVRProvider::GetCountries() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   return Tokenize(m_strCountries);
 }
 
 bool CPVRProvider::SetCountries(const std::vector<std::string>& countries)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strCountries = DeTokenize(countries);
   if (m_strCountries != strCountries)
   {
@@ -232,13 +232,13 @@ bool CPVRProvider::SetCountries(const std::vector<std::string>& countries)
 
 std::string CPVRProvider::GetCountriesDBString() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strCountries;
 }
 
 bool CPVRProvider::SetCountriesFromDBString(const std::string& strCountries)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_strCountries != strCountries)
   {
     m_strCountries = strCountries;
@@ -250,13 +250,13 @@ bool CPVRProvider::SetCountriesFromDBString(const std::string& strCountries)
 
 std::vector<std::string> CPVRProvider::GetLanguages() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return Tokenize(m_strLanguages);
 }
 
 bool CPVRProvider::SetLanguages(const std::vector<std::string>& languages)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::string strLanguages = DeTokenize(languages);
   if (m_strLanguages != strLanguages)
   {
@@ -269,13 +269,13 @@ bool CPVRProvider::SetLanguages(const std::vector<std::string>& languages)
 
 std::string CPVRProvider::GetLanguagesDBString() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strLanguages;
 }
 
 bool CPVRProvider::SetLanguagesFromDBString(const std::string& strLanguages)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_strLanguages != strLanguages)
   {
     m_strLanguages = strLanguages;
@@ -290,7 +290,7 @@ bool CPVRProvider::Persist(bool updateRecord /* = false */)
   const std::shared_ptr<CPVRDatabase> database = CServiceBroker::GetPVRManager().GetTVDatabase();
   if (database)
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     return database->Persist(*this, updateRecord);
   }
 
@@ -302,7 +302,7 @@ bool CPVRProvider::DeleteFromDatabase()
   const std::shared_ptr<CPVRDatabase> database = CServiceBroker::GetPVRManager().GetTVDatabase();
   if (database)
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     return database->Delete(*this);
   }
 
@@ -313,7 +313,7 @@ bool CPVRProvider::UpdateEntry(const std::shared_ptr<CPVRProvider>& fromProvider
                                ProviderUpdateMode updateMode)
 {
   bool bChanged = false;
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (updateMode == ProviderUpdateMode::BY_DATABASE)
   {
@@ -376,25 +376,25 @@ bool CPVRProvider::UpdateEntry(const std::shared_ptr<CPVRProvider>& fromProvider
 
 bool CPVRProvider::HasThumbPath() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return (m_type == PVR_PROVIDER_TYPE_ADDON && !m_thumbPath.GetLocalImage().empty());
 }
 
 std::string CPVRProvider::GetThumbPath() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_thumbPath.GetLocalImage();
 }
 
 std::string CPVRProvider::GetClientThumbPath() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_thumbPath.GetClientImage();
 }
 
 void CPVRProvider::ToSortable(SortItem& sortable, Field field) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (field == FieldProvider)
     sortable[FieldProvider] = StringUtils::Format(
         "{} {} {} {}", m_iClientId, m_type == PVR_PROVIDER_TYPE_ADDON ? 0 : 1, m_type, m_strName);

--- a/xbmc/pvr/providers/PVRProviders.cpp
+++ b/xbmc/pvr/providers/PVRProviders.cpp
@@ -29,7 +29,7 @@ using namespace PVR;
 
 bool CPVRProvidersContainer::UpdateFromClient(const std::shared_ptr<CPVRProvider>& provider)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::shared_ptr<CPVRProvider> providerToUpdate =
       GetByClient(provider->GetClientId(), provider->GetUniqueId());
   if (providerToUpdate)
@@ -48,7 +48,7 @@ bool CPVRProvidersContainer::UpdateFromClient(const std::shared_ptr<CPVRProvider
 std::shared_ptr<CPVRProvider> CPVRProvidersContainer::GetByClient(int iClientId,
                                                                   int iUniqueId) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const auto it = std::find_if(
       m_providers.cbegin(), m_providers.cend(), [iClientId, iUniqueId](const auto& provider) {
         return provider->GetClientId() == iClientId && provider->GetUniqueId() == iUniqueId;
@@ -78,14 +78,14 @@ void CPVRProvidersContainer::InsertEntry(const std::shared_ptr<CPVRProvider>& ne
 
 std::vector<std::shared_ptr<CPVRProvider>> CPVRProvidersContainer::GetProvidersList() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_providers;
 }
 
 std::vector<std::shared_ptr<CPVRProvider>> CPVRProviders::GetProviders() const
 {
   std::vector<std::shared_ptr<CPVRProvider>> providers;
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   //! @todo optimize; get rid of iteration.
   providers.reserve(m_providers.size());
@@ -106,7 +106,7 @@ std::vector<std::shared_ptr<CPVRProvider>> CPVRProviders::GetProviders() const
 
 std::size_t CPVRProviders::GetNumProviders() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return GetProviders().size();
 }
 
@@ -118,7 +118,7 @@ bool CPVRProviders::Update(const std::vector<std::shared_ptr<CPVRClient>>& clien
 void CPVRProviders::Unload()
 {
   // remove all tags
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_providers.clear();
 }
 
@@ -142,7 +142,7 @@ bool CPVRProviders::LoadFromDatabase(const std::vector<std::shared_ptr<CPVRClien
 bool CPVRProviders::UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients)
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     if (m_bIsUpdating)
       return false;
     m_bIsUpdating = true;
@@ -181,7 +181,7 @@ bool CPVRProviders::UpdateDefaultEntries(const CPVRProvidersContainer& newProvid
 {
   bool bChanged = false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // go through the provider list and check for updated or new providers
   const auto newProviderList = newProviders.GetProvidersList();
@@ -234,7 +234,7 @@ bool CPVRProviders::UpdateClientEntries(const CPVRProvidersContainer& newProvide
                                         const std::vector<int>& failedClients,
                                         const std::vector<int>& disabledClients)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // go through the provider list and check for updated or new providers
   for (const auto& newProvider : newProviders.GetProvidersList())
@@ -286,7 +286,7 @@ std::shared_ptr<CPVRProvider> CPVRProviders::CheckAndAddEntry(
 {
   bool bChanged = false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   std::shared_ptr<CPVRProvider> provider =
       GetByClient(newProvider->GetClientId(), newProvider->GetUniqueId());
   if (provider)
@@ -316,7 +316,7 @@ std::shared_ptr<CPVRProvider> CPVRProviders::CheckAndPersistEntry(
 {
   bool bChanged = false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   std::shared_ptr<CPVRProvider> provider =
       GetByClient(newProvider->GetClientId(), newProvider->GetUniqueId());
   if (provider)
@@ -364,7 +364,7 @@ bool CPVRProviders::PersistUserChanges(const std::vector<std::shared_ptr<CPVRPro
 
 std::shared_ptr<CPVRProvider> CPVRProviders::GetById(int iProviderId) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const auto it =
       std::find_if(m_providers.cbegin(), m_providers.cend(), [iProviderId](const auto& provider) {
         return provider->GetDatabaseId() == iProviderId;
@@ -374,7 +374,7 @@ std::shared_ptr<CPVRProvider> CPVRProviders::GetById(int iProviderId) const
 
 void CPVRProviders::RemoveEntry(const std::shared_ptr<CPVRProvider>& provider)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_providers.erase(
       std::remove_if(m_providers.begin(), m_providers.end(),
@@ -389,7 +389,7 @@ int CPVRProviders::CleanupCachedImages()
 {
   std::vector<std::string> urlsToCheck;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     for (const auto& provider : m_providers)
     {

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -174,7 +174,7 @@ CPVRRecording::CPVRRecording(const PVR_RECORDING& recording, unsigned int iClien
 
 bool CPVRRecording::operator==(const CPVRRecording& right) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return (this == &right) ||
          (m_strRecordingId == right.m_strRecordingId && m_iClientId == right.m_iClientId &&
           m_strChannelName == right.m_strChannelName && m_recordingTime == right.m_recordingTime &&
@@ -241,7 +241,7 @@ void CPVRRecording::Serialize(CVariant& value) const
 
 void CPVRRecording::ToSortable(SortItem& sortable, Field field) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (field == FieldSize)
     sortable[FieldSize] = m_sizeInBytes;
   else if (field == FieldProvider)
@@ -271,7 +271,7 @@ void CPVRRecording::Reset()
   m_bRadio = false;
   m_iFlags = PVR_RECORDING_FLAG_UNDEFINED;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     m_sizeInBytes = 0;
   }
   m_strProviderName.clear();
@@ -397,7 +397,7 @@ bool CPVRRecording::UpdateRecordingSize()
     int64_t sizeInBytes = -1;
     client->GetRecordingSize(*this, sizeInBytes);
 
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     if (sizeInBytes >= 0 && sizeInBytes != m_sizeInBytes)
     {
       m_sizeInBytes = sizeInBytes;
@@ -483,7 +483,7 @@ void CPVRRecording::Update(const CPVRRecording& tag, const CPVRClient& client)
   m_firstAired = tag.m_firstAired;
   m_iFlags = tag.m_iFlags;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     m_sizeInBytes = tag.m_sizeInBytes;
     m_strProviderName = tag.m_strProviderName;
     m_iClientProviderUid = tag.m_iClientProviderUid;
@@ -706,19 +706,19 @@ bool CPVRRecording::IsFinale() const
 
 int64_t CPVRRecording::GetSizeInBytes() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_sizeInBytes;
 }
 
 int CPVRRecording::ClientProviderUid() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iClientProviderUid;
 }
 
 std::string CPVRRecording::ProviderName() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_strProviderName;
 }
 
@@ -730,7 +730,7 @@ std::shared_ptr<CPVRProvider> CPVRRecording::GetDefaultProvider() const
 
 bool CPVRRecording::HasClientProvider() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iClientProviderUid != PVR_PROVIDER_INVALID_UID;
 }
 
@@ -747,36 +747,36 @@ std::shared_ptr<CPVRProvider> CPVRRecording::GetProvider() const
 
 unsigned int CPVRRecording::GetParentalRating() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_parentalRating;
 }
 
 const std::string& CPVRRecording::GetParentalRatingCode() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_parentalRatingCode;
 }
 
 const std::string& CPVRRecording::GetParentalRatingIcon() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_parentalRatingIcon.GetLocalImage();
 }
 
 const std::string& CPVRRecording::GetParentalRatingSource() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_parentalRatingSource;
 }
 
 int CPVRRecording::EpisodePart() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_episodePartNumber;
 }
 
 const std::string& CPVRRecording::TitleExtraInfo() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_titleExtraInfo;
 }

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -39,7 +39,7 @@ CPVRRecordings::~CPVRRecordings()
 
 bool CPVRRecordings::UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_bIsUpdating)
     return false;
@@ -75,7 +75,7 @@ bool CPVRRecordings::Update(const std::vector<std::shared_ptr<CPVRClient>>& clie
 
 void CPVRRecordings::Unload()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_bDeletedTVRecordings = false;
   m_bDeletedRadioRecordings = false;
   m_iTVRecordings = 0;
@@ -85,7 +85,7 @@ void CPVRRecordings::Unload()
 
 void CPVRRecordings::UpdateInProgressSize()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_bIsUpdating)
     return;
   m_bIsUpdating = true;
@@ -108,25 +108,25 @@ void CPVRRecordings::UpdateInProgressSize()
 
 int CPVRRecordings::GetNumTVRecordings() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iTVRecordings;
 }
 
 bool CPVRRecordings::HasDeletedTVRecordings() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_bDeletedTVRecordings;
 }
 
 int CPVRRecordings::GetNumRadioRecordings() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_iRadioRecordings;
 }
 
 bool CPVRRecordings::HasDeletedRadioRecordings() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_bDeletedRadioRecordings;
 }
 
@@ -134,7 +134,7 @@ std::vector<std::shared_ptr<CPVRRecording>> CPVRRecordings::GetAll() const
 {
   std::vector<std::shared_ptr<CPVRRecording>> recordings;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   std::transform(m_recordings.cbegin(), m_recordings.cend(), std::back_inserter(recordings),
                  [](const auto& recordingEntry) { return recordingEntry.second; });
 
@@ -143,7 +143,7 @@ std::vector<std::shared_ptr<CPVRRecording>> CPVRRecordings::GetAll() const
 
 std::shared_ptr<CPVRRecording> CPVRRecordings::GetById(unsigned int iId) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const auto it =
       std::find_if(m_recordings.cbegin(), m_recordings.cend(),
                    [iId](const auto& recording) { return recording.second->RecordingID() == iId; });
@@ -152,7 +152,7 @@ std::shared_ptr<CPVRRecording> CPVRRecordings::GetById(unsigned int iId) const
 
 std::shared_ptr<CPVRRecording> CPVRRecordings::GetByPath(const std::string& path) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   CPVRRecordingsPath recPath(path);
   if (recPath.IsValid())
@@ -179,7 +179,7 @@ std::shared_ptr<CPVRRecording> CPVRRecordings::GetById(int iClientId,
                                                        const std::string& strRecordingId) const
 {
   std::shared_ptr<CPVRRecording> retVal;
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const auto it = m_recordings.find(CPVRRecordingUid(iClientId, strRecordingId));
   if (it != m_recordings.end())
     retVal = it->second;
@@ -201,7 +201,7 @@ bool MatchProvider(const std::shared_ptr<CPVRRecording>& recording,
 
 bool CPVRRecordings::HasRecordingForProvider(bool isRadio, int clientId, int providerId) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return std::any_of(m_recordings.cbegin(), m_recordings.cend(),
                      [isRadio, clientId, providerId](const auto& entry)
                      { return MatchProvider(entry.second, isRadio, clientId, providerId); });
@@ -211,7 +211,7 @@ unsigned int CPVRRecordings::GetRecordingCountByProvider(bool isRadio,
                                                          int clientId,
                                                          int providerId) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   auto recs = std::count_if(m_recordings.cbegin(), m_recordings.cend(),
                             [isRadio, clientId, providerId](const auto& entry)
                             { return MatchProvider(entry.second, isRadio, clientId, providerId); });
@@ -221,7 +221,7 @@ unsigned int CPVRRecordings::GetRecordingCountByProvider(bool isRadio,
 void CPVRRecordings::UpdateFromClient(const std::shared_ptr<CPVRRecording>& tag,
                                       const CPVRClient& client)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (tag->IsDeleted())
   {
@@ -255,7 +255,7 @@ std::shared_ptr<CPVRRecording> CPVRRecordings::GetRecordingForEpgTag(
   if (!epgTag)
     return {};
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& recording : m_recordings)
   {
@@ -301,7 +301,7 @@ bool CPVRRecordings::ChangeRecordingsPlayCount(const std::shared_ptr<CPVRRecordi
 {
   if (recording)
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     CVideoDatabase& db = GetVideoDatabase();
     if (db.IsOpen())
@@ -340,7 +340,7 @@ bool CPVRRecordings::ResetResumePoint(const std::shared_ptr<CPVRRecording>& reco
 
   if (recording)
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     CVideoDatabase& db = GetVideoDatabase();
     if (db.IsOpen())
@@ -385,7 +385,7 @@ int CPVRRecordings::CleanupCachedImages()
 {
   std::vector<std::string> urlsToCheck;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     for (const auto& recording : m_recordings)
     {
       urlsToCheck.emplace_back(recording.second->ClientIconPath());

--- a/xbmc/pvr/settings/PVRSettings.cpp
+++ b/xbmc/pvr/settings/PVRSettings.cpp
@@ -65,13 +65,13 @@ CPVRSettings::~CPVRSettings()
 
 void CPVRSettings::RegisterCallback(ISettingCallback* callback)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_callbacks.insert(callback);
 }
 
 void CPVRSettings::UnregisterCallback(ISettingCallback* callback)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_callbacks.erase(callback);
 }
 
@@ -86,7 +86,7 @@ void CPVRSettings::Init(const std::set<std::string>& settingNames)
       continue;
     }
 
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     m_settings.insert(std::make_pair(settingName, setting->Clone(settingName)));
   }
 }
@@ -96,7 +96,7 @@ void CPVRSettings::OnSettingsLoaded()
   std::set<std::string> settingNames;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     for (const auto& settingName : m_settings)
       settingNames.insert(settingName.first);
 
@@ -111,7 +111,7 @@ void CPVRSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& setti
   if (setting == nullptr)
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_settings[setting->GetId()] = setting->Clone(setting->GetId());
   const auto callbacks(m_callbacks);
   lock.unlock();
@@ -122,7 +122,7 @@ void CPVRSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& setti
 
 bool CPVRSettings::GetBoolValue(const std::string& settingName) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   auto settingIt = m_settings.find(settingName);
   if (settingIt != m_settings.end() && (*settingIt).second->GetType() == SettingType::Boolean)
   {
@@ -137,7 +137,7 @@ bool CPVRSettings::GetBoolValue(const std::string& settingName) const
 
 int CPVRSettings::GetIntValue(const std::string& settingName) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   auto settingIt = m_settings.find(settingName);
   if (settingIt != m_settings.end() && (*settingIt).second->GetType() == SettingType::Integer)
   {
@@ -152,7 +152,7 @@ int CPVRSettings::GetIntValue(const std::string& settingName) const
 
 std::string CPVRSettings::GetStringValue(const std::string& settingName) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   auto settingIt = m_settings.find(settingName);
   if (settingIt != m_settings.end() && (*settingIt).second->GetType() == SettingType::String)
   {

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -337,7 +337,7 @@ void CPVRTimerInfoTag::Serialize(CVariant& value) const
 
 void CPVRTimerInfoTag::UpdateSummary()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strSummary.clear();
 
   const std::string startDate(StartAsLocalTime().GetAsLocalizedDate());
@@ -391,7 +391,7 @@ void CPVRTimerInfoTag::SetTimerType(const std::shared_ptr<CPVRTimerType>& type)
   if (!type)
     throw std::logic_error("CPVRTimerInfoTag::SetTimerType - Attempt to set 'null' timer type!");
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_timerType = type;
 
   if (m_iClientIndex == PVR_TIMER_NO_CLIENT_INDEX)
@@ -410,7 +410,7 @@ void CPVRTimerInfoTag::SetTimerType(const std::shared_ptr<CPVRTimerType>& type)
 std::string CPVRTimerInfoTag::GetStatus(bool bRadio) const
 {
   std::string strReturn = g_localizeStrings.Get(305);
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (URIUtils::PathEquals(m_strFileNameAndPath, CPVRTimersPath::PATH_ADDTIMER))
     strReturn = g_localizeStrings.Get(19026);
   else if (m_state == PVR_TIMER_STATE_CANCELLED || m_state == PVR_TIMER_STATE_ABORTED)
@@ -455,7 +455,7 @@ std::string CPVRTimerInfoTag::GetStatus(bool bRadio) const
  */
 std::string CPVRTimerInfoTag::GetTypeAsString() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_timerType->GetDescription();
 }
 
@@ -541,7 +541,7 @@ std::string CPVRTimerInfoTag::GetWeekdaysString(unsigned int iWeekdays,
 
 std::string CPVRTimerInfoTag::GetWeekdaysString() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return GetWeekdaysString(m_iWeekdays, m_timerType->IsEpgBased(), false);
 }
 
@@ -592,7 +592,7 @@ bool CPVRTimerInfoTag::DeleteFromDatabase()
 
 bool CPVRTimerInfoTag::UpdateEntry(const std::shared_ptr<const CPVRTimerInfoTag>& tag)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_iClientId = tag->m_iClientId;
   m_iClientIndex = tag->m_iClientIndex;
@@ -1183,7 +1183,7 @@ void CPVRTimerInfoTag::SetFirstDayFromLocalTime(const CDateTime& firstDay)
 
 std::string CPVRTimerInfoTag::GetNotificationText() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   int stringID = 0;
 
@@ -1227,7 +1227,7 @@ std::string CPVRTimerInfoTag::GetNotificationText() const
 
 std::string CPVRTimerInfoTag::GetDeletedNotificationText() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   int stringID = 0;
   // The state in this case is the state the timer had when it was last seen
@@ -1249,14 +1249,14 @@ std::string CPVRTimerInfoTag::GetDeletedNotificationText() const
 
 void CPVRTimerInfoTag::SetEpgInfoTag(const std::shared_ptr<CPVREpgInfoTag>& tag)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_epgTag = tag;
   m_bProbedEpgTag = true;
 }
 
 void CPVRTimerInfoTag::UpdateEpgInfoTag()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_epgTag.reset();
   m_bProbedEpgTag = false;
   GetEpgInfoTag();
@@ -1275,7 +1275,7 @@ std::shared_ptr<CPVREpgInfoTag> CPVRTimerInfoTag::GetEpgInfoTag(bool bCreate /* 
                     ->GetGroupAll()
                     ->GetByUniqueID(m_iClientChannelUid, m_iClientId);
 
-      std::unique_lock<CCriticalSection> lock(m_critSection);
+      std::unique_lock lock(m_critSection);
       m_channel = channel;
     }
 
@@ -1284,7 +1284,7 @@ std::shared_ptr<CPVREpgInfoTag> CPVRTimerInfoTag::GetEpgInfoTag(bool bCreate /* 
       const std::shared_ptr<CPVREpg> epg(channel->GetEPG());
       if (epg)
       {
-        std::unique_lock<CCriticalSection> lock(m_critSection);
+        std::unique_lock lock(m_critSection);
         if (!m_epgTag && m_iEpgUid != EPG_TAG_INVALID_UID)
         {
           m_epgTag = epg->GetTagByBroadcastId(m_iEpgUid);
@@ -1333,7 +1333,7 @@ void CPVRTimerInfoTag::UpdateChannel()
                                                  ->GetGroupAll()
                                                  ->GetByUniqueID(m_iClientChannelUid, m_iClientId));
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_channel = channel;
 }
 

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -44,7 +44,7 @@ constexpr auto MAX_NOTIFICATION_DELAY = 10s;
 
 bool CPVRTimersContainer::UpdateFromClient(const std::shared_ptr<CPVRTimerInfoTag>& timer)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   std::shared_ptr<CPVRTimerInfoTag> tag = GetByClient(timer->ClientID(), timer->ClientIndex());
   if (tag)
   {
@@ -62,7 +62,7 @@ bool CPVRTimersContainer::UpdateFromClient(const std::shared_ptr<CPVRTimerInfoTa
 std::shared_ptr<CPVRTimerInfoTag> CPVRTimersContainer::GetByClient(int iClientId,
                                                                    int iClientIndex) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& startDates : m_tags)
   {
     const auto it = std::find_if(startDates.second.cbegin(), startDates.second.cend(),
@@ -132,7 +132,7 @@ bool CPVRTimers::LoadFromDatabase(const std::vector<std::shared_ptr<CPVRClient>>
 void CPVRTimers::Unload()
 {
   // remove all tags
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_tags.clear();
 }
 
@@ -153,7 +153,7 @@ void CPVRTimers::Stop()
 bool CPVRTimers::UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients)
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     if (m_bIsUpdating)
       return false;
     m_bIsUpdating = true;
@@ -188,7 +188,7 @@ void CPVRTimers::Process()
 
 bool CPVRTimers::IsRecording() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& tagsEntry : m_tags)
   {
@@ -202,7 +202,7 @@ bool CPVRTimers::IsRecording() const
 
 void CPVRTimers::RemoveEntry(const std::shared_ptr<const CPVRTimerInfoTag>& tag)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   auto it = m_tags.find(tag->IsStartAnyTime() ? CDateTime() : tag->StartAsUTC());
   if (it != m_tags.end())
@@ -243,7 +243,7 @@ bool CPVRTimers::UpdateEntries(const CPVRTimersContainer& timers,
   bool bAddedOrDeleted(false);
   std::vector<std::pair<int, std::string>> timerNotifications;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   /* go through the timer list and check for updated or new timers */
   for (const auto& tagsEntry : timers.GetTags())
@@ -508,7 +508,7 @@ bool CPVRTimers::UpdateEntries(int iMaxNotificationDelay)
   bool bFetchedAllEpgs = false;
   std::map<std::shared_ptr<CPVREpg>, std::vector<std::shared_ptr<CPVRTimerRuleMatcher>>> epgMap;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (auto it = m_tags.begin(); it != m_tags.end();)
   {
@@ -729,7 +729,7 @@ bool CPVRTimers::UpdateEntries(int iMaxNotificationDelay)
 std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetNextReminderToAnnnounce()
 {
   std::shared_ptr<CPVRTimerInfoTag> ret;
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (!m_remindersToAnnounce.empty())
   {
     ret = m_remindersToAnnounce.front();
@@ -748,7 +748,7 @@ bool CPVRTimers::KindMatchesTag(const TimerKind& eKind,
 std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetNextActiveTimer(const TimerKind& eKind,
                                                                  bool bIgnoreReminders) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& tagsEntry : m_tags)
   {
@@ -785,7 +785,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetNextActiveRadioTimer() const
 std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRTimers::GetActiveTimers() const
 {
   std::vector<std::shared_ptr<CPVRTimerInfoTag>> tags;
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& tagsEntry : m_tags)
   {
@@ -802,7 +802,7 @@ std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRTimers::GetActiveTimers() con
 int CPVRTimers::AmountActiveTimers(const TimerKind& eKind) const
 {
   int iReturn = 0;
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& tagsEntry : m_tags)
   {
@@ -836,7 +836,7 @@ std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRTimers::GetActiveRecordings(
     const TimerKind& eKind) const
 {
   std::vector<std::shared_ptr<CPVRTimerInfoTag>> tags;
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& tagsEntry : m_tags)
   {
@@ -869,7 +869,7 @@ std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRTimers::GetActiveRadioRecordi
 int CPVRTimers::AmountActiveRecordings(const TimerKind& eKind) const
 {
   int iReturn = 0;
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& tagsEntry : m_tags)
   {
@@ -908,7 +908,7 @@ bool CPVRTimers::DeleteTimersOnChannel(const std::shared_ptr<CPVRChannel>& chann
   bool bReturn = false;
   bool bChanged = false;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     for (MapTags::reverse_iterator it = m_tags.rbegin(); it != m_tags.rend(); ++it)
     {
@@ -940,7 +940,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::UpdateEntry(
 {
   bool bChanged = false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   std::shared_ptr<CPVRTimerInfoTag> tag = GetByClient(timer->ClientID(), timer->ClientIndex());
   if (tag)
   {
@@ -1037,7 +1037,7 @@ bool CPVRTimers::UpdateTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag)
 
 bool CPVRTimers::AddLocalTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag, bool bNotify)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   const std::shared_ptr<CPVRTimerInfoTag> persistedTimer = PersistAndUpdateLocalTimer(tag, nullptr);
   bool bReturn = !!persistedTimer;
@@ -1089,7 +1089,7 @@ bool CPVRTimers::AddLocalTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag, boo
 
 bool CPVRTimers::DeleteLocalTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag, bool bNotify)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   RemoveEntry(tag);
 
@@ -1162,7 +1162,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::PersistAndUpdateLocalTimer(
 
 bool CPVRTimers::IsRecordingOnChannel(const CPVRChannel& channel) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& tagsEntry : m_tags)
   {
@@ -1181,7 +1181,7 @@ bool CPVRTimers::IsRecordingOnChannel(const CPVRChannel& channel) const
 std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetActiveTimerForChannel(
     const std::shared_ptr<const CPVRChannel>& channel) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& tagsEntry : m_tags)
   {
     const auto it = std::find_if(tagsEntry.second.cbegin(), tagsEntry.second.cend(),
@@ -1202,7 +1202,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetTimerForEpgTag(
 {
   if (epgTag)
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     for (const auto& tagsEntry : m_tags)
     {
@@ -1244,7 +1244,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetTimerRule(
     {
       int iClientId = timer->ClientID();
 
-      std::unique_lock<CCriticalSection> lock(m_critSection);
+      std::unique_lock lock(m_critSection);
       for (const auto& tagsEntry : m_tags)
       {
         const auto it = std::find_if(tagsEntry.second.cbegin(), tagsEntry.second.cend(),
@@ -1273,7 +1273,7 @@ void CPVRTimers::Notify(const PVREvent& event)
     case PVREvent::Epg:
     case PVREvent::EpgItemUpdate:
     {
-      std::unique_lock<CCriticalSection> lock(m_critSection);
+      std::unique_lock lock(m_critSection);
       m_bReminderRulesUpdatePending = true;
       break;
     }
@@ -1331,7 +1331,7 @@ CDateTime CPVRTimers::GetNextEventTime() const
 
 void CPVRTimers::UpdateChannels()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& tagsEntry : m_tags)
   {
     for (const auto& timersEntry : tagsEntry.second)
@@ -1343,7 +1343,7 @@ std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRTimers::GetAll() const
 {
   std::vector<std::shared_ptr<CPVRTimerInfoTag>> timers;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& tagsEntry : m_tags)
   {
     std::copy(tagsEntry.second.cbegin(), tagsEntry.second.cend(), std::back_inserter(timers));
@@ -1354,7 +1354,7 @@ std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRTimers::GetAll() const
 
 std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetById(unsigned int iTimerId) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& tagsEntry : m_tags)
   {
     const auto it = std::find_if(

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -248,7 +248,7 @@ bool CGUIWindowPVRBase::ActivateNextChannelGroup()
 
 void CGUIWindowPVRBase::ClearData()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_channelGroup.reset();
   m_channelGroupsSelector = std::make_unique<CGUIPVRChannelGroupsSelector>();
 }
@@ -507,7 +507,7 @@ bool CGUIWindowPVRBase::InitChannelGroup()
 
   if (group)
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     if (m_channelGroup != group)
     {
       m_viewControl.SetSelectedItem(0);
@@ -522,7 +522,7 @@ bool CGUIWindowPVRBase::InitChannelGroup()
 
 std::shared_ptr<CPVRChannelGroup> CGUIWindowPVRBase::GetChannelGroup()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_channelGroup;
 }
 
@@ -533,7 +533,7 @@ void CGUIWindowPVRBase::SetChannelGroup(std::shared_ptr<CPVRChannelGroup> &&grou
 
   std::shared_ptr<CPVRChannelGroup> updateChannelGroup;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     if (m_channelGroup != group)
     {
       if (m_channelGroup)
@@ -558,7 +558,7 @@ void CGUIWindowPVRBase::SetChannelGroupPath(const std::string& path)
   const CURL url{path};
   const std::string pathWithoutOptions{url.GetWithoutOptions()};
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_channelGroupPath != pathWithoutOptions)
   {
     m_channelGroupPath = pathWithoutOptions;

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -105,7 +105,7 @@ bool CGUIWindowPVRChannelsBase::Update(const std::string& strDirectory,
 
   if (bReturn)
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     /* empty list for hidden channels */
     if (m_vecItems->GetObjectCount() == 0 && m_bShowHiddenChannels)
     {

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -109,7 +109,7 @@ void CGUIWindowPVRGuideBase::InitEpgGridControl()
 void CGUIWindowPVRGuideBase::ClearData()
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     m_cachedChannelGroup.reset();
   }
 
@@ -244,7 +244,7 @@ bool CGUIWindowPVRGuideBase::Update(const std::string& strDirectory,
 bool CGUIWindowPVRGuideBase::GetDirectory(const std::string& strDirectory, CFileItemList& items)
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     if (m_cachedChannelGroup && *m_cachedChannelGroup != *GetChannelGroup())
     {
@@ -777,7 +777,7 @@ bool CGUIWindowPVRGuideBase::RefreshTimelineItems()
       epgGridContainer->SetTimelineItems(channels, startDate, endDate);
 
       {
-        std::unique_lock<CCriticalSection> lock(m_critSection);
+        std::unique_lock lock(m_critSection);
         m_cachedChannelGroup = group;
       }
       return true;

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -178,7 +178,7 @@ bool CGUIWindowPVRRecordingsBase::Update(const std::string& strDirectory,
     //       to see the deleted recordings? Or is this just another hack to avoid misbehavior
     //       of CGUIMediaWindow if it has no content?
 
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     /* empty list for deleted recordings */
     if (m_vecItems->GetObjectCount() == 0 && m_bShowDeletedRecordings)


### PR DESCRIPTION
…mplate arguments by relying on the class template argument deduction.

With C++17, `std::unique_lock` does not need a template argument for the mutex type anymore.

Runtime-tested on macOS, latest Kodi master.

@phunkyfish please review.