### PR TITLE
[guiinfo][Estuary] Add guiinfo bool Player.IsLive, update Estuary video OSD to use it

### DIFF
--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -394,7 +394,11 @@ msgctxt "#31080"
 msgid "Ends at"
 msgstr ""
 
-#empty string with id 31081
+#: /xml/Custom_1109_TopBarOverlay.xml
+#. Label to highlight that live stream is being played
+msgctxt "#31081"
+msgid "Live"
+msgstr ""
 
 #: /xml/Custom_1105_MusicOSDSettings.xml
 msgctxt "#31082"

--- a/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
+++ b/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
@@ -249,15 +249,21 @@
 						<shadowcolor>text_shadow</shadowcolor>
 						<height>100</height>
 						<width>auto</width>
-						<visible>!String.isempty(Player.Duration)</visible>
-						<visible>Player.HasVideo + ![Player.HasGame | VideoPlayer.HasEpg]</visible>
+						<visible>!Player.IsLive + Player.HasVideo + ![Player.HasGame | VideoPlayer.HasEpg] !String.IsEmpty(Player.Duration)</visible>
+					</control>
+					<control type="label">
+						<label>$LOCALIZE[31081]</label>
+						<shadowcolor>text_shadow</shadowcolor>
+						<height>100</height>
+						<width>auto</width>
+						<visible>Player.IsLive</visible>
 					</control>
 					<control type="label">
 						<label>$INFO[PVR.EpgEventFinishTime,$LOCALIZE[31080]: ]</label>
 						<shadowcolor>text_shadow</shadowcolor>
 						<height>100</height>
 						<width>auto</width>
-						<visible>VideoPlayer.HasEpg</visible>
+						<visible>!Player.IsLive + VideoPlayer.HasEpg</visible>
 					</control>
 					<control type="image">
 						<top>2</top>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -834,14 +834,23 @@ constexpr std::array<InfoMap, 7> integer_bools = {{
 ///     @skinning_v21 **[New Boolean Condition]** \link Player_IsRemote `Player.IsRemote`\endlink
 ///     <p>
 ///   }
+///   \table_row3{   <b>`Player.IsLive`</b>,
+///                  \anchor Player_IsLive
+///                  _boolean_,
+///     @return **True** if the inputstream of the player is a live stream (a.k.a. real time stream)\, **False** otherwise
+///     <p><hr>
+///     @skinning_v22 **[New Boolean Condition]** \link Player_IsLive `Player.IsLive`\endlink
+///     <p>
+///   }
 // clang-format off
-constexpr std::array<InfoMap, 57> player_labels = {{
+constexpr std::array<InfoMap, 58> player_labels = {{
     {"hasmedia",              PLAYER_HAS_MEDIA},
     {"hasaudio",              PLAYER_HAS_AUDIO},
     {"hasvideo",              PLAYER_HAS_VIDEO},
     {"hasgame",               PLAYER_HAS_GAME},
     {"isexternal",            PLAYER_IS_EXTERNAL},
     {"isremote",              PLAYER_IS_REMOTE},
+    {"islive",                PLAYER_IS_LIVE},
     {"playing",               PLAYER_PLAYING},
     {"paused",                PLAYER_PAUSED},
     {"rewinding",             PLAYER_REWINDING},

--- a/xbmc/application/ApplicationPlayer.cpp
+++ b/xbmc/application/ApplicationPlayer.cpp
@@ -278,6 +278,15 @@ bool CApplicationPlayer::IsPlayingRDS() const
   return (IsPlaying() && HasRDS());
 }
 
+bool CApplicationPlayer::IsLiveStream() const
+{
+  std::shared_ptr<const IPlayer> player = GetInternal();
+  if (player)
+    return player->IsLiveStream();
+
+  return false;
+}
+
 void CApplicationPlayer::Pause()
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/application/ApplicationPlayer.h
+++ b/xbmc/application/ApplicationPlayer.h
@@ -136,6 +136,7 @@ public:
   bool IsPlayingVideo() const;
   bool IsPlayingGame() const;
   bool IsPlayingRDS() const;
+  bool IsLiveStream() const;
   void LoadPage(int p, int sp, unsigned char* buffer);
   bool OnAction(const CAction &action);
   void OnNothingToQueueNotify();

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -238,6 +238,7 @@ public:
   virtual float GetRenderAspectRatio() const { return 1.0; }
   virtual void TriggerUpdateResolution() {}
   virtual bool IsRenderingVideo() const { return false; }
+  virtual bool IsLiveStream() const { return false; }
   virtual void GetRects(CRect& source, CRect& dest, CRect& view) const
   {
     source = {};

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5213,6 +5213,13 @@ bool CVideoPlayer::IsRenderingVideo() const
   return m_renderManager.IsConfigured();
 }
 
+bool CVideoPlayer::IsLiveStream() const
+{
+  if (m_pInputStream)
+    return m_pInputStream->IsRealtime();
+  return false;
+}
+
 bool CVideoPlayer::Supports(EINTERLACEMETHOD method) const
 {
   if (!m_processInfo)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -347,6 +347,7 @@ public:
   unsigned int GetOrientation() const override;
   void TriggerUpdateResolution() override;
   bool IsRenderingVideo() const override;
+  bool IsLiveStream() const override;
   bool Supports(EINTERLACEMETHOD method) const override;
   EINTERLACEMETHOD GetDeinterlacingMethodDefault() const override;
   bool Supports(ESCALINGMETHOD method) const override;

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -95,6 +95,7 @@ constexpr int      PLAYER_OFFSET_POSITION_LAST       = PLAYER_FILENAME;
 
 constexpr uint32_t PLAYER_IS_REMOTE                  = 85;
 constexpr uint32_t PLAYER_IS_EXTERNAL                = 86;
+constexpr uint32_t PLAYER_IS_LIVE                    = 87;
 
 constexpr uint32_t WEATHER_CONDITIONS_TEXT           = 100;
 constexpr uint32_t WEATHER_TEMPERATURE               = 101;

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -438,6 +438,9 @@ bool CPlayerGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
     case PLAYER_IS_EXTERNAL:
       value = m_appPlayer->IsExternalPlaying();
       return true;
+    case PLAYER_IS_LIVE:
+      value = m_appPlayer->IsLiveStream();
+      return true;
     case PLAYER_PLAYING:
       value = m_appPlayer->GetPlaySpeed() == 1.0f;
       return true;


### PR DESCRIPTION
## Description
This PR adds the `isLive` flag to the `Player` object at the GUI skinning level (`GUIInfoLabels.h`). 

## Motivation and context
This is my first PR, and it may be that I misunderstood some parts of the code and how Kodi works in general, but here are my two cents:

To me, it makes little sense to show "Ends at" for a live stream:
![image](https://github.com/user-attachments/assets/33486386-ab74-4583-af63-b09bec2169f3)

The `Ends at` label is meaningless - this is a live stream; it's not going to end at a fixed time.

After applying the PR:
![image](https://github.com/user-attachments/assets/561b895e-4788-4552-8036-c5e8237fcd30)

## How has this been tested?
I implemented the changes using main branch, i tested on multiple plugins that provides live streams. 

## What is the effect on users?
For the user it will be much easier to figure to what time of the live stream the current content is playing from.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
