### PR TITLE
[windowing][gbm] Apply clang-format-18

### DIFF
--- a/xbmc/windowing/gbm/GBMDPMSSupport.cpp
+++ b/xbmc/windowing/gbm/GBMDPMSSupport.cpp
@@ -26,10 +26,10 @@ bool CGBMDPMSSupport::EnablePowerSaving(PowerSavingMode mode)
 
   switch (mode)
   {
-  case OFF:
-    return winSystem->Hide();
-  default:
-    return false;
+    case OFF:
+      return winSystem->Hide();
+    default:
+      return false;
   }
 }
 

--- a/xbmc/windowing/gbm/GBMUtils.cpp
+++ b/xbmc/windowing/gbm/GBMUtils.cpp
@@ -86,8 +86,8 @@ CGBMUtils::CGBMDevice::CGBMSurface::CGBMSurfaceBuffer& CGBMUtils::CGBMDevice::CG
      * we have to release buffers. This means that the maximum amount of buffers had been reached.
      * For mesa this should be 4 buffers but it may vary across other implementations.
      */
-    std::call_once(
-        flag, [this]() { CLog::Log(LOGDEBUG, "CGBMUtils - using {} buffers", m_buffers.size()); });
+    std::call_once(flag, [this]()
+                   { CLog::Log(LOGDEBUG, "CGBMUtils - using {} buffers", m_buffers.size()); });
 
     m_buffers.pop();
   }

--- a/xbmc/windowing/gbm/GBMUtils.h
+++ b/xbmc/windowing/gbm/GBMUtils.h
@@ -172,6 +172,6 @@ private:
   std::unique_ptr<CGBMDevice, CGBMDeviceDeleter> m_device;
 };
 
-}
-}
-}
+} // namespace GBM
+} // namespace WINDOWING
+} // namespace KODI

--- a/xbmc/windowing/gbm/OptionalsReg.cpp
+++ b/xbmc/windowing/gbm/OptionalsReg.cpp
@@ -11,9 +11,10 @@
 //-----------------------------------------------------------------------------
 // VAAPI
 //-----------------------------------------------------------------------------
-#if defined (HAVE_LIBVA)
-#include <va/va_drm.h>
+#if defined(HAVE_LIBVA)
 #include "cores/VideoPlayer/DVDCodecs/Video/VAAPI.h"
+
+#include <va/va_drm.h>
 #if defined(HAS_GL)
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.h"
 #endif
@@ -31,13 +32,13 @@ namespace GBM
 class CVaapiProxy : public VAAPI::IVaapiWinSystem
 {
 public:
-  CVaapiProxy(int fd) : m_fd(fd) {};
+  CVaapiProxy(int fd) : m_fd(fd){};
   virtual ~CVaapiProxy() = default;
   VADisplay GetVADisplay() override;
-  void *GetEGLDisplay() override { return eglDisplay; };
+  void* GetEGLDisplay() override { return eglDisplay; };
 
   VADisplay vaDpy;
-  void *eglDisplay;
+  void* eglDisplay;
 
 private:
   int m_fd{-1};
@@ -53,18 +54,18 @@ CVaapiProxy* VaapiProxyCreate(int fd)
   return new CVaapiProxy(fd);
 }
 
-void VaapiProxyDelete(CVaapiProxy *proxy)
+void VaapiProxyDelete(CVaapiProxy* proxy)
 {
   delete proxy;
 }
 
-void VaapiProxyConfig(CVaapiProxy *proxy, void *eglDpy)
+void VaapiProxyConfig(CVaapiProxy* proxy, void* eglDpy)
 {
   proxy->vaDpy = proxy->GetVADisplay();
   proxy->eglDisplay = eglDpy;
 }
 
-void VAAPIRegister(CVaapiProxy *winSystem, bool deepColor)
+void VAAPIRegister(CVaapiProxy* winSystem, bool deepColor)
 {
   VAAPI::CDecoder::Register(winSystem, deepColor);
 }
@@ -84,9 +85,9 @@ void VAAPIRegisterRenderGLES(CVaapiProxy* winSystem, bool& general, bool& deepCo
                                deepColor);
 }
 #endif
-}
-}
-}
+} // namespace GBM
+} // namespace WINDOWING
+} // namespace KODI
 
 #else
 
@@ -106,24 +107,21 @@ CVaapiProxy* VaapiProxyCreate(int fd)
   return nullptr;
 }
 
-void VaapiProxyDelete(CVaapiProxy *proxy)
+void VaapiProxyDelete(CVaapiProxy* proxy)
 {
 }
 
-void VaapiProxyConfig(CVaapiProxy *proxy, void *eglDpy)
+void VaapiProxyConfig(CVaapiProxy* proxy, void* eglDpy)
 {
-
 }
 
-void VAAPIRegister(CVaapiProxy *winSystem, bool deepColor)
+void VAAPIRegister(CVaapiProxy* winSystem, bool deepColor)
 {
-
 }
 
 #if defined(HAS_GL)
 void VAAPIRegisterRenderGL(CVaapiProxy* winSystem, bool& general, bool& deepColor)
 {
-
 }
 #endif
 
@@ -132,8 +130,8 @@ void VAAPIRegisterRenderGLES(CVaapiProxy* winSystem, bool& general, bool& deepCo
 {
 }
 #endif
-}
-}
-}
+} // namespace GBM
+} // namespace WINDOWING
+} // namespace KODI
 
 #endif

--- a/xbmc/windowing/gbm/OptionalsReg.h
+++ b/xbmc/windowing/gbm/OptionalsReg.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-
 //-----------------------------------------------------------------------------
 // VAAPI
 //-----------------------------------------------------------------------------
@@ -22,15 +21,15 @@ namespace GBM
 class CVaapiProxy;
 
 CVaapiProxy* VaapiProxyCreate(int fd);
-void VaapiProxyDelete(CVaapiProxy *proxy);
-void VaapiProxyConfig(CVaapiProxy *proxy, void *eglDpy);
-void VAAPIRegister(CVaapiProxy *winSystem, bool deepColor);
+void VaapiProxyDelete(CVaapiProxy* proxy);
+void VaapiProxyConfig(CVaapiProxy* proxy, void* eglDpy);
+void VAAPIRegister(CVaapiProxy* winSystem, bool deepColor);
 #if defined(HAS_GL)
 void VAAPIRegisterRenderGL(CVaapiProxy* winSystem, bool& general, bool& deepColor);
 #endif
 #if defined(HAS_GLES)
 void VAAPIRegisterRenderGLES(CVaapiProxy* winSystem, bool& general, bool& deepColor);
 #endif
-}
-}
-}
+} // namespace GBM
+} // namespace WINDOWING
+} // namespace KODI

--- a/xbmc/windowing/gbm/VideoLayerBridge.h
+++ b/xbmc/windowing/gbm/VideoLayerBridge.h
@@ -22,6 +22,6 @@ public:
   virtual void Disable() {}
 };
 
-}
-}
-}
+} // namespace GBM
+} // namespace WINDOWING
+} // namespace KODI

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -85,10 +85,8 @@ constexpr auto ColorimetryMap = make_map<KODI::UTILS::Colorimetry, std::string_v
 });
 } // namespace
 
-CWinSystemGbm::CWinSystemGbm() :
-  m_DRM(nullptr),
-  m_GBM(new CGBMUtils),
-  m_libinput(new CLibInputHandler)
+CWinSystemGbm::CWinSystemGbm()
+  : m_DRM(nullptr), m_GBM(new CGBMUtils), m_libinput(new CLibInputHandler)
 {
   m_dpms = std::make_shared<CGBMDPMSSupport>();
   m_libinput->Start();
@@ -198,17 +196,14 @@ void CWinSystemGbm::UpdateResolutions()
   {
     CDisplaySettings::GetInstance().ClearCustomResolutions();
 
-    for (auto &res : resolutions)
+    for (auto& res : resolutions)
     {
       CServiceBroker::GetWinSystem()->GetGfxContext().ResetOverscan(res);
       CDisplaySettings::GetInstance().AddResolutionInfo(res);
 
-      if (current.iScreenWidth == res.iScreenWidth &&
-          current.iScreenHeight == res.iScreenHeight &&
-          current.iWidth == res.iWidth &&
-          current.iHeight == res.iHeight &&
-          current.fRefreshRate == res.fRefreshRate &&
-          current.dwFlags == res.dwFlags)
+      if (current.iScreenWidth == res.iScreenWidth && current.iScreenHeight == res.iScreenHeight &&
+          current.iWidth == res.iWidth && current.iHeight == res.iHeight &&
+          current.fRefreshRate == res.fRefreshRate && current.dwFlags == res.dwFlags)
       {
         CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP) = res;
       }
@@ -232,13 +227,13 @@ bool CWinSystemGbm::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   // Notify other subsystems that we will change resolution
   OnLostDevice();
 
-  if(!m_DRM->SetMode(res))
+  if (!m_DRM->SetMode(res))
   {
     CLog::Log(LOGERROR, "CWinSystemGbm::{} - failed to set DRM mode", __FUNCTION__);
     return false;
   }
 
-  struct gbm_bo *bo = nullptr;
+  struct gbm_bo* bo = nullptr;
 
   if (!std::dynamic_pointer_cast<CDRMAtomic>(m_DRM))
   {
@@ -286,7 +281,7 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
     m_videoLayerBridge->Disable();
   }
 
-  struct gbm_bo *bo = nullptr;
+  struct gbm_bo* bo = nullptr;
 
   if (rendered)
   {
@@ -304,7 +299,8 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
 
 bool CWinSystemGbm::UseLimitedColor()
 {
-  return CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE);
+  return CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+      CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE);
 }
 
 bool CWinSystemGbm::Hide()
@@ -321,13 +317,13 @@ bool CWinSystemGbm::Show(bool raise)
   return ret;
 }
 
-void CWinSystemGbm::Register(IDispResource *resource)
+void CWinSystemGbm::Register(IDispResource* resource)
 {
   std::unique_lock lock(m_resourceSection);
   m_resources.push_back(resource);
 }
 
-void CWinSystemGbm::Unregister(IDispResource *resource)
+void CWinSystemGbm::Unregister(IDispResource* resource)
 {
   std::unique_lock lock(m_resourceSection);
   std::vector<IDispResource*>::iterator i = find(m_resources.begin(), m_resources.end(), resource);

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -86,7 +86,7 @@ protected:
   std::shared_ptr<CVideoLayerBridge> m_videoLayerBridge;
 
   CCriticalSection m_resourceSection;
-  std::vector<IDispResource*>  m_resources;
+  std::vector<IDispResource*> m_resources;
 
   bool m_dispReset = false;
   XbmcThreads::EndTime<> m_dispResetTimer;
@@ -98,6 +98,6 @@ private:
   std::unique_ptr<UTILS::CDisplayInfo> m_info;
 };
 
-}
-}
+} // namespace GBM
+} // namespace WINDOWING
 } // namespace KODI

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -106,7 +106,8 @@ bool CWinSystemGbmEGLContext::CreateNewWindow(const std::string& name,
   }
 
   // This check + the reinterpret cast is for security reason, if the user has outdated platform header files which often is the case
-  static_assert(sizeof(EGLNativeWindowType) == sizeof(gbm_surface*), "Declaration specifier differs in size");
+  static_assert(sizeof(EGLNativeWindowType) == sizeof(gbm_surface*),
+                "Declaration specifier differs in size");
 
   if (!m_eglContext.CreatePlatformSurface(
           m_GBM->GetDevice().GetSurface().Get(),
@@ -146,7 +147,7 @@ bool CWinSystemGbmEGLContext::DestroyWindowSystem()
   return CWinSystemGbm::DestroyWindowSystem();
 }
 
-void CWinSystemGbmEGLContext::delete_CVaapiProxy::operator()(CVaapiProxy *p) const
+void CWinSystemGbmEGLContext::delete_CVaapiProxy::operator()(CVaapiProxy* p) const
 {
   VaapiProxyDelete(p);
 }

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
@@ -30,9 +30,7 @@ public:
   ~CWinSystemGbmEGLContext() override = default;
 
   bool DestroyWindowSystem() override;
-  bool CreateNewWindow(const std::string& name,
-                       bool fullScreen,
-                       RESOLUTION_INFO& res) override;
+  bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override;
   bool DestroyWindow() override;
   void SetDirtyRegions(const CDirtyRegionList& dirtyRegions) override
   {
@@ -47,7 +45,8 @@ public:
 protected:
   CWinSystemGbmEGLContext(EGLenum platform, std::string const& platformExtension)
     : CWinSystemEGL{platform, platformExtension}
-  {}
+  {
+  }
 
   /**
    * Inheriting classes should override InitWindowSystem() without parameters
@@ -60,11 +59,11 @@ protected:
 
   struct delete_CVaapiProxy
   {
-    void operator()(CVaapiProxy *p) const;
+    void operator()(CVaapiProxy* p) const;
   };
   std::unique_ptr<CVaapiProxy, delete_CVaapiProxy> m_vaapiProxy;
 };
 
-}
-}
-}
+} // namespace GBM
+} // namespace WINDOWING
+} // namespace KODI

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -34,8 +34,9 @@ using namespace KODI::WINDOWING::GBM;
 using namespace std::chrono_literals;
 
 CWinSystemGbmGLContext::CWinSystemGbmGLContext()
-: CWinSystemGbmEGLContext(EGL_PLATFORM_GBM_MESA, "EGL_MESA_platform_gbm")
-{}
+  : CWinSystemGbmEGLContext(EGL_PLATFORM_GBM_MESA, "EGL_MESA_platform_gbm")
+{
+}
 
 void CWinSystemGbmGLContext::Register()
 {
@@ -88,10 +89,11 @@ bool CWinSystemGbmGLContext::InitWindowSystem()
   return true;
 }
 
-bool CWinSystemGbmGLContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
+bool CWinSystemGbmGLContext::SetFullScreen(bool fullScreen,
+                                           RESOLUTION_INFO& res,
+                                           bool blankOtherDisplays)
 {
-  if (res.iWidth != m_nWidth ||
-      res.iHeight != m_nHeight)
+  if (res.iWidth != m_nWidth || res.iHeight != m_nHeight)
   {
     CLog::Log(LOGDEBUG, "CWinSystemGbmGLContext::{} - resolution changed, creating a new window",
               __FUNCTION__);
@@ -174,9 +176,10 @@ bool CWinSystemGbmGLContext::CreateContext()
   const EGLint glMinor = 2;
 
   CEGLAttributesVec contextAttribs;
-  contextAttribs.Add({{EGL_CONTEXT_MAJOR_VERSION_KHR, glMajor},
-                      {EGL_CONTEXT_MINOR_VERSION_KHR, glMinor},
-                      {EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR, EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT_KHR}});
+  contextAttribs.Add(
+      {{EGL_CONTEXT_MAJOR_VERSION_KHR, glMajor},
+       {EGL_CONTEXT_MINOR_VERSION_KHR, glMinor},
+       {EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR, EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT_KHR}});
 
   if (!m_eglContext.CreateContext(contextAttribs))
   {
@@ -190,7 +193,10 @@ bool CWinSystemGbmGLContext::CreateContext()
     }
     else
     {
-      CLog::Log(LOGWARNING, "Your OpenGL drivers do not support OpenGL {}.{} core profile. Kodi will run in compatibility mode, but performance may suffer.", glMajor, glMinor);
+      CLog::Log(LOGWARNING,
+                "Your OpenGL drivers do not support OpenGL {}.{} core profile. Kodi will run in "
+                "compatibility mode, but performance may suffer.",
+                glMajor, glMinor);
     }
   }
 

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.h
@@ -33,16 +33,17 @@ public:
   static std::unique_ptr<CWinSystemBase> CreateWinSystem();
 
   // Implementation of CWinSystemBase via CWinSystemGbm
-  CRenderSystemBase *GetRenderSystem() override { return this; }
+  CRenderSystemBase* GetRenderSystem() override { return this; }
   bool InitWindowSystem() override;
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
   void PresentRender(bool rendered, bool videoLayer) override;
+
 protected:
   void SetVSyncImpl(bool enable) override {}
   void PresentRenderImpl(bool rendered) override {};
   bool CreateContext() override;
 };
 
-}
-}
-}
+} // namespace GBM
+} // namespace WINDOWING
+} // namespace KODI

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -38,8 +38,9 @@ using namespace KODI::WINDOWING::GBM;
 using namespace std::chrono_literals;
 
 CWinSystemGbmGLESContext::CWinSystemGbmGLESContext()
-: CWinSystemGbmEGLContext(EGL_PLATFORM_GBM_MESA, "EGL_MESA_platform_gbm")
-{}
+  : CWinSystemGbmEGLContext(EGL_PLATFORM_GBM_MESA, "EGL_MESA_platform_gbm")
+{
+}
 
 void CWinSystemGbmGLESContext::Register()
 {
@@ -97,10 +98,11 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
   return true;
 }
 
-bool CWinSystemGbmGLESContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
+bool CWinSystemGbmGLESContext::SetFullScreen(bool fullScreen,
+                                             RESOLUTION_INFO& res,
+                                             bool blankOtherDisplays)
 {
-  if (res.iWidth != m_nWidth ||
-      res.iHeight != m_nHeight)
+  if (res.iWidth != m_nWidth || res.iHeight != m_nHeight)
   {
     CLog::Log(LOGDEBUG, "CWinSystemGbmGLESContext::{} - resolution changed, creating a new window",
               __FUNCTION__);

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
@@ -33,16 +33,17 @@ public:
   static std::unique_ptr<CWinSystemBase> CreateWinSystem();
 
   // Implementation of CWinSystemBase via CWinSystemGbm
-  CRenderSystemBase *GetRenderSystem() override { return this; }
+  CRenderSystemBase* GetRenderSystem() override { return this; }
   bool InitWindowSystem() override;
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
   void PresentRender(bool rendered, bool videoLayer) override;
+
 protected:
   void SetVSyncImpl(bool enable) override {}
   void PresentRenderImpl(bool rendered) override {};
   bool CreateContext() override;
 };
 
-}
-}
-}
+} // namespace GBM
+} // namespace WINDOWING
+} // namespace KODI

--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
@@ -147,8 +147,7 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
   ret = drmModeAtomicCommit(m_fd, m_req->Get(), flags, nullptr);
   if (ret < 0)
   {
-    CLog::Log(LOGERROR, "CDRMAtomic::{} - atomic commit failed: {}", __FUNCTION__,
-              strerror(errno));
+    CLog::Log(LOGERROR, "CDRMAtomic::{} - atomic commit failed: {}", __FUNCTION__, strerror(errno));
     m_atomicRequestQueue.pop_back();
   }
   else if (m_atomicRequestQueue.size() > 1)
@@ -175,7 +174,7 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
 
 void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
 {
-  struct drm_fb *drm_fb = nullptr;
+  struct drm_fb* drm_fb = nullptr;
   uint32_t flags = 0;
 
   if (rendered)
@@ -249,7 +248,7 @@ void CDRMAtomic::DestroyDrm()
   CDRMUtils::DestroyDrm();
 }
 
-bool CDRMAtomic::SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo *bo)
+bool CDRMAtomic::SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo)
 {
   m_need_modeset = true;
 
@@ -283,7 +282,9 @@ CDRMAtomic::CDRMAtomicRequest::CDRMAtomicRequest() : m_atomicRequest(drmModeAtom
 {
 }
 
-bool CDRMAtomic::CDRMAtomicRequest::AddProperty(CDRMObject* object, const char* name, uint64_t value)
+bool CDRMAtomic::CDRMAtomicRequest::AddProperty(CDRMObject* object,
+                                                const char* name,
+                                                uint64_t value)
 {
   uint32_t propertyId = object->GetPropertyId(name);
   if (propertyId == 0)

--- a/xbmc/windowing/gbm/drm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
@@ -76,6 +76,6 @@ private:
   std::deque<std::unique_ptr<CDRMAtomicRequest>> m_atomicRequestQueue;
 };
 
-}
-}
-}
+} // namespace GBM
+} // namespace WINDOWING
+} // namespace KODI

--- a/xbmc/windowing/gbm/drm/DRMLegacy.h
+++ b/xbmc/windowing/gbm/drm/DRMLegacy.h
@@ -29,11 +29,11 @@ public:
 
 private:
   bool WaitingForFlip();
-  bool QueueFlip(struct gbm_bo *bo);
-  static void PageFlipHandler(int fd, unsigned int frame, unsigned int sec,
-                              unsigned int usec, void *data);
+  bool QueueFlip(struct gbm_bo* bo);
+  static void PageFlipHandler(
+      int fd, unsigned int frame, unsigned int sec, unsigned int usec, void* data);
 };
 
-}
-}
-}
+} // namespace GBM
+} // namespace WINDOWING
+} // namespace KODI

--- a/xbmc/windowing/gbm/drm/DRMPlane.cpp
+++ b/xbmc/windowing/gbm/drm/DRMPlane.cpp
@@ -82,9 +82,8 @@ bool CDRMPlane::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
 
 void CDRMPlane::FindModifiers()
 {
-  auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(), [](auto& prop) {
-    return StringUtils::EqualsNoCase(prop->name, "IN_FORMATS");
-  });
+  auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(), [](auto& prop)
+                               { return StringUtils::EqualsNoCase(prop->name, "IN_FORMATS"); });
 
   uint64_t blob_id = 0;
   if (property != m_propsInfo.end())

--- a/xbmc/windowing/gbm/drm/DRMUtils.h
+++ b/xbmc/windowing/gbm/drm/DRMUtils.h
@@ -30,7 +30,7 @@ namespace GBM
 
 struct drm_fb
 {
-  struct gbm_bo *bo = nullptr;
+  struct gbm_bo* bo = nullptr;
   uint32_t fb_id;
   uint32_t format;
 };
@@ -72,7 +72,7 @@ public:
 
 protected:
   bool OpenDrm(bool needConnector);
-  drm_fb* DrmFbGetFromBo(struct gbm_bo *bo);
+  drm_fb* DrmFbGetFromBo(struct gbm_bo* bo);
 
   int m_fd;
   CDRMConnector* m_connector{nullptr};
@@ -81,7 +81,7 @@ protected:
   CDRMCrtc* m_orig_crtc{nullptr};
   CDRMPlane* m_video_plane{nullptr};
   CDRMPlane* m_gui_plane{nullptr};
-  drmModeModeInfo *m_mode = nullptr;
+  drmModeModeInfo* m_mode = nullptr;
 
   int m_width = 0;
   int m_height = 0;
@@ -109,6 +109,6 @@ private:
   std::vector<std::unique_ptr<CDRMCrtc>> m_crtcs;
 };
 
-}
-}
-}
+} // namespace GBM
+} // namespace WINDOWING
+} // namespace KODI

--- a/xbmc/windowing/gbm/drm/OffScreenModeSetting.cpp
+++ b/xbmc/windowing/gbm/drm/OffScreenModeSetting.cpp
@@ -30,9 +30,9 @@ bool COffScreenModeSetting::InitDrm()
 
 std::vector<RESOLUTION_INFO> COffScreenModeSetting::GetModes()
 {
-    std::vector<RESOLUTION_INFO> resolutions;
-    resolutions.push_back(GetCurrentMode());
-    return resolutions;
+  std::vector<RESOLUTION_INFO> resolutions;
+  resolutions.push_back(GetCurrentMode());
+  return resolutions;
 }
 
 RESOLUTION_INFO COffScreenModeSetting::GetCurrentMode()

--- a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
+++ b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
@@ -23,7 +23,7 @@ public:
   COffScreenModeSetting() = default;
   ~COffScreenModeSetting() override = default;
   void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override {}
-  bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo *bo) override { return false; }
+  bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override { return false; }
   bool SetActive(bool active) override { return false; }
   bool InitDrm() override;
   void DestroyDrm() override {}
@@ -33,6 +33,6 @@ public:
   bool SetMode(const RESOLUTION_INFO& res) override { return true; }
 };
 
-}
-}
-}
+} // namespace GBM
+} // namespace WINDOWING
+} // namespace KODI


### PR DESCRIPTION
## Description

As title says, this applies clang-format to a narrow part of the codebase, specifically the `windowing/gmb` subfolder.

## Motivation and context

For years in my release notes I've included:

> ### Added fixes
>
> * Fixed black screen in some games on LibreELEC ([report](https://forum.kodi.tv/showthread.php?tid=373658), [temporary fix](https://github.com/garbear/xbmc/commit/6f753254e04e4165992f9bc0269a58f7f7f8713e))

Now that Codex totally rocks, I'm going to fix this, and because Codex has been trained on clang-format, applying it now will reduce code review overhead for what it generates in the future.

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
