### PR TITLE
drop typedef LanguageInvokerPtr

### DIFF
--- a/xbmc/ContextMenuItem.cpp
+++ b/xbmc/ContextMenuItem.cpp
@@ -66,7 +66,7 @@ bool CContextMenuItem::Execute(const std::shared_ptr<CFileItem>& item) const
     reuseLanguageInvoker = addon->ExtraInfo().at("reuselanguageinvoker") == "true";
 
 #ifdef HAS_PYTHON
-  LanguageInvokerPtr invoker(new CContextItemAddonInvoker(&CServiceBroker::GetXBPython(), item));
+  auto invoker = std::make_shared<CContextItemAddonInvoker>(&CServiceBroker::GetXBPython(), item);
   return (CScriptInvocationManager::GetInstance().ExecuteAsync(m_library, invoker, addon, m_args, reuseLanguageInvoker) != -1);
 #else
   return false;

--- a/xbmc/interfaces/generic/ILanguageInvoker.h
+++ b/xbmc/interfaces/generic/ILanguageInvoker.h
@@ -73,5 +73,3 @@ private:
   InvokerState m_state = InvokerStateUninitialized;
   ILanguageInvocationHandler *m_invocationHandler;
 };
-
-typedef std::shared_ptr<ILanguageInvoker> LanguageInvokerPtr;

--- a/xbmc/interfaces/generic/LanguageInvokerThread.cpp
+++ b/xbmc/interfaces/generic/LanguageInvokerThread.cpp
@@ -12,7 +12,7 @@
 
 #include <utility>
 
-CLanguageInvokerThread::CLanguageInvokerThread(LanguageInvokerPtr invoker,
+CLanguageInvokerThread::CLanguageInvokerThread(std::shared_ptr<ILanguageInvoker> invoker,
                                                CScriptInvocationManager* invocationManager,
                                                bool reuseable)
   : ILanguageInvoker(NULL),

--- a/xbmc/interfaces/generic/LanguageInvokerThread.h
+++ b/xbmc/interfaces/generic/LanguageInvokerThread.h
@@ -19,7 +19,7 @@ class CScriptInvocationManager;
 class CLanguageInvokerThread : public ILanguageInvoker, protected CThread
 {
 public:
-  CLanguageInvokerThread(LanguageInvokerPtr invoker,
+  CLanguageInvokerThread(std::shared_ptr<ILanguageInvoker> invoker,
                          CScriptInvocationManager* invocationManager,
                          bool reuseable);
   ~CLanguageInvokerThread() override;
@@ -27,7 +27,7 @@ public:
   virtual InvokerState GetState() const;
 
   const std::string& GetScript() const { return m_script; }
-  LanguageInvokerPtr GetInvoker() const { return m_invoker; }
+  std::shared_ptr<ILanguageInvoker> GetInvoker() const { return m_invoker; }
   bool Reuseable(const std::string& script) const
   {
     return !m_bStop && m_reusable && GetState() == InvokerStateScriptDone && m_script == script;
@@ -44,7 +44,7 @@ protected:
   void OnException() override;
 
 private:
-  LanguageInvokerPtr m_invoker;
+  std::shared_ptr<ILanguageInvoker> m_invoker;
   CScriptInvocationManager *m_invocationManager;
   std::string m_script;
   std::vector<std::string> m_args;

--- a/xbmc/interfaces/generic/ScriptInvocationManager.cpp
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.cpp
@@ -190,7 +190,8 @@ int CScriptInvocationManager::GetReusablePluginHandle(const std::string& script)
   return -1;
 }
 
-LanguageInvokerPtr CScriptInvocationManager::GetLanguageInvoker(const std::string& script)
+std::shared_ptr<ILanguageInvoker> CScriptInvocationManager::GetLanguageInvoker(
+    const std::string& script)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
 
@@ -212,9 +213,9 @@ LanguageInvokerPtr CScriptInvocationManager::GetLanguageInvoker(const std::strin
 
   std::map<std::string, ILanguageInvocationHandler*>::const_iterator it = m_invocationHandlers.find(extension);
   if (it != m_invocationHandlers.end() && it->second != NULL)
-    return LanguageInvokerPtr(it->second->CreateInvoker());
+    return std::shared_ptr<ILanguageInvoker>(it->second->CreateInvoker());
 
-  return LanguageInvokerPtr();
+  return {};
 }
 
 int CScriptInvocationManager::ExecuteAsync(
@@ -233,13 +234,13 @@ int CScriptInvocationManager::ExecuteAsync(
     return -1;
   }
 
-  LanguageInvokerPtr invoker = GetLanguageInvoker(script);
+  auto invoker = GetLanguageInvoker(script);
   return ExecuteAsync(script, invoker, addon, arguments, reuseable, pluginHandle);
 }
 
 int CScriptInvocationManager::ExecuteAsync(
     const std::string& script,
-    const LanguageInvokerPtr& languageInvoker,
+    const std::shared_ptr<ILanguageInvoker>& languageInvoker,
     const ADDON::AddonPtr& addon /* = ADDON::AddonPtr() */,
     const std::vector<std::string>& arguments /* = std::vector<std::string>() */,
     bool reuseable /* = false */,
@@ -306,13 +307,13 @@ int CScriptInvocationManager::ExecuteSync(
     return -1;
   }
 
-  LanguageInvokerPtr invoker = GetLanguageInvoker(script);
+  auto invoker = GetLanguageInvoker(script);
   return ExecuteSync(script, invoker, addon, arguments, timeoutMs, waitShutdown);
 }
 
 int CScriptInvocationManager::ExecuteSync(
     const std::string& script,
-    const LanguageInvokerPtr& languageInvoker,
+    const std::shared_ptr<ILanguageInvoker>& languageInvoker,
     const ADDON::AddonPtr& addon /* = ADDON::AddonPtr() */,
     const std::vector<std::string>& arguments /* = std::vector<std::string>() */,
     uint32_t timeoutMs /* = 0 */,

--- a/xbmc/interfaces/generic/ScriptInvocationManager.h
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.h
@@ -32,7 +32,7 @@ public:
   void RegisterLanguageInvocationHandler(ILanguageInvocationHandler *invocationHandler, const std::set<std::string> &extensions);
   void UnregisterLanguageInvocationHandler(ILanguageInvocationHandler *invocationHandler);
   bool HasLanguageInvoker(const std::string &script) const;
-  LanguageInvokerPtr GetLanguageInvoker(const std::string& script);
+  std::shared_ptr<ILanguageInvoker> GetLanguageInvoker(const std::string& script);
 
   /*!
   * \brief Returns addon_handle if last reusable invoker is ready to use.
@@ -62,7 +62,7 @@ public:
   * \return -1 if an error occurred, otherwise the ID of the script
   */
   int ExecuteAsync(const std::string& script,
-                   const LanguageInvokerPtr& languageInvoker,
+                   const std::shared_ptr<ILanguageInvoker>& languageInvoker,
                    const ADDON::AddonPtr& addon = ADDON::AddonPtr(),
                    const std::vector<std::string>& arguments = std::vector<std::string>(),
                    bool reuseable = false,
@@ -107,7 +107,7 @@ public:
   * \return -1 if an error occurred, 0 if the script terminated or ETIMEDOUT if the given timeout expired
   */
   int ExecuteSync(const std::string& script,
-                  const LanguageInvokerPtr& languageInvoker,
+                  const std::shared_ptr<ILanguageInvoker>& languageInvoker,
                   const ADDON::AddonPtr& addon = ADDON::AddonPtr(),
                   const std::vector<std::string>& arguments = std::vector<std::string>(),
                   uint32_t timeoutMs = 0,

--- a/xbmc/network/httprequesthandler/HTTPPythonHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPPythonHandler.cpp
@@ -151,10 +151,10 @@ MHD_RESULT CHTTPPythonHandler::HandleRequest()
       pythonRequest->port = port;
     }
 
-    CHTTPPythonInvoker* pythonInvoker =
-        new CHTTPPythonWsgiInvoker(&CServiceBroker::GetXBPython(), pythonRequest);
-    LanguageInvokerPtr languageInvokerPtr(pythonInvoker);
-    int result = CScriptInvocationManager::GetInstance().ExecuteSync(m_scriptPath, languageInvokerPtr, m_addon, args, 30000, false);
+    auto languageInvokerPtr =
+        std::make_shared<CHTTPPythonWsgiInvoker>(&CServiceBroker::GetXBPython(), pythonRequest);
+    int result = CScriptInvocationManager::GetInstance().ExecuteSync(
+        m_scriptPath, languageInvokerPtr, m_addon, args, 30000, false);
 
     // check if the script couldn't be started
     if (result < 0)
@@ -177,7 +177,7 @@ MHD_RESULT CHTTPPythonHandler::HandleRequest()
       return MHD_YES;
     }
 
-    HTTPPythonRequest* pythonFinalizedRequest = pythonInvoker->GetRequest();
+    HTTPPythonRequest* pythonFinalizedRequest = languageInvokerPtr->GetRequest();
     if (pythonFinalizedRequest == NULL)
     {
       m_response.type = HTTPError;


### PR DESCRIPTION
## Description
Drop a typedef, use shared_ptr or auto

## Motivation and context
Reduced ambiguity, more explicit

## How has this been tested?
It builds

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
