### PR TITLE
[PVR] Profile switch related fixes

### DIFF
--- a/xbmc/pvr/addons/PVRClientUID.cpp
+++ b/xbmc/pvr/addons/PVRClientUID.cpp
@@ -74,3 +74,8 @@ int CPVRClientUID::GetLegacyUID() const
 
   return uid;
 }
+
+void CPVRClientUID::ClearCache()
+{
+  s_idMap.clear();
+}

--- a/xbmc/pvr/addons/PVRClientUID.h
+++ b/xbmc/pvr/addons/PVRClientUID.h
@@ -34,6 +34,11 @@ public:
    */
   int GetLegacyUID() const;
 
+  /*!
+   * @brief Clear the UID cache.
+   */
+  static void ClearCache();
+
 private:
   CPVRClientUID() = delete;
 

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -67,6 +67,8 @@ void CPVRClients::Stop()
   {
     client->Stop();
   }
+
+  CPVRClientUID::ClearCache();
 }
 
 void CPVRClients::Continue()

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -278,6 +278,9 @@ bool CGUIWindowPVRGuideBase::GetDirectory(const std::string& strDirectory, CFile
     items.Assign(*newTimeline, false);
   }
 
+  // update the view state's reference to the current items
+  m_guiState.reset(CGUIViewState::GetViewState(GetID(), items));
+
   return true;
 }
 


### PR DESCRIPTION
Fixes two bugs which can happen in certain constellations after switching profiles:

1) Wrong last recently played information, missing channels, ... Reason: PVR uses a cache for client UIDs, which needs to be cleared when switching profiles, otherwise invalid client UIDs (from old previous profile) could be used with the new profile.
2) Wrong view state data (like sort criteria) used in guide window. Reason: View state needs to be reset when switching profiles.

Runtime-tested on macOS, latest Kodi master.

@phunkyfish should be easy to review.