### PR TITLE
FFmpegImage: Add WebP magic byte detection and fix TIFF magic byte detection

### DIFF
--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -199,11 +199,16 @@ bool CFFmpegImage::Initialize(unsigned char* buffer, size_t bufSize)
   constexpr uint8_t pngHeader[] = {0x89, 'P', 'N', 'G'};
   constexpr uint8_t tiffLEHeader[] = {'I', 'I', '*', '\0'};
   constexpr uint8_t tiffBEHeader[] = {'M', 'M', '\0', '*'};
+  constexpr uint8_t webpHeader1[] = {'R', 'I', 'F', 'F'};
+  constexpr uint8_t webpHeader2[] = {'W', 'E', 'B', 'P'};
   const bool is_jpeg = (bufSize > 2 && std::memcmp(buffer, jpegHeader, sizeof(jpegHeader)) == 0);
   const bool is_png = (bufSize > 3 && std::memcmp(buffer, pngHeader, sizeof(pngHeader)) == 0);
   const bool is_tiff =
       (bufSize > 3 && (std::memcmp(buffer, tiffLEHeader, sizeof(tiffLEHeader)) == 0 ||
                        std::memcmp(buffer, tiffBEHeader, sizeof(tiffBEHeader)) == 0));
+  const bool is_webp =
+      (bufSize > 11 && std::memcmp(buffer, webpHeader1, sizeof(webpHeader1)) == 0 &&
+       std::memcmp(buffer + 8, webpHeader2, sizeof(webpHeader2)) == 0);
 
   // See Github #19113
 #if LIBAVCODEC_VERSION_MAJOR < 60
@@ -221,11 +226,13 @@ bool CFFmpegImage::Initialize(unsigned char* buffer, size_t bufSize)
     inp = av_find_input_format("png_pipe");
   else if (is_tiff)
     inp = av_find_input_format("tiff_pipe");
+  else if (is_webp)
+    inp = av_find_input_format("webp_pipe");
   else if (m_strMimeType == "image/jp2")
     inp = av_find_input_format("j2k_pipe");
+  // brute force parse if above check already failed
   else if (m_strMimeType == "image/webp")
     inp = av_find_input_format("webp_pipe");
-  // brute force parse if above check already failed
   else if (m_strMimeType == "image/jpeg" || m_strMimeType == "image/jpg")
     inp = av_find_input_format(jpegFormat);
   else if (m_strMimeType == "image/png")

--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -15,6 +15,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <cstdint>
 
 extern "C"
 {
@@ -193,10 +194,13 @@ bool CFFmpegImage::Initialize(unsigned char* buffer, size_t bufSize)
 
   // Some clients have pngs saved as jpeg or ask us for png but are jpeg
   // mythv throws all mimetypes away and asks us with application/octet-stream
-  // this is poor man's fallback to at least identify png / jpeg
-  bool is_jpeg = (bufSize > 2 && buffer[0] == 0xFF && buffer[1] == 0xD8 && buffer[2] == 0xFF);
-  bool is_png = (bufSize > 3 && buffer[1] == 'P' && buffer[2] == 'N' && buffer[3] == 'G');
-  bool is_tiff = (bufSize > 2 && buffer[0] == 'I' && buffer[1] == 'I' && buffer[2] == '*');
+  // this is poor man's fallback to at least identify the most important formats
+  constexpr uint8_t jpegHeader[] = {0xFF, 0xD8, 0xFF};
+  constexpr uint8_t pngHeader[] = {'P', 'N', 'G'};
+  constexpr uint8_t tiffHeader[] = {'I', 'I', '*'};
+  const bool is_jpeg = (bufSize > 2 && std::memcmp(buffer, jpegHeader, sizeof(jpegHeader)) == 0);
+  const bool is_png = (bufSize > 3 && std::memcmp(buffer + 1, pngHeader, sizeof(pngHeader)) == 0);
+  const bool is_tiff = (bufSize > 2 && std::memcmp(buffer, tiffHeader, sizeof(tiffHeader)) == 0);
 
   // See Github #19113
 #if LIBAVCODEC_VERSION_MAJOR < 60

--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -197,10 +197,13 @@ bool CFFmpegImage::Initialize(unsigned char* buffer, size_t bufSize)
   // this is poor man's fallback to at least identify the most important formats
   constexpr uint8_t jpegHeader[] = {0xFF, 0xD8, 0xFF};
   constexpr uint8_t pngHeader[] = {0x89, 'P', 'N', 'G'};
-  constexpr uint8_t tiffHeader[] = {'I', 'I', '*'};
+  constexpr uint8_t tiffLEHeader[] = {'I', 'I', '*', '\0'};
+  constexpr uint8_t tiffBEHeader[] = {'M', 'M', '\0', '*'};
   const bool is_jpeg = (bufSize > 2 && std::memcmp(buffer, jpegHeader, sizeof(jpegHeader)) == 0);
   const bool is_png = (bufSize > 3 && std::memcmp(buffer, pngHeader, sizeof(pngHeader)) == 0);
-  const bool is_tiff = (bufSize > 2 && std::memcmp(buffer, tiffHeader, sizeof(tiffHeader)) == 0);
+  const bool is_tiff =
+      (bufSize > 3 && (std::memcmp(buffer, tiffLEHeader, sizeof(tiffLEHeader)) == 0 ||
+                       std::memcmp(buffer, tiffBEHeader, sizeof(tiffBEHeader)) == 0));
 
   // See Github #19113
 #if LIBAVCODEC_VERSION_MAJOR < 60

--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -196,10 +196,10 @@ bool CFFmpegImage::Initialize(unsigned char* buffer, size_t bufSize)
   // mythv throws all mimetypes away and asks us with application/octet-stream
   // this is poor man's fallback to at least identify the most important formats
   constexpr uint8_t jpegHeader[] = {0xFF, 0xD8, 0xFF};
-  constexpr uint8_t pngHeader[] = {'P', 'N', 'G'};
+  constexpr uint8_t pngHeader[] = {0x89, 'P', 'N', 'G'};
   constexpr uint8_t tiffHeader[] = {'I', 'I', '*'};
   const bool is_jpeg = (bufSize > 2 && std::memcmp(buffer, jpegHeader, sizeof(jpegHeader)) == 0);
-  const bool is_png = (bufSize > 3 && std::memcmp(buffer + 1, pngHeader, sizeof(pngHeader)) == 0);
+  const bool is_png = (bufSize > 3 && std::memcmp(buffer, pngHeader, sizeof(pngHeader)) == 0);
   const bool is_tiff = (bufSize > 2 && std::memcmp(buffer, tiffHeader, sizeof(tiffHeader)) == 0);
 
   // See Github #19113


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

In #26796 and #26221 it was reported that WebP images with incorrect file extensions are not shown in Kodi. As this seems to be not uncommon I added detection of WebP files by _Magic Bytes_.

I also noticed that the Magic Byte detection for TIFF files was incomplete, this has also been fixed.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #26796.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Got a WebP file, changed the extension to .jpg and verified that it is shown when selected through the file manager.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Show WebP images disguised as JPEG.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
