### PR TITLE
[guilib/listproviders] Fix initialization of CPVRSubscriber.

### DIFF
--- a/xbmc/guilib/listproviders/DirectoryProvider.cpp
+++ b/xbmc/guilib/listproviders/DirectoryProvider.cpp
@@ -157,6 +157,9 @@ public:
     : CDirectoryProvider::CSubscriber(invalidate)
   {
     CServiceBroker::GetPVRManager().Events().Subscribe(this, &CPVRSubscriber::OnPVRManagerEvent);
+
+    if (CServiceBroker::GetPVRManager().IsStarted())
+      m_pvrStarted.test_and_set();
   }
   ~CPVRSubscriber() override { CServiceBroker::GetPVRManager().Events().Unsubscribe(this); }
 


### PR DESCRIPTION
Fixes late init of PVR message processing that was introduced with https://github.com/xbmc/xbmc/pull/26699

Initial implementation did not respect that the `CPVRSubscriber` instance can be created at a time where the PVR manager is already started. The "PVR ready" flag (`m_pvrStarted`) was never set for the subscriber, thus all messages from PVR ignored.

Visual effect for the user in Estuary was indefinitely spinning circles for home screen items in PVR home screen widget, under certain circumstances (PVR manager starting very fast, a PVR window used as Kodi start window, ...). Was also reported by a user somewhere (on one of the Kodi forums, IIRC).

Reproduced and runtime-tested with pvr.demo and PVR Guide window as Kodi start window - latest kodi master, macOS.

@phunkyfish should be a no-brainer to review.