### PR TITLE
[PVR] SonarQube findings, round 2

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -658,7 +658,7 @@ void CPVRManager::UpdateComponents(ManagerState stateToCheck)
       g_localizeStrings.Get(19235))}; // PVR manager is starting up
 
   // Wait for at least one client to come up and load/update data
-  while (!UpdateComponents(stateToCheck, progressHandler) && m_addons->HasCreatedClients() &&
+  while (!UpdateComponents(stateToCheck, progressHandler.get()) && m_addons->HasCreatedClients() &&
          (stateToCheck == GetState()))
   {
     CThread::Sleep(1000ms);
@@ -669,7 +669,7 @@ void CPVRManager::UpdateComponents(ManagerState stateToCheck)
 }
 
 bool CPVRManager::UpdateComponents(ManagerState stateToCheck,
-                                   const std::unique_ptr<CPVRGUIProgressHandler>& progressHandler)
+                                   CPVRGUIProgressHandler* progressHandler)
 {
   // find clients which appeared since last check and update them
   const CPVRClientMap clientMap = m_addons->GetCreatedClients();
@@ -996,7 +996,7 @@ void CPVRManager::TriggerCleanupCachedImages()
   });
 }
 
-void CPVRManager::ConnectionStateChange(CPVRClient* client,
+void CPVRManager::ConnectionStateChange(const CPVRClient* client,
                                         const std::string& connectString,
                                         PVR_CONNECTION_STATE state,
                                         const std::string& message) const

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -324,7 +324,7 @@ public:
   /*!
    * @brief Signal a connection change of a client
    */
-  void ConnectionStateChange(CPVRClient* client,
+  void ConnectionStateChange(const CPVRClient* client,
                              const std::string& connectString,
                              PVR_CONNECTION_STATE state,
                              const std::string& message) const;
@@ -395,8 +395,7 @@ private:
    * @param progressHandler The progress handler to use for showing the different stages.
    * @return True if at least one client is known and successfully loaded, false otherwise.
    */
-  bool UpdateComponents(ManagerState stateToCheck,
-                        const std::unique_ptr<CPVRGUIProgressHandler>& progressHandler);
+  bool UpdateComponents(ManagerState stateToCheck, CPVRGUIProgressHandler* progressHandler);
 
   /*!
    * @brief Unload all PVR data (recordings, timers, channelgroups).

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -795,6 +795,38 @@ const std::string& CPVRClient::GetConnectionString() const
   return m_strConnectionString;
 }
 
+SBackendProperties CPVRClient::GetBackendProperties() const
+{
+  SBackendProperties properties;
+
+  if (GetDriveSpace(properties.diskTotal, properties.diskUsed) == PVR_ERROR_NO_ERROR)
+  {
+    properties.diskTotal *= 1024;
+    properties.diskUsed *= 1024;
+  }
+
+  int iAmount{0};
+  if (GetProvidersAmount(iAmount) == PVR_ERROR_NO_ERROR)
+    properties.numProviders = iAmount;
+  if (GetChannelGroupsAmount(iAmount) == PVR_ERROR_NO_ERROR)
+    properties.numChannelGroups = iAmount;
+  if (GetChannelsAmount(iAmount) == PVR_ERROR_NO_ERROR)
+    properties.numChannels = iAmount;
+  if (GetTimersAmount(iAmount) == PVR_ERROR_NO_ERROR)
+    properties.numTimers = iAmount;
+  if (GetRecordingsAmount(false, iAmount) == PVR_ERROR_NO_ERROR)
+    properties.numRecordings = iAmount;
+  if (GetRecordingsAmount(true, iAmount) == PVR_ERROR_NO_ERROR)
+    properties.numDeletedRecordings = iAmount;
+  properties.clientname = GetClientName();
+  properties.instancename = GetInstanceName();
+  properties.name = GetBackendName();
+  properties.version = GetBackendVersion();
+  properties.host = GetConnectionString();
+
+  return properties;
+}
+
 std::string CPVRClient::GetClientName() const
 {
   return Name();

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -1082,19 +1082,19 @@ PVR_ERROR CPVRClient::GetChannelGroups(CPVRChannelGroups* groups) const
 }
 
 PVR_ERROR CPVRClient::GetChannelGroupMembers(
-    const CPVRChannelGroup* group,
+    const CPVRChannelGroup& group,
     std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers) const
 {
-  const bool radio{group->IsRadio()};
+  const bool radio{group.IsRadio()};
   return DoAddonCall(
       std::source_location::current().function_name(),
-      [this, group, &groupMembers](const AddonInstance* addon)
+      [this, &group, &groupMembers](const AddonInstance* addon)
       {
         PVR_HANDLE_STRUCT handle = {};
         handle.callerAddress = this;
         handle.dataAddress = &groupMembers;
 
-        const CAddonChannelGroup addonGroup{*group};
+        const CAddonChannelGroup addonGroup{group};
         return addon->toAddon->GetChannelGroupMembers(addon, &handle, &addonGroup);
       },
       m_clientCapabilities.SupportsChannelGroups() &&

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -50,6 +50,26 @@ class CPVRTimerType;
 class CPVRTimersContainer;
 
 /*!
+ * @brief Holds generic data about a backend (number of channels etc.)
+ */
+struct SBackendProperties
+{
+  std::string clientname;
+  std::string instancename;
+  std::string name;
+  std::string version;
+  std::string host;
+  int numTimers{0};
+  int numRecordings{0};
+  int numDeletedRecordings{0};
+  int numProviders{0};
+  int numChannelGroups{0};
+  int numChannels{0};
+  uint64_t diskUsed{0};
+  uint64_t diskTotal{0};
+};
+
+/*!
  * Interface from Kodi to a PVR add-on.
  *
  * Also translates Kodi's C++ structures to the add-on's C structures.
@@ -201,6 +221,12 @@ public:
    * @return PVR_ERROR_NO_ERROR if the drive space has been fetched successfully.
    */
   PVR_ERROR GetDriveSpace(uint64_t& iTotal, uint64_t& iUsed) const;
+
+  /*!
+   * @brief Returns backend properties about this client
+   * @return the properties
+   */
+  SBackendProperties GetBackendProperties() const;
 
   /*!
    * @brief Start a channel scan on the server.

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -916,6 +916,16 @@ private:
                                     unsigned int iPropertyCount,
                                     CPVRStreamProperties& props);
 
+  using AddonInstance = AddonInstance_PVR;
+
+  /*!
+   * @brief Get the timer typed for the given addon.
+   * @param timerTypes [out] the timer types.
+   * @return PVR_ERROR_NO_ERROR on success, any other PVR_ERROR_* value otherwise.
+   */
+  PVR_ERROR GetTimerTypes(const AddonInstance* addon,
+                          std::vector<std::shared_ptr<CPVRTimerType>>& timerTypes);
+
   /*!
    * @brief Whether a channel can be played by this add-on
    * @param channel The channel to check.

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -361,7 +361,7 @@ public:
    * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
    */
   PVR_ERROR GetChannelGroupMembers(
-      const CPVRChannelGroup* group,
+      const CPVRChannelGroup& group,
       std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers) const;
 
   //@}

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <memory>
 #include <optional>
+#include <span>
 #include <string>
 #include <utility>
 #include <vector>
@@ -909,11 +910,9 @@ private:
   /*!
    * @brief Write the given addon properties to the given properties container.
    * @param properties Pointer to an array of addon properties pointers.
-   * @param iPropertyCount The number of properties contained in the addon properties array.
    * @param props The container the addon properties shall be written to.
    */
-  static void WriteStreamProperties(PVR_NAMED_VALUE** properties,
-                                    unsigned int iPropertyCount,
+  static void WriteStreamProperties(std::span<PVR_NAMED_VALUE*> properties,
                                     CPVRStreamProperties& props);
 
   using AddonInstance = AddonInstance_PVR;

--- a/xbmc/pvr/addons/PVRClientCapabilities.cpp
+++ b/xbmc/pvr/addons/PVRClientCapabilities.cpp
@@ -23,7 +23,7 @@ CPVRClientCapabilities::CPVRClientCapabilities(const CPVRClientCapabilities& oth
   InitRecordingsLifetimeValues();
 }
 
-const CPVRClientCapabilities& CPVRClientCapabilities::operator=(const CPVRClientCapabilities& other)
+CPVRClientCapabilities& CPVRClientCapabilities::operator=(const CPVRClientCapabilities& other)
 {
   if (other.m_addonCapabilities)
     m_addonCapabilities = std::make_unique<PVR_ADDON_CAPABILITIES>(*other.m_addonCapabilities);
@@ -31,7 +31,7 @@ const CPVRClientCapabilities& CPVRClientCapabilities::operator=(const CPVRClient
   return *this;
 }
 
-const CPVRClientCapabilities& CPVRClientCapabilities::operator=(
+CPVRClientCapabilities& CPVRClientCapabilities::operator=(
     const PVR_ADDON_CAPABILITIES& addonCapabilities)
 {
   m_addonCapabilities = std::make_unique<PVR_ADDON_CAPABILITIES>(addonCapabilities);

--- a/xbmc/pvr/addons/PVRClientCapabilities.h
+++ b/xbmc/pvr/addons/PVRClientCapabilities.h
@@ -25,9 +25,9 @@ public:
   virtual ~CPVRClientCapabilities() = default;
 
   CPVRClientCapabilities(const CPVRClientCapabilities& other);
-  const CPVRClientCapabilities& operator=(const CPVRClientCapabilities& other);
+  CPVRClientCapabilities& operator=(const CPVRClientCapabilities& other);
 
-  const CPVRClientCapabilities& operator=(const PVR_ADDON_CAPABILITIES& addonCapabilities);
+  CPVRClientCapabilities& operator=(const PVR_ADDON_CAPABILITIES& addonCapabilities);
 
   void clear();
 

--- a/xbmc/pvr/addons/PVRClientUID.cpp
+++ b/xbmc/pvr/addons/PVRClientUID.cpp
@@ -51,7 +51,7 @@ int CPVRClientUID::GetUID() const
         return PVR_CLIENT_INVALID_UID;
       }
 
-      s_idMap.insert({{m_addonID, m_instanceID}, m_uid});
+      s_idMap.try_emplace({m_addonID, m_instanceID}, m_uid);
     }
     m_uidCreated = true;
   }

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -686,13 +686,13 @@ PVR_ERROR CPVRClients::GetChannelGroups(const std::vector<std::shared_ptr<CPVRCl
 
 PVR_ERROR CPVRClients::GetChannelGroupMembers(
     const std::vector<std::shared_ptr<CPVRClient>>& clients,
-    CPVRChannelGroup* group,
+    const CPVRChannelGroup& group,
     std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers,
     std::vector<int>& failedClients) const
 {
   return ForClients(
       std::source_location::current().function_name(), clients,
-      [group, &groupMembers](const std::shared_ptr<const CPVRClient>& client)
+      [&group, &groupMembers](const std::shared_ptr<const CPVRClient>& client)
       { return client->GetChannelGroupMembers(group, groupMembers); },
       failedClients);
 }

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -565,42 +565,15 @@ std::vector<std::pair<ADDON::AddonInstanceId, bool>> CPVRClients::GetInstanceIds
 // client API calls
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-std::vector<SBackend> CPVRClients::GetBackendProperties() const
+std::vector<SBackendProperties> CPVRClients::GetBackendProperties() const
 {
-  std::vector<SBackend> backendProperties;
+  std::vector<SBackendProperties> backendProperties;
 
   ForCreatedClients(std::source_location::current().function_name(),
                     [&backendProperties](const std::shared_ptr<const CPVRClient>& client)
                     {
-                      SBackend properties;
-
-                      if (client->GetDriveSpace(properties.diskTotal, properties.diskUsed) ==
-                          PVR_ERROR_NO_ERROR)
-                      {
-                        properties.diskTotal *= 1024;
-                        properties.diskUsed *= 1024;
-                      }
-
-                      int iAmount{0};
-                      if (client->GetProvidersAmount(iAmount) == PVR_ERROR_NO_ERROR)
-                        properties.numProviders = iAmount;
-                      if (client->GetChannelGroupsAmount(iAmount) == PVR_ERROR_NO_ERROR)
-                        properties.numChannelGroups = iAmount;
-                      if (client->GetChannelsAmount(iAmount) == PVR_ERROR_NO_ERROR)
-                        properties.numChannels = iAmount;
-                      if (client->GetTimersAmount(iAmount) == PVR_ERROR_NO_ERROR)
-                        properties.numTimers = iAmount;
-                      if (client->GetRecordingsAmount(false, iAmount) == PVR_ERROR_NO_ERROR)
-                        properties.numRecordings = iAmount;
-                      if (client->GetRecordingsAmount(true, iAmount) == PVR_ERROR_NO_ERROR)
-                        properties.numDeletedRecordings = iAmount;
-                      properties.clientname = client->GetClientName();
-                      properties.instancename = client->GetInstanceName();
-                      properties.name = client->GetBackendName();
-                      properties.version = client->GetBackendVersion();
-                      properties.host = client->GetConnectionString();
-
-                      backendProperties.emplace_back(properties);
+                      SBackendProperties properties;
+                      backendProperties.emplace_back(client->GetBackendProperties());
                       return PVR_ERROR_NO_ERROR;
                     });
 

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -413,6 +413,19 @@ private:
   std::vector<std::pair<ADDON::AddonInstanceId, bool>> GetInstanceIdsWithStatus(
       const std::shared_ptr<ADDON::CAddonInfo>& addon, bool addonIsEnabled) const;
 
+  enum class UpdateClientAction
+  {
+    NONE,
+    CREATE,
+    RECREATE,
+    DESTROY,
+  };
+
+  UpdateClientAction GetUpdateClientAction(const std::shared_ptr<ADDON::CAddonInfo>& addon,
+                                           ADDON::AddonInstanceId instanceId,
+                                           int clientId,
+                                           bool instanceEnabled) const;
+
   /*!
    * @brief Get the client instance for a given client id.
    * @param clientId The id of the client to get.

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -41,27 +41,9 @@ class CPVRRecordings;
 class CPVRTimerType;
 class CPVRTimersContainer;
 
-using CPVRClientMap = std::map<int, std::shared_ptr<CPVRClient>>;
+struct SBackendProperties;
 
-/*!
- * @brief Holds generic data about a backend (number of channels etc.)
- */
-struct SBackend
-{
-  std::string clientname;
-  std::string instancename;
-  std::string name;
-  std::string version;
-  std::string host;
-  int numTimers = 0;
-  int numRecordings = 0;
-  int numDeletedRecordings = 0;
-  int numProviders = 0;
-  int numChannelGroups = 0;
-  int numChannels = 0;
-  uint64_t diskUsed = 0;
-  uint64_t diskTotal = 0;
-};
+using CPVRClientMap = std::map<int, std::shared_ptr<CPVRClient>>;
 
 class CPVRClients : public ADDON::IAddonMgrCallback, public CPowerState
 {
@@ -195,7 +177,7 @@ public:
    * @brief Returns properties about all created clients
    * @return the properties
    */
-  std::vector<SBackend> GetBackendProperties() const;
+  std::vector<SBackendProperties> GetBackendProperties() const;
 
   //@}
 

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -69,10 +69,8 @@ public:
   /*!
    * @brief Update all clients, sync with Addon Manager state (start, restart, shutdown clients).
    * @param changedAddonId The id of the changed addon, empty string denotes 'any addon'.
-   * @param changedInstanceId The Identifier of the changed add-on instance
    */
-  void UpdateClients(const std::string& changedAddonId = "",
-                     ADDON::AddonInstanceId changedInstanceId = ADDON::ADDON_SINGLETON_INSTANCE_ID);
+  void UpdateClients(const std::string& changedAddonId = "");
 
   /*!
    * @brief Restart a single client add-on.

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -319,7 +319,7 @@ public:
    */
   PVR_ERROR GetChannelGroupMembers(
       const std::vector<std::shared_ptr<CPVRClient>>& clients,
-      CPVRChannelGroup* group,
+      const CPVRChannelGroup& group,
       std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers,
       std::vector<int>& failedClients) const;
 

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -624,7 +624,7 @@ bool CPVRChannel::SetEPGEnabled(bool bEPGEnabled)
   return false;
 }
 
-bool CPVRChannel::SetEPGScraper(const std::string& strScraper)
+bool CPVRChannel::SetEPGScraper(std::string_view strScraper)
 {
   std::unique_lock lock(m_critSection);
 

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -432,7 +433,7 @@ public:
    * @param strScraper The new scraper name.
    * @return True if something changed, false otherwise.
    */
-  bool SetEPGScraper(const std::string& strScraper);
+  bool SetEPGScraper(std::string_view strScraper);
 
   bool CanRecord() const;
 

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -531,24 +531,22 @@ int CPVRChannelGroup::LoadFromDatabase(const std::vector<std::shared_ptr<CPVRCli
         continue;
       }
 
-      if (member->ChannelClientID() > 0 && member->ChannelUID() > 0 &&
-          member->IsRadio() == IsRadio())
-      {
-        // Ignore data from unknown/disabled clients
-        if (allClients->IsEnabledClient(member->ChannelClientID()))
-        {
-          m_sortedMembers.emplace_back(member);
-          m_members.emplace(std::make_pair(member->ChannelClientID(), member->ChannelUID()),
-                            member);
-        }
-      }
-      else
+      if (member->ChannelClientID() <= 0 || member->ChannelUID() <= 0 ||
+          member->IsRadio() != IsRadio())
       {
         CLog::LogF(LOGWARNING,
                    "Skipping member with channel database id {} of {} channel group '{}'. "
                    "Channel not found in the database or radio flag changed.",
                    member->ChannelDatabaseID(), IsRadio() ? "radio" : "TV", GroupName());
         membersToDelete.emplace_back(member);
+        continue;
+      }
+
+      if (allClients->IsEnabledClient(member->ChannelClientID()))
+      {
+        // Ignore data from unknown/disabled clients
+        m_sortedMembers.emplace_back(member);
+        m_members.emplace(std::make_pair(member->ChannelClientID(), member->ChannelUID()), member);
       }
     }
 

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -546,7 +546,7 @@ int CPVRChannelGroup::LoadFromDatabase(const std::vector<std::shared_ptr<CPVRCli
       {
         // Ignore data from unknown/disabled clients
         m_sortedMembers.emplace_back(member);
-        m_members.emplace(std::make_pair(member->ChannelClientID(), member->ChannelUID()), member);
+        m_members.try_emplace({member->ChannelClientID(), member->ChannelUID()}, member);
       }
     }
 
@@ -630,7 +630,7 @@ bool CPVRChannelGroup::UpdateFromClient(const std::shared_ptr<CPVRChannelGroupMe
       channel->SetDateTimeAdded(CDateTime::GetUTCDateTime());
 
     m_sortedMembers.emplace_back(groupMember);
-    m_members.emplace(channel->StorageId(), groupMember);
+    m_members.try_emplace(channel->StorageId(), groupMember);
 
     CLog::LogFC(LOGDEBUG, LOGPVR, "Added {} channel group member '{}' to group '{}'",
                 IsRadio() ? "radio" : "TV", channel->ChannelName(), GroupName());
@@ -670,15 +670,10 @@ bool CPVRChannelGroup::UpdateChannelNumbersFromAllChannelsGroup()
 {
   std::unique_lock lock(m_critSection);
 
-  bool bChanged = false;
-
-  if (!IsChannelsOwner())
-  {
-    // Make sure the channel numbers are set from the all channels group using the non default
-    // renumber call before sorting.
-    if (Renumber(RenumberMode::IGNORE_NUMBERING_FROM_ONE) || SortAndRenumber())
-      bChanged = true;
-  }
+  // Make sure the channel numbers are set from the all channels group using the non default
+  // renumber call before sorting.
+  const bool bChanged{!IsChannelsOwner() &&
+                      (Renumber(RenumberMode::IGNORE_NUMBERING_FROM_ONE) || SortAndRenumber())};
 
   m_events.Publish(IsChannelsOwner() || bChanged ? PVREvent::ChannelGroupInvalidated
                                                  : PVREvent::ChannelGroup);
@@ -827,7 +822,7 @@ bool CPVRChannelGroup::AppendToGroup(
     newMember->SetClientPriority(groupMember->ClientPriority());
 
     m_sortedMembers.emplace_back(newMember);
-    m_members.emplace(channel->StorageId(), newMember);
+    m_members.try_emplace(channel->StorageId(), newMember);
 
     SortAndRenumber();
     bReturn = true;
@@ -883,12 +878,8 @@ void CPVRChannelGroup::Delete()
   }
 
   std::unique_lock lock(m_critSection);
-
-  if (m_iGroupId > 0)
-  {
-    if (database->Delete(*this))
-      m_bDeleted = true;
-  }
+  if (m_iGroupId > 0 && database->Delete(*this))
+    m_bDeleted = true;
 }
 
 bool CPVRChannelGroup::Renumber(RenumberMode mode /* = NORMAL */)
@@ -1057,7 +1048,7 @@ std::string CPVRChannelGroup::ClientGroupName() const
   return m_clientGroupName;
 }
 
-void CPVRChannelGroup::SetClientGroupName(const std::string& groupName)
+void CPVRChannelGroup::SetClientGroupName(std::string_view groupName)
 {
   std::unique_lock lock(m_critSection);
   if (m_clientGroupName != groupName)

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -17,6 +17,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -157,7 +158,7 @@ public:
    * @brief Set the name this group has on the client.
    * @param groupName The client group name.
    */
-  void SetClientGroupName(const std::string& groupName);
+  void SetClientGroupName(std::string_view groupName);
 
   /*!
    * @brief Check whether the group name was set by the user.

--- a/xbmc/pvr/channels/PVRChannelGroupAllChannels.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupAllChannels.cpp
@@ -45,11 +45,8 @@ void CPVRChannelGroupAllChannels::CheckGroupName()
   //! @todo major design flaw to fix: channel and group URLs must not contain the group name!
 
   // Ensure the group name is still correct, or channels may fail to load after a locale change
-  if (!IsUserSetName())
-  {
-    if (SetGroupName(g_localizeStrings.Get(19287)))
-      Persist();
-  }
+  if (!IsUserSetName() && SetGroupName(g_localizeStrings.Get(19287)))
+    Persist();
 }
 
 bool CPVRChannelGroupAllChannels::UpdateFromClients(

--- a/xbmc/pvr/channels/PVRChannelGroupFromClient.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupFromClient.cpp
@@ -65,7 +65,7 @@ bool CPVRChannelGroupFromClient::UpdateFromClients(
 
   // get the channel group members from the backends.
   std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers;
-  CServiceBroker::GetPVRManager().Clients()->GetChannelGroupMembers({client}, this, groupMembers,
+  CServiceBroker::GetPVRManager().Clients()->GetChannelGroupMembers({client}, *this, groupMembers,
                                                                     m_failedClients);
   return UpdateGroupEntries(groupMembers);
 }

--- a/xbmc/pvr/channels/PVRChannelGroupMergedByName.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupMergedByName.cpp
@@ -41,16 +41,16 @@ bool CPVRChannelGroupMergedByName::ShouldBeIgnored(
       if (group->GroupName() != mergedGroupName && group->ClientGroupName() != mergedGroupName)
         continue;
 
-      if (group->IsGroupMember(member))
+      if (!group->IsGroupMember(member))
+        continue;
+
+      if (matchingGroup != NO_GROUP_FOUND && matchingGroup != group->GroupID())
       {
-        if (matchingGroup != NO_GROUP_FOUND && matchingGroup != group->GroupID())
-        {
-          // Found a second group containing a member of this group. This group must not be ignored.
-          return false;
-        }
-        // First match or no new group. Continue with next group.
-        matchingGroup = group->GroupID();
+        // Found a second group containing a member of this group. This group must not be ignored.
+        return false;
       }
+      // First match or no new group. Continue with next group.
+      matchingGroup = group->GroupID();
     }
   }
   return true;
@@ -72,14 +72,14 @@ std::vector<std::string> GetGroupNames(const std::vector<std::shared_ptr<CPVRCha
       case CPVRChannelGroup::Origin::SYSTEM:
       {
         // Ignore system-created groups, except merged by name groups
-        if (group->GroupType() == PVR_GROUP_TYPE_SYSTEM_MERGED_BY_NAME)
-        {
-          const auto it = knownNamesCountMap.find(groupName);
-          if (it == knownNamesCountMap.end())
-            knownNamesCountMap.insert({groupName, 0}); // remember we found a merged group
-          else
-            (*it).second = 0; // reset groups counter. we do not need a new merged group
-        }
+        if (group->GroupType() != PVR_GROUP_TYPE_SYSTEM_MERGED_BY_NAME)
+          break;
+
+        const auto it = knownNamesCountMap.find(groupName);
+        if (it == knownNamesCountMap.cend())
+          knownNamesCountMap.try_emplace(groupName, 0); // remember we found a merged group
+        else
+          (*it).second = 0; // reset groups counter. we do not need a new merged group
         break;
       }
 
@@ -87,8 +87,8 @@ std::vector<std::string> GetGroupNames(const std::vector<std::shared_ptr<CPVRCha
       case CPVRChannelGroup::Origin::CLIENT:
       {
         const auto it = knownNamesCountMap.find(groupName);
-        if (it == knownNamesCountMap.end())
-          knownNamesCountMap.insert({groupName, 1}); // first occurrence
+        if (it == knownNamesCountMap.cend())
+          knownNamesCountMap.try_emplace(groupName, 1); // first occurrence
         else if ((*it).second > 0)
           (*it).second++; // second+ occurrence
         break;

--- a/xbmc/pvr/channels/PVRChannelGroupSettings.h
+++ b/xbmc/pvr/channels/PVRChannelGroupSettings.h
@@ -32,7 +32,7 @@ class CPVRChannelGroupSettings : public ISettingCallback
 {
 public:
   CPVRChannelGroupSettings();
-  virtual ~CPVRChannelGroupSettings();
+  ~CPVRChannelGroupSettings() override;
 
   void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
 

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -334,9 +334,8 @@ bool CPVRChannelGroups::HasValidDataForClients(
          std::ranges::none_of(clients,
                               [this](const std::shared_ptr<const CPVRClient>& client)
                               {
-                                return std::find(m_failedClientsForChannelGroups.cbegin(),
-                                                 m_failedClientsForChannelGroups.cend(),
-                                                 client->GetID()) !=
+                                return std::ranges::find(m_failedClientsForChannelGroups,
+                                                         client->GetID()) !=
                                        m_failedClientsForChannelGroups.cend();
                               });
 }
@@ -541,14 +540,12 @@ GroupMemberPair CPVRChannelGroups::GetLastAndPreviousToLastPlayedChannelGroupMem
 
   // Previous to last is either 'second' of first group or 'first' of second group.
   if (groups.size() > 1 && groups[0]->LastWatched() && groups[1]->LastWatched() && previousToLast &&
-      previousToLast->Channel()->LastWatched())
+      previousToLast->Channel()->LastWatched() &&
+      groups[1]->LastWatched() >= previousToLast->Channel()->LastWatched())
   {
-    if (groups[1]->LastWatched() >= previousToLast->Channel()->LastWatched())
-    {
-      const auto [membersPreviousToLastPlayedGroup, _] =
-          groups[1]->GetLastAndPreviousToLastPlayedChannelGroupMember();
-      previousToLast = membersPreviousToLastPlayedGroup;
-    }
+    const auto [membersPreviousToLastPlayedGroup, _] =
+        groups[1]->GetLastAndPreviousToLastPlayedChannelGroupMember();
+    previousToLast = membersPreviousToLastPlayedGroup;
   }
 
   return {last, previousToLast};

--- a/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
+++ b/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
@@ -592,7 +592,7 @@ const std::string& CPVRRadioRDSInfoTag::GetSMSStudio() const
   return m_strSMSStudio;
 }
 
-void CPVRRadioRDSInfoTag::SetRadioStyle(const std::string& style)
+void CPVRRadioRDSInfoTag::SetRadioStyle(std::string_view style)
 {
   std::unique_lock lock(m_critSection);
   m_strRadioStyle = style;
@@ -691,7 +691,7 @@ void CPVRRadioRDSInfoTag::Info::Clear()
 
 void CPVRRadioRDSInfoTag::Info::Add(const std::string& text)
 {
-  const std::string tmp{TrimAndToUTF8(text)};
+  std::string tmp{TrimAndToUTF8(text)};
   if (std::ranges::find(m_data, tmp) != m_data.cend())
     return;
 

--- a/xbmc/pvr/channels/PVRRadioRDSInfoTag.h
+++ b/xbmc/pvr/channels/PVRRadioRDSInfoTag.h
@@ -114,7 +114,7 @@ public:
   void SetEditorialStaff(const std::string& strEditorialStaff);
   std::string GetEditorialStaff() const;
 
-  void SetRadioStyle(const std::string& style);
+  void SetRadioStyle(std::string_view style);
   std::string GetRadioStyle() const;
 
   void SetPlayingRadioText(bool yesNo);

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -700,7 +700,7 @@ bool CGUIDialogPVRChannelManager::OnPopupMenu(int iItem)
   if (choice < 0)
     return false;
 
-  return OnContextButton(iItem, (CONTEXT_BUTTON)choice);
+  return OnContextButton(iItem, static_cast<CONTEXT_BUTTON>(choice));
 }
 
 bool CGUIDialogPVRChannelManager::OnContextButton(int itemNumber, CONTEXT_BUTTON button)

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -150,20 +150,18 @@ bool CGUIDialogPVRGroupManager::ActionButtonNewGroup(const CGUIMessage& message)
   {
     std::string strGroupName;
     if (CGUIKeyboardFactory::ShowAndGetInput(strGroupName, CVariant{g_localizeStrings.Get(19139)},
-                                             false))
+                                             false) &&
+        !strGroupName.empty())
     {
-      if (!strGroupName.empty())
+      // add the group if it doesn't already exist
+      const std::shared_ptr<CPVRChannelGroups> groups{
+          CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio)};
+      const std::shared_ptr<CPVRChannelGroup> group{groups->AddGroup(strGroupName)};
+      if (group)
       {
-        // add the group if it doesn't already exist
-        const std::shared_ptr<CPVRChannelGroups> groups{
-            CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio)};
-        const auto group = groups->AddGroup(strGroupName);
-        if (group)
-        {
-          m_selectedGroup = group;
-          m_iSelectedChannelGroup = -1; // recalc index in Update()
-          Update();
-        }
+        m_selectedGroup = group;
+        m_iSelectedChannelGroup = -1; // recalc index in Update()
+        Update();
       }
     }
     bReturn = true;

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -95,7 +95,7 @@ void CGUIDialogPVRGuideSearch::UpdateChannelSpin()
   for (const auto& groupMember : groupMembers)
   {
     labels.emplace_back(groupMember->Channel()->ChannelName(), iIndex);
-    m_channelsMap.insert(std::make_pair(iIndex, groupMember));
+    m_channelsMap.try_emplace(iIndex, groupMember);
 
     if (iSelectedChannel == EPG_SEARCH_UNSET &&
         groupMember->ChannelUID() == m_searchFilter->GetChannelUID() &&

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
@@ -225,9 +225,8 @@ void CGUIDialogPVRRecordingSettings::LifetimesFiller(const SettingConstPtr& sett
     if (it == list.end())
     {
       // PVR backend supplied value is not in the list of predefined values. Insert it.
-      list.emplace(it, IntegerSettingOption(
-                           StringUtils::Format(g_localizeStrings.Get(17999), current) /* {} days */,
-                           current));
+      list.emplace(it, StringUtils::Format(g_localizeStrings.Get(17999), current) /* {} days */,
+                   current);
     }
   }
   else

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -686,15 +686,12 @@ bool CGUIDialogPVRTimerSettings::Validate() const
     bEndAnyTime = false; // Assume end time change needs checking for
 
   // Begin and end time
-  if (!bStartAnyTime && !bEndAnyTime)
+  if (!bStartAnyTime && !bEndAnyTime && m_timerType->SupportsStartTime() &&
+      m_timerType->SupportsEndTime() && m_endLocalTime < m_startLocalTime)
   {
-    if (m_timerType->SupportsStartTime() && m_timerType->SupportsEndTime() &&
-        m_endLocalTime < m_startLocalTime)
-    {
-      HELPERS::ShowOKDialogText(CVariant{19065}, // "Timer settings"
-                                CVariant{19072}); // In order to add/update a timer
-      return false;
-    }
+    HELPERS::ShowOKDialogText(CVariant{19065}, // "Timer settings"
+                              CVariant{19072}); // In order to add/update a timer ...
+    return false;
   }
 
   return true;
@@ -902,7 +899,7 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
   // If timer is read-only or was created by a timer rule, only add current type, for information. Type can't be changed.
   if (m_timerType->IsReadOnly() || m_timerInfoTag->HasParent())
   {
-    m_typeEntries.insert(std::make_pair(0, m_timerType));
+    m_typeEntries.try_emplace(0, m_timerType);
     return;
   }
 
@@ -958,13 +955,13 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
     if (!bFoundThisType && *type == *m_timerType)
       bFoundThisType = true;
 
-    m_typeEntries.insert(std::make_pair(idx, type));
+    m_typeEntries.try_emplace(idx, type);
     idx++;
   }
 
   if (!bFoundThisType)
   {
-    m_typeEntries.insert(std::make_pair(idx, m_timerType));
+    m_typeEntries.try_emplace(idx, m_timerType);
     idx++;
   }
 }
@@ -980,23 +977,23 @@ void CGUIDialogPVRTimerSettings::InitializeChannelsList()
   const CPVRClientMap clients = CServiceBroker::GetPVRManager().Clients()->GetCreatedClients();
   if (clients.size() > 1)
   {
-    m_channelEntries.insert(
-        {index, ChannelDescriptor(PVR_CHANNEL_INVALID_UID, PVR_CLIENT_INVALID_UID,
-                                  // Any channel from any client
-                                  g_localizeStrings.Get(854))});
+    m_channelEntries.try_emplace(index,
+                                 ChannelDescriptor(PVR_CHANNEL_INVALID_UID, PVR_CLIENT_INVALID_UID,
+                                                   // Any channel from any client
+                                                   g_localizeStrings.Get(854)));
     index++;
   }
 
   for (const auto& [_, client] : clients)
   {
-    m_channelEntries.insert(
-        {index, ChannelDescriptor(PVR_CHANNEL_INVALID_UID, client->GetID(),
-                                  clients.size() == 1
-                                      // Any channel
-                                      ? g_localizeStrings.Get(809)
-                                      // Any channel from client "X"
-                                      : StringUtils::Format(g_localizeStrings.Get(853),
-                                                            client->GetFullClientName()))});
+    m_channelEntries.try_emplace(
+        index, ChannelDescriptor(PVR_CHANNEL_INVALID_UID, client->GetID(),
+                                 clients.size() == 1
+                                     // Any channel
+                                     ? g_localizeStrings.Get(809)
+                                     // Any channel from client "X"
+                                     : StringUtils::Format(g_localizeStrings.Get(853),
+                                                           client->GetFullClientName())));
     index++;
   }
 
@@ -1010,8 +1007,8 @@ void CGUIDialogPVRTimerSettings::InitializeChannelsList()
     const std::shared_ptr<const CPVRChannel> channel = groupMember->Channel();
     const std::string channelDescription = StringUtils::Format(
         "{} {}", groupMember->ChannelNumber().FormattedChannelNumber(), channel->ChannelName());
-    m_channelEntries.insert(
-        {index, ChannelDescriptor(channel->UniqueID(), channel->ClientID(), channelDescription)});
+    m_channelEntries.try_emplace(
+        index, ChannelDescriptor(channel->UniqueID(), channel->ClientID(), channelDescription));
     ++index;
   }
 }
@@ -1021,7 +1018,7 @@ void CGUIDialogPVRTimerSettings::TypesFiller(const SettingConstPtr& setting,
                                              int& current,
                                              void* data)
 {
-  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
+  const auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
@@ -1126,7 +1123,7 @@ void CGUIDialogPVRTimerSettings::DaysFiller(const SettingConstPtr& setting,
                                             int& current,
                                             void* data)
 {
-  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
+  const auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
@@ -1175,7 +1172,7 @@ void CGUIDialogPVRTimerSettings::DupEpisodesFiller(const SettingConstPtr& settin
                                                    int& current,
                                                    void* data)
 {
-  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
+  const auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
@@ -1197,7 +1194,7 @@ void CGUIDialogPVRTimerSettings::WeekdaysFiller(const SettingConstPtr& setting,
                                                 int& current,
                                                 void* data)
 {
-  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
+  const auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
@@ -1220,7 +1217,7 @@ void CGUIDialogPVRTimerSettings::PrioritiesFiller(const SettingConstPtr& setting
                                                   int& current,
                                                   void* data)
 {
-  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
+  const auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
@@ -1244,7 +1241,7 @@ void CGUIDialogPVRTimerSettings::PrioritiesFiller(const SettingConstPtr& setting
     if (it == list.end())
     {
       // PVR backend supplied value is not in the list of predefined values. Insert it.
-      list.emplace(it, IntegerSettingOption(std::to_string(current), current));
+      list.emplace(it, std::to_string(current), current);
     }
   }
   else
@@ -1256,7 +1253,7 @@ void CGUIDialogPVRTimerSettings::LifetimesFiller(const SettingConstPtr& setting,
                                                  int& current,
                                                  void* data)
 {
-  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
+  const auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
@@ -1280,9 +1277,8 @@ void CGUIDialogPVRTimerSettings::LifetimesFiller(const SettingConstPtr& setting,
     if (it == list.end())
     {
       // PVR backend supplied value is not in the list of predefined values. Insert it.
-      list.emplace(it, IntegerSettingOption(
-                           StringUtils::Format(g_localizeStrings.Get(17999), current) /* {} days */,
-                           current));
+      list.emplace(it, StringUtils::Format(g_localizeStrings.Get(17999), current) /* {} days */,
+                   current);
     }
   }
   else
@@ -1294,7 +1290,7 @@ void CGUIDialogPVRTimerSettings::MaxRecordingsFiller(const SettingConstPtr& sett
                                                      int& current,
                                                      void* data)
 {
-  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
+  const auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
@@ -1318,7 +1314,7 @@ void CGUIDialogPVRTimerSettings::MaxRecordingsFiller(const SettingConstPtr& sett
     if (it == list.end())
     {
       // PVR backend supplied value is not in the list of predefined values. Insert it.
-      list.emplace(it, IntegerSettingOption(std::to_string(current), current));
+      list.emplace(it, std::to_string(current), current);
     }
   }
   else
@@ -1330,7 +1326,7 @@ void CGUIDialogPVRTimerSettings::RecordingGroupFiller(const SettingConstPtr& set
                                                       int& current,
                                                       void* data)
 {
-  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
+  const auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
@@ -1351,7 +1347,7 @@ void CGUIDialogPVRTimerSettings::MarginTimeFiller(const SettingConstPtr& setting
                                                   int& current,
                                                   void* data)
 {
-  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
+  const auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
@@ -1365,16 +1361,13 @@ void CGUIDialogPVRTimerSettings::MarginTimeFiller(const SettingConstPtr& setting
       current = pThis->m_iMarginEnd;
 
     bool bInsertValue = true;
-    auto it = list.begin();
-    while (it != list.end())
+    auto it = list.cbegin();
+    while (it != list.cend())
     {
       if (it->value == current)
-      {
         bInsertValue = false;
-        break; // value already in list
-      }
 
-      if (it->value > current)
+      if (it->value >= current)
         break;
 
       ++it;
@@ -1383,9 +1376,8 @@ void CGUIDialogPVRTimerSettings::MarginTimeFiller(const SettingConstPtr& setting
     if (bInsertValue)
     {
       // PVR backend supplied value is not in the list of predefined values. Insert it.
-      list.emplace(it, IntegerSettingOption(
-                           StringUtils::Format(g_localizeStrings.Get(14044), current) /* {} min */,
-                           current));
+      list.emplace(it, StringUtils::Format(g_localizeStrings.Get(14044), current) /* {} min */,
+                   current);
     }
   }
   else
@@ -1398,7 +1390,7 @@ void CGUIDialogPVRTimerSettings::CustomIntSettingDefinitionsFiller(
     int& current,
     void* data)
 {
-  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
+  const auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (pThis)
   {
     list.clear();
@@ -1619,7 +1611,7 @@ bool CGUIDialogPVRTimerSettings::StartAnytimeSetCondition(const std::string& con
   if (!setting)
     return false;
 
-  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
+  const auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (!pThis)
   {
     CLog::LogF(LOGERROR, "No dialog");
@@ -1666,7 +1658,7 @@ bool CGUIDialogPVRTimerSettings::EndAnytimeSetCondition(const std::string& condi
   if (!setting)
     return false;
 
-  auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
+  const auto* pThis{static_cast<CGUIDialogPVRTimerSettings*>(data)};
   if (!pThis)
   {
     CLog::LogF(LOGERROR, "No dialog");

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
@@ -80,6 +80,8 @@ private:
   void InitializeChannelsList();
   void SetButtonLabels();
 
+  void FixupEndLocalTime();
+
   static int GetDateAsIndex(const CDateTime& datetime);
   static void SetDateFromIndex(CDateTime& datetime, int date);
   static void SetTimeFromSystemTime(CDateTime& datetime, const KODI::TIME::SystemTime& time);

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -544,7 +544,7 @@ void CPVREpg::RemovedFromContainer()
   m_events.Publish(PVREvent::EpgDeleted);
 }
 
-int CPVREpg::CleanupCachedImages(const std::shared_ptr<const CPVREpgDatabase>& database)
+int CPVREpg::CleanupCachedImages(const std::shared_ptr<const CPVREpgDatabase>& database) const
 {
   std::vector<std::string> urlsToCheck;
   database->GetAllIconPaths(EpgID(), urlsToCheck);

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -281,7 +281,7 @@ namespace PVR
      * @param database The EPG database
      * @return number of cleaned up images.
      */
-    int CleanupCachedImages(const std::shared_ptr<const CPVREpgDatabase>& database);
+    int CleanupCachedImages(const std::shared_ptr<const CPVREpgDatabase>& database) const;
 
   private:
     CPVREpg() = delete;

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -548,7 +548,7 @@ void CPVREpgContainer::InsertFromDB(const std::shared_ptr<CPVREpg>& newEpg)
   {
     // create a new epg table
     epg = newEpg;
-    m_epgIdToEpgMap.insert({epg->EpgID(), epg});
+    m_epgIdToEpgMap.try_emplace(epg->EpgID(), epg);
     epg->Events().Subscribe(this, &CPVREpgContainer::Notify);
   }
 }
@@ -572,14 +572,16 @@ std::shared_ptr<CPVREpg> CPVREpgContainer::CreateChannelEpg(int iEpgId, const st
                                     GetEpgDatabase());
 
     std::unique_lock lock(m_critSection);
-    m_epgIdToEpgMap.insert({iEpgId, epg});
-    m_channelUidToEpgMap.insert({{channelData->ClientId(), channelData->UniqueClientChannelId()}, epg});
+    m_epgIdToEpgMap.try_emplace(iEpgId, epg);
+    m_channelUidToEpgMap.try_emplace(
+        {channelData->ClientId(), channelData->UniqueClientChannelId()}, epg);
     epg->Events().Subscribe(this, &CPVREpgContainer::Notify);
   }
   else if (epg->ChannelID() == -1)
   {
     std::unique_lock lock(m_critSection);
-    m_channelUidToEpgMap.insert({{channelData->ClientId(), channelData->UniqueClientChannelId()}, epg});
+    m_channelUidToEpgMap.try_emplace(
+        {channelData->ClientId(), channelData->UniqueClientChannelId()}, epg);
     epg->SetChannelData(channelData);
   }
 

--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -443,9 +443,9 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::CreateEpgTag(dbiplus::Dataset& 
 {
   if (!ds.eof())
   {
-    std::shared_ptr<CPVREpgInfoTag> newTag(
-        new CPVREpgInfoTag(m_pDS->fv("idEpg").get_asInt(), m_pDS->fv("sIconPath").get_asString(),
-                           m_pDS->fv("sParentalRatingIcon").get_asString()));
+    std::shared_ptr<CPVREpgInfoTag> newTag{std::make_shared<CPVREpgInfoTag>(
+        m_pDS->fv("idEpg").get_asInt(), m_pDS->fv("sIconPath").get_asString(),
+        m_pDS->fv("sParentalRatingIcon").get_asString())};
 
     auto iStartTime{static_cast<time_t>(m_pDS->fv("iStartTime").get_asInt())};
     const CDateTime startTime(iStartTime);

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -410,7 +410,7 @@ int CPVREpgInfoTag::GenreSubType() const
   return m_iGenreSubType;
 }
 
-const std::vector<std::string> CPVREpgInfoTag::Genre() const
+std::vector<std::string> CPVREpgInfoTag::Genre() const
 {
   if (m_genre.empty())
   {

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -64,6 +64,16 @@ public:
                  bool bIsGapTag);
 
   /*!
+   * @brief Create a new EPG infotag.
+   * @param iEpgID The id of the EPG this tag belongs to.
+   * @param iconPath the path for the icon of the channel.
+   * @param parentalRatingIconPath the path for the parental rating icon of the channel.
+   */
+  CPVREpgInfoTag(int iEpgID,
+                 const std::string& iconPath,
+                 const std::string& parentalRatingIconPath);
+
+  /*!
    * @brief Set data for the channel linked to this EPG infotag.
    * @param data The channel data.
    */
@@ -298,7 +308,7 @@ public:
    * @brief Get the genre as human readable string.
    * @return The genre.
    */
-  const std::vector<std::string> Genre() const;
+  std::vector<std::string> Genre() const;
 
   /*!
    * @brief Get the first air date of this event.
@@ -494,10 +504,6 @@ public:
   static std::string DeTokenize(const std::vector<std::string>& tokens);
 
 private:
-  CPVREpgInfoTag(int iEpgID,
-                 const std::string& iconPath,
-                 const std::string& parentalRatingIconPath);
-
   CPVREpgInfoTag() = delete;
   CPVREpgInfoTag(const CPVREpgInfoTag& tag) = delete;
   CPVREpgInfoTag& operator=(const CPVREpgInfoTag& other) = delete;

--- a/xbmc/pvr/epg/EpgSearch.cpp
+++ b/xbmc/pvr/epg/EpgSearch.cpp
@@ -28,16 +28,11 @@ void CPVREpgSearch::Execute()
 
   // Tags can still contain false positives, for search criteria that cannot be handled via
   // database. So, run extended search filters on what we got from the database.
-  for (auto it = tags.cbegin(); it != tags.cend();)
-  {
-    it = tags.erase(std::remove_if(tags.begin(), tags.end(),
-                                   [this](const std::shared_ptr<const CPVREpgInfoTag>& entry)
-                                   { return !m_filter.FilterEntry(entry); }),
-                    tags.cend());
-  }
+  std::erase_if(tags, [this](const std::shared_ptr<const CPVREpgInfoTag>& entry)
+                { return !m_filter.FilterEntry(entry); });
 
   if (m_filter.ShouldRemoveDuplicates())
-    m_filter.RemoveDuplicates(tags);
+    CPVREpgSearchFilter::RemoveDuplicates(tags);
 
   m_filter.SetLastExecutedDateTime(CDateTime::GetUTCDateTime());
 

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -2140,7 +2140,7 @@ void CPVRGUIInfo::UpdateBackendCache()
   // an update has been requested
   if (m_iCurrentActiveClient == 0 && m_updateBackendCacheRequested)
   {
-    std::vector<SBackend> backendProperties;
+    std::vector<SBackendProperties> backendProperties;
     {
       CSingleExit exit(m_critSection);
       backendProperties = CServiceBroker::GetPVRManager().Clients()->GetBackendProperties();

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
@@ -196,7 +196,7 @@ private:
 
   CPVRSignalStatus m_qualityInfo; /*!< stream quality information */
   CPVRDescrambleInfo m_descrambleInfo; /*!< stream descramble information */
-  std::vector<SBackend> m_backendProperties;
+  std::vector<SBackendProperties> m_backendProperties;
 
   std::string m_channelNumberInput;
   bool m_previewAndPlayerShowInfo{false};


### PR DESCRIPTION
Next round of fixes for SonarQube findings, among them:

* Control flow statements "if", "for", "while", "switch" and "try" should not be nested too deeply cpp:S134
-> Refactor this code to not nest more than 3 if|for|do|while|switch
* "try_emplace" should be used with "std::map" and "std::unordered_map" cpp:S6030
* Mergeable "if" statements should be combined cpp:S1066
* Memory should not be managed manually cpp:S5025
* Function parameters should not be of type "std::unique_ptr<T> const &" cpp:S4998
* Pointer and reference parameters should be "const" if the corresponding object is not modified cpp:S995
* "std::span" should be used for a uniform sequence of elements contiguous in memory cpp:S6188
* Transparent function objects should be used with associative "std::string" containers cpp:S6045
* Assignment operators should return non-"const" reference to the assigned object cpp:S1236
* "std::string_view" should be used to pass a read-only string to a function cpp:S6009
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* "override" or "final" should be used instead of "virtual" cpp:S3471
* "std::move" should only be used where moving can happen cpp:S5415
* Structured binding should be used cpp:S6005
* Objects should not be created solely to be passed as arguments to functions that perform delegated object creation cpp:S6011
* Loops should not have more than one "break" or "goto" statement cpp:S924
* Return type of functions shouldn't be const qualified value cpp:S5951
* "static" members should be accessed statically cpp:S2209
* Elements in a container should be erased with "std::erase" or "std::erase_if" cpp:S6165

No functional changes intended.

Runtime-tested on macOS and Android, latest Kodi master

@neo1973 , @phunkyfish please review, commit-by-commit.