### PR TITLE
[guilib/guiinfo] GUILabels.h: Fix typo in copyright statement.

### DIFF
--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C; 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2018 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later


### PR DESCRIPTION
Fixes a typo that slipped in with #26799 

Thanks @CrystalP for reporting this. Could you please review and approve?