### PR TITLE
[Windows] fix two malformed LogF calls

### DIFF
--- a/xbmc/platform/win10/filesystem/WinLibraryDirectory.cpp
+++ b/xbmc/platform/win10/filesystem/WinLibraryDirectory.cpp
@@ -187,7 +187,7 @@ bool CWinLibraryDirectory::Remove(const CURL& url)
   catch (const winrt::hresult_error& ex)
   {
     std::string error = FromW(ex.message().c_str());
-    CLog::LogF(LOGERROR, __FUNCTION__, "unable remove folder '{}' with error", url.Get(), error);
+    CLog::LogF(LOGERROR, "unable to remove folder '{}' with error: {}", url.Get(), error);
     exists = false;
   }
   return exists;
@@ -216,7 +216,7 @@ StorageFolder CWinLibraryDirectory::GetFolder(const CURL& url)
     catch (const winrt::hresult_error& ex)
     {
       std::string error = FromW(ex.message().c_str());
-      CLog::LogF(LOGERROR, "unable to get folder '{}' with error", url.GetRedacted(), error);
+      CLog::LogF(LOGERROR, "unable to get folder '{}' with error: {}", url.GetRedacted(), error);
     }
     return nullptr;
   }


### PR DESCRIPTION
## Description
[Windows] fix two malformed LogF calls

## Motivation and context
Found while review https://github.com/xbmc/xbmc/pull/26767

## How has this been tested?
Build UWP

## What is the effect on users?
This not seems cause any crash issue at runtime but sure intended info is not logged.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
