### PR TITLE
[*] SonarQube finding: std::unique_lock: Redundant class template arg…

### DIFF
--- a/xbmc/BackgroundInfoLoader.cpp
+++ b/xbmc/BackgroundInfoLoader.cpp
@@ -97,7 +97,7 @@ void CBackgroundInfoLoader::Load(CFileItemList& items)
   if (items.IsEmpty())
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
 
   std::ranges::copy(items, std::back_inserter(m_vecItems));
 

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -59,7 +59,7 @@ void CContextMenuManager::Init()
   m_addonMgr.Events().Subscribe(this, &CContextMenuManager::OnEvent);
   CPVRContextMenuManager::GetInstance().Events().Subscribe(this, &CContextMenuManager::OnPVREvent);
 
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
   m_items = {
       std::make_shared<CONTEXTMENU::CVideoBrowse>(),
       std::make_shared<CONTEXTMENU::CVideoResume>(),
@@ -132,7 +132,7 @@ void CContextMenuManager::ReloadAddonItems()
     }
   }
 
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
   m_addonItems = std::move(addonItems);
 
   CLog::Log(LOGDEBUG, "ContextMenuManager: addon menus reloaded.");
@@ -151,7 +151,7 @@ void CContextMenuManager::OnEvent(const ADDON::AddonEvent& event)
     if (m_addonMgr.GetAddon(event.addonId, addon, AddonType::CONTEXTMENU_ITEM,
                             OnlyEnabled::CHOICE_YES))
     {
-      std::unique_lock<CCriticalSection> lock(m_criticalSection);
+      std::unique_lock lock(m_criticalSection);
       auto items = std::static_pointer_cast<CContextMenuAddon>(addon)->GetItems();
       for (auto& item : items)
       {
@@ -177,13 +177,13 @@ void CContextMenuManager::OnPVREvent(const PVRContextMenuEvent& event)
   {
     case PVRContextMenuEventAction::ADD_ITEM:
     {
-      std::unique_lock<CCriticalSection> lock(m_criticalSection);
+      std::unique_lock lock(m_criticalSection);
       m_items.emplace_back(event.item);
       break;
     }
     case PVRContextMenuEventAction::REMOVE_ITEM:
     {
-      std::unique_lock<CCriticalSection> lock(m_criticalSection);
+      std::unique_lock lock(m_criticalSection);
       auto it = std::find(m_items.begin(), m_items.end(), event.item);
       if (it != m_items.end())
         m_items.erase(it);
@@ -203,7 +203,7 @@ bool CContextMenuManager::IsVisible(
 
   if (menuItem.IsGroup())
   {
-    std::unique_lock<CCriticalSection> lock(m_criticalSection);
+    std::unique_lock lock(m_criticalSection);
     return std::any_of(m_addonItems.begin(), m_addonItems.end(),
         [&](const CContextMenuItem& other){ return menuItem.IsParentOf(other) && other.IsVisible(fileItem); });
   }
@@ -216,7 +216,7 @@ bool CContextMenuManager::HasItems(const CFileItem& fileItem, const CContextMenu
   //! @todo implement group support
   if (&root == &CContextMenuManager::MAIN)
   {
-    std::unique_lock<CCriticalSection> lock(m_criticalSection);
+    std::unique_lock lock(m_criticalSection);
     return std::any_of(m_items.cbegin(), m_items.cend(),
                        [&fileItem](const std::shared_ptr<const IContextMenuItem>& menu) {
                          return menu->IsVisible(fileItem);
@@ -232,7 +232,7 @@ ContextMenuView CContextMenuManager::GetItems(const CFileItem& fileItem,
   //! @todo implement group support
   if (&root == &CContextMenuManager::MAIN)
   {
-    std::unique_lock<CCriticalSection> lock(m_criticalSection);
+    std::unique_lock lock(m_criticalSection);
     std::copy_if(m_items.begin(), m_items.end(), std::back_inserter(result),
         [&](const std::shared_ptr<IContextMenuItem>& menu){ return menu->IsVisible(fileItem); });
   }
@@ -242,7 +242,7 @@ ContextMenuView CContextMenuManager::GetItems(const CFileItem& fileItem,
 bool CContextMenuManager::HasAddonItems(const CFileItem& fileItem,
                                         const CContextMenuItem& root) const
 {
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
   return std::any_of(m_addonItems.cbegin(), m_addonItems.cend(),
                      [this, root, &fileItem](const CContextMenuItem& menu) {
                        return IsVisible(menu, root, fileItem);
@@ -254,7 +254,7 @@ ContextMenuView CContextMenuManager::GetAddonItems(const CFileItem& fileItem,
 {
   ContextMenuView result;
   {
-    std::unique_lock<CCriticalSection> lock(m_criticalSection);
+    std::unique_lock lock(m_criticalSection);
     for (const auto& menu : m_addonItems)
       if (IsVisible(menu, root, fileItem))
         result.emplace_back(new CContextMenuItem(menu));

--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -37,7 +37,7 @@ CDatabaseManager::~CDatabaseManager() = default;
 
 bool CDatabaseManager::Initialize()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   m_dbStatus.clear();
 
@@ -69,7 +69,7 @@ bool CDatabaseManager::Initialize()
 
 bool CDatabaseManager::CanOpen(const std::string &name)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   const auto i = m_dbStatus.find(name);
   if (i != m_dbStatus.end())
     return i->second == DBStatus::READY;
@@ -240,13 +240,13 @@ bool CDatabaseManager::UpdateVersion(CDatabase &db, const std::string &dbName)
 
 void CDatabaseManager::UpdateStatus(const std::string& name, DBStatus status)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   m_dbStatus[name] = status;
 }
 
 void CDatabaseManager::LocalizationChanged()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   // update video version type table after language changed
   CVideoDatabase videodb;

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -84,7 +84,7 @@ void CFileItemList::SetIgnoreURLOptions(bool ignoreURLOptions)
 
 void CFileItemList::SetFastLookup(bool fastLookup)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
 
   if (fastLookup && !m_fastLookup)
   { // generate the map
@@ -103,7 +103,7 @@ void CFileItemList::SetFastLookup(bool fastLookup)
 
 bool CFileItemList::Contains(const std::string& fileName) const
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
 
   const std::string fname = m_ignoreURLOptions ? CURL(fileName).GetWithoutOptions() : fileName;
   if (m_fastLookup)
@@ -115,7 +115,7 @@ bool CFileItemList::Contains(const std::string& fileName) const
 
 void CFileItemList::Clear()
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
 
   ClearItems();
   m_sortDescription.sortBy = SortByNone;
@@ -130,7 +130,7 @@ void CFileItemList::Clear()
 
 void CFileItemList::ClearItems()
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   // make sure we free the memory of the items (these are GUIControls which may have allocated resources)
   FreeMemory();
   std::ranges::for_each(m_items, [](const auto& item) { item->FreeMemory(); });
@@ -140,7 +140,7 @@ void CFileItemList::ClearItems()
 
 void CFileItemList::Add(CFileItemPtr pItem)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   if (m_fastLookup)
     m_map.emplace(
         m_ignoreURLOptions ? CURL(pItem->GetPath()).GetWithoutOptions() : pItem->GetPath(), pItem);
@@ -149,7 +149,7 @@ void CFileItemList::Add(CFileItemPtr pItem)
 
 void CFileItemList::Add(CFileItem&& item)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   auto ptr = std::make_shared<CFileItem>(std::move(item));
   if (m_fastLookup)
     m_map.emplace(m_ignoreURLOptions ? CURL(ptr->GetPath()).GetWithoutOptions() : ptr->GetPath(),
@@ -159,7 +159,7 @@ void CFileItemList::Add(CFileItem&& item)
 
 void CFileItemList::AddFront(const CFileItemPtr& pItem, int itemPosition)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
 
   if (itemPosition >= 0)
   {
@@ -178,7 +178,7 @@ void CFileItemList::AddFront(const CFileItemPtr& pItem, int itemPosition)
 
 void CFileItemList::Remove(CFileItem* pItem)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   const auto it =
       std::ranges::find_if(m_items, [pItem](const auto& item) { return item.get() == pItem; });
   if (it != m_items.end())
@@ -194,13 +194,13 @@ void CFileItemList::Remove(CFileItem* pItem)
 
 CFileItemList::Iterator CFileItemList::erase(Iterator first, Iterator last)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   return m_items.erase(first, last);
 }
 
 void CFileItemList::Remove(int iItem)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
 
   if (iItem >= 0 && iItem < Size())
   {
@@ -216,14 +216,14 @@ void CFileItemList::Remove(int iItem)
 
 void CFileItemList::Append(const CFileItemList& itemlist)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
 
   std::ranges::for_each(itemlist, [this](const auto& item) { Add(item); });
 }
 
 void CFileItemList::Assign(const CFileItemList& itemlist, bool append)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   if (!append)
     Clear();
   Append(itemlist);
@@ -263,7 +263,7 @@ bool CFileItemList::Copy(const CFileItemList& items, bool copyItems /* = true */
 
 CFileItemPtr CFileItemList::Get(int iItem) const
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
 
   if (iItem > -1 && iItem < static_cast<int>(m_items.size()))
     return m_items[iItem];
@@ -273,7 +273,7 @@ CFileItemPtr CFileItemList::Get(int iItem) const
 
 CFileItemPtr CFileItemList::Get(const std::string& strPath) const
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
 
   if (m_fastLookup)
   {
@@ -292,19 +292,19 @@ CFileItemPtr CFileItemList::Get(const std::string& strPath) const
 
 int CFileItemList::Size() const
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   return static_cast<int>(m_items.size());
 }
 
 bool CFileItemList::IsEmpty() const
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   return m_items.empty();
 }
 
 void CFileItemList::Reserve(size_t iCount)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   m_items.reserve(iCount);
 }
 
@@ -381,13 +381,13 @@ void CFileItemList::Sort(SortDescription sortDescription)
 
 void CFileItemList::Randomize()
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   KODI::UTILS::RandomShuffle(m_items.begin(), m_items.end());
 }
 
 void CFileItemList::Archive(CArchive& ar)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   if (ar.IsStoring())
   {
     CFileItem::Archive(ar);
@@ -510,19 +510,19 @@ void CFileItemList::Archive(CArchive& ar)
 
 void CFileItemList::FillInDefaultIcons()
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   std::ranges::for_each(m_items, [](const auto& pItem) { ART::FillInDefaultIcon(*pItem); });
 }
 
 int CFileItemList::GetFolderCount() const
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   return std::ranges::count_if(m_items, [](const auto& pItem) { return pItem->m_bIsFolder; });
 }
 
 int CFileItemList::GetObjectCount() const
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
 
   int numObjects = static_cast<int>(m_items.size());
   if (numObjects && m_items[0]->IsParentFolder())
@@ -533,19 +533,19 @@ int CFileItemList::GetObjectCount() const
 
 int CFileItemList::GetFileCount() const
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   return std::ranges::count_if(m_items, [](const auto& pItem) { return !pItem->m_bIsFolder; });
 }
 
 int CFileItemList::GetSelectedCount() const
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   return std::ranges::count_if(m_items, [](const auto& pItem) { return pItem->IsSelected(); });
 }
 
 void CFileItemList::FilterCueItems()
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   // Handle .CUE sheet files...
   std::vector<std::string> itemstodelete;
   for (auto& pItem : m_items)
@@ -633,13 +633,13 @@ void CFileItemList::FilterCueItems()
 // Remove the extensions from the filenames
 void CFileItemList::RemoveExtensions()
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   std::ranges::for_each(m_items, [](auto& item) { item->RemoveExtension(); });
 }
 
 void CFileItemList::Stack(bool stackFiles /* = true */)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
 
   // not allowed here
   if (IsVirtualDirectoryRoot() || IsLiveTV() || IsSourcesPath() || IsLibraryFolder())
@@ -1052,7 +1052,7 @@ bool CFileItemList::UpdateItem(const CFileItem* item)
   if (!item)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   const auto it =
       std::ranges::find_if(m_items, [&item](const auto& pItem) { return pItem->IsSamePath(item); });
   if (it != m_items.end())

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -12118,7 +12118,7 @@ void CGUIInfoManager::RegisterInfoProvider(IGUIInfoProvider *provider)
   if (!CServiceBroker::GetWinSystem())
     return;
 
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   m_infoProviders.RegisterProvider(provider, false);
 }
@@ -12128,7 +12128,7 @@ void CGUIInfoManager::UnregisterInfoProvider(IGUIInfoProvider *provider)
   if (!CServiceBroker::GetWinSystem())
     return;
 
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   m_infoProviders.UnregisterProvider(provider);
 }

--- a/xbmc/GUILargeTextureManager.cpp
+++ b/xbmc/GUILargeTextureManager.cpp
@@ -165,7 +165,7 @@ CGUILargeTextureManager::~CGUILargeTextureManager() = default;
 
 void CGUILargeTextureManager::CleanupUnusedImages(bool immediately)
 {
-  std::unique_lock<CCriticalSection> lock(m_listSection);
+  std::unique_lock lock(m_listSection);
   // check for items to remove from allocated list, and remove
   listIterator it = m_allocated.begin();
   while (it != m_allocated.end())
@@ -188,7 +188,7 @@ bool CGUILargeTextureManager::GetImage(const std::string& path,
                                        bool firstRequest,
                                        const bool useCache)
 {
-  std::unique_lock<CCriticalSection> lock(m_listSection);
+  std::unique_lock lock(m_listSection);
   for (listIterator it = m_allocated.begin(); it != m_allocated.end(); ++it)
   {
     CLargeTexture *image = *it;
@@ -214,7 +214,7 @@ void CGUILargeTextureManager::ReleaseImage(const std::string& path,
                                            CAspectRatio::AspectRatio aspectRatio,
                                            bool immediately)
 {
-  std::unique_lock<CCriticalSection> lock(m_listSection);
+  std::unique_lock lock(m_listSection);
   for (listIterator it = m_allocated.begin(); it != m_allocated.end(); ++it)
   {
     CLargeTexture *image = *it;
@@ -252,7 +252,7 @@ void CGUILargeTextureManager::QueueImage(const std::string& path,
   if (path.empty())
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_listSection);
+  std::unique_lock lock(m_listSection);
   for (queueIterator it = m_queued.begin(); it != m_queued.end(); ++it)
   {
     CLargeTexture *image = it->second;
@@ -274,7 +274,7 @@ void CGUILargeTextureManager::QueueImage(const std::string& path,
 void CGUILargeTextureManager::OnJobComplete(unsigned int jobID, bool success, CJob *job)
 {
   // see if we still have this job id
-  std::unique_lock<CCriticalSection> lock(m_listSection);
+  std::unique_lock lock(m_listSection);
   for (queueIterator it = m_queued.begin(); it != m_queued.end(); ++it)
   {
     if (it->first == jobID)

--- a/xbmc/PasswordManager.cpp
+++ b/xbmc/PasswordManager.cpp
@@ -35,7 +35,7 @@ CPasswordManager::CPasswordManager()
 
 bool CPasswordManager::AuthenticateURL(CURL &url)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (!m_loaded)
     Load();
@@ -58,7 +58,7 @@ bool CPasswordManager::AuthenticateURL(CURL &url)
 
 bool CPasswordManager::PromptToAuthenticateURL(CURL &url)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   std::string passcode;
   std::string username = url.GetUserName();
@@ -99,7 +99,7 @@ void CPasswordManager::SaveAuthenticatedURL(const CURL &url, bool saveToProfile)
   if (url.GetUserName().empty())
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   std::string path = GetLookupPath(url);
   std::string authenticatedPath = url.Get();

--- a/xbmc/SectionLoader.cpp
+++ b/xbmc/SectionLoader.cpp
@@ -32,7 +32,7 @@ CSectionLoader::~CSectionLoader(void)
 
 LibraryLoader *CSectionLoader::LoadDLL(const std::string &dllname, bool bDelayUnload /*=true*/, bool bLoadSymbols /*=false*/)
 {
-  std::unique_lock<CCriticalSection> lock(g_sectionLoader.m_critSection);
+  std::unique_lock lock(g_sectionLoader.m_critSection);
 
   if (dllname.empty()) return NULL;
   // check if it's already loaded, and increase the reference count if so
@@ -64,7 +64,7 @@ LibraryLoader *CSectionLoader::LoadDLL(const std::string &dllname, bool bDelayUn
 
 void CSectionLoader::UnloadDLL(const std::string &dllname)
 {
-  std::unique_lock<CCriticalSection> lock(g_sectionLoader.m_critSection);
+  std::unique_lock lock(g_sectionLoader.m_critSection);
 
   if (dllname.empty()) return;
   // check if it's already loaded, and decrease the reference count if so
@@ -94,7 +94,7 @@ void CSectionLoader::UnloadDLL(const std::string &dllname)
 
 void CSectionLoader::UnloadDelayed()
 {
-  std::unique_lock<CCriticalSection> lock(g_sectionLoader.m_critSection);
+  std::unique_lock lock(g_sectionLoader.m_critSection);
 
   // check if we can unload any unreferenced dlls
   for (int i = 0; i < (int)g_sectionLoader.m_vecLoadedDLLs.size(); ++i)
@@ -118,7 +118,7 @@ void CSectionLoader::UnloadDelayed()
 void CSectionLoader::UnloadAll()
 {
   // delete the dll's
-  std::unique_lock<CCriticalSection> lock(g_sectionLoader.m_critSection);
+  std::unique_lock lock(g_sectionLoader.m_critSection);
   std::vector<CDll>::iterator it = g_sectionLoader.m_vecLoadedDLLs.begin();
   while (it != g_sectionLoader.m_vecLoadedDLLs.end())
   {

--- a/xbmc/SeekHandler.cpp
+++ b/xbmc/SeekHandler.cpp
@@ -121,7 +121,7 @@ int CSeekHandler::GetSeekStepSize(SeekType type, int step)
 
 void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bool analogSeek /* = false */, SeekType type /* = SEEK_TYPE_VIDEO */)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // not yet seeking
   if (!m_requireSeek)
@@ -182,7 +182,7 @@ void CSeekHandler::SeekSeconds(int seconds)
   if (seconds == 0)
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   SetSeekSize(seconds);
 
   // perform relative seek
@@ -220,7 +220,7 @@ void CSeekHandler::FrameMove()
 {
   if (m_timer.GetElapsedMilliseconds() >= m_seekDelay && m_requireSeek)
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     // perform relative seek
     auto& components = CServiceBroker::GetAppComponents();
@@ -373,7 +373,7 @@ bool CSeekHandler::SeekTimeCode(const CAction &action)
     case ACTION_PLAYER_PLAY:
     case ACTION_PAUSE:
     {
-      std::unique_lock<CCriticalSection> lock(m_critSection);
+      std::unique_lock lock(m_critSection);
 
       g_application.SeekTime(GetTimeCodeSeconds());
       Reset();

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -48,7 +48,7 @@ CTextureCache::~CTextureCache() = default;
 void CTextureCache::Initialize()
 {
   m_cleanTimer.Start(60s);
-  std::unique_lock<CCriticalSection> lock(m_databaseSection);
+  std::unique_lock lock(m_databaseSection);
   if (!m_database.IsOpen())
     m_database.Open();
 }
@@ -57,7 +57,7 @@ void CTextureCache::Deinitialize()
 {
   CancelJobs();
 
-  std::unique_lock<CCriticalSection> lock(m_databaseSection);
+  std::unique_lock lock(m_databaseSection);
   m_database.Close();
 }
 
@@ -136,7 +136,7 @@ void CTextureCache::BackgroundCacheImage(const std::string &url)
 
 bool CTextureCache::StartCacheImage(const std::string& image)
 {
-  std::unique_lock<CCriticalSection> lock(m_processingSection);
+  std::unique_lock lock(m_processingSection);
   std::set<std::string>::iterator i = m_processinglist.find(image);
   if (i == m_processinglist.end())
   {
@@ -158,7 +158,7 @@ std::string CTextureCache::CacheImage(
   if (url.empty())
     return "";
 
-  std::unique_lock<CCriticalSection> lock(m_processingSection);
+  std::unique_lock lock(m_processingSection);
   if (m_processinglist.find(url) == m_processinglist.end())
   {
     m_processinglist.insert(url);
@@ -178,7 +178,7 @@ std::string CTextureCache::CacheImage(
   {
     m_completeEvent.Wait(1000ms);
     {
-      std::unique_lock<CCriticalSection> lock(m_processingSection);
+      std::unique_lock lock(m_processingSection);
       if (m_processinglist.find(url) == m_processinglist.end())
         break;
     }
@@ -244,20 +244,20 @@ bool CTextureCache::ClearCachedImage(int id)
 
 bool CTextureCache::GetCachedTexture(const std::string &url, CTextureDetails &details)
 {
-  std::unique_lock<CCriticalSection> lock(m_databaseSection);
+  std::unique_lock lock(m_databaseSection);
   return m_database.GetCachedTexture(url, details);
 }
 
 bool CTextureCache::AddCachedTexture(const std::string &url, const CTextureDetails &details)
 {
-  std::unique_lock<CCriticalSection> lock(m_databaseSection);
+  std::unique_lock lock(m_databaseSection);
   return m_database.AddCachedTexture(url, details);
 }
 
 void CTextureCache::IncrementUseCount(const CTextureDetails &details)
 {
   static const size_t count_before_update = 100;
-  std::unique_lock<CCriticalSection> lock(m_useCountSection);
+  std::unique_lock lock(m_useCountSection);
   m_useCounts.reserve(count_before_update);
   m_useCounts.push_back(details);
   if (m_useCounts.size() >= count_before_update)
@@ -269,19 +269,19 @@ void CTextureCache::IncrementUseCount(const CTextureDetails &details)
 
 bool CTextureCache::SetCachedTextureValid(const std::string &url, bool updateable)
 {
-  std::unique_lock<CCriticalSection> lock(m_databaseSection);
+  std::unique_lock lock(m_databaseSection);
   return m_database.SetCachedTextureValid(url, updateable);
 }
 
 bool CTextureCache::ClearCachedTexture(const std::string &url, std::string &cachedURL)
 {
-  std::unique_lock<CCriticalSection> lock(m_databaseSection);
+  std::unique_lock lock(m_databaseSection);
   return m_database.ClearCachedTexture(url, cachedURL);
 }
 
 bool CTextureCache::ClearCachedTexture(int id, std::string &cachedURL)
 {
-  std::unique_lock<CCriticalSection> lock(m_databaseSection);
+  std::unique_lock lock(m_databaseSection);
   return m_database.ClearCachedTexture(id, cachedURL);
 }
 
@@ -311,7 +311,7 @@ void CTextureCache::OnCachingComplete(bool success, CTextureCacheJob *job)
   }
 
   { // remove from our processing list
-    std::unique_lock<CCriticalSection> lock(m_processingSection);
+    std::unique_lock lock(m_processingSection);
     std::set<std::string>::iterator i = m_processinglist.find(job->m_url);
     if (i != m_processinglist.end())
       m_processinglist.erase(i);

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -156,7 +156,7 @@ CAddonInstaller &CAddonInstaller::GetInstance()
 
 void CAddonInstaller::OnJobComplete(unsigned int jobID, bool success, CJob* job)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   JobMap::iterator i = find_if(m_downloadJobs.begin(), m_downloadJobs.end(), [jobID](const std::pair<std::string, CDownloadJob>& p) {
     return p.second.jobID == jobID;
   });
@@ -173,7 +173,7 @@ void CAddonInstaller::OnJobComplete(unsigned int jobID, bool success, CJob* job)
 
 void CAddonInstaller::OnJobProgress(unsigned int jobID, unsigned int progress, unsigned int total, const CJob *job)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   JobMap::iterator i = find_if(m_downloadJobs.begin(), m_downloadJobs.end(), [jobID](const std::pair<std::string, CDownloadJob>& p) {
     return p.second.jobID == jobID;
   });
@@ -191,13 +191,13 @@ void CAddonInstaller::OnJobProgress(unsigned int jobID, unsigned int progress, u
 
 bool CAddonInstaller::IsDownloading() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return !m_downloadJobs.empty();
 }
 
 void CAddonInstaller::GetInstallList(VECADDONS &addons) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   std::vector<std::string> addonIDs;
   for (JobMap::const_iterator i = m_downloadJobs.begin(); i != m_downloadJobs.end(); ++i)
   {
@@ -217,7 +217,7 @@ void CAddonInstaller::GetInstallList(VECADDONS &addons) const
 
 bool CAddonInstaller::GetProgress(const std::string& addonID, unsigned int& percent, bool& downloadFinshed) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   JobMap::const_iterator i = m_downloadJobs.find(addonID);
   if (i != m_downloadJobs.end())
   {
@@ -230,7 +230,7 @@ bool CAddonInstaller::GetProgress(const std::string& addonID, unsigned int& perc
 
 bool CAddonInstaller::Cancel(const std::string &addonID)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   JobMap::iterator i = m_downloadJobs.find(addonID);
   if (i != m_downloadJobs.end())
   {
@@ -365,7 +365,7 @@ bool CAddonInstaller::DoInstall(const AddonPtr& addon,
                                 AllowCheckForUpdates allowCheckForUpdates)
 {
   // check whether we already have the addon installing
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_downloadJobs.find(addon->ID()) != m_downloadJobs.end())
     return false;
 
@@ -533,7 +533,7 @@ bool CAddonInstaller::CheckDependencies(const AddonPtr &addon,
 
 bool CAddonInstaller::HasJob(const std::string& ID) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_downloadJobs.find(ID) != m_downloadJobs.end();
 }
 
@@ -601,7 +601,7 @@ void CAddonInstaller::InstallAddons(const VECADDONS& addons,
   }
   if (wait)
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     if (!m_downloadJobs.empty())
     {
       m_idle.Reset();

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -122,7 +122,7 @@ void CAddonMgr::UnregisterAddonMgrCallback(AddonType type)
 
 bool CAddonMgr::Init()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (!LoadManifest(m_systemAddons, m_optionalSystemAddons))
   {
@@ -160,7 +160,7 @@ void CAddonMgr::DeInit()
 
 bool CAddonMgr::HasAddons(AddonType type)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& addonInfo : m_installedAddons)
   {
@@ -172,7 +172,7 @@ bool CAddonMgr::HasAddons(AddonType type)
 
 bool CAddonMgr::HasInstalledAddons(AddonType type)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& addonInfo : m_installedAddons)
   {
@@ -184,13 +184,13 @@ bool CAddonMgr::HasInstalledAddons(AddonType type)
 
 void CAddonMgr::AddToUpdateableAddons(AddonPtr &pAddon)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_updateableAddons.push_back(pAddon);
 }
 
 void CAddonMgr::RemoveFromUpdateableAddons(AddonPtr &pAddon)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   VECADDONS::iterator it = std::find(m_updateableAddons.begin(), m_updateableAddons.end(), pAddon);
 
   if(it != m_updateableAddons.end())
@@ -215,7 +215,7 @@ struct AddonIdFinder
 
 bool CAddonMgr::ReloadSettings(const std::string& addonId, AddonInstanceId instanceId)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   VECADDONS::iterator it =
       std::find_if(m_updateableAddons.begin(), m_updateableAddons.end(), AddonIdFinder(addonId));
 
@@ -273,7 +273,7 @@ std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetAvailableUpdatesOrOutdatedAdd
 
 std::map<std::string, AddonWithUpdate> CAddonMgr::GetAddonsWithAvailableUpdate() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   auto start = std::chrono::steady_clock::now();
 
   std::vector<std::shared_ptr<IAddon>> installed;
@@ -296,7 +296,7 @@ std::map<std::string, AddonWithUpdate> CAddonMgr::GetAddonsWithAvailableUpdate()
 std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetCompatibleVersions(
     const std::string& addonId) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   auto start = std::chrono::steady_clock::now();
 
   CAddonRepos addonRepos(addonId);
@@ -403,7 +403,7 @@ bool CAddonMgr::GetInstallableAddons(VECADDONS& addons)
 
 bool CAddonMgr::GetInstallableAddons(VECADDONS& addons, AddonType type)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   CAddonRepos addonRepos;
 
   if (!addonRepos.IsValid())
@@ -434,7 +434,7 @@ bool CAddonMgr::GetInstallableAddons(VECADDONS& addons, AddonType type)
 
 bool CAddonMgr::FindInstallableById(const std::string& addonId, AddonPtr& result)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   CAddonRepos addonRepos(addonId);
   if (!addonRepos.IsValid())
@@ -466,7 +466,7 @@ bool CAddonMgr::GetAddonsInternal(AddonType type,
                                   OnlyEnabled onlyEnabled,
                                   CheckIncompatible checkIncompatible) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& addonInfo : m_installedAddons)
   {
@@ -634,7 +634,7 @@ bool CAddonMgr::GetAddon(const std::string& str,
                          AddonType type,
                          OnlyEnabled onlyEnabled) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   AddonInfoPtr addonInfo = GetAddonInfo(str, type);
   if (addonInfo)
@@ -683,7 +683,7 @@ bool CAddonMgr::FindAddon(const std::string& addonId,
   if (it == installedAddons.cend() || it->second->Version() != addonVersion)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_database->GetInstallData(it->second);
   CLog::Log(LOGINFO, "CAddonMgr::{}: {} v{} installed", __FUNCTION__, addonId,
@@ -715,7 +715,7 @@ bool CAddonMgr::FindAddons()
   for (const auto& addon : installedAddons)
     installed.insert(addon.second->ID());
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // Sync with db
   m_database->SyncInstalled(installed, m_systemAddons, m_optionalSystemAddons);
@@ -740,7 +740,7 @@ bool CAddonMgr::FindAddons()
 
 bool CAddonMgr::UnloadAddon(const std::string& addonId)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (!IsAddonInstalled(addonId))
     return true;
@@ -769,7 +769,7 @@ bool CAddonMgr::LoadAddon(const std::string& addonId,
                           const std::string& origin,
                           const CAddonVersion& addonVersion)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   AddonPtr addon;
   if (GetAddon(addonId, addon, AddonType::UNKNOWN, OnlyEnabled::CHOICE_NO))
@@ -808,7 +808,7 @@ bool CAddonMgr::LoadAddon(const std::string& addonId,
 
 void CAddonMgr::OnPostUnInstall(const std::string& id)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_disabled.erase(id);
   RemoveAllUpdateRulesFromList(id);
   m_events.Publish(AddonEvents::UnInstalled(id));
@@ -819,7 +819,7 @@ void CAddonMgr::UpdateLastUsed(const std::string& id)
   auto time = CDateTime::GetCurrentDateTime();
   CServiceBroker::GetJobManager()->Submit([this, id, time]() {
     {
-      std::unique_lock<CCriticalSection> lock(m_critSection);
+      std::unique_lock lock(m_critSection);
       m_database->SetLastUsed(id, time);
       auto addonInfo = GetAddonInfo(id, AddonType::UNKNOWN);
       if (addonInfo)
@@ -849,7 +849,7 @@ static void ResolveDependencies(const std::string& addonId, std::vector<std::str
 
 bool CAddonMgr::DisableAddon(const std::string& id, AddonDisabledReason disabledReason)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (!CanAddonBeDisabled(id))
     return false;
   if (m_disabled.find(id) != m_disabled.end())
@@ -875,7 +875,7 @@ bool CAddonMgr::DisableAddon(const std::string& id, AddonDisabledReason disabled
 
 bool CAddonMgr::UpdateDisabledReason(const std::string& id, AddonDisabledReason newDisabledReason)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (!IsAddonDisabled(id))
     return false;
   if (!m_database->DisableAddon(id, newDisabledReason))
@@ -891,7 +891,7 @@ bool CAddonMgr::UpdateDisabledReason(const std::string& id, AddonDisabledReason 
 
 bool CAddonMgr::EnableSingle(const std::string& id)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_disabled.find(id) == m_disabled.end())
     return true; //already enabled
@@ -948,14 +948,14 @@ bool CAddonMgr::EnableAddon(const std::string& id)
 
 bool CAddonMgr::IsAddonDisabled(const std::string& ID) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_disabled.find(ID) != m_disabled.end();
 }
 
 bool CAddonMgr::IsAddonDisabledExcept(const std::string& ID,
                                       AddonDisabledReason disabledReason) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const auto disabledAddon = m_disabled.find(ID);
   return disabledAddon != m_disabled.end() && disabledAddon->second != disabledReason;
 }
@@ -965,7 +965,7 @@ bool CAddonMgr::CanAddonBeDisabled(const std::string& ID)
   if (ID.empty())
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   // Required system add-ons can not be disabled
   if (IsRequiredSystemAddon(ID))
     return false;
@@ -1057,13 +1057,13 @@ bool CAddonMgr::IsSystemAddon(const std::string& id)
 
 bool CAddonMgr::IsRequiredSystemAddon(const std::string& id)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return std::find(m_systemAddons.begin(), m_systemAddons.end(), id) != m_systemAddons.end();
 }
 
 bool CAddonMgr::IsOptionalSystemAddon(const std::string& id)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return std::find(m_optionalSystemAddons.begin(), m_optionalSystemAddons.end(), id) !=
          m_optionalSystemAddons.end();
 }
@@ -1205,7 +1205,7 @@ std::vector<DependencyInfo> CAddonMgr::GetDepsRecursive(const std::string& id,
 
 bool CAddonMgr::GetAddonInfos(AddonInfos& addonInfos, bool onlyEnabled, AddonType type) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   bool forUnknown = type == AddonType::UNKNOWN;
   for (auto& info : m_installedAddons)
@@ -1227,7 +1227,7 @@ std::vector<AddonInfoPtr> CAddonMgr::GetAddonInfos(bool onlyEnabled,
   if (types.empty())
     return infos;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (auto& info : m_installedAddons)
   {
@@ -1255,7 +1255,7 @@ bool CAddonMgr::GetDisabledAddonInfos(std::vector<AddonInfoPtr>& addonInfos,
                                       AddonType type,
                                       AddonDisabledReason disabledReason) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   bool forUnknown = type == AddonType::UNKNOWN;
   for (const auto& info : m_installedAddons)
@@ -1275,7 +1275,7 @@ bool CAddonMgr::GetDisabledAddonInfos(std::vector<AddonInfoPtr>& addonInfos,
 
 const AddonInfoPtr CAddonMgr::GetAddonInfo(const std::string& id, AddonType type) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   auto addon = m_installedAddons.find(id);
   if (addon != m_installedAddons.end())
@@ -1331,7 +1331,7 @@ AddonOriginType CAddonMgr::GetAddonOriginType(const AddonPtr& addon) const
 bool CAddonMgr::IsAddonDisabledWithReason(const std::string& ID,
                                           AddonDisabledReason disabledReason) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const auto& disabledAddon = m_disabled.find(ID);
   return disabledAddon != m_disabled.end() && disabledAddon->second == disabledReason;
 }
@@ -1343,7 +1343,7 @@ bool CAddonMgr::IsAddonDisabledWithReason(const std::string& ID,
 
 bool CAddonMgr::SetAddonOrigin(const std::string& addonId, const std::string& repoAddonId, bool isUpdate)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_database->SetOrigin(addonId, repoAddonId);
   if (isUpdate)

--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -85,7 +85,7 @@ void CAddonStatusHandler::OnExit()
 
 void CAddonStatusHandler::Process()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   std::string heading = StringUtils::Format(
       "{}: {}", CAddonInfo::TranslateType(m_addon->Type(), true), m_addon->Name());

--- a/xbmc/addons/AddonUpdateRules.cpp
+++ b/xbmc/addons/AddonUpdateRules.cpp
@@ -26,13 +26,13 @@ bool CAddonUpdateRules::RefreshRulesMap(const CAddonDatabase& db)
 
 bool CAddonUpdateRules::IsAutoUpdateable(const std::string& id) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_updateRules.find(id) == m_updateRules.end();
 }
 
 bool CAddonUpdateRules::IsUpdateableByRule(const std::string& id, AddonUpdateRule updateRule) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const auto& updateRulesEntry = m_updateRules.find(id);
   return (updateRulesEntry == m_updateRules.end() ||
           std::none_of(updateRulesEntry->second.begin(), updateRulesEntry->second.end(),
@@ -43,7 +43,7 @@ bool CAddonUpdateRules::AddUpdateRuleToList(CAddonDatabase& db,
                                             const std::string& id,
                                             AddonUpdateRule updateRule)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (!IsUpdateableByRule(id, updateRule))
   {
@@ -74,7 +74,7 @@ bool CAddonUpdateRules::RemoveFromUpdateRuleslist(CAddonDatabase& db,
                                                   const std::string& id,
                                                   AddonUpdateRule updateRule)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   const auto& updateRulesEntry = m_updateRules.find(id);
   if (updateRulesEntry != m_updateRules.end())

--- a/xbmc/addons/BinaryAddonCache.cpp
+++ b/xbmc/addons/BinaryAddonCache.cpp
@@ -62,7 +62,7 @@ void CBinaryAddonCache::GetDisabledAddons(VECADDONS& addons, AddonType type)
 
 void CBinaryAddonCache::GetInstalledAddons(VECADDONS& addons, AddonType type)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   auto it = m_addons.find(type);
   if (it != m_addons.end())
     addons = it->second;
@@ -72,7 +72,7 @@ AddonPtr CBinaryAddonCache::GetAddonInstance(const std::string& strId, AddonType
 {
   AddonPtr addon;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   auto it = m_addons.find(type);
   if (it != m_addons.end())
@@ -125,7 +125,7 @@ void CBinaryAddonCache::Update()
   }
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     m_addons = std::move(addonmap);
   }
 }

--- a/xbmc/addons/ExtsMimeSupportList.cpp
+++ b/xbmc/addons/ExtsMimeSupportList.cpp
@@ -58,7 +58,7 @@ void CExtsMimeSupportList::Update(const std::string& id)
 {
   // Stop used instance if present, otherwise the new becomes created on already created addon base one.
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     const auto itAddon =
         std::find_if(m_supportedList.begin(), m_supportedList.end(),
@@ -78,7 +78,7 @@ void CExtsMimeSupportList::Update(const std::string& id)
     {
       SupportValues values = ScanAddonProperties(addonInfo->MainType(), addonInfo);
       {
-        std::unique_lock<CCriticalSection> lock(m_critSection);
+        std::unique_lock lock(m_critSection);
         m_supportedList.emplace_back(values);
       }
     }
@@ -168,7 +168,7 @@ std::vector<CExtsMimeSupportList::SupportValues> CExtsMimeSupportList::GetSuppor
 {
   std::vector<SupportValues> addonInfos;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& entry : m_supportedList)
   {
@@ -182,7 +182,7 @@ std::vector<CExtsMimeSupportList::SupportValues> CExtsMimeSupportList::GetSuppor
 
 bool CExtsMimeSupportList::IsExtensionSupported(const std::string& ext)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& entry : m_supportedList)
   {
@@ -201,7 +201,7 @@ std::vector<std::pair<AddonType, std::shared_ptr<ADDON::CAddonInfo>>> CExtsMimeS
 {
   std::vector<std::pair<AddonType, std::shared_ptr<CAddonInfo>>> addonInfos;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& entry : m_supportedList)
   {
@@ -219,7 +219,7 @@ std::vector<std::pair<AddonType, std::shared_ptr<ADDON::CAddonInfo>>> CExtsMimeS
 
 bool CExtsMimeSupportList::IsMimetypeSupported(const std::string& mimetype)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& entry : m_supportedList)
   {
@@ -239,7 +239,7 @@ std::vector<std::pair<AddonType, std::shared_ptr<CAddonInfo>>> CExtsMimeSupportL
 {
   std::vector<std::pair<AddonType, std::shared_ptr<CAddonInfo>>> addonInfos;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& entry : m_supportedList)
   {

--- a/xbmc/addons/RepositoryUpdater.cpp
+++ b/xbmc/addons/RepositoryUpdater.cpp
@@ -158,7 +158,7 @@ void CRepositoryUpdater::OnEvent(const ADDON::AddonEvent& event)
 
 void CRepositoryUpdater::OnJobComplete(unsigned int jobID, bool success, CJob* job)
 {
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
   m_jobs.erase(std::find(m_jobs.begin(), m_jobs.end(), job));
   if (m_jobs.empty())
   {
@@ -205,7 +205,7 @@ bool CRepositoryUpdater::CheckForUpdates(bool showProgress)
   VECADDONS addons;
   if (m_addonMgr.GetAddons(addons, AddonType::REPOSITORY) && !addons.empty())
   {
-    std::unique_lock<CCriticalSection> lock(m_criticalSection);
+    std::unique_lock lock(m_criticalSection);
     for (const auto& addon : addons)
       CheckForUpdates(std::static_pointer_cast<ADDON::CRepository>(addon), showProgress);
 
@@ -224,7 +224,7 @@ static void SetProgressIndicator(CRepositoryUpdateJob* job)
 
 void CRepositoryUpdater::CheckForUpdates(const ADDON::RepositoryPtr& repo, bool showProgress)
 {
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
   if (IsSleeping())
   {
     CLog::LogF(LOGDEBUG, "Repository update check postponed. System is sleeping.");
@@ -321,7 +321,7 @@ void CRepositoryUpdater::ScheduleUpdate(UpdateScheduleType scheduleType)
 {
   using namespace std::chrono;
 
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
   m_timer.Stop(true);
 
   if (CAddonSystemSettings::GetInstance().GetAddonAutoUpdateMode() == AUTO_UPDATES_NEVER)

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -77,7 +77,7 @@ void CServiceAddonManager::Start(const std::string& addonId)
 
 void CServiceAddonManager::Start(const AddonPtr& addon)
 {
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
   if (m_services.find(addon->ID()) != m_services.end())
   {
     CLog::Log(LOGDEBUG, "CServiceAddonManager: {} already started.", addon->ID());
@@ -101,7 +101,7 @@ void CServiceAddonManager::Stop()
 {
   m_addonMgr.Events().Unsubscribe(this);
   m_addonMgr.UnloadEvents().Unsubscribe(this);
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
   for (const auto& service : m_services)
   {
     Stop(service);
@@ -111,7 +111,7 @@ void CServiceAddonManager::Stop()
 
 void CServiceAddonManager::Stop(const std::string& addonId)
 {
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
   auto it = m_services.find(addonId);
   if (it != m_services.end())
   {

--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -61,7 +61,7 @@ void CVFSAddonCache::Init()
   std::vector<AddonInfoPtr> addonInfos;
   CServiceBroker::GetAddonMgr().GetAddonInfos(addonInfos, true, AddonType::VFS);
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& addonInfo : addonInfos)
   {
     VFSEntryPtr vfs = std::make_shared<CVFSEntry>(addonInfo);
@@ -81,7 +81,7 @@ void CVFSAddonCache::Deinit()
 
 const std::vector<VFSEntryPtr> CVFSAddonCache::GetAddonInstances()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_addonsInstances;
 }
 
@@ -89,7 +89,7 @@ VFSEntryPtr CVFSAddonCache::GetAddonInstance(const std::string& strId)
 {
   VFSEntryPtr addon;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   const auto& itAddon = std::find_if(m_addonsInstances.begin(), m_addonsInstances.end(),
     [&strId](const VFSEntryPtr& addon)
@@ -129,7 +129,7 @@ void CVFSAddonCache::OnEvent(const AddonEvent& event)
 
 bool CVFSAddonCache::IsInUse(const std::string& id)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   const auto& itAddon = std::find_if(m_addonsInstances.begin(), m_addonsInstances.end(),
                                      [&id](const VFSEntryPtr& addon) { return addon->ID() == id; });
@@ -144,7 +144,7 @@ void CVFSAddonCache::Update(const std::string& id)
 
   // Stop used instance if present, otherwise the new becomes created on already created addon base one.
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     const auto& itAddon =
         std::find_if(m_addonsInstances.begin(), m_addonsInstances.end(),
@@ -166,7 +166,7 @@ void CVFSAddonCache::Update(const std::string& id)
     if (!vfs->GetZeroconfType().empty())
       CZeroconfBrowser::GetInstance()->AddServiceType(vfs->GetZeroconfType());
 
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     m_addonsInstances.emplace_back(vfs);
   }
 }

--- a/xbmc/addons/binary-addons/AddonInstanceHandler.cpp
+++ b/xbmc/addons/binary-addons/AddonInstanceHandler.cpp
@@ -119,7 +119,7 @@ ADDON_STATUS IAddonInstanceHandler::CreateInstance()
   if (!m_addon)
     return ADDON_STATUS_UNKNOWN;
 
-  std::unique_lock<CCriticalSection> lock(m_cdSec);
+  std::unique_lock lock(m_cdSec);
 
   ADDON_STATUS status = m_addon->CreateInstance(&m_ifc);
   if (status != ADDON_STATUS_OK)
@@ -133,7 +133,7 @@ ADDON_STATUS IAddonInstanceHandler::CreateInstance()
 
 void IAddonInstanceHandler::DestroyInstance()
 {
-  std::unique_lock<CCriticalSection> lock(m_cdSec);
+  std::unique_lock lock(m_cdSec);
   if (m_addon)
     m_addon->DestroyInstance(&m_ifc);
 }

--- a/xbmc/addons/binary-addons/BinaryAddonBase.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonBase.cpp
@@ -31,7 +31,7 @@ AddonDllPtr CBinaryAddonBase::GetAddon(IAddonInstanceHandler* handler)
     return nullptr;
   }
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // If no 'm_activeAddon' is defined create it new.
   if (m_activeAddon == nullptr)
@@ -52,7 +52,7 @@ void CBinaryAddonBase::ReleaseAddon(IAddonInstanceHandler* handler)
     return;
   }
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   auto presentHandler = m_activeAddonHandlers.find(handler);
   if (presentHandler == m_activeAddonHandlers.end())
@@ -69,13 +69,13 @@ void CBinaryAddonBase::ReleaseAddon(IAddonInstanceHandler* handler)
 
 size_t CBinaryAddonBase::UsedInstanceCount() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_activeAddonHandlers.size();
 }
 
 AddonDllPtr CBinaryAddonBase::GetActiveAddon()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_activeAddon;
 }
 

--- a/xbmc/addons/binary-addons/BinaryAddonManager.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.cpp
@@ -21,7 +21,7 @@ BinaryAddonBasePtr CBinaryAddonManager::GetAddonBase(const AddonInfoPtr& addonIn
                                                      IAddonInstanceHandler* handler,
                                                      AddonDllPtr& addon)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   BinaryAddonBasePtr addonBase;
 
@@ -67,7 +67,7 @@ void CBinaryAddonManager::ReleaseAddonBase(const BinaryAddonBasePtr& addonBase,
 
 BinaryAddonBasePtr CBinaryAddonManager::GetRunningAddonBase(const std::string& addonId) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   const auto& addonInstances = m_runningAddons.find(addonId);
   if (addonInstances != m_runningAddons.end())
@@ -78,7 +78,7 @@ BinaryAddonBasePtr CBinaryAddonManager::GetRunningAddonBase(const std::string& a
 
 AddonPtr CBinaryAddonManager::GetRunningAddon(const std::string& addonId) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   const BinaryAddonBasePtr base = GetRunningAddonBase(addonId);
   if (base)

--- a/xbmc/addons/interfaces/gui/General.cpp
+++ b/xbmc/addons/interfaces/gui/General.cpp
@@ -194,7 +194,7 @@ int Interface_GUIGeneral::get_current_window_dialog_id(KODI_HANDLE kodiBase)
     return -1;
   }
 
-  std::unique_lock<CCriticalSection> gl(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock gl(CServiceBroker::GetWinSystem()->GetGfxContext());
   return CServiceBroker::GetGUI()->GetWindowManager().GetTopmostModalDialog();
 }
 
@@ -207,7 +207,7 @@ int Interface_GUIGeneral::get_current_window_id(KODI_HANDLE kodiBase)
     return -1;
   }
 
-  std::unique_lock<CCriticalSection> gl(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock gl(CServiceBroker::GetWinSystem()->GetGfxContext());
   return CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();
 }
 

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -284,7 +284,7 @@ bool CAddonSettings::AddInstanceSettings()
 
 bool CAddonSettings::Initialize(const CXBMCTinyXML& doc, bool allowEmpty /* = false */)
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (m_initialized)
     return false;
 
@@ -313,7 +313,7 @@ bool CAddonSettings::Initialize(const CXBMCTinyXML& doc, bool allowEmpty /* = fa
 
 bool CAddonSettings::Load(const CXBMCTinyXML& doc)
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (!m_initialized)
     return false;
 
@@ -418,7 +418,7 @@ bool CAddonSettings::Load(const CXBMCTinyXML& doc)
 
 bool CAddonSettings::Save(CXBMCTinyXML& doc) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (!m_initialized)
     return false;
 

--- a/xbmc/application/AppInboundProtocol.cpp
+++ b/xbmc/application/AppInboundProtocol.cpp
@@ -30,7 +30,7 @@ CAppInboundProtocol::CAppInboundProtocol(CApplication &app) : m_pApp(app)
 
 bool CAppInboundProtocol::OnEvent(const XBMC_Event& newEvent)
 {
-  std::unique_lock<CCriticalSection> lock(m_portSection);
+  std::unique_lock lock(m_portSection);
   if (m_closed)
     return false;
   m_portEvents.push_back(newEvent);
@@ -39,7 +39,7 @@ bool CAppInboundProtocol::OnEvent(const XBMC_Event& newEvent)
 
 void CAppInboundProtocol::Close()
 {
-  std::unique_lock<CCriticalSection> lock(m_portSection);
+  std::unique_lock lock(m_portSection);
   m_closed = true;
 }
 
@@ -52,7 +52,7 @@ void CAppInboundProtocol::SetRenderGUI(bool renderGUI)
 
 void CAppInboundProtocol::HandleEvents()
 {
-  std::unique_lock<CCriticalSection> lock(m_portSection);
+  std::unique_lock lock(m_portSection);
   while (!m_portEvents.empty())
   {
     auto newEvent = m_portEvents.front();

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -1790,7 +1790,7 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
 
     if (processGUI && renderGUI)
     {
-      std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+      std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
       // check if there are notifications to display
       CGUIDialogKaiToast *toast = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogKaiToast>(WINDOW_DIALOG_KAI_TOAST);
       if (toast && toast->DoWork())

--- a/xbmc/application/ApplicationActionListeners.cpp
+++ b/xbmc/application/ApplicationActionListeners.cpp
@@ -21,7 +21,7 @@ CApplicationActionListeners::CApplicationActionListeners(CCriticalSection& secti
 
 void CApplicationActionListeners::RegisterActionListener(KODI::ACTION::IActionListener* listener)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const auto it = std::find(m_actionListeners.begin(), m_actionListeners.end(), listener);
   if (it == m_actionListeners.end())
     m_actionListeners.push_back(listener);
@@ -29,7 +29,7 @@ void CApplicationActionListeners::RegisterActionListener(KODI::ACTION::IActionLi
 
 void CApplicationActionListeners::UnregisterActionListener(KODI::ACTION::IActionListener* listener)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   auto it = std::find(m_actionListeners.begin(), m_actionListeners.end(), listener);
   if (it != m_actionListeners.end())
     m_actionListeners.erase(it);
@@ -37,7 +37,7 @@ void CApplicationActionListeners::UnregisterActionListener(KODI::ACTION::IAction
 
 bool CApplicationActionListeners::NotifyActionListeners(const CAction& action) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& listener : m_actionListeners)
   {
     if (listener->OnAction(action))

--- a/xbmc/application/ApplicationPlayer.cpp
+++ b/xbmc/application/ApplicationPlayer.cpp
@@ -26,13 +26,13 @@ using namespace std::chrono_literals;
 
 std::shared_ptr<const IPlayer> CApplicationPlayer::GetInternal() const
 {
-  std::unique_lock<CCriticalSection> lock(m_playerLock);
+  std::unique_lock lock(m_playerLock);
   return m_pPlayer;
 }
 
 std::shared_ptr<IPlayer> CApplicationPlayer::GetInternal()
 {
-  std::unique_lock<CCriticalSection> lock(m_playerLock);
+  std::unique_lock lock(m_playerLock);
   return m_pPlayer;
 }
 
@@ -50,7 +50,7 @@ void CApplicationPlayer::ClosePlayer()
 void CApplicationPlayer::ResetPlayer()
 {
   // we need to do this directly on the member
-  std::unique_lock<CCriticalSection> lock(m_playerLock);
+  std::unique_lock lock(m_playerLock);
   m_pPlayer.reset();
 }
 
@@ -65,7 +65,7 @@ void CApplicationPlayer::CloseFile(bool reopen)
 
 void CApplicationPlayer::CreatePlayer(const CPlayerCoreFactory &factory, const std::string &player, IPlayerCallback& callback)
 {
-  std::unique_lock<CCriticalSection> lock(m_playerLock);
+  std::unique_lock lock(m_playerLock);
   if (!m_pPlayer)
   {
     CDataCacheCore::GetInstance().Reset();
@@ -120,7 +120,7 @@ bool CApplicationPlayer::OpenFile(const CFileItem& item, const CPlayerOptions& o
       CloseFile();
       if (player->m_name != newPlayer)
       {
-        std::unique_lock<CCriticalSection> lock(m_playerLock);
+        std::unique_lock lock(m_playerLock);
         m_pPlayer.reset();
       }
       return true;
@@ -130,7 +130,7 @@ bool CApplicationPlayer::OpenFile(const CFileItem& item, const CPlayerOptions& o
   {
     CloseFile();
     {
-      std::unique_lock<CCriticalSection> lock(m_playerLock);
+      std::unique_lock lock(m_playerLock);
       m_pPlayer.reset();
       player.reset();
     }

--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -102,7 +102,7 @@ void CApplicationPlayerCallback::OnPlayerCloseFile(const CFileItem& file,
   auto& components = CServiceBroker::GetAppComponents();
   const auto stackHelper = components.GetComponent<CApplicationStackHelper>();
 
-  std::unique_lock<CCriticalSection> lock(stackHelper->m_critSection);
+  std::unique_lock lock(stackHelper->m_critSection);
 
   CFileItem fileItem(file);
   CBookmark bookmark = bookmarkParam;

--- a/xbmc/application/ApplicationSkinHandling.cpp
+++ b/xbmc/application/ApplicationSkinHandling.cpp
@@ -98,7 +98,7 @@ bool CApplicationSkinHandling::LoadSkin(const std::string& skinID)
     }
   }
 
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   // store current active window with its focused control
   int currentWindowID = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();

--- a/xbmc/application/ApplicationStackHelper.cpp
+++ b/xbmc/application/ApplicationStackHelper.cpp
@@ -35,7 +35,7 @@ void CApplicationStackHelper::Clear()
 
 void CApplicationStackHelper::OnPlayBackStarted(const CFileItem& item)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // time to clean up stack map
   if (!HasRegisteredStack(item))

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -40,7 +40,7 @@ constexpr double MAX_BUFFER_TIME = 0.1; // max time of a buffer in seconds;
 
 void CEngineStats::Reset(unsigned int sampleRate, bool pcm)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   m_sinkDelay.SetDelay(0.0);
   m_sinkSampleRate = sampleRate;
   m_bufferedSamples = 0;
@@ -50,7 +50,7 @@ void CEngineStats::Reset(unsigned int sampleRate, bool pcm)
 
 void CEngineStats::UpdateSinkDelay(const AEDelayStatus& status, int samples)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   m_sinkDelay = status;
   if (samples > m_bufferedSamples)
   {
@@ -62,7 +62,7 @@ void CEngineStats::UpdateSinkDelay(const AEDelayStatus& status, int samples)
 
 void CEngineStats::AddSamples(int samples, const std::list<CActiveAEStream*>& streams)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   m_bufferedSamples += samples;
 
   for (auto stream : streams)
@@ -73,7 +73,7 @@ void CEngineStats::AddSamples(int samples, const std::list<CActiveAEStream*>& st
 
 void CEngineStats::GetDelay(AEDelayStatus& status)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   status = m_sinkDelay;
   if (m_pcmOutput)
     status.delay += (double)m_bufferedSamples / m_sinkSampleRate;
@@ -107,7 +107,7 @@ void CEngineStats::RemoveStream(unsigned int streamid)
 
 void CEngineStats::UpdateStream(CActiveAEStream *stream)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   for (auto &str : m_streamStats)
   {
     if (str.m_streamId == stream->m_id)
@@ -125,7 +125,7 @@ void CEngineStats::UpdateStream(CActiveAEStream *stream)
         str.m_resampleRatio = 1.0;
       }
 
-      std::unique_lock<CCriticalSection> lock(stream->m_statsLock);
+      std::unique_lock lock(stream->m_statsLock);
       std::deque<CSampleBuffer*>::iterator itBuf;
       for(itBuf=stream->m_processingSamples.begin(); itBuf!=stream->m_processingSamples.end(); ++itBuf)
       {
@@ -144,7 +144,7 @@ void CEngineStats::UpdateStream(CActiveAEStream *stream)
 // this is used to sync a/v so we need to add sink latency here
 void CEngineStats::GetDelay(AEDelayStatus& status, CActiveAEStream *stream)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   status = m_sinkDelay;
   status.delay += static_cast<double>(m_sinkLatency);
   if (m_pcmOutput)
@@ -157,7 +157,7 @@ void CEngineStats::GetDelay(AEDelayStatus& status, CActiveAEStream *stream)
   {
     if (str.m_streamId == stream->m_id)
     {
-      std::unique_lock<CCriticalSection> lock(stream->m_statsLock);
+      std::unique_lock lock(stream->m_statsLock);
       float buffertime = static_cast<float>(str.m_bufferedTime) + stream->m_bufferedTime;
       status.delay += static_cast<double>(buffertime) / str.m_resampleRatio;
       return;
@@ -168,7 +168,7 @@ void CEngineStats::GetDelay(AEDelayStatus& status, CActiveAEStream *stream)
 // this is used to sync a/v so we need to add sink latency here
 void CEngineStats::GetSyncInfo(CAESyncInfo& info, CActiveAEStream *stream)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   AEDelayStatus status;
   status = m_sinkDelay;
   if (m_pcmOutput)
@@ -183,7 +183,7 @@ void CEngineStats::GetSyncInfo(CAESyncInfo& info, CActiveAEStream *stream)
   {
     if (str.m_streamId == stream->m_id)
     {
-      std::unique_lock<CCriticalSection> lock(stream->m_statsLock);
+      std::unique_lock lock(stream->m_statsLock);
       float buffertime = static_cast<float>(str.m_bufferedTime) + stream->m_bufferedTime;
       status.delay += static_cast<double>(buffertime) / str.m_resampleRatio;
       info.delay = status.GetDelay();
@@ -198,14 +198,14 @@ void CEngineStats::GetSyncInfo(CAESyncInfo& info, CActiveAEStream *stream)
 
 float CEngineStats::GetCacheTime(CActiveAEStream *stream)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   float delay = 0;
 
   for (auto &str : m_streamStats)
   {
     if (str.m_streamId == stream->m_id)
     {
-      std::unique_lock<CCriticalSection> lock(stream->m_statsLock);
+      std::unique_lock lock(stream->m_statsLock);
       float buffertime = static_cast<float>(str.m_bufferedTime) + stream->m_bufferedTime;
       delay += buffertime / static_cast<float>(str.m_resampleRatio);
       break;
@@ -226,7 +226,7 @@ float CEngineStats::GetMaxDelay() const
 
 float CEngineStats::GetWaterLevel()
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   if (m_pcmOutput)
     return static_cast<float>(m_bufferedSamples) / m_sinkSampleRate;
   else
@@ -235,25 +235,25 @@ float CEngineStats::GetWaterLevel()
 
 void CEngineStats::SetSuspended(bool state)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   m_suspended = state;
 }
 
 bool CEngineStats::IsSuspended()
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   return m_suspended;
 }
 
 void CEngineStats::SetCurrentSinkFormat(const AEAudioFormat& SinkFormat)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   m_sinkFormat = SinkFormat;
 }
 
 AEAudioFormat CEngineStats::GetCurrentSinkFormat()
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   return m_sinkFormat;
 }
 
@@ -1904,7 +1904,7 @@ bool CActiveAE::RunStages()
         (*it)->m_processingBuffers &&
         ((*it)->m_processingBuffers->HasInputLevel(50)))
     {
-      std::unique_lock<CCriticalSection> lock((*it)->m_streamLock);
+      std::unique_lock lock((*it)->m_streamLock);
       (*it)->m_streamIsBuffering = false;
     }
 
@@ -1937,7 +1937,7 @@ bool CActiveAE::RunStages()
         (*it)->m_started = false;
 
         // set variables being polled via stream interface
-        std::unique_lock<CCriticalSection> lock((*it)->m_streamLock);
+        std::unique_lock lock((*it)->m_streamLock);
         if ((*it)->m_streamSlave)
         {
           CActiveAEStream *slave = (CActiveAEStream*)((*it)->m_streamSlave);
@@ -2072,7 +2072,7 @@ bool CActiveAE::RunStages()
               else
               {
                 (*it)->m_volume = (*it)->m_fadingTarget;
-                std::unique_lock<CCriticalSection> lock((*it)->m_streamLock);
+                std::unique_lock lock((*it)->m_streamLock);
                 (*it)->m_streamFading = false;
               }
             }
@@ -2106,7 +2106,7 @@ bool CActiveAE::RunStages()
                 if ((*it)->m_fadingSamples == 0)
                 {
                   // set variables being polled via stream interface
-                  std::unique_lock<CCriticalSection> lock((*it)->m_streamLock);
+                  std::unique_lock lock((*it)->m_streamLock);
                   (*it)->m_streamFading = false;
                 }
               }
@@ -2173,7 +2173,7 @@ bool CActiveAE::RunStages()
                 if ((*it)->m_fadingSamples == 0)
                 {
                   // set variables being polled via stream interface
-                  std::unique_lock<CCriticalSection> lock((*it)->m_streamLock);
+                  std::unique_lock lock((*it)->m_streamLock);
                   (*it)->m_streamFading = false;
                 }
               }
@@ -2228,7 +2228,7 @@ bool CActiveAE::RunStages()
       {
         // viz
         {
-          std::unique_lock<CCriticalSection> lock(m_vizLock);
+          std::unique_lock lock(m_vizLock);
           if (!m_audioCallback.empty() && !m_streams.empty())
           {
             if (!m_vizInitialized || !m_vizBuffers)
@@ -3506,14 +3506,14 @@ void CActiveAE::SetStreamFade(CActiveAEStream *stream, float from, float target,
 
 void CActiveAE::RegisterAudioCallback(IAudioCallback* pCallback)
 {
-  std::unique_lock<CCriticalSection> lock(m_vizLock);
+  std::unique_lock lock(m_vizLock);
   m_audioCallback.push_back(pCallback);
   m_vizInitialized = false;
 }
 
 void CActiveAE::UnregisterAudioCallback(IAudioCallback* pCallback)
 {
-  std::unique_lock<CCriticalSection> lock(m_vizLock);
+  std::unique_lock lock(m_vizLock);
   auto it = std::find(m_audioCallback.begin(), m_audioCallback.end(), pCallback);
   if (it != m_audioCallback.end())
     m_audioCallback.erase(it);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
@@ -30,7 +30,7 @@ CActiveAESettings::CActiveAESettings(CActiveAE &ae) : m_audioEngine(ae)
 {
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
 
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
   m_instance = this;
 
   settings->GetSettingsManager()->RegisterCallback(
@@ -66,7 +66,7 @@ CActiveAESettings::~CActiveAESettings()
 {
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
 
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
   settings->GetSettingsManager()->UnregisterSettingOptionsFiller("aequalitylevels");
   settings->GetSettingsManager()->UnregisterSettingOptionsFiller("audiodevices");
   settings->GetSettingsManager()->UnregisterSettingOptionsFiller("audiodevicespassthrough");
@@ -77,7 +77,7 @@ CActiveAESettings::~CActiveAESettings()
 
 void CActiveAESettings::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)
 {
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
   m_instance->m_audioEngine.OnSettingsChange();
 }
 
@@ -104,7 +104,7 @@ void CActiveAESettings::SettingOptionsAudioQualityLevelsFiller(
     int& current,
     void* data)
 {
-  std::unique_lock<CCriticalSection> lock(m_instance->m_cs);
+  std::unique_lock lock(m_instance->m_cs);
 
   if (m_instance->m_audioEngine.SupportsQualityLevel(AE_QUALITY_LOW))
     list.emplace_back(g_localizeStrings.Get(13506), AE_QUALITY_LOW);
@@ -124,7 +124,7 @@ void CActiveAESettings::SettingOptionsAudioStreamsilenceFiller(
     int& current,
     void* data)
 {
-  std::unique_lock<CCriticalSection> lock(m_instance->m_cs);
+  std::unique_lock lock(m_instance->m_cs);
 
   list.emplace_back(g_localizeStrings.Get(20422),
                     XbmcThreads::EndTime<std::chrono::minutes>::Max().count());
@@ -148,7 +148,7 @@ bool CActiveAESettings::IsSettingVisible(const std::string& condition,
   if (setting == NULL || value.empty())
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_instance->m_cs);
+  std::unique_lock lock(m_instance->m_cs);
   if (!m_instance)
     return false;
 
@@ -164,7 +164,7 @@ void CActiveAESettings::SettingOptionsAudioDevicesFillerGeneral(
   current = std::static_pointer_cast<const CSettingString>(setting)->GetValue();
   std::string firstDevice;
 
-  std::unique_lock<CCriticalSection> lock(m_instance->m_cs);
+  std::unique_lock lock(m_instance->m_cs);
 
   bool foundValue = false;
   AEDeviceList sinkList;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -54,19 +54,19 @@ CActiveAEStream::CActiveAEStream(AEAudioFormat* format, unsigned int streamid, C
 
 void CActiveAEStream::IncFreeBuffers()
 {
-  std::unique_lock<CCriticalSection> lock(m_streamLock);
+  std::unique_lock lock(m_streamLock);
   m_streamFreeBuffers++;
 }
 
 void CActiveAEStream::DecFreeBuffers()
 {
-  std::unique_lock<CCriticalSection> lock(m_streamLock);
+  std::unique_lock lock(m_streamLock);
   m_streamFreeBuffers--;
 }
 
 void CActiveAEStream::ResetFreeBuffers()
 {
-  std::unique_lock<CCriticalSection> lock(m_streamLock);
+  std::unique_lock lock(m_streamLock);
   m_streamFreeBuffers = 0;
 }
 
@@ -211,7 +211,7 @@ std::chrono::milliseconds CActiveAEStream::GetErrorInterval()
 
 unsigned int CActiveAEStream::GetSpace()
 {
-  std::unique_lock<CCriticalSection> lock(m_streamLock);
+  std::unique_lock lock(m_streamLock);
   if (m_format.m_dataFormat == AE_FMT_RAW)
     return m_streamFreeBuffers;
   else
@@ -285,7 +285,7 @@ unsigned int CActiveAEStream::AddData(const uint8_t* const *data, unsigned int o
 
       bool rawPktComplete = false;
       {
-        std::unique_lock<CCriticalSection> lock(m_statsLock);
+        std::unique_lock lock(m_statsLock);
         if (m_format.m_dataFormat != AE_FMT_RAW)
         {
           m_currentBuffer->pkt->nb_samples += minFrames;
@@ -352,7 +352,7 @@ CAESyncInfo CActiveAEStream::GetSyncInfo()
 
 bool CActiveAEStream::IsBuffering()
 {
-  std::unique_lock<CCriticalSection> lock(m_streamLock);
+  std::unique_lock lock(m_streamLock);
   return m_streamIsBuffering;
 }
 
@@ -444,13 +444,13 @@ void CActiveAEStream::Drain(bool wait)
 
 bool CActiveAEStream::IsDraining()
 {
-  std::unique_lock<CCriticalSection> lock(m_streamLock);
+  std::unique_lock lock(m_streamLock);
   return m_streamDraining;
 }
 
 bool CActiveAEStream::IsDrained()
 {
-  std::unique_lock<CCriticalSection> lock(m_streamLock);
+  std::unique_lock lock(m_streamLock);
   return m_streamDrained;
 }
 
@@ -533,7 +533,7 @@ void CActiveAEStream::FadeVolume(float from, float target, unsigned int time)
 
 bool CActiveAEStream::IsFading()
 {
-  std::unique_lock<CCriticalSection> lock(m_streamLock);
+  std::unique_lock lock(m_streamLock);
   return m_streamFading;
 }
 
@@ -567,7 +567,7 @@ void CActiveAEStream::UnRegisterAudioCallback()
 
 void CActiveAEStream::RegisterSlave(IAEStream *slave)
 {
-  std::unique_lock<CCriticalSection> lock(m_streamLock);
+  std::unique_lock lock(m_streamLock);
   m_streamSlave = slave;
 }
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.mm
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.mm
@@ -226,7 +226,7 @@ unsigned int CAAudioUnitSink::write(uint8_t *data, unsigned int frames)
 {
   if (m_buffer->GetWriteSize() < frames * m_frameSize)
   { // no space to write - wait for a bit
-    std::unique_lock<CCriticalSection> lock(mutex);
+    std::unique_lock lock(mutex);
     auto timeout = std::chrono::milliseconds(900 * frames / m_sampleRate);
     if (!m_started)
       timeout = 4500ms;
@@ -257,7 +257,7 @@ void CAAudioUnitSink::drain()
   auto timeout = std::chrono::milliseconds(900 * bytes / (m_sampleRate * m_frameSize));
   while (bytes && maxNumTimeouts > 0)
   {
-    std::unique_lock<CCriticalSection> lock(mutex);
+    std::unique_lock lock(mutex);
     XbmcThreads::EndTime<> timer(timeout);
     condVar.wait(mutex, timeout);
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -74,7 +74,7 @@ static void EnumerateDevices()
   CADeviceList devices;
   EnumerateDevices(devices);
   {
-    std::unique_lock<CCriticalSection> lock(s_devicesLock);
+    std::unique_lock lock(s_devicesLock);
     s_devices = devices;
   }
 }
@@ -83,7 +83,7 @@ static CADeviceList GetDevices()
 {
   CADeviceList list;
   {
-    std::unique_lock<CCriticalSection> lock(s_devicesLock);
+    std::unique_lock lock(s_devicesLock);
     list = s_devices;
   }
   return list;
@@ -423,7 +423,7 @@ unsigned int CAESinkDARWINOSX::AddPackets(uint8_t **data, unsigned int frames, u
 {
   if (m_buffer->GetWriteSize() < frames * m_frameSizePerPlane)
   { // no space to write - wait for a bit
-    std::unique_lock<CCriticalSection> lock(mutex);
+    std::unique_lock lock(mutex);
     auto timeout = std::chrono::milliseconds(900 * frames / m_framesPerSecond);
     if (!m_started)
       timeout = 4500ms;
@@ -456,7 +456,7 @@ void CAESinkDARWINOSX::Drain()
   auto timeout = std::chrono::milliseconds(900 * bytes / (m_framesPerSecond * m_frameSizePerPlane));
   while (bytes && maxNumTimeouts > 0)
   {
-    std::unique_lock<CCriticalSection> lock(mutex);
+    std::unique_lock lock(mutex);
     XbmcThreads::EndTime<> timer(timeout);
     condVar.wait(mutex, timeout);
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
@@ -362,7 +362,7 @@ unsigned int CAAudioUnitSink::write(uint8_t* data, unsigned int frames, unsigned
   // CAAudioUnitSink owns them.
   if (m_buffer->GetWriteSize() < frames * framesize)
   { // no space to write - wait for a bit
-    std::unique_lock<CCriticalSection> lock(mutex);
+    std::unique_lock lock(mutex);
     auto timeout = std::chrono::milliseconds(900 * frames / m_sampleRate);
     if (!m_started)
       timeout = 4500ms;
@@ -394,7 +394,7 @@ void CAAudioUnitSink::drain()
 
   while (bytes && maxNumTimeouts > 0)
   {
-    std::unique_lock<CCriticalSection> lock(mutex);
+    std::unique_lock lock(mutex);
     XbmcThreads::EndTime<> timer(timeout);
     condVar.wait(mutex, timeout);
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -490,7 +490,7 @@ void CAESinkDirectSound::CheckPlayStatus()
 
 bool CAESinkDirectSound::UpdateCacheStatus()
 {
-  std::unique_lock<CCriticalSection> lock(m_runLock);
+  std::unique_lock lock(m_runLock);
 
   DWORD playCursor = 0, writeCursor = 0;
   HRESULT res = m_pBuffer->GetCurrentPosition(&playCursor, &writeCursor); // Get the current playback and safe write positions
@@ -550,7 +550,7 @@ bool CAESinkDirectSound::UpdateCacheStatus()
 
 unsigned int CAESinkDirectSound::GetSpace()
 {
-  std::unique_lock<CCriticalSection> lock(m_runLock);
+  std::unique_lock lock(m_runLock);
   if (!UpdateCacheStatus())
     m_isDirtyDS = true;
   unsigned int space = m_dwBufferLen - m_CacheLen;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -258,7 +258,7 @@ static void SinkCallback(pa_context* c,
   if (!p)
     return;
 
-  std::unique_lock<CCriticalSection> lock(p->m_sec);
+  std::unique_lock lock(p->m_sec);
   if (p->IsInitialized())
   {
     if ((t & PA_SUBSCRIPTION_EVENT_FACILITY_MASK) == PA_SUBSCRIPTION_EVENT_SINK)
@@ -291,7 +291,7 @@ static void SinkChangedCallback(pa_context *c, pa_subscription_event_type_t t, u
   if(!p)
     return;
 
-  std::unique_lock<CCriticalSection> lock(p->m_sec);
+  std::unique_lock lock(p->m_sec);
   if (p->IsInitialized())
   {
     if ((t & PA_SUBSCRIPTION_EVENT_FACILITY_MASK) == PA_SUBSCRIPTION_EVENT_SINK_INPUT)
@@ -710,7 +710,7 @@ bool CDriverMonitor::Start(bool allowPipeWireCompatServer)
 
   m_isInit = true;
 
-  std::unique_lock<CCriticalSection> lock(m_sec);
+  std::unique_lock lock(m_sec);
   // Register Callback for Sink changes
   pa_context_set_subscribe_callback(m_pContext, SinkCallback, this);
   const pa_subscription_mask_t mask = pa_subscription_mask_t(PA_SUBSCRIPTION_MASK_SINK);
@@ -798,7 +798,7 @@ CAESinkPULSE::~CAESinkPULSE()
 bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_sec);
+    std::unique_lock lock(m_sec);
     m_IsAllocated = false;
   }
   m_passthrough = false;
@@ -1018,7 +1018,7 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
   }
 
   {
-    std::unique_lock<CCriticalSection> lock(m_sec);
+    std::unique_lock lock(m_sec);
     // Register Callback for Sink changes
     pa_context_set_subscribe_callback(m_Context, SinkChangedCallback, this);
     const pa_subscription_mask_t mask = pa_subscription_mask_t(PA_SUBSCRIPTION_MASK_SINK_INPUT);
@@ -1042,7 +1042,7 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
   // Cork stream will resume when adding first package
   Pause(true);
   {
-    std::unique_lock<CCriticalSection> lock(m_sec);
+    std::unique_lock lock(m_sec);
     m_IsAllocated = true;
   }
   return true;
@@ -1050,7 +1050,7 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
 
 void CAESinkPULSE::Deinitialize()
 {
-  std::unique_lock<CCriticalSection> lock(m_sec);
+  std::unique_lock lock(m_sec);
   m_IsAllocated = false;
   m_passthrough = false;
   m_periodSize = 0;
@@ -1302,7 +1302,7 @@ void CAESinkPULSE::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
 
 bool CAESinkPULSE::IsInitialized()
 {
-  std::unique_lock<CCriticalSection> lock(m_sec);
+  std::unique_lock lock(m_sec);
   return m_IsAllocated;
 }
 

--- a/xbmc/cores/DataCacheCore.cpp
+++ b/xbmc/cores/DataCacheCore.cpp
@@ -30,25 +30,25 @@ CDataCacheCore& CDataCacheCore::GetInstance()
 void CDataCacheCore::Reset()
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_stateSection);
+    std::unique_lock lock(m_stateSection);
     m_stateInfo = {};
     m_playerStateChanged = false;
   }
   {
-    std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
+    std::unique_lock lock(m_videoPlayerSection);
     m_playerVideoInfo = {};
   }
   {
-    std::unique_lock<CCriticalSection> lock(m_audioPlayerSection);
+    std::unique_lock lock(m_audioPlayerSection);
     m_playerAudioInfo = {};
   }
   m_hasAVInfoChanges = false;
   {
-    std::unique_lock<CCriticalSection> lock(m_renderSection);
+    std::unique_lock lock(m_renderSection);
     m_renderInfo = {};
   }
   {
-    std::unique_lock<CCriticalSection> lock(m_contentSection);
+    std::unique_lock lock(m_contentSection);
     m_contentInfo.Reset();
   }
   m_timeInfo = {};
@@ -78,7 +78,7 @@ void CDataCacheCore::SignalSubtitleInfoChange()
 
 void CDataCacheCore::SetVideoDecoderName(std::string name, bool isHw)
 {
-  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
+  std::unique_lock lock(m_videoPlayerSection);
 
   m_playerVideoInfo.decoderName = std::move(name);
   m_playerVideoInfo.isHwDecoder = isHw;
@@ -86,14 +86,14 @@ void CDataCacheCore::SetVideoDecoderName(std::string name, bool isHw)
 
 std::string CDataCacheCore::GetVideoDecoderName()
 {
-  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
+  std::unique_lock lock(m_videoPlayerSection);
 
   return m_playerVideoInfo.decoderName;
 }
 
 bool CDataCacheCore::IsVideoHwDecoder()
 {
-  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
+  std::unique_lock lock(m_videoPlayerSection);
 
   return m_playerVideoInfo.isHwDecoder;
 }
@@ -101,49 +101,49 @@ bool CDataCacheCore::IsVideoHwDecoder()
 
 void CDataCacheCore::SetVideoDeintMethod(std::string method)
 {
-  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
+  std::unique_lock lock(m_videoPlayerSection);
 
   m_playerVideoInfo.deintMethod = std::move(method);
 }
 
 std::string CDataCacheCore::GetVideoDeintMethod()
 {
-  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
+  std::unique_lock lock(m_videoPlayerSection);
 
   return m_playerVideoInfo.deintMethod;
 }
 
 void CDataCacheCore::SetVideoPixelFormat(std::string pixFormat)
 {
-  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
+  std::unique_lock lock(m_videoPlayerSection);
 
   m_playerVideoInfo.pixFormat = std::move(pixFormat);
 }
 
 std::string CDataCacheCore::GetVideoPixelFormat()
 {
-  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
+  std::unique_lock lock(m_videoPlayerSection);
 
   return m_playerVideoInfo.pixFormat;
 }
 
 void CDataCacheCore::SetVideoStereoMode(std::string mode)
 {
-  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
+  std::unique_lock lock(m_videoPlayerSection);
 
   m_playerVideoInfo.stereoMode = std::move(mode);
 }
 
 std::string CDataCacheCore::GetVideoStereoMode()
 {
-  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
+  std::unique_lock lock(m_videoPlayerSection);
 
   return m_playerVideoInfo.stereoMode;
 }
 
 void CDataCacheCore::SetVideoDimensions(int width, int height)
 {
-  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
+  std::unique_lock lock(m_videoPlayerSection);
 
   m_playerVideoInfo.width = width;
   m_playerVideoInfo.height = height;
@@ -151,173 +151,173 @@ void CDataCacheCore::SetVideoDimensions(int width, int height)
 
 int CDataCacheCore::GetVideoWidth()
 {
-  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
+  std::unique_lock lock(m_videoPlayerSection);
 
   return m_playerVideoInfo.width;
 }
 
 int CDataCacheCore::GetVideoHeight()
 {
-  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
+  std::unique_lock lock(m_videoPlayerSection);
 
   return m_playerVideoInfo.height;
 }
 
 void CDataCacheCore::SetVideoFps(float fps)
 {
-  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
+  std::unique_lock lock(m_videoPlayerSection);
 
   m_playerVideoInfo.fps = fps;
 }
 
 float CDataCacheCore::GetVideoFps()
 {
-  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
+  std::unique_lock lock(m_videoPlayerSection);
 
   return m_playerVideoInfo.fps;
 }
 
 void CDataCacheCore::SetVideoDAR(float dar)
 {
-  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
+  std::unique_lock lock(m_videoPlayerSection);
 
   m_playerVideoInfo.dar = dar;
 }
 
 float CDataCacheCore::GetVideoDAR()
 {
-  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
+  std::unique_lock lock(m_videoPlayerSection);
 
   return m_playerVideoInfo.dar;
 }
 
 void CDataCacheCore::SetVideoInterlaced(bool isInterlaced)
 {
-  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
+  std::unique_lock lock(m_videoPlayerSection);
   m_playerVideoInfo.m_isInterlaced = isInterlaced;
 }
 
 bool CDataCacheCore::IsVideoInterlaced()
 {
-  std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
+  std::unique_lock lock(m_videoPlayerSection);
   return m_playerVideoInfo.m_isInterlaced;
 }
 
 // player audio info
 void CDataCacheCore::SetAudioDecoderName(std::string name)
 {
-  std::unique_lock<CCriticalSection> lock(m_audioPlayerSection);
+  std::unique_lock lock(m_audioPlayerSection);
 
   m_playerAudioInfo.decoderName = std::move(name);
 }
 
 std::string CDataCacheCore::GetAudioDecoderName()
 {
-  std::unique_lock<CCriticalSection> lock(m_audioPlayerSection);
+  std::unique_lock lock(m_audioPlayerSection);
 
   return m_playerAudioInfo.decoderName;
 }
 
 void CDataCacheCore::SetAudioChannels(std::string channels)
 {
-  std::unique_lock<CCriticalSection> lock(m_audioPlayerSection);
+  std::unique_lock lock(m_audioPlayerSection);
 
   m_playerAudioInfo.channels = std::move(channels);
 }
 
 std::string CDataCacheCore::GetAudioChannels()
 {
-  std::unique_lock<CCriticalSection> lock(m_audioPlayerSection);
+  std::unique_lock lock(m_audioPlayerSection);
 
   return m_playerAudioInfo.channels;
 }
 
 void CDataCacheCore::SetAudioSampleRate(int sampleRate)
 {
-  std::unique_lock<CCriticalSection> lock(m_audioPlayerSection);
+  std::unique_lock lock(m_audioPlayerSection);
 
   m_playerAudioInfo.sampleRate = sampleRate;
 }
 
 int CDataCacheCore::GetAudioSampleRate()
 {
-  std::unique_lock<CCriticalSection> lock(m_audioPlayerSection);
+  std::unique_lock lock(m_audioPlayerSection);
 
   return m_playerAudioInfo.sampleRate;
 }
 
 void CDataCacheCore::SetAudioBitsPerSample(int bitsPerSample)
 {
-  std::unique_lock<CCriticalSection> lock(m_audioPlayerSection);
+  std::unique_lock lock(m_audioPlayerSection);
 
   m_playerAudioInfo.bitsPerSample = bitsPerSample;
 }
 
 int CDataCacheCore::GetAudioBitsPerSample()
 {
-  std::unique_lock<CCriticalSection> lock(m_audioPlayerSection);
+  std::unique_lock lock(m_audioPlayerSection);
 
   return m_playerAudioInfo.bitsPerSample;
 }
 
 void CDataCacheCore::SetEditList(const std::vector<EDL::Edit>& editList)
 {
-  std::unique_lock<CCriticalSection> lock(m_contentSection);
+  std::unique_lock lock(m_contentSection);
   m_contentInfo.SetEditList(editList);
 }
 
 const std::vector<EDL::Edit>& CDataCacheCore::GetEditList() const
 {
-  std::unique_lock<CCriticalSection> lock(m_contentSection);
+  std::unique_lock lock(m_contentSection);
   return m_contentInfo.GetEditList();
 }
 
 void CDataCacheCore::SetCuts(const std::vector<std::chrono::milliseconds>& cuts)
 {
-  std::unique_lock<CCriticalSection> lock(m_contentSection);
+  std::unique_lock lock(m_contentSection);
   m_contentInfo.SetCuts(cuts);
 }
 
 const std::vector<std::chrono::milliseconds>& CDataCacheCore::GetCuts() const
 {
-  std::unique_lock<CCriticalSection> lock(m_contentSection);
+  std::unique_lock lock(m_contentSection);
   return m_contentInfo.GetCuts();
 }
 
 void CDataCacheCore::SetSceneMarkers(const std::vector<std::chrono::milliseconds>& sceneMarkers)
 {
-  std::unique_lock<CCriticalSection> lock(m_contentSection);
+  std::unique_lock lock(m_contentSection);
   m_contentInfo.SetSceneMarkers(sceneMarkers);
 }
 
 const std::vector<std::chrono::milliseconds>& CDataCacheCore::GetSceneMarkers() const
 {
-  std::unique_lock<CCriticalSection> lock(m_contentSection);
+  std::unique_lock lock(m_contentSection);
   return m_contentInfo.GetSceneMarkers();
 }
 
 void CDataCacheCore::SetChapters(const std::vector<std::pair<std::string, int64_t>>& chapters)
 {
-  std::unique_lock<CCriticalSection> lock(m_contentSection);
+  std::unique_lock lock(m_contentSection);
   m_contentInfo.SetChapters(chapters);
 }
 
 const std::vector<std::pair<std::string, int64_t>>& CDataCacheCore::GetChapters() const
 {
-  std::unique_lock<CCriticalSection> lock(m_contentSection);
+  std::unique_lock lock(m_contentSection);
   return m_contentInfo.GetChapters();
 }
 
 void CDataCacheCore::SetRenderClockSync(bool enable)
 {
-  std::unique_lock<CCriticalSection> lock(m_renderSection);
+  std::unique_lock lock(m_renderSection);
 
   m_renderInfo.m_isClockSync = enable;
 }
 
 bool CDataCacheCore::IsRenderClockSync()
 {
-  std::unique_lock<CCriticalSection> lock(m_renderSection);
+  std::unique_lock lock(m_renderSection);
 
   return m_renderInfo.m_isClockSync;
 }
@@ -325,20 +325,20 @@ bool CDataCacheCore::IsRenderClockSync()
 // player states
 void CDataCacheCore::SeekFinished(int64_t offset)
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
   m_stateInfo.m_lastSeekTime = std::chrono::system_clock::now();
   m_stateInfo.m_lastSeekOffset = offset;
 }
 
 int64_t CDataCacheCore::GetSeekOffSet() const
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
   return m_stateInfo.m_lastSeekOffset;
 }
 
 bool CDataCacheCore::HasPerformedSeek(int64_t lastSecondInterval) const
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
   if (m_stateInfo.m_lastSeekTime == std::chrono::time_point<std::chrono::system_clock>{})
   {
     return false;
@@ -350,7 +350,7 @@ bool CDataCacheCore::HasPerformedSeek(int64_t lastSecondInterval) const
 
 void CDataCacheCore::SetStateSeeking(bool active)
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   m_stateInfo.m_stateSeeking = active;
   m_playerStateChanged = true;
@@ -358,14 +358,14 @@ void CDataCacheCore::SetStateSeeking(bool active)
 
 bool CDataCacheCore::IsSeeking()
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   return m_stateInfo.m_stateSeeking;
 }
 
 void CDataCacheCore::SetSpeed(float tempo, float speed)
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   m_stateInfo.m_tempo = tempo;
   m_stateInfo.m_speed = speed;
@@ -373,35 +373,35 @@ void CDataCacheCore::SetSpeed(float tempo, float speed)
 
 float CDataCacheCore::GetSpeed()
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   return m_stateInfo.m_speed;
 }
 
 float CDataCacheCore::GetTempo()
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   return m_stateInfo.m_tempo;
 }
 
 void CDataCacheCore::SetFrameAdvance(bool fa)
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   m_stateInfo.m_frameAdvance = fa;
 }
 
 bool CDataCacheCore::IsFrameAdvance()
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   return m_stateInfo.m_frameAdvance;
 }
 
 bool CDataCacheCore::IsPlayerStateChanged()
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   bool ret(m_playerStateChanged);
   m_playerStateChanged = false;
@@ -411,7 +411,7 @@ bool CDataCacheCore::IsPlayerStateChanged()
 
 void CDataCacheCore::SetGuiRender(bool gui)
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   m_stateInfo.m_renderGuiLayer = gui;
   m_playerStateChanged = true;
@@ -419,14 +419,14 @@ void CDataCacheCore::SetGuiRender(bool gui)
 
 bool CDataCacheCore::GetGuiRender()
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   return m_stateInfo.m_renderGuiLayer;
 }
 
 void CDataCacheCore::SetVideoRender(bool video)
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   m_stateInfo.m_renderVideoLayer = video;
   m_playerStateChanged = true;
@@ -434,14 +434,14 @@ void CDataCacheCore::SetVideoRender(bool video)
 
 bool CDataCacheCore::GetVideoRender()
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   return m_stateInfo.m_renderVideoLayer;
 }
 
 void CDataCacheCore::SetPlayTimes(time_t start, int64_t current, int64_t min, int64_t max)
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
   m_timeInfo.m_startTime = start;
   m_timeInfo.m_time = current;
   m_timeInfo.m_timeMin = min;
@@ -450,7 +450,7 @@ void CDataCacheCore::SetPlayTimes(time_t start, int64_t current, int64_t min, in
 
 void CDataCacheCore::GetPlayTimes(time_t &start, int64_t &current, int64_t &min, int64_t &max)
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
   start = m_timeInfo.m_startTime;
   current = m_timeInfo.m_time;
   min = m_timeInfo.m_timeMin;
@@ -459,31 +459,31 @@ void CDataCacheCore::GetPlayTimes(time_t &start, int64_t &current, int64_t &min,
 
 time_t CDataCacheCore::GetStartTime()
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
   return m_timeInfo.m_startTime;
 }
 
 int64_t CDataCacheCore::GetPlayTime()
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
   return m_timeInfo.m_time;
 }
 
 int64_t CDataCacheCore::GetMinTime()
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
   return m_timeInfo.m_timeMin;
 }
 
 int64_t CDataCacheCore::GetMaxTime()
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
   return m_timeInfo.m_timeMax;
 }
 
 float CDataCacheCore::GetPlayPercentage()
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   // Note: To calculate accurate percentage, all time data must be consistent,
   //       which is the case for data cache core. Calculation can not be done

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -1854,7 +1854,7 @@ extern "C"
           value[size - 1] = '\0';
 
         {
-          std::unique_lock<CCriticalSection> lock(dll_cs_environ);
+          std::unique_lock lock(dll_cs_environ);
 
           char** free_position = NULL;
           for (int i = 0; i < EMU_MAX_ENVIRONMENT_ITEMS && free_position == NULL; i++)
@@ -1906,7 +1906,7 @@ extern "C"
     char* value = NULL;
 
     {
-      std::unique_lock<CCriticalSection> lock(dll_cs_environ);
+      std::unique_lock lock(dll_cs_environ);
 
       update_emu_environ();//apply any changes
 

--- a/xbmc/cores/DllLoader/exports/util/EmuFileWrapper.cpp
+++ b/xbmc/cores/DllLoader/exports/util/EmuFileWrapper.cpp
@@ -41,7 +41,7 @@ CEmuFileWrapper::~CEmuFileWrapper()
 
 void CEmuFileWrapper::CleanUp()
 {
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
   for (EmuFileObject& file : m_files)
   {
     if (file.used)
@@ -64,7 +64,7 @@ EmuFileObject* CEmuFileWrapper::RegisterFileObject(XFILE::CFile* pFile)
 {
   EmuFileObject* object = nullptr;
 
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
 
   for (int i = 0; i < MAX_EMULATED_FILES; i++)
   {
@@ -92,7 +92,7 @@ void CEmuFileWrapper::UnRegisterFileObjectByDescriptor(int fd)
   if (!m_files[i].used)
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
 
   // we assume the emulated function already deleted the CFile object
   if (m_files[i].file_lock)

--- a/xbmc/cores/FFmpeg.cpp
+++ b/xbmc/cores/FFmpeg.cpp
@@ -68,7 +68,7 @@ std::map<const CThread*, std::string> g_logbuffer;
 
 void ff_flush_avutil_log_buffers(void)
 {
-  std::unique_lock<CCriticalSection> lock(m_logSection);
+  std::unique_lock lock(m_logSection);
   /* Loop through the logbuffer list and remove any blank buffers
      If the thread using the buffer is still active, it will just
      add a new buffer next time it writes to the log */
@@ -82,7 +82,7 @@ void ff_flush_avutil_log_buffers(void)
 
 void ff_avutil_log(void* ptr, int level, const char* format, va_list va)
 {
-  std::unique_lock<CCriticalSection> lock(m_logSection);
+  std::unique_lock lock(m_logSection);
   const CThread* threadId = CThread::GetCurrentThread();
   std::string &buffer = g_logbuffer[threadId];
 

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -103,7 +103,7 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
   m_guiMessenger = std::make_unique<CGUIGameMessenger>(*m_processInfo);
   m_renderManager = std::make_unique<CRPRenderManager>(*m_processInfo);
 
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   if (IsPlaying())
     CloseFile();
@@ -228,7 +228,7 @@ bool CRetroPlayer::CloseFile(bool reopen /* = false */)
 
   m_playbackControl.reset();
 
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   if (m_gameClient && m_gameServices.GameSettings().AutosaveEnabled())
   {

--- a/xbmc/cores/RetroPlayer/buffers/BaseRenderBufferPool.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/BaseRenderBufferPool.cpp
@@ -24,14 +24,14 @@ CBaseRenderBufferPool::~CBaseRenderBufferPool()
 
 void CBaseRenderBufferPool::RegisterRenderer(CRPBaseRenderer* renderer)
 {
-  std::unique_lock<CCriticalSection> lock(m_rendererMutex);
+  std::unique_lock lock(m_rendererMutex);
 
   m_renderers.push_back(renderer);
 }
 
 void CBaseRenderBufferPool::UnregisterRenderer(CRPBaseRenderer* renderer)
 {
-  std::unique_lock<CCriticalSection> lock(m_rendererMutex);
+  std::unique_lock lock(m_rendererMutex);
 
   m_renderers.erase(std::remove(m_renderers.begin(), m_renderers.end(), renderer),
                     m_renderers.end());
@@ -39,7 +39,7 @@ void CBaseRenderBufferPool::UnregisterRenderer(CRPBaseRenderer* renderer)
 
 bool CBaseRenderBufferPool::HasVisibleRenderer() const
 {
-  std::unique_lock<CCriticalSection> lock(m_rendererMutex);
+  std::unique_lock lock(m_rendererMutex);
 
   for (auto renderer : m_renderers)
   {
@@ -71,7 +71,7 @@ IRenderBuffer* CBaseRenderBufferPool::GetBuffer(unsigned int width, unsigned int
 
   if (GetHeaderWithTimeout(header))
   {
-    std::unique_lock<CCriticalSection> lock(m_bufferMutex);
+    std::unique_lock lock(m_bufferMutex);
 
     for (auto it = m_free.begin(); it != m_free.end(); ++it)
     {
@@ -115,7 +115,7 @@ IRenderBuffer* CBaseRenderBufferPool::GetBuffer(unsigned int width, unsigned int
 
 void CBaseRenderBufferPool::Return(IRenderBuffer* buffer)
 {
-  std::unique_lock<CCriticalSection> lock(m_bufferMutex);
+  std::unique_lock lock(m_bufferMutex);
 
   buffer->SetLoaded(false);
   buffer->SetRendered(false);
@@ -126,7 +126,7 @@ void CBaseRenderBufferPool::Return(IRenderBuffer* buffer)
 
 void CBaseRenderBufferPool::Prime(unsigned int width, unsigned int height)
 {
-  std::unique_lock<CCriticalSection> lock(m_bufferMutex);
+  std::unique_lock lock(m_bufferMutex);
 
   // Allocate two buffers for double buffering
   unsigned int bufferCount = 2;
@@ -149,7 +149,7 @@ void CBaseRenderBufferPool::Prime(unsigned int width, unsigned int height)
 
 void CBaseRenderBufferPool::Flush()
 {
-  std::unique_lock<CCriticalSection> lock(m_bufferMutex);
+  std::unique_lock lock(m_bufferMutex);
 
   m_free.clear();
   m_bConfigured = false;

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferManager.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferManager.cpp
@@ -25,7 +25,7 @@ CRenderBufferManager::~CRenderBufferManager()
 
 void CRenderBufferManager::RegisterPools(IRendererFactory* factory, RenderBufferPoolVector pools)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_pools.emplace_back(RenderBufferPools{factory, std::move(pools)});
 }
@@ -34,7 +34,7 @@ RenderBufferPoolVector CRenderBufferManager::GetPools(IRendererFactory* factory)
 {
   RenderBufferPoolVector bufferPools;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   auto it =
       std::find_if(m_pools.begin(), m_pools.end(),
@@ -50,7 +50,7 @@ std::vector<IRenderBufferPool*> CRenderBufferManager::GetBufferPools()
 {
   std::vector<IRenderBufferPool*> bufferPools;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& pools : m_pools)
   {
@@ -63,7 +63,7 @@ std::vector<IRenderBufferPool*> CRenderBufferManager::GetBufferPools()
 
 void CRenderBufferManager::FlushPools()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& pools : m_pools)
   {
@@ -74,7 +74,7 @@ void CRenderBufferManager::FlushPools()
 
 std::string CRenderBufferManager::GetRenderSystemName(IRenderBufferPool* renderBufferPool) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& pools : m_pools)
   {

--- a/xbmc/cores/RetroPlayer/guibridge/GUIGameRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/guibridge/GUIGameRenderManager.cpp
@@ -29,20 +29,20 @@ void CGUIGameRenderManager::RegisterPlayer(CGUIRenderTargetFactory* factory,
 {
   // Set factory
   {
-    std::unique_lock<CCriticalSection> lock(m_targetMutex);
+    std::unique_lock lock(m_targetMutex);
     m_factory = factory;
     UpdateRenderTargets();
   }
 
   // Set callback
   {
-    std::unique_lock<CCriticalSection> lock(m_callbackMutex);
+    std::unique_lock lock(m_callbackMutex);
     m_callback = callback;
   }
 
   // Set game callback
   {
-    std::unique_lock<CCriticalSection> lock(m_gameCallbackMutex);
+    std::unique_lock lock(m_gameCallbackMutex);
     m_gameCallback = gameCallback;
   }
 }
@@ -51,19 +51,19 @@ void CGUIGameRenderManager::UnregisterPlayer()
 {
   // Reset game callback
   {
-    std::unique_lock<CCriticalSection> lock(m_gameCallbackMutex);
+    std::unique_lock lock(m_gameCallbackMutex);
     m_gameCallback = nullptr;
   }
 
   // Reset callback
   {
-    std::unique_lock<CCriticalSection> lock(m_callbackMutex);
+    std::unique_lock lock(m_callbackMutex);
     m_callback = nullptr;
   }
 
   // Reset factory
   {
-    std::unique_lock<CCriticalSection> lock(m_targetMutex);
+    std::unique_lock lock(m_targetMutex);
     m_factory = nullptr;
     UpdateRenderTargets();
   }
@@ -71,7 +71,7 @@ void CGUIGameRenderManager::UnregisterPlayer()
 
 std::shared_ptr<CGUIRenderHandle> CGUIGameRenderManager::RegisterControl(CGUIGameControl& control)
 {
-  std::unique_lock<CCriticalSection> lock(m_targetMutex);
+  std::unique_lock lock(m_targetMutex);
 
   // Create handle for game control
   std::shared_ptr<CGUIRenderHandle> renderHandle(new CGUIRenderControlHandle(*this, control));
@@ -88,7 +88,7 @@ std::shared_ptr<CGUIRenderHandle> CGUIGameRenderManager::RegisterControl(CGUIGam
 std::shared_ptr<CGUIRenderHandle> CGUIGameRenderManager::RegisterWindow(
     CGameWindowFullScreen& window)
 {
-  std::unique_lock<CCriticalSection> lock(m_targetMutex);
+  std::unique_lock lock(m_targetMutex);
 
   // Create handle for game window
   std::shared_ptr<CGUIRenderHandle> renderHandle(new CGUIRenderFullScreenHandle(*this, window));
@@ -115,14 +115,14 @@ std::shared_ptr<CGUIGameSettingsHandle> CGUIGameRenderManager::RegisterGameSetti
 
 void CGUIGameRenderManager::UnregisterHandle(CGUIRenderHandle* handle)
 {
-  std::unique_lock<CCriticalSection> lock(m_targetMutex);
+  std::unique_lock lock(m_targetMutex);
 
   m_renderTargets.erase(handle);
 }
 
 void CGUIGameRenderManager::Render(CGUIRenderHandle* handle)
 {
-  std::unique_lock<CCriticalSection> lock(m_targetMutex);
+  std::unique_lock lock(m_targetMutex);
 
   auto it = m_renderTargets.find(handle);
   if (it != m_renderTargets.end())
@@ -135,7 +135,7 @@ void CGUIGameRenderManager::Render(CGUIRenderHandle* handle)
 
 void CGUIGameRenderManager::RenderEx(CGUIRenderHandle* handle)
 {
-  std::unique_lock<CCriticalSection> lock(m_targetMutex);
+  std::unique_lock lock(m_targetMutex);
 
   auto it = m_renderTargets.find(handle);
   if (it != m_renderTargets.end())
@@ -148,7 +148,7 @@ void CGUIGameRenderManager::RenderEx(CGUIRenderHandle* handle)
 
 void CGUIGameRenderManager::ClearBackground(CGUIRenderHandle* handle)
 {
-  std::unique_lock<CCriticalSection> lock(m_targetMutex);
+  std::unique_lock lock(m_targetMutex);
 
   auto it = m_renderTargets.find(handle);
   if (it != m_renderTargets.end())
@@ -161,7 +161,7 @@ void CGUIGameRenderManager::ClearBackground(CGUIRenderHandle* handle)
 
 bool CGUIGameRenderManager::IsDirty(CGUIRenderHandle* handle)
 {
-  std::unique_lock<CCriticalSection> lock(m_targetMutex);
+  std::unique_lock lock(m_targetMutex);
 
   auto it = m_renderTargets.find(handle);
   if (it != m_renderTargets.end())
@@ -176,14 +176,14 @@ bool CGUIGameRenderManager::IsDirty(CGUIRenderHandle* handle)
 
 bool CGUIGameRenderManager::IsPlayingGame()
 {
-  std::unique_lock<CCriticalSection> lock(m_callbackMutex);
+  std::unique_lock lock(m_callbackMutex);
 
   return m_callback != nullptr;
 }
 
 bool CGUIGameRenderManager::SupportsRenderFeature(RENDERFEATURE feature)
 {
-  std::unique_lock<CCriticalSection> lock(m_callbackMutex);
+  std::unique_lock lock(m_callbackMutex);
 
   if (m_callback != nullptr)
     return m_callback->SupportsRenderFeature(feature);
@@ -193,7 +193,7 @@ bool CGUIGameRenderManager::SupportsRenderFeature(RENDERFEATURE feature)
 
 bool CGUIGameRenderManager::SupportsScalingMethod(SCALINGMETHOD method)
 {
-  std::unique_lock<CCriticalSection> lock(m_callbackMutex);
+  std::unique_lock lock(m_callbackMutex);
 
   if (m_callback != nullptr)
     return m_callback->SupportsScalingMethod(method);
@@ -203,7 +203,7 @@ bool CGUIGameRenderManager::SupportsScalingMethod(SCALINGMETHOD method)
 
 std::string CGUIGameRenderManager::GameClientID()
 {
-  std::unique_lock<CCriticalSection> lock(m_callbackMutex);
+  std::unique_lock lock(m_callbackMutex);
 
   if (m_gameCallback != nullptr)
     return m_gameCallback->GameClientID();
@@ -213,7 +213,7 @@ std::string CGUIGameRenderManager::GameClientID()
 
 std::string CGUIGameRenderManager::GetPlayingGame()
 {
-  std::unique_lock<CCriticalSection> lock(m_callbackMutex);
+  std::unique_lock lock(m_callbackMutex);
 
   if (m_gameCallback != nullptr)
     return m_gameCallback->GetPlayingGame();
@@ -223,7 +223,7 @@ std::string CGUIGameRenderManager::GetPlayingGame()
 
 std::string CGUIGameRenderManager::CreateSavestate(bool autosave)
 {
-  std::unique_lock<CCriticalSection> lock(m_callbackMutex);
+  std::unique_lock lock(m_callbackMutex);
 
   if (m_gameCallback != nullptr)
     return m_gameCallback->CreateSavestate(autosave);
@@ -233,7 +233,7 @@ std::string CGUIGameRenderManager::CreateSavestate(bool autosave)
 
 bool CGUIGameRenderManager::UpdateSavestate(const std::string& savestatePath)
 {
-  std::unique_lock<CCriticalSection> lock(m_callbackMutex);
+  std::unique_lock lock(m_callbackMutex);
 
   if (m_gameCallback != nullptr)
     return m_gameCallback->UpdateSavestate(savestatePath);
@@ -243,7 +243,7 @@ bool CGUIGameRenderManager::UpdateSavestate(const std::string& savestatePath)
 
 bool CGUIGameRenderManager::LoadSavestate(const std::string& savestatePath)
 {
-  std::unique_lock<CCriticalSection> lock(m_callbackMutex);
+  std::unique_lock lock(m_callbackMutex);
 
   if (m_gameCallback != nullptr)
     return m_gameCallback->LoadSavestate(savestatePath);
@@ -253,7 +253,7 @@ bool CGUIGameRenderManager::LoadSavestate(const std::string& savestatePath)
 
 void CGUIGameRenderManager::FreeSavestateResources(const std::string& savestatePath)
 {
-  std::unique_lock<CCriticalSection> lock(m_callbackMutex);
+  std::unique_lock lock(m_callbackMutex);
 
   if (m_gameCallback != nullptr)
     m_gameCallback->FreeSavestateResources(savestatePath);
@@ -261,7 +261,7 @@ void CGUIGameRenderManager::FreeSavestateResources(const std::string& savestateP
 
 void CGUIGameRenderManager::CloseOSD()
 {
-  std::unique_lock<CCriticalSection> lock(m_callbackMutex);
+  std::unique_lock lock(m_callbackMutex);
 
   if (m_gameCallback != nullptr)
     m_gameCallback->CloseOSDCallback();

--- a/xbmc/cores/RetroPlayer/guibridge/GUIGameSettings.cpp
+++ b/xbmc/cores/RetroPlayer/guibridge/GUIGameSettings.cpp
@@ -35,7 +35,7 @@ CGUIGameSettings::~CGUIGameSettings()
 
 CRenderSettings CGUIGameSettings::GetSettings() const
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   return m_renderSettings;
 }
@@ -56,7 +56,7 @@ void CGUIGameSettings::Notify(const Observable& obs, const ObservableMessage msg
 
 void CGUIGameSettings::UpdateSettings()
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   // Get settings from GUI
   std::string videoFilter = m_guiSettings.VideoFilter();

--- a/xbmc/cores/RetroPlayer/guicontrols/GUIRenderSettings.cpp
+++ b/xbmc/cores/RetroPlayer/guicontrols/GUIRenderSettings.cpp
@@ -41,63 +41,63 @@ bool CGUIRenderSettings::HasPixels() const
 
 CRenderSettings CGUIRenderSettings::GetSettings() const
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   return m_renderSettings;
 }
 
 CRect CGUIRenderSettings::GetDimensions() const
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   return m_renderDimensions;
 }
 
 void CGUIRenderSettings::Reset()
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   return m_renderSettings.Reset();
 }
 
 void CGUIRenderSettings::SetSettings(const CRenderSettings& settings)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   m_renderSettings = settings;
 }
 
 void CGUIRenderSettings::SetDimensions(const CRect& dimensions)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   m_renderDimensions = dimensions;
 }
 
 void CGUIRenderSettings::SetVideoFilter(const std::string& videoFilter)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   m_renderSettings.VideoSettings().SetVideoFilter(videoFilter);
 }
 
 void CGUIRenderSettings::SetStretchMode(STRETCHMODE stretchMode)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   m_renderSettings.VideoSettings().SetRenderStretchMode(stretchMode);
 }
 
 void CGUIRenderSettings::SetRotationDegCCW(unsigned int rotationDegCCW)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   m_renderSettings.VideoSettings().SetRenderRotation(rotationDegCCW);
 }
 
 void CGUIRenderSettings::SetPixels(const std::string& pixelPath)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   m_renderSettings.VideoSettings().SetPixels(pixelPath);
 }

--- a/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
+++ b/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
@@ -145,7 +145,7 @@ std::string CReversiblePlayback::CreateSavestate(bool autosave,
   // Get the savestate path
   std::string savePath(savestatePath);
   {
-    std::unique_lock<CCriticalSection> lock(m_savestateMutex);
+    std::unique_lock lock(m_savestateMutex);
 
     if (autosave && savePath.empty())
       savePath = m_autosavePath;
@@ -168,7 +168,7 @@ std::string CReversiblePlayback::CreateSavestate(bool autosave,
   m_renderManager.CacheVideoFrame(savePath);
 
   {
-    std::unique_lock<CCriticalSection> lock(m_savestateMutex);
+    std::unique_lock lock(m_savestateMutex);
 
     // Prune any finished autosave threads
     m_savestateThreads.erase(std::remove_if(m_savestateThreads.begin(), m_savestateThreads.end(),
@@ -202,7 +202,7 @@ void CReversiblePlayback::CommitSavestate(bool autosave,
 
   // Copy the savestate memory
   {
-    std::unique_lock<CCriticalSection> lock(m_mutex);
+    std::unique_lock lock(m_mutex);
     if (m_memoryStream && m_memoryStream->CurrentFrame() != nullptr)
     {
       std::memcpy(memoryData, m_memoryStream->CurrentFrame(), memorySize);
@@ -217,7 +217,7 @@ void CReversiblePlayback::CommitSavestate(bool autosave,
 
   // Attempt to get existing properties
   {
-    std::unique_lock<CCriticalSection> lock(m_savestateMutex);
+    std::unique_lock lock(m_savestateMutex);
     if (!savePath.empty() && XFILE::CFile::Exists(savePath))
     {
       loadedSavestate = CSavestateDatabase::AllocateSavestate();
@@ -250,7 +250,7 @@ void CReversiblePlayback::CommitSavestate(bool autosave,
 
   bool success;
   {
-    std::unique_lock<CCriticalSection> lock(m_savestateMutex);
+    std::unique_lock lock(m_savestateMutex);
     success = m_savestateDatabase->AddSavestate(savePath, m_gameClient->GetGamePath(), *savestate);
   }
 
@@ -285,7 +285,7 @@ bool CReversiblePlayback::LoadSavestate(const std::string& savestatePath)
     else
     {
       {
-        std::unique_lock<CCriticalSection> lock(m_mutex);
+        std::unique_lock lock(m_mutex);
         if (m_memoryStream)
         {
           m_memoryStream->SetFrameCounter(savestate->TimestampFrames());
@@ -325,7 +325,7 @@ void CReversiblePlayback::RewindEvent()
 
 void CReversiblePlayback::AddFrame()
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   if (m_memoryStream)
   {
@@ -341,7 +341,7 @@ void CReversiblePlayback::AddFrame()
 
 void CReversiblePlayback::RewindFrames(uint64_t frames)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   if (m_memoryStream)
   {
@@ -355,7 +355,7 @@ void CReversiblePlayback::RewindFrames(uint64_t frames)
 
 void CReversiblePlayback::AdvanceFrames(uint64_t frames)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   if (m_memoryStream)
   {
@@ -395,7 +395,7 @@ void CReversiblePlayback::Notify(const Observable& obs, const ObservableMessage 
 
 void CReversiblePlayback::UpdateMemoryStream()
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   bool bRewindEnabled = false;
 

--- a/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp
+++ b/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp
@@ -69,7 +69,7 @@ std::unique_ptr<CRPProcessInfo> CRPProcessInfo::CreateInstance()
 {
   std::unique_ptr<CRPProcessInfo> processInfo;
 
-  std::unique_lock<CCriticalSection> lock(m_createSection);
+  std::unique_lock lock(m_createSection);
 
   if (m_processControl != nullptr)
   {
@@ -96,7 +96,7 @@ void CRPProcessInfo::RegisterProcessControl(const CreateRPProcessControl& create
 
 void CRPProcessInfo::RegisterRendererFactory(IRendererFactory* factory)
 {
-  std::unique_lock<CCriticalSection> lock(m_createSection);
+  std::unique_lock lock(m_createSection);
 
   CLog::Log(LOGINFO, "RetroPlayer[RENDER]: Registering renderer factory for {}",
             factory->RenderSystemName());
@@ -112,7 +112,7 @@ std::string CRPProcessInfo::GetRenderSystemName(IRenderBufferPool* renderBufferP
 CRPBaseRenderer* CRPProcessInfo::CreateRenderer(IRenderBufferPool* renderBufferPool,
                                                 const CRenderSettings& renderSettings)
 {
-  std::unique_lock<CCriticalSection> lock(m_createSection);
+  std::unique_lock lock(m_createSection);
 
   for (auto& rendererFactory : m_rendererFactories)
   {

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -116,7 +116,7 @@ bool CRPRenderManager::Configure(AVPixelFormat format,
   m_maxHeight = maxHeight;
   m_pixelAspectRatio = pixelAspectRatio;
 
-  std::unique_lock<CCriticalSection> lock(m_stateMutex);
+  std::unique_lock lock(m_stateMutex);
 
   m_state = RENDER_STATE::CONFIGURING;
 
@@ -223,7 +223,7 @@ void CRPRenderManager::AddFrame(const uint8_t* data,
   }
 
   {
-    std::unique_lock<CCriticalSection> lock(m_bufferMutex);
+    std::unique_lock lock(m_bufferMutex);
 
     // Set render buffers
     for (auto renderBuffer : m_renderBuffers)
@@ -306,7 +306,7 @@ void CRPRenderManager::FrameMove()
   bool bIsConfigured = false;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_stateMutex);
+    std::unique_lock lock(m_stateMutex);
 
     if (m_state == RENDER_STATE::CONFIGURING)
     {
@@ -331,7 +331,7 @@ void CRPRenderManager::CheckFlush()
   if (m_bFlush)
   {
     {
-      std::unique_lock<CCriticalSection> lock(m_bufferMutex);
+      std::unique_lock lock(m_bufferMutex);
       for (auto renderBuffer : m_renderBuffers)
         renderBuffer->Release();
       m_renderBuffers.clear();
@@ -535,7 +535,7 @@ std::shared_ptr<CRPBaseRenderer> CRPRenderManager::GetRendererForSettings(
   std::shared_ptr<CRPBaseRenderer> renderer;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_stateMutex);
+    std::unique_lock lock(m_stateMutex);
     if (m_state == RENDER_STATE::UNCONFIGURED)
       return renderer;
   }
@@ -611,7 +611,7 @@ bool CRPRenderManager::HasRenderBuffer(IRenderBufferPool* bufferPool)
 {
   bool bHasRenderBuffer = false;
 
-  std::unique_lock<CCriticalSection> lock(m_bufferMutex);
+  std::unique_lock lock(m_bufferMutex);
 
   auto it = std::find_if(m_renderBuffers.begin(), m_renderBuffers.end(),
                          [bufferPool](IRenderBuffer* renderBuffer)
@@ -630,7 +630,7 @@ IRenderBuffer* CRPRenderManager::GetRenderBuffer(IRenderBufferPool* bufferPool)
 
   IRenderBuffer* renderBuffer = nullptr;
 
-  std::unique_lock<CCriticalSection> lock(m_bufferMutex);
+  std::unique_lock lock(m_bufferMutex);
 
   auto getRenderBuffer = [bufferPool](IRenderBuffer* renderBuffer)
   { return renderBuffer->GetPool() == bufferPool; };
@@ -658,7 +658,7 @@ IRenderBuffer* CRPRenderManager::GetRenderBufferForSavestate(const std::string& 
 {
   IRenderBuffer* renderBuffer = nullptr;
 
-  std::unique_lock<CCriticalSection> lock(m_bufferMutex);
+  std::unique_lock lock(m_bufferMutex);
 
   // Check to see if we have a buffers for the specified path
   auto it = m_savestateBuffers.find(savestatePath);
@@ -692,7 +692,7 @@ void CRPRenderManager::CreateRenderBuffer(IRenderBufferPool* bufferPool)
   if (m_bFlush || m_state != RENDER_STATE::CONFIGURED)
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_bufferMutex);
+  std::unique_lock lock(m_bufferMutex);
 
   if (!HasRenderBuffer(bufferPool) && m_bHasCachedFrame)
   {
@@ -892,7 +892,7 @@ void CRPRenderManager::SaveThumbnail(const std::string& thumbnailPath)
 
 void CRPRenderManager::CacheVideoFrame(const std::string& savestatePath)
 {
-  std::unique_lock<CCriticalSection> lock(m_bufferMutex);
+  std::unique_lock lock(m_bufferMutex);
 
   // Get the render buffers for this savestate path
   std::vector<IRenderBuffer*>& savestateBuffers = m_savestateBuffers[savestatePath];
@@ -972,7 +972,7 @@ void CRPRenderManager::SaveVideoFrame(const std::string& savestatePath, ISavesta
 
 void CRPRenderManager::ClearVideoFrame(const std::string& savestatePath)
 {
-  std::unique_lock<CCriticalSection> lock(m_bufferMutex);
+  std::unique_lock lock(m_bufferMutex);
 
   auto it = m_savestateBuffers.find(savestatePath);
   if (it != m_savestateBuffers.end())
@@ -986,7 +986,7 @@ void CRPRenderManager::ClearVideoFrame(const std::string& savestatePath)
 void CRPRenderManager::GetVideoFrame(IRenderBuffer*& readableBuffer,
                                      std::vector<uint8_t>& cachedFrame)
 {
-  std::unique_lock<CCriticalSection> lock(m_bufferMutex);
+  std::unique_lock lock(m_bufferMutex);
 
   // Get a readable render buffer
   auto it = std::find_if(m_renderBuffers.begin(), m_renderBuffers.end(),
@@ -1010,7 +1010,7 @@ void CRPRenderManager::GetVideoFrame(IRenderBuffer*& readableBuffer,
 void CRPRenderManager::FreeVideoFrame(IRenderBuffer* readableBuffer,
                                       std::vector<uint8_t> cachedFrame)
 {
-  std::unique_lock<CCriticalSection> lock(m_bufferMutex);
+  std::unique_lock lock(m_bufferMutex);
 
   // Free resources
   if (readableBuffer != nullptr)
@@ -1089,6 +1089,6 @@ void CRPRenderManager::LoadVideoFrameSync(const std::string& savestatePath)
   }
 
   // Save render buffers
-  std::unique_lock<CCriticalSection> lock(m_bufferMutex);
+  std::unique_lock lock(m_bufferMutex);
   m_savestateBuffers[savestatePath] = std::move(renderBuffers);
 }

--- a/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
+++ b/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
@@ -35,7 +35,7 @@ CAudioSinkAE::CAudioSinkAE(CDVDClock *clock) : m_pClock(clock)
 
 CAudioSinkAE::~CAudioSinkAE()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 }
 
 bool CAudioSinkAE::Create(const DVDAudioFrame &audioframe, AVCodecID codec, bool needresampler)
@@ -45,7 +45,7 @@ bool CAudioSinkAE::Create(const DVDAudioFrame &audioframe, AVCodecID codec, bool
             audioframe.passthrough ? "pass-through" : "no pass-through");
 
   // if passthrough isset do something else
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   unsigned int options = needresampler && !audioframe.passthrough ? AESTREAM_FORCE_RESAMPLE : 0;
   options |= AESTREAM_PAUSED;
 
@@ -70,7 +70,7 @@ bool CAudioSinkAE::Create(const DVDAudioFrame &audioframe, AVCodecID codec, bool
 
 void CAudioSinkAE::Destroy(bool finish)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_pAudioStream)
   {
@@ -90,7 +90,7 @@ unsigned int CAudioSinkAE::AddPackets(const DVDAudioFrame &audioframe)
 {
   m_bAbort = false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (!m_pAudioStream)
     return 0;
@@ -159,28 +159,28 @@ unsigned int CAudioSinkAE::AddPackets(const DVDAudioFrame &audioframe)
 
 void CAudioSinkAE::Drain()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_pAudioStream)
     m_pAudioStream->Drain(true);
 }
 
 void CAudioSinkAE::SetVolume(float volume)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_pAudioStream)
     m_pAudioStream->SetVolume(volume);
 }
 
 void CAudioSinkAE::SetDynamicRangeCompression(long drc)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_pAudioStream)
     m_pAudioStream->SetAmplification(powf(10.0f, (float)drc / 2000.0f));
 }
 
 void CAudioSinkAE::Pause()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_pAudioStream)
     m_pAudioStream->Pause();
   CLog::Log(LOGDEBUG,"CDVDAudio::Pause - pausing audio stream");
@@ -189,7 +189,7 @@ void CAudioSinkAE::Pause()
 
 void CAudioSinkAE::Resume()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_pAudioStream)
     m_pAudioStream->Resume();
   CLog::Log(LOGDEBUG,"CDVDAudio::Resume - resume audio stream");
@@ -197,7 +197,7 @@ void CAudioSinkAE::Resume()
 
 double CAudioSinkAE::GetDelay()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   double delay = 0.3;
   if(m_pAudioStream)
@@ -210,7 +210,7 @@ void CAudioSinkAE::Flush()
 {
   m_bAbort = true;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_pAudioStream)
   {
     m_pAudioStream->Flush();
@@ -249,7 +249,7 @@ bool CAudioSinkAE::IsValidFormat(const DVDAudioFrame &audioframe)
 
 double CAudioSinkAE::GetCacheTime()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (!m_pAudioStream)
     return 0.0;
 
@@ -258,7 +258,7 @@ double CAudioSinkAE::GetCacheTime()
 
 double CAudioSinkAE::GetCacheTotal()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (!m_pAudioStream)
     return 0.0;
   return m_pAudioStream->GetCacheTotal();
@@ -266,7 +266,7 @@ double CAudioSinkAE::GetCacheTotal()
 
 double CAudioSinkAE::GetMaxDelay()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (!m_pAudioStream)
     return 0.0;
   return m_pAudioStream->GetMaxDelay();
@@ -309,7 +309,7 @@ double CAudioSinkAE::GetResampleRatio()
 
 void CAudioSinkAE::SetResampleMode(int mode)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if(m_pAudioStream)
   {
     m_pAudioStream->SetResampleMode(mode);

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBuffer.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBuffer.cpp
@@ -290,7 +290,7 @@ bool CVideoBufferSysMem::Alloc()
 
 CVideoBufferPoolSysMem::~CVideoBufferPoolSysMem()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (auto buf : m_all)
   {
@@ -300,7 +300,7 @@ CVideoBufferPoolSysMem::~CVideoBufferPoolSysMem()
 
 CVideoBuffer* CVideoBufferPoolSysMem::Get()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   CVideoBufferSysMem *buf = nullptr;
   if (!m_free.empty())
@@ -325,7 +325,7 @@ CVideoBuffer* CVideoBufferPoolSysMem::Get()
 
 void CVideoBufferPoolSysMem::Return(int id)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   auto it = m_used.begin();
   while (it != m_used.end())
@@ -369,7 +369,7 @@ bool CVideoBufferPoolSysMem::IsCompatible(AVPixelFormat format, int size)
 
 void CVideoBufferPoolSysMem::Discard(CVideoBufferManager *bm, ReadyToDispose cb)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_bm = bm;
   m_cbDispose = cb;
 
@@ -388,26 +388,26 @@ std::shared_ptr<IVideoBufferPool> CVideoBufferPoolSysMem::CreatePool()
 
 CVideoBufferManager::CVideoBufferManager()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   RegisterPoolFactory("SysMem", &CVideoBufferPoolSysMem::CreatePool);
 }
 
 void CVideoBufferManager::RegisterPool(const std::shared_ptr<IVideoBufferPool>& pool)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   // preferred pools are to the front
   m_pools.push_front(pool);
 }
 
 void CVideoBufferManager::RegisterPoolFactory(const std::string& id, CreatePoolFunc createFunc)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_poolFactories[id] = createFunc;
 }
 
 void CVideoBufferManager::ReleasePools()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   std::list<std::shared_ptr<IVideoBufferPool>> pools = m_pools;
   m_pools.clear();
 
@@ -421,7 +421,7 @@ void CVideoBufferManager::ReleasePools()
 
 void CVideoBufferManager::ReleasePool(IVideoBufferPool *pool)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (auto it = m_pools.begin(); it != m_pools.end(); ++it)
   {
@@ -437,7 +437,7 @@ void CVideoBufferManager::ReleasePool(IVideoBufferPool *pool)
 
 void CVideoBufferManager::ReadyForDisposal(IVideoBufferPool *pool)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (auto it = m_discardedPools.begin(); it != m_discardedPools.end(); ++it)
   {
@@ -452,7 +452,7 @@ void CVideoBufferManager::ReadyForDisposal(IVideoBufferPool *pool)
 
 CVideoBuffer* CVideoBufferManager::Get(AVPixelFormat format, int size, IVideoBufferPool **pPool)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& pool : m_pools)
   {
     if (!pool->IsConfigured())

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
@@ -130,7 +130,7 @@ CVideoBufferPoolDRMPRIMEFFmpeg::~CVideoBufferPoolDRMPRIMEFFmpeg()
 
 CVideoBuffer* CVideoBufferPoolDRMPRIMEFFmpeg::Get()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   CVideoBufferDRMPRIMEFFmpeg* buf = nullptr;
   if (!m_free.empty())
@@ -154,7 +154,7 @@ CVideoBuffer* CVideoBufferPoolDRMPRIMEFFmpeg::Get()
 
 void CVideoBufferPoolDRMPRIMEFFmpeg::Return(int id)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_all[id]->Unref();
   auto it = m_used.begin();

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferPoolDMA.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferPoolDMA.cpp
@@ -22,7 +22,7 @@ extern "C"
 
 CVideoBufferPoolDMA::~CVideoBufferPoolDMA()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (auto buf : m_all)
     delete buf;
@@ -30,7 +30,7 @@ CVideoBufferPoolDMA::~CVideoBufferPoolDMA()
 
 CVideoBuffer* CVideoBufferPoolDMA::Get()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   CVideoBufferDMA* buf = nullptr;
   if (!m_free.empty())
@@ -61,7 +61,7 @@ CVideoBuffer* CVideoBufferPoolDMA::Get()
 
 void CVideoBufferPoolDMA::Return(int id)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_all[id]->Unref();
   auto it = m_used.begin();
@@ -80,7 +80,7 @@ void CVideoBufferPoolDMA::Return(int id)
 
 void CVideoBufferPoolDMA::Configure(AVPixelFormat format, int size)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_fourcc = TranslateFormat(format);
   m_size = static_cast<uint64_t>(size);
@@ -88,14 +88,14 @@ void CVideoBufferPoolDMA::Configure(AVPixelFormat format, int size)
 
 bool CVideoBufferPoolDMA::IsConfigured()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   return (m_fourcc != 0 && m_size != 0);
 }
 
 bool CVideoBufferPoolDMA::IsCompatible(AVPixelFormat format, int size)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_fourcc != TranslateFormat(format) || m_size != static_cast<uint64_t>(size))
     return false;

--- a/xbmc/cores/VideoPlayer/DVDClock.cpp
+++ b/xbmc/cores/VideoPlayer/DVDClock.cpp
@@ -21,7 +21,7 @@
 
 CDVDClock::CDVDClock()
 {
-  std::unique_lock<CCriticalSection> lock(m_systemsection);
+  std::unique_lock lock(m_systemsection);
 
   m_pauseClock = 0;
   m_bReset = true;
@@ -47,7 +47,7 @@ CDVDClock::~CDVDClock() = default;
 // Returns the current absolute clock in units of DVD_TIME_BASE (usually microseconds).
 double CDVDClock::GetAbsoluteClock(bool interpolated /*= true*/)
 {
-  std::unique_lock<CCriticalSection> lock(m_systemsection);
+  std::unique_lock lock(m_systemsection);
 
   int64_t current;
   current = m_videoRefClock->GetTime(interpolated);
@@ -57,7 +57,7 @@ double CDVDClock::GetAbsoluteClock(bool interpolated /*= true*/)
 
 double CDVDClock::GetClock(bool interpolated /*= true*/)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   int64_t current = m_videoRefClock->GetTime(interpolated);
   m_systemAdjust += m_speedAdjust * (current - m_lastSystemTime);
@@ -70,7 +70,7 @@ double CDVDClock::GetClock(double& absolute, bool interpolated /*= true*/)
 {
   int64_t current = m_videoRefClock->GetTime(interpolated);
 
-  std::unique_lock<CCriticalSection> lock(m_systemsection);
+  std::unique_lock lock(m_systemsection);
   absolute = SystemToAbsolute(current);
 
   m_systemAdjust += m_speedAdjust * (current - m_lastSystemTime);
@@ -81,19 +81,19 @@ double CDVDClock::GetClock(double& absolute, bool interpolated /*= true*/)
 
 void CDVDClock::SetVsyncAdjust(double adjustment)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_vSyncAdjust = adjustment;
 }
 
 double CDVDClock::GetVsyncAdjust()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_vSyncAdjust;
 }
 
 void CDVDClock::Pause(bool pause)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (pause && !m_paused)
   {
@@ -114,7 +114,7 @@ void CDVDClock::Pause(bool pause)
 
 void CDVDClock::Advance(double time)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_pauseClock)
   {
@@ -125,7 +125,7 @@ void CDVDClock::Advance(double time)
 void CDVDClock::SetSpeed(int iSpeed)
 {
   // this will sometimes be a little bit of due to rounding errors, ie clock might jump a bit when changing speed
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_paused)
   {
@@ -158,19 +158,19 @@ void CDVDClock::SetSpeedAdjust(double adjust)
 {
   CLog::Log(LOGDEBUG, "CDVDClock::SetSpeedAdjust - adjusted:{:f}", adjust);
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_speedAdjust = adjust;
 }
 
 double CDVDClock::GetSpeedAdjust()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_speedAdjust;
 }
 
 double CDVDClock::ErrorAdjust(double error, const char* log)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   double clock, absolute, adjustment;
   clock = GetClock(absolute);
@@ -210,7 +210,7 @@ double CDVDClock::ErrorAdjust(double error, const char* log)
 
 void CDVDClock::Discontinuity(double clock, double absolute)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_startClock = AbsoluteToSystem(absolute);
   if(m_pauseClock)
     m_pauseClock = m_startClock;
@@ -222,7 +222,7 @@ void CDVDClock::Discontinuity(double clock, double absolute)
 
 void CDVDClock::SetMaxSpeedAdjust(double speed)
 {
-  std::unique_lock<CCriticalSection> lock(m_speedsection);
+  std::unique_lock lock(m_speedsection);
 
   m_maxspeedadjust = speed;
 }
@@ -242,7 +242,7 @@ int CDVDClock::UpdateFramerate(double fps, double* interval /*= NULL*/)
   if (rate <= 0)
     return -1;
 
-  std::unique_lock<CCriticalSection> lock(m_speedsection);
+  std::unique_lock lock(m_speedsection);
 
   double weight = (rate * 2) / fps;
 
@@ -303,7 +303,7 @@ double CDVDClock::SystemToPlaying(int64_t system)
 
 double CDVDClock::GetClockSpeed()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   double speed = (double)m_systemFrequency / m_systemUsed;
   return m_videoRefClock->GetSpeed() * speed + m_speedAdjust;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -44,7 +44,7 @@ CCriticalSection videoCodecSection, audioCodecSection;
 std::unique_ptr<CDVDVideoCodec> CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo& hint,
                                                                    CProcessInfo& processInfo)
 {
-  std::unique_lock<CCriticalSection> lock(videoCodecSection);
+  std::unique_lock lock(videoCodecSection);
 
   std::unique_ptr<CDVDVideoCodec> pCodec;
   CDVDCodecOptions options;
@@ -95,7 +95,7 @@ std::unique_ptr<CDVDVideoCodec> CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInf
 std::unique_ptr<CDVDVideoCodec> CDVDFactoryCodec::CreateVideoCodecHW(const std::string& id,
                                                                      CProcessInfo& processInfo)
 {
-  std::unique_lock<CCriticalSection> lock(videoCodecSection);
+  std::unique_lock lock(videoCodecSection);
 
   auto it = m_hwVideoCodecs.find(id);
   if (it != m_hwVideoCodecs.end())
@@ -111,7 +111,7 @@ IHardwareDecoder* CDVDFactoryCodec::CreateVideoCodecHWAccel(const std::string& i
                                                             CProcessInfo& processInfo,
                                                             AVPixelFormat fmt)
 {
-  std::unique_lock<CCriticalSection> lock(videoCodecSection);
+  std::unique_lock lock(videoCodecSection);
 
   auto it = m_hwAccels.find(id);
   if (it != m_hwAccels.end())
@@ -125,21 +125,21 @@ IHardwareDecoder* CDVDFactoryCodec::CreateVideoCodecHWAccel(const std::string& i
 
 void CDVDFactoryCodec::RegisterHWVideoCodec(const std::string& id, CreateHWVideoCodec createFunc)
 {
-  std::unique_lock<CCriticalSection> lock(videoCodecSection);
+  std::unique_lock lock(videoCodecSection);
 
   m_hwVideoCodecs[id] = std::move(createFunc);
 }
 
 void CDVDFactoryCodec::ClearHWVideoCodecs()
 {
-  std::unique_lock<CCriticalSection> lock(videoCodecSection);
+  std::unique_lock lock(videoCodecSection);
 
   m_hwVideoCodecs.clear();
 }
 
 std::vector<std::string> CDVDFactoryCodec::GetHWAccels()
 {
-  std::unique_lock<CCriticalSection> lock(videoCodecSection);
+  std::unique_lock lock(videoCodecSection);
 
   std::vector<std::string> ret;
   ret.reserve(m_hwAccels.size());
@@ -152,14 +152,14 @@ std::vector<std::string> CDVDFactoryCodec::GetHWAccels()
 
 void CDVDFactoryCodec::RegisterHWAccel(const std::string& id, CreateHWAccel createFunc)
 {
-  std::unique_lock<CCriticalSection> lock(videoCodecSection);
+  std::unique_lock lock(videoCodecSection);
 
   m_hwAccels[id] = std::move(createFunc);
 }
 
 void CDVDFactoryCodec::ClearHWAccels()
 {
-  std::unique_lock<CCriticalSection> lock(videoCodecSection);
+  std::unique_lock lock(videoCodecSection);
 
   m_hwAccels.clear();
 }
@@ -215,14 +215,14 @@ std::unique_ptr<CDVDAudioCodec> CDVDFactoryCodec::CreateAudioCodec(
 
 void CDVDFactoryCodec::RegisterHWAudioCodec(const std::string& id, CreateHWAudioCodec createFunc)
 {
-  std::unique_lock<CCriticalSection> lock(audioCodecSection);
+  std::unique_lock lock(audioCodecSection);
 
   m_hwAudioCodecs[id] = std::move(createFunc);
 }
 
 void CDVDFactoryCodec::ClearHWAudioCodecs()
 {
-  std::unique_lock<CCriticalSection> lock(audioCodecSection);
+  std::unique_lock lock(audioCodecSection);
 
   m_hwAudioCodecs.clear();
 }
@@ -230,7 +230,7 @@ void CDVDFactoryCodec::ClearHWAudioCodecs()
 std::unique_ptr<CDVDAudioCodec> CDVDFactoryCodec::CreateAudioCodecHW(const std::string& id,
                                                                      CProcessInfo& processInfo)
 {
-  std::unique_lock<CCriticalSection> lock(audioCodecSection);
+  std::unique_lock lock(audioCodecSection);
 
   auto it = m_hwAudioCodecs.find(id);
   if (it != m_hwAudioCodecs.end())

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -244,7 +244,7 @@ CMediaCodecVideoBufferPool::~CMediaCodecVideoBufferPool()
 
 CVideoBuffer* CMediaCodecVideoBufferPool::Get()
 {
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
 
   if (m_freeBuffers.empty())
   {
@@ -261,14 +261,14 @@ CVideoBuffer* CMediaCodecVideoBufferPool::Get()
 
 void CMediaCodecVideoBufferPool::Return(int id)
 {
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
   m_videoBuffers[id]->ReleaseOutputBuffer(false, 0, this);
   m_freeBuffers.push_back(id);
 }
 
 std::shared_ptr<CJNIMediaCodec> CMediaCodecVideoBufferPool::GetMediaCodec()
 {
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
   return m_codec;
 }
 
@@ -276,13 +276,13 @@ void CMediaCodecVideoBufferPool::ResetMediaCodec()
 {
   ReleaseMediaCodecBuffers();
 
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
   m_codec = nullptr;
 }
 
 void CMediaCodecVideoBufferPool::ReleaseMediaCodecBuffers()
 {
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
   for (auto buffer : m_videoBuffers)
     buffer->ReleaseOutputBuffer(false, 0, this);
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -144,7 +144,7 @@ CVideoBufferPoolFFmpeg::~CVideoBufferPoolFFmpeg()
 
 CVideoBuffer* CVideoBufferPoolFFmpeg::Get()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   CVideoBufferFFmpeg *buf = nullptr;
   if (!m_free.empty())
@@ -168,7 +168,7 @@ CVideoBuffer* CVideoBufferPoolFFmpeg::Get()
 
 void CVideoBufferPoolFFmpeg::Return(int id)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_all[id]->Unref();
   auto it = m_used.begin();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -258,7 +258,7 @@ CContext::~CContext()
 
 void CContext::Release(CDecoder* decoder)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   const auto it = std::find(m_decoders.begin(), m_decoders.end(), decoder);
   if (it != m_decoders.end())
@@ -273,7 +273,7 @@ void CContext::Close()
 
 CContext::shared_ptr CContext::EnsureContext(CDecoder* decoder)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   auto context = m_context.lock();
   if (context)
@@ -656,7 +656,7 @@ bool CContext::CreateSurfaces(const D3D11_VIDEO_DECODER_DESC& format, uint32_t c
 bool CContext::CreateDecoder(const D3D11_VIDEO_DECODER_DESC &format, const D3D11_VIDEO_DECODER_CONFIG &config
                                , ID3D11VideoDecoder **decoder, ID3D11VideoContext **context)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   int retry = 0;
   while (retry < 2)
@@ -1020,7 +1020,7 @@ CVideoBufferPool::~CVideoBufferPool()
 
 ::CVideoBuffer* CVideoBufferPool::Get()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   CVideoBuffer* retPic;
   if (!m_freeOut.empty())
@@ -1042,7 +1042,7 @@ CVideoBufferPool::~CVideoBufferPool()
 
 void CVideoBufferPool::Return(int id)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   auto buf = m_out[id];
   buf->Unref();
@@ -1052,7 +1052,7 @@ void CVideoBufferPool::Return(int id)
 
 void CVideoBufferPool::AddView(ID3D11View* view)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   const size_t idx = m_views.size();
   m_views.push_back(view);
   m_freeViews.push_back(idx);
@@ -1060,13 +1060,13 @@ void CVideoBufferPool::AddView(ID3D11View* view)
 
 bool CVideoBufferPool::IsValid(ID3D11View* view)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   return std::find(m_views.begin(), m_views.end(), view) != m_views.end();
 }
 
 bool CVideoBufferPool::ReturnView(ID3D11View* view)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   const auto it = std::find(m_views.begin(), m_views.end(), view);
   if (it == m_views.end())
@@ -1079,7 +1079,7 @@ bool CVideoBufferPool::ReturnView(ID3D11View* view)
 
 ID3D11View* CVideoBufferPool::GetView()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   if (!m_freeViews.empty())
   {
@@ -1093,7 +1093,7 @@ ID3D11View* CVideoBufferPool::GetView()
 
 void CVideoBufferPool::Reset()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   for (auto v : m_views)
     if (v)
@@ -1110,13 +1110,13 @@ void CVideoBufferPool::Reset()
 
 size_t CVideoBufferPool::Size()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   return m_views.size();
 }
 
 bool CVideoBufferPool::HasFree()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   return !m_freeViews.empty();
 }
 
@@ -1165,7 +1165,7 @@ CDecoder::~CDecoder()
 
 void CDecoder::Close()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   m_pD3D11Decoder = nullptr;
   m_pD3D11Context = nullptr;
 
@@ -1309,7 +1309,7 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, enum AVPixel
   if (avctx->codec_id == AV_CODEC_ID_MPEG2VIDEO && avctx->height <= 576)
     m_DVDWorkaround = true;
 
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   Close();
 
   if (m_state == DXVA_LOST)
@@ -1463,7 +1463,7 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, enum AVPixel
 
 CDVDVideoCodec::VCReturn CDecoder::Decode(AVCodecContext* avctx, AVFrame* frame)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   const CDVDVideoCodec::VCReturn result = Check(avctx);
   if (result != CDVDVideoCodec::VC_NONE)
     return result;
@@ -1494,7 +1494,7 @@ CDVDVideoCodec::VCReturn CDecoder::Decode(AVCodecContext* avctx, AVFrame* frame)
 bool CDecoder::GetPicture(AVCodecContext* avctx, VideoPicture* picture)
 {
   static_cast<ICallbackHWAccel*>(avctx->opaque)->GetPictureCommon(picture);
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   if (picture->videoBuffer)
     picture->videoBuffer->Release();
@@ -1528,7 +1528,7 @@ void CDecoder::Reset()
 
 CDVDVideoCodec::VCReturn CDecoder::Check(AVCodecContext* avctx)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   // we may not have a hw decoder on systems (AMD HD2xxx, HD3xxx) which are only capable
   // of opening a single decoder and VideoPlayer opened a new stream without having flushed
@@ -1736,6 +1736,6 @@ unsigned CDecoder::GetAllowedReferences()
 
 void CDecoder::CloseDXVADecoder()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   m_pD3D11Decoder = nullptr;
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.h
@@ -246,13 +246,13 @@ protected:
   // ID3DResource overrides
   void OnCreateDevice() override
   {
-    std::unique_lock<CCriticalSection> lock(m_section);
+    std::unique_lock lock(m_section);
     m_state = DXVA_RESET;
     m_event.Set();
   }
   void OnDestroyDevice(bool fatal) override
   {
-    std::unique_lock<CCriticalSection> lock(m_section);
+    std::unique_lock lock(m_section);
     m_state = DXVA_LOST;
     m_event.Reset();
   }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -93,7 +93,7 @@ CVAAPIContext::CVAAPIContext()
 
 void CVAAPIContext::Release(CDecoder *decoder)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   auto it = find(m_decoders.begin(), m_decoders.end(), decoder);
   if (it != m_decoders.end())
@@ -121,7 +121,7 @@ void CVAAPIContext::Close()
 
 bool CVAAPIContext::EnsureContext(CVAAPIContext **ctx, CDecoder *decoder)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   if (m_context)
   {
@@ -135,7 +135,7 @@ bool CVAAPIContext::EnsureContext(CVAAPIContext **ctx, CDecoder *decoder)
   m_context = new CVAAPIContext();
   *ctx = m_context;
   {
-    std::unique_lock<CCriticalSection> gLock(CServiceBroker::GetWinSystem()->GetGfxContext());
+    std::unique_lock gLock(CServiceBroker::GetWinSystem()->GetGfxContext());
     if (!m_context->CreateContext())
     {
       delete m_context;
@@ -271,7 +271,7 @@ void CVAAPIContext::QueryCaps()
 
 VAConfigAttrib CVAAPIContext::GetAttrib(VAProfile profile)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   VAConfigAttrib attrib;
   attrib.type = VAConfigAttribRTFormat;
@@ -282,7 +282,7 @@ VAConfigAttrib CVAAPIContext::GetAttrib(VAProfile profile)
 
 bool CVAAPIContext::SupportsProfile(VAProfile profile)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   for (int i=0; i<m_profileCount; i++)
   {
@@ -294,7 +294,7 @@ bool CVAAPIContext::SupportsProfile(VAProfile profile)
 
 VAConfigID CVAAPIContext::CreateConfig(VAProfile profile, VAConfigAttrib attrib)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   VAConfigID config = VA_INVALID_ID;
   CheckSuccess(vaCreateConfig(m_display, profile, VAEntrypointVLD, &attrib, 1, &config), "vaCreateConfig");
@@ -344,14 +344,14 @@ void CVAAPIContext::FFReleaseBuffer(void *opaque, uint8_t *data)
 
 void CVideoSurfaces::AddSurface(VASurfaceID surf)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   m_state[surf] = 0;
   m_freeSurfaces.push_back(surf);
 }
 
 void CVideoSurfaces::ClearReference(VASurfaceID surf)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (m_state.find(surf) == m_state.end())
   {
     CLog::Log(LOGWARNING, "CVideoSurfaces::ClearReference - surface invalid");
@@ -366,7 +366,7 @@ void CVideoSurfaces::ClearReference(VASurfaceID surf)
 
 bool CVideoSurfaces::MarkRender(VASurfaceID surf)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (m_state.find(surf) == m_state.end())
   {
     CLog::Log(LOGWARNING, "CVideoSurfaces::MarkRender - surface invalid");
@@ -383,7 +383,7 @@ bool CVideoSurfaces::MarkRender(VASurfaceID surf)
 
 void CVideoSurfaces::ClearRender(VASurfaceID surf)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (m_state.find(surf) == m_state.end())
   {
     CLog::Log(LOGWARNING, "CVideoSurfaces::ClearRender - surface invalid");
@@ -398,7 +398,7 @@ void CVideoSurfaces::ClearRender(VASurfaceID surf)
 
 bool CVideoSurfaces::IsValid(VASurfaceID surf)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (m_state.find(surf) != m_state.end())
     return true;
   else
@@ -407,7 +407,7 @@ bool CVideoSurfaces::IsValid(VASurfaceID surf)
 
 VASurfaceID CVideoSurfaces::GetFree(VASurfaceID surf)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (m_state.find(surf) != m_state.end())
   {
     auto it = std::find(m_freeSurfaces.begin(), m_freeSurfaces.end(), surf);
@@ -447,7 +447,7 @@ VASurfaceID CVideoSurfaces::GetAtIndex(int idx)
 
 VASurfaceID CVideoSurfaces::RemoveNext(bool skiprender)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   VASurfaceID surf;
   for(auto it = m_state.begin(); it != m_state.end(); ++it)
   {
@@ -466,32 +466,32 @@ VASurfaceID CVideoSurfaces::RemoveNext(bool skiprender)
 
 void CVideoSurfaces::Reset()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   m_freeSurfaces.clear();
   m_state.clear();
 }
 
 int CVideoSurfaces::Size()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   return m_state.size();
 }
 
 bool CVideoSurfaces::HasFree()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   return !m_freeSurfaces.empty();
 }
 
 int CVideoSurfaces::NumFree()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   return m_freeSurfaces.size();
 }
 
 bool CVideoSurfaces::HasRefs()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   for (const auto &i : m_state)
   {
     if (i.second & SURFACE_USED_FOR_REFERENCE)
@@ -761,7 +761,7 @@ void CDecoder::Close()
 {
   CLog::Log(LOGINFO, "VAAPI::{}", __FUNCTION__);
 
-  std::unique_lock<CCriticalSection> lock(m_DecoderSection);
+  std::unique_lock lock(m_DecoderSection);
 
   FiniVAAPIOutput();
 
@@ -783,10 +783,10 @@ long CDecoder::Release()
   // a second decoder might need resources
   if (m_vaapiConfigured == true)
   {
-    std::unique_lock<CCriticalSection> lock(m_DecoderSection);
+    std::unique_lock lock(m_DecoderSection);
     CLog::Log(LOGDEBUG, LOGVIDEO, "VAAPI::Release pre-cleanup");
 
-    std::unique_lock<CCriticalSection> lock1(CServiceBroker::GetWinSystem()->GetGfxContext());
+    std::unique_lock lock1(CServiceBroker::GetWinSystem()->GetGfxContext());
     Message *reply;
     if (m_vaapiOutput.m_controlPort.SendOutMessageSync(COutputControlProtocol::PRECLEANUP, &reply,
                                                        2s))
@@ -825,7 +825,7 @@ int CDecoder::FFGetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags)
   CDecoder* va = static_cast<CDecoder*>(cb->GetHWAccel());
 
   // while we are waiting to recover we can't do anything
-  std::unique_lock<CCriticalSection> lock(va->m_DecoderSection);
+  std::unique_lock lock(va->m_DecoderSection);
 
   if(va->m_DisplayState != VAAPI_OPEN)
   {
@@ -874,7 +874,7 @@ void CDecoder::FFReleaseBuffer(uint8_t *data)
   {
     VASurfaceID surf;
 
-    std::unique_lock<CCriticalSection> lock(m_DecoderSection);
+    std::unique_lock lock(m_DecoderSection);
 
     surf = (VASurfaceID)(uintptr_t)data;
     m_videoSurfaces.ClearReference(surf);
@@ -894,7 +894,7 @@ CDVDVideoCodec::VCReturn CDecoder::Decode(AVCodecContext* avctx, AVFrame* pFrame
   if (result != CDVDVideoCodec::VC_NOBUFFER && result != CDVDVideoCodec::VC_NONE)
     return result;
 
-  std::unique_lock<CCriticalSection> lock(m_DecoderSection);
+  std::unique_lock lock(m_DecoderSection);
 
   if (!m_vaapiConfigured)
     return CDVDVideoCodec::VC_ERROR;
@@ -1004,7 +1004,7 @@ CDVDVideoCodec::VCReturn CDecoder::Check(AVCodecContext* avctx)
   EDisplayState state;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_DecoderSection);
+    std::unique_lock lock(m_DecoderSection);
     state = m_DisplayState;
   }
 
@@ -1018,13 +1018,13 @@ CDVDVideoCodec::VCReturn CDecoder::Check(AVCodecContext* avctx)
     }
     else
     {
-      std::unique_lock<CCriticalSection> lock(m_DecoderSection);
+      std::unique_lock lock(m_DecoderSection);
       state = m_DisplayState;
     }
   }
   if (state == VAAPI_RESET || state == VAAPI_ERROR)
   {
-    std::unique_lock<CCriticalSection> lock(m_DecoderSection);
+    std::unique_lock lock(m_DecoderSection);
 
     avcodec_flush_buffers(avctx);
     FiniVAAPIOutput();
@@ -1063,7 +1063,7 @@ bool CDecoder::GetPicture(AVCodecContext* avctx, VideoPicture* picture)
     picture->videoBuffer = nullptr;
   }
 
-  std::unique_lock<CCriticalSection> lock(m_DecoderSection);
+  std::unique_lock lock(m_DecoderSection);
 
   if (m_DisplayState != VAAPI_OPEN)
     return false;
@@ -1077,7 +1077,7 @@ bool CDecoder::GetPicture(AVCodecContext* avctx, VideoPicture* picture)
 
 void CDecoder::Reset()
 {
-  std::unique_lock<CCriticalSection> lock(m_DecoderSection);
+  std::unique_lock lock(m_DecoderSection);
 
   if (m_presentPicture)
   {
@@ -1186,7 +1186,7 @@ bool CDecoder::ConfigVAAPI()
   }
 
   // initialize output
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   m_vaapiConfig.stats = &m_bufferStats;
   m_bufferStats.Reset();
   m_vaapiOutput.Start();
@@ -1516,7 +1516,7 @@ COutput::~COutput()
 
 void COutput::Dispose()
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   m_bStop = true;
   m_outMsgEvent.Set();
   StopThread();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -70,37 +70,37 @@ public:
 
   void IncDecoded()
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     decodedPics++;
   }
   void DecDecoded()
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     decodedPics--;
   }
   void IncProcessed()
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     processedPics++;
   }
   void DecProcessed()
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     processedPics--;
   }
   void IncRender()
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     renderPics++;
   }
   void DecRender()
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     renderPics--;
   }
   void Reset()
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     decodedPics = 0;
     processedPics = 0;
     renderPics = 0;
@@ -112,41 +112,41 @@ public:
   }
   void Get(uint16_t& decoded, uint16_t& processed, uint16_t& render, bool& vpp)
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     decoded = decodedPics, processed = processedPics, render = renderPics;
     vpp = isVpp;
   }
   void SetParams(uint64_t time, int flags)
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     latency = time;
     codecFlags = flags;
   }
   void GetParams(uint64_t& lat, int& flags)
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     lat = latency;
     flags = codecFlags;
   }
   void SetCmd(int cmd)
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     processCmd = cmd;
   }
   void GetCmd(int& cmd)
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     cmd = processCmd;
     processCmd = 0;
   }
   void SetCanSkipDeint(bool canSkip)
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     canSkipDeint = canSkip;
   }
   bool CanSkipDeint()
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     if (canSkipDeint)
       return true;
     else
@@ -154,7 +154,7 @@ public:
   }
   void SetVpp(bool vpp)
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     isVpp = vpp;
   }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
@@ -92,7 +92,7 @@ CVDPAUContext::CVDPAUContext()
 
 void CVDPAUContext::Release()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   m_refCount--;
   if (m_refCount <= 0)
@@ -111,7 +111,7 @@ void CVDPAUContext::Close()
 
 bool CVDPAUContext::EnsureContext(CVDPAUContext **ctx)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   if (m_context)
   {
@@ -123,7 +123,7 @@ bool CVDPAUContext::EnsureContext(CVDPAUContext **ctx)
   m_context = new CVDPAUContext();
   *ctx = m_context;
   {
-    std::unique_lock<CCriticalSection> gLock(CServiceBroker::GetWinSystem()->GetGfxContext());
+    std::unique_lock gLock(CServiceBroker::GetWinSystem()->GetGfxContext());
     if (!m_context->LoadSymbols() || !m_context->CreateContext())
     {
       delete m_context;
@@ -189,7 +189,7 @@ bool CVDPAUContext::CreateContext()
 
   int screen;
   {
-    std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+    std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
     if (!m_display)
       m_display = XOpenDisplay(NULL);
@@ -346,13 +346,13 @@ bool CVDPAUContext::Supports(VdpVideoMixerFeature feature)
 
 void CVideoSurfaces::AddSurface(VdpVideoSurface surf)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   m_state[surf] = SURFACE_USED_FOR_REFERENCE;
 }
 
 void CVideoSurfaces::ClearReference(VdpVideoSurface surf)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (m_state.find(surf) == m_state.end())
   {
     CLog::Log(LOGWARNING, "CVideoSurfaces::ClearReference - surface invalid");
@@ -367,7 +367,7 @@ void CVideoSurfaces::ClearReference(VdpVideoSurface surf)
 
 bool CVideoSurfaces::MarkRender(VdpVideoSurface surf)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (m_state.find(surf) == m_state.end())
   {
     CLog::Log(LOGWARNING, "CVideoSurfaces::MarkRender - surface invalid");
@@ -385,7 +385,7 @@ bool CVideoSurfaces::MarkRender(VdpVideoSurface surf)
 
 void CVideoSurfaces::ClearRender(VdpVideoSurface surf)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (m_state.find(surf) == m_state.end())
   {
     CLog::Log(LOGWARNING, "CVideoSurfaces::ClearRender - surface invalid");
@@ -400,7 +400,7 @@ void CVideoSurfaces::ClearRender(VdpVideoSurface surf)
 
 bool CVideoSurfaces::IsValid(VdpVideoSurface surf)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (m_state.find(surf) != m_state.end())
     return true;
   else
@@ -409,7 +409,7 @@ bool CVideoSurfaces::IsValid(VdpVideoSurface surf)
 
 VdpVideoSurface CVideoSurfaces::GetFree(VdpVideoSurface surf)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (m_state.find(surf) != m_state.end())
   {
     std::list<VdpVideoSurface>::iterator it;
@@ -439,7 +439,7 @@ VdpVideoSurface CVideoSurfaces::GetFree(VdpVideoSurface surf)
 
 VdpVideoSurface CVideoSurfaces::RemoveNext(bool skiprender)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   VdpVideoSurface surf;
   std::map<VdpVideoSurface, int>::iterator it;
   for(it = m_state.begin(); it != m_state.end(); ++it)
@@ -460,14 +460,14 @@ VdpVideoSurface CVideoSurfaces::RemoveNext(bool skiprender)
 
 void CVideoSurfaces::Reset()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   m_freeSurfaces.clear();
   m_state.clear();
 }
 
 int CVideoSurfaces::Size()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   return m_state.size();
 }
 
@@ -632,7 +632,7 @@ void CDecoder::Close()
 
   CServiceBroker::GetWinSystem()->Unregister(this);
 
-  std::unique_lock<CCriticalSection> lock(m_DecoderSection);
+  std::unique_lock lock(m_DecoderSection);
 
   FiniVDPAUOutput();
   m_vdpauOutput.Dispose();
@@ -648,7 +648,7 @@ long CDecoder::Release()
   // a second decoder might need resources
   if (m_vdpauConfigured == true)
   {
-    std::unique_lock<CCriticalSection> lock(m_DecoderSection);
+    std::unique_lock lock(m_DecoderSection);
     CLog::Log(LOGINFO, "CVDPAU::Release pre-cleanup");
 
     Message *reply;
@@ -718,7 +718,7 @@ void CDecoder::OnLostDisplay()
 
   int count = CServiceBroker::GetWinSystem()->GetGfxContext().exit();
 
-  std::unique_lock<CCriticalSection> lock(m_DecoderSection);
+  std::unique_lock lock(m_DecoderSection);
   FiniVDPAUOutput();
   if (m_vdpauConfig.context)
     m_vdpauConfig.context->Release();
@@ -737,7 +737,7 @@ void CDecoder::OnResetDisplay()
 
   int count = CServiceBroker::GetWinSystem()->GetGfxContext().exit();
 
-  std::unique_lock<CCriticalSection> lock(m_DecoderSection);
+  std::unique_lock lock(m_DecoderSection);
   if (m_DisplayState == VDPAU_LOST)
   {
     m_DisplayState = VDPAU_RESET;
@@ -753,7 +753,7 @@ CDVDVideoCodec::VCReturn CDecoder::Check(AVCodecContext* avctx)
   EDisplayState state;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_DecoderSection);
+    std::unique_lock lock(m_DecoderSection);
     state = m_DisplayState;
   }
 
@@ -767,13 +767,13 @@ CDVDVideoCodec::VCReturn CDecoder::Check(AVCodecContext* avctx)
     }
     else
     {
-      std::unique_lock<CCriticalSection> lock(m_DecoderSection);
+      std::unique_lock lock(m_DecoderSection);
       state = m_DisplayState;
     }
   }
   if (state == VDPAU_RESET || state == VDPAU_ERROR)
   {
-    std::unique_lock<CCriticalSection> lock(m_DecoderSection);
+    std::unique_lock lock(m_DecoderSection);
 
     FiniVDPAUOutput();
     if (m_vdpauConfig.context)
@@ -940,7 +940,7 @@ bool CDecoder::ConfigVDPAU(AVCodecContext* avctx, int ref_frames)
     return false;
 
   // initialize output
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   m_vdpauConfig.stats = &m_bufferStats;
   m_vdpauConfig.vdpau = this;
   m_bufferStats.Reset();
@@ -978,7 +978,7 @@ int CDecoder::FFGetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags)
   CDecoder* vdp = static_cast<CDecoder*>(cb->GetHWAccel());
 
   // while we are waiting to recover we can't do anything
-  std::unique_lock<CCriticalSection> lock(vdp->m_DecoderSection);
+  std::unique_lock lock(vdp->m_DecoderSection);
 
   if(vdp->m_DisplayState != VDPAU_OPEN)
   {
@@ -1035,7 +1035,7 @@ void CDecoder::FFReleaseBuffer(void *opaque, uint8_t *data)
 
   VdpVideoSurface surf;
 
-  std::unique_lock<CCriticalSection> lock(vdp->m_DecoderSection);
+  std::unique_lock lock(vdp->m_DecoderSection);
 
   surf = (VdpVideoSurface)(uintptr_t)data;
 
@@ -1050,7 +1050,7 @@ int CDecoder::Render(struct AVCodecContext *s, struct AVFrame *src,
   CDecoder* vdp = static_cast<CDecoder*>(ctx->GetHWAccel());
 
   // while we are waiting to recover we can't do anything
-  std::unique_lock<CCriticalSection> lock(vdp->m_DecoderSection);
+  std::unique_lock lock(vdp->m_DecoderSection);
 
   if(vdp->m_DisplayState != VDPAU_OPEN)
     return -1;
@@ -1116,7 +1116,7 @@ CDVDVideoCodec::VCReturn CDecoder::Decode(AVCodecContext *avctx, AVFrame *pFrame
   if (result != CDVDVideoCodec::VC_NONE)
     return result;
 
-  std::unique_lock<CCriticalSection> lock(m_DecoderSection);
+  std::unique_lock lock(m_DecoderSection);
 
   if (!m_vdpauConfigured)
     return CDVDVideoCodec::VC_ERROR;
@@ -1230,7 +1230,7 @@ bool CDecoder::GetPicture(AVCodecContext* avctx, VideoPicture* picture)
     picture->videoBuffer = nullptr;
   }
 
-  std::unique_lock<CCriticalSection> lock(m_DecoderSection);
+  std::unique_lock lock(m_DecoderSection);
 
   if (m_DisplayState != VDPAU_OPEN)
     return false;
@@ -1244,7 +1244,7 @@ bool CDecoder::GetPicture(AVCodecContext* avctx, VideoPicture* picture)
 
 void CDecoder::Reset()
 {
-  std::unique_lock<CCriticalSection> lock(m_DecoderSection);
+  std::unique_lock lock(m_DecoderSection);
 
   if (m_presentPicture)
   {
@@ -2831,7 +2831,7 @@ COutput::~COutput()
 
 void COutput::Dispose()
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   m_bStop = true;
   m_outMsgEvent.Set();
   StopThread();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.h
@@ -122,37 +122,37 @@ public:
 
   void IncDecoded()
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     decodedPics++;
   }
   void DecDecoded()
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     decodedPics--;
   }
   void IncProcessed()
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     processedPics++;
   }
   void DecProcessed()
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     processedPics--;
   }
   void IncRender()
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     renderPics++;
   }
   void DecRender()
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     renderPics--;
   }
   void Reset()
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     decodedPics = 0;
     processedPics = 0;
     renderPics = 0;
@@ -160,29 +160,29 @@ public:
   }
   void Get(uint16_t& decoded, uint16_t& processed, uint16_t& render)
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     decoded = decodedPics, processed = processedPics, render = renderPics;
   }
   void SetParams(uint64_t time, int flags)
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     latency = time;
     codecFlags = flags;
   }
   void GetParams(uint64_t& lat, int& flags)
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     lat = latency;
     flags = codecFlags;
   }
   void SetCanSkipDeint(bool canSkip)
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     canSkipDeint = canSkip;
   }
   bool CanSkipDeint()
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     if (canSkipDeint)
       return true;
     else
@@ -190,12 +190,12 @@ public:
   }
   void SetDraining(bool drain)
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     draining = drain;
   }
   bool IsDraining()
   {
-    std::unique_lock<CCriticalSection> l(m_sec);
+    std::unique_lock l(m_sec);
     if (draining)
       return true;
     else

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp
@@ -82,7 +82,7 @@ CVideoBufferPoolVTB::~CVideoBufferPoolVTB()
 
 CVideoBuffer* CVideoBufferPoolVTB::Get()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   CVideoBufferVTB *buf = nullptr;
   if (!m_free.empty())
@@ -106,7 +106,7 @@ CVideoBuffer* CVideoBufferPoolVTB::Get()
 
 void CVideoBufferPoolVTB::Return(int id)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_all[id]->Unref();
   auto it = m_used.begin();

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -968,7 +968,7 @@ DemuxPacket* CDVDDemuxFFmpeg::ReadInternal(bool keep)
   // would consider this the end of stream and stop.
   bool bReturnEmpty = false;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection); // open lock scope
+    std::unique_lock lock(m_critSection); // open lock scope
     if (m_pFormatContext)
     {
       // assume we are not eof
@@ -1259,7 +1259,7 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double* startpts)
 
   int ret;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     ret = av_seek_frame(m_pFormatContext, m_seekStream, seek_pts, backwards ? AVSEEK_FLAG_BACKWARD : 0);
 
     if (ret < 0)
@@ -1336,7 +1336,7 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double* startpts)
 
 bool CDVDDemuxFFmpeg::SeekByte(int64_t pos)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   int ret = av_seek_frame(m_pFormatContext, -1, pos, AVSEEK_FLAG_BYTE);
 
   if (ret >= 0)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -695,7 +695,7 @@ int CDVDInputStreamBluray::ReadBlocks(uint8_t* buf, int lba, int num_blocks)
     return -1;
   int result = -1;
   int64_t offset = static_cast<int64_t>(lba) * 2048;
-  std::unique_lock<CCriticalSection> lock(m_readBlocksLock);
+  std::unique_lock lock(m_readBlocksLock);
   if (lpstream->Seek(offset, SEEK_SET) >= 0)
   {
     int64_t size = static_cast<int64_t>(num_blocks) * 2048;

--- a/xbmc/cores/VideoPlayer/DVDMessage.cpp
+++ b/xbmc/cores/VideoPlayer/DVDMessage.cpp
@@ -51,7 +51,7 @@ CDVDMsgGeneralSynchronize::~CDVDMsgGeneralSynchronize()
 
 bool CDVDMsgGeneralSynchronize::Wait(std::chrono::milliseconds timeout, unsigned int source)
 {
-  std::unique_lock<CCriticalSection> lock(m_p->section);
+  std::unique_lock lock(m_p->section);
 
   XbmcThreads::EndTime<> timer{timeout};
 

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
@@ -46,7 +46,7 @@ void CDVDMessageQueue::Init()
 
 void CDVDMessageQueue::Flush(CDVDMsg::Message type)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   m_messages.remove_if([type](const DVDMessageListItem &item){
     return type == CDVDMsg::NONE || item.message->IsType(type);
@@ -66,7 +66,7 @@ void CDVDMessageQueue::Flush(CDVDMsg::Message type)
 
 void CDVDMessageQueue::Abort()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   m_bAbortRequest = true;
 
@@ -76,7 +76,7 @@ void CDVDMessageQueue::Abort()
 
 void CDVDMessageQueue::End()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   Flush(CDVDMsg::NONE);
 
@@ -99,7 +99,7 @@ MsgQueueReturnCode CDVDMessageQueue::Put(const std::shared_ptr<CDVDMsg>& pMsg,
                                          int priority,
                                          bool front)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   if (!m_bInitialized)
   {
@@ -162,7 +162,7 @@ MsgQueueReturnCode CDVDMessageQueue::Get(std::shared_ptr<CDVDMsg>& pMsg,
                                          std::chrono::milliseconds timeout,
                                          int& priority)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   int ret = 0;
 
@@ -269,7 +269,7 @@ void CDVDMessageQueue::UpdateTimeBack()
 
 unsigned CDVDMessageQueue::GetPacketCount(CDVDMsg::Message type)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   if (!m_bInitialized)
     return 0;
@@ -292,7 +292,7 @@ unsigned CDVDMessageQueue::GetPacketCount(CDVDMsg::Message type)
 void CDVDMessageQueue::WaitUntilEmpty()
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_section);
+    std::unique_lock lock(m_section);
     m_drain = true;
   }
 
@@ -302,14 +302,14 @@ void CDVDMessageQueue::WaitUntilEmpty()
   msg->Wait(m_bAbortRequest, 0);
 
   {
-    std::unique_lock<CCriticalSection> lock(m_section);
+    std::unique_lock lock(m_section);
     m_drain = false;
   }
 }
 
 int CDVDMessageQueue::GetLevel() const
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   if (m_iDataSize > m_iMaxDataSize)
     return 100;
@@ -335,7 +335,7 @@ int CDVDMessageQueue::GetLevel() const
 
 double CDVDMessageQueue::GetTimeSize() const
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   if (IsDataBased())
     return 0.0;

--- a/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
@@ -21,7 +21,7 @@ CDVDOverlayContainer::~CDVDOverlayContainer()
 
 void CDVDOverlayContainer::ProcessAndAddOverlayIfValid(const std::shared_ptr<CDVDOverlay>& pOverlay)
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
 
   // markup any non ending overlays, to finish
   // when this new one starts, there can be
@@ -53,13 +53,13 @@ VecOverlays* CDVDOverlayContainer::GetOverlays()
 
 VecOverlays::iterator CDVDOverlayContainer::Remove(VecOverlays::iterator itOverlay)
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
   return m_overlays.erase(itOverlay);
 }
 
 void CDVDOverlayContainer::CleanUp(double pts)
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
 
   auto it = m_overlays.begin();
   while (it != m_overlays.end())
@@ -101,7 +101,7 @@ void CDVDOverlayContainer::CleanUp(double pts)
 
 void CDVDOverlayContainer::Flush()
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
 
   // Flush only the overlays marked as flushable
   m_overlays.erase(std::remove_if(m_overlays.begin(), m_overlays.end(),
@@ -113,7 +113,7 @@ void CDVDOverlayContainer::Flush()
 
 void CDVDOverlayContainer::Clear()
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
   m_overlays.clear();
 }
 
@@ -126,7 +126,7 @@ bool CDVDOverlayContainer::ContainsOverlayType(DVDOverlayType type)
 {
   bool result = false;
 
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
 
   auto it = m_overlays.begin();
   while (!result && it != m_overlays.end())
@@ -144,7 +144,7 @@ bool CDVDOverlayContainer::ContainsOverlayType(DVDOverlayType type)
 void CDVDOverlayContainer::UpdateOverlayInfo(
     const std::shared_ptr<CDVDInputStreamNavigator>& pStream, CDVDDemuxSPU* pSpu, int iAction)
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
 
   pStream->CheckButtons();
 

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -157,7 +157,7 @@ void CDVDSubtitlesLibass::Configure()
 
 bool CDVDSubtitlesLibass::DecodeHeader(char* data, int size)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (!m_library || !data)
     return false;
 
@@ -170,7 +170,7 @@ bool CDVDSubtitlesLibass::DecodeHeader(char* data, int size)
 
 bool CDVDSubtitlesLibass::DecodeDemuxPkt(const char* data, int size, double start, double duration)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (!m_track)
   {
     CLog::Log(LOGERROR, "{} - No SSA header found.", __FUNCTION__);
@@ -185,7 +185,7 @@ bool CDVDSubtitlesLibass::DecodeDemuxPkt(const char* data, int size, double star
 
 bool CDVDSubtitlesLibass::CreateTrack()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (!m_library)
   {
     CLog::Log(LOGERROR, "{} - Failed to create ASS track, library not initialized.", __FUNCTION__);
@@ -216,7 +216,7 @@ bool CDVDSubtitlesLibass::CreateTrack()
 
 bool CDVDSubtitlesLibass::CreateStyle()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (!m_library)
   {
     CLog::Log(LOGERROR, "{} - Failed to create ASS style, library not initialized.", __FUNCTION__);
@@ -235,7 +235,7 @@ bool CDVDSubtitlesLibass::CreateStyle()
 
 bool CDVDSubtitlesLibass::CreateTrack(char* buf, size_t size)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (!m_library)
   {
     CLog::Log(LOGERROR, "{} - No ASS library struct (m_library)", __FUNCTION__);
@@ -257,7 +257,7 @@ ASS_Image* CDVDSubtitlesLibass::RenderImage(double pts,
                                             const std::shared_ptr<struct style>& subStyle,
                                             int* changes)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (!m_renderer || !m_track)
   {
     CLog::Log(LOGERROR, "{} - ASS renderer/ASS track not initialized.", __FUNCTION__);
@@ -603,7 +603,7 @@ void CDVDSubtitlesLibass::ConfigureAssOverride(const std::shared_ptr<struct styl
 
 ASS_Event* CDVDSubtitlesLibass::GetEvents()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (!m_track)
   {
     CLog::Log(LOGERROR, "{} -  Missing ASS structs (m_track)", __FUNCTION__);
@@ -614,7 +614,7 @@ ASS_Event* CDVDSubtitlesLibass::GetEvents()
 
 int CDVDSubtitlesLibass::GetNrOfEvents() const
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (!m_track)
     return 0;
   return m_track->n_events;
@@ -638,7 +638,7 @@ int CDVDSubtitlesLibass::AddEvent(const char* text,
     return ASS_NO_ID;
   }
 
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (!m_library || !m_track)
   {
     CLog::Log(LOGERROR, "{} - Missing ASS structs (m_library or m_track)", __FUNCTION__);
@@ -669,7 +669,7 @@ int CDVDSubtitlesLibass::AddEvent(const char* text,
 
 void CDVDSubtitlesLibass::AppendTextToEvent(int eventId, const char* text)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (eventId == ASS_NO_ID || text == NULL || text[0] == '\0')
     return;
   if (!m_track)
@@ -701,7 +701,7 @@ void CDVDSubtitlesLibass::AppendTextToEvent(int eventId, const char* text)
 
 void CDVDSubtitlesLibass::ChangeEventStopTime(int eventId, double stopTime)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (eventId == ASS_NO_ID)
     return;
   if (!m_track)
@@ -725,7 +725,7 @@ void CDVDSubtitlesLibass::ChangeEventStopTime(int eventId, double stopTime)
 
 void CDVDSubtitlesLibass::FlushEvents()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (!m_library || !m_track)
   {
     CLog::Log(LOGERROR, "{} - Missing ASS structs (m_library or m_track)", __FUNCTION__);
@@ -737,7 +737,7 @@ void CDVDSubtitlesLibass::FlushEvents()
 
 int CDVDSubtitlesLibass::DeleteEvents(int nEvents, int threshold)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (!m_library || !m_track)
   {
     CLog::Log(LOGERROR, "{} - Missing ASS structs (m_library or m_track)", __FUNCTION__);

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -21,7 +21,7 @@ std::map<std::string, CreateProcessControl> CProcessInfo::m_processControls;
 
 void CProcessInfo::RegisterProcessControl(const std::string& id, CreateProcessControl createFunc)
 {
-  std::unique_lock<CCriticalSection> lock(createSection);
+  std::unique_lock lock(createSection);
 
   m_processControls.clear();
   m_processControls[id] = createFunc;
@@ -29,7 +29,7 @@ void CProcessInfo::RegisterProcessControl(const std::string& id, CreateProcessCo
 
 CProcessInfo* CProcessInfo::CreateInstance()
 {
-  std::unique_lock<CCriticalSection> lock(createSection);
+  std::unique_lock lock(createSection);
 
   CProcessInfo *ret = nullptr;
   for (auto &info : m_processControls)
@@ -63,7 +63,7 @@ void CProcessInfo::SetDataCache(CDataCacheCore *cache)
 //******************************************************************************
 void CProcessInfo::ResetVideoCodecInfo()
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   m_videoIsHWDecoder = false;
   m_videoDecoderName = "unknown";
@@ -95,7 +95,7 @@ void CProcessInfo::ResetVideoCodecInfo()
 
 void CProcessInfo::SetVideoDecoderName(const std::string &name, bool isHw)
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   m_videoIsHWDecoder = isHw;
   m_videoDecoderName = name;
@@ -106,21 +106,21 @@ void CProcessInfo::SetVideoDecoderName(const std::string &name, bool isHw)
 
 std::string CProcessInfo::GetVideoDecoderName()
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   return m_videoDecoderName;
 }
 
 bool CProcessInfo::IsVideoHwDecoder()
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   return m_videoIsHWDecoder;
 }
 
 void CProcessInfo::SetVideoDeintMethod(const std::string &method)
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   m_videoDeintMethod = method;
 
@@ -130,14 +130,14 @@ void CProcessInfo::SetVideoDeintMethod(const std::string &method)
 
 std::string CProcessInfo::GetVideoDeintMethod()
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   return m_videoDeintMethod;
 }
 
 void CProcessInfo::SetVideoPixelFormat(const std::string &pixFormat)
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   m_videoPixelFormat = pixFormat;
 
@@ -147,14 +147,14 @@ void CProcessInfo::SetVideoPixelFormat(const std::string &pixFormat)
 
 std::string CProcessInfo::GetVideoPixelFormat()
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   return m_videoPixelFormat;
 }
 
 void CProcessInfo::SetVideoStereoMode(const std::string &mode)
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   m_videoStereoMode = mode;
 
@@ -164,14 +164,14 @@ void CProcessInfo::SetVideoStereoMode(const std::string &mode)
 
 std::string CProcessInfo::GetVideoStereoMode()
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   return m_videoStereoMode;
 }
 
 void CProcessInfo::SetVideoDimensions(int width, int height)
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   m_videoWidth = width;
   m_videoHeight = height;
@@ -182,7 +182,7 @@ void CProcessInfo::SetVideoDimensions(int width, int height)
 
 void CProcessInfo::GetVideoDimensions(int &width, int &height)
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   width = m_videoWidth;
   height = m_videoHeight;
@@ -190,7 +190,7 @@ void CProcessInfo::GetVideoDimensions(int &width, int &height)
 
 void CProcessInfo::SetVideoFps(float fps)
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   m_videoFPS = fps;
 
@@ -200,14 +200,14 @@ void CProcessInfo::SetVideoFps(float fps)
 
 float CProcessInfo::GetVideoFps()
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   return m_videoFPS;
 }
 
 void CProcessInfo::SetVideoDAR(float dar)
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   m_videoDAR = dar;
 
@@ -217,14 +217,14 @@ void CProcessInfo::SetVideoDAR(float dar)
 
 float CProcessInfo::GetVideoDAR()
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   return m_videoDAR;
 }
 
 void CProcessInfo::SetVideoInterlaced(bool interlaced)
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   m_videoIsInterlaced = interlaced;
 
@@ -234,7 +234,7 @@ void CProcessInfo::SetVideoInterlaced(bool interlaced)
 
 bool CProcessInfo::GetVideoInterlaced()
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   return m_videoIsInterlaced;
 }
@@ -257,7 +257,7 @@ void CProcessInfo::SetSwDeinterlacingMethods()
 
 void CProcessInfo::UpdateDeinterlacingMethods(std::list<EINTERLACEMETHOD> &methods)
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   m_deintMethods = methods;
 
@@ -273,7 +273,7 @@ void CProcessInfo::UpdateDeinterlacingMethods(std::list<EINTERLACEMETHOD> &metho
 
 bool CProcessInfo::Supports(EINTERLACEMETHOD method) const
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   auto it = std::find(m_deintMethods.begin(), m_deintMethods.end(), method);
   if (it != m_deintMethods.end())
@@ -284,14 +284,14 @@ bool CProcessInfo::Supports(EINTERLACEMETHOD method) const
 
 void CProcessInfo::SetDeinterlacingMethodDefault(EINTERLACEMETHOD method)
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   m_deintMethodDefault = method;
 }
 
 EINTERLACEMETHOD CProcessInfo::GetDeinterlacingMethodDefault() const
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   return m_deintMethodDefault;
 }
@@ -303,7 +303,7 @@ CVideoBufferManager& CProcessInfo::GetVideoBufferManager()
 
 std::vector<AVPixelFormat> CProcessInfo::GetPixFormats()
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   if (m_pixFormats.empty())
   {
@@ -314,7 +314,7 @@ std::vector<AVPixelFormat> CProcessInfo::GetPixFormats()
 
 void CProcessInfo::SetPixFormats(std::vector<AVPixelFormat> &formats)
 {
-  std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+  std::unique_lock lock(m_videoCodecSection);
 
   m_pixFormats = formats;
 }
@@ -324,7 +324,7 @@ void CProcessInfo::SetPixFormats(std::vector<AVPixelFormat> &formats)
 //******************************************************************************
 void CProcessInfo::ResetAudioCodecInfo()
 {
-  std::unique_lock<CCriticalSection> lock(m_audioCodecSection);
+  std::unique_lock lock(m_audioCodecSection);
 
   m_audioDecoderName = "unknown";
   m_audioChannels = "unknown";
@@ -342,7 +342,7 @@ void CProcessInfo::ResetAudioCodecInfo()
 
 void CProcessInfo::SetAudioDecoderName(const std::string &name)
 {
-  std::unique_lock<CCriticalSection> lock(m_audioCodecSection);
+  std::unique_lock lock(m_audioCodecSection);
 
   m_audioDecoderName = name;
 
@@ -352,14 +352,14 @@ void CProcessInfo::SetAudioDecoderName(const std::string &name)
 
 std::string CProcessInfo::GetAudioDecoderName()
 {
-  std::unique_lock<CCriticalSection> lock(m_audioCodecSection);
+  std::unique_lock lock(m_audioCodecSection);
 
   return m_audioDecoderName;
 }
 
 void CProcessInfo::SetAudioChannels(const std::string &channels)
 {
-  std::unique_lock<CCriticalSection> lock(m_audioCodecSection);
+  std::unique_lock lock(m_audioCodecSection);
 
   m_audioChannels = channels;
 
@@ -369,14 +369,14 @@ void CProcessInfo::SetAudioChannels(const std::string &channels)
 
 std::string CProcessInfo::GetAudioChannels()
 {
-  std::unique_lock<CCriticalSection> lock(m_audioCodecSection);
+  std::unique_lock lock(m_audioCodecSection);
 
   return m_audioChannels;
 }
 
 void CProcessInfo::SetAudioSampleRate(int sampleRate)
 {
-  std::unique_lock<CCriticalSection> lock(m_audioCodecSection);
+  std::unique_lock lock(m_audioCodecSection);
 
   m_audioSampleRate = sampleRate;
 
@@ -386,14 +386,14 @@ void CProcessInfo::SetAudioSampleRate(int sampleRate)
 
 int CProcessInfo::GetAudioSampleRate()
 {
-  std::unique_lock<CCriticalSection> lock(m_audioCodecSection);
+  std::unique_lock lock(m_audioCodecSection);
 
   return m_audioSampleRate;
 }
 
 void CProcessInfo::SetAudioBitsPerSample(int bitsPerSample)
 {
-  std::unique_lock<CCriticalSection> lock(m_audioCodecSection);
+  std::unique_lock lock(m_audioCodecSection);
 
   m_audioBitsPerSample = bitsPerSample;
 
@@ -403,7 +403,7 @@ void CProcessInfo::SetAudioBitsPerSample(int bitsPerSample)
 
 int CProcessInfo::GetAudioBitsPerSample()
 {
-  std::unique_lock<CCriticalSection> lock(m_audioCodecSection);
+  std::unique_lock lock(m_audioCodecSection);
 
   return m_audioBitsPerSample;
 }
@@ -415,7 +415,7 @@ bool CProcessInfo::AllowDTSHDDecode()
 
 void CProcessInfo::SetRenderClockSync(bool enabled)
 {
-  std::unique_lock<CCriticalSection> lock(m_renderSection);
+  std::unique_lock lock(m_renderSection);
 
   m_isClockSync = enabled;
 
@@ -425,14 +425,14 @@ void CProcessInfo::SetRenderClockSync(bool enabled)
 
 bool CProcessInfo::IsRenderClockSync()
 {
-  std::unique_lock<CCriticalSection> lock(m_renderSection);
+  std::unique_lock lock(m_renderSection);
 
   return m_isClockSync;
 }
 
 void CProcessInfo::UpdateRenderInfo(CRenderInfo &info)
 {
-  std::unique_lock<CCriticalSection> lock(m_renderSection);
+  std::unique_lock lock(m_renderSection);
 
   m_renderInfo = info;
 
@@ -445,7 +445,7 @@ void CProcessInfo::UpdateRenderInfo(CRenderInfo &info)
 
 void CProcessInfo::UpdateRenderBuffers(int queued, int discard, int free)
 {
-  std::unique_lock<CCriticalSection> lock(m_renderSection);
+  std::unique_lock lock(m_renderSection);
   m_renderBufQueued = queued;
   m_renderBufDiscard = discard;
   m_renderBufFree = free;
@@ -453,7 +453,7 @@ void CProcessInfo::UpdateRenderBuffers(int queued, int discard, int free)
 
 void CProcessInfo::GetRenderBuffers(int &queued, int &discard, int &free)
 {
-  std::unique_lock<CCriticalSection> lock(m_renderSection);
+  std::unique_lock lock(m_renderSection);
   queued = m_renderBufQueued;
   discard = m_renderBufDiscard;
   free = m_renderBufFree;
@@ -471,14 +471,14 @@ std::vector<AVPixelFormat> CProcessInfo::GetRenderFormats()
 //******************************************************************************
 void CProcessInfo::SeekFinished(int64_t offset)
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
   if (m_dataCache)
     m_dataCache->SeekFinished(offset);
 }
 
 void CProcessInfo::SetStateSeeking(bool active)
 {
-  std::unique_lock<CCriticalSection> lock(m_renderSection);
+  std::unique_lock lock(m_renderSection);
 
   m_stateSeeking = active;
 
@@ -488,28 +488,28 @@ void CProcessInfo::SetStateSeeking(bool active)
 
 bool CProcessInfo::IsSeeking()
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   return m_stateSeeking;
 }
 
 void CProcessInfo::SetStateRealtime(bool state)
 {
-  std::unique_lock<CCriticalSection> lock(m_renderSection);
+  std::unique_lock lock(m_renderSection);
 
   m_realTimeStream = state;
 }
 
 bool CProcessInfo::IsRealtimeStream()
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   return m_realTimeStream;
 }
 
 void CProcessInfo::SetSpeed(float speed)
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   m_speed = speed;
   m_newSpeed = speed;
@@ -520,7 +520,7 @@ void CProcessInfo::SetSpeed(float speed)
 
 void CProcessInfo::SetNewSpeed(float speed)
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   m_newSpeed = speed;
 
@@ -530,14 +530,14 @@ void CProcessInfo::SetNewSpeed(float speed)
 
 float CProcessInfo::GetNewSpeed()
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   return m_newSpeed;
 }
 
 void CProcessInfo::SetFrameAdvance(bool fa)
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   m_frameAdvance = fa;
 
@@ -547,14 +547,14 @@ void CProcessInfo::SetFrameAdvance(bool fa)
 
 bool CProcessInfo::IsFrameAdvance()
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   return m_frameAdvance;
 }
 
 void CProcessInfo::SetTempo(float tempo)
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   m_tempo = tempo;
   m_newTempo = tempo;
@@ -565,7 +565,7 @@ void CProcessInfo::SetTempo(float tempo)
 
 void CProcessInfo::SetNewTempo(float tempo)
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   m_newTempo = tempo;
 
@@ -575,7 +575,7 @@ void CProcessInfo::SetNewTempo(float tempo)
 
 float CProcessInfo::GetNewTempo()
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   return m_newTempo;
 }
@@ -618,7 +618,7 @@ int CProcessInfo::GetLevelVQ()
 
 void CProcessInfo::SetGuiRender(bool gui)
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   bool change = (m_renderGuiLayer != gui);
   m_renderGuiLayer = gui;
@@ -631,14 +631,14 @@ void CProcessInfo::SetGuiRender(bool gui)
 
 bool CProcessInfo::GetGuiRender()
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   return m_renderGuiLayer;
 }
 
 void CProcessInfo::SetVideoRender(bool video)
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   bool change = (m_renderVideoLayer != video);
   m_renderVideoLayer = video;
@@ -651,14 +651,14 @@ void CProcessInfo::SetVideoRender(bool video)
 
 bool CProcessInfo::GetVideoRender()
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
 
   return m_renderVideoLayer;
 }
 
 void CProcessInfo::SetPlayTimes(time_t start, int64_t current, int64_t min, int64_t max)
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
   m_startTime = start;
   m_time = current;
   m_timeMin = min;
@@ -672,7 +672,7 @@ void CProcessInfo::SetPlayTimes(time_t start, int64_t current, int64_t min, int6
 
 int64_t CProcessInfo::GetMaxTime()
 {
-  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  std::unique_lock lock(m_stateSection);
   return m_timeMax;
 }
 
@@ -681,18 +681,18 @@ int64_t CProcessInfo::GetMaxTime()
 //******************************************************************************
 CVideoSettings CProcessInfo::GetVideoSettings()
 {
-  std::unique_lock<CCriticalSection> lock(m_settingsSection);
+  std::unique_lock lock(m_settingsSection);
   return m_videoSettings;
 }
 
 CVideoSettingsLocked& CProcessInfo::GetVideoSettingsLocked()
 {
-  std::unique_lock<CCriticalSection> lock(m_settingsSection);
+  std::unique_lock lock(m_settingsSection);
   return *m_videoSettingsLocked;
 }
 
 void CProcessInfo::SetVideoSettings(CVideoSettings &settings)
 {
-  std::unique_lock<CCriticalSection> lock(m_settingsSection);
+  std::unique_lock lock(m_settingsSection);
   m_videoSettings = settings;
 }

--- a/xbmc/cores/VideoPlayer/Process/X11/ProcessInfoX11.cpp
+++ b/xbmc/cores/VideoPlayer/Process/X11/ProcessInfoX11.cpp
@@ -31,7 +31,7 @@ void CProcessInfoX11::SetSwDeinterlacingMethods()
   std::list<EINTERLACEMETHOD> methods;
   {
     // get the current methods
-    std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+    std::unique_lock lock(m_videoCodecSection);
     methods = m_deintMethods;
   }
   // add bob and blend deinterlacer for osx

--- a/xbmc/cores/VideoPlayer/Process/ios/ProcessInfoIos.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ios/ProcessInfoIos.cpp
@@ -31,7 +31,7 @@ void CProcessInfoIOS::SetSwDeinterlacingMethods()
   std::list<EINTERLACEMETHOD> methods;
   {
     // get the current methods
-    std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+    std::unique_lock lock(m_videoCodecSection);
     methods = m_deintMethods;
   }
   // add bob deinterlacer for ios

--- a/xbmc/cores/VideoPlayer/Process/osx/ProcessInfoOSX.cpp
+++ b/xbmc/cores/VideoPlayer/Process/osx/ProcessInfoOSX.cpp
@@ -32,7 +32,7 @@ void CProcessInfoOSX::SetSwDeinterlacingMethods()
   std::list<EINTERLACEMETHOD> methods;
   {
     // get the current methods
-    std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+    std::unique_lock lock(m_videoCodecSection);
     methods = m_deintMethods;
   }
   // add bob and blend deinterlacer for osx

--- a/xbmc/cores/VideoPlayer/Process/wayland/ProcessInfoWayland.cpp
+++ b/xbmc/cores/VideoPlayer/Process/wayland/ProcessInfoWayland.cpp
@@ -37,7 +37,7 @@ void CProcessInfoWayland::SetSwDeinterlacingMethods()
   std::list<EINTERLACEMETHOD> methods;
   {
     // get the current methods
-    std::unique_lock<CCriticalSection> lock(m_videoCodecSection);
+    std::unique_lock lock(m_videoCodecSection);
     methods = m_deintMethods;
   }
   // add bob and blend deinterlacer

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3279,7 +3279,7 @@ void CVideoPlayer::SetPlaySpeed(int speed)
 
 bool CVideoPlayer::CanPause() const
 {
-  std::unique_lock<CCriticalSection> lock(m_StateSection);
+  std::unique_lock lock(m_StateSection);
   return m_State.canpause;
 }
 
@@ -3323,7 +3323,7 @@ bool CVideoPlayer::IsPassthrough() const
 
 bool CVideoPlayer::CanSeek() const
 {
-  std::unique_lock<CCriticalSection> lock(m_StateSection);
+  std::unique_lock lock(m_StateSection);
   return m_State.canseek;
 }
 
@@ -3443,7 +3443,7 @@ void CVideoPlayer::GetGeneralInfo(std::string& strGeneralInfo)
       dDiff = (apts - vpts) / DVD_TIME_BASE;
 
     std::string strBuf;
-    std::unique_lock<CCriticalSection> lock(m_StateSection);
+    std::unique_lock lock(m_StateSection);
     if (m_State.cache_bytes >= 0)
     {
       strBuf += StringUtils::Format("forward: {} / {:2.0f}% / {:6.3f}s / {:.3f}%",
@@ -3478,7 +3478,7 @@ float CVideoPlayer::GetPercentage()
 
 float CVideoPlayer::GetCachePercentage() const
 {
-  std::unique_lock<CCriticalSection> lock(m_StateSection);
+  std::unique_lock lock(m_StateSection);
   return (float) (m_State.cache_offset * 100); // NOTE: Percentage returned is relative
 }
 
@@ -3615,7 +3615,7 @@ bool CVideoPlayer::SeekTimeRelative(int64_t iTime)
 // return the time in milliseconds
 int64_t CVideoPlayer::GetTime()
 {
-  std::unique_lock<CCriticalSection> lock(m_StateSection);
+  std::unique_lock lock(m_StateSection);
   return llrint(m_State.time);
 }
 
@@ -4723,19 +4723,19 @@ bool CVideoPlayer::IsInMenuInternal() const
 
 bool CVideoPlayer::IsInMenu() const
 {
-  std::unique_lock<CCriticalSection> lock(m_StateSection);
+  std::unique_lock lock(m_StateSection);
   return m_State.isInMenu;
 }
 
 MenuType CVideoPlayer::GetSupportedMenuType() const
 {
-  std::unique_lock<CCriticalSection> lock(m_StateSection);
+  std::unique_lock lock(m_StateSection);
   return m_State.menuType;
 }
 
 std::string CVideoPlayer::GetPlayerState()
 {
-  std::unique_lock<CCriticalSection> lock(m_StateSection);
+  std::unique_lock lock(m_StateSection);
   return m_State.player_state;
 }
 
@@ -4747,19 +4747,19 @@ bool CVideoPlayer::SetPlayerState(const std::string& state)
 
 int CVideoPlayer::GetChapterCount() const
 {
-  std::unique_lock<CCriticalSection> lock(m_StateSection);
+  std::unique_lock lock(m_StateSection);
   return m_State.chapters.size();
 }
 
 int CVideoPlayer::GetChapter() const
 {
-  std::unique_lock<CCriticalSection> lock(m_StateSection);
+  std::unique_lock lock(m_StateSection);
   return m_State.chapter;
 }
 
 void CVideoPlayer::GetChapterName(std::string& strChapterName, int chapterIdx) const
 {
-  std::unique_lock<CCriticalSection> lock(m_StateSection);
+  std::unique_lock lock(m_StateSection);
   if (chapterIdx == -1 && m_State.chapter > 0 && m_State.chapter <= (int) m_State.chapters.size())
     strChapterName = m_State.chapters[m_State.chapter - 1].first;
   else if (chapterIdx > 0 && chapterIdx <= (int) m_State.chapters.size())
@@ -4785,7 +4785,7 @@ int CVideoPlayer::SeekChapter(int iChapter)
 
 int64_t CVideoPlayer::GetChapterPos(int chapterIdx) const
 {
-  std::unique_lock<CCriticalSection> lock(m_StateSection);
+  std::unique_lock lock(m_StateSection);
   if (chapterIdx > 0 && chapterIdx <= (int) m_State.chapters.size())
     return m_State.chapters[chapterIdx - 1].second;
 
@@ -4812,13 +4812,13 @@ void CVideoPlayer::AddSubtitle(const std::string& strSubPath)
 
 bool CVideoPlayer::IsCaching() const
 {
-  std::unique_lock<CCriticalSection> lock(m_StateSection);
+  std::unique_lock lock(m_StateSection);
   return !m_State.isInMenu && m_State.caching;
 }
 
 int CVideoPlayer::GetCacheLevel() const
 {
-  std::unique_lock<CCriticalSection> lock(m_StateSection);
+  std::unique_lock lock(m_StateSection);
   return (int)(m_State.cache_level * 100);
 }
 
@@ -5133,7 +5133,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
 
   m_processInfo->SetPlayTimes(state.startTime, state.time, state.timeMin, state.timeMax);
 
-  std::unique_lock<CCriticalSection> lock(m_StateSection);
+  std::unique_lock lock(m_StateSection);
   m_State = state;
 }
 
@@ -5357,14 +5357,14 @@ void CVideoPlayer::UpdateFileItemStreamDetails(CFileItem& item)
 
 void CVideoPlayer::UpdateContent()
 {
-  std::unique_lock<CCriticalSection> lock(m_content.m_section);
+  std::unique_lock lock(m_content.m_section);
   m_content.m_selectionStreams = m_SelectionStreams;
   m_content.m_programs = m_programs;
 }
 
 void CVideoPlayer::UpdateContentState()
 {
-  std::unique_lock<CCriticalSection> lock(m_content.m_section);
+  std::unique_lock lock(m_content.m_section);
 
   m_content.m_videoIndex = m_SelectionStreams.TypeIndexOf(STREAM_VIDEO, m_CurrentVideo.source,
                                                       m_CurrentVideo.demuxerId, m_CurrentVideo.id);
@@ -5396,7 +5396,7 @@ void CVideoPlayer::UpdateContentState()
 
 void CVideoPlayer::GetVideoStreamInfo(int streamId, VideoStreamInfo& info) const
 {
-  std::unique_lock<CCriticalSection> lock(m_content.m_section);
+  std::unique_lock lock(m_content.m_section);
 
   if (streamId == CURRENT_STREAM)
     streamId = m_content.m_videoIndex;
@@ -5431,13 +5431,13 @@ void CVideoPlayer::GetVideoStreamInfo(int streamId, VideoStreamInfo& info) const
 
 int CVideoPlayer::GetVideoStreamCount() const
 {
-  std::unique_lock<CCriticalSection> lock(m_content.m_section);
+  std::unique_lock lock(m_content.m_section);
   return m_content.m_selectionStreams.CountType(STREAM_VIDEO);
 }
 
 int CVideoPlayer::GetVideoStream() const
 {
-  std::unique_lock<CCriticalSection> lock(m_content.m_section);
+  std::unique_lock lock(m_content.m_section);
   return m_content.m_videoIndex;
 }
 
@@ -5450,7 +5450,7 @@ void CVideoPlayer::SetVideoStream(int iStream)
 
 void CVideoPlayer::GetAudioStreamInfo(int index, AudioStreamInfo& info) const
 {
-  std::unique_lock<CCriticalSection> lock(m_content.m_section);
+  std::unique_lock lock(m_content.m_section);
 
   if (index == CURRENT_STREAM)
     index = m_content.m_audioIndex;
@@ -5478,13 +5478,13 @@ void CVideoPlayer::GetAudioStreamInfo(int index, AudioStreamInfo& info) const
 
 int CVideoPlayer::GetAudioStreamCount() const
 {
-  std::unique_lock<CCriticalSection> lock(m_content.m_section);
+  std::unique_lock lock(m_content.m_section);
   return m_content.m_selectionStreams.CountType(STREAM_AUDIO);
 }
 
 int CVideoPlayer::GetAudioStream()
 {
-  std::unique_lock<CCriticalSection> lock(m_content.m_section);
+  std::unique_lock lock(m_content.m_section);
   return m_content.m_audioIndex;
 }
 
@@ -5497,7 +5497,7 @@ void CVideoPlayer::SetAudioStream(int iStream)
 
 void CVideoPlayer::GetSubtitleStreamInfo(int index, SubtitleStreamInfo& info) const
 {
-  std::unique_lock<CCriticalSection> lock(m_content.m_section);
+  std::unique_lock lock(m_content.m_section);
 
   if (index == CURRENT_STREAM)
     index = m_content.m_subtitleIndex;
@@ -5531,19 +5531,19 @@ void CVideoPlayer::SetSubtitle(int iStream)
 
 int CVideoPlayer::GetSubtitleCount() const
 {
-  std::unique_lock<CCriticalSection> lock(m_content.m_section);
+  std::unique_lock lock(m_content.m_section);
   return m_content.m_selectionStreams.CountType(STREAM_SUBTITLE);
 }
 
 int CVideoPlayer::GetSubtitle()
 {
-  std::unique_lock<CCriticalSection> lock(m_content.m_section);
+  std::unique_lock lock(m_content.m_section);
   return m_content.m_subtitleIndex;
 }
 
 int CVideoPlayer::GetPrograms(std::vector<ProgramInfo>& programs)
 {
-  std::unique_lock<CCriticalSection> lock(m_content.m_section);
+  std::unique_lock lock(m_content.m_section);
   programs = m_programs;
   return programs.size();
 }
@@ -5555,7 +5555,7 @@ void CVideoPlayer::SetProgram(int progId)
 
 int CVideoPlayer::GetProgramsCount() const
 {
-  std::unique_lock<CCriticalSection> lock(m_content.m_section);
+  std::unique_lock lock(m_content.m_section);
   return m_programs.size();
 }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -220,7 +220,7 @@ void CVideoPlayerAudio::UpdatePlayerInfo()
   info.passthrough = m_pAudioCodec && m_pAudioCodec->NeedPassthrough();
 
   {
-    std::unique_lock<CCriticalSection> lock(m_info_section);
+    std::unique_lock lock(m_info_section);
     m_info = info;
   }
 }
@@ -676,7 +676,7 @@ bool CVideoPlayerAudio::SwitchCodecIfNeeded()
 
 std::string CVideoPlayerAudio::GetPlayerInfo()
 {
-  std::unique_lock<CCriticalSection> lock(m_info_section);
+  std::unique_lock lock(m_info_section);
   return m_info.info;
 }
 
@@ -687,6 +687,6 @@ int CVideoPlayerAudio::GetAudioChannels()
 
 bool CVideoPlayerAudio::IsPassthrough() const
 {
-  std::unique_lock<CCriticalSection> lock(m_info_section);
+  std::unique_lock lock(m_info_section);
   return m_info.passthrough;
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -61,7 +61,7 @@ public:
 
   double GetCurrentPts() override
   {
-    std::unique_lock<CCriticalSection> lock(m_info_section);
+    std::unique_lock lock(m_info_section);
     return m_info.pts;
   }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.cpp
@@ -141,7 +141,7 @@ void CVideoPlayerAudioID3::Process()
 
     if (pMsg->IsType(CDVDMsg::DEMUXER_PACKET))
     {
-      std::unique_lock<CCriticalSection> lock(m_critSection);
+      std::unique_lock lock(m_critSection);
       DemuxPacket* pPacket = std::static_pointer_cast<CDVDMsgDemuxerPacket>(pMsg)->GetPacket();
       if (pPacket)
         ProcessID3(pPacket->pData, pPacket->iSize);

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -552,7 +552,7 @@ void CDVDRadioRDSData::CloseStream(bool bWaitForBuffers)
 
 void CDVDRadioRDSData::ResetRDSCache()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_currentFileUpdate = false;
 
@@ -632,7 +632,7 @@ void CDVDRadioRDSData::Process()
 
     if (pMsg->IsType(CDVDMsg::DEMUXER_PACKET))
     {
-      std::unique_lock<CCriticalSection> lock(m_critSection);
+      std::unique_lock lock(m_critSection);
 
       DemuxPacket* pPacket = std::static_pointer_cast<CDVDMsgDemuxerPacket>(pMsg)->GetPacket();
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
@@ -39,7 +39,7 @@ void CVideoPlayerSubtitle::Flush()
 
 void CVideoPlayerSubtitle::SendMessage(std::shared_ptr<CDVDMsg> pMsg, int priority)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   if (pMsg->IsType(CDVDMsg::DEMUXER_PACKET))
   {
@@ -115,7 +115,7 @@ void CVideoPlayerSubtitle::SendMessage(std::shared_ptr<CDVDMsg> pMsg, int priori
 
 bool CVideoPlayerSubtitle::OpenStream(CDVDStreamInfo &hints, std::string &filename)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   CloseStream(false);
   m_streaminfo = hints;
@@ -160,7 +160,7 @@ bool CVideoPlayerSubtitle::OpenStream(CDVDStreamInfo &hints, std::string &filena
 
 void CVideoPlayerSubtitle::CloseStream(bool bWaitForBuffers)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   m_pSubtitleFileParser.reset();
   m_pOverlayCodec.reset();
@@ -173,7 +173,7 @@ void CVideoPlayerSubtitle::CloseStream(bool bWaitForBuffers)
 
 void CVideoPlayerSubtitle::Process(double pts, double offset)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   if (m_pSubtitleFileParser)
   {

--- a/xbmc/cores/VideoPlayer/VideoPlayerTeletext.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerTeletext.cpp
@@ -142,7 +142,7 @@ void CDVDTeletextData::CloseStream(bool bWaitForBuffers)
 
 void CDVDTeletextData::ResetTeletextCache()
 {
-  std::unique_lock<CCriticalSection> lock(m_TXTCache->m_critSection);
+  std::unique_lock lock(m_TXTCache->m_critSection);
 
   /* Reset Data structures */
   for (auto& pages : m_TXTCache->astCachetable)
@@ -250,7 +250,7 @@ void CDVDTeletextData::Process()
 
     if (pMsg->IsType(CDVDMsg::DEMUXER_PACKET))
     {
-      std::unique_lock<CCriticalSection> lock(m_TXTCache->m_critSection);
+      std::unique_lock lock(m_TXTCache->m_critSection);
 
       DemuxPacket* pPacket = std::static_pointer_cast<CDVDMsgDemuxerPacket>(pMsg)->GetPacket();
       uint8_t *Datai       = pPacket->pData;
@@ -716,7 +716,7 @@ void CDVDTeletextData::Decode_p2829(unsigned char *vtxt_row, TextExtData_t **ptE
 
 void CDVDTeletextData::SavePage(int p, int sp, unsigned char* buffer)
 {
-  std::unique_lock<CCriticalSection> lock(m_TXTCache->m_critSection);
+  std::unique_lock lock(m_TXTCache->m_critSection);
   TextCachedPage_t* pg = m_TXTCache->astCachetable[p][sp];
   if (!pg)
   {
@@ -729,7 +729,7 @@ void CDVDTeletextData::SavePage(int p, int sp, unsigned char* buffer)
 
 void CDVDTeletextData::LoadPage(int p, int sp, unsigned char* buffer)
 {
-  std::unique_lock<CCriticalSection> lock(m_TXTCache->m_critSection);
+  std::unique_lock lock(m_TXTCache->m_critSection);
   TextCachedPage_t* pg = m_TXTCache->astCachetable[p][sp];
   if (!pg)
   {
@@ -742,7 +742,7 @@ void CDVDTeletextData::LoadPage(int p, int sp, unsigned char* buffer)
 
 void CDVDTeletextData::ErasePage(int magazine)
 {
-  std::unique_lock<CCriticalSection> lock(m_TXTCache->m_critSection);
+  std::unique_lock lock(m_TXTCache->m_critSection);
   TextCachedPage_t* pg = m_TXTCache->astCachetable[m_TXTCache->CurrentPage[magazine]][m_TXTCache->CurrentSubPage[magazine]];
   if (pg)
   {

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -812,7 +812,7 @@ void CVideoPlayerVideo::ProcessOverlays(const VideoPicture* pSource, double pts)
   VecOverlays overlays;
 
   {
-    std::unique_lock<CCriticalSection> lock(*m_pOverlayContainer);
+    std::unique_lock lock(*m_pOverlayContainer);
 
     VecOverlays* pVecOverlays = m_pOverlayContainer->GetOverlays();
     auto it = pVecOverlays->begin();

--- a/xbmc/cores/VideoPlayer/VideoReferenceClock.cpp
+++ b/xbmc/cores/VideoPlayer/VideoReferenceClock.cpp
@@ -52,7 +52,7 @@ void CVideoReferenceClock::Start()
 
 void CVideoReferenceClock::UpdateClock(int NrVBlanks, uint64_t time)
 {
-  std::unique_lock<CCriticalSection> lock(m_CritSection);
+  std::unique_lock lock(m_CritSection);
 
   m_VblankTime = time;
   UpdateClockInternal(NrVBlanks, true);
@@ -73,7 +73,7 @@ void CVideoReferenceClock::Process()
       UpdateRefreshrate();
     }
 
-    std::unique_lock<CCriticalSection> SingleLock(m_CritSection);
+    std::unique_lock SingleLock(m_CritSection);
     Now = CurrentHostCounter();
     m_CurrTime = Now;
     m_LastIntTime = m_CurrTime;
@@ -161,7 +161,7 @@ double CVideoReferenceClock::UpdateInterval() const
 //called from dvdclock to get the time
 int64_t CVideoReferenceClock::GetTime(bool interpolated /* = true*/)
 {
-  std::unique_lock<CCriticalSection> SingleLock(m_CritSection);
+  std::unique_lock SingleLock(m_CritSection);
 
   //when using vblank, get the time from that, otherwise use the systemclock
   if (m_UseVblank)
@@ -205,7 +205,7 @@ int64_t CVideoReferenceClock::GetTime(bool interpolated /* = true*/)
 
 void CVideoReferenceClock::SetSpeed(double Speed)
 {
-  std::unique_lock<CCriticalSection> SingleLock(m_CritSection);
+  std::unique_lock SingleLock(m_CritSection);
   //VideoPlayer can change the speed to fit the rereshrate
   if (m_UseVblank)
   {
@@ -219,7 +219,7 @@ void CVideoReferenceClock::SetSpeed(double Speed)
 
 double CVideoReferenceClock::GetSpeed()
 {
-  std::unique_lock<CCriticalSection> SingleLock(m_CritSection);
+  std::unique_lock SingleLock(m_CritSection);
 
   //VideoPlayer needs to know the speed for the resampler
   if (m_UseVblank)
@@ -230,7 +230,7 @@ double CVideoReferenceClock::GetSpeed()
 
 void CVideoReferenceClock::UpdateRefreshrate()
 {
-  std::unique_lock<CCriticalSection> SingleLock(m_CritSection);
+  std::unique_lock SingleLock(m_CritSection);
   m_RefreshRate = static_cast<double>(m_pVideoSync->GetFps());
   m_ClockSpeed = 1.0;
 
@@ -240,7 +240,7 @@ void CVideoReferenceClock::UpdateRefreshrate()
 //VideoPlayer needs to know the refreshrate for matching the fps of the video playing to it
 double CVideoReferenceClock::GetRefreshRate(double* interval /*= NULL*/)
 {
-  std::unique_lock<CCriticalSection> SingleLock(m_CritSection);
+  std::unique_lock SingleLock(m_CritSection);
 
   if (m_UseVblank)
   {
@@ -265,7 +265,7 @@ int64_t CVideoReferenceClock::TimeOfNextVblank() const
 //for the codec information screen
 bool CVideoReferenceClock::GetClockInfo(int& MissedVblanks, double& ClockSpeed, double& RefreshRate) const
 {
-  std::unique_lock<CCriticalSection> SingleLock(m_CritSection);
+  std::unique_lock SingleLock(m_CritSection);
 
   if (m_UseVblank)
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
@@ -37,7 +37,7 @@ CEnumeratorHD::CEnumeratorHD()
 
 CEnumeratorHD::~CEnumeratorHD()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   DX::Windowing()->Unregister(this);
   UnInit();
 }
@@ -49,7 +49,7 @@ void CEnumeratorHD::UnInit()
 
 void CEnumeratorHD::Close()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   m_pEnumerator1 = nullptr;
   m_pEnumerator = nullptr;
   m_pVideoDevice = nullptr;
@@ -59,7 +59,7 @@ bool CEnumeratorHD::Open(unsigned int width, unsigned int height, DXGI_FORMAT in
 {
   Close();
 
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   m_width = width;
   m_height = height;
   m_input_dxgi_format = input_dxgi_format;
@@ -108,7 +108,7 @@ bool CEnumeratorHD::OpenEnumerator()
 
 ProcessorCapabilities CEnumeratorHD::ProbeProcessorCaps()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   if (!m_pEnumerator)
     return {};
@@ -307,7 +307,7 @@ bool CEnumeratorHD::CheckConversion(DXGI_FORMAT inputFormat,
                                     DXGI_FORMAT outputFormat,
                                     DXGI_COLOR_SPACE_TYPE outputCS)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   return CheckConversionInternal(inputFormat, inputCS, outputFormat, outputCS);
 }
 
@@ -367,7 +367,7 @@ ProcessorConversions CEnumeratorHD::ListConversions(
 void CEnumeratorHD::LogSupportedConversions(const DXGI_FORMAT inputFormat,
                                             const DXGI_COLOR_SPACE_TYPE inputNativeCS)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   if (!m_pEnumerator)
     return;
@@ -456,12 +456,12 @@ void CEnumeratorHD::LogSupportedConversions(const DXGI_FORMAT inputFormat,
 
 bool CEnumeratorHD::IsFormatSupportedInput(DXGI_FORMAT format)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   return IsFormatSupportedInternal(format, D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_INPUT);
 }
 bool CEnumeratorHD::IsFormatSupportedOutput(DXGI_FORMAT format)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   return IsFormatSupportedInternal(format, D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_OUTPUT);
 }
 
@@ -486,7 +486,7 @@ bool CEnumeratorHD::IsFormatSupportedInternal(DXGI_FORMAT format,
 
 ComPtr<ID3D11VideoProcessor> CEnumeratorHD::CreateVideoProcessor(UINT RateConversionIndex)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   // Not initialized yet
   if (!m_pEnumerator)
@@ -510,7 +510,7 @@ ComPtr<ID3D11VideoProcessor> CEnumeratorHD::CreateVideoProcessor(UINT RateConver
 ComPtr<ID3D11VideoProcessorInputView> CEnumeratorHD::CreateVideoProcessorInputView(
     ID3D11Resource* pResource, const D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC* pDesc)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   // Not initialized yet
   if (!m_pEnumerator)
@@ -531,7 +531,7 @@ ComPtr<ID3D11VideoProcessorInputView> CEnumeratorHD::CreateVideoProcessorInputVi
 ComPtr<ID3D11VideoProcessorOutputView> CEnumeratorHD::CreateVideoProcessorOutputView(
     ID3D11Resource* pResource, const D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC* pDesc)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   // Not initialized yet
   if (!m_pEnumerator)
@@ -550,7 +550,7 @@ ComPtr<ID3D11VideoProcessorOutputView> CEnumeratorHD::CreateVideoProcessorOutput
 
 ProcessorConversions CEnumeratorHD::SupportedConversions(const SupportedConversionsArgs& args)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   // Not initialized yet
   if (!m_pEnumerator)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -195,14 +195,14 @@ public:
   // ID3DResource overrides
   void OnCreateDevice() override
   {
-    std::unique_lock<CCriticalSection> lock(m_section);
+    std::unique_lock lock(m_section);
     if (m_width > 0 && m_height > 0)
       OpenEnumerator();
   }
 
   void OnDestroyDevice(bool) override
   {
-    std::unique_lock<CCriticalSection> lock(m_section);
+    std::unique_lock lock(m_section);
     UnInit();
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -72,14 +72,14 @@ CProcessorHD::~CProcessorHD()
 
 void CProcessorHD::UnInit()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   m_enumerator = nullptr;
   Close();
 }
 
 void CProcessorHD::Close()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   m_pVideoProcessor = nullptr;
   m_pVideoContext = nullptr;
   m_pVideoDevice = nullptr;
@@ -133,7 +133,7 @@ bool CProcessorHD::Open(const VideoPicture& picture,
 {
   Close();
 
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   m_color_primaries = picture.color_primaries;
   m_color_transfer = picture.color_transfer;
@@ -147,7 +147,7 @@ bool CProcessorHD::Open(const VideoPicture& picture,
 
 bool CProcessorHD::ReInit()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   Close();
 
   if (!InitProcessor())
@@ -161,7 +161,7 @@ bool CProcessorHD::ReInit()
 
 bool CProcessorHD::OpenProcessor()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   if ((!m_pVideoDevice || !m_pVideoContext || !m_enumerator || !m_procCaps.m_valid) && !ReInit())
   {
@@ -388,7 +388,7 @@ bool CProcessorHD::CheckVideoParameters(const CRect& src,
 
 bool CProcessorHD::Render(CRect src, CRect dst, ID3D11Resource* target, CRenderBuffer** views, DWORD flags, UINT frameIdx, UINT rotation, float contrast, float brightness)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   // restore processor if it was lost
   if (!m_pVideoProcessor && !OpenProcessor())
@@ -643,7 +643,7 @@ void CProcessorHD::EnableNvidiaRTXVideoSuperResolution()
 
 bool CProcessorHD::SetConversion(const ProcessorConversion& conversion)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   if (!m_enumerator)
     return false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -50,7 +50,7 @@ public:
   void OnCreateDevice() override  {}
   void OnDestroyDevice(bool) override
   {
-    std::unique_lock<CCriticalSection> lock(m_section);
+    std::unique_lock lock(m_section);
     UnInit();
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -1041,7 +1041,7 @@ void CLinuxRendererGL::LoadShaders(int field)
 void CLinuxRendererGL::UnInit()
 {
   CLog::Log(LOGDEBUG, "LinuxRendererGL: Cleaning up GL resources");
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   glFinish();
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -777,7 +777,7 @@ void CLinuxRendererGLES::ReleaseShaders()
 void CLinuxRendererGLES::UnInit()
 {
   CLog::Log(LOGDEBUG, "LinuxRendererGLES: Cleaning up GLES resources");
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   glFinish();
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -57,7 +57,7 @@ CRenderer::~CRenderer()
 
 void CRenderer::AddOverlay(std::shared_ptr<CDVDOverlay> o, double pts, int index)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   SElement   e;
   e.pts = pts;
@@ -84,7 +84,7 @@ void CRenderer::UnInit()
 
 void CRenderer::Flush()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   for(std::vector<SElement>& buffer : m_buffers)
     Release(buffer);
@@ -101,7 +101,7 @@ void CRenderer::Reset()
 
 void CRenderer::Release(int idx)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   Release(m_buffers[idx]);
 }
 
@@ -140,7 +140,7 @@ void CRenderer::ReleaseUnused()
 
 void CRenderer::Render(int idx, float depth)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   std::vector<SElement>& list = m_buffers[idx];
   for(std::vector<SElement>::iterator it = list.begin(); it != list.end(); ++it)
@@ -250,7 +250,7 @@ bool CRenderer::HasOverlay(int idx)
 {
   bool hasOverlay = false;
 
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   std::vector<SElement>& list = m_buffers[idx];
   for(std::vector<SElement>::iterator it = list.begin(); it != list.end(); ++it)
@@ -287,7 +287,7 @@ void CRenderer::SetStereoMode(const std::string &stereomode)
 
 void CRenderer::SetSubtitleVerticalPosition(const int value, bool save)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   m_subtitlePosition = value;
 
   if (save && m_subtitleAlign == SUBTITLES::Align::MANUAL)
@@ -594,7 +594,7 @@ void CRenderer::Notify(const Observable& obs, const ObservableMessage msg)
     }
     case ObservableMessagePositionChanged:
     {
-      std::unique_lock<CCriticalSection> lock(m_section);
+      std::unique_lock lock(m_section);
       m_subtitlePosResInfo = POSRESINFO_UNSET;
       break;
     }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderFactory.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderFactory.cpp
@@ -18,7 +18,7 @@ std::map<std::string, VIDEOPLAYER::CreateRenderer> CRendererFactory::m_renderers
 
 CBaseRenderer* CRendererFactory::CreateRenderer(const std::string& id, CVideoBuffer* buffer)
 {
-  std::unique_lock<CCriticalSection> lock(renderSection);
+  std::unique_lock lock(renderSection);
 
   auto it = m_renderers.find(id);
   if (it != m_renderers.end())
@@ -31,7 +31,7 @@ CBaseRenderer* CRendererFactory::CreateRenderer(const std::string& id, CVideoBuf
 
 std::vector<std::string> CRendererFactory::GetRenderers()
 {
-  std::unique_lock<CCriticalSection> lock(renderSection);
+  std::unique_lock lock(renderSection);
 
   std::vector<std::string> ret;
   ret.reserve(m_renderers.size());
@@ -44,14 +44,14 @@ std::vector<std::string> CRendererFactory::GetRenderers()
 
 void CRendererFactory::RegisterRenderer(const std::string& id, ::CreateRenderer createFunc)
 {
-  std::unique_lock<CCriticalSection> lock(renderSection);
+  std::unique_lock lock(renderSection);
 
   m_renderers[id] = createFunc;
 }
 
 void CRendererFactory::ClearRenderer()
 {
-  std::unique_lock<CCriticalSection> lock(renderSection);
+  std::unique_lock lock(renderSection);
 
   m_renderers.clear();
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
@@ -249,14 +249,14 @@ void CWinRenderer::SetBufferSize(int numBuffers)
 
 void CWinRenderer::PreInit()
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   m_bConfigured = false;
   UnInit();
 }
 
 void CWinRenderer::UnInit()
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   m_renderer.reset();
   m_bConfigured = false;

--- a/xbmc/cores/VideoSettings.cpp
+++ b/xbmc/cores/VideoSettings.cpp
@@ -91,50 +91,50 @@ CVideoSettingsLocked::CVideoSettingsLocked(CVideoSettings &vs, CCriticalSection 
 
 void CVideoSettingsLocked::SetSubtitleStream(int stream)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_videoSettings.m_SubtitleStream = stream;
 }
 
 void CVideoSettingsLocked::SetSubtitleVisible(bool visible)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_videoSettings.m_SubtitleOn = visible;
 }
 
 void CVideoSettingsLocked::SetAudioStream(int stream)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_videoSettings.m_AudioStream = stream;
 }
 
 void CVideoSettingsLocked::SetVideoStream(int stream)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_videoSettings.m_VideoStream = stream;
 }
 
 void CVideoSettingsLocked::SetAudioDelay(float delay)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_videoSettings.m_AudioDelay = delay;
 }
 
 void CVideoSettingsLocked::SetSubtitleDelay(float delay)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_videoSettings.m_SubtitleDelay = delay;
 }
 
 void CVideoSettingsLocked::SetSubtitleVerticalPosition(int value, bool save)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_videoSettings.m_subtitleVerticalPosition = value;
   m_videoSettings.m_subtitleVerticalPositionSave = save;
 }
 
 void CVideoSettingsLocked::SetViewMode(int mode, float zoom, float par, float shift, bool stretch)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_videoSettings.m_ViewMode = mode;
   m_videoSettings.m_CustomZoomAmount = zoom;
   m_videoSettings.m_CustomPixelRatio = par;
@@ -144,6 +144,6 @@ void CVideoSettingsLocked::SetViewMode(int mode, float zoom, float par, float sh
 
 void CVideoSettingsLocked::SetVolumeAmplification(float amp)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_videoSettings.m_VolumeAmplification = amp;
 }

--- a/xbmc/cores/paplayer/AudioDecoder.cpp
+++ b/xbmc/cores/paplayer/AudioDecoder.cpp
@@ -50,7 +50,7 @@ CAudioDecoder::~CAudioDecoder()
 
 void CAudioDecoder::Destroy()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_status = STATUS_NO_FILE;
 
   m_pcmBuffer.Destroy();
@@ -66,7 +66,7 @@ bool CAudioDecoder::Create(const CFileItem &file, int64_t seekOffset)
 {
   Destroy();
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // reset our playback timing variables
   m_eof = false;
@@ -254,7 +254,7 @@ int CAudioDecoder::ReadSamples(int numsamples)
     m_status = STATUS_PLAYING;
 
   // grab a lock to ensure the codec is created at this point.
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_codec->m_format.m_dataFormat != AE_FMT_RAW)
   {

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -59,7 +59,7 @@ void CPlayerCoreFactory::OnSettingsLoaded()
 std::shared_ptr<IPlayer> CPlayerCoreFactory::CreatePlayer(const std::string& nameId,
                                                           IPlayerCallback& callback) const
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   size_t idx = GetPlayerIndex(nameId);
 
   if (m_vecPlayerConfigs.empty() || idx > m_vecPlayerConfigs.size())
@@ -70,7 +70,7 @@ std::shared_ptr<IPlayer> CPlayerCoreFactory::CreatePlayer(const std::string& nam
 
 void CPlayerCoreFactory::GetPlayers(std::vector<std::string>&players) const
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   players.clear();
   for (auto& conf : m_vecPlayerConfigs)
   {
@@ -81,7 +81,7 @@ void CPlayerCoreFactory::GetPlayers(std::vector<std::string>&players) const
 
 void CPlayerCoreFactory::GetPlayers(std::vector<std::string>&players, const bool audio, const bool video) const
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers: for video={}, audio={}", video, audio);
 
   for (auto& conf : m_vecPlayerConfigs)
@@ -193,7 +193,7 @@ void CPlayerCoreFactory::GetPlayers(const CFileItem& item, std::vector<std::stri
 
 int CPlayerCoreFactory::GetPlayerIndex(const std::string& strCoreName) const
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (!strCoreName.empty())
   {
     // Dereference "*default*player" aliases
@@ -218,7 +218,7 @@ int CPlayerCoreFactory::GetPlayerIndex(const std::string& strCoreName) const
 
 std::string CPlayerCoreFactory::GetPlayerName(size_t idx) const
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (m_vecPlayerConfigs.empty() || idx > m_vecPlayerConfigs.size())
     return "";
 
@@ -227,7 +227,7 @@ std::string CPlayerCoreFactory::GetPlayerName(size_t idx) const
 
 void CPlayerCoreFactory::GetPlayers(std::vector<std::string>&players, std::string &type) const
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   for (auto& config : m_vecPlayerConfigs)
   {
     if (config->m_type != type)
@@ -238,7 +238,7 @@ void CPlayerCoreFactory::GetPlayers(std::vector<std::string>&players, std::strin
 
 void CPlayerCoreFactory::GetRemotePlayers(std::vector<std::string>&players) const
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   for (auto& config : m_vecPlayerConfigs)
   {
     if (config->m_type != "remote")
@@ -249,7 +249,7 @@ void CPlayerCoreFactory::GetRemotePlayers(std::vector<std::string>&players) cons
 
 std::string CPlayerCoreFactory::GetPlayerType(const std::string& player) const
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   size_t idx = GetPlayerIndex(player);
 
   if (m_vecPlayerConfigs.empty() || idx > m_vecPlayerConfigs.size())
@@ -270,7 +270,7 @@ bool CPlayerCoreFactory::IsRemotePlayer(const std::string& player) const
 
 bool CPlayerCoreFactory::PlaysAudio(const std::string& player) const
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   size_t idx = GetPlayerIndex(player);
 
   if (m_vecPlayerConfigs.empty() || idx > m_vecPlayerConfigs.size())
@@ -281,7 +281,7 @@ bool CPlayerCoreFactory::PlaysAudio(const std::string& player) const
 
 bool CPlayerCoreFactory::PlaysVideo(const std::string& player) const
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   size_t idx = GetPlayerIndex(player);
 
   if (m_vecPlayerConfigs.empty() || idx > m_vecPlayerConfigs.size())
@@ -334,7 +334,7 @@ std::string CPlayerCoreFactory::SelectPlayerDialog(float posX, float posY) const
 
 bool CPlayerCoreFactory::LoadConfiguration(const std::string &file, bool clear)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   CLog::Log(LOGINFO, "Loading player core factory settings from {}.", file);
   if (!CFileUtils::Exists(file))
@@ -458,7 +458,7 @@ bool CPlayerCoreFactory::LoadConfiguration(const std::string &file, bool clear)
 
 void CPlayerCoreFactory::OnPlayerDiscovered(const std::string& id, const std::string& name)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   for (auto& playerConfig : m_vecPlayerConfigs)
   {
     if (playerConfig->GetId() == id)
@@ -487,7 +487,7 @@ void CPlayerCoreFactory::OnPlayerDiscovered(const std::string& id, const std::st
 
 void CPlayerCoreFactory::OnPlayerRemoved(const std::string& id)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   for (auto& playerConfig : m_vecPlayerConfigs)
   {
     if (playerConfig->GetId() == id)

--- a/xbmc/dialogs/GUIDialogBoxBase.cpp
+++ b/xbmc/dialogs/GUIDialogBoxBase.cpp
@@ -52,7 +52,7 @@ bool CGUIDialogBoxBase::IsConfirmed() const
 void CGUIDialogBoxBase::SetHeading(const CVariant& heading)
 {
   std::string label = GetLocalized(heading);
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (label != m_strHeading)
   {
     m_strHeading = label;
@@ -62,14 +62,14 @@ void CGUIDialogBoxBase::SetHeading(const CVariant& heading)
 
 bool CGUIDialogBoxBase::HasHeading() const
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   return !m_strHeading.empty();
 }
 
 void CGUIDialogBoxBase::SetLine(unsigned int iLine, const CVariant& line)
 {
   std::string label = GetLocalized(line);
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   std::vector<std::string> lines = StringUtils::Split(m_text, '\n');
   if (iLine >= lines.size())
     lines.resize(iLine+1);
@@ -81,7 +81,7 @@ void CGUIDialogBoxBase::SetLine(unsigned int iLine, const CVariant& line)
 void CGUIDialogBoxBase::SetText(const CVariant& text)
 {
   std::string label = GetLocalized(text);
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   StringUtils::Trim(label, "\n");
   if (label != m_text)
   {
@@ -92,7 +92,7 @@ void CGUIDialogBoxBase::SetText(const CVariant& text)
 
 bool CGUIDialogBoxBase::HasText() const
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   return !m_text.empty();
 }
 
@@ -102,7 +102,7 @@ void CGUIDialogBoxBase::SetChoice(int iButton, const CVariant &choice) // iButto
     return;
 
   std::string label = GetLocalized(choice);
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (label != m_strChoices[iButton])
   {
     m_strChoices[iButton] = label;
@@ -118,7 +118,7 @@ void CGUIDialogBoxBase::Process(unsigned int currentTime, CDirtyRegionList &dirt
     std::vector<std::string> choices;
     choices.reserve(DIALOG_MAX_CHOICES);
     {
-      std::unique_lock<CCriticalSection> lock(m_section);
+      std::unique_lock lock(m_section);
       heading = m_strHeading;
       text = m_text;
       for (const std::string& choice : m_strChoices)
@@ -154,7 +154,7 @@ void CGUIDialogBoxBase::OnInitWindow()
 
   // set initial labels
   {
-    std::unique_lock<CCriticalSection> lock(m_section);
+    std::unique_lock lock(m_section);
     for (int i = 0 ; i < DIALOG_MAX_CHOICES ; ++i)
     {
       if (m_strChoices[i].empty())
@@ -168,7 +168,7 @@ void CGUIDialogBoxBase::OnDeinitWindow(int nextWindowID)
 {
   // make sure we set default labels for heading, lines and choices
   {
-    std::unique_lock<CCriticalSection> lock(m_section);
+    std::unique_lock lock(m_section);
     m_strHeading.clear();
     m_text.clear();
     for (std::string& choice : m_strChoices)

--- a/xbmc/dialogs/GUIDialogCache.cpp
+++ b/xbmc/dialogs/GUIDialogCache.cpp
@@ -131,7 +131,7 @@ void CGUIDialogCache::Process()
 
       try
       {
-        std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+        std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
         m_pDlg->Progress();
         if( bSentCancel )
         {

--- a/xbmc/dialogs/GUIDialogExtendedProgressBar.cpp
+++ b/xbmc/dialogs/GUIDialogExtendedProgressBar.cpp
@@ -23,20 +23,20 @@
 
 std::string CGUIDialogProgressBarHandle::Text(void) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   std::string retVal(m_strText);
   return retVal;
 }
 
 void CGUIDialogProgressBarHandle::SetText(const std::string &strText)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strText = strText;
 }
 
 void CGUIDialogProgressBarHandle::SetTitle(const std::string &strTitle)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_strTitle = strTitle;
 }
 
@@ -59,7 +59,7 @@ CGUIDialogProgressBarHandle *CGUIDialogExtendedProgressBar::GetHandle(const std:
 {
   CGUIDialogProgressBarHandle *handle = new CGUIDialogProgressBarHandle(strTitle);
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     m_handles.push_back(handle);
   }
 
@@ -102,7 +102,7 @@ void CGUIDialogExtendedProgressBar::UpdateState(unsigned int currentTime)
   float  fProgress(-1.0f);
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     // delete finished items
     for (int iPtr = m_handles.size() - 1; iPtr >= 0; iPtr--)

--- a/xbmc/dialogs/GUIDialogKaiToast.cpp
+++ b/xbmc/dialogs/GUIDialogKaiToast.cpp
@@ -71,7 +71,7 @@ void CGUIDialogKaiToast::QueueNotification(const std::string& aImageFile, const 
 
 void CGUIDialogKaiToast::AddToQueue(const std::string& aImageFile, const eMessageType eType, const std::string& aCaption, const std::string& aDescription, unsigned int displayTime /*= TOAST_DISPLAY_TIME*/, bool withSound /*= true*/, unsigned int messageTime /*= TOAST_MESSAGE_TIME*/)
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
 
   if (!m_notifications.empty())
   {
@@ -95,7 +95,7 @@ void CGUIDialogKaiToast::AddToQueue(const std::string& aImageFile, const eMessag
 
 bool CGUIDialogKaiToast::DoWork()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
 
   if (!m_notifications.empty() &&
       CTimeUtils::GetFrameTime() - m_timer > m_toastMessageTime)
@@ -114,7 +114,7 @@ bool CGUIDialogKaiToast::DoWork()
     m_toastDisplayTime = toast.displayTime;
     m_toastMessageTime = toast.messageTime;
 
-    std::unique_lock<CCriticalSection> lock2(CServiceBroker::GetWinSystem()->GetGfxContext());
+    std::unique_lock lock2(CServiceBroker::GetWinSystem()->GetGfxContext());
 
     if(!Initialize())
       return false;
@@ -174,7 +174,7 @@ void CGUIDialogKaiToast::FrameMove()
         dynamic_cast<const CGUIFadeLabelControl*>(GetControl(POPUP_NOTIFICATION_BUTTON));
     if (notificationText)
     {
-      std::unique_lock<CCriticalSection> lock(m_critical);
+      std::unique_lock lock(m_critical);
       bClose = notificationText->AllLabelsShown() && m_notifications.empty();
     }
 

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -749,7 +749,7 @@ void CGUIDialogKeyboardGeneric::ChangeWordList(int direct)
 
 void CGUIDialogKeyboardGeneric::ShowWordList(int direct)
 {
-  std::unique_lock<CCriticalSection> lock(m_CS);
+  std::unique_lock lock(m_CS);
   std::wstring hzlist = L"";
   CServiceBroker::GetWinSystem()->GetGfxContext().SetScalingResolution(m_coordsRes, true);
   float width = m_listfont->GetCharWidth(L'<') + m_listfont->GetCharWidth(L'>');

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -29,7 +29,7 @@ CGUIDialogProgress::~CGUIDialogProgress(void) = default;
 
 void CGUIDialogProgress::Reset()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   m_iCurrent = 0;
   m_iMax = 0;
   m_percentage = 0;
@@ -43,7 +43,7 @@ void CGUIDialogProgress::Reset()
 
 void CGUIDialogProgress::SetCanCancel(bool bCanCancel)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   m_bCanCancel = bCanCancel;
   SetInvalid();
 }
@@ -68,7 +68,7 @@ void CGUIDialogProgress::Open(const std::string &param /* = "" */)
   CLog::Log(LOGDEBUG, "DialogProgress::Open called {}", m_active ? "(already running)!" : "");
 
   {
-    std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+    std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
     ShowProgressBar(true);
   }
 
@@ -190,7 +190,7 @@ bool CGUIDialogProgress::Abort()
 
 void CGUIDialogProgress::ShowProgressBar(bool bOnOff)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   m_showProgress = bOnOff;
   SetInvalid();
 }
@@ -224,7 +224,7 @@ void CGUIDialogProgress::UpdateControls()
   bool bShowCancel;
   std::array<bool, DIALOG_MAX_CHOICES> choices;
   {
-    std::unique_lock<CCriticalSection> lock(m_section);
+    std::unique_lock lock(m_section);
     bShowProgress = m_showProgress;
     bShowCancel = m_bCanCancel;
     choices = m_supportedChoices;

--- a/xbmc/dialogs/GUIDialogVolumeBar.cpp
+++ b/xbmc/dialogs/GUIDialogVolumeBar.cpp
@@ -61,21 +61,21 @@ bool CGUIDialogVolumeBar::OnMessage(CGUIMessage& message)
 
 void CGUIDialogVolumeBar::RegisterCallback(IGUIVolumeBarCallback *callback)
 {
-  std::unique_lock<CCriticalSection> lock(m_callbackMutex);
+  std::unique_lock lock(m_callbackMutex);
 
   m_callbacks.insert(callback);
 }
 
 void CGUIDialogVolumeBar::UnregisterCallback(IGUIVolumeBarCallback *callback)
 {
-  std::unique_lock<CCriticalSection> lock(m_callbackMutex);
+  std::unique_lock lock(m_callbackMutex);
 
   m_callbacks.erase(callback);
 }
 
 bool CGUIDialogVolumeBar::IsVolumeBarEnabled() const
 {
-  std::unique_lock<CCriticalSection> lock(m_callbackMutex);
+  std::unique_lock lock(m_callbackMutex);
 
   // Hide volume bar if any callbacks are shown
   for (const auto &callback : m_callbacks)

--- a/xbmc/events/EventLog.cpp
+++ b/xbmc/events/EventLog.cpp
@@ -66,7 +66,7 @@ Events CEventLog::Get(EventLevel level, bool includeHigherLevels /* = false */) 
 {
   Events events;
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   for (const auto& eventPtr : m_events)
   {
     if (eventPtr->GetLevel() == level ||
@@ -82,7 +82,7 @@ EventPtr CEventLog::Get(const std::string& eventPtrIdentifier) const
   if (eventPtrIdentifier.empty())
     return EventPtr();
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   const auto& eventPtr = m_eventsMap.find(eventPtrIdentifier);
   if (eventPtr == m_eventsMap.end())
     return EventPtr();
@@ -97,7 +97,7 @@ void CEventLog::Add(const EventPtr& eventPtr)
      (eventPtr->GetLevel() == EventLevel::Information && !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_EVENTLOG_ENABLED_NOTIFICATIONS)))
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (m_eventsMap.find(eventPtr->GetIdentifier()) != m_eventsMap.end())
     return;
 
@@ -159,7 +159,7 @@ void CEventLog::Remove(const std::string& eventPtrIdentifier)
   if (eventPtrIdentifier.empty())
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   const auto& itEvent = m_eventsMap.find(eventPtrIdentifier);
   if (itEvent == m_eventsMap.end())
     return;
@@ -173,7 +173,7 @@ void CEventLog::Remove(const std::string& eventPtrIdentifier)
 
 void CEventLog::Clear()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   m_events.clear();
   m_eventsMap.clear();
 }
@@ -195,7 +195,7 @@ bool CEventLog::Execute(const std::string& eventPtrIdentifier)
   if (eventPtrIdentifier.empty())
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   const auto& itEvent = m_eventsMap.find(eventPtrIdentifier);
   if (itEvent == m_eventsMap.end())
     return false;

--- a/xbmc/events/EventLogManager.cpp
+++ b/xbmc/events/EventLogManager.cpp
@@ -16,7 +16,7 @@
 
 CEventLog& CEventLogManager::GetEventLog(unsigned int profileId)
 {
-  std::unique_lock<CCriticalSection> lock(m_eventMutex);
+  std::unique_lock lock(m_eventMutex);
 
   auto eventLog = m_eventLogs.find(profileId);
   if (eventLog == m_eventLogs.end())

--- a/xbmc/filesystem/CircularCache.cpp
+++ b/xbmc/filesystem/CircularCache.cpp
@@ -69,7 +69,7 @@ void CCircularCache::Close()
 
 size_t CCircularCache::GetMaxWriteSize(const size_t& iRequestSize)
 {
-  std::unique_lock<CCriticalSection> lock(m_sync);
+  std::unique_lock lock(m_sync);
 
   size_t back  = (size_t)(m_cur - m_beg); // Backbuffer size
   size_t front = (size_t)(m_end - m_cur); // Frontbuffer size
@@ -100,7 +100,7 @@ size_t CCircularCache::GetMaxWriteSize(const size_t& iRequestSize)
  */
 int CCircularCache::WriteToCache(const char *buf, size_t len)
 {
-  std::unique_lock<CCriticalSection> lock(m_sync);
+  std::unique_lock lock(m_sync);
 
   // where are we in the buffer
   size_t pos   = m_end % m_size;
@@ -144,7 +144,7 @@ int CCircularCache::WriteToCache(const char *buf, size_t len)
  */
 int CCircularCache::ReadFromCache(char *buf, size_t len)
 {
-  std::unique_lock<CCriticalSection> lock(m_sync);
+  std::unique_lock lock(m_sync);
 
   size_t pos   = m_cur % m_size;
   size_t front = (size_t)(m_end - m_cur);
@@ -181,7 +181,7 @@ int CCircularCache::ReadFromCache(char *buf, size_t len)
  */
 int64_t CCircularCache::WaitForData(uint32_t minimum, std::chrono::milliseconds timeout)
 {
-  std::unique_lock<CCriticalSection> lock(m_sync);
+  std::unique_lock lock(m_sync);
   int64_t avail = m_end - m_cur;
 
   if (timeout == 0ms || IsEndOfInput())
@@ -204,7 +204,7 @@ int64_t CCircularCache::WaitForData(uint32_t minimum, std::chrono::milliseconds 
 
 int64_t CCircularCache::Seek(int64_t pos)
 {
-  std::unique_lock<CCriticalSection> lock(m_sync);
+  std::unique_lock lock(m_sync);
 
   // if seek is a bit over what we have, try to wait a few seconds for the data to be available.
   // we try to avoid a (heavy) seek on the source
@@ -237,7 +237,7 @@ int64_t CCircularCache::Seek(int64_t pos)
 
 bool CCircularCache::Reset(int64_t pos)
 {
-  std::unique_lock<CCriticalSection> lock(m_sync);
+  std::unique_lock lock(m_sync);
   if (IsCachedPosition(pos))
   {
     m_cur = pos;

--- a/xbmc/filesystem/DirectoryCache.cpp
+++ b/xbmc/filesystem/DirectoryCache.cpp
@@ -53,7 +53,7 @@ CDirectoryCache::~CDirectoryCache(void) = default;
 
 bool CDirectoryCache::GetDirectory(const std::string& strPath, CFileItemList &items, bool retrieveAll)
 {
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
 
   // Get rid of any URL options, else the compare may be wrong
   std::string storedPath = CURL(strPath).GetWithoutOptions();
@@ -94,7 +94,7 @@ void CDirectoryCache::SetDirectory(const std::string& strPath,
   // IDEALLY, any further processing on the item would actually create a new item
   // instead of altering it, but we can't really enforce that in an easy way, so
   // this is the best solution for now.
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
 
   // Get rid of any URL options, else the compare may be wrong
   std::string storedPath = CURL(strPath).GetWithoutOptions();
@@ -121,7 +121,7 @@ void CDirectoryCache::ClearFile(const std::string& strFile)
 
 void CDirectoryCache::ClearDirectory(const std::string& strPath)
 {
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
 
   // Get rid of any URL options, else the compare may be wrong
   std::string storedPath = CURL(strPath).GetWithoutOptions();
@@ -132,7 +132,7 @@ void CDirectoryCache::ClearDirectory(const std::string& strPath)
 
 void CDirectoryCache::ClearSubPaths(const std::string& strPath)
 {
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
 
   // Get rid of any URL options, else the compare may be wrong
   std::string storedPath = CURL(strPath).GetWithoutOptions();
@@ -149,7 +149,7 @@ void CDirectoryCache::ClearSubPaths(const std::string& strPath)
 
 void CDirectoryCache::AddFile(const std::string& strFile)
 {
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
 
   // Get rid of any URL options, else the compare may be wrong
   std::string strPath = URIUtils::GetDirectory(CURL(strFile).GetWithoutOptions());
@@ -167,7 +167,7 @@ void CDirectoryCache::AddFile(const std::string& strFile)
 
 bool CDirectoryCache::FileExists(const std::string& strFile, bool& bInCache)
 {
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
   bInCache = false;
 
   // Get rid of any URL options, else the compare may be wrong
@@ -196,7 +196,7 @@ bool CDirectoryCache::FileExists(const std::string& strFile, bool& bInCache)
 void CDirectoryCache::Clear()
 {
   // this routine clears everything
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
   m_cache.clear();
 }
 
@@ -224,7 +224,7 @@ void CDirectoryCache::ClearCache(std::set<std::string>& dirs)
 
 void CDirectoryCache::CheckIfFull()
 {
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
 
   // find the last accessed folder, and remove if the number of cached folders is too many
   auto lastAccessed = m_cache.end();
@@ -247,7 +247,7 @@ void CDirectoryCache::CheckIfFull()
 #ifdef _DEBUG
 void CDirectoryCache::PrintStats() const
 {
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
   CLog::Log(LOGDEBUG, "{} - total of {} cache hits, and {} cache misses", __FUNCTION__, m_cacheHits,
             m_cacheMisses);
   // run through and find the oldest and the number of items cached

--- a/xbmc/filesystem/DllLibCurl.cpp
+++ b/xbmc/filesystem/DllLibCurl.cpp
@@ -138,7 +138,7 @@ DllLibCurlGlobal::~DllLibCurlGlobal()
 
 void DllLibCurlGlobal::CheckIdle()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   /* 20 seconds idle time before closing handle */
   const unsigned int idletime = 30000;
 
@@ -175,7 +175,7 @@ void DllLibCurlGlobal::easy_acquire(const char* protocol,
 {
   assert(easy_handle != NULL);
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (auto& it : m_sessions)
   {
@@ -231,7 +231,7 @@ void DllLibCurlGlobal::easy_acquire(const char* protocol,
 
 void DllLibCurlGlobal::easy_release(CURL_HANDLE** easy_handle, CURLM** multi_handle)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   CURL_HANDLE* easy = NULL;
   CURLM* multi = NULL;
@@ -264,7 +264,7 @@ void DllLibCurlGlobal::easy_release(CURL_HANDLE** easy_handle, CURLM** multi_han
 
 CURL_HANDLE* DllLibCurlGlobal::easy_duphandle(CURL_HANDLE* easy_handle)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& it : m_sessions)
   {
@@ -284,7 +284,7 @@ void DllLibCurlGlobal::easy_duplicate(CURL_HANDLE* easy,
                                       CURL_HANDLE** easy_out,
                                       CURLM** multi_out)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (easy_out && easy)
     *easy_out = DllLibCurl::easy_duphandle(easy);

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -95,7 +95,7 @@ bool CFileCache::Open(const CURL& url)
 {
   Close();
 
-  std::unique_lock<CCriticalSection> lock(m_sync);
+  std::unique_lock lock(m_sync);
 
   m_sourcePath = url.GetRedacted();
 
@@ -468,7 +468,7 @@ int CFileCache::Stat(const CURL& url, struct __stat64* buffer)
 
 ssize_t CFileCache::Read(void* lpBuf, size_t uiBufSize)
 {
-  std::unique_lock<CCriticalSection> lock(m_sync);
+  std::unique_lock lock(m_sync);
   if (!m_pCache)
   {
     CLog::Log(LOGERROR, "CFileCache::{} - <{}> sanity failed. no cache strategy!", __FUNCTION__,
@@ -515,7 +515,7 @@ retry:
 
 int64_t CFileCache::Seek(int64_t iFilePosition, int iWhence)
 {
-  std::unique_lock<CCriticalSection> lock(m_sync);
+  std::unique_lock lock(m_sync);
 
   if (!m_pCache)
   {
@@ -579,7 +579,7 @@ void CFileCache::Close()
 {
   StopThread();
 
-  std::unique_lock<CCriticalSection> lock(m_sync);
+  std::unique_lock lock(m_sync);
   if (m_pCache)
     m_pCache->Close();
 

--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -103,7 +103,7 @@ bool CNFSDirectory::GetServerList(CFileItemList &items)
 
 bool CNFSDirectory::ResolveSymlink( const std::string &dirName, struct nfsdirent *dirent, CURL &resolvedUrl)
 {
-  std::unique_lock<CCriticalSection> lock(gNfsConnection);
+  std::unique_lock lock(gNfsConnection);
   int ret = 0;
   bool retVal = true;
   std::string fullpath = dirName;
@@ -204,7 +204,7 @@ bool CNFSDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   // We accept nfs://server/path[/file]]]]
   int ret = 0;
   KODI::TIME::FileTime fileTime, localTime;
-  std::unique_lock<CCriticalSection> lock(gNfsConnection);
+  std::unique_lock lock(gNfsConnection);
   std::string strDirName="";
   std::string myStrPath(url.Get());
   URIUtils::AddSlashAtEnd(myStrPath); //be sure the dir ends with a slash
@@ -317,7 +317,7 @@ bool CNFSDirectory::Create(const CURL& url2)
   int ret = 0;
   bool success=true;
 
-  std::unique_lock<CCriticalSection> lock(gNfsConnection);
+  std::unique_lock lock(gNfsConnection);
   std::string folderName(url2.Get());
   URIUtils::RemoveSlashAtEnd(folderName);//mkdir fails if a slash is at the end!!!
   CURL url(folderName);
@@ -339,7 +339,7 @@ bool CNFSDirectory::Remove(const CURL& url2)
 {
   int ret = 0;
 
-  std::unique_lock<CCriticalSection> lock(gNfsConnection);
+  std::unique_lock lock(gNfsConnection);
   std::string folderName(url2.Get());
   URIUtils::RemoveSlashAtEnd(folderName);//rmdir fails if a slash is at the end!!!
   CURL url(folderName);
@@ -363,7 +363,7 @@ bool CNFSDirectory::Exists(const CURL& url2)
 {
   int ret = 0;
 
-  std::unique_lock<CCriticalSection> lock(gNfsConnection);
+  std::unique_lock lock(gNfsConnection);
   std::string folderName(url2.Get());
   URIUtils::RemoveSlashAtEnd(folderName);//remove slash at end or URIUtils::GetFileName won't return what we want...
   CURL url(folderName);

--- a/xbmc/filesystem/PipeFile.cpp
+++ b/xbmc/filesystem/PipeFile.cpp
@@ -170,7 +170,7 @@ std::string CPipeFile::GetName() const
 
 void CPipeFile::OnPipeOverFlow()
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   for (size_t l=0; l<m_listeners.size(); l++)
     m_listeners[l]->OnPipeOverFlow();
 }
@@ -188,7 +188,7 @@ void CPipeFile::OnPipeUnderFlow()
 
 void CPipeFile::AddListener(IPipeListener *l)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   for (size_t i=0; i<m_listeners.size(); i++)
   {
     if (m_listeners[i] == l)
@@ -199,7 +199,7 @@ void CPipeFile::AddListener(IPipeListener *l)
 
 void CPipeFile::RemoveListener(IPipeListener *l)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   std::vector<XFILE::IPipeListener *>::iterator i = m_listeners.begin();
   while(i != m_listeners.end())
   {

--- a/xbmc/filesystem/PipesManager.cpp
+++ b/xbmc/filesystem/PipesManager.cpp
@@ -43,19 +43,19 @@ const std::string &Pipe::GetName()
 
 void Pipe::AddRef()
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   m_nRefCount++;
 }
 
 void Pipe::DecRef()
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   m_nRefCount--;
 }
 
 int  Pipe::RefCount()
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   return m_nRefCount;
 }
 
@@ -76,7 +76,7 @@ bool Pipe::IsEmpty()
 
 void Pipe::Flush()
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
 
   if (!m_bOpen || !m_bReadyForRead || m_bEof)
   {
@@ -88,7 +88,7 @@ void Pipe::Flush()
 
 int  Pipe::Read(char *buf, int nMaxSize, int nWaitMillis)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
 
   if (!m_bOpen)
   {
@@ -152,7 +152,7 @@ int  Pipe::Read(char *buf, int nMaxSize, int nWaitMillis)
 
 bool Pipe::Write(const char *buf, int nSize, int nWaitMillis)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   if (!m_bOpen)
     return false;
   bool bOk = false;
@@ -217,7 +217,7 @@ void Pipe::CheckStatus()
 
 void Pipe::Close()
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   m_bOpen = false;
   m_readEvent.Set();
   m_writeEvent.Set();
@@ -225,7 +225,7 @@ void Pipe::Close()
 
 void Pipe::AddListener(IPipeListener *l)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   for (size_t i=0; i<m_listeners.size(); i++)
   {
     if (m_listeners[i] == l)
@@ -236,7 +236,7 @@ void Pipe::AddListener(IPipeListener *l)
 
 void Pipe::RemoveListener(IPipeListener *l)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   std::vector<XFILE::IPipeListener *>::iterator i = m_listeners.begin();
   while(i != m_listeners.end())
   {
@@ -249,7 +249,7 @@ void Pipe::RemoveListener(IPipeListener *l)
 
 int	Pipe::GetAvailableRead()
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   return m_buffer.getMaxReadSize();
 }
 
@@ -263,7 +263,7 @@ PipesManager &PipesManager::GetInstance()
 
 std::string   PipesManager::GetUniquePipeName()
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   return StringUtils::Format("pipe://{}/", m_nGenIdHelper++);
 }
 
@@ -273,7 +273,7 @@ XFILE::Pipe *PipesManager::CreatePipe(const std::string &name, int nMaxPipeSize)
   if (pName.empty())
     pName = GetUniquePipeName();
 
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   if (m_pipes.find(pName) != m_pipes.end())
     return NULL;
 
@@ -284,7 +284,7 @@ XFILE::Pipe *PipesManager::CreatePipe(const std::string &name, int nMaxPipeSize)
 
 XFILE::Pipe *PipesManager::OpenPipe(const std::string &name)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   if (m_pipes.find(name) == m_pipes.end())
     return NULL;
   m_pipes[name]->AddRef();
@@ -293,7 +293,7 @@ XFILE::Pipe *PipesManager::OpenPipe(const std::string &name)
 
 void         PipesManager::ClosePipe(XFILE::Pipe *pipe)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   if (!pipe)
     return ;
 
@@ -308,7 +308,7 @@ void         PipesManager::ClosePipe(XFILE::Pipe *pipe)
 
 bool         PipesManager::Exists(const std::string &name)
 {
-  std::unique_lock<CCriticalSection> lock(m_lock);
+  std::unique_lock lock(m_lock);
   return (m_pipes.find(name) != m_pipes.end());
 }
 

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -166,7 +166,7 @@ bool CPluginDirectory::GetPluginResult(const std::string& strPath, CFileItem &re
 
 bool CPluginDirectory::AddItem(int handle, const CFileItem *item, int totalItems)
 {
-  std::unique_lock<CCriticalSection> lock(GetScriptsLock());
+  std::unique_lock lock(GetScriptsLock());
   CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (!dir)
     return false;
@@ -180,7 +180,7 @@ bool CPluginDirectory::AddItem(int handle, const CFileItem *item, int totalItems
 
 bool CPluginDirectory::AddItems(int handle, const CFileItemList *items, int totalItems)
 {
-  std::unique_lock<CCriticalSection> lock(GetScriptsLock());
+  std::unique_lock lock(GetScriptsLock());
   CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (!dir)
     return false;
@@ -195,7 +195,7 @@ bool CPluginDirectory::AddItems(int handle, const CFileItemList *items, int tota
 
 void CPluginDirectory::EndOfDirectory(int handle, bool success, bool replaceListing, bool cacheToDisc)
 {
-  std::unique_lock<CCriticalSection> lock(GetScriptsLock());
+  std::unique_lock lock(GetScriptsLock());
   CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (!dir)
     return;
@@ -219,7 +219,7 @@ void CPluginDirectory::AddSortMethod(int handle,
                                      const std::string& labelMask,
                                      const std::string& label2Mask)
 {
-  std::unique_lock<CCriticalSection> lock(GetScriptsLock());
+  std::unique_lock lock(GetScriptsLock());
   CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (!dir)
     return;
@@ -498,7 +498,7 @@ bool CPluginDirectory::RunScriptWithParams(const std::string& strPath, bool resu
 
 void CPluginDirectory::SetResolvedUrl(int handle, bool success, const CFileItem *resultItem)
 {
-  std::unique_lock<CCriticalSection> lock(GetScriptsLock());
+  std::unique_lock lock(GetScriptsLock());
   CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (!dir)
     return;
@@ -512,7 +512,7 @@ void CPluginDirectory::SetResolvedUrl(int handle, bool success, const CFileItem 
 
 std::string CPluginDirectory::GetSetting(int handle, const std::string &strID)
 {
-  std::unique_lock<CCriticalSection> lock(GetScriptsLock());
+  std::unique_lock lock(GetScriptsLock());
   CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (dir && dir->GetAddon())
     return dir->GetAddon()->GetSetting(strID);
@@ -522,7 +522,7 @@ std::string CPluginDirectory::GetSetting(int handle, const std::string &strID)
 
 void CPluginDirectory::SetSetting(int handle, const std::string &strID, const std::string &value)
 {
-  std::unique_lock<CCriticalSection> lock(GetScriptsLock());
+  std::unique_lock lock(GetScriptsLock());
   CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (dir && dir->GetAddon())
     dir->GetAddon()->UpdateSetting(strID, value);
@@ -530,7 +530,7 @@ void CPluginDirectory::SetSetting(int handle, const std::string &strID, const st
 
 void CPluginDirectory::SetContent(int handle, const std::string &strContent)
 {
-  std::unique_lock<CCriticalSection> lock(GetScriptsLock());
+  std::unique_lock lock(GetScriptsLock());
   CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (dir)
     dir->m_listItems->SetContent(strContent);
@@ -538,7 +538,7 @@ void CPluginDirectory::SetContent(int handle, const std::string &strContent)
 
 void CPluginDirectory::SetProperty(int handle, const std::string &strProperty, const std::string &strValue)
 {
-  std::unique_lock<CCriticalSection> lock(GetScriptsLock());
+  std::unique_lock lock(GetScriptsLock());
   CPluginDirectory* dir = GetScriptFromHandle(handle);
   if (!dir)
     return;

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -589,7 +589,7 @@ bool CRSSDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   URIUtils::RemoveSlashAtEnd(strPath);
   std::map<std::string,CDateTime>::iterator it;
   items.SetPath(strPath);
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if ((it=m_cache.find(strPath)) != m_cache.end())
   {
     if (it->second > CDateTime::GetCurrentDateTime() &&
@@ -648,7 +648,7 @@ bool CRSSDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   time += CDateTimeSpan(0,0,mins,0);
   items.SetPath(strPath);
   items.Save();
-  std::unique_lock<CCriticalSection> lock2(m_section);
+  std::unique_lock lock2(m_section);
   m_cache.insert(make_pair(strPath,time));
 
   return true;

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -119,7 +119,7 @@ bool CShoutcastFile::Open(const CURL& url)
 
   if (result)
   {
-    std::unique_lock<CCriticalSection> lock(m_tagSection);
+    std::unique_lock lock(m_tagSection);
 
     m_masterTag = std::make_shared<CMusicInfoTag>();
     m_masterTag->SetStationName(icyTitle);
@@ -173,7 +173,7 @@ void CShoutcastFile::Close()
   m_title.clear();
 
   {
-    std::unique_lock<CCriticalSection> lock(m_tagSection);
+    std::unique_lock lock(m_tagSection);
     while (!m_tags.empty())
       m_tags.pop();
     m_masterTag.reset();
@@ -297,7 +297,7 @@ bool CShoutcastFile::ExtractTagInfo(const char* buf)
       if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bShoutcastArt)
         coverURL.clear();
 
-      std::unique_lock<CCriticalSection> lock(m_tagSection);
+      std::unique_lock lock(m_tagSection);
 
       const std::shared_ptr<CMusicInfoTag> tag = std::make_shared<CMusicInfoTag>(*m_masterTag);
       tag->SetArtist(artistInfo);
@@ -327,7 +327,7 @@ int CShoutcastFile::IoControl(IOControl control, void* payload)
 {
   if (control == IOControl::SET_CACHE && m_cacheReader == nullptr)
   {
-    std::unique_lock<CCriticalSection> lock(m_tagSection);
+    std::unique_lock lock(m_tagSection);
     m_cacheReader = static_cast<CFileCache*>(payload);
     Create();
   }
@@ -341,7 +341,7 @@ void CShoutcastFile::Process()
   {
     if (m_tagChange.Wait(500ms))
     {
-      std::unique_lock<CCriticalSection> lock(m_tagSection);
+      std::unique_lock lock(m_tagSection);
       while (!m_bStop && !m_tags.empty())
       {
         const TagInfo& front = m_tags.front();

--- a/xbmc/filesystem/UDFBlockInput.cpp
+++ b/xbmc/filesystem/UDFBlockInput.cpp
@@ -34,7 +34,7 @@ int CUDFBlockInput::Read(
     udfread_block_input* bi, uint32_t lba, void* buf, uint32_t blocks, int flags)
 {
   auto m_bi = reinterpret_cast<UDF_BI*>(bi);
-  std::unique_lock<CCriticalSection> lock(m_bi->lock);
+  std::unique_lock lock(m_bi->lock);
 
   int64_t pos = static_cast<int64_t>(lba) * UDF_BLOCK_SIZE;
 

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -226,7 +226,7 @@ bool CGameClient::OpenFile(const CFileItem& file,
   std::string path = translatedUrl.Get();
   CLog::Log(LOGDEBUG, "GameClient: Loading {}", CURL::GetRedacted(path));
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (!Initialized())
     return false;
@@ -268,7 +268,7 @@ bool CGameClient::OpenStandalone(RETRO::IStreamManager& streamManager, IGameInpu
 {
   CLog::Log(LOGDEBUG, "GameClient: Loading {} in standalone mode", ID());
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (!Initialized())
     return false;
@@ -459,7 +459,7 @@ std::string CGameClient::GetMissingResource()
 
 void CGameClient::Reset()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_bIsPlaying)
   {
@@ -476,7 +476,7 @@ void CGameClient::Reset()
 
 void CGameClient::CloseFile()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_bIsPlaying)
   {
@@ -508,14 +508,14 @@ void CGameClient::RunFrame()
   IGameInputCallback* input;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     input = m_input;
   }
 
   if (input)
     input->PollInput();
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_bIsPlaying)
   {
@@ -535,7 +535,7 @@ bool CGameClient::Serialize(uint8_t* data, size_t size)
   if (data == nullptr || size == 0)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   bool bSuccess = false;
   if (m_bIsPlaying)
@@ -558,7 +558,7 @@ bool CGameClient::Deserialize(const uint8_t* data, size_t size)
   if (data == nullptr || size == 0)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   bool bSuccess = false;
   if (m_bIsPlaying)

--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -355,7 +355,7 @@ bool CGameClientInput::ConnectController(const std::string& portAddress,
   inputHandlingLock.reset();
 
   {
-    std::unique_lock<CCriticalSection> lock(m_clientAccess);
+    std::unique_lock lock(m_clientAccess);
 
     if (!m_gameClient.Initialized())
       return false;
@@ -431,7 +431,7 @@ bool CGameClientInput::DisconnectControllerRecursive(const std::string& portAddr
   inputHandlingLock.reset();
 
   {
-    std::unique_lock<CCriticalSection> lock(m_clientAccess);
+    std::unique_lock lock(m_clientAccess);
 
     if (!m_gameClient.Initialized())
       return false;
@@ -507,7 +507,7 @@ bool CGameClientInput::OpenKeyboard(const ControllerPtr& controller,
   bool bSuccess = false;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_clientAccess);
+    std::unique_lock lock(m_clientAccess);
 
     if (m_gameClient.Initialized())
     {
@@ -544,7 +544,7 @@ void CGameClientInput::CloseKeyboard()
   {
     m_keyboard.reset();
 
-    std::unique_lock<CCriticalSection> lock(m_clientAccess);
+    std::unique_lock lock(m_clientAccess);
 
     if (m_gameClient.Initialized())
     {
@@ -577,7 +577,7 @@ bool CGameClientInput::OpenMouse(const ControllerPtr& controller,
   bool bSuccess = false;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_clientAccess);
+    std::unique_lock lock(m_clientAccess);
 
     if (m_gameClient.Initialized())
     {
@@ -613,7 +613,7 @@ void CGameClientInput::CloseMouse()
   {
     m_mouse.reset();
 
-    std::unique_lock<CCriticalSection> lock(m_clientAccess);
+    std::unique_lock lock(m_clientAccess);
 
     if (m_gameClient.Initialized())
     {

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -67,7 +67,7 @@ void CGUIConfigurationWizard::Run(const std::string& strControllerId,
   Abort();
 
   {
-    std::unique_lock<CCriticalSection> lock(m_stateMutex);
+    std::unique_lock lock(m_stateMutex);
 
     // Set Run() parameters
     m_strControllerId = strControllerId;
@@ -87,7 +87,7 @@ void CGUIConfigurationWizard::Run(const std::string& strControllerId,
 
 void CGUIConfigurationWizard::OnUnfocus(IFeatureButton* button)
 {
-  std::unique_lock<CCriticalSection> lock(m_stateMutex);
+  std::unique_lock lock(m_stateMutex);
 
   if (button == m_currentButton)
     Abort(false);
@@ -128,7 +128,7 @@ void CGUIConfigurationWizard::Process(void)
   bool bLateAxisDetected = false;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_stateMutex);
+    std::unique_lock lock(m_stateMutex);
     for (IFeatureButton* button : m_buttons)
     {
       // Allow other threads to access the button we're using
@@ -188,7 +188,7 @@ void CGUIConfigurationWizard::Process(void)
     bool bInMotion;
 
     {
-      std::unique_lock<CCriticalSection> lock(m_motionMutex);
+      std::unique_lock lock(m_motionMutex);
       bInMotion = !m_bInMotion.empty();
     }
 
@@ -253,7 +253,7 @@ bool CGUIConfigurationWizard::MapPrimitive(JOYSTICK::IButtonMap* buttonMap,
     WHEEL_DIRECTION wheelDirection;
     THROTTLE_DIRECTION throttleDirection;
     {
-      std::unique_lock<CCriticalSection> lock(m_stateMutex);
+      std::unique_lock lock(m_stateMutex);
       currentButton = m_currentButton;
       cardinalDirection = m_cardinalDirection;
       wheelDirection = m_wheelDirection;
@@ -364,7 +364,7 @@ bool CGUIConfigurationWizard::MapPrimitive(JOYSTICK::IButtonMap* buttonMap,
 
 void CGUIConfigurationWizard::OnEventFrame(const JOYSTICK::IButtonMap* buttonMap, bool bMotion)
 {
-  std::unique_lock<CCriticalSection> lock(m_motionMutex);
+  std::unique_lock lock(m_motionMutex);
 
   if (m_bInMotion.find(buttonMap) != m_bInMotion.end() && !bMotion)
     OnMotionless(buttonMap);
@@ -373,7 +373,7 @@ void CGUIConfigurationWizard::OnEventFrame(const JOYSTICK::IButtonMap* buttonMap
 void CGUIConfigurationWizard::OnLateAxis(const JOYSTICK::IButtonMap* buttonMap,
                                          unsigned int axisIndex)
 {
-  std::unique_lock<CCriticalSection> lock(m_stateMutex);
+  std::unique_lock lock(m_stateMutex);
 
   m_lateAxisDetected = true;
   Abort(false);
@@ -381,7 +381,7 @@ void CGUIConfigurationWizard::OnLateAxis(const JOYSTICK::IButtonMap* buttonMap,
 
 void CGUIConfigurationWizard::OnMotion(const JOYSTICK::IButtonMap* buttonMap)
 {
-  std::unique_lock<CCriticalSection> lock(m_motionMutex);
+  std::unique_lock lock(m_motionMutex);
 
   m_motionlessEvent.Reset();
   m_bInMotion.insert(buttonMap);

--- a/xbmc/guilib/GUIAudioManager.cpp
+++ b/xbmc/guilib/GUIAudioManager.cpp
@@ -86,13 +86,13 @@ void CGUIAudioManager::Initialize()
 
 void CGUIAudioManager::DeInitialize()
 {
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
   UnLoad();
 }
 
 void CGUIAudioManager::Stop()
 {
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
   for (const auto& windowSound : m_windowSoundMap)
   {
     if (windowSound.second.initSound)
@@ -110,7 +110,7 @@ void CGUIAudioManager::Stop()
 // \brief Play a sound associated with a CAction
 void CGUIAudioManager::PlayActionSound(const CAction& action)
 {
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
 
   // it's not possible to play gui sounds when passthrough is active
   if (!m_bEnabled)
@@ -132,7 +132,7 @@ void CGUIAudioManager::PlayActionSound(const CAction& action)
 // Events: SOUND_INIT, SOUND_DEINIT
 void CGUIAudioManager::PlayWindowSound(int id, WINDOW_SOUND event)
 {
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
 
   // it's not possible to play gui sounds when passthrough is active
   if (!m_bEnabled)
@@ -164,7 +164,7 @@ void CGUIAudioManager::PlayWindowSound(int id, WINDOW_SOUND event)
 // \brief Play a sound given by filename
 void CGUIAudioManager::PlayPythonSound(const std::string& strFileName, bool useCached /*= true*/)
 {
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
 
   // it's not possible to play gui sounds when passthrough is active
   if (!m_bEnabled)
@@ -226,7 +226,7 @@ std::string GetSoundSkinPath()
 // \brief Load the config file (sounds.xml) for nav sounds
 bool CGUIAudioManager::Load()
 {
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
   UnLoad();
 
   m_strMediaDir = GetSoundSkinPath();
@@ -321,7 +321,7 @@ bool CGUIAudioManager::Load()
 
 std::shared_ptr<IAESound> CGUIAudioManager::LoadSound(const std::string& filename)
 {
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
   const auto it = m_soundCache.find(filename);
   if (it != m_soundCache.end())
   {
@@ -366,14 +366,14 @@ void CGUIAudioManager::Enable(bool bEnable)
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_LOOKANDFEEL_SOUNDSKIN).empty())
     bEnable = false;
 
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
   m_bEnabled = bEnable;
 }
 
 // \brief Sets the volume of all playing sounds
 void CGUIAudioManager::SetVolume(float level)
 {
-  std::unique_lock<CCriticalSection> lock(m_cs);
+  std::unique_lock lock(m_cs);
 
   {
     for (const auto& actionSound : m_actionSoundMap)

--- a/xbmc/guilib/GUIFont.cpp
+++ b/xbmc/guilib/GUIFont.cpp
@@ -270,7 +270,7 @@ float CGUIFont::GetTextWidth(const vecText& text)
 
   CGraphicContext& context = winSystem->GetGfxContext();
 
-  std::unique_lock<CCriticalSection> lock(context);
+  std::unique_lock lock(context);
   return m_font->GetTextWidthInternal(text) * context.GetGUIScaleX();
 }
 
@@ -282,7 +282,7 @@ float CGUIFont::GetCharWidth(character_t ch)
 
   CGraphicContext& context = winSystem->GetGfxContext();
 
-  std::unique_lock<CCriticalSection> lock(context);
+  std::unique_lock lock(context);
   return m_font->GetCharWidthInternal(ch) * context.GetGUIScaleX();
 }
 

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -572,7 +572,7 @@ void GUIFontManager::SettingOptionsFontsFiller(const SettingConstPtr& setting,
 
 void GUIFontManager::Initialize()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   LoadUserFonts();
 }
 

--- a/xbmc/guilib/GUIMultiImage.cpp
+++ b/xbmc/guilib/GUIMultiImage.cpp
@@ -241,7 +241,7 @@ void CGUIMultiImage::LoadDirectory()
     return;
   }
   // slow(er) checks necessary - do them in the background
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   m_directoryStatus = LOADING;
   m_jobID = CServiceBroker::GetJobManager()->AddJob(new CMultiImageJob(m_currentPath), this,
                                                     CJob::PRIORITY_NORMAL);
@@ -262,7 +262,7 @@ void CGUIMultiImage::OnDirectoryLoaded()
 
 void CGUIMultiImage::CancelLoading()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (m_directoryStatus == LOADING)
     CServiceBroker::GetJobManager()->CancelJob(m_jobID);
   m_directoryStatus = UNLOADED;
@@ -277,7 +277,7 @@ void CGUIMultiImage::ResetMultiImage()
 
 void CGUIMultiImage::OnJobComplete(unsigned int jobID, bool success, CJob *job)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (m_directoryStatus == LOADING && strncmp(job->GetType(), "multiimage", 10) == 0)
   {
     m_files = ((CMultiImageJob *)job)->m_files;

--- a/xbmc/guilib/GUIRSSControl.cpp
+++ b/xbmc/guilib/GUIRSSControl.cpp
@@ -64,7 +64,7 @@ CGUIRSSControl::CGUIRSSControl(const CGUIRSSControl& from)
 
 CGUIRSSControl::~CGUIRSSControl(void)
 {
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
   if (m_pReader)
     m_pReader->SetObserver(NULL);
   m_pReader = NULL;
@@ -99,7 +99,7 @@ void CGUIRSSControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyre
   bool dirty = false;
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_LOOKANDFEEL_ENABLERSSFEEDS) && CRssManager::GetInstance().IsActive())
   {
-    std::unique_lock<CCriticalSection> lock(m_criticalSection);
+    std::unique_lock lock(m_criticalSection);
     // Create RSS background/worker thread if needed
     if (m_pReader == NULL)
     {
@@ -188,7 +188,7 @@ CRect CGUIRSSControl::CalcRenderRegion() const
 
 void CGUIRSSControl::OnFeedUpdate(const vecText &feed)
 {
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
   m_feed = feed;
   m_dirty = true;
 }

--- a/xbmc/guilib/GUIRenderingControl.cpp
+++ b/xbmc/guilib/GUIRenderingControl.cpp
@@ -38,7 +38,7 @@ bool CGUIRenderingControl::InitCallback(IRenderingCallback *callback)
   if (!callback)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_rendering);
+  std::unique_lock lock(m_rendering);
   CServiceBroker::GetWinSystem()->GetGfxContext().CaptureStateBlock();
   float x = CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalXCoord(GetXPosition(), GetYPosition());
   float y = CServiceBroker::GetWinSystem()->GetGfxContext().ScaleFinalYCoord(GetXPosition(), GetYPosition());
@@ -74,7 +74,7 @@ void CGUIRenderingControl::UpdateVisibility(const CGUIListItem *item)
 void CGUIRenderingControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   //! @todo Add processing to the addon so it could mark when actually changing
-  std::unique_lock<CCriticalSection> lock(m_rendering);
+  std::unique_lock lock(m_rendering);
   if (m_callback && m_callback->IsDirty())
     MarkDirtyRegion();
 
@@ -83,7 +83,7 @@ void CGUIRenderingControl::Process(unsigned int currentTime, CDirtyRegionList &d
 
 void CGUIRenderingControl::Render()
 {
-  std::unique_lock<CCriticalSection> lock(m_rendering);
+  std::unique_lock lock(m_rendering);
   if (m_callback)
   {
     // set the viewport - note: We currently don't have any control over how
@@ -101,7 +101,7 @@ void CGUIRenderingControl::Render()
 
 void CGUIRenderingControl::FreeResources(bool immediately)
 {
-  std::unique_lock<CCriticalSection> lock(m_rendering);
+  std::unique_lock lock(m_rendering);
 
   if (!m_callback) return;
 

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -371,7 +371,7 @@ void CGUIWindow::AfterRender()
 
 void CGUIWindow::Close_Internal(bool forceClose /*= false*/, int nextWindowID /*= 0*/, bool enableSound /*= true*/)
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   if (!m_active)
     return;
@@ -743,7 +743,7 @@ bool CGUIWindow::NeedLoad() const
 
 void CGUIWindow::AllocResources(bool forceLoad /*= false */)
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
 #ifdef _DEBUG
   const auto start = std::chrono::steady_clock::now();
@@ -1005,7 +1005,7 @@ void CGUIWindow::SetDefaults()
 
 CRect CGUIWindow::GetScaledBounds() const
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   CServiceBroker::GetWinSystem()->GetGfxContext().SetScalingResolution(m_coordsRes, m_needsScaling);
   CPoint pos(GetPosition());
   CRect rect(pos.x, pos.y, pos.x + m_width, pos.y + m_height);

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -486,7 +486,7 @@ bool CGUIWindowManager::DestroyWindows()
 
 void CGUIWindowManager::DestroyWindow(int id)
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   CGUIWindow *pWindow = GetWindow(id);
   if (pWindow)
   {
@@ -521,7 +521,7 @@ bool CGUIWindowManager::SendMessage(CGUIMessage& message)
   //  and all windows whether they are active or not
   if (message.GetMessage()==GUI_MSG_NOTIFY_ALL)
   {
-    std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+    std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
     for (auto it = m_activeDialogs.rbegin(); it != m_activeDialogs.rend(); ++it)
     {
@@ -545,7 +545,7 @@ bool CGUIWindowManager::SendMessage(CGUIMessage& message)
   bool modalAcceptedMessage(false);
   // don't use an iterator for this loop, as some messages mean that m_activeDialogs is altered,
   // which will invalidate any iterator
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   size_t topWindow = m_activeDialogs.size();
   while (topWindow)
   {
@@ -606,7 +606,7 @@ bool CGUIWindowManager::SendMessage(CGUIMessage& message, int window)
 
 void CGUIWindowManager::AddUniqueInstance(CGUIWindow *window)
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   // increment our instance (upper word of windowID)
   // until we get a window we don't have
   int instance = 0;
@@ -623,7 +623,7 @@ void CGUIWindowManager::Add(CGUIWindow* pWindow)
     return;
   }
   // push back all the windows if there are more than one covered by this class
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   for (int id : pWindow->GetIDRange())
   {
@@ -643,14 +643,14 @@ void CGUIWindowManager::Add(CGUIWindow* pWindow)
 
 void CGUIWindowManager::AddCustomWindow(CGUIWindow* pWindow)
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   Add(pWindow);
   m_vecCustomWindows.emplace_back(pWindow);
 }
 
 void CGUIWindowManager::RegisterDialog(CGUIWindow* dialog)
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   // only add the window if it does not exists
   for (const auto& window : m_activeDialogs)
   {
@@ -662,7 +662,7 @@ void CGUIWindowManager::RegisterDialog(CGUIWindow* dialog)
 
 void CGUIWindowManager::Remove(int id)
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   auto it = m_mapWindows.find(id);
   if (it != m_mapWindows.end())
@@ -691,7 +691,7 @@ void CGUIWindowManager::Remove(int id)
 // from the class that created the window using new.
 void CGUIWindowManager::Delete(int id)
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   CGUIWindow *pWindow = GetWindow(id);
   if (pWindow)
   {
@@ -703,7 +703,7 @@ void CGUIWindowManager::Delete(int id)
 void CGUIWindowManager::PreviousWindow()
 {
   // deactivate any window
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   CLog::Log(LOGDEBUG,"CGUIWindowManager::PreviousWindow: Deactivate");
   int currentWindow = GetActiveWindow();
   CGUIWindow *pCurrentWindow = GetWindow(currentWindow);
@@ -804,7 +804,7 @@ void CGUIWindowManager::ActivateWindow(int iWindowID, const std::vector<std::str
   }
   else
   {
-    std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+    std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
     ActivateWindow_Internal(iWindowID, params, swappingWindows, force);
   }
 }
@@ -905,7 +905,7 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const std::vector
 
 void CGUIWindowManager::CloseDialogs(bool forceClose) const
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   //This is to avoid an assert about out of bounds iterator
   //when m_activeDialogs happens to be empty
@@ -922,7 +922,7 @@ void CGUIWindowManager::CloseDialogs(bool forceClose) const
 
 void CGUIWindowManager::CloseInternalModalDialogs(bool forceClose) const
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   if (m_activeDialogs.empty())
     return;
 
@@ -1167,7 +1167,7 @@ bool CGUIWindowManager::OnAction(const CAction &action) const
 
 bool CGUIWindowManager::HandleAction(CAction const& action) const
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   size_t topmost = m_activeDialogs.size();
   while (topmost)
   {
@@ -1214,7 +1214,7 @@ bool RenderOrderSortFunction(CGUIWindow *first, CGUIWindow *second)
 void CGUIWindowManager::Process(unsigned int currentTime)
 {
   assert(CServiceBroker::GetAppMessenger()->IsProcessThread());
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   m_dirtyregions.clear();
 
@@ -1436,7 +1436,7 @@ void CGUIWindowManager::AfterRender()
 void CGUIWindowManager::FrameMove()
 {
   assert(CServiceBroker::GetAppMessenger()->IsProcessThread());
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   if(m_iNested == 0)
   {
@@ -1477,7 +1477,7 @@ CGUIWindow* CGUIWindowManager::GetWindow(int id) const
   if (id == 0 || id == WINDOW_INVALID)
     return nullptr;
 
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   auto it = m_mapWindows.find(id);
   if (it != m_mapWindows.end())
@@ -1515,7 +1515,7 @@ void CGUIWindowManager::SetCallback(IWindowManagerCallback& callback)
 
 void CGUIWindowManager::DeInitialize()
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   // Need a copy because addon-dialogs removes itself on Close()
   std::unordered_map<int, CGUIWindow*> closeMap(m_mapWindows);
@@ -1554,7 +1554,7 @@ void CGUIWindowManager::DeInitialize()
 /// \param id ID of the window routed
 void CGUIWindowManager::RemoveDialog(int id)
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   m_activeDialogs.erase(std::remove_if(m_activeDialogs.begin(),
                                        m_activeDialogs.end(),
                                        [id](CGUIWindow* dialog) { return dialog->GetID() == id; }),
@@ -1563,7 +1563,7 @@ void CGUIWindowManager::RemoveDialog(int id)
 
 bool CGUIWindowManager::HasModalDialog(bool ignoreClosing) const
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   for (const auto& window : m_activeDialogs)
   {
     if (window->IsDialog() &&
@@ -1583,7 +1583,7 @@ bool CGUIWindowManager::HasVisibleModalDialog() const
 
 int CGUIWindowManager::GetTopmostDialog(bool modal, bool ignoreClosing) const
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   for (auto it = m_activeDialogs.rbegin(); it != m_activeDialogs.rend(); ++it)
   {
     CGUIWindow *dialog = *it;
@@ -1605,7 +1605,7 @@ int CGUIWindowManager::GetTopmostModalDialog(bool ignoreClosing /*= false*/) con
 
 void CGUIWindowManager::SendThreadMessage(const CGUIMessage& message, int window /*= 0*/)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   CGUIMessage* msg = new CGUIMessage(message);
   m_vecThreadMessages.emplace_back(msg, window);
@@ -1631,7 +1631,7 @@ void CGUIWindowManager::DispatchThreadMessages()
   // 5. If possible, queued messages can be removed by certain filter condition
   //    and not break above.
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   while (!m_vecThreadMessages.empty())
   {
@@ -1657,7 +1657,7 @@ void CGUIWindowManager::DispatchThreadMessages()
 
 int CGUIWindowManager::RemoveThreadMessageByMessageIds(int *pMessageIDList)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   int removedMsgCount = 0;
   for (std::list < std::pair<CGUIMessage*,int> >::iterator it = m_vecThreadMessages.begin();
        it != m_vecThreadMessages.end();)
@@ -1717,7 +1717,7 @@ bool CGUIWindowManager::IsWindowActive(int id, bool ignoreClosing /* = true */) 
   if ((GetActiveWindow() & WINDOW_ID_MASK) == id)
     return true;
   // run through the dialogs
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   for (const auto& window : m_activeDialogs)
   {
     if ((window->GetID() & WINDOW_ID_MASK) == id && (!ignoreClosing || !window->IsAnimating(ANIM_TYPE_WINDOW_CLOSE)))
@@ -1728,7 +1728,7 @@ bool CGUIWindowManager::IsWindowActive(int id, bool ignoreClosing /* = true */) 
 
 bool CGUIWindowManager::IsWindowActive(const std::string &xmlFile, bool ignoreClosing /* = true */) const
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   CGUIWindow *window = GetWindow(GetActiveWindow());
   if (window && StringUtils::EqualsNoCase(URIUtils::GetFileName(window->GetProperty("xmlfile").asString()), xmlFile))
     return true;
@@ -1754,7 +1754,7 @@ bool CGUIWindowManager::IsWindowVisible(const std::string &xmlFile) const
 
 void CGUIWindowManager::LoadNotOnDemandWindows()
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   for (const auto& entry : m_mapWindows)
   {
     CGUIWindow *pWindow = entry.second;
@@ -1768,7 +1768,7 @@ void CGUIWindowManager::LoadNotOnDemandWindows()
 
 void CGUIWindowManager::UnloadNotOnDemandWindows()
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   for (const auto& entry : m_mapWindows)
   {
     CGUIWindow *pWindow = entry.second;
@@ -1894,7 +1894,7 @@ void CGUIWindowManager::DumpTextureUse()
   if (pWindow)
     pWindow->DumpTextureUse();
 
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   for (const auto& window : m_activeDialogs)
   {
     if (window->IsDialogRunning())

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -109,7 +109,7 @@ void CTextureArray::Set(std::shared_ptr<CTexture> texture, int width, int height
 
 void CTextureArray::Free()
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   Reset();
 }
 
@@ -243,7 +243,7 @@ bool CGUITextureManager::CanLoad(const std::string &texturePath)
 
 bool CGUITextureManager::HasTexture(const std::string &textureName, std::string *path, int *bundle, int *size)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
 
   // default values
   if (bundle) *bundle = -1;
@@ -331,7 +331,7 @@ const CTextureArray& CGUITextureManager::Load(const std::string& strTextureName,
     return emptyTexture;
 
   //Lock here, we will do stuff that could break rendering
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
 #ifdef _DEBUG_TEXTURES
   const auto start = std::chrono::steady_clock::now();
@@ -471,7 +471,7 @@ const CTextureArray& CGUITextureManager::Load(const std::string& strTextureName,
 
 void CGUITextureManager::ReleaseTexture(const std::string& strTextureName, bool immediately /*= false */)
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   ivecTextures i;
   i = m_vecTextures.begin();
@@ -501,7 +501,7 @@ void CGUITextureManager::ReleaseTexture(const std::string& strTextureName, bool 
 
 void CGUITextureManager::FreeUnusedTextures(unsigned int timeDelay)
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   for (auto i = m_unusedTextures.begin(); i != m_unusedTextures.end();)
   {
     auto now = std::chrono::steady_clock::now();
@@ -534,13 +534,13 @@ void CGUITextureManager::FreeUnusedTextures(unsigned int timeDelay)
 
 void CGUITextureManager::ReleaseHwTexture(unsigned int texture)
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   m_unusedHwTextures.push_back(texture);
 }
 
 void CGUITextureManager::Cleanup()
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   ivecTextures i;
   i = m_vecTextures.begin();
@@ -572,7 +572,7 @@ void CGUITextureManager::Dump() const
 
 void CGUITextureManager::Flush()
 {
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   ivecTextures i;
   i = m_vecTextures.begin();
@@ -604,21 +604,21 @@ unsigned int CGUITextureManager::GetMemoryUsage() const
 
 void CGUITextureManager::SetTexturePath(const std::string &texturePath)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   m_texturePaths.clear();
   AddTexturePath(texturePath);
 }
 
 void CGUITextureManager::AddTexturePath(const std::string &texturePath)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   if (!texturePath.empty())
     m_texturePaths.push_back(texturePath);
 }
 
 void CGUITextureManager::RemoveTexturePath(const std::string &texturePath)
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
+  std::unique_lock lock(m_section);
   for (std::vector<std::string>::iterator it = m_texturePaths.begin(); it != m_texturePaths.end(); ++it)
   {
     if (*it == texturePath)
@@ -635,7 +635,7 @@ std::string CGUITextureManager::GetTexturePath(const std::string &textureName, b
     return textureName;
   else
   { // texture doesn't include the full path, so check all fallbacks
-    std::unique_lock<CCriticalSection> lock(m_section);
+    std::unique_lock lock(m_section);
     for (const std::string& it : m_texturePaths)
     {
       std::string path = URIUtils::AddFileToFolder(it, "media", textureName);

--- a/xbmc/guilib/imagefactory.cpp
+++ b/xbmc/guilib/imagefactory.cpp
@@ -45,7 +45,7 @@ IImage* ImageFactory::CreateLoaderFromMimeType(const std::string& strMimeType)
     if (addonInfo.first != ADDON::AddonType::IMAGEDECODER)
       continue;
 
-    std::unique_lock<CCriticalSection> lock(m_createSec);
+    std::unique_lock lock(m_createSec);
     std::unique_ptr<CImageDecoder> result =
         std::make_unique<CImageDecoder>(addonInfo.second, strMimeType);
     if (!result->IsCreated())

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -305,7 +305,7 @@ void CInputManager::ProcessQueuedActions()
 {
   std::vector<CAction> queuedActions;
   {
-    std::unique_lock<CCriticalSection> lock(m_actionMutex);
+    std::unique_lock lock(m_actionMutex);
     queuedActions.swap(m_queuedActions);
   }
 
@@ -315,7 +315,7 @@ void CInputManager::ProcessQueuedActions()
 
 void CInputManager::QueueAction(const CAction& action)
 {
-  std::unique_lock<CCriticalSection> lock(m_actionMutex);
+  std::unique_lock lock(m_actionMutex);
 
   // Avoid dispatching multiple analog actions per frame with the same ID
   if (action.IsAnalog())

--- a/xbmc/input/touch/generic/GenericTouchInputHandler.cpp
+++ b/xbmc/input/touch/generic/GenericTouchInputHandler.cpp
@@ -56,7 +56,7 @@ bool CGenericTouchInputHandler::HandleTouchInput(TouchInput event,
   if (time < 0 || pointer < 0 || pointer >= MAX_POINTERS)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
 
   bool result = true;
 
@@ -291,7 +291,7 @@ bool CGenericTouchInputHandler::UpdateTouchPointer(
   if (pointer < 0 || pointer >= MAX_POINTERS)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
 
   m_pointers[pointer].last.copy(m_pointers[pointer].current);
 
@@ -325,7 +325,7 @@ void CGenericTouchInputHandler::saveLastTouch()
 
 void CGenericTouchInputHandler::OnTimeout()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
 
   switch (m_gestureState)
   {

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -49,7 +49,7 @@ void CAnnouncementManager::Deinitialize()
   m_bStop = true;
   m_queueEvent.Set();
   StopThread();
-  std::unique_lock<CCriticalSection> lock(m_announcersCritSection);
+  std::unique_lock lock(m_announcersCritSection);
   m_announcers.clear();
 }
 
@@ -63,7 +63,7 @@ void CAnnouncementManager::AddAnnouncer(IAnnouncer* listener, int flagMask)
   if (!listener)
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_announcersCritSection);
+  std::unique_lock lock(m_announcersCritSection);
   m_announcers.emplace(listener, flagMask);
 }
 
@@ -72,7 +72,7 @@ void CAnnouncementManager::RemoveAnnouncer(IAnnouncer *listener)
   if (!listener)
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_announcersCritSection);
+  std::unique_lock lock(m_announcersCritSection);
   m_announcers.erase(listener);
 }
 
@@ -138,7 +138,7 @@ void CAnnouncementManager::Announce(AnnouncementFlag flag,
     announcement.item = std::make_shared<CFileItem>(*item);
 
   {
-    std::unique_lock<CCriticalSection> lock(m_queueCritSection);
+    std::unique_lock lock(m_queueCritSection);
     m_announcementQueue.push_back(announcement);
   }
   m_queueEvent.Set();
@@ -151,7 +151,7 @@ void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag,
 {
   CLog::Log(LOGDEBUG, LOGANNOUNCE, "CAnnouncementManager - Announcement: {} from {}", message, sender);
 
-  std::unique_lock<CCriticalSection> lock(m_announcersCritSection);
+  std::unique_lock lock(m_announcersCritSection);
 
   // Make a copy of announcers. They may be removed or even remove themselves during execution of IAnnouncer::Announce()!
   std::unordered_map<IAnnouncer*, int> announcers{m_announcers};
@@ -327,7 +327,7 @@ void CAnnouncementManager::Process()
 
   while (!m_bStop)
   {
-    std::unique_lock<CCriticalSection> lock(m_queueCritSection);
+    std::unique_lock lock(m_queueCritSection);
     if (!m_announcementQueue.empty())
     {
       auto announcement = m_announcementQueue.front();

--- a/xbmc/interfaces/generic/RunningScriptsHandler.h
+++ b/xbmc/interfaces/generic/RunningScriptsHandler.h
@@ -57,7 +57,7 @@ protected:
 
   static HandleType GetNewScriptHandle(TScript* script)
   {
-    std::unique_lock<CCriticalSection> lock(s_critical);
+    std::unique_lock lock(s_critical);
     uint32_t handle = ++s_scriptHandleCounter;
     s_scriptHandles[handle] = script;
 
@@ -66,19 +66,19 @@ protected:
 
   static void ReuseScriptHandle(HandleType handle, TScript* script)
   {
-    std::unique_lock<CCriticalSection> lock(s_critical);
+    std::unique_lock lock(s_critical);
     s_scriptHandles[handle] = script;
   }
 
   static void RemoveScriptHandle(HandleType handle)
   {
-    std::unique_lock<CCriticalSection> lock(s_critical);
+    std::unique_lock lock(s_critical);
     s_scriptHandles.erase(handle);
   }
 
   static TScript* GetScriptFromHandle(HandleType handle)
   {
-    std::unique_lock<CCriticalSection> lock(s_critical);
+    std::unique_lock lock(s_critical);
     auto scriptHandle = s_scriptHandles.find(handle);
     if (scriptHandle == s_scriptHandles.end())
       return nullptr;

--- a/xbmc/interfaces/generic/ScriptInvocationManager.cpp
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.cpp
@@ -36,7 +36,7 @@ CScriptInvocationManager& CScriptInvocationManager::GetInstance()
 
 void CScriptInvocationManager::Process()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   // go through all active threads and find and remove all which are done
   std::vector<LanguageInvokerThread> tempList;
   for (LanguageInvokerThreadMap::iterator it = m_scripts.begin(); it != m_scripts.end(); )
@@ -68,7 +68,7 @@ void CScriptInvocationManager::Process()
 
 void CScriptInvocationManager::Uninitialize()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // execute Process() once more to handle the remaining scripts
   Process();
@@ -117,7 +117,7 @@ void CScriptInvocationManager::RegisterLanguageInvocationHandler(ILanguageInvoca
   if (!StringUtils::StartsWithNoCase(ext, "."))
     ext = "." + ext;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_invocationHandlers.find(ext) != m_invocationHandlers.end())
     return;
 
@@ -152,7 +152,7 @@ void CScriptInvocationManager::UnregisterLanguageInvocationHandler(ILanguageInvo
   if (invocationHandler == NULL)
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   //  get all extensions of the given language invoker
   for (std::map<std::string, ILanguageInvocationHandler*>::iterator it = m_invocationHandlers.begin(); it != m_invocationHandlers.end(); )
   {
@@ -171,14 +171,14 @@ bool CScriptInvocationManager::HasLanguageInvoker(const std::string &script) con
   std::string extension = URIUtils::GetExtension(script);
   StringUtils::ToLower(extension);
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   std::map<std::string, ILanguageInvocationHandler*>::const_iterator it = m_invocationHandlers.find(extension);
   return it != m_invocationHandlers.end() && it->second != NULL;
 }
 
 int CScriptInvocationManager::GetReusablePluginHandle(const std::string& script)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_lastInvokerThread)
   {
@@ -192,7 +192,7 @@ int CScriptInvocationManager::GetReusablePluginHandle(const std::string& script)
 
 LanguageInvokerPtr CScriptInvocationManager::GetLanguageInvoker(const std::string& script)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_lastInvokerThread)
   {
@@ -254,7 +254,7 @@ int CScriptInvocationManager::ExecuteAsync(
     return -1;
   }
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (m_lastInvokerThread && m_lastInvokerThread->GetInvoker() == languageInvoker)
   {
@@ -349,7 +349,7 @@ bool CScriptInvocationManager::Stop(int scriptId, bool wait /* = false */)
   if (scriptId < 0)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   CLanguageInvokerThreadPtr invokerThread = getInvokerThread(scriptId).thread;
   if (invokerThread == NULL)
     return false;
@@ -371,7 +371,7 @@ bool CScriptInvocationManager::Stop(const std::string &scriptPath, bool wait /* 
   if (scriptPath.empty())
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   std::map<std::string, int>::const_iterator script = m_scriptPaths.find(scriptPath);
   if (script == m_scriptPaths.end())
     return false;
@@ -381,7 +381,7 @@ bool CScriptInvocationManager::Stop(const std::string &scriptPath, bool wait /* 
 
 bool CScriptInvocationManager::IsRunning(int scriptId) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   LanguageInvokerThread invokerThread = getInvokerThread(scriptId);
   if (invokerThread.thread == NULL)
     return false;
@@ -391,7 +391,7 @@ bool CScriptInvocationManager::IsRunning(int scriptId) const
 
 bool CScriptInvocationManager::IsRunning(const std::string& scriptPath) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   auto it = m_scriptPaths.find(scriptPath);
   if (it == m_scriptPaths.end())
     return false;
@@ -404,7 +404,7 @@ void CScriptInvocationManager::OnExecutionDone(int scriptId)
   if (scriptId < 0)
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   LanguageInvokerThreadMap::iterator script = m_scripts.find(scriptId);
   if (script != m_scripts.end())
     script->second.done = true;

--- a/xbmc/interfaces/legacy/AddonClass.h
+++ b/xbmc/interfaces/legacy/AddonClass.h
@@ -81,7 +81,7 @@ namespace XBMCAddon
      */
     virtual void deallocating()
     {
-      std::unique_lock<CCriticalSection> lock(*this);
+      std::unique_lock lock(*this);
       m_isDeallocating = true;
     }
 

--- a/xbmc/interfaces/legacy/CallbackHandler.cpp
+++ b/xbmc/interfaces/legacy/CallbackHandler.cpp
@@ -38,14 +38,14 @@ namespace XBMCAddon
   void RetardedAsyncCallbackHandler::invokeCallback(Callback* cb)
   {
     XBMC_TRACE;
-    std::unique_lock<CCriticalSection> lock(critSection);
+    std::unique_lock lock(critSection);
     g_callQueue.push_back(new AsyncCallbackMessage(cb,this));
   }
 
   RetardedAsyncCallbackHandler::~RetardedAsyncCallbackHandler()
   {
     XBMC_TRACE;
-    std::unique_lock<CCriticalSection> lock(critSection);
+    std::unique_lock lock(critSection);
 
     // find any messages that might be there because of me ... and remove them
     CallbackQueue::iterator iter = g_callQueue.begin();
@@ -64,7 +64,7 @@ namespace XBMCAddon
   void RetardedAsyncCallbackHandler::makePendingCalls()
   {
     XBMC_TRACE;
-    std::unique_lock<CCriticalSection> lock(critSection);
+    std::unique_lock lock(critSection);
     CallbackQueue::iterator iter = g_callQueue.begin();
     while (iter != g_callQueue.end())
     {
@@ -94,7 +94,7 @@ namespace XBMCAddon
 #endif
           AddonClass* obj = (p->cb->getObject());
           AddonClass::Ref<AddonClass> ref(obj);
-          std::unique_lock<CCriticalSection> lock2(*obj);
+          std::unique_lock lock2(*obj);
           if (!p->cb->getObject()->isDeallocating())
           {
             try
@@ -125,7 +125,7 @@ namespace XBMCAddon
   void RetardedAsyncCallbackHandler::clearPendingCalls(void* userData)
   {
     XBMC_TRACE;
-    std::unique_lock<CCriticalSection> lock(critSection);
+    std::unique_lock lock(critSection);
     CallbackQueue::iterator iter = g_callQueue.begin();
     while (iter != g_callQueue.end())
     {

--- a/xbmc/interfaces/legacy/ModuleXbmcgui.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmcgui.cpp
@@ -27,14 +27,14 @@ namespace XBMCAddon
     long getCurrentWindowId()
     {
       DelayedCallGuard dg;
-      std::unique_lock<CCriticalSection> gl(CServiceBroker::GetWinSystem()->GetGfxContext());
+      std::unique_lock gl(CServiceBroker::GetWinSystem()->GetGfxContext());
       return CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();
     }
 
     long getCurrentWindowDialogId()
     {
       DelayedCallGuard dg;
-      std::unique_lock<CCriticalSection> gl(CServiceBroker::GetWinSystem()->GetGfxContext());
+      std::unique_lock gl(CServiceBroker::GetWinSystem()->GetGfxContext());
       return CServiceBroker::GetGUI()->GetWindowManager().GetTopmostModalDialog();
     }
 

--- a/xbmc/interfaces/legacy/Window.h
+++ b/xbmc/interfaces/legacy/Window.h
@@ -286,7 +286,7 @@ namespace XBMCAddon
        */
       inline void interceptorClear()
       {
-        std::unique_lock<CCriticalSection> lock(*this);
+        std::unique_lock lock(*this);
         window = NULL;
       }
 #endif

--- a/xbmc/interfaces/legacy/WindowDialog.cpp
+++ b/xbmc/interfaces/legacy/WindowDialog.cpp
@@ -23,7 +23,7 @@ namespace XBMCAddon
     WindowDialog::WindowDialog() :
       Window(true), WindowDialogMixin(this)
     {
-      std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+      std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
       InterceptorBase* interceptor = new Interceptor<CGUIWindow>("CGUIWindow", this, getNextAvailableWindowId());
       // set the render order to the dialog's default because this dialog is mapped to CGUIWindow instead of CGUIDialog
       interceptor->SetRenderOrder(RENDER_ORDER_DIALOG);

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -149,7 +149,7 @@ namespace XBMCAddon
     int WindowXML::lockingGetNextAvailableWindowId()
     {
       XBMC_TRACE;
-      std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+      std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
       return getNextAvailableWindowId();
     }
 

--- a/xbmc/interfaces/python/LanguageHook.cpp
+++ b/xbmc/interfaces/python/LanguageHook.cpp
@@ -55,14 +55,14 @@ namespace XBMCAddon
     void PythonLanguageHook::RegisterMe()
     {
       XBMC_TRACE;
-      std::unique_lock<CCriticalSection> lock(hooksMutex);
+      std::unique_lock lock(hooksMutex);
       hooks[m_interp] = AddonClass::Ref<PythonLanguageHook>(this);
     }
 
     void PythonLanguageHook::UnregisterMe()
     {
       XBMC_TRACE;
-      std::unique_lock<CCriticalSection> lock(hooksMutex);
+      std::unique_lock lock(hooksMutex);
       hooks.erase(m_interp);
     }
 
@@ -76,7 +76,7 @@ namespace XBMCAddon
     AddonClass::Ref<PythonLanguageHook> PythonLanguageHook::GetIfExists(PyInterpreterState* interp)
     {
       XBMC_TRACE;
-      std::unique_lock<CCriticalSection> lock(hooksMutex);
+      std::unique_lock lock(hooksMutex);
       std::map<PyInterpreterState*,AddonClass::Ref<PythonLanguageHook> >::iterator iter = hooks.find(interp);
       if (iter != hooks.end())
         return iter->second;
@@ -208,7 +208,7 @@ namespace XBMCAddon
     void PythonLanguageHook::RegisterAddonClassInstance(AddonClass* obj)
     {
       XBMC_TRACE;
-      std::unique_lock<CCriticalSection> l(*this);
+      std::unique_lock l(*this);
       obj->Acquire();
       currentObjects.insert(obj);
     }
@@ -216,7 +216,7 @@ namespace XBMCAddon
     void PythonLanguageHook::UnregisterAddonClassInstance(AddonClass* obj)
     {
       XBMC_TRACE;
-      std::unique_lock<CCriticalSection> l(*this);
+      std::unique_lock l(*this);
       if (currentObjects.erase(obj) > 0)
         obj->Release();
     }
@@ -224,7 +224,7 @@ namespace XBMCAddon
     bool PythonLanguageHook::HasRegisteredAddonClassInstance(AddonClass* obj)
     {
       XBMC_TRACE;
-      std::unique_lock<CCriticalSection> l(*this);
+      std::unique_lock l(*this);
       return currentObjects.find(obj) != currentObjects.end();
     }
   }

--- a/xbmc/interfaces/python/LanguageHook.h
+++ b/xbmc/interfaces/python/LanguageHook.h
@@ -78,7 +78,7 @@ namespace XBMCAddon
       bool HasRegisteredAddonClassInstance(AddonClass* obj);
       inline bool HasRegisteredAddonClasses()
       {
-        std::unique_lock<CCriticalSection> l(*this);
+        std::unique_lock l(*this);
         return !currentObjects.empty();
       }
 

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -68,7 +68,7 @@ static const std::string getListOfAddonClassesAsString(
     XBMCAddon::AddonClass::Ref<XBMCAddon::Python::PythonLanguageHook>& languageHook)
 {
   std::string message;
-  std::unique_lock<CCriticalSection> l(*(languageHook.get()));
+  std::unique_lock l(*(languageHook.get()));
   const std::set<XBMCAddon::AddonClass*>& acs = languageHook->GetRegisteredAddonClasses();
   bool firstTime = true;
   for (const auto& iter : acs)
@@ -249,7 +249,7 @@ bool CPythonInvoker::execute(const std::string& script, std::vector<std::wstring
     }
 
     { // set the m_threadState to this new interp
-      std::unique_lock<CCriticalSection> lockMe(m_critical);
+      std::unique_lock lockMe(m_critical);
       m_threadState = l_threadState;
     }
   }
@@ -371,7 +371,7 @@ bool CPythonInvoker::execute(const std::string& script, std::vector<std::wstring
     onError(exceptionType, exceptionValue, exceptionTraceback);
   }
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   // no need to do anything else because the script has already stopped
   if (failed)
   {
@@ -449,7 +449,7 @@ FILE* CPythonInvoker::PyFile_AsFileWithMode(PyObject* py_file, const char* mode)
 
 bool CPythonInvoker::stop(bool abort)
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   m_stop = true;
 
   if (!IsRunning() && !m_threadState)
@@ -545,7 +545,7 @@ bool CPythonInvoker::stop(bool abort)
 // Always called from Invoker thread
 void CPythonInvoker::onExecutionDone()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (m_threadState != NULL)
   {
     CLog::Log(LOGDEBUG, "{}({}, {})", __FUNCTION__, GetId(), m_sourceFile);
@@ -611,7 +611,7 @@ void CPythonInvoker::onExecutionFailed()
   CLog::Log(LOGERROR, "CPythonInvoker({}, {}): abnormally terminating python thread", GetId(),
             m_sourceFile);
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   m_threadState = NULL;
 
   ILanguageInvoker::onExecutionFailed();
@@ -663,7 +663,7 @@ void CPythonInvoker::onError(const std::string& exceptionType /* = "" */,
                              const std::string& exceptionTraceback /* = "" */)
 {
   CPyThreadState releaseGil;
-  std::unique_lock<CCriticalSection> gc(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock gc(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   CGUIDialogKaiToast* pDlgToast =
       CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogKaiToast>(

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -72,7 +72,7 @@ XBPython::~XBPython()
 #define LOCK_AND_COPY(type, dest, src) \
   if (!m_bInitialized) \
     return; \
-  std::unique_lock<CCriticalSection> lock(src); \
+  std::unique_lock lock(src); \
   src.hadSomethingRemoved = false; \
   type dest; \
   dest = src
@@ -276,14 +276,14 @@ void XBPython::OnQueueNextItem()
 void XBPython::RegisterPythonPlayerCallBack(IPlayerCallback* pCallback)
 {
   XBMC_TRACE;
-  std::unique_lock<CCriticalSection> lock(m_vecPlayerCallbackList);
+  std::unique_lock lock(m_vecPlayerCallbackList);
   m_vecPlayerCallbackList.push_back(pCallback);
 }
 
 void XBPython::UnregisterPythonPlayerCallBack(IPlayerCallback* pCallback)
 {
   XBMC_TRACE;
-  std::unique_lock<CCriticalSection> lock(m_vecPlayerCallbackList);
+  std::unique_lock lock(m_vecPlayerCallbackList);
   PlayerCallbackList::iterator it = m_vecPlayerCallbackList.begin();
   while (it != m_vecPlayerCallbackList.end())
   {
@@ -300,14 +300,14 @@ void XBPython::UnregisterPythonPlayerCallBack(IPlayerCallback* pCallback)
 void XBPython::RegisterPythonMonitorCallBack(XBMCAddon::xbmc::Monitor* pCallback)
 {
   XBMC_TRACE;
-  std::unique_lock<CCriticalSection> lock(m_vecMonitorCallbackList);
+  std::unique_lock lock(m_vecMonitorCallbackList);
   m_vecMonitorCallbackList.push_back(pCallback);
 }
 
 void XBPython::UnregisterPythonMonitorCallBack(XBMCAddon::xbmc::Monitor* pCallback)
 {
   XBMC_TRACE;
-  std::unique_lock<CCriticalSection> lock(m_vecMonitorCallbackList);
+  std::unique_lock lock(m_vecMonitorCallbackList);
   MonitorCallbackList::iterator it = m_vecMonitorCallbackList.begin();
   while (it != m_vecMonitorCallbackList.end())
   {
@@ -455,7 +455,7 @@ void XBPython::Process()
   if (m_bInitialized)
   {
     PyList tmpvec;
-    std::unique_lock<CCriticalSection> lock(m_vecPyList);
+    std::unique_lock lock(m_vecPyList);
     for (PyList::iterator it = m_vecPyList.begin(); it != m_vecPyList.end();)
     {
       if (it->bDone)
@@ -481,7 +481,7 @@ bool XBPython::OnScriptInitialized(ILanguageInvoker* invoker)
 
   XBMC_TRACE;
   CLog::Log(LOGDEBUG, "initializing python engine.");
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_iDllScriptCounter++;
   if (!m_bInitialized)
   {
@@ -579,7 +579,7 @@ void XBPython::OnScriptStarted(ILanguageInvoker* invoker)
   inf.id = invoker->GetId();
   inf.bDone = false;
   inf.pyThread = static_cast<CPythonInvoker*>(invoker);
-  std::unique_lock<CCriticalSection> lock(m_vecPyList);
+  std::unique_lock lock(m_vecPyList);
   m_vecPyList.push_back(inf);
 }
 
@@ -604,7 +604,7 @@ void XBPython::NotifyScriptAborting(ILanguageInvoker* invoker)
 
 void XBPython::OnExecutionEnded(ILanguageInvoker* invoker)
 {
-  std::unique_lock<CCriticalSection> lock(m_vecPyList);
+  std::unique_lock lock(m_vecPyList);
   PyList::iterator it = m_vecPyList.begin();
   while (it != m_vecPyList.end())
   {
@@ -623,7 +623,7 @@ void XBPython::OnExecutionEnded(ILanguageInvoker* invoker)
 void XBPython::OnScriptFinalized(ILanguageInvoker* invoker)
 {
   XBMC_TRACE;
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   // for linux - we never release the library. its loaded and stays in memory.
   if (m_iDllScriptCounter)
     m_iDllScriptCounter--;

--- a/xbmc/media/decoderfilter/DecoderFilterManager.cpp
+++ b/xbmc/media/decoderfilter/DecoderFilterManager.cpp
@@ -100,21 +100,21 @@ bool CDecoderFilter::Save(tinyxml2::XMLNode* node) const
 
 bool CDecoderFilterManager::isValid(const std::string& name, const CDVDStreamInfo& streamInfo)
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   std::set<CDecoderFilter>::const_iterator filter(m_filters.find(name));
   return filter != m_filters.end() ? filter->isValid(streamInfo) : m_filters.empty();
 }
 
 void CDecoderFilterManager::add(const CDecoderFilter& filter)
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   std::pair<std::set<CDecoderFilter>::iterator, bool> res = m_filters.insert(filter);
   m_dirty = m_dirty || res.second;
 }
 
 bool CDecoderFilterManager::Load()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
 
   m_filters.clear();
 
@@ -151,7 +151,7 @@ bool CDecoderFilterManager::Load()
 
 bool CDecoderFilterManager::Save() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (!m_dirty || m_filters.empty())
     return true;
 

--- a/xbmc/messaging/ApplicationMessenger.cpp
+++ b/xbmc/messaging/ApplicationMessenger.cpp
@@ -58,7 +58,7 @@ CApplicationMessenger::~CApplicationMessenger()
 
 void CApplicationMessenger::Cleanup()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   while (!m_vecMessages.empty())
   {
@@ -115,7 +115,7 @@ int CApplicationMessenger::SendMsg(ThreadMessage&& message, bool wait)
 
   ThreadMessage* msg = new ThreadMessage(std::move(message));
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (msg->dwMessage == TMSG_GUI_MESSAGE)
     m_vecWindowMessages.push(msg);
@@ -201,7 +201,7 @@ void CApplicationMessenger::PostMsg(uint32_t messageId, int param1, int param2, 
 void CApplicationMessenger::ProcessMessages()
 {
   // process threadmessages
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   while (!m_vecMessages.empty())
   {
     ThreadMessage* pMsg = m_vecMessages.front();
@@ -234,7 +234,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
     return;
   }
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   int mask = pMsg->dwMessage & TMSG_MASK_MESSAGE;
 
   const auto it = m_mapTargets.find(mask);
@@ -249,7 +249,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
 
 void CApplicationMessenger::ProcessWindowMessages()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   //message type is window, process window messages
   while (!m_vecWindowMessages.empty())
   {
@@ -281,7 +281,7 @@ void CApplicationMessenger::SendGUIMessage(const CGUIMessage &message, int windo
 
 void CApplicationMessenger::RegisterReceiver(IMessageTarget* target)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_mapTargets.insert(std::make_pair(target->GetMessageMask(), target));
 }
 

--- a/xbmc/music/MusicLibraryQueue.cpp
+++ b/xbmc/music/MusicLibraryQueue.cpp
@@ -34,7 +34,7 @@ CMusicLibraryQueue::CMusicLibraryQueue()
 
 CMusicLibraryQueue::~CMusicLibraryQueue()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   m_jobs.clear();
 }
 
@@ -175,7 +175,7 @@ bool CMusicLibraryQueue::IsScanningLibrary() const
 
 void CMusicLibraryQueue::StopLibraryScanning()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   MusicLibraryJobMap::const_iterator scanningJobs = m_jobs.find("MusicLibraryScanningJob");
   if (scanningJobs == m_jobs.end())
     return;
@@ -218,7 +218,7 @@ void CMusicLibraryQueue::AddJob(CMusicLibraryJob *job)
   if (job == NULL)
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (!CJobQueue::AddJob(job))
     return;
 
@@ -240,7 +240,7 @@ void CMusicLibraryQueue::CancelJob(CMusicLibraryJob *job)
   if (job == NULL)
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   // remember the job type needed later because the job might be deleted
   // in the call to CJobQueue::CancelJob()
   std::string jobType;
@@ -262,7 +262,7 @@ void CMusicLibraryQueue::CancelJob(CMusicLibraryJob *job)
 
 void CMusicLibraryQueue::CancelAllJobs()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   CJobQueue::CancelJobs();
 
   // remove all scanning jobs
@@ -290,7 +290,7 @@ void CMusicLibraryQueue::OnJobComplete(unsigned int jobID, bool success, CJob *j
   }
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critical);
+    std::unique_lock lock(m_critical);
     // remove the job from our list of queued/running jobs
     MusicLibraryJobMap::iterator jobsIt = m_jobs.find(job->GetType());
     if (jobsIt != m_jobs.end())

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -167,7 +167,7 @@ void CAirPlayServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
                               const std::string& message,
                               const CVariant& data)
 {
-  std::unique_lock<CCriticalSection> lock(ServerInstanceLock);
+  std::unique_lock lock(ServerInstanceLock);
 
   if (sender == ANNOUNCEMENT::CAnnouncementManager::ANNOUNCEMENT_SENDER && ServerInstance)
   {
@@ -198,7 +198,7 @@ bool CAirPlayServer::StartServer(int port, bool nonlocal)
 {
   StopServer(true);
 
-  std::unique_lock<CCriticalSection> lock(ServerInstanceLock);
+  std::unique_lock lock(ServerInstanceLock);
 
   ServerInstance = new CAirPlayServer(port, nonlocal);
   if (ServerInstance->Initialize())
@@ -212,7 +212,7 @@ bool CAirPlayServer::StartServer(int port, bool nonlocal)
 
 bool CAirPlayServer::SetCredentials(bool usePassword, const std::string& password)
 {
-  std::unique_lock<CCriticalSection> lock(ServerInstanceLock);
+  std::unique_lock lock(ServerInstanceLock);
   bool ret = false;
 
   if (ServerInstance)
@@ -253,7 +253,7 @@ void ClearPhotoAssetCache()
 
 void CAirPlayServer::StopServer(bool bWait)
 {
-  std::unique_lock<CCriticalSection> lock(ServerInstanceLock);
+  std::unique_lock lock(ServerInstanceLock);
   //clean up the photo cache temp folder
   ClearPhotoAssetCache();
 
@@ -278,7 +278,7 @@ bool CAirPlayServer::IsRunning()
 
 void CAirPlayServer::AnnounceToClients(int state)
 {
-  std::unique_lock<CCriticalSection> lock(m_connectionLock);
+  std::unique_lock lock(m_connectionLock);
 
   for (auto& it : m_connections)
   {
@@ -389,7 +389,7 @@ void CAirPlayServer::Process()
           }
           if (nread <= 0)
           {
-            std::unique_lock<CCriticalSection> lock(m_connectionLock);
+            std::unique_lock lock(m_connectionLock);
             CLog::Log(LOGINFO, "AIRPLAY Server: Disconnection detected");
             m_connections[i].Disconnect();
             m_connections.erase(m_connections.begin() + i);
@@ -419,7 +419,7 @@ void CAirPlayServer::Process()
           }
           else
           {
-            std::unique_lock<CCriticalSection> lock(m_connectionLock);
+            std::unique_lock lock(m_connectionLock);
             CLog::Log(LOGINFO, "AIRPLAY Server: New connection added");
             m_connections.push_back(newconnection);
           }
@@ -451,7 +451,7 @@ bool CAirPlayServer::Initialize()
 
 void CAirPlayServer::Deinitialize()
 {
-  std::unique_lock<CCriticalSection> lock(m_connectionLock);
+  std::unique_lock lock(m_connectionLock);
   for (unsigned int i = 0; i < m_connections.size(); i++)
     m_connections[i].Disconnect();
 
@@ -568,7 +568,7 @@ void CAirPlayServer::CTCPClient::Disconnect()
 {
   if (m_socket != INVALID_SOCKET)
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     shutdown(m_socket, SHUT_RDWR);
     close(m_socket);
     m_socket = INVALID_SOCKET;
@@ -731,7 +731,7 @@ bool CAirPlayServer::CTCPClient::checkAuthorization(const std::string& authStr,
 
 void CAirPlayServer::backupVolume()
 {
-  std::unique_lock<CCriticalSection> lock(ServerInstanceLock);
+  std::unique_lock lock(ServerInstanceLock);
 
   if (ServerInstance && ServerInstance->m_origVolume == -1)
   {
@@ -743,7 +743,7 @@ void CAirPlayServer::backupVolume()
 
 void CAirPlayServer::restoreVolume()
 {
-  std::unique_lock<CCriticalSection> lock(ServerInstanceLock);
+  std::unique_lock lock(ServerInstanceLock);
 
   const auto& settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   if (ServerInstance && ServerInstance->m_origVolume != -1 &&

--- a/xbmc/network/EventClient.cpp
+++ b/xbmc/network/EventClient.cpp
@@ -161,7 +161,7 @@ void CEventClient::ProcessEvents()
 
 bool CEventClient::GetNextAction(CEventAction &action)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (!m_actionQueue.empty())
   {
     // grab the next action in line
@@ -376,7 +376,7 @@ bool CEventClient::OnPacketBUTTON(CEventPacket *packet)
   if(flags & PTB_QUEUE)
   {
     /* find the last queued item of this type */
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     CEventButtonState state( keycode,
                              map,
@@ -447,7 +447,7 @@ bool CEventClient::OnPacketBUTTON(CEventPacket *packet)
   }
   else
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     if ( flags & PTB_DOWN )
     {
       m_currentButton.m_iKeyCode   = keycode;
@@ -503,7 +503,7 @@ bool CEventClient::OnPacketMOUSE(CEventPacket *packet)
     return false;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     if ( flags & PTM_ABSOLUTE )
     {
       m_iMouseX = mx;
@@ -610,7 +610,7 @@ bool CEventClient::OnPacketACTION(CEventPacket *packet)
   case AT_EXEC_BUILTIN:
   case AT_BUTTON:
     {
-      std::unique_lock<CCriticalSection> lock(m_critSection);
+      std::unique_lock lock(m_critSection);
       m_actionQueue.emplace(actionString.c_str(), actionType);
     }
     break;
@@ -673,7 +673,7 @@ bool CEventClient::ParseUInt16(unsigned char* &payload, int &psize, unsigned sho
 
 void CEventClient::FreePacketQueues()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   while ( ! m_readyPackets.empty() )
     m_readyPackets.pop();
@@ -683,7 +683,7 @@ void CEventClient::FreePacketQueues()
 
 unsigned int CEventClient::GetButtonCode(std::string& strMapName, bool& isAxis, float& amount, bool &isJoystick)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   unsigned int bcode = 0;
 
   if ( m_currentButton.Active() )
@@ -752,7 +752,7 @@ unsigned int CEventClient::GetButtonCode(std::string& strMapName, bool& isAxis, 
 
 bool CEventClient::GetMousePos(float& x, float& y)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_bMouseMoved)
   {
     x = (m_iMouseX / 65535.0f) * CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth();

--- a/xbmc/network/EventServer.cpp
+++ b/xbmc/network/EventServer.cpp
@@ -63,7 +63,7 @@ CEventServer* CEventServer::GetInstance()
 
 void CEventServer::StartServer()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_bRunning)
     return;
 
@@ -94,14 +94,14 @@ void CEventServer::Cleanup()
   if (m_pSocket)
     m_pSocket->Close();
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_clients.clear();
 }
 
 int CEventServer::GetNumberOfClients()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_clients.size();
 }
 
@@ -217,7 +217,7 @@ void CEventServer::ProcessPacket(CAddress& addr, int pSize)
   if (!clientToken)
     clientToken = addr.ULong(); // use IP if packet doesn't have a token
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // first check if we have a client for this address
   auto iter = m_clients.find(clientToken);
@@ -245,7 +245,7 @@ void CEventServer::ProcessPacket(CAddress& addr, int pSize)
 
 void CEventServer::RefreshClients()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   auto iter = m_clients.begin();
 
   while ( iter != m_clients.end() )
@@ -271,7 +271,7 @@ void CEventServer::RefreshClients()
 
 void CEventServer::ProcessEvents()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   auto iter = m_clients.begin();
 
   while (iter != m_clients.end())
@@ -283,7 +283,7 @@ void CEventServer::ProcessEvents()
 
 bool CEventServer::ExecuteNextAction()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   CEventAction actionEvent;
   auto iter = m_clients.begin();
@@ -323,7 +323,7 @@ bool CEventServer::ExecuteNextAction()
 
 unsigned int CEventServer::GetButtonCode(std::string& strMapName, bool& isAxis, float& fAmount, bool &isJoystick)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   auto iter = m_clients.begin();
   unsigned int bcode = 0;
 
@@ -339,7 +339,7 @@ unsigned int CEventServer::GetButtonCode(std::string& strMapName, bool& isAxis, 
 
 bool CEventServer::GetMousePos(float &x, float &y)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   auto iter = m_clients.begin();
 
   while (iter != m_clients.end())

--- a/xbmc/network/EventServer.h
+++ b/xbmc/network/EventServer.h
@@ -44,7 +44,7 @@ namespace EVENTSERVER
 
     void RefreshSettings()
     {
-      std::unique_lock<CCriticalSection> lock(m_critSection);
+      std::unique_lock lock(m_critSection);
       m_bRefreshSettings = true;
     }
 

--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -245,7 +245,7 @@ void CTCPServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
   for (unsigned int i = 0; i < m_connections.size(); i++)
   {
     {
-      std::unique_lock<CCriticalSection> lock(m_connections[i]->m_critSection);
+      std::unique_lock lock(m_connections[i]->m_critSection);
       if ((m_connections[i]->GetAnnouncementFlags() & flag) == 0)
         continue;
     }
@@ -546,7 +546,7 @@ void CTCPServer::CTCPClient::Send(const char *data, unsigned int size)
   unsigned int sent = 0;
   do
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     sent += send(m_socket, data + sent, size - sent, 0);
   } while (sent < size);
 }
@@ -627,7 +627,7 @@ void CTCPServer::CTCPClient::Disconnect()
 {
   if (m_socket > 0)
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     shutdown(m_socket, SHUT_RDWR);
     closesocket(m_socket);
     m_socket = INVALID_SOCKET;

--- a/xbmc/network/UdpClient.cpp
+++ b/xbmc/network/UdpClient.cpp
@@ -79,7 +79,7 @@ void CUdpClient::OnStartup()
 
 bool CUdpClient::Broadcast(int aPort, const std::string& aMessage)
 {
-  std::unique_lock<CCriticalSection> lock(critical_section);
+  std::unique_lock lock(critical_section);
 
   struct sockaddr_in addr;
   addr.sin_family = AF_INET;
@@ -96,7 +96,7 @@ bool CUdpClient::Broadcast(int aPort, const std::string& aMessage)
 
 bool CUdpClient::Send(const std::string& aIpAddress, int aPort, const std::string& aMessage)
 {
-  std::unique_lock<CCriticalSection> lock(critical_section);
+  std::unique_lock lock(critical_section);
 
   struct sockaddr_in addr;
   addr.sin_family = AF_INET;
@@ -112,7 +112,7 @@ bool CUdpClient::Send(const std::string& aIpAddress, int aPort, const std::strin
 
 bool CUdpClient::Send(struct sockaddr_in aAddress, const std::string& aMessage)
 {
-  std::unique_lock<CCriticalSection> lock(critical_section);
+  std::unique_lock lock(critical_section);
 
   UdpCommand transmit = {aAddress, aMessage, NULL, 0};
   commands.push_back(transmit);
@@ -122,7 +122,7 @@ bool CUdpClient::Send(struct sockaddr_in aAddress, const std::string& aMessage)
 
 bool CUdpClient::Send(struct sockaddr_in aAddress, unsigned char* pMessage, DWORD dwSize)
 {
-  std::unique_lock<CCriticalSection> lock(critical_section);
+  std::unique_lock lock(critical_section);
 
   UdpCommand transmit = {aAddress, "", pMessage, dwSize};
   commands.push_back(transmit);
@@ -212,7 +212,7 @@ bool CUdpClient::DispatchNextCommand()
 {
   UdpCommand command;
   {
-    std::unique_lock<CCriticalSection> lock(critical_section);
+    std::unique_lock lock(critical_section);
 
     if (commands.size() <= 0)
       return false;

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -562,7 +562,7 @@ bool CWakeOnAccess::WakeUpHost(const WakeUpEntry& server)
 
 bool CWakeOnAccess::FindOrTouchHostEntry(const std::string& hostName, bool upnpMode, WakeUpEntry& result)
 {
-  std::unique_lock<CCriticalSection> lock(m_entrylist_protect);
+  std::unique_lock lock(m_entrylist_protect);
 
   bool need_wakeup = false;
 
@@ -602,7 +602,7 @@ bool CWakeOnAccess::FindOrTouchHostEntry(const std::string& hostName, bool upnpM
 
 void CWakeOnAccess::TouchHostEntry(const std::string& hostName, bool upnpMode)
 {
-  std::unique_lock<CCriticalSection> lock(m_entrylist_protect);
+  std::unique_lock lock(m_entrylist_protect);
 
   UPnPServer* upnp = upnpMode ? LookupUPnPServer(m_UPnPServers, hostName) : nullptr;
 
@@ -745,7 +745,7 @@ void CWakeOnAccess::OnJobComplete(unsigned int jobID, bool success, CJob *job)
 
   if (success)
   {
-    std::unique_lock<CCriticalSection> lock(m_entrylist_protect);
+    std::unique_lock lock(m_entrylist_protect);
 
     SaveMACDiscoveryResult(host, mac);
   }
@@ -786,7 +786,7 @@ std::string CWakeOnAccess::GetSettingFile()
 
 void CWakeOnAccess::OnSettingsLoaded()
 {
-  std::unique_lock<CCriticalSection> lock(m_entrylist_protect);
+  std::unique_lock lock(m_entrylist_protect);
 
   LoadFromXML();
 }

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -124,7 +124,7 @@ MHD_RESULT CWebServer::AskForAuthentication(const HTTPRequest& request) const
 
 bool CWebServer::IsAuthenticated(const HTTPRequest& request) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (!m_authenticationRequired)
     return true;
@@ -1301,7 +1301,7 @@ bool CWebServer::WebServerSupportsSSL()
 
 void CWebServer::SetCredentials(const std::string& username, const std::string& password)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_authenticationUsername = username;
   m_authenticationPassword = password;

--- a/xbmc/network/Zeroconf.cpp
+++ b/xbmc/network/Zeroconf.cpp
@@ -70,7 +70,7 @@ bool CZeroconf::PublishService(const std::string& fcr_identifier,
                                unsigned int f_port,
                                std::vector<std::pair<std::string, std::string> > txt /* = std::vector<std::pair<std::string, std::string> >() */)
 {
-  std::unique_lock<CCriticalSection> lock(*mp_crit_sec);
+  std::unique_lock lock(*mp_crit_sec);
   CZeroconf::PublishInfo info = {fcr_type, fcr_name, f_port, std::move(txt)};
   std::pair<tServiceMap::const_iterator, bool> ret = m_service_map.insert(std::make_pair(fcr_identifier, info));
   if(!ret.second) //identifier exists
@@ -84,7 +84,7 @@ bool CZeroconf::PublishService(const std::string& fcr_identifier,
 
 bool CZeroconf::RemoveService(const std::string& fcr_identifier)
 {
-  std::unique_lock<CCriticalSection> lock(*mp_crit_sec);
+  std::unique_lock lock(*mp_crit_sec);
   tServiceMap::iterator it = m_service_map.find(fcr_identifier);
   if(it == m_service_map.end())
     return false;
@@ -111,7 +111,7 @@ bool CZeroconf::HasService(const std::string& fcr_identifier) const
 
 bool CZeroconf::Start()
 {
-  std::unique_lock<CCriticalSection> lock(*mp_crit_sec);
+  std::unique_lock lock(*mp_crit_sec);
   if(!IsZCdaemonRunning())
   {
     const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
@@ -130,7 +130,7 @@ bool CZeroconf::Start()
 
 void CZeroconf::Stop()
 {
-  std::unique_lock<CCriticalSection> lock(*mp_crit_sec);
+  std::unique_lock lock(*mp_crit_sec);
   if(!m_started)
     return;
   doStop();

--- a/xbmc/network/ZeroconfBrowser.cpp
+++ b/xbmc/network/ZeroconfBrowser.cpp
@@ -66,7 +66,7 @@ CZeroconfBrowser::~CZeroconfBrowser()
 
 void CZeroconfBrowser::Start()
 {
-  std::unique_lock<CCriticalSection> lock(*mp_crit_sec);
+  std::unique_lock lock(*mp_crit_sec);
   if(m_started)
     return;
   m_started = true;
@@ -76,7 +76,7 @@ void CZeroconfBrowser::Start()
 
 void CZeroconfBrowser::Stop()
 {
-  std::unique_lock<CCriticalSection> lock(*mp_crit_sec);
+  std::unique_lock lock(*mp_crit_sec);
   if(!m_started)
     return;
   for (const auto& it : m_services)
@@ -86,7 +86,7 @@ void CZeroconfBrowser::Stop()
 
 bool CZeroconfBrowser::AddServiceType(const std::string& fcr_service_type /*const std::string& domain*/ )
 {
-  std::unique_lock<CCriticalSection> lock(*mp_crit_sec);
+  std::unique_lock lock(*mp_crit_sec);
   std::pair<tServices::iterator, bool> ret = m_services.insert(fcr_service_type);
   if(!ret.second)
   {
@@ -101,7 +101,7 @@ bool CZeroconfBrowser::AddServiceType(const std::string& fcr_service_type /*cons
 
 bool CZeroconfBrowser::RemoveServiceType(const std::string& fcr_service_type)
 {
-  std::unique_lock<CCriticalSection> lock(*mp_crit_sec);
+  std::unique_lock lock(*mp_crit_sec);
   tServices::iterator ret = m_services.find(fcr_service_type);
   if(ret == m_services.end())
     return false;
@@ -113,7 +113,7 @@ bool CZeroconfBrowser::RemoveServiceType(const std::string& fcr_service_type)
 
 std::vector<CZeroconfBrowser::ZeroconfService> CZeroconfBrowser::GetFoundServices()
 {
-  std::unique_lock<CCriticalSection> lock(*mp_crit_sec);
+  std::unique_lock lock(*mp_crit_sec);
   if(m_started)
     return doGetFoundServices();
   else
@@ -125,7 +125,7 @@ std::vector<CZeroconfBrowser::ZeroconfService> CZeroconfBrowser::GetFoundService
 
 bool CZeroconfBrowser::ResolveService(ZeroconfService& fr_service, double f_timeout)
 {
-  std::unique_lock<CCriticalSection> lock(*mp_crit_sec);
+  std::unique_lock lock(*mp_crit_sec);
   if(m_started)
   {
     return doResolveService(fr_service, f_timeout);

--- a/xbmc/network/mdns/ZeroconfBrowserMDNS.cpp
+++ b/xbmc/network/mdns/ZeroconfBrowserMDNS.cpp
@@ -33,7 +33,7 @@ CZeroconfBrowserMDNS::CZeroconfBrowserMDNS()
 
 CZeroconfBrowserMDNS::~CZeroconfBrowserMDNS()
 {
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   //make sure there are no browsers anymore
   for (const auto& it : m_service_browsers)
     doRemoveServiceType(it.first);
@@ -177,7 +177,7 @@ void DNSSD_API CZeroconfBrowserMDNS::ResolveCallback(DNSServiceRef              
 /// adds the service to list of found services
 void CZeroconfBrowserMDNS::addDiscoveredService(DNSServiceRef browser, CZeroconfBrowser::ZeroconfService const& fcr_service)
 {
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   tDiscoveredServicesMap::iterator browserIt = m_discovered_services.find(browser);
   if(browserIt == m_discovered_services.end())
   {
@@ -200,7 +200,7 @@ void CZeroconfBrowserMDNS::addDiscoveredService(DNSServiceRef browser, CZeroconf
 
 void CZeroconfBrowserMDNS::removeDiscoveredService(DNSServiceRef browser, CZeroconfBrowser::ZeroconfService const& fcr_service)
 {
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   tDiscoveredServicesMap::iterator browserIt = m_discovered_services.find(browser);
   //search this service
   std::vector<std::pair<ZeroconfService, unsigned int> >& services = browserIt->second;
@@ -251,7 +251,7 @@ bool CZeroconfBrowserMDNS::doAddServiceType(const std::string& fcr_service_type)
 #endif //!HAS_MDNS_EMBEDDED
 
   {
-    std::unique_lock<CCriticalSection> lock(m_data_guard);
+    std::unique_lock lock(m_data_guard);
     browser = m_browser;
     err = DNSServiceBrowse(&browser, kDNSServiceFlagsShareConnection, kDNSServiceInterfaceIndexAny, fcr_service_type.c_str(), NULL, BrowserCallback, this);
   }
@@ -267,7 +267,7 @@ bool CZeroconfBrowserMDNS::doAddServiceType(const std::string& fcr_service_type)
 
   //store the browser
   {
-    std::unique_lock<CCriticalSection> lock(m_data_guard);
+    std::unique_lock lock(m_data_guard);
     m_service_browsers.insert(std::make_pair(fcr_service_type, browser));
   }
 
@@ -279,7 +279,7 @@ bool CZeroconfBrowserMDNS::doRemoveServiceType(const std::string& fcr_service_ty
   //search for this browser and remove it from the map
   DNSServiceRef browser = 0;
   {
-    std::unique_lock<CCriticalSection> lock(m_data_guard);
+    std::unique_lock lock(m_data_guard);
     tBrowserMap::iterator it = m_service_browsers.find(fcr_service_type);
     if(it == m_service_browsers.end())
     {
@@ -291,7 +291,7 @@ bool CZeroconfBrowserMDNS::doRemoveServiceType(const std::string& fcr_service_ty
 
   //remove the services of this browser
   {
-    std::unique_lock<CCriticalSection> lock(m_data_guard);
+    std::unique_lock lock(m_data_guard);
     tDiscoveredServicesMap::iterator it = m_discovered_services.find(browser);
     if(it != m_discovered_services.end())
       m_discovered_services.erase(it);
@@ -306,7 +306,7 @@ bool CZeroconfBrowserMDNS::doRemoveServiceType(const std::string& fcr_service_ty
 std::vector<CZeroconfBrowser::ZeroconfService> CZeroconfBrowserMDNS::doGetFoundServices()
 {
   std::vector<CZeroconfBrowser::ZeroconfService> ret;
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   for (const auto& it : m_discovered_services)
   {
     auto& services = it.second;
@@ -411,7 +411,7 @@ bool CZeroconfBrowserMDNS::doResolveService(CZeroconfBrowser::ZeroconfService& f
 
 void CZeroconfBrowserMDNS::ProcessResults()
 {
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   DNSServiceErrorType err = DNSServiceProcessResult(m_browser);
   if (err != kDNSServiceErr_NoError)
     CLog::Log(LOGERROR, "ZeroconfWIN: DNSServiceProcessResult returned (error = {})", (int)err);

--- a/xbmc/network/mdns/ZeroconfMDNS.cpp
+++ b/xbmc/network/mdns/ZeroconfMDNS.cpp
@@ -89,7 +89,7 @@ bool CZeroconfMDNS::doPublishService(const std::string& fcr_identifier,
   TXTRecordCreate(&txtRecord, 0, NULL);
 
 #if !defined(HAS_MDNS_EMBEDDED)
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   if(m_service == NULL)
   {
     err = DNSServiceCreateConnection(&m_service);
@@ -124,7 +124,7 @@ bool CZeroconfMDNS::doPublishService(const std::string& fcr_identifier,
   }
 
   {
-    std::unique_lock<CCriticalSection> lock(m_data_guard);
+    std::unique_lock lock(m_data_guard);
     netService = m_service;
     err = DNSServiceRegister(&netService, kDNSServiceFlagsShareConnection, 0, fcr_name.c_str(), fcr_type.c_str(), NULL, NULL, htons(f_port), TXTRecordGetLength(&txtRecord), TXTRecordGetBytesPtr(&txtRecord), registerCallback, NULL);
   }
@@ -139,7 +139,7 @@ bool CZeroconfMDNS::doPublishService(const std::string& fcr_identifier,
   }
   else
   {
-    std::unique_lock<CCriticalSection> lock(m_data_guard);
+    std::unique_lock lock(m_data_guard);
     struct tServiceRef newService;
     newService.serviceRef = netService;
     newService.txtRecordRef = txtRecord;
@@ -153,7 +153,7 @@ bool CZeroconfMDNS::doPublishService(const std::string& fcr_identifier,
 bool CZeroconfMDNS::doForceReAnnounceService(const std::string& fcr_identifier)
 {
   bool ret = false;
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   tServiceMap::iterator it = m_services.find(fcr_identifier);
   if(it != m_services.end())
   {
@@ -174,7 +174,7 @@ bool CZeroconfMDNS::doForceReAnnounceService(const std::string& fcr_identifier)
 
 bool CZeroconfMDNS::doRemoveService(const std::string& fcr_ident)
 {
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   tServiceMap::iterator it = m_services.find(fcr_ident);
   if(it != m_services.end())
   {
@@ -191,7 +191,7 @@ bool CZeroconfMDNS::doRemoveService(const std::string& fcr_ident)
 void CZeroconfMDNS::doStop()
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_data_guard);
+    std::unique_lock lock(m_data_guard);
     CLog::Log(LOGDEBUG, "ZeroconfMDNS: Shutdown services");
     for (auto& it : m_services)
     {
@@ -202,7 +202,7 @@ void CZeroconfMDNS::doStop()
     m_services.clear();
   }
   {
-    std::unique_lock<CCriticalSection> lock(m_data_guard);
+    std::unique_lock lock(m_data_guard);
 #if defined(TARGET_WINDOWS_STORE)
     CLog::Log(LOGERROR, "ZeroconfMDNS: WSAAsyncSelect not yet supported for TARGET_WINDOWS_STORE");
 #else
@@ -237,7 +237,7 @@ void DNSSD_API CZeroconfMDNS::registerCallback(DNSServiceRef sdref, const DNSSer
 
 void CZeroconfMDNS::ProcessResults()
 {
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   DNSServiceErrorType err = DNSServiceProcessResult(m_service);
   if (err != kDNSServiceErr_NoError)
     CLog::Log(LOGERROR, "ZeroconfMDNS: DNSServiceProcessResult returned (error = {})", (int)err);

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -690,7 +690,7 @@ bool CUPnP::UpdateItem(const std::string& path, const CFileItem& item)
 +---------------------------------------------------------------------*/
 void CUPnP::StartClient()
 {
-  std::unique_lock<CCriticalSection> lock(m_lockMediaBrowser);
+  std::unique_lock lock(m_lockMediaBrowser);
   if (m_MediaBrowser != NULL)
     return;
 
@@ -705,7 +705,7 @@ void CUPnP::StartClient()
 +---------------------------------------------------------------------*/
 void CUPnP::StopClient()
 {
-  std::unique_lock<CCriticalSection> lock(m_lockMediaBrowser);
+  std::unique_lock lock(m_lockMediaBrowser);
   if (m_MediaBrowser == NULL)
     return;
 

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -89,13 +89,13 @@ public:
 
   NPT_String GetTransportState() const
   {
-    std::unique_lock<CCriticalSection> lock(m_section);
+    std::unique_lock lock(m_section);
     return m_trainfo.cur_transport_state;
   }
 
   NPT_String GetTransportStatus() const
   {
-    std::unique_lock<CCriticalSection> lock(m_section);
+    std::unique_lock lock(m_section);
     return m_trainfo.cur_transport_status;
   }
 
@@ -113,7 +113,7 @@ public:
                                 PLT_TransportInfo* info,
                                 void* userdata) override
   {
-    std::unique_lock<CCriticalSection> lock(m_section);
+    std::unique_lock lock(m_section);
 
     if (NPT_FAILED(res))
     {
@@ -142,7 +142,7 @@ public:
                                PLT_PositionInfo* info,
                                void* userdata) override
   {
-    std::unique_lock<CCriticalSection> lock(m_section);
+    std::unique_lock lock(m_section);
 
     if (NPT_FAILED(res) || info == NULL)
     {

--- a/xbmc/network/upnp/UPnPSettings.cpp
+++ b/xbmc/network/upnp/UPnPSettings.cpp
@@ -47,7 +47,7 @@ void CUPnPSettings::OnSettingsUnloaded()
 
 bool CUPnPSettings::Load(const std::string &file)
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
 
   Clear();
 
@@ -80,7 +80,7 @@ bool CUPnPSettings::Load(const std::string &file)
 
 bool CUPnPSettings::Save(const std::string &file) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
 
   CXBMCTinyXML2 doc;
   auto* element = doc.NewElement(XML_UPNP);
@@ -100,7 +100,7 @@ bool CUPnPSettings::Save(const std::string &file) const
 
 void CUPnPSettings::Clear()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
 
   m_serverUUID.clear();
   m_serverPort = 0;

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -129,7 +129,7 @@ void CPeripherals::Initialise()
   busses.push_back(std::make_shared<CPeripheralBusApplication>(*this));
 
   {
-    std::unique_lock<CCriticalSection> bussesLock(m_critSectionBusses);
+    std::unique_lock bussesLock(m_critSectionBusses);
     m_busses = busses;
   }
 
@@ -157,7 +157,7 @@ void CPeripherals::Clear()
   // avoid deadlocks by copying all busses into a temporary variable and destroying them from there
   std::vector<PeripheralBusPtr> busses;
   {
-    std::unique_lock<CCriticalSection> bussesLock(m_critSectionBusses);
+    std::unique_lock bussesLock(m_critSectionBusses);
     /* delete busses and devices */
     busses = m_busses;
     m_busses.clear();
@@ -168,7 +168,7 @@ void CPeripherals::Clear()
   busses.clear();
 
   {
-    std::unique_lock<CCriticalSection> mappingsLock(m_critSectionMappings);
+    std::unique_lock mappingsLock(m_critSectionMappings);
     /* delete mappings */
     for (auto& mapping : m_mappings)
       mapping.m_settings.clear();
@@ -184,7 +184,7 @@ void CPeripherals::TriggerDeviceScan(const PeripheralBusType type /* = PERIPHERA
 {
   std::vector<PeripheralBusPtr> busses;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSectionBusses);
+    std::unique_lock lock(m_critSectionBusses);
     busses = m_busses;
   }
 
@@ -206,7 +206,7 @@ void CPeripherals::TriggerDeviceScan(const PeripheralBusType type /* = PERIPHERA
 
 PeripheralBusPtr CPeripherals::GetBusByType(const PeripheralBusType type) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSectionBusses);
+  std::unique_lock lock(m_critSectionBusses);
 
   const auto& bus =
       std::find_if(m_busses.cbegin(), m_busses.cend(),
@@ -222,7 +222,7 @@ PeripheralPtr CPeripherals::GetPeripheralAtLocation(
 {
   PeripheralPtr result;
 
-  std::unique_lock<CCriticalSection> lock(m_critSectionBusses);
+  std::unique_lock lock(m_critSectionBusses);
   for (const auto& bus : m_busses)
   {
     /* check whether the bus matches if a bus type other than unknown was passed */
@@ -249,7 +249,7 @@ bool CPeripherals::HasPeripheralAtLocation(
 
 PeripheralBusPtr CPeripherals::GetBusWithDevice(const std::string& strLocation) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSectionBusses);
+  std::unique_lock lock(m_critSectionBusses);
 
   const auto& bus = std::find_if(m_busses.cbegin(), m_busses.cend(),
                                  [&strLocation](const PeripheralBusPtr& bus)
@@ -264,7 +264,7 @@ bool CPeripherals::SupportsFeature(PeripheralFeature feature) const
 {
   bool bSupportsFeature = false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSectionBusses);
+  std::unique_lock lock(m_critSectionBusses);
   for (const auto& bus : m_busses)
     bSupportsFeature |= bus->SupportsFeature(feature);
 
@@ -276,7 +276,7 @@ int CPeripherals::GetPeripheralsWithFeature(
     const PeripheralFeature feature,
     PeripheralBusType busType /* = PERIPHERAL_BUS_UNKNOWN */) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSectionBusses);
+  std::unique_lock lock(m_critSectionBusses);
   int iReturn(0);
   for (const auto& bus : m_busses)
   {
@@ -293,7 +293,7 @@ int CPeripherals::GetPeripheralsWithFeature(
 size_t CPeripherals::GetNumberOfPeripherals() const
 {
   size_t iReturn(0);
-  std::unique_lock<CCriticalSection> lock(m_critSectionBusses);
+  std::unique_lock lock(m_critSectionBusses);
   for (const auto& bus : m_busses)
     iReturn += bus->GetNumberOfPeripherals();
 
@@ -439,7 +439,7 @@ void CPeripherals::OnDeviceChanged()
 bool CPeripherals::GetMappingForDevice(const CPeripheralBus& bus,
                                        PeripheralScanResult& result) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSectionMappings);
+  std::unique_lock lock(m_critSectionMappings);
 
   /* check all mappings in the order in which they are defined in peripherals.xml */
   for (const auto& mapping : m_mappings)
@@ -479,7 +479,7 @@ bool CPeripherals::GetMappingForDevice(const CPeripheralBus& bus,
 
 void CPeripherals::GetSettingsFromMapping(CPeripheral& peripheral) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSectionMappings);
+  std::unique_lock lock(m_critSectionMappings);
 
   /* check all mappings in the order in which they are defined in peripherals.xml */
   for (const auto& mapping : m_mappings)
@@ -511,7 +511,7 @@ void CPeripherals::GetSettingsFromMapping(CPeripheral& peripheral) const
 #define SS(x) ((x) ? x : "")
 bool CPeripherals::LoadMappings()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSectionMappings);
+  std::unique_lock lock(m_critSectionMappings);
 
   CXBMCTinyXML2 xmlDoc;
   if (!xmlDoc.LoadFile("special://xbmc/system/peripherals.xml"))
@@ -682,7 +682,7 @@ void CPeripherals::GetDirectory(const std::string& strPath, CFileItemList& items
   std::string strPathCut = strPath.substr(14);
   std::string strBus = strPathCut.substr(0, strPathCut.find('/'));
 
-  std::unique_lock<CCriticalSection> lock(m_critSectionBusses);
+  std::unique_lock lock(m_critSectionBusses);
   for (const auto& bus : m_busses)
   {
     if (StringUtils::EqualsNoCase(strBus, "all") ||
@@ -701,7 +701,7 @@ PeripheralPtr CPeripherals::GetByPath(const std::string& strPath) const
   std::string strPathCut = strPath.substr(14);
   std::string strBus = strPathCut.substr(0, strPathCut.find('/'));
 
-  std::unique_lock<CCriticalSection> lock(m_critSectionBusses);
+  std::unique_lock lock(m_critSectionBusses);
   for (const auto& bus : m_busses)
   {
     if (StringUtils::EqualsNoCase(strBus, PeripheralTypeTranslator::BusTypeToString(bus->Type())))
@@ -905,7 +905,7 @@ void CPeripherals::ProcessEvents(void)
 {
   std::vector<PeripheralBusPtr> busses;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSectionBusses);
+    std::unique_lock lock(m_critSectionBusses);
     busses = m_busses;
   }
 
@@ -917,7 +917,7 @@ void CPeripherals::EnableButtonMapping()
 {
   std::vector<PeripheralBusPtr> busses;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSectionBusses);
+    std::unique_lock lock(m_critSectionBusses);
     busses = m_busses;
   }
 

--- a/xbmc/peripherals/addons/AddonButtonMap.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMap.cpp
@@ -96,7 +96,7 @@ bool CAddonButtonMap::Load(void)
     CLog::Log(LOGDEBUG, "Failed to load button map for \"{}\"", m_device->Location());
 
   {
-    std::unique_lock<CCriticalSection> lock(m_mutex);
+    std::unique_lock lock(m_mutex);
     m_controllerAppearance = std::move(controllerAppearance);
     m_features = std::move(features);
     m_driverMap = std::move(driverMap);
@@ -114,14 +114,14 @@ void CAddonButtonMap::Reset(void)
 
 bool CAddonButtonMap::IsEmpty(void) const
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   return m_driverMap.empty();
 }
 
 std::string CAddonButtonMap::GetAppearance() const
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   return m_controllerAppearance;
 }
@@ -136,7 +136,7 @@ bool CAddonButtonMap::SetAppearance(const std::string& controllerId) const
 
 bool CAddonButtonMap::GetFeature(const CDriverPrimitive& primitive, FeatureName& feature)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   DriverMap::const_iterator it = m_driverMap.find(primitive);
   if (it != m_driverMap.end())
@@ -152,7 +152,7 @@ FEATURE_TYPE CAddonButtonMap::GetFeatureType(const FeatureName& feature)
 {
   FEATURE_TYPE type = FEATURE_TYPE::UNKNOWN;
 
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   FeatureMap::const_iterator it = m_features.find(feature);
   if (it != m_features.end())
@@ -165,7 +165,7 @@ bool CAddonButtonMap::GetScalar(const FeatureName& feature, CDriverPrimitive& pr
 {
   bool retVal(false);
 
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   FeatureMap::const_iterator it = m_features.find(feature);
   if (it != m_features.end())
@@ -203,7 +203,7 @@ bool CAddonButtonMap::GetAnalogStick(const FeatureName& feature,
 {
   bool retVal(false);
 
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   FeatureMap::const_iterator it = m_features.find(feature);
   if (it != m_features.end())
@@ -234,7 +234,7 @@ void CAddonButtonMap::AddAnalogStick(const FeatureName& feature,
   kodi::addon::JoystickFeature analogStick(feature, JOYSTICK_FEATURE_TYPE_ANALOG_STICK);
 
   {
-    std::unique_lock<CCriticalSection> lock(m_mutex);
+    std::unique_lock lock(m_mutex);
     auto it = m_features.find(feature);
     if (it != m_features.end())
       analogStick = it->second;
@@ -260,7 +260,7 @@ bool CAddonButtonMap::GetRelativePointer(const FeatureName& feature,
 {
   bool retVal(false);
 
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   FeatureMap::const_iterator it = m_features.find(feature);
   if (it != m_features.end())
@@ -291,7 +291,7 @@ void CAddonButtonMap::AddRelativePointer(const FeatureName& feature,
   kodi::addon::JoystickFeature relPointer(feature, JOYSTICK_FEATURE_TYPE_RELPOINTER);
 
   {
-    std::unique_lock<CCriticalSection> lock(m_mutex);
+    std::unique_lock lock(m_mutex);
     auto it = m_features.find(feature);
     if (it != m_features.end())
       relPointer = it->second;
@@ -318,7 +318,7 @@ bool CAddonButtonMap::GetAccelerometer(const FeatureName& feature,
 {
   bool retVal(false);
 
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   FeatureMap::const_iterator it = m_features.find(feature);
   if (it != m_features.end())
@@ -366,7 +366,7 @@ bool CAddonButtonMap::GetWheel(const KODI::JOYSTICK::FeatureName& feature,
 {
   bool retVal(false);
 
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   FeatureMap::const_iterator it = m_features.find(feature);
   if (it != m_features.end())
@@ -397,7 +397,7 @@ void CAddonButtonMap::AddWheel(const KODI::JOYSTICK::FeatureName& feature,
   kodi::addon::JoystickFeature joystickFeature(feature, JOYSTICK_FEATURE_TYPE_WHEEL);
 
   {
-    std::unique_lock<CCriticalSection> lock(m_mutex);
+    std::unique_lock lock(m_mutex);
     auto it = m_features.find(feature);
     if (it != m_features.end())
       joystickFeature = it->second;
@@ -423,7 +423,7 @@ bool CAddonButtonMap::GetThrottle(const KODI::JOYSTICK::FeatureName& feature,
 {
   bool retVal(false);
 
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   FeatureMap::const_iterator it = m_features.find(feature);
   if (it != m_features.end())
@@ -454,7 +454,7 @@ void CAddonButtonMap::AddThrottle(const KODI::JOYSTICK::FeatureName& feature,
   kodi::addon::JoystickFeature joystickFeature(feature, JOYSTICK_FEATURE_TYPE_THROTTLE);
 
   {
-    std::unique_lock<CCriticalSection> lock(m_mutex);
+    std::unique_lock lock(m_mutex);
     auto it = m_features.find(feature);
     if (it != m_features.end())
       joystickFeature = it->second;
@@ -478,7 +478,7 @@ bool CAddonButtonMap::GetKey(const FeatureName& feature, CDriverPrimitive& primi
 {
   bool retVal(false);
 
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   FeatureMap::const_iterator it = m_features.find(feature);
   if (it != m_features.end())
@@ -522,7 +522,7 @@ bool CAddonButtonMap::IsIgnored(const JOYSTICK::CDriverPrimitive& primitive)
 
 bool CAddonButtonMap::GetAxisProperties(unsigned int axisIndex, int& center, unsigned int& range)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   for (const auto& it : m_driverMap)
   {

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -130,12 +130,12 @@ bool CPeripheralAddon::CreateAddon(void)
 void CPeripheralAddon::DestroyAddon()
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     m_peripherals.clear();
   }
 
   {
-    std::unique_lock<CCriticalSection> lock(m_buttonMapMutex);
+    std::unique_lock lock(m_buttonMapMutex);
     // only clear buttonMaps but don't delete them as they are owned by a
     // CAddonJoystickInputHandling instance
     m_buttonMaps.clear();
@@ -188,7 +188,7 @@ bool CPeripheralAddon::Register(unsigned int peripheralIndex, const PeripheralPt
   if (!peripheral)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_peripherals.find(peripheralIndex) == m_peripherals.end())
   {
     if (peripheral->Type() == PERIPHERAL_JOYSTICK)
@@ -212,7 +212,7 @@ void CPeripheralAddon::UnregisterRemovedDevices(const PeripheralScanResults& res
   std::vector<unsigned int> removedIndexes;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     for (auto& it : m_peripherals)
     {
       const PeripheralPtr& peripheral = it.second;
@@ -259,7 +259,7 @@ void CPeripheralAddon::GetFeatures(std::vector<PeripheralFeature>& features) con
 PeripheralPtr CPeripheralAddon::GetPeripheral(unsigned int index) const
 {
   PeripheralPtr peripheral;
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   auto it = m_peripherals.find(index);
   if (it != m_peripherals.end())
     peripheral = it->second;
@@ -270,7 +270,7 @@ PeripheralPtr CPeripheralAddon::GetByPath(const std::string& strPath) const
 {
   PeripheralPtr result;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& it : m_peripherals)
   {
     if (StringUtils::EqualsNoCase(strPath, it.second->FileLocation()))
@@ -302,7 +302,7 @@ unsigned int CPeripheralAddon::GetPeripheralsWithFeature(PeripheralVector& resul
                                                          const PeripheralFeature feature) const
 {
   unsigned int iReturn = 0;
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& it : m_peripherals)
   {
     if (it.second->HasFeature(feature))
@@ -316,7 +316,7 @@ unsigned int CPeripheralAddon::GetPeripheralsWithFeature(PeripheralVector& resul
 
 unsigned int CPeripheralAddon::GetNumberOfPeripherals(void) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return static_cast<unsigned int>(m_peripherals.size());
 }
 
@@ -324,7 +324,7 @@ unsigned int CPeripheralAddon::GetNumberOfPeripheralsWithId(const int iVendorId,
                                                             const int iProductId) const
 {
   unsigned int iReturn = 0;
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& it : m_peripherals)
   {
     if (it.second->VendorId() == iVendorId && it.second->ProductId() == iProductId)
@@ -336,7 +336,7 @@ unsigned int CPeripheralAddon::GetNumberOfPeripheralsWithId(const int iVendorId,
 
 void CPeripheralAddon::GetDirectory(const std::string& strPath, CFileItemList& items) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& it : m_peripherals)
   {
     const PeripheralPtr& peripheral = it.second;
@@ -835,7 +835,7 @@ void CPeripheralAddon::PowerOffJoystick(unsigned int index)
 
 void CPeripheralAddon::RegisterButtonMap(CPeripheral* device, IButtonMap* buttonMap)
 {
-  std::unique_lock<CCriticalSection> lock(m_buttonMapMutex);
+  std::unique_lock lock(m_buttonMapMutex);
 
   UnregisterButtonMap(buttonMap);
   m_buttonMaps.emplace_back(device, buttonMap);
@@ -843,7 +843,7 @@ void CPeripheralAddon::RegisterButtonMap(CPeripheral* device, IButtonMap* button
 
 void CPeripheralAddon::UnregisterButtonMap(IButtonMap* buttonMap)
 {
-  std::unique_lock<CCriticalSection> lock(m_buttonMapMutex);
+  std::unique_lock lock(m_buttonMapMutex);
 
   for (auto it = m_buttonMaps.begin(); it != m_buttonMaps.end(); ++it)
   {
@@ -857,7 +857,7 @@ void CPeripheralAddon::UnregisterButtonMap(IButtonMap* buttonMap)
 
 void CPeripheralAddon::UnregisterButtonMap(CPeripheral* device)
 {
-  std::unique_lock<CCriticalSection> lock(m_buttonMapMutex);
+  std::unique_lock lock(m_buttonMapMutex);
 
   m_buttonMaps.erase(
       std::remove_if(m_buttonMaps.begin(), m_buttonMaps.end(),
@@ -868,7 +868,7 @@ void CPeripheralAddon::UnregisterButtonMap(CPeripheral* device)
 
 void CPeripheralAddon::RefreshButtonMaps(const std::string& strDeviceName /* = "" */)
 {
-  std::unique_lock<CCriticalSection> lock(m_buttonMapMutex);
+  std::unique_lock lock(m_buttonMapMutex);
 
   for (auto it = m_buttonMaps.begin(); it != m_buttonMaps.end(); ++it)
   {

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -67,7 +67,7 @@ void CPeripheralBus::Clear(void)
     StopThread(true);
   }
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   m_peripherals.clear();
 }
@@ -77,7 +77,7 @@ void CPeripheralBus::UnregisterRemovedDevices(const PeripheralScanResults& resul
   PeripheralVector removedPeripherals;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     for (int iDevicePtr = (int)m_peripherals.size() - 1; iDevicePtr >= 0; iDevicePtr--)
     {
       const PeripheralPtr& peripheral = m_peripherals.at(iDevicePtr);
@@ -142,7 +142,7 @@ bool CPeripheralBus::ScanForDevices(void)
 bool CPeripheralBus::HasFeature(const PeripheralFeature feature) const
 {
   bool bReturn(false);
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (unsigned int iPeripheralPtr = 0; iPeripheralPtr < m_peripherals.size(); iPeripheralPtr++)
   {
     if (m_peripherals.at(iPeripheralPtr)->HasFeature(feature))
@@ -156,7 +156,7 @@ bool CPeripheralBus::HasFeature(const PeripheralFeature feature) const
 
 void CPeripheralBus::GetFeatures(std::vector<PeripheralFeature>& features) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (unsigned int iPeripheralPtr = 0; iPeripheralPtr < m_peripherals.size(); iPeripheralPtr++)
     m_peripherals.at(iPeripheralPtr)->GetFeatures(features);
 }
@@ -164,7 +164,7 @@ void CPeripheralBus::GetFeatures(std::vector<PeripheralFeature>& features) const
 PeripheralPtr CPeripheralBus::GetPeripheral(const std::string& strLocation) const
 {
   PeripheralPtr result;
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (auto& peripheral : m_peripherals)
   {
     if (peripheral->Location() == strLocation)
@@ -180,7 +180,7 @@ unsigned int CPeripheralBus::GetPeripheralsWithFeature(PeripheralVector& results
                                                        const PeripheralFeature feature) const
 {
   unsigned int iReturn = 0;
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (auto& peripheral : m_peripherals)
   {
     if (peripheral->HasFeature(feature))
@@ -197,7 +197,7 @@ unsigned int CPeripheralBus::GetNumberOfPeripheralsWithId(const int iVendorId,
                                                           const int iProductId) const
 {
   unsigned int iReturn = 0;
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& peripheral : m_peripherals)
   {
     if (peripheral->VendorId() == iVendorId && peripheral->ProductId() == iProductId)
@@ -234,7 +234,7 @@ void CPeripheralBus::Initialise(void)
 
   if (!IsRunning())
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     bNeedsPolling = m_bNeedsPolling;
   }
 
@@ -254,7 +254,7 @@ void CPeripheralBus::Register(const PeripheralPtr& peripheral)
   bool bPeripheralAdded = false;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     if (!HasPeripheral(peripheral->Location()))
     {
       m_peripherals.push_back(peripheral);
@@ -278,7 +278,7 @@ void CPeripheralBus::TriggerDeviceScan(void)
   bool bNeedsPolling;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     bNeedsPolling = m_bNeedsPolling;
   }
 
@@ -295,7 +295,7 @@ bool CPeripheralBus::HasPeripheral(const std::string& strLocation) const
 
 void CPeripheralBus::GetDirectory(const std::string& strPath, CFileItemList& items) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& peripheral : m_peripherals)
   {
     if (peripheral->IsHidden())
@@ -338,7 +338,7 @@ PeripheralPtr CPeripheralBus::GetByPath(const std::string& strPath) const
 {
   PeripheralPtr result;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (auto& peripheral : m_peripherals)
   {
     if (StringUtils::EqualsNoCase(strPath, peripheral->FileLocation()))
@@ -353,6 +353,6 @@ PeripheralPtr CPeripheralBus::GetByPath(const std::string& strPath) const
 
 unsigned int CPeripheralBus::GetNumberOfPeripherals() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return static_cast<unsigned int>(m_peripherals.size());
 }

--- a/xbmc/peripherals/bus/PeripheralBus.h
+++ b/xbmc/peripherals/bus/PeripheralBus.h
@@ -58,7 +58,7 @@ public:
    */
   bool NeedsPolling(void) const
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     return m_bNeedsPolling;
   }
 

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -56,7 +56,7 @@ CPeripheralBusAddon::~CPeripheralBusAddon()
 
 bool CPeripheralBusAddon::GetAddonWithButtonMap(PeripheralAddonPtr& addon) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   auto it = std::find_if(m_addons.begin(), m_addons.end(),
                          [](const PeripheralAddonPtr& addon) { return addon->HasButtonMaps(); });
@@ -73,7 +73,7 @@ bool CPeripheralBusAddon::GetAddonWithButtonMap(PeripheralAddonPtr& addon) const
 bool CPeripheralBusAddon::GetAddonWithButtonMap(const CPeripheral* device,
                                                 PeripheralAddonPtr& addon) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // If device is from an add-on, try to use that add-on
   if (device && device->GetBusType() == PERIPHERAL_BUS_ADDON)
@@ -106,7 +106,7 @@ bool CPeripheralBusAddon::PerformDeviceScan(PeripheralScanResults& results)
 {
   PeripheralAddonVector addons;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     addons = m_addons;
   }
 
@@ -163,7 +163,7 @@ void CPeripheralBusAddon::ProcessEvents(void)
   PeripheralAddonVector addons;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     addons = m_addons;
   }
 
@@ -175,7 +175,7 @@ void CPeripheralBusAddon::EnableButtonMapping()
 {
   using namespace ADDON;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   PeripheralAddonPtr dummy;
 
@@ -198,7 +198,7 @@ void CPeripheralBusAddon::PowerOff(const std::string& strLocation)
 
 void CPeripheralBusAddon::UnregisterRemovedDevices(const PeripheralScanResults& results)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   PeripheralVector removedPeripherals;
 
@@ -217,7 +217,7 @@ void CPeripheralBusAddon::Register(const PeripheralPtr& peripheral)
   PeripheralAddonPtr addon;
   unsigned int peripheralIndex;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (SplitLocation(peripheral->Location(), addon, peripheralIndex))
   {
@@ -228,7 +228,7 @@ void CPeripheralBusAddon::Register(const PeripheralPtr& peripheral)
 
 void CPeripheralBusAddon::GetFeatures(std::vector<PeripheralFeature>& features) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& addon : m_addons)
     addon->GetFeatures(features);
 }
@@ -236,7 +236,7 @@ void CPeripheralBusAddon::GetFeatures(std::vector<PeripheralFeature>& features) 
 bool CPeripheralBusAddon::HasFeature(const PeripheralFeature feature) const
 {
   bool bReturn(false);
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& addon : m_addons)
     bReturn = bReturn || addon->HasFeature(feature);
   return bReturn;
@@ -248,7 +248,7 @@ PeripheralPtr CPeripheralBusAddon::GetPeripheral(const std::string& strLocation)
   PeripheralAddonPtr addon;
   unsigned int peripheralIndex;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   if (SplitLocation(strLocation, addon, peripheralIndex))
     peripheral = addon->GetPeripheral(peripheralIndex);
@@ -260,7 +260,7 @@ PeripheralPtr CPeripheralBusAddon::GetByPath(const std::string& strPath) const
 {
   PeripheralPtr result;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   for (const auto& addon : m_addons)
   {
@@ -279,7 +279,7 @@ bool CPeripheralBusAddon::SupportsFeature(PeripheralFeature feature) const
 {
   bool bSupportsFeature = false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& addon : m_addons)
     bSupportsFeature |= addon->SupportsFeature(feature);
 
@@ -290,7 +290,7 @@ unsigned int CPeripheralBusAddon::GetPeripheralsWithFeature(PeripheralVector& re
                                                             const PeripheralFeature feature) const
 {
   unsigned int iReturn = 0;
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& addon : m_addons)
     iReturn += addon->GetPeripheralsWithFeature(results, feature);
   return iReturn;
@@ -299,7 +299,7 @@ unsigned int CPeripheralBusAddon::GetPeripheralsWithFeature(PeripheralVector& re
 unsigned int CPeripheralBusAddon::GetNumberOfPeripherals(void) const
 {
   unsigned int iReturn = 0;
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& addon : m_addons)
     iReturn += addon->GetNumberOfPeripherals();
   return iReturn;
@@ -309,7 +309,7 @@ unsigned int CPeripheralBusAddon::GetNumberOfPeripheralsWithId(const int iVendor
                                                                const int iProductId) const
 {
   unsigned int iReturn = 0;
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& addon : m_addons)
     iReturn += addon->GetNumberOfPeripheralsWithId(iVendorId, iProductId);
   return iReturn;
@@ -317,7 +317,7 @@ unsigned int CPeripheralBusAddon::GetNumberOfPeripheralsWithId(const int iVendor
 
 void CPeripheralBusAddon::GetDirectory(const std::string& strPath, CFileItemList& items) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (const auto& addon : m_addons)
     addon->GetDirectory(strPath, items);
 }
@@ -350,7 +350,7 @@ bool CPeripheralBusAddon::SplitLocation(const std::string& strLocation,
   {
     addon.reset();
 
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
 
     const std::string& strAddonId = parts[0];
     for (const auto& addonIt : m_addons)
@@ -393,7 +393,7 @@ void CPeripheralBusAddon::UpdateAddons(void)
   std::transform(newAddons.begin(), newAddons.end(), std::inserter(newIds, newIds.end()),
                  GetAddonID);
 
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
 
   // Get current add-ons
   std::transform(m_addons.begin(), m_addons.end(), std::inserter(currentIds, currentIds.end()),

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -991,7 +991,7 @@ GAME::ControllerPtr CPeripheral::InstallAsync(const std::string& controllerId)
 
   // Only 1 install at a time. Remaining installs will wake when this one
   // is done.
-  std::unique_lock<CCriticalSection> lockInstall(m_manager.GetAddonInstallMutex());
+  std::unique_lock lockInstall(m_manager.GetAddonInstallMutex());
 
   CLog::LogF(LOGDEBUG, "Installing {}", controllerId);
 

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -212,7 +212,7 @@ void CPeripheralJoystick::ResetDefaultSettings()
 
 void CPeripheralJoystick::RegisterJoystickDriverHandler(IDriverHandler* handler, bool bPromiscuous)
 {
-  std::unique_lock<CCriticalSection> lock(m_handlerMutex);
+  std::unique_lock lock(m_handlerMutex);
 
   DriverHandler driverHandler = {handler, bPromiscuous};
   m_driverHandlers.insert(m_driverHandlers.begin(), driverHandler);
@@ -220,7 +220,7 @@ void CPeripheralJoystick::RegisterJoystickDriverHandler(IDriverHandler* handler,
 
 void CPeripheralJoystick::UnregisterJoystickDriverHandler(IDriverHandler* handler)
 {
-  std::unique_lock<CCriticalSection> lock(m_handlerMutex);
+  std::unique_lock lock(m_handlerMutex);
 
   m_driverHandlers.erase(std::remove_if(m_driverHandlers.begin(), m_driverHandlers.end(),
                                         [handler](const DriverHandler& driverHandler)
@@ -291,7 +291,7 @@ bool CPeripheralJoystick::OnButtonMotion(unsigned int buttonIndex, bool bPressed
   if (bPressed && !g_application.IsAppFocused())
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_handlerMutex);
+  std::unique_lock lock(m_handlerMutex);
 
   // Update state
   SetLastActive(CDateTime::GetCurrentDateTime());
@@ -351,7 +351,7 @@ bool CPeripheralJoystick::OnHatMotion(unsigned int hatIndex, HAT_STATE state)
   // Update state
   SetLastActive(CDateTime::GetCurrentDateTime());
 
-  std::unique_lock<CCriticalSection> lock(m_handlerMutex);
+  std::unique_lock lock(m_handlerMutex);
 
   // Check GUI setting and send hat unpressed if controllers are disabled
   if (!m_manager.GetInputManager().IsControllerEnabled())
@@ -408,7 +408,7 @@ bool CPeripheralJoystick::OnAxisMotion(unsigned int axisIndex, float position)
   if (position != static_cast<float>(center) && !g_application.IsAppFocused())
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_handlerMutex);
+  std::unique_lock lock(m_handlerMutex);
 
   // Check GUI setting and send analog axis centered if controllers are disabled
   if (!m_manager.GetInputManager().IsControllerEnabled())
@@ -455,7 +455,7 @@ bool CPeripheralJoystick::OnAxisMotion(unsigned int axisIndex, float position)
 
 void CPeripheralJoystick::OnInputFrame(void)
 {
-  std::unique_lock<CCriticalSection> lock(m_handlerMutex);
+  std::unique_lock lock(m_handlerMutex);
 
   for (auto& it : m_driverHandlers)
     it.handler->OnInputFrame();

--- a/xbmc/peripherals/devices/PeripheralKeyboard.cpp
+++ b/xbmc/peripherals/devices/PeripheralKeyboard.cpp
@@ -60,7 +60,7 @@ bool CPeripheralKeyboard::InitialiseFeature(const PeripheralFeature feature)
 void CPeripheralKeyboard::RegisterKeyboardDriverHandler(
     KODI::KEYBOARD::IKeyboardDriverHandler* handler, bool bPromiscuous)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   KeyboardHandle handle{handler, bPromiscuous};
   m_keyboardHandlers.insert(m_keyboardHandlers.begin(), handle);
@@ -69,7 +69,7 @@ void CPeripheralKeyboard::RegisterKeyboardDriverHandler(
 void CPeripheralKeyboard::UnregisterKeyboardDriverHandler(
     KODI::KEYBOARD::IKeyboardDriverHandler* handler)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   auto it =
       std::find_if(m_keyboardHandlers.begin(), m_keyboardHandlers.end(),
@@ -98,7 +98,7 @@ GAME::ControllerPtr CPeripheralKeyboard::ControllerProfile() const
 
 bool CPeripheralKeyboard::OnKeyPress(const CKey& key)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   // Update state
   SetLastActive(CDateTime::GetCurrentDateTime());
@@ -128,7 +128,7 @@ bool CPeripheralKeyboard::OnKeyPress(const CKey& key)
 
 void CPeripheralKeyboard::OnKeyRelease(const CKey& key)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   for (const KeyboardHandle& handle : m_keyboardHandlers)
     handle.handler->OnKeyRelease(key);

--- a/xbmc/peripherals/devices/PeripheralMouse.cpp
+++ b/xbmc/peripherals/devices/PeripheralMouse.cpp
@@ -54,7 +54,7 @@ bool CPeripheralMouse::InitialiseFeature(const PeripheralFeature feature)
 void CPeripheralMouse::RegisterMouseDriverHandler(MOUSE::IMouseDriverHandler* handler,
                                                   bool bPromiscuous)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   MouseHandle handle{handler, bPromiscuous};
   m_mouseHandlers.insert(m_mouseHandlers.begin(), handle);
@@ -62,7 +62,7 @@ void CPeripheralMouse::RegisterMouseDriverHandler(MOUSE::IMouseDriverHandler* ha
 
 void CPeripheralMouse::UnregisterMouseDriverHandler(MOUSE::IMouseDriverHandler* handler)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   auto it =
       std::find_if(m_mouseHandlers.begin(), m_mouseHandlers.end(),
@@ -91,7 +91,7 @@ GAME::ControllerPtr CPeripheralMouse::ControllerProfile() const
 
 bool CPeripheralMouse::OnPosition(int x, int y)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   bool bHandled = false;
 
@@ -122,7 +122,7 @@ bool CPeripheralMouse::OnPosition(int x, int y)
 
 bool CPeripheralMouse::OnButtonPress(MOUSE::BUTTON_ID button)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   // Update state
   SetLastActive(CDateTime::GetCurrentDateTime());
@@ -152,7 +152,7 @@ bool CPeripheralMouse::OnButtonPress(MOUSE::BUTTON_ID button)
 
 void CPeripheralMouse::OnButtonRelease(MOUSE::BUTTON_ID button)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   for (const MouseHandle& handle : m_mouseHandlers)
     handle.handler->OnButtonRelease(button);

--- a/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
@@ -58,7 +58,7 @@ CFileItemPtr CGUIDialogPeripherals::GetItem(unsigned int pos) const
 {
   CFileItemPtr item;
 
-  std::unique_lock<CCriticalSection> lock(m_peripheralsMutex);
+  std::unique_lock lock(m_peripheralsMutex);
 
   if (static_cast<int>(pos) < m_peripherals.Size())
     item = m_peripherals[pos];
@@ -177,7 +177,7 @@ void CGUIDialogPeripherals::UpdatePeripheralsSync()
 {
   int iPos = GetSelectedItem();
 
-  std::unique_lock<CCriticalSection> lock(m_peripheralsMutex);
+  std::unique_lock lock(m_peripheralsMutex);
 
   CFileItemPtr selectedItem;
   if (iPos > 0)

--- a/xbmc/peripherals/events/EventScanner.cpp
+++ b/xbmc/peripherals/events/EventScanner.cpp
@@ -45,7 +45,7 @@ EventPollHandlePtr CEventScanner::RegisterPollHandle()
   EventPollHandlePtr handle(new CEventPollHandle(*this));
 
   {
-    std::unique_lock<CCriticalSection> lock(m_handleMutex);
+    std::unique_lock lock(m_handleMutex);
     m_activeHandles.insert(handle.get());
   }
 
@@ -57,7 +57,7 @@ EventPollHandlePtr CEventScanner::RegisterPollHandle()
 void CEventScanner::Activate(CEventPollHandle& handle)
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_handleMutex);
+    std::unique_lock lock(m_handleMutex);
     m_activeHandles.insert(&handle);
   }
 
@@ -67,7 +67,7 @@ void CEventScanner::Activate(CEventPollHandle& handle)
 void CEventScanner::Deactivate(CEventPollHandle& handle)
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_handleMutex);
+    std::unique_lock lock(m_handleMutex);
     m_activeHandles.erase(&handle);
   }
 
@@ -78,7 +78,7 @@ void CEventScanner::HandleEvents(bool bWait)
 {
   if (bWait)
   {
-    std::unique_lock<CCriticalSection> lock(m_pollMutex);
+    std::unique_lock lock(m_pollMutex);
 
     m_scanFinishedEvent.Reset();
     m_scanEvent.Set();
@@ -93,7 +93,7 @@ void CEventScanner::HandleEvents(bool bWait)
 void CEventScanner::Release(CEventPollHandle& handle)
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_handleMutex);
+    std::unique_lock lock(m_handleMutex);
     m_activeHandles.erase(&handle);
   }
 
@@ -105,7 +105,7 @@ EventLockHandlePtr CEventScanner::RegisterLock()
   EventLockHandlePtr handle(new CEventLockHandle(*this));
 
   {
-    std::unique_lock<CCriticalSection> lock(m_lockMutex);
+    std::unique_lock lock(m_lockMutex);
     m_activeLocks.insert(handle.get());
   }
 
@@ -117,7 +117,7 @@ EventLockHandlePtr CEventScanner::RegisterLock()
 void CEventScanner::ReleaseLock(CEventLockHandle& handle)
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_lockMutex);
+    std::unique_lock lock(m_lockMutex);
     m_activeLocks.erase(&handle);
   }
 
@@ -131,7 +131,7 @@ void CEventScanner::Process()
   while (!m_bStop)
   {
     {
-      std::unique_lock<CCriticalSection> lock(m_lockMutex);
+      std::unique_lock lock(m_lockMutex);
       if (m_activeLocks.empty())
         m_callback.ProcessEvents();
     }
@@ -160,7 +160,7 @@ std::chrono::milliseconds CEventScanner::GetScanIntervalMs() const
   bool bHasActiveHandle;
 
   {
-    std::unique_lock<CCriticalSection> lock(m_handleMutex);
+    std::unique_lock lock(m_handleMutex);
     bHasActiveHandle = !m_activeHandles.empty();
   }
 

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -55,7 +55,7 @@ CSlideShowPic::~CSlideShowPic()
 
 void CSlideShowPic::Close()
 {
-  std::unique_lock<CCriticalSection> lock(m_textureAccess);
+  std::unique_lock lock(m_textureAccess);
   m_pImage.reset();
   m_bIsLoaded = false;
   m_bDrawNextImage = false;
@@ -66,7 +66,7 @@ void CSlideShowPic::Close()
 
 void CSlideShowPic::Reset(DISPLAY_EFFECT dispEffect, TRANSITION_EFFECT transEffect)
 {
-  std::unique_lock<CCriticalSection> lock(m_textureAccess);
+  std::unique_lock lock(m_textureAccess);
   if (m_pImage)
     SetTexture_Internal(m_iSlideNumber, std::move(m_pImage), dispEffect, transEffect);
   else
@@ -102,7 +102,7 @@ void CSlideShowPic::SetTexture(int iSlideNumber,
                                DISPLAY_EFFECT dispEffect,
                                TRANSITION_EFFECT transEffect)
 {
-  std::unique_lock<CCriticalSection> lock(m_textureAccess);
+  std::unique_lock lock(m_textureAccess);
   Close();
   SetTexture_Internal(iSlideNumber, std::move(pTexture), dispEffect, transEffect);
 }
@@ -112,7 +112,7 @@ void CSlideShowPic::SetTexture_Internal(int iSlideNumber,
                                         DISPLAY_EFFECT dispEffect,
                                         TRANSITION_EFFECT transEffect)
 {
-  std::unique_lock<CCriticalSection> lock(m_textureAccess);
+  std::unique_lock lock(m_textureAccess);
   m_bPause = false;
   m_bNoEffect = false;
   m_bTransitionImmediately = false;
@@ -254,7 +254,7 @@ int CSlideShowPic::GetOriginalHeight()
 
 void CSlideShowPic::UpdateTexture(std::unique_ptr<CTexture> pTexture)
 {
-  std::unique_lock<CCriticalSection> lock(m_textureAccess);
+  std::unique_lock lock(m_textureAccess);
   m_pImage = std::move(pTexture);
   m_fWidth = static_cast<float>(m_pImage->GetWidth());
   m_fHeight = static_cast<float>(m_pImage->GetHeight());
@@ -762,7 +762,7 @@ void CSlideShowPic::Render()
   if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
       RENDER_ORDER_FRONT_TO_BACK)
     return;
-  std::unique_lock<CCriticalSection> lock(m_textureAccess);
+  std::unique_lock lock(m_textureAccess);
 
   Render(m_ax, m_ay, m_pImage.get(), (m_alpha << 24) | 0xFFFFFF);
 

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -326,7 +326,7 @@ void CXBMCApp::onResume()
 
   // Clear the applications cache. We could have installed/deinstalled apps
   {
-    std::unique_lock<CCriticalSection> lock(m_applicationsMutex);
+    std::unique_lock lock(m_applicationsMutex);
     m_applications.clear();
   }
 
@@ -963,7 +963,7 @@ void CXBMCApp::ProcessSlow()
 
 std::vector<androidPackage> CXBMCApp::GetApplications() const
 {
-  std::unique_lock<CCriticalSection> lock(m_applicationsMutex);
+  std::unique_lock lock(m_applicationsMutex);
   if (m_applications.empty())
   {
     CJNIList<CJNIApplicationInfo> packageList =

--- a/xbmc/platform/android/network/NetworkAndroid.cpp
+++ b/xbmc/platform/android/network/NetworkAndroid.cpp
@@ -263,13 +263,13 @@ bool CNetworkAndroid::GetHostName(std::string& hostname)
 
 std::vector<CNetworkInterface*>& CNetworkAndroid::GetInterfaceList()
 {
-  std::unique_lock<CCriticalSection> lock(m_refreshMutex);
+  std::unique_lock lock(m_refreshMutex);
   return m_interfaces;
 }
 
 CNetworkInterface* CNetworkAndroid::GetFirstConnectedInterface()
 {
-  std::unique_lock<CCriticalSection> lock(m_refreshMutex);
+  std::unique_lock lock(m_refreshMutex);
 
   if (m_defaultInterface)
     return m_defaultInterface.get();
@@ -321,7 +321,7 @@ bool CNetworkAndroid::PingHost(unsigned long remote_ip, unsigned int timeout_ms)
 
 void CNetworkAndroid::RetrieveInterfaces()
 {
-  std::unique_lock<CCriticalSection> lock(m_refreshMutex);
+  std::unique_lock lock(m_refreshMutex);
 
   // Cannot delete interfaces here, as there still might have references to it
   for (auto intf : m_oldInterfaces)

--- a/xbmc/platform/android/network/ZeroconfAndroid.cpp
+++ b/xbmc/platform/android/network/ZeroconfAndroid.cpp
@@ -44,7 +44,7 @@ bool CZeroconfAndroid::doPublishService(const std::string& fcr_identifier, const
 
   m_manager.registerService(newService.serviceInfo, 1 /* PROTOCOL_DNS_SD */, newService.registrationListener);
 
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   newService.updateNumber = 0;
   m_services.insert(make_pair(fcr_identifier, newService));
 
@@ -54,7 +54,7 @@ bool CZeroconfAndroid::doPublishService(const std::string& fcr_identifier, const
 bool CZeroconfAndroid::doForceReAnnounceService(const std::string& fcr_identifier)
 {
   bool ret = false;
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   tServiceMap::iterator it = m_services.find(fcr_identifier);
   if(it != m_services.end())
   {
@@ -76,7 +76,7 @@ bool CZeroconfAndroid::doForceReAnnounceService(const std::string& fcr_identifie
 
 bool CZeroconfAndroid::doRemoveService(const std::string& fcr_ident)
 {
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   tServiceMap::iterator it = m_services.find(fcr_ident);
   if(it != m_services.end())
   {
@@ -92,7 +92,7 @@ bool CZeroconfAndroid::doRemoveService(const std::string& fcr_ident)
 void CZeroconfAndroid::doStop()
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_data_guard);
+    std::unique_lock lock(m_data_guard);
     CLog::Log(LOGDEBUG, "ZeroconfAndroid: Shutdown services");
     for (const auto& it : m_services)
     {

--- a/xbmc/platform/android/network/ZeroconfBrowserAndroid.cpp
+++ b/xbmc/platform/android/network/ZeroconfBrowserAndroid.cpp
@@ -25,7 +25,7 @@ CZeroconfBrowserAndroid::CZeroconfBrowserAndroid()
 
 CZeroconfBrowserAndroid::~CZeroconfBrowserAndroid()
 {
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   //make sure there are no browsers anymore
   for (const auto& it : m_service_browsers)
     doRemoveServiceType(it.first);
@@ -45,7 +45,7 @@ bool CZeroconfBrowserAndroid::doAddServiceType(const std::string& fcr_service_ty
 
   //store the browser
   {
-    std::unique_lock<CCriticalSection> lock(m_data_guard);
+    std::unique_lock lock(m_data_guard);
     m_service_browsers.insert(std::make_pair(fcr_service_type, discover));
   }
   return true;
@@ -58,7 +58,7 @@ bool CZeroconfBrowserAndroid::doRemoveServiceType(const std::string& fcr_service
   CZeroconfBrowserAndroidDiscover* discover;
   //search for this browser and remove it from the map
   {
-    std::unique_lock<CCriticalSection> lock(m_data_guard);
+    std::unique_lock lock(m_data_guard);
     tBrowserMap::iterator it = m_service_browsers.find(fcr_service_type);
     if(it == m_service_browsers.end())
     {
@@ -73,7 +73,7 @@ bool CZeroconfBrowserAndroid::doRemoveServiceType(const std::string& fcr_service
 
   //remove the services of this browser
   {
-    std::unique_lock<CCriticalSection> lock(m_data_guard);
+    std::unique_lock lock(m_data_guard);
     tDiscoveredServicesMap::iterator it = m_discovered_services.find(discover);
     if(it != m_discovered_services.end())
       m_discovered_services.erase(it);
@@ -86,7 +86,7 @@ bool CZeroconfBrowserAndroid::doRemoveServiceType(const std::string& fcr_service
 std::vector<CZeroconfBrowser::ZeroconfService> CZeroconfBrowserAndroid::doGetFoundServices()
 {
   std::vector<CZeroconfBrowser::ZeroconfService> ret;
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   for (const auto& it : m_discovered_services)
   {
     const auto& services = it.second;
@@ -147,7 +147,7 @@ bool CZeroconfBrowserAndroid::doResolveService(CZeroconfBrowser::ZeroconfService
 /// adds the service to list of found services
 void CZeroconfBrowserAndroid::addDiscoveredService(CZeroconfBrowserAndroidDiscover* browser, CZeroconfBrowser::ZeroconfService const& fcr_service)
 {
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   tDiscoveredServicesMap::iterator browserIt = m_discovered_services.find(browser);
   if(browserIt == m_discovered_services.end())
   {
@@ -170,7 +170,7 @@ void CZeroconfBrowserAndroid::addDiscoveredService(CZeroconfBrowserAndroidDiscov
 
 void CZeroconfBrowserAndroid::removeDiscoveredService(CZeroconfBrowserAndroidDiscover* browser, CZeroconfBrowser::ZeroconfService const& fcr_service)
 {
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   tDiscoveredServicesMap::iterator browserIt = m_discovered_services.find(browser);
   //search this service
   std::vector<std::pair<ZeroconfService, unsigned int> >& services = browserIt->second;

--- a/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
+++ b/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
@@ -411,7 +411,7 @@ void CAndroidJoystickState::GetEvents(std::vector<kodi::addon::PeripheralEvent>&
 
 void CAndroidJoystickState::GetButtonEvents(std::vector<kodi::addon::PeripheralEvent>& events)
 {
-  std::unique_lock<CCriticalSection> lock(m_eventMutex);
+  std::unique_lock lock(m_eventMutex);
 
   // Only report a single event per button (avoids dropping rapid presses)
   std::vector<kodi::addon::PeripheralEvent> repeatButtons;
@@ -446,7 +446,7 @@ bool CAndroidJoystickState::SetButtonValue(int axisId, JOYSTICK_STATE_BUTTON but
   if (!GetAxesIndex({axisId}, m_buttons, buttonIndex) || buttonIndex >= GetButtonCount())
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_eventMutex);
+  std::unique_lock lock(m_eventMutex);
 
   m_digitalEvents.emplace_back(m_deviceId, buttonIndex, buttonValue);
 

--- a/xbmc/platform/android/peripherals/PeripheralBusAndroid.cpp
+++ b/xbmc/platform/android/peripherals/PeripheralBusAndroid.cpp
@@ -112,7 +112,7 @@ bool CPeripheralBusAndroid::InitializeProperties(CPeripheral& peripheral)
   joystick.SetButtonCount(state.GetButtonCount());
   joystick.SetAxisCount(state.GetAxisCount());
 
-  std::unique_lock<CCriticalSection> lock(m_critSectionStates);
+  std::unique_lock lock(m_critSectionStates);
 
   // remember the joystick state
   m_joystickStates.insert(std::make_pair(deviceId, std::move(state)));
@@ -136,7 +136,7 @@ bool CPeripheralBusAndroid::InitializeButtonMap(const CPeripheral& peripheral,
     return false;
   }
 
-  std::unique_lock<CCriticalSection> lock(m_critSectionStates);
+  std::unique_lock lock(m_critSectionStates);
 
   // get the joystick state
   auto it = m_joystickStates.find(deviceId);
@@ -175,7 +175,7 @@ std::string CPeripheralBusAndroid::GetAppearance(const CPeripheral& peripheral) 
   if (!GetDeviceId(peripheral.Location(), deviceId))
     return "";
 
-  std::unique_lock<CCriticalSection> lock(m_critSectionStates);
+  std::unique_lock lock(m_critSectionStates);
 
   auto it = m_joystickStates.find(deviceId);
   if (it == m_joystickStates.end())
@@ -195,7 +195,7 @@ void CPeripheralBusAndroid::ProcessEvents()
 {
   std::vector<kodi::addon::PeripheralEvent> events;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSectionStates);
+    std::unique_lock lock(m_critSectionStates);
     for (auto& joystickState : m_joystickStates)
       joystickState.second.GetEvents(events);
   }
@@ -226,7 +226,7 @@ void CPeripheralBusAndroid::ProcessEvents()
   }
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critSectionStates);
+    std::unique_lock lock(m_critSectionStates);
     for (const auto& joystickState : m_joystickStates)
     {
       PeripheralPtr device = GetPeripheral(GetDeviceLocation(joystickState.second.GetDeviceId()));
@@ -242,7 +242,7 @@ void CPeripheralBusAndroid::OnInputDeviceAdded(int deviceId)
 {
   const std::string deviceLocation = GetDeviceLocation(deviceId);
   {
-    std::unique_lock<CCriticalSection> lock(m_critSectionResults);
+    std::unique_lock lock(m_critSectionResults);
     // add the device to the cached result list
     const auto& it = std::find_if(m_scanResults.m_results.cbegin(), m_scanResults.m_results.cend(),
                                   [&deviceLocation](const PeripheralScanResult& scanResult)
@@ -285,7 +285,7 @@ void CPeripheralBusAndroid::OnInputDeviceChanged(int deviceId)
   bool changed = false;
   const std::string deviceLocation = GetDeviceLocation(deviceId);
   {
-    std::unique_lock<CCriticalSection> lock(m_critSectionResults);
+    std::unique_lock lock(m_critSectionResults);
     // change the device in the cached result list
     for (auto result = m_scanResults.m_results.begin(); result != m_scanResults.m_results.end();
          ++result)
@@ -327,7 +327,7 @@ void CPeripheralBusAndroid::OnInputDeviceRemoved(int deviceId)
   bool removed = false;
   const std::string deviceLocation = GetDeviceLocation(deviceId);
   {
-    std::unique_lock<CCriticalSection> lock(m_critSectionResults);
+    std::unique_lock lock(m_critSectionResults);
     // remove the device from the cached result list
     for (auto result = m_scanResults.m_results.begin(); result != m_scanResults.m_results.end();
          ++result)
@@ -346,7 +346,7 @@ void CPeripheralBusAndroid::OnInputDeviceRemoved(int deviceId)
   if (removed)
   {
     {
-      std::unique_lock<CCriticalSection> lock(m_critSectionStates);
+      std::unique_lock lock(m_critSectionStates);
       m_joystickStates.erase(deviceId);
     }
 
@@ -364,7 +364,7 @@ bool CPeripheralBusAndroid::OnInputDeviceEvent(const AInputEvent* event)
   if (event == nullptr)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_critSectionStates);
+  std::unique_lock lock(m_critSectionStates);
   // get the id of the input device which generated the event
   int32_t deviceId = AInputEvent_getDeviceId(event);
 
@@ -383,7 +383,7 @@ bool CPeripheralBusAndroid::OnInputDeviceEvent(const AInputEvent* event)
 
 bool CPeripheralBusAndroid::PerformDeviceScan(PeripheralScanResults& results)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSectionResults);
+  std::unique_lock lock(m_critSectionResults);
   results = m_scanResults;
 
   return true;

--- a/xbmc/platform/android/speech/SpeechRecognitionAndroid.cpp
+++ b/xbmc/platform/android/speech/SpeechRecognitionAndroid.cpp
@@ -48,7 +48,7 @@ void CSpeechRecognitionAndroid::StartSpeechRecognition(
     if (CJNIContext::checkCallingOrSelfPermission("android.permission.RECORD_AUDIO") ==
         CJNIPackageManager::PERMISSION_GRANTED)
     {
-      std::unique_lock<CCriticalSection> lock(m_speechRecognitionListenersMutex);
+      std::unique_lock lock(m_speechRecognitionListenersMutex);
       m_speechRecognitionListeners.emplace_back(
           std::make_unique<CSpeechRecognitionListenerAndroid>(listener, *this));
       lock.unlock();
@@ -77,7 +77,7 @@ void CSpeechRecognitionAndroid::RegisterSpeechRecognitionListener(void* thiz)
   CJNISpeechRecognizer speechRecognizer =
       CJNISpeechRecognizer::createSpeechRecognizer(sra->m_context);
 
-  std::unique_lock<CCriticalSection> lock(sra->m_speechRecognitionListenersMutex);
+  std::unique_lock lock(sra->m_speechRecognitionListenersMutex);
   speechRecognizer.setRecognitionListener(*(sra->m_speechRecognitionListeners.back()));
   lock.unlock();
 
@@ -91,7 +91,7 @@ void CSpeechRecognitionAndroid::RegisterSpeechRecognitionListener(void* thiz)
 void CSpeechRecognitionAndroid::SpeechRecognitionDone(
     jni::CJNIXBMCSpeechRecognitionListener* listener)
 {
-  std::unique_lock<CCriticalSection> lock(m_speechRecognitionListenersMutex);
+  std::unique_lock lock(m_speechRecognitionListenersMutex);
   for (auto it = m_speechRecognitionListeners.begin(); it != m_speechRecognitionListeners.end();
        ++it)
   {

--- a/xbmc/platform/darwin/network/ZeroconfBrowserDarwin.cpp
+++ b/xbmc/platform/darwin/network/ZeroconfBrowserDarwin.cpp
@@ -116,7 +116,7 @@ CZeroconfBrowserDarwin::CZeroconfBrowserDarwin()
 
 CZeroconfBrowserDarwin::~CZeroconfBrowserDarwin()
 {
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   //make sure there are no browsers anymore
   for (const auto& it : m_service_browsers)
     doRemoveServiceType(it.first);
@@ -183,7 +183,7 @@ void CZeroconfBrowserDarwin::BrowserCallback(CFNetServiceBrowserRef browser, CFO
 void CZeroconfBrowserDarwin::
 addDiscoveredService(CFNetServiceBrowserRef browser, CFOptionFlags flags, CZeroconfBrowser::ZeroconfService const &fcr_service)
 {
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   tDiscoveredServicesMap::iterator browserIt = m_discovered_services.find(browser);
   if (browserIt == m_discovered_services.end())
   {
@@ -207,7 +207,7 @@ addDiscoveredService(CFNetServiceBrowserRef browser, CFOptionFlags flags, CZeroc
 void CZeroconfBrowserDarwin::
 removeDiscoveredService(CFNetServiceBrowserRef browser, CFOptionFlags flags, CZeroconfBrowser::ZeroconfService const &fcr_service)
 {
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   tDiscoveredServicesMap::iterator browserIt = m_discovered_services.find(browser);
   assert(browserIt != m_discovered_services.end());
   //search this service
@@ -263,7 +263,7 @@ bool CZeroconfBrowserDarwin::doAddServiceType(const std::string& fcr_service_typ
   else
   {
     //store the browser
-    std::unique_lock<CCriticalSection> lock(m_data_guard);
+    std::unique_lock lock(m_data_guard);
     m_service_browsers.insert(std::make_pair(fcr_service_type, p_browser));
   }
 
@@ -275,7 +275,7 @@ bool CZeroconfBrowserDarwin::doRemoveServiceType(const std::string &fcr_service_
   //search for this browser and remove it from the map
   CFNetServiceBrowserRef browser = 0;
   {
-    std::unique_lock<CCriticalSection> lock(m_data_guard);
+    std::unique_lock lock(m_data_guard);
     tBrowserMap::iterator it = m_service_browsers.find(fcr_service_type);
     if (it == m_service_browsers.end())
       return false;
@@ -292,7 +292,7 @@ bool CZeroconfBrowserDarwin::doRemoveServiceType(const std::string &fcr_service_
   CFNetServiceBrowserInvalidate(browser);
   //remove the services of this browser
   {
-    std::unique_lock<CCriticalSection> lock(m_data_guard);
+    std::unique_lock lock(m_data_guard);
     tDiscoveredServicesMap::iterator it = m_discovered_services.find(browser);
     if (it != m_discovered_services.end())
       m_discovered_services.erase(it);
@@ -305,7 +305,7 @@ bool CZeroconfBrowserDarwin::doRemoveServiceType(const std::string &fcr_service_
 std::vector<CZeroconfBrowser::ZeroconfService> CZeroconfBrowserDarwin::doGetFoundServices()
 {
   std::vector<CZeroconfBrowser::ZeroconfService> ret;
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   for (const auto& it : m_discovered_services)
   {
     const auto& services = it.second;

--- a/xbmc/platform/darwin/network/ZeroconfDarwin.cpp
+++ b/xbmc/platform/darwin/network/ZeroconfDarwin.cpp
@@ -102,7 +102,7 @@ bool CZeroconfDarwin::doPublishService(const std::string& fcr_identifier,
               (int)error.domain, (int64_t)error.error);
   } else
   {
-    std::unique_lock<CCriticalSection> lock(m_data_guard);
+    std::unique_lock lock(m_data_guard);
     m_services.insert(make_pair(fcr_identifier, netService));
   }
 
@@ -112,7 +112,7 @@ bool CZeroconfDarwin::doPublishService(const std::string& fcr_identifier,
 bool CZeroconfDarwin::doForceReAnnounceService(const std::string& fcr_identifier)
 {
   bool ret = false;
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   tServiceMap::iterator it = m_services.find(fcr_identifier);
   if(it != m_services.end())
   {
@@ -137,7 +137,7 @@ bool CZeroconfDarwin::doForceReAnnounceService(const std::string& fcr_identifier
 
 bool CZeroconfDarwin::doRemoveService(const std::string& fcr_ident)
 {
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   tServiceMap::iterator it = m_services.find(fcr_ident);
   if(it != m_services.end())
   {
@@ -150,7 +150,7 @@ bool CZeroconfDarwin::doRemoveService(const std::string& fcr_ident)
 
 void CZeroconfDarwin::doStop()
 {
-  std::unique_lock<CCriticalSection> lock(m_data_guard);
+  std::unique_lock lock(m_data_guard);
   for (const auto& it : m_services)
     cancelRegistration(it.second);
   m_services.clear();
@@ -175,7 +175,7 @@ void CZeroconfDarwin::registerCallback(CFNetServiceRef theService, CFStreamError
     }
     p_this->cancelRegistration(theService);
     //remove it
-    std::unique_lock<CCriticalSection> lock(p_this->m_data_guard);
+    std::unique_lock lock(p_this->m_data_guard);
     for (tServiceMap::iterator it = p_this->m_services.begin(); it != p_this->m_services.end();
          ++it)
     {

--- a/xbmc/platform/darwin/peripherals/Input_Gamecontroller.mm
+++ b/xbmc/platform/darwin/peripherals/Input_Gamecontroller.mm
@@ -117,7 +117,7 @@ struct PlayerControllerState
 - (void)controllerConnection:(GCController*)controller
 {
   // Lock so add/remove events are serialised
-  std::unique_lock<CCriticalSection> lock(m_controllerMutex);
+  std::unique_lock lock(m_controllerMutex);
 
   if ([controllerArray containsObject:controller])
   {
@@ -171,7 +171,7 @@ struct PlayerControllerState
 - (void)controllerWasDisconnected:(NSNotification*)notification
 {
   // Lock so add/remove events are serialised
-  std::unique_lock<CCriticalSection> lock(m_controllerMutex);
+  std::unique_lock lock(m_controllerMutex);
   // a controller was disconnected
   GCController* controller = (GCController*)notification.object;
   if (!controllerArray)
@@ -206,7 +206,7 @@ struct PlayerControllerState
         kodi::addon::PeripheralEvent newEvent;
         newEvent.SetPeripheralIndex(static_cast<unsigned int>(gamepad.controller.playerIndex));
 
-        std::unique_lock<CCriticalSection> lock(m_GCMutex);
+        std::unique_lock lock(m_GCMutex);
 
         // A button
         if (gamepad.buttonA == element)
@@ -265,7 +265,7 @@ struct PlayerControllerState
     newEvent.SetPeripheralIndex(playerIndex);
     axisEvent.SetPeripheralIndex(playerIndex);
 
-    std::unique_lock<CCriticalSection> lock(m_GCMutex);
+    std::unique_lock lock(m_GCMutex);
 
     // left trigger
     if (gamepad.leftTrigger == element)

--- a/xbmc/platform/darwin/peripherals/PeripheralBusGCController.mm
+++ b/xbmc/platform/darwin/peripherals/PeripheralBusGCController.mm
@@ -115,7 +115,7 @@ void PERIPHERALS::CPeripheralBusGCController::Initialise(void)
 
 bool PERIPHERALS::CPeripheralBusGCController::PerformDeviceScan(PeripheralScanResults& results)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSectionResults);
+  std::unique_lock lock(m_critSectionResults);
   results = m_scanResults;
 
   return true;
@@ -124,14 +124,14 @@ bool PERIPHERALS::CPeripheralBusGCController::PerformDeviceScan(PeripheralScanRe
 void PERIPHERALS::CPeripheralBusGCController::SetScanResults(
     const PERIPHERALS::PeripheralScanResults& resScanResults)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSectionResults);
+  std::unique_lock lock(m_critSectionResults);
   m_scanResults = resScanResults;
 }
 
 void PERIPHERALS::CPeripheralBusGCController::GetEvents(
     std::vector<kodi::addon::PeripheralEvent>& events)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSectionStates);
+  std::unique_lock lock(m_critSectionStates);
   std::vector<kodi::addon::PeripheralEvent> digitalEvents;
   digitalEvents = [m_peripheralGCController->callbackClass GetButtonEvents];
 
@@ -163,7 +163,7 @@ void PERIPHERALS::CPeripheralBusGCController::ProcessEvents()
 {
   std::vector<kodi::addon::PeripheralEvent> events;
   {
-    std::unique_lock<CCriticalSection> lock(m_critSectionStates);
+    std::unique_lock lock(m_critSectionStates);
 
     //! @todo Multiple controller event processing
     GetEvents(events);
@@ -194,7 +194,7 @@ void PERIPHERALS::CPeripheralBusGCController::ProcessEvents()
     }
   }
   {
-    std::unique_lock<CCriticalSection> lock(m_critSectionStates);
+    std::unique_lock lock(m_critSectionStates);
     //! @todo Multiple controller handling
     PeripheralPtr device = GetPeripheral(GetDeviceLocation(0));
 

--- a/xbmc/platform/darwin/peripherals/PeripheralBusGCControllerManager.mm
+++ b/xbmc/platform/darwin/peripherals/PeripheralBusGCControllerManager.mm
@@ -66,14 +66,14 @@
 
 - (void)SetDigitalEvent:(kodi::addon::PeripheralEvent)event
 {
-  std::unique_lock<CCriticalSection> lock(m_eventMutex);
+  std::unique_lock lock(m_eventMutex);
 
   m_digitalEvents.emplace_back(event);
 }
 
 - (void)SetAxisEvent:(kodi::addon::PeripheralEvent)event
 {
-  std::unique_lock<CCriticalSection> lock(m_eventMutex);
+  std::unique_lock lock(m_eventMutex);
 
   m_axisEvents.emplace_back(event);
 }
@@ -83,7 +83,7 @@
 - (std::vector<kodi::addon::PeripheralEvent>)GetAxisEvents
 {
   std::vector<kodi::addon::PeripheralEvent> events;
-  std::unique_lock<CCriticalSection> lock(m_eventMutex);
+  std::unique_lock lock(m_eventMutex);
 
   for (unsigned int i = 0; i < m_axisEvents.size(); i++)
     events.emplace_back(m_axisEvents[i]);
@@ -97,7 +97,7 @@
 {
   std::vector<kodi::addon::PeripheralEvent> events;
 
-  std::unique_lock<CCriticalSection> lock(m_eventMutex);
+  std::unique_lock lock(m_eventMutex);
   // Only report a single event per button (avoids dropping rapid presses)
   std::vector<kodi::addon::PeripheralEvent> repeatButtons;
 

--- a/xbmc/platform/darwin/speech/SpeechRecognitionDarwin.mm
+++ b/xbmc/platform/darwin/speech/SpeechRecognitionDarwin.mm
@@ -297,7 +297,7 @@ void CSpeechRecognitionDarwin::StartSpeechRecognition(
       return;
     }
 
-    std::unique_lock<CCriticalSection> lock(m_impl->m_listenersMutex);
+    std::unique_lock lock(m_impl->m_listenersMutex);
     m_impl->m_listeners.emplace_back(
         listener); // we need to ensure the listener lives as long as we do
     lock.unlock();
@@ -317,7 +317,7 @@ CSpeechRecognitionDarwin::~CSpeechRecognitionDarwin()
 
 void CSpeechRecognitionDarwin::OnRecognitionDone(speech::ISpeechRecognitionListener* listener)
 {
-  std::unique_lock<CCriticalSection> lock(m_impl->m_listenersMutex);
+  std::unique_lock lock(m_impl->m_listenersMutex);
   for (auto it = m_impl->m_listeners.begin(); it != m_impl->m_listeners.end(); ++it)
   {
     if ((*it).get() == listener)

--- a/xbmc/platform/linux/FDEventMonitor.cpp
+++ b/xbmc/platform/linux/FDEventMonitor.cpp
@@ -27,7 +27,7 @@ CFDEventMonitor::CFDEventMonitor() :
 
 CFDEventMonitor::~CFDEventMonitor()
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
   InterruptPoll();
 
   if (m_wakeupfd >= 0)
@@ -50,7 +50,7 @@ CFDEventMonitor::~CFDEventMonitor()
 
 void CFDEventMonitor::AddFD(const MonitoredFD& monitoredFD, int& id)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
   InterruptPoll();
 
   AddFDLocked(monitoredFD, id);
@@ -61,7 +61,7 @@ void CFDEventMonitor::AddFD(const MonitoredFD& monitoredFD, int& id)
 void CFDEventMonitor::AddFDs(const std::vector<MonitoredFD>& monitoredFDs,
                              std::vector<int>& ids)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
   InterruptPoll();
 
   for (unsigned int i = 0; i < monitoredFDs.size(); ++i)
@@ -76,7 +76,7 @@ void CFDEventMonitor::AddFDs(const std::vector<MonitoredFD>& monitoredFDs,
 
 void CFDEventMonitor::RemoveFD(int id)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
   InterruptPoll();
 
   if (m_monitoredFDs.erase(id) != 1)
@@ -90,7 +90,7 @@ void CFDEventMonitor::RemoveFD(int id)
 
 void CFDEventMonitor::RemoveFDs(const std::vector<int>& ids)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
   InterruptPoll();
 
   for (unsigned int i = 0; i < ids.size(); ++i)
@@ -113,8 +113,8 @@ void CFDEventMonitor::Process()
 
   while (!m_bStop)
   {
-    std::unique_lock<CCriticalSection> lock(m_mutex);
-    std::unique_lock<CCriticalSection> pollLock(m_pollMutex);
+    std::unique_lock lock(m_mutex);
+    std::unique_lock pollLock(m_pollMutex);
 
     /*
      * Leave the main mutex here to allow another thread to
@@ -238,6 +238,6 @@ void CFDEventMonitor::InterruptPoll()
   {
     eventfd_write(m_wakeupfd, 1);
     /* wait for the poll() result handling (if any) to end */
-    std::unique_lock<CCriticalSection> pollLock(m_pollMutex);
+    std::unique_lock pollLock(m_pollMutex);
   }
 }

--- a/xbmc/platform/linux/input/LIRC.cpp
+++ b/xbmc/platform/linux/input/LIRC.cpp
@@ -38,7 +38,7 @@ CLirc::CLirc() : CThread("Lirc"), m_irTranslator(std::make_unique<KEYMAP::CIRTra
 CLirc::~CLirc()
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     if (m_fd > 0)
       shutdown(m_fd, SHUT_RDWR);
   }
@@ -75,7 +75,7 @@ void CLirc::Process()
   while (!m_bStop)
   {
     {
-      std::unique_lock<CCriticalSection> lock(m_critSection);
+      std::unique_lock lock(m_critSection);
 
       // lirc_client is buggy because it does not close socket, if connect fails
       // work around by checking if daemon is running before calling lirc_init

--- a/xbmc/platform/posix/XHandle.cpp
+++ b/xbmc/platform/posix/XHandle.cpp
@@ -124,7 +124,7 @@ bool CloseHandle(HANDLE hObject) {
 
   bool bDelete = false;
   {
-    std::unique_lock<CCriticalSection> lock((*hObject->m_internalLock));
+    std::unique_lock lock((*hObject->m_internalLock));
     if (--hObject->m_nRefCount == 0)
       bDelete = true;
   }

--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -61,7 +61,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   // We accept smb://[[[domain;]user[:password@]]server[/share[/path[/file]]]]
 
   /* samba isn't thread safe with old interface, always lock */
-  std::unique_lock<CCriticalSection> lock(smb);
+  std::unique_lock lock(smb);
 
   smb.Init();
 
@@ -290,7 +290,7 @@ int CSMBDirectory::OpenDir(const CURL& url, std::string& strAuth)
   CLog::LogFC(LOGDEBUG, LOGSAMBA, "Using authentication url {}", CURL::GetRedacted(s));
 
   {
-    std::unique_lock<CCriticalSection> lock(smb);
+    std::unique_lock lock(smb);
     if (!smb.IsSmbValid())
       return -1;
     fd = smbc_opendir(s.c_str());
@@ -338,7 +338,7 @@ int CSMBDirectory::OpenDir(const CURL& url, std::string& strAuth)
 
 bool CSMBDirectory::Create(const CURL& url2)
 {
-  std::unique_lock<CCriticalSection> lock(smb);
+  std::unique_lock lock(smb);
   smb.Init();
 
   CURL url = CSMB::GetResolvedUrl(url2);
@@ -355,7 +355,7 @@ bool CSMBDirectory::Create(const CURL& url2)
 
 bool CSMBDirectory::Remove(const CURL& url2)
 {
-  std::unique_lock<CCriticalSection> lock(smb);
+  std::unique_lock lock(smb);
   smb.Init();
 
   CURL url = CSMB::GetResolvedUrl(url2);
@@ -375,7 +375,7 @@ bool CSMBDirectory::Remove(const CURL& url2)
 
 bool CSMBDirectory::Exists(const CURL& url2)
 {
-  std::unique_lock<CCriticalSection> lock(smb);
+  std::unique_lock lock(smb);
   smb.Init();
 
   CURL url = CSMB::GetResolvedUrl(url2);

--- a/xbmc/platform/posix/filesystem/SMBWSDiscovery.cpp
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscovery.cpp
@@ -74,7 +74,7 @@ bool CWSDiscoveryPosix::IsRunning()
 bool CWSDiscoveryPosix::GetServerList(CFileItemList& items)
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_critWSD);
+    std::unique_lock lock(m_critWSD);
 
     for (const auto& item : m_vecWSDInfo)
     {
@@ -102,7 +102,7 @@ bool CWSDiscoveryPosix::GetCached(const std::string& strHostName, std::string& s
 {
   const std::string match = strHostName + "/";
 
-  std::unique_lock<CCriticalSection> lock(m_critWSD);
+  std::unique_lock lock(m_critWSD);
   for (const auto& item : m_vecWSDInfo)
   {
     if (!item.computer.empty() && StringUtils::StartsWithNoCase(item.computer, match))
@@ -120,7 +120,7 @@ bool CWSDiscoveryPosix::GetCached(const std::string& strHostName, std::string& s
 void CWSDiscoveryPosix::SetItems(std::vector<wsd_req_info> entries)
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_critWSD);
+    std::unique_lock lock(m_critWSD);
     m_vecWSDInfo = std::move(entries);
   }
 }

--- a/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
@@ -322,7 +322,7 @@ bool CWSDiscoveryListenerUDP::DispatchCommand()
 {
   Command sendCommand;
   {
-    std::unique_lock<CCriticalSection> lock(crit_commandqueue);
+    std::unique_lock lock(crit_commandqueue);
     if (m_commandbuffer.size() <= 0)
       return false;
 
@@ -355,7 +355,7 @@ void CWSDiscoveryListenerUDP::AddCommand(const std::string& message,
                                          const std::string& extraparameter /* = "" */)
 {
 
-  std::unique_lock<CCriticalSection> lock(crit_commandqueue);
+  std::unique_lock lock(crit_commandqueue);
 
   std::string msg{};
 
@@ -447,7 +447,7 @@ void CWSDiscoveryListenerUDP::ParseBuffer(const std::string& buffer)
   }
 
   {
-    std::unique_lock<CCriticalSection> lock(crit_wsdqueue);
+    std::unique_lock lock(crit_wsdqueue);
     auto searchitem = std::find_if(m_vecWSDInfo.begin(), m_vecWSDInfo.end(),
                                    [info](const wsd_req_info& item) { return item == info; });
 

--- a/xbmc/platform/win10/network/NetworkWin10.cpp
+++ b/xbmc/platform/win10/network/NetworkWin10.cpp
@@ -167,7 +167,7 @@ CNetworkWin10::CNetworkWin10() : CNetworkBase()
   NetworkInformation::NetworkStatusChanged(
       [this](auto&&)
       {
-        std::unique_lock<CCriticalSection> lock(m_critSection);
+        std::unique_lock lock(m_critSection);
         queryInterfaceList();
       });
 }
@@ -190,13 +190,13 @@ void CNetworkWin10::CleanInterfaceList()
 
 std::vector<CNetworkInterface*>& CNetworkWin10::GetInterfaceList(void)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_interfaces;
 }
 
 CNetworkInterface* CNetworkWin10::GetFirstConnectedInterface()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   for (CNetworkInterface* intf : m_interfaces)
   {
     if (intf->IsEnabled() && intf->IsConnected() && !intf->GetCurrentDefaultGateway().empty())

--- a/xbmc/platform/win32/input/IRServerSuite.cpp
+++ b/xbmc/platform/win32/input/IRServerSuite.cpp
@@ -38,7 +38,7 @@ CIRServerSuite::~CIRServerSuite()
 {
   m_event.Set();
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     Close();
   }
   StopThread();
@@ -413,7 +413,7 @@ int CIRServerSuite::ReadN(char *buffer, int n)
   {
     int nBytes = 0;
     {
-      std::unique_lock<CCriticalSection> lock(m_critSection);
+      std::unique_lock lock(m_critSection);
       nBytes = recv(m_socket, ptr, n, 0);
     }
 
@@ -452,7 +452,7 @@ bool CIRServerSuite::WriteN(const char *buffer, int n)
   {
     int nBytes;
     {
-      std::unique_lock<CCriticalSection> lock(m_critSection);
+      std::unique_lock lock(m_critSection);
       nBytes = send(m_socket, ptr, n, 0);
     }
 

--- a/xbmc/platform/win32/network/NetworkWin32.cpp
+++ b/xbmc/platform/win32/network/NetworkWin32.cpp
@@ -128,7 +128,7 @@ void CNetworkWin32::CleanInterfaceList()
 
 std::vector<CNetworkInterface*>& CNetworkWin32::GetInterfaceList(void)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if(m_netrefreshTimer.GetElapsedSeconds() >= 5.0f)
     queryInterfaceList();
 

--- a/xbmc/platform/win32/network/WSDiscoveryWin32.cpp
+++ b/xbmc/platform/win32/network/WSDiscoveryWin32.cpp
@@ -57,7 +57,7 @@ HRESULT STDMETHODCALLTYPE CClientNotificationSink::Add(IWSDiscoveredService* ser
   if (!service)
     return E_INVALIDARG;
 
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
 
   WSD_NAME_LIST* list = nullptr;
   service->GetTypes(&list);
@@ -109,7 +109,7 @@ HRESULT STDMETHODCALLTYPE CClientNotificationSink::Remove(IWSDiscoveredService* 
   if (!service)
     return E_INVALIDARG;
 
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
 
   LPCWSTR address = nullptr;
   service->GetRemoteTransportAddress(&address);
@@ -138,7 +138,7 @@ HRESULT STDMETHODCALLTYPE CClientNotificationSink::Remove(IWSDiscoveredService* 
 
 HRESULT STDMETHODCALLTYPE CClientNotificationSink::SearchFailed(HRESULT hr, LPCWSTR tag)
 {
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
 
   // This must not happen. At least localhost (127.0.0.1) has to be found
   CLog::Log(LOGWARNING,
@@ -149,7 +149,7 @@ HRESULT STDMETHODCALLTYPE CClientNotificationSink::SearchFailed(HRESULT hr, LPCW
 
 HRESULT STDMETHODCALLTYPE CClientNotificationSink::SearchComplete(LPCWSTR tag)
 {
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
 
   std::string list;
 

--- a/xbmc/platform/win32/threads/ThreadImplWin.cpp
+++ b/xbmc/platform/win32/threads/ThreadImplWin.cpp
@@ -97,7 +97,7 @@ bool CThreadImplWin::SetPriority(const ThreadPriority& priority)
 {
   bool bReturn = false;
 
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
   if (m_handle)
     bReturn = SetThreadPriority(m_handle, ThreadPriorityToNativePriority(priority)) == TRUE;
 

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -137,7 +137,7 @@ bool CProfileManager::Load()
   bool ret = true;
   const std::string file = PROFILES_FILE;
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
 
   // clear out our profiles
   m_profiles.clear();
@@ -222,7 +222,7 @@ bool CProfileManager::Save() const
 {
   const std::string file = PROFILES_FILE;
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
 
   CXBMCTinyXML xmlDoc;
   TiXmlElement xmlRootElement(XML_PROFILES);
@@ -244,7 +244,7 @@ bool CProfileManager::Save() const
 
 void CProfileManager::Clear()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   m_usingLoginScreen = false;
   m_profileLoadedForLogin = false;
   m_previousProfileLoadedForLogin = false;
@@ -288,7 +288,7 @@ bool CProfileManager::LoadProfile(unsigned int index)
     return true;
   }
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   // check if the index is valid or not
   if (index >= m_profiles.size())
     return false;
@@ -468,7 +468,7 @@ void CProfileManager::LogOff()
 
 bool CProfileManager::DeleteProfile(unsigned int index)
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   const CProfile *profile = GetProfile(index);
   if (profile == NULL)
     return false;
@@ -536,7 +536,7 @@ void CProfileManager::CreateProfileFolders()
 
 const CProfile& CProfileManager::GetMasterProfile() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (!m_profiles.empty())
     return m_profiles[0];
 
@@ -546,7 +546,7 @@ const CProfile& CProfileManager::GetMasterProfile() const
 
 const CProfile& CProfileManager::GetCurrentProfile() const
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (m_currentProfile < m_profiles.size())
     return m_profiles[m_currentProfile];
 
@@ -556,7 +556,7 @@ const CProfile& CProfileManager::GetCurrentProfile() const
 
 const CProfile* CProfileManager::GetProfile(unsigned int index) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (index < m_profiles.size())
     return &m_profiles[index];
 
@@ -565,7 +565,7 @@ const CProfile* CProfileManager::GetProfile(unsigned int index) const
 
 CProfile* CProfileManager::GetProfile(unsigned int index)
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (index < m_profiles.size())
     return &m_profiles[index];
 
@@ -574,7 +574,7 @@ CProfile* CProfileManager::GetProfile(unsigned int index)
 
 int CProfileManager::GetProfileIndex(const std::string &name) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   for (int i = 0; i < static_cast<int>(m_profiles.size()); i++)
   {
     if (StringUtils::EqualsNoCase(m_profiles[i].getName(), name))
@@ -587,7 +587,7 @@ int CProfileManager::GetProfileIndex(const std::string &name) const
 void CProfileManager::AddProfile(const CProfile &profile)
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_critical);
+    std::unique_lock lock(m_critical);
     // data integrity check - covers off migration from old profiles.xml,
     // incrementing of the m_nextIdProfile,and bad data coming in
     m_nextProfileId = std::max(m_nextProfileId, profile.getId() + 1);
@@ -599,7 +599,7 @@ void CProfileManager::AddProfile(const CProfile &profile)
 
 void CProfileManager::UpdateCurrentProfileDate()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (m_currentProfile < m_profiles.size())
   {
     m_profiles[m_currentProfile].setDate();
@@ -610,7 +610,7 @@ void CProfileManager::UpdateCurrentProfileDate()
 
 void CProfileManager::LoadMasterProfileForLogin()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   // save the previous user
   m_lastUsedProfile = m_currentProfile;
   if (m_currentProfile != 0)
@@ -627,7 +627,7 @@ void CProfileManager::LoadMasterProfileForLogin()
 
 bool CProfileManager::GetProfileName(const unsigned int profileId, std::string& name) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   const CProfile *profile = GetProfile(profileId);
   if (!profile)
     return false;
@@ -736,7 +736,7 @@ void CProfileManager::OnSettingAction(const std::shared_ptr<const CSetting>& set
 void CProfileManager::SetCurrentProfileId(unsigned int profileId)
 {
   {
-    std::unique_lock<CCriticalSection> lock(m_critical);
+    std::unique_lock lock(m_critical);
     m_currentProfile = profileId;
     CSpecialProtocol::SetProfilePath(GetProfileUserDataFolder());
   }

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -124,7 +124,7 @@ bool CRenderSystemDX::IsFormatSupport(DXGI_FORMAT format, unsigned int usage) co
 
 bool CRenderSystemDX::DestroyRenderSystem()
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
 
   if (m_pGUIShader)
   {
@@ -281,7 +281,7 @@ void CRenderSystemDX::PresentRender(bool rendered, bool videoLayer)
 
   // time for decoder that may require the context
   {
-    std::unique_lock<CCriticalSection> lock(m_decoderSection);
+    std::unique_lock lock(m_decoderSection);
     XbmcThreads::EndTime<> timer;
     timer.Set(5ms);
     while (!m_decodingTimer.IsTimePast() && !timer.IsTimePast())
@@ -295,13 +295,13 @@ void CRenderSystemDX::PresentRender(bool rendered, bool videoLayer)
 
 void CRenderSystemDX::RequestDecodingTime()
 {
-  std::unique_lock<CCriticalSection> lock(m_decoderSection);
+  std::unique_lock lock(m_decoderSection);
   m_decodingTimer.Set(3ms);
 }
 
 void CRenderSystemDX::ReleaseDecodingTime()
 {
-  std::unique_lock<CCriticalSection> lock(m_decoderSection);
+  std::unique_lock lock(m_decoderSection);
   m_decodingTimer.SetExpired();
   m_decodingEvent.notify();
 }

--- a/xbmc/rendering/dx/ScreenshotSurfaceWindows.cpp
+++ b/xbmc/rendering/dx/ScreenshotSurfaceWindows.cpp
@@ -42,7 +42,7 @@ bool CScreenshotSurfaceWindows::Capture()
   if (!gui)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(winsystem->GetGfxContext());
+  std::unique_lock lock(winsystem->GetGfxContext());
   gui->GetWindowManager().Render();
 
   auto deviceResources = DX::DeviceResources::Get();

--- a/xbmc/rendering/gl/ScreenshotSurfaceGL.cpp
+++ b/xbmc/rendering/gl/ScreenshotSurfaceGL.cpp
@@ -40,7 +40,7 @@ bool CScreenshotSurfaceGL::Capture()
   if (!gui)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(winsystem->GetGfxContext());
+  std::unique_lock lock(winsystem->GetGfxContext());
   gui->GetWindowManager().Render();
 
   glReadBuffer(GL_BACK);

--- a/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
+++ b/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
@@ -40,7 +40,7 @@ bool CScreenshotSurfaceGLES::Capture()
   if (!gui)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(winsystem->GetGfxContext());
+  std::unique_lock lock(winsystem->GetGfxContext());
   gui->GetWindowManager().Render();
 
   //get current viewport

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -99,7 +99,7 @@ CDisplaySettings& CDisplaySettings::GetInstance()
 
 bool CDisplaySettings::Load(const TiXmlNode *settings)
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   m_calibrations.clear();
 
   if (settings == NULL)
@@ -166,7 +166,7 @@ bool CDisplaySettings::Save(TiXmlNode *settings) const
   if (settings == NULL)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   TiXmlElement xmlRootElement("resolutions");
   TiXmlNode *pRoot = settings->InsertEndChild(xmlRootElement);
   if (pRoot == NULL)
@@ -208,7 +208,7 @@ bool CDisplaySettings::Save(TiXmlNode *settings) const
 
 void CDisplaySettings::Clear()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   m_calibrations.clear();
   m_resolutions.clear();
   m_resolutions.resize(RES_CUSTOM);
@@ -454,7 +454,7 @@ RESOLUTION CDisplaySettings::GetDisplayResolution() const
 
 const RESOLUTION_INFO& CDisplaySettings::GetResolutionInfo(size_t index) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (index >= m_resolutions.size())
     return EmptyResolution;
 
@@ -471,7 +471,7 @@ const RESOLUTION_INFO& CDisplaySettings::GetResolutionInfo(RESOLUTION resolution
 
 RESOLUTION_INFO& CDisplaySettings::GetResolutionInfo(size_t index)
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (index >= m_resolutions.size())
   {
     EmptyModifiableResolution = RESOLUTION_INFO();
@@ -494,7 +494,7 @@ RESOLUTION_INFO& CDisplaySettings::GetResolutionInfo(RESOLUTION resolution)
 
 void CDisplaySettings::AddResolutionInfo(const RESOLUTION_INFO &resolution)
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   RESOLUTION_INFO res(resolution);
 
   if((res.dwFlags & D3DPRESENTFLAG_MODE3DTB) == 0)
@@ -520,7 +520,7 @@ void CDisplaySettings::AddResolutionInfo(const RESOLUTION_INFO &resolution)
 
 void CDisplaySettings::ApplyCalibrations()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   // apply all calibrations to the resolutions
   for (ResolutionInfos::const_iterator itCal = m_calibrations.begin(); itCal != m_calibrations.end(); ++itCal)
   {
@@ -573,7 +573,7 @@ void CDisplaySettings::ApplyCalibrations()
 
 void CDisplaySettings::UpdateCalibrations()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
 
   if (m_resolutions.size() <= RES_DESKTOP)
     return;
@@ -599,7 +599,7 @@ void CDisplaySettings::UpdateCalibrations()
 
 void CDisplaySettings::ClearCalibrations()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   m_calibrations.clear();
 }
 

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -73,7 +73,7 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
   if (settings == NULL)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   const TiXmlElement *pElement = settings->FirstChildElement("defaultvideosettings");
   if (pElement != NULL)
   {
@@ -211,7 +211,7 @@ bool CMediaSettings::Save(TiXmlNode *settings) const
   if (settings == NULL)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   // default video settings
   TiXmlElement videoSettingsNode("defaultvideosettings");
   TiXmlNode *pNode = settings->InsertEndChild(videoSettingsNode);
@@ -385,7 +385,7 @@ void CMediaSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& set
 
 int CMediaSettings::GetWatchedMode(const std::string &content) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   WatchedModes::const_iterator it = m_watchedModes.find(GetWatchedContent(content));
   if (it != m_watchedModes.end())
     return it->second;
@@ -395,7 +395,7 @@ int CMediaSettings::GetWatchedMode(const std::string &content) const
 
 void CMediaSettings::SetWatchedMode(const std::string &content, WatchedMode mode)
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   WatchedModes::iterator it = m_watchedModes.find(GetWatchedContent(content));
   if (it != m_watchedModes.end())
     it->second = mode;
@@ -403,7 +403,7 @@ void CMediaSettings::SetWatchedMode(const std::string &content, WatchedMode mode
 
 void CMediaSettings::CycleWatchedMode(const std::string &content)
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   WatchedModes::iterator it = m_watchedModes.find(GetWatchedContent(content));
   if (it != m_watchedModes.end())
   {

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -63,7 +63,7 @@ using namespace XFILE;
 
 bool CSettings::Initialize()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (m_initialized)
     return false;
 
@@ -97,7 +97,7 @@ void CSettings::RegisterSubSettings(ISubSettings* subSettings)
   if (subSettings == nullptr)
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   m_subSettings.insert(subSettings);
 }
 
@@ -106,7 +106,7 @@ void CSettings::UnregisterSubSettings(ISubSettings* subSettings)
   if (subSettings == nullptr)
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   m_subSettings.erase(subSettings);
 }
 
@@ -170,7 +170,7 @@ bool CSettings::Save(const std::string &file)
 
 bool CSettings::Save(TiXmlNode* root) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   // save any ISubSettings implementations
   for (const auto& subSetting : m_subSettings)
   {
@@ -197,7 +197,7 @@ bool CSettings::GetBool(const std::string& id) const
 
 void CSettings::Clear()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (!m_initialized)
     return;
 
@@ -223,7 +223,7 @@ bool CSettings::Load(const TiXmlElement* root, bool& updated)
 bool CSettings::Load(const TiXmlNode* settings)
 {
   bool ok = true;
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   for (const auto& subSetting : m_subSettings)
     ok &= subSetting->Load(settings);
 

--- a/xbmc/settings/SettingsBase.cpp
+++ b/xbmc/settings/SettingsBase.cpp
@@ -32,7 +32,7 @@ CSettingsBase::~CSettingsBase()
 
 bool CSettingsBase::Initialize()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (m_initialized)
     return false;
 
@@ -135,7 +135,7 @@ void CSettingsBase::Unload()
 
 void CSettingsBase::Uninitialize()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (!m_initialized)
     return;
 

--- a/xbmc/settings/SkinSettings.cpp
+++ b/xbmc/settings/SkinSettings.cpp
@@ -117,7 +117,7 @@ bool CSkinSettings::Load(const TiXmlNode *settings)
     return true;
   }
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   m_settings.clear();
   m_settings = ADDON::CSkinInfo::ParseSettings(rootElement);
 
@@ -136,7 +136,7 @@ bool CSkinSettings::Save(TiXmlNode *settings) const
 
 void CSkinSettings::Clear()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   m_settings.clear();
 }
 
@@ -145,7 +145,7 @@ void CSkinSettings::MigrateSettings(const std::shared_ptr<ADDON::CSkinInfo>& ski
   if (skin == nullptr)
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
 
   bool settingsMigrated = false;
   const std::string& skinId = skin->ID();

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -100,7 +100,7 @@ void CDetectDVDMedia::UpdateDvdrom()
   // that we are busy detecting the
   // newly inserted media.
   {
-    std::unique_lock<CCriticalSection> waitLock(m_muReadingMedia);
+    std::unique_lock waitLock(m_muReadingMedia);
     switch (PollDriveState())
     {
       case DriveState::NONE:
@@ -378,7 +378,7 @@ DriveState CDetectDVDMedia::PollDriveState()
 
 void CDetectDVDMedia::UpdateState()
 {
-  std::unique_lock<CCriticalSection> waitLock(m_muReadingMedia);
+  std::unique_lock waitLock(m_muReadingMedia);
   m_pInstance->DetectMediaType();
 }
 
@@ -386,7 +386,7 @@ void CDetectDVDMedia::UpdateState()
 // Wait for drive, to finish media detection.
 void CDetectDVDMedia::WaitMediaReady()
 {
-  std::unique_lock<CCriticalSection> waitLock(m_muReadingMedia);
+  std::unique_lock waitLock(m_muReadingMedia);
 }
 
 DriveState CDetectDVDMedia::GetDriveState()
@@ -407,7 +407,7 @@ bool CDetectDVDMedia::IsDiscInDrive()
 // Can be NULL
 CCdInfo* CDetectDVDMedia::GetCdInfo()
 {
-  std::unique_lock<CCriticalSection> waitLock(m_muReadingMedia);
+  std::unique_lock waitLock(m_muReadingMedia);
   CCdInfo* pCdInfo = m_pCdInfo;
   return pCdInfo;
 }

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -152,13 +152,13 @@ bool CMediaManager::SaveSources()
 
 void CMediaManager::GetLocalDrives(std::vector<CMediaSource>& localDrives, bool includeQ)
 {
-  std::unique_lock<CCriticalSection> lock(m_CritSecStorageProvider);
+  std::unique_lock lock(m_CritSecStorageProvider);
   m_platformStorage->GetLocalDrives(localDrives);
 }
 
 void CMediaManager::GetRemovableDrives(std::vector<CMediaSource>& removableDrives)
 {
-  std::unique_lock<CCriticalSection> lock(m_CritSecStorageProvider);
+  std::unique_lock lock(m_CritSecStorageProvider);
   if (m_platformStorage)
     m_platformStorage->GetRemovableDrives(removableDrives);
 }
@@ -372,7 +372,7 @@ void CMediaManager::RemoveAutoSource(const CMediaSource &share)
 
 std::string CMediaManager::TranslateDevicePath(const std::string& devicePath, bool bReturnAsDevice)
 {
-  std::unique_lock<CCriticalSection> waitLock(m_muAutoSource);
+  std::unique_lock waitLock(m_muAutoSource);
   std::string strDevice = devicePath;
   // fallback for cdda://local/ and empty devicePath
 #ifdef HAS_OPTICAL_DRIVE
@@ -403,7 +403,7 @@ bool CMediaManager::IsDiscInDrive(const std::string& devicePath)
 
   std::string strDevice = TranslateDevicePath(devicePath, false);
   std::map<std::string,CCdInfo*>::iterator it;
-  std::unique_lock<CCriticalSection> waitLock(m_muAutoSource);
+  std::unique_lock waitLock(m_muAutoSource);
   it = m_mapCdInfo.find(strDevice);
   if(it != m_mapCdInfo.end())
     return true;
@@ -478,7 +478,7 @@ CCdInfo* CMediaManager::GetCdInfo(const std::string& devicePath)
   std::string strDevice = TranslateDevicePath(devicePath, false);
   std::map<std::string,CCdInfo*>::iterator it;
   {
-    std::unique_lock<CCriticalSection> waitLock(m_muAutoSource);
+    std::unique_lock waitLock(m_muAutoSource);
     it = m_mapCdInfo.find(strDevice);
     if(it != m_mapCdInfo.end())
       return it->second;
@@ -489,7 +489,7 @@ CCdInfo* CMediaManager::GetCdInfo(const std::string& devicePath)
   pCdInfo = cdio.GetCdInfo((char*)strDevice.c_str());
   if(pCdInfo!=NULL)
   {
-    std::unique_lock<CCriticalSection> waitLock(m_muAutoSource);
+    std::unique_lock waitLock(m_muAutoSource);
     m_mapCdInfo.insert(std::pair<std::string,CCdInfo*>(strDevice,pCdInfo));
   }
 
@@ -507,7 +507,7 @@ bool CMediaManager::RemoveCdInfo(const std::string& devicePath)
   std::string strDevice = TranslateDevicePath(devicePath, false);
 
   std::map<std::string,CCdInfo*>::iterator it;
-  std::unique_lock<CCriticalSection> waitLock(m_muAutoSource);
+  std::unique_lock waitLock(m_muAutoSource);
   it = m_mapCdInfo.find(strDevice);
   if(it != m_mapCdInfo.end())
   {
@@ -639,7 +639,7 @@ std::string CMediaManager::GetDiscPath()
   return CServiceBroker::GetMediaManager().TranslateDevicePath("");
 #else
 
-  std::unique_lock<CCriticalSection> lock(m_CritSecStorageProvider);
+  std::unique_lock lock(m_CritSecStorageProvider);
   std::vector<CMediaSource> drives;
   m_platformStorage->GetRemovableDrives(drives);
   for(unsigned i = 0; i < drives.size(); ++i)
@@ -661,13 +661,13 @@ std::shared_ptr<IDiscDriveHandler> CMediaManager::GetDiscDriveHandler()
 
 void CMediaManager::SetHasOpticalDrive(bool bstatus)
 {
-  std::unique_lock<CCriticalSection> waitLock(m_muAutoSource);
+  std::unique_lock waitLock(m_muAutoSource);
   m_bhasoptical = bstatus;
 }
 
 bool CMediaManager::Eject(const std::string& mountpath)
 {
-  std::unique_lock<CCriticalSection> lock(m_CritSecStorageProvider);
+  std::unique_lock lock(m_CritSecStorageProvider);
   return m_platformStorage->Eject(mountpath);
 }
 
@@ -703,7 +703,7 @@ void CMediaManager::ToggleTray(const char cDriveLetter)
 
 void CMediaManager::ProcessEvents()
 {
-  std::unique_lock<CCriticalSection> lock(m_CritSecStorageProvider);
+  std::unique_lock lock(m_CritSecStorageProvider);
   if (m_platformStorage->PumpDriveChangeEvents(this))
   {
 #if defined(HAS_OPTICAL_DRIVE) && defined(TARGET_DARWIN_OSX)
@@ -722,7 +722,7 @@ void CMediaManager::ProcessEvents()
 
 std::vector<std::string> CMediaManager::GetDiskUsage()
 {
-  std::unique_lock<CCriticalSection> lock(m_CritSecStorageProvider);
+  std::unique_lock lock(m_CritSecStorageProvider);
   return m_platformStorage->GetDiskUsage();
 }
 

--- a/xbmc/storage/cdioSupport.cpp
+++ b/xbmc/storage/cdioSupport.cpp
@@ -119,35 +119,35 @@ std::shared_ptr<CLibcdio> CLibcdio::GetInstance()
 
 CdIo_t* CLibcdio::cdio_open(const char *psz_source, driver_id_t driver_id)
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
 
   return( ::cdio_open(psz_source, driver_id) );
 }
 
 CdIo_t* CLibcdio::cdio_open_win32(const char *psz_source)
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
 
   return( ::cdio_open_win32(psz_source) );
 }
 
 void CLibcdio::cdio_destroy(CdIo_t *p_cdio)
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
 
   ::cdio_destroy(p_cdio);
 }
 
 discmode_t CLibcdio::cdio_get_discmode(CdIo_t *p_cdio)
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
 
   return( ::cdio_get_discmode(p_cdio) );
 }
 
 CdioTrayStatus CLibcdio::mmc_get_tray_status(const CdIo_t* p_cdio)
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
 
   int status = ::mmc_get_tray_status(p_cdio);
   switch (status)
@@ -166,28 +166,28 @@ CdioTrayStatus CLibcdio::mmc_get_tray_status(const CdIo_t* p_cdio)
 
 driver_return_code_t CLibcdio::cdio_eject_media(CdIo_t** p_cdio)
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
 
   return( ::cdio_eject_media(p_cdio) );
 }
 
 track_t CLibcdio::cdio_get_last_track_num(const CdIo_t *p_cdio)
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
 
   return( ::cdio_get_last_track_num(p_cdio) );
 }
 
 lsn_t CLibcdio::cdio_get_track_lsn(const CdIo_t *p_cdio, track_t i_track)
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
 
   return( ::cdio_get_track_lsn(p_cdio, i_track) );
 }
 
 lsn_t CLibcdio::cdio_get_track_last_lsn(const CdIo_t *p_cdio, track_t i_track)
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
 
   return( ::cdio_get_track_last_lsn(p_cdio, i_track) );
 }
@@ -195,14 +195,14 @@ lsn_t CLibcdio::cdio_get_track_last_lsn(const CdIo_t *p_cdio, track_t i_track)
 driver_return_code_t CLibcdio::cdio_read_audio_sectors(
     const CdIo_t *p_cdio, void *p_buf, lsn_t i_lsn, uint32_t i_blocks)
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
 
   return( ::cdio_read_audio_sectors(p_cdio, p_buf, i_lsn, i_blocks) );
 }
 
 driver_return_code_t CLibcdio::cdio_close_tray(const char* psz_source, driver_id_t* driver_id)
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
   return (::cdio_close_tray(psz_source, driver_id));
 }
 
@@ -213,7 +213,7 @@ const char* CLibcdio::cdio_driver_errmsg(driver_return_code_t drc)
 
 char* CLibcdio::GetDeviceFileName()
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
 
   // If We don't have a DVD device initially present (Darwin or a USB DVD drive),
   // We have to keep checking in case one appears.
@@ -277,7 +277,7 @@ bool CCdIoSupport::CloseTray()
 
 HANDLE CCdIoSupport::OpenCDROM()
 {
-  std::unique_lock<CCriticalSection> lock(*m_cdio);
+  std::unique_lock lock(*m_cdio);
 
   char* source_name = m_cdio->GetDeviceFileName();
   CdIo* cdio = ::cdio_open(source_name, DRIVER_UNKNOWN);
@@ -287,7 +287,7 @@ HANDLE CCdIoSupport::OpenCDROM()
 
 HANDLE CCdIoSupport::OpenIMAGE( std::string& strFilename )
 {
-  std::unique_lock<CCriticalSection> lock(*m_cdio);
+  std::unique_lock lock(*m_cdio);
 
   CdIo* cdio = ::cdio_open(strFilename.c_str(), DRIVER_UNKNOWN);
 
@@ -296,7 +296,7 @@ HANDLE CCdIoSupport::OpenIMAGE( std::string& strFilename )
 
 int CCdIoSupport::ReadSector(HANDLE hDevice, DWORD dwSector, char* lpczBuffer)
 {
-  std::unique_lock<CCriticalSection> lock(*m_cdio);
+  std::unique_lock lock(*m_cdio);
 
   CdIo* cdio = (CdIo*) hDevice;
   if ( cdio == NULL )
@@ -310,7 +310,7 @@ int CCdIoSupport::ReadSector(HANDLE hDevice, DWORD dwSector, char* lpczBuffer)
 
 int CCdIoSupport::ReadSectorMode2(HANDLE hDevice, DWORD dwSector, char* lpczBuffer)
 {
-  std::unique_lock<CCriticalSection> lock(*m_cdio);
+  std::unique_lock lock(*m_cdio);
 
   CdIo* cdio = (CdIo*) hDevice;
   if ( cdio == NULL )
@@ -324,7 +324,7 @@ int CCdIoSupport::ReadSectorMode2(HANDLE hDevice, DWORD dwSector, char* lpczBuff
 
 int CCdIoSupport::ReadSectorCDDA(HANDLE hDevice, DWORD dwSector, char* lpczBuffer)
 {
-  std::unique_lock<CCriticalSection> lock(*m_cdio);
+  std::unique_lock lock(*m_cdio);
 
   CdIo* cdio = (CdIo*) hDevice;
   if ( cdio == NULL )
@@ -338,7 +338,7 @@ int CCdIoSupport::ReadSectorCDDA(HANDLE hDevice, DWORD dwSector, char* lpczBuffe
 
 void CCdIoSupport::CloseCDROM(HANDLE hDevice)
 {
-  std::unique_lock<CCriticalSection> lock(*m_cdio);
+  std::unique_lock lock(*m_cdio);
 
   CdIo* cdio = (CdIo*) hDevice;
 
@@ -471,7 +471,7 @@ void CCdIoSupport::PrintAnalysis(int fs, int num_audio)
 
 int CCdIoSupport::ReadBlock(int superblock, uint32_t offset, uint8_t bufnum, track_t track_num)
 {
-  std::unique_lock<CCriticalSection> lock(*m_cdio);
+  std::unique_lock lock(*m_cdio);
 
   unsigned int track_sec_count = ::cdio_get_track_sec_count(cdio, track_num);
   memset(buffer[bufnum], 0, CDIO_CD_FRAMESIZE);
@@ -562,7 +562,7 @@ int CCdIoSupport::GetJolietLevel( void )
 
 int CCdIoSupport::GuessFilesystem(int start_session, track_t track_num)
 {
-  std::unique_lock<CCriticalSection> lock(*m_cdio);
+  std::unique_lock lock(*m_cdio);
 
   int ret = FS_UNKNOWN;
   cdio_iso_analysis_t anal;
@@ -644,7 +644,7 @@ void CCdIoSupport::GetCdTextInfo(xbmc_cdtext_t &xcdt, int trackNum)
   // cdtext disabled for windows as some setup doesn't like mmc commands
   // and stall for over a minute in cdio_get_cdtext 83
 #if !defined(TARGET_WINDOWS)
-  std::unique_lock<CCriticalSection> lock(*m_cdio);
+  std::unique_lock lock(*m_cdio);
 
   // Get the CD-Text , if any
 #if defined(LIBCDIO_VERSION_NUM) && (LIBCDIO_VERSION_NUM >= 84)
@@ -673,7 +673,7 @@ void CCdIoSupport::GetCdTextInfo(xbmc_cdtext_t &xcdt, int trackNum)
 
 CCdInfo* CCdIoSupport::GetCdInfo(char* cDeviceFileName)
 {
-  std::unique_lock<CCriticalSection> lock(*m_cdio);
+  std::unique_lock lock(*m_cdio);
 
   char* source_name;
   if(cDeviceFileName == NULL)
@@ -921,7 +921,7 @@ int CCdIoSupport::CddbDecDigitSum(int n)
 // Return the number of seconds (discarding frame portion) of an MSF
 unsigned int CCdIoSupport::MsfSeconds(msf_t *msf)
 {
-  std::unique_lock<CCriticalSection> lock(*m_cdio);
+  std::unique_lock lock(*m_cdio);
 
   return ::cdio_from_bcd8(msf->m)*60 + ::cdio_from_bcd8(msf->s);
 }
@@ -935,7 +935,7 @@ unsigned int CCdIoSupport::MsfSeconds(msf_t *msf)
 
 uint32_t CCdIoSupport::CddbDiscId()
 {
-  std::unique_lock<CCriticalSection> lock(*m_cdio);
+  std::unique_lock lock(*m_cdio);
 
   int i, t, n = 0;
   msf_t start_msf;

--- a/xbmc/threads/Event.cpp
+++ b/xbmc/threads/Event.cpp
@@ -19,7 +19,7 @@ using namespace std::chrono_literals;
 
 void CEvent::addGroup(XbmcThreads::CEventGroup* group)
 {
-  std::unique_lock<CCriticalSection> lock(groupListMutex);
+  std::unique_lock lock(groupListMutex);
   if (!groups)
     groups = std::make_unique<std::vector<XbmcThreads::CEventGroup*>>();
 
@@ -28,7 +28,7 @@ void CEvent::addGroup(XbmcThreads::CEventGroup* group)
 
 void CEvent::removeGroup(XbmcThreads::CEventGroup* group)
 {
-  std::unique_lock<CCriticalSection> lock(groupListMutex);
+  std::unique_lock lock(groupListMutex);
   if (groups)
   {
     groups->erase(std::remove(groups->begin(), groups->end(), group), groups->end());
@@ -49,13 +49,13 @@ void CEvent::Set()
   // CEvent class. This now perfectly matches the boost example here:
   // http://www.boost.org/doc/libs/1_41_0/doc/html/thread/synchronization.html#thread.synchronization.condvar_ref
   {
-    std::unique_lock<CCriticalSection> slock(mutex);
+    std::unique_lock slock(mutex);
     signaled = true;
   }
 
   actualCv.notifyAll();
 
-  std::unique_lock<CCriticalSection> l(groupListMutex);
+  std::unique_lock l(groupListMutex);
   if (groups)
   {
     for (auto* group : *groups)

--- a/xbmc/threads/Event.h
+++ b/xbmc/threads/Event.h
@@ -69,7 +69,7 @@ public:
 
   inline void Reset()
   {
-    std::unique_lock<CCriticalSection> lock(mutex);
+    std::unique_lock lock(mutex);
     signaled = false;
   }
   void Set();
@@ -80,7 +80,7 @@ public:
    */
   inline bool Signaled()
   {
-    std::unique_lock<CCriticalSection> lock(mutex);
+    std::unique_lock lock(mutex);
     return signaled;
   }
 
@@ -93,7 +93,7 @@ public:
   template<typename Rep, typename Period>
   inline bool Wait(std::chrono::duration<Rep, Period> duration)
   {
-    std::unique_lock<CCriticalSection> lock(mutex);
+    std::unique_lock lock(mutex);
     numWaits++;
     actualCv.wait(mutex, duration, std::bind(&CEvent::Signaled, this));
     numWaits--;
@@ -108,7 +108,7 @@ public:
    */
   inline bool Wait()
   {
-    std::unique_lock<CCriticalSection> lock(mutex);
+    std::unique_lock lock(mutex);
     numWaits++;
     actualCv.wait(mutex, std::bind(&CEvent::Signaled, this));
     numWaits--;
@@ -122,7 +122,7 @@ public:
    */
   inline int getNumWaits()
   {
-    std::unique_lock<CCriticalSection> lock(mutex);
+    std::unique_lock lock(mutex);
     return numWaits;
   }
 };
@@ -147,7 +147,7 @@ class CEventGroup
   // This is ONLY called from CEvent::Set.
   inline void Set(CEvent* child)
   {
-    std::unique_lock<CCriticalSection> l(mutex);
+    std::unique_lock l(mutex);
     signaled = child;
     actualCv.notifyAll();
   }
@@ -185,7 +185,7 @@ public:
   template<typename Rep, typename Period>
   CEvent* wait(std::chrono::duration<Rep, Period> duration)
   {
-    std::unique_lock<CCriticalSection> lock(mutex); // grab CEventGroup::mutex
+    std::unique_lock lock(mutex); // grab CEventGroup::mutex
     numWaits++;
 
     // ==================================================
@@ -196,7 +196,7 @@ public:
     signaled = nullptr;
     for (auto* cur : events)
     {
-      std::unique_lock<CCriticalSection> lock2(cur->mutex);
+      std::unique_lock lock2(cur->mutex);
       if (cur->signaled)
         signaled = cur;
     }
@@ -232,7 +232,7 @@ public:
    */
   inline int getNumWaits()
   {
-    std::unique_lock<CCriticalSection> lock(mutex);
+    std::unique_lock lock(mutex);
     return numWaits;
   }
 };

--- a/xbmc/threads/SharedSection.h
+++ b/xbmc/threads/SharedSection.h
@@ -28,7 +28,7 @@ public:
 
   inline void lock()
   {
-    std::unique_lock<CCriticalSection> l(sec);
+    std::unique_lock l(sec);
     while (sharedCount)
       actualCv.wait(l, [this]() { return sharedCount == 0; });
     sec.lock();
@@ -38,13 +38,13 @@ public:
 
   inline void lock_shared()
   {
-    std::unique_lock<CCriticalSection> l(sec);
+    std::unique_lock l(sec);
     sharedCount++;
   }
   inline bool try_lock_shared() { return (sec.try_lock() ? sharedCount++, sec.unlock(), true : false); }
   inline void unlock_shared()
   {
-    std::unique_lock<CCriticalSection> l(sec);
+    std::unique_lock l(sec);
     sharedCount--;
     if (!sharedCount)
     {

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -103,7 +103,7 @@ void CThread::Create(bool bAutoDelete)
   m_StartEvent.Reset();
 
   // lock?
-  //std::unique_lock<CCriticalSection> l(m_CriticalSection);
+  //std::unique_lock l(m_CriticalSection);
 
   std::promise<bool> prom;
   m_future = prom.get_future();
@@ -114,7 +114,7 @@ void CThread::Create(bool bAutoDelete)
     //   is fully initialized. Interestingly, using a std::atomic doesn't
     //   have the appropriate memory barrier behavior to accomplish the
     //   same thing so a full system mutex needs to be used.
-    std::unique_lock<CCriticalSection> blockLambdaTillDone(m_CriticalSection);
+    std::unique_lock blockLambdaTillDone(m_CriticalSection);
     m_thread = new std::thread([](CThread* pThread, std::promise<bool> promise)
     {
       try
@@ -126,8 +126,7 @@ void CThread::Create(bool bAutoDelete)
           // lambda's call stack prior to the thread that kicked off this lambda
           // having it set. Once this lock is released, the CThread::Create function
           // that kicked this off is done so everything should be set.
-          std::unique_lock<CCriticalSection> waitForThreadInternalsToBeSet(
-              pThread->m_CriticalSection);
+          std::unique_lock waitForThreadInternalsToBeSet(pThread->m_CriticalSection);
         }
 
         // This is used in various helper methods like GetCurrentThread so it needs
@@ -209,7 +208,7 @@ void CThread::StopThread(bool bWait /*= true*/)
 
   m_bStop = true;
   m_StopEvent.Set();
-  std::unique_lock<CCriticalSection> lock(m_CriticalSection);
+  std::unique_lock lock(m_CriticalSection);
   std::thread* lthread = m_thread;
   if (lthread != nullptr && bWait && !IsCurrentThread())
   {
@@ -242,7 +241,7 @@ CThread* CThread::GetCurrentThread()
 
 bool CThread::Join(std::chrono::milliseconds duration)
 {
-  std::unique_lock<CCriticalSection> l(m_CriticalSection);
+  std::unique_lock l(m_CriticalSection);
   std::thread* lthread = m_thread;
   if (lthread != nullptr)
   {

--- a/xbmc/threads/test/TestHelpers.h
+++ b/xbmc/threads/test/TestHelpers.h
@@ -40,7 +40,7 @@ inline static bool waitForThread(std::atomic<long>& mutex,
       return true;
 
     {
-      std::unique_lock<CCriticalSection> tmplock(sec); // kick any memory syncs
+      std::unique_lock tmplock(sec); // kick any memory syncs
     }
 
     std::this_thread::sleep_for(std::chrono::milliseconds(1));

--- a/xbmc/threads/test/TestSharedSection.cpp
+++ b/xbmc/threads/test/TestSharedSection.cpp
@@ -54,8 +54,8 @@ TEST(TestCritSection, General)
 {
   CCriticalSection sec;
 
-  std::unique_lock<CCriticalSection> l1(sec);
-  std::unique_lock<CCriticalSection> l2(sec);
+  std::unique_lock l1(sec);
+  std::unique_lock l2(sec);
 }
 
 TEST(TestSharedSection, General)

--- a/xbmc/utils/ActorProtocol.cpp
+++ b/xbmc/utils/ActorProtocol.cpp
@@ -90,7 +90,7 @@ Message *Protocol::GetMessage()
 {
   Message *msg;
 
-  std::unique_lock<CCriticalSection> lock(criticalSection);
+  std::unique_lock lock(criticalSection);
 
   if (!freeMessageQueue.empty())
   {
@@ -113,7 +113,7 @@ Message *Protocol::GetMessage()
 
 void Protocol::ReturnMessage(Message *msg)
 {
-  std::unique_lock<CCriticalSection> lock(criticalSection);
+  std::unique_lock lock(criticalSection);
 
   freeMessageQueue.push(msg);
 }
@@ -142,7 +142,7 @@ bool Protocol::SendOutMessage(int signal,
   }
 
   {
-    std::unique_lock<CCriticalSection> lock(criticalSection);
+    std::unique_lock lock(criticalSection);
     outMessages.push(msg);
   }
   if (containerOutEvent)
@@ -165,7 +165,7 @@ bool Protocol::SendOutMessage(int signal, CPayloadWrapBase *payload, Message *ou
   msg->payloadObj.reset(payload);
 
   {
-    std::unique_lock<CCriticalSection> lock(criticalSection);
+    std::unique_lock lock(criticalSection);
     outMessages.push(msg);
   }
   if (containerOutEvent)
@@ -198,7 +198,7 @@ bool Protocol::SendInMessage(int signal,
   }
 
   {
-    std::unique_lock<CCriticalSection> lock(criticalSection);
+    std::unique_lock lock(criticalSection);
     inMessages.push(msg);
   }
   if (containerInEvent)
@@ -221,7 +221,7 @@ bool Protocol::SendInMessage(int signal, CPayloadWrapBase *payload, Message *out
   msg->payloadObj.reset(payload);
 
   {
-    std::unique_lock<CCriticalSection> lock(criticalSection);
+    std::unique_lock lock(criticalSection);
     inMessages.push(msg);
   }
   if (containerInEvent)
@@ -245,7 +245,7 @@ bool Protocol::SendOutMessageSync(int signal,
 
   if (!msg->event->Wait(timeout))
   {
-    const std::unique_lock<CCriticalSection> lock(criticalSection);
+    const std::unique_lock lock(criticalSection);
     if (msg->replyMessage)
       *retMsg = msg->replyMessage;
     else
@@ -279,7 +279,7 @@ bool Protocol::SendOutMessageSync(int signal,
 
   if (!msg->event->Wait(timeout))
   {
-    const std::unique_lock<CCriticalSection> lock(criticalSection);
+    const std::unique_lock lock(criticalSection);
     if (msg->replyMessage)
       *retMsg = msg->replyMessage;
     else
@@ -301,7 +301,7 @@ bool Protocol::SendOutMessageSync(int signal,
 
 bool Protocol::ReceiveOutMessage(Message **msg)
 {
-  std::unique_lock<CCriticalSection> lock(criticalSection);
+  std::unique_lock lock(criticalSection);
 
   if (outMessages.empty() || outDefered)
     return false;
@@ -314,7 +314,7 @@ bool Protocol::ReceiveOutMessage(Message **msg)
 
 bool Protocol::ReceiveInMessage(Message **msg)
 {
-  std::unique_lock<CCriticalSection> lock(criticalSection);
+  std::unique_lock lock(criticalSection);
 
   if (inMessages.empty() || inDefered)
     return false;
@@ -342,7 +342,7 @@ void Protocol::PurgeIn(int signal)
   Message *msg;
   std::queue<Message*> msgs;
 
-  std::unique_lock<CCriticalSection> lock(criticalSection);
+  std::unique_lock lock(criticalSection);
 
   while (!inMessages.empty())
   {
@@ -364,7 +364,7 @@ void Protocol::PurgeOut(int signal)
   Message *msg;
   std::queue<Message*> msgs;
 
-  std::unique_lock<CCriticalSection> lock(criticalSection);
+  std::unique_lock lock(criticalSection);
 
   while (!outMessages.empty())
   {

--- a/xbmc/utils/AlarmClock.cpp
+++ b/xbmc/utils/AlarmClock.cpp
@@ -73,14 +73,14 @@ void CAlarmClock::Start(const std::string& strName, float n_secs, const std::str
   }
 
   event.watch.StartZero();
-  std::unique_lock<CCriticalSection> lock(m_events);
+  std::unique_lock lock(m_events);
   m_event.insert(make_pair(lowerName,event));
   CLog::Log(LOGDEBUG, "started alarm with name: {}", lowerName);
 }
 
 void CAlarmClock::Stop(const std::string& strName, bool bSilent /* false */)
 {
-  std::unique_lock<CCriticalSection> lock(m_events);
+  std::unique_lock lock(m_events);
 
   std::string lowerName(strName);
   StringUtils::ToLower(lowerName);          // lookup as lowercase only
@@ -143,7 +143,7 @@ void CAlarmClock::Process()
   {
     std::string strLast;
     {
-      std::unique_lock<CCriticalSection> lock(m_events);
+      std::unique_lock lock(m_events);
       for (std::map<std::string,SAlarmClockEvent>::iterator iter=m_event.begin();iter != m_event.end(); ++iter)
         if (iter->second.watch.IsRunning() &&
             iter->second.watch.GetElapsedSeconds() >= static_cast<float>(iter->second.m_fSecs))

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -160,7 +160,7 @@ CConverterType::CConverterType(const CConverterType& other) : CCriticalSection()
 
 CConverterType::~CConverterType()
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
   if (m_iconv != NO_ICONV)
     iconv_close(m_iconv);
   lock.unlock(); // ensure unlocking before final destruction
@@ -191,7 +191,7 @@ iconv_t CConverterType::GetConverter(std::unique_lock<CCriticalSection>& convert
 
 void CConverterType::Reset(void)
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
   if (m_iconv != NO_ICONV)
   {
     iconv_close(m_iconv);
@@ -207,7 +207,7 @@ void CConverterType::Reset(void)
 
 void CConverterType::ReinitTo(const std::string& sourceCharset, const std::string& targetCharset, unsigned int targetSingleCharMaxLen /*= 1*/)
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
   if (sourceCharset != m_sourceCharset || targetCharset != m_targetCharset)
   {
     if (m_iconv != NO_ICONV)
@@ -489,7 +489,7 @@ bool CCharsetConverter::CInnerConverter::logicalToVisualBiDi(
   size_t lineStart = 0;
 
   // libfribidi is not threadsafe, so make sure we make it so
-  std::unique_lock<CCriticalSection> lock(m_critSectionFriBiDi);
+  std::unique_lock lock(m_critSectionFriBiDi);
   do
   {
     size_t lineEnd = stringSrc.find('\n', lineStart);

--- a/xbmc/utils/ComponentContainer.h
+++ b/xbmc/utils/ComponentContainer.h
@@ -37,7 +37,7 @@ public:
   template<class T>
   std::shared_ptr<const T> GetComponent() const
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     const auto it = m_components.find(std::type_index(typeid(T)));
     if (it != m_components.end())
       return std::static_pointer_cast<const T>((*it).second);
@@ -60,14 +60,14 @@ protected:
     // https://stackoverflow.com/questions/46494928/clang-warning-on-expression-side-effects
     const auto& componentRef = *component;
 
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     m_components.insert({std::type_index(typeid(componentRef)), component});
   }
 
   //! \brief Deregister a component.
   void DeregisterComponent(const std::type_info& typeInfo)
   {
-    std::unique_lock<CCriticalSection> lock(m_critSection);
+    std::unique_lock lock(m_critSection);
     m_components.erase(typeInfo);
   }
 

--- a/xbmc/utils/EventStream.h
+++ b/xbmc/utils/EventStream.h
@@ -27,7 +27,7 @@ public:
   void Subscribe(A* owner, void (A::*fn)(const Event&))
   {
     auto subscription = std::make_shared<detail::CSubscription<Event, A>>(owner, fn);
-    std::unique_lock<CCriticalSection> lock(m_criticalSection);
+    std::unique_lock lock(m_criticalSection);
     m_subscriptions.emplace_back(std::move(subscription));
   }
 
@@ -36,7 +36,7 @@ public:
   {
     std::vector<std::shared_ptr<detail::ISubscription<Event>>> toCancel;
     {
-      std::unique_lock<CCriticalSection> lock(m_criticalSection);
+      std::unique_lock lock(m_criticalSection);
       auto it = m_subscriptions.begin();
       while (it != m_subscriptions.end())
       {
@@ -70,7 +70,7 @@ public:
   template<typename A>
   void Publish(A event)
   {
-    std::unique_lock<CCriticalSection> lock(this->m_criticalSection);
+    std::unique_lock lock(this->m_criticalSection);
     auto& subscriptions = this->m_subscriptions;
     auto task = [subscriptions, event](){
       for (auto& s: subscriptions)
@@ -91,7 +91,7 @@ public:
   template<typename A>
   void HandleEvent(A event)
   {
-    std::unique_lock<CCriticalSection> lock(this->m_criticalSection);
+    std::unique_lock lock(this->m_criticalSection);
     for (const auto& subscription : this->m_subscriptions)
     {
       subscription->HandleEvent(event);

--- a/xbmc/utils/EventStreamDetail.h
+++ b/xbmc/utils/EventStreamDetail.h
@@ -49,21 +49,21 @@ CSubscription<Event, Owner>::CSubscription(Owner* owner, Fn fn)
 template<typename Event, typename Owner>
 bool CSubscription<Event, Owner>::IsOwnedBy(void* obj)
 {
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
   return obj != nullptr && obj == m_owner;
 }
 
 template<typename Event, typename Owner>
 void CSubscription<Event, Owner>::Cancel()
 {
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
   m_owner = nullptr;
 }
 
 template<typename Event, typename Owner>
 void CSubscription<Event, Owner>::HandleEvent(const Event& event)
 {
-  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  std::unique_lock lock(m_criticalSection);
   if (m_owner)
     (m_owner->*m_eventHandler)(event);
 }

--- a/xbmc/utils/Observer.cpp
+++ b/xbmc/utils/Observer.cpp
@@ -14,7 +14,7 @@
 
 Observable &Observable::operator=(const Observable &observable)
 {
-  std::unique_lock<CCriticalSection> lock(m_obsCritSection);
+  std::unique_lock lock(m_obsCritSection);
 
   m_bObservableChanged = static_cast<bool>(observable.m_bObservableChanged);
   m_observers = observable.m_observers;
@@ -24,13 +24,13 @@ Observable &Observable::operator=(const Observable &observable)
 
 bool Observable::IsObserving(const Observer &obs) const
 {
-  std::unique_lock<CCriticalSection> lock(m_obsCritSection);
+  std::unique_lock lock(m_obsCritSection);
   return std::find(m_observers.begin(), m_observers.end(), &obs) != m_observers.end();
 }
 
 void Observable::RegisterObserver(Observer *obs)
 {
-  std::unique_lock<CCriticalSection> lock(m_obsCritSection);
+  std::unique_lock lock(m_obsCritSection);
   if (!IsObserving(*obs))
   {
     m_observers.push_back(obs);
@@ -39,7 +39,7 @@ void Observable::RegisterObserver(Observer *obs)
 
 void Observable::UnregisterObserver(Observer *obs)
 {
-  std::unique_lock<CCriticalSection> lock(m_obsCritSection);
+  std::unique_lock lock(m_obsCritSection);
   auto iter = std::remove(m_observers.begin(), m_observers.end(), obs);
   if (iter != m_observers.end())
     m_observers.erase(iter);
@@ -62,7 +62,7 @@ void Observable::SetChanged(bool SetTo)
 
 void Observable::SendMessage(const ObservableMessage message)
 {
-  std::unique_lock<CCriticalSection> lock(m_obsCritSection);
+  std::unique_lock lock(m_obsCritSection);
 
   for (auto& observer : m_observers)
   {

--- a/xbmc/utils/RingBuffer.cpp
+++ b/xbmc/utils/RingBuffer.cpp
@@ -32,7 +32,7 @@ CRingBuffer::~CRingBuffer()
 /* Create a ring buffer with the specified 'size' */
 bool CRingBuffer::Create(unsigned int size)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_buffer = (char*)malloc(size);
   if (m_buffer != NULL)
   {
@@ -45,7 +45,7 @@ bool CRingBuffer::Create(unsigned int size)
 /* Free the ring buffer and set all values to NULL or 0 */
 void CRingBuffer::Destroy()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_buffer != NULL)
   {
     free(m_buffer);
@@ -60,7 +60,7 @@ void CRingBuffer::Destroy()
 /* Clear the ring buffer */
 void CRingBuffer::Clear()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   m_readPtr = 0;
   m_writePtr = 0;
   m_fillCount = 0;
@@ -71,7 +71,7 @@ void CRingBuffer::Clear()
  */
 bool CRingBuffer::ReadData(char *buf, unsigned int size)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (size > m_fillCount)
   {
     return false;
@@ -99,7 +99,7 @@ bool CRingBuffer::ReadData(char *buf, unsigned int size)
  */
 bool CRingBuffer::ReadData(CRingBuffer &rBuf, unsigned int size)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (rBuf.getBuffer() == NULL)
     rBuf.Create(size);
 
@@ -122,7 +122,7 @@ bool CRingBuffer::ReadData(CRingBuffer &rBuf, unsigned int size)
  */
 bool CRingBuffer::WriteData(const char *buf, unsigned int size)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (size > m_size - m_fillCount)
   {
     return false;
@@ -150,7 +150,7 @@ bool CRingBuffer::WriteData(const char *buf, unsigned int size)
  */
 bool CRingBuffer::WriteData(CRingBuffer &rBuf, unsigned int size)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (m_buffer == NULL)
     Create(size);
 
@@ -170,7 +170,7 @@ bool CRingBuffer::WriteData(CRingBuffer &rBuf, unsigned int size)
 /* Skip bytes in buffer to be read */
 bool CRingBuffer::SkipBytes(int skipSize)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   if (skipSize < 0)
   {
     return false; // skipping backwards is not supported
@@ -217,7 +217,7 @@ char *CRingBuffer::getBuffer()
 
 unsigned int CRingBuffer::getSize()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_size;
 }
 
@@ -228,18 +228,18 @@ unsigned int CRingBuffer::getReadPtr() const
 
 unsigned int CRingBuffer::getWritePtr()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_writePtr;
 }
 
 unsigned int CRingBuffer::getMaxReadSize()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_fillCount;
 }
 
 unsigned int CRingBuffer::getMaxWriteSize()
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   return m_size - m_fillCount;
 }

--- a/xbmc/utils/RssManager.cpp
+++ b/xbmc/utils/RssManager.cpp
@@ -82,7 +82,7 @@ void CRssManager::Start()
 
 void CRssManager::Stop()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   m_bActive = false;
   for (unsigned int i = 0; i < m_readers.size(); i++)
   {
@@ -96,7 +96,7 @@ bool CRssManager::Load()
 {
   const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
 
   std::string rssXML = profileManager->GetUserDataItem("RssFeeds.xml");
   if (!CFileUtils::Exists(rssXML))
@@ -170,14 +170,14 @@ bool CRssManager::Reload()
 
 void CRssManager::Clear()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   m_mapRssUrls.clear();
 }
 
 // returns true if the reader doesn't need creating, false otherwise
 bool CRssManager::GetReader(int controlID, int windowID, IRssObserver* observer, CRssReader *&reader)
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   // check to see if we've already created this reader
   for (unsigned int i = 0; i < m_readers.size(); i++)
   {

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -57,7 +57,7 @@ CRssReader::~CRssReader()
 
 void CRssReader::Create(IRssObserver* aObserver, const std::vector<std::string>& aUrls, const std::vector<int> &times, int spacesBetweenFeeds, bool rtl)
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
 
   m_pObserver = aObserver;
   m_spacesBetweenFeeds = spacesBetweenFeeds;
@@ -86,7 +86,7 @@ void CRssReader::requestRefresh()
 
 void CRssReader::AddToQueue(int iAdd)
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (iAdd < (int)m_vecUrls.size())
     m_vecQueue.push_back(iAdd);
   if (!m_bIsRunning)
@@ -104,7 +104,7 @@ void CRssReader::OnExit()
 
 int CRssReader::GetQueueSize()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   return m_vecQueue.size();
 }
 
@@ -112,7 +112,7 @@ void CRssReader::Process()
 {
   while (GetQueueSize())
   {
-    std::unique_lock<CCriticalSection> lock(m_critical);
+    std::unique_lock lock(m_critical);
 
     int iFeed = m_vecQueue.front();
     m_vecQueue.erase(m_vecQueue.begin());
@@ -362,7 +362,7 @@ void CRssReader::UpdateObserver()
   getFeed(feed);
   if (!feed.empty())
   {
-    std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+    std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
     if (m_pObserver) // need to check again when locked to make sure observer wasnt removed
       m_pObserver->OnFeedUpdate(feed);
   }

--- a/xbmc/utils/test/TestJobManager.cpp
+++ b/xbmc/utils/test/TestJobManager.cpp
@@ -137,7 +137,7 @@ public:
 
   void FinishAndStopBlocking()
   {
-    std::unique_lock<CCriticalSection> lock(m_blockMutex);
+    std::unique_lock lock(m_blockMutex);
 
     m_finish = true;
     m_block.notifyAll();
@@ -151,13 +151,13 @@ public:
   bool DoWork() override
   {
     {
-      std::unique_lock<CCriticalSection> lock(m_package.jobCreatedMutex);
+      std::unique_lock lock(m_package.jobCreatedMutex);
 
       m_package.ready = true;
       m_package.jobCreatedCond.notifyAll();
     }
 
-    std::unique_lock<CCriticalSection> blockLock(m_blockMutex);
+    std::unique_lock blockLock(m_blockMutex);
 
     // Block until we're told to go away
     while (!m_finish)

--- a/xbmc/video/Teletext.cpp
+++ b/xbmc/video/Teletext.cpp
@@ -452,7 +452,7 @@ CTeletextDecoder::~CTeletextDecoder() = default;
 
 bool CTeletextDecoder::Changed()
 {
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
   if (IsSubtitlePage(m_txtCache->Page))
   {
     m_updateTexture = true;
@@ -477,7 +477,7 @@ bool CTeletextDecoder::HandleAction(const CAction &action)
     return false;
   }
 
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   if (action.GetID() == ACTION_MOVE_UP)
   {
@@ -748,7 +748,7 @@ void CTeletextDecoder::EndDecoder()
   }
   else
   {
-    std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+    std::unique_lock lock(m_txtCache->m_critSection);
     m_txtCache->PageUpdate = true;
     CLog::Log(LOGDEBUG, "Teletext: Rendering ended");
   }
@@ -756,7 +756,7 @@ void CTeletextDecoder::EndDecoder()
 
 void CTeletextDecoder::PageInput(int Number)
 {
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   m_updateTexture = true;
 
@@ -841,7 +841,7 @@ void CTeletextDecoder::PageInput(int Number)
 
 void CTeletextDecoder::GetNextPageOne(bool up)
 {
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   /* disable subpage zapping */
   m_txtCache->ZapSubpageManual = false;
@@ -875,7 +875,7 @@ void CTeletextDecoder::GetNextPageOne(bool up)
 
 void CTeletextDecoder::GetNextSubPage(int offset)
 {
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   /* abort pageinput */
   m_RenderInfo.InputCounter = 2;
@@ -909,7 +909,7 @@ void CTeletextDecoder::GetNextSubPage(int offset)
 
 void CTeletextDecoder::SwitchZoomMode()
 {
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   if (m_txtCache->SubPageTable[m_txtCache->Page] != 0xFF)
   {
@@ -926,7 +926,7 @@ void CTeletextDecoder::SwitchZoomMode()
 
 void CTeletextDecoder::SwitchTranspMode()
 {
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   /* toggle mode */
   if (!m_RenderInfo.TranspMode)
@@ -949,7 +949,7 @@ void CTeletextDecoder::SwitchTranspMode()
 
 void CTeletextDecoder::SwitchHintMode()
 {
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   /* toggle mode */
   m_RenderInfo.HintMode ^= true;
@@ -964,7 +964,7 @@ void CTeletextDecoder::SwitchHintMode()
 
 void CTeletextDecoder::ColorKey(int target)
 {
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   if (!target)
     return;
@@ -1002,7 +1002,7 @@ void CTeletextDecoder::StartPageCatching()
 
   if (!m_CatchedPage)
   {
-    std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+    std::unique_lock lock(m_txtCache->m_critSection);
 
     m_RenderInfo.PageCatching = false;
     m_txtCache->PageUpdate    = true;
@@ -1012,7 +1012,7 @@ void CTeletextDecoder::StartPageCatching()
 
 void CTeletextDecoder::StopPageCatching()
 {
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   /* set new page */
   if (m_RenderInfo.ZoomMode == 2)
@@ -1179,7 +1179,7 @@ void CTeletextDecoder::RenderCatchedPage()
 
 void CTeletextDecoder::RenderPage()
 {
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   int StartRow = 0;
   int national_subset_bak = m_txtCache->NationalSubset;
@@ -1354,7 +1354,7 @@ bool CTeletextDecoder::IsSubtitlePage(int pageNumber) const
   if (!m_txtCache)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   for (const auto subPage : m_txtCache->SubtitlePages)
   {
@@ -1367,7 +1367,7 @@ bool CTeletextDecoder::IsSubtitlePage(int pageNumber) const
 
 void CTeletextDecoder::DoFlashing(int startrow)
 {
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   TextCachedPage_t* textCachepage =
       m_txtCache->astCachetable[m_txtCache->Page][m_txtCache->SubPage];
@@ -1508,7 +1508,7 @@ void CTeletextDecoder::DoFlashing(int startrow)
 
 void CTeletextDecoder::DoRenderPage(int startrow, int national_subset_bak)
 {
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   /* display first column?  */
   m_RenderInfo.nofirst = m_RenderInfo.Show39;
@@ -1625,7 +1625,7 @@ void CTeletextDecoder::Decode_BTT()
   int current, b1, b2, b3, b4;
   unsigned char btt[23*40];
 
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   if (m_txtCache->SubPageTable[0x1f0] == 0xff || 0 == m_txtCache->astCachetable[0x1f0][m_txtCache->SubPageTable[0x1f0]]) /* not yet received */
     return;
@@ -1693,7 +1693,7 @@ void CTeletextDecoder::Decode_ADIP() /* additional information table */
   int i, p, j, b1, b2, b3, charfound;
   unsigned char padip[23*40];
 
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
@@ -1765,7 +1765,7 @@ int CTeletextDecoder::TopText_GetNext(int startpage, int up, int findgroup)
   nextgrp = nextblk = 0;
   current = startpage;
 
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   do {
     if (up)
@@ -1856,7 +1856,7 @@ void CTeletextDecoder::Showlink(int column, int linkpage)
 
 void CTeletextDecoder::CreateLine25()
 {
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   /* btt completely received and not yet decoded */
   if (!m_txtCache->BTTok)
@@ -1919,7 +1919,7 @@ void CTeletextDecoder::CopyBB2FB()
   int screenwidth;
   Color fillcolor;
 
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   /* line 25 */
   if (!m_RenderInfo.PageCatching)
@@ -2300,7 +2300,7 @@ void CTeletextDecoder::RenderCharIntern(TextRenderInfo_t* RenderInfo, int Char, 
   int factor, xfactor;
   unsigned char *sbitbuffer;
 
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   int national_subset_local = m_txtCache->NationalSubset;
   int curfontwidth          = GetCurFontWidth();
@@ -2499,7 +2499,7 @@ int CTeletextDecoder::RenderChar(
   Color bgcolor, fgcolor;
   int factor, xfactor;
 
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   int national_subset_local = m_txtCache->NationalSubset;
   int ymosaic[4];
@@ -2861,7 +2861,7 @@ TextPageinfo_t* CTeletextDecoder::DecodePage(bool showl25,             // 1=deco
   unsigned char held_mosaic, *p;
   TextCachedPage_t *pCachedPage;
 
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   /* copy page to decode buffer */
   if (m_txtCache->SubPageTable[m_txtCache->Page] == 0xff) /* not cached: do nothing */
@@ -3307,7 +3307,7 @@ TextPageinfo_t* CTeletextDecoder::DecodePage(bool showl25,             // 1=deco
 
 void CTeletextDecoder::Eval_l25(unsigned char* PageChar, TextPageAttr_t *PageAtrb, bool HintMode)
 {
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   memset(m_txtCache->FullRowColor, 0, sizeof(m_txtCache->FullRowColor));
   m_txtCache->FullScrColor = TXT_ColorBlack;
@@ -3590,7 +3590,7 @@ void CTeletextDecoder::Eval_NumberedObject(int p, int s, int packet, int triplet
                  unsigned char *pAPx, unsigned char *pAPy,
                  unsigned char *pAPx0, unsigned char *pAPy0, unsigned char* PageChar, TextPageAttr_t* PageAtrb)
 {
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   if (!packet || 0 == m_txtCache->astCachetable[p][s])
     return;
@@ -3625,7 +3625,7 @@ int CTeletextDecoder::Eval_Triplet(int iOData, TextCachedPage_t *pstCachedPage,
   int iMode    = (iOData >>  6) & 0x1f;
   int iData    = (iOData >> 11) & 0x7f;
 
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   if (iAddress < 40) /* column addresses */
   {
@@ -4052,7 +4052,7 @@ int CTeletextDecoder::iTripletNumber2Data(int iONr, TextCachedPage_t *pstCachedP
 
 int CTeletextDecoder::SetNational(unsigned char sec)
 {
-  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  std::unique_lock lock(m_txtCache->m_critSection);
 
   switch (sec)
   {

--- a/xbmc/video/VideoLibraryQueue.cpp
+++ b/xbmc/video/VideoLibraryQueue.cpp
@@ -30,7 +30,7 @@ CVideoLibraryQueue::CVideoLibraryQueue()
 
 CVideoLibraryQueue::~CVideoLibraryQueue()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   m_jobs.clear();
 }
 
@@ -66,7 +66,7 @@ bool CVideoLibraryQueue::IsScanningLibrary() const
 
 void CVideoLibraryQueue::StopLibraryScanning()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   VideoLibraryJobMap::const_iterator scanningJobs = m_jobs.find("VideoLibraryScanningJob");
   if (scanningJobs == m_jobs.end())
     return;
@@ -172,7 +172,7 @@ void CVideoLibraryQueue::AddJob(CVideoLibraryJob *job)
   if (job == NULL)
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (!CJobQueue::AddJob(job))
     return;
 
@@ -194,7 +194,7 @@ void CVideoLibraryQueue::CancelJob(CVideoLibraryJob *job)
   if (job == NULL)
     return;
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   // remember the job type needed later because the job might be deleted
   // in the call to CJobQueue::CancelJob()
   std::string jobType;
@@ -216,7 +216,7 @@ void CVideoLibraryQueue::CancelJob(CVideoLibraryJob *job)
 
 void CVideoLibraryQueue::CancelAllJobs()
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   CJobQueue::CancelJobs();
 
   // remove all scanning jobs
@@ -244,7 +244,7 @@ void CVideoLibraryQueue::OnJobComplete(unsigned int jobID, bool success, CJob *j
   }
 
   {
-    std::unique_lock<CCriticalSection> lock(m_critical);
+    std::unique_lock lock(m_critical);
     // remove the job from our list of queued/running jobs
     VideoLibraryJobMap::iterator jobsIt = m_jobs.find(job->GetType());
     if (jobsIt != m_jobs.end())

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -221,7 +221,7 @@ void CGUIDialogSubtitles::Process(unsigned int currentTime, CDirtyRegionList &di
     std::string status;
     CFileItemList subs;
     {
-      std::unique_lock<CCriticalSection> lock(m_critsection);
+      std::unique_lock lock(m_critsection);
       status = m_status;
       subs.Assign(*m_subtitles);
     }
@@ -406,7 +406,7 @@ void CGUIDialogSubtitles::OnJobComplete(unsigned int jobID, bool success, CJob *
 
 void CGUIDialogSubtitles::OnSearchComplete(const CFileItemList *items)
 {
-  std::unique_lock<CCriticalSection> lock(m_critsection);
+  std::unique_lock lock(m_critsection);
   m_subtitles->Assign(*items);
   UpdateStatus(SEARCH_COMPLETE);
   m_updateSubsList = true;
@@ -486,7 +486,7 @@ void CGUIDialogSubtitles::OnSubtitleServiceContextMenu(int itemIdx)
 
 void CGUIDialogSubtitles::UpdateStatus(STATUS status)
 {
-  std::unique_lock<CCriticalSection> lock(m_critsection);
+  std::unique_lock lock(m_critsection);
   std::string label;
   switch (status)
   {
@@ -685,7 +685,7 @@ void CGUIDialogSubtitles::ClearSubtitles()
 {
   CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), CONTROL_SUBLIST);
   OnMessage(msg);
-  std::unique_lock<CCriticalSection> lock(m_critsection);
+  std::unique_lock lock(m_critsection);
   m_subtitles->Clear();
 }
 

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -242,7 +242,7 @@ void CGUIDialogVideoBookmarks::OnRefreshList()
   videoDatabase.GetBookMarksForFile(m_filePath, m_bookmarks, CBookmark::EPISODE, true);
   videoDatabase.Close();
 
-  std::unique_lock<CCriticalSection> lock(m_refreshSection);
+  std::unique_lock lock(m_refreshSection);
   m_vecItems->Clear();
 
   // cycle through each stored bookmark and add it to our list control

--- a/xbmc/view/ViewStateSettings.cpp
+++ b/xbmc/view/ViewStateSettings.cpp
@@ -74,7 +74,7 @@ bool CViewStateSettings::Load(const TiXmlNode *settings)
   if (settings == NULL)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   const TiXmlNode *pElement = settings->FirstChildElement(XML_VIEWSTATESETTINGS);
   if (pElement == NULL)
   {
@@ -145,7 +145,7 @@ bool CViewStateSettings::Save(TiXmlNode *settings) const
   if (settings == NULL)
     return false;
 
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   // add the <viewstates> tag
   TiXmlElement xmlViewStateElement(XML_VIEWSTATESETTINGS);
   TiXmlNode *pViewStateNode = settings->InsertEndChild(xmlViewStateElement);
@@ -201,7 +201,7 @@ void CViewStateSettings::Clear()
 
 const CViewState* CViewStateSettings::Get(const std::string &viewState) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   std::map<std::string, CViewState*>::const_iterator view = m_viewStates.find(viewState);
   if (view != m_viewStates.end())
     return view->second;
@@ -211,7 +211,7 @@ const CViewState* CViewStateSettings::Get(const std::string &viewState) const
 
 CViewState* CViewStateSettings::Get(const std::string &viewState)
 {
-  std::unique_lock<CCriticalSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   std::map<std::string, CViewState*>::iterator view = m_viewStates.find(viewState);
   if (view != m_viewStates.end())
     return view->second;

--- a/xbmc/windowing/GraphicContext.cpp
+++ b/xbmc/windowing/GraphicContext.cpp
@@ -320,7 +320,7 @@ void CGraphicContext::SetViewWindow(float left, float top, float right, float bo
 
 void CGraphicContext::SetFullScreenVideo(bool bOnOff)
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
 
   m_bFullScreenVideo = bOnOff;
 
@@ -424,7 +424,7 @@ void CGraphicContext::SetVideoResolutionInternal(RESOLUTION res, bool forceUpdat
     m_bFullScreenRoot = false;
   }
 
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
 
   // FIXME Wayland windowing needs some way to "deny" resolution updates since what Kodi
   // requests might not get actually set by the compositor.
@@ -510,7 +510,7 @@ void CGraphicContext::ApplyVideoResolution(RESOLUTION res)
     m_bFullScreenRoot = false;
   }
 
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
 
   UpdateInternalStateWithResolution(res);
 
@@ -739,7 +739,7 @@ void CGraphicContext::SetScalingResolution(const RESOLUTION_INFO &res, bool need
 
 void CGraphicContext::SetRenderingResolution(const RESOLUTION_INFO &res, bool needsScaling)
 {
-  std::unique_lock<CCriticalSection> lock(*this);
+  std::unique_lock lock(*this);
 
   SetScalingResolution(res, needsScaling);
   UpdateCameraPosition(m_cameras.top(), m_stereoFactors.top());

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -268,13 +268,13 @@ KODI::WINDOWING::COSScreenSaverManager* CWinSystemBase::GetOSScreenSaver()
 
 void CWinSystemBase::RegisterRenderLoop(IRenderLoop *client)
 {
-  std::unique_lock<CCriticalSection> lock(m_renderLoopSection);
+  std::unique_lock lock(m_renderLoopSection);
   m_renderLoopClients.push_back(client);
 }
 
 void CWinSystemBase::UnregisterRenderLoop(IRenderLoop *client)
 {
-  std::unique_lock<CCriticalSection> lock(m_renderLoopSection);
+  std::unique_lock lock(m_renderLoopSection);
   auto i = find(m_renderLoopClients.begin(), m_renderLoopClients.end(), client);
   if (i != m_renderLoopClients.end())
     m_renderLoopClients.erase(i);
@@ -285,7 +285,7 @@ void CWinSystemBase::DriveRenderLoop()
   MessagePump();
 
   {
-    std::unique_lock<CCriticalSection> lock(m_renderLoopSection);
+    std::unique_lock lock(m_renderLoopSection);
     for (auto i = m_renderLoopClients.begin(); i != m_renderLoopClients.end(); ++i)
       (*i)->FrameMove();
   }

--- a/xbmc/windowing/X11/GLContextEGL.cpp
+++ b/xbmc/windowing/X11/GLContextEGL.cpp
@@ -514,7 +514,7 @@ void CGLContextEGL::SwapBuffers()
     msc2++;
   }
   {
-    std::unique_lock<CCriticalSection> lock(m_syncLock);
+    std::unique_lock lock(m_syncLock);
     m_sync.ust1 = ust1;
     m_sync.ust2 = ust2;
     m_sync.msc1 = msc1;
@@ -532,7 +532,7 @@ uint64_t CGLContextEGL::GetVblankTiming(uint64_t &msc, uint64_t &interval)
   now = static_cast<uint64_t>(nowTs.tv_sec) * 1000000000ULL + nowTs.tv_nsec;
   now /= 1000;
 
-  std::unique_lock<CCriticalSection> lock(m_syncLock);
+  std::unique_lock lock(m_syncLock);
   msc = m_sync.msc2;
 
   interval = (m_sync.cont >= 5) ? m_sync.interval : m_sync.ust2 - m_sync.ust1;

--- a/xbmc/windowing/X11/VideoSyncGLX.cpp
+++ b/xbmc/windowing/X11/VideoSyncGLX.cpp
@@ -42,7 +42,7 @@ void CVideoSyncGLX::OnResetDisplay()
 
 bool CVideoSyncGLX::Setup()
 {
-  std::unique_lock<CCriticalSection> lock(m_winSystem.GetGfxContext());
+  std::unique_lock lock(m_winSystem.GetGfxContext());
 
   m_glXWaitVideoSyncSGI = NULL;
   m_glXGetVideoSyncSGI = NULL;
@@ -246,7 +246,7 @@ void CVideoSyncGLX::Cleanup()
   CLog::Log(LOGDEBUG, "CVideoReferenceClock: Cleaning up GLX");
 
   {
-    std::unique_lock<CCriticalSection> lock(m_winSystem.GetGfxContext());
+    std::unique_lock lock(m_winSystem.GetGfxContext());
 
     if (m_vInfo)
     {

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -562,7 +562,7 @@ void CWinSystemX11::NotifyXRREvent()
 {
   CLog::Log(LOGDEBUG, "{} - notify display reset event", __FUNCTION__);
 
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   if (!g_xrandr.Query(true))
   {
@@ -583,7 +583,7 @@ void CWinSystemX11::RecreateWindow()
 {
   m_windowDirty = true;
 
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
   XOutput *out = g_xrandr.GetOutput(m_userOutput);
   XMode   mode = g_xrandr.GetCurrentMode(m_userOutput);
@@ -624,7 +624,7 @@ void CWinSystemX11::OnLostDevice()
   CLog::Log(LOGDEBUG, "{} - notify display change event", __FUNCTION__);
 
   {
-    std::unique_lock<CCriticalSection> lock(m_resourceSection);
+    std::unique_lock lock(m_resourceSection);
     for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
       (*i)->OnLostDisplay();
   }
@@ -634,13 +634,13 @@ void CWinSystemX11::OnLostDevice()
 
 void CWinSystemX11::Register(IDispResource *resource)
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   m_resources.push_back(resource);
 }
 
 void CWinSystemX11::Unregister(IDispResource* resource)
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   std::vector<IDispResource*>::iterator i = find(m_resources.begin(), m_resources.end(), resource);
   if (i != m_resources.end())
     m_resources.erase(i);

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -62,7 +62,7 @@ void CWinSystemX11GLContext::PresentRenderImpl(bool rendered)
   if (m_delayDispReset && m_dispResetTimer.IsTimePast())
   {
     m_delayDispReset = false;
-    std::unique_lock<CCriticalSection> lock(m_resourceSection);
+    std::unique_lock lock(m_resourceSection);
     // tell any shared resources
     for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
       (*i)->OnResetDisplay();
@@ -154,7 +154,7 @@ bool CWinSystemX11GLContext::SetWindow(int width, int height, bool fullscreen, c
 
     if (!m_delayDispReset)
     {
-      std::unique_lock<CCriticalSection> lock(m_resourceSection);
+      std::unique_lock lock(m_resourceSection);
       // tell any shared resources
       for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
         (*i)->OnResetDisplay();

--- a/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
@@ -52,7 +52,7 @@ void CWinSystemX11GLESContext::PresentRenderImpl(bool rendered)
   if (m_delayDispReset && m_dispResetTimer.IsTimePast())
   {
     m_delayDispReset = false;
-    std::unique_lock<CCriticalSection> lock(m_resourceSection);
+    std::unique_lock lock(m_resourceSection);
     // tell any shared resources
     for (std::vector<IDispResource*>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
       (*i)->OnResetDisplay();
@@ -134,7 +134,7 @@ bool CWinSystemX11GLESContext::SetWindow(int width, int height, bool fullscreen,
 
     if (!m_delayDispReset)
     {
-      std::unique_lock<CCriticalSection> lock(m_resourceSection);
+      std::unique_lock lock(m_resourceSection);
       // tell any shared resources
       for (std::vector<IDispResource*>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
         (*i)->OnResetDisplay();

--- a/xbmc/windowing/android/WinEventsAndroid.cpp
+++ b/xbmc/windowing/android/WinEventsAndroid.cpp
@@ -53,14 +53,14 @@ CWinEventsAndroid::~CWinEventsAndroid()
 
 void CWinEventsAndroid::MessagePush(XBMC_Event *newEvent)
 {
-  std::unique_lock<CCriticalSection> lock(m_eventsCond);
+  std::unique_lock lock(m_eventsCond);
 
   m_events.push_back(*newEvent);
 }
 
 void CWinEventsAndroid::MessagePushRepeat(XBMC_Event *repeatEvent)
 {
-  std::unique_lock<CCriticalSection> lock(m_eventsCond);
+  std::unique_lock lock(m_eventsCond);
 
   std::list<XBMC_Event>::iterator itt;
   for (itt = m_events.begin(); itt != m_events.end(); ++itt)
@@ -89,7 +89,7 @@ bool CWinEventsAndroid::MessagePump()
     // deeper message loop and call the deeper MessagePump from there.
     XBMC_Event pumpEvent;
     {
-      std::unique_lock<CCriticalSection> lock(m_eventsCond);
+      std::unique_lock lock(m_eventsCond);
       if (m_events.empty())
         return ret;
       pumpEvent = m_events.front();
@@ -109,7 +109,7 @@ bool CWinEventsAndroid::MessagePump()
 
 size_t CWinEventsAndroid::GetQueueSize()
 {
-  std::unique_lock<CCriticalSection> lock(m_eventsCond);
+  std::unique_lock lock(m_eventsCond);
   return m_events.size();
 }
 
@@ -127,7 +127,7 @@ void CWinEventsAndroid::Process()
     // run a 10ms (timeout) wait cycle
     CThread::Sleep(std::chrono::milliseconds(timeout));
 
-    std::unique_lock<CCriticalSection> lock(m_lasteventCond);
+    std::unique_lock lock(m_lasteventCond);
 
     switch(state)
     {

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -222,7 +222,7 @@ void CWinSystemAndroid::InitiateModeChange()
 
 void CWinSystemAndroid::SetHdmiState(bool connected)
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   CLog::Log(LOGDEBUG, "CWinSystemAndroid::SetHdmiState: state: {}", static_cast<int>(connected));
 
   if (connected)
@@ -283,13 +283,13 @@ bool CWinSystemAndroid::Show(bool raise)
 
 void CWinSystemAndroid::Register(IDispResource *resource)
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   m_resources.push_back(resource);
 }
 
 void CWinSystemAndroid::Unregister(IDispResource *resource)
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   std::vector<IDispResource*>::iterator i = find(m_resources.begin(), m_resources.end(), resource);
   if (i != m_resources.end())
     m_resources.erase(i);

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -323,13 +323,13 @@ bool CWinSystemGbm::Show(bool raise)
 
 void CWinSystemGbm::Register(IDispResource *resource)
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   m_resources.push_back(resource);
 }
 
 void CWinSystemGbm::Unregister(IDispResource *resource)
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   std::vector<IDispResource*>::iterator i = find(m_resources.begin(), m_resources.end(), resource);
   if (i != m_resources.end())
   {
@@ -342,7 +342,7 @@ void CWinSystemGbm::OnLostDevice()
   CLog::Log(LOGDEBUG, "{} - notify display change event", __FUNCTION__);
   m_dispReset = true;
 
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   for (auto resource : m_resources)
     resource->OnLostDisplay();
 }

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -156,7 +156,7 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
       CLog::Log(LOGDEBUG, "CWinSystemGbmGLContext::{} - Sending display reset to all clients",
                 __FUNCTION__);
       m_dispReset = false;
-      std::unique_lock<CCriticalSection> lock(m_resourceSection);
+      std::unique_lock lock(m_resourceSection);
 
       for (auto resource : m_resources)
         resource->OnResetDisplay();

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -166,7 +166,7 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
       CLog::Log(LOGDEBUG, "CWinSystemGbmGLESContext::{} - Sending display reset to all clients",
                 __FUNCTION__);
       m_dispReset = false;
-      std::unique_lock<CCriticalSection> lock(m_resourceSection);
+      std::unique_lock lock(m_resourceSection);
 
       for (auto resource : m_resources)
         resource->OnResetDisplay();

--- a/xbmc/windowing/ios/WinEventsIOS.mm
+++ b/xbmc/windowing/ios/WinEventsIOS.mm
@@ -35,7 +35,7 @@ bool CWinEventsIOS::MessagePump()
     // deeper message loop and call the deeper MessagePump from there.
     XBMC_Event pumpEvent;
     {
-      std::unique_lock<CCriticalSection> lock(g_inputCond);
+      std::unique_lock lock(g_inputCond);
       if (events.empty())
         return ret;
       pumpEvent = events.front();
@@ -50,6 +50,6 @@ bool CWinEventsIOS::MessagePump()
 
 size_t CWinEventsIOS::GetQueueSize()
 {
-  std::unique_lock<CCriticalSection> lock(g_inputCond);
+  std::unique_lock lock(g_inputCond);
   return events.size();
 }

--- a/xbmc/windowing/ios/WinSystemIOS.mm
+++ b/xbmc/windowing/ios/WinSystemIOS.mm
@@ -351,13 +351,13 @@ bool CWinSystemIOS::EndRender()
 
 void CWinSystemIOS::Register(IDispResource *resource)
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   m_resources.push_back(resource);
 }
 
 void CWinSystemIOS::Unregister(IDispResource* resource)
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   std::vector<IDispResource*>::iterator i = find(m_resources.begin(), m_resources.end(), resource);
   if (i != m_resources.end())
     m_resources.erase(i);
@@ -365,7 +365,7 @@ void CWinSystemIOS::Unregister(IDispResource* resource)
 
 void CWinSystemIOS::OnAppFocusChange(bool focus)
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   m_bIsBackgrounded = !focus;
   CLog::Log(LOGDEBUG, "CWinSystemIOS::OnAppFocusChange: {}", focus ? 1 : 0);
   for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); i++)

--- a/xbmc/windowing/osx/WinEventsOSXImpl.mm
+++ b/xbmc/windowing/osx/WinEventsOSXImpl.mm
@@ -54,7 +54,7 @@
 
 - (void)MessagePush:(XBMC_Event*)newEvent
 {
-  std::unique_lock<CCriticalSection> lock(m_inputlock);
+  std::unique_lock lock(m_inputlock);
   events.emplace(*newEvent);
 }
 
@@ -71,7 +71,7 @@
     // deeper message loop and call the deeper MessagePump from there.
     XBMC_Event pumpEvent = {};
     {
-      std::unique_lock<CCriticalSection> lock(m_inputlock);
+      std::unique_lock lock(m_inputlock);
       if (events.size() == 0)
         return ret;
       pumpEvent = events.front();
@@ -86,7 +86,7 @@
 
 - (size_t)GetQueueSize
 {
-  std::unique_lock<CCriticalSection> lock(m_inputlock);
+  std::unique_lock lock(m_inputlock);
   return events.size();
 }
 

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -596,13 +596,13 @@ CWinSystemOSX::~CWinSystemOSX() = default;
 
 void CWinSystemOSX::Register(IDispResource* resource)
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   m_resources.push_back(resource);
 }
 
 void CWinSystemOSX::Unregister(IDispResource* resource)
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   std::vector<IDispResource*>::iterator i = find(m_resources.begin(), m_resources.end(), resource);
   if (i != m_resources.end())
     m_resources.erase(i);
@@ -610,7 +610,7 @@ void CWinSystemOSX::Unregister(IDispResource* resource)
 
 void CWinSystemOSX::AnnounceOnLostDevice()
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   // tell any shared resources
   CLog::LogF(LOGDEBUG, "Lost Device Announce");
   for (std::vector<IDispResource*>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
@@ -640,7 +640,7 @@ void CWinSystemOSX::AnnounceOnResetDevice()
   auto screenResolution = GetScreenResolution(m_lastDisplayNr);
   m_gfxContext->SetFPS(screenResolution.refreshrate);
 
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   // tell any shared resources
   CLog::LogF(LOGDEBUG, "Reset Device Announce");
   for (std::vector<IDispResource*>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
@@ -906,7 +906,7 @@ bool CWinSystemOSX::ResizeWindow(int newWidth, int newHeight, int newLeft, int n
 
 bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
+  std::unique_lock lock(m_critSection);
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   m_lastDisplayNr = GetDisplayIndex(settings->GetString(CSettings::SETTING_VIDEOSCREEN_MONITOR));
   m_nWidth = res.iWidth;

--- a/xbmc/windowing/tvos/WinEventsTVOS.mm
+++ b/xbmc/windowing/tvos/WinEventsTVOS.mm
@@ -37,14 +37,14 @@ CWinEventsTVOS::~CWinEventsTVOS()
 
 void CWinEventsTVOS::MessagePush(XBMC_Event* newEvent)
 {
-  std::unique_lock<CCriticalSection> lock(m_eventsCond);
+  std::unique_lock lock(m_eventsCond);
 
   m_events.push_back(*newEvent);
 }
 
 size_t CWinEventsTVOS::GetQueueSize()
 {
-  std::unique_lock<CCriticalSection> lock(g_inputCond);
+  std::unique_lock lock(g_inputCond);
   return events.size();
 }
 
@@ -62,7 +62,7 @@ bool CWinEventsTVOS::MessagePump()
     // deeper message loop and call the deeper MessagePump from there.
     XBMC_Event pumpEvent;
     {
-      std::unique_lock<CCriticalSection> lock(g_inputCond);
+      std::unique_lock lock(g_inputCond);
       if (events.empty())
         return ret;
       pumpEvent = events.front();

--- a/xbmc/windowing/tvos/WinSystemTVOS.mm
+++ b/xbmc/windowing/tvos/WinSystemTVOS.mm
@@ -98,7 +98,7 @@ size_t CWinSystemTVOS::GetQueueSize()
 
 void CWinSystemTVOS::AnnounceOnLostDevice()
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   // tell any shared resources
   CLog::Log(LOGDEBUG, "CWinSystemTVOS::AnnounceOnLostDevice");
   for (auto dispResource : m_resources)
@@ -107,7 +107,7 @@ void CWinSystemTVOS::AnnounceOnLostDevice()
 
 void CWinSystemTVOS::AnnounceOnResetDevice()
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   // tell any shared resources
   CLog::Log(LOGDEBUG, "CWinSystemTVOS::AnnounceOnResetDevice");
   for (auto dispResource : m_resources)
@@ -329,13 +329,13 @@ bool CWinSystemTVOS::EndRender()
 
 void CWinSystemTVOS::Register(IDispResource* resource)
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   m_resources.push_back(resource);
 }
 
 void CWinSystemTVOS::Unregister(IDispResource* resource)
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   std::vector<IDispResource*>::iterator i = find(m_resources.begin(), m_resources.end(), resource);
   if (i != m_resources.end())
     m_resources.erase(i);
@@ -343,7 +343,7 @@ void CWinSystemTVOS::Unregister(IDispResource* resource)
 
 void CWinSystemTVOS::OnAppFocusChange(bool focus)
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   m_bIsBackgrounded = !focus;
   CLog::Log(LOGDEBUG, "CWinSystemTVOS::OnAppFocusChange: {}", focus ? 1 : 0);
   for (auto dispResource : m_resources)

--- a/xbmc/windowing/wayland/Output.cpp
+++ b/xbmc/windowing/wayland/Output.cpp
@@ -29,7 +29,7 @@ COutput::COutput(std::uint32_t globalName,
                                   std::string const& make, std::string const& model,
                                   const wayland::output_transform&)
   {
-    std::unique_lock<CCriticalSection> lock(m_geometryCriticalSection);
+    std::unique_lock lock(m_geometryCriticalSection);
     m_position = {x, y};
     // Some monitors report invalid (non-positive) values that would cause an exception
     // with CSizeInt and/or lead to nonsensical DPI values.
@@ -46,7 +46,7 @@ COutput::COutput(std::uint32_t globalName,
     // element and boolean information whether the element was actually added
     // which we do not need
     auto modeIterator = m_modes.emplace(CSizeInt{width, height}, refresh).first;
-    std::unique_lock<CCriticalSection> lock(m_iteratorCriticalSection);
+    std::unique_lock lock(m_iteratorCriticalSection);
     // Remember current and preferred mode
     // Current mode is the last one that was sent with current flag set
     if (flags & wayland::output_mode::current)
@@ -87,7 +87,7 @@ COutput::~COutput() noexcept
 
 const COutput::Mode& COutput::GetCurrentMode() const
 {
-  std::unique_lock<CCriticalSection> lock(m_iteratorCriticalSection);
+  std::unique_lock lock(m_iteratorCriticalSection);
   if (m_currentMode == m_modes.end())
   {
     throw std::runtime_error("Current mode not set");
@@ -97,7 +97,7 @@ const COutput::Mode& COutput::GetCurrentMode() const
 
 const COutput::Mode& COutput::GetPreferredMode() const
 {
-  std::unique_lock<CCriticalSection> lock(m_iteratorCriticalSection);
+  std::unique_lock lock(m_iteratorCriticalSection);
   if (m_preferredMode == m_modes.end())
   {
     throw std::runtime_error("Preferred mode not set");
@@ -107,7 +107,7 @@ const COutput::Mode& COutput::GetPreferredMode() const
 
 float COutput::GetPixelRatioForMode(const Mode& mode) const
 {
-  std::unique_lock<CCriticalSection> lock(m_geometryCriticalSection);
+  std::unique_lock lock(m_geometryCriticalSection);
   if (m_physicalSize.IsZero() || mode.size.IsZero())
   {
     return 1.0f;
@@ -124,7 +124,7 @@ float COutput::GetPixelRatioForMode(const Mode& mode) const
 
 float COutput::GetDpiForMode(const Mode& mode) const
 {
-  std::unique_lock<CCriticalSection> lock(m_geometryCriticalSection);
+  std::unique_lock lock(m_geometryCriticalSection);
   if (m_physicalSize.IsZero())
   {
     // We really have no idea, so use a "sane" default

--- a/xbmc/windowing/wayland/Output.h
+++ b/xbmc/windowing/wayland/Output.h
@@ -50,7 +50,7 @@ public:
    */
   CPointInt GetPosition() const
   {
-    std::unique_lock<CCriticalSection> lock(m_geometryCriticalSection);
+    std::unique_lock lock(m_geometryCriticalSection);
     return m_position;
   }
   /**
@@ -59,17 +59,17 @@ public:
    */
   CSizeInt GetPhysicalSize() const
   {
-    std::unique_lock<CCriticalSection> lock(m_geometryCriticalSection);
+    std::unique_lock lock(m_geometryCriticalSection);
     return m_physicalSize;
   }
   std::string const& GetMake() const
   {
-    std::unique_lock<CCriticalSection> lock(m_geometryCriticalSection);
+    std::unique_lock lock(m_geometryCriticalSection);
     return m_make;
   }
   std::string const& GetModel() const
   {
-    std::unique_lock<CCriticalSection> lock(m_geometryCriticalSection);
+    std::unique_lock lock(m_geometryCriticalSection);
     return m_model;
   }
   std::int32_t GetScale() const

--- a/xbmc/windowing/wayland/SeatSelection.cpp
+++ b/xbmc/windowing/wayland/SeatSelection.cpp
@@ -73,7 +73,7 @@ CSeatSelection::CSeatSelection(CConnection& connection, wayland::seat_t const& s
   };
   m_dataDevice.on_selection() = [this](const wayland::data_offer_t& offer)
   {
-    std::unique_lock<CCriticalSection> lock(m_currentSelectionMutex);
+    std::unique_lock lock(m_currentSelectionMutex);
     m_matchedMimeType.clear();
 
     if (offer != m_currentOffer)
@@ -110,7 +110,7 @@ CSeatSelection::CSeatSelection(CConnection& connection, wayland::seat_t const& s
 
 std::string CSeatSelection::GetSelectionText() const
 {
-  std::unique_lock<CCriticalSection> lock(m_currentSelectionMutex);
+  std::unique_lock lock(m_currentSelectionMutex);
   if (!m_currentSelection || m_matchedMimeType.empty())
   {
     return "";

--- a/xbmc/windowing/wayland/Signals.h
+++ b/xbmc/windowing/wayland/Signals.h
@@ -91,7 +91,7 @@ class CSignalHandlerList
 
     void Unregister(RegistrationIdentifierType id) override
     {
-      std::unique_lock<CCriticalSection> lock(m_handlerCriticalSection);
+      std::unique_lock lock(m_handlerCriticalSection);
       m_handlers.erase(id);
     }
   };
@@ -109,7 +109,7 @@ public:
 
   CSignalRegistration Register(ManagedT const& handler)
   {
-    std::unique_lock<CCriticalSection> lock(m_data->m_handlerCriticalSection);
+    std::unique_lock lock(m_data->m_handlerCriticalSection);
     bool inserted{false};
     while(!inserted)
     {
@@ -126,7 +126,7 @@ public:
   template<typename... ArgsT>
   void Invoke(ArgsT&&... args)
   {
-    std::unique_lock<CCriticalSection> lock(m_data->m_handlerCriticalSection);
+    std::unique_lock lock(m_data->m_handlerCriticalSection);
     for (auto const& handler : *this)
     {
       handler.second(std::forward<ArgsT>(args)...);

--- a/xbmc/windowing/wayland/WinEventsWayland.cpp
+++ b/xbmc/windowing/wayland/WinEventsWayland.cpp
@@ -67,7 +67,7 @@ public:
   {
     Stop();
     // Wait for roundtrip invocation to finish
-    std::unique_lock<CCriticalSection> lock(m_roundtripQueueMutex);
+    std::unique_lock lock(m_roundtripQueueMutex);
   }
 
   void Stop()
@@ -86,7 +86,7 @@ public:
 
     // Serialize invocations of this function - it's used very rarely and usually
     // not in parallel anyway, and doing it avoids lots of complications
-    std::unique_lock<CCriticalSection> lock(m_roundtripQueueMutex);
+    std::unique_lock lock(m_roundtripQueueMutex);
 
     m_roundtripQueueEvent.Reset();
     // We can just set the value here since there is no other writer in parallel
@@ -250,7 +250,7 @@ bool CWinEventsWayland::MessagePump()
     XBMC_Event event;
     {
       // Scoped lock for reentrancy
-      std::unique_lock<CCriticalSection> lock(m_queueMutex);
+      std::unique_lock lock(m_queueMutex);
 
       if (m_queue.empty())
       {
@@ -272,6 +272,6 @@ bool CWinEventsWayland::MessagePump()
 
 void CWinEventsWayland::MessagePush(XBMC_Event* ev)
 {
-  std::unique_lock<CCriticalSection> lock(m_queueMutex);
+  std::unique_lock lock(m_queueMutex);
   m_queue.emplace(*ev);
 }

--- a/xbmc/windowing/wayland/WindowDecorator.cpp
+++ b/xbmc/windowing/wayland/WindowDecorator.cpp
@@ -454,7 +454,7 @@ void CWindowDecorator::OnPointerEnter(CSeat* seat,
   auto& seatState = seatStateI->second;
   // Reset first so we ignore events for surfaces we don't handle
   seatState.currentSurface = SURFACE_COUNT;
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
   for (std::size_t i{0}; i < m_borderSurfaces.size(); i++)
   {
     if (m_borderSurfaces[i].surface.wlSurface == surface)
@@ -530,7 +530,7 @@ void CWindowDecorator::OnTouchDown(CSeat* seat,
     return;
   }
   auto& seatState = seatStateI->second;
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
   for (std::size_t i{0}; i < m_borderSurfaces.size(); i++)
   {
     if (m_borderSurfaces[i].surface.wlSurface == surface)
@@ -553,7 +553,7 @@ void CWindowDecorator::UpdateSeatCursor(SeatState& seatState)
   std::string cursorName{"default"};
 
   {
-    std::unique_lock<CCriticalSection> lock(m_mutex);
+    std::unique_lock lock(m_mutex);
     auto resizeEdge = ResizeEdgeForPosition(seatState.currentSurface, SurfaceGeometry(seatState.currentSurface, m_mainSurfaceSize).ToSize(), CPointInt{seatState.pointerPosition});
     if (resizeEdge != wayland::shell_surface_resize::none)
     {
@@ -601,7 +601,7 @@ void CWindowDecorator::UpdateButtonHoverState()
 {
   std::vector<CPoint> pointerPositions;
 
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   for (auto const& seatPair : m_seats)
   {
@@ -633,7 +633,7 @@ void CWindowDecorator::HandleSeatClick(SeatState const& seatState, SurfaceIndex 
   {
     case BTN_LEFT:
     {
-      std::unique_lock<CCriticalSection> lock(m_mutex);
+      std::unique_lock lock(m_mutex);
       auto resizeEdge = ResizeEdgeForPosition(surface, SurfaceGeometry(surface, m_mainSurfaceSize).ToSize(), CPointInt{position});
       if (resizeEdge == wayland::shell_surface_resize::none)
       {
@@ -718,7 +718,7 @@ CSizeInt CWindowDecorator::CalculateFullSurfaceSize(CSizeInt size, IShellSurface
 void CWindowDecorator::SetState(CSizeInt size, int scale, IShellSurface::StateBitset state)
 {
   CSizeInt mainSurfaceSize{CalculateMainSurfaceSize(size, state)};
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
   if (mainSurfaceSize == m_mainSurfaceSize && scale == m_scale && state == m_windowState)
   {
     return;
@@ -765,7 +765,7 @@ void CWindowDecorator::Reset(bool reallocate)
 {
   // The complete reset operation should be seen as one atomic update to the
   // internal state, otherwise buffer/surface state might be mismatched
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
 
   if (reallocate)
   {
@@ -991,7 +991,7 @@ void CWindowDecorator::Repaint()
 
 void CWindowDecorator::CommitAllBuffers()
 {
-  std::unique_lock<CCriticalSection> lock(m_pendingBuffersMutex);
+  std::unique_lock lock(m_pendingBuffersMutex);
 
   for (auto& borderSurface : m_borderSurfaces)
   {
@@ -1009,7 +1009,7 @@ void CWindowDecorator::CommitAllBuffers()
       // never allow the object to be freed), so use the raw pointer for now
       wlBuffer.on_release() = [this, wlBufferC]()
       {
-        std::unique_lock<CCriticalSection> lock(m_pendingBuffersMutex);
+        std::unique_lock lock(m_pendingBuffersMutex);
         // Construct a dummy object for searching the set
         wayland::buffer_t findDummy(wlBufferC, wayland::proxy_t::wrapper_type::foreign);
         auto iter = m_pendingBuffers.find(findDummy);
@@ -1034,7 +1034,7 @@ void CWindowDecorator::CommitAllBuffers()
 
 void CWindowDecorator::LoadCursorTheme()
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
   if (!m_cursorTheme)
   {
     // Load default cursor theme

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -568,13 +568,13 @@ bool CWinSystemWin10::Show(bool raise)
 
 void CWinSystemWin10::Register(IDispResource *resource)
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   m_resources.push_back(resource);
 }
 
 void CWinSystemWin10::Unregister(IDispResource* resource)
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   std::vector<IDispResource*>::iterator i = find(m_resources.begin(), m_resources.end(), resource);
   if (i != m_resources.end())
     m_resources.erase(i);
@@ -585,7 +585,7 @@ void CWinSystemWin10::OnDisplayLost()
   CLog::Log(LOGDEBUG, "{} - notify display lost event", __FUNCTION__);
 
   {
-    std::unique_lock<CCriticalSection> lock(m_resourceSection);
+    std::unique_lock lock(m_resourceSection);
     for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
       (*i)->OnLostDisplay();
   }
@@ -596,7 +596,7 @@ void CWinSystemWin10::OnDisplayReset()
   if (!m_delayDispReset)
   {
     CLog::Log(LOGDEBUG, "{} - notify display reset event", __FUNCTION__);
-    std::unique_lock<CCriticalSection> lock(m_resourceSection);
+    std::unique_lock lock(m_resourceSection);
     for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
       (*i)->OnResetDisplay();
   }

--- a/xbmc/windowing/windows/VideoSyncD3D.cpp
+++ b/xbmc/windowing/windows/VideoSyncD3D.cpp
@@ -50,7 +50,7 @@ void CVideoSyncD3D::RefreshChanged()
 bool CVideoSyncD3D::Setup()
 {
   CLog::Log(LOGDEBUG, "CVideoSyncD3D: Setting up Direct3d");
-  std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   DX::Windowing()->Register(this);
   m_displayLost = false;
   m_displayReset = false;

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -1141,13 +1141,13 @@ bool CWinSystemWin32::Show(bool raise)
 
 void CWinSystemWin32::Register(IDispResource *resource)
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   m_resources.push_back(resource);
 }
 
 void CWinSystemWin32::Unregister(IDispResource* resource)
 {
-  std::unique_lock<CCriticalSection> lock(m_resourceSection);
+  std::unique_lock lock(m_resourceSection);
   std::vector<IDispResource*>::iterator i = find(m_resources.begin(), m_resources.end(), resource);
   if (i != m_resources.end())
     m_resources.erase(i);
@@ -1158,7 +1158,7 @@ void CWinSystemWin32::OnDisplayLost()
   CLog::LogF(LOGDEBUG, "notify display lost event");
 
   {
-    std::unique_lock<CCriticalSection> lock(m_resourceSection);
+    std::unique_lock lock(m_resourceSection);
     for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
       (*i)->OnLostDisplay();
   }
@@ -1169,7 +1169,7 @@ void CWinSystemWin32::OnDisplayReset()
   if (!m_delayDispReset)
   {
     CLog::LogF(LOGDEBUG, "notify display reset event");
-    std::unique_lock<CCriticalSection> lock(m_resourceSection);
+    std::unique_lock lock(m_resourceSection);
     for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
       (*i)->OnResetDisplay();
   }


### PR DESCRIPTION
…uments should not be used cpp:S6012

One big trivial change to get rid of ~2.000 SonarQube findings: Across the whole code base, remove template argument when defining `std::unique_lock` local variables.

@neo1973 whenever you find some time for this.

