### PR TITLE
[String][Estuary] Update path string to remove colon

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9170,8 +9170,10 @@ msgctxt "#15310"
 msgid "Opening multi-path source"
 msgstr ""
 
+#. Label for the path infolabel which shows the location of the media file
+#: xbmc/addons/skin.estuary/xml/Includes_MusicInfo.xml
 msgctxt "#15311"
-msgid "Path:"
+msgid "Path"
 msgstr ""
 
 #. Game settings category name

--- a/addons/skin.estuary/xml/Includes_MusicInfo.xml
+++ b/addons/skin.estuary/xml/Includes_MusicInfo.xml
@@ -134,7 +134,7 @@
 			<visible>!String.IsEmpty(ListItem.Userrating)</visible>
 		</item>
 		<item>
-			<label>$LOCALIZE[15311]</label>
+			<label>$LOCALIZE[15311]:</label>
 			<label2>$INFO[ListItem.FilenameAndPath]</label2>
 			<visible>!String.IsEmpty(ListItem.FilenameAndPath)</visible>
 		</item>
@@ -266,7 +266,7 @@
 			<visible>!String.IsEmpty(ListItem.Property(Role.Mixer))</visible>
 		</item>
 		<item>
-			<label>$LOCALIZE[15311]</label>
+			<label>$LOCALIZE[15311]:</label>
 			<label2>$INFO[ListItem.FilenameAndPath]</label2>
 			<visible>!String.IsEmpty(ListItem.FilenameAndPath)</visible>
 		</item>


### PR DESCRIPTION
## Description
String 15311 `Path:` includes a colon which restricts the ability to reuse.

## Motivation and context
An upcoming PR from @Hitcher will refactor the Estuary info dialogs, this will allow string 15311 to be reused in dialogs other than music info.

From a search on 15311 on the entire code base the only hits found were

![image](https://github.com/user-attachments/assets/8703781b-fc78-4f79-ad51-b5d66235a8be)

Thus Estuary is currently the only user in the xbmc repo.

## How has this been tested?
Checked there has been no change in Estuary

![image](https://github.com/user-attachments/assets/167b8def-ac03-4383-9e4d-323ce44f8b9f)



## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
