### PR TITLE
[lib/libUPnP/Platinum] Fix path transversal vulnerability

### DIFF
--- a/lib/libUPnP/Platinum/Source/Core/PltHttpServer.cpp
+++ b/lib/libUPnP/Platinum/Source/Core/PltHttpServer.cpp
@@ -190,7 +190,7 @@ PLT_HttpServer::ServeFile(const NPT_HttpRequest&        request,
     NPT_FileInfo             file_info;
     
     // prevent hackers from accessing files outside of our root
-    if ((file_path.Find("/..") >= 0) || (file_path.Find("\\..") >= 0)) {
+    if ((file_path.Find("../") >= 0) || (file_path.Find("..\\") >= 0)) {
         return NPT_ERROR_NO_SUCH_ITEM;
     }
     


### PR DESCRIPTION
## Description
This PR fixes a potential vulnerability in PLT_HttpServer::ServeFile() in `lib/libUPnP/Platinum/Source/Core/PltHttpServer.cpp` that was cloned from Platinum but did not receive the security patch. 

## Motivation and context
To fix a potential path transversal vulnerability in `lib/libUPnP/Platinum`

The original issue was reported and fixed under https://github.com/plutinosoft/Platinum/commit/9a4ceaccb1585ec35c45fd8e2585538fff6a865e.

Reference:
https://nvd.nist.gov/vuln/detail/CVE-2020-19858

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
