### PR TITLE
[depends][samba] Specify usage of libiconv

### DIFF
--- a/tools/depends/target/samba-gplv3/Makefile
+++ b/tools/depends/target/samba-gplv3/Makefile
@@ -35,6 +35,10 @@ CONFIGURE=./configure --prefix=$(PREFIX) \
           --without-regedit \
           --without-lttng
 
+ifeq ($(NEED_LIBICONV), 1)
+  CONFIGURE += --with-libiconv=$(PREFIX)/lib
+endif
+
 LIBDYLIB=$(PLATFORM)/bin/default/source3/libsmb/libsmbclient.a
 
 ifeq ($(OS), darwin_embedded)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Specify `--with-libiconv` manually when building samba to avoid leaking of host libraries into build.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

```
Checking if size of bool == 1                            : not found 
Checking if size of bool == 2                            : not found 
Checking if size of bool == 4                            : not found 
Checking if size of bool == 8                            : not found 
Checking if size of bool == 16                           : not found 
Checking if size of bool == 32                           : not found 
Checking if size of bool == 64                           : not found 
Couldn't determine size of 'bool'
```

The log shows this is because the program cannot be compiled due to buildroot's toolchain wrapper which checks if host paths leak into the toolchain:
```
err: arm-webos-linux-gnueabi-gcc: ERROR: unsafe header/library path used in cross-compilation: '-L/usr/local/lib'
```

It turns out this is actually caused by samba trying to resolve iconv which resolves to `/usr/local`. This was not an issue before because host path checking has only recently been made the default in buildroot. In any case we don't acidentally want host paths leaking into the compilation so specify `--with-libiconv` manually to avoid this.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
