### PR TITLE
Apply clang-format-18 to files in CODEOWNERS

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/Filesystem.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/Filesystem.h
@@ -568,7 +568,7 @@ public:
   //----------------------------------------------------------------------------
 
   //============================================================================
-  // @note Not necessary for addon development, therefore it's 
+  // @note Not necessary for addon development, therefore it's
   // disabled for doxygen below!
   //
   // @ingroup cpp_kodi_vfs_CDirEntry

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/peripheral/PeripheralUtils.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/peripheral/PeripheralUtils.h
@@ -29,7 +29,7 @@
 #define PERIPHERAL_SAFE_DELETE_ARRAY(x) \
   do \
   { \
-    delete[](x); \
+    delete[] (x); \
     (x) = NULL; \
   } while (0)
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream/timing_constants.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream/timing_constants.h
@@ -35,8 +35,8 @@
 #define STREAM_NOPTS_VALUE 0xFFF0000000000000
 
 // "C" defines to translate stream times
-#define STREAM_TIME_TO_MSEC(x) ((int)((double)(x)*1000 / STREAM_TIME_BASE))
-#define STREAM_SEC_TO_TIME(x) ((double)(x)*STREAM_TIME_BASE)
-#define STREAM_MSEC_TO_TIME(x) ((double)(x)*STREAM_TIME_BASE / 1000)
+#define STREAM_TIME_TO_MSEC(x) ((int)((double)(x) * 1000 / STREAM_TIME_BASE))
+#define STREAM_SEC_TO_TIME(x) ((double)(x) * STREAM_TIME_BASE)
+#define STREAM_MSEC_TO_TIME(x) ((double)(x) * STREAM_TIME_BASE / 1000)
 
 #endif /* !C_API_ADDONINSTANCE_INPUTSTREAM_TIMINGCONSTANTS_H */

--- a/xbmc/addons/kodi-dev-kit/include/kodi/tools/StringUtils.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/tools/StringUtils.h
@@ -1453,10 +1453,7 @@ public:
   /// EXPECT_STREQ(refstr.c_str(), varstr.c_str());
   /// ~~~~~~~~~~~~~
   ///
-  inline static void RemoveCRLF(std::string& strLine)
-  {
-    StringUtils::TrimRight(strLine, "\n\r");
-  }
+  inline static void RemoveCRLF(std::string& strLine) { StringUtils::TrimRight(strLine, "\n\r"); }
   //----------------------------------------------------------------------------
 
   //============================================================================
@@ -2028,10 +2025,7 @@ public:
   /// @param[in] c Character to check
   /// @return true if space, false otherwise
   ///
-  inline static int IsSpace(char c)
-  {
-    return (c & 0x80) == 0 && ::isspace(c);
-  }
+  inline static int IsSpace(char c) { return (c & 0x80) == 0 && ::isspace(c); }
   //----------------------------------------------------------------------------
 
   //============================================================================

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -188,7 +188,7 @@
                                                       "c-api/addon-instance/inputstream/stream_crypto.h" \
                                                       "addon-instance/VideoCodec.h" \
                                                       "addon-instance/inputstream/StreamCodec.h" \
-                                                      "addon-instance/inputstream/StreamCrypto.h" \
+                                                      "addon-instance/inputstream/StreamCrypto.h"
 // clang-format on
 
 //==============================================================================
@@ -260,276 +260,279 @@ typedef enum ADDON_TYPE
 //------------------------------------------------------------------------------
 
 #ifdef __cplusplus
-extern "C" {
-namespace kodi {
-namespace addon {
+extern "C"
+{
+  namespace kodi
+  {
+  namespace addon
+  {
 #endif
 
-///
-/// This is used from Kodi to get the active version of add-on parts.
-/// It is compiled in add-on and also in Kodi itself, with this can be Kodi
-/// compare the version from him with them on add-on.
-///
-/// @param[in] type The with 'enum ADDON_TYPE' type to ask
-/// @return version The current version of asked type
-///
-inline const char* GetTypeVersion(int type)
-{
-  /*
+  ///
+  /// This is used from Kodi to get the active version of add-on parts.
+  /// It is compiled in add-on and also in Kodi itself, with this can be Kodi
+  /// compare the version from him with them on add-on.
+  ///
+  /// @param[in] type The with 'enum ADDON_TYPE' type to ask
+  /// @return version The current version of asked type
+  ///
+  inline const char* GetTypeVersion(int type)
+  {
+    /*
    * #ifdef's below becomes set by cmake, no set by hand needed.
    */
-  switch (type)
-  {
-    /* addon global parts */
-    case ADDON_GLOBAL_MAIN:
-      return ADDON_GLOBAL_VERSION_MAIN;
+    switch (type)
+    {
+      /* addon global parts */
+      case ADDON_GLOBAL_MAIN:
+        return ADDON_GLOBAL_VERSION_MAIN;
 #if !defined(BUILD_KODI_ADDON) || defined(ADDON_GLOBAL_VERSION_GENERAL_USED)
-    case ADDON_GLOBAL_GENERAL:
-      return ADDON_GLOBAL_VERSION_GENERAL;
+      case ADDON_GLOBAL_GENERAL:
+        return ADDON_GLOBAL_VERSION_GENERAL;
 #endif
 #if !defined(BUILD_KODI_ADDON) || defined(ADDON_GLOBAL_VERSION_GUI_USED)
-    case ADDON_GLOBAL_GUI:
-      return ADDON_GLOBAL_VERSION_GUI;
+      case ADDON_GLOBAL_GUI:
+        return ADDON_GLOBAL_VERSION_GUI;
 #endif
 #if !defined(BUILD_KODI_ADDON) || defined(ADDON_GLOBAL_VERSION_AUDIOENGINE_USED)
-    case ADDON_GLOBAL_AUDIOENGINE:
-      return ADDON_GLOBAL_VERSION_AUDIOENGINE;
+      case ADDON_GLOBAL_AUDIOENGINE:
+        return ADDON_GLOBAL_VERSION_AUDIOENGINE;
 #endif
 #if !defined(BUILD_KODI_ADDON) || defined(ADDON_GLOBAL_VERSION_FILESYSTEM_USED)
-    case ADDON_GLOBAL_FILESYSTEM:
-      return ADDON_GLOBAL_VERSION_FILESYSTEM;
+      case ADDON_GLOBAL_FILESYSTEM:
+        return ADDON_GLOBAL_VERSION_FILESYSTEM;
 #endif
 #if !defined(BUILD_KODI_ADDON) || defined(ADDON_GLOBAL_VERSION_NETWORK_USED)
-    case ADDON_GLOBAL_NETWORK:
-      return ADDON_GLOBAL_VERSION_NETWORK;
+      case ADDON_GLOBAL_NETWORK:
+        return ADDON_GLOBAL_VERSION_NETWORK;
 #endif
 #if !defined(BUILD_KODI_ADDON) || defined(ADDON_GLOBAL_VERSION_TOOLS_USED)
-    case ADDON_GLOBAL_TOOLS:
-      return ADDON_GLOBAL_VERSION_TOOLS;
+      case ADDON_GLOBAL_TOOLS:
+        return ADDON_GLOBAL_VERSION_TOOLS;
 #endif
 
-    /* addon type instances */
+        /* addon type instances */
 #if !defined(BUILD_KODI_ADDON) || defined(ADDON_INSTANCE_VERSION_AUDIODECODER_USED)
-    case ADDON_INSTANCE_AUDIODECODER:
-      return ADDON_INSTANCE_VERSION_AUDIODECODER;
+      case ADDON_INSTANCE_AUDIODECODER:
+        return ADDON_INSTANCE_VERSION_AUDIODECODER;
 #endif
 #if !defined(BUILD_KODI_ADDON) || defined(ADDON_INSTANCE_VERSION_AUDIOENCODER_USED)
-    case ADDON_INSTANCE_AUDIOENCODER:
-      return ADDON_INSTANCE_VERSION_AUDIOENCODER;
+      case ADDON_INSTANCE_AUDIOENCODER:
+        return ADDON_INSTANCE_VERSION_AUDIOENCODER;
 #endif
 #if !defined(BUILD_KODI_ADDON) || defined(ADDON_INSTANCE_VERSION_GAME_USED)
-    case ADDON_INSTANCE_GAME:
-      return ADDON_INSTANCE_VERSION_GAME;
+      case ADDON_INSTANCE_GAME:
+        return ADDON_INSTANCE_VERSION_GAME;
 #endif
 #if !defined(BUILD_KODI_ADDON) || defined(ADDON_INSTANCE_VERSION_IMAGEDECODER_USED)
-    case ADDON_INSTANCE_IMAGEDECODER:
-      return ADDON_INSTANCE_VERSION_IMAGEDECODER;
+      case ADDON_INSTANCE_IMAGEDECODER:
+        return ADDON_INSTANCE_VERSION_IMAGEDECODER;
 #endif
 #if !defined(BUILD_KODI_ADDON) || defined(ADDON_INSTANCE_VERSION_INPUTSTREAM_USED)
-    case ADDON_INSTANCE_INPUTSTREAM:
-      return ADDON_INSTANCE_VERSION_INPUTSTREAM;
+      case ADDON_INSTANCE_INPUTSTREAM:
+        return ADDON_INSTANCE_VERSION_INPUTSTREAM;
 #endif
 #if !defined(BUILD_KODI_ADDON) || defined(ADDON_INSTANCE_VERSION_PERIPHERAL_USED)
-    case ADDON_INSTANCE_PERIPHERAL:
-      return ADDON_INSTANCE_VERSION_PERIPHERAL;
+      case ADDON_INSTANCE_PERIPHERAL:
+        return ADDON_INSTANCE_VERSION_PERIPHERAL;
 #endif
 #if !defined(BUILD_KODI_ADDON) || defined(ADDON_INSTANCE_VERSION_PVR_USED)
-    case ADDON_INSTANCE_PVR:
-      return ADDON_INSTANCE_VERSION_PVR;
+      case ADDON_INSTANCE_PVR:
+        return ADDON_INSTANCE_VERSION_PVR;
 #endif
 #if !defined(BUILD_KODI_ADDON) || defined(ADDON_INSTANCE_VERSION_SCREENSAVER_USED)
-    case ADDON_INSTANCE_SCREENSAVER:
-      return ADDON_INSTANCE_VERSION_SCREENSAVER;
+      case ADDON_INSTANCE_SCREENSAVER:
+        return ADDON_INSTANCE_VERSION_SCREENSAVER;
 #endif
 #if !defined(BUILD_KODI_ADDON) || defined(ADDON_INSTANCE_VERSION_SHADERPRESET_USED)
-    case ADDON_INSTANCE_SHADERPRESET:
-      return ADDON_INSTANCE_VERSION_SHADERPRESET;
+      case ADDON_INSTANCE_SHADERPRESET:
+        return ADDON_INSTANCE_VERSION_SHADERPRESET;
 #endif
 #if !defined(BUILD_KODI_ADDON) || defined(ADDON_INSTANCE_VERSION_VFS_USED)
-    case ADDON_INSTANCE_VFS:
-      return ADDON_INSTANCE_VERSION_VFS;
+      case ADDON_INSTANCE_VFS:
+        return ADDON_INSTANCE_VERSION_VFS;
 #endif
 #if !defined(BUILD_KODI_ADDON) || defined(ADDON_INSTANCE_VERSION_VISUALIZATION_USED)
-    case ADDON_INSTANCE_VISUALIZATION:
-      return ADDON_INSTANCE_VERSION_VISUALIZATION;
+      case ADDON_INSTANCE_VISUALIZATION:
+        return ADDON_INSTANCE_VERSION_VISUALIZATION;
 #endif
 #if !defined(BUILD_KODI_ADDON) || defined(ADDON_INSTANCE_VERSION_VIDEOCODEC_USED)
-    case ADDON_INSTANCE_VIDEOCODEC:
-      return ADDON_INSTANCE_VERSION_VIDEOCODEC;
+      case ADDON_INSTANCE_VIDEOCODEC:
+        return ADDON_INSTANCE_VERSION_VIDEOCODEC;
 #endif
+    }
+    return "0.0.0";
   }
-  return "0.0.0";
-}
 
-///
-/// This is used from Kodi to get the minimum supported version of add-on parts.
-/// It is compiled in add-on and also in Kodi itself, with this can be Kodi
-/// compare the version from him with them on add-on.
-///
-/// @param[in] type The with 'enum ADDON_TYPE' type to ask
-/// @return version The minimum version of asked type
-///
-inline const char* GetTypeMinVersion(int type)
-{
-  switch (type)
+  ///
+  /// This is used from Kodi to get the minimum supported version of add-on parts.
+  /// It is compiled in add-on and also in Kodi itself, with this can be Kodi
+  /// compare the version from him with them on add-on.
+  ///
+  /// @param[in] type The with 'enum ADDON_TYPE' type to ask
+  /// @return version The minimum version of asked type
+  ///
+  inline const char* GetTypeMinVersion(int type)
   {
-    /* addon global parts */
-    case ADDON_GLOBAL_MAIN:
-      return ADDON_GLOBAL_VERSION_MAIN_MIN;
-    case ADDON_GLOBAL_GUI:
-      return ADDON_GLOBAL_VERSION_GUI_MIN;
-    case ADDON_GLOBAL_GENERAL:
-      return ADDON_GLOBAL_VERSION_GENERAL_MIN;
-    case ADDON_GLOBAL_AUDIOENGINE:
-      return ADDON_GLOBAL_VERSION_AUDIOENGINE_MIN;
-    case ADDON_GLOBAL_FILESYSTEM:
-      return ADDON_GLOBAL_VERSION_FILESYSTEM_MIN;
-    case ADDON_GLOBAL_NETWORK:
-      return ADDON_GLOBAL_VERSION_NETWORK_MIN;
-    case ADDON_GLOBAL_TOOLS:
-      return ADDON_GLOBAL_VERSION_TOOLS_MIN;
+    switch (type)
+    {
+      /* addon global parts */
+      case ADDON_GLOBAL_MAIN:
+        return ADDON_GLOBAL_VERSION_MAIN_MIN;
+      case ADDON_GLOBAL_GUI:
+        return ADDON_GLOBAL_VERSION_GUI_MIN;
+      case ADDON_GLOBAL_GENERAL:
+        return ADDON_GLOBAL_VERSION_GENERAL_MIN;
+      case ADDON_GLOBAL_AUDIOENGINE:
+        return ADDON_GLOBAL_VERSION_AUDIOENGINE_MIN;
+      case ADDON_GLOBAL_FILESYSTEM:
+        return ADDON_GLOBAL_VERSION_FILESYSTEM_MIN;
+      case ADDON_GLOBAL_NETWORK:
+        return ADDON_GLOBAL_VERSION_NETWORK_MIN;
+      case ADDON_GLOBAL_TOOLS:
+        return ADDON_GLOBAL_VERSION_TOOLS_MIN;
 
-    /* addon type instances */
-    case ADDON_INSTANCE_AUDIODECODER:
-      return ADDON_INSTANCE_VERSION_AUDIODECODER_MIN;
-    case ADDON_INSTANCE_AUDIOENCODER:
-      return ADDON_INSTANCE_VERSION_AUDIOENCODER_MIN;
-    case ADDON_INSTANCE_GAME:
-      return ADDON_INSTANCE_VERSION_GAME_MIN;
-    case ADDON_INSTANCE_IMAGEDECODER:
-      return ADDON_INSTANCE_VERSION_IMAGEDECODER_MIN;
-    case ADDON_INSTANCE_INPUTSTREAM:
-      return ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN;
-    case ADDON_INSTANCE_PERIPHERAL:
-      return ADDON_INSTANCE_VERSION_PERIPHERAL_MIN;
-    case ADDON_INSTANCE_PVR:
-      return ADDON_INSTANCE_VERSION_PVR_MIN;
-    case ADDON_INSTANCE_SCREENSAVER:
-      return ADDON_INSTANCE_VERSION_SCREENSAVER_MIN;
-    case ADDON_INSTANCE_SHADERPRESET:
-      return ADDON_INSTANCE_VERSION_SHADERPRESET_MIN;
-    case ADDON_INSTANCE_VFS:
-      return ADDON_INSTANCE_VERSION_VFS_MIN;
-    case ADDON_INSTANCE_VISUALIZATION:
-      return ADDON_INSTANCE_VERSION_VISUALIZATION_MIN;
-    case ADDON_INSTANCE_VIDEOCODEC:
-      return ADDON_INSTANCE_VERSION_VIDEOCODEC_MIN;
+      /* addon type instances */
+      case ADDON_INSTANCE_AUDIODECODER:
+        return ADDON_INSTANCE_VERSION_AUDIODECODER_MIN;
+      case ADDON_INSTANCE_AUDIOENCODER:
+        return ADDON_INSTANCE_VERSION_AUDIOENCODER_MIN;
+      case ADDON_INSTANCE_GAME:
+        return ADDON_INSTANCE_VERSION_GAME_MIN;
+      case ADDON_INSTANCE_IMAGEDECODER:
+        return ADDON_INSTANCE_VERSION_IMAGEDECODER_MIN;
+      case ADDON_INSTANCE_INPUTSTREAM:
+        return ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN;
+      case ADDON_INSTANCE_PERIPHERAL:
+        return ADDON_INSTANCE_VERSION_PERIPHERAL_MIN;
+      case ADDON_INSTANCE_PVR:
+        return ADDON_INSTANCE_VERSION_PVR_MIN;
+      case ADDON_INSTANCE_SCREENSAVER:
+        return ADDON_INSTANCE_VERSION_SCREENSAVER_MIN;
+      case ADDON_INSTANCE_SHADERPRESET:
+        return ADDON_INSTANCE_VERSION_SHADERPRESET_MIN;
+      case ADDON_INSTANCE_VFS:
+        return ADDON_INSTANCE_VERSION_VFS_MIN;
+      case ADDON_INSTANCE_VISUALIZATION:
+        return ADDON_INSTANCE_VERSION_VISUALIZATION_MIN;
+      case ADDON_INSTANCE_VIDEOCODEC:
+        return ADDON_INSTANCE_VERSION_VIDEOCODEC_MIN;
+    }
+    return "0.0.0";
   }
-  return "0.0.0";
-}
 
-///
-/// Function used internally on add-on and in Kodi itself to get name
-/// about given type.
-///
-/// @param[in] type The with 'enum ADDON_TYPE' defined type to ask
-/// @return Name of the asked instance type
-///
-inline const char* GetTypeName(int type)
-{
-  switch (type)
+  ///
+  /// Function used internally on add-on and in Kodi itself to get name
+  /// about given type.
+  ///
+  /// @param[in] type The with 'enum ADDON_TYPE' defined type to ask
+  /// @return Name of the asked instance type
+  ///
+  inline const char* GetTypeName(int type)
   {
-    /* addon global parts */
-    case ADDON_GLOBAL_MAIN:
-      return "Addon";
-    case ADDON_GLOBAL_GUI:
-      return "GUI";
-    case ADDON_GLOBAL_GENERAL:
-      return "General";
-    case ADDON_GLOBAL_AUDIOENGINE:
-      return "AudioEngine";
-    case ADDON_GLOBAL_FILESYSTEM:
-      return "Filesystem";
-    case ADDON_GLOBAL_NETWORK:
-      return "Network";
-    case ADDON_GLOBAL_TOOLS:
-      return "Tools";
+    switch (type)
+    {
+      /* addon global parts */
+      case ADDON_GLOBAL_MAIN:
+        return "Addon";
+      case ADDON_GLOBAL_GUI:
+        return "GUI";
+      case ADDON_GLOBAL_GENERAL:
+        return "General";
+      case ADDON_GLOBAL_AUDIOENGINE:
+        return "AudioEngine";
+      case ADDON_GLOBAL_FILESYSTEM:
+        return "Filesystem";
+      case ADDON_GLOBAL_NETWORK:
+        return "Network";
+      case ADDON_GLOBAL_TOOLS:
+        return "Tools";
 
-    /* addon type instances */
-    case ADDON_INSTANCE_AUDIODECODER:
-      return "AudioDecoder";
-    case ADDON_INSTANCE_AUDIOENCODER:
-      return "AudioEncoder";
-    case ADDON_INSTANCE_GAME:
-      return "Game";
-    case ADDON_INSTANCE_IMAGEDECODER:
-      return "ImageDecoder";
-    case ADDON_INSTANCE_INPUTSTREAM:
-      return "Inputstream";
-    case ADDON_INSTANCE_PERIPHERAL:
-      return "Peripheral";
-    case ADDON_INSTANCE_PVR:
-      return "PVR";
-    case ADDON_INSTANCE_SCREENSAVER:
-      return "ScreenSaver";
-    case ADDON_INSTANCE_SHADERPRESET:
-      return "ShaderPreset";
-    case ADDON_INSTANCE_VISUALIZATION:
-      return "Visualization";
-    case ADDON_INSTANCE_VIDEOCODEC:
-      return "VideoCodec";
+      /* addon type instances */
+      case ADDON_INSTANCE_AUDIODECODER:
+        return "AudioDecoder";
+      case ADDON_INSTANCE_AUDIOENCODER:
+        return "AudioEncoder";
+      case ADDON_INSTANCE_GAME:
+        return "Game";
+      case ADDON_INSTANCE_IMAGEDECODER:
+        return "ImageDecoder";
+      case ADDON_INSTANCE_INPUTSTREAM:
+        return "Inputstream";
+      case ADDON_INSTANCE_PERIPHERAL:
+        return "Peripheral";
+      case ADDON_INSTANCE_PVR:
+        return "PVR";
+      case ADDON_INSTANCE_SCREENSAVER:
+        return "ScreenSaver";
+      case ADDON_INSTANCE_SHADERPRESET:
+        return "ShaderPreset";
+      case ADDON_INSTANCE_VISUALIZATION:
+        return "Visualization";
+      case ADDON_INSTANCE_VIDEOCODEC:
+        return "VideoCodec";
+    }
+    return "unknown";
   }
-  return "unknown";
-}
 
-///
-/// Function used internally on add-on and in Kodi itself to get id number
-/// about given type name.
-///
-/// @param[in] name The type name string to ask
-/// @return Id number of the asked instance type
-///
-/// @warning String must be lower case here!
-///
-inline int GetTypeId(const char* name)
-{
-  if (name)
+  ///
+  /// Function used internally on add-on and in Kodi itself to get id number
+  /// about given type name.
+  ///
+  /// @param[in] name The type name string to ask
+  /// @return Id number of the asked instance type
+  ///
+  /// @warning String must be lower case here!
+  ///
+  inline int GetTypeId(const char* name)
   {
-    if (strcmp(name, "addon") == 0)
-      return ADDON_GLOBAL_MAIN;
-    else if (strcmp(name, "general") == 0)
-      return ADDON_GLOBAL_GENERAL;
-    else if (strcmp(name, "gui") == 0)
-      return ADDON_GLOBAL_GUI;
-    else if (strcmp(name, "audioengine") == 0)
-      return ADDON_GLOBAL_AUDIOENGINE;
-    else if (strcmp(name, "filesystem") == 0)
-      return ADDON_GLOBAL_FILESYSTEM;
-    else if (strcmp(name, "network") == 0)
-      return ADDON_GLOBAL_NETWORK;
-    else if (strcmp(name, "tools") == 0)
-      return ADDON_GLOBAL_TOOLS;
-    else if (strcmp(name, "audiodecoder") == 0)
-      return ADDON_INSTANCE_AUDIODECODER;
-    else if (strcmp(name, "audioencoder") == 0)
-      return ADDON_INSTANCE_AUDIOENCODER;
-    else if (strcmp(name, "game") == 0)
-      return ADDON_INSTANCE_GAME;
-    else if (strcmp(name, "imagedecoder") == 0)
-      return ADDON_INSTANCE_IMAGEDECODER;
-    else if (strcmp(name, "inputstream") == 0)
-      return ADDON_INSTANCE_INPUTSTREAM;
-    else if (strcmp(name, "peripheral") == 0)
-      return ADDON_INSTANCE_PERIPHERAL;
-    else if (strcmp(name, "pvr") == 0)
-      return ADDON_INSTANCE_PVR;
-    else if (strcmp(name, "screensaver") == 0)
-      return ADDON_INSTANCE_SCREENSAVER;
-    else if (strcmp(name, "shaderpreset") == 0)
-      return ADDON_INSTANCE_SHADERPRESET;
-    else if (strcmp(name, "vfs") == 0)
-      return ADDON_INSTANCE_VFS;
-    else if (strcmp(name, "visualization") == 0)
-      return ADDON_INSTANCE_VISUALIZATION;
-    else if (strcmp(name, "videocodec") == 0)
-      return ADDON_INSTANCE_VIDEOCODEC;
+    if (name)
+    {
+      if (strcmp(name, "addon") == 0)
+        return ADDON_GLOBAL_MAIN;
+      else if (strcmp(name, "general") == 0)
+        return ADDON_GLOBAL_GENERAL;
+      else if (strcmp(name, "gui") == 0)
+        return ADDON_GLOBAL_GUI;
+      else if (strcmp(name, "audioengine") == 0)
+        return ADDON_GLOBAL_AUDIOENGINE;
+      else if (strcmp(name, "filesystem") == 0)
+        return ADDON_GLOBAL_FILESYSTEM;
+      else if (strcmp(name, "network") == 0)
+        return ADDON_GLOBAL_NETWORK;
+      else if (strcmp(name, "tools") == 0)
+        return ADDON_GLOBAL_TOOLS;
+      else if (strcmp(name, "audiodecoder") == 0)
+        return ADDON_INSTANCE_AUDIODECODER;
+      else if (strcmp(name, "audioencoder") == 0)
+        return ADDON_INSTANCE_AUDIOENCODER;
+      else if (strcmp(name, "game") == 0)
+        return ADDON_INSTANCE_GAME;
+      else if (strcmp(name, "imagedecoder") == 0)
+        return ADDON_INSTANCE_IMAGEDECODER;
+      else if (strcmp(name, "inputstream") == 0)
+        return ADDON_INSTANCE_INPUTSTREAM;
+      else if (strcmp(name, "peripheral") == 0)
+        return ADDON_INSTANCE_PERIPHERAL;
+      else if (strcmp(name, "pvr") == 0)
+        return ADDON_INSTANCE_PVR;
+      else if (strcmp(name, "screensaver") == 0)
+        return ADDON_INSTANCE_SCREENSAVER;
+      else if (strcmp(name, "shaderpreset") == 0)
+        return ADDON_INSTANCE_SHADERPRESET;
+      else if (strcmp(name, "vfs") == 0)
+        return ADDON_INSTANCE_VFS;
+      else if (strcmp(name, "visualization") == 0)
+        return ADDON_INSTANCE_VISUALIZATION;
+      else if (strcmp(name, "videocodec") == 0)
+        return ADDON_INSTANCE_VIDEOCODEC;
+    }
+    return -1;
   }
-  return -1;
-}
 
 #ifdef __cplusplus
-} /* namespace addon */
-} /* namespace kodi */
+  } /* namespace addon */
+  } /* namespace kodi */
 } /* extern "C" */
 #endif
 

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferManager.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferManager.cpp
@@ -36,9 +36,8 @@ RenderBufferPoolVector CRenderBufferManager::GetPools(IRendererFactory* factory)
 
   std::unique_lock lock(m_critSection);
 
-  auto it =
-      std::find_if(m_pools.begin(), m_pools.end(),
-                   [factory](const RenderBufferPools& pools) { return pools.factory == factory; });
+  auto it = std::find_if(m_pools.begin(), m_pools.end(), [factory](const RenderBufferPools& pools)
+                         { return pools.factory == factory; });
 
   if (it != m_pools.end())
     bufferPools = it->pools;

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -678,9 +678,9 @@ IRenderBuffer* CRPRenderManager::GetRenderBufferForSavestate(const std::string& 
     // Get a render buffer belonging to the specified pool
     const std::vector<IRenderBuffer*>& renderBuffers = it->second;
 
-    auto it2 = std::find_if(renderBuffers.begin(), renderBuffers.end(),
-                            [bufferPool](IRenderBuffer* buffer)
-                            { return buffer->GetPool() == bufferPool; });
+    auto it2 =
+        std::find_if(renderBuffers.begin(), renderBuffers.end(), [bufferPool](IRenderBuffer* buffer)
+                     { return buffer->GetPool() == bufferPool; });
 
     if (it2 != renderBuffers.end())
     {

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
@@ -48,12 +48,11 @@ CRPBaseRenderer* CRendererFactoryGuiTexture::CreateRenderer(
 
 RenderBufferPoolVector CRendererFactoryGuiTexture::CreateBufferPools(CRenderContext& context)
 {
-  return
-  {
+  return {
 #if !defined(HAS_DX)
-    std::make_shared<CRenderBufferPoolGuiTexture>(SCALINGMETHOD::NEAREST),
+      std::make_shared<CRenderBufferPoolGuiTexture>(SCALINGMETHOD::NEAREST),
 #endif
-        std::make_shared<CRenderBufferPoolGuiTexture>(SCALINGMETHOD::LINEAR),
+      std::make_shared<CRenderBufferPoolGuiTexture>(SCALINGMETHOD::LINEAR),
   };
 }
 

--- a/xbmc/cores/RetroPlayer/streams/memory/BasicMemoryStream.h
+++ b/xbmc/cores/RetroPlayer/streams/memory/BasicMemoryStream.h
@@ -37,7 +37,7 @@ public:
   uint64_t PastFramesAvailable() const override { return 0; }
   uint64_t RewindFrames(uint64_t frameCount) override { return 0; }
   uint64_t GetFrameCounter() const override { return 0; }
-  void SetFrameCounter(uint64_t frameCount) override{};
+  void SetFrameCounter(uint64_t frameCount) override {}
 
 private:
   size_t m_frameSize;

--- a/xbmc/cores/RetroPlayer/streams/memory/LinearMemoryStream.cpp
+++ b/xbmc/cores/RetroPlayer/streams/memory/LinearMemoryStream.cpp
@@ -12,7 +12,7 @@ using namespace KODI;
 using namespace RETRO;
 
 // Pad forward to nearest boundary of bytes
-#define PAD_TO_CEIL(x, bytes) ((((x) + (bytes)-1) / (bytes)) * (bytes))
+#define PAD_TO_CEIL(x, bytes) ((((x) + (bytes) - 1) / (bytes)) * (bytes))
 
 CLinearMemoryStream::CLinearMemoryStream()
 {

--- a/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.cpp
@@ -44,8 +44,7 @@ std::string CGUIDialogIgnoreInput::GetDialogText()
   std::vector<std::string> primitives;
 
   std::transform(m_capturedPrimitives.begin(), m_capturedPrimitives.end(),
-                 std::back_inserter(primitives),
-                 [](const JOYSTICK::CDriverPrimitive& primitive)
+                 std::back_inserter(primitives), [](const JOYSTICK::CDriverPrimitive& primitive)
                  { return JOYSTICK::CJoystickTranslator::GetPrimitiveName(primitive); });
 
   return StringUtils::Format(dialogText, StringUtils::Join(primitives, " | "));

--- a/xbmc/games/controllers/types/ControllerGrid.cpp
+++ b/xbmc/games/controllers/types/ControllerGrid.cpp
@@ -48,16 +48,13 @@ unsigned int CControllerGrid::AddPorts(const PortVec& ports, ControllerGrid& gri
 {
   unsigned int height = 0;
 
-  auto itKeyboard =
-      std::find_if(ports.begin(), ports.end(),
-                   [](const CPortNode& port) { return port.GetPortType() == PORT_TYPE::KEYBOARD; });
+  auto itKeyboard = std::find_if(ports.begin(), ports.end(), [](const CPortNode& port)
+                                 { return port.GetPortType() == PORT_TYPE::KEYBOARD; });
 
-  auto itMouse =
-      std::find_if(ports.begin(), ports.end(),
-                   [](const CPortNode& port) { return port.GetPortType() == PORT_TYPE::MOUSE; });
+  auto itMouse = std::find_if(ports.begin(), ports.end(), [](const CPortNode& port)
+                              { return port.GetPortType() == PORT_TYPE::MOUSE; });
 
-  auto itController = std::find_if(ports.begin(), ports.end(),
-                                   [](const CPortNode& port)
+  auto itController = std::find_if(ports.begin(), ports.end(), [](const CPortNode& port)
                                    { return port.GetPortType() == PORT_TYPE::CONTROLLER; });
 
   // Keyboard and mouse are not allowed to have ports because they might

--- a/xbmc/games/controllers/types/ControllerHub.cpp
+++ b/xbmc/games/controllers/types/ControllerHub.cpp
@@ -51,8 +51,7 @@ void CControllerHub::SetPorts(PortVec ports)
 
 bool CControllerHub::IsControllerAccepted(const std::string& controllerId) const
 {
-  return std::any_of(m_ports.begin(), m_ports.end(),
-                     [controllerId](const CPortNode& port)
+  return std::any_of(m_ports.begin(), m_ports.end(), [controllerId](const CPortNode& port)
                      { return port.IsControllerAccepted(controllerId); });
 }
 

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -743,9 +743,10 @@ std::string CGUIControlFactory::GetType(const TiXmlElement* pControlNode)
   return type;
 }
 
-bool CGUIControlFactory::GetMovingSpeedConfig(const TiXmlNode* pRootNode,
-                                              const char* strTag,
-                                              KODI::UTILS::MOVING_SPEED::MapEventConfig& movingSpeedCfg)
+bool CGUIControlFactory::GetMovingSpeedConfig(
+    const TiXmlNode* pRootNode,
+    const char* strTag,
+    KODI::UTILS::MOVING_SPEED::MapEventConfig& movingSpeedCfg)
 {
   const TiXmlElement* msNode = pRootNode->FirstChildElement(strTag);
   if (!msNode)

--- a/xbmc/input/keymaps/generic/KeyHandler.cpp
+++ b/xbmc/input/keymaps/generic/KeyHandler.cpp
@@ -151,8 +151,7 @@ CAction CKeyHandler::ProcessActions(std::vector<const KeymapAction*> actions,
   CAction dispatchAction;
 
   // Filter out actions without pressed hotkeys
-  actions.erase(std::remove_if(actions.begin(), actions.end(),
-                               [this](const KeymapAction* action)
+  actions.erase(std::remove_if(actions.begin(), actions.end(), [this](const KeymapAction* action)
                                { return !m_keymapHandler->HotkeysPressed(action->hotkeys); }),
                 actions.end());
 

--- a/xbmc/input/mouse/MouseStat.h
+++ b/xbmc/input/mouse/MouseStat.h
@@ -13,7 +13,7 @@
 /// \ingroup mouse
 /// \{
 
-#define XBMC_BUTTON(X) (1 << ((X)-1))
+#define XBMC_BUTTON(X) (1 << ((X) - 1))
 #define XBMC_BUTTON_LEFT 1
 #define XBMC_BUTTON_MIDDLE 2
 #define XBMC_BUTTON_RIGHT 3

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -251,9 +251,9 @@ PeripheralBusPtr CPeripherals::GetBusWithDevice(const std::string& strLocation) 
 {
   std::unique_lock lock(m_critSectionBusses);
 
-  const auto& bus = std::find_if(m_busses.cbegin(), m_busses.cend(),
-                                 [&strLocation](const PeripheralBusPtr& bus)
-                                 { return bus->HasPeripheral(strLocation); });
+  const auto& bus =
+      std::find_if(m_busses.cbegin(), m_busses.cend(), [&strLocation](const PeripheralBusPtr& bus)
+                   { return bus->HasPeripheral(strLocation); });
   if (bus != m_busses.cend())
     return *bus;
 

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -348,26 +348,17 @@ public:
   /*!
    * \brief Access the input manager passed to the constructor
    */
-  CInputManager& GetInputManager()
-  {
-    return m_inputManager;
-  }
+  CInputManager& GetInputManager() { return m_inputManager; }
 
   /*!
    * \brief Access controller profiles through the construction parameter
    */
-  KODI::GAME::CControllerManager& GetControllerProfiles()
-  {
-    return m_controllerProfiles;
-  }
+  KODI::GAME::CControllerManager& GetControllerProfiles() { return m_controllerProfiles; }
 
   /*!
    * \brief Get a mutex that allows for add-on install tasks to block on each other
    */
-  CCriticalSection& GetAddonInstallMutex()
-  {
-    return m_addonInstallMutex;
-  }
+  CCriticalSection& GetAddonInstallMutex() { return m_addonInstallMutex; }
 
   /*!
    * \brief Get the current activation of a peripheral

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -479,9 +479,9 @@ void CPeripheralBusAddon::PromptEnableAddons(
   // True if the user confirms enabling the disabled peripheral add-on
   bool bAccepted = false;
 
-  auto itAddon = std::find_if(disabledAddons.begin(), disabledAddons.end(),
-                              [](const AddonInfoPtr& addonInfo)
-                              { return CPeripheralAddon::ProvidesJoysticks(addonInfo); });
+  auto itAddon =
+      std::find_if(disabledAddons.begin(), disabledAddons.end(), [](const AddonInfoPtr& addonInfo)
+                   { return CPeripheralAddon::ProvidesJoysticks(addonInfo); });
 
   if (itAddon != disabledAddons.end())
   {


### PR DESCRIPTION
## Description

Formatted with:

```bash
clang-format-18 -style=file -i \
  $(find \
    xbmc/addons/kodi-dev-kit \
    xbmc/cores/RetroPlayer \
    xbmc/games \
    xbmc/guilib/GUIControlFactory.* \
    xbmc/input \
    xbmc/peripherals \
    xbmc/platform/android/peripherals \
    xbmc/ServiceBroker.* \
    xbmc/ServiceManager.* \
      -name '*.cpp' -o -name '*.h' \
  )
```

## Motivation and context

Our Jenkins formatter now runs on Ubuntu 24.04, which currently uses clang-format-18.

## How has this been tested?

Moment of truth: Jenkins should give no formatting patches.

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
