### PR TITLE
[cmake] FindFFMPEG avoid fallthrough build

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -294,12 +294,7 @@ else()
     endforeach()
 
   else()
-    if(FFMPEG_PATH)
-      message(FATAL_ERROR "FFmpeg not found, please consider using -DENABLE_INTERNAL_FFMPEG=ON")
-    else()
-      message(STATUS "FFmpeg ${REQUIRED_FFMPEG_VERSION} not found, falling back to internal build")
-      buildFFMPEG()
-    endif()
+    message(FATAL_ERROR "FFmpeg ${REQUIRED_FFMPEG_VERSION} not found, consider using -DENABLE_INTERNAL_FFMPEG=ON")
   endif()
 endif()
 

--- a/tools/buildsteps/freebsd/configure-xbmc
+++ b/tools/buildsteps/freebsd/configure-xbmc
@@ -4,4 +4,4 @@ XBMC_PLATFORM_DIR=freebsd
 
 mkdir -p $WORKSPACE/build
 cd $WORKSPACE/build
-cmake -DCMAKE_BUILD_TYPE=$Configuration -DAPP_RENDER_SYSTEM=gl ..
+cmake -DCMAKE_BUILD_TYPE=$Configuration -DAPP_RENDER_SYSTEM=gl -DENABLE_INTERNAL_FFMPEG=ON ..


### PR DESCRIPTION
## Description
Error on not available ffmpeg always. Force user to explicitly request internal build, rather than silently falling through. Simplifies control flow logic for other dependencies control flow

## Motivation and context
Simplify cmake logic, have users be more explicit with requirements of build

@wsnipex if you have time for your opinion. My view is the ffmpeg stuff is already complex, which is generally why i avoid it at all costs. Id rather people be explicit with what they want/need, but i know there are opinions in times gone by that obviously would prefer fallbacks at all costs.

## How has this been tested?
N/A

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
