### PR TITLE
[depends] Avoid leaking host arch libraries onto target cmake path

### DIFF
--- a/tools/depends/target/Toolchain.cmake.in
+++ b/tools/depends/target/Toolchain.cmake.in
@@ -86,11 +86,14 @@ if(NOT "@use_sdk_path@" STREQUAL "")
 endif()
 # Currently this is only set to reject android by default
 if(NOT "@use_toolchain@" STREQUAL "")
-  list(APPEND CMAKE_FIND_ROOT_PATH @use_toolchain@/@use_host@ @use_toolchain@/@use_host@/sysroot @use_toolchain@/@use_host@/sysroot/usr @use_toolchain@/@use_host@/libc @use_toolchain@/lib/@use_host@/sysroot @use_toolchain@/usr @use_toolchain@/sysroot/usr)
-  # Explicitly set this as last. This potentially is /usr which can then cause linux
-  # cross compilation to search paths that are not relevant to target arch (eg host libs)
-  # x86/x86_64 jenkins CI jobs require /usr for libs like iconv
-  list(APPEND CMAKE_FIND_ROOT_PATH @use_toolchain@)
+  list(APPEND CMAKE_FIND_ROOT_PATH @use_toolchain@/@use_host@ @use_toolchain@/@use_host@/sysroot @use_toolchain@/@use_host@/sysroot/usr @use_toolchain@/@use_host@/libc @use_toolchain@/lib/@use_host@/sysroot @use_toolchain@/sysroot/usr)
+
+  if (OS STREQUAL linux AND NOT PLATFORM STREQUAL webos)
+    # Explicitly set this as last. This potentially is /usr which can then cause linux
+    # cross compilation to search paths that are not relevant to target arch (eg host libs)
+    # x86/x86_64 jenkins CI jobs require /usr for libs like iconv
+    list(APPEND CMAKE_FIND_ROOT_PATH @use_toolchain@/usr @use_toolchain@)
+  endif()
   set(CMAKE_LIBRARY_PATH "${CMAKE_LIBRARY_PATH}:@use_toolchain@/usr/lib/@use_host@:@use_toolchain@/lib/@use_host@")
 endif()
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Avoid putting host arch libraries onto `CMAKE_FIND_ROOT_PATH` during target build.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There's currently a build failure using the new prebuilt webOS toolchain when building mariadb-connector:

```bash
-- Found ZSTD: /build/arm-webos-linux-gnueabi_sdk-buildroot/usr/lib/libzstd.so
[...]
make[3]: Entering directory '/build/kodi/tools/depends/target/mariadb/arm-webos-linux-gnueabi-release/build'
[  1%] Building C object CMakeFiles/zstd.dir/plugins/compress/c_zstd.c.o
[  2%] Linking C shared module zstd.so
/build/arm-webos-linux-gnueabi_sdk-buildroot/usr/lib/libzstd.so: file not recognized: file format not recognized
collect2: error: ld returned 1 exit status
make[3]: *** [CMakeFiles/zstd.dir/build.make:102: zstd.so] Error 1
```

mariadb-connector finds `libzstd.so` that is bundled from the host's arch. Usually the root folder (and /usr) of the toolchain cannot be considered safe as it usually would contain host arch libraries.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
