### PR TITLE
[Cmake] Fix window NFS check and remove unnecessary define

### DIFF
--- a/cmake/modules/FindNFS.cmake
+++ b/cmake/modules/FindNFS.cmake
@@ -89,7 +89,11 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
       set(CMAKE_REQUIRED_INCLUDES "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR}")
       set(CMAKE_REQUIRED_LIBRARIES ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY})
 
-      # Check for mount_getexports_timeout
+      if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+        set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} "ws2_32.lib")
+      endif()
+
+      # Check for mount_getexports_timeout libnfs>5.0.0
       check_cxx_source_compiles("
          ${LIBNFS_CXX_INCLUDE}
          #include <nfsc/libnfs.h>

--- a/cmake/modules/FindNFS.cmake
+++ b/cmake/modules/FindNFS.cmake
@@ -23,8 +23,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
     BUILD_DEP_TARGET()
 
-    set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_COMPILE_DEFINITIONS HAS_NFS_SET_TIMEOUT
-                                                                 HAS_NFS_MOUNT_GETEXPORTS_TIMEOUT)
+    set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_COMPILE_DEFINITIONS HAS_NFS_MOUNT_GETEXPORTS_TIMEOUT)
   endmacro()
 
   include(cmake/scripts/common/ModuleHelpers.cmake)
@@ -89,20 +88,6 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     if(NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
       set(CMAKE_REQUIRED_INCLUDES "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR}")
       set(CMAKE_REQUIRED_LIBRARIES ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY})
-
-      # Check for nfs_set_timeout
-      check_cxx_source_compiles("
-         ${LIBNFS_CXX_INCLUDE}
-         #include <nfsc/libnfs.h>
-         int main()
-         {
-           nfs_set_timeout(NULL, 0);
-         }
-      " NFS_SET_TIMEOUT)
-
-      if(NFS_SET_TIMEOUT)
-        list(APPEND ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_COMPILE_DEFINITIONS HAS_NFS_SET_TIMEOUT)
-      endif()
 
       # Check for mount_getexports_timeout
       check_cxx_source_compiles("

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -559,10 +559,9 @@ void CNfsConnection::setOptions(struct nfs_context* context)
   if (!advancedSettings)
     return;
 
-#ifdef HAS_NFS_SET_TIMEOUT
   uint32_t timeout = advancedSettings->m_nfsTimeout;
   nfs_set_timeout(context, timeout > 0 ? timeout * 1000 : -1);
-#endif
+
   int retries = advancedSettings->m_nfsRetries;
   nfs_set_autoreconnect(context, retries);
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -535,11 +535,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     }
     if (network->FirstChildElement("nfstimeout"))
     {
-#ifdef HAS_NFS_SET_TIMEOUT
       XMLUtils::GetUInt(network, "nfstimeout", m_nfsTimeout, 0, 3600);
-#else
-      CLog::Log(LOGWARNING, "nfstimeout unsupported");
-#endif
     }
     if (network->FirstChildElement("nfsretries"))
     {


### PR DESCRIPTION
## Description
Fix windows test for NFS_MOUNT_GETEXPORTS_TIMEOUT
Remove nfs_set_timeout, as it exists in libnfs >=2.0.0 and our minimum required is 3.0.0

## Motivation and context
Fix an inconsistency with windows nfs. If lib existed, tests would fail. For some reason i removed the ws2_32.lib link requirement for the tests, no idea why, my bad.

## How has this been tested?
Before
```
-- Found NFS: C:/source/repos/xbmc/project/BuildDependencies/arm64/lib/nfs.lib (Required is at least version "3.0.0")
-- Performing Test NFS_SET_TIMEOUT
-- Performing Test NFS_SET_TIMEOUT - Failed
-- Performing Test NFS_MOUNT_GETEXPORTS_TIMEOUT
-- Performing Test NFS_MOUNT_GETEXPORTS_TIMEOUT - Failed
```

After
```
-- Found NFS: C:/source/repos/xbmc/project/BuildDependencies/arm64/lib/nfs.lib (Required is at least version "3.0.0")
-- Performing Test NFS_MOUNT_GETEXPORTS_TIMEOUT
-- Performing Test NFS_MOUNT_GETEXPORTS_TIMEOUT - Success
```

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
