### PR TITLE
[PVR] SonarQube findings

### DIFF
--- a/xbmc/pvr/PVRCachedImage.cpp
+++ b/xbmc/pvr/PVRCachedImage.cpp
@@ -30,11 +30,6 @@ bool CPVRCachedImage::operator==(const CPVRCachedImage& right) const
                               m_localImage == right.m_localImage && m_owner == right.m_owner);
 }
 
-bool CPVRCachedImage::operator!=(const CPVRCachedImage& right) const
-{
-  return !(*this == right);
-}
-
 void CPVRCachedImage::SetClientImage(const std::string& image)
 {
   if (StringUtils::StartsWith(image, "image://"))
@@ -53,7 +48,7 @@ void CPVRCachedImage::SetClientImage(const std::string& image)
   UpdateLocalImage();
 }
 
-void CPVRCachedImage::SetOwner(const std::string& owner)
+void CPVRCachedImage::SetOwner(std::string_view owner)
 {
   if (m_owner != owner)
   {

--- a/xbmc/pvr/PVRCachedImage.h
+++ b/xbmc/pvr/PVRCachedImage.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 namespace PVR
 {
@@ -23,14 +24,13 @@ public:
   CPVRCachedImage(const std::string& clientImage, const std::string& owner);
 
   bool operator==(const CPVRCachedImage& right) const;
-  bool operator!=(const CPVRCachedImage& right) const;
 
   const std::string& GetClientImage() const { return m_clientImage; }
   const std::string& GetLocalImage() const { return m_localImage; }
 
   void SetClientImage(const std::string& image);
 
-  void SetOwner(const std::string& owner);
+  void SetOwner(std::string_view owner);
 
 private:
   void UpdateLocalImage();

--- a/xbmc/pvr/PVRCachedImages.cpp
+++ b/xbmc/pvr/PVRCachedImages.cpp
@@ -18,6 +18,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <string_view>
 
 using namespace PVR;
 
@@ -48,12 +49,12 @@ int CPVRCachedImages::Cleanup(const std::vector<PVRImagePattern>& urlPatterns,
         StringUtils::Format("{}@{}", pattern.owner, CURL::Encode(pattern.path));
 
     std::string escapedPattern;
-    for (size_t i = 0; i < encodedPattern.size(); ++i)
+    for (const auto& pos : encodedPattern)
     {
-      if (encodedPattern[i] == '%' || encodedPattern[i] == '^')
+      if (pos == '%' || pos == '^')
         escapedPattern += '^';
 
-      escapedPattern += encodedPattern[i];
+      escapedPattern += pos;
     }
 
     const std::string where =
@@ -74,8 +75,8 @@ int CPVRCachedImages::Cleanup(const std::vector<PVRImagePattern>& urlPatterns,
     const std::string textureURL =
         IMAGE_FILES::CImageFileURL(items[i]["url"].asString()).GetTargetFile();
 
-    if (std::none_of(urlsToCheck.cbegin(), urlsToCheck.cend(),
-                     [&textureURL](const std::string& url) { return url == textureURL; }))
+    if (std::ranges::none_of(urlsToCheck,
+                             [&textureURL](std::string_view url) { return url == textureURL; }))
     {
       CLog::LogFC(LOGDEBUG, LOGPVR, "Removing stale cached image: '{}'", textureURL);
       CServiceBroker::GetTextureCache()->ClearCachedImage(items[i]["textureid"].asInteger());

--- a/xbmc/pvr/PVRChannelNumberInputHandler.cpp
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.cpp
@@ -106,7 +106,7 @@ void CPVRChannelNumberInputHandler::AppendChannelNumberCharacter(char cCharacter
     m_sortedChannelNumbers.clear();
     GetChannelNumbers(m_sortedChannelNumbers);
 
-    std::sort(m_sortedChannelNumbers.begin(), m_sortedChannelNumbers.end());
+    std::ranges::sort(m_sortedChannelNumbers);
   }
 
   m_inputBuffer.append(&cCharacter, 1);
@@ -177,7 +177,7 @@ std::string CPVRChannelNumberInputHandler::GetChannelNumberLabel() const
   return m_label;
 }
 
-void CPVRChannelNumberInputHandler::SetLabel(const std::string& label)
+void CPVRChannelNumberInputHandler::SetLabel(std::string_view label)
 {
   std::unique_lock lock(m_mutex);
   if (label != m_label)

--- a/xbmc/pvr/PVRChannelNumberInputHandler.h
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.h
@@ -14,6 +14,7 @@
 #include "utils/EventStream.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace PVR
@@ -89,15 +90,14 @@ protected:
    */
   size_t GetCurrentDigitCount() const { return m_inputBuffer.size(); }
 
-  mutable CCriticalSection m_mutex;
-
 private:
   void ExecuteAction();
 
-  void SetLabel(const std::string& label);
+  void SetLabel(std::string_view label);
 
+  mutable CCriticalSection m_mutex;
   std::vector<std::string> m_sortedChannelNumbers;
-  const uint32_t m_delay;
+  const uint32_t m_delay{2000}; // 2 secs
   std::string m_inputBuffer;
   std::string m_label;
   CTimer m_timer;

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -571,7 +571,7 @@ bool DeleteTimerRule::IsVisible(const CFileItem& item) const
 
 bool DeleteTimerRule::Execute(const CFileItemPtr& item) const
 {
-  auto& timers = CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>();
+  const auto& timers{CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>()};
   const std::shared_ptr<CFileItem> parentTimer = timers.GetTimerRule(*item);
   if (parentTimer)
     return timers.DeleteTimerRule(*parentTimer);
@@ -852,8 +852,7 @@ void CPVRContextMenuManager::RemoveMenuHook(const CPVRClientMenuHook& hook)
 
   for (auto it = m_items.begin(); it < m_items.end(); ++it)
   {
-    const CONTEXTMENUITEM::PVRClientMenuHook* cmh =
-        dynamic_cast<const CONTEXTMENUITEM::PVRClientMenuHook*>((*it).get());
+    const auto* cmh{dynamic_cast<const CONTEXTMENUITEM::PVRClientMenuHook*>((*it).get())};
     if (cmh && cmh->GetHook() == hook)
     {
       m_events.Publish(PVRContextMenuEvent(PVRContextMenuEventAction::REMOVE_ITEM, *it));

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -26,7 +26,6 @@ namespace PVR
   class CPVRProviders;
   class CPVRClient;
   class CPVRTimerInfoTag;
-  class CPVRTimers;
 
   /** The PVR database */
 
@@ -145,14 +144,14 @@ namespace PVR
      * @param bCommit queue only or queue and commit
      * @return True when persisted or queued, false otherwise.
      */
-    bool Persist(CPVRChannel& channel, bool bCommit);
+    bool Persist(const CPVRChannel& channel, bool bCommit);
 
     /*!
      * @brief Remove a channel entry from the database
      * @param channel The channel to remove.
      * @return True if the channel was removed, false otherwise.
      */
-    bool QueueDeleteQuery(const CPVRChannel& channel);
+    bool QueueChannelDeleteQuery(const CPVRChannel& channel);
 
     //@}
 
@@ -164,7 +163,7 @@ namespace PVR
      * @param groupMember The group member to remove.
      * @return True if the member was removed, false otherwise.
      */
-    bool QueueDeleteQuery(const CPVRChannelGroupMember& groupMember);
+    bool QueueGroupMemberDeleteQuery(const CPVRChannelGroupMember& groupMember);
 
     //@}
 
@@ -268,12 +267,11 @@ namespace PVR
 
     /*!
      * @brief Get the timers.
-     * @param timers The container for the timers.
      * @param clients The PVR clients the timers should be loaded for. Leave empty for all clients.
      * @return The timers.
      */
     std::vector<std::shared_ptr<CPVRTimerInfoTag>> GetTimers(
-        CPVRTimers& timers, const std::vector<std::shared_ptr<CPVRClient>>& clients) const;
+        const std::vector<std::shared_ptr<CPVRClient>>& clients) const;
 
     /*!
      * @brief Add or update a timer entry in the database

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -36,6 +36,7 @@
 #include "pvr/providers/PVRProviders.h"
 #include "pvr/recordings/PVRRecording.h"
 #include "pvr/recordings/PVRRecordings.h"
+#include "pvr/settings/PVRSettings.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/timers/PVRTimers.h"
 #include "settings/Settings.h"
@@ -64,9 +65,7 @@ public:
   virtual ~CPVRJob() = default;
 
   virtual bool DoWork() = 0;
-  virtual const std::string GetType() const = 0;
-
-protected:
+  virtual std::string GetType() const = 0;
 };
 
 template<typename F>
@@ -74,19 +73,22 @@ class CPVRLambdaJob : public CPVRJob
 {
 public:
   CPVRLambdaJob() = delete;
-  CPVRLambdaJob(const std::string& type, F&& f) : m_type(type), m_f(std::forward<F>(f)) {}
+
+  CPVRLambdaJob(const std::string& type, F function) : m_type(type), m_function(std::move(function))
+  {
+  }
 
   bool DoWork() override
   {
-    m_f();
+    m_function();
     return true;
   }
 
-  const std::string GetType() const override { return m_type; }
+  std::string GetType() const override { return m_type; }
 
 private:
   std::string m_type;
-  F m_f;
+  F m_function;
 };
 
 } // unnamed namespace
@@ -97,16 +99,14 @@ namespace PVR
 class CPVRManagerJobQueue
 {
 public:
-  CPVRManagerJobQueue() : m_triggerEvent(false) {}
-
   void Start();
   void Stop();
   void Clear();
 
   template<typename F>
-  void Append(const std::string& type, F&& f)
+  void Append(const std::string& type, F function)
   {
-    AppendJob(new CPVRLambdaJob<F>(type, std::forward<F>(f)));
+    AppendJob(new CPVRLambdaJob<F>(type, function));
   }
 
   void ExecutePendingJobs();
@@ -120,9 +120,9 @@ private:
   void AppendJob(CPVRJob* job);
 
   CCriticalSection m_critSection;
-  CEvent m_triggerEvent;
+  CEvent m_triggerEvent{false};
   std::vector<CPVRJob*> m_pendingUpdates;
-  bool m_bStopped = true;
+  bool m_bStopped{true};
 };
 
 } // namespace PVR
@@ -156,8 +156,8 @@ void CPVRManagerJobQueue::AppendJob(CPVRJob* job)
   std::unique_lock lock(m_critSection);
 
   // check for another pending job of given type...
-  if (std::any_of(m_pendingUpdates.cbegin(), m_pendingUpdates.cend(),
-                  [job](CPVRJob* updateJob) { return updateJob->GetType() == job->GetType(); }))
+  if (std::ranges::any_of(m_pendingUpdates, [job](const CPVRJob* updateJob)
+                          { return updateJob->GetType() == job->GetType(); }))
   {
     delete job;
     return;
@@ -194,21 +194,22 @@ void CPVRManagerJobQueue::ExecutePendingJobs()
 
 CPVRManager::CPVRManager()
   : CThread("PVRManager"),
-    m_providers(new CPVRProviders),
-    m_channelGroups(new CPVRChannelGroupsContainer),
-    m_recordings(new CPVRRecordings),
-    m_timers(new CPVRTimers),
-    m_addons(new CPVRClients),
-    m_guiInfo(new CPVRGUIInfo),
-    m_components(new CPVRComponentRegistration),
-    m_epgContainer(new CPVREpgContainer(m_events)),
-    m_pendingUpdates(new CPVRManagerJobQueue),
-    m_database(new CPVRDatabase),
-    m_parentalTimer(new CStopWatch),
-    m_playbackState(new CPVRPlaybackState),
-    m_settings({CSettings::SETTING_PVRPOWERMANAGEMENT_ENABLED,
-                CSettings::SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD,
-                CSettings::SETTING_PVRPARENTAL_ENABLED, CSettings::SETTING_PVRPARENTAL_DURATION})
+    m_providers(std::make_shared<CPVRProviders>()),
+    m_channelGroups(std::make_shared<CPVRChannelGroupsContainer>()),
+    m_recordings(std::make_shared<CPVRRecordings>()),
+    m_timers(std::make_shared<CPVRTimers>()),
+    m_addons(std::make_shared<CPVRClients>()),
+    m_guiInfo(std::make_unique<CPVRGUIInfo>()),
+    m_components(std::make_shared<CPVRComponentRegistration>()),
+    m_epgContainer(std::make_unique<CPVREpgContainer>(m_events)),
+    m_pendingUpdates(std::make_unique<CPVRManagerJobQueue>()),
+    m_database(std::make_shared<CPVRDatabase>()),
+    m_parentalTimer(std::make_unique<CStopWatch>()),
+    m_playbackState(std::make_shared<CPVRPlaybackState>()),
+    m_settings(std::make_unique<CPVRSettings>(std::set<std::string>(
+        {CSettings::SETTING_PVRPOWERMANAGEMENT_ENABLED,
+         CSettings::SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD, CSettings::SETTING_PVRPARENTAL_ENABLED,
+         CSettings::SETTING_PVRPARENTAL_DURATION})))
 {
   CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this, ANNOUNCEMENT::GUI);
   m_actionListener.Init(*this);
@@ -232,7 +233,7 @@ void CPVRManager::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
   if (!IsStarted())
     return;
 
-  if ((flag & (ANNOUNCEMENT::GUI)))
+  if (flag & ANNOUNCEMENT::GUI)
   {
     if (message == "OnScreensaverActivated")
       m_addons->OnPowerSavingActivated();
@@ -360,7 +361,7 @@ void CPVRManager::ResetProperties()
   m_knownClients.clear();
 }
 
-void CPVRManager::Init()
+void CPVRManager::Init() const
 {
   // initial check for enabled addons
   // if at least one pvr addon is enabled, PVRManager start up
@@ -451,16 +452,18 @@ void CPVRManager::SetState(CPVRManager::ManagerState state)
   PVREvent event;
   switch (state)
   {
-    case ManagerState::STATE_STOPPED:
+    using enum ManagerState;
+
+    case STATE_STOPPED:
       event = PVREvent::ManagerStopped;
       break;
-    case ManagerState::STATE_STARTING:
+    case STATE_STARTING:
       event = PVREvent::ManagerStarting;
       break;
-    case ManagerState::STATE_STOPPING:
+    case STATE_STOPPING:
       event = PVREvent::ManagerStopped;
       break;
-    case ManagerState::STATE_STARTED:
+    case STATE_STARTED:
       event = PVREvent::ManagerStarted;
       break;
     default:
@@ -596,14 +599,14 @@ void CPVRManager::Process()
   SetState(ManagerState::STATE_STOPPED);
 }
 
-bool CPVRManager::SetWakeupCommand()
+bool CPVRManager::SetWakeupCommand() const
 {
 #if !defined(TARGET_DARWIN_EMBEDDED) && !defined(TARGET_WINDOWS_STORE)
-  if (!m_settings.GetBoolValue(CSettings::SETTING_PVRPOWERMANAGEMENT_ENABLED))
+  if (!m_settings->GetBoolValue(CSettings::SETTING_PVRPOWERMANAGEMENT_ENABLED))
     return false;
 
   const std::string strWakeupCommand(
-      m_settings.GetStringValue(CSettings::SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD));
+      m_settings->GetStringValue(CSettings::SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD));
   if (!strWakeupCommand.empty() && m_timers)
   {
     const CDateTime nextEvent = m_timers->GetNextEventTime();
@@ -664,8 +667,8 @@ void CPVRManager::OnWake()
 void CPVRManager::UpdateComponents(ManagerState stateToCheck)
 {
   XbmcThreads::EndTime<> progressTimeout(30s);
-  std::unique_ptr<CPVRGUIProgressHandler> progressHandler(
-      new CPVRGUIProgressHandler(g_localizeStrings.Get(19235))); // PVR manager is starting up
+  auto progressHandler{std::make_unique<CPVRGUIProgressHandler>(
+      g_localizeStrings.Get(19235))}; // PVR manager is starting up
 
   // Wait for at least one client to come up and load/update data
   while (!UpdateComponents(stateToCheck, progressHandler) && m_addons->HasCreatedClients() &&
@@ -692,23 +695,22 @@ bool CPVRManager::UpdateComponents(ManagerState stateToCheck,
   }
 
   std::vector<std::shared_ptr<CPVRClient>> newClients;
-  for (const auto& entry : clientMap)
+  for (const auto& [clientId, client] : clientMap)
   {
     // skip not (yet) connected clients
-    if (entry.second->IgnoreClient())
+    if (client->IgnoreClient())
     {
-      CLog::LogFC(LOGDEBUG, LOGPVR, "Skipping not (yet) connected PVR client {}",
-                  entry.second->GetID());
+      CLog::LogFC(LOGDEBUG, LOGPVR, "Skipping not (yet) connected PVR client {}", client->GetID());
       continue;
     }
 
-    if (!IsKnownClient(entry.first))
+    if (!IsKnownClient(clientId))
     {
-      m_knownClients.emplace_back(entry.second);
-      newClients.emplace_back(entry.second);
+      m_knownClients.emplace_back(client);
+      newClients.emplace_back(client);
 
       CLog::LogFC(LOGDEBUG, LOGPVR, "Adding new PVR client {} to list of known clients",
-                  entry.second->GetID());
+                  client->GetID());
     }
   }
 
@@ -780,8 +782,8 @@ void CPVRManager::UnloadComponents()
 
 bool CPVRManager::IsKnownClient(int clientID) const
 {
-  return std::any_of(m_knownClients.cbegin(), m_knownClients.cend(),
-                     [clientID](const auto& client) { return client->GetID() == clientID; });
+  return std::ranges::any_of(m_knownClients, [clientID](const auto& client)
+                             { return client->GetID() == clientID; });
 }
 
 void CPVRManager::TriggerPlayChannelOnStartup()
@@ -825,10 +827,11 @@ bool CPVRManager::IsCurrentlyParentalLocked(const std::shared_ptr<const CPVRChan
   if ( // if channel in question is currently playing it must be currently unlocked.
       (!currentChannel || channel != currentChannel) &&
       // parental control enabled
-      m_settings.GetBoolValue(CSettings::SETTING_PVRPARENTAL_ENABLED))
+      m_settings->GetBoolValue(CSettings::SETTING_PVRPARENTAL_ENABLED))
   {
-    float parentalDurationMs =
-        m_settings.GetIntValue(CSettings::SETTING_PVRPARENTAL_DURATION) * 1000.0f;
+    const float parentalDurationMs{
+        static_cast<float>(m_settings->GetIntValue(CSettings::SETTING_PVRPARENTAL_DURATION)) *
+        1000.0f};
     bReturn = m_parentalTimer && (!m_parentalTimer->IsRunning() ||
                                   m_parentalTimer->GetElapsedMilliseconds() > parentalDurationMs);
   }
@@ -1009,7 +1012,7 @@ void CPVRManager::TriggerCleanupCachedImages()
 void CPVRManager::ConnectionStateChange(CPVRClient* client,
                                         const std::string& connectString,
                                         PVR_CONNECTION_STATE state,
-                                        const std::string& message)
+                                        const std::string& message) const
 {
   CServiceBroker::GetJobManager()->Submit([this, client, connectString, state, message] {
     Clients()->ConnectionStateChange(client, connectString, state, message);

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -506,9 +506,6 @@ void CPVRManager::Process()
     return;
   }
 
-  // Load EPGs from database.
-  m_epgContainer->Load();
-
   // Reinit playbackstate
   m_playbackState->ReInit();
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -13,7 +13,6 @@
 #include "powermanagement/PowerState.h"
 #include "pvr/PVRComponentRegistration.h"
 #include "pvr/guilib/PVRGUIActionListener.h"
-#include "pvr/settings/PVRSettings.h"
 #include "threads/CriticalSection.h"
 #include "threads/Event.h"
 #include "threads/Thread.h"
@@ -41,6 +40,7 @@ class CPVRManagerJobQueue;
 class CPVRPlaybackState;
 class CPVRRecording;
 class CPVRRecordings;
+class CPVRSettings;
 class CPVRTimers;
 class CPVREpgContainer;
 class CPVREpgInfoTag;
@@ -179,7 +179,7 @@ public:
   /*!
    * @brief Init PVRManager.
    */
-  void Init();
+  void Init() const;
 
   /*!
    * @brief Start the PVRManager, which loads all PVR data and starts some threads to update the PVR data.
@@ -327,7 +327,7 @@ public:
   void ConnectionStateChange(CPVRClient* client,
                              const std::string& connectString,
                              PVR_CONNECTION_STATE state,
-                             const std::string& message);
+                             const std::string& message) const;
 
   /*!
    * @brief Query the events available for CEventStream
@@ -350,7 +350,7 @@ private:
   /*!
    * @brief Executes "pvrpowermanagement.setwakeupcmd"
    */
-  bool SetWakeupCommand();
+  bool SetWakeupCommand() const;
 
   enum class ManagerState
   {
@@ -458,6 +458,6 @@ private:
 
   const std::shared_ptr<CPVRPlaybackState> m_playbackState;
   CPVRGUIActionListener m_actionListener;
-  CPVRSettings m_settings;
+  std::unique_ptr<CPVRSettings> m_settings;
 };
 } // namespace PVR

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -188,7 +188,7 @@ bool ResolveEPG(CFileItem& item,
   return true;
 }
 
-bool ResolveRecording(CFileItem& item,
+bool ResolveRecording(const CFileItem& item,
                       CPVRStreamProperties& props,
                       const std::shared_ptr<const CPVRClient>& client)
 {
@@ -197,7 +197,7 @@ bool ResolveRecording(CFileItem& item,
 }
 } // unnamed namespace
 
-bool CPVRPlaybackState::OnPreparePlayback(CFileItem& item)
+bool CPVRPlaybackState::OnPreparePlayback(CFileItem& item) const
 {
   // Obtain dynamic playback url and properties from the respective pvr client
   const std::shared_ptr<const CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(item);
@@ -225,8 +225,8 @@ bool CPVRPlaybackState::OnPreparePlayback(CFileItem& item)
       item.SetContentLookup(false);
     }
 
-    for (const auto& prop : props)
-      item.SetProperty(prop.first, prop.second);
+    for (const auto& [name, value] : props)
+      item.SetProperty(name, value);
   }
 
   return true;
@@ -708,7 +708,7 @@ CDateTime CPVRPlaybackState::GetChannelPlaybackTime(int iClientID, int iUniqueCh
 }
 
 void CPVRPlaybackState::UpdateLastWatched(const std::shared_ptr<CPVRChannelGroupMember>& channel,
-                                          const CDateTime& time)
+                                          const CDateTime& time) const
 {
   time_t iTime;
   time.GetAsTime(iTime);

--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -56,7 +56,7 @@ public:
    * @param item The item that shall be played.
    * @return True on success, false otherwise.
    */
-  bool OnPreparePlayback(CFileItem& item);
+  bool OnPreparePlayback(CFileItem& item) const;
 
   /*!
    * @brief Inform that playback of an item just started.
@@ -283,7 +283,7 @@ private:
    * @param time The last watched time to set
    */
   void UpdateLastWatched(const std::shared_ptr<CPVRChannelGroupMember>& channel,
-                         const CDateTime& time);
+                         const CDateTime& time) const;
 
   mutable CCriticalSection m_critSection;
 

--- a/xbmc/pvr/PVRStreamProperties.cpp
+++ b/xbmc/pvr/PVRStreamProperties.cpp
@@ -15,34 +15,31 @@
 
 using namespace PVR;
 
+namespace
+{
+constexpr auto KeyProjection = &std::pair<std::string, std::string>::first;
+}
+
 std::string CPVRStreamProperties::GetStreamURL() const
 {
-  const auto it = std::find_if(cbegin(), cend(), [](const auto& prop) {
-    return prop.first == PVR_STREAM_PROPERTY_STREAMURL;
-  });
+  const auto it = std::ranges::find(*this, PVR_STREAM_PROPERTY_STREAMURL, KeyProjection);
   return it != cend() ? (*it).second : std::string();
 }
 
 std::string CPVRStreamProperties::GetStreamMimeType() const
 {
-  const auto it = std::find_if(cbegin(), cend(), [](const auto& prop) {
-    return prop.first == PVR_STREAM_PROPERTY_MIMETYPE;
-  });
+  const auto it = std::ranges::find(*this, PVR_STREAM_PROPERTY_MIMETYPE, KeyProjection);
   return it != cend() ? (*it).second : std::string();
 }
 
 bool CPVRStreamProperties::EPGPlaybackAsLive() const
 {
-  const auto it = std::find_if(cbegin(), cend(), [](const auto& prop) {
-    return prop.first == PVR_STREAM_PROPERTY_EPGPLAYBACKASLIVE;
-  });
+  const auto it = std::ranges::find(*this, PVR_STREAM_PROPERTY_EPGPLAYBACKASLIVE, KeyProjection);
   return it != cend() ? StringUtils::EqualsNoCase((*it).second, "true") : false;
 }
 
 bool CPVRStreamProperties::LivePlaybackAsEPG() const
 {
-  const auto it = std::find_if(cbegin(), cend(),
-                               [](const auto& prop)
-                               { return prop.first == PVR_STREAM_PROPERTY_LIVEPLAYBACKASEPG; });
+  const auto it = std::ranges::find(*this, PVR_STREAM_PROPERTY_LIVEPLAYBACKASEPG, KeyProjection);
   return it != cend() ? StringUtils::EqualsNoCase((*it).second, "true") : false;
 }

--- a/xbmc/pvr/PVRThumbLoader.cpp
+++ b/xbmc/pvr/PVRThumbLoader.cpp
@@ -17,7 +17,7 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
-#include <ctime>
+#include <chrono>
 
 namespace PVR
 {
@@ -77,7 +77,7 @@ bool CPVRThumbLoader::FillThumb(CFileItem& item)
   if (thumb.empty())
   {
     if (item.IsPVRChannelGroup())
-      thumb = CreateChannelGroupThumb(item);
+      thumb = GetChannelGroupThumbURL(item);
     else
       CLog::LogF(LOGERROR, "Unsupported PVR item '{}'", item.GetPath());
 
@@ -95,11 +95,12 @@ bool CPVRThumbLoader::FillThumb(CFileItem& item)
   return true;
 }
 
-std::string CPVRThumbLoader::CreateChannelGroupThumb(const CFileItem& channelGroupItem)
+std::string CPVRThumbLoader::GetChannelGroupThumbURL(const CFileItem& channelGroupItem) const
 {
+  const auto now{std::chrono::system_clock::now()};
   return StringUtils::Format("{}?ts={}", // append timestamp to Thumb URL to enforce texture refresh
                              IMAGE_FILES::URLFromFile(channelGroupItem.GetPath(), "pvr"),
-                             std::time(nullptr));
+                             std::chrono::system_clock::to_time_t(now));
 }
 
 } // namespace PVR

--- a/xbmc/pvr/PVRThumbLoader.h
+++ b/xbmc/pvr/PVRThumbLoader.h
@@ -32,7 +32,7 @@ protected:
 
 private:
   bool FillThumb(CFileItem& item);
-  std::string CreateChannelGroupThumb(const CFileItem& channelGroupItem);
+  std::string GetChannelGroupThumbURL(const CFileItem& channelGroupItem) const;
 
   bool m_bInvalidated = false;
 };

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -52,6 +52,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <source_location>
 #include <string>
 #include <utility>
 
@@ -65,13 +66,17 @@ using namespace PVR;
 
 namespace
 {
+using AddonInstance = AddonInstance_PVR;
+
+constexpr const char* DEFAULT_INFO_STRING_VALUE = "unknown";
+
 class CAddonChannelGroup : public PVR_CHANNEL_GROUP
 {
 public:
   explicit CAddonChannelGroup(const CPVRChannelGroup& group) : m_groupName(group.ClientGroupName())
   {
     // zero-init base struct members
-    PVR_CHANNEL_GROUP* base = static_cast<PVR_CHANNEL_GROUP*>(this);
+    auto* base{static_cast<PVR_CHANNEL_GROUP*>(this)};
     *base = {};
 
     bIsRadio = group.IsRadio();
@@ -93,7 +98,7 @@ public:
       m_iconPath(channel.ClientIconPath())
   {
     // zero-init base struct members
-    PVR_CHANNEL* base = static_cast<PVR_CHANNEL*>(this);
+    PVR_CHANNEL* base{static_cast<PVR_CHANNEL*>(this)};
     *base = {};
 
     iUniqueId = channel.UniqueID();
@@ -139,7 +144,7 @@ public:
       m_parentalRatingSource(recording.GetParentalRatingSource())
   {
     // zero-init base struct members
-    PVR_RECORDING* base = static_cast<PVR_RECORDING*>(this);
+    auto* base{static_cast<PVR_RECORDING*>(this)};
     *base = {};
 
     time_t recTime;
@@ -218,7 +223,7 @@ public:
       m_seriesLink(timer.SeriesLink())
   {
     // zero-init base struct members
-    PVR_TIMER* base = static_cast<PVR_TIMER*>(this);
+    auto* base{static_cast<PVR_TIMER*>(this)};
     *base = {};
 
     time_t start;
@@ -265,13 +270,13 @@ public:
     {
       m_customProps = std::make_unique<PVR_SETTING_KEY_VALUE_PAIR[]>(iCustomPropsSize);
       int idx{0};
-      for (const auto& entry : props)
+      for (const auto& [key, value] : props)
       {
         PVR_SETTING_KEY_VALUE_PAIR& prop{m_customProps[idx]};
-        prop.iKey = entry.first;
-        prop.eType = entry.second.type;
-        prop.iValue = entry.second.value.asInteger32();
-        m_customPropStringValues.emplace_back(entry.second.value.asString());
+        prop.iKey = key;
+        prop.eType = value.type;
+        prop.iValue = value.value.asInteger32();
+        m_customPropStringValues.emplace_back(value.value.asString());
         prop.strValue = m_customPropStringValues.back().c_str();
         ++idx;
       }
@@ -299,9 +304,9 @@ public:
       m_plotOutline(tag.PlotOutline()),
       m_plot(tag.Plot()),
       m_originalTitle(tag.OriginalTitle()),
-      m_cast(tag.DeTokenize(tag.Cast())),
-      m_director(tag.DeTokenize(tag.Directors())),
-      m_writer(tag.DeTokenize(tag.Writers())),
+      m_cast(CPVREpgInfoTag::DeTokenize(tag.Cast())),
+      m_director(CPVREpgInfoTag::DeTokenize(tag.Directors())),
+      m_writer(CPVREpgInfoTag::DeTokenize(tag.Writers())),
       m_IMDBNumber(tag.IMDBNumber()),
       m_episodeName(tag.EpisodeName()),
       m_iconPath(tag.ClientIconPath()),
@@ -313,7 +318,7 @@ public:
       m_parentalRatingSource(tag.ParentalRatingSource())
   {
     // zero-init base struct members
-    EPG_TAG* base = static_cast<EPG_TAG*>(this);
+    auto* base{static_cast<EPG_TAG*>(this)};
     *base = {};
 
     time_t t;
@@ -390,17 +395,19 @@ EDL::Edit ConvertAddonEdl(const PVR_EDL_ENTRY& entry)
 
   switch (entry.type)
   {
+    using enum EDL::Action;
+
     case PVR_EDL_TYPE_CUT:
-      edit.action = EDL::Action::CUT;
+      edit.action = CUT;
       break;
     case PVR_EDL_TYPE_MUTE:
-      edit.action = EDL::Action::MUTE;
+      edit.action = MUTE;
       break;
     case PVR_EDL_TYPE_SCENE:
-      edit.action = EDL::Action::SCENE;
+      edit.action = SCENE;
       break;
     case PVR_EDL_TYPE_COMBREAK:
-      edit.action = EDL::Action::COMM_BREAK;
+      edit.action = COMM_BREAK;
       break;
     default:
       CLog::LogF(LOGWARNING, "Ignoring entry of unknown EDL type: {}", entry.type);
@@ -413,9 +420,6 @@ EDL::Edit ConvertAddonEdl(const PVR_EDL_ENTRY& entry)
 
 namespace PVR
 {
-
-#define DEFAULT_INFO_STRING_VALUE "unknown"
-
 CPVRClient::CPVRClient(const ADDON::AddonInfoPtr& addonInfo,
                        ADDON::AddonInstanceId instanceId,
                        int clientId)
@@ -665,7 +669,7 @@ bool CPVRClient::GetAddonProperties()
 
   /* get the capabilities */
   PVR_ERROR retVal = DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&addonCapabilities](const AddonInstance* addon)
       { return addon->toAddon->GetCapabilities(addon, &addonCapabilities); },
       true, false);
@@ -678,7 +682,7 @@ bool CPVRClient::GetAddonProperties()
 
   /* free the resources of the capabilities instance */
   DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&addonCapabilities](const AddonInstance* addon)
       { return addon->toAddon->FreeCapabilities(addon, &addonCapabilities); },
       true, false);
@@ -695,7 +699,7 @@ bool CPVRClient::GetAddonNameStringProperties()
 
   /* get the name of the backend */
   PVR_ERROR retVal = DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&backendName](const AddonInstance* addon)
       {
         char* strBackendName{nullptr};
@@ -712,7 +716,7 @@ bool CPVRClient::GetAddonNameStringProperties()
 
   /* get the connection string */
   retVal = DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&connectionString](const AddonInstance* addon)
       {
         char* strConnectionString{nullptr};
@@ -729,7 +733,7 @@ bool CPVRClient::GetAddonNameStringProperties()
 
   /* backend version number */
   retVal = DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&backendVersion](const AddonInstance* addon)
       {
         char* strBackendVersion{nullptr};
@@ -746,7 +750,7 @@ bool CPVRClient::GetAddonNameStringProperties()
 
   /* backend hostname */
   retVal = DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&backendHostname](const AddonInstance* addon)
       {
         char* strBackendHostname{nullptr};
@@ -823,7 +827,7 @@ PVR_ERROR CPVRClient::GetDriveSpace(uint64_t& iTotal, uint64_t& iUsed) const
   iTotal = 0;
   iUsed = 0;
 
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [&iTotal, &iUsed](const AddonInstance* addon)
                      {
                        uint64_t iTotalSpace = 0;
@@ -842,7 +846,7 @@ PVR_ERROR CPVRClient::GetDriveSpace(uint64_t& iTotal, uint64_t& iUsed) const
 PVR_ERROR CPVRClient::StartChannelScan()
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [](const AddonInstance* addon) { return addon->toAddon->OpenDialogChannelScan(addon); },
       m_clientCapabilities.SupportsChannelScan());
 }
@@ -850,7 +854,7 @@ PVR_ERROR CPVRClient::StartChannelScan()
 PVR_ERROR CPVRClient::OpenDialogChannelAdd(const std::shared_ptr<const CPVRChannel>& channel)
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [channel](const AddonInstance* addon)
       {
         const CAddonChannel addonChannel{*channel};
@@ -862,7 +866,7 @@ PVR_ERROR CPVRClient::OpenDialogChannelAdd(const std::shared_ptr<const CPVRChann
 PVR_ERROR CPVRClient::OpenDialogChannelSettings(const std::shared_ptr<const CPVRChannel>& channel)
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [channel](const AddonInstance* addon)
       {
         const CAddonChannel addonChannel{*channel};
@@ -874,7 +878,7 @@ PVR_ERROR CPVRClient::OpenDialogChannelSettings(const std::shared_ptr<const CPVR
 PVR_ERROR CPVRClient::DeleteChannel(const std::shared_ptr<const CPVRChannel>& channel)
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [channel](const AddonInstance* addon)
       {
         const CAddonChannel addonChannel{*channel};
@@ -886,7 +890,7 @@ PVR_ERROR CPVRClient::DeleteChannel(const std::shared_ptr<const CPVRChannel>& ch
 PVR_ERROR CPVRClient::RenameChannel(const std::shared_ptr<const CPVRChannel>& channel)
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [channel](const AddonInstance* addon)
       {
         const CAddonChannel addonChannel{*channel, channel->ChannelName()};
@@ -901,7 +905,7 @@ PVR_ERROR CPVRClient::GetEPGForChannel(int iChannelUid,
                                        time_t end) const
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [this, iChannelUid, epg, start, end](const AddonInstance* addon)
       {
         PVR_HANDLE_STRUCT handle = {};
@@ -921,7 +925,7 @@ PVR_ERROR CPVRClient::GetEPGForChannel(int iChannelUid,
 PVR_ERROR CPVRClient::SetEPGMaxPastDays(int iPastDays)
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [iPastDays](const AddonInstance* addon)
       { return addon->toAddon->SetEPGMaxPastDays(addon, iPastDays); },
       m_clientCapabilities.SupportsEPG());
@@ -930,7 +934,7 @@ PVR_ERROR CPVRClient::SetEPGMaxPastDays(int iPastDays)
 PVR_ERROR CPVRClient::SetEPGMaxFutureDays(int iFutureDays)
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [iFutureDays](const AddonInstance* addon)
       { return addon->toAddon->SetEPGMaxFutureDays(addon, iFutureDays); },
       m_clientCapabilities.SupportsEPG());
@@ -940,7 +944,7 @@ PVR_ERROR CPVRClient::IsRecordable(const std::shared_ptr<const CPVREpgInfoTag>& 
                                    bool& bIsRecordable) const
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [tag, &bIsRecordable](const AddonInstance* addon)
       {
         CAddonEpgTag addonTag(*tag);
@@ -953,7 +957,7 @@ PVR_ERROR CPVRClient::IsPlayable(const std::shared_ptr<const CPVREpgInfoTag>& ta
                                  bool& bIsPlayable) const
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [tag, &bIsPlayable](const AddonInstance* addon)
       {
         CAddonEpgTag addonTag(*tag);
@@ -976,7 +980,7 @@ void CPVRClient::WriteStreamProperties(PVR_NAMED_VALUE** properties,
 PVR_ERROR CPVRClient::GetEpgTagStreamProperties(const std::shared_ptr<const CPVREpgInfoTag>& tag,
                                                 CPVRStreamProperties& props) const
 {
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [&tag, &props](const AddonInstance* addon)
                      {
                        CAddonEpgTag addonTag(*tag);
@@ -998,7 +1002,7 @@ PVR_ERROR CPVRClient::GetEpgTagEdl(const std::shared_ptr<const CPVREpgInfoTag>& 
 {
   edls.clear();
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&epgTag, &edls](const AddonInstance* addon)
       {
         CAddonEpgTag addonTag(*epgTag);
@@ -1022,7 +1026,7 @@ PVR_ERROR CPVRClient::GetChannelGroupsAmount(int& iGroups) const
 {
   iGroups = -1;
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&iGroups](const AddonInstance* addon)
       { return addon->toAddon->GetChannelGroupsAmount(addon, &iGroups); },
       m_clientCapabilities.SupportsChannelGroups());
@@ -1032,7 +1036,7 @@ PVR_ERROR CPVRClient::GetChannelGroups(CPVRChannelGroups* groups) const
 {
   const bool radio{groups->IsRadio()};
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [this, groups](const AddonInstance* addon)
       {
         PVR_HANDLE_STRUCT handle = {};
@@ -1046,12 +1050,12 @@ PVR_ERROR CPVRClient::GetChannelGroups(CPVRChannelGroups* groups) const
 }
 
 PVR_ERROR CPVRClient::GetChannelGroupMembers(
-    CPVRChannelGroup* group,
+    const CPVRChannelGroup* group,
     std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers) const
 {
   const bool radio{group->IsRadio()};
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [this, group, &groupMembers](const AddonInstance* addon)
       {
         PVR_HANDLE_STRUCT handle = {};
@@ -1069,14 +1073,15 @@ PVR_ERROR CPVRClient::GetChannelGroupMembers(
 PVR_ERROR CPVRClient::GetProvidersAmount(int& iProviders) const
 {
   iProviders = -1;
-  return DoAddonCall(__func__, [&iProviders](const AddonInstance* addon)
+  return DoAddonCall(std::source_location::current().function_name(),
+                     [&iProviders](const AddonInstance* addon)
                      { return addon->toAddon->GetProvidersAmount(addon, &iProviders); });
 }
 
 PVR_ERROR CPVRClient::GetProviders(CPVRProvidersContainer& providers) const
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [this, &providers](const AddonInstance* addon)
       {
         PVR_HANDLE_STRUCT handle = {};
@@ -1090,7 +1095,8 @@ PVR_ERROR CPVRClient::GetProviders(CPVRProvidersContainer& providers) const
 PVR_ERROR CPVRClient::GetChannelsAmount(int& iChannels) const
 {
   iChannels = -1;
-  return DoAddonCall(__func__, [&iChannels](const AddonInstance* addon)
+  return DoAddonCall(std::source_location::current().function_name(),
+                     [&iChannels](const AddonInstance* addon)
                      { return addon->toAddon->GetChannelsAmount(addon, &iChannels); });
 }
 
@@ -1098,7 +1104,7 @@ PVR_ERROR CPVRClient::GetChannels(bool radio,
                                   std::vector<std::shared_ptr<CPVRChannel>>& channels) const
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [this, radio, &channels](const AddonInstance* addon)
       {
         PVR_HANDLE_STRUCT handle = {};
@@ -1127,7 +1133,7 @@ PVR_ERROR CPVRClient::GetRecordingsAmount(bool deleted, int& iRecordings) const
 {
   iRecordings = -1;
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [deleted, &iRecordings](const AddonInstance* addon)
       { return addon->toAddon->GetRecordingsAmount(addon, deleted, &iRecordings); },
       m_clientCapabilities.SupportsRecordings() &&
@@ -1137,7 +1143,7 @@ PVR_ERROR CPVRClient::GetRecordingsAmount(bool deleted, int& iRecordings) const
 PVR_ERROR CPVRClient::GetRecordings(CPVRRecordings* results, bool deleted) const
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [this, results, deleted](const AddonInstance* addon)
       {
         PVR_HANDLE_STRUCT handle = {};
@@ -1152,7 +1158,7 @@ PVR_ERROR CPVRClient::GetRecordings(CPVRRecordings* results, bool deleted) const
 PVR_ERROR CPVRClient::DeleteRecording(const CPVRRecording& recording)
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&recording](const AddonInstance* addon)
       {
         const CAddonRecording tag{recording};
@@ -1164,7 +1170,7 @@ PVR_ERROR CPVRClient::DeleteRecording(const CPVRRecording& recording)
 PVR_ERROR CPVRClient::UndeleteRecording(const CPVRRecording& recording)
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&recording](const AddonInstance* addon)
       {
         const CAddonRecording tag{recording};
@@ -1176,7 +1182,7 @@ PVR_ERROR CPVRClient::UndeleteRecording(const CPVRRecording& recording)
 PVR_ERROR CPVRClient::DeleteAllRecordingsFromTrash()
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [](const AddonInstance* addon)
       { return addon->toAddon->DeleteAllRecordingsFromTrash(addon); },
       m_clientCapabilities.SupportsRecordingsUndelete());
@@ -1185,7 +1191,7 @@ PVR_ERROR CPVRClient::DeleteAllRecordingsFromTrash()
 PVR_ERROR CPVRClient::RenameRecording(const CPVRRecording& recording)
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&recording](const AddonInstance* addon)
       {
         const CAddonRecording tag{recording};
@@ -1197,7 +1203,7 @@ PVR_ERROR CPVRClient::RenameRecording(const CPVRRecording& recording)
 PVR_ERROR CPVRClient::SetRecordingLifetime(const CPVRRecording& recording)
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&recording](const AddonInstance* addon)
       {
         const CAddonRecording tag{recording};
@@ -1209,7 +1215,7 @@ PVR_ERROR CPVRClient::SetRecordingLifetime(const CPVRRecording& recording)
 PVR_ERROR CPVRClient::SetRecordingPlayCount(const CPVRRecording& recording, int count)
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&recording, count](const AddonInstance* addon)
       {
         const CAddonRecording tag{recording};
@@ -1222,7 +1228,7 @@ PVR_ERROR CPVRClient::SetRecordingLastPlayedPosition(const CPVRRecording& record
                                                      int lastplayedposition)
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&recording, lastplayedposition](const AddonInstance* addon)
       {
         const CAddonRecording tag{recording};
@@ -1236,7 +1242,7 @@ PVR_ERROR CPVRClient::GetRecordingLastPlayedPosition(const CPVRRecording& record
 {
   iPosition = -1;
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&recording, &iPosition](const AddonInstance* addon)
       {
         const CAddonRecording tag{recording};
@@ -1250,7 +1256,7 @@ PVR_ERROR CPVRClient::GetRecordingEdl(const CPVRRecording& recording,
 {
   edls.clear();
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&recording, &edls](const AddonInstance* addon)
       {
         const CAddonRecording tag{recording};
@@ -1273,7 +1279,7 @@ PVR_ERROR CPVRClient::GetRecordingEdl(const CPVRRecording& recording,
 PVR_ERROR CPVRClient::GetRecordingSize(const CPVRRecording& recording, int64_t& sizeInBytes) const
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&recording, &sizeInBytes](const AddonInstance* addon)
       {
         const CAddonRecording tag{recording};
@@ -1286,7 +1292,7 @@ PVR_ERROR CPVRClient::GetTimersAmount(int& iTimers) const
 {
   iTimers = -1;
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&iTimers](const AddonInstance* addon)
       { return addon->toAddon->GetTimersAmount(addon, &iTimers); },
       m_clientCapabilities.SupportsTimers());
@@ -1295,7 +1301,7 @@ PVR_ERROR CPVRClient::GetTimersAmount(int& iTimers) const
 PVR_ERROR CPVRClient::GetTimers(CPVRTimersContainer* results) const
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [this, results](const AddonInstance* addon)
       {
         PVR_HANDLE_STRUCT handle = {};
@@ -1309,7 +1315,7 @@ PVR_ERROR CPVRClient::GetTimers(CPVRTimersContainer* results) const
 PVR_ERROR CPVRClient::AddTimer(const CPVRTimerInfoTag& timer)
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&timer](const AddonInstance* addon)
       {
         const CAddonTimer tag{timer};
@@ -1321,7 +1327,7 @@ PVR_ERROR CPVRClient::AddTimer(const CPVRTimerInfoTag& timer)
 PVR_ERROR CPVRClient::DeleteTimer(const CPVRTimerInfoTag& timer, bool bForce /* = false */)
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&timer, bForce](const AddonInstance* addon)
       {
         const CAddonTimer tag{timer};
@@ -1333,7 +1339,7 @@ PVR_ERROR CPVRClient::DeleteTimer(const CPVRTimerInfoTag& timer, bool bForce /* 
 PVR_ERROR CPVRClient::UpdateTimer(const CPVRTimerInfoTag& timer)
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&timer](const AddonInstance* addon)
       {
         const CAddonTimer tag{timer};
@@ -1353,7 +1359,7 @@ PVR_ERROR CPVRClient::UpdateTimerTypes()
   std::vector<std::shared_ptr<CPVRTimerType>> timerTypes;
 
   PVR_ERROR retVal = DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [this, &timerTypes](const AddonInstance* addon)
       {
         PVR_TIMER_TYPE** types_array{nullptr};
@@ -1462,9 +1468,9 @@ PVR_ERROR CPVRClient::UpdateTimerTypes()
 
     for (const auto& type : timerTypes)
     {
-      const auto it = std::find_if(m_timertypes.cbegin(), m_timertypes.cend(),
-                                   [&type](const std::shared_ptr<const CPVRTimerType>& entry)
-                                   { return entry->GetTypeId() == type->GetTypeId(); });
+      const auto it = std::ranges::find_if(
+          m_timertypes, [&type](const std::shared_ptr<const CPVRTimerType>& entry)
+          { return entry->GetTypeId() == type->GetTypeId(); });
       if (it == m_timertypes.cend())
       {
         newTimerTypes.emplace_back(type);
@@ -1484,7 +1490,7 @@ PVR_ERROR CPVRClient::UpdateTimerTypes()
 PVR_ERROR CPVRClient::GetStreamReadChunkSize(int& iChunkSize) const
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&iChunkSize](const AddonInstance* addon)
       { return addon->toAddon->GetStreamReadChunkSize(addon, &iChunkSize); },
       m_clientCapabilities.SupportsRecordings() || m_clientCapabilities.HandlesInputStream());
@@ -1493,7 +1499,7 @@ PVR_ERROR CPVRClient::GetStreamReadChunkSize(int& iChunkSize) const
 PVR_ERROR CPVRClient::ReadLiveStream(void* lpBuf, int64_t uiBufSize, int& iRead)
 {
   iRead = -1;
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [&lpBuf, uiBufSize, &iRead](const AddonInstance* addon)
                      {
                        iRead = addon->toAddon->ReadLiveStream(
@@ -1508,7 +1514,7 @@ PVR_ERROR CPVRClient::ReadRecordedStream(int64_t streamId,
                                          int& iRead)
 {
   iRead = -1;
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [streamId, &lpBuf, uiBufSize, &iRead](const AddonInstance* addon)
                      {
                        iRead = addon->toAddon->ReadRecordedStream(
@@ -1521,7 +1527,7 @@ PVR_ERROR CPVRClient::ReadRecordedStream(int64_t streamId,
 PVR_ERROR CPVRClient::SeekLiveStream(int64_t iFilePosition, int iWhence, int64_t& iPosition)
 {
   iPosition = -1;
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [iFilePosition, iWhence, &iPosition](const AddonInstance* addon)
                      {
                        iPosition = addon->toAddon->SeekLiveStream(addon, iFilePosition, iWhence);
@@ -1535,7 +1541,7 @@ PVR_ERROR CPVRClient::SeekRecordedStream(int64_t streamId,
                                          int64_t& iPosition)
 {
   iPosition = -1;
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [streamId, iFilePosition, iWhence, &iPosition](const AddonInstance* addon)
                      {
                        iPosition = addon->toAddon->SeekRecordedStream(addon, streamId,
@@ -1546,7 +1552,7 @@ PVR_ERROR CPVRClient::SeekRecordedStream(int64_t streamId,
 
 PVR_ERROR CPVRClient::SeekTime(double time, bool backwards, double* startpts)
 {
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [time, backwards, &startpts](const AddonInstance* addon)
                      {
                        return addon->toAddon->SeekTime(addon, time, backwards, startpts)
@@ -1558,7 +1564,7 @@ PVR_ERROR CPVRClient::SeekTime(double time, bool backwards, double* startpts)
 PVR_ERROR CPVRClient::GetLiveStreamLength(int64_t& iLength) const
 {
   iLength = -1;
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [&iLength](const AddonInstance* addon)
                      {
                        iLength = addon->toAddon->LengthLiveStream(addon);
@@ -1569,7 +1575,7 @@ PVR_ERROR CPVRClient::GetLiveStreamLength(int64_t& iLength) const
 PVR_ERROR CPVRClient::GetRecordedStreamLength(int64_t streamId, int64_t& iLength) const
 {
   iLength = -1;
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [streamId, &iLength](const AddonInstance* addon)
                      {
                        iLength = addon->toAddon->LengthRecordedStream(addon, streamId);
@@ -1579,7 +1585,7 @@ PVR_ERROR CPVRClient::GetRecordedStreamLength(int64_t streamId, int64_t& iLength
 
 PVR_ERROR CPVRClient::SignalQuality(int channelUid, CPVRSignalStatus& qualityinfo) const
 {
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [channelUid, &qualityinfo](const AddonInstance* addon)
                      {
                        PVR_SIGNAL_STATUS info{};
@@ -1596,7 +1602,7 @@ PVR_ERROR CPVRClient::SignalQuality(int channelUid, CPVRSignalStatus& qualityinf
 PVR_ERROR CPVRClient::GetDescrambleInfo(int channelUid, CPVRDescrambleInfo& descrambleinfo) const
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [channelUid, &descrambleinfo](const AddonInstance* addon)
       {
         PVR_DESCRAMBLE_INFO info{};
@@ -1615,7 +1621,7 @@ PVR_ERROR CPVRClient::GetChannelStreamProperties(const std::shared_ptr<const CPV
                                                  CPVRStreamProperties& props) const
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [this, &channel, source, &props](const AddonInstance* addon)
       {
         if (!CanPlayChannel(channel))
@@ -1639,7 +1645,7 @@ PVR_ERROR CPVRClient::GetRecordingStreamProperties(
     const std::shared_ptr<const CPVRRecording>& recording, CPVRStreamProperties& props) const
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [this, &recording, &props](const AddonInstance* addon)
       {
         if (!m_clientCapabilities.SupportsRecordings())
@@ -1661,20 +1667,21 @@ PVR_ERROR CPVRClient::GetRecordingStreamProperties(
 
 PVR_ERROR CPVRClient::GetStreamProperties(PVR_STREAM_PROPERTIES* props) const
 {
-  return DoAddonCall(__func__, [&props](const AddonInstance* addon)
+  return DoAddonCall(std::source_location::current().function_name(),
+                     [&props](const AddonInstance* addon)
                      { return addon->toAddon->GetStreamProperties(addon, props); });
 }
 
 PVR_ERROR CPVRClient::StreamClosed() const
 {
-  return DoAddonCall(__func__, [](const AddonInstance* addon)
+  return DoAddonCall(std::source_location::current().function_name(), [](const AddonInstance* addon)
                      { return addon->toAddon->StreamClosed(addon); });
 }
 
 PVR_ERROR CPVRClient::DemuxReset()
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [](const AddonInstance* addon)
       {
         addon->toAddon->DemuxReset(addon);
@@ -1686,7 +1693,7 @@ PVR_ERROR CPVRClient::DemuxReset()
 PVR_ERROR CPVRClient::DemuxAbort()
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [](const AddonInstance* addon)
       {
         addon->toAddon->DemuxAbort(addon);
@@ -1698,7 +1705,7 @@ PVR_ERROR CPVRClient::DemuxAbort()
 PVR_ERROR CPVRClient::DemuxFlush()
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [](const AddonInstance* addon)
       {
         addon->toAddon->DemuxFlush(addon);
@@ -1710,7 +1717,7 @@ PVR_ERROR CPVRClient::DemuxFlush()
 PVR_ERROR CPVRClient::DemuxRead(DemuxPacket*& packet)
 {
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [&packet](const AddonInstance* addon)
       {
         packet = static_cast<DemuxPacket*>(addon->toAddon->DemuxRead(addon));
@@ -1747,8 +1754,9 @@ const char* CPVRClient::ToString(const PVR_ERROR error)
   }
 }
 
+template<typename F>
 PVR_ERROR CPVRClient::DoAddonCall(const char* strFunctionName,
-                                  const std::function<PVR_ERROR(const AddonInstance*)>& function,
+                                  F function,
                                   bool bIsImplemented /* = true */,
                                   bool bCheckReadyToUse /* = true */) const
 {
@@ -1811,7 +1819,7 @@ PVR_ERROR CPVRClient::OpenLiveStream(const std::shared_ptr<const CPVRChannel>& c
   if (!channel)
     return PVR_ERROR_INVALID_PARAMETERS;
 
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [this, channel](const AddonInstance* addon)
                      {
                        CloseLiveStream();
@@ -1841,7 +1849,7 @@ PVR_ERROR CPVRClient::OpenRecordedStream(const std::shared_ptr<const CPVRRecordi
     return PVR_ERROR_INVALID_PARAMETERS;
 
   return DoAddonCall(
-      __func__,
+      std::source_location::current().function_name(),
       [this, recording, &streamId](const AddonInstance* addon)
       {
         if (!m_clientCapabilities.SupportsMultipleRecordedStreams())
@@ -1858,7 +1866,7 @@ PVR_ERROR CPVRClient::OpenRecordedStream(const std::shared_ptr<const CPVRRecordi
 
 PVR_ERROR CPVRClient::CloseLiveStream()
 {
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [](const AddonInstance* addon)
                      {
                        addon->toAddon->CloseLiveStream(addon);
@@ -1868,7 +1876,7 @@ PVR_ERROR CPVRClient::CloseLiveStream()
 
 PVR_ERROR CPVRClient::CloseRecordedStream(int64_t streamId)
 {
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [streamId](const AddonInstance* addon)
                      {
                        addon->toAddon->CloseRecordedStream(addon, streamId);
@@ -1881,7 +1889,8 @@ PVR_ERROR CPVRClient::IsRecordedStreamRealTime(int64_t streamId, bool& isRealTim
   if (m_clientCapabilities.SupportsMultipleRecordedStreams())
   {
     return DoAddonCall(
-        __func__, [streamId, &isRealTime](const AddonInstance* addon)
+        std::source_location::current().function_name(),
+        [streamId, &isRealTime](const AddonInstance* addon)
         { return addon->toAddon->IsRecordedStreamRealTime(addon, streamId, &isRealTime); });
   }
   else
@@ -1894,7 +1903,8 @@ PVR_ERROR CPVRClient::PauseRecordedStream(int64_t streamId, bool paused)
 {
   if (m_clientCapabilities.SupportsMultipleRecordedStreams())
   {
-    return DoAddonCall(__func__, [streamId, paused](const AddonInstance* addon)
+    return DoAddonCall(std::source_location::current().function_name(),
+                       [streamId, paused](const AddonInstance* addon)
                        { return addon->toAddon->PauseRecordedStream(addon, streamId, paused); });
   }
   else
@@ -1907,7 +1917,8 @@ PVR_ERROR CPVRClient::GetRecordedStreamTimes(int64_t streamId, PVR_STREAM_TIMES*
 {
   if (m_clientCapabilities.SupportsMultipleRecordedStreams())
   {
-    return DoAddonCall(__func__, [streamId, &times](const AddonInstance* addon)
+    return DoAddonCall(std::source_location::current().function_name(),
+                       [streamId, &times](const AddonInstance* addon)
                        { return addon->toAddon->GetRecordedStreamTimes(addon, streamId, times); });
   }
   else
@@ -1918,7 +1929,7 @@ PVR_ERROR CPVRClient::GetRecordedStreamTimes(int64_t streamId, PVR_STREAM_TIMES*
 
 PVR_ERROR CPVRClient::PauseStream(bool bPaused)
 {
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [bPaused](const AddonInstance* addon)
                      {
                        addon->toAddon->PauseStream(addon, bPaused);
@@ -1928,7 +1939,7 @@ PVR_ERROR CPVRClient::PauseStream(bool bPaused)
 
 PVR_ERROR CPVRClient::SetSpeed(int speed)
 {
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [speed](const AddonInstance* addon)
                      {
                        addon->toAddon->SetSpeed(addon, speed);
@@ -1938,7 +1949,7 @@ PVR_ERROR CPVRClient::SetSpeed(int speed)
 
 PVR_ERROR CPVRClient::FillBuffer(bool mode)
 {
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [mode](const AddonInstance* addon)
                      {
                        addon->toAddon->FillBuffer(addon, mode);
@@ -1949,7 +1960,7 @@ PVR_ERROR CPVRClient::FillBuffer(bool mode)
 PVR_ERROR CPVRClient::CanPauseStream(bool& bCanPause) const
 {
   bCanPause = false;
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [&bCanPause](const AddonInstance* addon)
                      {
                        bCanPause = addon->toAddon->CanPauseStream(addon);
@@ -1960,7 +1971,7 @@ PVR_ERROR CPVRClient::CanPauseStream(bool& bCanPause) const
 PVR_ERROR CPVRClient::CanSeekStream(bool& bCanSeek) const
 {
   bCanSeek = false;
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [&bCanSeek](const AddonInstance* addon)
                      {
                        bCanSeek = addon->toAddon->CanSeekStream(addon);
@@ -1970,14 +1981,15 @@ PVR_ERROR CPVRClient::CanSeekStream(bool& bCanSeek) const
 
 PVR_ERROR CPVRClient::GetStreamTimes(PVR_STREAM_TIMES* times) const
 {
-  return DoAddonCall(__func__, [&times](const AddonInstance* addon)
+  return DoAddonCall(std::source_location::current().function_name(),
+                     [&times](const AddonInstance* addon)
                      { return addon->toAddon->GetStreamTimes(addon, times); });
 }
 
 PVR_ERROR CPVRClient::IsRealTimeStream(bool& bRealTime) const
 {
   bRealTime = false;
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [&bRealTime](const AddonInstance* addon)
                      {
                        bRealTime = addon->toAddon->IsRealTimeStream(addon);
@@ -1987,8 +1999,9 @@ PVR_ERROR CPVRClient::IsRealTimeStream(bool& bRealTime) const
 
 PVR_ERROR CPVRClient::OnSystemSleep()
 {
-  const PVR_ERROR ret = DoAddonCall(__func__, [](const AddonInstance* addon)
-                                    { return addon->toAddon->OnSystemSleep(addon); });
+  const PVR_ERROR ret =
+      DoAddonCall(std::source_location::current().function_name(),
+                  [](const AddonInstance* addon) { return addon->toAddon->OnSystemSleep(addon); });
   m_bBlockAddonCalls = true;
   return ret;
 }
@@ -1996,19 +2009,19 @@ PVR_ERROR CPVRClient::OnSystemSleep()
 PVR_ERROR CPVRClient::OnSystemWake()
 {
   m_bBlockAddonCalls = false;
-  return DoAddonCall(__func__, [](const AddonInstance* addon)
+  return DoAddonCall(std::source_location::current().function_name(), [](const AddonInstance* addon)
                      { return addon->toAddon->OnSystemWake(addon); });
 }
 
 PVR_ERROR CPVRClient::OnPowerSavingActivated()
 {
-  return DoAddonCall(__func__, [](const AddonInstance* addon)
+  return DoAddonCall(std::source_location::current().function_name(), [](const AddonInstance* addon)
                      { return addon->toAddon->OnPowerSavingActivated(addon); });
 }
 
 PVR_ERROR CPVRClient::OnPowerSavingDeactivated()
 {
-  return DoAddonCall(__func__, [](const AddonInstance* addon)
+  return DoAddonCall(std::source_location::current().function_name(), [](const AddonInstance* addon)
                      { return addon->toAddon->OnPowerSavingDeactivated(addon); });
 }
 
@@ -2023,7 +2036,7 @@ std::shared_ptr<CPVRClientMenuHooks> CPVRClient::GetMenuHooks() const
 PVR_ERROR CPVRClient::CallEpgTagMenuHook(const CPVRClientMenuHook& hook,
                                          const std::shared_ptr<const CPVREpgInfoTag>& tag)
 {
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [&hook, &tag](const AddonInstance* addon)
                      {
                        CAddonEpgTag addonTag(*tag);
@@ -2040,7 +2053,7 @@ PVR_ERROR CPVRClient::CallEpgTagMenuHook(const CPVRClientMenuHook& hook,
 PVR_ERROR CPVRClient::CallChannelMenuHook(const CPVRClientMenuHook& hook,
                                           const std::shared_ptr<const CPVRChannel>& channel)
 {
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [&hook, &channel](const AddonInstance* addon)
                      {
                        const CAddonChannel addonChannel{*channel};
@@ -2058,7 +2071,7 @@ PVR_ERROR CPVRClient::CallRecordingMenuHook(const CPVRClientMenuHook& hook,
                                             const std::shared_ptr<const CPVRRecording>& recording,
                                             bool bDeleted)
 {
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [&hook, &recording, &bDeleted](const AddonInstance* addon)
                      {
                        const CAddonRecording tag(*recording);
@@ -2076,7 +2089,7 @@ PVR_ERROR CPVRClient::CallRecordingMenuHook(const CPVRClientMenuHook& hook,
 PVR_ERROR CPVRClient::CallTimerMenuHook(const CPVRClientMenuHook& hook,
                                         const std::shared_ptr<const CPVRTimerInfoTag>& timer)
 {
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [&hook, &timer](const AddonInstance* addon)
                      {
                        const CAddonTimer tag(*timer);
@@ -2092,7 +2105,7 @@ PVR_ERROR CPVRClient::CallTimerMenuHook(const CPVRClientMenuHook& hook,
 
 PVR_ERROR CPVRClient::CallSettingsMenuHook(const CPVRClientMenuHook& hook)
 {
-  return DoAddonCall(__func__,
+  return DoAddonCall(std::source_location::current().function_name(),
                      [&hook](const AddonInstance* addon)
                      {
                        PVR_MENUHOOK menuHook;
@@ -2152,13 +2165,14 @@ void CPVRClient::SetDateTimeFirstChannelsAdded(const CDateTime& dateTime)
   }
 }
 
+template<typename F>
 void CPVRClient::HandleAddonCallback(const char* strFunctionName,
                                      void* kodiInstance,
-                                     const std::function<void(CPVRClient* client)>& function,
+                                     F function,
                                      bool bForceCall /* = false */)
 {
   // Check preconditions.
-  CPVRClient* client = static_cast<CPVRClient*>(kodiInstance);
+  auto* client{static_cast<CPVRClient*>(kodiInstance)};
   if (!client)
   {
     CLog::Log(LOGERROR, "{}: No instance pointer given!", strFunctionName);
@@ -2180,8 +2194,8 @@ void CPVRClient::cb_transfer_channel_group(void* kodiInstance,
                                            const PVR_HANDLE handle,
                                            const PVR_CHANNEL_GROUP* group)
 {
-  HandleAddonCallback(__func__, kodiInstance,
-                      [&](CPVRClient* client)
+  HandleAddonCallback(std::source_location::current().function_name(), kodiInstance,
+                      [handle, group](const CPVRClient* client)
                       {
                         if (!handle || !group)
                         {
@@ -2196,8 +2210,7 @@ void CPVRClient::cb_transfer_channel_group(void* kodiInstance,
                         }
 
                         // transfer this entry to the groups container
-                        CPVRChannelGroups* kodiGroups =
-                            static_cast<CPVRChannelGroups*>(handle->dataAddress);
+                        auto* kodiGroups{static_cast<CPVRChannelGroups*>(handle->dataAddress)};
                         const auto transferGroup = kodiGroups->GetGroupFactory()->CreateClientGroup(
                             *group, client->GetID(), kodiGroups->GetGroupAll());
                         kodiGroups->UpdateFromClient(transferGroup);
@@ -2208,8 +2221,8 @@ void CPVRClient::cb_transfer_channel_group_member(void* kodiInstance,
                                                   const PVR_HANDLE handle,
                                                   const PVR_CHANNEL_GROUP_MEMBER* member)
 {
-  HandleAddonCallback(__func__, kodiInstance,
-                      [&](CPVRClient* client)
+  HandleAddonCallback(std::source_location::current().function_name(), kodiInstance,
+                      [handle, member](const CPVRClient* client)
                       {
                         if (!handle || !member)
                         {
@@ -2227,9 +2240,9 @@ void CPVRClient::cb_transfer_channel_group_member(void* kodiInstance,
                         }
                         else
                         {
-                          auto* groupMembers =
+                          auto* groupMembers{
                               static_cast<std::vector<std::shared_ptr<CPVRChannelGroupMember>>*>(
-                                  handle->dataAddress);
+                                  handle->dataAddress)};
                           groupMembers->emplace_back(std::make_shared<CPVRChannelGroupMember>(
                               member->strGroupName, client->GetID(), member->iOrder, channel));
                         }
@@ -2240,8 +2253,8 @@ void CPVRClient::cb_transfer_epg_entry(void* kodiInstance,
                                        const PVR_HANDLE handle,
                                        const EPG_TAG* epgentry)
 {
-  HandleAddonCallback(__func__, kodiInstance,
-                      [&](CPVRClient* client)
+  HandleAddonCallback(std::source_location::current().function_name(), kodiInstance,
+                      [handle, epgentry](const CPVRClient* client)
                       {
                         if (!handle || !epgentry)
                         {
@@ -2250,7 +2263,7 @@ void CPVRClient::cb_transfer_epg_entry(void* kodiInstance,
                         }
 
                         // transfer this entry to the epg
-                        CPVREpg* epg = static_cast<CPVREpg*>(handle->dataAddress);
+                        auto* epg{static_cast<CPVREpg*>(handle->dataAddress)};
                         epg->UpdateEntry(epgentry, client->GetID());
                       });
 }
@@ -2260,7 +2273,7 @@ void CPVRClient::cb_transfer_provider_entry(void* kodiInstance,
                                             const PVR_PROVIDER* provider)
 {
   HandleAddonCallback(
-      __func__, kodiInstance,
+      std::source_location::current().function_name(), kodiInstance,
       [handle, provider](const CPVRClient* client)
       {
         if (!handle || !provider)
@@ -2281,8 +2294,8 @@ void CPVRClient::cb_transfer_channel_entry(void* kodiInstance,
                                            const PVR_CHANNEL* channel)
 {
   HandleAddonCallback(
-      __func__, kodiInstance,
-      [&](CPVRClient* client)
+      std::source_location::current().function_name(), kodiInstance,
+      [handle, channel](const CPVRClient* client)
       {
         if (!handle || !channel)
         {
@@ -2290,8 +2303,8 @@ void CPVRClient::cb_transfer_channel_entry(void* kodiInstance,
           return;
         }
 
-        auto* channels =
-            static_cast<std::vector<std::shared_ptr<CPVRChannel>>*>(handle->dataAddress);
+        auto* channels{
+            static_cast<std::vector<std::shared_ptr<CPVRChannel>>*>(handle->dataAddress)};
         channels->emplace_back(std::make_shared<CPVRChannel>(*channel, client->GetID()));
       });
 }
@@ -2300,8 +2313,8 @@ void CPVRClient::cb_transfer_recording_entry(void* kodiInstance,
                                              const PVR_HANDLE handle,
                                              const PVR_RECORDING* recording)
 {
-  HandleAddonCallback(__func__, kodiInstance,
-                      [&](CPVRClient* client)
+  HandleAddonCallback(std::source_location::current().function_name(), kodiInstance,
+                      [handle, recording](const CPVRClient* client)
                       {
                         if (!handle || !recording)
                         {
@@ -2310,10 +2323,9 @@ void CPVRClient::cb_transfer_recording_entry(void* kodiInstance,
                         }
 
                         // transfer this entry to the recordings container
-                        const std::shared_ptr<CPVRRecording> transferRecording =
-                            std::make_shared<CPVRRecording>(*recording, client->GetID());
-                        CPVRRecordings* recordings =
-                            static_cast<CPVRRecordings*>(handle->dataAddress);
+                        const auto transferRecording{
+                            std::make_shared<CPVRRecording>(*recording, client->GetID())};
+                        auto* recordings{static_cast<CPVRRecordings*>(handle->dataAddress)};
                         recordings->UpdateFromClient(transferRecording, *client);
                       });
 }
@@ -2322,8 +2334,8 @@ void CPVRClient::cb_transfer_timer_entry(void* kodiInstance,
                                          const PVR_HANDLE handle,
                                          const PVR_TIMER* timer)
 {
-  HandleAddonCallback(__func__, kodiInstance,
-                      [&](CPVRClient* client)
+  HandleAddonCallback(std::source_location::current().function_name(), kodiInstance,
+                      [handle, timer](const CPVRClient* client)
                       {
                         if (!handle || !timer)
                         {
@@ -2338,18 +2350,17 @@ void CPVRClient::cb_transfer_timer_entry(void* kodiInstance,
                                 timer->iClientChannelUid, client->GetID());
 
                         // transfer this entry to the timers container
-                        const std::shared_ptr<CPVRTimerInfoTag> transferTimer =
-                            std::make_shared<CPVRTimerInfoTag>(*timer, channel, client->GetID());
-                        CPVRTimersContainer* timers =
-                            static_cast<CPVRTimersContainer*>(handle->dataAddress);
+                        const auto transferTimer{
+                            std::make_shared<CPVRTimerInfoTag>(*timer, channel, client->GetID())};
+                        auto* timers{static_cast<CPVRTimersContainer*>(handle->dataAddress)};
                         timers->UpdateFromClient(transferTimer);
                       });
 }
 
 void CPVRClient::cb_add_menu_hook(void* kodiInstance, const PVR_MENUHOOK* hook)
 {
-  HandleAddonCallback(__func__, kodiInstance,
-                      [&](CPVRClient* client)
+  HandleAddonCallback(std::source_location::current().function_name(), kodiInstance,
+                      [hook](const CPVRClient* client)
                       {
                         if (!hook)
                         {
@@ -2367,8 +2378,8 @@ void CPVRClient::cb_recording_notification(void* kodiInstance,
                                            bool bOnOff)
 {
   HandleAddonCallback(
-      __func__, kodiInstance,
-      [&](CPVRClient* client)
+      std::source_location::current().function_name(), kodiInstance,
+      [strName, strFileName, bOnOff](const CPVRClient* client)
       {
         if (!strFileName)
         {
@@ -2389,8 +2400,8 @@ void CPVRClient::cb_recording_notification(void* kodiInstance,
                                               false);
         auto eventLog = CServiceBroker::GetEventLog();
         if (eventLog)
-          eventLog->Add(EventPtr(new CNotificationEvent(client->GetFullClientName(), strLine1,
-                                                        client->Icon(), strLine2)));
+          eventLog->Add(EventPtr(std::make_shared<CNotificationEvent>(
+              client->GetFullClientName(), strLine1, client->Icon(), strLine2)));
 
         CLog::LogFC(LOGDEBUG, LOGPVR, "Recording {} on client {}. name='{}' filename='{}'",
                     bOnOff ? "started" : "finished", client->GetID(), strName, strFileName);
@@ -2399,8 +2410,8 @@ void CPVRClient::cb_recording_notification(void* kodiInstance,
 
 void CPVRClient::cb_trigger_channel_update(void* kodiInstance)
 {
-  HandleAddonCallback(__func__, kodiInstance,
-                      [&](CPVRClient* client)
+  HandleAddonCallback(std::source_location::current().function_name(), kodiInstance,
+                      [](const CPVRClient* client)
                       {
                         // update channels in the next iteration of the pvrmanager's main loop
                         CServiceBroker::GetPVRManager().TriggerChannelsUpdate(client->GetID());
@@ -2409,8 +2420,8 @@ void CPVRClient::cb_trigger_channel_update(void* kodiInstance)
 
 void CPVRClient::cb_trigger_provider_update(void* kodiInstance)
 {
-  HandleAddonCallback(__func__, kodiInstance,
-                      [&](CPVRClient* client)
+  HandleAddonCallback(std::source_location::current().function_name(), kodiInstance,
+                      [](const CPVRClient* client)
                       {
                         /* update the providers table in the next iteration of the pvrmanager's main loop */
                         CServiceBroker::GetPVRManager().TriggerProvidersUpdate(client->GetID());
@@ -2419,8 +2430,8 @@ void CPVRClient::cb_trigger_provider_update(void* kodiInstance)
 
 void CPVRClient::cb_trigger_timer_update(void* kodiInstance)
 {
-  HandleAddonCallback(__func__, kodiInstance,
-                      [&](CPVRClient* client)
+  HandleAddonCallback(std::source_location::current().function_name(), kodiInstance,
+                      [](const CPVRClient* client)
                       {
                         // update timers in the next iteration of the pvrmanager's main loop
                         CServiceBroker::GetPVRManager().TriggerTimersUpdate(client->GetID());
@@ -2429,8 +2440,8 @@ void CPVRClient::cb_trigger_timer_update(void* kodiInstance)
 
 void CPVRClient::cb_trigger_recording_update(void* kodiInstance)
 {
-  HandleAddonCallback(__func__, kodiInstance,
-                      [&](CPVRClient* client)
+  HandleAddonCallback(std::source_location::current().function_name(), kodiInstance,
+                      [](const CPVRClient* client)
                       {
                         // update recordings in the next iteration of the pvrmanager's main loop
                         CServiceBroker::GetPVRManager().TriggerRecordingsUpdate(client->GetID());
@@ -2439,8 +2450,8 @@ void CPVRClient::cb_trigger_recording_update(void* kodiInstance)
 
 void CPVRClient::cb_trigger_channel_groups_update(void* kodiInstance)
 {
-  HandleAddonCallback(__func__, kodiInstance,
-                      [&](CPVRClient* client)
+  HandleAddonCallback(std::source_location::current().function_name(), kodiInstance,
+                      [](const CPVRClient* client)
                       {
                         // update all channel groups in the next iteration of the pvrmanager's main loop
                         CServiceBroker::GetPVRManager().TriggerChannelGroupsUpdate(client->GetID());
@@ -2449,8 +2460,8 @@ void CPVRClient::cb_trigger_channel_groups_update(void* kodiInstance)
 
 void CPVRClient::cb_trigger_epg_update(void* kodiInstance, unsigned int iChannelUid)
 {
-  HandleAddonCallback(__func__, kodiInstance,
-                      [&](CPVRClient* client) {
+  HandleAddonCallback(std::source_location::current().function_name(), kodiInstance,
+                      [iChannelUid](const CPVRClient* client) {
                         CServiceBroker::GetPVRManager().EpgContainer().UpdateRequest(
                             client->GetID(), iChannelUid);
                       });
@@ -2459,8 +2470,8 @@ void CPVRClient::cb_trigger_epg_update(void* kodiInstance, unsigned int iChannel
 void CPVRClient::cb_free_demux_packet(void* kodiInstance, DEMUX_PACKET* pPacket)
 {
   HandleAddonCallback(
-      __func__, kodiInstance,
-      [&](CPVRClient* client)
+      std::source_location::current().function_name(), kodiInstance,
+      [pPacket](const CPVRClient* client)
       { CDVDDemuxUtils::FreeDemuxPacket(static_cast<DemuxPacket*>(pPacket)); },
       true);
 }
@@ -2470,8 +2481,10 @@ DEMUX_PACKET* CPVRClient::cb_allocate_demux_packet(void* kodiInstance, int iData
   DEMUX_PACKET* result = nullptr;
 
   HandleAddonCallback(
-      __func__, kodiInstance,
-      [&](CPVRClient* client) { result = CDVDDemuxUtils::AllocateDemuxPacket(iDataSize); }, true);
+      std::source_location::current().function_name(), kodiInstance,
+      [iDataSize, &result](const CPVRClient* client)
+      { result = CDVDDemuxUtils::AllocateDemuxPacket(iDataSize); },
+      true);
 
   return result;
 }
@@ -2481,8 +2494,8 @@ void CPVRClient::cb_connection_state_change(void* kodiInstance,
                                             PVR_CONNECTION_STATE newState,
                                             const char* strMessage)
 {
-  HandleAddonCallback(__func__, kodiInstance,
-                      [&](CPVRClient* client)
+  HandleAddonCallback(std::source_location::current().function_name(), kodiInstance,
+                      [strConnectionString, newState, strMessage](CPVRClient* client)
                       {
                         if (!strConnectionString)
                         {
@@ -2513,8 +2526,8 @@ void CPVRClient::cb_epg_event_state_change(void* kodiInstance,
                                            EPG_TAG* tag,
                                            EPG_EVENT_STATE newState)
 {
-  HandleAddonCallback(__func__, kodiInstance,
-                      [&](CPVRClient* client)
+  HandleAddonCallback(std::source_location::current().function_name(), kodiInstance,
+                      [tag, newState](const CPVRClient* client)
                       {
                         if (!tag)
                         {
@@ -2523,8 +2536,8 @@ void CPVRClient::cb_epg_event_state_change(void* kodiInstance,
                         }
 
                         // Note: channel data and epg id may not yet be available. Tag will be fully initialized later.
-                        const std::shared_ptr<CPVREpgInfoTag> epgTag =
-                            std::make_shared<CPVREpgInfoTag>(*tag, client->GetID(), nullptr, -1);
+                        const auto epgTag{
+                            std::make_shared<CPVREpgInfoTag>(*tag, client->GetID(), nullptr, -1)};
                         CServiceBroker::GetPVRManager().EpgContainer().UpdateFromClient(epgTag,
                                                                                         newState);
                       });
@@ -2602,8 +2615,9 @@ PVR_CODEC CPVRClient::cb_get_codec_by_name(const void* kodiInstance, const char*
   PVR_CODEC result = PVR_INVALID_CODEC;
 
   HandleAddonCallback(
-      __func__, const_cast<void*>(kodiInstance),
-      [&](CPVRClient* client) { result = CCodecIds::GetInstance().GetCodecByName(strCodecName); },
+      std::source_location::current().function_name(), const_cast<void*>(kodiInstance),
+      [&result, strCodecName](const CPVRClient* client)
+      { result = CCodecIds::GetInstance().GetCodecByName(strCodecName); },
       true);
 
   return result;

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -15,7 +15,6 @@
 #include "threads/Event.h"
 
 #include <atomic>
-#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -336,7 +335,7 @@ public:
    * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
    */
   PVR_ERROR GetChannelGroupMembers(
-      CPVRChannelGroup* group,
+      const CPVRChannelGroup* group,
       std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers) const;
 
   //@}
@@ -911,9 +910,9 @@ private:
    * @param bCheckReadyToUse If true, this method will check whether this instance is ready for use and return PVR_ERROR_SERVER_ERROR if it is not.
    * @return PVR_ERROR_NO_ERROR on success, any other PVR_ERROR_* value otherwise.
    */
-  typedef AddonInstance_PVR AddonInstance;
+  template<typename F>
   PVR_ERROR DoAddonCall(const char* strFunctionName,
-                        const std::function<PVR_ERROR(const AddonInstance*)>& function,
+                        F function,
                         bool bIsImplemented = true,
                         bool bCheckReadyToUse = true) const;
 
@@ -924,9 +923,10 @@ private:
    * @param function The function to wrap. It must take one parameter of type CPVRClient*.
    * @param bForceCall If true, make the call, ignoring client's state.
    */
+  template<typename F>
   static void HandleAddonCallback(const char* strFunctionName,
                                   void* kodiInstance,
-                                  const std::function<void(CPVRClient* client)>& function,
+                                  F function,
                                   bool bForceCall = false);
 
   /*!

--- a/xbmc/pvr/addons/PVRClientCapabilities.cpp
+++ b/xbmc/pvr/addons/PVRClientCapabilities.cpp
@@ -12,7 +12,6 @@
 #include "utils/StringUtils.h"
 
 #include <algorithm>
-#include <iterator>
 #include <memory>
 
 using namespace PVR;
@@ -82,6 +81,5 @@ void CPVRClientCapabilities::InitRecordingsLifetimeValues()
 void CPVRClientCapabilities::GetRecordingsLifetimeValues(
     std::vector<std::pair<std::string, int>>& list) const
 {
-  std::copy(m_recordingsLifetimeValues.cbegin(), m_recordingsLifetimeValues.cend(),
-            std::back_inserter(list));
+  std::ranges::copy(m_recordingsLifetimeValues, std::back_inserter(list));
 }

--- a/xbmc/pvr/addons/PVRClientMenuHooks.cpp
+++ b/xbmc/pvr/addons/PVRClientMenuHooks.cpp
@@ -19,8 +19,7 @@ namespace PVR
 {
 
 CPVRClientMenuHook::CPVRClientMenuHook(const std::string& addonId, const PVR_MENUHOOK& hook)
-: m_addonId(addonId),
-  m_hook(new PVR_MENUHOOK(hook))
+  : m_addonId(addonId), m_hook(std::make_shared<PVR_MENUHOOK>(hook))
 {
   if (hook.category != PVR_MENUHOOK_UNKNOWN &&
       hook.category != PVR_MENUHOOK_ALL &&
@@ -115,8 +114,8 @@ void CPVRClientMenuHooks::Clear()
   m_hooks.reset();
 }
 
-std::vector<CPVRClientMenuHook> CPVRClientMenuHooks::GetHooks(
-    const std::function<bool(const CPVRClientMenuHook& hook)>& function) const
+template<typename F>
+std::vector<CPVRClientMenuHook> CPVRClientMenuHooks::GetHooks(F function) const
 {
   std::vector<CPVRClientMenuHook> hooks;
 

--- a/xbmc/pvr/addons/PVRClientMenuHooks.h
+++ b/xbmc/pvr/addons/PVRClientMenuHooks.h
@@ -64,8 +64,8 @@ namespace PVR
     std::vector<CPVRClientMenuHook> GetSettingsHooks() const;
 
   private:
-    std::vector<CPVRClientMenuHook> GetHooks(
-        const std::function<bool(const CPVRClientMenuHook& hook)>& function) const;
+    template<typename F>
+    std::vector<CPVRClientMenuHook> GetHooks(F function) const;
 
     std::string m_addonId;
     std::unique_ptr<std::vector<CPVRClientMenuHook>> m_hooks;

--- a/xbmc/pvr/addons/PVRClientUID.cpp
+++ b/xbmc/pvr/addons/PVRClientUID.cpp
@@ -21,7 +21,7 @@ using namespace PVR;
 namespace
 {
 using ClientUIDParts = std::pair<std::string, ADDON::AddonInstanceId>;
-static std::map<ClientUIDParts, int> s_idMap;
+std::map<ClientUIDParts, int> s_idMap;
 } // unnamed namespace
 
 int CPVRClientUID::GetUID() const

--- a/xbmc/pvr/addons/PVRClientUID.h
+++ b/xbmc/pvr/addons/PVRClientUID.h
@@ -22,8 +22,6 @@ public:
   {
   }
 
-  virtual ~CPVRClientUID() = default;
-
   /*!
    * @brief Return the numeric UID.
    * @return The numeric UID, or PVR_CLIENT_INVALID_UID on error.

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -125,7 +125,7 @@ bool CPVRChannel::QueueDelete()
   if (epg)
     ResetEPG();
 
-  bReturn = database->QueueDeleteQuery(*this);
+  bReturn = database->QueueChannelDeleteQuery(*this);
   return bReturn;
 }
 

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -37,11 +37,6 @@ bool CPVRChannel::operator==(const CPVRChannel& right) const
           m_iClientId == right.m_iClientId);
 }
 
-bool CPVRChannel::operator!=(const CPVRChannel& right) const
-{
-  return !(*this == right);
-}
-
 CPVRChannel::CPVRChannel(bool bRadio)
   : m_bIsRadio(bRadio),
     m_iconPath("", StringUtils::Format(IMAGE_OWNER_PATTERN, bRadio ? "radio" : "tv"))

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -48,7 +48,6 @@ public:
   virtual ~CPVRChannel();
 
   bool operator==(const CPVRChannel& right) const;
-  bool operator!=(const CPVRChannel& right) const;
 
   void Serialize(CVariant& value) const override;
 

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -589,7 +589,7 @@ void CPVRChannelGroup::DeleteGroupMembersFromDb(
 
     for (const auto& member : membersToDelete)
     {
-      commitPending |= database->QueueDeleteQuery(*member);
+      commitPending |= database->QueueGroupMemberDeleteQuery(*member);
 
       size_t queryCount = database->GetDeleteQueriesCount();
       if (queryCount > CHANNEL_COMMIT_QUERY_COUNT_LIMIT)

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -40,7 +40,7 @@ class CPVRChannelGroupMember;
 class CPVRClient;
 class CPVREpgInfoTag;
 
-enum RenumberMode
+enum class RenumberMode
 {
   NORMAL = 0,
   IGNORE_NUMBERING_FROM_ONE = 1
@@ -67,7 +67,6 @@ public:
   ~CPVRChannelGroup() override;
 
   bool operator==(const CPVRChannelGroup& right) const;
-  bool operator!=(const CPVRChannelGroup& right) const;
 
   /*!
    * @brief Query the events available for CEventStream
@@ -244,7 +243,7 @@ public:
    * @param mode the numbering mode to use
    * @return True if something changed, false otherwise.
    */
-  bool Renumber(RenumberMode mode = NORMAL);
+  bool Renumber(RenumberMode mode = RenumberMode::NORMAL);
 
   //@}
 
@@ -610,7 +609,7 @@ private:
    * @param membersToDelete The channel group members.
    */
   void DeleteGroupMembersFromDb(
-      const std::vector<std::shared_ptr<CPVRChannelGroupMember>>& membersToDelete);
+      const std::vector<std::shared_ptr<CPVRChannelGroupMember>>& membersToDelete) const;
 
   /*!
    * @brief Update this group's data with a channel group member provided by a client.

--- a/xbmc/pvr/channels/PVRChannelGroupAllChannels.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupAllChannels.cpp
@@ -20,7 +20,6 @@
 #include "utils/log.h"
 
 #include <algorithm>
-#include <iterator>
 #include <mutex>
 #include <string>
 #include <utility>
@@ -39,9 +38,7 @@ CPVRChannelGroupAllChannels::CPVRChannelGroupAllChannels(const CPVRChannelsPath&
 {
 }
 
-CPVRChannelGroupAllChannels::~CPVRChannelGroupAllChannels()
-{
-}
+CPVRChannelGroupAllChannels::~CPVRChannelGroupAllChannels() = default;
 
 void CPVRChannelGroupAllChannels::CheckGroupName()
 {
@@ -65,11 +62,12 @@ bool CPVRChannelGroupAllChannels::UpdateFromClients(
 
   // create group members for the channels
   std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers;
-  std::transform(channels.cbegin(), channels.cend(), std::back_inserter(groupMembers),
-                 [this](const auto& channel) {
-                   return std::make_shared<CPVRChannelGroupMember>(GroupID(), GroupName(),
-                                                                   GetClientID(), channel);
-                 });
+  std::ranges::transform(channels, std::back_inserter(groupMembers),
+                         [this](const auto& channel)
+                         {
+                           return std::make_shared<CPVRChannelGroupMember>(GroupID(), GroupName(),
+                                                                           GetClientID(), channel);
+                         });
 
   return UpdateGroupEntries(groupMembers);
 }

--- a/xbmc/pvr/channels/PVRChannelGroupAllChannelsSingleClient.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupAllChannelsSingleClient.cpp
@@ -46,7 +46,7 @@ std::vector<std::shared_ptr<CPVRChannelGroup>> CPVRChannelGroupAllChannelsSingle
   for (int clientId : clientIds)
   {
     const std::shared_ptr<const CPVRClient> client{
-        CServiceBroker().GetPVRManager().GetClient(clientId)};
+        CServiceBroker::GetPVRManager().GetClient(clientId)};
     if (!client)
     {
       CLog::LogFC(LOGERROR, LOGPVR, "Failed to get client instance for client id {}", clientId);
@@ -54,13 +54,13 @@ std::vector<std::shared_ptr<CPVRChannelGroup>> CPVRChannelGroupAllChannelsSingle
     }
 
     // Create a group containing all channels for this client, if not yet existing.
-    const auto it = std::find_if(allChannelGroups.cbegin(), allChannelGroups.cend(),
-                                 [&client](const auto& group)
-                                 {
-                                   return (group->GroupType() ==
-                                           PVR_GROUP_TYPE_SYSTEM_ALL_CHANNELS_SINGLE_CLIENT) &&
-                                          (group->GetClientID() == client->GetID());
-                                 });
+    const auto it = std::ranges::find_if(
+        allChannelGroups,
+        [&client](const auto& group)
+        {
+          return (group->GroupType() == PVR_GROUP_TYPE_SYSTEM_ALL_CHANNELS_SINGLE_CLIENT) &&
+                 (group->GetClientID() == client->GetID());
+        });
     if (it == allChannelGroups.cend())
     {
       const std::string name{

--- a/xbmc/pvr/channels/PVRChannelGroupAllChannelsSingleClient.h
+++ b/xbmc/pvr/channels/PVRChannelGroupAllChannelsSingleClient.h
@@ -16,16 +16,7 @@ namespace PVR
 class CPVRChannelGroupAllChannelsSingleClient : public CPVRChannelGroup
 {
 public:
-  /*!
-   * @brief Create a new channel group instance.
-   * @param path The channel group path.
-   * @param allChannelsGroup The channel group containing all TV or radio channels.
-   */
-  CPVRChannelGroupAllChannelsSingleClient(
-      const CPVRChannelsPath& path, const std::shared_ptr<const CPVRChannelGroup>& allChannelsGroup)
-    : CPVRChannelGroup(path, allChannelsGroup)
-  {
-  }
+  using CPVRChannelGroup::CPVRChannelGroup;
 
   /*!
    * @brief Get the group's origin.

--- a/xbmc/pvr/channels/PVRChannelGroupFactory.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupFactory.cpp
@@ -18,7 +18,8 @@
 
 using namespace PVR;
 
-std::shared_ptr<CPVRChannelGroup> CPVRChannelGroupFactory::CreateAllChannelsGroup(bool isRadio)
+std::shared_ptr<CPVRChannelGroup> CPVRChannelGroupFactory::CreateAllChannelsGroup(
+    bool isRadio) const
 {
   return std::make_shared<CPVRChannelGroupAllChannels>(isRadio);
 }
@@ -26,7 +27,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroupFactory::CreateAllChannelsGrou
 std::shared_ptr<CPVRChannelGroup> CPVRChannelGroupFactory::CreateClientGroup(
     const PVR_CHANNEL_GROUP& groupData,
     int clientID,
-    const std::shared_ptr<const CPVRChannelGroup>& allChannels)
+    const std::shared_ptr<const CPVRChannelGroup>& allChannels) const
 {
   return std::make_shared<CPVRChannelGroupFromClient>(groupData, clientID, allChannels);
 }
@@ -34,7 +35,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroupFactory::CreateClientGroup(
 std::shared_ptr<CPVRChannelGroup> CPVRChannelGroupFactory::CreateUserGroup(
     bool isRadio,
     const std::string& name,
-    const std::shared_ptr<const CPVRChannelGroup>& allChannels)
+    const std::shared_ptr<const CPVRChannelGroup>& allChannels) const
 {
   return std::make_shared<CPVRChannelGroupFromUser>(
       CPVRChannelsPath{isRadio, name, PVR_GROUP_CLIENT_ID_LOCAL}, allChannels);
@@ -43,7 +44,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroupFactory::CreateUserGroup(
 std::shared_ptr<CPVRChannelGroup> CPVRChannelGroupFactory::CreateGroup(
     int groupType,
     const CPVRChannelsPath& groupPath,
-    const std::shared_ptr<const CPVRChannelGroup>& allChannels)
+    const std::shared_ptr<const CPVRChannelGroup>& allChannels) const
 {
   switch (groupType)
   {
@@ -94,7 +95,7 @@ int CPVRChannelGroupFactory::GetGroupTypePriority(
 
 std::vector<std::shared_ptr<CPVRChannelGroup>> CPVRChannelGroupFactory::CreateMissingGroups(
     const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup,
-    const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups)
+    const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups) const
 {
   std::vector<std::shared_ptr<CPVRChannelGroup>> newGroups{
       CPVRChannelGroupAllChannelsSingleClient::CreateMissingGroups(allChannelsGroup,

--- a/xbmc/pvr/channels/PVRChannelGroupFactory.h
+++ b/xbmc/pvr/channels/PVRChannelGroupFactory.h
@@ -30,7 +30,7 @@ public:
    * @param isRadio Whether Radio or TV.
    * @return The new group.
    */
-  std::shared_ptr<CPVRChannelGroup> CreateAllChannelsGroup(bool isRadio);
+  std::shared_ptr<CPVRChannelGroup> CreateAllChannelsGroup(bool isRadio) const;
 
   /*!
    * @brief Create an instance for a group provided by a PVR client add-on.
@@ -42,7 +42,7 @@ public:
   std::shared_ptr<CPVRChannelGroup> CreateClientGroup(
       const PVR_CHANNEL_GROUP& groupData,
       int clientID,
-      const std::shared_ptr<const CPVRChannelGroup>& allChannels);
+      const std::shared_ptr<const CPVRChannelGroup>& allChannels) const;
 
   /*!
    * @brief Create an instance for a group created by the user.
@@ -54,7 +54,7 @@ public:
   std::shared_ptr<CPVRChannelGroup> CreateUserGroup(
       bool isRadio,
       const std::string& name,
-      const std::shared_ptr<const CPVRChannelGroup>& allChannels);
+      const std::shared_ptr<const CPVRChannelGroup>& allChannels) const;
 
   /*!
    * @brief Create a channel group matching the given type.
@@ -66,7 +66,7 @@ public:
   std::shared_ptr<CPVRChannelGroup> CreateGroup(
       int groupType,
       const CPVRChannelsPath& groupPath,
-      const std::shared_ptr<const CPVRChannelGroup>& allChannels);
+      const std::shared_ptr<const CPVRChannelGroup>& allChannels) const;
 
   /*!
    * @brief Get the priority (e.g. for sorting groups) for the type of the given group. Lower number means higher priority.
@@ -83,6 +83,6 @@ public:
    */
   std::vector<std::shared_ptr<CPVRChannelGroup>> CreateMissingGroups(
       const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup,
-      const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups);
+      const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups) const;
 };
 } // namespace PVR

--- a/xbmc/pvr/channels/PVRChannelGroupFromClient.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupFromClient.cpp
@@ -14,6 +14,8 @@
 #include "pvr/addons/PVRClients.h"
 #include "utils/log.h"
 
+#include <algorithm>
+
 using namespace PVR;
 
 CPVRChannelGroupFromClient::CPVRChannelGroupFromClient(
@@ -53,9 +55,8 @@ bool CPVRChannelGroupFromClient::UpdateFromClients(
   }
   else
   {
-    const auto it =
-        std::find_if(clients.cbegin(), clients.cend(),
-                     [this](const auto& client) { return client->GetID() == GetClientID(); });
+    const auto it = std::ranges::find_if(clients, [this](const auto& c)
+                                         { return c->GetID() == GetClientID(); });
     if (it == clients.cend())
       return true; // this group is not provided by one of the clients to get the group members for
 

--- a/xbmc/pvr/channels/PVRChannelGroupFromUser.h
+++ b/xbmc/pvr/channels/PVRChannelGroupFromUser.h
@@ -16,16 +16,7 @@ namespace PVR
 class CPVRChannelGroupFromUser : public CPVRChannelGroup
 {
 public:
-  /*!
-   * @brief Create a new channel group instance.
-   * @param path The channel group path.
-   * @param allChannelsGroup The channel group containing all TV or radio channels.
-   */
-  CPVRChannelGroupFromUser(const CPVRChannelsPath& path,
-                           const std::shared_ptr<const CPVRChannelGroup>& allChannelsGroup)
-    : CPVRChannelGroup(path, allChannelsGroup)
-  {
-  }
+  using CPVRChannelGroup::CPVRChannelGroup;
 
   /*!
    * @brief Get the group's origin.

--- a/xbmc/pvr/channels/PVRChannelGroupMergedByName.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupMergedByName.cpp
@@ -31,7 +31,7 @@ bool CPVRChannelGroupMergedByName::ShouldBeIgnored(
   static constexpr int NO_GROUP_FOUND{-1};
   int matchingGroup{NO_GROUP_FOUND};
 
-  for (const auto& member : m_members)
+  for (const auto& [_, member] : m_members)
   {
     for (const auto& group : allChannelGroups)
     {
@@ -41,7 +41,7 @@ bool CPVRChannelGroupMergedByName::ShouldBeIgnored(
       if (group->GroupName() != mergedGroupName && group->ClientGroupName() != mergedGroupName)
         continue;
 
-      if (group->IsGroupMember(member.second))
+      if (group->IsGroupMember(member))
       {
         if (matchingGroup != NO_GROUP_FOUND && matchingGroup != group->GroupID())
         {
@@ -99,10 +99,10 @@ std::vector<std::string> GetGroupNames(const std::vector<std::shared_ptr<CPVRCha
   }
 
   std::vector<std::string> names;
-  for (const auto& name : knownNamesCountMap)
+  for (const auto& [name, occurences] : knownNamesCountMap)
   {
-    if (name.second > 1)
-      names.emplace_back(name.first);
+    if (occurences > 1)
+      names.emplace_back(name);
   }
   return names;
 }

--- a/xbmc/pvr/channels/PVRChannelGroupMergedByName.h
+++ b/xbmc/pvr/channels/PVRChannelGroupMergedByName.h
@@ -16,16 +16,7 @@ namespace PVR
 class CPVRChannelGroupMergedByName : public CPVRChannelGroup
 {
 public:
-  /*!
-   * @brief Create a new channel group instance.
-   * @param path The channel group path.
-   * @param allChannelsGroup The channel group containing all TV or radio channels.
-   */
-  CPVRChannelGroupMergedByName(const CPVRChannelsPath& path,
-                               const std::shared_ptr<const CPVRChannelGroup>& allChannelsGroup)
-    : CPVRChannelGroup(path, allChannelsGroup)
-  {
-  }
+  using CPVRChannelGroup::CPVRChannelGroup;
 
   /*!
    * @brief Get the group's origin.

--- a/xbmc/pvr/channels/PVRChannelGroupSettings.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupSettings.cpp
@@ -11,27 +11,29 @@
 #include "ServiceBroker.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClients.h"
+#include "pvr/settings/PVRSettings.h"
 #include "settings/Settings.h"
 #include "settings/lib/Setting.h"
 
 using namespace PVR;
 
 CPVRChannelGroupSettings::CPVRChannelGroupSettings()
-  : m_settings({CSettings::SETTING_PVRMANAGER_BACKENDCHANNELORDER,
-                CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERS,
-                CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERSALWAYS,
-                CSettings::SETTING_PVRMANAGER_STARTGROUPCHANNELNUMBERSFROMONE})
+  : m_settings(std::make_unique<CPVRSettings>(
+        std::set<std::string>({CSettings::SETTING_PVRMANAGER_BACKENDCHANNELORDER,
+                               CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERS,
+                               CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERSALWAYS,
+                               CSettings::SETTING_PVRMANAGER_STARTGROUPCHANNELNUMBERSFROMONE})))
 {
   UpdateUseBackendChannelOrder();
   UpdateUseBackendChannelNumbers();
   UpdateStartGroupChannelNumbersFromOne();
 
-  m_settings.RegisterCallback(this);
+  m_settings->RegisterCallback(this);
 }
 
 CPVRChannelGroupSettings::~CPVRChannelGroupSettings()
 {
-  m_settings.UnregisterCallback(this);
+  m_settings->UnregisterCallback(this);
 }
 
 void CPVRChannelGroupSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)
@@ -80,7 +82,7 @@ void CPVRChannelGroupSettings::UnregisterCallback(IChannelGroupSettingsCallback*
 bool CPVRChannelGroupSettings::UpdateUseBackendChannelOrder()
 {
   m_bUseBackendChannelOrder =
-      m_settings.GetBoolValue(CSettings::SETTING_PVRMANAGER_BACKENDCHANNELORDER);
+      m_settings->GetBoolValue(CSettings::SETTING_PVRMANAGER_BACKENDCHANNELORDER);
   return m_bUseBackendChannelOrder;
 }
 
@@ -89,9 +91,9 @@ bool CPVRChannelGroupSettings::UpdateUseBackendChannelNumbers()
   const size_t enabledClientAmount =
       CServiceBroker::GetPVRManager().Clients()->EnabledClientAmount();
   m_bUseBackendChannelNumbers =
-      m_settings.GetBoolValue(CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERS) &&
+      m_settings->GetBoolValue(CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERS) &&
       (enabledClientAmount == 1 ||
-       (m_settings.GetBoolValue(CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERSALWAYS) &&
+       (m_settings->GetBoolValue(CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERSALWAYS) &&
         enabledClientAmount > 1));
   return m_bUseBackendChannelNumbers;
 }
@@ -99,7 +101,7 @@ bool CPVRChannelGroupSettings::UpdateUseBackendChannelNumbers()
 bool CPVRChannelGroupSettings::UpdateStartGroupChannelNumbersFromOne()
 {
   m_bStartGroupChannelNumbersFromOne =
-      m_settings.GetBoolValue(CSettings::SETTING_PVRMANAGER_STARTGROUPCHANNELNUMBERSFROMONE) &&
+      m_settings->GetBoolValue(CSettings::SETTING_PVRMANAGER_STARTGROUPCHANNELNUMBERSFROMONE) &&
       !UseBackendChannelNumbers();
   return m_bStartGroupChannelNumbersFromOne;
 }

--- a/xbmc/pvr/channels/PVRChannelGroupSettings.h
+++ b/xbmc/pvr/channels/PVRChannelGroupSettings.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "pvr/settings/PVRSettings.h"
 #include "settings/lib/ISettingCallback.h"
 
 #include <memory>
@@ -16,6 +15,8 @@
 
 namespace PVR
 {
+
+class CPVRSettings;
 
 class IChannelGroupSettingsCallback
 {
@@ -51,7 +52,7 @@ private:
   bool m_bUseBackendChannelNumbers = false;
   bool m_bStartGroupChannelNumbersFromOne = false;
 
-  CPVRSettings m_settings;
+  std::unique_ptr<CPVRSettings> m_settings;
   std::set<IChannelGroupSettingsCallback*> m_callbacks;
 };
 

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -9,12 +9,10 @@
 #pragma once
 
 #include "pvr/channels/PVRChannelGroup.h"
-#include "pvr/settings/PVRSettings.h"
 #include "settings/lib/ISettingCallback.h"
 #include "threads/CriticalSection.h"
 
 #include <memory>
-#include <mutex>
 #include <string>
 #include <vector>
 
@@ -25,6 +23,7 @@ enum class PVREvent;
 class CPVRChannel;
 class CPVRChannelGroupFactory;
 class CPVRClient;
+class CPVRsettings;
 
 /** A container class for channel groups */
 
@@ -36,7 +35,7 @@ public:
    * @param bRadio True if this is a container for radio channels, false if it is for tv channels.
    */
   explicit CPVRChannelGroups(bool bRadio);
-  virtual ~CPVRChannelGroups();
+  ~CPVRChannelGroups() override;
 
   // ISettingCallback implementation
   void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
@@ -62,11 +61,7 @@ public:
   /*!
    * @return Amount of groups in this container
    */
-  size_t Size() const
-  {
-    std::unique_lock lock(m_critSection);
-    return m_groups.size();
-  }
+  size_t Size() const;
 
   /*!
    * @brief Update a group or add it if it's not in here yet.
@@ -301,7 +296,7 @@ private:
   mutable CCriticalSection m_critSection;
   std::vector<int> m_failedClientsForChannelGroups;
   bool m_isSubscribed{false};
-  CPVRSettings m_settings;
+  std::unique_ptr<CPVRSettings> m_settings;
   std::shared_ptr<CPVRChannelGroup> m_allChannelsGroup;
   std::shared_ptr<CPVRChannelGroupFactory> m_channelGroupFactory;
 };

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -20,7 +20,8 @@
 using namespace PVR;
 
 CPVRChannelGroupsContainer::CPVRChannelGroupsContainer()
-  : m_groupsRadio(new CPVRChannelGroups(true)), m_groupsTV(new CPVRChannelGroups(false))
+  : m_groupsRadio(std::make_shared<CPVRChannelGroups>(true)),
+    m_groupsTV(std::make_shared<CPVRChannelGroups>(false))
 {
 }
 
@@ -35,7 +36,7 @@ bool CPVRChannelGroupsContainer::Update(const std::vector<std::shared_ptr<CPVRCl
 }
 
 bool CPVRChannelGroupsContainer::LoadFromDatabase(
-    const std::vector<std::shared_ptr<CPVRClient>>& clients)
+    const std::vector<std::shared_ptr<CPVRClient>>& clients) const
 {
   return m_groupsTV->LoadFromDatabase(clients) && m_groupsRadio->LoadFromDatabase(clients);
 }
@@ -60,7 +61,7 @@ bool CPVRChannelGroupsContainer::UpdateFromClients(
   return bReturn;
 }
 
-void CPVRChannelGroupsContainer::Unload()
+void CPVRChannelGroupsContainer::Unload() const
 {
   m_groupsRadio->Unload();
   m_groupsTV->Unload();
@@ -188,7 +189,7 @@ unsigned int CPVRChannelGroupsContainer::GetChannelCountByProvider(bool isRadio,
     return m_groupsTV->GetGroupAll()->GetChannelCountByProvider(clientId, providerId);
 }
 
-int CPVRChannelGroupsContainer::CleanupCachedImages()
+int CPVRChannelGroupsContainer::CleanupCachedImages() const
 {
   return m_groupsTV->CleanupCachedImages() + m_groupsRadio->CleanupCachedImages();
 }

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.h
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.h
@@ -54,7 +54,7 @@ public:
   /*!
    * @brief Unload and destruct all channel groups and all channels in them.
    */
-  void Unload();
+  void Unload() const;
 
   /*!
    * @brief Get the TV channel groups.
@@ -174,7 +174,7 @@ public:
    * @brief Erase stale texture db entries and image files.
    * @return number of cleaned up images.
    */
-  int CleanupCachedImages();
+  int CleanupCachedImages() const;
 
 private:
   CPVRChannelGroupsContainer& operator=(const CPVRChannelGroupsContainer&) = delete;
@@ -185,7 +185,7 @@ private:
    * @param clients The PVR clients data should be loaded for. Leave empty for all clients.
    * @return True on success, false otherwise.
    */
-  bool LoadFromDatabase(const std::vector<std::shared_ptr<CPVRClient>>& clients);
+  bool LoadFromDatabase(const std::vector<std::shared_ptr<CPVRClient>>& clients) const;
 
   std::shared_ptr<CPVRChannelGroups> m_groupsRadio; /*!< all radio channel groups */
   std::shared_ptr<CPVRChannelGroups> m_groupsTV; /*!< all TV channel groups */

--- a/xbmc/pvr/channels/PVRChannelNumber.h
+++ b/xbmc/pvr/channels/PVRChannelNumber.h
@@ -20,23 +20,7 @@ namespace PVR
     constexpr CPVRChannelNumber(unsigned int iChannelNumber, unsigned int iSubChannelNumber)
     : m_iChannelNumber(iChannelNumber), m_iSubChannelNumber(iSubChannelNumber) {}
 
-    constexpr bool operator ==(const CPVRChannelNumber& right) const
-    {
-      return (m_iChannelNumber == right.m_iChannelNumber &&
-              m_iSubChannelNumber == right.m_iSubChannelNumber);
-    }
-
-    constexpr bool operator !=(const CPVRChannelNumber& right) const
-    {
-      return !(*this == right);
-    }
-
-    constexpr bool operator <(const CPVRChannelNumber& right) const
-    {
-      return m_iChannelNumber == right.m_iChannelNumber
-        ? m_iSubChannelNumber < right.m_iSubChannelNumber
-        : m_iChannelNumber < right.m_iChannelNumber;
-    }
+    constexpr auto operator<=>(const CPVRChannelNumber& right) const = default;
 
     /*!
      * @brief Check whether this channel number is valid (main channel number > 0).

--- a/xbmc/pvr/channels/PVRChannelsPath.cpp
+++ b/xbmc/pvr/channels/PVRChannelsPath.cpp
@@ -188,9 +188,9 @@ CPVRChannelsPath::CPVRChannelsPath(bool bRadio, const std::string& strGroupName,
 }
 
 CPVRChannelsPath::CPVRChannelsPath(bool bRadio,
-                                   const std::string& strGroupName,
+                                   std::string_view strGroupName,
                                    int iGroupClientID,
-                                   const std::string& strAddonID,
+                                   std::string_view strAddonID,
                                    ADDON::AddonInstanceId instanceID,
                                    int iChannelUID)
   : m_bRadio(bRadio)

--- a/xbmc/pvr/channels/PVRChannelsPath.h
+++ b/xbmc/pvr/channels/PVRChannelsPath.h
@@ -11,6 +11,8 @@
 #include "addons/IAddon.h"
 #include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 
+#include <string_view>
+
 class CDateTime;
 
 namespace PVR
@@ -28,15 +30,14 @@ namespace PVR
                      const std::string& strGroupName,
                      int iGroupClientID);
     CPVRChannelsPath(bool bRadio,
-                     const std::string& strGroupName,
+                     std::string_view strGroupName,
                      int iGroupClientID,
-                     const std::string& strAddonID,
+                     std::string_view strAddonID,
                      ADDON::AddonInstanceId instanceID,
                      int iChannelUID);
 
     operator std::string() const { return m_path; }
-    bool operator ==(const CPVRChannelsPath& right) const { return m_path == right.m_path; }
-    bool operator !=(const CPVRChannelsPath& right) const { return !(*this == right); }
+    bool operator==(const CPVRChannelsPath& right) const { return m_path == right.m_path; }
 
     bool IsValid() const { return m_kind > Kind::PROTO; }
 

--- a/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
+++ b/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
@@ -21,9 +21,28 @@
 #include <algorithm>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <utility>
 
 using namespace PVR;
+
+namespace
+{
+std::string Trim(std::string_view value)
+{
+  std::string ret{value};
+  StringUtils::TrimLeft(ret);
+  StringUtils::TrimRight(ret, " \n\r");
+  return ret;
+}
+
+std::string TrimAndToUTF8(std::string_view value)
+{
+  std::string ret{Trim(value)};
+  CCharsetConverter::unknownToUTF8(ret);
+  return ret;
+}
+} // unnamed namespace
 
 CPVRRadioRDSInfoTag::CPVRRadioRDSInfoTag()
 {
@@ -142,14 +161,6 @@ bool CPVRRadioRDSInfoTag::operator==(const CPVRRadioRDSInfoTag& right) const
       m_bHaveRadioTextPlus == right.m_bHaveRadioTextPlus);
 }
 
-bool CPVRRadioRDSInfoTag::operator !=(const CPVRRadioRDSInfoTag& right) const
-{
-  if (this == &right)
-    return false;
-
-  return !(*this == right);
-}
-
 void CPVRRadioRDSInfoTag::Clear()
 {
   std::unique_lock lock(m_critSection);
@@ -248,29 +259,25 @@ void CPVRRadioRDSInfoTag::SetArtist(const std::string& strArtist)
 void CPVRRadioRDSInfoTag::SetBand(const std::string& strBand)
 {
   std::unique_lock lock(m_critSection);
-  m_strBand = Trim(strBand);
-  g_charsetConverter.unknownToUTF8(m_strBand);
+  m_strBand = TrimAndToUTF8(strBand);
 }
 
 void CPVRRadioRDSInfoTag::SetComposer(const std::string& strComposer)
 {
   std::unique_lock lock(m_critSection);
-  m_strComposer = Trim(strComposer);
-  g_charsetConverter.unknownToUTF8(m_strComposer);
+  m_strComposer = TrimAndToUTF8(strComposer);
 }
 
 void CPVRRadioRDSInfoTag::SetConductor(const std::string& strConductor)
 {
   std::unique_lock lock(m_critSection);
-  m_strConductor = Trim(strConductor);
-  g_charsetConverter.unknownToUTF8(m_strConductor);
+  m_strConductor = TrimAndToUTF8(strConductor);
 }
 
 void CPVRRadioRDSInfoTag::SetAlbum(const std::string& strAlbum)
 {
   std::unique_lock lock(m_critSection);
-  m_strAlbum = Trim(strAlbum);
-  g_charsetConverter.unknownToUTF8(m_strAlbum);
+  m_strAlbum = TrimAndToUTF8(strAlbum);
 }
 
 void CPVRRadioRDSInfoTag::SetAlbumTrackNumber(int track)
@@ -282,8 +289,7 @@ void CPVRRadioRDSInfoTag::SetAlbumTrackNumber(int track)
 void CPVRRadioRDSInfoTag::SetComment(const std::string& strComment)
 {
   std::unique_lock lock(m_critSection);
-  m_strComment = Trim(strComment);
-  g_charsetConverter.unknownToUTF8(m_strComment);
+  m_strComment = TrimAndToUTF8(strComment);
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetTitle() const
@@ -340,7 +346,7 @@ void CPVRRadioRDSInfoTag::SetInfoNews(const std::string& strNews)
   m_strInfoNews.Add(strNews);
 }
 
-const std::string CPVRRadioRDSInfoTag::GetInfoNews() const
+std::string CPVRRadioRDSInfoTag::GetInfoNews() const
 {
   std::unique_lock lock(m_critSection);
   return m_strInfoNews.GetText();
@@ -352,7 +358,7 @@ void CPVRRadioRDSInfoTag::SetInfoNewsLocal(const std::string& strNews)
   m_strInfoNewsLocal.Add(strNews);
 }
 
-const std::string CPVRRadioRDSInfoTag::GetInfoNewsLocal() const
+std::string CPVRRadioRDSInfoTag::GetInfoNewsLocal() const
 {
   std::unique_lock lock(m_critSection);
   return m_strInfoNewsLocal.GetText();
@@ -364,7 +370,7 @@ void CPVRRadioRDSInfoTag::SetInfoSport(const std::string& strSport)
   m_strInfoSport.Add(strSport);
 }
 
-const std::string CPVRRadioRDSInfoTag::GetInfoSport() const
+std::string CPVRRadioRDSInfoTag::GetInfoSport() const
 {
   std::unique_lock lock(m_critSection);
   return m_strInfoSport.GetText();
@@ -376,7 +382,7 @@ void CPVRRadioRDSInfoTag::SetInfoStock(const std::string& strStock)
   m_strInfoStock.Add(strStock);
 }
 
-const std::string CPVRRadioRDSInfoTag::GetInfoStock() const
+std::string CPVRRadioRDSInfoTag::GetInfoStock() const
 {
   std::unique_lock lock(m_critSection);
   return m_strInfoStock.GetText();
@@ -388,7 +394,7 @@ void CPVRRadioRDSInfoTag::SetInfoWeather(const std::string& strWeather)
   m_strInfoWeather.Add(strWeather);
 }
 
-const std::string CPVRRadioRDSInfoTag::GetInfoWeather() const
+std::string CPVRRadioRDSInfoTag::GetInfoWeather() const
 {
   std::unique_lock lock(m_critSection);
   return m_strInfoWeather.GetText();
@@ -400,7 +406,7 @@ void CPVRRadioRDSInfoTag::SetInfoLottery(const std::string& strLottery)
   m_strInfoLottery.Add(strLottery);
 }
 
-const std::string CPVRRadioRDSInfoTag::GetInfoLottery() const
+std::string CPVRRadioRDSInfoTag::GetInfoLottery() const
 {
   std::unique_lock lock(m_critSection);
   return m_strInfoLottery.GetText();
@@ -412,7 +418,7 @@ void CPVRRadioRDSInfoTag::SetEditorialStaff(const std::string& strEditorialStaff
   m_strEditorialStaff.Add(strEditorialStaff);
 }
 
-const std::string CPVRRadioRDSInfoTag::GetEditorialStaff() const
+std::string CPVRRadioRDSInfoTag::GetEditorialStaff() const
 {
   std::unique_lock lock(m_critSection);
   return m_strEditorialStaff.GetText();
@@ -424,7 +430,7 @@ void CPVRRadioRDSInfoTag::SetInfoHoroscope(const std::string& strHoroscope)
   m_strInfoHoroscope.Add(strHoroscope);
 }
 
-const std::string CPVRRadioRDSInfoTag::GetInfoHoroscope() const
+std::string CPVRRadioRDSInfoTag::GetInfoHoroscope() const
 {
   std::unique_lock lock(m_critSection);
   return m_strInfoHoroscope.GetText();
@@ -436,7 +442,7 @@ void CPVRRadioRDSInfoTag::SetInfoCinema(const std::string& strCinema)
   m_strInfoCinema.Add(strCinema);
 }
 
-const std::string CPVRRadioRDSInfoTag::GetInfoCinema() const
+std::string CPVRRadioRDSInfoTag::GetInfoCinema() const
 {
   std::unique_lock lock(m_critSection);
   return m_strInfoCinema.GetText();
@@ -448,7 +454,7 @@ void CPVRRadioRDSInfoTag::SetInfoOther(const std::string& strOther)
   m_strInfoOther.Add(strOther);
 }
 
-const std::string CPVRRadioRDSInfoTag::GetInfoOther() const
+std::string CPVRRadioRDSInfoTag::GetInfoOther() const
 {
   std::unique_lock lock(m_critSection);
   return m_strInfoOther.GetText();
@@ -457,78 +463,67 @@ const std::string CPVRRadioRDSInfoTag::GetInfoOther() const
 void CPVRRadioRDSInfoTag::SetProgStation(const std::string& strProgStation)
 {
   std::unique_lock lock(m_critSection);
-  m_strProgStation = Trim(strProgStation);
-  g_charsetConverter.unknownToUTF8(m_strProgStation);
+  m_strProgStation = TrimAndToUTF8(strProgStation);
 }
 
 void CPVRRadioRDSInfoTag::SetProgHost(const std::string& strProgHost)
 {
   std::unique_lock lock(m_critSection);
-  m_strProgHost = Trim(strProgHost);
-  g_charsetConverter.unknownToUTF8(m_strProgHost);
+  m_strProgHost = TrimAndToUTF8(strProgHost);
 }
 
 void CPVRRadioRDSInfoTag::SetProgStyle(const std::string& strProgStyle)
 {
   std::unique_lock lock(m_critSection);
-  m_strProgStyle = Trim(strProgStyle);
-  g_charsetConverter.unknownToUTF8(m_strProgStyle);
+  m_strProgStyle = TrimAndToUTF8(strProgStyle);
 }
 
 void CPVRRadioRDSInfoTag::SetProgWebsite(const std::string& strWebsite)
 {
   std::unique_lock lock(m_critSection);
-  m_strProgWebsite = Trim(strWebsite);
-  g_charsetConverter.unknownToUTF8(m_strProgWebsite);
+  m_strProgWebsite = TrimAndToUTF8(strWebsite);
 }
 
 void CPVRRadioRDSInfoTag::SetProgNow(const std::string& strNow)
 {
   std::unique_lock lock(m_critSection);
-  m_strProgNow = Trim(strNow);
-  g_charsetConverter.unknownToUTF8(m_strProgNow);
+  m_strProgNow = TrimAndToUTF8(strNow);
 }
 
 void CPVRRadioRDSInfoTag::SetProgNext(const std::string& strNext)
 {
   std::unique_lock lock(m_critSection);
-  m_strProgNext = Trim(strNext);
-  g_charsetConverter.unknownToUTF8(m_strProgNext);
+  m_strProgNext = TrimAndToUTF8(strNext);
 }
 
 void CPVRRadioRDSInfoTag::SetPhoneHotline(const std::string& strHotline)
 {
   std::unique_lock lock(m_critSection);
-  m_strPhoneHotline = Trim(strHotline);
-  g_charsetConverter.unknownToUTF8(m_strPhoneHotline);
+  m_strPhoneHotline = TrimAndToUTF8(strHotline);
 }
 
 void CPVRRadioRDSInfoTag::SetEMailHotline(const std::string& strHotline)
 {
   std::unique_lock lock(m_critSection);
-  m_strEMailHotline = Trim(strHotline);
-  g_charsetConverter.unknownToUTF8(m_strEMailHotline);
+  m_strEMailHotline = TrimAndToUTF8(strHotline);
 }
 
 void CPVRRadioRDSInfoTag::SetPhoneStudio(const std::string& strPhone)
 {
   std::unique_lock lock(m_critSection);
-  m_strPhoneStudio = Trim(strPhone);
-  g_charsetConverter.unknownToUTF8(m_strPhoneStudio);
+  m_strPhoneStudio = TrimAndToUTF8(strPhone);
 }
 
 void CPVRRadioRDSInfoTag::SetEMailStudio(const std::string& strEMail)
 {
   std::unique_lock lock(m_critSection);
-  m_strEMailStudio = Trim(strEMail);
-  g_charsetConverter.unknownToUTF8(m_strEMailStudio);
+  m_strEMailStudio = TrimAndToUTF8(strEMail);
 }
 
 void CPVRRadioRDSInfoTag::SetSMSStudio(const std::string& strSMS)
 {
   std::unique_lock lock(m_critSection);
-  m_strSMSStudio = Trim(strSMS);
-  g_charsetConverter.unknownToUTF8(m_strSMSStudio);
+  m_strSMSStudio = TrimAndToUTF8(strSMS);
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetProgStyle() const
@@ -603,7 +598,7 @@ void CPVRRadioRDSInfoTag::SetRadioStyle(const std::string& style)
   m_strRadioStyle = style;
 }
 
-const std::string CPVRRadioRDSInfoTag::GetRadioStyle() const
+std::string CPVRRadioRDSInfoTag::GetRadioStyle() const
 {
   std::unique_lock lock(m_critSection);
   return m_strRadioStyle;
@@ -679,14 +674,6 @@ bool CPVRRadioRDSInfoTag::IsPlayingRadioTextPlus() const
   return m_bHaveRadioTextPlus;
 }
 
-std::string CPVRRadioRDSInfoTag::Trim(const std::string& value)
-{
-  std::string trimmedValue(value);
-  StringUtils::TrimLeft(trimmedValue);
-  StringUtils::TrimRight(trimmedValue, " \n\r");
-  return trimmedValue;
-}
-
 bool CPVRRadioRDSInfoTag::Info::operator==(const CPVRRadioRDSInfoTag::Info& right) const
 {
   if (this == &right)
@@ -704,10 +691,8 @@ void CPVRRadioRDSInfoTag::Info::Clear()
 
 void CPVRRadioRDSInfoTag::Info::Add(const std::string& text)
 {
-  std::string tmp = Trim(text);
-  g_charsetConverter.unknownToUTF8(tmp);
-
-  if (std::find(m_data.begin(), m_data.end(), tmp) != m_data.end())
+  const std::string tmp{TrimAndToUTF8(text)};
+  if (std::ranges::find(m_data, tmp) != m_data.cend())
     return;
 
   if (m_data.size() >= m_maxSize)

--- a/xbmc/pvr/channels/PVRRadioRDSInfoTag.h
+++ b/xbmc/pvr/channels/PVRRadioRDSInfoTag.h
@@ -23,8 +23,7 @@ class CPVRRadioRDSInfoTag final : public IArchivable, public ISerializable
 public:
   CPVRRadioRDSInfoTag();
 
-  bool operator ==(const CPVRRadioRDSInfoTag& right) const;
-  bool operator !=(const CPVRRadioRDSInfoTag& right) const;
+  bool operator==(const CPVRRadioRDSInfoTag& right) const;
 
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;
@@ -86,37 +85,37 @@ public:
   const std::string& GetSMSStudio() const;
 
   void SetInfoNews(const std::string& strNews);
-  const std::string GetInfoNews() const;
+  std::string GetInfoNews() const;
 
   void SetInfoNewsLocal(const std::string& strNews);
-  const std::string GetInfoNewsLocal() const;
+  std::string GetInfoNewsLocal() const;
 
   void SetInfoSport(const std::string& strSport);
-  const std::string GetInfoSport() const;
+  std::string GetInfoSport() const;
 
   void SetInfoStock(const std::string& strSport);
-  const std::string GetInfoStock() const;
+  std::string GetInfoStock() const;
 
   void SetInfoWeather(const std::string& strWeather);
-  const std::string GetInfoWeather() const;
+  std::string GetInfoWeather() const;
 
   void SetInfoHoroscope(const std::string& strHoroscope);
-  const std::string GetInfoHoroscope() const;
+  std::string GetInfoHoroscope() const;
 
   void SetInfoCinema(const std::string& strCinema);
-  const std::string GetInfoCinema() const;
+  std::string GetInfoCinema() const;
 
   void SetInfoLottery(const std::string& strLottery);
-  const std::string GetInfoLottery() const;
+  std::string GetInfoLottery() const;
 
   void SetInfoOther(const std::string& strOther);
-  const std::string GetInfoOther() const;
+  std::string GetInfoOther() const;
 
   void SetEditorialStaff(const std::string& strEditorialStaff);
-  const std::string GetEditorialStaff() const;
+  std::string GetEditorialStaff() const;
 
   void SetRadioStyle(const std::string& style);
-  const std::string GetRadioStyle() const;
+  std::string GetRadioStyle() const;
 
   void SetPlayingRadioText(bool yesNo);
   bool IsPlayingRadioText() const;
@@ -127,8 +126,6 @@ public:
 private:
   CPVRRadioRDSInfoTag(const CPVRRadioRDSInfoTag& tag) = delete;
   const CPVRRadioRDSInfoTag& operator =(const CPVRRadioRDSInfoTag& tag) = delete;
-
-  static std::string Trim(const std::string& value);
 
   mutable CCriticalSection m_critSection;
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
@@ -50,7 +50,7 @@ private:
   void SaveList();
   void Renumber();
   void SetData(int iItem);
-  void RenameChannel(const CFileItemPtr& pItem);
+  void RenameChannel(const std::shared_ptr<CFileItem>& pItem) const;
 
   void ClearChannelOptions();
   void EnableChannelOptions(bool bEnable);
@@ -75,7 +75,7 @@ private:
   bool OnClickButtonRefreshChannelLogos();
 
   bool UpdateChannelData(const std::shared_ptr<CFileItem>& pItem,
-                         const std::shared_ptr<CPVRChannelGroup>& group);
+                         const std::shared_ptr<CPVRChannelGroup>& group) const;
 
   bool HasChangedItems() const;
   void SetItemChanged(const CFileItemPtr& pItem);
@@ -88,7 +88,7 @@ private:
 
   std::shared_ptr<CFileItem> m_initialSelection;
   int m_iSelected = 0;
-  CFileItemList* m_channelItems;
+  std::unique_ptr<CFileItemList> m_channelItems;
   CGUIViewControl m_viewControl;
 
   std::vector<std::shared_ptr<CPVRClient>> m_clientsWithSettingsList;

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -37,7 +37,11 @@ using namespace PVR;
 
 using namespace std::chrono_literals;
 
-#define MAX_INVALIDATION_FREQUENCY 2000ms // limit to one invalidation per X milliseconds
+namespace
+{
+constexpr auto MAX_INVALIDATION_FREQUENCY = 2000ms; // limit to one invalidation per X milliseconds
+
+} // unnamed namespace
 
 CGUIDialogPVRChannelsOSD::CGUIDialogPVRChannelsOSD()
   : CGUIDialogPVRItemsViewBase(WINDOW_DIALOG_PVR_OSD_CHANNELS, "DialogPVRChannelsOSD.xml")
@@ -58,13 +62,15 @@ bool CGUIDialogPVRChannelsOSD::OnMessage(CGUIMessage& message)
   {
     switch (static_cast<PVREvent>(message.GetParam1()))
     {
-      case PVREvent::CurrentItem:
+      using enum PVR::PVREvent;
+
+      case CurrentItem:
         m_viewControl.SetItems(*m_vecItems);
         return true;
 
-      case PVREvent::Epg:
-      case PVREvent::EpgContainer:
-      case PVREvent::EpgActiveItem:
+      case Epg:
+      case EpgContainer:
+      case EpgActiveItem:
         if (IsActive())
           SetInvalid();
         return true;

--- a/xbmc/pvr/dialogs/GUIDialogPVRClientPriorities.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRClientPriorities.cpp
@@ -68,10 +68,10 @@ void CGUIDialogPVRClientPriorities::InitializeSettings()
   }
 
   m_clients = CServiceBroker::GetPVRManager().Clients()->GetCreatedClients();
-  for (const auto& client : m_clients)
+  for (const auto& [_, client] : m_clients)
   {
-    AddEdit(group, std::to_string(client.second->GetID()), 13205 /* Unknown */, SettingLevel::Basic,
-            client.second->GetPriority());
+    AddEdit(group, std::to_string(client->GetID()), 13205 /* Unknown */, SettingLevel::Basic,
+            client->GetPriority());
   }
 }
 
@@ -90,12 +90,12 @@ void CGUIDialogPVRClientPriorities::OnSettingChanged(const std::shared_ptr<const
 
 bool CGUIDialogPVRClientPriorities::Save()
 {
-  for (const auto& changedClient : m_changedValues)
+  for (const auto& [clientIdString, priority] : m_changedValues)
   {
-    int iClientId = std::atoi(changedClient.first.c_str());
-    auto clientEntry = m_clients.find(iClientId);
-    if (clientEntry != m_clients.end())
-      clientEntry->second->SetPriority(changedClient.second);
+    const int clientId{std::atoi(clientIdString.c_str())};
+    const auto it = m_clients.find(clientId);
+    if (it != m_clients.cend())
+      (*it).second->SetPriority(priority);
   }
 
   return true;

--- a/xbmc/pvr/dialogs/GUIDialogPVRClientPriorities.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRClientPriorities.h
@@ -11,6 +11,7 @@
 #include "pvr/addons/PVRClients.h"
 #include "settings/dialogs/GUIDialogSettingsManualBase.h"
 
+#include <functional>
 #include <map>
 #include <string>
 
@@ -36,6 +37,6 @@ namespace PVR
 
   private:
     CPVRClientMap m_clients;
-    std::map<std::string, int> m_changedValues;
+    std::map<std::string, int, std::less<>> m_changedValues;
   };
 } // namespace PVR

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -21,7 +21,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
-#include "messaging/helpers//DialogOKHelper.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "pvr/PVRManager.h"
 #include "pvr/PVRPlaybackState.h"
 #include "pvr/addons/PVRClient.h"
@@ -43,42 +43,36 @@
 using namespace KODI::MESSAGING;
 using namespace PVR;
 
-#define CONTROL_LIST_CHANNELS_LEFT 11
-#define CONTROL_LIST_CHANNELS_RIGHT 12
-#define CONTROL_LIST_CHANNEL_GROUPS 13
-#define CONTROL_CURRENT_GROUP_LABEL 20
-#define CONTROL_UNGROUPED_LABEL 21
-#define CONTROL_IN_GROUP_LABEL 22
-#define BUTTON_HIDE_GROUP 25
-#define BUTTON_NEWGROUP 26
-#define BUTTON_RENAMEGROUP 27
-#define BUTTON_DELGROUP 28
-#define BUTTON_OK 29
-#define BUTTON_TOGGLE_RADIO_TV 34
-#define BUTTON_RECREATE_GROUP_THUMB 35
-
 namespace
 {
+constexpr unsigned int CONTROL_LIST_CHANNELS_LEFT = 11;
+constexpr unsigned int CONTROL_LIST_CHANNELS_RIGHT = 12;
+constexpr unsigned int CONTROL_LIST_CHANNEL_GROUPS = 13;
+constexpr unsigned int CONTROL_CURRENT_GROUP_LABEL = 20;
+constexpr unsigned int CONTROL_UNGROUPED_LABEL = 21;
+constexpr unsigned int CONTROL_IN_GROUP_LABEL = 22;
+constexpr unsigned int BUTTON_HIDE_GROUP = 25;
+constexpr unsigned int BUTTON_NEWGROUP = 26;
+constexpr unsigned int BUTTON_RENAMEGROUP = 27;
+constexpr unsigned int BUTTON_DELGROUP = 28;
+constexpr unsigned int BUTTON_OK = 29;
+constexpr unsigned int BUTTON_TOGGLE_RADIO_TV = 34;
+constexpr unsigned int BUTTON_RECREATE_GROUP_THUMB = 35;
+
 constexpr const char* PROPERTY_CLIENT_NAME = "ClientName";
 
 } // namespace
 
 CGUIDialogPVRGroupManager::CGUIDialogPVRGroupManager()
-  : CGUIDialog(WINDOW_DIALOG_PVR_GROUP_MANAGER, "DialogPVRGroupManager.xml")
+  : CGUIDialog(WINDOW_DIALOG_PVR_GROUP_MANAGER, "DialogPVRGroupManager.xml"),
+    m_ungroupedChannels(std::make_unique<CFileItemList>()),
+    m_groupMembers(std::make_unique<CFileItemList>()),
+    m_channelGroups(std::make_unique<CFileItemList>())
 {
-  m_ungroupedChannels = new CFileItemList;
-  m_groupMembers = new CFileItemList;
-  m_channelGroups = new CFileItemList;
-
   SetRadio(false);
 }
 
-CGUIDialogPVRGroupManager::~CGUIDialogPVRGroupManager()
-{
-  delete m_ungroupedChannels;
-  delete m_groupMembers;
-  delete m_channelGroups;
-}
+CGUIDialogPVRGroupManager::~CGUIDialogPVRGroupManager() = default;
 
 void CGUIDialogPVRGroupManager::SetRadio(bool bIsRadio)
 {
@@ -400,17 +394,13 @@ bool CGUIDialogPVRGroupManager::ActionButtonHideGroup(const CGUIMessage& message
 
   if (message.GetSenderId() == BUTTON_HIDE_GROUP && m_selectedGroup)
   {
-    CGUIRadioButtonControl* button =
-        static_cast<CGUIRadioButtonControl*>(GetControl(message.GetSenderId()));
-    if (button)
+    const auto* button{static_cast<CGUIRadioButtonControl*>(GetControl(message.GetSenderId()))};
+    if (button && CServiceBroker::GetPVRManager()
+                      .ChannelGroups()
+                      ->Get(m_bIsRadio)
+                      ->HideGroup(m_selectedGroup, button->IsSelected()))
     {
-      if (CServiceBroker::GetPVRManager()
-              .ChannelGroups()
-              ->Get(m_bIsRadio)
-              ->HideGroup(m_selectedGroup, button->IsSelected()))
-      {
-        Update();
-      }
+      Update();
     }
 
     bReturn = true;
@@ -458,15 +448,9 @@ bool CGUIDialogPVRGroupManager::OnMessageClick(const CGUIMessage& message)
 
 bool CGUIDialogPVRGroupManager::OnMessage(CGUIMessage& message)
 {
-  unsigned int iMessage = message.GetMessage();
-
-  switch (iMessage)
+  if (message.GetMessage() == GUI_MSG_CLICKED)
   {
-    case GUI_MSG_CLICKED:
-    {
-      OnMessageClick(message);
-    }
-    break;
+    OnMessageClick(message);
   }
 
   return CGUIDialog::OnMessage(message);
@@ -605,7 +589,7 @@ void CGUIDialogPVRGroupManager::Update()
   // get the groups list
   CPVRGUIDirectory::GetChannelGroupsDirectory(m_bIsRadio, false, *m_channelGroups);
 
-  for (auto& group : *m_channelGroups)
+  for (const auto& group : *m_channelGroups)
   {
     const std::shared_ptr<const CPVRClient> client =
         CServiceBroker::GetPVRManager().GetClient(*group);

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.h
@@ -65,9 +65,9 @@ private:
   int m_iSelectedGroupMember = 0;
   int m_iSelectedChannelGroup = 0;
 
-  CFileItemList* m_ungroupedChannels;
-  CFileItemList* m_groupMembers;
-  CFileItemList* m_channelGroups;
+  std::unique_ptr<CFileItemList> m_ungroupedChannels;
+  std::unique_ptr<CFileItemList> m_groupMembers;
+  std::unique_ptr<CFileItemList> m_channelGroups;
 
   CGUIViewControl m_viewUngroupedChannels;
   CGUIViewControl m_viewGroupMembers;

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -27,14 +27,18 @@
 
 using namespace PVR;
 
-#define CONTROL_BTN_FIND 4
-#define CONTROL_BTN_SWITCH 5
-#define CONTROL_BTN_RECORD 6
-#define CONTROL_BTN_OK 7
-#define CONTROL_BTN_PLAY_RECORDING 8
-#define CONTROL_BTN_ADD_TIMER 9
-#define CONTROL_BTN_PLAY_EPGTAG 10
-#define CONTROL_BTN_SET_REMINDER 11
+namespace
+{
+constexpr unsigned int CONTROL_BTN_FIND = 4;
+constexpr unsigned int CONTROL_BTN_SWITCH = 5;
+constexpr unsigned int CONTROL_BTN_RECORD = 6;
+constexpr unsigned int CONTROL_BTN_OK = 7;
+constexpr unsigned int CONTROL_BTN_PLAY_RECORDING = 8;
+constexpr unsigned int CONTROL_BTN_ADD_TIMER = 9;
+constexpr unsigned int CONTROL_BTN_PLAY_EPGTAG = 10;
+constexpr unsigned int CONTROL_BTN_SET_REMINDER = 11;
+
+} // unnamed namespace
 
 CGUIDialogPVRGuideInfo::CGUIDialogPVRGuideInfo()
   : CGUIDialog(WINDOW_DIALOG_PVR_GUIDE_INFO, "DialogPVRInfo.xml")
@@ -179,12 +183,11 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonFind(const CGUIMessage& message)
 
 bool CGUIDialogPVRGuideInfo::OnMessage(CGUIMessage& message)
 {
-  switch (message.GetMessage())
+  if (message.GetMessage() == GUI_MSG_CLICKED)
   {
-    case GUI_MSG_CLICKED:
-      return OnClickButtonOK(message) || OnClickButtonRecord(message) ||
-             OnClickButtonPlay(message) || OnClickButtonFind(message) ||
-             OnClickButtonAddTimer(message) || OnClickButtonSetReminder(message);
+    return OnClickButtonOK(message) || OnClickButtonRecord(message) || OnClickButtonPlay(message) ||
+           OnClickButtonFind(message) || OnClickButtonAddTimer(message) ||
+           OnClickButtonSetReminder(message);
   }
 
   return CGUIDialog::OnMessage(message);
@@ -216,7 +219,7 @@ void CGUIDialogPVRGuideInfo::OnInitWindow()
     return;
   }
 
-  auto& mgr = CServiceBroker::GetPVRManager();
+  const auto& mgr{CServiceBroker::GetPVRManager()};
   const auto epgTag = m_progItem->GetEPGInfoTag();
 
   if (!mgr.Recordings()->GetRecordingForEpgTag(epgTag))

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -22,37 +22,42 @@
 #include "pvr/epg/EpgSearchFilter.h"
 #include "utils/StringUtils.h"
 
+#include <cstdio>
 #include <string>
 #include <utility>
 #include <vector>
 
 using namespace PVR;
 
-#define CONTROL_EDIT_SEARCH       9
-#define CONTROL_BTN_INC_DESC      10
-#define CONTROL_BTN_CASE_SENS     11
-#define CONTROL_SPIN_MIN_DURATION 12
-#define CONTROL_SPIN_MAX_DURATION 13
-#define CONTROL_EDIT_START_DATE   14
-#define CONTROL_EDIT_STOP_DATE    15
-#define CONTROL_EDIT_START_TIME   16
-#define CONTROL_EDIT_STOP_TIME    17
-#define CONTROL_SPIN_GENRE        18
-#define CONTROL_SPIN_NO_REPEATS   19
-#define CONTROL_BTN_UNK_GENRE     20
-#define CONTROL_SPIN_GROUPS       21
-#define CONTROL_BTN_FTA_ONLY      22
-#define CONTROL_SPIN_CHANNELS     23
-#define CONTROL_BTN_IGNORE_TMR    24
-#define CONTROL_BTN_CANCEL        25
-#define CONTROL_BTN_SEARCH        26
-#define CONTROL_BTN_IGNORE_REC    27
-#define CONTROL_BTN_DEFAULTS      28
-static constexpr int CONTROL_BTN_SAVE = 29;
-static constexpr int CONTROL_BTN_IGNORE_FINISHED = 30;
-static constexpr int CONTROL_BTN_IGNORE_FUTURE = 31;
-static constexpr int CONTROL_BTN_START_ANY_TIME = 32;
-static constexpr int CONTROL_BTN_END_ANY_TIME = 33;
+namespace
+{
+constexpr unsigned int CONTROL_EDIT_SEARCH = 9;
+constexpr unsigned int CONTROL_BTN_INC_DESC = 10;
+constexpr unsigned int CONTROL_BTN_CASE_SENS = 11;
+constexpr unsigned int CONTROL_SPIN_MIN_DURATION = 12;
+constexpr unsigned int CONTROL_SPIN_MAX_DURATION = 13;
+constexpr unsigned int CONTROL_EDIT_START_DATE = 14;
+constexpr unsigned int CONTROL_EDIT_STOP_DATE = 15;
+constexpr unsigned int CONTROL_EDIT_START_TIME = 16;
+constexpr unsigned int CONTROL_EDIT_STOP_TIME = 17;
+constexpr unsigned int CONTROL_SPIN_GENRE = 18;
+constexpr unsigned int CONTROL_SPIN_NO_REPEATS = 19;
+constexpr unsigned int CONTROL_BTN_UNK_GENRE = 20;
+constexpr unsigned int CONTROL_SPIN_GROUPS = 21;
+constexpr unsigned int CONTROL_BTN_FTA_ONLY = 22;
+constexpr unsigned int CONTROL_SPIN_CHANNELS = 23;
+constexpr unsigned int CONTROL_BTN_IGNORE_TMR = 24;
+constexpr unsigned int CONTROL_BTN_CANCEL = 25;
+constexpr unsigned int CONTROL_BTN_SEARCH = 26;
+constexpr unsigned int CONTROL_BTN_IGNORE_REC = 27;
+constexpr unsigned int CONTROL_BTN_DEFAULTS = 28;
+constexpr unsigned int CONTROL_BTN_SAVE = 29;
+constexpr unsigned int CONTROL_BTN_IGNORE_FINISHED = 30;
+constexpr unsigned int CONTROL_BTN_IGNORE_FUTURE = 31;
+constexpr unsigned int CONTROL_BTN_START_ANY_TIME = 32;
+constexpr unsigned int CONTROL_BTN_END_ANY_TIME = 33;
+
+} // unnamed namespace
 
 CGUIDialogPVRGuideSearch::CGUIDialogPVRGuideSearch()
   : CGUIDialog(WINDOW_DIALOG_PVR_GUIDE_SEARCH, "DialogPVRGuideSearch.xml")
@@ -166,12 +171,11 @@ bool CGUIDialogPVRGuideSearch::OnMessage(CGUIMessage& message)
 {
   CGUIDialog::OnMessage(message);
 
-  switch (message.GetMessage())
+  if (message.GetMessage() == GUI_MSG_CLICKED)
   {
-    case GUI_MSG_CLICKED:
+    switch (message.GetSenderId())
     {
-      int iControl = message.GetSenderId();
-      if (iControl == CONTROL_BTN_SEARCH)
+      case CONTROL_BTN_SEARCH:
       {
         // Read data from controls, update m_searchfilter accordingly
         UpdateSearchFilter();
@@ -180,13 +184,13 @@ bool CGUIDialogPVRGuideSearch::OnMessage(CGUIMessage& message)
         Close();
         return true;
       }
-      else if (iControl == CONTROL_BTN_CANCEL)
+      case CONTROL_BTN_CANCEL:
       {
         m_result = Result::CANCEL;
         Close();
         return true;
       }
-      else if (iControl == CONTROL_BTN_DEFAULTS)
+      case CONTROL_BTN_DEFAULTS:
       {
         if (m_searchFilter)
         {
@@ -195,12 +199,12 @@ bool CGUIDialogPVRGuideSearch::OnMessage(CGUIMessage& message)
         }
         return true;
       }
-      else if (iControl == CONTROL_BTN_SAVE)
+      case CONTROL_BTN_SAVE:
       {
         // Read data from controls, update m_searchfilter accordingly
         UpdateSearchFilter();
 
-        std::string title = m_searchFilter->GetTitle();
+        std::string title{m_searchFilter->GetTitle()};
         if (title.empty())
         {
           title = m_searchFilter->GetSearchTerm();
@@ -222,21 +226,22 @@ bool CGUIDialogPVRGuideSearch::OnMessage(CGUIMessage& message)
         Close();
         return true;
       }
-      else if (iControl == CONTROL_SPIN_GROUPS)
+      case CONTROL_SPIN_GROUPS:
       {
         UpdateChannelSpin();
         return true;
       }
-      else if (iControl == CONTROL_BTN_START_ANY_TIME || iControl == CONTROL_BTN_END_ANY_TIME)
+      case CONTROL_BTN_START_ANY_TIME:
+      case CONTROL_BTN_END_ANY_TIME:
       {
         UpdateSearchFilter();
         Update();
         return true;
       }
+      default:
+        break;
     }
-    break;
   }
-
   return false;
 }
 
@@ -256,8 +261,9 @@ void CGUIDialogPVRGuideSearch::OnWindowLoaded()
 CDateTime CGUIDialogPVRGuideSearch::ReadDateTime(const std::string& strDate, const std::string& strTime) const
 {
   CDateTime dateTime;
-  int iHours, iMinutes;
-  sscanf(strTime.c_str(), "%d:%d", &iHours, &iMinutes);
+  int iHours{0};
+  int iMinutes{0};
+  std::sscanf(strTime.c_str(), "%d:%d", &iHours, &iMinutes);
   dateTime.SetFromDBDate(strDate);
   dateTime.SetDateTime(dateTime.GetYear(), dateTime.GetMonth(), dateTime.GetDay(), iHours, iMinutes, 0);
   return dateTime.GetAsUTCDateTime();
@@ -361,11 +367,12 @@ void CGUIDialogPVRGuideSearch::Update()
   m_endDateTime = m_searchFilter->GetEndDateTime();
   if (!m_startDateTime.IsValid() || !m_endDateTime.IsValid())
   {
-    const auto dates = CServiceBroker::GetPVRManager().EpgContainer().GetFirstAndLastEPGDate();
+    const auto [first, last] =
+        CServiceBroker::GetPVRManager().EpgContainer().GetFirstAndLastEPGDate();
     if (!m_startDateTime.IsValid())
-      m_startDateTime = dates.first;
+      m_startDateTime = first;
     if (!m_endDateTime.IsValid())
-      m_endDateTime = dates.second;
+      m_endDateTime = last;
   }
 
   if (!m_startDateTime.IsValid())

--- a/xbmc/pvr/dialogs/GUIDialogPVRItemsViewBase.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRItemsViewBase.cpp
@@ -21,12 +21,16 @@
 
 #include <utility>
 
-#define CONTROL_LIST 11
+namespace
+{
+constexpr unsigned int CONTROL_LIST = 11;
+
+} // unnamed namespace
 
 using namespace PVR;
 
 CGUIDialogPVRItemsViewBase::CGUIDialogPVRItemsViewBase(int id, const std::string& xmlFile)
-  : CGUIDialog(id, xmlFile), m_vecItems(new CFileItemList)
+  : CGUIDialog(id, xmlFile), m_vecItems(std::make_unique<CFileItemList>())
 {
 }
 
@@ -42,11 +46,6 @@ void CGUIDialogPVRItemsViewBase::OnWindowUnload()
 {
   CGUIDialog::OnWindowUnload();
   m_viewControl.Reset();
-}
-
-void CGUIDialogPVRItemsViewBase::OnInitWindow()
-{
-  CGUIDialog::OnInitWindow();
 }
 
 void CGUIDialogPVRItemsViewBase::OnDeinitWindow(int nextWindowID)
@@ -86,7 +85,7 @@ CGUIControl* CGUIDialogPVRItemsViewBase::GetFirstFocusableControl(int id)
   return CGUIDialog::GetFirstFocusableControl(id);
 }
 
-void CGUIDialogPVRItemsViewBase::ShowInfo(int itemIdx)
+void CGUIDialogPVRItemsViewBase::ShowInfo(int itemIdx) const
 {
   if (itemIdx < 0 || itemIdx >= m_vecItems->Size())
     return;

--- a/xbmc/pvr/dialogs/GUIDialogPVRItemsViewBase.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRItemsViewBase.h
@@ -32,7 +32,6 @@ public:
 protected:
   void Init();
 
-  void OnInitWindow() override;
   void OnDeinitWindow(int nextWindowID) override;
   CGUIControl* GetFirstFocusableControl(int id) override;
 
@@ -41,7 +40,7 @@ protected:
 
 private:
   void Clear();
-  void ShowInfo(int itemIdx);
+  void ShowInfo(int itemIdx) const;
   bool ContextMenu(int iItemIdx);
 };
 } // namespace PVR

--- a/xbmc/pvr/dialogs/GUIDialogPVRRadioRDSInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRadioRDSInfo.cpp
@@ -21,21 +21,24 @@
 
 using namespace PVR;
 
-#define CONTROL_BTN_OK    10
-#define SPIN_CONTROL_INFO 21
-#define TEXT_INFO         22
-#define CONTROL_NEXT_PAGE 60
-#define CONTROL_INFO_LIST 70
+namespace
+{
+constexpr unsigned int CONTROL_BTN_OK = 10;
+constexpr unsigned int SPIN_CONTROL_INFO = 21;
+constexpr unsigned int TEXT_INFO = 22;
+constexpr unsigned int CONTROL_INFO_LIST = 70;
 
-#define INFO_NEWS         1
-#define INFO_NEWS_LOCAL   2
-#define INFO_SPORT        3
-#define INFO_WEATHER      4
-#define INFO_LOTTERY      5
-#define INFO_STOCK        6
-#define INFO_OTHER        7
-#define INFO_CINEMA       8
-#define INFO_HOROSCOPE    9
+constexpr unsigned int INFO_NEWS = 1;
+constexpr unsigned int INFO_NEWS_LOCAL = 2;
+constexpr unsigned int INFO_SPORT = 3;
+constexpr unsigned int INFO_WEATHER = 4;
+constexpr unsigned int INFO_LOTTERY = 5;
+constexpr unsigned int INFO_STOCK = 6;
+constexpr unsigned int INFO_OTHER = 7;
+constexpr unsigned int INFO_CINEMA = 8;
+constexpr unsigned int INFO_HOROSCOPE = 9;
+
+} // unnamed namespace
 
 CGUIDialogPVRRadioRDSInfo::CGUIDialogPVRRadioRDSInfo()
   : CGUIDialog(WINDOW_DIALOG_PVR_RADIO_RDS_INFO, "DialogPVRRadioRDSInfo.xml")
@@ -73,11 +76,11 @@ bool CGUIDialogPVRRadioRDSInfo::OnMessage(CGUIMessage& message)
       if (!currentRDS)
         return false;
 
-      const CGUISpinControl* spin = static_cast<CGUISpinControl*>(GetControl(SPIN_CONTROL_INFO));
+      const auto* spin{static_cast<CGUISpinControl*>(GetControl(SPIN_CONTROL_INFO))};
       if (!spin)
         return false;
 
-      CGUITextBox* textbox = static_cast<CGUITextBox*>(GetControl(TEXT_INFO));
+      auto* textbox{static_cast<CGUITextBox*>(GetControl(TEXT_INFO))};
       if (!textbox)
         return false;
 
@@ -111,6 +114,8 @@ bool CGUIDialogPVRRadioRDSInfo::OnMessage(CGUIMessage& message)
         case INFO_HOROSCOPE:
           text = currentRDS->GetInfoHoroscope();
           break;
+        default:
+          break;
       }
 
       if (!text.empty())
@@ -141,11 +146,11 @@ void CGUIDialogPVRRadioRDSInfo::InitInfoControls()
 {
   SET_CONTROL_HIDDEN(CONTROL_INFO_LIST);
 
-  CGUISpinControl* spin = static_cast<CGUISpinControl*>(GetControl(SPIN_CONTROL_INFO));
+  auto* spin{static_cast<CGUISpinControl*>(GetControl(SPIN_CONTROL_INFO))};
   if (spin)
     spin->Clear();
 
-  CGUITextBox* textbox = static_cast<CGUITextBox*>(GetControl(TEXT_INFO));
+  auto* textbox{static_cast<CGUITextBox*>(GetControl(TEXT_INFO))};
 
   m_InfoNews.Init(spin, textbox);
   m_InfoNewsLocal.Init(spin, textbox);

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
@@ -17,21 +17,25 @@
 
 using namespace PVR;
 
-#define CONTROL_BTN_FIND 4
-#define CONTROL_BTN_OK 7
-#define CONTROL_BTN_PLAY_RECORDING 8
+namespace
+{
+constexpr unsigned int CONTROL_BTN_FIND = 4;
+constexpr unsigned int CONTROL_BTN_OK = 7;
+constexpr unsigned int CONTROL_BTN_PLAY_RECORDING = 8;
+
+} // unnamed namespace
 
 CGUIDialogPVRRecordingInfo::CGUIDialogPVRRecordingInfo()
-  : CGUIDialog(WINDOW_DIALOG_PVR_RECORDING_INFO, "DialogPVRInfo.xml"), m_recordItem(new CFileItem)
+  : CGUIDialog(WINDOW_DIALOG_PVR_RECORDING_INFO, "DialogPVRInfo.xml"),
+    m_recordItem(std::make_shared<CFileItem>())
 {
 }
 
 bool CGUIDialogPVRRecordingInfo::OnMessage(CGUIMessage& message)
 {
-  switch (message.GetMessage())
+  if (message.GetMessage() == GUI_MSG_CLICKED)
   {
-    case GUI_MSG_CLICKED:
-      return OnClickButtonOK(message) || OnClickButtonPlay(message) || OnClickButtonFind(message);
+    return OnClickButtonOK(message) || OnClickButtonPlay(message) || OnClickButtonFind(message);
   }
 
   return CGUIDialog::OnMessage(message);

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.h
@@ -10,6 +10,8 @@
 
 #include "guilib/GUIDialog.h"
 
+#include <memory>
+
 class CFileItem;
 class CGUIMessage;
 
@@ -32,6 +34,6 @@ private:
   bool OnClickButtonOK(const CGUIMessage& message);
   bool OnClickButtonPlay(const CGUIMessage& message);
 
-  CFileItemPtr m_recordItem;
+  std::shared_ptr<CFileItem> m_recordItem;
 };
 } // namespace PVR

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -36,7 +36,6 @@
 #include "utils/log.h"
 
 #include <algorithm>
-#include <iterator>
 #include <memory>
 #include <string>
 #include <utility>
@@ -45,34 +44,37 @@
 using namespace PVR;
 using namespace KODI::MESSAGING;
 
-#define SETTING_TMR_TYPE "timer.type"
-#define SETTING_TMR_ACTIVE "timer.active"
-#define SETTING_TMR_NAME "timer.name"
-#define SETTING_TMR_EPGSEARCH "timer.epgsearch"
-#define SETTING_TMR_FULLTEXT "timer.fulltext"
-#define SETTING_TMR_CHANNEL "timer.channel"
-#define SETTING_TMR_START_ANYTIME "timer.startanytime"
-#define SETTING_TMR_END_ANYTIME "timer.endanytime"
-#define SETTING_TMR_START_DAY "timer.startday"
-#define SETTING_TMR_END_DAY "timer.endday"
-#define SETTING_TMR_BEGIN "timer.begin"
-#define SETTING_TMR_END "timer.end"
-#define SETTING_TMR_WEEKDAYS "timer.weekdays"
-#define SETTING_TMR_FIRST_DAY "timer.firstday"
-#define SETTING_TMR_NEW_EPISODES "timer.newepisodes"
-#define SETTING_TMR_BEGIN_PRE "timer.startmargin"
-#define SETTING_TMR_END_POST "timer.endmargin"
-#define SETTING_TMR_PRIORITY "timer.priority"
-#define SETTING_TMR_LIFETIME "timer.lifetime"
-#define SETTING_TMR_MAX_REC "timer.maxrecordings"
-#define SETTING_TMR_DIR "timer.directory"
-#define SETTING_TMR_REC_GROUP "timer.recgroup"
+namespace
+{
+constexpr const char* SETTING_TMR_TYPE = "timer.type";
+constexpr const char* SETTING_TMR_ACTIVE = "timer.active";
+constexpr const char* SETTING_TMR_NAME = "timer.name";
+constexpr const char* SETTING_TMR_EPGSEARCH = "timer.epgsearch";
+constexpr const char* SETTING_TMR_FULLTEXT = "timer.fulltext";
+constexpr const char* SETTING_TMR_CHANNEL = "timer.channel";
+constexpr const char* SETTING_TMR_START_ANYTIME = "timer.startanytime";
+constexpr const char* SETTING_TMR_END_ANYTIME = "timer.endanytime";
+constexpr const char* SETTING_TMR_START_DAY = "timer.startday";
+constexpr const char* SETTING_TMR_END_DAY = "timer.endday";
+constexpr const char* SETTING_TMR_BEGIN = "timer.begin";
+constexpr const char* SETTING_TMR_END = "timer.end";
+constexpr const char* SETTING_TMR_WEEKDAYS = "timer.weekdays";
+constexpr const char* SETTING_TMR_FIRST_DAY = "timer.firstday";
+constexpr const char* SETTING_TMR_NEW_EPISODES = "timer.newepisodes";
+constexpr const char* SETTING_TMR_BEGIN_PRE = "timer.startmargin";
+constexpr const char* SETTING_TMR_END_POST = "timer.endmargin";
+constexpr const char* SETTING_TMR_PRIORITY = "timer.priority";
+constexpr const char* SETTING_TMR_LIFETIME = "timer.lifetime";
+constexpr const char* SETTING_TMR_MAX_REC = "timer.maxrecordings";
+constexpr const char* SETTING_TMR_DIR = "timer.directory";
+constexpr const char* SETTING_TMR_REC_GROUP = "timer.recgroup";
 
-#define TYPE_DEP_VISIBI_COND_ID_POSTFIX "visibi.typedep"
-#define TYPE_DEP_ENABLE_COND_ID_POSTFIX "enable.typedep"
-#define CHANNEL_DEP_VISIBI_COND_ID_POSTFIX "visibi.channeldep"
-#define START_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX "visibi.startanytimedep"
-#define END_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX "visibi.endanytimedep"
+constexpr const char* TYPE_DEP_VISIBI_COND_ID_POSTFIX = "visibi.typedep";
+constexpr const char* TYPE_DEP_ENABLE_COND_ID_POSTFIX = "enable.typedep";
+constexpr const char* START_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX = "visibi.startanytimedep";
+constexpr const char* END_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX = "visibi.endanytimedep";
+
+} // unnamed namespace
 
 CGUIDialogPVRTimerSettings::CGUIDialogPVRTimerSettings()
   : CGUIDialogSettingsManualBase(WINDOW_DIALOG_PVR_TIMER_SETTING, "DialogSettings.xml"),
@@ -161,11 +163,13 @@ void CGUIDialogPVRTimerSettings::SetTimer(const std::shared_ptr<CPVRTimerInfoTag
     if (m_timerType->SupportsAnyChannel())
     {
       // Select first matching "Any channel" entry.
-      const auto it = std::find_if(m_channelEntries.cbegin(), m_channelEntries.cend(),
-                                   [this](const auto& channel) {
-                                     return channel.second.channelUid == PVR_CHANNEL_INVALID_UID &&
-                                            channel.second.clientId == m_timerInfoTag->m_iClientId;
-                                   });
+      const auto it =
+          std::ranges::find_if(m_channelEntries,
+                               [this](const auto& channel)
+                               {
+                                 return channel.second.channelUid == PVR_CHANNEL_INVALID_UID &&
+                                        channel.second.clientId == m_timerInfoTag->m_iClientId;
+                               });
 
       if (it != m_channelEntries.cend())
       {
@@ -179,11 +183,13 @@ void CGUIDialogPVRTimerSettings::SetTimer(const std::shared_ptr<CPVRTimerInfoTag
     else if (m_bIsNewTimer)
     {
       // Select first matching regular (not "Any channel") entry.
-      const auto it = std::find_if(m_channelEntries.cbegin(), m_channelEntries.cend(),
-                                   [this](const auto& channel) {
-                                     return channel.second.channelUid != PVR_CHANNEL_INVALID_UID &&
-                                            channel.second.clientId == m_timerInfoTag->m_iClientId;
-                                   });
+      const auto it =
+          std::ranges::find_if(m_channelEntries,
+                               [this](const auto& channel)
+                               {
+                                 return channel.second.channelUid != PVR_CHANNEL_INVALID_UID &&
+                                        channel.second.clientId == m_timerInfoTag->m_iClientId;
+                               });
 
       if (it != m_channelEntries.cend())
       {
@@ -198,8 +204,10 @@ void CGUIDialogPVRTimerSettings::SetTimer(const std::shared_ptr<CPVRTimerInfoTag
   else
   {
     // Find matching channel entry
-    const auto it = std::find_if(
-        m_channelEntries.cbegin(), m_channelEntries.cend(), [this](const auto& channel) {
+    const auto it = std::ranges::find_if(
+        m_channelEntries,
+        [this](const auto& channel)
+        {
           return channel.second.channelUid == m_timerInfoTag->m_iClientChannelUid &&
                  channel.second.clientId == m_timerInfoTag->m_iClientId;
         });
@@ -230,29 +238,29 @@ void CGUIDialogPVRTimerSettings::InitializeSettings()
   CGUIDialogSettingsManualBase::InitializeSettings();
 
   const std::shared_ptr<CSettingCategory> category = AddCategory("pvrtimersettings", -1);
-  if (category == NULL)
+  if (!category)
   {
     CLog::LogF(LOGERROR, "Unable to add settings category");
     return;
   }
 
   const std::shared_ptr<CSettingGroup> group = AddGroup(category);
-  if (group == NULL)
+  if (!group)
   {
     CLog::LogF(LOGERROR, "Unable to add settings group");
     return;
   }
 
-  std::shared_ptr<CSetting> setting = NULL;
+  std::shared_ptr<CSetting> setting;
 
   // Timer type
   bool useDetails = false;
   bool foundClientSupportingTimers = false;
 
   const CPVRClientMap clients = CServiceBroker::GetPVRManager().Clients()->GetCreatedClients();
-  for (const auto& client : clients)
+  for (const auto& [_, client] : clients)
   {
-    if (client.second->GetClientCapabilities().SupportsTimers())
+    if (client->GetClientCapabilities().SupportsTimers())
     {
       if (foundClientSupportingTimers)
       {
@@ -482,7 +490,7 @@ int CGUIDialogPVRTimerSettings::GetWeekdaysFromSetting(const SettingConstPtr& se
 
 void CGUIDialogPVRTimerSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)
 {
-  if (setting == NULL)
+  if (!setting)
   {
     CLog::LogF(LOGERROR, "No setting");
     return;
@@ -626,7 +634,7 @@ void CGUIDialogPVRTimerSettings::OnSettingChanged(const std::shared_ptr<const CS
 
 void CGUIDialogPVRTimerSettings::OnSettingAction(const std::shared_ptr<const CSetting>& setting)
 {
-  if (setting == NULL)
+  if (!setting)
   {
     CLog::LogF(LOGERROR, "No setting");
     return;
@@ -659,7 +667,7 @@ void CGUIDialogPVRTimerSettings::OnSettingAction(const std::shared_ptr<const CSe
   }
 }
 
-bool CGUIDialogPVRTimerSettings::Validate()
+bool CGUIDialogPVRTimerSettings::Validate() const
 {
   // @todo: Timer rules may have no date (time-only), so we can't check those for now.
   //        We need to extend the api with additional attributes to properly fix this
@@ -834,14 +842,14 @@ void CGUIDialogPVRTimerSettings::SetButtonLabels()
 {
   // timer start time
   BaseSettingControlPtr settingControl = GetSettingControl(SETTING_TMR_BEGIN);
-  if (settingControl != NULL && settingControl->GetControl() != NULL)
+  if (settingControl && settingControl->GetControl())
   {
     SET_CONTROL_LABEL2(settingControl->GetID(), m_timerStartTimeStr);
   }
 
   // timer end time
   settingControl = GetSettingControl(SETTING_TMR_END);
-  if (settingControl != NULL && settingControl->GetControl() != NULL)
+  if (settingControl && settingControl->GetControl())
   {
     SET_CONTROL_LABEL2(settingControl->GetID(), m_timerEndTimeStr);
   }
@@ -948,11 +956,15 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
     if (!bFoundThisType && *type == *m_timerType)
       bFoundThisType = true;
 
-    m_typeEntries.insert(std::make_pair(idx++, type));
+    m_typeEntries.insert(std::make_pair(idx, type));
+    idx++;
   }
 
   if (!bFoundThisType)
-    m_typeEntries.insert(std::make_pair(idx++, m_timerType));
+  {
+    m_typeEntries.insert(std::make_pair(idx, m_timerType));
+    idx++;
+  }
 }
 
 void CGUIDialogPVRTimerSettings::InitializeChannelsList()
@@ -965,22 +977,25 @@ void CGUIDialogPVRTimerSettings::InitializeChannelsList()
   // and for reminder rules another one representing any channel from any client.
   const CPVRClientMap clients = CServiceBroker::GetPVRManager().Clients()->GetCreatedClients();
   if (clients.size() > 1)
-    m_channelEntries.insert(
-        {index++, ChannelDescriptor(PVR_CHANNEL_INVALID_UID, PVR_CLIENT_INVALID_UID,
-                                    // Any channel from any client
-                                    g_localizeStrings.Get(854))});
-
-  for (const auto& client : clients)
   {
     m_channelEntries.insert(
-        {index, ChannelDescriptor(PVR_CHANNEL_INVALID_UID, client.second->GetID(),
+        {index, ChannelDescriptor(PVR_CHANNEL_INVALID_UID, PVR_CLIENT_INVALID_UID,
+                                  // Any channel from any client
+                                  g_localizeStrings.Get(854))});
+    index++;
+  }
+
+  for (const auto& [_, client] : clients)
+  {
+    m_channelEntries.insert(
+        {index, ChannelDescriptor(PVR_CHANNEL_INVALID_UID, client->GetID(),
                                   clients.size() == 1
                                       // Any channel
                                       ? g_localizeStrings.Get(809)
                                       // Any channel from client "X"
                                       : StringUtils::Format(g_localizeStrings.Get(853),
-                                                            client.second->GetFullClientName()))});
-    ++index;
+                                                            client->GetFullClientName()))});
+    index++;
   }
 
   // Add regular channels
@@ -1004,7 +1019,7 @@ void CGUIDialogPVRTimerSettings::TypesFiller(const SettingConstPtr& setting,
                                              int& current,
                                              void* data)
 {
-  CGUIDialogPVRTimerSettings* pThis = static_cast<CGUIDialogPVRTimerSettings*>(data);
+  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
@@ -1018,20 +1033,20 @@ void CGUIDialogPVRTimerSettings::TypesFiller(const SettingConstPtr& setting,
     const auto clients = CServiceBroker::GetPVRManager().Clients();
 
     bool foundCurrent(false);
-    for (const auto& typeEntry : pThis->m_typeEntries)
+    for (const auto& [timerId, timer] : pThis->m_typeEntries)
     {
       std::string clientName;
 
-      const auto client = clients->GetCreatedClient(typeEntry.second->GetClientId());
+      const auto client{clients->GetCreatedClient(timer->GetClientId())};
       if (client)
         clientName = client->GetFullClientName();
 
-      list.emplace_back(typeEntry.second->GetDescription(), clientName, typeEntry.first,
-                        typeEntry.second->IsReminder() ? reminderTimerProps : recordingTimerProps);
+      list.emplace_back(timer->GetDescription(), clientName, timerId,
+                        timer->IsReminder() ? reminderTimerProps : recordingTimerProps);
 
-      if (!foundCurrent && (*(pThis->m_timerType) == *(typeEntry.second)))
+      if (!foundCurrent && (*(pThis->m_timerType) == *timer))
       {
-        current = typeEntry.first;
+        current = timerId;
         foundCurrent = true;
       }
     }
@@ -1045,36 +1060,36 @@ void CGUIDialogPVRTimerSettings::ChannelsFiller(const SettingConstPtr& setting,
                                                 int& current,
                                                 void* data)
 {
-  CGUIDialogPVRTimerSettings* pThis = static_cast<CGUIDialogPVRTimerSettings*>(data);
+  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
     current = 0;
 
     bool foundCurrent(false);
-    for (const auto& channelEntry : pThis->m_channelEntries)
+    for (const auto& [channelId, channelDescriptor] : pThis->m_channelEntries)
     {
       // Only include channels for the currently selected timer type or all channels if type is client-independent.
       if (pThis->m_timerType->GetClientId() == PVR_CLIENT_INVALID_UID || // client-independent
-          pThis->m_timerType->GetClientId() == channelEntry.second.clientId)
+          pThis->m_timerType->GetClientId() == channelDescriptor.clientId)
       {
         // Do not add "any channel" entry if not supported by selected timer type.
-        if (channelEntry.second.channelUid == PVR_CHANNEL_INVALID_UID &&
+        if (channelDescriptor.channelUid == PVR_CHANNEL_INVALID_UID &&
             !pThis->m_timerType->SupportsAnyChannel())
           continue;
 
         // Do not add "any channel from any client" entry for reminder rules.
-        if (channelEntry.second.channelUid == PVR_CHANNEL_INVALID_UID &&
-            channelEntry.second.clientId == PVR_CLIENT_INVALID_UID &&
+        if (channelDescriptor.channelUid == PVR_CHANNEL_INVALID_UID &&
+            channelDescriptor.clientId == PVR_CLIENT_INVALID_UID &&
             !pThis->m_timerType->IsReminder() && !pThis->m_timerType->IsTimerRule())
           continue;
 
-        list.emplace_back(channelEntry.second.description, channelEntry.first);
+        list.emplace_back(channelDescriptor.description, channelId);
       }
 
-      if (!foundCurrent && (pThis->m_channel == channelEntry.second))
+      if (!foundCurrent && (pThis->m_channel == channelDescriptor))
       {
-        current = channelEntry.first;
+        current = channelId;
         foundCurrent = true;
       }
     }
@@ -1082,15 +1097,11 @@ void CGUIDialogPVRTimerSettings::ChannelsFiller(const SettingConstPtr& setting,
     if (foundCurrent)
     {
       // Verify m_channel is still valid. Update if not.
-      if (std::find_if(list.cbegin(), list.cend(),
-                       [&current](const auto& channel)
-                       { return channel.value == current; }) == list.cend())
+      if (std::ranges::find(list, current, &IntegerSettingOption::value) == list.cend())
       {
         // Set m_channel and current to first valid channel in list
         const int first{list.front().value};
-        const auto it =
-            std::find_if(pThis->m_channelEntries.cbegin(), pThis->m_channelEntries.cend(),
-                         [first](const auto& channel) { return channel.first == first; });
+        const auto it = pThis->m_channelEntries.find(first);
 
         if (it != pThis->m_channelEntries.cend())
         {
@@ -1113,7 +1124,7 @@ void CGUIDialogPVRTimerSettings::DaysFiller(const SettingConstPtr& setting,
                                             int& current,
                                             void* data)
 {
-  CGUIDialogPVRTimerSettings* pThis = static_cast<CGUIDialogPVRTimerSettings*>(data);
+  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
@@ -1162,16 +1173,16 @@ void CGUIDialogPVRTimerSettings::DupEpisodesFiller(const SettingConstPtr& settin
                                                    int& current,
                                                    void* data)
 {
-  CGUIDialogPVRTimerSettings* pThis = static_cast<CGUIDialogPVRTimerSettings*>(data);
+  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
 
     const std::vector<SettingIntValue>& values{
         pThis->m_timerType->GetPreventDuplicateEpisodesValues()};
-    std::transform(values.cbegin(), values.cend(), std::back_inserter(list), [](const auto& value) {
-      return IntegerSettingOption(value.first, value.second);
-    });
+    std::ranges::transform(values, std::back_inserter(list),
+                           [](const auto& value)
+                           { return IntegerSettingOption(value.first, value.second); });
 
     current = pThis->m_iPreventDupEpisodes;
   }
@@ -1184,7 +1195,7 @@ void CGUIDialogPVRTimerSettings::WeekdaysFiller(const SettingConstPtr& setting,
                                                 int& current,
                                                 void* data)
 {
-  CGUIDialogPVRTimerSettings* pThis = static_cast<CGUIDialogPVRTimerSettings*>(data);
+  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
@@ -1207,15 +1218,15 @@ void CGUIDialogPVRTimerSettings::PrioritiesFiller(const SettingConstPtr& setting
                                                   int& current,
                                                   void* data)
 {
-  CGUIDialogPVRTimerSettings* pThis = static_cast<CGUIDialogPVRTimerSettings*>(data);
+  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
 
     const std::vector<SettingIntValue>& values{pThis->m_timerType->GetPriorityValues()};
-    std::transform(values.cbegin(), values.cend(), std::back_inserter(list), [](const auto& value) {
-      return IntegerSettingOption(value.first, value.second);
-    });
+    std::ranges::transform(values, std::back_inserter(list),
+                           [](const auto& value)
+                           { return IntegerSettingOption(value.first, value.second); });
 
     current = pThis->m_iPriority;
 
@@ -1231,7 +1242,7 @@ void CGUIDialogPVRTimerSettings::PrioritiesFiller(const SettingConstPtr& setting
     if (it == list.end())
     {
       // PVR backend supplied value is not in the list of predefined values. Insert it.
-      list.insert(it, IntegerSettingOption(std::to_string(current), current));
+      list.emplace(it, IntegerSettingOption(std::to_string(current), current));
     }
   }
   else
@@ -1243,15 +1254,15 @@ void CGUIDialogPVRTimerSettings::LifetimesFiller(const SettingConstPtr& setting,
                                                  int& current,
                                                  void* data)
 {
-  CGUIDialogPVRTimerSettings* pThis = static_cast<CGUIDialogPVRTimerSettings*>(data);
+  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
 
     const std::vector<SettingIntValue>& values{pThis->m_timerType->GetLifetimeValues()};
-    std::transform(values.cbegin(), values.cend(), std::back_inserter(list), [](const auto& value) {
-      return IntegerSettingOption(value.first, value.second);
-    });
+    std::ranges::transform(values, std::back_inserter(list),
+                           [](const auto& value)
+                           { return IntegerSettingOption(value.first, value.second); });
 
     current = pThis->m_iLifetime;
 
@@ -1267,9 +1278,9 @@ void CGUIDialogPVRTimerSettings::LifetimesFiller(const SettingConstPtr& setting,
     if (it == list.end())
     {
       // PVR backend supplied value is not in the list of predefined values. Insert it.
-      list.insert(it, IntegerSettingOption(
-                          StringUtils::Format(g_localizeStrings.Get(17999), current) /* {} days */,
-                          current));
+      list.emplace(it, IntegerSettingOption(
+                           StringUtils::Format(g_localizeStrings.Get(17999), current) /* {} days */,
+                           current));
     }
   }
   else
@@ -1281,15 +1292,15 @@ void CGUIDialogPVRTimerSettings::MaxRecordingsFiller(const SettingConstPtr& sett
                                                      int& current,
                                                      void* data)
 {
-  CGUIDialogPVRTimerSettings* pThis = static_cast<CGUIDialogPVRTimerSettings*>(data);
+  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
 
     const std::vector<SettingIntValue>& values{pThis->m_timerType->GetMaxRecordingsValues()};
-    std::transform(values.cbegin(), values.cend(), std::back_inserter(list), [](const auto& value) {
-      return IntegerSettingOption(value.first, value.second);
-    });
+    std::ranges::transform(values, std::back_inserter(list),
+                           [](const auto& value)
+                           { return IntegerSettingOption(value.first, value.second); });
 
     current = pThis->m_iMaxRecordings;
 
@@ -1305,7 +1316,7 @@ void CGUIDialogPVRTimerSettings::MaxRecordingsFiller(const SettingConstPtr& sett
     if (it == list.end())
     {
       // PVR backend supplied value is not in the list of predefined values. Insert it.
-      list.insert(it, IntegerSettingOption(std::to_string(current), current));
+      list.emplace(it, IntegerSettingOption(std::to_string(current), current));
     }
   }
   else
@@ -1317,15 +1328,15 @@ void CGUIDialogPVRTimerSettings::RecordingGroupFiller(const SettingConstPtr& set
                                                       int& current,
                                                       void* data)
 {
-  CGUIDialogPVRTimerSettings* pThis = static_cast<CGUIDialogPVRTimerSettings*>(data);
+  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
 
     const std::vector<SettingIntValue>& values{pThis->m_timerType->GetRecordingGroupValues()};
-    std::transform(values.cbegin(), values.cend(), std::back_inserter(list), [](const auto& value) {
-      return IntegerSettingOption(value.first, value.second);
-    });
+    std::ranges::transform(values, std::back_inserter(list),
+                           [](const auto& value)
+                           { return IntegerSettingOption(value.first, value.second); });
 
     current = pThis->m_iRecordingGroup;
   }
@@ -1338,7 +1349,7 @@ void CGUIDialogPVRTimerSettings::MarginTimeFiller(const SettingConstPtr& setting
                                                   int& current,
                                                   void* data)
 {
-  CGUIDialogPVRTimerSettings* pThis = static_cast<CGUIDialogPVRTimerSettings*>(data);
+  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
@@ -1370,9 +1381,9 @@ void CGUIDialogPVRTimerSettings::MarginTimeFiller(const SettingConstPtr& setting
     if (bInsertValue)
     {
       // PVR backend supplied value is not in the list of predefined values. Insert it.
-      list.insert(it, IntegerSettingOption(
-                          StringUtils::Format(g_localizeStrings.Get(14044), current) /* {} min */,
-                          current));
+      list.emplace(it, IntegerSettingOption(
+                           StringUtils::Format(g_localizeStrings.Get(14044), current) /* {} min */,
+                           current));
     }
   }
   else
@@ -1385,7 +1396,7 @@ void CGUIDialogPVRTimerSettings::CustomIntSettingDefinitionsFiller(
     int& current,
     void* data)
 {
-  CGUIDialogPVRTimerSettings* pThis = static_cast<CGUIDialogPVRTimerSettings*>(data);
+  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
@@ -1404,7 +1415,7 @@ void CGUIDialogPVRTimerSettings::CustomStringSettingDefinitionsFiller(
     std::string& current,
     void* data)
 {
-  CGUIDialogPVRTimerSettings* pThis = static_cast<CGUIDialogPVRTimerSettings*>(data);
+  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
@@ -1436,11 +1447,11 @@ bool CGUIDialogPVRTimerSettings::TypeReadOnlyCondition(const std::string& condit
                                                        const SettingConstPtr& setting,
                                                        void* data)
 {
-  if (setting == NULL)
+  if (!setting)
     return false;
 
-  CGUIDialogPVRTimerSettings* pThis = static_cast<CGUIDialogPVRTimerSettings*>(data);
-  if (pThis == NULL)
+  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
+  if (!pThis)
   {
     CLog::LogF(LOGERROR, "No dialog");
     return false;
@@ -1516,11 +1527,11 @@ bool CGUIDialogPVRTimerSettings::TypeSupportsCondition(const std::string& condit
                                                        const SettingConstPtr& setting,
                                                        void* data)
 {
-  if (setting == NULL)
+  if (!setting)
     return false;
 
-  CGUIDialogPVRTimerSettings* pThis = static_cast<CGUIDialogPVRTimerSettings*>(data);
-  if (pThis == NULL)
+  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
+  if (!pThis)
   {
     CLog::LogF(LOGERROR, "No dialog");
     return false;
@@ -1603,11 +1614,11 @@ bool CGUIDialogPVRTimerSettings::StartAnytimeSetCondition(const std::string& con
                                                           const SettingConstPtr& setting,
                                                           void* data)
 {
-  if (setting == NULL)
+  if (!setting)
     return false;
 
-  CGUIDialogPVRTimerSettings* pThis = static_cast<CGUIDialogPVRTimerSettings*>(data);
-  if (pThis == NULL)
+  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
+  if (!pThis)
   {
     CLog::LogF(LOGERROR, "No dialog");
     return false;
@@ -1650,11 +1661,11 @@ bool CGUIDialogPVRTimerSettings::EndAnytimeSetCondition(const std::string& condi
                                                         const SettingConstPtr& setting,
                                                         void* data)
 {
-  if (setting == NULL)
+  if (!setting)
     return false;
 
-  CGUIDialogPVRTimerSettings* pThis = static_cast<CGUIDialogPVRTimerSettings*>(data);
-  if (pThis == NULL)
+  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
+  if (!pThis)
   {
     CLog::LogF(LOGERROR, "No dialog");
     return false;

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -23,6 +23,7 @@
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/settings/PVRCustomTimerSettings.h"
+#include "pvr/settings/PVRSettings.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/timers/PVRTimerType.h"
 #include "settings/SettingUtils.h"

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
@@ -75,7 +75,7 @@ protected:
   void InitializeSettings() override;
 
 private:
-  bool Validate();
+  bool Validate() const;
   void InitializeTypesList();
   void InitializeChannelsList();
   void SetButtonLabels();
@@ -170,9 +170,9 @@ private:
                                      const std::shared_ptr<const CSetting>& setting,
                                      void* data);
 
-  typedef std::map<int, std::shared_ptr<CPVRTimerType>> TypeEntriesMap;
+  using TypeEntriesMap = std::map<int, std::shared_ptr<CPVRTimerType>>;
 
-  typedef struct ChannelDescriptor
+  struct ChannelDescriptor
   {
     int channelUid;
     int clientId;
@@ -185,15 +185,10 @@ private:
     {
     }
 
-    inline bool operator==(const ChannelDescriptor& right) const
-    {
-      return (channelUid == right.channelUid && clientId == right.clientId &&
-              description == right.description);
-    }
+    bool operator==(const ChannelDescriptor& right) const = default;
+  };
 
-  } ChannelDescriptor;
-
-  typedef std::map<int, ChannelDescriptor> ChannelEntriesMap;
+  using ChannelEntriesMap = std::map<int, ChannelDescriptor>;
 
   std::unique_ptr<CPVRCustomTimerSettings> m_customTimerSettings;
 
@@ -215,7 +210,7 @@ private:
   CDateTime m_endLocalTime;
   bool m_bStartAnyTime = false;
   bool m_bEndAnyTime = false;
-  unsigned int m_iWeekdays;
+  unsigned int m_iWeekdays{0};
   CDateTime m_firstDayLocalTime;
   unsigned int m_iPreventDupEpisodes = 0;
   unsigned int m_iMarginStart = 0;

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -36,7 +36,7 @@ CPVREpg::CPVREpg(int iEpgID,
   : m_iEpgID(iEpgID),
     m_strName(strName),
     m_strScraperName(strScraperName),
-    m_channelData(new CPVREpgChannelData),
+    m_channelData(std::make_shared<CPVREpgChannelData>()),
     m_tags(m_iEpgID, m_channelData, database)
 {
 }
@@ -140,8 +140,8 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpg::GetTagBetween(const CDateTime& beginTim
     time_t e;
     endTime.GetAsTime(e);
 
-    const std::shared_ptr<CPVREpg> tmpEpg = std::make_shared<CPVREpg>(
-        m_iEpgID, m_strName, m_strScraperName, m_channelData, std::shared_ptr<CPVREpgDatabase>());
+    const auto tmpEpg{std::make_shared<CPVREpg>(m_iEpgID, m_strName, m_strScraperName,
+                                                m_channelData, std::shared_ptr<CPVREpgDatabase>())};
     if (tmpEpg->UpdateFromScraper(b, e, true))
       tag = tmpEpg->GetTagBetween(beginTime, endTime, false);
 
@@ -197,8 +197,7 @@ bool CPVREpg::UpdateEntry(const EPG_TAG* data, int iClientId)
   if (!data)
     return false;
 
-  const std::shared_ptr<CPVREpgInfoTag> tag =
-      std::make_shared<CPVREpgInfoTag>(*data, iClientId, m_channelData, m_iEpgID);
+  const auto tag{std::make_shared<CPVREpgInfoTag>(*data, iClientId, m_channelData, m_iEpgID)};
 
   return !IsTagExpired(tag) && m_tags.UpdateEntry(tag);
 }
@@ -379,10 +378,10 @@ bool CPVREpg::QueueDeleteQueries(const std::shared_ptr<CPVREpgDatabase>& databas
   return true;
 }
 
-std::pair<CDateTime, CDateTime> CPVREpg::GetFirstAndLastUncommitedEPGDate() const
+std::pair<CDateTime, CDateTime> CPVREpg::GetFirstAndLastUncommittedEPGDate() const
 {
   std::unique_lock lock(m_critSection);
-  return m_tags.GetFirstAndLastUncommitedEPGDate();
+  return m_tags.GetFirstAndLastUncommittedEPGDate();
 }
 
 bool CPVREpg::UpdateFromScraper(time_t start, time_t end, bool bForceUpdate)

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -228,7 +228,7 @@ namespace PVR
      * @brief Get the start and end time of the last not yet committed entry in this table.
      * @return The times; first: start time, second: end time.
      */
-    std::pair<CDateTime, CDateTime> GetFirstAndLastUncommitedEPGDate() const;
+    std::pair<CDateTime, CDateTime> GetFirstAndLastUncommittedEPGDate() const;
 
     /*!
      * @brief Notify observers when the currently active tag changed.

--- a/xbmc/pvr/epg/EpgChannelData.cpp
+++ b/xbmc/pvr/epg/EpgChannelData.cpp
@@ -91,7 +91,7 @@ const std::string& CPVREpgChannelData::ChannelName() const
   return m_strChannelName;
 }
 
-void CPVREpgChannelData::SetChannelName(const std::string& strChannelName)
+void CPVREpgChannelData::SetChannelName(std::string_view strChannelName)
 {
   m_strChannelName = strChannelName;
 }
@@ -101,7 +101,7 @@ const std::string& CPVREpgChannelData::ChannelIconPath() const
   return m_strChannelIconPath;
 }
 
-void CPVREpgChannelData::SetChannelIconPath(const std::string& strChannelIconPath)
+void CPVREpgChannelData::SetChannelIconPath(std::string_view strChannelIconPath)
 {
   m_strChannelIconPath = strChannelIconPath;
 }

--- a/xbmc/pvr/epg/EpgChannelData.h
+++ b/xbmc/pvr/epg/EpgChannelData.h
@@ -12,6 +12,7 @@
 
 #include <ctime>
 #include <string>
+#include <string_view>
 
 namespace PVR
 {
@@ -41,10 +42,10 @@ public:
   void SetChannelId(int iChannelId);
 
   const std::string& ChannelName() const;
-  void SetChannelName(const std::string& strChannelName);
+  void SetChannelName(std::string_view strChannelName);
 
   const std::string& ChannelIconPath() const;
-  void SetChannelIconPath(const std::string& strChannelIconPath);
+  void SetChannelIconPath(std::string_view strChannelIconPath);
 
 private:
   const bool m_bIsRadio = false;

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -10,7 +10,6 @@
 
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_epg.h"
 #include "powermanagement/PowerState.h"
-#include "pvr/settings/PVRSettings.h"
 #include "threads/CriticalSection.h"
 #include "threads/Event.h"
 #include "threads/Thread.h"
@@ -35,6 +34,7 @@ class CPVREpgChannelData;
 class CPVREpgDatabase;
 class CPVREpgInfoTag;
 class CPVREpgSearchFilter;
+class CPVRSettings;
 
 enum class PVREvent;
 
@@ -72,12 +72,6 @@ public:
    * @brief Stop the EPG update thread.
    */
   void Stop();
-
-  /**
-   * @brief (re)load EPG data.
-   * @return True if loaded successfully, false otherwise.
-   */
-  bool Load();
 
   /**
    * @brief unload all EPG data.
@@ -239,7 +233,7 @@ public:
    * @param epgSearch The search.
    * @return True on success, false otherwise.
    */
-  bool UpdateSavedSearchLastExecuted(const CPVREpgSearchFilter& epgSearch);
+  bool UpdateSavedSearchLastExecuted(const CPVREpgSearchFilter& epgSearch) const;
 
   /*!
    * @brief Delete a saved search from the database.
@@ -351,7 +345,7 @@ private:
 
   bool m_bUpdateNotificationPending =
       false; /*!< true while an epg updated notification to observers is pending. */
-  CPVRSettings m_settings;
+  std::unique_ptr<CPVRSettings> m_settings;
   CEventSource<PVREvent>& m_events;
 };
 } // namespace PVR

--- a/xbmc/pvr/epg/EpgDatabase.h
+++ b/xbmc/pvr/epg/EpgDatabase.h
@@ -379,11 +379,10 @@ namespace PVR
 
     int GetMinSchemaVersion() const override { return 4; }
 
-    std::shared_ptr<CPVREpgInfoTag> CreateEpgTag(
-        const std::unique_ptr<dbiplus::Dataset>& pDS) const;
+    std::shared_ptr<CPVREpgInfoTag> CreateEpgTag(dbiplus::Dataset& ds) const;
 
-    std::shared_ptr<CPVREpgSearchFilter> CreateEpgSearchFilter(
-        bool bRadio, const std::unique_ptr<dbiplus::Dataset>& pDS) const;
+    std::shared_ptr<CPVREpgSearchFilter> CreateEpgSearchFilter(bool bRadio,
+                                                               dbiplus::Dataset& ds) const;
 
     mutable CCriticalSection m_critSection;
   };

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -39,7 +39,7 @@ CPVREpgInfoTag::CPVREpgInfoTag(int iEpgID,
     m_iUniqueBroadcastID(EPG_TAG_INVALID_UID),
     m_iconPath(iconPath, StringUtils::Format(IMAGE_OWNER_PATTERN, iEpgID)),
     m_iFlags(EPG_TAG_FLAG_UNDEFINED),
-    m_channelData(new CPVREpgChannelData),
+    m_channelData(std::make_shared<CPVREpgChannelData>()),
     m_iEpgID(iEpgID)
 {
 }
@@ -165,14 +165,6 @@ bool CPVREpgInfoTag::operator==(const CPVREpgInfoTag& right) const
           m_channelData->ClientId() == right.m_channelData->ClientId());
 }
 
-bool CPVREpgInfoTag::operator!=(const CPVREpgInfoTag& right) const
-{
-  if (this == &right)
-    return false;
-
-  return !(*this == right);
-}
-
 void CPVREpgInfoTag::Serialize(CVariant& value) const
 {
   std::unique_lock lock(m_critSection);
@@ -249,9 +241,13 @@ double CPVREpgInfoTag::ProgressPercentage() const
 {
   double ret = 0.0;
 
-  time_t currentTime, startTime, endTime;
+  time_t currentTime{0};
   CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(currentTime);
+
+  time_t startTime{0};
   m_startTime.GetAsTime(startTime);
+
+  time_t endTime{0};
   m_endTime.GetAsTime(endTime);
 
   if (currentTime >= startTime && currentTime <= endTime)
@@ -273,8 +269,10 @@ double CPVREpgInfoTag::ProgressPercentage() const
 
 unsigned int CPVREpgInfoTag::Progress() const
 {
-  time_t currentTime, startTime;
+  time_t currentTime{0};
   CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(currentTime);
+
+  time_t startTime{0};
   m_startTime.GetAsTime(startTime);
 
   if (currentTime > startTime)
@@ -346,8 +344,10 @@ void CPVREpgInfoTag::SetEndFromUTC(const CDateTime& end)
 
 unsigned int CPVREpgInfoTag::GetDuration() const
 {
-  time_t start, end;
+  time_t start{0};
   m_startTime.GetAsTime(start);
+
+  time_t end{0};
   m_endTime.GetAsTime(end);
 
   if (end > start)
@@ -361,14 +361,14 @@ unsigned int CPVREpgInfoTag::GetDuration() const
   }
 }
 
-const std::string CPVREpgInfoTag::GetCastLabel(const std::string& separator) const
+std::string CPVREpgInfoTag::GetCastLabel(const std::string& separator) const
 {
   // Note: see CVideoInfoTag::GetCast for reference implementation.
   const std::string sep{separator.empty() ? "\n" : separator};
   return StringUtils::Join(m_cast, sep);
 }
 
-const std::string CPVREpgInfoTag::GetDirectorsLabel(const std::string& separator) const
+std::string CPVREpgInfoTag::GetDirectorsLabel(const std::string& separator) const
 {
   const std::string sep{
       separator.empty()
@@ -377,7 +377,7 @@ const std::string CPVREpgInfoTag::GetDirectorsLabel(const std::string& separator
   return StringUtils::Join(m_directors, sep);
 }
 
-const std::string CPVREpgInfoTag::GetWritersLabel(const std::string& separator) const
+std::string CPVREpgInfoTag::GetWritersLabel(const std::string& separator) const
 {
   const std::string sep{
       separator.empty()
@@ -386,7 +386,7 @@ const std::string CPVREpgInfoTag::GetWritersLabel(const std::string& separator) 
   return StringUtils::Join(m_writers, sep);
 }
 
-const std::string CPVREpgInfoTag::GetGenresLabel(const std::string& separator) const
+std::string CPVREpgInfoTag::GetGenresLabel(const std::string& separator) const
 {
   const std::string sep{
       separator.empty()
@@ -544,7 +544,7 @@ bool CPVREpgInfoTag::Update(const CPVREpgInfoTag& tag, bool bUpdateBroadcastId /
   return bChanged;
 }
 
-bool CPVREpgInfoTag::QueuePersistQuery(const std::shared_ptr<CPVREpgDatabase>& database)
+bool CPVREpgInfoTag::QueuePersistQuery(const std::shared_ptr<CPVREpgDatabase>& database) const
 {
   if (!database)
   {
@@ -658,12 +658,12 @@ bool CPVREpgInfoTag::IsLive() const
   return (m_iFlags & EPG_TAG_FLAG_IS_LIVE) > 0;
 }
 
-const std::vector<std::string> CPVREpgInfoTag::Tokenize(const std::string& str)
+std::vector<std::string> CPVREpgInfoTag::Tokenize(const std::string& str)
 {
   return StringUtils::Split(str, EPG_STRING_TOKEN_SEPARATOR);
 }
 
-const std::string CPVREpgInfoTag::DeTokenize(const std::vector<std::string>& tokens)
+std::string CPVREpgInfoTag::DeTokenize(const std::vector<std::string>& tokens)
 {
   return StringUtils::Join(tokens, EPG_STRING_TOKEN_SEPARATOR);
 }

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -70,7 +70,6 @@ public:
   void SetChannelData(const std::shared_ptr<CPVREpgChannelData>& data);
 
   bool operator==(const CPVREpgInfoTag& right) const;
-  bool operator!=(const CPVREpgInfoTag& right) const;
 
   // ISerializable implementation
   void Serialize(CVariant& value) const override;
@@ -242,28 +241,28 @@ public:
    * @param separator The separator for the different cast members, default value if empty.
    * @return The cast label.
    */
-  const std::string GetCastLabel(const std::string& separator) const;
+  std::string GetCastLabel(const std::string& separator) const;
 
   /*!
    * @brief Get the director(s) of this event as formatted string.
    * @param separator The separator for the different directors, default value if empty.
    * @return The directors label.
    */
-  const std::string GetDirectorsLabel(const std::string& separator) const;
+  std::string GetDirectorsLabel(const std::string& separator) const;
 
   /*!
    * @brief Get the writer(s) of this event as formatted string.
    * @param separator The separator for the different writers, default value if empty.
    * @return The writers label.
    */
-  const std::string GetWritersLabel(const std::string& separator) const;
+  std::string GetWritersLabel(const std::string& separator) const;
 
   /*!
    * @brief Get the genre(s) of this event as formatted string.
    * @param separator The separator for the different genres, default value if empty.
    * @return The genres label.
    */
-  const std::string GetGenresLabel(const std::string& separator) const;
+  std::string GetGenresLabel(const std::string& separator) const;
 
   /*!
    * @brief Get the year of this event.
@@ -407,7 +406,7 @@ public:
    * @param database The database.
    * @return True on success, false otherwise.
    */
-  bool QueuePersistQuery(const std::shared_ptr<CPVREpgDatabase>& database);
+  bool QueuePersistQuery(const std::shared_ptr<CPVREpgDatabase>& database) const;
 
   /*!
    * @brief Update the information in this tag with the info in the given tag.
@@ -484,7 +483,7 @@ public:
    * @param str The string to tokenize.
    * @return the tokens.
    */
-  static const std::vector<std::string> Tokenize(const std::string& str);
+  static std::vector<std::string> Tokenize(const std::string& str);
 
   /*!
    * @brief Combine the given strings to a single string. Inserts EPG_STRING_TOKEN_SEPARATOR as
@@ -492,7 +491,7 @@ public:
    * @param tokens The tokens.
    * @return the combined string.
    */
-  static const std::string DeTokenize(const std::vector<std::string>& tokens);
+  static std::string DeTokenize(const std::vector<std::string>& tokens);
 
 private:
   CPVREpgInfoTag(int iEpgID,

--- a/xbmc/pvr/epg/EpgSearchFilter.cpp
+++ b/xbmc/pvr/epg/EpgSearchFilter.cpp
@@ -61,7 +61,7 @@ std::string CPVREpgSearchFilter::GetPath() const
   return CPVREpgSearchPath(*this).GetPath();
 }
 
-void CPVREpgSearchFilter::SetSearchTerm(const std::string& strSearchTerm)
+void CPVREpgSearchFilter::SetSearchTerm(std::string_view strSearchTerm)
 {
   if (m_searchData.m_strSearchTerm != strSearchTerm)
   {
@@ -256,7 +256,7 @@ void CPVREpgSearchFilter::SetDatabaseId(int iDatabaseId)
   }
 }
 
-void CPVREpgSearchFilter::SetTitle(const std::string& title)
+void CPVREpgSearchFilter::SetTitle(std::string_view title)
 {
   if (m_title != title)
   {
@@ -265,7 +265,7 @@ void CPVREpgSearchFilter::SetTitle(const std::string& title)
   }
 }
 
-void CPVREpgSearchFilter::SetIconPath(const std::string& iconPath)
+void CPVREpgSearchFilter::SetIconPath(std::string_view iconPath)
 {
   if (m_iconPath != iconPath)
   {

--- a/xbmc/pvr/epg/EpgSearchFilter.h
+++ b/xbmc/pvr/epg/EpgSearchFilter.h
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace PVR
@@ -64,7 +65,7 @@ public:
   bool IsRadio() const { return m_bIsRadio; }
 
   const std::string& GetSearchTerm() const { return m_searchData.m_strSearchTerm; }
-  void SetSearchTerm(const std::string& strSearchTerm);
+  void SetSearchTerm(std::string_view strSearchTerm);
 
   void SetSearchPhrase(const std::string& strSearchPhrase);
 
@@ -129,10 +130,10 @@ public:
   void SetDatabaseId(int iDatabaseId);
 
   const std::string& GetTitle() const { return m_title; }
-  void SetTitle(const std::string& title);
+  void SetTitle(std::string_view title);
 
   const std::string& GetIconPath() const { return m_iconPath; }
-  void SetIconPath(const std::string& iconPath);
+  void SetIconPath(std::string_view iconPath);
 
   const CDateTime& GetLastExecutedDateTime() const { return m_lastExecutedDateTime; }
   void SetLastExecutedDateTime(const CDateTime& lastExecutedDateTime);

--- a/xbmc/pvr/epg/EpgTagsContainer.h
+++ b/xbmc/pvr/epg/EpgTagsContainer.h
@@ -156,7 +156,7 @@ public:
    * @brief Get the start and end time of the last not yet committed entry in this EPG.
    * @return The times; first: start time, second: end time.
    */
-  std::pair<CDateTime, CDateTime> GetFirstAndLastUncommitedEPGDate() const;
+  std::pair<CDateTime, CDateTime> GetFirstAndLastUncommittedEPGDate() const;
 
   /*!
    * @brief Check whether this container has unsaved data.

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.h
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -133,7 +134,7 @@ public:
    * @param channel the channel's path.
    * @return true if the selection was set to the given channel, false otherwise.
    */
-  bool SetChannel(const std::string& channel);
+  bool SetChannel(std::string_view channel);
 
   /*!
    * @brief Set the control's selection to the given channel and set the control's view port to show the channel.
@@ -142,12 +143,12 @@ public:
    */
   bool SetChannel(const CPVRChannelNumber& channelNumber);
 
-  virtual void AssignDepth() override;
+  void AssignDepth() override;
 
-  void AssignItemDepth(CGUIListItem* item, bool focused);
+  void AssignItemDepth(CGUIListItem* item, bool focused) const;
 
 private:
-  bool OnClick(int actionID);
+  bool OnClick(int actionID) const;
   bool SelectItemFromPoint(const CPoint& point, bool justGrid = true);
 
   void SetChannel(int channel);
@@ -186,14 +187,14 @@ private:
                    unsigned int currentTime,
                    CDirtyRegionList& dirtyregions,
                    float resize = -1.0f);
-  void RenderItem(float posX, float posY, CGUIListItem* item, bool focused);
+  void RenderItem(float posX, float posY, CGUIListItem* item, bool focused) const;
   void GetCurrentLayouts();
 
   void ProcessChannels(unsigned int currentTime, CDirtyRegionList& dirtyregions);
   void ProcessRuler(unsigned int currentTime, CDirtyRegionList& dirtyregions);
   void ProcessRulerDate(unsigned int currentTime, CDirtyRegionList& dirtyregions);
   void ProcessProgrammeGrid(unsigned int currentTime, CDirtyRegionList& dirtyregions);
-  void ProcessProgressIndicator(unsigned int currentTime, CDirtyRegionList& dirtyregions);
+  void ProcessProgressIndicator(unsigned int currentTime);
   void RenderChannels();
   void RenderRulerDate();
   void RenderRuler();
@@ -220,13 +221,13 @@ private:
 
   int m_pageControl = 0;
 
-  void GetChannelCacheOffsets(int& cacheBefore, int& cacheAfter);
-  void GetProgrammeCacheOffsets(int& cacheBefore, int& cacheAfter);
+  void GetChannelCacheOffsets(int& cacheBefore, int& cacheAfter) const;
+  void GetProgrammeCacheOffsets(int& cacheBefore, int& cacheAfter) const;
 
 private:
   bool OnMouseClick(int dwButton, const CPoint& point);
   bool OnMouseDoubleClick(int dwButton, const CPoint& point);
-  bool OnMouseWheel(char wheel, const CPoint& point);
+  bool OnMouseWheel(char wheel);
 
   void HandleChannels(bool bRender,
                       unsigned int currentTime,
@@ -253,7 +254,7 @@ private:
 
   float GetChannelScrollOffsetPos() const;
   float GetProgrammeScrollOffsetPos() const;
-  int GetChannelScrollOffset(CGUIListItemLayout* layout) const;
+  int GetChannelScrollOffset(const CGUIListItemLayout& layout) const;
   int GetProgrammeScrollOffset() const;
 
   int GetBlockScrollOffset() const;
@@ -273,22 +274,22 @@ private:
   int m_cacheProgrammeItems;
   int m_cacheRulerItems;
 
-  float m_rulerDateHeight = 0; //! height of ruler date item
-  float m_rulerDateWidth = 0; //! width of ruler date item
-  float m_rulerPosX = 0; //! X position of first ruler item
-  float m_rulerPosY = 0; //! Y position of first ruler item
-  float m_rulerHeight = 0; //! height of the scrolling timeline above the ruler items
-  float m_rulerWidth = 0; //! width of each element of the ruler
-  float m_channelPosX = 0; //! X position of first channel row
-  float m_channelPosY = 0; //! Y position of first channel row
-  float m_channelHeight = 0; //! height of the channel item
-  float m_channelWidth = 0; //! width of the channel item
-  float m_gridPosX = 0; //! X position of first grid item
-  float m_gridPosY = 0; //! Y position of first grid item
-  float m_gridWidth = 0; //! width of the epg grid control
-  float m_gridHeight = 0; //! height of the epg grid control
-  float m_blockSize = 0; //! a block's width in pixels
-  float m_analogScrollCount = 0;
+  float m_rulerDateHeight{0.0f}; //! height of ruler date item
+  float m_rulerDateWidth{0.0f}; //! width of ruler date item
+  float m_rulerPosX{0.0f}; //! X position of first ruler item
+  float m_rulerPosY{0.0f}; //! Y position of first ruler item
+  float m_rulerHeight{0.0f}; //! height of the scrolling timeline above the ruler items
+  float m_rulerWidth{0.0f}; //! width of each element of the ruler
+  float m_channelPosX{0.0f}; //! X position of first channel row
+  float m_channelPosY{0.0f}; //! Y position of first channel row
+  float m_channelHeight{0.0f}; //! height of the channel item
+  float m_channelWidth{0.0f}; //! width of the channel item
+  float m_gridPosX{0.0f}; //! X position of first grid item
+  float m_gridPosY{0.0f}; //! Y position of first grid item
+  float m_gridWidth{0.0f}; //! width of the epg grid control
+  float m_gridHeight{0.0f}; //! height of the epg grid control
+  float m_blockSize{0.0f}; //! a block's width in pixels
+  float m_analogScrollCount{0.0f};
 
   std::unique_ptr<CGUITexture> m_guiProgressIndicatorTexture;
   uint32_t m_guiProgressIndicatorTextureDepth{0};
@@ -301,13 +302,13 @@ private:
 
   int m_scrollTime;
 
-  int m_programmeScrollLastTime = 0;
-  float m_programmeScrollSpeed = 0;
-  float m_programmeScrollOffset = 0;
+  unsigned int m_programmeScrollLastTime{0};
+  float m_programmeScrollSpeed{0.0f};
+  float m_programmeScrollOffset{0.0f};
 
-  int m_channelScrollLastTime = 0;
-  float m_channelScrollSpeed = 0;
-  float m_channelScrollOffset = 0;
+  unsigned int m_channelScrollLastTime{0};
+  float m_channelScrollSpeed{0.0f};
+  float m_channelScrollOffset{0.0f};
 
   mutable CCriticalSection m_critSection;
   std::unique_ptr<CGUIEPGGridContainerModel> m_gridModel;

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
@@ -58,7 +58,7 @@ public:
                   int iBlocksPerPage,
                   int blocksPerRulerItem,
                   float fBlockSize);
-  void SetInvalid();
+  void SetInvalid() const;
 
   static const int INVALID_INDEX = -1;
   void FindChannelAndBlockIndex(int channelUid,
@@ -130,7 +130,7 @@ private:
   using EpgTagsMap = std::unordered_map<int, EpgTags>;
 
   std::shared_ptr<CFileItem> CreateEpgTags(int iChannel, int iBlock) const;
-  std::shared_ptr<CFileItem> GetEpgTags(EpgTagsMap::iterator& itEpg,
+  std::shared_ptr<CFileItem> GetEpgTags(const EpgTagsMap::iterator& itEpg,
                                         int iChannel,
                                         int iBlock) const;
   std::shared_ptr<CFileItem> GetEpgTagsBefore(EpgTags& epgTags, int iChannel, int iBlock) const;
@@ -148,10 +148,7 @@ private:
   {
     GridCoordinates(int _channel, int _block) : channel(_channel), block(_block) {}
 
-    bool operator==(const GridCoordinates& other) const
-    {
-      return (channel == other.channel && block == other.block);
-    }
+    bool operator==(const GridCoordinates& other) const = default;
 
     int channel = 0;
     int block = 0;

--- a/xbmc/pvr/guilib/PVRGUIActionListener.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionListener.cpp
@@ -118,17 +118,19 @@ bool CPVRGUIActionListener::OnAction(const CAction& action)
         case ACTION_PVR_PLAY:
           if (!bIsPlayingPVR)
             CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
-                PlaybackTypeAny);
+                PlaybackType::TYPE_ANY);
           break;
         case ACTION_PVR_PLAY_TV:
           if (!bIsPlayingPVR || g_application.CurrentFileItem().GetPVRChannelInfoTag()->IsRadio())
             CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
-                PlaybackTypeTV);
+                PlaybackType::TYPE_TV);
           break;
         case ACTION_PVR_PLAY_RADIO:
           if (!bIsPlayingPVR || !g_application.CurrentFileItem().GetPVRChannelInfoTag()->IsRadio())
             CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
-                PlaybackTypeRadio);
+                PlaybackType::TYPE_RADIO);
+          break;
+        default:
           break;
       }
       return true;
@@ -280,8 +282,8 @@ bool CPVRGUIActionListener::OnAction(const CAction& action)
       if (!bIsPlayingPVR)
         return false;
 
-      int iChannelNumber = static_cast<int>(action.GetAmount(0));
-      int iSubChannelNumber = static_cast<int>(action.GetAmount(1));
+      const auto iChannelNumber{static_cast<int>(action.GetAmount(0))};
+      const auto iSubChannelNumber{static_cast<int>(action.GetAmount(1))};
 
       const std::shared_ptr<const CPVRPlaybackState> playbackState =
           CServiceBroker::GetPVRManager().PlaybackState();
@@ -309,6 +311,9 @@ bool CPVRGUIActionListener::OnAction(const CAction& action)
       CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().AnnounceReminders();
       return true;
     }
+
+    default:
+      break;
   }
   return false;
 }

--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.h
@@ -11,11 +11,11 @@
 #include "pvr/IPVRComponent.h"
 #include "pvr/PVRChannelNumberInputHandler.h"
 #include "pvr/guilib/PVRGUIChannelNavigator.h"
-#include "pvr/settings/PVRSettings.h"
 #include "threads/CriticalSection.h"
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 class CFileItem;
@@ -24,6 +24,7 @@ namespace PVR
 {
 class CPVRChannel;
 class CPVRChannelGroupMember;
+class CPVRSettings;
 
 class CPVRChannelSwitchingInputHandler : public CPVRChannelNumberInputHandler
 {
@@ -38,12 +39,12 @@ private:
    * @brief Switch to the channel with the given number.
    * @param channelNumber the channel number
    */
-  void SwitchToChannel(const CPVRChannelNumber& channelNumber);
+  void SwitchToChannel(const CPVRChannelNumber& channelNumber) const;
 
   /*!
    * @brief Switch to the previously played channel.
    */
-  void SwitchToPreviousChannel();
+  void SwitchToPreviousChannel() const;
 };
 
 class CPVRGUIActionsChannels : public IPVRComponent
@@ -156,7 +157,7 @@ public:
    * @param bRadio True to set the selected path for PVR radio, false for Live TV.
    * @param path The new path to set.
    */
-  void SetSelectedChannelPath(bool bRadio, const std::string& path);
+  void SetSelectedChannelPath(bool bRadio, std::string_view path);
 
 private:
   CPVRGUIActionsChannels(const CPVRGUIActionsChannels&) = delete;
@@ -168,7 +169,7 @@ private:
   CEventSource<PVRChannelNumberInputChangedEvent> m_events;
 
   mutable CCriticalSection m_critSection;
-  CPVRSettings m_settings;
+  std::unique_ptr<CPVRSettings> m_settings;
   std::string m_selectedChannelPathTV;
   std::string m_selectedChannelPathRadio;
 };

--- a/xbmc/pvr/guilib/PVRGUIActionsClients.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsClients.h
@@ -22,7 +22,7 @@ public:
    * @brief Select and invoke client-specific settings actions
    * @return true on success, false otherwise.
    */
-  bool ProcessSettingsMenuHooks();
+  bool ProcessSettingsMenuHooks() const;
 
 private:
   CPVRGUIActionsClients(const CPVRGUIActionsClients&) = delete;

--- a/xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
@@ -58,49 +58,47 @@ public:
 
     CFileItemList options;
 
-    const std::shared_ptr<CFileItem> itemAll =
-        std::make_shared<CFileItem>(StringUtils::Format(g_localizeStrings.Get(593))); // All
+    const auto itemAll{
+        std::make_shared<CFileItem>(StringUtils::Format(g_localizeStrings.Get(593)))}; // All
     itemAll->SetPath("all");
     options.Add(itemAll);
 
     // if channels are cleared, groups, EPG data and providers must also be cleared
-    const std::shared_ptr<CFileItem> itemChannels =
-        std::make_shared<CFileItem>(StringUtils::Format("{}, {}, {}, {}",
-                                                        g_localizeStrings.Get(19019), // Channels
-                                                        g_localizeStrings.Get(19146), // Groups
-                                                        g_localizeStrings.Get(19069), // Guide
-                                                        g_localizeStrings.Get(19334))); // Providers
+    const auto itemChannels{std::make_shared<CFileItem>(
+        StringUtils::Format("{}, {}, {}, {}",
+                            g_localizeStrings.Get(19019), // Channels
+                            g_localizeStrings.Get(19146), // Groups
+                            g_localizeStrings.Get(19069), // Guide
+                            g_localizeStrings.Get(19334)))}; // Providers
     itemChannels->SetPath("channels");
     itemChannels->Select(true); // preselect this item in dialog
     options.Add(itemChannels);
 
-    const std::shared_ptr<CFileItem> itemGroups =
-        std::make_shared<CFileItem>(g_localizeStrings.Get(19146)); // Groups
+    const auto itemGroups{std::make_shared<CFileItem>(g_localizeStrings.Get(19146))}; // Groups
     itemGroups->SetPath("groups");
     options.Add(itemGroups);
 
-    const std::shared_ptr<CFileItem> itemGuide =
-        std::make_shared<CFileItem>(g_localizeStrings.Get(19069)); // Guide
+    const auto itemGuide{std::make_shared<CFileItem>(g_localizeStrings.Get(19069))}; // Guide
     itemGuide->SetPath("guide");
     options.Add(itemGuide);
 
-    const std::shared_ptr<CFileItem> itemProviders =
-        std::make_shared<CFileItem>(g_localizeStrings.Get(19334)); // Providers
+    const auto itemProviders{
+        std::make_shared<CFileItem>(g_localizeStrings.Get(19334))}; // Providers
     itemProviders->SetPath("providers");
     options.Add(itemProviders);
 
-    const std::shared_ptr<CFileItem> itemReminders =
-        std::make_shared<CFileItem>(g_localizeStrings.Get(19215)); // Reminders
+    const auto itemReminders{
+        std::make_shared<CFileItem>(g_localizeStrings.Get(19215))}; // Reminders
     itemReminders->SetPath("reminders");
     options.Add(itemReminders);
 
-    const std::shared_ptr<CFileItem> itemRecordings =
-        std::make_shared<CFileItem>(g_localizeStrings.Get(19017)); // Recordings
+    const auto itemRecordings{
+        std::make_shared<CFileItem>(g_localizeStrings.Get(19017))}; // Recordings
     itemRecordings->SetPath("recordings");
     options.Add(itemRecordings);
 
-    const std::shared_ptr<CFileItem> itemClients =
-        std::make_shared<CFileItem>(g_localizeStrings.Get(24019)); // PVR clients
+    const auto itemClients{
+        std::make_shared<CFileItem>(g_localizeStrings.Get(24019))}; // PVR clients
     itemClients->SetPath("clients");
     options.Add(itemClients);
 
@@ -154,7 +152,7 @@ private:
 
 } // unnamed namespace
 
-bool CPVRGUIActionsDatabase::ResetDatabase(bool bResetEPGOnly)
+bool CPVRGUIActionsDatabase::ResetDatabase(bool bResetEPGOnly) const
 {
   CGUIDialogProgress* pDlgProgress =
       CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogProgress>(
@@ -237,8 +235,9 @@ bool CPVRGUIActionsDatabase::ResetDatabase(bool bResetEPGOnly)
   CServiceBroker::GetPVRManager().Stop();
 
   const int iProgressStepPercentage =
-      100 / ((2 * bResetChannels) + bResetGroups + bResetGuide + bResetProviders + bResetReminders +
-             bResetRecordings + bResetClients + 1);
+      100 / ((2 * bResetChannels) + (bResetGroups ? 1 : 0) + (bResetGuide ? 1 : 0) +
+             (bResetProviders ? 1 : 0) + (bResetReminders ? 1 : 0) + (bResetRecordings ? 1 : 0) +
+             (bResetClients ? 1 : 0) + 1);
   int iProgressStepsDone = 0;
 
   if (bResetProviders)

--- a/xbmc/pvr/guilib/PVRGUIActionsDatabase.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsDatabase.h
@@ -24,7 +24,7 @@ public:
    * database.
    * @return true on success, false otherwise.
    */
-  bool ResetDatabase(bool bResetEPGOnly);
+  bool ResetDatabase(bool bResetEPGOnly) const;
 
 private:
   CPVRGUIActionsDatabase(const CPVRGUIActionsDatabase&) = delete;

--- a/xbmc/pvr/guilib/PVRGUIActionsEPG.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsEPG.cpp
@@ -47,7 +47,7 @@ PVR::CGUIWindowPVRSearchBase* GetSearchWindow(bool bRadio)
 
   PVR::CGUIWindowPVRSearchBase* windowSearch;
 
-  CGUIWindowManager& windowMgr = CServiceBroker::GetGUI()->GetWindowManager();
+  const CGUIWindowManager& windowMgr = CServiceBroker::GetGUI()->GetWindowManager();
   if (bRadio)
     windowSearch = windowMgr.GetWindow<PVR::CGUIWindowPVRRadioSearch>(windowSearchId);
   else
@@ -143,7 +143,7 @@ bool CPVRGUIActionsEPG::FindSimilar(const CFileItem& item) const
   return true;
 };
 
-bool CPVRGUIActionsEPG::ExecuteSavedSearch(const CFileItem& item)
+bool CPVRGUIActionsEPG::ExecuteSavedSearch(const CFileItem& item) const
 {
   const auto searchFilter = item.GetEPGSearchFilter();
 
@@ -162,7 +162,7 @@ bool CPVRGUIActionsEPG::ExecuteSavedSearch(const CFileItem& item)
   return true;
 }
 
-bool CPVRGUIActionsEPG::EditSavedSearch(const CFileItem& item)
+bool CPVRGUIActionsEPG::EditSavedSearch(const CFileItem& item) const
 {
   const auto searchFilter = item.GetEPGSearchFilter();
 
@@ -182,7 +182,7 @@ bool CPVRGUIActionsEPG::EditSavedSearch(const CFileItem& item)
   return true;
 }
 
-bool CPVRGUIActionsEPG::RenameSavedSearch(const CFileItem& item)
+bool CPVRGUIActionsEPG::RenameSavedSearch(const CFileItem& item) const
 {
   const auto searchFilter = item.GetEPGSearchFilter();
 
@@ -204,7 +204,7 @@ bool CPVRGUIActionsEPG::RenameSavedSearch(const CFileItem& item)
   return false;
 }
 
-bool CPVRGUIActionsEPG::ChooseIconForSavedSearch(const CFileItem& item)
+bool CPVRGUIActionsEPG::ChooseIconForSavedSearch(const CFileItem& item) const
 {
   const auto searchFilter{item.GetEPGSearchFilter()};
 
@@ -249,7 +249,7 @@ bool CPVRGUIActionsEPG::ChooseIconForSavedSearch(const CFileItem& item)
   return true;
 }
 
-bool CPVRGUIActionsEPG::DuplicateSavedSearch(const CFileItem& item)
+bool CPVRGUIActionsEPG::DuplicateSavedSearch(const CFileItem& item) const
 {
   const auto searchFilter{item.GetEPGSearchFilter()};
 
@@ -267,7 +267,7 @@ bool CPVRGUIActionsEPG::DuplicateSavedSearch(const CFileItem& item)
   return true;
 }
 
-bool CPVRGUIActionsEPG::DeleteSavedSearch(const CFileItem& item)
+bool CPVRGUIActionsEPG::DeleteSavedSearch(const CFileItem& item) const
 {
   const auto searchFilter = item.GetEPGSearchFilter();
 
@@ -286,7 +286,8 @@ bool CPVRGUIActionsEPG::DeleteSavedSearch(const CFileItem& item)
   return false;
 }
 
-std::string CPVRGUIActionsEPG::GetTitleForEpgTag(const std::shared_ptr<const CPVREpgInfoTag>& tag)
+std::string CPVRGUIActionsEPG::GetTitleForEpgTag(
+    const std::shared_ptr<const CPVREpgInfoTag>& tag) const
 {
   if (tag)
   {

--- a/xbmc/pvr/guilib/PVRGUIActionsEPG.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsEPG.h
@@ -52,42 +52,42 @@ public:
    * @param item The item containing a search filter.
    * @return True on success, false otherwise.
    */
-  bool ExecuteSavedSearch(const CFileItem& item);
+  bool ExecuteSavedSearch(const CFileItem& item) const;
 
   /*!
    * @brief Edit a saved search. Opens the search dialog.
    * @param item The item containing a search filter.
    * @return True on success, false otherwise.
    */
-  bool EditSavedSearch(const CFileItem& item);
+  bool EditSavedSearch(const CFileItem& item) const;
 
   /*!
    * @brief Rename a saved search. Opens a title input dialog.
    * @param item The item containing a search filter.
    * @return True on success, false otherwise.
    */
-  bool RenameSavedSearch(const CFileItem& item);
+  bool RenameSavedSearch(const CFileItem& item) const;
 
   /*!
    * @brief Choose an icon for a saved search. Opens an art chooser dialog.
    * @param item The item containing a search filter.
    * @return True on success, false otherwise.
    */
-  bool ChooseIconForSavedSearch(const CFileItem& item);
+  bool ChooseIconForSavedSearch(const CFileItem& item) const;
 
   /*!
    * @brief Duplicate a saved search.
    * @param item The item containing a search filter.
    * @return True on success, false otherwise.
    */
-  bool DuplicateSavedSearch(const CFileItem& item);
+  bool DuplicateSavedSearch(const CFileItem& item) const;
 
   /*!
    * @brief Delete a saved search. Opens confirmation dialog before deleting.
    * @param item The item containing a search filter.
    * @return True on success, false otherwise.
    */
-  bool DeleteSavedSearch(const CFileItem& item);
+  bool DeleteSavedSearch(const CFileItem& item) const;
 
   /*!
    * @brief Get the title for the given EPG tag, taking settings and parental controls into account.
@@ -97,7 +97,7 @@ public:
    * SETTING_EPG_HIDENOINFOAVAILABLE is false or tag is nullptr, the real EPG event title as given
    * by the EPG data provider otherwise.
    */
-  std::string GetTitleForEpgTag(const std::shared_ptr<const CPVREpgInfoTag>& tag);
+  std::string GetTitleForEpgTag(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
 
 private:
   CPVRGUIActionsEPG(const CPVRGUIActionsEPG&) = delete;

--- a/xbmc/pvr/guilib/PVRGUIActionsParentalControl.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsParentalControl.cpp
@@ -14,6 +14,7 @@
 #include "messaging/helpers/DialogOKHelper.h"
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannel.h"
+#include "pvr/settings/PVRSettings.h"
 #include "settings/Settings.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
@@ -25,9 +26,12 @@ using namespace PVR;
 using namespace KODI::MESSAGING;
 
 CPVRGUIActionsParentalControl::CPVRGUIActionsParentalControl()
-  : m_settings({CSettings::SETTING_PVRPARENTAL_PIN, CSettings::SETTING_PVRPARENTAL_ENABLED})
+  : m_settings(std::make_unique<CPVRSettings>(std::set<std::string>(
+        {CSettings::SETTING_PVRPARENTAL_PIN, CSettings::SETTING_PVRPARENTAL_ENABLED})))
 {
 }
+
+CPVRGUIActionsParentalControl::~CPVRGUIActionsParentalControl() = default;
 
 ParentalCheckResult CPVRGUIActionsParentalControl::CheckParentalLock(
     const std::shared_ptr<const CPVRChannel>& channel) const
@@ -46,10 +50,10 @@ ParentalCheckResult CPVRGUIActionsParentalControl::CheckParentalLock(
 
 ParentalCheckResult CPVRGUIActionsParentalControl::CheckParentalPIN() const
 {
-  if (!m_settings.GetBoolValue(CSettings::SETTING_PVRPARENTAL_ENABLED))
+  if (!m_settings->GetBoolValue(CSettings::SETTING_PVRPARENTAL_ENABLED))
     return ParentalCheckResult::SUCCESS;
 
-  std::string pinCode = m_settings.GetStringValue(CSettings::SETTING_PVRPARENTAL_PIN);
+  std::string pinCode{m_settings->GetStringValue(CSettings::SETTING_PVRPARENTAL_PIN)};
   if (pinCode.empty())
     return ParentalCheckResult::SUCCESS;
 

--- a/xbmc/pvr/guilib/PVRGUIActionsParentalControl.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsParentalControl.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "pvr/IPVRComponent.h"
-#include "pvr/settings/PVRSettings.h"
 
 #include <memory>
 
@@ -23,12 +22,13 @@ enum class ParentalCheckResult
 };
 
 class CPVRChannel;
+class CPVRSettings;
 
 class CPVRGUIActionsParentalControl : public IPVRComponent
 {
 public:
   CPVRGUIActionsParentalControl();
-  ~CPVRGUIActionsParentalControl() override = default;
+  ~CPVRGUIActionsParentalControl() override;
 
   /*!
    * @brief Check if channel is parental locked. Ask for PIN if necessary.
@@ -47,7 +47,7 @@ private:
   CPVRGUIActionsParentalControl(const CPVRGUIActionsParentalControl&) = delete;
   CPVRGUIActionsParentalControl const& operator=(CPVRGUIActionsParentalControl const&) = delete;
 
-  CPVRSettings m_settings;
+  std::unique_ptr<CPVRSettings> m_settings;
 };
 
 namespace GUI

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.h
@@ -9,27 +9,29 @@
 #pragma once
 
 #include "pvr/IPVRComponent.h"
-#include "pvr/settings/PVRSettings.h"
 #include "utils/ContentUtils.h"
 
+#include <memory>
 #include <string>
 
 class CFileItem;
 
 namespace PVR
 {
-enum PlaybackType
+class CPVRSettings;
+
+enum class PlaybackType
 {
-  PlaybackTypeAny = 0,
-  PlaybackTypeTV,
-  PlaybackTypeRadio
+  TYPE_ANY,
+  TYPE_TV,
+  TYPE_RADIO,
 };
 
 class CPVRGUIActionsPlayback : public IPVRComponent
 {
 public:
   CPVRGUIActionsPlayback();
-  ~CPVRGUIActionsPlayback() override = default;
+  ~CPVRGUIActionsPlayback() override;
 
   /*!
    * @brief Play recording.
@@ -81,7 +83,7 @@ public:
    * playing event. If there is no next event, seek to the end of the currently playing event (to
    * the 'live' position).
    */
-  void SeekForward();
+  void SeekForward() const;
 
   /*!
    * @brief Seek to the start of the previous epg event in timeshift buffer, relative to the
@@ -90,7 +92,7 @@ public:
    * @param iThreshold the value in seconds to trigger seek to start of current event instead of
    * start of previous event.
    */
-  void SeekBackward(unsigned int iThreshold);
+  void SeekBackward(unsigned int iThreshold) const;
 
 private:
   CPVRGUIActionsPlayback(const CPVRGUIActionsPlayback&) = delete;
@@ -102,7 +104,7 @@ private:
    */
   void CheckAndSwitchToFullscreen(bool bFullscreen) const;
 
-  CPVRSettings m_settings;
+  std::unique_ptr<CPVRSettings> m_settings;
 };
 
 namespace GUI

--- a/xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
@@ -15,6 +15,7 @@
 #include "network/Network.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClient.h"
+#include "pvr/settings/PVRSettings.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/timers/PVRTimers.h"
 #include "settings/Settings.h"
@@ -29,10 +30,13 @@ using namespace PVR;
 using namespace KODI::MESSAGING;
 
 CPVRGUIActionsPowerManagement::CPVRGUIActionsPowerManagement()
-  : m_settings({CSettings::SETTING_PVRPOWERMANAGEMENT_DAILYWAKEUPTIME,
-                CSettings::SETTING_PVRPOWERMANAGEMENT_BACKENDIDLETIME})
+  : m_settings(std::make_unique<CPVRSettings>(
+        std::set<std::string>({CSettings::SETTING_PVRPOWERMANAGEMENT_DAILYWAKEUPTIME,
+                               CSettings::SETTING_PVRPOWERMANAGEMENT_BACKENDIDLETIME})))
 {
 }
+
+CPVRGUIActionsPowerManagement::~CPVRGUIActionsPowerManagement() = default;
 
 bool CPVRGUIActionsPowerManagement::CanSystemPowerdown(bool bAskUser /*= true*/) const
 {
@@ -91,7 +95,7 @@ bool CPVRGUIActionsPowerManagement::CanSystemPowerdown(bool bAskUser /*= true*/)
 
           CDateTime dailywakeuptime;
           dailywakeuptime.SetFromDBTime(
-              m_settings.GetStringValue(CSettings::SETTING_PVRPOWERMANAGEMENT_DAILYWAKEUPTIME));
+              m_settings->GetStringValue(CSettings::SETTING_PVRPOWERMANAGEMENT_DAILYWAKEUPTIME));
           dailywakeuptime = dailywakeuptime.GetAsUTCDateTime();
 
           const CDateTimeSpan diff(dailywakeuptime - now);
@@ -182,7 +186,7 @@ bool CPVRGUIActionsPowerManagement::IsNextEventWithinBackendIdleTime() const
   // timers going off soon?
   const CDateTime now(CDateTime::GetUTCDateTime());
   const CDateTimeSpan idle(
-      0, 0, m_settings.GetIntValue(CSettings::SETTING_PVRPOWERMANAGEMENT_BACKENDIDLETIME), 0);
+      0, 0, m_settings->GetIntValue(CSettings::SETTING_PVRPOWERMANAGEMENT_BACKENDIDLETIME), 0);
   const CDateTime next(CServiceBroker::GetPVRManager().Timers()->GetNextEventTime());
   const CDateTimeSpan delta(next - now);
 

--- a/xbmc/pvr/guilib/PVRGUIActionsPowerManagement.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsPowerManagement.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "pvr/IPVRComponent.h"
-#include "pvr/settings/PVRSettings.h"
 
 #include <memory>
 
@@ -17,13 +16,14 @@ class CFileItem;
 
 namespace PVR
 {
+class CPVRSettings;
 class CPVRTimerInfoTag;
 
 class CPVRGUIActionsPowerManagement : public IPVRComponent
 {
 public:
   CPVRGUIActionsPowerManagement();
-  ~CPVRGUIActionsPowerManagement() override = default;
+  ~CPVRGUIActionsPowerManagement() override;
 
   /*!
    * @brief Check whether the system Kodi is running on can be powered down
@@ -43,7 +43,7 @@ private:
   bool EventOccursOnLocalBackend(const std::shared_ptr<CPVRTimerInfoTag>& event) const;
   bool IsNextEventWithinBackendIdleTime() const;
 
-  CPVRSettings m_settings;
+  std::unique_ptr<CPVRSettings> m_settings;
 };
 
 namespace GUI

--- a/xbmc/pvr/guilib/PVRGUIActionsRecordings.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsRecordings.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "pvr/IPVRComponent.h"
-#include "pvr/settings/PVRSettings.h"
 
 #include <memory>
 
@@ -18,12 +17,13 @@ class CFileItem;
 namespace PVR
 {
 class CPVRRecording;
+class CPVRSettings;
 
 class CPVRGUIActionsRecordings : public IPVRComponent
 {
 public:
   CPVRGUIActionsRecordings();
-  ~CPVRGUIActionsRecordings() override = default;
+  ~CPVRGUIActionsRecordings() override;
 
   /*!
    * @brief Open a dialog with information for a given recording.
@@ -127,7 +127,7 @@ private:
    */
   bool ProcessDeleteAfterWatch(const CFileItem& item) const;
 
-  CPVRSettings m_settings;
+  std::unique_ptr<CPVRSettings> m_settings;
 };
 
 namespace GUI

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "pvr/IPVRComponent.h"
-#include "pvr/settings/PVRSettings.h"
 
 #include <memory>
 
@@ -18,13 +17,14 @@ class CFileItem;
 namespace PVR
 {
 class CPVRChannel;
+class CPVRSettings;
 class CPVRTimerInfoTag;
 
 class CPVRGUIActionsTimers : public IPVRComponent
 {
 public:
   CPVRGUIActionsTimers();
-  ~CPVRGUIActionsTimers() override = default;
+  ~CPVRGUIActionsTimers() override;
 
   /*!
    * @brief Open the timer settings dialog to create a new tv or radio timer.
@@ -138,7 +138,7 @@ public:
    * @param bOnOff True to start recording, false to stop.
    * @return True if the recording was started or stopped successfully, false otherwise.
    */
-  bool SetRecordingOnChannel(const std::shared_ptr<CPVRChannel>& channel, bool bOnOff);
+  bool SetRecordingOnChannel(const std::shared_ptr<CPVRChannel>& channel, bool bOnOff) const;
 
   /*!
    * @brief Stop a currently active recording, always showing a confirmation dialog.
@@ -222,7 +222,7 @@ private:
    */
   void AnnounceReminder(const std::shared_ptr<CPVRTimerInfoTag>& timer) const;
 
-  CPVRSettings m_settings;
+  std::unique_ptr<CPVRSettings> m_settings;
   mutable bool m_bReminderAnnouncementRunning{false};
 };
 

--- a/xbmc/pvr/guilib/PVRGUIActionsUtils.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsUtils.cpp
@@ -28,7 +28,7 @@ bool CPVRGUIActionsUtils::HasInfoForItem(const CFileItem& item) const
          item.HasPVRTimerInfoTag() || item.HasEPGSearchFilter();
 }
 
-bool CPVRGUIActionsUtils::OnInfo(const CFileItem& item)
+bool CPVRGUIActionsUtils::OnInfo(const CFileItem& item) const
 {
   if (item.HasPVRRecordingInfoTag())
   {
@@ -90,7 +90,7 @@ std::shared_ptr<CFileItem> LoadChannelItem(const CFileItem& item)
 }
 } // unnamed namespace
 
-std::shared_ptr<CFileItem> CPVRGUIActionsUtils::LoadItem(const CFileItem& item)
+std::shared_ptr<CFileItem> CPVRGUIActionsUtils::LoadItem(const CFileItem& item) const
 {
   std::shared_ptr<CFileItem> loadedItem{LoadRecordingFileOrFolderItem(item)};
   if (loadedItem)

--- a/xbmc/pvr/guilib/PVRGUIActionsUtils.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsUtils.h
@@ -34,14 +34,14 @@ public:
      * @param item The item.
      * @return True on success, false otherwise.
      */
-  bool OnInfo(const CFileItem& item);
+  bool OnInfo(const CFileItem& item) const;
 
   /*!
    * @brief Load item details (create recording info tag etc.).
    * @param item The item.
    * @return Loaded item on success, nullptr otherwise.
    */
-  std::shared_ptr<CFileItem> LoadItem(const CFileItem& item);
+  std::shared_ptr<CFileItem> LoadItem(const CFileItem& item) const;
 
 private:
   CPVRGUIActionsUtils(const CPVRGUIActionsUtils&) = delete;

--- a/xbmc/pvr/guilib/PVRGUIChannelIconUpdater.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelIconUpdater.cpp
@@ -70,7 +70,8 @@ void CPVRGUIChannelIconUpdater::SearchAndUpdateMissingChannelIcons() const
     {
       const std::shared_ptr<CPVRChannel> channel = member->Channel();
 
-      progressHandler->UpdateProgress(channel->ChannelName(), channelIndex++, members.size());
+      progressHandler->UpdateProgress(channel->ChannelName(), channelIndex, members.size());
+      channelIndex++;
 
       // skip if an icon is already set and exists
       if (CFileUtils::Exists(channel->IconPath()))

--- a/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
@@ -218,7 +218,7 @@ void CPVRGUIChannelNavigator::SelectChannel(
       if (m_iChannelEntryJobId >= 0)
         CServiceBroker::GetJobManager()->CancelJob(m_iChannelEntryJobId);
 
-      CPVRChannelEntryTimeoutJob* job = new CPVRChannelEntryTimeoutJob(*this, timeout);
+      auto* job = new CPVRChannelEntryTimeoutJob(*this, timeout);
       m_iChannelEntryJobId =
           CServiceBroker::GetJobManager()->AddJob(job, dynamic_cast<IJobCallback*>(job));
     }
@@ -289,7 +289,7 @@ void CPVRGUIChannelNavigator::ShowInfo(bool bForce)
 
     if (!bForce && timeout > 0s)
     {
-      CPVRChannelInfoTimeoutJob* job = new CPVRChannelInfoTimeoutJob(*this, timeout);
+      auto* job{new CPVRChannelInfoTimeoutJob(*this, timeout)};
       m_iChannelInfoJobId =
           CServiceBroker::GetJobManager()->AddJob(job, dynamic_cast<IJobCallback*>(job));
     }

--- a/xbmc/pvr/guilib/PVRGUIChannelNavigator.h
+++ b/xbmc/pvr/guilib/PVRGUIChannelNavigator.h
@@ -13,16 +13,10 @@
 
 #include <memory>
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 struct PlayerShowInfoChangedEvent;
 }
-} // namespace GUILIB
-} // namespace KODI
 
 namespace PVR
 {

--- a/xbmc/pvr/guilib/PVRGUIProgressHandler.cpp
+++ b/xbmc/pvr/guilib/PVRGUIProgressHandler.cpp
@@ -29,7 +29,7 @@ CPVRGUIProgressHandler::CPVRGUIProgressHandler(const std::string& strTitle)
 {
 }
 
-void CPVRGUIProgressHandler::UpdateProgress(const std::string& strText, float fProgress)
+void CPVRGUIProgressHandler::UpdateProgress(std::string_view strText, float fProgress)
 {
   std::unique_lock lock(m_critSection);
   m_bChanged = true;
@@ -43,7 +43,7 @@ void CPVRGUIProgressHandler::UpdateProgress(const std::string& strText, float fP
   }
 }
 
-void CPVRGUIProgressHandler::UpdateProgress(const std::string& text,
+void CPVRGUIProgressHandler::UpdateProgress(std::string_view text,
                                             size_t currentValue,
                                             size_t maxValue)
 {

--- a/xbmc/pvr/guilib/PVRGUIProgressHandler.h
+++ b/xbmc/pvr/guilib/PVRGUIProgressHandler.h
@@ -12,6 +12,7 @@
 #include "threads/Thread.h"
 
 #include <string>
+#include <string_view>
 
 namespace PVR
 {
@@ -33,7 +34,7 @@ namespace PVR
      * @param strText The new progress text.
      * @param fProgress The new progress value, in a range from 0.0 to 100.0.
      */
-    void UpdateProgress(const std::string& strText, float fProgress);
+    void UpdateProgress(std::string_view strText, float fProgress);
 
     /*!
      * @brief Update the progress dialogs's content.
@@ -41,7 +42,7 @@ namespace PVR
      * @param currentValue The new current progress value, must be less or equal iMax.
      * @param maxValue The new maximum progress value, must be greater or equal iCurrent.
      */
-    void UpdateProgress(const std::string& text, size_t currentValue, size_t maxValue);
+    void UpdateProgress(std::string_view text, size_t currentValue, size_t maxValue);
 
   protected:
     // CThread implementation

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -108,12 +108,12 @@ void CPVRGUIInfo::ResetProperties()
   m_bRegistered = false;
 }
 
-void CPVRGUIInfo::ClearQualityInfo(CPVRSignalStatus& qualityInfo)
+void CPVRGUIInfo::ClearQualityInfo(CPVRSignalStatus& qualityInfo) const
 {
-  qualityInfo = {g_localizeStrings.Get(13106).c_str(), g_localizeStrings.Get(13106).c_str()};
+  qualityInfo = {g_localizeStrings.Get(13106), g_localizeStrings.Get(13106)};
 }
 
-void CPVRGUIInfo::ClearDescrambleInfo(CPVRDescrambleInfo& descrambleInfo)
+void CPVRGUIInfo::ClearDescrambleInfo(CPVRDescrambleInfo& descrambleInfo) const
 {
   descrambleInfo = {};
 }
@@ -627,6 +627,8 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
         StringUtils::Replace(strValue, "\n", ", ");
         return true;
       }
+      default:
+        break;
     }
     return false;
   }
@@ -645,6 +647,8 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
           strValue = g_localizeStrings.Get(10006); // "N/A"
         return true;
       }
+      default:
+        break;
     }
     return false;
   }
@@ -671,10 +675,14 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
             case CPVRChannelGroup::Origin::USER:
               strValue = g_localizeStrings.Get(858); // User
               return true;
+            default:
+              break;
           }
         }
         break;
       }
+      default:
+        break;
     }
     return false;
   }
@@ -725,6 +733,8 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
         // associated with the epg event of a timer, if any, and not the title of the timer.
         strValue = CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().GetTitleForEpgTag(epgTag);
         return true;
+      default:
+        break;
     }
   }
 
@@ -905,6 +915,8 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
         StringUtils::Replace(strValue, "\n", ", ");
         return true;
       }
+      default:
+        break;
     }
   }
 
@@ -981,6 +993,8 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
             return true;
           }
         }
+        break;
+      default:
         break;
     }
   }
@@ -1221,6 +1235,8 @@ bool CPVRGUIInfo::GetPVRLabel(const CFileItem* item,
     case PVR_CHANNEL_NUMBER_INPUT:
       strValue = m_channelNumberInput;
       return true;
+    default:
+      break;
   }
 
   return false;
@@ -1363,6 +1379,8 @@ bool CPVRGUIInfo::GetRadioRDSLabel(const CFileItem* item,
       case RDS_GET_RADIOTEXT_LINE:
         strValue = tag->GetRadioText(info.GetData1());
         return true;
+      default:
+        break;
     }
   }
   return false;
@@ -1403,7 +1421,7 @@ bool CPVRGUIInfo::GetInt(int& value,
   if (!item->IsFileItem())
     return false;
 
-  const CFileItem* fitem = static_cast<const CFileItem*>(item);
+  const auto* fitem{static_cast<const CFileItem*>(item)};
   return GetListItemAndPlayerInt(fitem, info, value) || GetPVRInt(fitem, info, value);
 }
 
@@ -1421,6 +1439,8 @@ bool CPVRGUIInfo::GetListItemAndPlayerInt(const CFileItem* item,
           iValue = static_cast<int>(epgTag->ProgressPercentage());
       }
       return true;
+    default:
+      break;
   }
   return false;
 }
@@ -1485,6 +1505,8 @@ bool CPVRGUIInfo::GetPVRInt(const CFileItem* item, const CGUIInfo& info, int& iV
     case PVR_CLIENT_COUNT:
       iValue = static_cast<int>(CServiceBroker::GetPVRManager().Clients()->EnabledClientAmount());
       return true;
+    default:
+      break;
   }
   return false;
 }
@@ -1497,7 +1519,7 @@ bool CPVRGUIInfo::GetBool(bool& value,
   if (!item->IsFileItem())
     return false;
 
-  const CFileItem* fitem = static_cast<const CFileItem*>(item);
+  const auto* fitem{static_cast<const CFileItem*>(item)};
   return GetListItemAndPlayerBool(fitem, info, value) || GetPVRBool(fitem, info, value) ||
          GetRadioRDSBool(fitem, info, value);
 }
@@ -1803,6 +1825,8 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
         return true;
       }
       break;
+    default:
+      break;
   }
   return false;
 }
@@ -1873,6 +1897,8 @@ bool CPVRGUIInfo::GetPVRBool(const CFileItem* item, const CGUIInfo& info, bool& 
     case PVR_IS_PLAYING_ACTIVE_RECORDING:
       bValue = m_bIsPlayingActiveRecording;
       return true;
+    default:
+      break;
   }
   return false;
 }
@@ -1901,6 +1927,8 @@ bool CPVRGUIInfo::GetRadioRDSBool(const CFileItem* item, const CGUIInfo& info, b
         bValue = (!tag->GetEMailStudio().empty() || !tag->GetSMSStudio().empty() ||
                   !tag->GetPhoneStudio().empty());
         return true;
+      default:
+        break;
     }
   }
 
@@ -1913,6 +1941,8 @@ bool CPVRGUIInfo::GetRadioRDSBool(const CFileItem* item, const CGUIInfo& info, b
       bValue = appPlayer->IsPlayingRDS();
       return true;
     }
+    default:
+      break;
   }
 
   return false;
@@ -2206,7 +2236,7 @@ int CPVRGUIInfo::GetTimeShiftSeekPercent() const
   {
     int total = m_timesInfo.GetTimeshiftProgressDuration();
 
-    const double totalTime = static_cast<double>(total);
+    const auto totalTime{static_cast<double>(total)};
     if (totalTime == 0.0)
       return 0;
 

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
@@ -23,16 +23,10 @@
 
 class CFileItem;
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 class CGUIInfo;
 }
-} // namespace GUILIB
-} // namespace KODI
 
 namespace PVR
 {
@@ -90,8 +84,8 @@ public:
 
 private:
   void ResetProperties();
-  void ClearQualityInfo(CPVRSignalStatus& qualityInfo);
-  void ClearDescrambleInfo(CPVRDescrambleInfo& descrambleInfo);
+  void ClearQualityInfo(CPVRSignalStatus& qualityInfo) const;
+  void ClearDescrambleInfo(CPVRDescrambleInfo& descrambleInfo) const;
 
   void Process() override;
 

--- a/xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.cpp
@@ -66,7 +66,8 @@ bool CPVRGUITimerInfo::TimerInfoToggle()
   {
     unsigned int iPrevious = m_iTimerInfoToggleCurrent;
     unsigned int iBoundary = m_iRecordingTimerAmount > 0 ? m_iRecordingTimerAmount : m_iTimerAmount;
-    if (++m_iTimerInfoToggleCurrent > iBoundary - 1)
+    m_iTimerInfoToggleCurrent++;
+    if (m_iTimerInfoToggleCurrent > iBoundary - 1)
       m_iTimerInfoToggleCurrent = 0;
 
     if (m_iTimerInfoToggleCurrent != iPrevious)

--- a/xbmc/pvr/guilib/guiinfo/PVRGUITimesInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUITimesInfo.cpp
@@ -117,8 +117,10 @@ void CPVRGUITimesInfo::UpdateTimeshiftData()
   }
 
   time_t now = std::time(nullptr);
-  time_t iStartTime;
-  int64_t iPlayTime, iMinTime, iMaxTime;
+  time_t iStartTime{0};
+  int64_t iPlayTime{0};
+  int64_t iMinTime{0};
+  int64_t iMaxTime{0};
   CServiceBroker::GetDataCacheCore().GetPlayTimes(iStartTime, iPlayTime, iMinTime, iMaxTime);
   bool bPlaying = CServiceBroker::GetDataCacheCore().GetSpeed() == 1.0f;
   const std::shared_ptr<const CPVRChannel> playingChannel =

--- a/xbmc/pvr/providers/PVRProvider.cpp
+++ b/xbmc/pvr/providers/PVRProvider.cpp
@@ -65,11 +65,6 @@ bool CPVRProvider::operator==(const CPVRProvider& right) const
   return (m_iUniqueId == right.m_iUniqueId && m_iClientId == right.m_iClientId);
 }
 
-bool CPVRProvider::operator!=(const CPVRProvider& right) const
-{
-  return !(*this == right);
-}
-
 void CPVRProvider::Serialize(CVariant& value) const
 {
   value["providerid"] = m_iDatabaseId;
@@ -198,12 +193,12 @@ bool CPVRProvider::SetIconPath(const std::string& strIconPath)
 namespace
 {
 
-const std::vector<std::string> Tokenize(const std::string& str)
+std::vector<std::string> Tokenize(const std::string& str)
 {
   return StringUtils::Split(str, PROVIDER_STRING_TOKEN_SEPARATOR);
 }
 
-const std::string DeTokenize(const std::vector<std::string>& tokens)
+std::string DeTokenize(const std::vector<std::string>& tokens)
 {
   return StringUtils::Join(tokens, PROVIDER_STRING_TOKEN_SEPARATOR);
 }

--- a/xbmc/pvr/providers/PVRProvider.h
+++ b/xbmc/pvr/providers/PVRProvider.h
@@ -43,7 +43,6 @@ public:
                const std::string& addonThumbPath);
 
   bool operator==(const CPVRProvider& right) const;
-  bool operator!=(const CPVRProvider& right) const;
 
   void Serialize(CVariant& value) const override;
 

--- a/xbmc/pvr/providers/PVRProviders.h
+++ b/xbmc/pvr/providers/PVRProviders.h
@@ -118,7 +118,7 @@ public:
   /**
      * @brief Persist user changes to the current state of the providers in the DB.
      */
-  bool PersistUserChanges(const std::vector<std::shared_ptr<CPVRProvider>>& providers);
+  bool PersistUserChanges(const std::vector<std::shared_ptr<CPVRProvider>>& providers) const;
 
   /*!
      * @brief Get a provider given it's database ID

--- a/xbmc/pvr/providers/PVRProvidersPath.cpp
+++ b/xbmc/pvr/providers/PVRProvidersPath.cpp
@@ -32,9 +32,8 @@ CPVRProvidersPath::CPVRProvidersPath(CPVRProvidersPath::Kind kind,
                                      int clientId,
                                      int providerUid,
                                      const std::string& lastSegment /* = "" */)
+  : m_isValid((kind == Kind::RADIO) || (kind == Kind::TV)), m_kind(kind)
 {
-  m_kind = kind;
-  m_isValid = ((m_kind == Kind::RADIO) || (m_kind == Kind::TV));
   if (m_isValid)
   {
     if (lastSegment.empty())

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -201,11 +201,6 @@ bool CPVRRecording::operator==(const CPVRRecording& right) const
           m_titleExtraInfo == right.m_titleExtraInfo);
 }
 
-bool CPVRRecording::operator!=(const CPVRRecording& right) const
-{
-  return !(*this == right);
-}
-
 void CPVRRecording::Serialize(CVariant& value) const
 {
   CVideoInfoTag::Serialize(value);
@@ -287,19 +282,19 @@ void CPVRRecording::Reset()
   CVideoInfoTag::Reset();
 }
 
-bool CPVRRecording::Delete()
+bool CPVRRecording::Delete() const
 {
   std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
   return client && (client->DeleteRecording(*this) == PVR_ERROR_NO_ERROR);
 }
 
-bool CPVRRecording::Undelete()
+bool CPVRRecording::Undelete() const
 {
   const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
   return client && (client->UndeleteRecording(*this) == PVR_ERROR_NO_ERROR);
 }
 
-bool CPVRRecording::Rename(const std::string& strNewName)
+bool CPVRRecording::Rename(std::string_view strNewName)
 {
   m_strTitle = strNewName;
   const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
@@ -377,7 +372,7 @@ CBookmark CPVRRecording::GetResumePoint() const
       CBookmark resumePoint(CVideoInfoTag::GetResumePoint());
       resumePoint.timeInSeconds = pos;
       resumePoint.totalTimeInSeconds = (pos == 0) ? 0 : m_duration;
-      CPVRRecording* pThis = const_cast<CPVRRecording*>(this);
+      auto* pThis{const_cast<CPVRRecording*>(this)};
       pThis->CVideoInfoTag::SetResumePoint(resumePoint);
     }
   }
@@ -429,7 +424,7 @@ void CPVRRecording::UpdateMetadata(CVideoDatabase& db, const CPVRClient& client)
   m_bGotMetaData = true;
 }
 
-void CPVRRecording::DeleteMetadata(CVideoDatabase& db)
+void CPVRRecording::DeleteMetadata(CVideoDatabase& db) const
 {
   db.BeginTransaction();
   if (db.EraseAllForFile(m_strFileNameAndPath))
@@ -657,7 +652,7 @@ void CPVRRecording::SetGenre(int iGenreType, int iGenreSubType, const std::strin
   }
 }
 
-const std::string CPVRRecording::GetGenresLabel() const
+std::string CPVRRecording::GetGenresLabel() const
 {
   return StringUtils::Join(
       m_genre, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 class CVideoDatabase;
@@ -63,7 +64,6 @@ public:
   CPVRRecording(const PVR_RECORDING& recording, unsigned int iClientId);
 
   bool operator==(const CPVRRecording& right) const;
-  bool operator!=(const CPVRRecording& right) const;
 
   void Serialize(CVariant& value) const override;
 
@@ -73,26 +73,26 @@ public:
   /*!
    * @brief Reset this tag to it's initial state.
    */
-  void Reset();
+  void Reset() override;
 
   /*!
    * @brief Delete this recording on the client (if supported).
    * @return True if it was deleted successfully, false otherwise.
    */
-  bool Delete();
+  bool Delete() const;
 
   /*!
    * @brief Undelete this recording on the client (if supported).
    * @return True if it was undeleted successfully, false otherwise.
    */
-  bool Undelete();
+  bool Undelete() const;
 
   /*!
    * @brief Rename this recording on the client (if supported).
    * @param strNewName The new name.
    * @return True if it was renamed successfully, false otherwise.
    */
-  bool Rename(const std::string& strNewName);
+  bool Rename(std::string_view strNewName);
 
   /*!
    * @brief Set this recording's play count. The value will be transferred to the backend if it supports server-side play counts.
@@ -136,7 +136,7 @@ public:
    */
   bool SetResumePoint(double timeInSeconds,
                       double totalTimeInSeconds,
-                      const std::string& playerState = "") override;
+                      const std::string& playerState) override;
 
   /*!
    * @brief Get this recording's resume point. The value will be obtained from the backend if it supports server-side resume points.
@@ -174,7 +174,7 @@ public:
    * @brief Delete metadata like the resume point and play count from the database.
    * @param db The database to delete the data from.
    */
-  void DeleteMetadata(CVideoDatabase& db);
+  void DeleteMetadata(CVideoDatabase& db) const;
 
   /*!
    * @brief Update this tag with the contents of the given tag.
@@ -408,7 +408,7 @@ public:
    * @brief Get the genre(s) of this recording as formatted string.
    * @return The genres label.
    */
-  const std::string GetGenresLabel() const;
+  std::string GetGenresLabel() const;
 
   /*!
    * @brief Get the first air date of this recording.

--- a/xbmc/pvr/recordings/PVRRecordingsPath.cpp
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.cpp
@@ -105,7 +105,7 @@ CPVRRecordingsPath::CPVRRecordingsPath(bool bDeleted,
   strTitleN = CURL::Encode(strTitleN);
 
   std::string strSeasonEpisodeN;
-  if ((iSeason > -1 && iEpisode > -1 && (iSeason > 0 || iEpisode > 0)))
+  if (iSeason > -1 && iEpisode > -1 && (iSeason > 0 || iEpisode > 0))
     strSeasonEpisodeN = StringUtils::Format("s{:02}e{:02}", iSeason, iEpisode);
   if (!strSeasonEpisodeN.empty())
     strSeasonEpisodeN = StringUtils::Format(" {}", strSeasonEpisodeN);
@@ -181,7 +181,7 @@ std::string CPVRRecordingsPath::GetUnescapedSubDirectoryPath(const std::string& 
   return strReturn;
 }
 
-const std::string CPVRRecordingsPath::GetTitle() const
+std::string CPVRRecordingsPath::GetTitle() const
 {
   if (m_bValid)
   {

--- a/xbmc/pvr/recordings/PVRRecordingsPath.h
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.h
@@ -50,7 +50,7 @@ public:
   std::string GetUnescapedDirectoryPath() const;
   std::string GetUnescapedSubDirectoryPath(const std::string& strPath) const;
 
-  const std::string GetTitle() const;
+  std::string GetTitle() const;
   void AppendSegment(const std::string& strSegment);
 
 private:

--- a/xbmc/pvr/settings/PVRCustomTimerSettings.h
+++ b/xbmc/pvr/settings/PVRCustomTimerSettings.h
@@ -13,6 +13,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -40,9 +41,9 @@ public:
   void AddSettings(IPVRSettingsContainer& settingsContainer,
                    const std::shared_ptr<CSettingGroup>& group);
 
-  bool IsCustomSetting(const std::string& settingId) const;
-  bool IsCustomIntSetting(const std::string& settingId) const;
-  bool IsCustomStringSetting(const std::string& settingId) const;
+  bool IsCustomSetting(std::string_view settingId) const;
+  bool IsCustomIntSetting(std::string_view settingId) const;
+  bool IsCustomStringSetting(std::string_view settingId) const;
 
   const CPVRTimerInfoTag::CustomPropsMap& GetProperties() const { return m_customProps; }
 

--- a/xbmc/pvr/settings/PVRIntSettingDefinition.cpp
+++ b/xbmc/pvr/settings/PVRIntSettingDefinition.cpp
@@ -19,15 +19,4 @@ CPVRIntSettingDefinition::CPVRIntSettingDefinition(const PVR_INT_SETTING_DEFINIT
     m_maxValue{def.iMaxValue}
 {
 }
-
-bool CPVRIntSettingDefinition::operator==(const CPVRIntSettingDefinition& right) const
-{
-  return (m_values == right.m_values && m_minValue == right.m_minValue && m_step == right.m_step &&
-          m_maxValue == right.m_maxValue);
-}
-
-bool CPVRIntSettingDefinition::operator!=(const CPVRIntSettingDefinition& right) const
-{
-  return !(*this == right);
-}
 } // namespace PVR

--- a/xbmc/pvr/settings/PVRIntSettingDefinition.h
+++ b/xbmc/pvr/settings/PVRIntSettingDefinition.h
@@ -24,8 +24,7 @@ public:
 
   virtual ~CPVRIntSettingDefinition() = default;
 
-  bool operator==(const CPVRIntSettingDefinition& right) const;
-  bool operator!=(const CPVRIntSettingDefinition& right) const;
+  bool operator==(const CPVRIntSettingDefinition& right) const = default;
 
   const std::vector<SettingIntValue>& GetValues() const { return m_values.GetValues(); }
   int GetDefaultValue() const { return m_values.GetDefaultValue(); }

--- a/xbmc/pvr/settings/PVRIntSettingValues.cpp
+++ b/xbmc/pvr/settings/PVRIntSettingValues.cpp
@@ -16,7 +16,7 @@
 
 namespace PVR
 {
-CPVRIntSettingValues::CPVRIntSettingValues(struct PVR_ATTRIBUTE_INT_VALUE* values,
+CPVRIntSettingValues::CPVRIntSettingValues(const struct PVR_ATTRIBUTE_INT_VALUE* values,
                                            unsigned int valuesSize,
                                            int defaultValue,
                                            int defaultDescriptionResourceId /* = 0 */)

--- a/xbmc/pvr/settings/PVRIntSettingValues.h
+++ b/xbmc/pvr/settings/PVRIntSettingValues.h
@@ -23,7 +23,7 @@ class CPVRIntSettingValues
 public:
   CPVRIntSettingValues() = default;
   explicit CPVRIntSettingValues(int defaultValue);
-  CPVRIntSettingValues(struct PVR_ATTRIBUTE_INT_VALUE* values,
+  CPVRIntSettingValues(const struct PVR_ATTRIBUTE_INT_VALUE* values,
                        unsigned int valuesSize,
                        int defaultValue,
                        int defaultDescriptionResourceId = 0);

--- a/xbmc/pvr/settings/PVRSettings.cpp
+++ b/xbmc/pvr/settings/PVRSettings.cpp
@@ -97,8 +97,8 @@ void CPVRSettings::OnSettingsLoaded()
 
   {
     std::unique_lock lock(m_critSection);
-    for (const auto& settingName : m_settings)
-      settingNames.insert(settingName.first);
+    for (const auto& [settingName, _] : m_settings)
+      settingNames.insert(settingName);
 
     m_settings.clear();
   }

--- a/xbmc/pvr/settings/PVRStringSettingDefinition.cpp
+++ b/xbmc/pvr/settings/PVRStringSettingDefinition.cpp
@@ -17,14 +17,4 @@ CPVRStringSettingDefinition::CPVRStringSettingDefinition(const PVR_STRING_SETTIN
     m_allowEmptyValue{def.bAllowEmptyValue}
 {
 }
-
-bool CPVRStringSettingDefinition::operator==(const CPVRStringSettingDefinition& right) const
-{
-  return (m_values == right.m_values && m_allowEmptyValue == right.m_allowEmptyValue);
-}
-
-bool CPVRStringSettingDefinition::operator!=(const CPVRStringSettingDefinition& right) const
-{
-  return !(*this == right);
-}
 } // namespace PVR

--- a/xbmc/pvr/settings/PVRStringSettingDefinition.h
+++ b/xbmc/pvr/settings/PVRStringSettingDefinition.h
@@ -24,8 +24,7 @@ public:
 
   virtual ~CPVRStringSettingDefinition() = default;
 
-  bool operator==(const CPVRStringSettingDefinition& right) const;
-  bool operator!=(const CPVRStringSettingDefinition& right) const;
+  bool operator==(const CPVRStringSettingDefinition& right) const = default;
 
   const std::vector<SettingStringValue>& GetValues() const { return m_values.GetValues(); }
   const std::string& GetDefaultValue() const { return m_values.GetDefaultValue(); }

--- a/xbmc/pvr/settings/PVRStringSettingValues.cpp
+++ b/xbmc/pvr/settings/PVRStringSettingValues.cpp
@@ -16,7 +16,7 @@
 
 namespace PVR
 {
-CPVRStringSettingValues::CPVRStringSettingValues(struct PVR_ATTRIBUTE_STRING_VALUE* values,
+CPVRStringSettingValues::CPVRStringSettingValues(const struct PVR_ATTRIBUTE_STRING_VALUE* values,
                                                  unsigned int valuesSize,
                                                  const std::string& defaultValue,
                                                  int defaultDescriptionResourceId /* = 0 */)

--- a/xbmc/pvr/settings/PVRStringSettingValues.h
+++ b/xbmc/pvr/settings/PVRStringSettingValues.h
@@ -22,7 +22,7 @@ class CPVRStringSettingValues
 {
 public:
   CPVRStringSettingValues() = default;
-  CPVRStringSettingValues(struct PVR_ATTRIBUTE_STRING_VALUE* values,
+  CPVRStringSettingValues(const struct PVR_ATTRIBUTE_STRING_VALUE* values,
                           unsigned int valuesSize,
                           const std::string& defaultValue,
                           int defaultDescriptionResourceId = 0);

--- a/xbmc/pvr/settings/PVRTimerSettingDefinition.cpp
+++ b/xbmc/pvr/settings/PVRTimerSettingDefinition.cpp
@@ -61,11 +61,6 @@ bool CPVRTimerSettingDefinition::operator==(const CPVRTimerSettingDefinition& ri
           m_stringDefinition == right.m_stringDefinition);
 }
 
-bool CPVRTimerSettingDefinition::operator!=(const CPVRTimerSettingDefinition& right) const
-{
-  return !(*this == right);
-}
-
 CVariant CPVRTimerSettingDefinition::GetDefaultValue() const
 {
   if (GetType() == PVR_SETTING_TYPE::INTEGER)

--- a/xbmc/pvr/settings/PVRTimerSettingDefinition.h
+++ b/xbmc/pvr/settings/PVRTimerSettingDefinition.h
@@ -39,7 +39,6 @@ public:
   virtual ~CPVRTimerSettingDefinition() = default;
 
   bool operator==(const CPVRTimerSettingDefinition& right) const;
-  bool operator!=(const CPVRTimerSettingDefinition& right) const;
 
   int GetClientId() const { return m_clientId; }
   unsigned int GetTimerTypeId() const { return m_timerTypeId; }

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -46,7 +46,6 @@ public:
                    unsigned int iClientId);
 
   bool operator==(const CPVRTimerInfoTag& right) const;
-  bool operator!=(const CPVRTimerInfoTag& right) const;
 
   // ISerializable implementation
   void Serialize(CVariant& value) const override;
@@ -194,7 +193,7 @@ public:
    * @brief Gets the type of this timer.
    * @return the timer type or NULL if this tag has no timer type.
    */
-  const std::shared_ptr<CPVRTimerType> GetTimerType() const { return m_timerType; }
+  std::shared_ptr<CPVRTimerType> GetTimerType() const { return m_timerType; }
 
   /*!
    * @brief Sets the type of this timer.
@@ -523,10 +522,7 @@ public:
     PVR_SETTING_TYPE type{PVR_SETTING_TYPE::INTEGER};
     CVariant value;
 
-    bool operator==(const CustomPropDetails& right) const
-    {
-      return type == right.type && value == right.value;
-    }
+    bool operator==(const CustomPropDetails& right) const = default;
   };
 
   /*!
@@ -565,7 +561,7 @@ public:
    * the backend.
    * @return True on success, false otherwise.
    */
-  bool UpdateOnClient();
+  bool UpdateOnClient() const;
 
   /*!
    * @brief Persist this timer in the local database.

--- a/xbmc/pvr/timers/PVRTimerType.cpp
+++ b/xbmc/pvr/timers/PVRTimerType.cpp
@@ -18,7 +18,6 @@
 #include "utils/log.h"
 
 #include <algorithm>
-#include <iterator>
 #include <memory>
 #include <string>
 #include <utility>
@@ -26,7 +25,7 @@
 
 using namespace PVR;
 
-const std::vector<std::shared_ptr<CPVRTimerType>> CPVRTimerType::GetAllTypes()
+std::vector<std::shared_ptr<CPVRTimerType>> CPVRTimerType::GetAllTypes()
 {
   std::vector<std::shared_ptr<CPVRTimerType>> allTypes =
       CServiceBroker::GetPVRManager().Clients()->GetTimerTypes();
@@ -35,47 +34,52 @@ const std::vector<std::shared_ptr<CPVRTimerType>> CPVRTimerType::GetAllTypes()
   int iTypeId = PVR_TIMER_TYPE_NONE;
 
   // one time time-based reminder
+  iTypeId++;
   allTypes.emplace_back(std::make_shared<CPVRTimerType>(
-      ++iTypeId, PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_IS_REMINDER |
-                     PVR_TIMER_TYPE_SUPPORTS_CHANNELS | PVR_TIMER_TYPE_SUPPORTS_START_TIME |
-                     PVR_TIMER_TYPE_SUPPORTS_END_TIME));
+      iTypeId, PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_IS_REMINDER |
+                   PVR_TIMER_TYPE_SUPPORTS_CHANNELS | PVR_TIMER_TYPE_SUPPORTS_START_TIME |
+                   PVR_TIMER_TYPE_SUPPORTS_END_TIME));
 
   // one time epg-based reminder
+  iTypeId++;
   allTypes.emplace_back(std::make_shared<CPVRTimerType>(
-      ++iTypeId, PVR_TIMER_TYPE_IS_REMINDER | PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
-                     PVR_TIMER_TYPE_SUPPORTS_CHANNELS | PVR_TIMER_TYPE_SUPPORTS_START_TIME |
-                     PVR_TIMER_TYPE_SUPPORTS_START_MARGIN));
+      iTypeId, PVR_TIMER_TYPE_IS_REMINDER | PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
+                   PVR_TIMER_TYPE_SUPPORTS_CHANNELS | PVR_TIMER_TYPE_SUPPORTS_START_TIME |
+                   PVR_TIMER_TYPE_SUPPORTS_START_MARGIN));
 
   // time-based reminder rule
+  iTypeId++;
   allTypes.emplace_back(std::make_shared<CPVRTimerType>(
-      ++iTypeId, PVR_TIMER_TYPE_IS_REPEATING | PVR_TIMER_TYPE_IS_MANUAL |
-                     PVR_TIMER_TYPE_IS_REMINDER | PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
-                     PVR_TIMER_TYPE_SUPPORTS_CHANNELS | PVR_TIMER_TYPE_SUPPORTS_START_TIME |
-                     PVR_TIMER_TYPE_SUPPORTS_END_TIME | PVR_TIMER_TYPE_SUPPORTS_FIRST_DAY |
-                     PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS));
+      iTypeId, PVR_TIMER_TYPE_IS_REPEATING | PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_IS_REMINDER |
+                   PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE | PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
+                   PVR_TIMER_TYPE_SUPPORTS_START_TIME | PVR_TIMER_TYPE_SUPPORTS_END_TIME |
+                   PVR_TIMER_TYPE_SUPPORTS_FIRST_DAY | PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS));
 
   // one time read-only time-based reminder (created by timer rule)
+  iTypeId++;
   allTypes.emplace_back(std::make_shared<CPVRTimerType>(
-      ++iTypeId,
+      iTypeId,
       PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_IS_REMINDER |
           PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE | PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
           PVR_TIMER_TYPE_SUPPORTS_START_TIME | PVR_TIMER_TYPE_SUPPORTS_END_TIME,
       g_localizeStrings.Get(819))); // One time (Scheduled by timer rule)
 
   // epg-based reminder rule
+  iTypeId++;
   allTypes.emplace_back(std::make_shared<CPVRTimerType>(
-      ++iTypeId, PVR_TIMER_TYPE_IS_REPEATING | PVR_TIMER_TYPE_IS_REMINDER |
-                     PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
-                     PVR_TIMER_TYPE_SUPPORTS_TITLE_EPG_MATCH |
-                     PVR_TIMER_TYPE_SUPPORTS_FULLTEXT_EPG_MATCH | PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
-                     PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL | PVR_TIMER_TYPE_SUPPORTS_START_TIME |
-                     PVR_TIMER_TYPE_SUPPORTS_START_ANYTIME | PVR_TIMER_TYPE_SUPPORTS_END_TIME |
-                     PVR_TIMER_TYPE_SUPPORTS_END_ANYTIME | PVR_TIMER_TYPE_SUPPORTS_FIRST_DAY |
-                     PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS | PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN));
+      iTypeId, PVR_TIMER_TYPE_IS_REPEATING | PVR_TIMER_TYPE_IS_REMINDER |
+                   PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
+                   PVR_TIMER_TYPE_SUPPORTS_TITLE_EPG_MATCH |
+                   PVR_TIMER_TYPE_SUPPORTS_FULLTEXT_EPG_MATCH | PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
+                   PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL | PVR_TIMER_TYPE_SUPPORTS_START_TIME |
+                   PVR_TIMER_TYPE_SUPPORTS_START_ANYTIME | PVR_TIMER_TYPE_SUPPORTS_END_TIME |
+                   PVR_TIMER_TYPE_SUPPORTS_END_ANYTIME | PVR_TIMER_TYPE_SUPPORTS_FIRST_DAY |
+                   PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS | PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN));
 
   // one time read-only epg-based reminder (created by timer rule)
+  iTypeId++;
   allTypes.emplace_back(std::make_shared<CPVRTimerType>(
-      ++iTypeId,
+      iTypeId,
       PVR_TIMER_TYPE_IS_REMINDER | PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
           PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE | PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
           PVR_TIMER_TYPE_SUPPORTS_START_TIME | PVR_TIMER_TYPE_SUPPORTS_START_MARGIN,
@@ -84,7 +88,7 @@ const std::vector<std::shared_ptr<CPVRTimerType>> CPVRTimerType::GetAllTypes()
   return allTypes;
 }
 
-const std::shared_ptr<CPVRTimerType> CPVRTimerType::GetFirstAvailableType(
+std::shared_ptr<CPVRTimerType> CPVRTimerType::GetFirstAvailableType(
     const std::shared_ptr<const CPVRClient>& client)
 {
   if (client)
@@ -101,10 +105,9 @@ const std::shared_ptr<CPVRTimerType> CPVRTimerType::GetFirstAvailableType(
 std::shared_ptr<CPVRTimerType> CPVRTimerType::CreateFromIds(unsigned int iTypeId, int iClientId)
 {
   const std::vector<std::shared_ptr<CPVRTimerType>> types = GetAllTypes();
-  const auto it =
-      std::find_if(types.cbegin(), types.cend(),
-                   [iClientId, iTypeId](const auto& type)
-                   { return type->GetClientId() == iClientId && type->GetTypeId() == iTypeId; });
+  const auto it = std::ranges::find_if(
+      types, [iClientId, iTypeId](const auto& type)
+      { return type->GetClientId() == iClientId && type->GetTypeId() == iTypeId; });
   if (it != types.cend())
     return (*it);
 
@@ -125,13 +128,14 @@ std::shared_ptr<CPVRTimerType> CPVRTimerType::CreateFromAttributes(uint64_t iMus
                                                                    int iClientId)
 {
   const std::vector<std::shared_ptr<CPVRTimerType>> types = GetAllTypes();
-  const auto it = std::find_if(types.cbegin(), types.cend(),
-                               [iClientId, iMustHaveAttr, iMustNotHaveAttr](const auto& type)
-                               {
-                                 return type->GetClientId() == iClientId &&
-                                        (type->GetAttributes() & iMustHaveAttr) == iMustHaveAttr &&
-                                        (type->GetAttributes() & iMustNotHaveAttr) == 0;
-                               });
+  const auto it =
+      std::ranges::find_if(types,
+                           [iClientId, iMustHaveAttr, iMustNotHaveAttr](const auto& type)
+                           {
+                             return type->GetClientId() == iClientId &&
+                                    (type->GetAttributes() & iMustHaveAttr) == iMustHaveAttr &&
+                                    (type->GetAttributes() & iMustNotHaveAttr) == 0;
+                           });
   if (it != types.cend())
     return (*it);
 
@@ -174,23 +178,6 @@ CPVRTimerType::CPVRTimerType(unsigned int iTypeId,
 }
 
 CPVRTimerType::~CPVRTimerType() = default;
-
-bool CPVRTimerType::operator==(const CPVRTimerType& right) const
-{
-  return (m_iClientId == right.m_iClientId && m_iTypeId == right.m_iTypeId &&
-          m_iAttributes == right.m_iAttributes && m_strDescription == right.m_strDescription &&
-          m_priorityValues == right.m_priorityValues &&
-          m_lifetimeValues == right.m_lifetimeValues &&
-          m_maxRecordingsValues == right.m_maxRecordingsValues &&
-          m_preventDupEpisodesValues == right.m_preventDupEpisodesValues &&
-          m_recordingGroupValues == right.m_recordingGroupValues &&
-          m_customSettingDefs == right.m_customSettingDefs);
-}
-
-bool CPVRTimerType::operator!=(const CPVRTimerType& right) const
-{
-  return !(*this == right);
-}
 
 void CPVRTimerType::Update(const CPVRTimerType& type)
 {

--- a/xbmc/pvr/timers/PVRTimerType.h
+++ b/xbmc/pvr/timers/PVRTimerType.h
@@ -35,14 +35,14 @@ public:
    * @brief Return a list with all known timer types.
    * @return A list of timer types or an empty list if no types available.
    */
-  static const std::vector<std::shared_ptr<CPVRTimerType>> GetAllTypes();
+  static std::vector<std::shared_ptr<CPVRTimerType>> GetAllTypes();
 
   /*!
    * @brief Return the first available timer type from given client.
    * @param client the PVR client.
    * @return A timer type or NULL if none available.
    */
-  static const std::shared_ptr<CPVRTimerType> GetFirstAvailableType(
+  static std::shared_ptr<CPVRTimerType> GetFirstAvailableType(
       const std::shared_ptr<const CPVRClient>& client);
 
   /*!
@@ -73,8 +73,7 @@ public:
   CPVRTimerType(const CPVRTimerType& type) = delete;
   CPVRTimerType& operator=(const CPVRTimerType& orig) = delete;
 
-  bool operator==(const CPVRTimerType& right) const;
-  bool operator!=(const CPVRTimerType& right) const;
+  bool operator==(const CPVRTimerType& right) const = default;
 
   /*!
    * @brief Update the data of this instance with the data given by another type instance.

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -114,8 +114,7 @@ bool CPVRTimers::LoadFromDatabase(const std::vector<std::shared_ptr<CPVRClient>>
       CServiceBroker::GetPVRManager().GetTVDatabase();
   if (database)
   {
-    const std::vector<std::shared_ptr<CPVRTimerInfoTag>> timers =
-        database->GetTimers(*this, clients);
+    const std::vector<std::shared_ptr<CPVRTimerInfoTag>> timers{database->GetTimers(clients)};
 
     if (std::accumulate(timers.cbegin(), timers.cend(), false,
                         [this](bool changed, const auto& timer) {

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "powermanagement/PowerState.h"
-#include "pvr/settings/PVRSettings.h"
 #include "threads/Thread.h"
 
 #include <map>
@@ -27,6 +26,7 @@ enum class PVREvent;
 class CPVRChannel;
 class CPVRClient;
 class CPVREpgInfoTag;
+class CPVRSettings;
 class CPVRTimerInfoTag;
 class CPVRTimersPath;
 
@@ -49,8 +49,8 @@ public:
    */
   std::shared_ptr<CPVRTimerInfoTag> GetByClient(int iClientId, int iClientIndex) const;
 
-  typedef std::vector<std::shared_ptr<CPVRTimerInfoTag>> VecTimerInfoTag;
-  typedef std::map<CDateTime, VecTimerInfoTag> MapTags;
+  using VecTimerInfoTag = std::vector<std::shared_ptr<CPVRTimerInfoTag>>;
+  using MapTags = std::map<CDateTime, VecTimerInfoTag>;
 
   /*!
    * @brief Get the timertags map.
@@ -324,7 +324,7 @@ private:
                                        bool bDeleted) const;
 
   bool m_bIsUpdating = false;
-  CPVRSettings m_settings;
+  std::unique_ptr<CPVRSettings> m_settings;
   std::queue<std::shared_ptr<CPVRTimerInfoTag>> m_remindersToAnnounce;
   bool m_bReminderRulesUpdatePending = false;
 

--- a/xbmc/pvr/windows/GUIViewStatePVR.cpp
+++ b/xbmc/pvr/windows/GUIViewStatePVR.cpp
@@ -46,12 +46,13 @@ CGUIViewStateWindowPVRChannels::CGUIViewStateWindowPVRChannels(const int windowI
   // Default sorting
   SetSortMethod(SortByChannelNumber);
 
-  LoadViewState("pvr://channels/", m_windowId);
+  LoadViewState("pvr://channels/", GetWindowId());
 }
 
 void CGUIViewStateWindowPVRChannels::SaveViewState()
 {
-  SaveViewToDb("pvr://channels/", m_windowId, CViewStateSettings::GetInstance().Get("pvrchannels"));
+  SaveViewToDb("pvr://channels/", GetWindowId(),
+               CViewStateSettings::GetInstance().Get("pvrchannels"));
 }
 
 CGUIViewStateWindowPVRRecordings::CGUIViewStateWindowPVRRecordings(const int windowId,
@@ -85,12 +86,12 @@ CGUIViewStateWindowPVRRecordings::CGUIViewStateWindowPVRRecordings(const int win
   SetSortMethod(
       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_PVRDefaultSortOrder);
 
-  LoadViewState(items.GetPath(), m_windowId);
+  LoadViewState(items.GetPath(), GetWindowId());
 }
 
 void CGUIViewStateWindowPVRRecordings::SaveViewState()
 {
-  SaveViewToDb(m_items.GetPath(), m_windowId,
+  SaveViewToDb(m_items.GetPath(), GetWindowId(),
                CViewStateSettings::GetInstance().Get("pvrrecordings"));
 }
 
@@ -122,12 +123,12 @@ CGUIViewStateWindowPVRGuide::CGUIViewStateWindowPVRGuide(const int windowId,
   // Default sorting
   SetSortMethod(SortByChannelNumber);
 
-  LoadViewState("pvr://guide/", m_windowId);
+  LoadViewState("pvr://guide/", GetWindowId());
 }
 
 void CGUIViewStateWindowPVRGuide::SaveViewState()
 {
-  SaveViewToDb("pvr://guide/", m_windowId, CViewStateSettings::GetInstance().Get("pvrguide"));
+  SaveViewToDb("pvr://guide/", GetWindowId(), CViewStateSettings::GetInstance().Get("pvrguide"));
 }
 
 CGUIViewStateWindowPVRTimers::CGUIViewStateWindowPVRTimers(const int windowId,
@@ -147,12 +148,12 @@ CGUIViewStateWindowPVRTimers::CGUIViewStateWindowPVRTimers(const int windowId,
   // Default sorting
   SetSortMethod(SortByDate);
 
-  LoadViewState("pvr://timers/", m_windowId);
+  LoadViewState("pvr://timers/", GetWindowId());
 }
 
 void CGUIViewStateWindowPVRTimers::SaveViewState()
 {
-  SaveViewToDb("pvr://timers/", m_windowId, CViewStateSettings::GetInstance().Get("pvrtimers"));
+  SaveViewToDb("pvr://timers/", GetWindowId(), CViewStateSettings::GetInstance().Get("pvrtimers"));
 }
 
 bool CGUIViewStateWindowPVRTimers::HideParentDirItems()
@@ -175,12 +176,13 @@ CGUIViewStateWindowPVRSearch::CGUIViewStateWindowPVRSearch(const int windowId,
   else
     SetSortMethod(SortByDate, SortOrderAscending);
 
-  LoadViewState(m_items.GetPath(), m_windowId);
+  LoadViewState(m_items.GetPath(), GetWindowId());
 }
 
 void CGUIViewStateWindowPVRSearch::SaveViewState()
 {
-  SaveViewToDb(m_items.GetPath(), m_windowId, CViewStateSettings::GetInstance().Get("pvrsearch"));
+  SaveViewToDb(m_items.GetPath(), GetWindowId(),
+               CViewStateSettings::GetInstance().Get("pvrsearch"));
 }
 
 bool CGUIViewStateWindowPVRSearch::HideParentDirItems()
@@ -208,12 +210,12 @@ CGUIViewStateWindowPVRProviders::CGUIViewStateWindowPVRProviders(const int windo
     SetSortMethod(SortByLabel, SortOrderAscending);
   }
 
-  LoadViewState(m_items.GetPath(), m_windowId);
+  LoadViewState(m_items.GetPath(), GetWindowId());
 }
 
 void CGUIViewStateWindowPVRProviders::SaveViewState()
 {
-  SaveViewToDb(m_items.GetPath(), m_windowId,
+  SaveViewToDb(m_items.GetPath(), GetWindowId(),
                CViewStateSettings::GetInstance().Get("pvrproviders"));
 }
 

--- a/xbmc/pvr/windows/GUIViewStatePVR.h
+++ b/xbmc/pvr/windows/GUIViewStatePVR.h
@@ -17,15 +17,18 @@ namespace PVR
 class CGUIViewStatePVR : public CGUIViewState
 {
 public:
-  CGUIViewStatePVR(const int windowId, const CFileItemList& items) : CGUIViewState(items)
+  CGUIViewStatePVR(const int windowId, const CFileItemList& items)
+    : CGUIViewState(items), m_windowId(windowId)
   {
-    m_windowId = windowId;
   }
+
+  int GetWindowId() const { return m_windowId; }
 
 protected:
   bool HideParentDirItems() override { return true; }
 
-  int m_windowId;
+private:
+  const int m_windowId{-1};
 };
 
 class CGUIViewStateWindowPVRChannels : public CGUIViewStatePVR

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -16,120 +16,104 @@
 #include <memory>
 #include <string>
 
-#define CONTROL_BTNVIEWASICONS            2
-#define CONTROL_BTNSORTBY                 3
-#define CONTROL_BTNSORTASC                4
-#define CONTROL_BTNGROUPITEMS             5
-#define CONTROL_BTNSHOWHIDDEN             6
-#define CONTROL_BTNSHOWDELETED            7
-#define CONTROL_BTNHIDEDISABLEDTIMERS     8
-#define CONTROL_BTNSHOWMODE               10
-#define CONTROL_LSTCHANNELGROUPS          11
-
-#define CONTROL_BTNCHANNELGROUPS          28
-#define CONTROL_BTNFILTERCHANNELS         31
-
-#define CONTROL_LABEL_HEADER1             29
-#define CONTROL_LABEL_HEADER2             30
-
 class CGUIDialogProgressBarHandle;
 
 namespace PVR
 {
-  enum class PVREvent;
+enum class PVREvent;
 
-  enum EPGSelectAction
-  {
-    EPG_SELECT_ACTION_CONTEXT_MENU = 0,
-    EPG_SELECT_ACTION_SWITCH = 1,
-    EPG_SELECT_ACTION_INFO = 2,
-    EPG_SELECT_ACTION_RECORD = 3,
-    EPG_SELECT_ACTION_PLAY_RECORDING = 4,
-    EPG_SELECT_ACTION_SMART_SELECT = 5
-  };
+enum EPGSelectAction
+{
+  EPG_SELECT_ACTION_CONTEXT_MENU = 0,
+  EPG_SELECT_ACTION_SWITCH = 1,
+  EPG_SELECT_ACTION_INFO = 2,
+  EPG_SELECT_ACTION_RECORD = 3,
+  EPG_SELECT_ACTION_PLAY_RECORDING = 4,
+  EPG_SELECT_ACTION_SMART_SELECT = 5
+};
 
-  class CPVRChannelGroup;
-  class CGUIPVRChannelGroupsSelector;
+class CPVRChannelGroup;
+class CGUIPVRChannelGroupsSelector;
 
-  class CGUIWindowPVRBase : public CGUIMediaWindow
-  {
-  public:
-    ~CGUIWindowPVRBase() override;
+class CGUIWindowPVRBase : public CGUIMediaWindow
+{
+public:
+  ~CGUIWindowPVRBase() override;
 
-    void OnInitWindow() override;
-    void OnDeinitWindow(int nextWindowID) override;
-    bool OnMessage(CGUIMessage& message) override;
-    bool Update(const std::string& strDirectory, bool updateFilterPath = true) override;
-    void UpdateButtons() override;
-    bool OnAction(const CAction& action) override;
-    void SetInvalid() override;
-    bool CanBeActivated() const override;
+  void OnInitWindow() override;
+  void OnDeinitWindow(int nextWindowID) override;
+  bool OnMessage(CGUIMessage& message) override;
+  bool Update(const std::string& strDirectory, bool updateFilterPath = true) override;
+  void UpdateButtons() override;
+  bool OnAction(const CAction& action) override;
+  void SetInvalid() override;
+  bool CanBeActivated() const override;
 
-    bool UseFileDirectories() override { return false; }
+  bool UseFileDirectories() override { return false; }
 
-    /*!
-     * @brief CEventStream callback for PVR events.
-     * @param event The event.
-     */
-    void Notify(const PVREvent& event);
-    virtual void NotifyEvent(const PVREvent& event);
+  /*!
+   * @brief CEventStream callback for PVR events.
+   * @param event The event.
+   */
+  void Notify(const PVREvent& event);
+  virtual void NotifyEvent(const PVREvent& event);
 
-    bool ActivatePreviousChannelGroup();
-    bool ActivateNextChannelGroup();
-    bool OpenChannelGroupSelectionDialog();
+  bool ActivatePreviousChannelGroup();
+  bool ActivateNextChannelGroup();
+  bool OpenChannelGroupSelectionDialog();
 
-  protected:
-    CGUIWindowPVRBase(bool bRadio, int id, const std::string& xmlFile);
+protected:
+  CGUIWindowPVRBase(bool bRadio, int id, const std::string& xmlFile);
 
-    virtual std::string GetDirectoryPath() = 0;
+  virtual std::string GetDirectoryPath() = 0;
 
-    virtual void ClearData();
+  virtual void ClearData();
 
-    /*!
-     * @brief Init this window's channel group with the currently active (the "playing") channel group.
-     * @return true if group could be set, false otherwise.
-     */
-    bool InitChannelGroup();
+  /*!
+   * @brief Init this window's channel group with the currently active (the "playing") channel group.
+   * @return true if group could be set, false otherwise.
+   */
+  bool InitChannelGroup();
 
-    /*!
-     * @brief Get the channel group for this window.
-     * @return the group or null, if no group set.
-     */
-   std::shared_ptr<CPVRChannelGroup> GetChannelGroup();
+  /*!
+   * @brief Get the channel group for this window.
+   * @return the group or null, if no group set.
+   */
+  std::shared_ptr<CPVRChannelGroup> GetChannelGroup();
 
-    /*!
-     * @brief Set a new channel group, start listening to this group, optionally update window content.
-     * @param group The new group.
-     * @param bUpdate if true, window content will be updated.
-     */
-    void SetChannelGroup(std::shared_ptr<CPVRChannelGroup> &&group, bool bUpdate = true);
+  /*!
+   * @brief Set a new channel group, start listening to this group, optionally update window content.
+   * @param group The new group.
+   * @param bUpdate if true, window content will be updated.
+   */
+  void SetChannelGroup(const std::shared_ptr<CPVRChannelGroup>& group, bool bUpdate = true);
 
-    void SetChannelGroupPath(const std::string& path);
+  void SetChannelGroupPath(const std::string& path);
 
-    virtual void UpdateSelectedItemPath();
+  virtual void UpdateSelectedItemPath();
 
-    CCriticalSection m_critSection;
-    bool m_bRadio;
-    std::atomic_bool m_bUpdating = {false};
+  CCriticalSection m_critSection;
+  bool m_bRadio;
+  std::atomic_bool m_bUpdating = {false};
 
-  private:
-    /*!
-     * @brief Show or update the progress dialog.
-     * @param strText The current status.
-     * @param iProgress The current progress in %.
-     */
-    void ShowProgressDialog(const std::string& strText, int iProgress);
+private:
+  /*!
+   * @brief Show or update the progress dialog.
+   * @param strText The current status.
+   * @param iProgress The current progress in %.
+   */
+  void ShowProgressDialog(const std::string& strText, int iProgress);
 
-    /*!
-     * @brief Hide the progress dialog if it's visible.
-     */
-    void HideProgressDialog();
+  /*!
+   * @brief Hide the progress dialog if it's visible.
+   */
+  void HideProgressDialog();
 
-    std::unique_ptr<CGUIPVRChannelGroupsSelector> m_channelGroupsSelector;
-    std::shared_ptr<CPVRChannelGroup> m_channelGroup;
-    XbmcThreads::EndTime<> m_refreshTimeout;
-    CGUIDialogProgressBarHandle* m_progressHandle =
-        nullptr; /*!< progress dialog that is displayed while the pvr manager is loading */
-    std::string m_channelGroupPath;
-  };
-}
+  std::unique_ptr<CGUIPVRChannelGroupsSelector> m_channelGroupsSelector;
+  std::shared_ptr<CPVRChannelGroup> m_channelGroup;
+  XbmcThreads::EndTime<> m_refreshTimeout;
+  CGUIDialogProgressBarHandle* m_progressHandle =
+      nullptr; /*!< progress dialog that is displayed while the pvr manager is loading */
+  std::string m_channelGroupPath;
+};
+} // namespace PVR

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -46,6 +46,16 @@
 
 using namespace PVR;
 
+namespace
+{
+// Numeric values are part of the Skinning API. Do not change.
+constexpr unsigned int CONTROL_BTNSHOWHIDDEN = 6;
+constexpr unsigned int CONTROL_LABEL_HEADER1 = 29;
+constexpr unsigned int CONTROL_LABEL_HEADER2 = 30;
+constexpr unsigned int CONTROL_BTNFILTERCHANNELS = 31;
+
+} // unnamed namespace
+
 CGUIWindowPVRChannelsBase::CGUIWindowPVRChannelsBase(bool bRadio,
                                                      int id,
                                                      const std::string& xmlFile)
@@ -74,7 +84,7 @@ std::string CGUIWindowPVRChannelsBase::GetRootPath() const
   //! @todo Would it make sense to change GetRootPath() declaration in CGUIMediaWindow
   //! to be non-const to get rid of the const_cast's here?
 
-  CGUIWindowPVRChannelsBase* pThis = const_cast<CGUIWindowPVRChannelsBase*>(this);
+  auto* pThis{const_cast<CGUIWindowPVRChannelsBase*>(this)};
   if (pThis->InitChannelGroup())
     return pThis->GetDirectoryPath();
 
@@ -120,8 +130,7 @@ bool CGUIWindowPVRChannelsBase::Update(const std::string& strDirectory,
 
 void CGUIWindowPVRChannelsBase::UpdateButtons()
 {
-  CGUIRadioButtonControl* btnShowHidden =
-      static_cast<CGUIRadioButtonControl*>(GetControl(CONTROL_BTNSHOWHIDDEN));
+  auto* btnShowHidden{static_cast<CGUIRadioButtonControl*>(GetControl(CONTROL_BTNSHOWHIDDEN))};
   if (btnShowHidden)
   {
     btnShowHidden->SetVisible(CServiceBroker::GetPVRManager()
@@ -160,6 +169,9 @@ bool CGUIWindowPVRChannelsBase::OnAction(const CAction& action)
     case ACTION_CHANNEL_NUMBER_SEP:
       AppendChannelNumberCharacter(CPVRChannelNumber::SEPARATOR);
       return true;
+
+    default:
+      break;
   }
 
   return CGUIWindowPVRBase::OnAction(action);
@@ -241,8 +253,8 @@ bool CGUIWindowPVRChannelsBase::OnMessage(CGUIMessage& message)
       }
       else if (message.GetSenderId() == CONTROL_BTNSHOWHIDDEN)
       {
-        CGUIRadioButtonControl* radioButton =
-            static_cast<CGUIRadioButtonControl*>(GetControl(CONTROL_BTNSHOWHIDDEN));
+        const auto* radioButton{
+            static_cast<CGUIRadioButtonControl*>(GetControl(CONTROL_BTNSHOWHIDDEN))};
         if (radioButton)
         {
           m_bShowHiddenChannels = radioButton->IsSelected();
@@ -266,17 +278,19 @@ bool CGUIWindowPVRChannelsBase::OnMessage(CGUIMessage& message)
     {
       switch (static_cast<PVREvent>(message.GetParam1()))
       {
-        case PVREvent::ChannelGroup:
-        case PVREvent::CurrentItem:
-        case PVREvent::Epg:
-        case PVREvent::EpgActiveItem:
-        case PVREvent::EpgContainer:
-        case PVREvent::RecordingsInvalidated:
-        case PVREvent::Timers:
+        using enum PVREvent;
+
+        case ChannelGroup:
+        case CurrentItem:
+        case Epg:
+        case EpgActiveItem:
+        case EpgContainer:
+        case RecordingsInvalidated:
+        case Timers:
           SetInvalid();
           break;
 
-        case PVREvent::ChannelGroupInvalidated:
+        case ChannelGroupInvalidated:
           Refresh(true);
           break;
 
@@ -285,6 +299,9 @@ bool CGUIWindowPVRChannelsBase::OnMessage(CGUIMessage& message)
       }
       break;
     }
+
+    default:
+      break;
   }
 
   return bReturn || CGUIWindowPVRBase::OnMessage(message);
@@ -334,7 +351,7 @@ bool CGUIWindowPVRChannelsBase::OnContextButtonManage(const CFileItemPtr& item,
   return bReturn;
 }
 
-void CGUIWindowPVRChannelsBase::UpdateEpg(const CFileItemPtr& item)
+void CGUIWindowPVRChannelsBase::UpdateEpg(const std::shared_ptr<CFileItem>& item) const
 {
   const std::shared_ptr<const CPVRChannel> channel(item->GetPVRChannelInfoTag());
 
@@ -369,7 +386,7 @@ void CGUIWindowPVRChannelsBase::UpdateEpg(const CFileItemPtr& item)
   }
 }
 
-void CGUIWindowPVRChannelsBase::ShowChannelManager()
+void CGUIWindowPVRChannelsBase::ShowChannelManager() const
 {
   CGUIDialogPVRChannelManager* dialog =
       CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogPVRChannelManager>(
@@ -383,7 +400,7 @@ void CGUIWindowPVRChannelsBase::ShowChannelManager()
   dialog->Open(iItem >= 0 && iItem < m_vecItems->Size() ? m_vecItems->Get(iItem) : nullptr);
 }
 
-void CGUIWindowPVRChannelsBase::ShowGroupManager()
+void CGUIWindowPVRChannelsBase::ShowGroupManager() const
 {
   /* Load group manager dialog */
   CGUIDialogPVRGroupManager* pDlgInfo =

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.h
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.h
@@ -40,11 +40,10 @@ protected:
 private:
   bool OnContextButtonManage(const CFileItemPtr& item, CONTEXT_BUTTON button);
 
-  void ShowChannelManager();
-  void ShowGroupManager();
-  void UpdateEpg(const CFileItemPtr& item);
+  void ShowChannelManager() const;
+  void ShowGroupManager() const;
+  void UpdateEpg(const std::shared_ptr<CFileItem>& item) const;
 
-protected:
   bool m_bShowHiddenChannels = false;
 };
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -85,7 +85,7 @@ private:
 
   void RefreshView(CGUIMessage& message, bool bInitGridControl);
 
-  int GetCurrentListItemIndex(const std::shared_ptr<const CFileItem>& item);
+  int GetCurrentListItemIndex(const std::shared_ptr<const CFileItem>& item) const;
 
   std::unique_ptr<CPVRRefreshTimelineItemsThread> m_refreshTimelineItemsThread;
   std::atomic_bool m_bRefreshTimelineItems{false};

--- a/xbmc/pvr/windows/GUIWindowPVRProviders.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRProviders.cpp
@@ -30,6 +30,13 @@
 
 using namespace PVR;
 
+namespace
+{
+// Numeric values are part of the Skinning API. Do not change.
+constexpr unsigned int CONTROL_LABEL_HEADER1 = 29;
+
+} // unnamed namespace
+
 CGUIWindowPVRProvidersBase::CGUIWindowPVRProvidersBase(bool isRadio,
                                                        int id,
                                                        const std::string& xmlFile)
@@ -126,18 +133,23 @@ bool CGUIWindowPVRProvidersBase::OnMessage(CGUIMessage& message)
                 // Folders and ".." folders in subfolders are handled by base class.
                 ret = false;
               }
+              break;
             }
+            default:
+              break;
           }
         }
       }
       break;
     }
+    default:
+      break;
   }
 
   return ret || CGUIWindowPVRBase::OnMessage(message);
 }
 
-void CGUIWindowPVRProvidersBase::ActivateChannelsWindow(const CPVRProvidersPath& selectedPath)
+void CGUIWindowPVRProvidersBase::ActivateChannelsWindow(const CPVRProvidersPath& selectedPath) const
 {
   const CPVRManager& pvrMgr{CServiceBroker::GetPVRManager()};
   const std::shared_ptr<CPVRChannelGroup> allChannelsGroup{
@@ -153,7 +165,8 @@ void CGUIWindowPVRProvidersBase::ActivateChannelsWindow(const CPVRProvidersPath&
       selectedPath.IsRadio() ? WINDOW_RADIO_CHANNELS : WINDOW_TV_CHANNELS, targetPath);
 }
 
-void CGUIWindowPVRProvidersBase::ActivateRecordingsWindow(const CPVRProvidersPath& selectedPath)
+void CGUIWindowPVRProvidersBase::ActivateRecordingsWindow(
+    const CPVRProvidersPath& selectedPath) const
 {
   std::string targetPath{CPVRRecordingsPath(selectedPath.IsRadio()
                                                 ? CPVRRecordingsPath::PATH_ACTIVE_RADIO_RECORDINGS

--- a/xbmc/pvr/windows/GUIWindowPVRProviders.h
+++ b/xbmc/pvr/windows/GUIWindowPVRProviders.h
@@ -27,8 +27,8 @@ public:
   void UpdateButtons() override;
 
 private:
-  void ActivateChannelsWindow(const CPVRProvidersPath& selectedPath);
-  void ActivateRecordingsWindow(const CPVRProvidersPath& selectedPath);
+  void ActivateChannelsWindow(const CPVRProvidersPath& selectedPath) const;
+  void ActivateRecordingsWindow(const CPVRProvidersPath& selectedPath) const;
 };
 
 class CGUIWindowPVRTVProviders : public CGUIWindowPVRProvidersBase

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -24,6 +24,7 @@
 #include "pvr/recordings/PVRRecording.h"
 #include "pvr/recordings/PVRRecordings.h"
 #include "pvr/recordings/PVRRecordingsPath.h"
+#include "pvr/settings/PVRSettings.h"
 #include "pvr/utils/PVRPathUtils.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
@@ -41,11 +42,23 @@
 using namespace KODI;
 using namespace PVR;
 
+namespace
+{
+// Numeric values are part of the Skinning API. Do not change.
+constexpr unsigned int CONTROL_BTNGROUPITEMS = 5;
+constexpr unsigned int CONTROL_BTNSHOWDELETED = 7;
+constexpr unsigned int CONTROL_BTNSHOWMODE = 10;
+constexpr unsigned int CONTROL_LABEL_HEADER1 = 29;
+constexpr unsigned int CONTROL_LABEL_HEADER2 = 30;
+
+} // unnamed namespace
+
 CGUIWindowPVRRecordingsBase::CGUIWindowPVRRecordingsBase(bool bRadio,
                                                          int id,
                                                          const std::string& xmlFile)
   : CGUIWindowPVRBase(bRadio, id, xmlFile),
-    m_settings({CSettings::SETTING_PVRRECORD_GROUPRECORDINGS})
+    m_settings(std::make_unique<CPVRSettings>(
+        std::set<std::string>({CSettings::SETTING_PVRRECORD_GROUPRECORDINGS})))
 {
 }
 
@@ -156,10 +169,8 @@ bool CGUIWindowPVRRecordingsBase::OnContextButton(int itemNumber, CONTEXT_BUTTON
 {
   if (itemNumber < 0 || itemNumber >= m_vecItems->Size())
     return false;
-  CFileItemPtr pItem = m_vecItems->Get(itemNumber);
 
-  return OnContextButtonDeleteAll(pItem.get(), button) ||
-         CGUIMediaWindow::OnContextButton(itemNumber, button);
+  return OnContextButtonDeleteAll(button) || CGUIMediaWindow::OnContextButton(itemNumber, button);
 }
 
 bool CGUIWindowPVRRecordingsBase::Update(const std::string& strDirectory,
@@ -174,9 +185,9 @@ bool CGUIWindowPVRRecordingsBase::Update(const std::string& strDirectory,
 
   if (bReturn)
   {
-    // TODO: does it make sense to show the non-deleted recordings, although user wants
-    //       to see the deleted recordings? Or is this just another hack to avoid misbehavior
-    //       of CGUIMediaWindow if it has no content?
+    //! @todo does it make sense to show the non-deleted recordings, although user wants
+    //!       to see the deleted recordings? Or is this just another hack to avoid misbehavior
+    //!       of CGUIMediaWindow if it has no content?
 
     std::unique_lock lock(m_critSection);
 
@@ -216,11 +227,11 @@ void CGUIWindowPVRRecordingsBase::UpdateButtons()
 
   SET_CONTROL_LABEL(CONTROL_BTNSHOWMODE, g_localizeStrings.Get(iStringId));
 
-  bool bGroupRecordings = m_settings.GetBoolValue(CSettings::SETTING_PVRRECORD_GROUPRECORDINGS);
+  const bool bGroupRecordings{
+      m_settings->GetBoolValue(CSettings::SETTING_PVRRECORD_GROUPRECORDINGS)};
   SET_CONTROL_SELECTED(GetID(), CONTROL_BTNGROUPITEMS, bGroupRecordings);
 
-  CGUIRadioButtonControl* btnShowDeleted =
-      static_cast<CGUIRadioButtonControl*>(GetControl(CONTROL_BTNSHOWDELETED));
+  auto* btnShowDeleted{static_cast<CGUIRadioButtonControl*>(GetControl(CONTROL_BTNSHOWDELETED))};
   if (btnShowDeleted)
   {
     btnShowDeleted->SetVisible(
@@ -337,8 +348,8 @@ bool CGUIWindowPVRRecordingsBase::OnMessage(CGUIMessage& message)
       }
       else if (message.GetSenderId() == CONTROL_BTNSHOWDELETED)
       {
-        CGUIRadioButtonControl* radioButton =
-            static_cast<CGUIRadioButtonControl*>(GetControl(CONTROL_BTNSHOWDELETED));
+        const auto* radioButton{
+            static_cast<CGUIRadioButtonControl*>(GetControl(CONTROL_BTNSHOWDELETED))};
         if (radioButton)
         {
           m_bShowDeletedRecordings = radioButton->IsSelected();
@@ -359,16 +370,18 @@ bool CGUIWindowPVRRecordingsBase::OnMessage(CGUIMessage& message)
     {
       switch (static_cast<PVREvent>(message.GetParam1()))
       {
-        case PVREvent::CurrentItem:
-        case PVREvent::Epg:
-        case PVREvent::EpgActiveItem:
-        case PVREvent::EpgContainer:
-        case PVREvent::Timers:
+        using enum PVREvent;
+
+        case CurrentItem:
+        case Epg:
+        case EpgActiveItem:
+        case EpgContainer:
+        case Timers:
           SetInvalid();
           break;
 
-        case PVREvent::RecordingsInvalidated:
-        case PVREvent::TimersInvalidated:
+        case RecordingsInvalidated:
+        case TimersInvalidated:
           Refresh(true);
           break;
 
@@ -377,12 +390,14 @@ bool CGUIWindowPVRRecordingsBase::OnMessage(CGUIMessage& message)
       }
       break;
     }
+    default:
+      break;
   }
 
   return bReturn || CGUIWindowPVRBase::OnMessage(message);
 }
 
-bool CGUIWindowPVRRecordingsBase::OnContextButtonDeleteAll(CFileItem* item, CONTEXT_BUTTON button)
+bool CGUIWindowPVRRecordingsBase::OnContextButtonDeleteAll(CONTEXT_BUTTON button) const
 {
   if (button == CONTEXT_BUTTON_DELETE_ALL)
   {

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.h
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.h
@@ -9,17 +9,19 @@
 #pragma once
 
 #include "dialogs/GUIDialogContextMenu.h"
-#include "pvr/settings/PVRSettings.h"
 #include "pvr/windows/GUIWindowPVRBase.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoThumbLoader.h"
 
+#include <memory>
 #include <string>
 
 class CFileItem;
 
 namespace PVR
 {
+class CPVRSettings;
+
 class CGUIWindowPVRRecordingsBase : public CGUIWindowPVRBase
 {
 public:
@@ -43,12 +45,12 @@ protected:
   bool GetFilteredItems(const std::string& filter, CFileItemList& items) override;
 
 private:
-  bool OnContextButtonDeleteAll(CFileItem* item, CONTEXT_BUTTON button);
+  bool OnContextButtonDeleteAll(CONTEXT_BUTTON button) const;
 
   bool m_bShowDeletedRecordings{false};
   CVideoThumbLoader m_thumbLoader;
   CVideoDatabase m_database;
-  CPVRSettings m_settings;
+  std::unique_ptr<CPVRSettings> m_settings;
 };
 
 class CGUIWindowPVRTVRecordings : public CGUIWindowPVRRecordingsBase

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -46,6 +46,10 @@ using namespace KODI::MESSAGING;
 
 namespace
 {
+// Numeric values are part of the Skinning API. Do not change.
+constexpr unsigned int CONTROL_LABEL_HEADER1 = 29;
+constexpr unsigned int CONTROL_LABEL_HEADER2 = 30;
+
 class AsyncSearchAction : private IRunnable
 {
 public:
@@ -74,7 +78,7 @@ void AsyncSearchAction::Run()
 {
   CPVREpgSearch search(*m_filter);
   search.Execute();
-  const auto tags{search.GetResults()};
+  const auto& tags{search.GetResults()};
   for (const auto& tag : tags)
   {
     m_items->Add(std::make_shared<CFileItem>(tag));
@@ -87,9 +91,7 @@ CGUIWindowPVRSearchBase::CGUIWindowPVRSearchBase(bool bRadio, int id, const std:
 {
 }
 
-CGUIWindowPVRSearchBase::~CGUIWindowPVRSearchBase()
-{
-}
+CGUIWindowPVRSearchBase::~CGUIWindowPVRSearchBase() = default;
 
 void CGUIWindowPVRSearchBase::GetContextButtons(int itemNumber, CContextButtons& buttons)
 {
@@ -108,10 +110,8 @@ bool CGUIWindowPVRSearchBase::OnContextButton(int itemNumber, CONTEXT_BUTTON but
 {
   if (itemNumber < 0 || itemNumber >= m_vecItems->Size())
     return false;
-  CFileItemPtr pItem = m_vecItems->Get(itemNumber);
 
-  return OnContextButtonClear(pItem.get(), button) ||
-         CGUIMediaWindow::OnContextButton(itemNumber, button);
+  return OnContextButtonClear(button) || CGUIMediaWindow::OnContextButton(itemNumber, button);
 }
 
 void CGUIWindowPVRSearchBase::SetItemToSearch(const CFileItem& item)
@@ -264,6 +264,8 @@ bool CGUIWindowPVRSearchBase::OnMessage(CGUIMessage& message)
           case ACTION_RECORD:
             CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().ToggleTimer(*pItem);
             return true;
+          default:
+            break;
         }
       }
     }
@@ -372,7 +374,7 @@ void CGUIWindowPVRSearchBase::UpdateButtons()
     SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, "");
 }
 
-bool CGUIWindowPVRSearchBase::OnContextButtonClear(CFileItem* item, CONTEXT_BUTTON button)
+bool CGUIWindowPVRSearchBase::OnContextButtonClear(CONTEXT_BUTTON button)
 {
   bool bReturn = false;
 

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.h
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.h
@@ -51,7 +51,7 @@ protected:
   void OnPrepareFileItems(CFileItemList& items) override;
 
 private:
-  bool OnContextButtonClear(CFileItem* item, CONTEXT_BUTTON button);
+  bool OnContextButtonClear(CONTEXT_BUTTON button);
 
   CGUIDialogPVRGuideSearch::Result OpenDialogSearch(
       const std::shared_ptr<CPVREpgSearchFilter>& searchFilter);

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
@@ -30,6 +30,14 @@
 
 using namespace PVR;
 
+namespace
+{
+// Numeric values are part of the Skinning API. Do not change.
+constexpr unsigned int CONTROL_BTNHIDEDISABLEDTIMERS = 8;
+constexpr unsigned int CONTROL_LABEL_HEADER1 = 29;
+
+} // unnamed namespace
+
 CGUIWindowPVRTimersBase::CGUIWindowPVRTimersBase(bool bRadio, int id, const std::string& xmlFile)
   : CGUIWindowPVRBase(bRadio, id, xmlFile)
 {
@@ -167,15 +175,17 @@ bool CGUIWindowPVRTimersBase::OnMessage(CGUIMessage& message)
     {
       switch (static_cast<PVREvent>(message.GetParam1()))
       {
-        case PVREvent::CurrentItem:
-        case PVREvent::Epg:
-        case PVREvent::EpgActiveItem:
-        case PVREvent::EpgContainer:
-        case PVREvent::Timers:
+        using enum PVREvent;
+
+        case CurrentItem:
+        case Epg:
+        case EpgActiveItem:
+        case EpgContainer:
+        case Timers:
           SetInvalid();
           break;
 
-        case PVREvent::TimersInvalidated:
+        case TimersInvalidated:
           Refresh(true);
           break;
 
@@ -184,12 +194,14 @@ bool CGUIWindowPVRTimersBase::OnMessage(CGUIMessage& message)
       }
       break;
     }
+    default:
+      break;
   }
 
   return bReturn || CGUIWindowPVRBase::OnMessage(message);
 }
 
-bool CGUIWindowPVRTimersBase::ActionShowTimer(const CFileItem& item)
+bool CGUIWindowPVRTimersBase::ActionShowTimer(const CFileItem& item) const
 {
   bool bReturn = false;
 

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.h
@@ -29,7 +29,7 @@ public:
   void UpdateButtons() override;
 
 private:
-  bool ActionShowTimer(const CFileItem& item);
+  bool ActionShowTimer(const CFileItem& item) const;
 
   std::shared_ptr<CFileItem> m_currentFileItem;
 };

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -55,7 +55,7 @@ class CVideoInfoTag : public IArchivable, public ISerializable, public ISortable
 public:
   CVideoInfoTag() { Reset(); }
   virtual ~CVideoInfoTag() = default;
-  void Reset();
+  virtual void Reset();
   /* \brief Load information to a videoinfotag from an XML element
    There are three types of tags supported:
     1. Single-value tags, such as <title>.  These are set if available, else are left untouched.


### PR DESCRIPTION
Fixes a bunch of (those where easy to handle for me) SonarQube findings. No functional changes intended, only modernization of C++, and optimizations. Among them:

* "make_unique" and "make_shared" should be used to construct "unique_ptr" and "shared_ptr" cpp:S5950
* "auto" should be used to avoid repetition of types cpp:S5827
* "std::string_view" should be used to pass a read-only string to a function cpp:S6009
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* Member data should be initialized in-class or in a constructor initialization list cpp:S3230
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* Structured binding should be used cpp:S6005
* Function parameters should not be of type "std::unique_ptr<T> const &" cpp:S4998
* "static" members should be accessed statically cpp:S2209
* Multiple variables should not be declared on the same line cpp:S1659
* Return type of functions shouldn't be const qualified value cpp:S5951
* Redundant comparison operators should not be defined cpp:S6186
* Mergeable "if" statements should be combined cpp:S1066
* Macros should not be used to define constants cpp:S5028
* "switch" statements should cover all cases cpp:S3562
* Unused function parameters should be removed cpp:S1172
* Pointer and reference local variables should be "const" if the corresponding object is not modified cpp:S5350
* STL algorithms and range-based for loops should be preferred to traditional for loops cpp:S5566
* Calls to c_str() should not implicitly recreate strings or string_views cpp:S7121
* "std::source_location" should be used instead of "__FILE__", "__LINE__", and "__func__" macros cpp:S6190
* Default capture should not be used cpp:S3608
* "contains" should be used to check if a key exists in a container cpp:S6171
* Assignments should not be made from within conditions cpp:S1121
* Emplacement should be preferred when insertion creates a temporary with sequence containers cpp:S6003
* "std::chrono" components should be used to operate on time cpp:S6229
* Comparision operators ("<=>", "==") should be defaulted unless non-default behavior is required cpp:S6230
* Scoped enumerations should be used cpp:S3642
* Concise syntax should be used for concatenatable namespaces cpp:S5812
* Inherited functions should not be hidden cpp:S1242
* Parameters in an overriding virtual function shall either use the same default arguments as the function they override, or else shall not specify any default arguments cpp:S1006
* Redundant pairs of parentheses should be removed cpp:S1110
* Objects should not be created solely to be passed as arguments to functions that perform delegated object creation cpp:S6011
* Redundant casts should not be used cpp:S1905
* "bind" should not be used cpp:S5995
* Unnecessary expensive copy should be avoided when using auto as a placeholder type cpp:S6032

This is a big one, but separated directory by directory, and most of the changes should be pretty self-explaining to a person knowing C++ when reading the code change.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish best to be reviewed commit-by-commit.