### PR TITLE
[CURL][tests] Fixed encoding of rar files to be consistent with zip etc...

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -295,6 +295,7 @@ bool URIUtils::HasParentInHostname(const CURL& url)
 {
   return url.IsProtocol("zip") || url.IsProtocol("apk") || url.IsProtocol("bluray") ||
          url.IsProtocol("udf") || url.IsProtocol("iso9660") || url.IsProtocol("xbt") ||
+         url.IsProtocol("rar") ||
          (CServiceBroker::IsAddonInterfaceUp() &&
           CServiceBroker::GetFileExtensionProvider().EncodedHostName(url.GetProtocol()));
 }

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -600,3 +600,23 @@ TEST_F(TestURIUtils, UpdateUrlEncoding)
   EXPECT_FALSE(URIUtils::UpdateUrlEncoding(oldUrl));
   EXPECT_STRCASEEQ(newUrl.c_str(), oldUrl.c_str());
 }
+
+TEST_F(TestURIUtils, ContainersEncodeHostnamePaths)
+{
+  CURL curl("/path/thing");
+
+  EXPECT_EQ("zip://%2fpath%2fthing/my/archived/path",
+            URIUtils::CreateArchivePath("zip", curl, "/my/archived/path").Get());
+
+  EXPECT_EQ("apk://%2fpath%2fthing/my/archived/path",
+            URIUtils::CreateArchivePath("apk", curl, "/my/archived/path").Get());
+
+  EXPECT_EQ("udf://%2fpath%2fthing/my/archived/path",
+            URIUtils::CreateArchivePath("udf", curl, "/my/archived/path").Get());
+
+  EXPECT_EQ("iso9660://%2fpath%2fthing/my/archived/path",
+            URIUtils::CreateArchivePath("iso9660", curl, "/my/archived/path").Get());
+
+  EXPECT_EQ("rar://%2fpath%2fthing/my/archived/path",
+            URIUtils::CreateArchivePath("rar", curl, "/my/archived/path").Get());
+}


### PR DESCRIPTION
[CURL][tests] Added tests checking for differences between URIUtils::* and CURL::* methods.

Fixed issue found in testing when a service is unavailable. Check the service is non-null before calling its methods.

## Description
The aim of this PR is to start a discussion on the differences found between the duplicate implementations available surrounding CURL objects and URIUtils utility functions. 

## Motivation and context
From my understanding; URIUtils were created to quickly test strings which are representing paths avoiding the costly process of constructing a CURL object, which involves an expensive parse function. I want to investigate the usage of CURL objects through the codebase involving the constant conversion between CURL objects -> std::string (`CURL::Get()`) when a `std::string` is required for an interface and also the parsing of `std::string` into `CURL` objects when a CURL object is required.

While these test cases are trivial I would like different implementations to return the same results.

## How has this been tested?
The tests as submitted in this PR are currently wrong. I would like to find a consensus on the correct behaviour.

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [X] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
