### PR TITLE
[MUSIC][JSON-RPC] Add option for full tag rescan

### DIFF
--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -303,11 +303,12 @@ static int ExportLibrary2(const std::vector<std::string>& params)
   return 0;
 }
 
-
 /*! \brief Update a library.
  *  \param params The parameters.
  *  \details params[0] = "video" or "music".
- *           params[1] = "true" to suppress dialogs (optional).
+ *           params[1] = directory used as scan starting point (optional).
+ *           params[2] = "true" to suppress dialogs (optional).
+ *           params[3] = "true" to force full music tag rescan (optional).
  */
 static int UpdateLibrary(const std::vector<std::string>& params)
 {
@@ -316,12 +317,14 @@ static int UpdateLibrary(const std::vector<std::string>& params)
     userInitiated = StringUtils::EqualsNoCase(params[2], "true");
   if (StringUtils::EqualsNoCase(params[0], "music"))
   {
+    auto musicScanFlag = params.size() > 3 && StringUtils::EqualsNoCase(params[3], "true")
+                             ? MUSIC_INFO::CMusicInfoScanner::SCAN_RESCAN
+                             : MUSIC_INFO::CMusicInfoScanner::SCAN_NORMAL;
     if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
       CMusicLibraryQueue::GetInstance().StopLibraryScanning();
     else
       CMusicLibraryQueue::GetInstance().ScanLibrary(params.size() > 1 ? params[1] : "",
-                                                    MUSIC_INFO::CMusicInfoScanner::SCAN_NORMAL,
-                                                    userInitiated);
+                                                    musicScanFlag, userInitiated);
   }
   else if (StringUtils::EqualsNoCase(params[0], "video"))
   {
@@ -438,7 +441,9 @@ static int RefreshAlbum(const std::vector<std::string>& params)
 ///     ,
 ///     Update the selected library (music or video)
 ///     @param[in] type                  "video" or "music".
+///     @param[in] directory             Directory used as scan starting point (optional).
 ///     @param[in] suppressDialogs       Add "true" to suppress dialogs (optional).
+///     @param[in] rescan                Add "true" to force full tag rescan (optional).
 ///   }
 ///   \table_row2_l{
 ///     <b>`videolibrary.search`</b>

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -1037,8 +1037,9 @@ JSONRPC_STATUS CAudioLibrary::Scan(const std::string &method, ITransportLayer *t
 {
   std::string directory = parameterObject["directory"].asString();
   std::string cmd =
-      StringUtils::Format("updatelibrary(music, {}, {})", StringUtils::Paramify(directory),
-                          parameterObject["showdialogs"].asBoolean() ? "true" : "false");
+      StringUtils::Format("updatelibrary(music, {}, {}, {})", StringUtils::Paramify(directory),
+                          parameterObject["showdialogs"].asBoolean() ? "true" : "false",
+                          parameterObject["rescan"].asBoolean() ? "true" : "false");
 
   CServiceBroker::GetAppMessenger()->SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
   return ACK;

--- a/xbmc/interfaces/json-rpc/schema/methods.json
+++ b/xbmc/interfaces/json-rpc/schema/methods.json
@@ -3107,6 +3107,12 @@
         "type": "boolean",
         "default": true,
         "description": "Whether or not to show the progress bar or any other GUI dialog"
+      },
+      {
+        "name": "rescan",
+        "type": "boolean",
+        "default": false,
+        "description": "Force full tag rescan of music files"
       }
     ],
     "returns": "string"


### PR DESCRIPTION
## Description
This PR gives the possibility to trigger a full tag rescan through the json-rpc api.
On the AudioLibrary.Scan has been introduced a new boolean parameter "rescan" (default false). Enabling rescan triggers the full tag rescan now available only in the file view.
I've also updated the documentation about the UpdateLibrary builtin which doesn't specify the directory param, used by the api.

## Motivation and context
Could be an useful thing for people that use Kodi headless.

## How has this been tested?
Tested with local curls with my music collection

## What is the effect on users?


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
