### PR TITLE
[PVR] Channel manager: Fix channels marked as changed although not changed

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -1125,16 +1125,16 @@ void CGUIDialogPVRChannelManager::Renumber()
   int iNextChannelNumber{1};
   for (const auto& item : *m_channelItems)
   {
-    const std::string number = item->GetProperty(PROPERTY_CHANNEL_ENABLED).asBoolean()
-                                   ? std::to_string(iNextChannelNumber)
-                                   : LABEL_CHANNEL_DISABLED;
+    const bool channelIsEnabled{item->GetProperty(PROPERTY_CHANNEL_ENABLED).asBoolean()};
+    const std::string number{channelIsEnabled ? std::to_string(iNextChannelNumber)
+                                              : LABEL_CHANNEL_DISABLED};
+    if (channelIsEnabled)
+      iNextChannelNumber++;
 
     if (item->GetProperty(PROPERTY_CHANNEL_NUMBER).asString() != number)
     {
       item->SetProperty(PROPERTY_CHANNEL_NUMBER, number);
       SetItemChanged(item);
     }
-
-    iNextChannelNumber++;
   }
 }


### PR DESCRIPTION
Fallout from https://github.com/xbmc/xbmc/commit/3a6498b52751c3731881f00ed050a9adaf554a45

You do see the bug, don't you?

```diff
   if (!m_bAllowRenumber)
     return;
 
-  int iNextChannelNumber = 0;
+  int iNextChannelNumber{1};
   for (const auto& item : *m_channelItems)
   {
     const std::string number = item->GetProperty(PROPERTY_CHANNEL_ENABLED).asBoolean()
-                                   ? std::to_string(++iNextChannelNumber)
+                                   ? std::to_string(iNextChannelNumber)
                                    : LABEL_CHANNEL_DISABLED;
 
     if (item->GetProperty(PROPERTY_CHANNEL_NUMBER).asString() != number)
@@ -1138,5 +1134,7 @@ void CGUIDialogPVRChannelManager::Renumber()
       item->SetProperty(PROPERTY_CHANNEL_NUMBER, number);
       SetItemChanged(item);
     }
+
+    iNextChannelNumber++;
   }
 }
```

With the recent change, the channel number index will be increased with every iteration for every channel, not only if the channel is enabled.

The PR restores the old behavior.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish should be easy to review.