### PR TITLE
[Video][Bluray] Futher fixes for removable blurays.

### DIFF
--- a/xbmc/FileItemList.h
+++ b/xbmc/FileItemList.h
@@ -86,6 +86,11 @@ public:
    */
   void Stack(bool stackFiles = true);
 
+  /*! \brief replace any items in the list with bluray:// URLs
+   Only if these exist in the video database
+   */
+  void ReplaceBlurayFiles();
+
   SortOrder GetSortOrder() const { return m_sortDescription.sortOrder; }
   SortBy GetSortMethod() const { return m_sortDescription.sortBy; }
   void SetSortOrder(SortOrder sortOrder) { m_sortDescription.sortOrder = sortOrder; }

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1266,7 +1266,7 @@ constexpr std::array<InfoMap, 7> weather = {{
 ///                  \anchor System_HasMediaBlurayPlaylist
 ///                  _boolean_,
 ///     @return **True** if there is a bluray in the drive that has been played before.
-///     **False** if no drive available\, empty drive, other medium or new bluray.
+///     **False** if no drive available\, empty drive\, other medium or new bluray.
 ///   <p><hr>
 ///   @skinning_v18 **[New Boolean Condition]** \link System_HasMediaBlurayPlaylist
 ///   `System.System_HasMediaBlurayPlaylist` \endlink <p>

--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -28,6 +28,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/SettingsComponent.h"
+#include "storage/MediaManager.h"
 #include "utils/JobManager.h"
 #include "utils/SaveFileStateJob.h"
 #include "utils/URIUtils.h"
@@ -129,6 +130,7 @@ void CApplicationPlayerCallback::OnPlayerCloseFile(const CFileItem& file,
       url.SetFileName(fileUrl.GetFileName());
       fileItem.SetPath(url.Get());
       fileItem.SetDynPath("");
+      CServiceBroker::GetMediaManager().ResetBlurayPlaylistStatus();
     }
   }
 

--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -115,24 +115,48 @@ void CApplicationPlayerCallback::OnPlayerCloseFile(const CFileItem& file,
   if (bookmark.timeInSeconds == 0.0)
     return;
 
-  // Adjust paths of new fileItem for physical/removable blurays
-  // DynPath contains the mpls (playlist) played
-  // VideoInfoTag()->m_strFileNameAndPath contains the removable:// path
-  // We need to update DynPath with the removable:// path (for the database), keeping the playlist
-  if (fileItem.HasVideoInfoTag() &&
-      fileItem.GetVideoInfoTag()->m_strFileNameAndPath.starts_with("bluray://removable"))
+    // Adjust paths of new fileItem for physical/removable blurays
+    // DynPath contains the mpls (playlist) played
+    // VideoInfoTag()->m_strFileNameAndPath contains the removable:// path (if played through Disc node)
+    // otherwise if played through Video->Files we need to retrieve the removable:// path
+    // We need to update DynPath with the removable:// path (for the database), keeping the playlist
+#ifdef HAVE_LIBBLURAY
+  if (fileItem.HasVideoInfoTag())
   {
     const std::string dynPath{fileItem.GetDynPath()};
     if (URIUtils::IsBlurayPath(dynPath))
     {
-      CURL url{fileItem.GetVideoInfoTag()->m_strFileNameAndPath};
       const CURL fileUrl{dynPath};
-      url.SetFileName(fileUrl.GetFileName());
-      fileItem.SetPath(url.Get());
-      fileItem.SetDynPath("");
-      CServiceBroker::GetMediaManager().ResetBlurayPlaylistStatus();
+      CURL url;
+      if (fileItem.GetVideoInfoTag()->m_strFileNameAndPath.starts_with("bluray://removable"))
+      {
+        // Played through Disc node
+        url.Parse(fileItem.GetVideoInfoTag()->m_strFileNameAndPath);
+      }
+      else
+      {
+#ifdef HAS_OPTICAL_DRIVE
+        // Played through Video->Files
+        ::UTILS::DISCS::DiscInfo info{
+            CServiceBroker::GetMediaManager().GetDiscInfo(fileUrl.GetHostName())};
+        if (!info.empty() && info.type == ::UTILS::DISCS::DiscType::BLURAY)
+        {
+          url.Parse(CServiceBroker::GetMediaManager().GetDiskUniqueId(fileUrl.GetHostName()));
+        }
+#endif
+      }
+      if (!url.Get().empty())
+      {
+        url.SetFileName(fileUrl.GetFileName());
+        fileItem.SetPath(url.Get());
+        fileItem.SetDynPath("");
+#ifdef HAS_OPTICAL_DRIVE
+        CServiceBroker::GetMediaManager().ResetBlurayPlaylistStatus();
+#endif
+      }
     }
   }
+#endif
 
   if (stackHelper->GetRegisteredStack(fileItem) != nullptr)
   {

--- a/xbmc/filesystem/BlurayDirectory.h
+++ b/xbmc/filesystem/BlurayDirectory.h
@@ -199,6 +199,7 @@ public:
   static std::string GetBasePath(const CURL& url);
   std::string GetBlurayTitle() const;
   std::string GetBlurayID() const;
+  static std::string GetBlurayPlaylistPath(const CFileItem& item);
 
 private:
   enum class DiscInfo : uint8_t

--- a/xbmc/filesystem/DirectoryHistory.h
+++ b/xbmc/filesystem/DirectoryHistory.h
@@ -55,7 +55,7 @@ public:
 
   void AddPath(const std::string& strPath, const std::string &m_strFilterPath = "");
   void AddPathFront(const std::string& strPath, const std::string &m_strFilterPath = "");
-  std::string GetParentPath(bool filter = false);
+  std::string GetParentPath(const std::string& currentPath = "", bool filter = false);
   std::string RemoveParentPath(bool filter = false);
   void ClearPathHistory();
   void ClearSearchHistory();

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -120,6 +120,8 @@ public:
 
   bool playStubFile(const CFileItem& item);
 
+  UTILS::DISCS::DiscInfo GetDiscInfo(const std::string& mediaPath);
+
 protected:
   std::vector<CNetworkLocation> m_locations;
 
@@ -156,7 +158,6 @@ private:
   std::shared_ptr<IDiscDriveHandler> m_platformDiscDriveHander;
 #endif
 
-  UTILS::DISCS::DiscInfo GetDiscInfo(const std::string& mediaPath);
   void RemoveDiscInfo(const std::string& devicePath);
   std::map<std::string, UTILS::DISCS::DiscInfo> m_mapDiscInfo;
 #ifdef HAVE_LIBBLURAY

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -34,6 +34,13 @@ public:
 class CMediaManager : public IStorageEventsCallback, public IJobCallback
 {
 public:
+  enum class HasBlurayPlaylist : uint8_t
+  {
+    YES,
+    NO,
+    UNKNOWN
+  };
+
   CMediaManager();
 
   void Initialize();
@@ -64,6 +71,13 @@ public:
   std::string GetDiskLabel(const std::string& devicePath="");
   std::string GetDiskUniqueId(const std::string& devicePath="");
   bool HasMediaBlurayPlaylist(const std::string& devicePath = "");
+
+  /*! \brief Reset flag for removable bluray playlist status
+   * This is needed as HasMediaBlurayPlaylist() is called every screen refresh when
+   * the disc node is highlighted.
+   * It needs to be reset whenever a disc is ejected or played (as a playlist may have been selected).
+  */
+  void ResetBlurayPlaylistStatus();
 
   /*! \brief Gets the platform disc drive handler
   * @todo this likely doesn't belong here but in some discsupport component owned by media manager
@@ -145,4 +159,7 @@ private:
   UTILS::DISCS::DiscInfo GetDiscInfo(const std::string& mediaPath);
   void RemoveDiscInfo(const std::string& devicePath);
   std::map<std::string, UTILS::DISCS::DiscInfo> m_mapDiscInfo;
+#ifdef HAVE_LIBBLURAY
+  HasBlurayPlaylist m_hasBlurayPlaylist{HasBlurayPlaylist::UNKNOWN};
+#endif
 };

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -539,9 +539,10 @@ std::string URIUtils::GetBlurayAllEpisodesPath(const std::string& path)
   return AddFileToFolder(GetBlurayPath(path), "root", "episode", "all");
 }
 
-std::string URIUtils::GetBlurayPlaylistPath(const std::string& path)
+std::string URIUtils::GetBlurayPlaylistPath(const std::string& path, int playlist /* = -1 */)
 {
-  return AddFileToFolder(GetBlurayPath(path), "BDMV", "PLAYLIST", "");
+  return AddFileToFolder(GetBlurayPath(path), "BDMV", "PLAYLIST",
+                         playlist != -1 ? StringUtils::Format("{:05}.mpls", playlist) : "");
 }
 
 std::string URIUtils::GetBlurayPath(const std::string& path)
@@ -563,6 +564,8 @@ std::string URIUtils::GetBlurayPath(const std::string& path)
   }
   else if (IsBDFile(path))
     newPath = GetDiscBasePath(path);
+  else
+    newPath = path;
 
   if (!newPath.empty())
   {

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -138,9 +138,10 @@ public:
 
   /*! \brief Given a path to an .ISO or index.BDMV, returns a bluray:// path to default playlist path.
    \param path the ISO/index.BDMV path.
-   \return the bluray:// playlist path - BDMV/PLAYLIST
+   \param playlist (optional) the .mpls playlist
+   \return the bluray:// playlist path - BDMV/PLAYLIST(/xxxxx.mpls)
    */
-  static std::string GetBlurayPlaylistPath(const std::string& path);
+  static std::string GetBlurayPlaylistPath(const std::string& path, int playlist = -1);
 
   /*! \brief Given a path to an .ISO or index.BDMV, returns a bluray:// path.
    \param path the ISO/index.BDMV path.

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3618,6 +3618,40 @@ void CVideoDatabase::GetFilePathById(int idMovie, std::string& filePath, VideoDb
   }
 }
 
+std::vector<std::string> CVideoDatabase::GetFilesByPathId(int idPath)
+{
+  try
+  {
+    if (!m_pDB || !m_pDS || idPath < 0)
+      return {};
+
+    const std::string strSQL{PrepareSQL("SELECT path.strPath, files.strFileName FROM path "
+                                        "INNER JOIN files ON path.idPath=files.idPath "
+                                        "WHERE path.idPath=%i ORDER BY strFilename",
+                                        idPath)};
+
+    m_pDS->query(strSQL);
+
+    std::vector<std::string> files;
+    while (!m_pDS->eof())
+    {
+      std::string file;
+      ConstructPath(file, m_pDS->fv("strPath").get_asString(),
+                    m_pDS->fv("strFilename").get_asString());
+      files.emplace_back(file);
+      m_pDS->next();
+    }
+    m_pDS->close();
+
+    return files;
+  }
+  catch (const std::exception& e)
+  {
+    CLog::LogF(LOGERROR, "Failed with idPath {}, error {}", idPath, e.what());
+  }
+  return {};
+}
+
 //********************************************************************************************************************************
 void CVideoDatabase::GetBookMarksForFile(const std::string& strFilenameAndPath, VECBOOKMARKS& bookmarks, CBookmark::EType type /*= CBookmark::STANDARD*/, bool bAppend, long partNumber)
 {

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -582,6 +582,7 @@ public:
   bool HasMusicVideoInfo(const std::string& strFilenameAndPath);
 
   void GetFilePathById(int idMovie, std::string& filePath, VideoDbContentType iType);
+  std::vector<std::string> GetFilesByPathId(int idPath);
   std::string GetGenreById(int id) const;
   std::string GetCountryById(int id) const;
   std::string GetSetById(int id) const;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -731,7 +731,7 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
 {
   CURL pathToUrl(strDirectory);
 
-  std::string strParentPath = m_history.GetParentPath();
+  std::string strParentPath = m_history.GetParentPath(strDirectory);
 
   CLog::Log(LOGDEBUG, "CGUIMediaWindow::GetDirectory ({})", CURL::GetRedacted(strDirectory));
   CLog::Log(LOGDEBUG, "  ParentPath = [{}]", CURL::GetRedacted(strParentPath));
@@ -1283,7 +1283,7 @@ bool CGUIMediaWindow::GoParentFolder()
   CURL filterUrl(m_strFilterPath);
   if (filterUrl.HasOption("filter"))
   {
-    CURL parentUrl(m_history.GetParentPath(true));
+    CURL parentUrl(m_history.GetParentPath("", true));
     if (!parentUrl.HasOption("filter"))
     {
       // we need to overwrite m_strFilterPath because
@@ -1295,7 +1295,7 @@ bool CGUIMediaWindow::GoParentFolder()
   }
 
   // pop directory path from the stack
-  m_strFilterPath = m_history.GetParentPath(true);
+  m_strFilterPath = m_history.GetParentPath("", true);
   m_history.RemoveParentPath();
 
   if (!Update(parentPath, false))

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -756,6 +756,9 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
     if (!GetDirectoryItems(pathToUrl, dirItems, UseFileDirectories()))
       return false;
 
+    if (GetID() == WINDOW_VIDEO_NAV)
+      dirItems.ReplaceBlurayFiles();
+
     // assign fetched directory items
     items.Assign(dirItems);
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Following on from #26566.

Fixes 5 issues
1) After #26566 I noticed that HasMediaBlurayPlaylist() is called every screen refresh when the Disc node is highlighted.

In the log - repeated entries of:
```
2025-05-09 17:38:19.890 T:7784    debug <general>: CBlurayCallback::Logger - bluray.c:1472: libbluray version 1.3.4
                                                   
2025-05-09 17:38:19.891 T:7784    debug <general>: CBlurayCallback::Logger - bluray.c:1497: BLURAY initialized!
...                     
2025-05-09 17:38:19.912 T:7784    debug <general>: CBlurayCallback - Opening dir E:\BDMV\META\DL
2025-05-09 17:38:19.914 T:7784    debug <general>: CBlurayCallback - Closed dir (0x24094d36da0)
2025-05-09 17:38:19.914 T:7784    debug <general>: CBlurayCallback - Opening dir E:\BDMV\META\TN
2025-05-09 17:38:19.915 T:7784    debug <general>: CBlurayCallback - Closed dir (0x24094d36da0)
2025-05-09 17:38:19.916 T:7784    debug <general>: CBlurayCallback::Logger - bluray.c:1623: BLURAY destroyed!
                                                   
2025-05-09 17:38:19.916 T:7784    debug <general>: GetDiskUniqueId: Got ID bluray://removable%3a%2f%2fJohn%20Wick%203%3a%20Parabellum%20-%20Ultra%20HD%20Blu-ray%e2%84%a2_00000000000000000000000000000/BDMV/index.bdmv for disc with path E:
```

This is now resolved via a member variable that remembers whether a disc has a playlist in the library, which is reset when disc is ejected.

2) Properly identify removable discs played through Video -> Files as removable blurays so the playlist is saved (same as blurays played through the disc node). Thanks for pointing out @CrystalP.

3) After a bluray (removable, ISO or BDMV) is played through Video -> Files and the user is returned to the file manager, the parent directory `..` is not properly derived. This can result in:

![image](https://github.com/user-attachments/assets/b94625b5-0bab-47f4-af3f-fc95e372fb11)

After fix:

![image](https://github.com/user-attachments/assets/0f787351-e8c8-4b97-abd2-0825ae81d828)

This happens because CGUIMediaWindow::GetDirectory() the parent path is retrieved (as the last element in the vector in CDirectoryHistory) and then later the current paths is added to the CDirectoryHistory.

This means however, that when you return from play and the directory is refreshed the entry retrieved as the parent path is the current directory, not the previous directory - so to overcome this you pass the current directory to CDirectoryHistory::GetParentPath() it it seeks back for the first non-matching diectory.

4) Fix unescaped comma. Thanks @DeltaMikeCharlie.

5) Associate bookmarks with known bluray:// paths (including removable discs) when files viewed through the Video node.

In Omega, if you play a disc through Video -> Files the resume state (and stream details) are shown. This was lost when bluray:// paths were introduced as they are only referenced when the library is accessed. This commit adds a function to CFileItemList that associates phsyical bluray paths with any bluray:// paths that might exist in the database - thus restoring this functionality (and also extending it to removable discs).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As above.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
