### PR TITLE
[nfs] add patch to revert commit 8902b1b in libnfs

### DIFF
--- a/cmake/modules/FindNFS.cmake
+++ b/cmake/modules/FindNFS.cmake
@@ -16,6 +16,12 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
                    -DENABLE_UTILS=OFF
                    -DENABLE_EXAMPLES=OFF)
 
+    # Revert commit 8902b1b introduced in libnfs 6.0.0
+    # Causes windows to fail to mount nfs3 volume
+    set(patches "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/01-all-revert-8902b1b.patch")
+
+    generate_patchcommand("${patches}")
+
     if(WIN32 OR WINDOWS_STORE)
       set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_C_FLAGS "/sdl-")
       set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_CXX_FLAGS "/sdl-")

--- a/tools/depends/target/libnfs/01-all-revert-8902b1b.patch
+++ b/tools/depends/target/libnfs/01-all-revert-8902b1b.patch
@@ -1,0 +1,20 @@
+--- a/lib/socket.c
++++ b/lib/socket.c
+@@ -602,7 +602,7 @@
+ 		return 0;
+ 	}
+ 
+-        while (1){
++        do {
+                 if (rpc->inpos == 0) {
+                         switch (rpc->state) {
+                         case READ_RM:
+@@ -942,7 +942,7 @@
+                                 break;
+                         }
+                 }
+-	}
++	} while (rpc->is_nonblocking && rpc->waitpdu_len > 0);
+ 
+ 	return 0;
+ }

--- a/tools/depends/target/libnfs/Makefile
+++ b/tools/depends/target/libnfs/Makefile
@@ -1,5 +1,6 @@
 include ../../Makefile.include LIBNFS-VERSION ../../download-files.include
-DEPS= ../../Makefile.include Makefile LIBNFS-VERSION ../../download-files.include
+DEPS= ../../Makefile.include Makefile LIBNFS-VERSION ../../download-files.include \
+                01-all-revert-8902b1b.patch
 
 # configuration settings
 CMAKE_OPTIONS=-DBUILD_SHARED_LIBS=OFF \
@@ -16,6 +17,7 @@ $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 	-rm -rf $(PLATFORM); mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); mkdir -p build
+	cd $(PLATFORM); patch -p1 -i ../01-all-revert-8902b1b.patch
 	cd $(PLATFORM)/build; $(CMAKE) $(CMAKE_OPTIONS) ..
 
 $(LIBDYLIB): $(PLATFORM)


### PR DESCRIPTION
## Description
Add patch to libnfs internal build to revert commit 8902b1b in libnfs to fix mounting of nfs on windows

## Motivation and context
This commit was bisected in https://github.com/sahlberg/libnfs/issues/511 and it introduces a failure for windows nfs3 mounting volumes. Revert until an appropriate upstream patch becomes available

Only really bringing this in to have windows functional with nfs. I generally would prefer to wait for upstream to propose an actual solution going forward, so happy for this to not be merged and wait and see if people wish to.

## How has this been tested?
Build and run on windows aarch64 and macos aarch64

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
