### PR TITLE
[cmake] FindTexturePacker add DEPENDS_PATH to internal texturepacker build

### DIFF
--- a/cmake/modules/buildtools/FindTexturePacker.cmake
+++ b/cmake/modules/buildtools/FindTexturePacker.cmake
@@ -81,6 +81,7 @@ if(NOT TARGET TexturePacker::TexturePacker::Executable)
                      "-DCMAKE_STRIP=${CMAKE_STRIP}"
                      "-DCMAKE_OBJDUMP=${CMAKE_OBJDUMP}"
                      "-DCMAKE_RANLIB=${CMAKE_RANLIB}"
+                     "-DDEPENDS_PATH=${DEPENDS_PATH}"
                      -DKODI_SOURCE_DIR=${CMAKE_SOURCE_DIR}
                      -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/build)
 


### PR DESCRIPTION
## Description
Adds DEPENDS_PATH to externalproject_add call for texturepacker internal build

## Motivation and context
Flatpak building texturepacker fails due to FindLzo2.cmake not being able to locate lzo. This just passes DEPENDS_PATH to the call.

Flatpak can then use ``-DDEPENDS_PATH=/app`` in the kodi cmake configure command to hint to locations that have libs

For other platforms that already use DEPENDS_PATH, this would still be correct, however none of those platforms use this existing code path (once again, this texturepacker shit needs to be cleaned up completely).
For platforms that do not set DEPENDS_PATH (ie linux), this just passes on a cmake relevant path ``${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}`` that will have no change in behaviour

## How has this been tested?
Build flatpak of Piers on aarch64 Ubuntu 24.04

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
