### PR TITLE
[VFS] Fix Recently Added Movies node navigation for Movies with Versions/Extras

### DIFF
--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.cpp
@@ -36,3 +36,8 @@ bool CDirectoryNodeRecentlyAddedMovies::GetContent(CFileItemList& items) const
 
   return bSuccess;
 }
+
+NodeType CDirectoryNodeRecentlyAddedMovies::GetChildType() const
+{
+  return NodeType::MOVIE_ASSET_TYPES;
+}

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.h
@@ -20,6 +20,7 @@ namespace XFILE
       CDirectoryNodeRecentlyAddedMovies(const std::string& strEntryName, CDirectoryNode* pParent);
     protected:
       bool GetContent(CFileItemList& items) const override;
+      NodeType GetChildType() const override;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/test/CMakeLists.txt
+++ b/xbmc/filesystem/VideoDatabaseDirectory/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES TestNodeMovieAssets.cpp
             TestNodeMovieAssetTypes.cpp
+            TestNodeRecentlyAddedMovies.cpp
             TestNodeTitleMovies.cpp)
 
 core_add_test_library(videodatabasedirectory_test)

--- a/xbmc/filesystem/VideoDatabaseDirectory/test/TestNodeRecentlyAddedMovies.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/test/TestNodeRecentlyAddedMovies.cpp
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2005-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "filesystem/VideoDatabaseDirectory/DirectoryNode.h"
+#include "filesystem/VideoDatabaseDirectory/QueryParams.h"
+#include "test/TestUtils.h"
+#include "video/VideoDatabase.h"
+
+#include <gtest/gtest.h>
+
+using namespace XFILE::VIDEODATABASEDIRECTORY;
+
+TEST(TestNodeRecentlyAddedMovies, General)
+{
+  std::unique_ptr<CDirectoryNode> node(
+      CDirectoryNode::ParseURL("videodb://recentlyaddedmovies/123"));
+
+  EXPECT_TRUE(node);
+
+  ASSERT_EQ(node->GetType(), NodeType::RECENTLY_ADDED_MOVIES);
+  ASSERT_EQ(node->GetChildType(), NodeType::MOVIE_ASSET_TYPES);
+  EXPECT_TRUE(node->GetParent());
+  ASSERT_EQ(node->GetParent()->GetType(), NodeType::OVERVIEW);
+
+  CQueryParams params;
+  node->CollectQueryParams(params);
+
+  ASSERT_EQ(static_cast<VideoDbContentType>(params.GetContentType()), VideoDbContentType::MOVIES);
+  ASSERT_EQ(params.GetMovieId(), 123);
+
+  params = {};
+  CDirectoryNode::GetDatabaseInfo("videodb://recentlyaddedmovies", params);
+  ASSERT_EQ(static_cast<VideoDbContentType>(params.GetContentType()), VideoDbContentType::MOVIES);
+  ASSERT_EQ(params.GetMovieId(), -1);
+}


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Navigation of recently added movies needs a little adjustment after PR #26301 that modified the navigation of movie versions/extras.

videodb://recentlyaddedmovies behaves like videodb://movies/titles and ultimately GetRecentlyAddedMoviesNav relies on the same GetMoviesByWhere() function which was augmented with asset type and asset id "sub folders", so recentlyaddedmovies needs to define a child type to successfully parse videodb urls beyond the movie id.

Added the matching unit tests.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #26806

Happens for any movie that has versions and/or extras when navigating through the top level "Recently Added Movies" node.

Parsing of the movie videodb url fails, resulting in errors such as 
```
CGUIMediaWindow::GetDirectory(videodb://recentlyaddedmovies/99/-2/) failed
```

The "Recently added movies" panel of the home page uses a different playlist and is not impacted.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Movies with combinations of versions and/or extras, and without any > browse into or play successfully from the recentely added movies node.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Successful navigation into movies with versions and/or extras from the top level recently added movies node.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
