### PR TITLE
[guilib/guiinfo][GUIInfoManager] Misc SonarQube findings

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -47,43 +47,13 @@ using namespace KODI::GUILIB;
 using namespace KODI::GUILIB::GUIINFO;
 using namespace INFO;
 
-bool InfoBoolComparator(const InfoPtr &right, const InfoPtr &left)
+namespace
 {
-  return *right < *left;
-}
-
-CGUIInfoManager::CGUIInfoManager(void)
-: m_currentFile(new CFileItem),
-  m_bools(&InfoBoolComparator)
+struct InfoMap
 {
-}
-
-CGUIInfoManager::~CGUIInfoManager(void)
-{
-  delete m_currentFile;
-}
-
-void CGUIInfoManager::Initialize()
-{
-  CServiceBroker::GetAppMessenger()->RegisterReceiver(this);
-}
-
-/// \brief Translates a string as given by the skin into an int that we use for more
-/// efficient retrieval of data. Can handle combined strings on the form
-/// Player.Caching + VideoPlayer.IsFullscreen (Logical and)
-/// Player.HasVideo | Player.HasAudio (Logical or)
-int CGUIInfoManager::TranslateString(const std::string &condition)
-{
-  // translate $LOCALIZE as required
-  std::string strCondition(CGUIInfoLabel::ReplaceLocalize(condition));
-  return TranslateSingleString(strCondition);
-}
-
-typedef struct
-{
-  const char *str;
-  int  val;
-} infomap;
+  const char* str{nullptr};
+  int val{0};
+};
 
 /// \page modules__infolabels_boolean_conditions Infolabels and Boolean conditions
 /// \tableofcontents
@@ -179,11 +149,13 @@ typedef struct
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
-const infomap addons[] = {
-    {"settingstr", ADDON_SETTING_STRING},
+// clang-format off
+constexpr std::array<InfoMap, 3> addons = {{
+    {"settingstr",  ADDON_SETTING_STRING},
     {"settingbool", ADDON_SETTING_BOOL},
-    {"settingint", ADDON_SETTING_INT},
-};
+    {"settingint",  ADDON_SETTING_INT},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_String String
@@ -261,13 +233,15 @@ const infomap addons[] = {
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
-
-
-const infomap string_bools[] =   {{ "isempty",          STRING_IS_EMPTY },
-                                  { "isequal",          STRING_IS_EQUAL },
-                                  { "startswith",       STRING_STARTS_WITH },
-                                  { "endswith",         STRING_ENDS_WITH },
-                                  { "contains",         STRING_CONTAINS }};
+// clang-format off
+constexpr std::array<InfoMap, 5> string_bools = {{
+    {"isempty",     STRING_IS_EMPTY},
+    {"isequal",     STRING_IS_EQUAL},
+    {"startswith",  STRING_STARTS_WITH},
+    {"endswith",    STRING_ENDS_WITH},
+    {"contains",    STRING_CONTAINS},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_Integer Integer
@@ -374,14 +348,17 @@ const infomap string_bools[] =   {{ "isempty",          STRING_IS_EMPTY },
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
-
-const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
-                                  { "isgreater",        INTEGER_GREATER_THAN },
-                                  { "isgreaterorequal", INTEGER_GREATER_OR_EQUAL },
-                                  { "isless",           INTEGER_LESS_THAN },
-                                  { "islessorequal",    INTEGER_LESS_OR_EQUAL },
-                                  { "iseven",           INTEGER_EVEN },
-                                  { "isodd",            INTEGER_ODD }};
+// clang-format off
+constexpr std::array<InfoMap, 7> integer_bools = {{
+    {"isequal",           INTEGER_IS_EQUAL},
+    {"isgreater",         INTEGER_GREATER_THAN},
+    {"isgreaterorequal",  INTEGER_GREATER_OR_EQUAL},
+    {"isless",            INTEGER_LESS_THAN},
+    {"islessorequal",     INTEGER_LESS_OR_EQUAL},
+    {"iseven",            INTEGER_EVEN},
+    {"isodd",             INTEGER_ODD},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_Player Player
@@ -857,63 +834,67 @@ const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
 ///     @skinning_v21 **[New Boolean Condition]** \link Player_IsRemote `Player.IsRemote`\endlink
 ///     <p>
 ///   }
-const infomap player_labels[] = {{"hasmedia", PLAYER_HAS_MEDIA},
-                                 {"hasaudio", PLAYER_HAS_AUDIO},
-                                 {"hasvideo", PLAYER_HAS_VIDEO},
-                                 {"hasgame", PLAYER_HAS_GAME},
-                                 {"isexternal", PLAYER_IS_EXTERNAL},
-                                 {"isremote", PLAYER_IS_REMOTE},
-                                 {"playing", PLAYER_PLAYING},
-                                 {"paused", PLAYER_PAUSED},
-                                 {"rewinding", PLAYER_REWINDING},
-                                 {"forwarding", PLAYER_FORWARDING},
-                                 {"rewinding2x", PLAYER_REWINDING_2x},
-                                 {"rewinding4x", PLAYER_REWINDING_4x},
-                                 {"rewinding8x", PLAYER_REWINDING_8x},
-                                 {"rewinding16x", PLAYER_REWINDING_16x},
-                                 {"rewinding32x", PLAYER_REWINDING_32x},
-                                 {"forwarding2x", PLAYER_FORWARDING_2x},
-                                 {"forwarding4x", PLAYER_FORWARDING_4x},
-                                 {"forwarding8x", PLAYER_FORWARDING_8x},
-                                 {"forwarding16x", PLAYER_FORWARDING_16x},
-                                 {"forwarding32x", PLAYER_FORWARDING_32x},
-                                 {"caching", PLAYER_CACHING},
-                                 {"seekbar", PLAYER_SEEKBAR},
-                                 {"seeking", PLAYER_SEEKING},
-                                 {"showtime", PLAYER_SHOWTIME},
-                                 {"showinfo", PLAYER_SHOWINFO},
-                                 {"muted", PLAYER_MUTED},
-                                 {"hasduration", PLAYER_HASDURATION},
-                                 {"passthrough", PLAYER_PASSTHROUGH},
-                                 {"cachelevel", PLAYER_CACHELEVEL},
-                                 {"title", PLAYER_TITLE},
-                                 {"progress", PLAYER_PROGRESS},
-                                 {"progresscache", PLAYER_PROGRESS_CACHE},
-                                 {"volume", PLAYER_VOLUME},
-                                 {"subtitledelay", PLAYER_SUBTITLE_DELAY},
-                                 {"audiodelay", PLAYER_AUDIO_DELAY},
-                                 {"chapter", PLAYER_CHAPTER},
-                                 {"chaptercount", PLAYER_CHAPTERCOUNT},
-                                 {"chaptername", PLAYER_CHAPTERNAME},
-                                 {"folderpath", PLAYER_PATH},
-                                 {"filenameandpath", PLAYER_FILEPATH},
-                                 {"filename", PLAYER_FILENAME},
-                                 {"isinternetstream", PLAYER_ISINTERNETSTREAM},
-                                 {"pauseenabled", PLAYER_CAN_PAUSE},
-                                 {"seekenabled", PLAYER_CAN_SEEK},
-                                 {"channelpreviewactive", PLAYER_IS_CHANNEL_PREVIEW_ACTIVE},
-                                 {"tempoenabled", PLAYER_SUPPORTS_TEMPO},
-                                 {"istempo", PLAYER_IS_TEMPO},
-                                 {"playspeed", PLAYER_PLAYSPEED},
-                                 {"hasprograms", PLAYER_HAS_PROGRAMS},
-                                 {"hasresolutions", PLAYER_HAS_RESOLUTIONS},
-                                 {"frameadvance", PLAYER_FRAMEADVANCE},
-                                 {"icon", PLAYER_ICON},
-                                 {"editlist", PLAYER_EDITLIST},
-                                 {"cuts", PLAYER_CUTS},
-                                 {"scenemarkers", PLAYER_SCENE_MARKERS},
-                                 {"hasscenemarkers", PLAYER_HAS_SCENE_MARKERS},
-                                 {"chapters", PLAYER_CHAPTERS}};
+// clang-format off
+constexpr std::array<InfoMap, 57> player_labels = {{
+    {"hasmedia",              PLAYER_HAS_MEDIA},
+    {"hasaudio",              PLAYER_HAS_AUDIO},
+    {"hasvideo",              PLAYER_HAS_VIDEO},
+    {"hasgame",               PLAYER_HAS_GAME},
+    {"isexternal",            PLAYER_IS_EXTERNAL},
+    {"isremote",              PLAYER_IS_REMOTE},
+    {"playing",               PLAYER_PLAYING},
+    {"paused",                PLAYER_PAUSED},
+    {"rewinding",             PLAYER_REWINDING},
+    {"forwarding",            PLAYER_FORWARDING},
+    {"rewinding2x",           PLAYER_REWINDING_2x},
+    {"rewinding4x",           PLAYER_REWINDING_4x},
+    {"rewinding8x",           PLAYER_REWINDING_8x},
+    {"rewinding16x",          PLAYER_REWINDING_16x},
+    {"rewinding32x",          PLAYER_REWINDING_32x},
+    {"forwarding2x",          PLAYER_FORWARDING_2x},
+    {"forwarding4x",          PLAYER_FORWARDING_4x},
+    {"forwarding8x",          PLAYER_FORWARDING_8x},
+    {"forwarding16x",         PLAYER_FORWARDING_16x},
+    {"forwarding32x",         PLAYER_FORWARDING_32x},
+    {"caching",               PLAYER_CACHING},
+    {"seekbar",               PLAYER_SEEKBAR},
+    {"seeking",               PLAYER_SEEKING},
+    {"showtime",              PLAYER_SHOWTIME},
+    {"showinfo",              PLAYER_SHOWINFO},
+    {"muted",                 PLAYER_MUTED},
+    {"hasduration",           PLAYER_HASDURATION},
+    {"passthrough",           PLAYER_PASSTHROUGH},
+    {"cachelevel",            PLAYER_CACHELEVEL},
+    {"title",                 PLAYER_TITLE},
+    {"progress",              PLAYER_PROGRESS},
+    {"progresscache",         PLAYER_PROGRESS_CACHE},
+    {"volume",                PLAYER_VOLUME},
+    {"subtitledelay",         PLAYER_SUBTITLE_DELAY},
+    {"audiodelay",            PLAYER_AUDIO_DELAY},
+    {"chapter",               PLAYER_CHAPTER},
+    {"chaptercount",          PLAYER_CHAPTERCOUNT},
+    {"chaptername",           PLAYER_CHAPTERNAME},
+    {"folderpath",            PLAYER_PATH},
+    {"filenameandpath",       PLAYER_FILEPATH},
+    {"filename",              PLAYER_FILENAME},
+    {"isinternetstream",      PLAYER_ISINTERNETSTREAM},
+    {"pauseenabled",          PLAYER_CAN_PAUSE},
+    {"seekenabled",           PLAYER_CAN_SEEK},
+    {"channelpreviewactive",  PLAYER_IS_CHANNEL_PREVIEW_ACTIVE},
+    {"tempoenabled",          PLAYER_SUPPORTS_TEMPO},
+    {"istempo",               PLAYER_IS_TEMPO},
+    {"playspeed",             PLAYER_PLAYSPEED},
+    {"hasprograms",           PLAYER_HAS_PROGRAMS},
+    {"hasresolutions",        PLAYER_HAS_RESOLUTIONS},
+    {"frameadvance",          PLAYER_FRAMEADVANCE},
+    {"icon",                  PLAYER_ICON},
+    {"editlist",              PLAYER_EDITLIST},
+    {"cuts",                  PLAYER_CUTS},
+    {"scenemarkers",          PLAYER_SCENE_MARKERS},
+    {"hasscenemarkers",       PLAYER_HAS_SCENE_MARKERS},
+    {"chapters",              PLAYER_CHAPTERS},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 ///   \table_row3{   <b>`Player.Art(type)`</b>,
@@ -943,9 +924,12 @@ const infomap player_labels[] = {{"hasmedia", PLAYER_HAS_MEDIA},
 ///     @skinning_v20 **[New Boolean Condition]** \link Player_HasPerformedSeek `Player.HasPerformedSeek(interval)`\endlink
 ///     <p>
 ///   }
-
-const infomap player_param[] = {{"art", PLAYER_ITEM_ART},
-                                {"hasperformedseek", PLAYER_HASPERFORMEDSEEK}};
+// clang-format off
+constexpr std::array<InfoMap, 2> player_param = {{
+    {"art",               PLAYER_ITEM_ART},
+    {"hasperformedseek",  PLAYER_HASPERFORMEDSEEK},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 ///   \table_row3{   <b>`Player.SeekTime`</b>,
@@ -1027,17 +1011,20 @@ const infomap player_param[] = {{"art", PLAYER_ITEM_ART},
 ///     See \ref TIME_FORMAT for the list of possible values.
 ///     <p>
 ///   }
-const infomap player_times[] =   {{ "seektime",         PLAYER_SEEKTIME },
-                                  { "seekoffset",       PLAYER_SEEKOFFSET },
-                                  { "seekstepsize",     PLAYER_SEEKSTEPSIZE },
-                                  { "timeremaining",    PLAYER_TIME_REMAINING },
-                                  { "timespeed",        PLAYER_TIME_SPEED },
-                                  { "time",             PLAYER_TIME },
-                                  { "duration",         PLAYER_DURATION },
-                                  { "finishtime",       PLAYER_FINISH_TIME },
-                                  { "starttime",        PLAYER_START_TIME },
-                                  { "seeknumeric",      PLAYER_SEEKNUMERIC } };
-
+// clang-format off
+constexpr std::array<InfoMap, 10> player_times = {{
+    {"seektime",      PLAYER_SEEKTIME},
+    {"seekoffset",    PLAYER_SEEKOFFSET},
+    {"seekstepsize",  PLAYER_SEEKSTEPSIZE},
+    {"timeremaining", PLAYER_TIME_REMAINING},
+    {"timespeed",     PLAYER_TIME_SPEED},
+    {"time",          PLAYER_TIME},
+    {"duration",      PLAYER_DURATION},
+    {"finishtime",    PLAYER_FINISH_TIME},
+    {"starttime",     PLAYER_START_TIME},
+    {"seeknumeric",   PLAYER_SEEKNUMERIC},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 ///   \table_row3{   <b>`Player.Process(videohwdecoder)`</b>,
@@ -1147,20 +1134,23 @@ const infomap player_times[] =   {{ "seektime",         PLAYER_SEEKTIME },
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
-
-const infomap player_process[] = {{"videodecoder", PLAYER_PROCESS_VIDEODECODER},
-                                  {"deintmethod", PLAYER_PROCESS_DEINTMETHOD},
-                                  {"pixformat", PLAYER_PROCESS_PIXELFORMAT},
-                                  {"videowidth", PLAYER_PROCESS_VIDEOWIDTH},
-                                  {"videoheight", PLAYER_PROCESS_VIDEOHEIGHT},
-                                  {"videofps", PLAYER_PROCESS_VIDEOFPS},
-                                  {"videodar", PLAYER_PROCESS_VIDEODAR},
-                                  {"videohwdecoder", PLAYER_PROCESS_VIDEOHWDECODER},
-                                  {"audiodecoder", PLAYER_PROCESS_AUDIODECODER},
-                                  {"audiochannels", PLAYER_PROCESS_AUDIOCHANNELS},
-                                  {"audiosamplerate", PLAYER_PROCESS_AUDIOSAMPLERATE},
-                                  {"audiobitspersample", PLAYER_PROCESS_AUDIOBITSPERSAMPLE},
-                                  {"videoscantype", PLAYER_PROCESS_VIDEOSCANTYPE}};
+// clang-format off
+constexpr std::array<InfoMap, 13> player_process = {{
+    {"videodecoder",        PLAYER_PROCESS_VIDEODECODER},
+    {"deintmethod",         PLAYER_PROCESS_DEINTMETHOD},
+    {"pixformat",           PLAYER_PROCESS_PIXELFORMAT},
+    {"videowidth",          PLAYER_PROCESS_VIDEOWIDTH},
+    {"videoheight",         PLAYER_PROCESS_VIDEOHEIGHT},
+    {"videofps",            PLAYER_PROCESS_VIDEOFPS},
+    {"videodar",            PLAYER_PROCESS_VIDEODAR},
+    {"videohwdecoder",      PLAYER_PROCESS_VIDEOHWDECODER},
+    {"audiodecoder",        PLAYER_PROCESS_AUDIODECODER},
+    {"audiochannels",       PLAYER_PROCESS_AUDIOCHANNELS},
+    {"audiosamplerate",     PLAYER_PROCESS_AUDIOSAMPLERATE},
+    {"audiobitspersample",  PLAYER_PROCESS_AUDIOBITSPERSAMPLE},
+    {"videoscantype",       PLAYER_PROCESS_VIDEOSCANTYPE},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_Weather Weather
@@ -1213,13 +1203,17 @@ const infomap player_process[] = {{"videodecoder", PLAYER_PROCESS_VIDEODECODER},
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
-const infomap weather[] =        {{ "isfetched",        WEATHER_IS_FETCHED },
-                                  { "conditions",       WEATHER_CONDITIONS_TEXT },         // labels from here
-                                  { "temperature",      WEATHER_TEMPERATURE },
-                                  { "location",         WEATHER_LOCATION },
-                                  { "fanartcode",       WEATHER_FANART_CODE },
-                                  { "plugin",           WEATHER_PLUGIN },
-                                  { "conditionsicon",   WEATHER_CONDITIONS_ICON }};
+// clang-format off
+constexpr std::array<InfoMap, 7> weather = {{
+    {"isfetched",       WEATHER_IS_FETCHED},
+    {"conditions",      WEATHER_CONDITIONS_TEXT}, // labels from here
+    {"temperature",     WEATHER_TEMPERATURE},
+    {"location",        WEATHER_LOCATION},
+    {"fanartcode",      WEATHER_FANART_CODE},
+    {"plugin",          WEATHER_PLUGIN},
+    {"conditionsicon",  WEATHER_CONDITIONS_ICON},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_System System
@@ -1912,84 +1906,86 @@ const infomap weather[] =        {{ "isfetched",        WEATHER_IS_FETCHED },
 ///     @return **True** when screensaver on idle is disabled.
 ///     <p>
 ///   }
-const infomap system_labels[] = {
-    {"hasnetwork", SYSTEM_ETHERNET_LINK_ACTIVE},
-    {"hasmediadvd", SYSTEM_MEDIA_DVD},
-    {"hasmediaaudiocd", SYSTEM_MEDIA_AUDIO_CD},
-    {"hasmediablurayplaylist", SYSTEM_MEDIA_BLURAY_PLAYLIST},
-    {"dvdready", SYSTEM_DVDREADY},
-    {"trayopen", SYSTEM_TRAYOPEN},
-    {"haslocks", SYSTEM_HASLOCKS},
-    {"hashiddeninput", SYSTEM_HAS_INPUT_HIDDEN},
-    {"hasloginscreen", SYSTEM_HAS_LOGINSCREEN},
-    {"hasactivemodaldialog", SYSTEM_HAS_ACTIVE_MODAL_DIALOG},
-    {"hasvisiblemodaldialog", SYSTEM_HAS_VISIBLE_MODAL_DIALOG},
-    {"ismaster", SYSTEM_ISMASTER},
-    {"isfullscreen", SYSTEM_ISFULLSCREEN},
-    {"isstandalone", SYSTEM_ISSTANDALONE},
-    {"loggedon", SYSTEM_LOGGEDON},
-    {"showexitbutton", SYSTEM_SHOW_EXIT_BUTTON},
-    {"canpowerdown", SYSTEM_CAN_POWERDOWN},
-    {"cansuspend", SYSTEM_CAN_SUSPEND},
-    {"canhibernate", SYSTEM_CAN_HIBERNATE},
-    {"canreboot", SYSTEM_CAN_REBOOT},
-    {"screensaveractive", SYSTEM_SCREENSAVER_ACTIVE},
-    {"dpmsactive", SYSTEM_DPMS_ACTIVE},
-    {"cputemperature", SYSTEM_CPU_TEMPERATURE}, // labels from here
-    {"cpuusage", SYSTEM_CPU_USAGE},
-    {"gputemperature", SYSTEM_GPU_TEMPERATURE},
-    {"fanspeed", SYSTEM_FAN_SPEED},
-    {"freespace", SYSTEM_FREE_SPACE},
-    {"usedspace", SYSTEM_USED_SPACE},
-    {"totalspace", SYSTEM_TOTAL_SPACE},
-    {"usedspacepercent", SYSTEM_USED_SPACE_PERCENT},
-    {"freespacepercent", SYSTEM_FREE_SPACE_PERCENT},
-    {"buildversion", SYSTEM_BUILD_VERSION},
-    {"buildversionshort", SYSTEM_BUILD_VERSION_SHORT},
-    {"buildversioncode", SYSTEM_BUILD_VERSION_CODE},
-    {"buildversiongit", SYSTEM_BUILD_VERSION_GIT},
-    {"builddate", SYSTEM_BUILD_DATE},
-    {"fps", SYSTEM_FPS},
-    {"freememory", SYSTEM_FREE_MEMORY},
-    {"language", SYSTEM_LANGUAGE},
-    {"temperatureunits", SYSTEM_TEMPERATURE_UNITS},
-    {"screenmode", SYSTEM_SCREEN_MODE},
-    {"screenwidth", SYSTEM_SCREEN_WIDTH},
-    {"screenheight", SYSTEM_SCREEN_HEIGHT},
-    {"currentwindow", SYSTEM_CURRENT_WINDOW},
-    {"currentcontrol", SYSTEM_CURRENT_CONTROL},
-    {"currentcontrolid", SYSTEM_CURRENT_CONTROL_ID},
-    {"dvdlabel", SYSTEM_DVD_LABEL},
-    {"internetstate", SYSTEM_INTERNET_STATE},
-    {"osversioninfo", SYSTEM_OS_VERSION_INFO},
-    {"kernelversion", SYSTEM_OS_VERSION_INFO}, // old, not correct name
-    {"uptime", SYSTEM_UPTIME},
-    {"totaluptime", SYSTEM_TOTALUPTIME},
-    {"cpufrequency", SYSTEM_CPUFREQUENCY},
-    {"screenresolution", SYSTEM_SCREEN_RESOLUTION},
-    {"videoencoderinfo", SYSTEM_VIDEO_ENCODER_INFO},
-    {"profilename", SYSTEM_PROFILENAME},
-    {"profilethumb", SYSTEM_PROFILETHUMB},
-    {"profilecount", SYSTEM_PROFILECOUNT},
-    {"profileautologin", SYSTEM_PROFILEAUTOLOGIN},
-    {"progressbar", SYSTEM_PROGRESS_BAR},
-    {"batterylevel", SYSTEM_BATTERY_LEVEL},
-    {"friendlyname", SYSTEM_FRIENDLY_NAME},
-    {"alarmpos", SYSTEM_ALARM_POS},
-    {"isinhibit",
-     SYSTEM_IDLE_SHUTDOWN_INHIBITED}, // Deprecated, replaced by "idleshutdowninhibited"
-    {"idleshutdowninhibited", SYSTEM_IDLE_SHUTDOWN_INHIBITED},
-    {"hasshutdown", SYSTEM_HAS_SHUTDOWN},
-    {"haspvr", SYSTEM_HAS_PVR},
-    {"startupwindow", SYSTEM_STARTUP_WINDOW},
-    {"stereoscopicmode", SYSTEM_STEREOSCOPIC_MODE},
-    {"hascms", SYSTEM_HAS_CMS},
-    {"privacypolicy", SYSTEM_PRIVACY_POLICY},
-    {"haspvraddon", SYSTEM_HAS_PVR_ADDON},
-    {"addonupdatecount", SYSTEM_ADDON_UPDATE_COUNT},
-    {"supportscpuusage", SYSTEM_SUPPORTS_CPU_USAGE},
-    {"supportedhdrtypes", SYSTEM_SUPPORTED_HDR_TYPES},
-    {"isscreensaverinhibited", SYSTEM_IS_SCREENSAVER_INHIBITED}};
+// clang-format off
+constexpr std::array<InfoMap, 76> system_labels = {{
+    {"hasnetwork",              SYSTEM_ETHERNET_LINK_ACTIVE},
+    {"hasmediadvd",             SYSTEM_MEDIA_DVD},
+    {"hasmediaaudiocd",         SYSTEM_MEDIA_AUDIO_CD},
+    {"hasmediablurayplaylist",  SYSTEM_MEDIA_BLURAY_PLAYLIST},
+    {"dvdready",                SYSTEM_DVDREADY},
+    {"trayopen",                SYSTEM_TRAYOPEN},
+    {"haslocks",                SYSTEM_HASLOCKS},
+    {"hashiddeninput",          SYSTEM_HAS_INPUT_HIDDEN},
+    {"hasloginscreen",          SYSTEM_HAS_LOGINSCREEN},
+    {"hasactivemodaldialog",    SYSTEM_HAS_ACTIVE_MODAL_DIALOG},
+    {"hasvisiblemodaldialog",   SYSTEM_HAS_VISIBLE_MODAL_DIALOG},
+    {"ismaster",                SYSTEM_ISMASTER},
+    {"isfullscreen",            SYSTEM_ISFULLSCREEN},
+    {"isstandalone",            SYSTEM_ISSTANDALONE},
+    {"loggedon",                SYSTEM_LOGGEDON},
+    {"showexitbutton",          SYSTEM_SHOW_EXIT_BUTTON},
+    {"canpowerdown",            SYSTEM_CAN_POWERDOWN},
+    {"cansuspend",              SYSTEM_CAN_SUSPEND},
+    {"canhibernate",            SYSTEM_CAN_HIBERNATE},
+    {"canreboot",               SYSTEM_CAN_REBOOT},
+    {"screensaveractive",       SYSTEM_SCREENSAVER_ACTIVE},
+    {"dpmsactive",              SYSTEM_DPMS_ACTIVE},
+    {"cputemperature",          SYSTEM_CPU_TEMPERATURE}, // labels from here
+    {"cpuusage",                SYSTEM_CPU_USAGE},
+    {"gputemperature",          SYSTEM_GPU_TEMPERATURE},
+    {"fanspeed",                SYSTEM_FAN_SPEED},
+    {"freespace",               SYSTEM_FREE_SPACE},
+    {"usedspace",               SYSTEM_USED_SPACE},
+    {"totalspace",              SYSTEM_TOTAL_SPACE},
+    {"usedspacepercent",        SYSTEM_USED_SPACE_PERCENT},
+    {"freespacepercent",        SYSTEM_FREE_SPACE_PERCENT},
+    {"buildversion",            SYSTEM_BUILD_VERSION},
+    {"buildversionshort",       SYSTEM_BUILD_VERSION_SHORT},
+    {"buildversioncode",        SYSTEM_BUILD_VERSION_CODE},
+    {"buildversiongit",         SYSTEM_BUILD_VERSION_GIT},
+    {"builddate",               SYSTEM_BUILD_DATE},
+    {"fps",                     SYSTEM_FPS},
+    {"freememory",              SYSTEM_FREE_MEMORY},
+    {"language",                SYSTEM_LANGUAGE},
+    {"temperatureunits",        SYSTEM_TEMPERATURE_UNITS},
+    {"screenmode",              SYSTEM_SCREEN_MODE},
+    {"screenwidth",             SYSTEM_SCREEN_WIDTH},
+    {"screenheight",            SYSTEM_SCREEN_HEIGHT},
+    {"currentwindow",           SYSTEM_CURRENT_WINDOW},
+    {"currentcontrol",          SYSTEM_CURRENT_CONTROL},
+    {"currentcontrolid",        SYSTEM_CURRENT_CONTROL_ID},
+    {"dvdlabel",                SYSTEM_DVD_LABEL},
+    {"internetstate",           SYSTEM_INTERNET_STATE},
+    {"osversioninfo",           SYSTEM_OS_VERSION_INFO},
+    {"kernelversion",           SYSTEM_OS_VERSION_INFO}, // old, not correct name
+    {"uptime",                  SYSTEM_UPTIME},
+    {"totaluptime",             SYSTEM_TOTALUPTIME},
+    {"cpufrequency",            SYSTEM_CPUFREQUENCY},
+    {"screenresolution",        SYSTEM_SCREEN_RESOLUTION},
+    {"videoencoderinfo",        SYSTEM_VIDEO_ENCODER_INFO},
+    {"profilename",             SYSTEM_PROFILENAME},
+    {"profilethumb",            SYSTEM_PROFILETHUMB},
+    {"profilecount",            SYSTEM_PROFILECOUNT},
+    {"profileautologin",        SYSTEM_PROFILEAUTOLOGIN},
+    {"progressbar",             SYSTEM_PROGRESS_BAR},
+    {"batterylevel",            SYSTEM_BATTERY_LEVEL},
+    {"friendlyname",            SYSTEM_FRIENDLY_NAME},
+    {"alarmpos",                SYSTEM_ALARM_POS},
+    {"isinhibit",               SYSTEM_IDLE_SHUTDOWN_INHIBITED}, //! @deprecated, replaced by "idleshutdowninhibited"
+    {"idleshutdowninhibited",   SYSTEM_IDLE_SHUTDOWN_INHIBITED},
+    {"hasshutdown",             SYSTEM_HAS_SHUTDOWN},
+    {"haspvr",                  SYSTEM_HAS_PVR},
+    {"startupwindow",           SYSTEM_STARTUP_WINDOW},
+    {"stereoscopicmode",        SYSTEM_STEREOSCOPIC_MODE},
+    {"hascms",                  SYSTEM_HAS_CMS},
+    {"privacypolicy",           SYSTEM_PRIVACY_POLICY},
+    {"haspvraddon",             SYSTEM_HAS_PVR_ADDON},
+    {"addonupdatecount",        SYSTEM_ADDON_UPDATE_COUNT},
+    {"supportscpuusage",        SYSTEM_SUPPORTS_CPU_USAGE},
+    {"supportedhdrtypes",       SYSTEM_SUPPORTED_HDR_TYPES},
+    {"isscreensaverinhibited",  SYSTEM_IS_SCREENSAVER_INHIBITED},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 ///   \table_row3{   <b>`System.HasAddon(id)`</b>,
@@ -2048,12 +2044,16 @@ const infomap system_labels[] = {
 /// @todo Some values are hardcoded in the middle of the code  - refactor to make it easier to track
 ///
 /// -----------------------------------------------------------------------------
-const infomap system_param[] =   {{ "hasalarm",         SYSTEM_HAS_ALARM },
-                                  { "hascoreid",        SYSTEM_HAS_CORE_ID },
-                                  { "setting",          SYSTEM_SETTING },
-                                  { "hasaddon",         SYSTEM_HAS_ADDON },
-                                  { "addonisenabled",   SYSTEM_ADDON_IS_ENABLED },
-                                  { "coreusage",        SYSTEM_GET_CORE_USAGE }};
+// clang-format off
+constexpr std::array<InfoMap, 6> system_param = {{
+    {"hasalarm",        SYSTEM_HAS_ALARM},
+    {"hascoreid",       SYSTEM_HAS_CORE_ID},
+    {"setting",         SYSTEM_SETTING},
+    {"hasaddon",        SYSTEM_HAS_ADDON},
+    {"addonisenabled",  SYSTEM_ADDON_IS_ENABLED},
+    {"coreusage",       SYSTEM_GET_CORE_USAGE},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_Network Network
@@ -2112,16 +2112,16 @@ const infomap system_param[] =   {{ "hasalarm",         SYSTEM_HAS_ALARM },
 ///
 /// -----------------------------------------------------------------------------
 // clang-format off
-const infomap network_labels[] = {
+constexpr std::array<InfoMap, 8> network_labels = {{
     {"isdhcp", NETWORK_IS_DHCP},
-    {"ipaddress", NETWORK_IP_ADDRESS}, //labels from here
-    {"linkstate", NETWORK_LINK_STATE},
-    {"macaddress", NETWORK_MAC_ADDRESS},
-    {"subnetmask", NETWORK_SUBNET_MASK},
-    {"gatewayaddress", NETWORK_GATEWAY_ADDRESS},
-    {"dns1address", NETWORK_DNS1_ADDRESS},
-    {"dns2address", NETWORK_DNS2_ADDRESS}
-};
+    {"ipaddress",       NETWORK_IP_ADDRESS}, //labels from here
+    {"linkstate",       NETWORK_LINK_STATE},
+    {"macaddress",      NETWORK_MAC_ADDRESS},
+    {"subnetmask",      NETWORK_SUBNET_MASK},
+    {"gatewayaddress",  NETWORK_GATEWAY_ADDRESS},
+    {"dns1address",     NETWORK_DNS1_ADDRESS},
+    {"dns2address",     NETWORK_DNS2_ADDRESS},
+}};
 // clang-format on
 
 /// \page modules__infolabels_boolean_conditions
@@ -2173,13 +2173,17 @@ const infomap network_labels[] = {
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
-const infomap musicpartymode[] = {{ "enabled",           MUSICPM_ENABLED },
-                                  { "songsplayed",       MUSICPM_SONGSPLAYED },
-                                  { "matchingsongs",     MUSICPM_MATCHINGSONGS },
-                                  { "matchingsongspicked", MUSICPM_MATCHINGSONGSPICKED },
-                                  { "matchingsongsleft", MUSICPM_MATCHINGSONGSLEFT },
-                                  { "relaxedsongspicked", MUSICPM_RELAXEDSONGSPICKED },
-                                  { "randomsongspicked", MUSICPM_RANDOMSONGSPICKED }};
+// clang-format off
+constexpr std::array<InfoMap, 7> musicpartymode = {{
+    {"enabled",             MUSICPM_ENABLED},
+    {"songsplayed",         MUSICPM_SONGSPLAYED},
+    {"matchingsongs",       MUSICPM_MATCHINGSONGS},
+    {"matchingsongspicked", MUSICPM_MATCHINGSONGSPICKED},
+    {"matchingsongsleft",   MUSICPM_MATCHINGSONGSLEFT},
+    {"relaxedsongspicked",  MUSICPM_RELAXEDSONGSPICKED},
+    {"randomsongspicked",   MUSICPM_RANDOMSONGSPICKED},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_MusicPlayer Music player
@@ -2916,53 +2920,54 @@ const infomap musicpartymode[] = {{ "enabled",           MUSICPM_ENABLED },
 ///
 /// -----------------------------------------------------------------------------
 // clang-format off
-const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
-                                  { "album",            MUSICPLAYER_ALBUM },
-                                  { "artist",           MUSICPLAYER_ARTIST },
-                                  { "albumartist",      MUSICPLAYER_ALBUM_ARTIST },
-                                  { "year",             MUSICPLAYER_YEAR },
-                                  { "genre",            MUSICPLAYER_GENRE },
-                                  { "duration",         MUSICPLAYER_DURATION },
-                                  { "tracknumber",      MUSICPLAYER_TRACK_NUMBER },
-                                  { "cover",            MUSICPLAYER_COVER },
-                                  { "bitrate",          MUSICPLAYER_BITRATE },
-                                  { "playlistlength",   MUSICPLAYER_PLAYLISTLEN },
-                                  { "playlistposition", MUSICPLAYER_PLAYLISTPOS },
-                                  { "channels",         MUSICPLAYER_CHANNELS },
-                                  { "bitspersample",    MUSICPLAYER_BITSPERSAMPLE },
-                                  { "samplerate",       MUSICPLAYER_SAMPLERATE },
-                                  { "codec",            MUSICPLAYER_CODEC },
-                                  { "discnumber",       MUSICPLAYER_DISC_NUMBER },
-                                  { "disctitle",        MUSICPLAYER_DISC_TITLE },
-                                  { "rating",           MUSICPLAYER_RATING },
-                                  { "ratingandvotes",   MUSICPLAYER_RATING_AND_VOTES },
-                                  { "userrating",       MUSICPLAYER_USER_RATING },
-                                  { "votes",            MUSICPLAYER_VOTES },
-                                  { "comment",          MUSICPLAYER_COMMENT },
-                                  { "mood",             MUSICPLAYER_MOOD },
-                                  { "contributors",     MUSICPLAYER_CONTRIBUTORS },
-                                  { "contributorandrole", MUSICPLAYER_CONTRIBUTOR_AND_ROLE },
-                                  { "lyrics",           MUSICPLAYER_LYRICS },
-                                  { "playlistplaying",  MUSICPLAYER_PLAYLISTPLAYING },
-                                  { "exists",           MUSICPLAYER_EXISTS },
-                                  { "hasprevious",      MUSICPLAYER_HASPREVIOUS },
-                                  { "hasnext",          MUSICPLAYER_HASNEXT },
-                                  { "playcount",        MUSICPLAYER_PLAYCOUNT },
-                                  { "lastplayed",       MUSICPLAYER_LASTPLAYED },
-                                  { "channelname",      MUSICPLAYER_CHANNEL_NAME },
-                                  { "channellogo",      MUSICPLAYER_CHANNEL_LOGO },
-                                  { "channelnumberlabel", MUSICPLAYER_CHANNEL_NUMBER },
-                                  { "channelgroup",     MUSICPLAYER_CHANNEL_GROUP },
-                                  { "dbid",             MUSICPLAYER_DBID },
-                                  { "property",         MUSICPLAYER_PROPERTY },
-                                  { "releasedate",      MUSICPLAYER_RELEASEDATE },
-                                  { "originaldate",     MUSICPLAYER_ORIGINALDATE },
-                                  { "bpm",              MUSICPLAYER_BPM },
-                                  { "ismultidisc",      MUSICPLAYER_ISMULTIDISC },
-                                  { "totaldiscs",       MUSICPLAYER_TOTALDISCS },
-                                  { "station",          MUSICPLAYER_STATIONNAME },
-                                  { "mediaproviders",   MUSICPLAYER_MEDIAPROVIDERS },
-};
+constexpr std::array<InfoMap, 46> musicplayer = {{
+    {"title",               MUSICPLAYER_TITLE},
+    {"album",               MUSICPLAYER_ALBUM},
+    {"artist",              MUSICPLAYER_ARTIST},
+    {"albumartist",         MUSICPLAYER_ALBUM_ARTIST},
+    {"year",                MUSICPLAYER_YEAR},
+    {"genre",               MUSICPLAYER_GENRE},
+    {"duration",            MUSICPLAYER_DURATION},
+    {"tracknumber",         MUSICPLAYER_TRACK_NUMBER},
+    {"cover",               MUSICPLAYER_COVER},
+    {"bitrate",             MUSICPLAYER_BITRATE},
+    {"playlistlength",      MUSICPLAYER_PLAYLISTLEN},
+    {"playlistposition",    MUSICPLAYER_PLAYLISTPOS},
+    {"channels",            MUSICPLAYER_CHANNELS},
+    {"bitspersample",       MUSICPLAYER_BITSPERSAMPLE},
+    {"samplerate",          MUSICPLAYER_SAMPLERATE},
+    {"codec",               MUSICPLAYER_CODEC},
+    {"discnumber",          MUSICPLAYER_DISC_NUMBER},
+    {"disctitle",           MUSICPLAYER_DISC_TITLE},
+    {"rating",              MUSICPLAYER_RATING},
+    {"ratingandvotes",      MUSICPLAYER_RATING_AND_VOTES},
+    {"userrating",          MUSICPLAYER_USER_RATING},
+    {"votes",               MUSICPLAYER_VOTES},
+    {"comment",             MUSICPLAYER_COMMENT},
+    {"mood",                MUSICPLAYER_MOOD},
+    {"contributors",        MUSICPLAYER_CONTRIBUTORS},
+    {"contributorandrole",  MUSICPLAYER_CONTRIBUTOR_AND_ROLE},
+    {"lyrics",              MUSICPLAYER_LYRICS},
+    {"playlistplaying",     MUSICPLAYER_PLAYLISTPLAYING},
+    {"exists",              MUSICPLAYER_EXISTS},
+    {"hasprevious",         MUSICPLAYER_HASPREVIOUS},
+    {"hasnext",             MUSICPLAYER_HASNEXT},
+    {"playcount",           MUSICPLAYER_PLAYCOUNT},
+    {"lastplayed",          MUSICPLAYER_LASTPLAYED},
+    {"channelname",         MUSICPLAYER_CHANNEL_NAME},
+    {"channellogo",         MUSICPLAYER_CHANNEL_LOGO},
+    {"channelnumberlabel",  MUSICPLAYER_CHANNEL_NUMBER},
+    {"channelgroup",        MUSICPLAYER_CHANNEL_GROUP},
+    {"dbid",                MUSICPLAYER_DBID},
+    {"property",            MUSICPLAYER_PROPERTY},
+    {"releasedate",         MUSICPLAYER_RELEASEDATE},
+    {"originaldate",        MUSICPLAYER_ORIGINALDATE},
+    {"bpm",                 MUSICPLAYER_BPM},
+    {"ismultidisc",         MUSICPLAYER_ISMULTIDISC},
+    {"totaldiscs",          MUSICPLAYER_TOTALDISCS},
+    {"station",             MUSICPLAYER_STATIONNAME},
+    {"mediaproviders",      MUSICPLAYER_MEDIAPROVIDERS},
+}};
 // clang-format on
 
 /// \page modules__infolabels_boolean_conditions
@@ -4111,89 +4116,90 @@ const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
 ///
 /// -----------------------------------------------------------------------------
 // clang-format off
-const infomap videoplayer[] =    {{ "title",            VIDEOPLAYER_TITLE },
-                                  { "genre",            VIDEOPLAYER_GENRE },
-                                  { "country",          VIDEOPLAYER_COUNTRY },
-                                  { "originaltitle",    VIDEOPLAYER_ORIGINALTITLE },
-                                  { "director",         VIDEOPLAYER_DIRECTOR },
-                                  { "year",             VIDEOPLAYER_YEAR },
-                                  { "cover",            VIDEOPLAYER_COVER },
-                                  { "usingoverlays",    VIDEOPLAYER_USING_OVERLAYS },
-                                  { "isfullscreen",     VIDEOPLAYER_ISFULLSCREEN },
-                                  { "hasmenu",          VIDEOPLAYER_HASMENU },
-                                  { "playlistlength",   VIDEOPLAYER_PLAYLISTLEN },
-                                  { "playlistposition", VIDEOPLAYER_PLAYLISTPOS },
-                                  { "plot",             VIDEOPLAYER_PLOT },
-                                  { "plotoutline",      VIDEOPLAYER_PLOT_OUTLINE },
-                                  { "episode",          VIDEOPLAYER_EPISODE },
-                                  { "season",           VIDEOPLAYER_SEASON },
-                                  { "rating",           VIDEOPLAYER_RATING },
-                                  { "ratingandvotes",   VIDEOPLAYER_RATING_AND_VOTES },
-                                  { "userrating",       VIDEOPLAYER_USER_RATING },
-                                  { "votes",            VIDEOPLAYER_VOTES },
-                                  { "tvshowtitle",      VIDEOPLAYER_TVSHOW },
-                                  { "premiered",        VIDEOPLAYER_PREMIERED },
-                                  { "studio",           VIDEOPLAYER_STUDIO },
-                                  { "mpaa",             VIDEOPLAYER_MPAA },
-                                  { "top250",           VIDEOPLAYER_TOP250 },
-                                  { "cast",             VIDEOPLAYER_CAST },
-                                  { "castandrole",      VIDEOPLAYER_CAST_AND_ROLE },
-                                  { "artist",           VIDEOPLAYER_ARTIST },
-                                  { "album",            VIDEOPLAYER_ALBUM },
-                                  { "writer",           VIDEOPLAYER_WRITER },
-                                  { "tagline",          VIDEOPLAYER_TAGLINE },
-                                  { "hasinfo",          VIDEOPLAYER_HAS_INFO },
-                                  { "trailer",          VIDEOPLAYER_TRAILER },
-                                  { "videocodec",       VIDEOPLAYER_VIDEO_CODEC },
-                                  { "videoresolution",  VIDEOPLAYER_VIDEO_RESOLUTION },
-                                  { "videoaspect",      VIDEOPLAYER_VIDEO_ASPECT },
-                                  { "videobitrate",     VIDEOPLAYER_VIDEO_BITRATE },
-                                  { "audiocodec",       VIDEOPLAYER_AUDIO_CODEC },
-                                  { "audiochannels",    VIDEOPLAYER_AUDIO_CHANNELS },
-                                  { "audiobitrate",     VIDEOPLAYER_AUDIO_BITRATE },
-                                  { "audiolanguage",    VIDEOPLAYER_AUDIO_LANG },
-                                  { "hasteletext",      VIDEOPLAYER_HASTELETEXT },
-                                  { "lastplayed",       VIDEOPLAYER_LASTPLAYED },
-                                  { "playcount",        VIDEOPLAYER_PLAYCOUNT },
-                                  { "hassubtitles",     VIDEOPLAYER_HASSUBTITLES },
-                                  { "subtitlesenabled", VIDEOPLAYER_SUBTITLESENABLED },
-                                  { "subtitleslanguage",VIDEOPLAYER_SUBTITLES_LANG },
-                                  { "starttime",        VIDEOPLAYER_STARTTIME },
-                                  { "endtime",          VIDEOPLAYER_ENDTIME },
-                                  { "nexttitle",        VIDEOPLAYER_NEXT_TITLE },
-                                  { "nextgenre",        VIDEOPLAYER_NEXT_GENRE },
-                                  { "nextplot",         VIDEOPLAYER_NEXT_PLOT },
-                                  { "nextplotoutline",  VIDEOPLAYER_NEXT_PLOT_OUTLINE },
-                                  { "nextstarttime",    VIDEOPLAYER_NEXT_STARTTIME },
-                                  { "nextendtime",      VIDEOPLAYER_NEXT_ENDTIME },
-                                  { "nextduration",     VIDEOPLAYER_NEXT_DURATION },
-                                  { "channelname",      VIDEOPLAYER_CHANNEL_NAME },
-                                  { "channellogo",      VIDEOPLAYER_CHANNEL_LOGO },
-                                  { "channelnumberlabel", VIDEOPLAYER_CHANNEL_NUMBER },
-                                  { "channelgroup",     VIDEOPLAYER_CHANNEL_GROUP },
-                                  { "hasepg",           VIDEOPLAYER_HAS_EPG },
-                                  { "parentalrating",   VIDEOPLAYER_PARENTAL_RATING },
-                                  { "parentalratingcode",   VIDEOPLAYER_PARENTAL_RATING_CODE },
-                                  { "parentalratingicon",   VIDEOPLAYER_PARENTAL_RATING_ICON },
-                                  { "parentalratingsource", VIDEOPLAYER_PARENTAL_RATING_SOURCE },
-                                  { "isstereoscopic",   VIDEOPLAYER_IS_STEREOSCOPIC },
-                                  { "stereoscopicmode", VIDEOPLAYER_STEREOSCOPIC_MODE },
-                                  { "canresumelivetv",  VIDEOPLAYER_CAN_RESUME_LIVE_TV },
-                                  { "imdbnumber",       VIDEOPLAYER_IMDBNUMBER },
-                                  { "episodename",      VIDEOPLAYER_EPISODENAME },
-                                  { "dbid",             VIDEOPLAYER_DBID },
-                                  { "uniqueid",         VIDEOPLAYER_UNIQUEID },
-                                  { "tvshowdbid",       VIDEOPLAYER_TVSHOWDBID },
-                                  { "audiostreamcount", VIDEOPLAYER_AUDIOSTREAMCOUNT },
-                                  { "videostreamcount", VIDEOPLAYER_VIDEOSTREAMCOUNT },
-                                  { "hdrtype",          VIDEOPLAYER_HDR_TYPE },
-                                  { "art",              VIDEOPLAYER_ART},
-                                  { "videoversionname", VIDEOPLAYER_VIDEOVERSION_NAME},
-                                  { "hasvideoversions", VIDEOPLAYER_HAS_VIDEOVERSIONS},
-                                  { "episodepart",      VIDEOPLAYER_EPISODEPART},
-                                  { "mediaproviders",   VIDEOPLAYER_MEDIAPROVIDERS },
-                                  { "titleextrainfo",   VIDEOPLAYER_TITLE_EXTRAINFO },
-};
+constexpr std::array<InfoMap, 82> videoplayer = {{
+    {"title",                 VIDEOPLAYER_TITLE},
+    {"genre",                 VIDEOPLAYER_GENRE},
+    {"country",               VIDEOPLAYER_COUNTRY},
+    {"originaltitle",         VIDEOPLAYER_ORIGINALTITLE},
+    {"director",              VIDEOPLAYER_DIRECTOR},
+    {"year",                  VIDEOPLAYER_YEAR},
+    {"cover",                 VIDEOPLAYER_COVER},
+    {"usingoverlays",         VIDEOPLAYER_USING_OVERLAYS},
+    {"isfullscreen",          VIDEOPLAYER_ISFULLSCREEN},
+    {"hasmenu",               VIDEOPLAYER_HASMENU},
+    {"playlistlength",        VIDEOPLAYER_PLAYLISTLEN},
+    {"playlistposition",      VIDEOPLAYER_PLAYLISTPOS},
+    {"plot",                  VIDEOPLAYER_PLOT},
+    {"plotoutline",           VIDEOPLAYER_PLOT_OUTLINE},
+    {"episode",               VIDEOPLAYER_EPISODE},
+    {"season",                VIDEOPLAYER_SEASON},
+    {"rating",                VIDEOPLAYER_RATING},
+    {"ratingandvotes",        VIDEOPLAYER_RATING_AND_VOTES},
+    {"userrating",            VIDEOPLAYER_USER_RATING},
+    {"votes",                 VIDEOPLAYER_VOTES},
+    {"tvshowtitle",           VIDEOPLAYER_TVSHOW},
+    {"premiered",             VIDEOPLAYER_PREMIERED},
+    {"studio",                VIDEOPLAYER_STUDIO},
+    {"mpaa",                  VIDEOPLAYER_MPAA},
+    {"top250",                VIDEOPLAYER_TOP250},
+    {"cast",                  VIDEOPLAYER_CAST},
+    {"castandrole",           VIDEOPLAYER_CAST_AND_ROLE},
+    {"artist",                VIDEOPLAYER_ARTIST},
+    {"album",                 VIDEOPLAYER_ALBUM},
+    {"writer",                VIDEOPLAYER_WRITER},
+    {"tagline",               VIDEOPLAYER_TAGLINE},
+    {"hasinfo",               VIDEOPLAYER_HAS_INFO},
+    {"trailer",               VIDEOPLAYER_TRAILER},
+    {"videocodec",            VIDEOPLAYER_VIDEO_CODEC},
+    {"videoresolution",       VIDEOPLAYER_VIDEO_RESOLUTION},
+    {"videoaspect",           VIDEOPLAYER_VIDEO_ASPECT},
+    {"videobitrate",          VIDEOPLAYER_VIDEO_BITRATE},
+    {"audiocodec",            VIDEOPLAYER_AUDIO_CODEC},
+    {"audiochannels",         VIDEOPLAYER_AUDIO_CHANNELS},
+    {"audiobitrate",          VIDEOPLAYER_AUDIO_BITRATE},
+    {"audiolanguage",         VIDEOPLAYER_AUDIO_LANG},
+    {"hasteletext",           VIDEOPLAYER_HASTELETEXT},
+    {"lastplayed",            VIDEOPLAYER_LASTPLAYED},
+    {"playcount",             VIDEOPLAYER_PLAYCOUNT},
+    {"hassubtitles",          VIDEOPLAYER_HASSUBTITLES},
+    {"subtitlesenabled",      VIDEOPLAYER_SUBTITLESENABLED},
+    {"subtitleslanguage",     VIDEOPLAYER_SUBTITLES_LANG},
+    {"starttime",             VIDEOPLAYER_STARTTIME},
+    {"endtime",               VIDEOPLAYER_ENDTIME},
+    {"nexttitle",             VIDEOPLAYER_NEXT_TITLE},
+    {"nextgenre",             VIDEOPLAYER_NEXT_GENRE},
+    {"nextplot",              VIDEOPLAYER_NEXT_PLOT},
+    {"nextplotoutline",       VIDEOPLAYER_NEXT_PLOT_OUTLINE},
+    {"nextstarttime",         VIDEOPLAYER_NEXT_STARTTIME},
+    {"nextendtime",           VIDEOPLAYER_NEXT_ENDTIME},
+    {"nextduration",          VIDEOPLAYER_NEXT_DURATION},
+    {"channelname",           VIDEOPLAYER_CHANNEL_NAME},
+    {"channellogo",           VIDEOPLAYER_CHANNEL_LOGO},
+    {"channelnumberlabel",    VIDEOPLAYER_CHANNEL_NUMBER},
+    {"channelgroup",          VIDEOPLAYER_CHANNEL_GROUP},
+    {"hasepg",                VIDEOPLAYER_HAS_EPG},
+    {"parentalrating",        VIDEOPLAYER_PARENTAL_RATING},
+    {"parentalratingcode",    VIDEOPLAYER_PARENTAL_RATING_CODE},
+    {"parentalratingicon",    VIDEOPLAYER_PARENTAL_RATING_ICON},
+    {"parentalratingsource",  VIDEOPLAYER_PARENTAL_RATING_SOURCE},
+    {"isstereoscopic",        VIDEOPLAYER_IS_STEREOSCOPIC},
+    {"stereoscopicmode",      VIDEOPLAYER_STEREOSCOPIC_MODE},
+    {"canresumelivetv",       VIDEOPLAYER_CAN_RESUME_LIVE_TV},
+    {"imdbnumber",            VIDEOPLAYER_IMDBNUMBER},
+    {"episodename",           VIDEOPLAYER_EPISODENAME},
+    {"dbid",                  VIDEOPLAYER_DBID},
+    {"uniqueid",              VIDEOPLAYER_UNIQUEID},
+    {"tvshowdbid",            VIDEOPLAYER_TVSHOWDBID},
+    {"audiostreamcount",      VIDEOPLAYER_AUDIOSTREAMCOUNT},
+    {"videostreamcount",      VIDEOPLAYER_VIDEOSTREAMCOUNT},
+    {"hdrtype",               VIDEOPLAYER_HDR_TYPE},
+    {"art",                   VIDEOPLAYER_ART},
+    {"videoversionname",      VIDEOPLAYER_VIDEOVERSION_NAME},
+    {"hasvideoversions",      VIDEOPLAYER_HAS_VIDEOVERSIONS},
+    {"episodepart",           VIDEOPLAYER_EPISODEPART},
+    {"mediaproviders",        VIDEOPLAYER_MEDIAPROVIDERS},
+    {"titleextrainfo",        VIDEOPLAYER_TITLE_EXTRAINFO},
+}};
 // clang-format on
 
 /// \page modules__infolabels_boolean_conditions
@@ -4241,12 +4247,13 @@ const infomap videoplayer[] =    {{ "title",            VIDEOPLAYER_TITLE },
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
-const infomap retroplayer[] =
-{
-  { "videofilter",            RETROPLAYER_VIDEO_FILTER},
-  { "stretchmode",            RETROPLAYER_STRETCH_MODE},
-  { "videorotation",          RETROPLAYER_VIDEO_ROTATION},
-};
+// clang-format off
+constexpr std::array<InfoMap, 3> retroplayer = {{
+    {"videofilter",   RETROPLAYER_VIDEO_FILTER},
+    {"stretchmode",   RETROPLAYER_STRETCH_MODE},
+    {"videorotation", RETROPLAYER_VIDEO_ROTATION},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_Container Container
@@ -4383,25 +4390,29 @@ const infomap retroplayer[] =
 ///     @skinning_v17 **[New Infolabel]** \link Container_ShowTitle `Container.ShowTitle`\endlink
 ///     <p>
 ///   }
-const infomap mediacontainer[] = {{ "hasfiles",         CONTAINER_HASFILES },
-                                  { "hasfolders",       CONTAINER_HASFOLDERS },
-                                  { "isstacked",        CONTAINER_STACKED },
-                                  { "folderpath",       CONTAINER_FOLDERPATH },
-                                  { "foldername",       CONTAINER_FOLDERNAME },
-                                  { "pluginname",       CONTAINER_PLUGINNAME },
-                                  { "plugincategory",   CONTAINER_PLUGINCATEGORY },
-                                  { "viewmode",         CONTAINER_VIEWMODE },
-                                  { "viewcount",        CONTAINER_VIEWCOUNT },
-                                  { "totaltime",        CONTAINER_TOTALTIME },
-                                  { "totalwatched",     CONTAINER_TOTALWATCHED },
-                                  { "totalunwatched",   CONTAINER_TOTALUNWATCHED },
-                                  { "hasthumb",         CONTAINER_HAS_THUMB },
-                                  { "sortorder",        CONTAINER_SORT_ORDER },
-                                  { "canfilter",        CONTAINER_CAN_FILTER },
-                                  { "canfilteradvanced",CONTAINER_CAN_FILTERADVANCED },
-                                  { "filtered",         CONTAINER_FILTERED },
-                                  { "showplot",         CONTAINER_SHOWPLOT },
-                                  { "showtitle",        CONTAINER_SHOWTITLE }};
+// clang-format off
+constexpr std::array<InfoMap, 19> mediacontainer = {{
+    {"hasfiles",          CONTAINER_HASFILES},
+    {"hasfolders",        CONTAINER_HASFOLDERS},
+    {"isstacked",         CONTAINER_STACKED},
+    {"folderpath",        CONTAINER_FOLDERPATH},
+    {"foldername",        CONTAINER_FOLDERNAME},
+    {"pluginname",        CONTAINER_PLUGINNAME},
+    {"plugincategory",    CONTAINER_PLUGINCATEGORY},
+    {"viewmode",          CONTAINER_VIEWMODE},
+    {"viewcount",         CONTAINER_VIEWCOUNT},
+    {"totaltime",         CONTAINER_TOTALTIME},
+    {"totalwatched",      CONTAINER_TOTALWATCHED},
+    {"totalunwatched",    CONTAINER_TOTALUNWATCHED},
+    {"hasthumb",          CONTAINER_HAS_THUMB},
+    {"sortorder",         CONTAINER_SORT_ORDER},
+    {"canfilter",         CONTAINER_CAN_FILTER},
+    {"canfilteradvanced", CONTAINER_CAN_FILTERADVANCED},
+    {"filtered",          CONTAINER_FILTERED},
+    {"showplot",          CONTAINER_SHOWPLOT},
+    {"showtitle",         CONTAINER_SHOWTITLE},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 ///   \table_row3{   <b>`Container(id).OnNext`</b>,
@@ -4522,21 +4533,25 @@ const infomap mediacontainer[] = {{ "hasfiles",         CONTAINER_HASFILES },
 ///                  _boolean_,
 ///     @return **True** if the container with dynamic list content is currently updating.
 ///   }
-const infomap container_bools[] ={{ "onnext",           CONTAINER_MOVE_NEXT },
-                                  { "onprevious",       CONTAINER_MOVE_PREVIOUS },
-                                  { "onscrollnext",     CONTAINER_SCROLL_NEXT },
-                                  { "onscrollprevious", CONTAINER_SCROLL_PREVIOUS },
-                                  { "numpages",         CONTAINER_NUM_PAGES },
-                                  { "numitems",         CONTAINER_NUM_ITEMS },
-                                  { "numnonfolderitems", CONTAINER_NUM_NONFOLDER_ITEMS },
-                                  { "numallitems",      CONTAINER_NUM_ALL_ITEMS },
-                                  { "currentpage",      CONTAINER_CURRENT_PAGE },
-                                  { "currentitem",      CONTAINER_CURRENT_ITEM },
-                                  { "scrolling",        CONTAINER_SCROLLING },
-                                  { "hasnext",          CONTAINER_HAS_NEXT },
-                                  { "hasparent",        CONTAINER_HAS_PARENT_ITEM },
-                                  { "hasprevious",      CONTAINER_HAS_PREVIOUS },
-                                  { "isupdating",       CONTAINER_ISUPDATING }};
+// clang-format off
+constexpr std::array<InfoMap, 15> container_bools = {{
+    {"onnext",            CONTAINER_MOVE_NEXT},
+    {"onprevious",        CONTAINER_MOVE_PREVIOUS},
+    {"onscrollnext",      CONTAINER_SCROLL_NEXT},
+    {"onscrollprevious",  CONTAINER_SCROLL_PREVIOUS},
+    {"numpages",          CONTAINER_NUM_PAGES},
+    {"numitems",          CONTAINER_NUM_ITEMS},
+    {"numnonfolderitems", CONTAINER_NUM_NONFOLDER_ITEMS},
+    {"numallitems",       CONTAINER_NUM_ALL_ITEMS},
+    {"currentpage",       CONTAINER_CURRENT_PAGE},
+    {"currentitem",       CONTAINER_CURRENT_ITEM},
+    {"scrolling",         CONTAINER_SCROLLING},
+    {"hasnext",           CONTAINER_HAS_NEXT},
+    {"hasparent",         CONTAINER_HAS_PARENT_ITEM},
+    {"hasprevious",       CONTAINER_HAS_PREVIOUS},
+    {"isupdating",        CONTAINER_ISUPDATING},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 ///   \table_row3{   <b>`Container(id).Row`</b>,
@@ -4610,13 +4625,16 @@ const infomap container_bools[] ={{ "onnext",           CONTAINER_MOVE_NEXT },
 ///     @return **True** if the current sort method matches the specified SortID (see \ref List_of_sort_methods "SortUtils").
 ///     <p>
 ///   }
-const infomap container_ints[] = {{ "row",              CONTAINER_ROW },
-                                  { "column",           CONTAINER_COLUMN },
-                                  { "position",         CONTAINER_POSITION },
-                                  { "subitem",          CONTAINER_SUBITEM },
-                                  { "hasfocus",         CONTAINER_HAS_FOCUS },
-                                  { "sortmethod",       CONTAINER_SORT_METHOD },
-};
+// clang-format off
+constexpr std::array<InfoMap, 6> container_ints = {{
+    {"row",         CONTAINER_ROW},
+    {"column",      CONTAINER_COLUMN},
+    {"position",    CONTAINER_POSITION},
+    {"subitem",     CONTAINER_SUBITEM},
+    {"hasfocus",    CONTAINER_HAS_FOCUS},
+    {"sortmethod",  CONTAINER_SORT_METHOD},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 ///   \table_row3{   <b>`Container.Property(addoncategory)`</b>,
@@ -4722,9 +4740,13 @@ const infomap container_ints[] = {{ "row",              CONTAINER_ROW },
 ///     <p>
 ///   }
 ///
-const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
-                                  { "content",          CONTAINER_CONTENT },
-                                  { "art",              CONTAINER_ART }};
+// clang-format off
+constexpr std::array<InfoMap, 3> container_str = {{
+    {"property",  CONTAINER_PROPERTY},
+    {"content",   CONTAINER_CONTENT},
+    {"art",       CONTAINER_ART},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 ///   \table_row3{   <b>`Container.SortDirection(direction)`</b>,
@@ -7304,234 +7326,235 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///
 /// -----------------------------------------------------------------------------
 // clang-format off
-const infomap listitem_labels[]= {{ "thumb",            LISTITEM_THUMB },
-                                  { "icon",             LISTITEM_ICON },
-                                  { "actualicon",       LISTITEM_ACTUAL_ICON },
-                                  { "overlay",          LISTITEM_OVERLAY },
-                                  { "label",            LISTITEM_LABEL },
-                                  { "label2",           LISTITEM_LABEL2 },
-                                  { "title",            LISTITEM_TITLE },
-                                  { "tracknumber",      LISTITEM_TRACKNUMBER },
-                                  { "artist",           LISTITEM_ARTIST },
-                                  { "album",            LISTITEM_ALBUM },
-                                  { "albumartist",      LISTITEM_ALBUM_ARTIST },
-                                  { "year",             LISTITEM_YEAR },
-                                  { "genre",            LISTITEM_GENRE },
-                                  { "contributors",     LISTITEM_CONTRIBUTORS },
-                                  { "contributorandrole", LISTITEM_CONTRIBUTOR_AND_ROLE },
-                                  { "director",         LISTITEM_DIRECTOR },
-                                  { "disctitle",        LISTITEM_DISC_TITLE },
-                                  { "filename",         LISTITEM_FILENAME },
-                                  { "filenameandpath",  LISTITEM_FILENAME_AND_PATH },
-                                  { "decodedfilenameandpath", LISTITEM_DECODED_FILENAME_AND_PATH },
-                                  { "fileextension",    LISTITEM_FILE_EXTENSION },
-                                  { "filenamenoextension",  LISTITEM_FILENAME_NO_EXTENSION },
-                                  { "date",             LISTITEM_DATE },
-                                  { "datetime",         LISTITEM_DATETIME },
-                                  { "size",             LISTITEM_SIZE },
-                                  { "rating",           LISTITEM_RATING },
-                                  { "ratingandvotes",   LISTITEM_RATING_AND_VOTES },
-                                  { "userrating",       LISTITEM_USER_RATING },
-                                  { "votes",            LISTITEM_VOTES },
-                                  { "mood",             LISTITEM_MOOD },
-                                  { "programcount",     LISTITEM_PROGRAM_COUNT },
-                                  { "duration",         LISTITEM_DURATION },
-                                  { "isselected",       LISTITEM_ISSELECTED },
-                                  { "isplaying",        LISTITEM_ISPLAYING },
-                                  { "plot",             LISTITEM_PLOT },
-                                  { "plotoutline",      LISTITEM_PLOT_OUTLINE },
-                                  { "episode",          LISTITEM_EPISODE },
-                                  { "season",           LISTITEM_SEASON },
-                                  { "tvshowtitle",      LISTITEM_TVSHOW },
-                                  { "premiered",        LISTITEM_PREMIERED },
-                                  { "comment",          LISTITEM_COMMENT },
-                                  { "path",             LISTITEM_PATH },
-                                  { "foldername",       LISTITEM_FOLDERNAME },
-                                  { "folderpath",       LISTITEM_FOLDERPATH },
-                                  { "picturepath",      LISTITEM_PICTURE_PATH },
-                                  { "pictureresolution",LISTITEM_PICTURE_RESOLUTION },
-                                  { "picturedatetime",  LISTITEM_PICTURE_DATETIME },
-                                  { "picturedate",      LISTITEM_PICTURE_DATE },
-                                  { "picturelongdatetime",LISTITEM_PICTURE_LONGDATETIME },
-                                  { "picturelongdate",  LISTITEM_PICTURE_LONGDATE },
-                                  { "picturecomment",   LISTITEM_PICTURE_COMMENT },
-                                  { "picturecaption",   LISTITEM_PICTURE_CAPTION },
-                                  { "picturedesc",      LISTITEM_PICTURE_DESC },
-                                  { "picturekeywords",  LISTITEM_PICTURE_KEYWORDS },
-                                  { "picturecammake",   LISTITEM_PICTURE_CAM_MAKE },
-                                  { "picturecammodel",  LISTITEM_PICTURE_CAM_MODEL },
-                                  { "pictureaperture",  LISTITEM_PICTURE_APERTURE },
-                                  { "picturefocallen",  LISTITEM_PICTURE_FOCAL_LEN },
-                                  { "picturefocusdist", LISTITEM_PICTURE_FOCUS_DIST },
-                                  { "pictureexpmode",   LISTITEM_PICTURE_EXP_MODE },
-                                  { "pictureexptime",   LISTITEM_PICTURE_EXP_TIME },
-                                  { "pictureiso",       LISTITEM_PICTURE_ISO },
-                                  { "pictureauthor",                 LISTITEM_PICTURE_AUTHOR },
-                                  { "picturebyline",                 LISTITEM_PICTURE_BYLINE },
-                                  { "picturebylinetitle",            LISTITEM_PICTURE_BYLINE_TITLE },
-                                  { "picturecategory",               LISTITEM_PICTURE_CATEGORY },
-                                  { "pictureccdwidth",               LISTITEM_PICTURE_CCD_WIDTH },
-                                  { "picturecity",                   LISTITEM_PICTURE_CITY },
-                                  { "pictureurgency",                LISTITEM_PICTURE_URGENCY },
-                                  { "picturecopyrightnotice",        LISTITEM_PICTURE_COPYRIGHT_NOTICE },
-                                  { "picturecountry",                LISTITEM_PICTURE_COUNTRY },
-                                  { "picturecountrycode",            LISTITEM_PICTURE_COUNTRY_CODE },
-                                  { "picturecredit",                 LISTITEM_PICTURE_CREDIT },
-                                  { "pictureiptcdate",               LISTITEM_PICTURE_IPTCDATE },
-                                  { "picturedigitalzoom",            LISTITEM_PICTURE_DIGITAL_ZOOM },
-                                  { "pictureexposure",               LISTITEM_PICTURE_EXPOSURE },
-                                  { "pictureexposurebias",           LISTITEM_PICTURE_EXPOSURE_BIAS },
-                                  { "pictureflashused",              LISTITEM_PICTURE_FLASH_USED },
-                                  { "pictureheadline",               LISTITEM_PICTURE_HEADLINE },
-                                  { "picturecolour",                 LISTITEM_PICTURE_COLOUR },
-                                  { "picturelightsource",            LISTITEM_PICTURE_LIGHT_SOURCE },
-                                  { "picturemeteringmode",           LISTITEM_PICTURE_METERING_MODE },
-                                  { "pictureobjectname",             LISTITEM_PICTURE_OBJECT_NAME },
-                                  { "pictureorientation",            LISTITEM_PICTURE_ORIENTATION },
-                                  { "pictureprocess",                LISTITEM_PICTURE_PROCESS },
-                                  { "picturereferenceservice",       LISTITEM_PICTURE_REF_SERVICE },
-                                  { "picturesource",                 LISTITEM_PICTURE_SOURCE },
-                                  { "picturespecialinstructions",    LISTITEM_PICTURE_SPEC_INSTR },
-                                  { "picturestate",                  LISTITEM_PICTURE_STATE },
-                                  { "picturesupplementalcategories", LISTITEM_PICTURE_SUP_CATEGORIES },
-                                  { "picturetransmissionreference",  LISTITEM_PICTURE_TX_REFERENCE },
-                                  { "picturewhitebalance",           LISTITEM_PICTURE_WHITE_BALANCE },
-                                  { "pictureimagetype",              LISTITEM_PICTURE_IMAGETYPE },
-                                  { "picturesublocation",            LISTITEM_PICTURE_SUBLOCATION },
-                                  { "pictureiptctime",               LISTITEM_PICTURE_TIMECREATED },
-                                  { "picturegpslat",    LISTITEM_PICTURE_GPS_LAT },
-                                  { "picturegpslon",    LISTITEM_PICTURE_GPS_LON },
-                                  { "picturegpsalt",    LISTITEM_PICTURE_GPS_ALT },
-                                  { "studio",           LISTITEM_STUDIO },
-                                  { "country",          LISTITEM_COUNTRY },
-                                  { "mpaa",             LISTITEM_MPAA },
-                                  { "cast",             LISTITEM_CAST },
-                                  { "castandrole",      LISTITEM_CAST_AND_ROLE },
-                                  { "writer",           LISTITEM_WRITER },
-                                  { "tagline",          LISTITEM_TAGLINE },
-                                  { "status",           LISTITEM_STATUS },
-                                  { "top250",           LISTITEM_TOP250 },
-                                  { "trailer",          LISTITEM_TRAILER },
-                                  { "sortletter",       LISTITEM_SORT_LETTER },
-                                  { "tag",              LISTITEM_TAG },
-                                  { "set",              LISTITEM_SET },
-                                  { "setid",            LISTITEM_SETID },
-                                  { "videocodec",       LISTITEM_VIDEO_CODEC },
-                                  { "videoresolution",  LISTITEM_VIDEO_RESOLUTION },
-                                  { "videowidth",       LISTITEM_VIDEO_WIDTH},
-                                  { "videoheight",      LISTITEM_VIDEO_HEIGHT},
-                                  { "videoaspect",      LISTITEM_VIDEO_ASPECT },
-                                  { "audiocodec",       LISTITEM_AUDIO_CODEC },
-                                  { "audiochannels",    LISTITEM_AUDIO_CHANNELS },
-                                  { "audiolanguage",    LISTITEM_AUDIO_LANGUAGE },
-                                  { "subtitlelanguage", LISTITEM_SUBTITLE_LANGUAGE },
-                                  { "isresumable",      LISTITEM_IS_RESUMABLE},
-                                  { "percentplayed",    LISTITEM_PERCENT_PLAYED},
-                                  { "isfolder",         LISTITEM_IS_FOLDER },
-                                  { "isparentfolder",   LISTITEM_IS_PARENTFOLDER },
-                                  { "iscollection",     LISTITEM_IS_COLLECTION },
-                                  { "originaltitle",    LISTITEM_ORIGINALTITLE },
-                                  { "lastplayed",       LISTITEM_LASTPLAYED },
-                                  { "playcount",        LISTITEM_PLAYCOUNT },
-                                  { "discnumber",       LISTITEM_DISC_NUMBER },
-                                  { "starttime",        LISTITEM_STARTTIME },
-                                  { "endtime",          LISTITEM_ENDTIME },
-                                  { "endtimeresume",    LISTITEM_ENDTIME_RESUME },
-                                  { "startdate",        LISTITEM_STARTDATE },
-                                  { "enddate",          LISTITEM_ENDDATE },
-                                  { "nexttitle",        LISTITEM_NEXT_TITLE },
-                                  { "nextgenre",        LISTITEM_NEXT_GENRE },
-                                  { "nextplot",         LISTITEM_NEXT_PLOT },
-                                  { "nextplotoutline",  LISTITEM_NEXT_PLOT_OUTLINE },
-                                  { "nextstarttime",    LISTITEM_NEXT_STARTTIME },
-                                  { "nextendtime",      LISTITEM_NEXT_ENDTIME },
-                                  { "nextstartdate",    LISTITEM_NEXT_STARTDATE },
-                                  { "nextenddate",      LISTITEM_NEXT_ENDDATE },
-                                  { "nextduration",     LISTITEM_NEXT_DURATION },
-                                  { "channelname",      LISTITEM_CHANNEL_NAME },
-                                  { "channellogo",      LISTITEM_CHANNEL_LOGO },
-                                  { "channelnumberlabel", LISTITEM_CHANNEL_NUMBER },
-                                  { "channelgroup",     LISTITEM_CHANNEL_GROUP },
-                                  { "hasepg",           LISTITEM_HAS_EPG },
-                                  { "hastimer",         LISTITEM_HASTIMER },
-                                  { "hastimerschedule", LISTITEM_HASTIMERSCHEDULE },
-                                  { "hasreminder",      LISTITEM_HASREMINDER },
-                                  { "hasreminderrule",  LISTITEM_HASREMINDERRULE },
-                                  { "hasrecording",     LISTITEM_HASRECORDING },
-                                  { "isrecording",      LISTITEM_ISRECORDING },
-                                  { "isplayable",       LISTITEM_ISPLAYABLE },
-                                  { "hasarchive",       LISTITEM_HASARCHIVE },
-                                  { "inprogress",       LISTITEM_INPROGRESS },
-                                  { "isencrypted",      LISTITEM_ISENCRYPTED },
-                                  { "progress",         LISTITEM_PROGRESS },
-                                  { "dateadded",        LISTITEM_DATE_ADDED },
-                                  { "dbtype",           LISTITEM_DBTYPE },
-                                  { "dbid",             LISTITEM_DBID },
-                                  { "appearances",      LISTITEM_APPEARANCES },
-                                  { "stereoscopicmode", LISTITEM_STEREOSCOPIC_MODE },
-                                  { "isstereoscopic",   LISTITEM_IS_STEREOSCOPIC },
-                                  { "imdbnumber",       LISTITEM_IMDBNUMBER },
-                                  { "episodename",      LISTITEM_EPISODENAME },
-                                  { "timertype",        LISTITEM_TIMERTYPE },
-                                  { "epgeventtitle",    LISTITEM_EPG_EVENT_TITLE },
-                                  { "epgeventicon",     LISTITEM_EPG_EVENT_ICON },
-                                  { "timerisactive",    LISTITEM_TIMERISACTIVE },
-                                  { "timerhaserror",    LISTITEM_TIMERHASERROR },
-                                  { "timerhasconflict", LISTITEM_TIMERHASCONFLICT },
-                                  { "addonname",        LISTITEM_ADDON_NAME },
-                                  { "addonversion",     LISTITEM_ADDON_VERSION },
-                                  { "addoncreator",     LISTITEM_ADDON_CREATOR },
-                                  { "addonsummary",     LISTITEM_ADDON_SUMMARY },
-                                  { "addondescription", LISTITEM_ADDON_DESCRIPTION },
-                                  { "addondisclaimer",  LISTITEM_ADDON_DISCLAIMER },
-                                  { "addonnews",        LISTITEM_ADDON_NEWS },
-                                  { "addonbroken",      LISTITEM_ADDON_BROKEN },
-                                  { "addonlifecycletype", LISTITEM_ADDON_LIFECYCLE_TYPE },
-                                  { "addonlifecycledesc", LISTITEM_ADDON_LIFECYCLE_DESC },
-                                  { "addontype",        LISTITEM_ADDON_TYPE },
-                                  { "addoninstalldate", LISTITEM_ADDON_INSTALL_DATE },
-                                  { "addonlastupdated", LISTITEM_ADDON_LAST_UPDATED },
-                                  { "addonlastused",    LISTITEM_ADDON_LAST_USED },
-                                  { "addonorigin",      LISTITEM_ADDON_ORIGIN },
-                                  { "addonsize",        LISTITEM_ADDON_SIZE },
-                                  { "expirationdate",   LISTITEM_EXPIRATION_DATE },
-                                  { "expirationtime",   LISTITEM_EXPIRATION_TIME },
-                                  { "art",              LISTITEM_ART },
-                                  { "property",         LISTITEM_PROPERTY },
-                                  { "parentalrating",   LISTITEM_PARENTAL_RATING },
-                                  { "parentalratingcode", LISTITEM_PARENTAL_RATING_CODE },
-                                  { "parentalratingicon", LISTITEM_PARENTAL_RATING_ICON },
-                                  { "parentalratingsource", LISTITEM_PARENTAL_RATING_SOURCE },
-                                  { "currentitem",      LISTITEM_CURRENTITEM },
-                                  { "isnew",            LISTITEM_IS_NEW },
-                                  { "isboxset",         LISTITEM_IS_BOXSET },
-                                  { "totaldiscs",       LISTITEM_TOTALDISCS },
-                                  { "releasedate",      LISTITEM_RELEASEDATE },
-                                  { "originaldate",     LISTITEM_ORIGINALDATE },
-                                  { "bpm",              LISTITEM_BPM },
-                                  { "uniqueid",         LISTITEM_UNIQUEID },
-                                  { "bitrate",          LISTITEM_BITRATE },
-                                  { "samplerate",       LISTITEM_SAMPLERATE },
-                                  { "musicchannels",    LISTITEM_MUSICCHANNELS },
-                                  { "ispremiere",       LISTITEM_IS_PREMIERE },
-                                  { "isfinale",         LISTITEM_IS_FINALE },
-                                  { "islive",           LISTITEM_IS_LIVE },
-                                  { "tvshowdbid",       LISTITEM_TVSHOWDBID },
-                                  { "albumstatus",      LISTITEM_ALBUMSTATUS },
-                                  { "isautoupdateable", LISTITEM_ISAUTOUPDATEABLE },
-                                  { "hdrtype",          LISTITEM_VIDEO_HDR_TYPE },
-                                  { "songvideourl",     LISTITEM_SONG_VIDEO_URL },
-                                  { "hasvideoversions", LISTITEM_HASVIDEOVERSIONS },
-                                  { "isvideoextra",     LISTITEM_ISVIDEOEXTRA },
-                                  { "videoversionname", LISTITEM_VIDEOVERSION_NAME },
-                                  { "hasvideoextras",   LISTITEM_HASVIDEOEXTRAS },
-                                  { "pvrclientname",    LISTITEM_PVR_CLIENT_NAME },
-                                  { "pvrinstancename",  LISTITEM_PVR_INSTANCE_NAME },
-                                  { "pvrgrouporigin",   LISTITEM_PVR_GROUP_ORIGIN },
-                                  { "episodepart",      LISTITEM_EPISODEPART },
-                                  { "mediaproviders",   LISTITEM_MEDIAPROVIDERS },
-                                  { "titleextrainfo",   LISTITEM_TITLE_EXTRAINFO },
-};
+constexpr std::array<InfoMap, 227> listitem_labels = {{
+    {"thumb",                         LISTITEM_THUMB},
+    {"icon",                          LISTITEM_ICON},
+    {"actualicon",                    LISTITEM_ACTUAL_ICON},
+    {"overlay",                       LISTITEM_OVERLAY},
+    {"label",                         LISTITEM_LABEL},
+    {"label2",                        LISTITEM_LABEL2},
+    {"title",                         LISTITEM_TITLE},
+    {"tracknumber",                   LISTITEM_TRACKNUMBER},
+    {"artist",                        LISTITEM_ARTIST},
+    {"album",                         LISTITEM_ALBUM},
+    {"albumartist",                   LISTITEM_ALBUM_ARTIST},
+    {"year",                          LISTITEM_YEAR},
+    {"genre",                         LISTITEM_GENRE},
+    {"contributors",                  LISTITEM_CONTRIBUTORS},
+    {"contributorandrole",            LISTITEM_CONTRIBUTOR_AND_ROLE},
+    {"director",                      LISTITEM_DIRECTOR},
+    {"disctitle",                     LISTITEM_DISC_TITLE},
+    {"filename",                      LISTITEM_FILENAME},
+    {"filenameandpath",               LISTITEM_FILENAME_AND_PATH},
+    {"decodedfilenameandpath",        LISTITEM_DECODED_FILENAME_AND_PATH},
+    {"fileextension",                 LISTITEM_FILE_EXTENSION},
+    {"filenamenoextension",           LISTITEM_FILENAME_NO_EXTENSION},
+    {"date",                          LISTITEM_DATE},
+    {"datetime",                      LISTITEM_DATETIME},
+    {"size",                          LISTITEM_SIZE},
+    {"rating",                        LISTITEM_RATING},
+    {"ratingandvotes",                LISTITEM_RATING_AND_VOTES},
+    {"userrating",                    LISTITEM_USER_RATING},
+    {"votes",                         LISTITEM_VOTES},
+    {"mood",                          LISTITEM_MOOD},
+    {"programcount",                  LISTITEM_PROGRAM_COUNT},
+    {"duration",                      LISTITEM_DURATION},
+    {"isselected",                    LISTITEM_ISSELECTED},
+    {"isplaying",                     LISTITEM_ISPLAYING},
+    {"plot",                          LISTITEM_PLOT},
+    {"plotoutline",                   LISTITEM_PLOT_OUTLINE},
+    {"episode",                       LISTITEM_EPISODE},
+    {"season",                        LISTITEM_SEASON},
+    {"tvshowtitle",                   LISTITEM_TVSHOW},
+    {"premiered",                     LISTITEM_PREMIERED},
+    {"comment",                       LISTITEM_COMMENT},
+    {"path",                          LISTITEM_PATH},
+    {"foldername",                    LISTITEM_FOLDERNAME},
+    {"folderpath",                    LISTITEM_FOLDERPATH},
+    {"picturepath",                   LISTITEM_PICTURE_PATH},
+    {"pictureresolution",             LISTITEM_PICTURE_RESOLUTION},
+    {"picturedatetime",               LISTITEM_PICTURE_DATETIME},
+    {"picturedate",                   LISTITEM_PICTURE_DATE},
+    {"picturelongdatetime",           LISTITEM_PICTURE_LONGDATETIME},
+    {"picturelongdate",               LISTITEM_PICTURE_LONGDATE},
+    {"picturecomment",                LISTITEM_PICTURE_COMMENT},
+    {"picturecaption",                LISTITEM_PICTURE_CAPTION},
+    {"picturedesc",                   LISTITEM_PICTURE_DESC},
+    {"picturekeywords",               LISTITEM_PICTURE_KEYWORDS},
+    {"picturecammake",                LISTITEM_PICTURE_CAM_MAKE},
+    {"picturecammodel",               LISTITEM_PICTURE_CAM_MODEL},
+    {"pictureaperture",               LISTITEM_PICTURE_APERTURE},
+    {"picturefocallen",               LISTITEM_PICTURE_FOCAL_LEN},
+    {"picturefocusdist",              LISTITEM_PICTURE_FOCUS_DIST},
+    {"pictureexpmode",                LISTITEM_PICTURE_EXP_MODE},
+    {"pictureexptime",                LISTITEM_PICTURE_EXP_TIME},
+    {"pictureiso",                    LISTITEM_PICTURE_ISO},
+    {"pictureauthor",                 LISTITEM_PICTURE_AUTHOR},
+    {"picturebyline",                 LISTITEM_PICTURE_BYLINE},
+    {"picturebylinetitle",            LISTITEM_PICTURE_BYLINE_TITLE},
+    {"picturecategory",               LISTITEM_PICTURE_CATEGORY},
+    {"pictureccdwidth",               LISTITEM_PICTURE_CCD_WIDTH},
+    {"picturecity",                   LISTITEM_PICTURE_CITY},
+    {"pictureurgency",                LISTITEM_PICTURE_URGENCY},
+    {"picturecopyrightnotice",        LISTITEM_PICTURE_COPYRIGHT_NOTICE},
+    {"picturecountry",                LISTITEM_PICTURE_COUNTRY},
+    {"picturecountrycode",            LISTITEM_PICTURE_COUNTRY_CODE},
+    {"picturecredit",                 LISTITEM_PICTURE_CREDIT},
+    {"pictureiptcdate",               LISTITEM_PICTURE_IPTCDATE},
+    {"picturedigitalzoom",            LISTITEM_PICTURE_DIGITAL_ZOOM},
+    {"pictureexposure",               LISTITEM_PICTURE_EXPOSURE},
+    {"pictureexposurebias",           LISTITEM_PICTURE_EXPOSURE_BIAS},
+    {"pictureflashused",              LISTITEM_PICTURE_FLASH_USED},
+    {"pictureheadline",               LISTITEM_PICTURE_HEADLINE},
+    {"picturecolour",                 LISTITEM_PICTURE_COLOUR},
+    {"picturelightsource",            LISTITEM_PICTURE_LIGHT_SOURCE},
+    {"picturemeteringmode",           LISTITEM_PICTURE_METERING_MODE},
+    {"pictureobjectname",             LISTITEM_PICTURE_OBJECT_NAME},
+    {"pictureorientation",            LISTITEM_PICTURE_ORIENTATION},
+    {"pictureprocess",                LISTITEM_PICTURE_PROCESS},
+    {"picturereferenceservice",       LISTITEM_PICTURE_REF_SERVICE},
+    {"picturesource",                 LISTITEM_PICTURE_SOURCE},
+    {"picturespecialinstructions",    LISTITEM_PICTURE_SPEC_INSTR},
+    {"picturestate",                  LISTITEM_PICTURE_STATE},
+    {"picturesupplementalcategories", LISTITEM_PICTURE_SUP_CATEGORIES},
+    {"picturetransmissionreference",  LISTITEM_PICTURE_TX_REFERENCE},
+    {"picturewhitebalance",           LISTITEM_PICTURE_WHITE_BALANCE},
+    {"pictureimagetype",              LISTITEM_PICTURE_IMAGETYPE},
+    {"picturesublocation",            LISTITEM_PICTURE_SUBLOCATION},
+    {"pictureiptctime",               LISTITEM_PICTURE_TIMECREATED},
+    {"picturegpslat",                 LISTITEM_PICTURE_GPS_LAT},
+    {"picturegpslon",                 LISTITEM_PICTURE_GPS_LON},
+    {"picturegpsalt",                 LISTITEM_PICTURE_GPS_ALT},
+    {"studio",                        LISTITEM_STUDIO},
+    {"country",                       LISTITEM_COUNTRY},
+    {"mpaa",                          LISTITEM_MPAA},
+    {"cast",                          LISTITEM_CAST},
+    {"castandrole",                   LISTITEM_CAST_AND_ROLE},
+    {"writer",                        LISTITEM_WRITER},
+    {"tagline",                       LISTITEM_TAGLINE},
+    {"status",                        LISTITEM_STATUS},
+    {"top250",                        LISTITEM_TOP250},
+    {"trailer",                       LISTITEM_TRAILER},
+    {"sortletter",                    LISTITEM_SORT_LETTER},
+    {"tag",                           LISTITEM_TAG},
+    {"set",                           LISTITEM_SET},
+    {"setid",                         LISTITEM_SETID},
+    {"videocodec",                    LISTITEM_VIDEO_CODEC},
+    {"videoresolution",               LISTITEM_VIDEO_RESOLUTION},
+    {"videowidth",                    LISTITEM_VIDEO_WIDTH},
+    {"videoheight",                   LISTITEM_VIDEO_HEIGHT},
+    {"videoaspect",                   LISTITEM_VIDEO_ASPECT},
+    {"audiocodec",                    LISTITEM_AUDIO_CODEC},
+    {"audiochannels",                 LISTITEM_AUDIO_CHANNELS},
+    {"audiolanguage",                 LISTITEM_AUDIO_LANGUAGE},
+    {"subtitlelanguage",              LISTITEM_SUBTITLE_LANGUAGE},
+    {"isresumable",                   LISTITEM_IS_RESUMABLE},
+    {"percentplayed",                 LISTITEM_PERCENT_PLAYED},
+    {"isfolder",                      LISTITEM_IS_FOLDER},
+    {"isparentfolder",                LISTITEM_IS_PARENTFOLDER},
+    {"iscollection",                  LISTITEM_IS_COLLECTION},
+    {"originaltitle",                 LISTITEM_ORIGINALTITLE},
+    {"lastplayed",                    LISTITEM_LASTPLAYED},
+    {"playcount",                     LISTITEM_PLAYCOUNT},
+    {"discnumber",                    LISTITEM_DISC_NUMBER},
+    {"starttime",                     LISTITEM_STARTTIME},
+    {"endtime",                       LISTITEM_ENDTIME},
+    {"endtimeresume",                 LISTITEM_ENDTIME_RESUME},
+    {"startdate",                     LISTITEM_STARTDATE},
+    {"enddate",                       LISTITEM_ENDDATE},
+    {"nexttitle",                     LISTITEM_NEXT_TITLE},
+    {"nextgenre",                     LISTITEM_NEXT_GENRE},
+    {"nextplot",                      LISTITEM_NEXT_PLOT},
+    {"nextplotoutline",               LISTITEM_NEXT_PLOT_OUTLINE},
+    {"nextstarttime",                 LISTITEM_NEXT_STARTTIME},
+    {"nextendtime",                   LISTITEM_NEXT_ENDTIME},
+    {"nextstartdate",                 LISTITEM_NEXT_STARTDATE},
+    {"nextenddate",                   LISTITEM_NEXT_ENDDATE},
+    {"nextduration",                  LISTITEM_NEXT_DURATION},
+    {"channelname",                   LISTITEM_CHANNEL_NAME},
+    {"channellogo",                   LISTITEM_CHANNEL_LOGO},
+    {"channelnumberlabel",            LISTITEM_CHANNEL_NUMBER},
+    {"channelgroup",                  LISTITEM_CHANNEL_GROUP},
+    {"hasepg",                        LISTITEM_HAS_EPG},
+    {"hastimer",                      LISTITEM_HASTIMER},
+    {"hastimerschedule",              LISTITEM_HASTIMERSCHEDULE},
+    {"hasreminder",                   LISTITEM_HASREMINDER},
+    {"hasreminderrule",               LISTITEM_HASREMINDERRULE},
+    {"hasrecording",                  LISTITEM_HASRECORDING},
+    {"isrecording",                   LISTITEM_ISRECORDING},
+    {"isplayable",                    LISTITEM_ISPLAYABLE},
+    {"hasarchive",                    LISTITEM_HASARCHIVE},
+    {"inprogress",                    LISTITEM_INPROGRESS},
+    {"isencrypted",                   LISTITEM_ISENCRYPTED},
+    {"progress",                      LISTITEM_PROGRESS},
+    {"dateadded",                     LISTITEM_DATE_ADDED},
+    {"dbtype",                        LISTITEM_DBTYPE},
+    {"dbid",                          LISTITEM_DBID},
+    {"appearances",                   LISTITEM_APPEARANCES},
+    {"stereoscopicmode",              LISTITEM_STEREOSCOPIC_MODE},
+    {"isstereoscopic",                LISTITEM_IS_STEREOSCOPIC},
+    {"imdbnumber",                    LISTITEM_IMDBNUMBER},
+    {"episodename",                   LISTITEM_EPISODENAME},
+    {"timertype",                     LISTITEM_TIMERTYPE},
+    {"epgeventtitle",                 LISTITEM_EPG_EVENT_TITLE},
+    {"epgeventicon",                  LISTITEM_EPG_EVENT_ICON},
+    {"timerisactive",                 LISTITEM_TIMERISACTIVE},
+    {"timerhaserror",                 LISTITEM_TIMERHASERROR},
+    {"timerhasconflict",              LISTITEM_TIMERHASCONFLICT},
+    {"addonname",                     LISTITEM_ADDON_NAME},
+    {"addonversion",                  LISTITEM_ADDON_VERSION},
+    {"addoncreator",                  LISTITEM_ADDON_CREATOR},
+    {"addonsummary",                  LISTITEM_ADDON_SUMMARY},
+    {"addondescription",              LISTITEM_ADDON_DESCRIPTION},
+    {"addondisclaimer",               LISTITEM_ADDON_DISCLAIMER},
+    {"addonnews",                     LISTITEM_ADDON_NEWS},
+    {"addonbroken",                   LISTITEM_ADDON_BROKEN},
+    {"addonlifecycletype",            LISTITEM_ADDON_LIFECYCLE_TYPE},
+    {"addonlifecycledesc",            LISTITEM_ADDON_LIFECYCLE_DESC},
+    {"addontype",                     LISTITEM_ADDON_TYPE},
+    {"addoninstalldate",              LISTITEM_ADDON_INSTALL_DATE},
+    {"addonlastupdated",              LISTITEM_ADDON_LAST_UPDATED},
+    {"addonlastused",                 LISTITEM_ADDON_LAST_USED},
+    {"addonorigin",                   LISTITEM_ADDON_ORIGIN},
+    {"addonsize",                     LISTITEM_ADDON_SIZE},
+    {"expirationdate",                LISTITEM_EXPIRATION_DATE},
+    {"expirationtime",                LISTITEM_EXPIRATION_TIME},
+    {"art",                           LISTITEM_ART},
+    {"property",                      LISTITEM_PROPERTY},
+    {"parentalrating",                LISTITEM_PARENTAL_RATING},
+    {"parentalratingcode",            LISTITEM_PARENTAL_RATING_CODE},
+    {"parentalratingicon",            LISTITEM_PARENTAL_RATING_ICON},
+    {"parentalratingsource",          LISTITEM_PARENTAL_RATING_SOURCE},
+    {"currentitem",                   LISTITEM_CURRENTITEM},
+    {"isnew",                         LISTITEM_IS_NEW},
+    {"isboxset",                      LISTITEM_IS_BOXSET},
+    {"totaldiscs",                    LISTITEM_TOTALDISCS},
+    {"releasedate",                   LISTITEM_RELEASEDATE},
+    {"originaldate",                  LISTITEM_ORIGINALDATE},
+    {"bpm",                           LISTITEM_BPM},
+    {"uniqueid",                      LISTITEM_UNIQUEID},
+    {"bitrate",                       LISTITEM_BITRATE},
+    {"samplerate",                    LISTITEM_SAMPLERATE},
+    {"musicchannels",                 LISTITEM_MUSICCHANNELS},
+    {"ispremiere",                    LISTITEM_IS_PREMIERE},
+    {"isfinale",                      LISTITEM_IS_FINALE},
+    {"islive",                        LISTITEM_IS_LIVE},
+    {"tvshowdbid",                    LISTITEM_TVSHOWDBID},
+    {"albumstatus",                   LISTITEM_ALBUMSTATUS},
+    {"isautoupdateable",              LISTITEM_ISAUTOUPDATEABLE},
+    {"hdrtype",                       LISTITEM_VIDEO_HDR_TYPE},
+    {"songvideourl",                  LISTITEM_SONG_VIDEO_URL},
+    {"hasvideoversions",              LISTITEM_HASVIDEOVERSIONS},
+    {"isvideoextra",                  LISTITEM_ISVIDEOEXTRA},
+    {"videoversionname",              LISTITEM_VIDEOVERSION_NAME},
+    {"hasvideoextras",                LISTITEM_HASVIDEOEXTRAS},
+    {"pvrclientname",                 LISTITEM_PVR_CLIENT_NAME},
+    {"pvrinstancename",               LISTITEM_PVR_INSTANCE_NAME},
+    {"pvrgrouporigin",                LISTITEM_PVR_GROUP_ORIGIN},
+    {"episodepart",                   LISTITEM_EPISODEPART},
+    {"mediaproviders",                LISTITEM_MEDIAPROVIDERS},
+    {"titleextrainfo",                LISTITEM_TITLE_EXTRAINFO},
+}};
 // clang-format on
 
 /// \page modules__infolabels_boolean_conditions
@@ -7573,11 +7596,15 @@ const infomap listitem_labels[]= {{ "thumb",            LISTITEM_THUMB },
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
-const infomap visualisation[] =  {{ "locked",           VISUALISATION_LOCKED },
-                                  { "preset",           VISUALISATION_PRESET },
-                                  { "haspresets",       VISUALISATION_HAS_PRESETS },
-                                  { "name",             VISUALISATION_NAME },
-                                  { "enabled",          VISUALISATION_ENABLED }};
+// clang-format off
+constexpr std::array<InfoMap, 5> visualisation = {{
+    {"locked",      VISUALISATION_LOCKED},
+    {"preset",      VISUALISATION_PRESET},
+    {"haspresets",  VISUALISATION_HAS_PRESETS},
+    {"name",        VISUALISATION_NAME},
+    {"enabled",     VISUALISATION_ENABLED},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_Fanart Fanart
@@ -7616,10 +7643,14 @@ const infomap visualisation[] =  {{ "locked",           VISUALISATION_LOCKED },
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
-const infomap fanart_labels[] =  {{ "color1",           FANART_COLOR1 },
-                                  { "color2",           FANART_COLOR2 },
-                                  { "color3",           FANART_COLOR3 },
-                                  { "image",            FANART_IMAGE }};
+// clang-format off
+constexpr std::array<InfoMap, 4> fanart_labels = {{
+    {"color1",  FANART_COLOR1},
+    {"color2",  FANART_COLOR2},
+    {"color3",  FANART_COLOR3},
+    {"image",   FANART_IMAGE},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_Skin Skin
@@ -7714,10 +7745,14 @@ const infomap fanart_labels[] =  {{ "color1",           FANART_COLOR1 },
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
-const infomap skin_labels[] =    {{ "currenttheme",      SKIN_THEME },
-                                  { "currentcolourtheme",SKIN_COLOUR_THEME },
-                                  { "aspectratio",       SKIN_ASPECT_RATIO},
-                                  { "font",              SKIN_FONT}};
+// clang-format off
+constexpr std::array<InfoMap, 4> skin_labels = {{
+    {"currenttheme",        SKIN_THEME},
+    {"currentcolourtheme",  SKIN_COLOUR_THEME},
+    {"aspectratio",         SKIN_ASPECT_RATIO},
+    {"font",                SKIN_FONT},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_Window Window
@@ -7863,15 +7898,19 @@ const infomap skin_labels[] =    {{ "currenttheme",      SKIN_THEME },
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
-const infomap window_bools[] =   {{ "ismedia",          WINDOW_IS_MEDIA },
-                                  { "is",               WINDOW_IS },
-                                  { "isactive",         WINDOW_IS_ACTIVE },
-                                  { "isvisible",        WINDOW_IS_VISIBLE },
-                                  { "istopmost",        WINDOW_IS_DIALOG_TOPMOST }, //! @deprecated, remove in v19
-                                  { "isdialogtopmost",  WINDOW_IS_DIALOG_TOPMOST },
-                                  { "ismodaldialogtopmost", WINDOW_IS_MODAL_DIALOG_TOPMOST },
-                                  { "previous",         WINDOW_PREVIOUS },
-                                  { "next",             WINDOW_NEXT }};
+// clang-format off
+constexpr std::array<InfoMap, 9> window_bools = {{
+    {"ismedia",               WINDOW_IS_MEDIA},
+    {"is",                    WINDOW_IS},
+    {"isactive",              WINDOW_IS_ACTIVE},
+    {"isvisible",             WINDOW_IS_VISIBLE},
+    {"istopmost",             WINDOW_IS_DIALOG_TOPMOST}, //! @deprecated, remove in v19
+    {"isdialogtopmost",       WINDOW_IS_DIALOG_TOPMOST},
+    {"ismodaldialogtopmost",  WINDOW_IS_MODAL_DIALOG_TOPMOST},
+    {"previous",              WINDOW_PREVIOUS},
+    {"next",                  WINDOW_NEXT},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_Control Control
@@ -7916,10 +7955,14 @@ const infomap window_bools[] =   {{ "ismedia",          WINDOW_IS_MEDIA },
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
-const infomap control_labels[] = {{ "hasfocus",         CONTROL_HAS_FOCUS },
-                                  { "isvisible",        CONTROL_IS_VISIBLE },
-                                  { "isenabled",        CONTROL_IS_ENABLED },
-                                  { "getlabel",         CONTROL_GET_LABEL }};
+// clang-format off
+constexpr std::array<InfoMap, 4> control_labels = {{
+    {"hasfocus",  CONTROL_HAS_FOCUS},
+    {"isvisible", CONTROL_IS_VISIBLE},
+    {"isenabled", CONTROL_IS_ENABLED},
+    {"getlabel",  CONTROL_GET_LABEL},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_Playlist Playlist
@@ -7983,13 +8026,17 @@ const infomap control_labels[] = {{ "hasfocus",         CONTROL_HAS_FOCUS },
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
-const infomap playlist[] =       {{ "length",           PLAYLIST_LENGTH },
-                                  { "position",         PLAYLIST_POSITION },
-                                  { "random",           PLAYLIST_RANDOM },
-                                  { "repeat",           PLAYLIST_REPEAT },
-                                  { "israndom",         PLAYLIST_ISRANDOM },
-                                  { "isrepeat",         PLAYLIST_ISREPEAT },
-                                  { "isrepeatone",      PLAYLIST_ISREPEATONE }};
+// clang-format off
+constexpr std::array<InfoMap, 7> playlist = {{
+    {"length",      PLAYLIST_LENGTH},
+    {"position",    PLAYLIST_POSITION},
+    {"random",      PLAYLIST_RANDOM},
+    {"repeat",      PLAYLIST_REPEAT},
+    {"israndom",    PLAYLIST_ISRANDOM},
+    {"isrepeat",    PLAYLIST_ISREPEAT},
+    {"isrepeatone", PLAYLIST_ISREPEATONE},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_Pvr Pvr
@@ -8571,88 +8618,90 @@ const infomap playlist[] =       {{ "length",           PLAYLIST_LENGTH },
 ///
 /// -----------------------------------------------------------------------------
 // clang-format off
-const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING },
-                                  { "hastimer",                 PVR_HAS_TIMER },
-                                  { "hastvchannels",            PVR_HAS_TV_CHANNELS },
-                                  { "hasradiochannels",         PVR_HAS_RADIO_CHANNELS },
-                                  { "hasnonrecordingtimer",     PVR_HAS_NONRECORDING_TIMER },
-                                  { "backendname",              PVR_BACKEND_NAME },
-                                  { "backendversion",           PVR_BACKEND_VERSION },
-                                  { "backendhost",              PVR_BACKEND_HOST },
-                                  { "backenddiskspace",         PVR_BACKEND_DISKSPACE },
-                                  { "backenddiskspaceprogr",    PVR_BACKEND_DISKSPACE_PROGR },
-                                  { "backendchannels",          PVR_BACKEND_CHANNELS },
-                                  { "backendtimers",            PVR_BACKEND_TIMERS },
-                                  { "backendrecordings",        PVR_BACKEND_RECORDINGS },
-                                  { "backenddeletedrecordings", PVR_BACKEND_DELETED_RECORDINGS },
-                                  { "backendnumber",            PVR_BACKEND_NUMBER },
-                                  { "totaldiscspace",           PVR_TOTAL_DISKSPACE },
-                                  { "nexttimer",                PVR_NEXT_TIMER },
-                                  { "isplayingtv",              PVR_IS_PLAYING_TV },
-                                  { "isplayingradio",           PVR_IS_PLAYING_RADIO },
-                                  { "isplayingrecording",       PVR_IS_PLAYING_RECORDING },
-                                  { "isplayingepgtag",          PVR_IS_PLAYING_EPGTAG },
-                                  { "epgeventprogress",         PVR_EPG_EVENT_PROGRESS },
-                                  { "actstreamclient",          PVR_ACTUAL_STREAM_CLIENT },
-                                  { "actstreamdevice",          PVR_ACTUAL_STREAM_DEVICE },
-                                  { "actstreamstatus",          PVR_ACTUAL_STREAM_STATUS },
-                                  { "actstreamsignal",          PVR_ACTUAL_STREAM_SIG },
-                                  { "actstreamsnr",             PVR_ACTUAL_STREAM_SNR },
-                                  { "actstreamber",             PVR_ACTUAL_STREAM_BER },
-                                  { "actstreamunc",             PVR_ACTUAL_STREAM_UNC },
-                                  { "actstreamprogrsignal",     PVR_ACTUAL_STREAM_SIG_PROGR },
-                                  { "actstreamprogrsnr",        PVR_ACTUAL_STREAM_SNR_PROGR },
-                                  { "actstreamisencrypted",     PVR_ACTUAL_STREAM_ENCRYPTED },
-                                  { "actstreamencryptionname",  PVR_ACTUAL_STREAM_CRYPTION },
-                                  { "actstreamservicename",     PVR_ACTUAL_STREAM_SERVICE },
-                                  { "actstreammux",             PVR_ACTUAL_STREAM_MUX },
-                                  { "actstreamprovidername",    PVR_ACTUAL_STREAM_PROVIDER },
-                                  { "istimeshift",              PVR_IS_TIMESHIFTING },
-                                  { "timeshiftprogress",        PVR_TIMESHIFT_PROGRESS },
-                                  { "timeshiftseekbar",         PVR_TIMESHIFT_SEEKBAR },
-                                  { "nowrecordingtitle",        PVR_NOW_RECORDING_TITLE },
-                                  { "nowrecordingdatetime",     PVR_NOW_RECORDING_DATETIME },
-                                  { "nowrecordingchannel",      PVR_NOW_RECORDING_CHANNEL },
-                                  { "nowrecordingchannelicon",  PVR_NOW_RECORDING_CHAN_ICO },
-                                  { "nextrecordingtitle",       PVR_NEXT_RECORDING_TITLE },
-                                  { "nextrecordingdatetime",    PVR_NEXT_RECORDING_DATETIME },
-                                  { "nextrecordingchannel",     PVR_NEXT_RECORDING_CHANNEL },
-                                  { "nextrecordingchannelicon", PVR_NEXT_RECORDING_CHAN_ICO },
-                                  { "tvnowrecordingtitle",            PVR_TV_NOW_RECORDING_TITLE },
-                                  { "tvnowrecordingdatetime",         PVR_TV_NOW_RECORDING_DATETIME },
-                                  { "tvnowrecordingchannel",          PVR_TV_NOW_RECORDING_CHANNEL },
-                                  { "tvnowrecordingchannelicon",      PVR_TV_NOW_RECORDING_CHAN_ICO },
-                                  { "tvnextrecordingtitle",           PVR_TV_NEXT_RECORDING_TITLE },
-                                  { "tvnextrecordingdatetime",        PVR_TV_NEXT_RECORDING_DATETIME },
-                                  { "tvnextrecordingchannel",         PVR_TV_NEXT_RECORDING_CHANNEL },
-                                  { "tvnextrecordingchannelicon",     PVR_TV_NEXT_RECORDING_CHAN_ICO },
-                                  { "radionowrecordingtitle",         PVR_RADIO_NOW_RECORDING_TITLE },
-                                  { "radionowrecordingdatetime",      PVR_RADIO_NOW_RECORDING_DATETIME },
-                                  { "radionowrecordingchannel",       PVR_RADIO_NOW_RECORDING_CHANNEL },
-                                  { "radionowrecordingchannelicon",   PVR_RADIO_NOW_RECORDING_CHAN_ICO },
-                                  { "radionextrecordingtitle",        PVR_RADIO_NEXT_RECORDING_TITLE },
-                                  { "radionextrecordingdatetime",     PVR_RADIO_NEXT_RECORDING_DATETIME },
-                                  { "radionextrecordingchannel",      PVR_RADIO_NEXT_RECORDING_CHANNEL },
-                                  { "radionextrecordingchannelicon",  PVR_RADIO_NEXT_RECORDING_CHAN_ICO },
-                                  { "isrecordingtv",              PVR_IS_RECORDING_TV },
-                                  { "hastvtimer",                 PVR_HAS_TV_TIMER },
-                                  { "hasnonrecordingtvtimer",     PVR_HAS_NONRECORDING_TV_TIMER },
-                                  { "isrecordingradio",           PVR_IS_RECORDING_RADIO },
-                                  { "hasradiotimer",              PVR_HAS_RADIO_TIMER },
-                                  { "hasnonrecordingradiotimer",  PVR_HAS_NONRECORDING_RADIO_TIMER },
-                                  { "channelnumberinput",         PVR_CHANNEL_NUMBER_INPUT },
-                                  { "canrecordplayingchannel",    PVR_CAN_RECORD_PLAYING_CHANNEL },
-                                  { "isrecordingplayingchannel",  PVR_IS_RECORDING_PLAYING_CHANNEL },
-                                  { "isplayingactiverecording",   PVR_IS_PLAYING_ACTIVE_RECORDING },
-                                  { "timeshiftprogressplaypos",   PVR_TIMESHIFT_PROGRESS_PLAY_POS },
-                                  { "timeshiftprogressepgstart",  PVR_TIMESHIFT_PROGRESS_EPG_START },
-                                  { "timeshiftprogressepgend",    PVR_TIMESHIFT_PROGRESS_EPG_END },
-                                  { "timeshiftprogressbufferstart", PVR_TIMESHIFT_PROGRESS_BUFFER_START },
-                                  { "timeshiftprogressbufferend", PVR_TIMESHIFT_PROGRESS_BUFFER_END },
-                                  { "epgeventicon",               PVR_EPG_EVENT_ICON },
-                                  { "clientcount",                PVR_CLIENT_COUNT },
-                                  { "clientname",                 PVR_CLIENT_NAME },
-                                  { "instancename",               PVR_INSTANCE_NAME }};
+constexpr std::array<InfoMap, 82> pvr = {{
+    {"isrecording",                   PVR_IS_RECORDING},
+    {"hastimer",                      PVR_HAS_TIMER},
+    {"hastvchannels",                 PVR_HAS_TV_CHANNELS},
+    {"hasradiochannels",              PVR_HAS_RADIO_CHANNELS},
+    {"hasnonrecordingtimer",          PVR_HAS_NONRECORDING_TIMER},
+    {"backendname",                   PVR_BACKEND_NAME},
+    {"backendversion",                PVR_BACKEND_VERSION},
+    {"backendhost",                   PVR_BACKEND_HOST},
+    {"backenddiskspace",              PVR_BACKEND_DISKSPACE},
+    {"backenddiskspaceprogr",         PVR_BACKEND_DISKSPACE_PROGR},
+    {"backendchannels",               PVR_BACKEND_CHANNELS},
+    {"backendtimers",                 PVR_BACKEND_TIMERS},
+    {"backendrecordings",             PVR_BACKEND_RECORDINGS},
+    {"backenddeletedrecordings",      PVR_BACKEND_DELETED_RECORDINGS},
+    {"backendnumber",                 PVR_BACKEND_NUMBER},
+    {"totaldiscspace",                PVR_TOTAL_DISKSPACE},
+    {"nexttimer",                     PVR_NEXT_TIMER},
+    {"isplayingtv",                   PVR_IS_PLAYING_TV},
+    {"isplayingradio",                PVR_IS_PLAYING_RADIO},
+    {"isplayingrecording",            PVR_IS_PLAYING_RECORDING},
+    {"isplayingepgtag",               PVR_IS_PLAYING_EPGTAG},
+    {"epgeventprogress",              PVR_EPG_EVENT_PROGRESS},
+    {"actstreamclient",               PVR_ACTUAL_STREAM_CLIENT},
+    {"actstreamdevice",               PVR_ACTUAL_STREAM_DEVICE},
+    {"actstreamstatus",               PVR_ACTUAL_STREAM_STATUS},
+    {"actstreamsignal",               PVR_ACTUAL_STREAM_SIG},
+    {"actstreamsnr",                  PVR_ACTUAL_STREAM_SNR},
+    {"actstreamber",                  PVR_ACTUAL_STREAM_BER},
+    {"actstreamunc",                  PVR_ACTUAL_STREAM_UNC},
+    {"actstreamprogrsignal",          PVR_ACTUAL_STREAM_SIG_PROGR},
+    {"actstreamprogrsnr",             PVR_ACTUAL_STREAM_SNR_PROGR},
+    {"actstreamisencrypted",          PVR_ACTUAL_STREAM_ENCRYPTED},
+    {"actstreamencryptionname",       PVR_ACTUAL_STREAM_CRYPTION},
+    {"actstreamservicename",          PVR_ACTUAL_STREAM_SERVICE},
+    {"actstreammux",                  PVR_ACTUAL_STREAM_MUX},
+    {"actstreamprovidername",         PVR_ACTUAL_STREAM_PROVIDER},
+    {"istimeshift",                   PVR_IS_TIMESHIFTING},
+    {"timeshiftprogress",             PVR_TIMESHIFT_PROGRESS},
+    {"timeshiftseekbar",              PVR_TIMESHIFT_SEEKBAR},
+    {"nowrecordingtitle",             PVR_NOW_RECORDING_TITLE},
+    {"nowrecordingdatetime",          PVR_NOW_RECORDING_DATETIME},
+    {"nowrecordingchannel",           PVR_NOW_RECORDING_CHANNEL},
+    {"nowrecordingchannelicon",       PVR_NOW_RECORDING_CHAN_ICO},
+    {"nextrecordingtitle",            PVR_NEXT_RECORDING_TITLE},
+    {"nextrecordingdatetime",         PVR_NEXT_RECORDING_DATETIME},
+    {"nextrecordingchannel",          PVR_NEXT_RECORDING_CHANNEL},
+    {"nextrecordingchannelicon",      PVR_NEXT_RECORDING_CHAN_ICO},
+    {"tvnowrecordingtitle",           PVR_TV_NOW_RECORDING_TITLE},
+    {"tvnowrecordingdatetime",        PVR_TV_NOW_RECORDING_DATETIME},
+    {"tvnowrecordingchannel",         PVR_TV_NOW_RECORDING_CHANNEL},
+    {"tvnowrecordingchannelicon",     PVR_TV_NOW_RECORDING_CHAN_ICO},
+    {"tvnextrecordingtitle",          PVR_TV_NEXT_RECORDING_TITLE},
+    {"tvnextrecordingdatetime",       PVR_TV_NEXT_RECORDING_DATETIME},
+    {"tvnextrecordingchannel",        PVR_TV_NEXT_RECORDING_CHANNEL},
+    {"tvnextrecordingchannelicon",    PVR_TV_NEXT_RECORDING_CHAN_ICO},
+    {"radionowrecordingtitle",        PVR_RADIO_NOW_RECORDING_TITLE},
+    {"radionowrecordingdatetime",     PVR_RADIO_NOW_RECORDING_DATETIME},
+    {"radionowrecordingchannel",      PVR_RADIO_NOW_RECORDING_CHANNEL},
+    {"radionowrecordingchannelicon",  PVR_RADIO_NOW_RECORDING_CHAN_ICO},
+    {"radionextrecordingtitle",       PVR_RADIO_NEXT_RECORDING_TITLE},
+    {"radionextrecordingdatetime",    PVR_RADIO_NEXT_RECORDING_DATETIME},
+    {"radionextrecordingchannel",     PVR_RADIO_NEXT_RECORDING_CHANNEL},
+    {"radionextrecordingchannelicon", PVR_RADIO_NEXT_RECORDING_CHAN_ICO},
+    {"isrecordingtv",                 PVR_IS_RECORDING_TV},
+    {"hastvtimer",                    PVR_HAS_TV_TIMER},
+    {"hasnonrecordingtvtimer",        PVR_HAS_NONRECORDING_TV_TIMER},
+    {"isrecordingradio",              PVR_IS_RECORDING_RADIO},
+    {"hasradiotimer",                 PVR_HAS_RADIO_TIMER},
+    {"hasnonrecordingradiotimer",     PVR_HAS_NONRECORDING_RADIO_TIMER},
+    {"channelnumberinput",            PVR_CHANNEL_NUMBER_INPUT},
+    {"canrecordplayingchannel",       PVR_CAN_RECORD_PLAYING_CHANNEL},
+    {"isrecordingplayingchannel",     PVR_IS_RECORDING_PLAYING_CHANNEL},
+    {"isplayingactiverecording",      PVR_IS_PLAYING_ACTIVE_RECORDING},
+    {"timeshiftprogressplaypos",      PVR_TIMESHIFT_PROGRESS_PLAY_POS},
+    {"timeshiftprogressepgstart",     PVR_TIMESHIFT_PROGRESS_EPG_START},
+    {"timeshiftprogressepgend",       PVR_TIMESHIFT_PROGRESS_EPG_END},
+    {"timeshiftprogressbufferstart",  PVR_TIMESHIFT_PROGRESS_BUFFER_START},
+    {"timeshiftprogressbufferend",    PVR_TIMESHIFT_PROGRESS_BUFFER_END},
+    {"epgeventicon",                  PVR_EPG_EVENT_ICON},
+    {"clientcount",                   PVR_CLIENT_COUNT},
+    {"clientname",                    PVR_CLIENT_NAME},
+    {"instancename",                  PVR_INSTANCE_NAME},
+}};
 // clang-format on
 
 /// \page modules__infolabels_boolean_conditions
@@ -8869,18 +8918,22 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
-const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURATION },
-                                  { "epgeventelapsedtime",    PVR_EPG_EVENT_ELAPSED_TIME },
-                                  { "epgeventremainingtime",  PVR_EPG_EVENT_REMAINING_TIME },
-                                  { "epgeventfinishtime",     PVR_EPG_EVENT_FINISH_TIME },
-                                  { "epgeventseektime",       PVR_EPG_EVENT_SEEK_TIME },
-                                  { "timeshiftstart",         PVR_TIMESHIFT_START_TIME },
-                                  { "timeshiftend",           PVR_TIMESHIFT_END_TIME },
-                                  { "timeshiftcur",           PVR_TIMESHIFT_PLAY_TIME },
-                                  { "timeshiftoffset",        PVR_TIMESHIFT_OFFSET },
-                                  { "timeshiftprogressduration",  PVR_TIMESHIFT_PROGRESS_DURATION },
-                                  { "timeshiftprogressstarttime", PVR_TIMESHIFT_PROGRESS_START_TIME },
-                                  { "timeshiftprogressendtime",   PVR_TIMESHIFT_PROGRESS_END_TIME }};
+// clang-format off
+constexpr std::array<InfoMap, 12> pvr_times = {{
+    {"epgeventduration",            PVR_EPG_EVENT_DURATION},
+    {"epgeventelapsedtime",         PVR_EPG_EVENT_ELAPSED_TIME},
+    {"epgeventremainingtime",       PVR_EPG_EVENT_REMAINING_TIME},
+    {"epgeventfinishtime",          PVR_EPG_EVENT_FINISH_TIME},
+    {"epgeventseektime",            PVR_EPG_EVENT_SEEK_TIME},
+    {"timeshiftstart",              PVR_TIMESHIFT_START_TIME},
+    {"timeshiftend",                PVR_TIMESHIFT_END_TIME},
+    {"timeshiftcur",                PVR_TIMESHIFT_PLAY_TIME},
+    {"timeshiftoffset",             PVR_TIMESHIFT_OFFSET},
+    {"timeshiftprogressduration",   PVR_TIMESHIFT_PROGRESS_DURATION},
+    {"timeshiftprogressstarttime",  PVR_TIMESHIFT_PROGRESS_START_TIME},
+    {"timeshiftprogressendtime",    PVR_TIMESHIFT_PROGRESS_END_TIME},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_RDS RDS
@@ -9332,51 +9385,55 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
-const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
-                                  { "hasradiotext",             RDS_HAS_RADIOTEXT },
-                                  { "hasradiotextplus",         RDS_HAS_RADIOTEXT_PLUS },
-                                  { "audiolanguage",            RDS_AUDIO_LANG },
-                                  { "channelcountry",           RDS_CHANNEL_COUNTRY },
-                                  { "title",                    RDS_TITLE },
-                                  { "getline",                  RDS_GET_RADIOTEXT_LINE },
-                                  { "artist",                   RDS_ARTIST },
-                                  { "band",                     RDS_BAND },
-                                  { "composer",                 RDS_COMPOSER },
-                                  { "conductor",                RDS_CONDUCTOR },
-                                  { "album",                    RDS_ALBUM },
-                                  { "tracknumber",              RDS_ALBUM_TRACKNUMBER },
-                                  { "radiostyle",               RDS_GET_RADIO_STYLE },
-                                  { "comment",                  RDS_COMMENT },
-                                  { "infonews",                 RDS_INFO_NEWS },
-                                  { "infonewslocal",            RDS_INFO_NEWS_LOCAL },
-                                  { "infostock",                RDS_INFO_STOCK },
-                                  { "infostocksize",            RDS_INFO_STOCK_SIZE },
-                                  { "infosport",                RDS_INFO_SPORT },
-                                  { "infosportsize",            RDS_INFO_SPORT_SIZE },
-                                  { "infolottery",              RDS_INFO_LOTTERY },
-                                  { "infolotterysize",          RDS_INFO_LOTTERY_SIZE },
-                                  { "infoweather",              RDS_INFO_WEATHER },
-                                  { "infoweathersize",          RDS_INFO_WEATHER_SIZE },
-                                  { "infocinema",               RDS_INFO_CINEMA },
-                                  { "infocinemasize",           RDS_INFO_CINEMA_SIZE },
-                                  { "infohoroscope",            RDS_INFO_HOROSCOPE },
-                                  { "infohoroscopesize",        RDS_INFO_HOROSCOPE_SIZE },
-                                  { "infoother",                RDS_INFO_OTHER },
-                                  { "infoothersize",            RDS_INFO_OTHER_SIZE },
-                                  { "progstation",              RDS_PROG_STATION },
-                                  { "prognow",                  RDS_PROG_NOW },
-                                  { "prognext",                 RDS_PROG_NEXT },
-                                  { "proghost",                 RDS_PROG_HOST },
-                                  { "progeditstaff",            RDS_PROG_EDIT_STAFF },
-                                  { "proghomepage",             RDS_PROG_HOMEPAGE },
-                                  { "progstyle",                RDS_PROG_STYLE },
-                                  { "phonehotline",             RDS_PHONE_HOTLINE },
-                                  { "phonestudio",              RDS_PHONE_STUDIO },
-                                  { "smsstudio",                RDS_SMS_STUDIO },
-                                  { "emailhotline",             RDS_EMAIL_HOTLINE },
-                                  { "emailstudio",              RDS_EMAIL_STUDIO },
-                                  { "hashotline",               RDS_HAS_HOTLINE_DATA },
-                                  { "hasstudio",                RDS_HAS_STUDIO_DATA }};
+// clang-format off
+constexpr std::array<InfoMap, 45> rds = {{
+    {"hasrds",            RDS_HAS_RDS},
+    {"hasradiotext",      RDS_HAS_RADIOTEXT},
+    {"hasradiotextplus",  RDS_HAS_RADIOTEXT_PLUS},
+    {"audiolanguage",     RDS_AUDIO_LANG},
+    {"channelcountry",    RDS_CHANNEL_COUNTRY},
+    {"title",             RDS_TITLE},
+    {"getline",           RDS_GET_RADIOTEXT_LINE},
+    {"artist",            RDS_ARTIST},
+    {"band",              RDS_BAND},
+    {"composer",          RDS_COMPOSER},
+    {"conductor",         RDS_CONDUCTOR},
+    {"album",             RDS_ALBUM},
+    {"tracknumber",       RDS_ALBUM_TRACKNUMBER},
+    {"radiostyle",        RDS_GET_RADIO_STYLE},
+    {"comment",           RDS_COMMENT},
+    {"infonews",          RDS_INFO_NEWS},
+    {"infonewslocal",     RDS_INFO_NEWS_LOCAL},
+    {"infostock",         RDS_INFO_STOCK},
+    {"infostocksize",     RDS_INFO_STOCK_SIZE},
+    {"infosport",         RDS_INFO_SPORT},
+    {"infosportsize",     RDS_INFO_SPORT_SIZE},
+    {"infolottery",       RDS_INFO_LOTTERY},
+    {"infolotterysize",   RDS_INFO_LOTTERY_SIZE},
+    {"infoweather",       RDS_INFO_WEATHER},
+    {"infoweathersize",   RDS_INFO_WEATHER_SIZE},
+    {"infocinema",        RDS_INFO_CINEMA},
+    {"infocinemasize",    RDS_INFO_CINEMA_SIZE},
+    {"infohoroscope",     RDS_INFO_HOROSCOPE},
+    {"infohoroscopesize", RDS_INFO_HOROSCOPE_SIZE},
+    {"infoother",         RDS_INFO_OTHER},
+    {"infoothersize",     RDS_INFO_OTHER_SIZE},
+    {"progstation",       RDS_PROG_STATION},
+    {"prognow",           RDS_PROG_NOW},
+    {"prognext",          RDS_PROG_NEXT},
+    {"proghost",          RDS_PROG_HOST},
+    {"progeditstaff",     RDS_PROG_EDIT_STAFF},
+    {"proghomepage",      RDS_PROG_HOMEPAGE},
+    {"progstyle",         RDS_PROG_STYLE},
+    {"phonehotline",      RDS_PHONE_HOTLINE},
+    {"phonestudio",       RDS_PHONE_STUDIO},
+    {"smsstudio",         RDS_SMS_STUDIO},
+    {"emailhotline",      RDS_EMAIL_HOTLINE},
+    {"emailstudio",       RDS_EMAIL_STUDIO},
+    {"hashotline",        RDS_HAS_HOTLINE_DATA},
+    {"hasstudio",         RDS_HAS_STUDIO_DATA},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_slideshow Slideshow
@@ -9964,71 +10021,73 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
-const infomap slideshow[] = {
-    {"ispaused", SLIDESHOW_ISPAUSED},
-    {"isactive", SLIDESHOW_ISACTIVE},
-    {"isvideo", SLIDESHOW_ISVIDEO},
-    {"israndom", SLIDESHOW_ISRANDOM},
-    {"filename", SLIDESHOW_FILE_NAME},
-    {"path", SLIDESHOW_FILE_PATH},
-    {"filesize", SLIDESHOW_FILE_SIZE},
-    {"filedate", SLIDESHOW_FILE_DATE},
-    {"slideindex", SLIDESHOW_INDEX},
-    {"resolution", SLIDESHOW_RESOLUTION},
-    {"slidecomment", SLIDESHOW_COMMENT},
-    {"colour", SLIDESHOW_COLOUR},
-    {"process", SLIDESHOW_PROCESS},
-    {"exiftime", SLIDESHOW_EXIF_DATE_TIME},
-    {"exifdate", SLIDESHOW_EXIF_DATE},
-    {"longexiftime", SLIDESHOW_EXIF_LONG_DATE_TIME},
-    {"longexifdate", SLIDESHOW_EXIF_LONG_DATE},
-    {"exifdescription", SLIDESHOW_EXIF_DESCRIPTION},
-    {"cameramake", SLIDESHOW_EXIF_CAMERA_MAKE},
-    {"cameramodel", SLIDESHOW_EXIF_CAMERA_MODEL},
-    {"exifcomment", SLIDESHOW_EXIF_COMMENT},
-    {"aperture", SLIDESHOW_EXIF_APERTURE},
-    {"focallength", SLIDESHOW_EXIF_FOCAL_LENGTH},
-    {"focusdistance", SLIDESHOW_EXIF_FOCUS_DIST},
-    {"exposure", SLIDESHOW_EXIF_EXPOSURE},
-    {"exposuretime", SLIDESHOW_EXIF_EXPOSURE_TIME},
-    {"exposurebias", SLIDESHOW_EXIF_EXPOSURE_BIAS},
-    {"exposuremode", SLIDESHOW_EXIF_EXPOSURE_MODE},
-    {"flashused", SLIDESHOW_EXIF_FLASH_USED},
-    {"whitebalance", SLIDESHOW_EXIF_WHITE_BALANCE},
-    {"lightsource", SLIDESHOW_EXIF_LIGHT_SOURCE},
-    {"meteringmode", SLIDESHOW_EXIF_METERING_MODE},
-    {"isoequivalence", SLIDESHOW_EXIF_ISO_EQUIV},
-    {"digitalzoom", SLIDESHOW_EXIF_DIGITAL_ZOOM},
-    {"ccdwidth", SLIDESHOW_EXIF_CCD_WIDTH},
-    {"orientation", SLIDESHOW_EXIF_ORIENTATION},
-    {"supplementalcategories", SLIDESHOW_IPTC_SUP_CATEGORIES},
-    {"keywords", SLIDESHOW_IPTC_KEYWORDS},
-    {"caption", SLIDESHOW_IPTC_CAPTION},
-    {"author", SLIDESHOW_IPTC_AUTHOR},
-    {"headline", SLIDESHOW_IPTC_HEADLINE},
-    {"specialinstructions", SLIDESHOW_IPTC_SPEC_INSTR},
-    {"category", SLIDESHOW_IPTC_CATEGORY},
-    {"byline", SLIDESHOW_IPTC_BYLINE},
-    {"bylinetitle", SLIDESHOW_IPTC_BYLINE_TITLE},
-    {"credit", SLIDESHOW_IPTC_CREDIT},
-    {"source", SLIDESHOW_IPTC_SOURCE},
-    {"copyrightnotice", SLIDESHOW_IPTC_COPYRIGHT_NOTICE},
-    {"objectname", SLIDESHOW_IPTC_OBJECT_NAME},
-    {"city", SLIDESHOW_IPTC_CITY},
-    {"state", SLIDESHOW_IPTC_STATE},
-    {"country", SLIDESHOW_IPTC_COUNTRY},
-    {"transmissionreference", SLIDESHOW_IPTC_TX_REFERENCE},
-    {"iptcdate", SLIDESHOW_IPTC_DATE},
-    {"urgency", SLIDESHOW_IPTC_URGENCY},
-    {"countrycode", SLIDESHOW_IPTC_COUNTRY_CODE},
-    {"referenceservice", SLIDESHOW_IPTC_REF_SERVICE},
-    {"latitude", SLIDESHOW_EXIF_GPS_LATITUDE},
-    {"longitude", SLIDESHOW_EXIF_GPS_LONGITUDE},
-    {"altitude", SLIDESHOW_EXIF_GPS_ALTITUDE},
-    {"timecreated", SLIDESHOW_IPTC_TIMECREATED},
-    {"sublocation", SLIDESHOW_IPTC_SUBLOCATION},
-    {"imagetype", SLIDESHOW_IPTC_IMAGETYPE},
-};
+// clang-format off
+constexpr std::array<InfoMap, 63> slideshow = {{
+    {"ispaused",                SLIDESHOW_ISPAUSED},
+    {"isactive",                SLIDESHOW_ISACTIVE},
+    {"isvideo",                 SLIDESHOW_ISVIDEO},
+    {"israndom",                SLIDESHOW_ISRANDOM},
+    {"filename",                SLIDESHOW_FILE_NAME},
+    {"path",                    SLIDESHOW_FILE_PATH},
+    {"filesize",                SLIDESHOW_FILE_SIZE},
+    {"filedate",                SLIDESHOW_FILE_DATE},
+    {"slideindex",              SLIDESHOW_INDEX},
+    {"resolution",              SLIDESHOW_RESOLUTION},
+    {"slidecomment",            SLIDESHOW_COMMENT},
+    {"colour",                  SLIDESHOW_COLOUR},
+    {"process",                 SLIDESHOW_PROCESS},
+    {"exiftime",                SLIDESHOW_EXIF_DATE_TIME},
+    {"exifdate",                SLIDESHOW_EXIF_DATE},
+    {"longexiftime",            SLIDESHOW_EXIF_LONG_DATE_TIME},
+    {"longexifdate",            SLIDESHOW_EXIF_LONG_DATE},
+    {"exifdescription",         SLIDESHOW_EXIF_DESCRIPTION},
+    {"cameramake",              SLIDESHOW_EXIF_CAMERA_MAKE},
+    {"cameramodel",             SLIDESHOW_EXIF_CAMERA_MODEL},
+    {"exifcomment",             SLIDESHOW_EXIF_COMMENT},
+    {"aperture",                SLIDESHOW_EXIF_APERTURE},
+    {"focallength",             SLIDESHOW_EXIF_FOCAL_LENGTH},
+    {"focusdistance",           SLIDESHOW_EXIF_FOCUS_DIST},
+    {"exposure",                SLIDESHOW_EXIF_EXPOSURE},
+    {"exposuretime",            SLIDESHOW_EXIF_EXPOSURE_TIME},
+    {"exposurebias",            SLIDESHOW_EXIF_EXPOSURE_BIAS},
+    {"exposuremode",            SLIDESHOW_EXIF_EXPOSURE_MODE},
+    {"flashused",               SLIDESHOW_EXIF_FLASH_USED},
+    {"whitebalance",            SLIDESHOW_EXIF_WHITE_BALANCE},
+    {"lightsource",             SLIDESHOW_EXIF_LIGHT_SOURCE},
+    {"meteringmode",            SLIDESHOW_EXIF_METERING_MODE},
+    {"isoequivalence",          SLIDESHOW_EXIF_ISO_EQUIV},
+    {"digitalzoom",             SLIDESHOW_EXIF_DIGITAL_ZOOM},
+    {"ccdwidth",                SLIDESHOW_EXIF_CCD_WIDTH},
+    {"orientation",             SLIDESHOW_EXIF_ORIENTATION},
+    {"supplementalcategories",  SLIDESHOW_IPTC_SUP_CATEGORIES},
+    {"keywords",                SLIDESHOW_IPTC_KEYWORDS},
+    {"caption",                 SLIDESHOW_IPTC_CAPTION},
+    {"author",                  SLIDESHOW_IPTC_AUTHOR},
+    {"headline",                SLIDESHOW_IPTC_HEADLINE},
+    {"specialinstructions",     SLIDESHOW_IPTC_SPEC_INSTR},
+    {"category",                SLIDESHOW_IPTC_CATEGORY},
+    {"byline",                  SLIDESHOW_IPTC_BYLINE},
+    {"bylinetitle",             SLIDESHOW_IPTC_BYLINE_TITLE},
+    {"credit",                  SLIDESHOW_IPTC_CREDIT},
+    {"source",                  SLIDESHOW_IPTC_SOURCE},
+    {"copyrightnotice",         SLIDESHOW_IPTC_COPYRIGHT_NOTICE},
+    {"objectname",              SLIDESHOW_IPTC_OBJECT_NAME},
+    {"city",                    SLIDESHOW_IPTC_CITY},
+    {"state",                   SLIDESHOW_IPTC_STATE},
+    {"country",                 SLIDESHOW_IPTC_COUNTRY},
+    {"transmissionreference",   SLIDESHOW_IPTC_TX_REFERENCE},
+    {"iptcdate",                SLIDESHOW_IPTC_DATE},
+    {"urgency",                 SLIDESHOW_IPTC_URGENCY},
+    {"countrycode",             SLIDESHOW_IPTC_COUNTRY_CODE},
+    {"referenceservice",        SLIDESHOW_IPTC_REF_SERVICE},
+    {"latitude",                SLIDESHOW_EXIF_GPS_LATITUDE},
+    {"longitude",               SLIDESHOW_EXIF_GPS_LONGITUDE},
+    {"altitude",                SLIDESHOW_EXIF_GPS_ALTITUDE},
+    {"timecreated",             SLIDESHOW_IPTC_TIMECREATED},
+    {"sublocation",             SLIDESHOW_IPTC_SUBLOCATION},
+    {"imagetype",               SLIDESHOW_IPTC_IMAGETYPE},
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_Library Library
@@ -10311,13 +10370,43 @@ const infomap slideshow[] = {
 /// \page modules__infolabels_boolean_conditions
 /// \tableofcontents
 
-CGUIInfoManager::Property::Property(const std::string &property, const std::string &parameters)
-: name(property)
+bool InfoBoolComparator(const InfoPtr& right, const InfoPtr& left)
+{
+  return *right < *left;
+}
+
+} // unnamed namespace
+
+CGUIInfoManager::CGUIInfoManager()
+  : m_currentFile(std::make_unique<CFileItem>()), m_bools(&InfoBoolComparator)
+{
+}
+
+CGUIInfoManager::~CGUIInfoManager() = default;
+
+void CGUIInfoManager::Initialize()
+{
+  CServiceBroker::GetAppMessenger()->RegisterReceiver(this);
+}
+
+/// \brief Translates a string as given by the skin into an int that we use for more
+/// efficient retrieval of data. Can handle combined strings on the form
+/// Player.Caching + VideoPlayer.IsFullscreen (Logical and)
+/// Player.HasVideo | Player.HasAudio (Logical or)
+int CGUIInfoManager::TranslateString(const std::string& condition)
+{
+  // translate $LOCALIZE as required
+  std::string strCondition(CGUIInfoLabel::ReplaceLocalize(condition));
+  return TranslateSingleString(strCondition);
+}
+
+CGUIInfoManager::Property::Property(const std::string& property, const std::string& parameters)
+  : m_name(property)
 {
   CUtil::SplitParams(parameters, params);
 }
 
-const std::string &CGUIInfoManager::Property::param(unsigned int n /* = 0 */) const
+const std::string& CGUIInfoManager::Property::param(size_t n /* = 0 */) const
 {
   if (n < params.size())
     return params[n];
@@ -10329,7 +10418,8 @@ unsigned int CGUIInfoManager::Property::num_params() const
   return params.size();
 }
 
-void CGUIInfoManager::SplitInfoString(const std::string &infoString, std::vector<Property> &info)
+void CGUIInfoManager::SplitInfoString(const std::string& infoString,
+                                      std::vector<Property>& info) const
 {
   // our string is of the form:
   // category[(params)][.info(params).info2(params)] ...
@@ -10337,21 +10427,21 @@ void CGUIInfoManager::SplitInfoString(const std::string &infoString, std::vector
   unsigned int parentheses = 0;
   std::string property;
   std::string param;
-  for (size_t i = 0; i < infoString.size(); ++i)
+  for (const char c : infoString)
   {
-    if (infoString[i] == '(')
+    if (c == '(')
     {
       if (!parentheses++)
         continue;
     }
-    else if (infoString[i] == ')')
+    else if (c == ')')
     {
       if (!parentheses)
         CLog::Log(LOGERROR, "unmatched parentheses in {}", infoString);
       else if (!--parentheses)
         continue;
     }
-    else if (infoString[i] == '.' && !parentheses)
+    else if (c == '.' && !parentheses)
     {
       if (!property.empty()) // add our property and parameters
       {
@@ -10363,9 +10453,9 @@ void CGUIInfoManager::SplitInfoString(const std::string &infoString, std::vector
       continue;
     }
     if (parentheses)
-      param += infoString[i];
+      param += c;
     else
-      property += infoString[i];
+      property += c;
   }
 
   if (parentheses)
@@ -10434,25 +10524,25 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
   const Property &cat = info[0];
   if (info.size() == 1)
   { // single category
-    if (cat.name == "false" || cat.name == "no")
+    if (cat.Name() == "false" || cat.Name() == "no")
       return SYSTEM_ALWAYS_FALSE;
-    else if (cat.name == "true" || cat.name == "yes")
+    else if (cat.Name() == "true" || cat.Name() == "yes")
       return SYSTEM_ALWAYS_TRUE;
   }
   else if (info.size() == 2)
   {
     const Property &prop = info[1];
-    if (cat.name == "string")
+    if (cat.Name() == "string")
     {
-      if (prop.name == "isempty")
+      if (prop.Name() == "isempty")
       {
         return AddMultiInfo(CGUIInfo(STRING_IS_EMPTY, TranslateSingleString(prop.param(), listItemDependent)));
       }
       else if (prop.num_params() == 2)
       {
-        for (const infomap& string_bool : string_bools)
+        for (const auto& string_bool : string_bools)
         {
-          if (prop.name == string_bool.str)
+          if (prop.Name() == string_bool.str)
           {
             int data1 = TranslateSingleString(prop.param(0), listItemDependent);
             // pipe our original string through the localize parsing then make it lowercase (picks up $LBRACKET etc.)
@@ -10470,18 +10560,18 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         }
       }
     }
-    if (cat.name == "integer")
+    if (cat.Name() == "integer")
     {
-      if (prop.name == "valueof")
+      if (prop.Name() == "valueof")
       {
         int value = -1;
         std::from_chars(prop.param(0).data(), prop.param(0).data() + prop.param(0).size(), value);
         return AddMultiInfo(CGUIInfo(INTEGER_VALUEOF, value));
       }
 
-      for (const infomap& integer_bool : integer_bools)
+      for (const auto& integer_bool : integer_bools)
       {
-        if (prop.name == integer_bool.str)
+        if (prop.Name() == integer_bool.str)
         {
           std::array<int, 2> data = {-1, -1};
           for (size_t i = 0; i < data.size(); i++)
@@ -10503,21 +10593,21 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         }
       }
     }
-    else if (cat.name == "player")
+    else if (cat.Name() == "player")
     {
-      for (const infomap& player_label : player_labels)
+      for (const auto& player_label : player_labels)
       {
-        if (prop.name == player_label.str)
+        if (prop.Name() == player_label.str)
           return player_label.val;
       }
-      for (const infomap& player_time : player_times)
+      for (const auto& player_time : player_times)
       {
-        if (prop.name == player_time.str)
+        if (prop.Name() == player_time.str)
           return AddMultiInfo(CGUIInfo(player_time.val, TranslateTimeFormat(prop.param())));
       }
-      if (prop.name == "process" && prop.num_params())
+      if (prop.Name() == "process" && prop.num_params())
       {
-        for (const infomap& player_proces : player_process)
+        for (const auto& player_proces : player_process)
         {
           if (StringUtils::EqualsNoCase(prop.param(), player_proces.str))
             return player_proces.val;
@@ -10525,67 +10615,67 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
       }
       if (prop.num_params() == 1)
       {
-        for (const infomap& i : player_param)
+        for (const auto& i : player_param)
         {
-          if (prop.name == i.str)
+          if (prop.Name() == i.str)
             return AddMultiInfo(CGUIInfo(i.val, prop.param()));
         }
       }
     }
-    else if (cat.name == "addon")
+    else if (cat.Name() == "addon")
     {
-      for (const infomap& i : addons)
+      for (const auto& i : addons)
       {
-        if (prop.name == i.str && prop.num_params() == 2)
+        if (prop.Name() == i.str && prop.num_params() == 2)
           return AddMultiInfo(CGUIInfo(i.val, prop.param(0), prop.param(1)));
       }
     }
-    else if (cat.name == "weather")
+    else if (cat.Name() == "weather")
     {
-      for (const infomap& i : weather)
+      for (const auto& i : weather)
       {
-        if (prop.name == i.str)
+        if (prop.Name() == i.str)
           return i.val;
       }
     }
-    else if (cat.name == "network")
+    else if (cat.Name() == "network")
     {
-      for (const infomap& network_label : network_labels)
+      for (const auto& network_label : network_labels)
       {
-        if (prop.name == network_label.str)
+        if (prop.Name() == network_label.str)
           return network_label.val;
       }
     }
-    else if (cat.name == "musicpartymode")
+    else if (cat.Name() == "musicpartymode")
     {
-      for (const infomap& i : musicpartymode)
+      for (const auto& i : musicpartymode)
       {
-        if (prop.name == i.str)
+        if (prop.Name() == i.str)
           return i.val;
       }
     }
-    else if (cat.name == "system")
+    else if (cat.Name() == "system")
     {
-      for (const infomap& system_label : system_labels)
+      for (const auto& system_label : system_labels)
       {
-        if (prop.name == system_label.str)
+        if (prop.Name() == system_label.str)
           return system_label.val;
       }
       if (prop.num_params() == 1)
       {
         const std::string &param = prop.param();
-        if (prop.name == "getbool")
+        if (prop.Name() == "getbool")
         {
           std::string paramCopy = param;
           StringUtils::ToLower(paramCopy);
           return AddMultiInfo(CGUIInfo(SYSTEM_GET_BOOL, paramCopy));
         }
-        for (const infomap& i : system_param)
+        for (const auto& i : system_param)
         {
-          if (prop.name == i.str)
+          if (prop.Name() == i.str)
             return AddMultiInfo(CGUIInfo(i.val, param));
         }
-        if (prop.name == "memory")
+        if (prop.Name() == "memory")
         {
           if (param == "free")
             return SYSTEM_FREE_MEMORY;
@@ -10598,7 +10688,7 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
           else if (param == "total")
             return SYSTEM_TOTAL_MEMORY;
         }
-        else if (prop.name == "addontitle")
+        else if (prop.Name() == "addontitle")
         {
           // Example: System.AddonTitle(Skin.String(HomeVideosButton1)) => skin string HomeVideosButton1 holds an addon identifier string
           int infoLabel = TranslateSingleString(param, listItemDependent);
@@ -10608,7 +10698,7 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
           StringUtils::ToLower(label);
           return AddMultiInfo(CGUIInfo(SYSTEM_ADDON_TITLE, label, 1));
         }
-        else if (prop.name == "addonicon")
+        else if (prop.Name() == "addonicon")
         {
           int infoLabel = TranslateSingleString(param, listItemDependent);
           if (infoLabel > 0)
@@ -10617,7 +10707,7 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
           StringUtils::ToLower(label);
           return AddMultiInfo(CGUIInfo(SYSTEM_ADDON_ICON, label, 1));
         }
-        else if (prop.name == "addonversion")
+        else if (prop.Name() == "addonversion")
         {
           int infoLabel = TranslateSingleString(param, listItemDependent);
           if (infoLabel > 0)
@@ -10626,9 +10716,9 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
           StringUtils::ToLower(label);
           return AddMultiInfo(CGUIInfo(SYSTEM_ADDON_VERSION, label, 1));
         }
-        else if (prop.name == "idletime")
+        else if (prop.Name() == "idletime")
           return AddMultiInfo(CGUIInfo(SYSTEM_IDLE_TIME, atoi(param.c_str())));
-        else if (prop.name == "locale")
+        else if (prop.Name() == "locale")
         {
           if (param == "region")
           {
@@ -10640,9 +10730,9 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
           }
         }
       }
-      if (prop.name == "alarmlessorequal" && prop.num_params() == 2)
+      if (prop.Name() == "alarmlessorequal" && prop.num_params() == 2)
         return AddMultiInfo(CGUIInfo(SYSTEM_ALARM_LESS_OR_EQUAL, prop.param(0), atoi(prop.param(1).c_str())));
-      else if (prop.name == "date")
+      else if (prop.Name() == "date")
       {
         if (prop.num_params() == 2)
           return AddMultiInfo(CGUIInfo(SYSTEM_DATE, StringUtils::DateStringToYYYYMMDD(prop.param(0)) % 10000, StringUtils::DateStringToYYYYMMDD(prop.param(1)) % 10000));
@@ -10656,7 +10746,7 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         }
         return SYSTEM_DATE;
       }
-      else if (prop.name == "time")
+      else if (prop.Name() == "time")
       {
         if (prop.num_params() == 0)
           return AddMultiInfo(CGUIInfo(SYSTEM_TIME, TIME_FORMAT_GUESS));
@@ -10671,161 +10761,164 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
           return AddMultiInfo(CGUIInfo(SYSTEM_TIME, StringUtils::TimeStringToSeconds(prop.param(0)), StringUtils::TimeStringToSeconds(prop.param(1))));
       }
     }
-    else if (cat.name == "library")
+    else if (cat.Name() == "library")
     {
-      if (prop.name == "isscanning")
+      if (prop.Name() == "isscanning")
         return LIBRARY_IS_SCANNING;
-      else if (prop.name == "isscanningvideo")
+      else if (prop.Name() == "isscanningvideo")
         return LIBRARY_IS_SCANNING_VIDEO; //! @todo change to IsScanning(Video)
-      else if (prop.name == "isscanningmusic")
+      else if (prop.Name() == "isscanningmusic")
         return LIBRARY_IS_SCANNING_MUSIC;
-      else if (prop.name == "hascontent" && prop.num_params())
+      else if (prop.Name() == "hascontent" && prop.num_params())
       {
-        std::string cat = prop.param(0);
-        StringUtils::ToLower(cat);
-        if (cat == "music")
+        std::string content{prop.param(0)};
+        StringUtils::ToLower(content);
+        if (content == "music")
           return LIBRARY_HAS_MUSIC;
-        else if (cat == "video")
+        else if (content == "video")
           return LIBRARY_HAS_VIDEO;
-        else if (cat == "movies")
+        else if (content == "movies")
           return LIBRARY_HAS_MOVIES;
-        else if (cat == "tvshows")
+        else if (content == "tvshows")
           return LIBRARY_HAS_TVSHOWS;
-        else if (cat == "musicvideos")
+        else if (content == "musicvideos")
           return LIBRARY_HAS_MUSICVIDEOS;
-        else if (cat == "moviesets")
+        else if (content == "moviesets")
           return LIBRARY_HAS_MOVIE_SETS;
-        else if (cat == "singles")
+        else if (content == "singles")
           return LIBRARY_HAS_SINGLES;
-        else if (cat == "compilations")
+        else if (content == "compilations")
           return LIBRARY_HAS_COMPILATIONS;
-        else if (cat == "boxsets")
+        else if (content == "boxsets")
           return LIBRARY_HAS_BOXSETS;
-        else if (cat == "role" && prop.num_params() > 1)
+        else if (content == "role" && prop.num_params() > 1)
           return AddMultiInfo(CGUIInfo(LIBRARY_HAS_ROLE, prop.param(1), 0));
       }
-      else if (prop.name == "hasnode" && prop.num_params())
+      else if (prop.Name() == "hasnode" && prop.num_params())
       {
         std::string node = prop.param(0);
         StringUtils::ToLower(node);
         return AddMultiInfo(CGUIInfo(LIBRARY_HAS_NODE, prop.param(), 0));
       }
     }
-    else if (cat.name == "musicplayer")
+    else if (cat.Name() == "musicplayer")
     {
-      for (const infomap& player_time : player_times) //! @todo remove these, they're repeats
+      for (const auto& player_time : player_times) //! @todo remove these, they're repeats
       {
-        if (prop.name == player_time.str)
+        if (prop.Name() == player_time.str)
           return AddMultiInfo(CGUIInfo(player_time.val, TranslateTimeFormat(prop.param())));
       }
-      if (prop.name == "content" && prop.num_params())
+      if (prop.Name() == "content" && prop.num_params())
       {
         return AddMultiInfo(CGUIInfo(MUSICPLAYER_CONTENT, prop.param(), 0));
       }
-      else if (prop.name == "genre" && prop.num_params() > 0)
+      else if (prop.Name() == "genre" && prop.num_params() > 0)
       {
         return AddMultiInfo(CGUIInfo(MUSICPLAYER_GENRE, TranslateListSeparator(prop.param()), 0));
       }
-      else if (prop.name == "property")
+      else if (prop.Name() == "property")
       {
         if (StringUtils::EqualsNoCase(prop.param(), "fanart_image"))
           return AddMultiInfo(CGUIInfo(PLAYER_ITEM_ART, "fanart"));
 
         return AddMultiInfo(CGUIInfo(MUSICPLAYER_PROPERTY, prop.param()));
       }
-      return TranslateMusicPlayerString(prop.name);
+      return TranslateMusicPlayerString(prop.Name());
     }
-    else if (cat.name == "videoplayer")
+    else if (cat.Name() == "videoplayer")
     {
-      if (prop.name != "starttime") // player.starttime is semantically different from videoplayer.starttime which has its own implementation!
+      if (prop.Name() !=
+          "starttime") // player.starttime is semantically different from videoplayer.starttime which has its own implementation!
       {
-        for (const infomap& player_time : player_times) //! @todo remove these, they're repeats
+        for (const auto& player_time : player_times) //! @todo remove these, they're repeats
         {
-          if (prop.name == player_time.str)
+          if (prop.Name() == player_time.str)
             return AddMultiInfo(CGUIInfo(player_time.val, TranslateTimeFormat(prop.param())));
         }
       }
-      if (prop.name == "content" && prop.num_params())
+      if (prop.Name() == "content" && prop.num_params())
       {
         return AddMultiInfo(CGUIInfo(VIDEOPLAYER_CONTENT, prop.param(), 0));
       }
-      if (prop.name == "uniqueid" && prop.num_params())
+      if (prop.Name() == "uniqueid" && prop.num_params())
       {
         return AddMultiInfo(CGUIInfo(VIDEOPLAYER_UNIQUEID, prop.param(), 0));
       }
-      if (prop.name == "art" && prop.num_params() > 0)
+      if (prop.Name() == "art" && prop.num_params() > 0)
       {
         return AddMultiInfo(CGUIInfo(VIDEOPLAYER_ART, prop.param(), 0));
       }
-      if (prop.name == "cast" && prop.num_params() > 0)
+      if (prop.Name() == "cast" && prop.num_params() > 0)
       {
         return AddMultiInfo(CGUIInfo(VIDEOPLAYER_CAST, TranslateListSeparator(prop.param()), 0));
       }
-      if (prop.name == "castandrole" && prop.num_params() > 0)
+      if (prop.Name() == "castandrole" && prop.num_params() > 0)
       {
         return AddMultiInfo(
             CGUIInfo(VIDEOPLAYER_CAST_AND_ROLE, TranslateListSeparator(prop.param()), 0));
       }
-      if (prop.name == "writer" && prop.num_params() > 0)
+      if (prop.Name() == "writer" && prop.num_params() > 0)
       {
         return AddMultiInfo(CGUIInfo(VIDEOPLAYER_WRITER, TranslateListSeparator(prop.param()), 0));
       }
-      if (prop.name == "director" && prop.num_params() > 0)
+      if (prop.Name() == "director" && prop.num_params() > 0)
       {
         return AddMultiInfo(
             CGUIInfo(VIDEOPLAYER_DIRECTOR, TranslateListSeparator(prop.param()), 0));
       }
-      if (prop.name == "genre" && prop.num_params() > 0)
+      if (prop.Name() == "genre" && prop.num_params() > 0)
       {
         return AddMultiInfo(CGUIInfo(VIDEOPLAYER_GENRE, TranslateListSeparator(prop.param()), 0));
       }
-      if (prop.name == "nextgenre" && prop.num_params() > 0)
+      if (prop.Name() == "nextgenre" && prop.num_params() > 0)
       {
         return AddMultiInfo(
             CGUIInfo(VIDEOPLAYER_NEXT_GENRE, TranslateListSeparator(prop.param()), 0));
       }
-      return TranslateVideoPlayerString(prop.name);
+      return TranslateVideoPlayerString(prop.Name());
     }
-    else if (cat.name == "retroplayer")
+    else if (cat.Name() == "retroplayer")
     {
-      for (const infomap& i : retroplayer)
+      for (const auto& i : retroplayer)
       {
-        if (prop.name == i.str)
+        if (prop.Name() == i.str)
           return i.val;
       }
     }
-    else if (cat.name == "slideshow")
+    else if (cat.Name() == "slideshow")
     {
-      for (const infomap& i : slideshow)
+      for (const auto& i : slideshow)
       {
-        if (prop.name == i.str)
+        if (prop.Name() == i.str)
           return i.val;
       }
     }
-    else if (cat.name == "container")
+    else if (cat.Name() == "container")
     {
-      for (const infomap& i : mediacontainer) // these ones don't have or need an id
+      for (const auto& i : mediacontainer) // these ones don't have or need an id
       {
-        if (prop.name == i.str)
+        if (prop.Name() == i.str)
           return i.val;
       }
       int id = atoi(cat.param().c_str());
-      for (const infomap& container_bool : container_bools) // these ones can have an id (but don't need to?)
+      for (const auto& container_bool :
+           container_bools) // these ones can have an id (but don't need to?)
       {
-        if (prop.name == container_bool.str)
+        if (prop.Name() == container_bool.str)
           return id ? AddMultiInfo(CGUIInfo(container_bool.val, id)) : container_bool.val;
       }
-      for (const infomap& container_int : container_ints) // these ones can have an int param on the property
+      for (const auto& container_int :
+           container_ints) // these ones can have an int param on the property
       {
-        if (prop.name == container_int.str)
+        if (prop.Name() == container_int.str)
           return AddMultiInfo(CGUIInfo(container_int.val, id, atoi(prop.param().c_str())));
       }
-      for (const infomap& i : container_str) // these ones have a string param on the property
+      for (const auto& i : container_str) // these ones have a string param on the property
       {
-        if (prop.name == i.str)
+        if (prop.Name() == i.str)
           return AddMultiInfo(CGUIInfo(i.val, id, prop.param()));
       }
-      if (prop.name == "sortdirection")
+      if (prop.Name() == "sortdirection")
       {
         SortOrder order = SortOrderNone;
         if (StringUtils::EqualsNoCase(prop.param(), "ascending"))
@@ -10835,74 +10928,72 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         return AddMultiInfo(CGUIInfo(CONTAINER_SORT_DIRECTION, order));
       }
     }
-    else if (cat.name == "listitem" ||
-             cat.name == "listitemposition" ||
-             cat.name == "listitemnowrap" ||
-             cat.name == "listitemabsolute")
+    else if (cat.Name() == "listitem" || cat.Name() == "listitemposition" ||
+             cat.Name() == "listitemnowrap" || cat.Name() == "listitemabsolute")
     {
       int ret = TranslateListItem(cat, prop, 0, false);
       if (ret)
         listItemDependent = true;
       return ret;
     }
-    else if (cat.name == "visualisation")
+    else if (cat.Name() == "visualisation")
     {
-      for (const infomap& i : visualisation)
+      for (const auto& i : visualisation)
       {
-        if (prop.name == i.str)
+        if (prop.Name() == i.str)
           return i.val;
       }
     }
-    else if (cat.name == "fanart")
+    else if (cat.Name() == "fanart")
     {
-      for (const infomap& fanart_label : fanart_labels)
+      for (const auto& fanart_label : fanart_labels)
       {
-        if (prop.name == fanart_label.str)
+        if (prop.Name() == fanart_label.str)
           return fanart_label.val;
       }
     }
-    else if (cat.name == "skin")
+    else if (cat.Name() == "skin")
     {
-      for (const infomap& skin_label : skin_labels)
+      for (const auto& skin_label : skin_labels)
       {
-        if (prop.name == skin_label.str)
+        if (prop.Name() == skin_label.str)
           return skin_label.val;
       }
       if (prop.num_params())
       {
-        if (prop.name == "string")
+        if (prop.Name() == "string")
         {
           if (prop.num_params() == 2)
             return AddMultiInfo(CGUIInfo(SKIN_STRING_IS_EQUAL, CSkinSettings::GetInstance().TranslateString(prop.param(0)), prop.param(1)));
           else
             return AddMultiInfo(CGUIInfo(SKIN_STRING, CSkinSettings::GetInstance().TranslateString(prop.param(0))));
         }
-        else if (prop.name == "numeric")
+        else if (prop.Name() == "numeric")
         {
           return AddMultiInfo(
               CGUIInfo(SKIN_INTEGER, CSkinSettings::GetInstance().TranslateString(prop.param(0))));
         }
-        else if (prop.name == "hassetting")
+        else if (prop.Name() == "hassetting")
           return AddMultiInfo(CGUIInfo(SKIN_BOOL, CSkinSettings::GetInstance().TranslateBool(prop.param(0))));
-        else if (prop.name == "hastheme")
+        else if (prop.Name() == "hastheme")
           return AddMultiInfo(CGUIInfo(SKIN_HAS_THEME, prop.param(0)));
-        else if (prop.name == "timerisrunning")
+        else if (prop.Name() == "timerisrunning")
           return AddMultiInfo(CGUIInfo(SKIN_TIMER_IS_RUNNING, prop.param(0)));
-        else if (prop.name == "timerelapsedsecs")
+        else if (prop.Name() == "timerelapsedsecs")
           return AddMultiInfo(CGUIInfo(SKIN_TIMER_ELAPSEDSECS, prop.param(0)));
       }
     }
-    else if (cat.name == "window")
+    else if (cat.Name() == "window")
     {
-      if (prop.name == "property" && prop.num_params() == 1)
+      if (prop.Name() == "property" && prop.num_params() == 1)
       { //! @todo this doesn't support foo.xml
         int winID = cat.param().empty() ? 0 : CWindowTranslator::TranslateWindow(cat.param());
         if (winID != WINDOW_INVALID)
           return AddMultiInfo(CGUIInfo(WINDOW_PROPERTY, winID, prop.param()));
       }
-      for (const infomap& window_bool : window_bools)
+      for (const auto& window_bool : window_bools)
       {
-        if (prop.name == window_bool.str)
+        if (prop.Name() == window_bool.str)
         { //! @todo The parameter for these should really be on the first not the second property
           if (prop.param().find("xml") != std::string::npos)
             return AddMultiInfo(CGUIInfo(window_bool.val, 0, prop.param()));
@@ -10911,11 +11002,11 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         }
       }
     }
-    else if (cat.name == "control")
+    else if (cat.Name() == "control")
     {
-      for (const infomap& control_label : control_labels)
+      for (const auto& control_label : control_labels)
       {
-        if (prop.name == control_label.str)
+        if (prop.Name() == control_label.str)
         { //! @todo The parameter for these should really be on the first not the second property
           int controlID = atoi(prop.param().c_str());
           if (controlID)
@@ -10924,18 +11015,18 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         }
       }
     }
-    else if (cat.name == "controlgroup" && prop.name == "hasfocus")
+    else if (cat.Name() == "controlgroup" && prop.Name() == "hasfocus")
     {
       int groupID = atoi(cat.param().c_str());
       if (groupID)
         return AddMultiInfo(CGUIInfo(CONTROL_GROUP_HAS_FOCUS, groupID, atoi(prop.param(0).c_str())));
     }
-    else if (cat.name == "playlist")
+    else if (cat.Name() == "playlist")
     {
       int ret = -1;
-      for (const infomap& i : playlist)
+      for (const auto& i : playlist)
       {
-        if (prop.name == i.str)
+        if (prop.Name() == i.str)
         {
           ret = i.val;
           break;
@@ -10958,36 +11049,36 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         }
       }
     }
-    else if (cat.name == "pvr")
+    else if (cat.Name() == "pvr")
     {
-      for (const infomap& i : pvr)
+      for (const auto& i : pvr)
       {
-        if (prop.name == i.str)
+        if (prop.Name() == i.str)
           return i.val;
       }
-      for (const infomap& pvr_time : pvr_times)
+      for (const auto& pvr_time : pvr_times)
       {
-        if (prop.name == pvr_time.str)
+        if (prop.Name() == pvr_time.str)
           return AddMultiInfo(CGUIInfo(pvr_time.val, TranslateTimeFormat(prop.param())));
       }
     }
-    else if (cat.name == "rds")
+    else if (cat.Name() == "rds")
     {
-      if (prop.name == "getline")
+      if (prop.Name() == "getline")
         return AddMultiInfo(CGUIInfo(RDS_GET_RADIOTEXT_LINE, atoi(prop.param(0).c_str())));
 
-      for (const infomap& rd : rds)
+      for (const auto& rd : rds)
       {
-        if (prop.name == rd.str)
+        if (prop.Name() == rd.str)
           return rd.val;
       }
     }
   }
   else if (info.size() == 3 || info.size() == 4)
   {
-    if (info[0].name == "system" && info[1].name == "platform")
+    if (info[0].Name() == "system" && info[1].Name() == "platform")
     { //! @todo replace with a single system.platform
-      std::string platform = info[2].name;
+      std::string platform = info[2].Name();
       if (platform == "linux")
         return SYSTEM_PLATFORM_LINUX;
       else if (platform == "windows")
@@ -11007,62 +11098,60 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
       else if (platform == "webos")
         return SYSTEM_PLATFORM_WEBOS;
     }
-    if (info[0].name == "musicplayer")
+    if (info[0].Name() == "musicplayer")
     { //! @todo these two don't allow duration(foo) and also don't allow more than this number of levels...
-      if (info[1].name == "position")
+      if (info[1].Name() == "position")
       {
         int position = atoi(info[1].param().c_str());
-        int value = TranslateMusicPlayerString(info[2].name); // musicplayer.position(foo).bar
+        int value = TranslateMusicPlayerString(info[2].Name()); // musicplayer.position(foo).bar
         return AddMultiInfo(CGUIInfo(value, 2, position)); // 2 => absolute (0 used for not set)
       }
-      else if (info[1].name == "offset")
+      else if (info[1].Name() == "offset")
       {
         int position = atoi(info[1].param().c_str());
-        int value = TranslateMusicPlayerString(info[2].name); // musicplayer.offset(foo).bar
+        int value = TranslateMusicPlayerString(info[2].Name()); // musicplayer.offset(foo).bar
         return AddMultiInfo(CGUIInfo(value, 1, position)); // 1 => relative
       }
     }
-    else if (info[0].name == "videoplayer")
+    else if (info[0].Name() == "videoplayer")
     { //! @todo these two don't allow duration(foo) and also don't allow more than this number of levels...
-      if (info[1].name == "position")
+      if (info[1].Name() == "position")
       {
         int position = atoi(info[1].param().c_str());
-        int value = TranslateVideoPlayerString(info[2].name); // videoplayer.position(foo).bar
+        int value = TranslateVideoPlayerString(info[2].Name()); // videoplayer.position(foo).bar
         // additional param for the requested infolabel, e.g. VideoPlayer.Position(1).Art(poster): art is the value, poster is the param
         const std::string& param = info[2].param();
         return AddMultiInfo(
             CGUIInfo(value, 2, position, param)); // 2 => absolute (0 used for not set)
       }
-      else if (info[1].name == "offset")
+      else if (info[1].Name() == "offset")
       {
         int position = atoi(info[1].param().c_str());
-        int value = TranslateVideoPlayerString(info[2].name); // videoplayer.offset(foo).bar
+        int value = TranslateVideoPlayerString(info[2].Name()); // videoplayer.offset(foo).bar
         // additional param for the requested infolabel, e.g. VideoPlayer.Offset(1).Art(poster): art is the value, poster is the param
         const std::string& param = info[2].param();
         return AddMultiInfo(CGUIInfo(value, 1, position, param)); // 1 => relative
       }
     }
-    else if (info[0].name == "player")
+    else if (info[0].Name() == "player")
     { //! @todo these two don't allow duration(foo) and also don't allow more than this number of levels...
-      if (info[1].name == "position")
+      if (info[1].Name() == "position")
       {
         int position = atoi(info[1].param().c_str());
-        int value = TranslatePlayerString(info[2].name); // player.position(foo).bar
+        int value = TranslatePlayerString(info[2].Name()); // player.position(foo).bar
         return AddMultiInfo(CGUIInfo(value, 2, position)); // 2 => absolute (0 used for not set)
       }
-      else if (info[1].name == "offset")
+      else if (info[1].Name() == "offset")
       {
         int position = atoi(info[1].param().c_str());
-        int value = TranslatePlayerString(info[2].name); // player.offset(foo).bar
+        int value = TranslatePlayerString(info[2].Name()); // player.offset(foo).bar
         return AddMultiInfo(CGUIInfo(value, 1, position)); // 1 => relative
       }
     }
-    else if (info[0].name == "container")
+    else if (info[0].Name() == "container")
     {
-      if (info[1].name == "listitem" ||
-          info[1].name == "listitemposition" ||
-          info[1].name == "listitemabsolute" ||
-          info[1].name == "listitemnowrap")
+      if (info[1].Name() == "listitem" || info[1].Name() == "listitemposition" ||
+          info[1].Name() == "listitemabsolute" || info[1].Name() == "listitemnowrap")
       {
         int id = atoi(info[0].param().c_str());
         int ret = TranslateListItem(info[1], info[2], id, true);
@@ -11071,12 +11160,12 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         return ret;
       }
     }
-    else if (info[0].name == "control")
+    else if (info[0].Name() == "control")
     {
       const Property &prop = info[1];
-      for (const infomap& control_label : control_labels)
+      for (const auto& control_label : control_labels)
       {
-        if (prop.name == control_label.str)
+        if (prop.Name() == control_label.str)
         { //! @todo The parameter for these should really be on the first not the second property
           int controlID = atoi(prop.param().c_str());
           if (controlID)
@@ -11098,26 +11187,22 @@ int CGUIInfoManager::TranslateListItem(const Property& cat, const Property& prop
   if (prop.num_params() == 1)
   {
     // special case: map 'property(fanart_image)' to 'art(fanart)'
-    if (prop.name == "property" && StringUtils::EqualsNoCase(prop.param(), "fanart_image"))
+    if (prop.Name() == "property" && StringUtils::EqualsNoCase(prop.param(), "fanart_image"))
     {
       ret = LISTITEM_ART;
       data3 = "fanart";
     }
-    else if (prop.name == "property" ||
-             prop.name == "art" ||
-             prop.name == "rating" ||
-             prop.name == "votes" ||
-             prop.name == "ratingandvotes" ||
-             prop.name == "uniqueid")
+    else if (prop.Name() == "property" || prop.Name() == "art" || prop.Name() == "rating" ||
+             prop.Name() == "votes" || prop.Name() == "ratingandvotes" || prop.Name() == "uniqueid")
     {
       data3 = prop.param();
     }
-    else if (prop.name == "cast" || prop.name == "castandrole" || prop.name == "director" ||
-             prop.name == "writer" || prop.name == "genre" || prop.name == "nextgenre")
+    else if (prop.Name() == "cast" || prop.Name() == "castandrole" || prop.Name() == "director" ||
+             prop.Name() == "writer" || prop.Name() == "genre" || prop.Name() == "nextgenre")
     {
       data3 = TranslateListSeparator(prop.param());
     }
-    else if (prop.name == "duration" || prop.name == "nextduration")
+    else if (prop.Name() == "duration" || prop.Name() == "nextduration")
     {
       data4 = TranslateTimeFormat(prop.param());
     }
@@ -11125,9 +11210,9 @@ int CGUIInfoManager::TranslateListItem(const Property& cat, const Property& prop
 
   if (ret == 0)
   {
-    for (const infomap& listitem_label : listitem_labels) // these ones don't have or need an id
+    for (const auto& listitem_label : listitem_labels) // these ones don't have or need an id
     {
-      if (prop.name == listitem_label.str)
+      if (prop.Name() == listitem_label.str)
       {
         ret = listitem_label.val;
         break;
@@ -11140,13 +11225,13 @@ int CGUIInfoManager::TranslateListItem(const Property& cat, const Property& prop
     int offset = std::atoi(cat.param().c_str());
 
     int flags = 0;
-    if (cat.name == "listitem")
+    if (cat.Name() == "listitem")
       flags = INFOFLAG_LISTITEM_WRAP;
-    else if (cat.name == "listitemposition")
+    else if (cat.Name() == "listitemposition")
       flags = INFOFLAG_LISTITEM_POSITION;
-    else if (cat.name == "listitemabsolute")
+    else if (cat.Name() == "listitemabsolute")
       flags = INFOFLAG_LISTITEM_ABSOLUTE;
-    else if (cat.name == "listitemnowrap")
+    else if (cat.Name() == "listitemnowrap")
       flags = INFOFLAG_LISTITEM_NOWRAP;
 
     if (container)
@@ -11158,9 +11243,9 @@ int CGUIInfoManager::TranslateListItem(const Property& cat, const Property& prop
   return 0;
 }
 
-int CGUIInfoManager::TranslateMusicPlayerString(const std::string &info) const
+int CGUIInfoManager::TranslateMusicPlayerString(std::string_view info) const
 {
-  for (const infomap& i : musicplayer)
+  for (const auto& i : musicplayer)
   {
     if (info == i.str)
       return i.val;
@@ -11168,9 +11253,9 @@ int CGUIInfoManager::TranslateMusicPlayerString(const std::string &info) const
   return 0;
 }
 
-int CGUIInfoManager::TranslateVideoPlayerString(const std::string& info) const
+int CGUIInfoManager::TranslateVideoPlayerString(std::string_view info) const
 {
-  for (const infomap& i : videoplayer)
+  for (const auto& i : videoplayer)
   {
     if (info == i.str)
       return i.val;
@@ -11178,9 +11263,9 @@ int CGUIInfoManager::TranslateVideoPlayerString(const std::string& info) const
   return 0;
 }
 
-int CGUIInfoManager::TranslatePlayerString(const std::string& info) const
+int CGUIInfoManager::TranslatePlayerString(std::string_view info) const
 {
-  for (const infomap& i : player_labels)
+  for (const auto& i : player_labels)
   {
     if (info == i.str)
       return i.val;
@@ -11243,7 +11328,7 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
   }
 
   std::string strLabel;
-  m_infoProviders.GetLabel(strLabel, m_currentFile, contextWindow, CGUIInfo(info), fallback);
+  m_infoProviders.GetLabel(strLabel, m_currentFile.get(), contextWindow, CGUIInfo(info), fallback);
   return strLabel;
 }
 
@@ -11265,7 +11350,7 @@ bool CGUIInfoManager::GetInt(int &value, int info, int contextWindow, const CGUI
   }
 
   value = 0;
-  return m_infoProviders.GetInt(value, m_currentFile, contextWindow, CGUIInfo(info));
+  return m_infoProviders.GetInt(value, m_currentFile.get(), contextWindow, CGUIInfo(info));
 }
 
 INFO::InfoPtr CGUIInfoManager::Register(const std::string &expression, int context)
@@ -11276,10 +11361,10 @@ INFO::InfoPtr CGUIInfoManager::Register(const std::string &expression, int conte
   if (condition.empty())
     return INFO::InfoPtr();
 
-  std::unique_lock<CCriticalSection> lock(m_critInfo);
+  std::unique_lock lock(m_critInfo);
   std::pair<INFOBOOLTYPE::iterator, bool> res;
 
-  if (condition.find_first_of("|+[]!") != condition.npos)
+  if (condition.find_first_of("|+[]!") != std::string::npos)
     res = m_bools.insert(std::make_shared<InfoExpression>(condition, context, m_refreshCounter));
   else
     res = m_bools.insert(std::make_shared<InfoSingle>(condition, context, m_refreshCounter));
@@ -11292,7 +11377,7 @@ INFO::InfoPtr CGUIInfoManager::Register(const std::string &expression, int conte
 
 void CGUIInfoManager::UnRegister(const INFO::InfoPtr& expression)
 {
-  std::unique_lock<CCriticalSection> lock(m_critInfo);
+  std::unique_lock lock(m_critInfo);
   m_bools.erase(expression);
 }
 
@@ -11325,7 +11410,8 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
   {
     bReturn = GetMultiInfoBool(m_multiInfo[condition - MULTI_INFO_START], contextWindow, item);
   }
-  else if (!m_infoProviders.GetBool(bReturn, m_currentFile, contextWindow, CGUIInfo(condition)))
+  else if (!m_infoProviders.GetBool(bReturn, m_currentFile.get(), contextWindow,
+                                    CGUIInfo(condition)))
   {
     // default: use integer value different from 0 as true
     int val;
@@ -11338,7 +11424,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
 bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, const CGUIListItem *item)
 {
   bool bReturn = false;
-  int condition = std::abs(info.m_info);
+  int condition = std::abs(info.GetInfo());
 
   if (condition >= LISTITEM_START && condition <= LISTITEM_END)
   {
@@ -11363,7 +11449,7 @@ bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, 
       bReturn = false;
     }
   }
-  else if (!m_infoProviders.GetBool(bReturn, m_currentFile, contextWindow, info))
+  else if (!m_infoProviders.GetBool(bReturn, m_currentFile.get(), contextWindow, info))
   {
     switch (condition)
     {
@@ -11378,54 +11464,56 @@ bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, 
       case STRING_ENDS_WITH:
       case STRING_CONTAINS:
       case STRING_IS_EQUAL:
+      {
+        std::string compare;
+        if (info.GetData2() < 0) // info labels are stored with negative numbers
         {
-          std::string compare;
-          if (info.GetData2() < 0) // info labels are stored with negative numbers
+          int info2 = -info.GetData2();
+          std::shared_ptr<CGUIListItem> item2;
+
+          if (IsListItemInfo(info2))
           {
-            int info2 = -info.GetData2();
-            std::shared_ptr<CGUIListItem> item2;
-
-            if (IsListItemInfo(info2))
+            int iResolvedInfo2 = ResolveMultiInfo(info2);
+            if (iResolvedInfo2 != 0)
             {
-              int iResolvedInfo2 = ResolveMultiInfo(info2);
-              if (iResolvedInfo2 != 0)
-              {
-                const GUIINFO::CGUIInfo& resolvedInfo2 = m_multiInfo[iResolvedInfo2 - MULTI_INFO_START];
-                if (resolvedInfo2.GetInfoFlag() & INFOFLAG_LISTITEM_CONTAINER)
-                  item2 = GUIINFO::GetCurrentListItem(contextWindow, resolvedInfo2.GetData1()); // data1 contains the container id
-              }
+              const GUIINFO::CGUIInfo& resolvedInfo2 =
+                  m_multiInfo[iResolvedInfo2 - MULTI_INFO_START];
+              if (resolvedInfo2.GetInfoFlag() & INFOFLAG_LISTITEM_CONTAINER)
+                item2 = GUIINFO::GetCurrentListItem(
+                    contextWindow, resolvedInfo2.GetData1()); // data1 contains the container id
             }
-
-            if (item2 && item2->IsFileItem())
-              compare = GetItemImage(item2.get(), contextWindow, info2);
-            else if (item && item->IsFileItem())
-              compare = GetItemImage(item, contextWindow, info2);
-            else
-              compare = GetImage(info2, contextWindow);
           }
-          else if (!info.GetData3().empty())
-          { // conditional string
-            compare = info.GetData3();
-          }
-          StringUtils::ToLower(compare);
 
-          std::string label;
-          if (item && item->IsFileItem() && IsListItemInfo(info.GetData1()))
-            label = GetItemImage(item, contextWindow, info.GetData1());
+          if (item2 && item2->IsFileItem())
+            compare = GetItemImage(item2.get(), contextWindow, info2);
+          else if (item && item->IsFileItem())
+            compare = GetItemImage(item, contextWindow, info2);
           else
-            label = GetImage(info.GetData1(), contextWindow);
-          StringUtils::ToLower(label);
-
-          if (condition == STRING_STARTS_WITH)
-            bReturn = StringUtils::StartsWith(label, compare);
-          else if (condition == STRING_ENDS_WITH)
-            bReturn = StringUtils::EndsWith(label, compare);
-          else if (condition == STRING_CONTAINS)
-            bReturn = label.find(compare) != std::string::npos;
-          else
-            bReturn = StringUtils::EqualsNoCase(label, compare);
+            compare = GetImage(info2, contextWindow);
         }
+        else if (!info.GetData3().empty())
+        { // conditional string
+          compare = info.GetData3();
+        }
+        StringUtils::ToLower(compare);
+
+        std::string label;
+        if (item && item->IsFileItem() && IsListItemInfo(info.GetData1()))
+          label = GetItemImage(item, contextWindow, info.GetData1());
+        else
+          label = GetImage(info.GetData1(), contextWindow);
+        StringUtils::ToLower(label);
+
+        if (condition == STRING_STARTS_WITH)
+          bReturn = StringUtils::StartsWith(label, compare);
+        else if (condition == STRING_ENDS_WITH)
+          bReturn = StringUtils::EndsWith(label, compare);
+        else if (condition == STRING_CONTAINS)
+          bReturn = label.find(compare) != std::string::npos;
+        else
+          bReturn = StringUtils::EqualsNoCase(label, compare);
         break;
+      }
       case INTEGER_IS_EQUAL:
       case INTEGER_GREATER_THAN:
       case INTEGER_GREATER_OR_EQUAL:
@@ -11433,60 +11521,63 @@ bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, 
       case INTEGER_LESS_OR_EQUAL:
       case INTEGER_EVEN:
       case INTEGER_ODD:
+      {
+        auto getIntValue = [this, &item, &contextWindow](int infoNum)
         {
-          auto getIntValue = [this, &item, &contextWindow](int infoNum) {
-            int intValue = 0;
-            if (!GetInt(intValue, infoNum, contextWindow, item))
-            {
-              std::string value;
-              if (item && item->IsFileItem() && IsListItemInfo(infoNum))
-                value = GetItemImage(item, contextWindow, infoNum);
-              else
-                value = GetImage(infoNum, contextWindow);
+          int intValue = 0;
+          if (!GetInt(intValue, infoNum, contextWindow, item))
+          {
+            std::string value;
+            if (item && item->IsFileItem() && IsListItemInfo(infoNum))
+              value = GetItemImage(item, contextWindow, infoNum);
+            else
+              value = GetImage(infoNum, contextWindow);
 
-              // Handle the case when a value contains time separator (:). This makes Integer.IsGreater
-              // useful for Player.Time* members without adding a separate set of members returning time in seconds
-              if (value.find_first_of(':') != value.npos)
-                intValue = StringUtils::TimeStringToSeconds(value);
-              else
-                std::from_chars(value.data(), value.data() + value.size(), intValue);
-            }
-            return intValue;
-          };
+            // Handle the case when a value contains time separator (:). This makes Integer.IsGreater
+            // useful for Player.Time* members without adding a separate set of members returning time in seconds
+            if (value.find_first_of(':') != std::string::npos)
+              intValue = StringUtils::TimeStringToSeconds(value);
+            else
+              std::from_chars(value.data(), value.data() + value.size(), intValue);
+          }
+          return intValue;
+        };
 
-          int leftIntValue = getIntValue(info.GetData1());
-          int rightIntValue = getIntValue(info.GetData2());
+        int leftIntValue = getIntValue(info.GetData1());
+        int rightIntValue = getIntValue(info.GetData2());
 
-          // compare
-          if (condition == INTEGER_IS_EQUAL)
-            bReturn = leftIntValue == rightIntValue;
-          else if (condition == INTEGER_GREATER_THAN)
-            bReturn = leftIntValue > rightIntValue;
-          else if (condition == INTEGER_GREATER_OR_EQUAL)
-            bReturn = leftIntValue >= rightIntValue;
-          else if (condition == INTEGER_LESS_THAN)
-            bReturn = leftIntValue < rightIntValue;
-          else if (condition == INTEGER_LESS_OR_EQUAL)
-            bReturn = leftIntValue <= rightIntValue;
-          else if (condition == INTEGER_EVEN)
-            bReturn = leftIntValue % 2 == 0;
-          else if (condition == INTEGER_ODD)
-            bReturn = leftIntValue % 2 != 0;
-        }
+        // compare
+        if (condition == INTEGER_IS_EQUAL)
+          bReturn = leftIntValue == rightIntValue;
+        else if (condition == INTEGER_GREATER_THAN)
+          bReturn = leftIntValue > rightIntValue;
+        else if (condition == INTEGER_GREATER_OR_EQUAL)
+          bReturn = leftIntValue >= rightIntValue;
+        else if (condition == INTEGER_LESS_THAN)
+          bReturn = leftIntValue < rightIntValue;
+        else if (condition == INTEGER_LESS_OR_EQUAL)
+          bReturn = leftIntValue <= rightIntValue;
+        else if (condition == INTEGER_EVEN)
+          bReturn = leftIntValue % 2 == 0;
+        else if (condition == INTEGER_ODD)
+          bReturn = leftIntValue % 2 != 0;
+        break;
+      }
+      default:
         break;
     }
   }
-  return (info.m_info < 0) ? !bReturn : bReturn;
+  return (info.GetInfo() < 0) ? !bReturn : bReturn;
 }
 
 bool CGUIInfoManager::GetMultiInfoInt(int &value, const CGUIInfo &info, int contextWindow, const CGUIListItem *item) const
 {
-  if (info.m_info == INTEGER_VALUEOF)
+  if (info.GetInfo() == INTEGER_VALUEOF)
   {
     value = info.GetData1();
     return true;
   }
-  else if (info.m_info >= LISTITEM_START && info.m_info <= LISTITEM_END)
+  else if (info.GetInfo() >= LISTITEM_START && info.GetInfo() <= LISTITEM_END)
   {
     std::shared_ptr<CGUIListItem> itemPtr;
     if (!item)
@@ -11496,7 +11587,7 @@ bool CGUIInfoManager::GetMultiInfoInt(int &value, const CGUIInfo &info, int cont
     }
     if (item)
     {
-      if (info.m_info == LISTITEM_PROPERTY)
+      if (info.GetInfo() == LISTITEM_PROPERTY)
       {
         if (item->HasProperty(info.GetData3()))
         {
@@ -11506,7 +11597,7 @@ bool CGUIInfoManager::GetMultiInfoInt(int &value, const CGUIInfo &info, int cont
         return false;
       }
       else
-        return GetItemInt(value, item, contextWindow, info.m_info);
+        return GetItemInt(value, item, contextWindow, info.GetInfo());
     }
     else
     {
@@ -11514,14 +11605,14 @@ bool CGUIInfoManager::GetMultiInfoInt(int &value, const CGUIInfo &info, int cont
     }
   }
 
-  return m_infoProviders.GetInt(value, m_currentFile, contextWindow, info);
+  return m_infoProviders.GetInt(value, m_currentFile.get(), contextWindow, info);
 }
 
 std::string CGUIInfoManager::GetMultiInfoLabel(const CGUIInfo &constinfo, int contextWindow, std::string *fallback) const
 {
   CGUIInfo info(constinfo);
 
-  if (info.m_info >= LISTITEM_START && info.m_info <= LISTITEM_END)
+  if (info.GetInfo() >= LISTITEM_START && info.GetInfo() <= LISTITEM_END)
   {
     const std::shared_ptr<CGUIListItem> item = GUIINFO::GetCurrentListItem(
         contextWindow, info.GetData1(), info.GetData2(), info.GetInfoFlag());
@@ -11535,20 +11626,19 @@ std::string CGUIInfoManager::GetMultiInfoLabel(const CGUIInfo &constinfo, int co
       return std::string();
     }
   }
-  else if (info.m_info == SYSTEM_ADDON_TITLE ||
-           info.m_info == SYSTEM_ADDON_ICON ||
-           info.m_info == SYSTEM_ADDON_VERSION)
+  else if (info.GetInfo() == SYSTEM_ADDON_TITLE || info.GetInfo() == SYSTEM_ADDON_ICON ||
+           info.GetInfo() == SYSTEM_ADDON_VERSION)
   {
     if (info.GetData2() == 0)
     {
       // resolve the addon id
       const std::string addonId = GetLabel(info.GetData1(), contextWindow);
-      info = CGUIInfo(info.m_info, addonId);
+      info = CGUIInfo(info.GetInfo(), addonId);
     }
   }
 
   std::string strValue;
-  m_infoProviders.GetLabel(strValue, m_currentFile, contextWindow, info, fallback);
+  m_infoProviders.GetLabel(strValue, m_currentFile.get(), contextWindow, info, fallback);
   return strValue;
 }
 
@@ -11593,7 +11683,7 @@ void CGUIInfoManager::SetCurrentItem(const CFileItem &item)
   *m_currentFile = item;
   ART::FillInDefaultIcon(*m_currentFile);
 
-  m_infoProviders.InitCurrentItem(m_currentFile);
+  m_infoProviders.InitCurrentItem(m_currentFile.get());
 
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Info, "OnChanged");
 }
@@ -11611,7 +11701,7 @@ void CGUIInfoManager::SetCurrentAlbumThumb(const std::string &thumbFileName)
 
 void CGUIInfoManager::Clear()
 {
-  std::unique_lock<CCriticalSection> lock(m_critInfo);
+  std::unique_lock lock(m_critInfo);
   m_skinVariableStrings.clear();
 
   /*
@@ -11630,9 +11720,9 @@ void CGUIInfoManager::Clear()
   } while (swapList.size() != m_bools.size());
 
   // log which ones are used - they should all be gone by now
-  for (INFOBOOLTYPE::const_iterator i = m_bools.begin(); i != m_bools.end(); ++i)
-    CLog::Log(LOGDEBUG, "Infobool '{}' still used by {} instances", (*i)->GetExpression(),
-              (unsigned int)i->use_count());
+  for (const auto& infoBool : m_bools)
+    CLog::Log(LOGDEBUG, "Infobool '{}' still used by {} instances", infoBool->GetExpression(),
+              infoBool.use_count());
 }
 
 void CGUIInfoManager::UpdateAVInfo()
@@ -11663,7 +11753,7 @@ int CGUIInfoManager::AddMultiInfo(const CGUIInfo &info)
   m_multiInfo.emplace_back(info);
   int id = static_cast<int>(m_multiInfo.size()) + MULTI_INFO_START - 1;
   if (id > MULTI_INFO_END)
-    CLog::Log(LOGERROR, "{} - too many multiinfo bool/labels in this skin", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Too many multiinfo bool/labels in this skin");
   return id;
 }
 
@@ -11675,7 +11765,7 @@ int CGUIInfoManager::ResolveMultiInfo(int info) const
   while (iResolvedInfo >= MULTI_INFO_START && iResolvedInfo <= MULTI_INFO_END)
   {
     iLastInfo = iResolvedInfo;
-    iResolvedInfo = m_multiInfo[iResolvedInfo - MULTI_INFO_START].m_info;
+    iResolvedInfo = m_multiInfo[iResolvedInfo - MULTI_INFO_START].GetInfo();
   }
 
   return iLastInfo;
@@ -11685,7 +11775,7 @@ bool CGUIInfoManager::IsListItemInfo(int info) const
 {
   int iResolvedInfo = info;
   while (iResolvedInfo >= MULTI_INFO_START && iResolvedInfo <= MULTI_INFO_END)
-    iResolvedInfo = m_multiInfo[iResolvedInfo - MULTI_INFO_START].m_info;
+    iResolvedInfo = m_multiInfo[iResolvedInfo - MULTI_INFO_START].GetInfo();
 
   return (iResolvedInfo >= LISTITEM_START && iResolvedInfo <= LISTITEM_END);
 }
@@ -11712,17 +11802,18 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int co
 
   std::string value;
 
-  if (info.m_info >= CONDITIONAL_LABEL_START && info.m_info <= CONDITIONAL_LABEL_END)
+  if (info.GetInfo() >= CONDITIONAL_LABEL_START && info.GetInfo() <= CONDITIONAL_LABEL_END)
   {
-    return GetSkinVariableString(info.m_info, contextWindow, false, item);
+    return GetSkinVariableString(info.GetInfo(), contextWindow, false, item);
   }
-  else if (info.m_info >= MULTI_INFO_START && info.m_info <= MULTI_INFO_END)
+  else if (info.GetInfo() >= MULTI_INFO_START && info.GetInfo() <= MULTI_INFO_END)
   {
-    return GetMultiInfoItemLabel(item, contextWindow, m_multiInfo[info.m_info - MULTI_INFO_START], fallback);
+    return GetMultiInfoItemLabel(item, contextWindow,
+                                 m_multiInfo[info.GetInfo() - MULTI_INFO_START], fallback);
   }
   else if (!m_infoProviders.GetLabel(value, item, contextWindow, info, fallback))
   {
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       case LISTITEM_PROPERTY:
         return item->GetProperty(info.GetData3()).asString();
@@ -11735,12 +11826,12 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int co
       case LISTITEM_FILENAME_NO_EXTENSION:
       {
         std::string strFile = URIUtils::GetFileName(item->GetPath());
-        if (info.m_info == LISTITEM_FILE_EXTENSION)
+        if (info.GetInfo() == LISTITEM_FILE_EXTENSION)
         {
           std::string strExtension = URIUtils::GetExtension(strFile);
           return StringUtils::TrimLeft(strExtension, ".");
         }
-        else if (info.m_info == LISTITEM_FILENAME_NO_EXTENSION)
+        else if (info.GetInfo() == LISTITEM_FILENAME_NO_EXTENSION)
         {
           URIUtils::RemoveExtension(strFile);
         }
@@ -11785,7 +11876,7 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int co
         std::string path;
         URIUtils::GetParentPath(item->GetPath(), path);
         path = CURL(path).GetWithoutUserDetails();
-        if (info.m_info == LISTITEM_FOLDERNAME)
+        if (info.GetInfo() == LISTITEM_FOLDERNAME)
         {
           URIUtils::RemoveSlashAtEnd(path);
           path = URIUtils::GetFileName(path);
@@ -11803,7 +11894,7 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int co
         std::string letter;
         std::wstring character(1, item->GetSortLabel()[0]);
         StringUtils::ToUpper(character);
-        g_charsetConverter.wToUTF8(character, letter);
+        CCharsetConverter::wToUTF8(character, letter);
         return letter;
       }
       case LISTITEM_STARTTIME:
@@ -11820,6 +11911,8 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int co
       }
       case LISTITEM_CURRENTITEM:
         return std::to_string(item->GetCurrentItem());
+      default:
+        break;
     }
   }
 
@@ -11836,13 +11929,14 @@ std::string CGUIInfoManager::GetItemImage(const CGUIListItem *item, int contextW
 
 std::string CGUIInfoManager::GetMultiInfoItemImage(const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback /*= nullptr*/) const
 {
-  if (info.m_info >= CONDITIONAL_LABEL_START && info.m_info <= CONDITIONAL_LABEL_END)
+  if (info.GetInfo() >= CONDITIONAL_LABEL_START && info.GetInfo() <= CONDITIONAL_LABEL_END)
   {
-    return GetSkinVariableString(info.m_info, contextWindow, true, item);
+    return GetSkinVariableString(info.GetInfo(), contextWindow, true, item);
   }
-  else if (info.m_info >= MULTI_INFO_START && info.m_info <= MULTI_INFO_END)
+  else if (info.GetInfo() >= MULTI_INFO_START && info.GetInfo() <= MULTI_INFO_END)
   {
-    return GetMultiInfoItemImage(item, contextWindow, m_multiInfo[info.m_info - MULTI_INFO_START], fallback);
+    return GetMultiInfoItemImage(item, contextWindow,
+                                 m_multiInfo[info.GetInfo() - MULTI_INFO_START], fallback);
   }
 
   return GetMultiInfoItemLabel(item, contextWindow, info, fallback);
@@ -11866,11 +11960,13 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int contextWindow, i
       {
         if (item->IsFileItem())
         {
-          const CFileItem *pItem = static_cast<const CFileItem *>(item);
+          const auto* pItem{static_cast<const CFileItem*>(item)};
           return pItem->IsParentFolder();
         }
         break;
       }
+      default:
+        break;
     }
   }
 
@@ -11880,7 +11976,7 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int contextWindow, i
 void CGUIInfoManager::ResetCache()
 {
   // mark our infobools as dirty
-  std::unique_lock<CCriticalSection> lock(m_critInfo);
+  std::unique_lock lock(m_critInfo);
   ++m_refreshCounter;
 }
 
@@ -11925,7 +12021,7 @@ int CGUIInfoManager::RegisterSkinVariableString(const CSkinVariableString* info)
   if (!info)
     return 0;
 
-  std::unique_lock<CCriticalSection> lock(m_critInfo);
+  std::unique_lock lock(m_critInfo);
   m_skinVariableStrings.emplace_back(*info);
   delete info;
   return CONDITIONAL_LABEL_START + m_skinVariableStrings.size() - 1;
@@ -11954,11 +12050,11 @@ std::string CGUIInfoManager::GetSkinVariableString(int info,
   return "";
 }
 
-bool CGUIInfoManager::ConditionsChangedValues(const std::map<INFO::InfoPtr, bool>& map)
+bool CGUIInfoManager::ConditionsChangedValues(const std::map<INFO::InfoPtr, bool>& map) const
 {
-  for (std::map<INFO::InfoPtr, bool>::const_iterator it = map.begin() ; it != map.end() ; ++it)
+  for (const auto& [info, value] : map)
   {
-    if (it->first->Get(INFO::DEFAULT_CONTEXT) != it->second)
+    if (info->Get(INFO::DEFAULT_CONTEXT) != value)
       return true;
   }
   return false;
@@ -11978,7 +12074,7 @@ void CGUIInfoManager::OnApplicationMessage(KODI::MESSAGING::ThreadMessage* pMsg)
     if (pMsg->lpVoid)
     {
       auto infoLabels = static_cast<std::vector<std::string>*>(pMsg->lpVoid);
-      for (auto& param : pMsg->params)
+      for (const auto& param : pMsg->params)
         infoLabels->emplace_back(GetLabel(TranslateString(param), DEFAULT_CONTEXT));
     }
   }
@@ -11989,7 +12085,7 @@ void CGUIInfoManager::OnApplicationMessage(KODI::MESSAGING::ThreadMessage* pMsg)
     if (pMsg->lpVoid)
     {
       auto infoLabels = static_cast<std::vector<bool>*>(pMsg->lpVoid);
-      for (auto& param : pMsg->params)
+      for (const auto& param : pMsg->params)
         infoLabels->push_back(EvaluateBool(param, DEFAULT_CONTEXT));
     }
   }
@@ -11997,7 +12093,7 @@ void CGUIInfoManager::OnApplicationMessage(KODI::MESSAGING::ThreadMessage* pMsg)
 
   case TMSG_UPDATE_CURRENT_ITEM:
   {
-    CFileItem* item = static_cast<CFileItem*>(pMsg->lpVoid);
+    auto* item{static_cast<CFileItem*>(pMsg->lpVoid)};
     if (!item)
       return;
 

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <string_view>
 #include <vector>
 
 class CFileItem;
@@ -25,21 +26,15 @@ class CVideoInfoTag;
 
 class CGUIListItem;
 
-namespace KODI
-{
-namespace GAME
+namespace KODI::GAME
 {
 class CGameInfoTag;
 }
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
   class CGUIInfo;
   class IGUIInfoProvider;
-}
-}
-}
+  } // namespace KODI::GUILIB::GUIINFO
 namespace INFO
 {
   class InfoSingle;
@@ -88,7 +83,7 @@ public:
   void UnRegister(const INFO::InfoPtr& expression);
 
   /// \brief iterates through boolean conditions and compares their stored values to current values. Returns true if any condition changed value.
-  bool ConditionsChangedValues(const std::map<INFO::InfoPtr, bool>& map);
+  bool ConditionsChangedValues(const std::map<INFO::InfoPtr, bool>& map) const;
 
   /*! \brief Evaluate a boolean expression
    \param expression the expression to evaluate
@@ -165,11 +160,13 @@ private:
   public:
     Property(const std::string &property, const std::string &parameters);
 
-    const std::string &param(unsigned int n = 0) const;
+    const std::string& Name() const { return m_name; }
+
+    const std::string& param(size_t n = 0) const;
     unsigned int num_params() const;
 
-    std::string name;
   private:
+    std::string m_name;
     std::vector<std::string> params;
   };
 
@@ -183,13 +180,13 @@ private:
    \param infoString the original string
    \param info the resulting pairs of info and parameters.
    */
-  void SplitInfoString(const std::string &infoString, std::vector<Property> &info);
+  void SplitInfoString(const std::string& infoString, std::vector<Property>& info) const;
 
   int TranslateSingleString(const std::string &strCondition);
   int TranslateListItem(const Property& cat, const Property& prop, int id, bool container);
-  int TranslateMusicPlayerString(const std::string &info) const;
-  int TranslateVideoPlayerString(const std::string& info) const;
-  int TranslatePlayerString(const std::string& info) const;
+  int TranslateMusicPlayerString(std::string_view info) const;
+  int TranslateVideoPlayerString(std::string_view info) const;
+  int TranslatePlayerString(std::string_view info) const;
   static TIME_FORMAT TranslateTimeFormat(const std::string &format);
 
   std::string GetMultiInfoLabel(const KODI::GUILIB::GUIINFO::CGUIInfo &info, int contextWindow, std::string *fallback = nullptr) const;
@@ -216,9 +213,10 @@ private:
   std::vector<KODI::GUILIB::GUIINFO::CGUIInfo> m_multiInfo;
 
   // Current playing stuff
-  CFileItem* m_currentFile;
+  std::unique_ptr<CFileItem> m_currentFile;
 
-  typedef std::set<INFO::InfoPtr, bool(*)(const INFO::InfoPtr&, const INFO::InfoPtr&)> INFOBOOLTYPE;
+  using INFOBOOLTYPE =
+      std::set<INFO::InfoPtr, bool (*)(const INFO::InfoPtr&, const INFO::InfoPtr&)>;
   INFOBOOLTYPE m_bools;
   unsigned int m_refreshCounter = 0;
   std::vector<INFO::CSkinVariableString> m_skinVariableStrings;

--- a/xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
@@ -30,7 +30,7 @@ bool CAddonsGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
   const std::shared_ptr<const ADDON::IAddon> addonInfo = item->GetAddonInfo();
   if (addonInfo)
   {
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       ///////////////////////////////////////////////////////////////////////////////////////////////
       // LISTITEM_*
@@ -70,15 +70,17 @@ bool CAddonsGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
         const ADDON::AddonLifecycleState state = addonInfo->LifecycleState();
         switch (state)
         {
-          case ADDON::AddonLifecycleState::BROKEN:
+          using enum ADDON::AddonLifecycleState;
+
+          case BROKEN:
             value = g_localizeStrings.Get(24171); // "Broken"
             break;
-          case ADDON::AddonLifecycleState::DEPRECATED:
-            value = g_localizeStrings.Get(24170); // "Deprecated";
+          case DEPRECATED:
+            value = g_localizeStrings.Get(24170); // "Deprecated"
             break;
-          case ADDON::AddonLifecycleState::NORMAL:
+          case NORMAL:
           default:
-            value = g_localizeStrings.Get(24169); // "Normal";
+            value = g_localizeStrings.Get(24169); // "Normal"
             break;
         }
         return true;
@@ -136,10 +138,12 @@ bool CAddonsGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
         }
         break;
       }
+      default:
+        break;
     }
   }
 
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // ADDON_*
@@ -174,17 +178,17 @@ bool CAddonsGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
         if (!success || !addon)
           break;
 
-        if (info.m_info == SYSTEM_ADDON_TITLE)
+        if (info.GetInfo() == SYSTEM_ADDON_TITLE)
         {
           value = addon->Name();
           return true;
         }
-        if (info.m_info == SYSTEM_ADDON_ICON)
+        if (info.GetInfo() == SYSTEM_ADDON_ICON)
         {
           value = addon->Icon();
           return true;
         }
-        if (info.m_info == SYSTEM_ADDON_VERSION)
+        if (info.GetInfo() == SYSTEM_ADDON_VERSION)
         {
           value = addon->Version().asString();
           return true;
@@ -192,6 +196,8 @@ bool CAddonsGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       }
       break;
     }
+    default:
+      break;
   }
 
   return false;
@@ -199,7 +205,7 @@ bool CAddonsGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
 
 bool CAddonsGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWindow, const CGUIInfo &info) const
 {
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // ADDON_*
@@ -214,13 +220,15 @@ bool CAddonsGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWi
       }
       return addon->GetSettingInt(info.GetData5(), value);
     }
+    default:
+      break;
   }
   return false;
 }
 
 bool CAddonsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextWindow, const CGUIInfo &info) const
 {
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // ADDON_*
@@ -255,20 +263,20 @@ bool CAddonsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
     case LISTITEM_ISAUTOUPDATEABLE:
     {
       value = true;
-      const CFileItem* item = static_cast<const CFileItem*>(gitem);
+      const auto* item{static_cast<const CFileItem*>(gitem)};
       if (item->GetAddonInfo())
         value = CServiceBroker::GetAddonMgr().IsAutoUpdateable(item->GetAddonInfo()->ID()) ||
                 !CServiceBroker::GetAddonMgr().IsAddonInstalled(item->GetAddonInfo()->ID(),
                                                                 item->GetAddonInfo()->Origin());
 
-      //! @Todo: store origin of not-autoupdateable installed addons in table 'update_rules'
-      //         of the addon database. this is needed to pin ambiguous addon-id's that are
-      //         available from multiple origins accordingly.
-      //
-      //         after this is done the above call should be changed to
-      //
-      //         value = CServiceBroker::GetAddonMgr().IsAutoUpdateable(item->GetAddonInfo()->ID(),
-      //                                                                item->GetAddonInfo()->Origin());
+      //! @todo: store origin of not-autoupdateable installed addons in table 'update_rules'
+      //!         of the addon database. this is needed to pin ambiguous addon-id's that are
+      //!         available from multiple origins accordingly.
+      //!
+      //!         after this is done the above call should be changed to
+      //!
+      //!         value = CServiceBroker::GetAddonMgr().IsAutoUpdateable(item->GetAddonInfo()->ID(),
+      //!                                                                item->GetAddonInfo()->Origin());
 
       return true;
     }

--- a/xbmc/guilib/guiinfo/AddonsGUIInfo.h
+++ b/xbmc/guilib/guiinfo/AddonsGUIInfo.h
@@ -10,11 +10,7 @@
 
 #include "guilib/guiinfo/GUIInfoProvider.h"
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
 class CGUIInfo;
@@ -32,6 +28,4 @@ public:
   bool GetBool(bool& value, const CGUIListItem *item, int contextWindow, const CGUIInfo &info) const override;
 };
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/GUIControlsGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/GUIControlsGUIInfo.cpp
@@ -56,7 +56,7 @@ bool CGUIControlsGUIInfo::InitCurrentItem(CFileItem *item)
 
 bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback) const
 {
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // CONTAINER_*
@@ -64,10 +64,10 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     case CONTAINER_FOLDERPATH:
     case CONTAINER_FOLDERNAME:
     {
-      CGUIMediaWindow* window = GUIINFO::GetMediaWindow(contextWindow);
+      const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
-        if (info.m_info == CONTAINER_FOLDERNAME)
+        if (info.GetInfo() == CONTAINER_FOLDERNAME)
           value = window->CurrentDirectory().GetLabel();
         else
           value = CURL(window->CurrentDirectory().GetPath()).GetWithoutUserDetails();
@@ -77,7 +77,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     }
     case CONTAINER_PLUGINNAME:
     {
-      CGUIMediaWindow* window = GUIINFO::GetMediaWindow(contextWindow);
+      const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         const CURL url(window->CurrentDirectory().GetPath());
@@ -92,18 +92,18 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     case CONTAINER_VIEWCOUNT:
     case CONTAINER_VIEWMODE:
     {
-      CGUIMediaWindow* window = GUIINFO::GetMediaWindow(contextWindow);
+      CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         const CGUIControl *control = window->GetControl(window->GetViewContainerID());
         if (control && control->IsContainer())
         {
-          if (info.m_info == CONTAINER_VIEWMODE)
+          if (info.GetInfo() == CONTAINER_VIEWMODE)
           {
             value = static_cast<const IGUIContainer*>(control)->GetLabel();
             return true;
           }
-          else if (info.m_info == CONTAINER_VIEWCOUNT)
+          else if (info.GetInfo() == CONTAINER_VIEWCOUNT)
           {
             value = std::to_string(window->GetViewCount());
             return true;
@@ -115,18 +115,18 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     case CONTAINER_SORT_METHOD:
     case CONTAINER_SORT_ORDER:
     {
-      CGUIMediaWindow* window = GUIINFO::GetMediaWindow(contextWindow);
+      const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         const CGUIViewState *viewState = window->GetViewState();
         if (viewState)
         {
-          if (info.m_info == CONTAINER_SORT_METHOD)
+          if (info.GetInfo() == CONTAINER_SORT_METHOD)
           {
             value = g_localizeStrings.Get(viewState->GetSortMethodLabel());
             return true;
           }
-          else if (info.m_info == CONTAINER_SORT_ORDER)
+          else if (info.GetInfo() == CONTAINER_SORT_ORDER)
           {
             value = g_localizeStrings.Get(viewState->GetSortOrderLabel());
             return true;
@@ -137,7 +137,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     }
     case CONTAINER_PROPERTY:
     {
-      CGUIMediaWindow* window = GUIINFO::GetMediaWindow(contextWindow);
+      const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         value = window->CurrentDirectory().GetProperty(info.GetData3()).asString();
@@ -147,7 +147,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     }
     case CONTAINER_ART:
     {
-      CGUIMediaWindow* window = GUIINFO::GetMediaWindow(contextWindow);
+      const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         value = window->CurrentDirectory().GetArt(info.GetData3());
@@ -157,7 +157,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     }
     case CONTAINER_CONTENT:
     {
-      CGUIMediaWindow* window = GUIINFO::GetMediaWindow(contextWindow);
+      const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         value = window->CurrentDirectory().GetContent();
@@ -167,7 +167,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     }
     case CONTAINER_SHOWPLOT:
     {
-      CGUIMediaWindow* window = GUIINFO::GetMediaWindow(contextWindow);
+      const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         value = window->CurrentDirectory().GetProperty("showplot").asString();
@@ -177,7 +177,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     }
     case CONTAINER_SHOWTITLE:
     {
-      CGUIMediaWindow* window = GUIINFO::GetMediaWindow(contextWindow);
+      const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         value = window->CurrentDirectory().GetProperty("showtitle").asString();
@@ -187,7 +187,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     }
     case CONTAINER_PLUGINCATEGORY:
     {
-      CGUIMediaWindow* window = GUIINFO::GetMediaWindow(contextWindow);
+      const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         value = window->CurrentDirectory().GetProperty("plugincategory").asString();
@@ -199,7 +199,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     case CONTAINER_TOTALWATCHED:
     case CONTAINER_TOTALUNWATCHED:
     {
-      CGUIMediaWindow* window = GUIINFO::GetMediaWindow(contextWindow);
+      const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         int count = 0;
@@ -207,23 +207,24 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
         for (const auto& i : items)
         {
           // Iterate through container and count watched, unwatched and total duration.
-          if (info.m_info == CONTAINER_TOTALWATCHED && i->HasVideoInfoTag() &&
+          if (info.GetInfo() == CONTAINER_TOTALWATCHED && i->HasVideoInfoTag() &&
               i->GetVideoInfoTag()->GetPlayCount() > 0)
             count += 1;
-          else if (info.m_info == CONTAINER_TOTALUNWATCHED && i->HasVideoInfoTag() &&
+          else if (info.GetInfo() == CONTAINER_TOTALUNWATCHED && i->HasVideoInfoTag() &&
                    i->GetVideoInfoTag()->GetPlayCount() == 0)
             count += 1;
-          else if (info.m_info == CONTAINER_TOTALTIME && i->HasMusicInfoTag())
+          else if (info.GetInfo() == CONTAINER_TOTALTIME && i->HasMusicInfoTag())
             count += i->GetMusicInfoTag()->GetDuration();
-          else if (info.m_info == CONTAINER_TOTALTIME && i->HasVideoInfoTag())
+          else if (info.GetInfo() == CONTAINER_TOTALTIME && i->HasVideoInfoTag())
             count += i->GetVideoInfoTag()->m_streamDetails.GetVideoDuration();
         }
-        if (info.m_info == CONTAINER_TOTALTIME && count > 0)
+        if (info.GetInfo() == CONTAINER_TOTALTIME && count > 0)
         {
           value = StringUtils::SecondsToTimeString(count);
           return true;
         }
-        else if (info.m_info == CONTAINER_TOTALWATCHED || info.m_info == CONTAINER_TOTALUNWATCHED)
+        else if (info.GetInfo() == CONTAINER_TOTALWATCHED ||
+                 info.GetInfo() == CONTAINER_TOTALUNWATCHED)
         {
           value = std::to_string(count);
           return true;
@@ -244,24 +245,24 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
       const CGUIControl *control = nullptr;
       if (info.GetData1())
       { // container specified
-        CGUIWindow *window = GUIINFO::GetWindow(contextWindow);
+        CGUIWindow* window{GUIINFO::GetWindow(contextWindow)};
         if (window)
           control = window->GetControl(info.GetData1());
       }
       else
       { // no container specified - assume a mediawindow
-        CGUIMediaWindow *window = GUIINFO::GetMediaWindow(contextWindow);
+        CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
         if (window)
           control = window->GetControl(window->GetViewContainerID());
       }
       if (control)
       {
         if (control->IsContainer())
-          value = static_cast<const IGUIContainer*>(control)->GetLabel(info.m_info);
+          value = static_cast<const IGUIContainer*>(control)->GetLabel(info.GetInfo());
         else if (control->GetControlType() == CGUIControl::GUICONTROL_GROUPLIST)
-          value = static_cast<const CGUIControlGroupList*>(control)->GetLabel(info.m_info);
+          value = static_cast<const CGUIControlGroupList*>(control)->GetLabel(info.GetInfo());
         else if (control->GetControlType() == CGUIControl::GUICONTROL_TEXTBOX)
-          value = static_cast<const CGUITextBox*>(control)->GetLabel(info.m_info);
+          value = static_cast<const CGUITextBox*>(control)->GetLabel(info.GetInfo());
         return true;
       }
       break;
@@ -272,7 +273,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case CONTROL_GET_LABEL:
     {
-      CGUIWindow *window = GUIINFO::GetWindow(contextWindow);
+      CGUIWindow* window{GUIINFO::GetWindow(contextWindow)};
       if (window)
       {
         const CGUIControl *control = window->GetControl(info.GetData1());
@@ -294,7 +295,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case WINDOW_PROPERTY:
     {
-      CGUIWindow *window = nullptr;
+      const CGUIWindow* window{nullptr};
       if (info.GetData1())
       { // window specified
         window = CServiceBroker::GetGUI()->GetWindowManager().GetWindow(info.GetData1());
@@ -324,15 +325,16 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     case SYSTEM_CURRENT_CONTROL:
     case SYSTEM_CURRENT_CONTROL_ID:
     {
-      CGUIWindow *window = CServiceBroker::GetGUI()->GetWindowManager().GetWindow(CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindowOrDialog());
+      const CGUIWindow* window{CServiceBroker::GetGUI()->GetWindowManager().GetWindow(
+          CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindowOrDialog())};
       if (window)
       {
         CGUIControl *control = window->GetFocusedControl();
         if (control)
         {
-          if (info.m_info == SYSTEM_CURRENT_CONTROL_ID)
+          if (info.GetInfo() == SYSTEM_CURRENT_CONTROL_ID)
             value = std::to_string(control->GetID());
-          else if (info.m_info == SYSTEM_CURRENT_CONTROL)
+          else if (info.GetInfo() == SYSTEM_CURRENT_CONTROL)
             value = control->GetDescription();
           return true;
         }
@@ -341,7 +343,9 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     }
     case SYSTEM_PROGRESS_BAR:
     {
-      CGUIDialogProgress *bar = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
+      const CGUIDialogProgress* bar{
+          CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogProgress>(
+              WINDOW_DIALOG_PROGRESS)};
       if (bar && bar->IsDialogRunning())
         value = std::to_string(bar->GetPercentage());
       return true;
@@ -352,7 +356,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case FANART_COLOR1:
     {
-      CGUIMediaWindow* window = GUIINFO::GetMediaWindow(contextWindow);
+      const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         value = window->CurrentDirectory().GetProperty("fanart_color1").asString();
@@ -362,7 +366,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     }
     case FANART_COLOR2:
     {
-      CGUIMediaWindow* window = GUIINFO::GetMediaWindow(contextWindow);
+      const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         value = window->CurrentDirectory().GetProperty("fanart_color2").asString();
@@ -372,7 +376,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     }
     case FANART_COLOR3:
     {
-      CGUIMediaWindow* window = GUIINFO::GetMediaWindow(contextWindow);
+      const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         value = window->CurrentDirectory().GetProperty("fanart_color3").asString();
@@ -382,7 +386,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
     }
     case FANART_IMAGE:
     {
-      CGUIMediaWindow* window = GUIINFO::GetMediaWindow(contextWindow);
+      const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         value = window->CurrentDirectory().GetArt("fanart");
@@ -390,6 +394,8 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
       }
       break;
     }
+    default:
+      break;
   }
 
   return false;
@@ -397,18 +403,22 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value, const CFileItem *item, in
 
 bool CGUIControlsGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWindow, const CGUIInfo &info) const
 {
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // SYSTEM_*
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case SYSTEM_PROGRESS_BAR:
     {
-      CGUIDialogProgress *bar = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
+      const CGUIDialogProgress* bar{
+          CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogProgress>(
+              WINDOW_DIALOG_PROGRESS)};
       if (bar && bar->IsDialogRunning())
         value = bar->GetPercentage();
       return true;
     }
+    default:
+      break;
   }
 
   return false;
@@ -416,7 +426,7 @@ bool CGUIControlsGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int cont
 
 bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextWindow, const CGUIInfo &info) const
 {
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // CONTAINER_*
@@ -424,14 +434,15 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
     case CONTAINER_HASFILES:
     case CONTAINER_HASFOLDERS:
     {
-      CGUIMediaWindow* window = GUIINFO::GetMediaWindow(contextWindow);
+      const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         const CFileItemList& items = window->CurrentDirectory();
         for (const auto& item : items)
         {
-          if ((!item->m_bIsFolder && info.m_info == CONTAINER_HASFILES) ||
-              (item->m_bIsFolder && !item->IsParentFolder() && info.m_info == CONTAINER_HASFOLDERS))
+          if ((!item->m_bIsFolder && info.GetInfo() == CONTAINER_HASFILES) ||
+              (item->m_bIsFolder && !item->IsParentFolder() &&
+               info.GetInfo() == CONTAINER_HASFOLDERS))
           {
             value = true;
             return true;
@@ -442,7 +453,7 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
     }
     case CONTAINER_STACKED:
     {
-      CGUIMediaWindow* window = GUIINFO::GetMediaWindow(contextWindow);
+      const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         value = window->CurrentDirectory().GetProperty("isstacked").asBoolean();
@@ -452,7 +463,7 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
     }
     case CONTAINER_HAS_THUMB:
     {
-      CGUIMediaWindow* window = GUIINFO::GetMediaWindow(contextWindow);
+      const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         value = window->CurrentDirectory().HasArt("thumb");
@@ -462,7 +473,7 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
     }
     case CONTAINER_CAN_FILTER:
     {
-      CGUIMediaWindow *window = GUIINFO::GetMediaWindow(contextWindow);
+      CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         value = !window->CanFilterAdvanced();
@@ -472,7 +483,7 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
     }
     case CONTAINER_CAN_FILTERADVANCED:
     {
-      CGUIMediaWindow *window = GUIINFO::GetMediaWindow(contextWindow);
+      CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         value = window->CanFilterAdvanced();
@@ -482,7 +493,7 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
     }
     case CONTAINER_FILTERED:
     {
-      CGUIMediaWindow *window = GUIINFO::GetMediaWindow(contextWindow);
+      CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         value = window->IsFiltered();
@@ -492,7 +503,7 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
     }
     case CONTAINER_SORT_METHOD:
     {
-      CGUIMediaWindow *window = GUIINFO::GetMediaWindow(contextWindow);
+      const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         const CGUIViewState *viewState = window->GetViewState();
@@ -506,7 +517,7 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
     }
     case CONTAINER_SORT_DIRECTION:
     {
-      CGUIMediaWindow *window = GUIINFO::GetMediaWindow(contextWindow);
+      const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
       if (window)
       {
         const CGUIViewState *viewState = window->GetViewState();
@@ -521,7 +532,7 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
     case CONTAINER_CONTENT:
     {
       std::string content;
-      CGUIWindow *window = GUIINFO::GetWindow(contextWindow);
+      CGUIWindow* window{GUIINFO::GetWindow(contextWindow)};
       if (window)
       {
         if (window->GetID() == WINDOW_DIALOG_MUSIC_INFO)
@@ -533,7 +544,7 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
       }
       if (content.empty())
       {
-        CGUIMediaWindow* mediaWindow = GUIINFO::GetMediaWindow(contextWindow);
+        const CGUIMediaWindow* mediaWindow{GUIINFO::GetMediaWindow(contextWindow)};
         if (mediaWindow)
           content = mediaWindow->CurrentDirectory().GetContent();
       }
@@ -552,13 +563,13 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
     {
       if (info.GetData1())
       {
-        CGUIWindow *window = GUIINFO::GetWindow(contextWindow);
+        CGUIWindow* window{GUIINFO::GetWindow(contextWindow)};
         if (window)
         {
           const CGUIControl *control = window->GetControl(info.GetData1());
           if (control)
           {
-            value = control->GetCondition(info.m_info, info.GetData2());
+            value = control->GetCondition(info.GetInfo(), info.GetData2());
             return true;
           }
         }
@@ -568,7 +579,7 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
         const CGUIControl *activeContainer = GUIINFO::GetActiveContainer(0, contextWindow);
         if (activeContainer)
         {
-          value = activeContainer->GetCondition(info.m_info, info.GetData2());
+          value = activeContainer->GetCondition(info.GetInfo(), info.GetData2());
           return true;
         }
       }
@@ -576,7 +587,7 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
     }
     case CONTAINER_HAS_FOCUS:
     { // grab our container
-      CGUIWindow *window = GUIINFO::GetWindow(contextWindow);
+      CGUIWindow* window{GUIINFO::GetWindow(contextWindow)};
       if (window)
       {
         const CGUIControl *control = window->GetControl(info.GetData1());
@@ -606,7 +617,7 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
       {
         // no parameters, so we assume it's just requested for a media window.  It therefore
         // can only happen if the list has focus.
-        CGUIMediaWindow *window = GUIINFO::GetMediaWindow(contextWindow);
+        const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
         if (window)
           containerId = window->GetViewContainerID();
       }
@@ -615,13 +626,13 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
         const std::map<int,int>::const_iterator it = m_containerMoves.find(containerId);
         if (it != m_containerMoves.end())
         {
-          if (info.m_info == CONTAINER_SCROLL_PREVIOUS)
+          if (info.GetInfo() == CONTAINER_SCROLL_PREVIOUS)
             value = it->second <= -2;
-          else if (info.m_info == CONTAINER_MOVE_PREVIOUS)
+          else if (info.GetInfo() == CONTAINER_MOVE_PREVIOUS)
             value = it->second <= -1;
-          else if (info.m_info == CONTAINER_MOVE_NEXT)
+          else if (info.GetInfo() == CONTAINER_MOVE_NEXT)
             value = it->second >= 1;
-          else if (info.m_info == CONTAINER_SCROLL_NEXT)
+          else if (info.GetInfo() == CONTAINER_SCROLL_NEXT)
             value = it->second >= 2;
           return true;
         }
@@ -634,7 +645,7 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case CONTROL_IS_VISIBLE:
     {
-      CGUIWindow *window = GUIINFO::GetWindow(contextWindow);
+      CGUIWindow* window{GUIINFO::GetWindow(contextWindow)};
       if (window)
       {
         // Note: This'll only work for unique id's
@@ -649,7 +660,7 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
     }
     case CONTROL_IS_ENABLED:
     {
-      CGUIWindow *window = GUIINFO::GetWindow(contextWindow);
+      CGUIWindow* window{GUIINFO::GetWindow(contextWindow)};
       if (window)
       {
         // Note: This'll only work for unique id's
@@ -664,7 +675,7 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
     }
     case CONTROL_HAS_FOCUS:
     {
-      CGUIWindow *window = GUIINFO::GetWindow(contextWindow);
+      const CGUIWindow* window{GUIINFO::GetWindow(contextWindow)};
       if (window)
       {
         value = (window->GetFocusedControlID() == static_cast<int>(info.GetData1()));
@@ -674,7 +685,7 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
     }
     case CONTROL_GROUP_HAS_FOCUS:
     {
-      CGUIWindow *window = GUIINFO::GetWindow(contextWindow);
+      CGUIWindow* window{GUIINFO::GetWindow(contextWindow)};
       if (window)
       {
         value = window->ControlGroupHasFocus(info.GetData1(), info.GetData2());
@@ -688,8 +699,8 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case WINDOW_IS_MEDIA:
     { // note: This doesn't return true for dialogs (content, favourites, login, videoinfo)
-      CGUIWindowManager& windowMgr = CServiceBroker::GetGUI()->GetWindowManager();
-      CGUIWindow *window = windowMgr.GetWindow(windowMgr.GetActiveWindow());
+      const CGUIWindowManager& windowMgr{CServiceBroker::GetGUI()->GetWindowManager()};
+      const CGUIWindow* window{windowMgr.GetWindow(windowMgr.GetActiveWindow())};
       if (window)
       {
         value = window->IsMediaWindow();
@@ -701,8 +712,8 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
     {
       if (info.GetData1())
       {
-        CGUIWindowManager& windowMgr = CServiceBroker::GetGUI()->GetWindowManager();
-        CGUIWindow *window = windowMgr.GetWindow(contextWindow);
+        const CGUIWindowManager& windowMgr{CServiceBroker::GetGUI()->GetWindowManager()};
+        const CGUIWindow* window{windowMgr.GetWindow(contextWindow)};
         if (!window)
         {
           // try topmost dialog
@@ -762,7 +773,8 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
       }
       else
       {
-        CGUIWindow *window = CServiceBroker::GetGUI()->GetWindowManager().GetWindow(m_nextWindowID);
+        const CGUIWindow* window{
+            CServiceBroker::GetGUI()->GetWindowManager().GetWindow(m_nextWindowID)};
         if (window && StringUtils::EqualsNoCase(URIUtils::GetFileName(window->GetProperty("xmlfile").asString()), info.GetData3()))
         {
           value = true;
@@ -780,7 +792,8 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
       }
       else
       {
-        CGUIWindow *window = CServiceBroker::GetGUI()->GetWindowManager().GetWindow(m_prevWindowID);
+        const CGUIWindow* window{
+            CServiceBroker::GetGUI()->GetWindowManager().GetWindow(m_prevWindowID)};
         if (window && StringUtils::EqualsNoCase(URIUtils::GetFileName(window->GetProperty("xmlfile").asString()), info.GetData3()))
         {
           value = true;
@@ -801,8 +814,12 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
       return true;
     case SYSTEM_HAS_INPUT_HIDDEN:
     {
-      CGUIDialogNumeric *pNumeric = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogNumeric>(WINDOW_DIALOG_NUMERIC);
-      CGUIDialogKeyboardGeneric *pKeyboard = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogKeyboardGeneric>(WINDOW_DIALOG_KEYBOARD);
+      const CGUIDialogNumeric* pNumeric{
+          CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogNumeric>(
+              WINDOW_DIALOG_NUMERIC)};
+      const CGUIDialogKeyboardGeneric* pKeyboard{
+          CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogKeyboardGeneric>(
+              WINDOW_DIALOG_KEYBOARD)};
 
       if (pNumeric && pNumeric->IsActive())
         value = pNumeric->IsInputHidden();
@@ -810,6 +827,8 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
         value = pKeyboard->IsInputHidden();
       return true;
     }
+    default:
+      break;
   }
 
   return false;

--- a/xbmc/guilib/guiinfo/GUIControlsGUIInfo.h
+++ b/xbmc/guilib/guiinfo/GUIControlsGUIInfo.h
@@ -13,11 +13,7 @@
 
 #include <map>
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
 class CGUIInfo;
@@ -51,6 +47,4 @@ private:
   std::map<int, int> m_containerMoves;  // direction of list moving
 };
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/GUIInfo.h
+++ b/xbmc/guilib/guiinfo/GUIInfo.h
@@ -11,14 +11,10 @@
 #include <stdint.h>
 #include <string>
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
-// class to hold multiple integer data
+// class to hold multiple integer and string data
 // for storage referenced from a single integer
 class CGUIInfo
 {
@@ -63,11 +59,9 @@ public:
   {
   }
 
-  bool operator ==(const CGUIInfo &right) const
-  {
-    return (m_info == right.m_info && m_data1 == right.m_data1 && m_data2 == right.m_data2 &&
-            m_data3 == right.m_data3 && m_data4 == right.m_data4 && m_data5 == right.m_data5);
-  }
+  bool operator==(const CGUIInfo& right) const = default;
+
+  int GetInfo() const { return m_info; }
 
   uint32_t GetInfoFlag() const;
   uint32_t GetData1() const;
@@ -76,10 +70,10 @@ public:
   int GetData4() const { return m_data4; }
   const std::string& GetData5() const { return m_data5; }
 
-  int m_info;
 private:
   void SetInfoFlag(uint32_t flag);
 
+  int m_info{0};
   uint32_t m_data1{0};
   int m_data2{0};
   std::string m_data3;
@@ -87,6 +81,4 @@ private:
   std::string m_data5;
 };
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/GUIInfoBool.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoBool.cpp
@@ -14,9 +14,8 @@
 
 using namespace KODI::GUILIB::GUIINFO;
 
-CGUIInfoBool::CGUIInfoBool(bool value)
+CGUIInfoBool::CGUIInfoBool(bool value) : m_value(value)
 {
-  m_value = value;
 }
 
 CGUIInfoBool::~CGUIInfoBool() = default;

--- a/xbmc/guilib/guiinfo/GUIInfoBool.h
+++ b/xbmc/guilib/guiinfo/GUIInfoBool.h
@@ -19,11 +19,7 @@
 
 class CGUIListItem;
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
 class CGUIInfoBool
@@ -41,6 +37,4 @@ private:
   bool m_value;
 };
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/GUIInfoColor.h
+++ b/xbmc/guilib/guiinfo/GUIInfoColor.h
@@ -20,11 +20,7 @@
 
 class CGUIListItem;
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
 class CGUIInfoColor
@@ -49,6 +45,4 @@ private:
   KODI::UTILS::COLOR::Color m_color;
 };
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/GUIInfoHelper.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoHelper.cpp
@@ -22,11 +22,7 @@
 #include "utils/URIUtils.h"
 #include "windows/GUIMediaWindow.h"
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
 // conditions for window retrieval
@@ -70,6 +66,8 @@ std::string GetPlaylistLabel(int item, PLAYLIST::Id playlistId /* = TYPE_NONE */
       else
         return g_localizeStrings.Get(594); // 594: Off
     }
+    default:
+      break;
   }
   return std::string();
 }
@@ -77,7 +75,7 @@ std::string GetPlaylistLabel(int item, PLAYLIST::Id playlistId /* = TYPE_NONE */
 namespace
 {
 
-bool CheckWindowCondition(CGUIWindow *window, int condition)
+bool CheckWindowCondition(const CGUIWindow* window, int condition)
 {
   // check if it satisfies our condition
   if (!window)
@@ -203,6 +201,4 @@ std::string GetFileInfoLabelValueFromPath(int info, const std::string& filenameA
   return value;
 }
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/GUIInfoHelper.h
+++ b/xbmc/guilib/guiinfo/GUIInfoHelper.h
@@ -21,11 +21,7 @@ class CGUIControl;
 class CGUIMediaWindow;
 class CGUIWindow;
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
 std::string GetPlaylistLabel(int item, PLAYLIST::Id playlistid = PLAYLIST::Id::TYPE_NONE);
@@ -40,6 +36,4 @@ std::shared_ptr<CGUIListItem> GetCurrentListItem(int contextWindow,
 
 std::string GetFileInfoLabelValueFromPath(int info, const std::string& filenameAndPath);
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/GUIInfoLabel.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabel.h
@@ -17,15 +17,12 @@
 
 #include <functional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 class CGUIListItem;
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
 class CGUIInfoLabel
@@ -47,7 +44,9 @@ public:
    \param fallback if non-NULL, is set to an alternate value to use should the actual value be not appropriate. Defaults to NULL.
    \return label (or image).
    */
-  const std::string &GetLabel(int contextWindow, bool preferImage = false, std::string *fallback = NULL) const;
+  const std::string& GetLabel(int contextWindow,
+                              bool preferImage = false,
+                              std::string* fallback = nullptr) const;
 
   /*!
    \brief Gets the label and returns it as an int value
@@ -102,7 +101,7 @@ public:
    */
   static std::string ReplaceControllerStrings(std::string&& label);
 
-  typedef std::function<std::string(const std::string&)> StringReplacerFunc;
+  using StringReplacerFunc = std::function<std::string(const std::string&)>;
 
   /*!
    \brief Replaces instances of $strKeyword[value] with the appropriate resolved string
@@ -128,10 +127,12 @@ private:
   {
   public:
     CInfoPortion(int info, const std::string &prefix, const std::string &postfix, bool escaped = false);
-    bool NeedsUpdate(const std::string &label) const;
+    bool NeedsUpdate(std::string_view label) const;
     std::string Get() const;
-    int m_info;
+    int GetInfo() const { return m_info; }
+
   private:
+    int m_info;
     bool m_escaped;
     mutable std::string m_label;
     std::string m_prefix;
@@ -191,7 +192,4 @@ private:
   std::vector<CInfoPortion> m_infoFallback;
 };
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
-
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/GUIInfoProvider.h
+++ b/xbmc/guilib/guiinfo/GUIInfoProvider.h
@@ -11,11 +11,7 @@
 #include "cores/VideoPlayer/Interface/StreamInfo.h"
 #include "guilib/guiinfo/IGUIInfoProvider.h"
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
 class CGUIInfo;
@@ -36,7 +32,11 @@ public:
   }
 
   void UpdateAVInfo(const AudioStreamInfo& audioInfo, const VideoStreamInfo& videoInfo, const SubtitleStreamInfo& subtitleInfo) override
-  { m_audioInfo = audioInfo, m_videoInfo = videoInfo, m_subtitleInfo = subtitleInfo; }
+  {
+    m_audioInfo = audioInfo;
+    m_videoInfo = videoInfo;
+    m_subtitleInfo = subtitleInfo;
+  }
 
 protected:
   VideoStreamInfo m_videoInfo;
@@ -44,6 +44,4 @@ protected:
   SubtitleStreamInfo m_subtitleInfo;
 };
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/GUIInfoProviders.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoProviders.cpp
@@ -50,7 +50,7 @@ CGUIInfoProviders::~CGUIInfoProviders()
 
 void CGUIInfoProviders::RegisterProvider(IGUIInfoProvider *provider, bool bAppend /* = true */)
 {
-  auto it = std::find(m_providers.begin(), m_providers.end(), provider);
+  auto it = std::ranges::find(m_providers, provider);
   if (it == m_providers.end())
   {
     if (bAppend)
@@ -62,12 +62,12 @@ void CGUIInfoProviders::RegisterProvider(IGUIInfoProvider *provider, bool bAppen
 
 void CGUIInfoProviders::UnregisterProvider(IGUIInfoProvider *provider)
 {
-  auto it = std::find(m_providers.begin(), m_providers.end(), provider);
+  auto it = std::ranges::find(m_providers, provider);
   if (it != m_providers.end())
     m_providers.erase(it);
 }
 
-bool CGUIInfoProviders::InitCurrentItem(CFileItem *item)
+bool CGUIInfoProviders::InitCurrentItem(CFileItem* item) const
 {
   bool bReturn = false;
 
@@ -113,7 +113,9 @@ bool CGUIInfoProviders::GetBool(bool& value, const CGUIListItem *item, int conte
   return false;
 }
 
-void CGUIInfoProviders::UpdateAVInfo(const AudioStreamInfo& audioInfo, const VideoStreamInfo& videoInfo, const SubtitleStreamInfo& subtitleInfo)
+void CGUIInfoProviders::UpdateAVInfo(const AudioStreamInfo& audioInfo,
+                                     const VideoStreamInfo& videoInfo,
+                                     const SubtitleStreamInfo& subtitleInfo) const
 {
   for (const auto& provider : m_providers)
   {

--- a/xbmc/guilib/guiinfo/GUIInfoProviders.h
+++ b/xbmc/guilib/guiinfo/GUIInfoProviders.h
@@ -30,11 +30,7 @@ class CGUIListItem;
 struct AudioStreamInfo;
 struct VideoStreamInfo;
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
 class CGUIInfo;
@@ -64,7 +60,7 @@ public:
    * @param item The new item.
    * @return True if the item was inited by one of the providers, false otherwise.
    */
-  bool InitCurrentItem(CFileItem *item);
+  bool InitCurrentItem(CFileItem* item) const;
 
   /*!
    * @brief Get a GUIInfoManager label string from one of the registered providers.
@@ -103,7 +99,9 @@ public:
    * @param videoInfo New video stream info.
    * @param subtitleInfo New subtitle stream info.
    */
-  void UpdateAVInfo(const AudioStreamInfo& audioInfo, const VideoStreamInfo& videoInfo, const SubtitleStreamInfo& subtitleInfo);
+  void UpdateAVInfo(const AudioStreamInfo& audioInfo,
+                    const VideoStreamInfo& videoInfo,
+                    const SubtitleStreamInfo& subtitleInfo) const;
 
   /*!
    * @brief Get the player guiinfo provider.
@@ -152,6 +150,4 @@ private:
   CWeatherGUIInfo m_weatherGUIInfo;
 };
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/GamesGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/GamesGUIInfo.cpp
@@ -47,7 +47,7 @@ bool CGamesGUIInfo::InitCurrentItem(CFileItem *item)
 
 bool CGamesGUIInfo::GetLabel(std::string& value, const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback) const
 {
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // RETROPLAYER_*

--- a/xbmc/guilib/guiinfo/GamesGUIInfo.h
+++ b/xbmc/guilib/guiinfo/GamesGUIInfo.h
@@ -10,11 +10,7 @@
 
 #include "guilib/guiinfo/GUIInfoProvider.h"
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
 class CGUIInfo;
@@ -32,6 +28,4 @@ public:
   bool GetBool(bool& value, const CGUIListItem *item, int contextWindow, const CGUIInfo &info) const override;
 };
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/IGUIInfoProvider.h
+++ b/xbmc/guilib/guiinfo/IGUIInfoProvider.h
@@ -16,11 +16,7 @@ class CGUIListItem;
 struct AudioStreamInfo;
 struct VideoStreamInfo;
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
 class CGUIInfo;
@@ -92,6 +88,4 @@ public:
   virtual void UpdateAVInfo(const AudioStreamInfo& audioInfo, const VideoStreamInfo& videoInfo, const SubtitleStreamInfo& subtitleInfo) = 0;
 };
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/LibraryGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/LibraryGUIInfo.cpp
@@ -102,7 +102,7 @@ bool CLibraryGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextW
 
 bool CLibraryGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextWindow, const CGUIInfo &info) const
 {
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // LIBRARY_*
@@ -230,11 +230,11 @@ bool CLibraryGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contex
       std::string strRole = info.GetData3();
       // Find value for role if already stored
       int artistcount = -1;
-      for (const auto &role : m_libraryRoleCounts)
+      for (const auto& [role, artists] : m_libraryRoleCounts)
       {
-        if (StringUtils::EqualsNoCase(strRole, role.first))
+        if (StringUtils::EqualsNoCase(strRole, role))
         {
-          artistcount = role.second;
+          artistcount = artists;
           break;
         }
       }
@@ -285,6 +285,8 @@ bool CLibraryGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contex
       value = CMusicLibraryQueue::GetInstance().IsScanningLibrary();
       return true;
     }
+    default:
+      break;
   }
 
   return false;

--- a/xbmc/guilib/guiinfo/LibraryGUIInfo.h
+++ b/xbmc/guilib/guiinfo/LibraryGUIInfo.h
@@ -14,11 +14,7 @@
 #include <utility>
 #include <vector>
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
 class CGUIInfo;
@@ -54,6 +50,4 @@ private:
   mutable std::vector<std::pair<std::string, int>> m_libraryRoleCounts;
 };
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -81,15 +81,16 @@ bool CMusicGUIInfo::InitCurrentItem(CFileItem *item)
 bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback) const
 {
   // For musicplayer "offset" and "position" info labels check playlist
-  if (info.GetData1() && ((info.m_info >= MUSICPLAYER_OFFSET_POSITION_FIRST &&
-      info.m_info <= MUSICPLAYER_OFFSET_POSITION_LAST) ||
-      (info.m_info >= PLAYER_OFFSET_POSITION_FIRST && info.m_info <= PLAYER_OFFSET_POSITION_LAST)))
+  if (info.GetData1() && ((info.GetInfo() >= MUSICPLAYER_OFFSET_POSITION_FIRST &&
+                           info.GetInfo() <= MUSICPLAYER_OFFSET_POSITION_LAST) ||
+                          (info.GetInfo() >= PLAYER_OFFSET_POSITION_FIRST &&
+                           info.GetInfo() <= PLAYER_OFFSET_POSITION_LAST)))
     return GetPlaylistInfo(value, info);
 
   const CMusicInfoTag* tag = item->GetMusicInfoTag();
   if (tag)
   {
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       /////////////////////////////////////////////////////////////////////////////////////////////
       // PLAYER_* / MUSICPLAYER_* / LISTITEM_*
@@ -100,11 +101,9 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         value = tag->GetURL();
         if (value.empty())
           value = item->GetPath();
-        value = GUIINFO::GetFileInfoLabelValueFromPath(info.m_info, value);
+        value = GUIINFO::GetFileInfoLabelValueFromPath(info.GetInfo(), value);
         return true;
       case PLAYER_TITLE:
-        value = tag->GetTitle();
-        return !value.empty();
       case MUSICPLAYER_TITLE:
         value = tag->GetTitle();
         return !value.empty();
@@ -271,10 +270,10 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         int iDuration = tag->GetDuration();
         if (iDuration > 0)
         {
-          value = StringUtils::SecondsToTimeString(iDuration,
-                                                   static_cast<TIME_FORMAT>(info.m_info == LISTITEM_DURATION
-                                                                            ? info.GetData4()
-                                                                            : info.GetData1()));
+          value = StringUtils::SecondsToTimeString(
+              iDuration,
+              static_cast<TIME_FORMAT>(info.GetInfo() == LISTITEM_DURATION ? info.GetData4()
+                                                                           : info.GetData1()));
           return true;
         }
         break;
@@ -374,12 +373,12 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         else
           value = URIUtils::GetFileName(item->GetPath());
 
-        if (info.m_info == LISTITEM_FILE_EXTENSION)
+        if (info.GetInfo() == LISTITEM_FILE_EXTENSION)
         {
           std::string strExtension = URIUtils::GetExtension(value);
           value = StringUtils::TrimLeft(strExtension, ".");
         }
-        else if (info.m_info == LISTITEM_FILENAME_NO_EXTENSION)
+        else if (info.GetInfo() == LISTITEM_FILENAME_NO_EXTENSION)
         {
           URIUtils::RemoveExtension(value);
         }
@@ -395,7 +394,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
 
         value = CURL(value).GetWithoutUserDetails();
 
-        if (info.m_info == LISTITEM_FOLDERNAME)
+        if (info.GetInfo() == LISTITEM_FOLDERNAME)
         {
           URIUtils::RemoveSlashAtEnd(value);
           value = URIUtils::GetFileName(value);
@@ -421,10 +420,12 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_SONG_VIDEO_URL:
         value = tag->GetSongVideoURL();
         return true;
+      default:
+        break;
     }
   }
 
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // MUSICPLAYER_*
@@ -510,6 +511,8 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
     case MUSICPLAYER_CODEC:
       value = m_audioInfo.codecName;
       return true;
+    default:
+      break;
   }
 
   ///////////////////////////////////////////////////////////////////////////////////////////////
@@ -525,7 +528,7 @@ bool CMusicGUIInfo::GetPartyModeLabel(std::string& value, const CGUIInfo &info) 
 {
   int iSongs = -1;
 
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     case MUSICPM_SONGSPLAYED:
       iSongs = g_partyModeManager.GetSongsPlayed();
@@ -544,6 +547,8 @@ bool CMusicGUIInfo::GetPartyModeLabel(std::string& value, const CGUIInfo &info) 
       break;
     case MUSICPM_RANDOMSONGSPICKED:
       iSongs = g_partyModeManager.GetRandomSongs();
+      break;
+    default:
       break;
   }
 
@@ -590,18 +595,18 @@ bool CMusicGUIInfo::GetPlaylistInfo(std::string& value, const CGUIInfo &info) co
     if (!playlistItem->HasArt("thumb"))
       playlistItem->SetArt("thumb", "DefaultAlbumCover.png");
   }
-  if (info.m_info == MUSICPLAYER_PLAYLISTPOS)
+  if (info.GetInfo() == MUSICPLAYER_PLAYLISTPOS)
   {
     value = std::to_string(index + 1);
     return true;
   }
-  else if (info.m_info == MUSICPLAYER_COVER)
+  else if (info.GetInfo() == MUSICPLAYER_COVER)
   {
     value = playlistItem->GetArt("thumb");
     return true;
   }
 
-  return GetLabel(value, playlistItem.get(), 0, CGUIInfo(info.m_info), nullptr);
+  return GetLabel(value, playlistItem.get(), 0, CGUIInfo(info.GetInfo()), nullptr);
 }
 
 bool CMusicGUIInfo::GetFallbackLabel(std::string& value,
@@ -611,15 +616,16 @@ bool CMusicGUIInfo::GetFallbackLabel(std::string& value,
                                      std::string* fallback)
 {
   // No fallback for musicplayer "offset" and "position" info labels
-  if (info.GetData1() && ((info.m_info >= MUSICPLAYER_OFFSET_POSITION_FIRST &&
-      info.m_info <= MUSICPLAYER_OFFSET_POSITION_LAST) ||
-      (info.m_info >= PLAYER_OFFSET_POSITION_FIRST && info.m_info <= PLAYER_OFFSET_POSITION_LAST)))
+  if (info.GetData1() && ((info.GetInfo() >= MUSICPLAYER_OFFSET_POSITION_FIRST &&
+                           info.GetInfo() <= MUSICPLAYER_OFFSET_POSITION_LAST) ||
+                          (info.GetInfo() >= PLAYER_OFFSET_POSITION_FIRST &&
+                           info.GetInfo() <= PLAYER_OFFSET_POSITION_LAST)))
     return false;
 
   const CMusicInfoTag* tag = item->GetMusicInfoTag();
   if (tag)
   {
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       /////////////////////////////////////////////////////////////////////////////////////////////
       // MUSICPLAYER_*
@@ -643,10 +649,10 @@ bool CMusicGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWin
 
 bool CMusicGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextWindow, const CGUIInfo &info) const
 {
-  const CFileItem* item = static_cast<const CFileItem*>(gitem);
+  const auto* item{static_cast<const CFileItem*>(gitem)};
   const CMusicInfoTag* tag = item->GetMusicInfoTag();
 
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // MUSICPLAYER_*

--- a/xbmc/guilib/guiinfo/MusicGUIInfo.h
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.h
@@ -10,11 +10,7 @@
 
 #include "guilib/guiinfo/GUIInfoProvider.h"
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
 class CGUIInfo;
@@ -41,6 +37,4 @@ private:
   bool GetPlaylistInfo(std::string& value, const CGUIInfo &info) const;
 };
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
@@ -122,12 +122,13 @@ bool CPicturesGUIInfo::InitCurrentItem(CFileItem *item)
 
 bool CPicturesGUIInfo::GetLabel(std::string& value, const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback) const
 {
-  if (item->IsPicture() && info.m_info >= LISTITEM_PICTURE_START && info.m_info <= LISTITEM_PICTURE_END)
+  if (item->IsPicture() && info.GetInfo() >= LISTITEM_PICTURE_START &&
+      info.GetInfo() <= LISTITEM_PICTURE_END)
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // LISTITEM_*
     ///////////////////////////////////////////////////////////////////////////////////////////////
-    const auto& it = listitem2slideshow_map.find(info.m_info);
+    const auto& it = listitem2slideshow_map.find(info.GetInfo());
     if (it != listitem2slideshow_map.end())
     {
       if (item->HasPictureInfoTag())
@@ -140,16 +141,17 @@ bool CPicturesGUIInfo::GetLabel(std::string& value, const CFileItem *item, int c
     {
       CLog::Log(LOGERROR,
                 "CPicturesGUIInfo::GetLabel - cannot map LISTITEM ({}) to SLIDESHOW label!",
-                info.m_info);
+                info.GetInfo());
       return false;
     }
   }
-  else if (m_currentSlide && info.m_info >= SLIDESHOW_LABELS_START && info.m_info <= SLIDESHOW_LABELS_END)
+  else if (m_currentSlide && info.GetInfo() >= SLIDESHOW_LABELS_START &&
+           info.GetInfo() <= SLIDESHOW_LABELS_END)
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // SLIDESHOW_*
     ///////////////////////////////////////////////////////////////////////////////////////////////
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       case SLIDESHOW_FILE_NAME:
       {
@@ -182,7 +184,7 @@ bool CPicturesGUIInfo::GetLabel(std::string& value, const CFileItem *item, int c
       }
       case SLIDESHOW_INDEX:
       {
-        CSlideShowDelegator& slideshow = CServiceBroker::GetSlideShowDelegator();
+        const CSlideShowDelegator& slideshow{CServiceBroker::GetSlideShowDelegator()};
         if (slideshow.NumSlides() > 0)
         {
           value = StringUtils::Format("{}/{}", slideshow.CurrentSlide(), slideshow.NumSlides());
@@ -192,7 +194,7 @@ bool CPicturesGUIInfo::GetLabel(std::string& value, const CFileItem *item, int c
       }
       default:
       {
-        value = m_currentSlide->GetPictureInfoTag()->GetInfo(info.m_info);
+        value = m_currentSlide->GetPictureInfoTag()->GetInfo(info.GetInfo());
         return true;
       }
     }
@@ -203,7 +205,7 @@ bool CPicturesGUIInfo::GetLabel(std::string& value, const CFileItem *item, int c
     /////////////////////////////////////////////////////////////////////////////////////////////////
     // LISTITEM_*
     /////////////////////////////////////////////////////////////////////////////////////////////////
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       case LISTITEM_PICTURE_PATH:
       {
@@ -214,6 +216,8 @@ bool CPicturesGUIInfo::GetLabel(std::string& value, const CFileItem *item, int c
         }
         break;
       }
+      default:
+        break;
     }
   }
 
@@ -227,35 +231,37 @@ bool CPicturesGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int context
 
 bool CPicturesGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextWindow, const CGUIInfo &info) const
 {
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // SLIDESHOW_*
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case SLIDESHOW_ISPAUSED:
     {
-      CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
+      const CSlideShowDelegator& slideShow{CServiceBroker::GetSlideShowDelegator()};
       value = slideShow.IsPaused();
       return true;
     }
     case SLIDESHOW_ISRANDOM:
     {
-      CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
+      const CSlideShowDelegator& slideShow{CServiceBroker::GetSlideShowDelegator()};
       value = slideShow.IsShuffled();
       return true;
     }
     case SLIDESHOW_ISACTIVE:
     {
-      CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
+      const CSlideShowDelegator& slideShow{CServiceBroker::GetSlideShowDelegator()};
       value = slideShow.InSlideShow();
       return true;
     }
     case SLIDESHOW_ISVIDEO:
     {
-      CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
+      CSlideShowDelegator& slideShow{CServiceBroker::GetSlideShowDelegator()};
       value = slideShow.GetCurrentSlide() && VIDEO::IsVideo(*slideShow.GetCurrentSlide());
       return true;
     }
+    default:
+      break;
   }
 
   return false;

--- a/xbmc/guilib/guiinfo/PicturesGUIInfo.h
+++ b/xbmc/guilib/guiinfo/PicturesGUIInfo.h
@@ -12,11 +12,7 @@
 
 #include <memory>
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
 class CGUIInfo;
@@ -40,6 +36,4 @@ private:
   std::unique_ptr<CFileItem> m_currentSlide;
 };
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.h
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.h
@@ -22,11 +22,7 @@ class CApplicationPlayer;
 class CApplicationVolumeHandling;
 class CDataCacheCore;
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
 class CGUIInfo;
@@ -88,6 +84,4 @@ private:
   CEventSource<PlayerShowInfoChangedEvent> m_events;
 };
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/SkinGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SkinGUIInfo.cpp
@@ -28,7 +28,7 @@ bool CSkinGUIInfo::InitCurrentItem(CFileItem *item)
 
 bool CSkinGUIInfo::GetLabel(std::string& value, const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback) const
 {
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // SKIN_*
@@ -77,6 +77,8 @@ bool CSkinGUIInfo::GetLabel(std::string& value, const CFileItem *item, int conte
       value = std::to_string(g_SkinInfo->GetTimerElapsedSeconds(info.GetData3()));
       return true;
     }
+    default:
+      break;
   }
 
   return false;
@@ -84,7 +86,7 @@ bool CSkinGUIInfo::GetLabel(std::string& value, const CFileItem *item, int conte
 
 bool CSkinGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWindow, const CGUIInfo &info) const
 {
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     case SKIN_INTEGER:
     {
@@ -96,13 +98,15 @@ bool CSkinGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWind
       value = g_SkinInfo->GetTimerElapsedSeconds(info.GetData3());
       return true;
     }
+    default:
+      break;
   }
   return false;
 }
 
 bool CSkinGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextWindow, const CGUIInfo &info) const
 {
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // SKIN_*
@@ -134,6 +138,8 @@ bool CSkinGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextWi
       value = g_SkinInfo->TimerIsRunning(info.GetData3());
       return true;
     }
+    default:
+      break;
   }
 
   return false;

--- a/xbmc/guilib/guiinfo/SkinGUIInfo.h
+++ b/xbmc/guilib/guiinfo/SkinGUIInfo.h
@@ -10,11 +10,7 @@
 
 #include "guilib/guiinfo/GUIInfoProvider.h"
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
 class CGUIInfo;
@@ -32,6 +28,4 @@ public:
   bool GetBool(bool& value, const CGUIListItem *item, int contextWindow, const CGUIInfo &info) const override;
 };
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -84,6 +84,8 @@ std::string CSystemGUIInfo::GetSystemHeatInfo(int info) const
       else
         text = g_localizeStrings.Get(10005); // Not available
       break;
+    default:
+      break;
   }
   return text;
 }
@@ -110,7 +112,7 @@ bool CSystemGUIInfo::InitCurrentItem(CFileItem *item)
 
 bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback) const
 {
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // SYSTEM_*
@@ -129,13 +131,13 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     case SYSTEM_TOTAL_SPACE:
     case SYSTEM_FREE_SPACE_PERCENT:
     case SYSTEM_USED_SPACE_PERCENT:
-      value = g_sysinfo.GetHddSpaceInfo(info.m_info);
+      value = g_sysinfo.GetHddSpaceInfo(info.GetInfo());
       return true;
     case SYSTEM_CPU_TEMPERATURE:
     case SYSTEM_GPU_TEMPERATURE:
     case SYSTEM_FAN_SPEED:
     case SYSTEM_CPU_USAGE:
-      value = GetSystemHeatInfo(info.m_info);
+      value = GetSystemHeatInfo(info.GetInfo());
       return true;
     case SYSTEM_VIDEO_ENCODER_INFO:
     case NETWORK_IP_ADDRESS:
@@ -151,7 +153,7 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     case SYSTEM_UPTIME:
     case SYSTEM_TOTALUPTIME:
     case SYSTEM_BATTERY_LEVEL:
-      value = g_sysinfo.GetInfo(info.m_info);
+      value = g_sysinfo.GetInfo(info.GetInfo());
       return true;
     case SYSTEM_PRIVACY_POLICY:
       value = g_sysinfo.GetPrivacyPolicy();
@@ -203,16 +205,16 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       int iMemPercentFree = 100 - static_cast<int>(100.0f * (stat.totalPhys - stat.availPhys) / stat.totalPhys + 0.5f);
       int iMemPercentUsed = 100 - iMemPercentFree;
 
-      if (info.m_info == SYSTEM_FREE_MEMORY)
+      if (info.GetInfo() == SYSTEM_FREE_MEMORY)
         value = StringUtils::Format("{}MB", static_cast<unsigned int>(stat.availPhys / MB));
-      else if (info.m_info == SYSTEM_FREE_MEMORY_PERCENT)
+      else if (info.GetInfo() == SYSTEM_FREE_MEMORY_PERCENT)
         value = StringUtils::Format("{}%", iMemPercentFree);
-      else if (info.m_info == SYSTEM_USED_MEMORY)
+      else if (info.GetInfo() == SYSTEM_USED_MEMORY)
         value = StringUtils::Format(
             "{}MB", static_cast<unsigned int>((stat.totalPhys - stat.availPhys) / MB));
-      else if (info.m_info == SYSTEM_USED_MEMORY_PERCENT)
+      else if (info.GetInfo() == SYSTEM_USED_MEMORY_PERCENT)
         value = StringUtils::Format("{}%", iMemPercentUsed);
-      else if (info.m_info == SYSTEM_TOTAL_MEMORY)
+      else if (info.GetInfo() == SYSTEM_TOTAL_MEMORY)
         value = StringUtils::Format("{}MB", static_cast<unsigned int>(stat.totalPhys / MB));
       return true;
     }
@@ -340,13 +342,15 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       value = g_langInfo.GetRegionLocale();
       return true;
     }
+    default:
+      break;
   }
   return false;
 }
 
 bool CSystemGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWindow, const CGUIInfo &info) const
 {
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // SYSTEM_*
@@ -357,7 +361,7 @@ bool CSystemGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWi
       KODI::MEMORY::MemoryStatus stat;
       KODI::MEMORY::GetMemoryStatus(&stat);
       int memPercentUsed = static_cast<int>(100.0f * (stat.totalPhys - stat.availPhys) / stat.totalPhys + 0.5f);
-      if (info.m_info == SYSTEM_FREE_MEMORY)
+      if (info.GetInfo() == SYSTEM_FREE_MEMORY)
         value = 100 - memPercentUsed;
       else
         value = memPercentUsed;
@@ -366,7 +370,7 @@ bool CSystemGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWi
     case SYSTEM_FREE_SPACE:
     case SYSTEM_USED_SPACE:
     {
-      g_sysinfo.GetHddSpaceInfo(value, info.m_info, true);
+      g_sysinfo.GetHddSpaceInfo(value, info.GetInfo(), true);
       return true;
     }
     case SYSTEM_CPU_USAGE:
@@ -375,6 +379,8 @@ bool CSystemGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWi
     case SYSTEM_BATTERY_LEVEL:
       value = CServiceBroker::GetPowerManager().BatteryLevel();
       return true;
+    default:
+      break;
   }
 
   return false;
@@ -382,7 +388,7 @@ bool CSystemGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWi
 
 bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextWindow, const CGUIInfo &info) const
 {
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // SYSTEM_*
@@ -394,7 +400,7 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       value = false;
       return true;
     case SYSTEM_ETHERNET_LINK_ACTIVE:
-      // wtf: not implemented - always returns true?!
+      //! @todo seems this was never implemented!
       value = true;
       return true;
     case SYSTEM_PLATFORM_LINUX:
@@ -516,7 +522,7 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
     {
       auto& components = CServiceBroker::GetAppComponents();
       const auto appPower = components.GetComponent<CApplicationPowerHandling>();
-      switch (info.m_info)
+      switch (info.GetInfo())
       {
         case SYSTEM_SCREENSAVER_ACTIVE:
           value = appPower->IsInScreenSaver();
@@ -583,7 +589,7 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       return true;
     case SYSTEM_INTERNET_STATE:
     {
-      g_sysinfo.GetInfo(info.m_info);
+      g_sysinfo.GetInfo(info.GetInfo());
       value = g_sysinfo.HasInternet();
       return true;
     }
@@ -640,7 +646,7 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
     {
       if (StringUtils::EqualsNoCase(info.GetData3(), "hidewatched"))
       {
-        CGUIMediaWindow* window = GUIINFO::GetMediaWindow(contextWindow);
+        const CGUIMediaWindow* window{GUIINFO::GetMediaWindow(contextWindow)};
         if (window)
         {
           value = CMediaSettings::GetInstance().GetWatchedMode(window->CurrentDirectory().GetContent()) == WatchedModeUnwatched;
@@ -658,6 +664,8 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       }
       break;
     }
+    default:
+      break;
   }
 
   return false;

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.h
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.h
@@ -14,11 +14,7 @@
 
 #include <memory>
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
 class CGUIInfo;
@@ -54,6 +50,4 @@ private:
   unsigned int m_lastFPSTime = 0;
 };
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -101,15 +101,16 @@ bool CVideoGUIInfo::InitCurrentItem(CFileItem *item)
 bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback) const
 {
   // For videoplayer "offset" and "position" info labels check playlist
-  if (info.GetData1() && ((info.m_info >= VIDEOPLAYER_OFFSET_POSITION_FIRST &&
-      info.m_info <= VIDEOPLAYER_OFFSET_POSITION_LAST) ||
-      (info.m_info >= PLAYER_OFFSET_POSITION_FIRST && info.m_info <= PLAYER_OFFSET_POSITION_LAST)))
+  if (info.GetData1() && ((info.GetInfo() >= VIDEOPLAYER_OFFSET_POSITION_FIRST &&
+                           info.GetInfo() <= VIDEOPLAYER_OFFSET_POSITION_LAST) ||
+                          (info.GetInfo() >= PLAYER_OFFSET_POSITION_FIRST &&
+                           info.GetInfo() <= PLAYER_OFFSET_POSITION_LAST)))
     return GetPlaylistInfo(value, info);
 
   const CVideoInfoTag* tag = item->GetVideoInfoTag();
   if (tag)
   {
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       /////////////////////////////////////////////////////////////////////////////////////////////
       // PLAYER_* / VIDEOPLAYER_* / LISTITEM_*
@@ -126,11 +127,9 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         value = tag->m_strFileNameAndPath;
         if (value.empty())
           value = item->GetPath();
-        value = GUIINFO::GetFileInfoLabelValueFromPath(info.m_info, value);
+        value = GUIINFO::GetFileInfoLabelValueFromPath(info.GetInfo(), value);
         return true;
       case PLAYER_TITLE:
-        value = tag->m_strTitle;
-        return !value.empty();
       case VIDEOPLAYER_TITLE:
         value = tag->m_strTitle;
         return !value.empty();
@@ -508,12 +507,12 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         else
           value = URIUtils::GetFileName(item->GetPath());
 
-        if (info.m_info == LISTITEM_FILE_EXTENSION)
+        if (info.GetInfo() == LISTITEM_FILE_EXTENSION)
         {
           std::string strExtension = URIUtils::GetExtension(value);
           value = StringUtils::TrimLeft(strExtension, ".");
         }
-        else if (info.m_info == LISTITEM_FILENAME_NO_EXTENSION)
+        else if (info.GetInfo() == LISTITEM_FILENAME_NO_EXTENSION)
         {
           URIUtils::RemoveExtension(value);
         }
@@ -534,7 +533,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
 
         value = CURL(value).GetWithoutUserDetails();
 
-        if (info.m_info == LISTITEM_FOLDERNAME)
+        if (info.GetInfo() == LISTITEM_FOLDERNAME)
         {
           URIUtils::RemoveSlashAtEnd(value);
           value = URIUtils::GetFileName(value);
@@ -554,7 +553,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         // Decode path for readability
         // Loop up to MAX_DECODE_PASSES times as each call to CURL::Decode() decodes one 'layer'
         // ie. bluray://udf://smb:// would require 2 passes to make fully human-readable
-        if (info.m_info == LISTITEM_DECODED_FILENAME_AND_PATH)
+        if (info.GetInfo() == LISTITEM_DECODED_FILENAME_AND_PATH)
         {
           static constexpr unsigned int MAX_DECODE_PASSES = 5;
           for (unsigned int i = 0; value.find('%') != std::string::npos && i < MAX_DECODE_PASSES;
@@ -566,10 +565,12 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_VIDEO_HDR_TYPE:
         value = tag->m_streamDetails.GetVideoHdrType();
         return true;
+      default:
+        break;
     }
   }
 
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // VIDEOPLAYER_*
@@ -666,6 +667,8 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
     case VIDEOPLAYER_AUDIO_LANG:
       value = m_audioInfo.language;
       return true;
+    default:
+      break;
   }
 
   return false;
@@ -697,23 +700,23 @@ bool CVideoGUIInfo::GetPlaylistInfo(std::string& value, const CGUIInfo& info) co
     CVideoThumbLoader loader;
     loader.LoadItem(playlistItem.get());
   }
-  if (info.m_info == VIDEOPLAYER_PLAYLISTPOS)
+  if (info.GetInfo() == VIDEOPLAYER_PLAYLISTPOS)
   {
     value = std::to_string(index + 1);
     return true;
   }
-  else if (info.m_info == VIDEOPLAYER_COVER)
+  else if (info.GetInfo() == VIDEOPLAYER_COVER)
   {
     value = playlistItem->GetArt("thumb");
     return true;
   }
-  else if (info.m_info == VIDEOPLAYER_ART)
+  else if (info.GetInfo() == VIDEOPLAYER_ART)
   {
     value = playlistItem->GetArt(info.GetData3());
     return true;
   }
 
-  return GetLabel(value, playlistItem.get(), 0, CGUIInfo(info.m_info), nullptr);
+  return GetLabel(value, playlistItem.get(), 0, CGUIInfo(info.GetInfo()), nullptr);
 }
 
 bool CVideoGUIInfo::GetFallbackLabel(std::string& value,
@@ -723,15 +726,16 @@ bool CVideoGUIInfo::GetFallbackLabel(std::string& value,
                                      std::string* fallback)
 {
   // No fallback for videoplayer "offset" and "position" info labels
-  if (info.GetData1() && ((info.m_info >= VIDEOPLAYER_OFFSET_POSITION_FIRST &&
-      info.m_info <= VIDEOPLAYER_OFFSET_POSITION_LAST) ||
-      (info.m_info >= PLAYER_OFFSET_POSITION_FIRST && info.m_info <= PLAYER_OFFSET_POSITION_LAST)))
+  if (info.GetData1() && ((info.GetInfo() >= VIDEOPLAYER_OFFSET_POSITION_FIRST &&
+                           info.GetInfo() <= VIDEOPLAYER_OFFSET_POSITION_LAST) ||
+                          (info.GetInfo() >= PLAYER_OFFSET_POSITION_FIRST &&
+                           info.GetInfo() <= PLAYER_OFFSET_POSITION_LAST)))
     return false;
 
   const CVideoInfoTag* tag = item->GetVideoInfoTag();
   if (tag)
   {
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       /////////////////////////////////////////////////////////////////////////////////////////////
       // VIDEOPLAYER_*
@@ -753,11 +757,11 @@ bool CVideoGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWin
   if (!gitem->IsFileItem())
     return false;
 
-  const CFileItem *item = static_cast<const CFileItem*>(gitem);
+  const auto* item{static_cast<const CFileItem*>(gitem)};
   const CVideoInfoTag* tag = item->GetVideoInfoTag();
   if (tag)
   {
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       /////////////////////////////////////////////////////////////////////////////////////////////
       // LISTITEM_*
@@ -765,10 +769,12 @@ bool CVideoGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWin
       case LISTITEM_PERCENT_PLAYED:
         value = GetPercentPlayed(tag);
         return true;
+      default:
+        break;
     }
   }
 
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // VIDEOPLAYER_*
@@ -779,7 +785,6 @@ bool CVideoGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWin
     case VIDEOPLAYER_AUDIOSTREAMCOUNT:
       value = m_appPlayer->GetAudioStreamCount();
       return true;
-
     default:
       break;
   }
@@ -792,11 +797,11 @@ bool CVideoGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextW
   if (!gitem->IsFileItem())
     return false;
 
-  const CFileItem *item = static_cast<const CFileItem*>(gitem);
+  const auto* item{static_cast<const CFileItem*>(gitem)};
   const CVideoInfoTag* tag = item->GetVideoInfoTag();
   if (tag)
   {
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       /////////////////////////////////////////////////////////////////////////////////////////////
       // VIDEOPLAYER_*
@@ -821,10 +826,12 @@ bool CVideoGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextW
       case LISTITEM_HASVIDEOEXTRAS:
         value = tag->HasVideoExtras();
         return true;
+      default:
+        break;
     }
   }
 
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // VIDEOPLAYER_*
@@ -882,6 +889,8 @@ bool CVideoGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextW
         value = true;
       return true;
     }
+    default:
+      break;
   }
 
   return false;

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.h
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.h
@@ -15,11 +15,7 @@
 class CApplicationPlayer;
 class CVideoInfoTag;
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
 class CGUIInfo;
@@ -48,6 +44,4 @@ private:
   const std::shared_ptr<CApplicationPlayer> m_appPlayer;
 };
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/VisualisationGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VisualisationGUIInfo.cpp
@@ -30,7 +30,7 @@ bool CVisualisationGUIInfo::InitCurrentItem(CFileItem *item)
 
 bool CVisualisationGUIInfo::GetLabel(std::string& value, const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback) const
 {
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // VISUALISATION_*
@@ -41,7 +41,7 @@ bool CVisualisationGUIInfo::GetLabel(std::string& value, const CFileItem *item, 
       CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
       if (msg.GetPointer())
       {
-        CGUIVisualisationControl* viz = static_cast<CGUIVisualisationControl*>(msg.GetPointer());
+        auto* viz{static_cast<CGUIVisualisationControl*>(msg.GetPointer())};
         value = viz->GetActivePresetName();
         URIUtils::RemoveExtension(value);
         return true;
@@ -60,6 +60,8 @@ bool CVisualisationGUIInfo::GetLabel(std::string& value, const CFileItem *item, 
       }
       break;
     }
+    default:
+      break;
   }
 
   return false;
@@ -72,7 +74,7 @@ bool CVisualisationGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int co
 
 bool CVisualisationGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextWindow, const CGUIInfo &info) const
 {
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // VISUALISATION_*
@@ -100,12 +102,14 @@ bool CVisualisationGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int 
       CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
       if (msg.GetPointer())
       {
-        CGUIVisualisationControl* viz = static_cast<CGUIVisualisationControl*>(msg.GetPointer());
+        auto* viz{static_cast<CGUIVisualisationControl*>(msg.GetPointer())};
         value = viz->HasPresets();
         return true;
       }
       break;
     }
+    default:
+      break;
   }
 
   return false;

--- a/xbmc/guilib/guiinfo/VisualisationGUIInfo.h
+++ b/xbmc/guilib/guiinfo/VisualisationGUIInfo.h
@@ -10,11 +10,7 @@
 
 #include "guilib/guiinfo/GUIInfoProvider.h"
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
 class CGUIInfo;
@@ -32,6 +28,4 @@ public:
   bool GetBool(bool& value, const CGUIListItem *item, int contextWindow, const CGUIInfo &info) const override;
 };
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/WeatherGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/WeatherGUIInfo.cpp
@@ -28,7 +28,7 @@ bool CWeatherGUIInfo::InitCurrentItem(CFileItem *item)
 
 bool CWeatherGUIInfo::GetLabel(std::string& value, const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback) const
 {
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // WEATHER_*
@@ -55,6 +55,8 @@ bool CWeatherGUIInfo::GetLabel(std::string& value, const CFileItem *item, int co
     case WEATHER_PLUGIN:
       value = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_WEATHER_ADDON);
       return true;
+    default:
+      break;
   }
 
   return false;
@@ -67,14 +69,16 @@ bool CWeatherGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextW
 
 bool CWeatherGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextWindow, const CGUIInfo &info) const
 {
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // WEATHER_*
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case WEATHER_IS_FETCHED:
       value = CServiceBroker::GetWeatherManager().IsFetched();
-      return true;;
+      return true;
+    default:
+      break;
   }
 
   return false;

--- a/xbmc/guilib/guiinfo/WeatherGUIInfo.h
+++ b/xbmc/guilib/guiinfo/WeatherGUIInfo.h
@@ -10,11 +10,7 @@
 
 #include "guilib/guiinfo/GUIInfoProvider.h"
 
-namespace KODI
-{
-namespace GUILIB
-{
-namespace GUIINFO
+namespace KODI::GUILIB::GUIINFO
 {
 
 class CGUIInfo;
@@ -32,6 +28,4 @@ public:
   bool GetBool(bool& value, const CGUIListItem *item, int contextWindow, const CGUIInfo &info) const override;
 };
 
-} // namespace GUIINFO
-} // namespace GUILIB
-} // namespace KODI
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -370,7 +370,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
   const std::shared_ptr<const CPVRTimerInfoTag> timer = item->GetPVRTimerInfoTag();
   if (timer)
   {
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       case LISTITEM_DATE:
         strValue = timer->Summary();
@@ -449,7 +449,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
   {
     // Note: CPVRRecoding is derived from CVideoInfoTag. All base class properties will be handled
     //       by CVideoGUIInfoProvider. Only properties introduced by CPVRRecording need to be handled here.
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       case LISTITEM_DATE:
         strValue = GetAsLocalizedDateTimeString(recording->RecordingTimeAsLocalTime());
@@ -636,7 +636,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
   const std::shared_ptr<const CPVREpgSearchFilter> filter = item->GetEPGSearchFilter();
   if (filter)
   {
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       case LISTITEM_DATE:
       {
@@ -655,7 +655,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
 
   if (item->IsPVRChannelGroup())
   {
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       case LISTITEM_PVR_GROUP_ORIGIN:
       {
@@ -694,7 +694,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
     CPVRItem pvrItem(item);
     channel = pvrItem.GetChannel();
 
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       case VIDEOPLAYER_NEXT_TITLE:
       case VIDEOPLAYER_NEXT_GENRE:
@@ -721,7 +721,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
         break;
     }
 
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       // special handling for channels without epg or with radio rds data
       case PLAYER_TITLE:
@@ -740,7 +740,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
 
   if (epgTag)
   {
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       case VIDEOPLAYER_GENRE:
       case LISTITEM_GENRE:
@@ -922,7 +922,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
 
   if (channel)
   {
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       case MUSICPLAYER_CHANNEL_NAME:
       {
@@ -1008,7 +1008,7 @@ bool CPVRGUIInfo::GetPVRLabel(const CFileItem* item,
 {
   std::unique_lock lock(m_critSection);
 
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     case PVR_EPG_EVENT_ICON:
     {
@@ -1253,7 +1253,7 @@ bool CPVRGUIInfo::GetRadioRDSLabel(const CFileItem* item,
       item->GetPVRChannelInfoTag()->GetRadioRDSInfoTag();
   if (tag)
   {
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       case RDS_CHANNEL_COUNTRY:
         strValue = tag->GetCountry();
@@ -1394,7 +1394,7 @@ bool CPVRGUIInfo::GetFallbackLabel(std::string& value,
 {
   if (item->IsPVRChannel() || item->IsEPG() || item->IsPVRTimer())
   {
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       /////////////////////////////////////////////////////////////////////////////////////////////
       // VIDEOPLAYER_*, MUSICPLAYER_*
@@ -1429,7 +1429,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerInt(const CFileItem* item,
                                           const CGUIInfo& info,
                                           int& iValue) const
 {
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     case LISTITEM_PROGRESS:
       if (item->IsPVRChannel() || item->IsEPG())
@@ -1449,7 +1449,7 @@ bool CPVRGUIInfo::GetPVRInt(const CFileItem* item, const CGUIInfo& info, int& iV
 {
   std::unique_lock lock(m_critSection);
 
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     case PVR_EPG_EVENT_DURATION:
     {
@@ -1528,7 +1528,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
                                            const CGUIInfo& info,
                                            bool& bValue) const
 {
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     case LISTITEM_HASARCHIVE:
       if (item->IsPVRChannel())
@@ -1835,7 +1835,7 @@ bool CPVRGUIInfo::GetPVRBool(const CFileItem* item, const CGUIInfo& info, bool& 
 {
   std::unique_lock lock(m_critSection);
 
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     case PVR_IS_RECORDING:
       bValue = m_anyTimersInfo.HasRecordingTimers();
@@ -1912,7 +1912,7 @@ bool CPVRGUIInfo::GetRadioRDSBool(const CFileItem* item, const CGUIInfo& info, b
       item->GetPVRChannelInfoTag()->GetRadioRDSInfoTag();
   if (tag)
   {
-    switch (info.m_info)
+    switch (info.GetInfo())
     {
       case RDS_HAS_RADIOTEXT:
         bValue = tag->IsPlayingRadioText();
@@ -1932,7 +1932,7 @@ bool CPVRGUIInfo::GetRadioRDSBool(const CFileItem* item, const CGUIInfo& info, b
     }
   }
 
-  switch (info.m_info)
+  switch (info.GetInfo())
   {
     case RDS_HAS_RDS:
     {


### PR DESCRIPTION
Fixes a bunch of SonarQube findings for `xbmc/guilib/guiinfo/*` and `xbmc/GUIInfoManager.(cpp|h)`, among them:

* "switch" statements should cover all cases cpp:S3562
* "using enum" should be used in scopes with high concentration of "enum" constants cpp:S6177
* "auto" should be used to avoid repetition of types cpp:S5827
* Concise syntax should be used for concatenatable namespaces cpp:S5812
* Pointer and reference local variables should be "const" if the corresponding object is not modified cpp:S5350
* Classes should not contain both public and private data members cpp:S5414
* Comparision operators ("<=>", "==") should be defaulted unless non-default behavior is required cpp:S6230
* Member data should be initialized in-class or in a constructor initialization list cpp:S3230
* "std::string_view" should be used to pass a read-only string to a function cpp:S6009
* Scoped enumerations should be used cpp:S3642
* Multiple variables should not be declared on the same line cpp:S1659
* "nullptr" should be used to denote the null pointer cpp:S4962
* "using" should be preferred for type aliasing cpp:S5416
* Comma operator should not be used cpp:S878
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* Structured binding should be used cpp:S6005
* Two branches in a conditional structure should not have exactly the same implementation cpp:S1871
* Empty statements should be removed cpp:S1116
* Memory should not be managed manually cpp:S5025
* C-style array should not be used cpp:S5945
* STL algorithms and range-based for loops should be preferred to traditional for loops cpp:S5566
* Variables should not be shadowed cpp:S1117
* Redundant class template arguments should not be used cpp:S6012
* "static" members should be accessed statically cpp:S2209

No functional changes intended.

The large number of changed lines in `GUIInfoManager.cpp` are mainly due to reformatting all the tables after switching from c-style arrays to `std::array`.

The rest should be relatively easy to review.

@neo1973 would be nice if you could take a look.