### PR TITLE
[BP][Cmake] Fix windows NFS check

### DIFF
--- a/cmake/modules/FindNFS.cmake
+++ b/cmake/modules/FindNFS.cmake
@@ -92,6 +92,10 @@ if(NOT TARGET libnfs::nfs)
       set(CMAKE_REQUIRED_INCLUDES "${LIBNFS_INCLUDE_DIR}")
       set(CMAKE_REQUIRED_LIBRARIES ${LIBNFS_LIBRARY})
 
+      if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+        set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} "ws2_32.lib")
+      endif()
+
       # Check for nfs_set_timeout
       check_cxx_source_compiles("
          ${LIBNFS_CXX_INCLUDE}
@@ -106,7 +110,7 @@ if(NOT TARGET libnfs::nfs)
         list(APPEND _nfs_definitions HAS_NFS_SET_TIMEOUT)
       endif()
 
-      # Check for mount_getexports_timeout
+      # Check for mount_getexports_timeout libnfs>5.0.0
       check_cxx_source_compiles("
          ${LIBNFS_CXX_INCLUDE}
          #include <nfsc/libnfs.h>


### PR DESCRIPTION
## Description
Fix windows test for NFS_MOUNT_GETEXPORTS_TIMEOUT and NFS_SET_TIMEOUT

## Motivation and context
Fix an inconsistency with windows nfs. If lib existed, tests would fail. For some reason i removed the ws2_32.lib link requirement for the tests, no idea why, my bad.

## How has this been tested?
Before
```
-- Found NFS: C:/source/repos/xbmc/project/BuildDependencies/x64/lib/nfs.lib (Required is at least version "3.0.0")
-- Performing Test NFS_SET_TIMEOUT
-- Performing Test NFS_SET_TIMEOUT - Failed
-- Performing Test NFS_MOUNT_GETEXPORTS_TIMEOUT
-- Performing Test NFS_MOUNT_GETEXPORTS_TIMEOUT - Failed
```

After
```
-- Found NFS: C:/source/repos/xbmc/project/BuildDependencies/x64/lib/nfs.lib (Required is at least version "3.0.0")
-- Performing Test NFS_SET_TIMEOUT
-- Performing Test NFS_SET_TIMEOUT - Success
-- Performing Test NFS_MOUNT_GETEXPORTS_TIMEOUT
-- Performing Test NFS_MOUNT_GETEXPORTS_TIMEOUT - Success
```

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
