### PR TITLE
[PVR] Fix resolving of plugin-supplied items before playback start.

### DIFF
--- a/xbmc/pvr/epg/CMakeLists.txt
+++ b/xbmc/pvr/epg/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES EpgContainer.cpp
             Epg.cpp
             EpgDatabase.cpp
+            EpgGuidePath.cpp
             EpgInfoTag.cpp
             EpgSearch.cpp
             EpgSearchFilter.cpp
@@ -12,6 +13,7 @@ set(SOURCES EpgContainer.cpp
 set(HEADERS Epg.h
             EpgContainer.h
             EpgDatabase.h
+            EpgGuidePath.h
             EpgInfoTag.h
             EpgSearch.h
             EpgSearchData.h

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -125,6 +125,12 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpg::GetTagByDatabaseId(int iDatabaseId) con
   return m_tags.GetTagByDatabaseID(iDatabaseId);
 }
 
+std::shared_ptr<CPVREpgInfoTag> CPVREpg::GetTagByStartDateTime(const CDateTime& start) const
+{
+  std::unique_lock lock(m_critSection);
+  return m_tags.GetTag(start);
+}
+
 std::shared_ptr<CPVREpgInfoTag> CPVREpg::GetTagBetween(const CDateTime& beginTime, const CDateTime& endTime, bool bUpdateFromClient /* = false */)
 {
   std::shared_ptr<CPVREpgInfoTag> tag;

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -164,6 +164,13 @@ namespace PVR
     std::shared_ptr<CPVREpgInfoTag> GetTagByDatabaseId(int iDatabaseId) const;
 
     /*!
+     * @brief Get the event matching the given start date and time
+     * @param start The start date and time to look up
+     * @return The matching event or empty ptr if it wasn't found.
+     */
+    std::shared_ptr<CPVREpgInfoTag> GetTagByStartDateTime(const CDateTime& start) const;
+
+    /*!
      * @brief Update an entry in this EPG.
      * @param data The tag to update.
      * @param iClientId The id of the pvr client this event belongs to.

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -16,6 +16,7 @@
 #include "pvr/epg/EpgChannelData.h"
 #include "pvr/epg/EpgContainer.h"
 #include "pvr/epg/EpgDatabase.h"
+#include "pvr/epg/EpgGuidePath.h"
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/guilib/PVRGUIProgressHandler.h"
 #include "pvr/settings/PVRSettings.h"
@@ -516,6 +517,18 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgContainer::GetTagByDatabaseId(int iDataba
   }
 
   return retval;
+}
+
+std::shared_ptr<CPVREpgInfoTag> CPVREpgContainer::GetTagByPath(const std::string& path) const
+{
+  const CPVREpgGuidePath guidePath{path};
+  if (guidePath.IsValid())
+  {
+    const std::shared_ptr<const CPVREpg> epg{GetById(guidePath.GetEpgId())};
+    if (epg)
+      return epg->GetTagByStartDateTime(guidePath.GetStartDateTime());
+  }
+  return {};
 }
 
 std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgContainer::GetTags(

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -152,6 +152,13 @@ public:
   std::shared_ptr<CPVREpgInfoTag> GetTagByDatabaseId(int iDatabaseId) const;
 
   /*!
+   * @brief Get the EPG event with the given path
+   * @param path The path
+   * @return The requested event, or an empty tag when not found
+   */
+  std::shared_ptr<CPVREpgInfoTag> GetTagByPath(const std::string& path) const;
+
+  /*!
    * @brief Get all EPG tags matching the given search criteria.
    * @param searchData The search criteria.
    * @return The matching tags.

--- a/xbmc/pvr/epg/EpgGuidePath.cpp
+++ b/xbmc/pvr/epg/EpgGuidePath.cpp
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "EpgGuidePath.h"
+
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+using namespace PVR;
+
+CPVREpgGuidePath::CPVREpgGuidePath(int epgId, const CDateTime& startDateTime)
+  : m_path(StringUtils::Format("pvr://guide/{:04}/{}.epg", epgId, startDateTime.GetAsDBDateTime())),
+    m_isValid(startDateTime.IsValid()),
+    m_epgId(epgId),
+    m_startDateTime(startDateTime)
+{
+}
+
+CPVREpgGuidePath::CPVREpgGuidePath(const std::string& path) : m_path(path)
+{
+  const std::vector<std::string> segments{URIUtils::SplitPath(m_path)};
+
+  m_isValid = (segments.size() == 4 && segments.at(1) == "guide" && segments.at(2).size() == 4 &&
+               StringUtils::IsNaturalNumber(segments.at(2)) && segments.at(3).ends_with(".epg"));
+  m_epgId = std::atoi(segments.at(2).c_str());
+  m_startDateTime = CDateTime::FromDBDateTime(segments.at(3).substr(0, segments.at(3).size() - 4));
+
+  m_isValid &= m_startDateTime.IsValid();
+}

--- a/xbmc/pvr/epg/EpgGuidePath.h
+++ b/xbmc/pvr/epg/EpgGuidePath.h
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "XBDateTime.h"
+
+#include <string>
+
+namespace PVR
+{
+class CPVREpgGuidePath
+{
+public:
+  CPVREpgGuidePath(int epgId, const CDateTime& startDateTime);
+  explicit CPVREpgGuidePath(const std::string& path);
+
+  bool IsValid() const { return m_isValid; }
+
+  const std::string& GetPath() const { return m_path; }
+  int GetEpgId() const { return m_epgId; }
+  CDateTime GetStartDateTime() const { return m_startDateTime; }
+
+private:
+  std::string m_path;
+  bool m_isValid{false};
+  int m_epgId{0};
+  CDateTime m_startDateTime;
+};
+} // namespace PVR

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -16,6 +16,7 @@
 #include "pvr/epg/Epg.h"
 #include "pvr/epg/EpgChannelData.h"
 #include "pvr/epg/EpgDatabase.h"
+#include "pvr/epg/EpgGuidePath.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -474,7 +475,7 @@ std::string CPVREpgInfoTag::ClientIconPath() const
 
 std::string CPVREpgInfoTag::Path() const
 {
-  return StringUtils::Format("pvr://guide/{:04}/{}.epg", EpgID(), m_startTime.GetAsDBDateTime());
+  return CPVREpgGuidePath(EpgID(), m_startTime).GetPath();
 }
 
 bool CPVREpgInfoTag::Update(const CPVREpgInfoTag& tag, bool bUpdateBroadcastId /* = true */)


### PR DESCRIPTION
Fixes an issue reported on the forum: https://forum.kodi.tv/showthread.php?tid=381623&pid=3232729#pid3232729

I earlier provided a test build for the issue reporter, still waiting for feedback.

However, as I was able to reproduce the issue and have runtime-tested myself, I'm quite confident that the fix is okay.

@phunkyfish could you have a look, please. I put a comment in the code that should explain the issue and how to solve it.