### PR TITLE
[Xbox] Fix HDR support for Xbox One models

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -685,7 +685,7 @@ void DX::DeviceResources::ResizeBuffers()
     scFSDesc.Windowed = windowed;
 
     ComPtr<IDXGISwapChain1> swapChain;
-    if (m_d3dFeatureLevel >= D3D_FEATURE_LEVEL_11_0 && !bHWStereoEnabled &&
+    if (m_d3dFeatureLevel >= D3D_FEATURE_LEVEL_10_0 && !bHWStereoEnabled &&
         (isHdrEnabled || use10bit))
     {
       swapChainDesc.Format = DXGI_FORMAT_R10G10B10A2_UNORM;


### PR DESCRIPTION
## Description
[Xbox] Fix HDR support for Xbox One models

## Motivation and context
According log posted from one Xbox One X user, this device has Direct3D feature level 10.1 and this is the reason not allow create swap chain with format `DXGI_FORMAT_R10G10B10A2_UNORM` (required for HDR) since current code has the condition:

`m_d3dFeatureLevel >= D3D_FEATURE_LEVEL_11_0`


```
2025-05-17 13:00:34.439 T:6252     info <general>: Starting Kodi (21.2 (21.2.0) Git:20250115-d1a1d48c3c). Platform: Windows NT x86 64-bit
2025-05-17 13:00:34.439 T:6252     info <general>: Using Release Kodi x64
2025-05-17 13:00:34.439 T:6252     info <general>: Kodi compiled 2025-01-18 by MSVC 194234436 for Windows NT x86 64-bit version 10.0 (0x0A00000C)
2025-05-17 13:00:34.440 T:6252     info <general>: Running on Microsoft Xbox One X with WINDOWS 10.0.26100.4026, kernel: WINDOWS x86 64-bit version 10.0.26100.4026
2025-05-17 13:00:34.440 T:6252     info <general>: FFmpeg version/source: 6.0.1-Kodi
2025-05-17 13:00:34.440 T:6252     info <general>: Host CPU: Unknown, 8 cores available
2025-05-17 13:00:34.441 T:6252     info <general>: System has 2.3 GB of RAM installed
2025-05-17 13:00:34.457 T:6252     info <general>: Desktop Resolution: 3840x2160 30Bit at 59.94Hz
2025-05-17 13:00:34.457 T:6252     info <general>: Running with restricted rights
2025-05-17 13:00:34.457 T:6252     info <general>: Aero is disabled
2025-05-17 13:00:34.465 T:6252     info <general>: Display HDR capable is detected and Windows HDR switch is OFF
```

```
2025-05-17 13:00:35.769 T:6252    debug <general>: DX::DeviceResources::CreateDeviceResources: creating DirectX 11 device.
2025-05-17 13:00:35.807 T:6252     info <general>: DX::DeviceResources::CreateDeviceResources: device is created on adapter 'SraKmd' with D3D_FEATURE_LEVEL_10_1
2025-05-17 13:00:35.807 T:6252    debug <general>: DX::DeviceResources::ReleaseBackBuffer: release buffers.
2025-05-17 13:00:35.812 T:6252    debug <general>: DX::DeviceResources::ResizeBuffers: resize buffers.
2025-05-17 13:00:35.834 T:6252     info <general>: DX::DeviceResources::ResizeBuffers: 8 bit swapchain is used with 3 flip discard buffers and SDR output (format B8G8R8A8_UNORM)
```

Since the device is known to support HDR, the requirements are relaxed. 

Researching this seems to be correct according to other sources:

```
// Direct3D hardware feature level 9.1 or later
DXGI_FORMAT_B8G8R8A8_UNORM
DXGI_FORMAT_B8G8R8A8_UNORM_SRGB

// Direct3D hardware feature level 9.3 or later
DXGI_FORMAT_R8G8B8A8_UNORM
DXGI_FORMAT_R8G8B8A8_UNORM_SRGB

// Direct3D hardware feature level 10.0 or later
DXGI_FORMAT_R16G16B16A16_FLOAT
DXGI_FORMAT_R10G10B10A2_UNORM
DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM
```
https://walbourn.github.io/anatomy-of-direct3d-11-create-device/


NOTE: Xbox Series S/X is not affected because is Direct3D FL 11.0


## How has this been tested?
Not tested but is supposed HDR should work with this change on Xbox One X.

For other devices / desktop this doesn't seem to be a problem since if it's not possible use 10 bits, fallback to 8-bit swap chain anyway.


## What is the effect on users?
Enable create swap chain with 10 bit format on devices with Direct3D FL >= 10.0

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
