### PR TITLE
[Video][Bluray] Further improvements to episode matching heuristics.

### DIFF
--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -78,6 +78,18 @@ void CDiscDirectoryHelper::InitialisePlaylistSearch(
   }
 }
 
+bool CDiscDirectoryHelper::IsValidSingleEpisodePlaylist(
+    const PlaylistInfo& singleEpisodePlaylistInformation, unsigned int clip) const
+{
+  // See if potential single episode playlist contains too many clips
+  // If there are 3 clips then expect the middle clip to be the main episode clip
+  // If there are numEpisodes clips this could be another play all playlist
+  return singleEpisodePlaylistInformation.clips.size() < 3 ||
+         (singleEpisodePlaylistInformation.clips.size() == 3 &&
+          singleEpisodePlaylistInformation.clips[1] == clip) ||
+         singleEpisodePlaylistInformation.clips.size() == m_numEpisodes;
+}
+
 void CDiscDirectoryHelper::FindPlayAllPlaylists(const ClipMap& clips, const PlaylistMap& playlists)
 {
   // Look for a potential play all playlist (gives episode order)
@@ -164,11 +176,8 @@ void CDiscDirectoryHelper::FindPlayAllPlaylists(const ClipMap& clips, const Play
           const auto& singleEpisodePlaylistInformation{
               playlists.find(singleEpisodePlaylist)->second};
 
-          // See if potential single episode playlist contains too many clips
-          // If there are 3 clips then expect the middle clip to be the main episode clip
-          if (singleEpisodePlaylistInformation.clips.size() > 3 ||
-              (singleEpisodePlaylistInformation.clips.size() == 3 &&
-               singleEpisodePlaylistInformation.clips[1] != clip))
+          // Check the playlist could be a single episode
+          if (!IsValidSingleEpisodePlaylist(singleEpisodePlaylistInformation, clip))
           {
             allClipsQualify = false;
             break;
@@ -177,6 +186,9 @@ void CDiscDirectoryHelper::FindPlayAllPlaylists(const ClipMap& clips, const Play
         }
       }
       playAllPlaylistClipMap[clip] = playAllPlaylistMap;
+
+      if (!allClipsQualify)
+        break;
     }
 
     // Found potential play all playlist

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -24,6 +24,7 @@
 #include <numeric>
 #include <ranges>
 #include <set>
+#include <string>
 
 using namespace XFILE;
 using namespace std::chrono_literals;
@@ -227,36 +228,38 @@ void CDiscDirectoryHelper::FindGroups(const PlaylistMap& playlists)
                                                  .duration = playlistInformation.duration,
                                                  .clips = {},
                                                  .languages = {}};
-      if (!m_groups.empty() && m_groups.back().back() == playlist - 1)
-      {
-        m_groups.back().emplace_back(playlist);
-        m_allGroups.back().emplace_back(groupPlaylist);
-      }
+      if (!m_groups.empty() && m_groups.back().back().playlist == playlist - 1)
+        m_groups.back().emplace_back(groupPlaylist);
       else
-      {
-        // New group
-        m_groups.emplace_back(std::vector{playlist});
-        m_allGroups.emplace_back(std::vector{groupPlaylist});
-      }
+        m_groups.emplace_back(std::vector{groupPlaylist}); // New group
     }
+    m_allGroups = m_groups;
 
     // See if any groups have at least numEpisode playlists and there are exactly
     // numEpisode playlists remaining and no specials, in which case make a group.
     // Assumption has to be playlists match episodes in ascending order
-    if (std::erase_if(m_groups, [this](const std::vector<unsigned int>& group)
-                      { return group.size() < m_numEpisodes; }) == 0 &&
-        m_numSpecials == 0 && longPlaylists.size() == m_numEpisodes)
+    std::erase_if(m_groups, [this](const std::vector<CandidatePlaylistInformation>& group)
+                  { return group.size() < m_numEpisodes; });
+    if (m_groups.empty() && m_numSpecials == 0 && longPlaylists.size() == m_numEpisodes)
     {
-      m_groups.clear();
-      const auto keys{std::views::keys(longPlaylists)};
-      m_groups.emplace_back(keys.begin(), keys.end());
+      std::ranges::transform(
+          longPlaylists, std::back_inserter(m_groups),
+          [](const auto& PlaylistInformation) -> std::vector<CandidatePlaylistInformation>
+          {
+            const auto& [playlist, playlistInformation] = PlaylistInformation;
+            return {{.playlist = playlist,
+                     .duration = playlistInformation.duration,
+                     .clips = {},
+                     .languages = {}}};
+          });
     }
 
     if (m_groups.empty())
       CLog::LogF(LOGDEBUG, "No playlist groups found");
     else
       for (const auto& group : m_groups)
-        CLog::LogF(LOGDEBUG, "Playlist group found from {} to {}", group.front(), group.back());
+        CLog::LogF(LOGDEBUG, "Playlist group found from {} to {}", group.front().playlist,
+                   group.back().playlist);
   }
   else
   {
@@ -310,13 +313,11 @@ void CDiscDirectoryHelper::UsePlayAllPlaylistMethod(unsigned int episodeIndex,
 
         m_candidatePlaylists.emplace(
             singleEpisodePlaylist,
-            CandidatePlaylistInformation{
-                .playlist = singleEpisodePlaylist,
-                .index = i + m_numSpecials,
-                .duration = singleEpisodePlaylistInformation.duration,
-                .clips = singleEpisodePlaylistInformation.clips,
-                .languages = singleEpisodePlaylistInformation
-                                 .languages}); // Also save episodeIndex for all episodes
+            CandidatePlaylistInformation{.playlist = singleEpisodePlaylist,
+                                         .index = i + m_numSpecials,
+                                         .duration = singleEpisodePlaylistInformation.duration,
+                                         .clips = singleEpisodePlaylistInformation.clips,
+                                         .languages = singleEpisodePlaylistInformation.languages});
       }
     }
     ++i;
@@ -385,36 +386,81 @@ void CDiscDirectoryHelper::UseLongOrCommonMethodForSingleEpisode(unsigned int ep
   }
 }
 
-void CDiscDirectoryHelper::UseGroupMethod(unsigned int episodeIndex, const PlaylistMap& playlists)
+std::vector<std::vector<CDiscDirectoryHelper::CandidatePlaylistInformation>> CDiscDirectoryHelper::
+    GetGroupsWithoutDuplicates(const std::vector<std::vector<CandidatePlaylistInformation>>& groups)
+{
+  std::vector<std::vector<CandidatePlaylistInformation>> uniqueGroups;
+  for (const auto& playlistGroup : groups)
+  {
+    std::set<int64_t> seenDurations;
+    std::ranges::copy_if(playlistGroup, std::back_inserter(uniqueGroups.emplace_back()),
+                         CandidatePlaylistInformationNotDuplicate(seenDurations));
+  }
+  return uniqueGroups;
+}
+
+void CDiscDirectoryHelper::GetPlaylistsFromGroup(
+    unsigned int episodeIndex, const std::vector<CandidatePlaylistInformation>& group)
+{
+  for (unsigned int i = 0; i < m_numEpisodes; ++i)
+  {
+    if (m_allEpisodes != AllEpisodes::ALL &&
+        i != episodeIndex - m_numSpecials) // Specials before episodes in episodesOnDisc
+      continue;
+
+    m_candidatePlaylists.emplace(group[i].playlist,
+                                 CandidatePlaylistInformation{.playlist = group[i].playlist,
+                                                              .index = i + m_numSpecials,
+                                                              .duration = group[i].duration,
+                                                              .clips = group[i].clips,
+                                                              .languages = group[i].languages});
+    CLog::LogF(LOGDEBUG, "Candidate playlist {}", group[i].playlist);
+  }
+}
+
+void CDiscDirectoryHelper::UseGroupMethod(unsigned int episodeIndex,
+                                          const std::vector<CVideoInfoTag>& episodesOnDisc)
 {
   // Method 2a - More than one episode on disc
 
   // Use groups and find nth playlist (or all for all episodes) in group
   // Groups are already contain at least numEpisodes playlists of minimum duration
-  for (const auto& group : m_groups)
+  // Firstly look just at groups that contain exactly numEpisodes playlists
+  CLog::LogF(LOGDEBUG, "Using group method - exact number of playlists");
+  const std::vector groups{GetGroupsWithoutDuplicates(m_groups)};
+  for (const auto& group : groups)
   {
     if (group.size() != m_numEpisodes)
       continue;
 
-    for (unsigned int i = 0; i < m_numEpisodes; ++i)
+    GetPlaylistsFromGroup(episodeIndex, group);
+  }
+
+  if (m_candidatePlaylists.empty())
+  {
+    // Now look for groups that contain more than numEpisodes playlists
+    // Check that the first numEpisodes playlists have a duration within 20% of the desired episode
+    CLog::LogF(LOGDEBUG, "Using group method - relaxed number of playlists");
+    const std::chrono::milliseconds duration{episodesOnDisc[episodeIndex].GetDuration() * 1000ms};
+    for (const auto& group : groups)
     {
-      if (m_allEpisodes != AllEpisodes::ALL &&
-          i != episodeIndex - m_numSpecials) // Specials before episodes in episodesOnDisc
+      if (group.size() <= m_numEpisodes)
         continue;
 
-      const auto& playlistInformation{playlists.at(group[i])};
-      m_candidatePlaylists.emplace(
-          group[i],
-          CandidatePlaylistInformation{
-              .playlist = group[i],
-              .index = i + m_numSpecials,
-              .duration = playlistInformation.duration,
-              .clips = playlistInformation.clips,
-              .languages =
-                  playlistInformation.languages}); // Also save episodeIndex for all episodes
-      CLog::LogF(LOGDEBUG, "Candidate playlist {}", group[i]);
+      // Check duration
+      constexpr double WITHIN_PERCENT{20.0};
+      if (!std::ranges::all_of(group | std::views::take(m_numEpisodes) |
+                                   std::views::transform(&CandidatePlaylistInformation::duration),
+                               [duration](std::chrono::milliseconds d)
+                               { return abs(d - duration) < (WITHIN_PERCENT / 100.0 * duration); }))
+        continue;
+
+      GetPlaylistsFromGroup(episodeIndex, group);
     }
   }
+
+  if (m_candidatePlaylists.empty())
+    CLog::LogF(LOGDEBUG, "No candidate playlists found");
 }
 
 int CDiscDirectoryHelper::CalculateMultiple(std::chrono::milliseconds duration,
@@ -435,7 +481,7 @@ void CDiscDirectoryHelper::UseGroupsWithMultiplesMethod(
   // No groups of numEpisodes length so see if there could be double episode playlists
   // Assume more than one playlist
   CLog::LogF(LOGDEBUG, "Using groups with multiples method");
-  for (auto& group : m_allGroups)
+  for (auto& group : GetGroupsWithoutDuplicates(m_allGroups))
   {
     // Calculate multiples
     // Find shortest playlist in group
@@ -494,7 +540,7 @@ void CDiscDirectoryHelper::UseGroupsWithMultiplesMethod(
 }
 
 void CDiscDirectoryHelper::ChooseSingleBestPlaylist(
-    const std::vector<CVideoInfoTag>& episodesOnDisc, const PlaylistMap& playlists)
+    const std::vector<CVideoInfoTag>& episodesOnDisc)
 {
   // Rebuild candidatePlaylists
   auto oldCandidatePlaylists{std::move(m_candidatePlaylists)};
@@ -586,7 +632,7 @@ void CDiscDirectoryHelper::FindCandidatePlaylists(const std::vector<CVideoInfoTa
   else if (m_numEpisodes == 1)
     UseLongOrCommonMethodForSingleEpisode(episodeIndex, playlists);
   else if (!m_groups.empty())
-    UseGroupMethod(episodeIndex, playlists);
+    UseGroupMethod(episodeIndex, episodesOnDisc);
 
   if (m_candidatePlaylists.empty() && !m_allGroups.empty() && m_numEpisodes > 1)
     UseGroupsWithMultiplesMethod(episodeIndex, episodesOnDisc);
@@ -595,7 +641,7 @@ void CDiscDirectoryHelper::FindCandidatePlaylists(const std::vector<CVideoInfoTa
   // For this, see which is closest in duration to the desired episode duration (from the scraper)
   // If we are looking for a special then leave all potential episode playlists in array
   if (m_candidatePlaylists.size() > 1 && m_isSpecial == IsSpecial::EPISODE)
-    ChooseSingleBestPlaylist(episodesOnDisc, playlists);
+    ChooseSingleBestPlaylist(episodesOnDisc);
 
   // candidatePlaylists should now (ideally) contain one candidate title for the episode or all episodes
   // Now look at durations of found playlist and add identical (in case language options)

--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -199,6 +199,8 @@ public:
 
 private:
   void InitialisePlaylistSearch(int episodeIndex, const std::vector<CVideoInfoTag>& episodesOnDisc);
+  bool IsValidSingleEpisodePlaylist(const PlaylistInfo& singleEpisodePlaylistInformation,
+                                    unsigned int clip) const;
   void FindPlayAllPlaylists(const ClipMap& clips, const PlaylistMap& playlists);
   void FindGroups(const PlaylistMap& playlists);
   void UsePlayAllPlaylistMethod(unsigned int episodeIndex, const PlaylistMap& playlists);

--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -190,6 +190,11 @@ private:
   void UseLongOrCommonMethodForSingleEpisode(unsigned int episodeIndex,
                                              const PlaylistMap& playlists);
   void UseGroupMethod(unsigned int episodeIndex, const PlaylistMap& playlists);
+  static int CalculateMultiple(std::chrono::milliseconds duration,
+                               std::chrono::milliseconds averageShortest,
+                               double multiplePercent);
+  void UseGroupsWithMultiplesMethod(unsigned int episodeIndex,
+                                    const std::vector<CVideoInfoTag>& episodesOnDisc);
   void ChooseSingleBestPlaylist(const std::vector<CVideoInfoTag>& episodesOnDisc,
                                 const PlaylistMap& playlists);
   void AddIdenticalPlaylists(const PlaylistMap& playlists);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Handles several corner cases:
- The Expanse R1 S1D2 - multiple episodes in a single playlist
- Rome R2 S1D1 - group of playlists larger than number of episodes (includes extras)
- Hawkeye R2 S1D1- group of playlists contains multiple identical episode playlists
- Vikings R2 S1D1 - two play all playlists

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Improved episode matching.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
