### PR TITLE
CLog: Format log message only if message is actually logged

### DIFF
--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -271,6 +271,18 @@ spdlog::level::level_enum CLog::MapLogLevel(int level)
   return spdlog::level::info;
 }
 
+void CLog::FormatAndLogInternal(spdlog::level::level_enum level,
+                                fmt::string_view format,
+                                fmt::format_args args)
+{
+  auto message = fmt::vformat(format, args);
+
+  // fixup newline alignment, number of spaces should equal prefix length
+  FormatLineBreaks(message);
+
+  m_defaultLogger->log(level, message);
+}
+
 Logger CLog::CreateLogger(const std::string& loggerName)
 {
   // create the logger

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -275,6 +275,9 @@ void CLog::FormatAndLogInternal(spdlog::level::level_enum level,
                                 fmt::string_view format,
                                 fmt::format_args args)
 {
+  if (level < m_defaultLogger->level())
+    return;
+
   auto message = fmt::vformat(format, args);
 
   // fixup newline alignment, number of spaces should equal prefix length

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -132,15 +132,7 @@ private:
 
   void FormatAndLogInternal(spdlog::level::level_enum level,
                             fmt::string_view format,
-                            fmt::format_args args)
-  {
-    auto message = fmt::vformat(format, args);
-
-    // fixup newline alignment, number of spaces should equal prefix length
-    FormatLineBreaks(message);
-
-    m_defaultLogger->log(level, message);
-  }
+                            fmt::format_args args);
 
   Logger CreateLogger(const std::string& loggerName);
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

See title.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Don't waste precious CPU cycles formatting messages that no one is going to see.

PS: If someone relies on side effects of formatting a log message they shall be banished to the deepest level of hell :wink: 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

logging and debug logging, with and without component logging.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
