### PR TITLE
[GUI] Audio Channels Improvements

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5446,7 +5446,6 @@ msgid "File browser"
 msgstr ""
 
 #. Audio Channel count
-#: xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
 #: xbmc/utils/StreamUtils.cpp
 #: xbmc/video/dialogs/GUIDialogAudioSettings.cpp
 msgctxt "#10127"
@@ -22470,19 +22469,7 @@ msgctxt "#37002"
 msgid "(Director's comments 2)"
 msgstr ""
 
-#. DVD short name for 1.0 channel layout
-#: xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
-msgctxt "#37003"
-msgid "mono"
-msgstr ""
-
-#. DVD short name for 2.0 channel layout
-#: xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
-msgctxt "#37004"
-msgid "stereo"
-msgstr ""
-
-#empty strings from id 37005 to 37013
+#empty strings from id 37003 to 37013
 
 #: xbmc/GUIInfoManager.cpp
 msgctxt "#37014"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6754,6 +6754,7 @@ msgstr ""
 #: xbmc/GUIInfoManager.cpp
 #: xbmc/LangInfo.cpp
 #: xbmc/addons/gui/GUIDialogAddonSettings.cpp
+#: xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
 #: xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
 #: xbmc/music/MusicDatabase.cpp
 #: xbmc/peripherals/bus/PeripheralBus.cpp

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5447,6 +5447,7 @@ msgstr ""
 
 #. Audio Channel count
 #: xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+#: xbmc/utils/StreamUtils.cpp
 #: xbmc/video/dialogs/GUIDialogAudioSettings.cpp
 msgctxt "#10127"
 msgid "channels"

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -847,22 +847,10 @@
 		<value condition="String.IsEqual(ListItem.AudioCodec,dtshd_ma_x_imax) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,dtshd_ma_x_imax)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Codec,dtshd_ma_x_imax)]">DTS:X IMAX</value>
 	</variable>
 	<variable name="AudioChannelsVar">
-		<value condition="String.IsEqual(ListItem.AudioChannels,0) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,0)] | String.IsEqual(ListItem.MusicChannels,0) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,0)]">0.0</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,1) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,1)] | String.IsEqual(ListItem.MusicChannels,1) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,1)]">1.0</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,2) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,2)] | String.IsEqual(ListItem.MusicChannels,2) | [Window.IsActive(visualisation)+ String.IsEqual(MusicPlayer.Channels,2)]">2.0</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,3) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,3)] | String.IsEqual(ListItem.MusicChannels,3) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,3)]">2.1</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,4) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,4)] | String.IsEqual(ListItem.MusicChannels,4) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,4)]">4.0</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,5) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,5)] | String.IsEqual(ListItem.MusicChannels,5) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,5)]">4.1</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,6) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,6)] | String.IsEqual(ListItem.MusicChannels,6) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,6)]">5.1</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,7) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,7)] | String.IsEqual(ListItem.MusicChannels,7) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,7)]">6.1</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,8) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,8)] | String.IsEqual(ListItem.MusicChannels,8) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,8)]">7.1</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,10) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,10)] | String.IsEqual(ListItem.MusicChannels,10) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,10)]">9.1</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,12) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,12)] | String.IsEqual(ListItem.MusicChannels,12) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,12)]">7.1.4</value>
-		<value condition="String.IsEqual(ListItem.AudioChannels,16) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioChannels,16)] | String.IsEqual(ListItem.MusicChannels,16) | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Channels,16)]">9.1.6</value>
-		<value condition="Window.IsActive(fullscreenvideo)">$INFO[VideoPlayer.AudioChannels]</value>
-		<value condition="Window.IsActive(visualisation)">$INFO[MusicPlayer.Channels]</value>
-		<value condition="Container.Content(albums) | Window.IsActive(10502)">$INFO[ListItem.MusicChannels]</value>
-		<value>$INFO[ListItem.AudioChannels]</value>
+		<value condition="Window.IsActive(fullscreenvideo)">$INFO[VideoPlayer.AudioChannels(DefaultLayout)]</value>
+		<value condition="Window.IsActive(visualisation)">$INFO[MusicPlayer.Channels(DefaultLayout)]</value>
+		<value condition="Container.Content(albums) | Window.IsActive(10502)">$INFO[ListItem.MusicChannels(DefaultLayout)]</value>
+		<value>$INFO[ListItem.AudioChannels(DefaultLayout)]</value>
 	</variable>
 	<variable name="StreamCodecVar">
 		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),av1)">AV1</value>
@@ -935,18 +923,6 @@
 		<value>$INFO[ListItem.Property(stream.codec)]</value>
 	</variable>
 	<variable name="StreamChannelsVar">
-		<value condition="String.IsEqual(ListItem.Property(stream.channels),0)">0.0</value>
-		<value condition="String.IsEqual(ListItem.Property(stream.channels),1)">1.0</value>
-		<value condition="String.IsEqual(ListItem.Property(stream.channels),2)">2.0</value>
-		<value condition="String.IsEqual(ListItem.Property(stream.channels),3)">2.1</value>
-		<value condition="String.IsEqual(ListItem.Property(stream.channels),4)">4.0</value>
-		<value condition="String.IsEqual(ListItem.Property(stream.channels),5)">4.1</value>
-		<value condition="String.IsEqual(ListItem.Property(stream.channels),6)">5.1</value>
-		<value condition="String.IsEqual(ListItem.Property(stream.channels),7)">6.1</value>
-		<value condition="String.IsEqual(ListItem.Property(stream.channels),8)">7.1</value>
-		<value condition="String.IsEqual(ListItem.Property(stream.channels),10)">9.1</value>
-		<value condition="String.IsEqual(ListItem.Property(stream.channels),12)">7.1.4</value>
-		<value condition="String.IsEqual(ListItem.Property(stream.channels),16)">9.1.6</value>
 		<value>$INFO[ListItem.Property(stream.channels)]</value>
 	</variable>
 	<variable name="StreamHDRTypeVar">

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -2772,10 +2772,16 @@ constexpr std::array<InfoMap, 7> musicpartymode = {{
 ///     @return The bitrate of current song.
 ///     <p>
 ///   }
-///   \table_row3{   <b>`MusicPlayer.Channels`</b>,
+///   \table_row3{   <b>`MusicPlayer.Channels(format)`</b>,
 ///                  \anchor MusicPlayer_Channels
 ///                  _string_,
-///     @return The number of channels of current song.
+///     @param[in] format (optional) format of the infolabel.
+///     (possible values: see \ref ListItem_AudioChannels "ListItem.AudioChannels").
+///     @return The channel information of the current song\, formatted in the optional format.
+///     (possible values: see \ref ListItem_AudioChannels "ListItem.AudioChannels").
+///     <p><hr>
+///     @skinning_v22 **[Infolabel Updated]** \link MusicPlayer_Channels `MusicPlayer.Channels`\endlink
+///     added optional format parameter
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`MusicPlayer.BitsPerSample`</b>,
@@ -3848,15 +3854,20 @@ constexpr std::array<InfoMap, 46> musicplayer = {{
 ///     \ref ListItem_AudioCodec "ListItem.AudioCodec").
 ///     <p>
 ///   }
-///   \table_row3{   <b>`VideoPlayer.AudioChannels`</b>,
+///   \table_row3{   <b>`VideoPlayer.AudioChannels(format)`</b>,
 ///                  \anchor VideoPlayer_AudioChannels
 ///                  _string_,
-///     @return The number of audio channels of the currently playing video
+///     @param[in] format (optional) format of the infolabel.
+///     (possible values: see \ref ListItem_AudioChannels "ListItem.AudioChannels").
+///     @return The audio channel information of the currently playing video\, formatted in the optional format
 ///     (possible values: see \ref ListItem_AudioChannels "ListItem.AudioChannels").
 ///     <p><hr>
 ///     @skinning_v16 **[Infolabel Updated]** \link VideoPlayer_AudioChannels `VideoPlayer.AudioChannels`\endlink
 ///     if a video contains no audio\, these infolabels will now return empty.
 ///     (they used to return 0)
+///
+///     @skinning_v22 **[Infolabel Updated]** \link VideoPlayer_AudioChannels `VideoPlayer.AudioChannels`\endlink
+///     added optional format parameter
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`VideoPlayer.AudioLanguage`</b>,
@@ -6348,10 +6359,17 @@ constexpr std::array<InfoMap, 3> container_str = {{
 ///       - <b>wmav2</b>
 ///     <p>
 ///   }
-///   \table_row3{   <b>`ListItem.AudioChannels`</b>,
+///   \table_row3{   <b>`ListItem.AudioChannels(format)`</b>,
 ///                  \anchor ListItem_AudioChannels
 ///                  _string_,
-///     @return The number of audio channels of the currently selected video. Possible values:
+///     @param[in] format (optional) format of the infolabel. Possible values for the format:
+///       - <b>(blank)</b> no format value: count of channels
+///       - <b>defaultlayout</b> return a default channel layout in the format x.y.z for the
+///         channel count (x=listener level speakers\, y=lfe channels\, z=overhead channels).
+///         If a default layout is not defined for the channel count then the text "x channels" is
+///         returned, with x replaced by the channel count and "channels" localized to the user language.
+///     @return The audio channel information of the currently selected video. Possible values
+///       for the default format:
 ///       - <b>1</b>
 ///       - <b>2</b>
 ///       - <b>4</b>
@@ -6359,10 +6377,23 @@ constexpr std::array<InfoMap, 3> container_str = {{
 ///       - <b>6</b>
 ///       - <b>8</b>
 ///       - <b>10</b>
+///
+///     Possible values for format "defaultlayout":
+///       - <b>1.0</b>
+///       - <b>2.0</b>
+///       - <b>5.1</b>
+///       - <b>6.1</b>
+///       - <b>7.1</b>
+///       - <b>9 channels</b>
+///       - <b>9.1.6</b>
+///
 ///     <p><hr>
 ///     @skinning_v16 **[Infolabel Updated]** \link ListItem_AudioChannels `ListItem.AudioChannels`\endlink
 ///     if a video contains no audio\, these infolabels will now return empty.
 ///     (they used to return 0)
+///
+///     @skinning_v22 **[Infolabel Updated]** \link ListItem_AudioChannels `ListItem.AudioChannels`\endlink
+///     added optional format parameter
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.AudioLanguage`</b>,
@@ -7191,12 +7222,18 @@ constexpr std::array<InfoMap, 3> container_str = {{
 ///     @skinning_v19 **[New Infolabel]** \link ListItem_SampleRate `ListItem.SampleRate`\endlink
 ///     <p>
 ///   }
-///   \table_row3{   <b>`ListItem.MusicChannels`</b>,
+///   \table_row3{   <b>`ListItem.MusicChannels(format)`</b>,
 ///                  \anchor ListItem_MusicChannels
 ///                  _string_,
+///     @param[in] format (optional) format of the infolabel.
+///     (possible values: see \ref ListItem_AudioChannels "ListItem.AudioChannels").
 ///     @return The number of audio channels of a song.
+///     (possible values: see \ref ListItem_AudioChannels "ListItem.AudioChannels").
 ///     <p><hr>
 ///     @skinning_v19 **[New Infolabel]** \link ListItem_No_Of_Channels `ListItem.NoOfChannels`\endlink
+///
+///     @skinning_v22 **[Infolabel Updated]** \link ListItem_MusicChannels `ListItem.MusicChannels`\endlink
+///     added optional format parameter
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.TvShowDBID`</b>,
@@ -10817,6 +10854,11 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
 
         return AddMultiInfo(CGUIInfo(MUSICPLAYER_PROPERTY, prop.param()));
       }
+      else if (prop.Name() == "channels" && prop.num_params() == 1)
+      {
+        return AddMultiInfo(CGUIInfo(MUSICPLAYER_CHANNELS, prop.param()));
+      }
+
       return TranslateMusicPlayerString(prop.Name());
     }
     else if (cat.Name() == "videoplayer")
@@ -10869,6 +10911,10 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         return AddMultiInfo(
             CGUIInfo(VIDEOPLAYER_NEXT_GENRE, TranslateListSeparator(prop.param()), 0));
       }
+
+      if (prop.Name() == "audiochannels" && prop.num_params() == 1)
+        return AddMultiInfo(CGUIInfo(VIDEOPLAYER_AUDIO_CHANNELS, prop.param(), 0));
+
       return TranslateVideoPlayerString(prop.Name());
     }
     else if (cat.Name() == "retroplayer")
@@ -11199,6 +11245,10 @@ int CGUIInfoManager::TranslateListItem(const Property& cat, const Property& prop
     else if (prop.Name() == "duration" || prop.Name() == "nextduration")
     {
       data4 = TranslateTimeFormat(prop.param());
+    }
+    else if (prop.Name() == "audiochannels" || prop.Name() == "musicchannels")
+    {
+      data3 = prop.param();
     }
   }
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
@@ -8,6 +8,8 @@
 
 #include "DVDDemux.h"
 
+#include "guilib/LocalizeStrings.h"
+#include "utils/StreamUtils.h"
 #include "utils/StringUtils.h"
 
 std::string CDemuxStreamAudio::GetStreamType()
@@ -132,8 +134,11 @@ std::string CDemuxStreamAudio::GetStreamType()
   if (codec >= AV_CODEC_ID_PCM_S16LE && codec <= AV_CODEC_ID_PCM_SGA)
     strInfo = "PCM";
 
-  if (!m_channelLayoutName.empty())
-    strInfo += (strInfo.empty() ? "" : " ") + m_channelLayoutName;
+  if (strInfo.empty())
+    strInfo = g_localizeStrings.Get(13205); // "Unknown"
+
+  strInfo.append(" ");
+  strInfo.append(StreamUtils::GetLayout(iChannels));
 
   return strInfo;
 }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -23,6 +23,7 @@
 #include "settings/SettingsComponent.h"
 #include "utils/Geometry.h"
 #include "utils/LangCodeExpander.h"
+#include "utils/StreamUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -1062,26 +1063,11 @@ void CDVDInputStreamNavigator::SetAudioStreamName(AudioStreamInfo &info, const a
     break;
   }
 
-  info.codecDesc.append(" ");
+  const int channels{audio_attributes.channels + 1};
+  info.channels = channels;
 
-  switch(audio_attributes.channels + 1)
-  {
-  case 1:
-    info.codecDesc += g_localizeStrings.Get(37003); // "mono"
-    break;
-  case 2:
-    info.codecDesc += g_localizeStrings.Get(37004); // "stereo"
-    break;
-  case 6:
-    info.codecDesc += "5.1";
-    break;
-  case 7:
-    info.codecDesc += "6.1";
-    break;
-  default:
-    info.codecDesc += StringUtils::Format("{:d} {}", audio_attributes.channels + 1,
-                                          g_localizeStrings.Get(10127)); // "channels"
-  }
+  info.codecDesc.append(" ");
+  info.codecDesc.append(StreamUtils::GetLayout(channels));
 }
 
 AudioStreamInfo CDVDInputStreamNavigator::GetAudioStreamInfo(const int iId)
@@ -1102,7 +1088,6 @@ AudioStreamInfo CDVDInputStreamNavigator::GetAudioStreamInfo(const int iId)
     lang[0] = (audio_attributes.lang_code >> 8) & 255;
 
     info.language = g_LangCodeExpander.ConvertToISO6392B(lang);
-    info.channels = audio_attributes.channels + 1;
   }
 
   return info;

--- a/xbmc/guilib/guiinfo/CMakeLists.txt
+++ b/xbmc/guilib/guiinfo/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES GUIInfo.cpp
             GUIInfoLabel.cpp
             GUIInfoBool.cpp
             GUIInfoColor.cpp
+            GUIInfoUtils.cpp
             AddonsGUIInfo.cpp
             GamesGUIInfo.cpp
             GUIControlsGUIInfo.cpp
@@ -25,6 +26,7 @@ set(HEADERS GUIInfo.h
             GUIInfoLabel.h
             GUIInfoBool.h
             GUIInfoColor.h
+            GUIInfoUtils.h
             IGUIInfoProvider.h
             AddonsGUIInfo.h
             GamesGUIInfo.h

--- a/xbmc/guilib/guiinfo/GUIInfoUtils.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoUtils.cpp
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2005-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GUIInfoUtils.h"
+
+#include "utils/StreamUtils.h"
+#include "utils/StringUtils.h"
+
+using namespace KODI::GUILIB::GUIINFO;
+
+std::optional<std::string> CGUIInfoUtils::FormatAudioChannels(const std::string& format,
+                                                              int channels)
+{
+  if (channels > 0)
+  {
+    if (format.empty())
+    {
+      return std::to_string(channels);
+    }
+    else if (StringUtils::EqualsNoCase(format, "defaultlayout"))
+    {
+      return StreamUtils::GetLayout(static_cast<unsigned int>(channels));
+    }
+  }
+
+  return std::nullopt;
+}

--- a/xbmc/guilib/guiinfo/GUIInfoUtils.h
+++ b/xbmc/guilib/guiinfo/GUIInfoUtils.h
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (C) 2005-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace KODI::GUILIB::GUIINFO
+{
+
+class CGUIInfoUtils
+{
+public:
+  CGUIInfoUtils() = delete;
+
+  static std::optional<std::string> FormatAudioChannels(const std::string& format, int channels);
+};
+
+} // namespace KODI::GUILIB::GUIINFO

--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -21,6 +21,7 @@
 #include "guilib/guiinfo/GUIInfo.h"
 #include "guilib/guiinfo/GUIInfoHelper.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
+#include "guilib/guiinfo/GUIInfoUtils.h"
 #include "music/MusicFileItemClassify.h"
 #include "music/MusicInfoLoader.h"
 #include "music/MusicThumbLoader.h"
@@ -352,10 +353,12 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       }
       case LISTITEM_MUSICCHANNELS:
       {
-        int channels = tag->GetNoOfChannels();
-        if (channels > 0)
+        const auto formatted{
+            CGUIInfoUtils::FormatAudioChannels(info.GetData3(), tag->GetNoOfChannels())};
+
+        if (formatted.has_value())
         {
-          value = std::to_string(channels);
+          value = formatted.value();
           return true;
         }
         break;
@@ -480,10 +483,12 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
     }
     case MUSICPLAYER_CHANNELS:
     {
-      int iChannels = m_audioInfo.channels;
-      if (iChannels > 0)
+      const auto formatted{
+          CGUIInfoUtils::FormatAudioChannels(info.GetData3(), m_audioInfo.channels)};
+
+      if (formatted.has_value())
       {
-        value = std::to_string(iChannels);
+        value = formatted.value();
         return true;
       }
       break;

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -26,6 +26,7 @@
 #include "guilib/guiinfo/GUIInfo.h"
 #include "guilib/guiinfo/GUIInfoHelper.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
+#include "guilib/guiinfo/GUIInfoUtils.h"
 #include "network/NetworkFileItemClassify.h"
 #include "playlists/PlayList.h"
 #include "settings/AdvancedSettings.h"
@@ -483,10 +484,12 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         return true;
       case LISTITEM_AUDIO_CHANNELS:
       {
-        int iChannels = tag->m_streamDetails.GetAudioChannels();
-        if (iChannels > 0)
+        const auto formatted{CGUIInfoUtils::FormatAudioChannels(
+            info.GetData3(), tag->m_streamDetails.GetAudioChannels())};
+
+        if (formatted.has_value())
         {
-          value = std::to_string(iChannels);
+          value = formatted.value();
           return true;
         }
         break;
@@ -636,10 +639,12 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       return true;
     case VIDEOPLAYER_AUDIO_CHANNELS:
     {
-      int iChannels = m_audioInfo.channels;
-      if (iChannels > 0)
+      const auto formatted{
+          CGUIInfoUtils::FormatAudioChannels(info.GetData3(), m_audioInfo.channels)};
+
+      if (formatted.has_value())
       {
-        value = std::to_string(iChannels);
+        value = formatted.value();
         return true;
       }
       break;

--- a/xbmc/utils/StreamUtils.cpp
+++ b/xbmc/utils/StreamUtils.cpp
@@ -8,6 +8,10 @@
 
 #include "StreamUtils.h"
 
+#include "guilib/LocalizeStrings.h"
+
+#include <array>
+
 extern "C"
 {
 #include <libavcodec/avcodec.h>
@@ -95,4 +99,46 @@ std::string StreamUtils::GetCodecName(int codecId, int profile)
     codecName = avcodec_get_name(codec->id);
 
   return codecName;
+}
+
+std::string StreamUtils::GetDefaultLayout(unsigned int channels)
+{
+  static constexpr std::array layouts{
+      "0.0", // 0
+      "1.0", // 1
+      "2.0", // 2
+      "2.1", // 3
+      "4.0", // 4
+      "5.0", // 5
+      "5.1", // 6
+      "6.1", // 7
+      "7.1", // 8
+      "", // 9
+      "5.1.4", // 10
+      "", // 11
+      "7.1.4", // 12
+      "", // 13
+      "9.1.4", // 14
+      "", // 15
+      "9.1.6", // 16
+  };
+
+  if (channels < layouts.size())
+    return layouts[channels];
+
+  return {};
+}
+
+std::string StreamUtils::GetLayout(unsigned int channels)
+{
+  std::string layout{GetDefaultLayout(channels)};
+
+  if (layout.empty())
+  {
+    layout = std::to_string(channels);
+    layout.append(" ");
+    layout.append(g_localizeStrings.Get(10127)); // "channels"
+  }
+
+  return layout;
 }

--- a/xbmc/utils/StreamUtils.h
+++ b/xbmc/utils/StreamUtils.h
@@ -39,4 +39,19 @@ public:
    * \return The codec name
    */
   static std::string GetCodecName(int codecId, int profile);
+
+  /*!
+   * \brief Return a default channel layout in x.y.z form for a channel count.
+   * \param[in] channels the count of channels
+   * \return the default layout
+   */
+  static std::string GetDefaultLayout(unsigned int channels);
+
+  /*!
+   * \brief Return a default channel layout for a channel count or localized count of channels
+   * when no default exists.
+   * \param[in] channels the count of channels
+   * \return the layout
+   */
+  static std::string GetLayout(unsigned int channels);
 };

--- a/xbmc/video/guilib/VideoStreamSelectHelper.cpp
+++ b/xbmc/video/guilib/VideoStreamSelectHelper.cpp
@@ -19,6 +19,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/LangCodeExpander.h"
 #include "utils/StreamDetails.h"
+#include "utils/StreamUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
@@ -404,7 +405,7 @@ void KODI::VIDEO::GUILIB::OpenDialogSelectAudioStream()
     fileItem->SetProperty("stream.description", info.name);
     fileItem->SetProperty("stream.codec", info.codecName);
     fileItem->SetProperty("stream.codecdesc", info.codecDesc);
-    fileItem->SetProperty("stream.channels", info.channels);
+    fileItem->SetProperty("stream.channels", StreamUtils::GetLayout(info.channels));
 
     fileItem->SetProperty("stream.isdefault", info.isDefault);
     fileItem->SetProperty("stream.isforced", info.isForced);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

A couple improvements in the display of audio channels in the skin:

- Add a parameter to the existing VideoPlayer.AudioChannels, ListItem.AudioChannels, ListItems.MusicChannels and MusicPlayer.Channels infolabels in order to make them return a default layout in x.y.z format such as 2.0 or 5.1 instead of a channel count when requested by the skin. Could be expanded to other formats later on.
- That idea could not be applied as is to the less standard way the information is provided to the stream selection dialog. Modified the existing property used for channels, since this is new to v22 and there is no legacy relying on current properties yet.
- Modified the functions generating codecdesc information from codec name and channels to be consistent with the previous change and to always contain information, and remove the now unnecessary "x channels" text appended in the audio osd stream descriptions after the codecdesc. A fallback is still provided in case of incomplete information.

This is an alternative to #26663 and #26747 since there are no practical examples where knowledge of the actual channel mask allows a more accurate display and this is more light weight. Input stream is covered as well.

If approved, a similar concept could be used for codec name / audio object tech name, currently mapped by the skins from the ffmpeg names to user-friendly names suited for display.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Provide consistent audio channel layout information for all screens and skins.
Do not require skins to provide their own logic with differences with strings provided by core.

Remove the redundant channels count in the audio osd audio streams descriptions.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Media flags displayed on home page, library/videos/music views, during playback the stream selection and OSD Audio Settings, flags displayed in visualization.

- Local and remote video files
- Input stream
- Music tracks

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Skinners benefit most.
Slightly shorter audio track descriptions in audio osd.

## Screenshots (if appropriate):

![441018149-232bec59-b30b-43c5-8248-81a7400f108a](https://github.com/user-attachments/assets/2211d038-ba6d-4e3f-a393-6542a58097f6)

![441018258-6c13e7ae-fe76-4751-95ab-85b2a5c62748](https://github.com/user-attachments/assets/898ef185-842e-4191-89fc-69e2c21db903)

![441018385-b6aba5b4-f521-4ca0-b1a9-ece0cee4b71e](https://github.com/user-attachments/assets/652d27c5-de40-494a-a85f-4de3db9de440)

![441019173-e215c621-0e67-41b2-89f3-a63ab696774f](https://github.com/user-attachments/assets/12354fd4-da19-47ae-b19e-dab276dbf95e)

stream selection screen:
![441019288-98a6d7f1-a07e-4c3f-9dfe-bb9a4773a384](https://github.com/user-attachments/assets/869e83f0-c104-4a0c-8631-ccf0dc2ab8ac)

![441019382-7e04ee7d-598e-4eb3-b9e7-5a4eb561462d](https://github.com/user-attachments/assets/46b974b1-0236-44f1-ba44-2098c5d0f154)

List of audio streams in OSD Audio settings (no more "x channels" appended):
![image](https://github.com/user-attachments/assets/be7a7618-9e6a-4746-a95c-6bb7d8aac21b)

Inputstream adaptive:
![441019878-c99a271c-5979-4d9d-a3d1-440ded95a301](https://github.com/user-attachments/assets/1ba6e525-07e3-46a7-819b-5c73702592c0)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
