### PR TITLE
Misc Sonarqube findings, part 3

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.h
@@ -30,7 +30,7 @@ class CInputStreamPVRBase
   , public CDVDInputStream::IDemux
 {
 public:
-  CInputStreamPVRBase(const CFileItem& fileitem);
+  explicit CInputStreamPVRBase(const CFileItem& fileitem);
   ~CInputStreamPVRBase() override;
   bool Open() override;
   void Close() override;

--- a/xbmc/games/controllers/guicontrols/GUIGameController.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.cpp
@@ -256,6 +256,6 @@ void CGUIGameController::SetActivation(float activation)
   const UTILS::COLOR::Color activationColor =
       (newAlpha << 24) | (newRed << 16) | (newGreen << 8) | newBlue;
 
-  if (CGUIImage::SetColorDiffuse(activationColor))
+  if (CGUIImage::SetColorDiffuse(GUILIB::GUIINFO::CGUIInfoColor(activationColor)))
     CGUIImage::UpdateDiffuseColor(nullptr);
 }

--- a/xbmc/guilib/guiinfo/GUIInfoColor.h
+++ b/xbmc/guilib/guiinfo/GUIInfoColor.h
@@ -26,9 +26,16 @@ namespace KODI::GUILIB::GUIINFO
 class CGUIInfoColor
 {
 public:
-  constexpr CGUIInfoColor(UTILS::COLOR::Color color = 0) : m_color(color) {}
-  constexpr CGUIInfoColor(UTILS::COLOR::Color color, int info) : m_info(info), m_color(color) {}
+  explicit constexpr CGUIInfoColor(KODI::UTILS::COLOR::Color color = 0) : m_color(color) {}
+  constexpr CGUIInfoColor(KODI::UTILS::COLOR::Color color, int info) : m_info(info), m_color(color)
+  {
+  }
 
+  constexpr CGUIInfoColor& operator=(int color)
+  {
+    m_color = color;
+    return *this;
+  }
   constexpr operator KODI::UTILS::COLOR::Color() const { return m_color; }
 
   bool Update(const CGUIListItem* item = nullptr);

--- a/xbmc/guilib/guiinfo/GUIInfoLabel.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoLabel.cpp
@@ -347,7 +347,8 @@ void CGUIInfoLabel::Parse(const std::string& label,
       if (pos2 != std::string::npos)
       {
         // decipher the block
-        std::vector<std::string> params = StringUtils::Split(work.substr(pos1 + len, pos2 - pos1 - len), ",");
+        const std::vector<std::string> params =
+            StringUtils::Split(std::string_view(work).substr(pos1 + len, pos2 - pos1 - len), ",");
         if (!params.empty())
         {
           CGUIInfoManager& infoMgr = CServiceBroker::GetGUI()->GetInfoManager();

--- a/xbmc/guilib/guiinfo/LibraryGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/LibraryGUIInfo.cpp
@@ -261,7 +261,7 @@ bool CLibraryGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contex
 
       std::string libDir = profileManager->GetLibraryFolder();
       XFILE::CDirectory::GetDirectory(libDir, items, "", XFILE::DIR_FLAG_NO_FILE_DIRS);
-      if (items.Size() == 0)
+      if (items.IsEmpty())
         libDir = "special://xbmc/system/library/";
 
       std::string nodePath = URIUtils::AddFileToFolder(libDir, url.GetHostName() + "/");

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -95,7 +95,7 @@ void CSystemGUIInfo::UpdateFPS()
   m_frameCounter++;
   unsigned int curTime = CTimeUtils::GetFrameTime();
 
-  float fTimeSpan = static_cast<float>(curTime - m_lastFPSTime);
+  auto fTimeSpan{static_cast<float>(curTime - m_lastFPSTime)};
   if (fTimeSpan >= 1000.0f)
   {
     fTimeSpan /= 1000.0f;
@@ -360,7 +360,8 @@ bool CSystemGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWi
     {
       KODI::MEMORY::MemoryStatus stat;
       KODI::MEMORY::GetMemoryStatus(&stat);
-      int memPercentUsed = static_cast<int>(100.0f * (stat.totalPhys - stat.availPhys) / stat.totalPhys + 0.5f);
+      const auto memPercentUsed{
+          static_cast<int>(100.0f * (stat.totalPhys - stat.availPhys) / stat.totalPhys + 0.5f)};
       if (info.GetInfo() == SYSTEM_FREE_MEMORY)
         value = 100 - memPercentUsed;
       else

--- a/xbmc/guilib/guiinfo/VisualisationGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VisualisationGUIInfo.cpp
@@ -85,7 +85,7 @@ bool CVisualisationGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int 
       CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
       if (msg.GetPointer())
       {
-        CGUIVisualisationControl* viz = static_cast<CGUIVisualisationControl*>(msg.GetPointer());
+        auto* viz{static_cast<CGUIVisualisationControl*>(msg.GetPointer())};
         value = viz->IsLocked();
         return true;
       }

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -2581,7 +2581,7 @@ public:
     std::string strUpperCodecName = strCodecName;
     StringUtils::ToUpper(strUpperCodecName);
 
-    std::map<std::string, PVR_CODEC>::const_iterator it = m_lookup.find(strUpperCodecName);
+    const auto it{m_lookup.find(strUpperCodecName)};
     if (it != m_lookup.end())
       retVal = it->second;
 

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -418,32 +418,37 @@ EDL::Edit ConvertAddonEdl(const PVR_EDL_ENTRY& entry)
 
 namespace PVR
 {
+class CPVRClient::CPVRAddonInstanceHolder
+{
+public:
+  explicit CPVRAddonInstanceHolder(KODI_ADDON_INSTANCE_STRUCT& instanceStruct)
+  {
+    instanceStruct.pvr = &m_instance;
+    instanceStruct.pvr->props = &m_props;
+    instanceStruct.pvr->toKodi = &m_callbacks;
+    instanceStruct.pvr->toAddon = &m_funcs;
+  }
+
+private:
+  AddonInstance_PVR m_instance{};
+  AddonProperties_PVR m_props{};
+  AddonToKodiFuncTable_PVR m_callbacks{};
+  KodiToAddonFuncTable_PVR m_funcs{};
+};
+
 CPVRClient::CPVRClient(const ADDON::AddonInfoPtr& addonInfo,
                        ADDON::AddonInstanceId instanceId,
                        int clientId)
-  : IAddonInstanceHandler(ADDON_INSTANCE_PVR, addonInfo, instanceId), m_iClientId(clientId)
+  : IAddonInstanceHandler(ADDON_INSTANCE_PVR, addonInfo, instanceId),
+    m_iClientId(clientId),
+    m_instance(std::make_unique<CPVRAddonInstanceHolder>(m_ifc))
 {
-  // Create all interface parts independent to make API changes easier if
-  // something is added
-  m_ifc.pvr = new AddonInstance_PVR;
-  m_ifc.pvr->props = new AddonProperties_PVR();
-  m_ifc.pvr->toKodi = new AddonToKodiFuncTable_PVR();
-  m_ifc.pvr->toAddon = new KodiToAddonFuncTable_PVR();
-
   ResetProperties();
 }
 
 CPVRClient::~CPVRClient()
 {
   Destroy();
-
-  if (m_ifc.pvr)
-  {
-    delete m_ifc.pvr->props;
-    delete m_ifc.pvr->toKodi;
-    delete m_ifc.pvr->toAddon;
-  }
-  delete m_ifc.pvr;
 }
 
 void CPVRClient::StopRunningInstance()
@@ -495,6 +500,7 @@ void CPVRClient::ResetProperties()
   m_ifc.pvr->props->iEpgMaxFutureDays =
       CServiceBroker::GetPVRManager().EpgContainer().GetFutureDaysToDisplay();
 
+  *m_ifc.pvr->toKodi = {};
   m_ifc.pvr->toKodi->kodiInstance = this;
   m_ifc.pvr->toKodi->TransferEpgEntry = cb_transfer_epg_entry;
   m_ifc.pvr->toKodi->TransferChannelEntry = cb_transfer_channel_entry;
@@ -517,8 +523,7 @@ void CPVRClient::ResetProperties()
   m_ifc.pvr->toKodi->EpgEventStateChange = cb_epg_event_state_change;
   m_ifc.pvr->toKodi->GetCodecByName = cb_get_codec_by_name;
 
-  // Clear function addresses to have NULL if not set by addon
-  memset(m_ifc.pvr->toAddon, 0, sizeof(KodiToAddonFuncTable_PVR));
+  *m_ifc.pvr->toAddon = {};
 }
 
 ADDON_STATUS CPVRClient::Create()
@@ -1389,8 +1394,7 @@ PVR_ERROR CPVRClient::GetTimerTypes(const AddonInstance* addon,
   unsigned int size{0};
   PVR_ERROR retval{addon->toAddon->GetTimerTypes(addon, &types_array, &size)};
 
-  const bool array_owner{retval == PVR_ERROR_NOT_IMPLEMENTED};
-  if (array_owner)
+  if (retval == PVR_ERROR_NOT_IMPLEMENTED)
   {
     // begin compat section
     CLog::LogF(LOGWARNING,
@@ -1405,49 +1409,51 @@ PVR_ERROR CPVRClient::GetTimerTypes(const AddonInstance* addon,
     // Isengard. Also, new features (like epg search) are not available to addons automatically.
     // This code can be removed once all addons actually support the respective PVR Addon API version.
 
-    size = 2;
-    if (m_clientCapabilities.SupportsEPG())
-      size++;
-
-    types_array = new PVR_TIMER_TYPE*[size];
-
-    // manual one time
-    types_array[0] = new PVR_TIMER_TYPE{};
-    types_array[0]->iId = 1;
-    types_array[0]->iAttributes =
-        PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
-        PVR_TIMER_TYPE_SUPPORTS_CHANNELS | PVR_TIMER_TYPE_SUPPORTS_START_TIME |
-        PVR_TIMER_TYPE_SUPPORTS_END_TIME | PVR_TIMER_TYPE_SUPPORTS_PRIORITY |
-        PVR_TIMER_TYPE_SUPPORTS_LIFETIME | PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS;
-
-    // manual timer rule
-    types_array[1] = new PVR_TIMER_TYPE{};
-    types_array[1]->iId = 2;
-    types_array[1]->iAttributes =
-        PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_IS_REPEATING |
-        PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE | PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
-        PVR_TIMER_TYPE_SUPPORTS_START_TIME | PVR_TIMER_TYPE_SUPPORTS_END_TIME |
-        PVR_TIMER_TYPE_SUPPORTS_PRIORITY | PVR_TIMER_TYPE_SUPPORTS_LIFETIME |
-        PVR_TIMER_TYPE_SUPPORTS_FIRST_DAY | PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS |
-        PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS;
-
-    if (m_clientCapabilities.SupportsEPG())
+    static PVR_TIMER_TYPE manualOneTime{};
+    if (manualOneTime.iId == 0)
     {
-      // One-shot epg-based
-      types_array[2] = new PVR_TIMER_TYPE{};
-      types_array[2]->iId = 3;
-      types_array[2]->iAttributes =
-          PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE | PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
+      manualOneTime.iId = 1;
+      manualOneTime.iAttributes =
+          PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
           PVR_TIMER_TYPE_SUPPORTS_CHANNELS | PVR_TIMER_TYPE_SUPPORTS_START_TIME |
           PVR_TIMER_TYPE_SUPPORTS_END_TIME | PVR_TIMER_TYPE_SUPPORTS_PRIORITY |
           PVR_TIMER_TYPE_SUPPORTS_LIFETIME | PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS;
+    }
+    timerTypes.emplace_back(std::make_shared<CPVRTimerType>(manualOneTime, m_iClientId));
+
+    static PVR_TIMER_TYPE manualTimerRule{};
+    if (manualTimerRule.iId == 0)
+    {
+      manualTimerRule.iId = 2;
+      manualTimerRule.iAttributes =
+          PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_IS_REPEATING |
+          PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE | PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
+          PVR_TIMER_TYPE_SUPPORTS_START_TIME | PVR_TIMER_TYPE_SUPPORTS_END_TIME |
+          PVR_TIMER_TYPE_SUPPORTS_PRIORITY | PVR_TIMER_TYPE_SUPPORTS_LIFETIME |
+          PVR_TIMER_TYPE_SUPPORTS_FIRST_DAY | PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS |
+          PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS;
+    }
+    timerTypes.emplace_back(std::make_shared<CPVRTimerType>(manualTimerRule, m_iClientId));
+
+    if (m_clientCapabilities.SupportsEPG())
+    {
+      static PVR_TIMER_TYPE epgOneTime{};
+      if (epgOneTime.iId == 0)
+      {
+        epgOneTime.iId = 3;
+        epgOneTime.iAttributes =
+            PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE | PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
+            PVR_TIMER_TYPE_SUPPORTS_CHANNELS | PVR_TIMER_TYPE_SUPPORTS_START_TIME |
+            PVR_TIMER_TYPE_SUPPORTS_END_TIME | PVR_TIMER_TYPE_SUPPORTS_PRIORITY |
+            PVR_TIMER_TYPE_SUPPORTS_LIFETIME | PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS;
+      }
+      timerTypes.emplace_back(std::make_shared<CPVRTimerType>(epgOneTime, m_iClientId));
     }
 
     retval = PVR_ERROR_NO_ERROR;
     // end compat section
   }
-
-  if (retval == PVR_ERROR_NO_ERROR)
+  else if (retval == PVR_ERROR_NO_ERROR)
   {
     timerTypes.reserve(size);
     for (unsigned int i = 0; i < size; ++i)
@@ -1459,24 +1465,9 @@ PVR_ERROR CPVRClient::GetTimerTypes(const AddonInstance* addon,
       }
       timerTypes.emplace_back(std::make_shared<CPVRTimerType>(*(types_array[i]), m_iClientId));
     }
-  }
-
-  /* free the resources of the timer types array */
-  if (array_owner)
-  {
-    // begin compat section
-    for (unsigned int i = 0; i < size; ++i)
-      delete types_array[i];
-
-    delete[] types_array;
-    // end compat section
-  }
-  else
-  {
     addon->toAddon->FreeTimerTypes(addon, types_array, size);
   }
   types_array = nullptr;
-
   return retval;
 }
 

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -1168,5 +1168,8 @@ private:
   std::string m_strClientPath; /*!< @brief translated path to this add-on */
 
   mutable CCriticalSection m_critSection;
+
+  class CPVRAddonInstanceHolder;
+  std::unique_ptr<CPVRAddonInstanceHolder> m_instance;
 };
 } // namespace PVR

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -382,7 +382,7 @@ public:
    * @param channels The container for the channels.
    * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
    */
-  PVR_ERROR GetChannels(bool bRadio, std::vector<std::shared_ptr<CPVRChannel>>& channels) const;
+  PVR_ERROR GetChannels(bool bRadio, std::vector<std::shared_ptr<CPVRChannel>>& channels);
 
   /*!
    * @brief Get the total amount of providers from the backend.
@@ -958,9 +958,9 @@ private:
    * @param function The function to wrap. It must take one parameter of type CPVRClient*.
    * @param bForceCall If true, make the call, ignoring client's state.
    */
-  template<typename F>
+  template<typename F, typename KodiInstance>
   static void HandleAddonCallback(const char* strFunctionName,
-                                  void* kodiInstance,
+                                  KodiInstance* kodiInstance,
                                   F function,
                                   bool bForceCall = false);
 

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -685,9 +685,8 @@ PVR_ERROR CPVRClients::GetChannels(const std::vector<std::shared_ptr<CPVRClient>
 {
   return ForClients(
       std::source_location::current().function_name(), clients,
-      [bRadio, &channels](const std::shared_ptr<const CPVRClient>& client)
-      { return client->GetChannels(bRadio, channels); },
-      failedClients);
+      [bRadio, &channels](const std::shared_ptr<CPVRClient>& client)
+      { return client->GetChannels(bRadio, channels); }, failedClients);
 }
 
 PVR_ERROR CPVRClients::GetProviders(const std::vector<std::shared_ptr<CPVRClient>>& clients,

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -576,26 +576,10 @@ protected:
 
   std::shared_ptr<CPVRChannelGroupSettings> GetSettings() const;
 
-  int m_iGroupId = INVALID_GROUP_ID; /*!< The ID of this group in the database */
-  bool m_bLoaded = false; /*!< True if this container is loaded, false otherwise */
-  bool m_bChanged =
-      false; /*!< true if anything changed in this group that hasn't been persisted, false otherwise */
-  time_t m_iLastWatched = 0; /*!< last time group has been watched */
-  uint64_t m_iLastOpened = 0; /*!< time in milliseconds from epoch this group was last opened */
-  bool m_bHidden = false; /*!< true if this group is hidden, false otherwise */
-  int m_iPosition = 0; /*!< the local position of this group within the group list */
-  std::vector<std::shared_ptr<CPVRChannelGroupMember>>
-      m_sortedMembers; /*!< members sorted by channel number */
   std::map<std::pair<int, int>, std::shared_ptr<CPVRChannelGroupMember>>
       m_members; /*!< members with key clientid+uniqueid */
   mutable CCriticalSection m_critSection;
   std::vector<int> m_failedClients;
-  CEventSource<PVREvent> m_events;
-  mutable std::shared_ptr<CPVRChannelGroupSettings> m_settings;
-
-  // the settings singleton shared between all group instances
-  static CCriticalSection m_settingsSingletonCritSection;
-  static std::weak_ptr<CPVRChannelGroupSettings> m_settingsSingleton;
 
 private:
   /*!
@@ -636,5 +620,22 @@ private:
   bool m_isUserSetName{false};
   std::string m_clientGroupName;
   int m_iClientPosition{0};
+
+  int m_iGroupId{INVALID_GROUP_ID}; /*!< The ID of this group in the database */
+  bool m_bLoaded{false}; /*!< True if this container is loaded, false otherwise */
+  bool m_bChanged{
+      false}; /*!< true if anything changed in this group that hasn't been persisted, false otherwise */
+  time_t m_iLastWatched{0}; /*!< last time group has been watched */
+  uint64_t m_iLastOpened{0}; /*!< time in milliseconds from epoch this group was last opened */
+  bool m_bHidden{false}; /*!< true if this group is hidden, false otherwise */
+  int m_iPosition{0}; /*!< the local position of this group within the group list */
+  std::vector<std::shared_ptr<CPVRChannelGroupMember>>
+      m_sortedMembers; /*!< members sorted by channel number */
+  CEventSource<PVREvent> m_events;
+  mutable std::shared_ptr<CPVRChannelGroupSettings> m_settings;
+
+  // the settings singleton shared between all group instances
+  static CCriticalSection m_settingsSingletonCritSection;
+  static std::weak_ptr<CPVRChannelGroupSettings> m_settingsSingleton;
 };
 } // namespace PVR

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
@@ -195,7 +195,7 @@ void CGUIDialogPVRRecordingSettings::LifetimesFiller(const SettingConstPtr& sett
                                                      int& current,
                                                      void* data)
 {
-  auto* pThis{static_cast<CGUIDialogPVRRecordingSettings*>(data)};
+  auto* pThis{static_cast<const CGUIDialogPVRRecordingSettings*>(data)};
   if (pThis)
   {
     list.clear();

--- a/xbmc/pvr/epg/EpgTagsContainer.cpp
+++ b/xbmc/pvr/epg/EpgTagsContainer.cpp
@@ -176,14 +176,14 @@ bool CPVREpgTagsContainer::UpdateEntries(const CPVREpgTagsContainer& tags)
         if (existingTag->Update(*tag, false))
         {
           // tag differs from existing tag and must be persisted
-          m_changedTags.insert({existingTag->StartAsUTC(), existingTag});
+          m_changedTags.try_emplace(existingTag->StartAsUTC(), existingTag);
           bResetCache = true;
         }
       }
       else
       {
         // new tags must always be persisted
-        m_changedTags.insert({tag->StartAsUTC(), tag});
+        m_changedTags.try_emplace(tag->StartAsUTC(), tag);
         bResetCache = true;
       }
     }

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -666,13 +666,15 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
           const CPVRChannelGroup::Origin origin{group->GetOrigin()};
           switch (origin)
           {
-            case CPVRChannelGroup::Origin::CLIENT:
+            using enum CPVRChannelGroup::Origin;
+
+            case CLIENT:
               strValue = g_localizeStrings.Get(856); // Client
               return true;
-            case CPVRChannelGroup::Origin::SYSTEM:
+            case SYSTEM:
               strValue = g_localizeStrings.Get(857); // System
               return true;
-            case CPVRChannelGroup::Origin::USER:
+            case USER:
               strValue = g_localizeStrings.Get(858); // User
               return true;
             default:
@@ -1520,7 +1522,7 @@ bool CPVRGUIInfo::GetBool(bool& value,
     return false;
 
   const auto* fitem{static_cast<const CFileItem*>(item)};
-  return GetListItemAndPlayerBool(fitem, info, value) || GetPVRBool(fitem, info, value) ||
+  return GetListItemAndPlayerBool(fitem, info, value) || GetPVRBool(info, value) ||
          GetRadioRDSBool(fitem, info, value);
 }
 
@@ -1831,7 +1833,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
   return false;
 }
 
-bool CPVRGUIInfo::GetPVRBool(const CFileItem* item, const CGUIInfo& info, bool& bValue) const
+bool CPVRGUIInfo::GetPVRBool(const CGUIInfo& info, bool& bValue) const
 {
   std::unique_lock lock(m_critSection);
 

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
@@ -121,9 +121,7 @@ private:
   bool GetListItemAndPlayerBool(const CFileItem* item,
                                 const KODI::GUILIB::GUIINFO::CGUIInfo& info,
                                 bool& bValue) const;
-  bool GetPVRBool(const CFileItem* item,
-                  const KODI::GUILIB::GUIINFO::CGUIInfo& info,
-                  bool& bValue) const;
+  bool GetPVRBool(const KODI::GUILIB::GUIINFO::CGUIInfo& info, bool& bValue) const;
   bool GetRadioRDSBool(const CFileItem* item,
                        const KODI::GUILIB::GUIINFO::CGUIInfo& info,
                        bool& bValue) const;

--- a/xbmc/utils/ColorUtils.h
+++ b/xbmc/utils/ColorUtils.h
@@ -18,7 +18,7 @@
 namespace KODI::UTILS::COLOR
 {
 
-typedef uint32_t Color;
+using Color = uint32_t;
 
 // Custom colors
 


### PR DESCRIPTION
Some more SonarQube stuff... no functional changes intended, only optimization and modernization of the code:

**cores/VideoPlayer/DVDInputStreams/InputStreamPVR***
* "explicit" should be used on single-parameter constructors and conversion operators cpp:S1709

**pvr**
* Memory should not be managed manually cpp:S5025
* Transparent function objects should be used with associative "std::string" containers cpp:S6045
* A cast shall not remove any const or volatile qualification from the type of a pointer or reference cpp:S859
* Member variables should not be "protected" cpp:S3656
* Pointer and reference local variables should be "const" if the corresponding object is not modified cpp:S5350
* "try_emplace" should be used with "std::map" and "std::unordered_map" cpp:S6030
* Unused function parameters should be removed cpp:S1172
* "using enum" should be used in scopes with high concentration of "enum" constants cpp:S6177

~~**favourites**~~
~~* "std::string_view" should be used to pass a read-only string to a function cpp:S6009~~

**guiinfo**
* "explicit" should be used on single-parameter constructors and conversion operators cpp:S1709
* "std::string_view" and "std::span" parameters should be directly constructed from sequences cpp:S6231
* "empty()" should be used to test for emptiness cpp:S1155
* "auto" should be used to avoid repetition of types cpp:S5827

@neo1973 could you please have a look. Best reviewed commit-by-commit