### PR TITLE
Misc Sonarqube findings, part 2

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -11725,7 +11725,7 @@ void CGUIInfoManager::Clear()
               infoBool.use_count());
 }
 
-void CGUIInfoManager::UpdateAVInfo()
+void CGUIInfoManager::UpdateAVInfo() const
 {
   if (CServiceBroker::GetDataCacheCore().HasAVInfoChanges())
   {
@@ -12052,12 +12052,12 @@ std::string CGUIInfoManager::GetSkinVariableString(int info,
 
 bool CGUIInfoManager::ConditionsChangedValues(const std::map<INFO::InfoPtr, bool>& map) const
 {
-  for (const auto& [info, value] : map)
-  {
-    if (info->Get(INFO::DEFAULT_CONTEXT) != value)
-      return true;
-  }
-  return false;
+  return std::ranges::any_of(map,
+                             [](const auto& entry)
+                             {
+                               const auto& [info, value] = entry;
+                               return info->Get(INFO::DEFAULT_CONTEXT) != value;
+                             });
 }
 
 int CGUIInfoManager::GetMessageMask()

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -132,7 +132,7 @@ public:
   // Current game stuff
   const KODI::GAME::CGameInfoTag* GetCurrentGameTag() const;
 
-  void UpdateAVInfo();
+  void UpdateAVInfo() const;
 
   int RegisterSkinVariableString(const INFO::CSkinVariableString* info);
   int TranslateSkinVariableString(const std::string& name, int context);

--- a/xbmc/addons/RepositoryUpdater.cpp
+++ b/xbmc/addons/RepositoryUpdater.cpp
@@ -129,10 +129,8 @@ CRepositoryUpdater::CRepositoryUpdater(CAddonMgr& addonMgr) :
   m_doneEvent(true),
   m_addonMgr(addonMgr)
 {
-  // Register settings
-  std::set<std::string> settingSet;
-  settingSet.insert(CSettings::SETTING_ADDONS_AUTOUPDATES);
-  CServiceBroker::GetSettingsComponent()->GetSettings()->RegisterCallback(this, settingSet);
+  CServiceBroker::GetSettingsComponent()->GetSettings()->RegisterCallback(
+      this, {CSettings::SETTING_ADDONS_AUTOUPDATES});
 }
 
 void CRepositoryUpdater::Start()

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
@@ -33,29 +33,28 @@ CActiveAESettings::CActiveAESettings(CActiveAE &ae) : m_audioEngine(ae)
   std::unique_lock<CCriticalSection> lock(m_cs);
   m_instance = this;
 
-  std::set<std::string> settingSet;
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_CONFIG);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_SAMPLERATE);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGH);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_CHANNELS);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_PROCESSQUALITY);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_ATEMPOTHRESHOLD);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_GUISOUNDMODE);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_STEREOUPMIX);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_AC3PASSTHROUGH);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_AC3TRANSCODE);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_EAC3PASSTHROUGH);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_DTSPASSTHROUGH);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_TRUEHDPASSTHROUGH);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_DTSHDPASSTHROUGH);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_AUDIODEVICE);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGHDEVICE);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_STREAMNOISE);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_MIXSUBLEVEL);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_MAINTAINORIGINALVOLUME);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_DTSHDCOREFALLBACK);
-  settings->GetSettingsManager()->RegisterCallback(this, settingSet);
+  settings->GetSettingsManager()->RegisterCallback(
+      this, {CSettings::SETTING_AUDIOOUTPUT_CONFIG,
+             CSettings::SETTING_AUDIOOUTPUT_SAMPLERATE,
+             CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGH,
+             CSettings::SETTING_AUDIOOUTPUT_CHANNELS,
+             CSettings::SETTING_AUDIOOUTPUT_PROCESSQUALITY,
+             CSettings::SETTING_AUDIOOUTPUT_ATEMPOTHRESHOLD,
+             CSettings::SETTING_AUDIOOUTPUT_GUISOUNDMODE,
+             CSettings::SETTING_AUDIOOUTPUT_STEREOUPMIX,
+             CSettings::SETTING_AUDIOOUTPUT_AC3PASSTHROUGH,
+             CSettings::SETTING_AUDIOOUTPUT_AC3TRANSCODE,
+             CSettings::SETTING_AUDIOOUTPUT_EAC3PASSTHROUGH,
+             CSettings::SETTING_AUDIOOUTPUT_DTSPASSTHROUGH,
+             CSettings::SETTING_AUDIOOUTPUT_TRUEHDPASSTHROUGH,
+             CSettings::SETTING_AUDIOOUTPUT_DTSHDPASSTHROUGH,
+             CSettings::SETTING_AUDIOOUTPUT_AUDIODEVICE,
+             CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGHDEVICE,
+             CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE,
+             CSettings::SETTING_AUDIOOUTPUT_STREAMNOISE,
+             CSettings::SETTING_AUDIOOUTPUT_MIXSUBLEVEL,
+             CSettings::SETTING_AUDIOOUTPUT_MAINTAINORIGINALVOLUME,
+             CSettings::SETTING_AUDIOOUTPUT_DTSHDCOREFALLBACK});
 
   settings->GetSettingsManager()->RegisterSettingOptionsFiller("aequalitylevels", SettingOptionsAudioQualityLevelsFiller);
   settings->GetSettingsManager()->RegisterSettingOptionsFiller("audiodevices", SettingOptionsAudioDevicesFiller);

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -93,10 +93,8 @@ CStereoscopicsManager::CStereoscopicsManager()
   m_lastStereoModeSetByUser = RENDER_STEREO_MODE_UNDEFINED;
 
   //! @todo Move this to Initialize() to avoid potential problems in ctor
-  std::set<std::string> settingSet{
-    CSettings::SETTING_VIDEOSCREEN_STEREOSCOPICMODE
-  };
-  m_settings->GetSettingsManager()->RegisterCallback(this, settingSet);
+  m_settings->GetSettingsManager()->RegisterCallback(
+      this, {CSettings::SETTING_VIDEOSCREEN_STEREOSCOPICMODE});
 }
 
 CStereoscopicsManager::~CStereoscopicsManager(void)

--- a/xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
@@ -280,6 +280,8 @@ bool CAddonsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
 
       return true;
     }
+    default:
+      break;
   }
 
   return false;

--- a/xbmc/guilib/guiinfo/GUIInfoLabel.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoLabel.cpp
@@ -19,6 +19,7 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
+#include <array>
 #include <stdexcept>
 #include <string>
 
@@ -38,11 +39,11 @@ int CGUIInfoLabel::GetIntValue(int contextWindow) const
     {
       return std::stoi(label);
     }
-    catch (std::invalid_argument const& ex)
+    catch (std::invalid_argument const&)
     {
       CLog::LogF(LOGERROR, "Error converting label value '{}' to int. Invalid argument.", label);
     }
-    catch (std::out_of_range const& ex)
+    catch (std::out_of_range const&)
     {
       CLog::LogF(LOGERROR, "Error converting label value '{}' to int. Value out of range.", label);
     }
@@ -299,10 +300,10 @@ struct InfoFormatData
   InfoFormat val{0};
 };
 
-const InfoFormatData infoformatmap[] = {{"$INFO[", InfoFormat::INFO},
-                                        {"$ESCINFO[", InfoFormat::ESC_INFO},
-                                        {"$VAR[", InfoFormat::VAR},
-                                        {"$ESCVAR[", InfoFormat::ESC_VAR}};
+constexpr std::array<InfoFormatData, 4> infoformatmap = {{{"$INFO[", InfoFormat::INFO},
+                                                          {"$ESCINFO[", InfoFormat::ESC_INFO},
+                                                          {"$VAR[", InfoFormat::VAR},
+                                                          {"$ESCVAR[", InfoFormat::ESC_VAR}}};
 
 } // unnamed namespace
 

--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -732,6 +732,8 @@ bool CMusicGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextW
         return true;
       }
       break;
+    default:
+      break;
   }
 
   return false;

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -76,11 +76,8 @@ CInputManager::CInputManager()
 
   RegisterKeyboardDriverHandler(m_keyboardEasterEgg.get());
 
-  // Register settings
-  std::set<std::string> settingSet;
-  settingSet.insert(CSettings::SETTING_INPUT_ENABLEMOUSE);
-  settingSet.insert(SETTING_INPUT_ENABLE_CONTROLLER);
-  CServiceBroker::GetSettingsComponent()->GetSettings()->RegisterCallback(this, settingSet);
+  CServiceBroker::GetSettingsComponent()->GetSettings()->RegisterCallback(
+      this, {CSettings::SETTING_INPUT_ENABLEMOUSE, SETTING_INPUT_ENABLE_CONTROLLER});
 }
 
 CInputManager::~CInputManager()

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -116,37 +116,35 @@ CNetworkServices::CNetworkServices()
   m_webserver.RegisterRequestHandler(&m_httpWebinterfaceHandler);
 #endif // HAS_WEB_INTERFACE
 #endif // HAS_WEB_SERVER
-  std::set<std::string> settingSet{
-      CSettings::SETTING_SERVICES_WEBSERVER,
-      CSettings::SETTING_SERVICES_WEBSERVERPORT,
-      CSettings::SETTING_SERVICES_WEBSERVERAUTHENTICATION,
-      CSettings::SETTING_SERVICES_WEBSERVERUSERNAME,
-      CSettings::SETTING_SERVICES_WEBSERVERPASSWORD,
-      CSettings::SETTING_SERVICES_WEBSERVERSSL,
-      CSettings::SETTING_SERVICES_ZEROCONF,
-      CSettings::SETTING_SERVICES_AIRPLAY,
-      CSettings::SETTING_SERVICES_AIRPLAYVOLUMECONTROL,
-      CSettings::SETTING_SERVICES_AIRPLAYVIDEOSUPPORT,
-      CSettings::SETTING_SERVICES_USEAIRPLAYPASSWORD,
-      CSettings::SETTING_SERVICES_AIRPLAYPASSWORD,
-      CSettings::SETTING_SERVICES_UPNP,
-      CSettings::SETTING_SERVICES_UPNPSERVER,
-      CSettings::SETTING_SERVICES_UPNPRENDERER,
-      CSettings::SETTING_SERVICES_UPNPCONTROLLER,
-      CSettings::SETTING_SERVICES_ESENABLED,
-      CSettings::SETTING_SERVICES_ESPORT,
-      CSettings::SETTING_SERVICES_ESALLINTERFACES,
-      CSettings::SETTING_SERVICES_ESINITIALDELAY,
-      CSettings::SETTING_SERVICES_ESCONTINUOUSDELAY,
-      CSettings::SETTING_SMB_WINSSERVER,
-      CSettings::SETTING_SMB_WORKGROUP,
-      CSettings::SETTING_SMB_MINPROTOCOL,
-      CSettings::SETTING_SMB_MAXPROTOCOL,
-      CSettings::SETTING_SMB_LEGACYSECURITY,
-      CSettings::SETTING_SERVICES_WSDISCOVERY,
-  };
   m_settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-  m_settings->GetSettingsManager()->RegisterCallback(this, settingSet);
+  m_settings->GetSettingsManager()->RegisterCallback(
+      this, {CSettings::SETTING_SERVICES_WEBSERVER,
+             CSettings::SETTING_SERVICES_WEBSERVERPORT,
+             CSettings::SETTING_SERVICES_WEBSERVERAUTHENTICATION,
+             CSettings::SETTING_SERVICES_WEBSERVERUSERNAME,
+             CSettings::SETTING_SERVICES_WEBSERVERPASSWORD,
+             CSettings::SETTING_SERVICES_WEBSERVERSSL,
+             CSettings::SETTING_SERVICES_ZEROCONF,
+             CSettings::SETTING_SERVICES_AIRPLAY,
+             CSettings::SETTING_SERVICES_AIRPLAYVOLUMECONTROL,
+             CSettings::SETTING_SERVICES_AIRPLAYVIDEOSUPPORT,
+             CSettings::SETTING_SERVICES_USEAIRPLAYPASSWORD,
+             CSettings::SETTING_SERVICES_AIRPLAYPASSWORD,
+             CSettings::SETTING_SERVICES_UPNP,
+             CSettings::SETTING_SERVICES_UPNPSERVER,
+             CSettings::SETTING_SERVICES_UPNPRENDERER,
+             CSettings::SETTING_SERVICES_UPNPCONTROLLER,
+             CSettings::SETTING_SERVICES_ESENABLED,
+             CSettings::SETTING_SERVICES_ESPORT,
+             CSettings::SETTING_SERVICES_ESALLINTERFACES,
+             CSettings::SETTING_SERVICES_ESINITIALDELAY,
+             CSettings::SETTING_SERVICES_ESCONTINUOUSDELAY,
+             CSettings::SETTING_SMB_WINSSERVER,
+             CSettings::SETTING_SMB_WORKGROUP,
+             CSettings::SETTING_SMB_MINPROTOCOL,
+             CSettings::SETTING_SMB_MAXPROTOCOL,
+             CSettings::SETTING_SMB_LEGACYSECURITY,
+             CSettings::SETTING_SERVICES_WSDISCOVERY});
 }
 
 CNetworkServices::~CNetworkServices()

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -82,14 +82,10 @@ CPeripherals::CPeripherals(CInputManager& inputManager,
     m_eventScanner(new CEventScanner(*this)),
     m_guiReadyEvent(std::make_unique<CEvent>())
 {
-  // Register settings
-  std::set<std::string> settingSet;
-  settingSet.insert(CSettings::SETTING_INPUT_PERIPHERALS);
-  settingSet.insert(CSettings::SETTING_INPUT_PERIPHERALLIBRARIES);
-  settingSet.insert(CSettings::SETTING_INPUT_CONTROLLERCONFIG);
-  settingSet.insert(CSettings::SETTING_INPUT_TESTRUMBLE);
-  settingSet.insert(CSettings::SETTING_LOCALE_LANGUAGE);
-  CServiceBroker::GetSettingsComponent()->GetSettings()->RegisterCallback(this, settingSet);
+  CServiceBroker::GetSettingsComponent()->GetSettings()->RegisterCallback(
+      this, {CSettings::SETTING_INPUT_PERIPHERALS, CSettings::SETTING_INPUT_PERIPHERALLIBRARIES,
+             CSettings::SETTING_INPUT_CONTROLLERCONFIG, CSettings::SETTING_INPUT_TESTRUMBLE,
+             CSettings::SETTING_LOCALE_LANGUAGE});
 }
 
 CPeripherals::~CPeripherals()

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -67,7 +67,7 @@ public:
   DebugLogSharingPresenter() : ISettingCallback()
   {
     CServiceBroker::GetSettingsComponent()->GetSettings()->RegisterCallback(
-        this, std::set<std::string>{CSettings::SETTING_DEBUG_SHARE_LOG});
+        this, {CSettings::SETTING_DEBUG_SHARE_LOG});
   }
   virtual ~DebugLogSharingPresenter()
   {

--- a/xbmc/platform/linux/input/LibInputSettings.cpp
+++ b/xbmc/platform/linux/input/LibInputSettings.cpp
@@ -55,9 +55,7 @@ CLibInputSettings::CLibInputSettings(CLibInputHandler *handler) :
 
   setting->SetVisible(true);
 
-  std::set<std::string> settingSet;
-  settingSet.insert(SETTING_INPUT_LIBINPUTKEYBOARDLAYOUT);
-  settingsManager->RegisterCallback(this, settingSet);
+  settingsManager->RegisterCallback(this, {SETTING_INPUT_LIBINPUTKEYBOARDLAYOUT});
   settingsManager->RegisterSettingOptionsFiller("libinputkeyboardlayout",
                                                 SettingOptionsKeyboardLayoutsFiller);
 

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -96,12 +96,7 @@ void CProfileManager::Initialize(const std::shared_ptr<CSettings>& settings)
     OnSettingsLoaded();
 
   m_settings->GetSettingsManager()->RegisterSettingsHandler(this);
-
-  std::set<std::string> settingSet = {
-    CSettings::SETTING_EVENTLOG_SHOW
-  };
-
-  m_settings->GetSettingsManager()->RegisterCallback(this, settingSet);
+  m_settings->GetSettingsManager()->RegisterCallback(this, {CSettings::SETTING_EVENTLOG_SHOW});
 }
 
 void CProfileManager::Uninitialize()

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -196,7 +196,7 @@ CPVRManager::CPVRManager()
     m_database(std::make_shared<CPVRDatabase>()),
     m_parentalTimer(std::make_unique<CStopWatch>()),
     m_playbackState(std::make_shared<CPVRPlaybackState>()),
-    m_settings(std::make_unique<CPVRSettings>(std::set<std::string>(
+    m_settings(std::make_unique<CPVRSettings>(SettingsContainer(
         {CSettings::SETTING_PVRPOWERMANAGEMENT_ENABLED,
          CSettings::SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD, CSettings::SETTING_PVRPARENTAL_ENABLED,
          CSettings::SETTING_PVRPARENTAL_DURATION})))

--- a/xbmc/pvr/channels/PVRChannelGroupSettings.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupSettings.cpp
@@ -19,10 +19,10 @@ using namespace PVR;
 
 CPVRChannelGroupSettings::CPVRChannelGroupSettings()
   : m_settings(std::make_unique<CPVRSettings>(
-        std::set<std::string>({CSettings::SETTING_PVRMANAGER_BACKENDCHANNELORDER,
-                               CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERS,
-                               CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERSALWAYS,
-                               CSettings::SETTING_PVRMANAGER_STARTGROUPCHANNELNUMBERSFROMONE})))
+        SettingsContainer({CSettings::SETTING_PVRMANAGER_BACKENDCHANNELORDER,
+                           CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERS,
+                           CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERSALWAYS,
+                           CSettings::SETTING_PVRMANAGER_STARTGROUPCHANNELNUMBERSFROMONE})))
 {
   UpdateUseBackendChannelOrder();
   UpdateUseBackendChannelNumbers();

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -41,7 +41,7 @@ using namespace PVR;
 CPVRChannelGroups::CPVRChannelGroups(bool bRadio)
   : m_bRadio(bRadio),
     m_settings(std::make_unique<CPVRSettings>(
-        std::set<std::string>({CSettings::SETTING_PVRMANAGER_BACKENDCHANNELGROUPSORDER}))),
+        SettingsContainer({CSettings::SETTING_PVRMANAGER_BACKENDCHANNELGROUPSORDER}))),
     m_channelGroupFactory(std::make_shared<CPVRChannelGroupFactory>())
 {
   m_settings->RegisterCallback(this);

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -977,23 +977,19 @@ void CGUIDialogPVRTimerSettings::InitializeChannelsList()
   const CPVRClientMap clients = CServiceBroker::GetPVRManager().Clients()->GetCreatedClients();
   if (clients.size() > 1)
   {
-    m_channelEntries.try_emplace(index,
-                                 ChannelDescriptor(PVR_CHANNEL_INVALID_UID, PVR_CLIENT_INVALID_UID,
-                                                   // Any channel from any client
-                                                   g_localizeStrings.Get(854)));
+    m_channelEntries.try_emplace(index, PVR_CHANNEL_INVALID_UID, PVR_CLIENT_INVALID_UID,
+                                 g_localizeStrings.Get(854)); // Any channel from any client
     index++;
   }
 
   for (const auto& [_, client] : clients)
   {
     m_channelEntries.try_emplace(
-        index, ChannelDescriptor(PVR_CHANNEL_INVALID_UID, client->GetID(),
-                                 clients.size() == 1
-                                     // Any channel
-                                     ? g_localizeStrings.Get(809)
-                                     // Any channel from client "X"
-                                     : StringUtils::Format(g_localizeStrings.Get(853),
-                                                           client->GetFullClientName())));
+        index, PVR_CHANNEL_INVALID_UID, client->GetID(),
+        clients.size() == 1
+            ? g_localizeStrings.Get(809) // Any channel
+            : StringUtils::Format(g_localizeStrings.Get(853), // Any channel from client "X"
+                                  client->GetFullClientName()));
     index++;
   }
 
@@ -1007,8 +1003,8 @@ void CGUIDialogPVRTimerSettings::InitializeChannelsList()
     const std::shared_ptr<const CPVRChannel> channel = groupMember->Channel();
     const std::string channelDescription = StringUtils::Format(
         "{} {}", groupMember->ChannelNumber().FormattedChannelNumber(), channel->ChannelName());
-    m_channelEntries.try_emplace(
-        index, ChannelDescriptor(channel->UniqueID(), channel->ClientID(), channelDescription));
+    m_channelEntries.try_emplace(index, channel->UniqueID(), channel->ClientID(),
+                                 channelDescription);
     ++index;
   }
 }
@@ -1093,24 +1089,22 @@ void CGUIDialogPVRTimerSettings::ChannelsFiller(const SettingConstPtr& setting,
       }
     }
 
-    if (foundCurrent)
+    // Verify m_channel is still valid. Update if not.
+    if (foundCurrent &&
+        std::ranges::find(list, current, &IntegerSettingOption::value) == list.cend())
     {
-      // Verify m_channel is still valid. Update if not.
-      if (std::ranges::find(list, current, &IntegerSettingOption::value) == list.cend())
-      {
-        // Set m_channel and current to first valid channel in list
-        const int first{list.front().value};
-        const auto it = pThis->m_channelEntries.find(first);
+      // Set m_channel and current to first valid channel in list
+      const int first{list.front().value};
+      const auto it{pThis->m_channelEntries.find(first)};
 
-        if (it != pThis->m_channelEntries.cend())
-        {
-          current = (*it).first;
-          pThis->m_channel = (*it).second;
-        }
-        else
-        {
-          CLog::LogF(LOGERROR, "Unable to find channel to select");
-        }
+      if (it != pThis->m_channelEntries.cend())
+      {
+        current = (*it).first;
+        pThis->m_channel = (*it).second;
+      }
+      else
+      {
+        CLog::LogF(LOGERROR, "Unable to find channel to select");
       }
     }
   }

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -89,7 +89,7 @@ void CEpgTagStateChange::Deliver(const std::shared_ptr<CPVREpg>& epg) const
 CPVREpgContainer::CPVREpgContainer(CEventSource<PVREvent>& eventSource)
   : CThread("EPGUpdater"),
     m_database(std::make_shared<CPVREpgDatabase>()),
-    m_settings(std::make_unique<CPVRSettings>(std::set<std::string>(
+    m_settings(std::make_unique<CPVRSettings>(SettingsContainer(
         {CSettings::SETTING_EPG_EPGUPDATE, CSettings::SETTING_EPG_FUTURE_DAYSTODISPLAY,
          CSettings::SETTING_EPG_PAST_DAYSTODISPLAY,
          CSettings::SETTING_EPG_PREVENTUPDATESWHILEPLAYINGTV}))),

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
@@ -165,7 +165,7 @@ std::shared_ptr<CFileItem> CGUIEPGGridContainerModel::CreateEpgTags(int iChannel
   if (firstResultBlock > lastResultBlock)
     return result;
 
-  auto it = m_epgItems.try_emplace(iChannel, EpgTags()).first;
+  auto it = m_epgItems.try_emplace(iChannel).first;
   EpgTags& epgTags = (*it).second;
 
   epgTags.firstBlock = firstResultBlock;
@@ -420,9 +420,7 @@ GridItem* CGUIEPGGridContainerModel::GetGridItemPtr(int iChannel, int iBlock) co
     item->SetProperty("GenreType", epgTag->GenreType());
 
     const float fItemWidth = (endBlock - startBlock + 1) * m_fBlockSize;
-    it = m_gridIndex
-             .try_emplace({iChannel, iBlock}, GridItem{item, fItemWidth, startBlock, endBlock})
-             .first;
+    it = m_gridIndex.try_emplace({iChannel, iBlock}, item, fItemWidth, startBlock, endBlock).first;
   }
 
   return &(*it).second;

--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
@@ -173,7 +173,7 @@ void CPVRChannelSwitchingInputHandler::SwitchToPreviousChannel() const
 
 CPVRGUIActionsChannels::CPVRGUIActionsChannels()
   : m_settings(std::make_unique<CPVRSettings>(
-        std::set<std::string>({CSettings::SETTING_PVRMANAGER_PRESELECTPLAYINGCHANNEL})))
+        SettingsContainer({CSettings::SETTING_PVRMANAGER_PRESELECTPLAYINGCHANNEL})))
 {
   RegisterChannelNumberInputHandler(&m_channelNumberInputHandler);
 }

--- a/xbmc/pvr/guilib/PVRGUIActionsParentalControl.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsParentalControl.cpp
@@ -26,7 +26,7 @@ using namespace PVR;
 using namespace KODI::MESSAGING;
 
 CPVRGUIActionsParentalControl::CPVRGUIActionsParentalControl()
-  : m_settings(std::make_unique<CPVRSettings>(std::set<std::string>(
+  : m_settings(std::make_unique<CPVRSettings>(SettingsContainer(
         {CSettings::SETTING_PVRPARENTAL_PIN, CSettings::SETTING_PVRPARENTAL_ENABLED})))
 {
 }

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
@@ -54,8 +54,8 @@ using namespace KODI::MESSAGING;
 
 CPVRGUIActionsPlayback::CPVRGUIActionsPlayback()
   : m_settings(std::make_unique<CPVRSettings>(
-        std::set<std::string>({CSettings::SETTING_LOOKANDFEEL_STARTUPACTION,
-                               CSettings::SETTING_PVRPLAYBACK_SWITCHTOFULLSCREENCHANNELTYPES})))
+        SettingsContainer({CSettings::SETTING_LOOKANDFEEL_STARTUPACTION,
+                           CSettings::SETTING_PVRPLAYBACK_SWITCHTOFULLSCREENCHANNELTYPES})))
 {
 }
 

--- a/xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
@@ -31,8 +31,8 @@ using namespace KODI::MESSAGING;
 
 CPVRGUIActionsPowerManagement::CPVRGUIActionsPowerManagement()
   : m_settings(std::make_unique<CPVRSettings>(
-        std::set<std::string>({CSettings::SETTING_PVRPOWERMANAGEMENT_DAILYWAKEUPTIME,
-                               CSettings::SETTING_PVRPOWERMANAGEMENT_BACKENDIDLETIME})))
+        SettingsContainer({CSettings::SETTING_PVRPOWERMANAGEMENT_DAILYWAKEUPTIME,
+                           CSettings::SETTING_PVRPOWERMANAGEMENT_BACKENDIDLETIME})))
 {
 }
 

--- a/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
@@ -201,7 +201,7 @@ private:
 
 CPVRGUIActionsRecordings::CPVRGUIActionsRecordings()
   : m_settings(std::make_unique<CPVRSettings>(
-        std::set<std::string>({CSettings::SETTING_PVRRECORD_DELETEAFTERWATCH})))
+        SettingsContainer({CSettings::SETTING_PVRRECORD_DELETEAFTERWATCH})))
 {
 }
 

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
@@ -117,7 +117,7 @@ private:
 } // unnamed namespace
 
 CPVRGUIActionsTimers::CPVRGUIActionsTimers()
-  : m_settings(std::make_unique<CPVRSettings>(std::set<std::string>(
+  : m_settings(std::make_unique<CPVRSettings>(SettingsContainer(
         {CSettings::SETTING_PVRRECORD_INSTANTRECORDTIME,
          CSettings::SETTING_PVRRECORD_INSTANTRECORDACTION,
          CSettings::SETTING_PVRREMINDERS_AUTOCLOSEDELAY, CSettings::SETTING_PVRREMINDERS_AUTORECORD,

--- a/xbmc/pvr/settings/PVRCustomTimerSettings.cpp
+++ b/xbmc/pvr/settings/PVRCustomTimerSettings.cpp
@@ -74,11 +74,9 @@ void CPVRCustomTimerSettings::SetTimerType(const CPVRTimerType& timerType)
     {
       const auto it{m_customProps.find(def->GetId())};
       if (it == m_customProps.cend())
-        newCustomProps.try_emplace(def->GetId(),
-                                   CustomProperty(def->GetType(), def->GetDefaultValue()));
+        newCustomProps.try_emplace(def->GetId(), def->GetType(), def->GetDefaultValue());
       else
-        newCustomProps.try_emplace(def->GetId(),
-                                   CustomProperty((*it).second.type, (*it).second.value));
+        newCustomProps.try_emplace(def->GetId(), (*it).second.type, (*it).second.value);
     }
   }
   m_customProps = newCustomProps;

--- a/xbmc/pvr/settings/PVRSettings.cpp
+++ b/xbmc/pvr/settings/PVRSettings.cpp
@@ -30,7 +30,7 @@ using namespace PVR;
 
 unsigned int CPVRSettings::m_iInstances = 0;
 
-CPVRSettings::CPVRSettings(const std::set<std::string>& settingNames)
+CPVRSettings::CPVRSettings(const SettingsContainer& settingNames)
 {
   Init(settingNames);
 
@@ -76,7 +76,7 @@ void CPVRSettings::UnregisterCallback(ISettingCallback* callback)
   m_callbacks.erase(callback);
 }
 
-void CPVRSettings::Init(const std::set<std::string>& settingNames)
+void CPVRSettings::Init(const SettingsContainer& settingNames)
 {
   for (const auto& settingName : settingNames)
   {
@@ -94,7 +94,7 @@ void CPVRSettings::Init(const std::set<std::string>& settingNames)
 
 void CPVRSettings::OnSettingsLoaded()
 {
-  std::set<std::string> settingNames;
+  SettingsContainer settingNames;
 
   {
     std::unique_lock lock(m_critSection);

--- a/xbmc/pvr/settings/PVRSettings.h
+++ b/xbmc/pvr/settings/PVRSettings.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "settings/SettingsContainer.h"
 #include "settings/lib/ISettingCallback.h"
 #include "settings/lib/ISettingsHandler.h"
 #include "threads/CriticalSection.h"
@@ -27,7 +28,7 @@ namespace PVR
   class CPVRSettings : private ISettingsHandler, private ISettingCallback
   {
   public:
-    explicit CPVRSettings(const std::set<std::string>& settingNames);
+    explicit CPVRSettings(const SettingsContainer& settingNames);
     ~CPVRSettings() override;
 
     void RegisterCallback(ISettingCallback* callback);
@@ -65,7 +66,7 @@ namespace PVR
     CPVRSettings(const CPVRSettings&) = delete;
     CPVRSettings& operator=(CPVRSettings const&) = delete;
 
-    void Init(const std::set<std::string>& settingNames);
+    void Init(const SettingsContainer& settingNames);
 
     mutable CCriticalSection m_critSection;
     std::map<std::string, std::shared_ptr<CSetting>, std::less<>> m_settings;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -138,9 +138,9 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER& timer,
   {
     const PVR_SETTING_KEY_VALUE_PAIR& prop{timer.customProps[i]};
     if (prop.eType == PVR_SETTING_TYPE::INTEGER)
-      m_customProps.try_emplace(prop.iKey, CustomProperty(prop.eType, CVariant{prop.iValue}));
+      m_customProps.try_emplace(prop.iKey, prop.eType, CVariant{prop.iValue});
     else if (prop.eType == PVR_SETTING_TYPE::STRING)
-      m_customProps.try_emplace(prop.iKey, CustomProperty(prop.eType, CVariant{prop.strValue}));
+      m_customProps.try_emplace(prop.iKey, prop.eType, CVariant{prop.strValue});
     else
       CLog::LogF(LOGERROR, "Unknown setting type for custom property");
   }

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -93,11 +93,11 @@ void CPVRTimersContainer::InsertEntry(const std::shared_ptr<CPVRTimerInfoTag>& n
 CPVRTimers::CPVRTimers()
   : CThread("PVRTimers"),
     m_settings(std::make_unique<CPVRSettings>(
-        std::set<std::string>({CSettings::SETTING_PVRPOWERMANAGEMENT_DAILYWAKEUP,
-                               CSettings::SETTING_PVRPOWERMANAGEMENT_PREWAKEUP,
-                               CSettings::SETTING_PVRPOWERMANAGEMENT_BACKENDIDLETIME,
-                               CSettings::SETTING_PVRPOWERMANAGEMENT_DAILYWAKEUPTIME,
-                               CSettings::SETTING_PVRRECORD_TIMERNOTIFICATIONS})))
+        SettingsContainer({CSettings::SETTING_PVRPOWERMANAGEMENT_DAILYWAKEUP,
+                           CSettings::SETTING_PVRPOWERMANAGEMENT_PREWAKEUP,
+                           CSettings::SETTING_PVRPOWERMANAGEMENT_BACKENDIDLETIME,
+                           CSettings::SETTING_PVRPOWERMANAGEMENT_DAILYWAKEUPTIME,
+                           CSettings::SETTING_PVRRECORD_TIMERNOTIFICATIONS})))
 {
 }
 

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -58,7 +58,7 @@ CGUIWindowPVRRecordingsBase::CGUIWindowPVRRecordingsBase(bool bRadio,
                                                          const std::string& xmlFile)
   : CGUIWindowPVRBase(bRadio, id, xmlFile),
     m_settings(std::make_unique<CPVRSettings>(
-        std::set<std::string>({CSettings::SETTING_PVRRECORD_GROUPRECORDINGS})))
+        SettingsContainer({CSettings::SETTING_PVRRECORD_GROUPRECORDINGS})))
 {
 }
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -107,9 +107,7 @@ void CAdvancedSettings::Initialize(CSettingsManager& settingsMgr)
     m_handleMounting = true;
 
   settingsMgr.RegisterSettingsHandler(this, true);
-  std::set<std::string> settingSet;
-  settingSet.insert(CSettings::SETTING_DEBUG_SHOWLOGINFO);
-  settingsMgr.RegisterCallback(this, settingSet);
+  settingsMgr.RegisterCallback(this, {CSettings::SETTING_DEBUG_SHOWLOGINFO});
 }
 
 void CAdvancedSettings::Uninitialize(CSettingsManager& settingsMgr)

--- a/xbmc/settings/CMakeLists.txt
+++ b/xbmc/settings/CMakeLists.txt
@@ -39,6 +39,7 @@ set(HEADERS AdvancedSettings.h
             SettingPath.h
             Settings.h
             SettingsBase.h
+            SettingsContainer.h
             SettingsValueFlatJsonSerializer.h
             SettingsValueXmlSerializer.h
             SettingUtils.h

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -552,90 +552,68 @@ void CSettings::UninitializeISubSettings()
 void CSettings::InitializeISettingCallbacks()
 {
   // register any ISettingCallback implementations
-  std::set<std::string> settingSet;
-  settingSet.insert(CSettings::SETTING_MUSICLIBRARY_CLEANUP);
-  settingSet.insert(CSettings::SETTING_MUSICLIBRARY_EXPORT);
-  settingSet.insert(CSettings::SETTING_MUSICLIBRARY_IMPORT);
-  settingSet.insert(CSettings::SETTING_MUSICFILES_TRACKFORMAT);
-  settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_FLATTENTVSHOWS);
-  settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_GROUPMOVIESETS);
-  settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_CLEANUP);
-  settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_IMPORT);
-  settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_EXPORT);
-  settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS);
-  settingSet.insert(CSettings::SETTING_MAINTENANCE_CLEANIMAGECACHE);
-  GetSettingsManager()->RegisterCallback(&CMediaSettings::GetInstance(), settingSet);
+  GetSettingsManager()->RegisterCallback(
+      &CMediaSettings::GetInstance(),
+      {CSettings::SETTING_MUSICLIBRARY_CLEANUP, CSettings::SETTING_MUSICLIBRARY_EXPORT,
+       CSettings::SETTING_MUSICLIBRARY_IMPORT, CSettings::SETTING_MUSICFILES_TRACKFORMAT,
+       CSettings::SETTING_VIDEOLIBRARY_FLATTENTVSHOWS,
+       CSettings::SETTING_VIDEOLIBRARY_GROUPMOVIESETS, CSettings::SETTING_VIDEOLIBRARY_CLEANUP,
+       CSettings::SETTING_VIDEOLIBRARY_IMPORT, CSettings::SETTING_VIDEOLIBRARY_EXPORT,
+       CSettings::SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS,
+       CSettings::SETTING_MAINTENANCE_CLEANIMAGECACHE});
 
-  settingSet.clear();
-  settingSet.insert(CSettings::SETTING_VIDEOSCREEN_SCREEN);
-  settingSet.insert(CSettings::SETTING_VIDEOSCREEN_RESOLUTION);
-  settingSet.insert(CSettings::SETTING_VIDEOSCREEN_SCREENMODE);
-  settingSet.insert(CSettings::SETTING_VIDEOSCREEN_MONITOR);
-  settingSet.insert(CSettings::SETTING_VIDEOSCREEN_PREFEREDSTEREOSCOPICMODE);
-  settingSet.insert(CSettings::SETTING_VIDEOSCREEN_3DLUT);
-  settingSet.insert(CSettings::SETTING_VIDEOSCREEN_DISPLAYPROFILE);
-  settingSet.insert(CSettings::SETTING_VIDEOSCREEN_BLANKDISPLAYS);
-  settingSet.insert(CSettings::SETTING_VIDEOSCREEN_WHITELIST);
-  settingSet.insert(CSettings::SETTING_VIDEOSCREEN_10BITSURFACES);
-  GetSettingsManager()->RegisterCallback(&CDisplaySettings::GetInstance(), settingSet);
+  GetSettingsManager()->RegisterCallback(
+      &CDisplaySettings::GetInstance(),
+      {CSettings::SETTING_VIDEOSCREEN_SCREEN, CSettings::SETTING_VIDEOSCREEN_RESOLUTION,
+       CSettings::SETTING_VIDEOSCREEN_SCREENMODE, CSettings::SETTING_VIDEOSCREEN_MONITOR,
+       CSettings::SETTING_VIDEOSCREEN_PREFEREDSTEREOSCOPICMODE,
+       CSettings::SETTING_VIDEOSCREEN_3DLUT, CSettings::SETTING_VIDEOSCREEN_DISPLAYPROFILE,
+       CSettings::SETTING_VIDEOSCREEN_BLANKDISPLAYS, CSettings::SETTING_VIDEOSCREEN_WHITELIST,
+       CSettings::SETTING_VIDEOSCREEN_10BITSURFACES});
 
-  settingSet.clear();
-  settingSet.insert(CSettings::SETTING_SUBTITLES_CHARSET);
-  settingSet.insert(CSettings::SETTING_LOCALE_CHARSET);
-  GetSettingsManager()->RegisterCallback(&g_charsetConverter, settingSet);
+  GetSettingsManager()->RegisterCallback(&g_charsetConverter, {CSettings::SETTING_SUBTITLES_CHARSET,
+                                                               CSettings::SETTING_LOCALE_CHARSET});
 
-  settingSet.clear();
-  settingSet.insert(CSettings::SETTING_LOCALE_AUDIOLANGUAGE);
-  settingSet.insert(CSettings::SETTING_LOCALE_SUBTITLELANGUAGE);
-  settingSet.insert(CSettings::SETTING_LOCALE_LANGUAGE);
-  settingSet.insert(CSettings::SETTING_LOCALE_COUNTRY);
-  settingSet.insert(CSettings::SETTING_LOCALE_SHORTDATEFORMAT);
-  settingSet.insert(CSettings::SETTING_LOCALE_LONGDATEFORMAT);
-  settingSet.insert(CSettings::SETTING_LOCALE_TIMEFORMAT);
-  settingSet.insert(CSettings::SETTING_LOCALE_USE24HOURCLOCK);
-  settingSet.insert(CSettings::SETTING_LOCALE_TEMPERATUREUNIT);
-  settingSet.insert(CSettings::SETTING_LOCALE_SPEEDUNIT);
-  GetSettingsManager()->RegisterCallback(&g_langInfo, settingSet);
+  GetSettingsManager()->RegisterCallback(
+      &g_langInfo,
+      {CSettings::SETTING_LOCALE_AUDIOLANGUAGE, CSettings::SETTING_LOCALE_SUBTITLELANGUAGE,
+       CSettings::SETTING_LOCALE_LANGUAGE, CSettings::SETTING_LOCALE_COUNTRY,
+       CSettings::SETTING_LOCALE_SHORTDATEFORMAT, CSettings::SETTING_LOCALE_LONGDATEFORMAT,
+       CSettings::SETTING_LOCALE_TIMEFORMAT, CSettings::SETTING_LOCALE_USE24HOURCLOCK,
+       CSettings::SETTING_LOCALE_TEMPERATUREUNIT, CSettings::SETTING_LOCALE_SPEEDUNIT});
 
-  settingSet.clear();
-  settingSet.insert(CSettings::SETTING_MASTERLOCK_LOCKCODE);
-  GetSettingsManager()->RegisterCallback(&g_passwordManager, settingSet);
+  GetSettingsManager()->RegisterCallback(&g_passwordManager,
+                                         {CSettings::SETTING_MASTERLOCK_LOCKCODE});
 
-  settingSet.clear();
-  settingSet.insert(CSettings::SETTING_LOOKANDFEEL_RSSEDIT);
-  GetSettingsManager()->RegisterCallback(&CRssManager::GetInstance(), settingSet);
+  GetSettingsManager()->RegisterCallback(&CRssManager::GetInstance(),
+                                         {CSettings::SETTING_LOOKANDFEEL_RSSEDIT});
 
 #if defined(TARGET_DARWIN_OSX) and defined(HAS_XBMCHELPER)
-  settingSet.clear();
-  settingSet.insert(CSettings::SETTING_INPUT_APPLEREMOTEMODE);
-  settingSet.insert(CSettings::SETTING_INPUT_APPLEREMOTEALWAYSON);
-  GetSettingsManager()->RegisterCallback(&XBMCHelper::GetInstance(), settingSet);
+  GetSettingsManager()->RegisterCallback(
+      &XBMCHelper::GetInstance(),
+      {CSettings::SETTING_INPUT_APPLEREMOTEMODE, CSettings::SETTING_INPUT_APPLEREMOTEALWAYSON});
 #endif
 
 #if defined(TARGET_DARWIN_TVOS)
-  settingSet.clear();
-  settingSet.insert(CSettings::SETTING_INPUT_SIRIREMOTEIDLETIMERENABLED);
-  settingSet.insert(CSettings::SETTING_INPUT_SIRIREMOTEIDLETIME);
-  settingSet.insert(CSettings::SETTING_INPUT_SIRIREMOTEHORIZONTALSENSITIVITY);
-  settingSet.insert(CSettings::SETTING_INPUT_SIRIREMOTEVERTICALSENSITIVITY);
-  GetSettingsManager()->RegisterCallback(&CTVOSInputSettings::GetInstance(), settingSet);
+  GetSettingsManager()->RegisterCallback(&CTVOSInputSettings::GetInstance(),
+                                         {CSettings::SETTING_INPUT_SIRIREMOTEIDLETIMERENABLED,
+                                          CSettings::SETTING_INPUT_SIRIREMOTEIDLETIME,
+                                          CSettings::SETTING_INPUT_SIRIREMOTEHORIZONTALSENSITIVITY,
+                                          CSettings::SETTING_INPUT_SIRIREMOTEVERTICALSENSITIVITY});
 #endif
 
-  settingSet.clear();
-  settingSet.insert(CSettings::SETTING_ADDONS_SHOW_RUNNING);
-  settingSet.insert(CSettings::SETTING_ADDONS_MANAGE_DEPENDENCIES);
-  settingSet.insert(CSettings::SETTING_ADDONS_REMOVE_ORPHANED_DEPENDENCIES);
-  settingSet.insert(CSettings::SETTING_ADDONS_ALLOW_UNKNOWN_SOURCES);
-  GetSettingsManager()->RegisterCallback(&ADDON::CAddonSystemSettings::GetInstance(), settingSet);
+  GetSettingsManager()->RegisterCallback(&ADDON::CAddonSystemSettings::GetInstance(),
+                                         {CSettings::SETTING_ADDONS_SHOW_RUNNING,
+                                          CSettings::SETTING_ADDONS_MANAGE_DEPENDENCIES,
+                                          CSettings::SETTING_ADDONS_REMOVE_ORPHANED_DEPENDENCIES,
+                                          CSettings::SETTING_ADDONS_ALLOW_UNKNOWN_SOURCES});
 
-  settingSet.clear();
-  settingSet.insert(CSettings::SETTING_POWERMANAGEMENT_WAKEONACCESS);
-  GetSettingsManager()->RegisterCallback(&CWakeOnAccess::GetInstance(), settingSet);
+  GetSettingsManager()->RegisterCallback(&CWakeOnAccess::GetInstance(),
+                                         {CSettings::SETTING_POWERMANAGEMENT_WAKEONACCESS});
 
 #ifdef HAVE_LIBBLURAY
-  settingSet.clear();
-  settingSet.insert(CSettings::SETTING_DISC_PLAYBACK);
-  GetSettingsManager()->RegisterCallback(&CDiscSettings::GetInstance(), settingSet);
+  GetSettingsManager()->RegisterCallback(&CDiscSettings::GetInstance(),
+                                         {CSettings::SETTING_DISC_PLAYBACK});
 #endif
 }
 

--- a/xbmc/settings/SettingsBase.cpp
+++ b/xbmc/settings/SettingsBase.cpp
@@ -159,7 +159,8 @@ void CSettingsBase::Uninitialize()
   m_initialized = false;
 }
 
-void CSettingsBase::RegisterCallback(ISettingCallback* callback, const std::set<std::string>& settingList)
+void CSettingsBase::RegisterCallback(ISettingCallback* callback,
+                                     const SettingsContainer& settingList)
 {
   m_settingsManager->RegisterCallback(callback, settingList);
 }

--- a/xbmc/settings/SettingsBase.h
+++ b/xbmc/settings/SettingsBase.h
@@ -8,10 +8,10 @@
 
 #pragma once
 
+#include "settings/SettingsContainer.h"
 #include "settings/lib/ISettingCallback.h"
 #include "threads/CriticalSection.h"
 
-#include <set>
 #include <string>
 #include <vector>
 
@@ -91,7 +91,7 @@ public:
    \param callback ISettingCallback implementation
    \param settingList List of setting identifiers for which the given callback shall be triggered
    */
-  void RegisterCallback(ISettingCallback* callback, const std::set<std::string>& settingList);
+  void RegisterCallback(ISettingCallback* callback, const SettingsContainer& settingList);
   /*!
    \brief Unregisters the given ISettingCallback implementation.
 

--- a/xbmc/settings/SettingsContainer.h
+++ b/xbmc/settings/SettingsContainer.h
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <functional>
+#include <set>
+#include <string>
+
+using SettingsContainer = std::set<std::string, std::less<>>;

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -535,11 +535,11 @@ void CGUIDialogSettingsBase::SetupView()
   SetupControls();
 }
 
-std::set<std::string> CGUIDialogSettingsBase::CreateSettings()
+SettingsContainer CGUIDialogSettingsBase::CreateSettings()
 {
   FreeSettingsControls();
 
-  std::set<std::string> settingMap;
+  SettingsContainer settingMap;
 
   if (m_categories.size() <= 0)
     return settingMap;

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.h
@@ -10,11 +10,11 @@
 
 #include "guilib/GUIDialog.h"
 #include "settings/SettingControl.h"
+#include "settings/SettingsContainer.h"
 #include "settings/lib/ISettingCallback.h"
 #include "threads/Timer.h"
 #include "utils/ILocalizer.h"
 
-#include <set>
 #include <vector>
 
 #define CONTROL_SETTINGS_LABEL 2
@@ -102,7 +102,7 @@ protected:
   virtual void OnCancel() {}
 
   virtual void SetupView();
-  virtual std::set<std::string> CreateSettings();
+  virtual SettingsContainer CreateSettings();
   virtual void UpdateSettings();
 
   /*!

--- a/xbmc/settings/dialogs/GUIDialogSettingsManagerBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManagerBase.cpp
@@ -36,11 +36,11 @@ bool CGUIDialogSettingsManagerBase::OnOkay()
   return false;
 }
 
-std::set<std::string> CGUIDialogSettingsManagerBase::CreateSettings()
+SettingsContainer CGUIDialogSettingsManagerBase::CreateSettings()
 {
   assert(GetSettingsManager() != nullptr);
 
-  std::set<std::string> settings = CGUIDialogSettingsBase::CreateSettings();
+  const SettingsContainer settings{CGUIDialogSettingsBase::CreateSettings()};
 
   if (!settings.empty())
     GetSettingsManager()->RegisterCallback(this, settings);

--- a/xbmc/settings/dialogs/GUIDialogSettingsManagerBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManagerBase.h
@@ -26,7 +26,7 @@ protected:
   std::shared_ptr<CSetting> GetSetting(const std::string &settingId) override;
   bool OnOkay() override;
 
-  std::set<std::string> CreateSettings() override;
+  SettingsContainer CreateSettings() override;
   void FreeSettingsControls() override;
 
   // implementation of ISettingControlCreator

--- a/xbmc/settings/lib/SettingDependency.cpp
+++ b/xbmc/settings/lib/SettingDependency.cpp
@@ -284,7 +284,7 @@ bool CSettingDependencyConditionCombination::Deserialize(const TiXmlNode *node)
       if (combination == nullptr)
         continue;
 
-      const std::set<std::string>& settings = combination->GetSettings();
+      const SettingsContainer& settings = combination->GetSettings();
       m_settings.insert(settings.begin(), settings.end());
     }
   }
@@ -374,14 +374,14 @@ bool CSettingDependency::Deserialize(const TiXmlNode *node)
   return CSettingCondition::Deserialize(node);
 }
 
-std::set<std::string> CSettingDependency::GetSettings() const
+SettingsContainer CSettingDependency::GetSettings() const
 {
   if (m_operation == nullptr)
-    return std::set<std::string>();
+    return {};
 
   auto combination = static_cast<CSettingDependencyConditionCombination*>(m_operation.get());
   if (combination == nullptr)
-    return std::set<std::string>();
+    return {};
 
   return combination->GetSettings();
 }

--- a/xbmc/settings/lib/SettingDependency.h
+++ b/xbmc/settings/lib/SettingDependency.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "SettingConditions.h"
+#include "settings/SettingsContainer.h"
 #include "utils/BooleanLogic.h"
 #include "utils/logtypes.h"
 
@@ -97,7 +98,7 @@ public:
 
   bool Deserialize(const TiXmlNode *node) override;
 
-  const std::set<std::string>& GetSettings() const { return m_settings; }
+  const SettingsContainer& GetSettings() const { return m_settings; }
 
   CSettingDependencyConditionCombination* Add(const CSettingDependencyConditionPtr& condition);
   CSettingDependencyConditionCombination* Add(
@@ -107,7 +108,7 @@ private:
   CBooleanLogicOperation* newOperation() override { return new CSettingDependencyConditionCombination(m_settingsManager); }
   CBooleanLogicValue* newValue() override { return new CSettingDependencyCondition(m_settingsManager); }
 
-  std::set<std::string> m_settings;
+  SettingsContainer m_settings;
 };
 
 class CSettingDependency : public CSettingCondition
@@ -120,7 +121,7 @@ public:
   bool Deserialize(const TiXmlNode *node) override;
 
   SettingDependencyType GetType() const { return m_type; }
-  std::set<std::string> GetSettings() const;
+  SettingsContainer GetSettings() const;
 
   CSettingDependencyConditionCombinationPtr And();
   CSettingDependencyConditionCombinationPtr Or();

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -363,7 +363,8 @@ bool CSettingsManager::AddSetting(const std::shared_ptr<CSetting>& setting,
   return true;
 }
 
-void CSettingsManager::RegisterCallback(ISettingCallback *callback, const std::set<std::string> &settingList)
+void CSettingsManager::RegisterCallback(ISettingCallback* callback,
+                                        const SettingsContainer& settingList)
 {
   std::unique_lock<CSharedSection> lock(m_settingsCritical);
   if (callback == nullptr)

--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -193,7 +193,7 @@ public:
    \param settingsHandler ISettingsHandler implementation
    \param settingList List of settings to trigger the given ISettingCallback implementation
    */
-  void RegisterCallback(ISettingCallback *callback, const std::set<std::string> &settingList);
+  void RegisterCallback(ISettingCallback* callback, const SettingsContainer& settingList);
   /*!
    \brief Unregisters the given ISettingCallback implementation.
 
@@ -498,7 +498,7 @@ private:
   struct Setting {
     std::shared_ptr<CSetting> setting;
     SettingDependencyMap dependencies;
-    std::set<std::string> children;
+    SettingsContainer children;
     CallbackSet callbacks;
     std::unordered_set<std::string> references;
   };

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -15,6 +15,7 @@
 #include "settings/SettingUtils.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "settings/SettingsContainer.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingsManager.h"
 #include "utils/StringUtils.h"
@@ -91,10 +92,8 @@ void CLog::Initialize(const std::string& path)
   settingsManager->RegisterSettingOptionsFiller("loggingcomponents",
                                                 SettingOptionsLoggingComponentsFiller);
   settingsManager->RegisterSettingsHandler(this);
-  std::set<std::string> settingSet;
-  settingSet.insert(CSettings::SETTING_DEBUG_EXTRALOGGING);
-  settingSet.insert(CSettings::SETTING_DEBUG_SETEXTRALOGLEVEL);
-  settingsManager->RegisterCallback(this, settingSet);
+  settingsManager->RegisterCallback(
+      this, {CSettings::SETTING_DEBUG_EXTRALOGGING, CSettings::SETTING_DEBUG_SETEXTRALOGLEVEL});
 
   if (path.empty())
     return;

--- a/xbmc/weather/WeatherManager.cpp
+++ b/xbmc/weather/WeatherManager.cpp
@@ -30,10 +30,8 @@ using namespace ADDON;
 
 CWeatherManager::CWeatherManager(void) : CInfoLoader(30 * 60 * 1000) // 30 minutes
 {
-  CServiceBroker::GetSettingsComponent()->GetSettings()->GetSettingsManager()->RegisterCallback(this, {
-    CSettings::SETTING_WEATHER_ADDON,
-    CSettings::SETTING_WEATHER_ADDONSETTINGS
-  });
+  CServiceBroker::GetSettingsComponent()->GetSettings()->GetSettingsManager()->RegisterCallback(
+      this, {CSettings::SETTING_WEATHER_ADDON, CSettings::SETTING_WEATHER_ADDONSETTINGS});
 
   Reset();
 }


### PR DESCRIPTION
The journey continues... as usual no functional changes intended, only optimizations and modernization of the code base.

**guilib/guiinfo**
* "switch" statements should cover all cases cpp:S3562
* Unused local variables should be removed cpp:S1481
* C-style array should not be used cpp:S5945
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* STL algorithms and range-based for loops should be preferred to traditional for loops cpp:S5566

**PVR**
* Objects should not be created solely to be passed as arguments to functions that perform delegated object creation cpp:S6011
* Mergeable "if" statements should be combined cpp:S1066

**settings**
* Use the transparent comparator "std::less<>" with this associative string container.
=> Transparent function objects should be used with associative "std::string" containers [cpp:S6045](https://sonarcloud.io/organizations/teamkodi/rules?open=cpp%3AS6045&rule_key=cpp%3AS6045)

The "settings" commit is a bit bigger, but the idea is simple: Replace hard-coded settings container type `std::set<std::string>` used across the whole code base by a dedicated new type `SettingsContainer`, which in fact is an alias for `std::set<std::string, std::less<>>`, fixing the SonarQube finding.

@neo1973 want to take a look?