### PR TITLE
[PVR] Fix CPVREpgSearchFilter::RemoveDuplicates.

### DIFF
--- a/xbmc/pvr/epg/EpgSearchFilter.cpp
+++ b/xbmc/pvr/epg/EpgSearchFilter.cpp
@@ -362,16 +362,20 @@ bool CPVREpgSearchFilter::FilterEntry(const std::shared_ptr<const CPVREpgInfoTag
 
 void CPVREpgSearchFilter::RemoveDuplicates(std::vector<std::shared_ptr<CPVREpgInfoTag>>& results)
 {
-  for (auto it = results.begin(); it != results.end();)
+  for (auto it = results.begin(); it != results.end(); ++it)
   {
-    it = results.erase(std::remove_if(results.begin(), results.end(),
-                                      [&it](const std::shared_ptr<const CPVREpgInfoTag>& entry)
-                                      {
-                                        return *it != entry && (*it)->Title() == entry->Title() &&
-                                               (*it)->Plot() == entry->Plot() &&
-                                               (*it)->PlotOutline() == entry->PlotOutline();
-                                      }),
-                       results.end());
+    auto next{std::next(it)};
+    if (next != results.end())
+    {
+      results.erase(std::remove_if(next, results.end(),
+                                   [&it](const std::shared_ptr<const CPVREpgInfoTag>& entry)
+                                   {
+                                     return (*it)->Title() == entry->Title() &&
+                                            (*it)->Plot() == entry->Plot() &&
+                                            (*it)->PlotOutline() == entry->PlotOutline();
+                                   }),
+                    results.end());
+    }
   }
 }
 


### PR DESCRIPTION
Some thing I found while I was checking SonarQube findings. `CPVREpgSearchFilter::RemoveDuplicates` implementation was just plain wrong. 

This PR fixes the implementation of the de-duplication to actually work as intended. To iterate the whole search results vector, removing all duplicates of the result pointed to by current iterator (`it`), beginning to check with successor of current iterator (`next`) until end of vector.

Runtime-tested on macOS, latest Kodu master.

@phunkyfish could you please have a look.