### PR TITLE
[Backport][Video] Not compare light metadata to avoid unnecessary video reconfigure

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
@@ -98,28 +98,13 @@ bool VideoPicture::CompareDisplayMetadata(const VideoPicture& pic) const
          this->displayMetadata.min_luminance.den == pic.displayMetadata.min_luminance.den;
 }
 
-bool VideoPicture::CompareLightMetadata(const VideoPicture& pic) const
-{
-  if (this->hasLightMetadata != pic.hasLightMetadata)
-    return false;
-
-  // both this and pic not has light metadata (e.g. SDR video)
-  // returns true because it is equal and there is no need to compare
-  if (!pic.hasLightMetadata)
-    return true;
-
-  // both this and pic has light metadata
-  return this->lightMetadata.MaxCLL == pic.lightMetadata.MaxCLL &&
-         this->lightMetadata.MaxFALL == pic.lightMetadata.MaxFALL;
-}
-
 bool VideoPicture::IsSameParams(const VideoPicture& pic) const
 {
   return this->iWidth == pic.iWidth && this->iHeight == pic.iHeight &&
          this->iDisplayWidth == pic.iDisplayWidth && this->iDisplayHeight == pic.iDisplayHeight &&
          this->stereoMode == pic.stereoMode && this->color_primaries == pic.color_primaries &&
          this->color_transfer == pic.color_transfer && this->hdrType == pic.hdrType &&
-         CompareDisplayMetadata(pic) && CompareLightMetadata(pic);
+         CompareDisplayMetadata(pic);
 }
 
 VideoPicture::VideoPicture(VideoPicture const&) = default;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -84,7 +84,6 @@ private:
   VideoPicture& operator=(VideoPicture const&);
 
   bool CompareDisplayMetadata(const VideoPicture& pic) const;
-  bool CompareLightMetadata(const VideoPicture& pic) const;
 };
 
 #define DVP_FLAG_TOP_FIELD_FIRST    0x00000001


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/26731



## What is the effect on users?
Prevents full video reconfigure when only change light metadata in middle of playback of same stream.



## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
