### PR TITLE
[Video] Not compare light metadata to avoid unnecessary video reconfigure

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
@@ -95,26 +95,11 @@ bool VideoPicture::CompareDisplayMetadata(const VideoPicture& pic) const
          this->displayMetadata.min_luminance.den == pic.displayMetadata.min_luminance.den;
 }
 
-bool VideoPicture::CompareLightMetadata(const VideoPicture& pic) const
-{
-  if (this->hasLightMetadata != pic.hasLightMetadata)
-    return false;
-
-  // both this and pic not has light metadata (e.g. SDR video)
-  // returns true because it is equal and there is no need to compare
-  if (!pic.hasLightMetadata)
-    return true;
-
-  // both this and pic has light metadata
-  return this->lightMetadata.MaxCLL == pic.lightMetadata.MaxCLL &&
-         this->lightMetadata.MaxFALL == pic.lightMetadata.MaxFALL;
-}
-
 bool VideoPicture::IsSameParams(const VideoPicture& pic) const
 {
   return this->iWidth == pic.iWidth && this->iHeight == pic.iHeight &&
          this->iDisplayWidth == pic.iDisplayWidth && this->iDisplayHeight == pic.iDisplayHeight &&
          this->stereoMode == pic.stereoMode && this->color_primaries == pic.color_primaries &&
          this->color_transfer == pic.color_transfer && this->hdrType == pic.hdrType &&
-         CompareDisplayMetadata(pic) && CompareLightMetadata(pic);
+         CompareDisplayMetadata(pic);
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -84,7 +84,6 @@ private:
   VideoPicture& operator=(VideoPicture const&) = default;
 
   bool CompareDisplayMetadata(const VideoPicture& pic) const;
-  bool CompareLightMetadata(const VideoPicture& pic) const;
 };
 
 #define DVP_FLAG_TOP_FIELD_FIRST    0x00000001


### PR DESCRIPTION
## Description
[Video] Not compare light metadata to avoid unnecessary video reconfigure

Background: despite light metadata is part of static HDR10 metadata, on some video sources (e.g. seamless branching Blu-Ray) this may change in middle of stream.

## Motivation and context
Reported in forum: https://forum.kodi.tv/showthread.php?tid=349861&pid=3231739#pid3231739

After https://github.com/xbmc/xbmc/pull/26028 in some Blu-Ray videos is triggered video reconfigure due light metadata changes in middle of playback. I have also been able to reproduce this on other Blu-Ray's such as "Hellboy (2004)" so it does not seem to be an isolated issue or a faulty/manipulated stream.

Note that is supposed _static_ metadata not changes and this probably violates the HDR10 spec... but it is a fact that it happens.

> MaxCLL/MaxFALL together forms static metadata as it uses the same values for the entire program, while Dolby Vision dynamic metadata changes on a shot by shot (or when required, frame by frame) basis. 

https://professionalsupport.dolby.com/s/article/Calculation-of-MaxFALL-and-MaxCLL-metadata?language=en_US

Similar discussion on mpv player here: https://github.com/mpv-player/mpv/issues/14811

## How has this been tested?
Tested with provided video sample (https://forum.kodi.tv/showthread.php?tid=349861&pid=3231954#pid3231954): 
Observe that Max FALL changes.

https://github.com/user-attachments/assets/c78f421d-5226-4546-9658-8e5a2d13c19e



## What is the effect on users?
This PR restores previous behavior respect light metadata only (display metadata is still compared) and other video parameters missing before. 

Note that in Windows exist an specific implementation to compare all metadata and send updates to TV / display on the fly during playback:

https://github.com/xbmc/xbmc/blob/45c877e17ee23bb1f97d8c6d2b326270370931a7/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp#L606-L611

That is to say, this has never been a problem on Windows and the bug the previous PR was intended to fix was only on Linux. 

Therefore, if we need to update light metadata on the display without triggering a complete video reconfigure (which causes a black screen), is possible use same or similar Windows solution on Linux code path (out of scope of this PR).


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
