### PR TITLE
[PVR] SonarQube findings, round 3

### DIFF
--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -637,13 +637,13 @@ bool CPVRGUIDirectory::GetSavedSearchesDirectory(bool bRadio, CFileItemList& res
 
 bool CPVRGUIDirectory::GetSavedSearchResults(bool isRadio, int id, CFileItemList& results) const
 {
-  auto& epgContainer{CServiceBroker::GetPVRManager().EpgContainer()};
+  const auto& epgContainer{CServiceBroker::GetPVRManager().EpgContainer()};
   const std::shared_ptr<CPVREpgSearchFilter> filter{epgContainer.GetSavedSearchById(isRadio, id)};
   if (filter)
   {
     CPVREpgSearch search(*filter);
     search.Execute();
-    const auto tags{search.GetResults()};
+    const auto& tags{search.GetResults()};
     for (const auto& tag : tags)
     {
       results.Add(std::make_shared<CFileItem>(tag));
@@ -845,7 +845,7 @@ bool CPVRGUIDirectory::GetChannelsDirectory(CFileItemList& results) const
           }
         }
 
-        const auto item{std::make_shared<CFileItem>(groupMember)};
+        auto item{std::make_shared<CFileItem>(groupMember)};
         if (dateAdded)
           item->SetProperty("hideable", true);
 

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -1361,7 +1361,7 @@ bool CGUIEPGGridContainer::OnClick(int actionID) const
   if (actionID == ACTION_SELECT_ITEM || actionID == ACTION_MOUSE_LEFT_CLICK)
   {
     // grab the currently focused subitem (if applicable)
-    CGUIListItemLayout* focusedLayout = GetFocusedLayout();
+    const CGUIListItemLayout* focusedLayout = GetFocusedLayout();
 
     if (focusedLayout)
       subItem = focusedLayout->GetFocusedItem();
@@ -2104,7 +2104,8 @@ void CGUIEPGGridContainer::HandleChannels(bool bRender,
 
   const int chanOffset{GetChannelScrollOffset(*m_programmeLayout)};
 
-  int cacheBeforeChannel, cacheAfterChannel;
+  int cacheBeforeChannel{0};
+  int cacheAfterChannel{0};
   GetChannelCacheOffsets(cacheBeforeChannel, cacheAfterChannel);
 
   if (bRender)

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -1829,7 +1829,7 @@ void CGUIEPGGridContainer::GoToMostRight()
   }
 }
 
-void CGUIEPGGridContainer::SetTimelineItems(const std::unique_ptr<CFileItemList>& items,
+void CGUIEPGGridContainer::SetTimelineItems(const CFileItemList& items,
                                             const CDateTime& gridStart,
                                             const CDateTime& gridEnd)
 {

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.h
@@ -116,7 +116,7 @@ public:
   void GoToMostLeft();
   void GoToMostRight();
 
-  void SetTimelineItems(const std::unique_ptr<CFileItemList>& items,
+  void SetTimelineItems(const CFileItemList& items,
                         const CDateTime& gridStart,
                         const CDateTime& gridEnd);
 

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.h
@@ -201,30 +201,9 @@ private:
   void RenderProgrammeGrid();
   void RenderProgressIndicator();
 
-  CPoint m_renderOffset; ///< \brief render offset of the first item in the list \sa SetRenderOffset
-
-  ORIENTATION m_orientation;
-
-  std::vector<CGUIListItemLayout> m_channelLayouts;
-  std::vector<CGUIListItemLayout> m_focusedChannelLayouts;
-  std::vector<CGUIListItemLayout> m_focusedProgrammeLayouts;
-  std::vector<CGUIListItemLayout> m_programmeLayouts;
-  std::vector<CGUIListItemLayout> m_rulerLayouts;
-  std::vector<CGUIListItemLayout> m_rulerDateLayouts;
-
-  CGUIListItemLayout* m_channelLayout = nullptr;
-  CGUIListItemLayout* m_focusedChannelLayout = nullptr;
-  CGUIListItemLayout* m_programmeLayout = nullptr;
-  CGUIListItemLayout* m_focusedProgrammeLayout = nullptr;
-  CGUIListItemLayout* m_rulerLayout = nullptr;
-  CGUIListItemLayout* m_rulerDateLayout = nullptr;
-
-  int m_pageControl = 0;
-
   void GetChannelCacheOffsets(int& cacheBefore, int& cacheAfter) const;
   void GetProgrammeCacheOffsets(int& cacheBefore, int& cacheAfter) const;
 
-private:
   bool OnMouseClick(int dwButton, const CPoint& point);
   bool OnMouseDoubleClick(int dwButton, const CPoint& point);
   bool OnMouseWheel(char wheel);
@@ -259,20 +238,40 @@ private:
 
   int GetBlockScrollOffset() const;
 
+  CPoint m_renderOffset; ///< \brief render offset of the first item in the list \sa SetRenderOffset
+
+  ORIENTATION m_orientation{VERTICAL};
+
+  std::vector<CGUIListItemLayout> m_channelLayouts;
+  std::vector<CGUIListItemLayout> m_focusedChannelLayouts;
+  std::vector<CGUIListItemLayout> m_focusedProgrammeLayouts;
+  std::vector<CGUIListItemLayout> m_programmeLayouts;
+  std::vector<CGUIListItemLayout> m_rulerLayouts;
+  std::vector<CGUIListItemLayout> m_rulerDateLayouts;
+
+  CGUIListItemLayout* m_channelLayout{nullptr};
+  CGUIListItemLayout* m_focusedChannelLayout{nullptr};
+  CGUIListItemLayout* m_programmeLayout{nullptr};
+  CGUIListItemLayout* m_focusedProgrammeLayout{nullptr};
+  CGUIListItemLayout* m_rulerLayout{nullptr};
+  CGUIListItemLayout* m_rulerDateLayout{nullptr};
+
+  int m_pageControl{0};
+
   const int m_blocksPerRulerItem{0}; //! number of blocks that make up one element of the ruler
   const int m_blocksPerPage{0};
   const unsigned int m_minutesPerBlock{DEFAULT_MINUTES_PER_BLOCK};
 
-  int m_channelsPerPage = 0;
-  int m_programmesPerPage = 0;
-  int m_channelCursor = 0;
-  int m_channelOffset = 0;
-  int m_blockCursor = 0;
-  int m_blockOffset = 0;
-  int m_blockTravelAxis = 0;
-  int m_cacheChannelItems;
-  int m_cacheProgrammeItems;
-  int m_cacheRulerItems;
+  int m_channelsPerPage{0};
+  int m_programmesPerPage{0};
+  int m_channelCursor{0};
+  int m_channelOffset{0};
+  int m_blockCursor{0};
+  int m_blockOffset{0};
+  int m_blockTravelAxis{0};
+  int m_cacheChannelItems{0};
+  int m_cacheProgrammeItems{0};
+  int m_cacheRulerItems{0};
 
   float m_rulerDateHeight{0.0f}; //! height of ruler date item
   float m_rulerDateWidth{0.0f}; //! width of ruler date item
@@ -297,10 +296,10 @@ private:
   std::shared_ptr<CFileItem> m_lastItem;
   std::shared_ptr<CFileItem> m_lastChannel;
 
-  bool m_bEnableProgrammeScrolling = true;
-  bool m_bEnableChannelScrolling = true;
+  bool m_bEnableProgrammeScrolling{true};
+  bool m_bEnableChannelScrolling{true};
 
-  int m_scrollTime;
+  int m_scrollTime{0};
 
   unsigned int m_programmeScrollLastTime{0};
   float m_programmeScrollSpeed{0.0f};
@@ -314,6 +313,6 @@ private:
   std::unique_ptr<CGUIEPGGridContainerModel> m_gridModel;
   std::unique_ptr<CGUIEPGGridContainerModel> m_updatedGridModel;
 
-  int m_itemStartBlock = 0;
+  int m_itemStartBlock{0};
 };
 } // namespace PVR

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
@@ -165,7 +165,7 @@ std::shared_ptr<CFileItem> CGUIEPGGridContainerModel::CreateEpgTags(int iChannel
   if (firstResultBlock > lastResultBlock)
     return result;
 
-  auto it = m_epgItems.insert({iChannel, EpgTags()}).first;
+  auto it = m_epgItems.try_emplace(iChannel, EpgTags()).first;
   EpgTags& epgTags = (*it).second;
 
   epgTags.firstBlock = firstResultBlock;
@@ -420,7 +420,9 @@ GridItem* CGUIEPGGridContainerModel::GetGridItemPtr(int iChannel, int iBlock) co
     item->SetProperty("GenreType", epgTag->GenreType());
 
     const float fItemWidth = (endBlock - startBlock + 1) * m_fBlockSize;
-    it = m_gridIndex.insert({{iChannel, iBlock}, {item, fItemWidth, startBlock, endBlock}}).first;
+    it = m_gridIndex
+             .try_emplace({iChannel, iBlock}, GridItem{item, fItemWidth, startBlock, endBlock})
+             .first;
   }
 
   return &(*it).second;

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
@@ -69,7 +69,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CGUIEPGGridContainerModel::GetEPGTi
                                                                           min, max);
 }
 
-void CGUIEPGGridContainerModel::Initialize(const std::unique_ptr<CFileItemList>& items,
+void CGUIEPGGridContainerModel::Initialize(const CFileItemList& items,
                                            const CDateTime& gridStart,
                                            const CDateTime& gridEnd,
                                            int iFirstChannel,
@@ -89,7 +89,7 @@ void CGUIEPGGridContainerModel::Initialize(const std::unique_ptr<CFileItemList>&
 
   ////////////////////////////////////////////////////////////////////////
   // Create channel items
-  std::ranges::copy(*items, std::back_inserter(m_channelItems));
+  std::ranges::copy(items, std::back_inserter(m_channelItems));
 
   /* check for invalid start and end time */
   if (gridStart >= gridEnd)

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
@@ -49,7 +49,7 @@ public:
   explicit CGUIEPGGridContainerModel(unsigned int minutesPerBlock);
   virtual ~CGUIEPGGridContainerModel() = default;
 
-  void Initialize(const std::unique_ptr<CFileItemList>& items,
+  void Initialize(const CFileItemList& items,
                   const CDateTime& gridStart,
                   const CDateTime& gridEnd,
                   int iFirstChannel,

--- a/xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
@@ -235,7 +235,7 @@ bool CPVRGUIActionsDatabase::ResetDatabase(bool bResetEPGOnly) const
   CServiceBroker::GetPVRManager().Stop();
 
   const int iProgressStepPercentage =
-      100 / ((2 * bResetChannels) + (bResetGroups ? 1 : 0) + (bResetGuide ? 1 : 0) +
+      100 / ((bResetChannels ? 2 : 0) + (bResetGroups ? 1 : 0) + (bResetGuide ? 1 : 0) +
              (bResetProviders ? 1 : 0) + (bResetReminders ? 1 : 0) + (bResetRecordings ? 1 : 0) +
              (bResetClients ? 1 : 0) + 1);
   int iProgressStepsDone = 0;

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
@@ -278,11 +278,8 @@ bool CPVRGUIActionsTimers::AddTimer(const CFileItem& item,
     }
   }
 
-  if (bShowTimerSettings)
-  {
-    if (!ShowTimerSettings(newTimer))
-      return false;
-  }
+  if (bShowTimerSettings && !ShowTimerSettings(newTimer))
+    return false;
 
   return AddTimer(newTimer);
 }
@@ -436,7 +433,7 @@ PVRRECORD_INSTANTRECORDACTION InstantRecordingActionSelector::Select()
 
 } // unnamed namespace
 
-bool CPVRGUIActionsTimers::ToggleRecordingOnPlayingChannel()
+bool CPVRGUIActionsTimers::ToggleRecordingOnPlayingChannel() const
 {
   const std::shared_ptr<CPVRChannel> channel =
       CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.h
@@ -130,7 +130,7 @@ public:
    * @brief Toggle recording on the currently playing channel, if any.
    * @return True if the recording was started or stopped successfully, false otherwise.
    */
-  bool ToggleRecordingOnPlayingChannel();
+  bool ToggleRecordingOnPlayingChannel() const;
 
   /*!
    * @brief Start or stop recording on a given channel.

--- a/xbmc/pvr/guilib/PVRGUIChannelIconUpdater.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelIconUpdater.cpp
@@ -48,13 +48,14 @@ void CPVRGUIChannelIconUpdater::SearchAndUpdateMissingChannelIcons() const
   CLog::Log(LOGINFO, "Starting PVR channel icon search");
 
   // create a map for fast lookup of normalized file base name
-  std::map<std::string, std::string> fileItemMap;
+  using FileNamesMap = std::map<std::string, std::string, std::less<>>;
+  FileNamesMap fileItemMap;
   for (const auto& item : fileItemList)
   {
     std::string baseName = URIUtils::GetFileName(item->GetPath());
     URIUtils::RemoveExtension(baseName);
     StringUtils::ToLower(baseName);
-    fileItemMap.insert({baseName, item->GetPath()});
+    fileItemMap.try_emplace(std::move(baseName), item->GetPath());
   }
 
   std::unique_ptr<CPVRGUIProgressHandler> progressHandler;
@@ -87,7 +88,7 @@ void CPVRGUIChannelIconUpdater::SearchAndUpdateMissingChannelIcons() const
       std::string strLegalChannelName = CUtil::MakeLegalFileName(channel->ChannelName());
       StringUtils::ToLower(strLegalChannelName);
 
-      std::map<std::string, std::string>::iterator itItem;
+      FileNamesMap::iterator itItem;
       if ((itItem = fileItemMap.find(strLegalClientChannelName)) != fileItemMap.end() ||
           (itItem = fileItemMap.find(strLegalChannelName)) != fileItemMap.end() ||
           (itItem = fileItemMap.find(strChannelUid)) != fileItemMap.end())

--- a/xbmc/pvr/providers/PVRProvider.cpp
+++ b/xbmc/pvr/providers/PVRProvider.cpp
@@ -136,7 +136,7 @@ std::string CPVRProvider::GetName() const
   return m_strName;
 }
 
-bool CPVRProvider::SetName(const std::string& strName)
+bool CPVRProvider::SetName(std::string_view strName)
 {
   std::unique_lock lock(m_critSection);
   if (m_strName != strName)
@@ -231,7 +231,7 @@ std::string CPVRProvider::GetCountriesDBString() const
   return m_strCountries;
 }
 
-bool CPVRProvider::SetCountriesFromDBString(const std::string& strCountries)
+bool CPVRProvider::SetCountriesFromDBString(std::string_view strCountries)
 {
   std::unique_lock lock(m_critSection);
   if (m_strCountries != strCountries)
@@ -268,7 +268,7 @@ std::string CPVRProvider::GetLanguagesDBString() const
   return m_strLanguages;
 }
 
-bool CPVRProvider::SetLanguagesFromDBString(const std::string& strLanguages)
+bool CPVRProvider::SetLanguagesFromDBString(std::string_view strLanguages)
 {
   std::unique_lock lock(m_critSection);
   if (m_strLanguages != strLanguages)

--- a/xbmc/pvr/providers/PVRProvider.h
+++ b/xbmc/pvr/providers/PVRProvider.h
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace PVR
@@ -91,7 +92,7 @@ public:
    * @param name The new name of the provider.
    * @return True if the something changed, false otherwise.
    */
-  bool SetName(const std::string& iName);
+  bool SetName(std::string_view iName);
 
   /*!
    * @brief Checks whether this provider has a known type
@@ -154,7 +155,7 @@ public:
    * @param strCountries The new ISO 3166 country codes for this provider.
    * @return true if the country codes were updated successfully
    */
-  bool SetCountriesFromDBString(const std::string& strCountries);
+  bool SetCountriesFromDBString(std::string_view strCountries);
 
   /*!
    * @brief Get this provider's language codes (RFC 5646).
@@ -180,7 +181,7 @@ public:
    * @param strLanguages The new RFC 5646 language codes for this provider.
    * @return true if the language codes were updated successfully
    */
-  bool SetLanguagesFromDBString(const std::string& strLanguages);
+  bool SetLanguagesFromDBString(std::string_view strLanguages);
 
   /*!
    * @brief Get if this provider has a thumb image path.

--- a/xbmc/pvr/providers/PVRProviders.cpp
+++ b/xbmc/pvr/providers/PVRProviders.cpp
@@ -371,13 +371,12 @@ void CPVRProviders::RemoveEntry(const std::shared_ptr<CPVRProvider>& provider)
 {
   std::unique_lock lock(m_critSection);
 
-  m_providers.erase(
-      std::remove_if(m_providers.begin(), m_providers.end(),
-                     [&provider](const std::shared_ptr<const CPVRProvider>& providerToRemove) {
-                       return provider->GetClientId() == providerToRemove->GetClientId() &&
-                              provider->GetUniqueId() == providerToRemove->GetUniqueId();
-                     }),
-      m_providers.end());
+  std::erase_if(m_providers,
+                [&provider](const std::shared_ptr<const CPVRProvider>& providerToRemove)
+                {
+                  return provider->GetClientId() == providerToRemove->GetClientId() &&
+                         provider->GetUniqueId() == providerToRemove->GetUniqueId();
+                });
 }
 
 int CPVRProviders::CleanupCachedImages()

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -38,33 +38,6 @@ using namespace PVR;
 
 using namespace std::chrono_literals;
 
-CPVRRecordingUid::CPVRRecordingUid(int iClientId, const std::string& strRecordingId)
-  : m_iClientId(iClientId), m_strRecordingId(strRecordingId)
-{
-}
-
-bool CPVRRecordingUid::operator>(const CPVRRecordingUid& right) const
-{
-  return (m_iClientId == right.m_iClientId) ? m_strRecordingId > right.m_strRecordingId
-                                            : m_iClientId > right.m_iClientId;
-}
-
-bool CPVRRecordingUid::operator<(const CPVRRecordingUid& right) const
-{
-  return (m_iClientId == right.m_iClientId) ? m_strRecordingId < right.m_strRecordingId
-                                            : m_iClientId < right.m_iClientId;
-}
-
-bool CPVRRecordingUid::operator==(const CPVRRecordingUid& right) const
-{
-  return m_iClientId == right.m_iClientId && m_strRecordingId == right.m_strRecordingId;
-}
-
-bool CPVRRecordingUid::operator!=(const CPVRRecordingUid& right) const
-{
-  return m_iClientId != right.m_iClientId || m_strRecordingId != right.m_strRecordingId;
-}
-
 const std::string CPVRRecording::IMAGE_OWNER_PATTERN = "pvrrecording";
 
 CPVRRecording::CPVRRecording()

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -44,15 +44,16 @@ class CPVRTimerInfoTag;
 class CPVRRecordingUid final
 {
 public:
-  int m_iClientId; /*!< ID of the backend */
+  CPVRRecordingUid(int iClientId, const std::string& strRecordingId)
+    : m_iClientId(iClientId), m_strRecordingId(strRecordingId)
+  {
+  }
+
+  auto operator<=>(const CPVRRecordingUid& other) const = default;
+
+private:
+  int m_iClientId{0}; /*!< ID of the backend */
   std::string m_strRecordingId; /*!< unique ID of the recording on the client */
-
-  CPVRRecordingUid(int iClientId, const std::string& strRecordingId);
-
-  bool operator>(const CPVRRecordingUid& right) const;
-  bool operator<(const CPVRRecordingUid& right) const;
-  bool operator==(const CPVRRecordingUid& right) const;
-  bool operator!=(const CPVRRecordingUid& right) const;
 };
 
 class CPVRRecording final : public CVideoInfoTag

--- a/xbmc/pvr/recordings/PVRRecordingsPath.cpp
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.cpp
@@ -188,10 +188,10 @@ std::string CPVRRecordingsPath::GetTitle() const
     CRegExp reg(true);
     if (reg.RegComp("pvr://recordings/(.*/)*(.*), TV( \\(.*\\))?, "
                     "(19[0-9][0-9]|20[0-9][0-9])[0-9][0-9][0-9][0-9]_[0-9][0-9][0-9][0-9][0-9][0-9]"
-                    ", (.*).pvr"))
+                    ", (.*).pvr") &&
+        reg.RegFind(m_path.c_str()) >= 0)
     {
-      if (reg.RegFind(m_path.c_str()) >= 0)
-        return reg.GetMatch(2);
+      return reg.GetMatch(2);
     }
   }
   return "";

--- a/xbmc/pvr/settings/CMakeLists.txt
+++ b/xbmc/pvr/settings/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES PVRCustomTimerSettings.cpp
             PVRTimerSettingDefinition.cpp)
 
 set(HEADERS IPVRSettingsContainer.h
+            PVRCustomProperty.h
             PVRCustomTimerSettings.h
             PVRIntSettingDefinition.h
             PVRIntSettingValues.h

--- a/xbmc/pvr/settings/PVRCustomProperty.h
+++ b/xbmc/pvr/settings/PVRCustomProperty.h
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h" // PVR_SETTING_TYPE
+#include "utils/Variant.h"
+
+#include <map>
+
+namespace PVR
+{
+/*!
+ * @brief custom property : type, value
+ */
+struct CustomProperty
+{
+  PVR_SETTING_TYPE type{PVR_SETTING_TYPE::INTEGER};
+  CVariant value{static_cast<int>(0)};
+
+  CustomProperty() = default;
+  CustomProperty(PVR_SETTING_TYPE t, const CVariant& v) : type(t), value(v) {}
+  bool operator==(const CustomProperty& right) const = default;
+};
+
+/*!
+ * @brief custom properties map: property id, details
+ */
+using CustomPropertiesMap = std::map<unsigned int, CustomProperty>;
+
+} // namespace PVR

--- a/xbmc/pvr/settings/PVRCustomTimerSettings.cpp
+++ b/xbmc/pvr/settings/PVRCustomTimerSettings.cpp
@@ -33,10 +33,10 @@ CPVRCustomTimerSettings::CPVRCustomTimerSettings(
   : m_customProps(customProps)
 {
   unsigned int idx{0};
-  for (const auto& [_, timerType] : typeEntries)
+  for (const auto& [_, type] : typeEntries)
   {
     const std::vector<std::shared_ptr<const CPVRTimerSettingDefinition>>& settingDefs{
-        timerType->GetCustomSettingDefinitions()};
+        type->GetCustomSettingDefinitions()};
     for (const auto& settingDef : settingDefs)
     {
       std::string settingIdPrefix;
@@ -74,9 +74,11 @@ void CPVRCustomTimerSettings::SetTimerType(const CPVRTimerType& timerType)
     {
       const auto it{m_customProps.find(def->GetId())};
       if (it == m_customProps.cend())
-        newCustomProps.insert({def->GetId(), {def->GetType(), def->GetDefaultValue()}});
+        newCustomProps.try_emplace(def->GetId(),
+                                   CustomProperty(def->GetType(), def->GetDefaultValue()));
       else
-        newCustomProps.insert({def->GetId(), {(*it).second.type, (*it).second.value}});
+        newCustomProps.try_emplace(def->GetId(),
+                                   CustomProperty((*it).second.type, (*it).second.value));
     }
   }
   m_customProps = newCustomProps;

--- a/xbmc/pvr/settings/PVRCustomTimerSettings.cpp
+++ b/xbmc/pvr/settings/PVRCustomTimerSettings.cpp
@@ -28,7 +28,7 @@ static constexpr const char* SETTING_TMR_CUSTOM_STRING{"customsetting.string"};
 
 CPVRCustomTimerSettings::CPVRCustomTimerSettings(
     const CPVRTimerType& timerType,
-    const CPVRTimerInfoTag::CustomPropsMap& customProps,
+    const CustomPropertiesMap& customProps,
     const std::map<int, std::shared_ptr<CPVRTimerType>>& typeEntries)
   : m_customProps(customProps)
 {
@@ -65,7 +65,7 @@ CPVRCustomTimerSettings::CPVRCustomTimerSettings(
 
 void CPVRCustomTimerSettings::SetTimerType(const CPVRTimerType& timerType)
 {
-  CPVRTimerInfoTag::CustomPropsMap newCustomProps;
+  CustomPropertiesMap newCustomProps;
   for (const auto& [_, def] : m_customSettingDefs)
   {
     // Complete custom props for given type.
@@ -138,6 +138,7 @@ bool CPVRCustomTimerSettings::UpdateIntProperty(const std::shared_ptr<const CSet
     return false;
   }
 
+  // Get/create the prop.
   CVariant& prop{m_customProps[def->GetId()].value};
   prop = std::static_pointer_cast<const CSettingInt>(setting)->GetValue();
   return true;
@@ -152,6 +153,7 @@ bool CPVRCustomTimerSettings::UpdateStringProperty(const std::shared_ptr<const C
     return false;
   }
 
+  // Get/create the prop.
   CVariant& prop{m_customProps[def->GetId()].value};
   prop = std::static_pointer_cast<const CSettingString>(setting)->GetValue();
   return true;

--- a/xbmc/pvr/settings/PVRCustomTimerSettings.h
+++ b/xbmc/pvr/settings/PVRCustomTimerSettings.h
@@ -9,8 +9,9 @@
 #pragma once
 
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_timers.h" // PVR_TIMER_STATE
-#include "pvr/timers/PVRTimerInfoTag.h"
+#include "pvr/settings/PVRCustomProperty.h"
 
+#include <map>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -32,7 +33,7 @@ class CPVRCustomTimerSettings
 {
 public:
   CPVRCustomTimerSettings(const CPVRTimerType& timerType,
-                          const CPVRTimerInfoTag::CustomPropsMap& customProps,
+                          const CustomPropertiesMap& customProps,
                           const std::map<int, std::shared_ptr<CPVRTimerType>>& typeEntries);
   virtual ~CPVRCustomTimerSettings() = default;
 
@@ -45,7 +46,7 @@ public:
   bool IsCustomIntSetting(std::string_view settingId) const;
   bool IsCustomStringSetting(std::string_view settingId) const;
 
-  const CPVRTimerInfoTag::CustomPropsMap& GetProperties() const { return m_customProps; }
+  const CustomPropertiesMap& GetProperties() const { return m_customProps; }
 
   bool UpdateIntProperty(const std::shared_ptr<const CSetting>& setting);
   bool UpdateStringProperty(const std::shared_ptr<const CSetting>& setting);
@@ -73,6 +74,6 @@ private:
                 std::shared_ptr<const CPVRTimerSettingDefinition>>>; // setting id, setting def
 
   CustomSettingDefinitionsVector m_customSettingDefs;
-  CPVRTimerInfoTag::CustomPropsMap m_customProps;
+  CustomPropertiesMap m_customProps;
 };
 } // namespace PVR

--- a/xbmc/pvr/settings/PVRSettings.cpp
+++ b/xbmc/pvr/settings/PVRSettings.cpp
@@ -19,6 +19,7 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
+#include <array>
 #include <memory>
 #include <mutex>
 #include <set>
@@ -87,7 +88,7 @@ void CPVRSettings::Init(const std::set<std::string>& settingNames)
     }
 
     std::unique_lock lock(m_critSection);
-    m_settings.insert(std::make_pair(settingName, setting->Clone(settingName)));
+    m_settings.try_emplace(settingName, setting->Clone(settingName));
   }
 }
 
@@ -172,7 +173,7 @@ void CPVRSettings::MarginTimeFiller(const SettingConstPtr& /*setting*/,
 {
   list.clear();
 
-  static const int marginTimeValues[] = {
+  static constexpr std::array<int, 13> marginTimeValues = {
       0, 1, 2, 3, 5, 10, 15, 20, 30, 60, 90, 120, 180 // minutes
   };
 

--- a/xbmc/pvr/settings/PVRSettings.h
+++ b/xbmc/pvr/settings/PVRSettings.h
@@ -68,7 +68,7 @@ namespace PVR
     void Init(const std::set<std::string>& settingNames);
 
     mutable CCriticalSection m_critSection;
-    std::map<std::string, std::shared_ptr<CSetting>> m_settings;
+    std::map<std::string, std::shared_ptr<CSetting>, std::less<>> m_settings;
     std::set<ISettingCallback*> m_callbacks;
 
     static unsigned int m_iInstances;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -9,13 +9,11 @@
 #pragma once
 
 #include "XBDateTime.h"
-#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h" // PVR_SETTING_TYPE
+#include "pvr/settings/PVRCustomProperty.h"
 #include "pvr/timers/PVRTimerType.h"
 #include "threads/CriticalSection.h"
 #include "utils/ISerializable.h"
-#include "utils/Variant.h"
 
-#include <map>
 #include <memory>
 #include <string>
 
@@ -515,26 +513,10 @@ public:
   int RecordingGroup() const { return m_iRecordingGroup; }
 
   /*!
-   * @brief custom property detail: type, value
-   */
-  struct CustomPropDetails
-  {
-    PVR_SETTING_TYPE type{PVR_SETTING_TYPE::INTEGER};
-    CVariant value;
-
-    bool operator==(const CustomPropDetails& right) const = default;
-  };
-
-  /*!
-   * @brief custom properties map: <prop id, details>
-   */
-  using CustomPropsMap = std::map<unsigned int, CustomPropDetails>;
-
-  /*!
    * @brief Get custom properties for this tag.
    * @return The list of properties or an empty list if none present.
    */
-  const CustomPropsMap& GetCustomProperties() const { return m_customProps; }
+  const CustomPropertiesMap& GetCustomProperties() const { return m_customProps; }
 
   /*!
    * @brief Get the UID of the epg event associated with this timer tag, if any.
@@ -672,7 +654,7 @@ private:
   mutable unsigned int
       m_iEpgUid; /*!< id of epg event associated with this timer, EPG_TAG_INVALID_UID if none. */
   std::string m_strSeriesLink; /*!< series link */
-  CustomPropsMap m_customProps; /*!< the map with custom properties supplied by the client. */
+  CustomPropertiesMap m_customProps; /*!< the map with custom properties supplied by the client. */
 
   CDateTime m_StartTime; /*!< start time */
   CDateTime m_StopTime; /*!< stop time */

--- a/xbmc/pvr/timers/PVRTimerRuleMatcher.cpp
+++ b/xbmc/pvr/timers/PVRTimerRuleMatcher.cpp
@@ -156,17 +156,15 @@ bool CPVRTimerRuleMatcher::MatchEnd(const std::shared_ptr<const CPVREpgInfoTag>&
 
 bool CPVRTimerRuleMatcher::MatchDayOfWeek(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
-  if (m_timerRule->GetTimerType()->SupportsWeekdays())
+  if (m_timerRule->GetTimerType()->SupportsWeekdays() &&
+      m_timerRule->WeekDays() != PVR_WEEKDAY_ALLDAYS)
   {
-    if (m_timerRule->WeekDays() != PVR_WEEKDAY_ALLDAYS)
-    {
-      const CDateTime startEpgLocal = CPVRTimerInfoTag::ConvertUTCToLocalTime(epgTag->StartAsUTC());
-      int startWeekday = startEpgLocal.GetDayOfWeek();
-      if (startWeekday == 0)
-        startWeekday = 7;
+    const CDateTime startEpgLocal{CPVRTimerInfoTag::ConvertUTCToLocalTime(epgTag->StartAsUTC())};
+    int startWeekday{startEpgLocal.GetDayOfWeek()};
+    if (startWeekday == 0)
+      startWeekday = 7;
 
-      return ((1 << (startWeekday - 1)) & m_timerRule->WeekDays());
-    }
+    return ((1 << (startWeekday - 1)) & m_timerRule->WeekDays());
   }
   return true;
 }

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -301,7 +301,7 @@ private:
   std::shared_ptr<CPVRTimerInfoTag> PersistAndUpdateLocalTimer(
       const std::shared_ptr<CPVRTimerInfoTag>& timer,
       const std::shared_ptr<CPVRTimerInfoTag>& parentTimer);
-  void NotifyTimersEvent(bool bAddedOrDeleted = true);
+  void NotifyTimersEvent(bool bAddedOrDeleted = true) const;
 
   enum TimerKind
   {

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -532,7 +532,7 @@ bool CGUIWindowPVRBase::InitChannelGroup()
     if (m_channelGroup != group)
     {
       m_viewControl.SetSelectedItem(0);
-      SetChannelGroup(std::move(group), false);
+      SetChannelGroup(group, false);
     }
     // Path might have changed since last init. Set it always, not just on group change.
     m_vecItems->SetPath(GetDirectoryPath());
@@ -560,7 +560,7 @@ void CGUIWindowPVRBase::SetChannelGroup(const std::shared_ptr<CPVRChannelGroup>&
     {
       if (m_channelGroup)
         m_channelGroup->Events().Unsubscribe(this);
-      m_channelGroup = std::move(group);
+      m_channelGroup = group;
       // we need to register the window to receive changes from the new group
       m_channelGroup->Events().Subscribe(this, &CGUIWindowPVRBase::Notify);
       if (bUpdate)

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -785,17 +785,17 @@ bool CGUIWindowPVRGuideBase::RefreshTimelineItems()
       if (endDate > maxFutureDate)
         endDate = maxFutureDate;
 
-      const auto channels{std::make_unique<CFileItemList>()};
+      CFileItemList channels;
       const std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers =
           group->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
 
       for (const auto& groupMember : groupMembers)
       {
-        channels->Add(std::make_shared<CFileItem>(groupMember));
+        channels.Add(std::make_shared<CFileItem>(groupMember));
       }
 
       if (m_guiState)
-        channels->Sort(m_guiState->GetSortMethod());
+        channels.Sort(m_guiState->GetSortMethod());
 
       epgGridContainer->SetTimelineItems(channels, startDate, endDate);
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -304,7 +304,7 @@ int CGUIWindowPVRGuideBase::GetCurrentListItemIndex(
 
 bool CGUIWindowPVRGuideBase::ShouldNavigateToGridContainer(int iAction)
 {
-  CGUIEPGGridContainer* epgGridContainer = GetGridControl();
+  const CGUIEPGGridContainer* epgGridContainer{GetGridControl()};
   const CGUIControl* control{GetControl(CONTROL_LSTCHANNELGROUPS)};
   if (epgGridContainer && control && GetFocusedControlID() == control->GetID())
   {
@@ -928,10 +928,7 @@ void CGUIWindowPVRGuideBase::GetChannelNumbers(std::vector<std::string>& channel
 }
 
 CPVRRefreshTimelineItemsThread::CPVRRefreshTimelineItemsThread(CGUIWindowPVRGuideBase* pGuideWindow)
-  : CThread("epg-grid-refresh-timeline-items"),
-    m_pGuideWindow(pGuideWindow),
-    m_ready(true),
-    m_done(false)
+  : CThread("epg-grid-refresh-timeline-items"), m_pGuideWindow(pGuideWindow)
 {
 }
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -122,8 +122,8 @@ public:
   void Stop();
 
 private:
-  CGUIWindowPVRGuideBase* m_pGuideWindow;
-  CEvent m_ready;
-  CEvent m_done;
+  CGUIWindowPVRGuideBase* m_pGuideWindow{nullptr};
+  CEvent m_ready{true};
+  CEvent m_done{false};
 };
 } // namespace PVR


### PR DESCRIPTION
Last (?) round of fixes for SonarQube findings, among them:

* Pointer and reference local variables should be "const" if the corresponding object is not modified cpp:S5350
* Unnecessary expensive copy should be avoided when using auto as a placeholder type cpp:S6032
* "std::move" should only be used where moving can happen cpp:S5415
* Function parameters should not be of type "std::unique_ptr<T> const &" cpp:S4998
* Multiple variables should not be declared on the same line cpp:S1659
* Access specifiers should not be redundant cpp:S3539
* "try_emplace" should be used with "std::map" and "std::unordered_map"
* "bool" expressions should not be used as operands to built-in operators other than =, &&, ||, !, ==, !=, unary &, and the conditional operator cpp:S872
* Mergeable "if" statements should be combined cpp:S1066
* Transparent function objects should be used with associative "std::string" containers cpp:S6045
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* Comparision operators ("<=>", "==") should be defaulted unless non-default behavior is required cpp:S6230
* Variables should not be shadowed cpp:S1117
* C-style array should not be used cpp:S5945
* Assignments should not be made from within conditions cpp:S1121

No functional changes intended.

Runtime-tested on macOS and Android, latest Kodi master

@neo1973 , @phunkyfish please review, best commit-by-commit.

