### PR TITLE
Misc Sonarqube findings

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -745,9 +745,8 @@ bool CLangInfo::SetLanguage(std::string language /* = "" */, bool reloadServices
     if (!addonMgr.IsAddonInstalled(language) ||
         (addonMgr.IsAddonDisabled(language) && !addonMgr.EnableAddon(language)))
     {
-      CLog::Log(LOGWARNING,
-                "CLangInfo::{}: could not find or enable language add-on '{}', loading default...",
-                __func__, language);
+      CLog::LogF(LOGWARNING, "Could not find or enable language add-on '{}', loading default...",
+                 language);
       language = std::static_pointer_cast<const CSettingString>(
                      CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(
                          CSettings::SETTING_LOCALE_LANGUAGE))
@@ -756,8 +755,7 @@ bool CLangInfo::SetLanguage(std::string language /* = "" */, bool reloadServices
       if (!addonMgr.GetAddon(language, addon, ADDON::AddonType::RESOURCE_LANGUAGE,
                              ADDON::OnlyEnabled::CHOICE_NO))
       {
-        CLog::Log(LOGFATAL, "CLangInfo::{}: could not find default language add-on '{}'", __func__,
-                  language);
+        CLog::LogF(LOGFATAL, "Could not find default language add-on '{}'", language);
         return false;
       }
     }
@@ -766,14 +764,14 @@ bool CLangInfo::SetLanguage(std::string language /* = "" */, bool reloadServices
   CLog::Log(LOGINFO, "CLangInfo: loading {} language information...", language);
   if (!Load(language))
   {
-    CLog::LogF(LOGFATAL, "CLangInfo: failed to load {} language information", language);
+    CLog::LogF(LOGFATAL, "Failed to load {} language information", language);
     return false;
   }
 
   CLog::Log(LOGINFO, "CLangInfo: loading {} language strings...", language);
   if (!g_localizeStrings.Load(GetLanguagePath(), language))
   {
-    CLog::LogF(LOGFATAL, "CLangInfo: failed to load {} language strings", language);
+    CLog::LogF(LOGFATAL, "Failed to load {} language strings", language);
     return false;
   }
 

--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -46,7 +46,7 @@ CApplicationPlayerCallback::CApplicationPlayerCallback()
 
 void CApplicationPlayerCallback::OnPlayBackEnded()
 {
-  CLog::LogF(LOGDEBUG, "CApplicationPlayerCallback::OnPlayBackEnded");
+  CLog::LogF(LOGDEBUG, "call");
 
   CGUIMessage msg(GUI_MSG_PLAYBACK_ENDED, 0, 0);
   CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
@@ -54,7 +54,7 @@ void CApplicationPlayerCallback::OnPlayBackEnded()
 
 void CApplicationPlayerCallback::OnPlayBackStarted(const CFileItem& file)
 {
-  CLog::LogF(LOGDEBUG, "CApplication::OnPlayBackStarted");
+  CLog::LogF(LOGDEBUG, "call");
   std::shared_ptr<CFileItem> itemCurrentFile;
 
   // check if VideoPlayer should set file item stream details from its current streams
@@ -218,7 +218,7 @@ void CApplicationPlayerCallback::OnPlayBackResumed()
 
 void CApplicationPlayerCallback::OnPlayBackStopped()
 {
-  CLog::LogF(LOGDEBUG, "CApplication::OnPlayBackStopped");
+  CLog::LogF(LOGDEBUG, "call");
 
   CGUIMessage msg(GUI_MSG_PLAYBACK_STOPPED, 0, 0);
   CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
@@ -235,7 +235,7 @@ void CApplicationPlayerCallback::OnPlayBackError()
 
 void CApplicationPlayerCallback::OnQueueNextItem()
 {
-  CLog::LogF(LOGDEBUG, "CApplication::OnQueueNextItem");
+  CLog::LogF(LOGDEBUG, "call");
 
   // informs python script currently running that we are requesting the next track
   // (does nothing if python is not loaded)
@@ -277,7 +277,7 @@ void CApplicationPlayerCallback::OnPlayBackSpeedChanged(int iSpeed)
 
 void CApplicationPlayerCallback::OnAVChange()
 {
-  CLog::LogF(LOGDEBUG, "CApplication::OnAVChange");
+  CLog::LogF(LOGDEBUG, "call");
 
   CServiceBroker::GetGUI()->GetStereoscopicsManager().OnStreamChange();
 
@@ -287,7 +287,7 @@ void CApplicationPlayerCallback::OnAVChange()
 
 void CApplicationPlayerCallback::OnAVStarted(const CFileItem& file)
 {
-  CLog::LogF(LOGDEBUG, "CApplication::OnAVStarted");
+  CLog::LogF(LOGDEBUG, "call");
 
   CGUIMessage msg(GUI_MSG_PLAYBACK_AVSTARTED, 0, 0);
   CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.cpp
@@ -97,7 +97,7 @@ bool CAESinkStarfish::Initialize(AEAudioFormat& format, std::string& device)
 
   if (m_format.m_dataFormat != AE_FMT_RAW)
   {
-    CLog::LogF(LOGERROR, "CAESinkStarfish: Unsupported format PCM");
+    CLog::LogF(LOGERROR, "Unsupported format PCM");
     return false;
   }
   m_format.m_frameSize = 1;
@@ -157,7 +157,7 @@ bool CAESinkStarfish::Initialize(AEAudioFormat& format, std::string& device)
       break;
     }
     default:
-      CLog::LogF(LOGDEBUG, "CAESinkStarfish: Unsupported format {}", m_format.m_streamInfo.m_type);
+      CLog::LogF(LOGDEBUG, "Unsupported format {}", m_format.m_streamInfo.m_type);
       return false;
   }
   payload["option"]["externalStreamingInfo"]["contents"]["codec"]["audio"] =
@@ -183,10 +183,10 @@ bool CAESinkStarfish::Initialize(AEAudioFormat& format, std::string& device)
   CJSONVariantWriter::Write(payloadArgs, json, true);
 
   m_starfishMediaAPI->notifyForeground();
-  CLog::LogFC(LOGDEBUG, LOGAUDIO, "CAESinkStarfish: Sending Load payload {}", json);
+  CLog::LogFC(LOGDEBUG, LOGAUDIO, "Sending Load payload {}", json);
   if (!m_starfishMediaAPI->Load(json.c_str(), &CAESinkStarfish::PlayerCallback, this))
   {
-    CLog::LogF(LOGERROR, "CAESinkStarfish: Load failed");
+    CLog::LogF(LOGERROR, "Load failed");
     return false;
   }
 
@@ -250,7 +250,7 @@ unsigned int CAESinkStarfish::AddPackets(uint8_t** data, unsigned int frames, un
     return frames;
   }
 
-  CLog::LogF(LOGWARNING, "CAESinkStarfish: Buffer submit returned error: {}", result);
+  CLog::LogF(LOGWARNING, "Buffer submit returned error: {}", result);
   return 0;
 }
 
@@ -283,8 +283,7 @@ void CAESinkStarfish::PlayerCallback(const int32_t type,
       break;
     default:
       std::string logstr = strValue != nullptr ? strValue : "";
-      CLog::LogF(LOGDEBUG, "CAESinkStarfish: type: {}, numValue: {}, strValue: {}", type, numValue,
-                 logstr);
+      CLog::LogF(LOGDEBUG, "type: {}, numValue: {}, strValue: {}", type, numValue, logstr);
   }
 }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -45,8 +45,7 @@ AVPixelFormat ConvertToPixelFormat(const VIDEOCODEC_FORMAT videoFormat)
     case VIDEOCODEC_FORMAT_YUV444P12:
       return AV_PIX_FMT_YUV444P12;
     default:
-      CLog::LogF(LOGWARNING,
-                 "CAddonVideoCodec: Video pixel format '{}' not valid, fallback to YUV420P.",
+      CLog::LogF(LOGWARNING, "Video pixel format '{}' not valid, fallback to YUV420P.",
                  videoFormat);
       return AV_PIX_FMT_YUV420P;
   }
@@ -72,8 +71,7 @@ unsigned int GetColorBitsFromVideoFormat(const VIDEOCODEC_FORMAT videoFormat)
     case VIDEOCODEC_FORMAT_YUV444P12:
       return 12;
     default:
-      CLog::LogF(LOGWARNING,
-                 "CAddonVideoCodec: Video pixel format '{}' not valid, fallback to 8 bits color.",
+      CLog::LogF(LOGWARNING, "Video pixel format '{}' not valid, fallback to 8 bits color.",
                  videoFormat);
       return 8;
   }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecStarfish.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecStarfish.cpp
@@ -86,7 +86,7 @@ bool CDVDVideoCodecStarfish::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
   // allow only 1 instance here
   if (ms_instanceGuard.exchange(true))
   {
-    CLog::LogF(LOGERROR, "CDVDVideoCodecStarfish: InstanceGuard locked");
+    CLog::LogF(LOGERROR, "InstanceGuard locked");
     return false;
   }
 
@@ -106,18 +106,18 @@ bool CDVDVideoCodecStarfish::OpenInternal(CDVDStreamInfo& hints, CDVDCodecOption
 
   if (hints.cryptoSession)
   {
-    CLog::LogF(LOGERROR, "CDVDVideoCodecStarfish: CryptoSessions unsupported");
+    CLog::LogF(LOGERROR, "CryptoSessions unsupported");
     return false;
   }
 
   if (!hints.width || !hints.height)
   {
-    CLog::LogF(LOGERROR, "CDVDVideoCodecStarfish: {}", "null size, cannot handle");
+    CLog::LogF(LOGERROR, "{}", "null size, cannot handle");
     return false;
   }
 
   CLog::LogF(LOGDEBUG,
-             "CDVDVideoCodecStarfish: hints: Width {} x Height {}, Fpsrate {} / Fpsscale {}, "
+             "Hints: Width {} x Height {}, Fpsrate {} / Fpsscale {}, "
              "CodecID {}, Level {}, Profile {}, PTS_invalid {}, Tag {}, Extradata-Size: {}",
              hints.width, hints.height, hints.fpsrate, hints.fpsscale, hints.codec, hints.level,
              hints.profile, hints.ptsinvalid, hints.codec_tag, hints.extradata.GetSize());
@@ -125,7 +125,7 @@ bool CDVDVideoCodecStarfish::OpenInternal(CDVDStreamInfo& hints, CDVDCodecOption
   if (ms_codecMap.find(hints.codec) == ms_codecMap.cend() ||
       ms_formatInfoMap.find(hints.codec) == ms_formatInfoMap.cend())
   {
-    CLog::LogF(LOGDEBUG, "CDVDVideoCodecStarfish: Unsupported hints.codec({})", hints.codec);
+    CLog::LogF(LOGDEBUG, "Unsupported hints.codec({})", hints.codec);
     return false;
   }
 
@@ -287,10 +287,10 @@ bool CDVDVideoCodecStarfish::OpenInternal(CDVDStreamInfo& hints, CDVDCodecOption
   std::string payload;
   CJSONVariantWriter::Write(payloadArgs, payload, true);
 
-  CLog::LogFC(LOGDEBUG, LOGVIDEO, "CDVDVideoCodecStarfish: Sending Load payload {}", payload);
+  CLog::LogFC(LOGDEBUG, LOGVIDEO, "Sending Load payload {}", payload);
   if (!m_starfishMediaAPI->Load(payload.c_str(), &CDVDVideoCodecStarfish::PlayerCallback, this))
   {
-    CLog::LogF(LOGERROR, "CDVDVideoCodecStarfish: Load failed");
+    CLog::LogF(LOGERROR, "Load failed");
     return false;
   }
 
@@ -298,7 +298,7 @@ bool CDVDVideoCodecStarfish::OpenInternal(CDVDStreamInfo& hints, CDVDCodecOption
 
   m_codecControlFlags = 0;
 
-  CLog::LogF(LOGINFO, "CDVDVideoCodecStarfish: Starfish {}", m_codecname);
+  CLog::LogF(LOGINFO, "Starfish {}", m_codecname);
 
   // first make sure all properties are reset.
   m_videobuffer.Reset();
@@ -373,7 +373,7 @@ bool CDVDVideoCodecStarfish::AddData(const DemuxPacket& packet)
 
     if (m_state == StarfishState::FLUSHED && !m_bitstream->CanStartDecode())
     {
-      CLog::LogF(LOGDEBUG, "CDVDVideoCodecStarfish: Waiting for keyframe (bitstream)");
+      CLog::LogF(LOGDEBUG, "Waiting for keyframe (bitstream)");
       return true;
     }
 
@@ -417,7 +417,7 @@ bool CDVDVideoCodecStarfish::AddData(const DemuxPacket& packet)
     if (result.find("BufferFull") != std::string::npos)
       return false;
 
-    CLog::LogF(LOGWARNING, "CDVDVideoCodecStarfish: Buffer submit returned error: {}", result);
+    CLog::LogF(LOGWARNING, "Buffer submit returned error: {}", result);
   }
 
   return true;
@@ -428,7 +428,7 @@ void CDVDVideoCodecStarfish::Reset()
   if (!m_opened)
     return;
 
-  CLog::LogF(LOGDEBUG, "CDVDVideoCodecStarfish: Reset");
+  CLog::LogF(LOGDEBUG, "Reset");
   m_starfishMediaAPI->flush();
 
   m_state = StarfishState::FLUSHED;
@@ -445,11 +445,11 @@ bool CDVDVideoCodecStarfish::Reconfigure(CDVDStreamInfo& hints)
   if (m_hints.Equal(hints, CDVDStreamInfo::COMPARE_ALL &
                                ~(CDVDStreamInfo::COMPARE_ID | CDVDStreamInfo::COMPARE_EXTRADATA)))
   {
-    CLog::LogF(LOGDEBUG, "CDVDVideoCodecStarfish: true");
+    CLog::LogF(LOGDEBUG, "true");
     m_hints = hints;
     return true;
   }
-  CLog::LogF(LOGDEBUG, "CDVDVideoCodecStarfish: false");
+  CLog::LogF(LOGDEBUG, "false");
   return false;
 }
 
@@ -476,7 +476,7 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecStarfish::GetPicture(VideoPicture* pVideo
       std::chrono::duration_cast<std::chrono::duration<double, dvdTime>>(m_currentPlaytime).count();
   m_newFrame = false;
 
-  CLog::LogFC(LOGDEBUG, LOGVIDEO, "CDVDVideoCodecStarfish: pts:{:0.4f}", pVideoPicture->pts);
+  CLog::LogFC(LOGDEBUG, LOGVIDEO, "pts:{:0.4f}", pVideoPicture->pts);
 
   return VC_PICTURE;
 }
@@ -485,8 +485,7 @@ void CDVDVideoCodecStarfish::SetCodecControl(int flags)
 {
   if (m_codecControlFlags != flags)
   {
-    CLog::LogFC(LOGDEBUG, LOGVIDEO, "CDVDVideoCodecStarfish: {:x}->{:x}", m_codecControlFlags,
-                flags);
+    CLog::LogFC(LOGDEBUG, LOGVIDEO, "{:x}->{:x}", m_codecControlFlags, flags);
     m_codecControlFlags = flags;
   }
 }
@@ -502,7 +501,7 @@ void CDVDVideoCodecStarfish::SetSpeed(int iSpeed)
       m_starfishMediaAPI->Pause();
       break;
     default:
-      CLog::LogF(LOGWARNING, "CDVDVideoCodecStarfish: Unknown playback speed");
+      CLog::LogF(LOGWARNING, "Unknown playback speed");
       break;
   }
 }
@@ -588,8 +587,7 @@ void CDVDVideoCodecStarfish::UpdateFpsDuration()
 {
   m_processInfo.SetVideoFps(static_cast<float>(m_hints.fpsrate) / m_hints.fpsscale);
 
-  CLog::LogF(LOGDEBUG, "CDVDVideoCodecStarfish: fpsRate:{} fpsscale:{}", m_hints.fpsrate,
-             m_hints.fpsscale);
+  CLog::LogF(LOGDEBUG, "fpsRate:{} fpsscale:{}", m_hints.fpsrate, m_hints.fpsscale);
 }
 
 void CDVDVideoCodecStarfish::PlayerCallback(const int32_t type,
@@ -597,8 +595,7 @@ void CDVDVideoCodecStarfish::PlayerCallback(const int32_t type,
                                             const char* strValue)
 {
   std::string logstr = strValue != nullptr ? strValue : "";
-  CLog::LogF(LOGDEBUG, "CDVDVideoCodecStarfish: type: {}, numValue: {}, strValue: {}", type,
-             numValue, logstr);
+  CLog::LogF(LOGDEBUG, "type: {}, numValue: {}, strValue: {}", type, numValue, logstr);
 
   switch (type)
   {
@@ -639,13 +636,11 @@ void CDVDVideoCodecStarfish::PlayerCallback(const int32_t type,
         AcbAPI_setState(m_acbId, APPSTATE_FOREGROUND, PLAYSTATE_UNLOADED, nullptr);
       break;
     case PF_EVENT_TYPE_INT_ERROR:
-      CLog::LogF(LOGERROR, "CDVDVideoCodecStarfish: Pipeline INT_ERROR numValue: {}, strValue: {}",
-                 numValue, logstr);
+      CLog::LogF(LOGERROR, "Pipeline INT_ERROR numValue: {}, strValue: {}", numValue, logstr);
       m_state = StarfishState::ERROR;
       break;
     case PF_EVENT_TYPE_STR_ERROR:
-      CLog::LogF(LOGERROR, "CDVDVideoCodecStarfish: Pipeline STR_ERROR numValue: {}, strValue: {}",
-                 numValue, logstr);
+      CLog::LogF(LOGERROR, "Pipeline STR_ERROR numValue: {}, strValue: {}", numValue, logstr);
       m_state = StarfishState::ERROR;
       break;
   }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -183,7 +183,7 @@ bool CDVDDemuxClient::ParsePacket(DemuxPacket* pkt)
       st->extraData = std::move(retExtraData);
       stream->m_parser_split = false;
       change = true;
-      CLog::Log(LOGDEBUG, "CDVDDemuxClient::ParsePacket - split extradata");
+      CLog::LogF(LOGDEBUG, "split extradata");
 
       // Allow ffmpeg to transport codec information to stream->m_context
       if (!avcodec_open2(stream->m_context, stream->m_context->codec, nullptr))

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -863,8 +863,7 @@ AVDictionary* CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput()
       if (!transportProp.isNull() &&
           (transportProp == "tcp" || transportProp == "udp" || transportProp == "udp_multicast"))
       {
-        CLog::LogF(LOGDEBUG, "GetFFMpegOptionsFromInput() Forcing rtsp transport protocol to '{}'",
-                   transportProp.asString());
+        CLog::LogF(LOGDEBUG, "Forcing rtsp transport protocol to '{}'", transportProp.asString());
         av_dict_set(&options, "rtsp_transport", transportProp.asString().c_str(), 0);
       }
     }
@@ -1798,8 +1797,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         // if analyzing streams is skipped, unknown streams may become valid later
         if (m_streaminfo && IsTransportStreamReady())
         {
-          CLog::Log(LOGDEBUG, "CDVDDemuxFFmpeg::AddStream - discarding unknown stream with id: {}",
-                    pStream->index);
+          CLog::LogF(LOGDEBUG, "Discarding unknown stream with id: {}", pStream->index);
           pStream->discard = AVDISCARD_ALL;
           return nullptr;
         }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -108,9 +108,9 @@ std::shared_ptr<CDVDInputStream> CDVDFactoryInputStream::CreateInputStream(IVide
   if (VIDEO::IsDVDFile(fileitem, false, true))
     return std::make_shared<CDVDInputStreamNavigator>(pPlayer, fileitem);
   else if (URIUtils::IsPVRChannel(file))
-    return std::make_shared<CInputStreamPVRChannel>(pPlayer, fileitem);
+    return std::make_shared<CInputStreamPVRChannel>(fileitem);
   else if (URIUtils::IsPVRRecording(file))
-    return std::make_shared<CInputStreamPVRRecording>(pPlayer, fileitem);
+    return std::make_shared<CInputStreamPVRRecording>(fileitem);
 #ifdef HAVE_LIBBLURAY
   else if (fileitem.IsType(".bdmv") || fileitem.IsType(".mpls")
           || fileitem.IsType(".bdm") || fileitem.IsType(".mpl")

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -1371,8 +1371,7 @@ bool CDVDInputStreamNavigator::GetState(std::string& xmlstate)
 
   if (!m_dvdStateSerializer.DVDStateToXML(xmlstate, dvdState))
   {
-    CLog::Log(LOGWARNING,
-              "CDVDInputStreamNavigator::SetNavigatorState - Failed to serialize state");
+    CLog::LogF(LOGWARNING, "Failed to serialize state");
     return false;
   }
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.cpp
@@ -17,15 +17,15 @@
 #include "settings/SettingsComponent.h"
 #include "utils/log.h"
 
-CInputStreamPVRBase::CInputStreamPVRBase(IVideoPlayer* pPlayer, const CFileItem& fileitem)
+CInputStreamPVRBase::CInputStreamPVRBase(const CFileItem& fileitem)
   : CDVDInputStream(DVDSTREAM_TYPE_PVRMANAGER, fileitem),
-    m_StreamProps(new PVR_STREAM_PROPERTIES()),
+    m_StreamProps(std::make_shared<PVR_STREAM_PROPERTIES>()),
     m_client(CServiceBroker::GetPVRManager().GetClient(fileitem))
 {
   if (!m_client)
-    CLog::Log(LOGERROR,
-              "CInputStreamPVRBase - {} - unable to obtain pvr addon instance for item '{}'",
-              __FUNCTION__, fileitem.GetPath());
+  {
+    CLog::LogF(LOGERROR, "Unable to obtain pvr addon instance for item '{}'", fileitem.GetPath());
+  }
 }
 
 CInputStreamPVRBase::~CInputStreamPVRBase()
@@ -189,8 +189,8 @@ std::vector<CDemuxStream*> CInputStreamPVRBase::GetStreams() const
   std::vector<CDemuxStream*> streams;
 
   streams.reserve(m_streamMap.size());
-  for (const auto& st : m_streamMap)
-    streams.emplace_back(st.second.get());
+  for (const auto& [_, st] : m_streamMap)
+    streams.emplace_back(st.get());
 
   return streams;
 }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.h
@@ -30,7 +30,7 @@ class CInputStreamPVRBase
   , public CDVDInputStream::IDemux
 {
 public:
-  CInputStreamPVRBase(IVideoPlayer* pPlayer, const CFileItem& fileitem);
+  CInputStreamPVRBase(const CFileItem& fileitem);
   ~CInputStreamPVRBase() override;
   bool Open() override;
   void Close() override;
@@ -59,11 +59,14 @@ public:
   int GetNrOfStreams() const override;
   void SetSpeed(int iSpeed) override;
   void FillBuffer(bool mode) override;
-  bool SeekTime(double time, bool backward = false, double* startpts = NULL) override;
+  bool SeekTime(double time, bool backward = false, double* startpts = nullptr) override;
   void AbortDemux() override;
   void FlushDemux() override;
 
 protected:
+  PVR::CPVRClient& GetClient() const { return *m_client; }
+  bool IsEOF() const { return m_eof; }
+
   void UpdateStreamMap();
   std::shared_ptr<CDemuxStream> GetStreamInternal(int iStreamId);
 
@@ -79,6 +82,7 @@ protected:
   virtual void PausePVRStream(bool paused) = 0;
   virtual bool GetPVRStreamTimes(Times& times) = 0;
 
+private:
   bool m_eof = true;
   std::shared_ptr<PVR_STREAM_PROPERTIES> m_StreamProps;
   std::map<int, std::shared_ptr<CDemuxStream>> m_streamMap;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRChannel.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRChannel.h
@@ -13,7 +13,7 @@
 class CInputStreamPVRChannel : public CInputStreamPVRBase
 {
 public:
-  CInputStreamPVRChannel(IVideoPlayer* pPlayer, const CFileItem& fileitem);
+  using CInputStreamPVRBase::CInputStreamPVRBase;
   ~CInputStreamPVRChannel() override;
 
   CDVDInputStream::IDemux* GetIDemux() override;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRRecording.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRRecording.cpp
@@ -16,11 +16,6 @@
 
 using namespace PVR;
 
-CInputStreamPVRRecording::CInputStreamPVRRecording(IVideoPlayer* pPlayer, const CFileItem& fileitem)
-  : CInputStreamPVRBase(pPlayer, fileitem)
-{
-}
-
 CInputStreamPVRRecording::~CInputStreamPVRRecording()
 {
   Close();
@@ -33,16 +28,11 @@ bool CInputStreamPVRRecording::OpenPVRStream()
     recording = CServiceBroker::GetPVRManager().Recordings()->GetByPath(m_item.GetPath());
 
   if (!recording)
-    CLog::Log(
-        LOGERROR,
-        "CInputStreamPVRRecording - {} - unable to obtain recording instance for recording {}",
-        __FUNCTION__, m_item.GetPath());
+    CLog::LogF(LOGERROR, "Unable to obtain recording instance for recording {}", m_item.GetPath());
 
-  if (recording && m_client &&
-      (m_client->OpenRecordedStream(recording, m_streamId) == PVR_ERROR_NO_ERROR))
+  if (recording && (GetClient().OpenRecordedStream(recording, m_streamId) == PVR_ERROR_NO_ERROR))
   {
-    CLog::Log(LOGDEBUG, "CInputStreamPVRRecording - {} - opened recording stream {}", __FUNCTION__,
-              m_item.GetPath());
+    CLog::LogF(LOGDEBUG, "Opened recording stream {}", m_item.GetPath());
     return true;
   }
   return false;
@@ -50,40 +40,30 @@ bool CInputStreamPVRRecording::OpenPVRStream()
 
 void CInputStreamPVRRecording::ClosePVRStream()
 {
-  if (m_client && (m_client->CloseRecordedStream(m_streamId) == PVR_ERROR_NO_ERROR))
+  if (GetClient().CloseRecordedStream(m_streamId) == PVR_ERROR_NO_ERROR)
   {
-    CLog::Log(LOGDEBUG, "CInputStreamPVRRecording - {} - closed recording stream {}", __FUNCTION__,
-              m_item.GetPath());
+    CLog::LogF(LOGDEBUG, "Closed recording stream {}", m_item.GetPath());
   }
 }
 
 int CInputStreamPVRRecording::ReadPVRStream(uint8_t* buf, int buf_size)
 {
   int iRead = -1;
-
-  if (m_client)
-    m_client->ReadRecordedStream(m_streamId, buf, buf_size, iRead);
-
+  GetClient().ReadRecordedStream(m_streamId, buf, buf_size, iRead);
   return iRead;
 }
 
 int64_t CInputStreamPVRRecording::SeekPVRStream(int64_t offset, int whence)
 {
   int64_t ret = -1;
-
-  if (m_client)
-    m_client->SeekRecordedStream(m_streamId, offset, whence, ret);
-
+  GetClient().SeekRecordedStream(m_streamId, offset, whence, ret);
   return ret;
 }
 
 int64_t CInputStreamPVRRecording::GetPVRStreamLength()
 {
   int64_t ret = -1;
-
-  if (m_client)
-    m_client->GetRecordedStreamLength(m_streamId, ret);
-
+  GetClient().GetRecordedStreamLength(m_streamId, ret);
   return ret;
 }
 
@@ -105,23 +85,19 @@ bool CInputStreamPVRRecording::CanSeekPVRStream()
 bool CInputStreamPVRRecording::IsRealtimePVRStream()
 {
   bool ret = false;
-
-  if (m_client)
-    m_client->IsRecordedStreamRealTime(m_streamId, ret);
-
+  GetClient().IsRecordedStreamRealTime(m_streamId, ret);
   return ret;
 }
 
 void CInputStreamPVRRecording::PausePVRStream(bool paused)
 {
-  if (m_client)
-    m_client->PauseRecordedStream(m_streamId, paused);
+  GetClient().PauseRecordedStream(m_streamId, paused);
 }
 
 bool CInputStreamPVRRecording::GetPVRStreamTimes(Times& times)
 {
   PVR_STREAM_TIMES streamTimes = {};
-  if (m_client && m_client->GetRecordedStreamTimes(m_streamId, &streamTimes) == PVR_ERROR_NO_ERROR)
+  if (GetClient().GetRecordedStreamTimes(m_streamId, &streamTimes) == PVR_ERROR_NO_ERROR)
   {
     times.startTime = streamTimes.startTime;
     times.ptsStart = streamTimes.ptsStart;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRRecording.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRRecording.h
@@ -13,7 +13,7 @@
 class CInputStreamPVRRecording : public CInputStreamPVRBase
 {
 public:
-  CInputStreamPVRRecording(IVideoPlayer* pPlayer, const CFileItem& fileitem);
+  using CInputStreamPVRBase::CInputStreamPVRBase;
   ~CInputStreamPVRRecording() override;
 
 protected:

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererStarfish.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererStarfish.cpp
@@ -20,7 +20,7 @@
 
 CRendererStarfish::CRendererStarfish()
 {
-  CLog::LogF(LOGINFO, "CRendererStarfish: Instanced");
+  CLog::LogF(LOGINFO, "Instanced");
 }
 
 CRendererStarfish::~CRendererStarfish() = default;

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -536,7 +536,7 @@ long MysqlDatabase::nextid(const char* sname)
   MYSQL_RES* res;
   char sqlcmd[512];
   snprintf(sqlcmd, sizeof(sqlcmd), "SELECT nextid FROM %s WHERE seq_name = '%s'", seq_table, sname);
-  CLog::LogFC(LOGDEBUG, LOGDATABASE, "MysqlDatabase::nextid will request");
+  CLog::LogFC(LOGDEBUG, LOGDATABASE, "will request");
   if ((last_err = query_with_reconnect(sqlcmd)) != 0)
   {
     return DB_UNEXPECTED_RESULT;
@@ -576,7 +576,7 @@ void MysqlDatabase::start_transaction()
   {
     assert(!_in_transaction);
     mysql_autocommit(conn, false);
-    CLog::LogFC(LOGDEBUG, LOGDATABASE, "Mysql Start transaction");
+    CLog::LogFC(LOGDEBUG, LOGDATABASE, "Start transaction");
 
     if (_in_transaction)
       CLog::LogF(LOGERROR, "error: nested transactions are not supported.");
@@ -592,7 +592,7 @@ void MysqlDatabase::commit_transaction()
     assert(_in_transaction);
     mysql_commit(conn);
     mysql_autocommit(conn, true);
-    CLog::LogFC(LOGDEBUG, LOGDATABASE, "Mysql commit transaction");
+    CLog::LogFC(LOGDEBUG, LOGDATABASE, "Commit transaction");
     _in_transaction = false;
   }
 }
@@ -604,7 +604,7 @@ void MysqlDatabase::rollback_transaction()
     assert(_in_transaction);
     mysql_rollback(conn);
     mysql_autocommit(conn, true);
-    CLog::LogFC(LOGDEBUG, LOGDATABASE, "Mysql rollback transaction");
+    CLog::LogFC(LOGDEBUG, LOGDATABASE, "Rollback transaction");
     _in_transaction = false;
   }
 }

--- a/xbmc/favourites/ContextMenus.cpp
+++ b/xbmc/favourites/ContextMenus.cpp
@@ -36,9 +36,8 @@ bool CFavouriteContextMenuAction::Execute(const std::shared_ptr<CFileItem>& item
   CFileItemList items;
   CServiceBroker::GetFavouritesService().GetAll(items);
 
-  const auto it = std::find_if(items.cbegin(), items.cend(), [&item](const auto& favourite) {
-    return favourite->GetPath() == item->GetPath();
-  });
+  const auto it = std::ranges::find_if(items, [&item](const auto& favourite)
+                                       { return favourite->GetPath() == item->GetPath(); });
 
   if ((it != items.cend()) && DoExecute(items, *it))
     return CServiceBroker::GetFavouritesService().Save(items);

--- a/xbmc/favourites/ContextMenus.h
+++ b/xbmc/favourites/ContextMenus.h
@@ -20,7 +20,8 @@ namespace CONTEXTMENU
 class CFavouriteContextMenuAction : public CStaticContextMenuAction
 {
 public:
-  explicit CFavouriteContextMenuAction(uint32_t label) : CStaticContextMenuAction(label) {}
+  using CStaticContextMenuAction::CStaticContextMenuAction;
+
   bool IsVisible(const CFileItem& item) const override;
   bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 

--- a/xbmc/favourites/FavouritesService.h
+++ b/xbmc/favourites/FavouritesService.h
@@ -56,7 +56,7 @@ private:
   CFavouritesService& operator=(CFavouritesService&&) = delete;
 
   void OnUpdated();
-  bool Persist();
+  bool Persist() const;
 
   void CleanupTargetsCache(const CFileItem& item);
 

--- a/xbmc/favourites/FavouritesURL.cpp
+++ b/xbmc/favourites/FavouritesURL.cpp
@@ -21,6 +21,7 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
+#include <string_view>
 #include <vector>
 
 namespace
@@ -29,39 +30,43 @@ std::string GetActionString(CFavouritesURL::Action action)
 {
   switch (action)
   {
-    case CFavouritesURL::Action::ACTIVATE_WINDOW:
+    using enum CFavouritesURL::Action;
+
+    case ACTIVATE_WINDOW:
       return "activatewindow";
-    case CFavouritesURL::Action::PLAY_MEDIA:
+    case PLAY_MEDIA:
       return "playmedia";
-    case CFavouritesURL::Action::SHOW_PICTURE:
+    case SHOW_PICTURE:
       return "showpicture";
-    case CFavouritesURL::Action::RUN_SCRIPT:
+    case RUN_SCRIPT:
       return "runscript";
-    case CFavouritesURL::Action::RUN_ADDON:
+    case RUN_ADDON:
       return "runaddon";
-    case CFavouritesURL::Action::START_ANDROID_ACTIVITY:
+    case START_ANDROID_ACTIVITY:
       return "startandroidactivity";
     default:
       return {};
   }
 }
 
-CFavouritesURL::Action GetActionId(const std::string& actionString)
+CFavouritesURL::Action GetActionId(std::string_view actionString)
 {
+  using enum CFavouritesURL::Action;
+
   if (actionString == "activatewindow")
-    return CFavouritesURL::Action::ACTIVATE_WINDOW;
+    return ACTIVATE_WINDOW;
   else if (actionString == "playmedia")
-    return CFavouritesURL::Action::PLAY_MEDIA;
+    return PLAY_MEDIA;
   else if (actionString == "showpicture")
-    return CFavouritesURL::Action::SHOW_PICTURE;
+    return SHOW_PICTURE;
   else if (actionString == "runscript")
-    return CFavouritesURL::Action::RUN_SCRIPT;
+    return RUN_SCRIPT;
   else if (actionString == "runaddon")
-    return CFavouritesURL::Action::RUN_ADDON;
+    return RUN_ADDON;
   else if (actionString == "startandroidactivity")
-    return CFavouritesURL::Action::START_ANDROID_ACTIVITY;
+    return START_ANDROID_ACTIVITY;
   else
-    return CFavouritesURL::Action::UNKNOWN;
+    return UNKNOWN;
 }
 } // namespace
 

--- a/xbmc/favourites/FavouritesUtils.cpp
+++ b/xbmc/favourites/FavouritesUtils.cpp
@@ -115,8 +115,8 @@ bool ShouldEnableMoveItems()
   if (CServiceBroker::GetFavouritesService().Size() <= 1)
     return false;
 
-  auto& mgr = CServiceBroker::GetGUI()->GetWindowManager();
-  CGUIWindowFavourites* window = mgr.GetWindow<CGUIWindowFavourites>(WINDOW_FAVOURITES);
+  const auto& mgr = CServiceBroker::GetGUI()->GetWindowManager();
+  const CGUIWindowFavourites* window = mgr.GetWindow<CGUIWindowFavourites>(WINDOW_FAVOURITES);
   if (window && window->IsActive())
   {
     const CGUIViewState* state = window->GetViewState();

--- a/xbmc/favourites/GUIWindowFavourites.cpp
+++ b/xbmc/favourites/GUIWindowFavourites.cpp
@@ -137,26 +137,22 @@ bool CGUIWindowFavourites::OnMessage(CGUIMessage& message)
 {
   bool ret = false;
 
-  switch (message.GetMessage())
+  if (message.GetMessage() == GUI_MSG_REFRESH_LIST)
   {
-    case GUI_MSG_REFRESH_LIST:
+    const int size{m_vecItems->Size()};
+    int selected{m_viewControl.GetSelectedItem()};
+    if (!m_vecItems->IsEmpty() && selected == size - 1)
+      --selected; // remove of last item, select the new last item after refresh
+
+    Refresh(true);
+
+    if (m_vecItems->Size() < size)
     {
-      const int size = m_vecItems->Size();
-      int selected = m_viewControl.GetSelectedItem();
-      if (m_vecItems->Size() > 0 && selected == size - 1)
-        --selected; // remove of last item, select the new last item after refresh
-
-      Refresh(true);
-
-      if (m_vecItems->Size() < size)
-      {
-        // item removed. select item after the removed item
-        m_viewControl.SetSelectedItem(selected);
-      }
-
-      ret = true;
-      break;
+      // item removed. select item after the removed item
+      m_viewControl.SetSelectedItem(selected);
     }
+
+    ret = true;
   }
 
   return ret || CGUIMediaWindow::OnMessage(message);

--- a/xbmc/games/controllers/listproviders/GUIGameControllerProvider.cpp
+++ b/xbmc/games/controllers/listproviders/GUIGameControllerProvider.cpp
@@ -42,7 +42,7 @@ CGUIGameControllerProvider::CGUIGameControllerProvider(unsigned int portCount,
 }
 
 CGUIGameControllerProvider::CGUIGameControllerProvider(const CGUIGameControllerProvider& other)
-  : IListProvider(other.m_parentID),
+  : IListProvider(other),
     m_portCount(other.m_portCount),
     m_portIndex(other.m_portIndex),
     m_peripheralLocation(other.m_peripheralLocation),

--- a/xbmc/guilib/listproviders/DirectoryProvider.h
+++ b/xbmc/guilib/listproviders/DirectoryProvider.h
@@ -52,13 +52,6 @@ class CDirectoryProvider : public IListProvider,
                            private ITimerCallback
 {
 public:
-  typedef enum
-  {
-    OK,
-    INVALIDATED,
-    DONE
-  } UpdateState;
-
   enum class BrowseMode
   {
     NEVER,
@@ -92,12 +85,19 @@ public:
   class CSubscriber;
 
 private:
+  enum class UpdateState
+  {
+    OK,
+    INVALIDATED,
+    DONE
+  };
+
   void StartDirectoryJob();
 
   // ITimerCallback implementation
   void OnTimeout() override;
 
-  UpdateState m_updateState = OK;
+  UpdateState m_updateState{UpdateState::OK};
   unsigned int m_jobID = 0;
   bool m_jobPending{false};
   std::chrono::time_point<std::chrono::system_clock> m_lastJobStartedAt;

--- a/xbmc/guilib/listproviders/IListProvider.h
+++ b/xbmc/guilib/listproviders/IListProvider.h
@@ -25,6 +25,11 @@ public:
   explicit IListProvider(const IListProvider& other) = default;
   virtual ~IListProvider() = default;
 
+  /*! \brief Get the parent id for the container.
+   \return the id.
+   */
+  int GetParentId() const { return m_parentID; }
+
   /*! \brief Factory to create list providers.
    \param parent a parent TiXmlNode for the container.
    \param parentID id of parent window for context.
@@ -110,6 +115,7 @@ public:
    \sa GetDefaultItem, SetDefaultItem
    */
   virtual bool AlwaysFocusDefaultItem() const { return false; }
-protected:
-  int m_parentID;
+
+private:
+  const int m_parentID{-1};
 };

--- a/xbmc/guilib/listproviders/MultiProvider.h
+++ b/xbmc/guilib/listproviders/MultiProvider.h
@@ -14,8 +14,6 @@
 #include <map>
 #include <vector>
 
-typedef std::unique_ptr<IListProvider> IListProviderPtr;
-
 class TiXmlNode;
 
 /*!
@@ -39,9 +37,9 @@ public:
   bool OnContextMenu(const std::shared_ptr<CGUIListItem>& item) override;
 
 protected:
-  typedef size_t item_key_type;
-  static item_key_type GetItemKey(std::shared_ptr<CGUIListItem> const& item);
-  std::vector<IListProviderPtr> m_providers;
+  using item_key_type = size_t;
+  static size_t GetItemKey(std::shared_ptr<CGUIListItem> const& item);
+  std::vector<std::unique_ptr<IListProvider>> m_providers;
   std::map<item_key_type, IListProvider*> m_itemMap;
   CCriticalSection m_section; // protects m_itemMap
 };

--- a/xbmc/guilib/listproviders/StaticProvider.h
+++ b/xbmc/guilib/listproviders/StaticProvider.h
@@ -34,8 +34,8 @@ public:
   int GetDefaultItem() const override;
   bool AlwaysFocusDefaultItem() const override;
 private:
-  int m_defaultItem;
-  bool m_defaultAlways;
-  unsigned int m_updateTime;
+  int m_defaultItem{-1};
+  bool m_defaultAlways{false};
+  unsigned int m_updateTime{0};
   std::vector<CGUIStaticItemPtr> m_items;
 };

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -15,6 +15,7 @@
 #include "pvr/PVRPlaybackState.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannel.h"
+#include "pvr/channels/PVRChannelGroup.h"
 #include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"

--- a/xbmc/interfaces/json-rpc/PVROperations.h
+++ b/xbmc/interfaces/json-rpc/PVROperations.h
@@ -9,11 +9,15 @@
 #pragma once
 
 #include "FileItemHandler.h"
-#include "pvr/channels/PVRChannelGroup.h"
 
 #include <memory>
 
 class CVariant;
+
+namespace PVR
+{
+class CPVRChannelGroup;
+}
 
 namespace JSONRPC
 {

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -29,16 +29,15 @@
 
 namespace
 {
-static constexpr unsigned char Utf8Bom[3] = {0xEF, 0xBB, 0xBF};
-static const std::string LogFileExtension = ".log";
-static const std::string LogPattern = "%Y-%m-%d %T.%e T:%-5t %7l <%n>: %v";
+constexpr unsigned char Utf8Bom[3] = {0xEF, 0xBB, 0xBF};
+const std::string LogFileExtension = ".log";
+const std::string LogPattern = "%Y-%m-%d %T.%e T:%-5t %7l <%n>: %v";
 } // namespace
 
 CLog::CLog()
   : m_platform(IPlatformLog::CreatePlatformLog()),
     m_sinks(std::make_shared<spdlog::sinks::dist_sink_mt>()),
-    m_defaultLogger(CreateLogger("general")),
-    m_logLevel(LOG_LEVEL_DEBUG)
+    m_defaultLogger(CreateLogger("general"))
 {
   // add platform-specific debug sinks
   m_platform->AddSinks(m_sinks);
@@ -70,7 +69,7 @@ void CLog::OnSettingsLoaded()
 
 void CLog::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)
 {
-  if (setting == NULL)
+  if (setting == nullptr)
     return;
 
   const std::string& settingId = setting->GetId();
@@ -178,7 +177,7 @@ void CLog::SetLogLevel(int level)
                        fmt::make_format_args(spdlog::level::to_string_view(spdLevel)));
 }
 
-bool CLog::IsLogLevelLogged(int loglevel)
+bool CLog::IsLogLevelLogged(int loglevel) const
 {
   if (m_logLevel >= LOG_LEVEL_DEBUG)
     return true;
@@ -295,7 +294,7 @@ void CLog::SetComponentLogLevel(const std::vector<CVariant>& components)
   }
 }
 
-void CLog::FormatLineBreaks(std::string& message)
+void CLog::FormatLineBreaks(std::string& message) const
 {
   StringUtils::Replace(message, "\n", "\n                                                   ");
 }

--- a/xbmc/windowing/wayland/OSScreenSaverWebOS.cpp
+++ b/xbmc/windowing/wayland/OSScreenSaverWebOS.cpp
@@ -30,7 +30,7 @@ COSScreenSaverWebOS::~COSScreenSaverWebOS()
   {
     // Luna helper functions return 0 on success
     if (HUnregisterServiceCallback(m_requestContext.get()))
-      CLog::LogF(LOGWARNING, "COSScreenSaverWebOS: Luna request unregister failed");
+      CLog::LogF(LOGWARNING, "Luna request unregister failed");
     m_requestContext = nullptr;
   }
 }
@@ -49,9 +49,9 @@ void COSScreenSaverWebOS::Inhibit()
   m_requestContext->callback = &OnScreenSaverAboutToStart;
   if (HLunaServiceCall(LUNA_REGISTER_SCREENSAVER, payload.c_str(), m_requestContext.get()))
   {
-    CLog::LogF(LOGWARNING, "COSScreenSaverWebOS: Luna request call failed");
+    CLog::LogF(LOGWARNING, "Luna request call failed");
     if (HUnregisterServiceCallback(m_requestContext.get()))
-      CLog::LogF(LOGWARNING, "COSScreenSaverWebOS: Luna request unregister failed");
+      CLog::LogF(LOGWARNING, "Luna request unregister failed");
     m_requestContext = nullptr;
   }
 }
@@ -61,7 +61,7 @@ void COSScreenSaverWebOS::Uninhibit()
   if (m_requestContext)
   {
     if (HUnregisterServiceCallback(m_requestContext.get()))
-      CLog::LogF(LOGWARNING, "COSScreenSaverWebOS: Luna request unregister failed");
+      CLog::LogF(LOGWARNING, "Luna request unregister failed");
     m_requestContext = nullptr;
   }
 }
@@ -72,7 +72,7 @@ bool COSScreenSaverWebOS::OnScreenSaverAboutToStart(LSHandle* sh, LSMessage* rep
   const char* msg = HLunaServiceMessage(reply);
   CJSONVariantParser::Parse(msg, request);
 
-  CLog::LogF(LOGDEBUG, "COSScreenSaverWebOS: Responded {}", msg);
+  CLog::LogF(LOGDEBUG, "Responded {}", msg);
 
   if (request["state"] != "Active")
     return true;
@@ -90,7 +90,7 @@ bool COSScreenSaverWebOS::OnScreenSaverAboutToStart(LSHandle* sh, LSMessage* rep
   response_ctx.callback = nullptr;
   if (HLunaServiceCall(LUNA_RESPONSE_SCREENSAVER, payload.c_str(), &response_ctx))
   {
-    CLog::LogF(LOGWARNING, "COSScreenSaverWebOS: Luna response call failed");
+    CLog::LogF(LOGWARNING, "Luna response call failed");
     return false;
   }
 

--- a/xbmc/windowing/wayland/WinSystemWaylandWebOS.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandWebOS.cpp
@@ -74,11 +74,10 @@ bool CWinSystemWaylandWebOS::CreateNewWindow(const std::string& name,
     m_exportedSurface = m_webosForeign.export_element(
         GetMainSurface(),
         static_cast<uint32_t>(wayland::webos_foreign_webos_exported_type::video_object));
-    m_exportedSurface.on_window_id_assigned() = [this](std::string window_id,
-                                                       uint32_t exported_type) {
-      CLog::Log(LOGDEBUG,
-                "CreateNewWindow:CDVDVideoCodecStarfish: Foreign video surface exported {}",
-                window_id);
+    m_exportedSurface.on_window_id_assigned() =
+        [this](std::string window_id, uint32_t exported_type)
+    {
+      CLog::LogF(LOGDEBUG, "Foreign video surface exported {}", window_id);
       this->m_exportedWindowName = window_id;
     };
   }
@@ -112,10 +111,9 @@ bool CWinSystemWaylandWebOS::SetExportedWindow(CRect orig, CRect src, CRect dest
 {
   if (m_webosForeign)
   {
-    CLog::LogF(LOGINFO,
-               "CWinSystemWaylandWebOS: orig {} {} {} {} src {} {} {} {} -> dest {} {} {} {}",
-               orig.x1, orig.y1, orig.x2, orig.y2, src.x1, src.y1, src.x2, src.y2, dest.x1, dest.y1,
-               dest.x2, dest.y2);
+    CLog::LogF(LOGINFO, "orig {} {} {} {} src {} {} {} {} -> dest {} {} {} {}", orig.x1, orig.y1,
+               orig.x2, orig.y2, src.x1, src.y1, src.x2, src.y2, dest.x1, dest.y1, dest.x2,
+               dest.y2);
     wayland::region_t origRegion = m_compositor.create_region();
     wayland::region_t srcRegion = m_compositor.create_region();
     wayland::region_t dstRegion = m_compositor.create_region();

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -193,7 +193,7 @@ void CWinSystemWin10::AdjustWindow()
     {
       if (!appView.TryResizeView(winrt::Windows::Foundation::Size(dipsWidth, dipsHeight)))
       {
-        CLog::LogF(LOGDEBUG, __FUNCTION__, "resizing ApplicationView failed.");
+        CLog::LogF(LOGDEBUG, "Resizing ApplicationView failed.");
       }
     }
 


### PR DESCRIPTION
Some more (random) SonarQube findings that crossed my way recently... No functional changes intended, just modernization and cleanup.

**utils/log.***
* Concise syntax should be used for concatenatable namespaces cpp:S5812
* "override" or "final" should be used instead of "virtual" cpp:S3471
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* "std::source_location" should be used instead of `__FILE__`, `__LINE__`, and `__func__` macros cpp:S6190
* "static" should not be used in unnamed namespaces cpp:S3609
* Member data should be initialized in-class or in a constructor initialization list cpp:S3230
* "nullptr" should be used to denote the null pointer cpp:S4962

**favourites/**
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* Inheriting constructors should be used cpp:S5952
* "auto" should be used to avoid repetition of types cpp:S5827
* Redundant class template arguments should not be used cpp:S6012
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* "try_emplace" should be used with "std::map" and "std::unordered_map" cpp:S6030
* "using enum" should be used in scopes with high concentration of "enum" constants cpp:S6177
* "std::string_view" should be used to pass a read-only string to a function cpp:S6009
* "if" statements should be preferred over "switch" when simpler cpp:S1301
* "empty()" should be used to test for emptiness cpp:S1155

**guilib/listproviders/**
* "override" or "final" should be used instead of "virtual" cpp:S3471
* "using enum" should be used in scopes with high concentration of "enum" constants cpp:S6177
* "auto" should be used to avoid repetition of types cpp:S5827
* "make_unique" and "make_shared" should be used to construct "unique_ptr" and "shared_ptr" cpp:S5950
* "contains" should be used to check if a key exists in a container cpp:S6171
* Structured binding should be used cpp:S6005
* Redundant class template arguments should not be used cpp:S6012
* Pointer and reference local variables should be "const" if the corresponding object is not modified cpp:S5350
* Scoped enumerations should be used cpp:S3642
* Member variables should not be "protected" cpp:S3656
* "using" should be preferred for type aliasing cpp:S5416
* Member data should be initialized in-class or in a constructor initialization list cpp:S3230

**cores/VideoPlayer/DVDInputStreams/InputStreamPVR***
* Unused function parameters should be removed cpp:S1172
* "make_unique" and "make_shared" should be used to construct "unique_ptr" and "shared_ptr" cpp:S5950
* Structured binding should be used cpp:S6005
* Member variables should not be "protected" cpp:S3656
* "nullptr" should be used to denote the null pointer cpp:S4962

@neo1973 could you have a look plaase?