### PR TITLE
[settings] Sonarqube findings

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -606,7 +606,7 @@ bool CLangInfo::UseLocaleCollation()
   return m_collationtype == 2;
 }
 
-void CLangInfo::LoadTokens(const TiXmlNode* pTokens, std::set<std::string>& vecTokens)
+void CLangInfo::LoadTokens(const TiXmlNode* pTokens, Tokens& vecTokens)
 {
   if (pTokens && !pTokens->NoChildren())
   {

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -198,7 +198,8 @@ public:
   static std::string GetLanguageInfoPath(const std::string &language);
   bool UseLocaleCollation();
 
-  static void LoadTokens(const TiXmlNode* pTokens, std::set<std::string>& vecTokens);
+  using Tokens = std::set<std::string, std::less<>>;
+  static void LoadTokens(const TiXmlNode* pTokens, Tokens& vecTokens);
 
   static void SettingOptionsLanguageNamesFiller(const std::shared_ptr<const CSetting>& setting,
                                                 std::vector<StringSettingOption>& list,

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -505,7 +505,8 @@ void CAddonSettings::InitializeConditions()
   CSettingConditions::Initialize();
 
   // add basic conditions
-  const std::set<std::string>& simpleConditions = CSettingConditions::GetSimpleConditions();
+  const CSettingConditions::SimpleConditions& simpleConditions =
+      CSettingConditions::GetSimpleConditions();
   for (const auto& condition : simpleConditions)
     GetSettingsManager()->AddCondition(condition);
 

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -220,11 +220,11 @@ static int ExportLibrary(const std::vector<std::string>& params)
     {
       CLibExportSettings settings;
       // ELIBEXPORT_SINGLEFILE, ELIBEXPORT_ALBUMS + ELIBEXPORT_ALBUMARTISTS by default
-      settings.m_strPath = path;
+      settings.SetPath(path);
       if (!singleFile)
         settings.SetExportType(ELIBEXPORT_TOLIBRARYFOLDER);
-      settings.m_artwork = thumbs;
-      settings.m_overwrite = overwrite;
+      settings.SetArtwork(thumbs);
+      settings.SetOverwrite(overwrite);
       // Export music library (not showing progress dialog)
       CMusicLibraryQueue::GetInstance().ExportLibrary(settings, false);
     }
@@ -253,27 +253,27 @@ static int ExportLibrary2(const std::vector<std::string>& params)
   CLibExportSettings settings;
   if (params.size() < 3)
     return -1;
-  settings.m_strPath = params[2];
+  settings.SetPath(params[2]);
   settings.SetExportType(ELIBEXPORT_SINGLEFILE);
   if (StringUtils::EqualsNoCase(params[1], "separate"))
     settings.SetExportType(ELIBEXPORT_SEPARATEFILES);
   else if (StringUtils::EqualsNoCase(params[1], "library"))
   {
     settings.SetExportType(ELIBEXPORT_TOLIBRARYFOLDER);
-    settings.m_strPath.clear();
+    settings.SetPath("");
   }
   settings.ClearItems();
 
   for (unsigned int i = 2; i < params.size(); i++)
   {
     if (StringUtils::EqualsNoCase(params[i], "artwork"))
-      settings.m_artwork = true;
+      settings.SetArtwork(true);
     else if (StringUtils::EqualsNoCase(params[i], "overwrite"))
-      settings.m_overwrite = true;
+      settings.SetOverwrite(true);
     else if (StringUtils::EqualsNoCase(params[i], "unscraped"))
-      settings.m_unscraped = true;
+      settings.SetUnscraped(true);
     else if (StringUtils::EqualsNoCase(params[i], "skipnfo"))
-      settings.m_skipnfo = true;
+      settings.SetSkipNfo(true);
     else if (StringUtils::EqualsNoCase(params[i], "albums"))
       settings.AddItem(ELIBEXPORT_ALBUMS);
     else if (StringUtils::EqualsNoCase(params[i], "albumartists"))
@@ -294,8 +294,9 @@ static int ExportLibrary2(const std::vector<std::string>& params)
   {
     CVideoDatabase videodatabase;
     videodatabase.Open();
-    videodatabase.ExportToXML(settings.m_strPath, settings.IsSingleFile(),
-      settings.m_artwork, settings.IsItemExported(ELIBEXPORT_ACTORTHUMBS), settings.m_overwrite);
+    videodatabase.ExportToXML(settings.GetPath(), settings.IsSingleFile(), settings.IsArtwork(),
+                              settings.IsItemExported(ELIBEXPORT_ACTORTHUMBS),
+                              settings.IsOverwrite());
     videodatabase.Close();
   }
   return 0;

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -11862,18 +11862,18 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
     return;
 
   // Exporting albums either art or NFO (or both) selected
-  if ((settings.IsToLibFolders() || settings.IsSeparateFiles()) && settings.m_skipnfo &&
-      !settings.m_artwork && settings.IsItemExported(ELIBEXPORT_ALBUMS))
+  if ((settings.IsToLibFolders() || settings.IsSeparateFiles()) && settings.IsSkipNfo() &&
+      !settings.IsArtwork() && settings.IsItemExported(ELIBEXPORT_ALBUMS))
     return;
 
   std::string strFolder;
   if (settings.IsSingleFile() || settings.IsSeparateFiles())
   {
     // Exporting to single file or separate files in a specified location
-    if (settings.m_strPath.empty())
+    if (settings.GetPath().empty())
       return;
 
-    strFolder = settings.m_strPath;
+    strFolder = settings.GetPath();
     if (!URIUtils::HasSlashAtEnd(strFolder))
       URIUtils::AddSlashAtEnd(strFolder);
     strFolder = URIUtils::GetDirectory(strFolder);
@@ -11895,7 +11895,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
   bool artistfoldersonly;
   artistfoldersonly = settings.IsArtistFoldersOnly() ||
                       ((settings.IsToLibFolders() || settings.IsSeparateFiles()) &&
-                       settings.m_skipnfo && !settings.m_artwork);
+                       settings.IsSkipNfo() && !settings.IsArtwork());
 
   int iFailCount = 0;
   try
@@ -11926,7 +11926,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
       std::vector<int> albumIds;
       std::string strSQL = PrepareSQL("SELECT idAlbum FROM album WHERE strReleaseType = '%s' ",
                                       CAlbum::ReleaseTypeToString(CAlbum::Album).c_str());
-      if (!settings.m_unscraped)
+      if (!settings.IsUnscraped())
         strSQL += "AND lastScraped IS NOT NULL";
       CLog::Log(LOGDEBUG, "CMusicDatabase::{} - {}", __FUNCTION__, strSQL);
       m_pDS->query(strSQL);
@@ -12017,12 +12017,12 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
           }
           if (pathfound)
           {
-            if (!settings.m_skipnfo)
+            if (!settings.IsSkipNfo())
             {
               // Save album to NFO, including album path
               album.Save(pMain, "album", strAlbumPath);
               std::string nfoFile = URIUtils::AddFileToFolder(strPath, "album.nfo");
-              if (settings.m_overwrite || !CFile::Exists(nfoFile))
+              if (settings.IsOverwrite() || !CFile::Exists(nfoFile))
               {
                 if (!xmlDoc.SaveFile(nfoFile))
                 {
@@ -12035,7 +12035,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
                 }
               }
             }
-            if (settings.m_artwork)
+            if (settings.IsArtwork())
             {
               // Save art in album folder
               // Note thumb resolution may be lower than original when overwriting
@@ -12050,7 +12050,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
                   else
                     savedArtfile = URIUtils::AddFileToFolder(strPath, art.first);
                   CServiceBroker::GetTextureCache()->Export(art.second, savedArtfile,
-                                                            settings.m_overwrite);
+                                                            settings.IsOverwrite());
                 }
               }
             }
@@ -12105,7 +12105,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
             "WHERE song_artist.idArtist = artist.idArtist AND song_artist.idRole > 1)",
             false);
 
-      if (!settings.m_unscraped && !artistfoldersonly)
+      if (!settings.IsUnscraped() && !artistfoldersonly)
         filter.AppendWhere("lastScraped IS NOT NULL", true);
 
       std::string strSQL = "SELECT idArtist FROM artist";
@@ -12163,11 +12163,11 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
           {
             if (!artistfoldersonly)
             {
-              if (!settings.m_skipnfo)
+              if (!settings.IsSkipNfo())
               {
                 artist.Save(pMain, "artist", strPath);
                 std::string nfoFile = URIUtils::AddFileToFolder(strPath, "artist.nfo");
-                if (settings.m_overwrite || !CFile::Exists(nfoFile))
+                if (settings.IsOverwrite() || !CFile::Exists(nfoFile))
                 {
                   if (!xmlDoc.SaveFile(nfoFile))
                   {
@@ -12180,7 +12180,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
                   }
                 }
               }
-              if (settings.m_artwork)
+              if (settings.IsArtwork())
               {
                 std::string savedArtfile;
                 if (GetArtForItem(artist.idArtist, MediaTypeArtist, artwork))
@@ -12192,7 +12192,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
                     else
                       savedArtfile = URIUtils::AddFileToFolder(strPath, art.first);
                     CServiceBroker::GetTextureCache()->Export(art.second, savedArtfile,
-                                                              settings.m_overwrite);
+                                                              settings.IsOverwrite());
                   }
                 }
               }

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -8,13 +8,13 @@
 
 #pragma once
 
+#include "LangInfo.h"
 #include "pictures/PictureScalingAlgorithm.h"
 #include "settings/lib/ISettingCallback.h"
 #include "settings/lib/ISettingsHandler.h"
 #include "utils/SortUtils.h"
 
 #include <cstdint>
-#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -73,11 +73,10 @@ struct TVShowRegexp
   bool byTitle;
   std::string regexp;
   int defaultSeason;
-  TVShowRegexp(bool d, const std::string& r, int s = 1, bool t = false) : regexp(r)
+
+  TVShowRegexp(bool d, const std::string& r, int s = 1, bool t = false)
+    : byDate(d), byTitle(t), regexp(r), defaultSeason(s)
   {
-    byDate = d;
-    defaultSeason = s;
-    byTitle = t;
   }
 };
 
@@ -102,12 +101,12 @@ struct RefreshVideoLatency
   float hdrextradelay;
 };
 
-typedef std::vector<TVShowRegexp> SETTINGS_TVSHOWLIST;
+using SETTINGS_TVSHOWLIST = std::vector<TVShowRegexp>;
 
 class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 {
   public:
-    CAdvancedSettings();
+    CAdvancedSettings() = default;
 
     void OnSettingsLoaded() override;
     void OnSettingsUnloaded() override;
@@ -122,7 +121,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     static void GetCustomTVRegexps(TiXmlElement *pRootElement, SETTINGS_TVSHOWLIST& settings);
     static void GetCustomRegexps(TiXmlElement *pRootElement, std::vector<std::string> &settings);
-    static void GetCustomExtensions(TiXmlElement *pRootElement, std::string& extensions);
+    static void GetCustomExtensions(const TiXmlElement* pRootElement, std::string& extensions);
 
     std::string m_audioDefaultPlayer;
     float m_audioPlayCountMinimumPercent;
@@ -224,7 +223,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::vector<std::string> m_trailerMatchRegExps;
     SETTINGS_TVSHOWLIST m_tvshowEnumRegExps;
     std::string m_tvshowMultiPartEnumRegExp;
-    typedef std::vector< std::pair<std::string, std::string> > StringMapping;
+    using StringMapping = std::vector<std::pair<std::string, std::string>>;
     StringMapping m_pathSubstitutions;
     int m_remoteDelay; ///< \brief number of remote messages to ignore before repeating
     bool m_bScanIRServer;
@@ -276,7 +275,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_caseSensitiveLocalArtMatch{true};
     int m_minimumEpisodePlaylistDuration; // seconds
 
-    std::set<std::string> m_vecTokens;
+    CLangInfo::Tokens m_vecTokens;
 
     int m_iEpgUpdateCheckInterval;  // seconds
     int m_iEpgCleanupInterval;      // seconds
@@ -307,7 +306,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::string m_caTrustFile;
 
     bool m_minimizeToTray; /* win32 only */
-    bool m_fullScreen;
+    bool m_fullScreen{false};
     bool m_startFullScreen;
     bool m_showExitButton; /* Ideal for appliances to hide a 'useless' button */
     bool m_canWindowed;
@@ -359,8 +358,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::vector<std::string> m_settingsFiles;
     void ParseSettingsFile(const std::string &file);
 
-    float GetLatencyTweak(float refreshrate, bool isHDREnabled);
-    bool m_initialized;
+    float GetLatencyTweak(float refreshrate, bool isHDREnabled) const;
+    bool m_initialized{false};
 
     void SetDebugMode(bool debug);
 
@@ -390,5 +389,5 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
   private:
     void Initialize();
     void Clear();
-    void SetExtraArtwork(const TiXmlElement* arttypes, std::vector<std::string>& artworkMap);
+    void SetExtraArtwork(const TiXmlElement* arttypes, std::vector<std::string>& artworkMap) const;
 };

--- a/xbmc/settings/DiscSettings.cpp
+++ b/xbmc/settings/DiscSettings.cpp
@@ -31,7 +31,7 @@ CDiscSettings& CDiscSettings::GetInstance()
 void CDiscSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)
 {
 #if (BLURAY_VERSION >= BLURAY_VERSION_CODE(1,0,1))
-  if (setting == NULL)
+  if (!setting)
     return;
 
   const std::string &settingId = setting->GetId();

--- a/xbmc/settings/DiscSettings.h
+++ b/xbmc/settings/DiscSettings.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "settings/lib/ISettingCallback.h"
+
 /**
 * Playback settings
 */
@@ -17,8 +19,6 @@ enum BDPlaybackMode
   BD_PLAYBACK_DISC_MENU,
   BD_PLAYBACK_MAIN_TITLE,
 };
-
-#include "settings/lib/ISettingCallback.h"
 
 class CDiscSettings : public ISettingCallback
 {

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -45,11 +45,13 @@ using namespace KODI::MESSAGING;
 
 using KODI::MESSAGING::HELPERS::DialogResponse;
 
+namespace
+{
 // 0.1 second increments
-#define MAX_REFRESH_CHANGE_DELAY 200
+static constexpr int MAX_REFRESH_CHANGE_DELAY = 200;
 
-static RESOLUTION_INFO EmptyResolution;
-static RESOLUTION_INFO EmptyModifiableResolution;
+const RESOLUTION_INFO EmptyResolution;
+RESOLUTION_INFO EmptyModifiableResolution;
 
 float square_error(float x, float y)
 {
@@ -58,7 +60,7 @@ float square_error(float x, float y)
   return std::max(yonx, xony);
 }
 
-static std::string ModeFlagsToString(unsigned int flags, bool identifier)
+std::string ModeFlagsToString(unsigned int flags, bool identifier)
 {
   std::string res;
   if(flags & D3DPRESENTFLAG_INTERLACED)
@@ -77,16 +79,11 @@ static std::string ModeFlagsToString(unsigned int flags, bool identifier)
     res += "std";
   return res;
 }
+} // unnamed namespace
 
 CDisplaySettings::CDisplaySettings()
 {
   m_resolutions.resize(RES_CUSTOM);
-
-  m_zoomAmount = 1.0f;
-  m_pixelRatio = 1.0f;
-  m_verticalShift = 0.0f;
-  m_nonLinearStretched = false;
-  m_resolutionChangeAborted = false;
 }
 
 CDisplaySettings::~CDisplaySettings() = default;
@@ -102,7 +99,7 @@ bool CDisplaySettings::Load(const TiXmlNode *settings)
   std::unique_lock lock(m_critical);
   m_calibrations.clear();
 
-  if (settings == NULL)
+  if (!settings)
     return false;
 
   const TiXmlElement *pElement = settings->FirstChildElement("resolutions");
@@ -163,44 +160,44 @@ bool CDisplaySettings::Load(const TiXmlNode *settings)
 
 bool CDisplaySettings::Save(TiXmlNode *settings) const
 {
-  if (settings == NULL)
+  if (!settings)
     return false;
 
   std::unique_lock lock(m_critical);
   TiXmlElement xmlRootElement("resolutions");
   TiXmlNode *pRoot = settings->InsertEndChild(xmlRootElement);
-  if (pRoot == NULL)
+  if (!pRoot)
     return false;
 
   // save calibrations
-  for (ResolutionInfos::const_iterator it = m_calibrations.begin(); it != m_calibrations.end(); ++it)
+  for (const auto& resInfo : m_calibrations)
   {
     // Write the resolution tag
     TiXmlElement resElement("resolution");
     TiXmlNode *pNode = pRoot->InsertEndChild(resElement);
-    if (pNode == NULL)
+    if (!pNode)
       return false;
 
     // Now write each of the pieces of information we need...
-    XMLUtils::SetString(pNode, "description", it->strMode);
-    XMLUtils::SetInt(pNode, "subtitles", it->iSubtitles);
-    XMLUtils::SetFloat(pNode, "pixelratio", it->fPixelRatio);
+    XMLUtils::SetString(pNode, "description", resInfo.strMode);
+    XMLUtils::SetInt(pNode, "subtitles", resInfo.iSubtitles);
+    XMLUtils::SetFloat(pNode, "pixelratio", resInfo.fPixelRatio);
 #ifdef HAVE_X11
-    XMLUtils::SetFloat(pNode, "refreshrate", it->fRefreshRate);
-    XMLUtils::SetString(pNode, "output", it->strOutput);
-    XMLUtils::SetString(pNode, "xrandrid", it->strId);
+    XMLUtils::SetFloat(pNode, "refreshrate", resInfo.fRefreshRate);
+    XMLUtils::SetString(pNode, "output", resInfo.strOutput);
+    XMLUtils::SetString(pNode, "xrandrid", resInfo.strId);
 #endif
 
     // create the overscan child
     TiXmlElement overscanElement("overscan");
     TiXmlNode *pOverscanNode = pNode->InsertEndChild(overscanElement);
-    if (pOverscanNode == NULL)
+    if (!pOverscanNode)
       return false;
 
-    XMLUtils::SetInt(pOverscanNode, "left", it->Overscan.left);
-    XMLUtils::SetInt(pOverscanNode, "top", it->Overscan.top);
-    XMLUtils::SetInt(pOverscanNode, "right", it->Overscan.right);
-    XMLUtils::SetInt(pOverscanNode, "bottom", it->Overscan.bottom);
+    XMLUtils::SetInt(pOverscanNode, "left", resInfo.Overscan.left);
+    XMLUtils::SetInt(pOverscanNode, "top", resInfo.Overscan.top);
+    XMLUtils::SetInt(pOverscanNode, "right", resInfo.Overscan.right);
+    XMLUtils::SetInt(pOverscanNode, "bottom", resInfo.Overscan.bottom);
   }
 
   return true;
@@ -221,7 +218,7 @@ void CDisplaySettings::Clear()
 
 void CDisplaySettings::OnSettingAction(const std::shared_ptr<const CSetting>& setting)
 {
-  if (setting == NULL)
+  if (!setting)
     return;
 
   const std::string &settingId = setting->GetId();
@@ -249,7 +246,7 @@ void CDisplaySettings::OnSettingAction(const std::shared_ptr<const CSetting>& se
 
 bool CDisplaySettings::OnSettingChanging(const std::shared_ptr<const CSetting>& setting)
 {
-  if (setting == NULL)
+  if (!setting)
     return false;
 
   const std::string &settingId = setting->GetId();
@@ -258,7 +255,8 @@ bool CDisplaySettings::OnSettingChanging(const std::shared_ptr<const CSetting>& 
   {
     RESOLUTION newRes = RES_DESKTOP;
     if (settingId == CSettings::SETTING_VIDEOSCREEN_RESOLUTION)
-      newRes = (RESOLUTION)std::static_pointer_cast<const CSettingInt>(setting)->GetValue();
+      newRes =
+          static_cast<RESOLUTION>(std::static_pointer_cast<const CSettingInt>(setting)->GetValue());
     else if (settingId == CSettings::SETTING_VIDEOSCREEN_SCREEN)
     {
       int screen = std::static_pointer_cast<const CSettingInt>(setting)->GetValue();
@@ -303,7 +301,7 @@ bool CDisplaySettings::OnSettingChanging(const std::shared_ptr<const CSetting>& 
   }
   else if (settingId == CSettings::SETTING_VIDEOSCREEN_MONITOR)
   {
-    auto winSystem = CServiceBroker::GetWinSystem();
+    CWinSystemBase* winSystem = CServiceBroker::GetWinSystem();
     if (winSystem->SupportsScreenMove())
     {
       const std::string screen =
@@ -341,7 +339,7 @@ bool CDisplaySettings::OnSettingChanging(const std::shared_ptr<const CSetting>& 
 #if defined(HAVE_X11) || defined(TARGET_WINDOWS_DESKTOP) || defined(TARGET_DARWIN_OSX)
   else if (settingId == CSettings::SETTING_VIDEOSCREEN_BLANKDISPLAYS)
   {
-    auto winSystem = CServiceBroker::GetWinSystem();
+    CWinSystemBase* winSystem = CServiceBroker::GetWinSystem();
 #if defined(HAVE_X11)
     winSystem->UpdateResolutions();
 #elif defined(TARGET_WINDOWS_DESKTOP) || defined(TARGET_DARWIN_OSX)
@@ -358,7 +356,7 @@ bool CDisplaySettings::OnSettingUpdate(const std::shared_ptr<CSetting>& setting,
                                        const char* oldSettingId,
                                        const TiXmlNode* oldSettingNode)
 {
-  if (setting == NULL)
+  if (!setting)
     return false;
 
   const std::string &settingId = setting->GetId();
@@ -378,7 +376,8 @@ bool CDisplaySettings::OnSettingUpdate(const std::shared_ptr<CSetting>& setting,
   {
     std::shared_ptr<CSettingInt> stereomodeSetting = std::static_pointer_cast<CSettingInt>(setting);
     const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-    STEREOSCOPIC_PLAYBACK_MODE playbackMode = (STEREOSCOPIC_PLAYBACK_MODE) settings->GetInt(CSettings::SETTING_VIDEOPLAYER_STEREOSCOPICPLAYBACKMODE);
+    const auto playbackMode = static_cast<STEREOSCOPIC_PLAYBACK_MODE>(
+        settings->GetInt(CSettings::SETTING_VIDEOPLAYER_STEREOSCOPICPLAYBACKMODE));
     if (stereomodeSetting->GetValue() == RENDER_STEREO_MODE_OFF)
     {
       // if preferred playback mode was OFF, update playback mode to ignore
@@ -580,9 +579,10 @@ void CDisplaySettings::UpdateCalibrations()
 
   // Add new (unique) resolutions
   for (ResolutionInfos::const_iterator res(m_resolutions.cbegin() + RES_CUSTOM); res != m_resolutions.cend(); ++res)
-    if (std::find_if(m_calibrations.cbegin(), m_calibrations.cend(),
-      [&](const RESOLUTION_INFO& info) { return StringUtils::EqualsNoCase(res->strMode, info.strMode); }) == m_calibrations.cend())
-        m_calibrations.push_back(*res);
+    if (std::ranges::find_if(m_calibrations, [&](const RESOLUTION_INFO& info)
+                             { return StringUtils::EqualsNoCase(res->strMode, info.strMode); }) ==
+        m_calibrations.cend())
+      m_calibrations.emplace_back(*res);
 
   for (auto &cal : m_calibrations)
   {
@@ -648,9 +648,10 @@ RESOLUTION CDisplaySettings::GetResolutionFromString(const std::string &strResol
   else if (strResolution.size() >= 20)
   {
     // format: WWWWWHHHHHRRR.RRRRRP333, where W = width, H = height, R = refresh, P = interlace, 3 = stereo mode
-    int width = std::strtol(StringUtils::Mid(strResolution, 0,5).c_str(), NULL, 10);
-    int height = std::strtol(StringUtils::Mid(strResolution, 5,5).c_str(), NULL, 10);
-    float refresh = (float)std::strtod(StringUtils::Mid(strResolution, 10,9).c_str(), NULL);
+    const int width = std::strtol(StringUtils::Mid(strResolution, 0, 5).c_str(), nullptr, 10);
+    const int height = std::strtol(StringUtils::Mid(strResolution, 5, 5).c_str(), nullptr, 10);
+    const auto refresh =
+        static_cast<float>(std::strtod(StringUtils::Mid(strResolution, 10, 9).c_str(), nullptr));
     unsigned flags = 0;
 
     // look for 'i' and treat everything else as progressive,
@@ -664,7 +665,8 @@ RESOLUTION CDisplaySettings::GetResolutionFromString(const std::string &strResol
 
     std::map<RESOLUTION, RESOLUTION_INFO> resolutionInfos;
     for (size_t resolution = RES_DESKTOP; resolution < CDisplaySettings::GetInstance().ResolutionInfoSize(); resolution++)
-      resolutionInfos.insert(std::make_pair((RESOLUTION)resolution, CDisplaySettings::GetInstance().GetResolutionInfo(resolution)));
+      resolutionInfos.try_emplace(static_cast<RESOLUTION>(resolution),
+                                  CDisplaySettings::GetInstance().GetResolutionInfo(resolution));
 
     return FindBestMatchingResolution(resolutionInfos, width, height, refresh, flags);
   }
@@ -677,7 +679,8 @@ std::string CDisplaySettings::GetStringFromResolution(RESOLUTION resolution, flo
   if (resolution == RES_WINDOW)
     return "WINDOW";
 
-  if (resolution >= RES_DESKTOP && resolution < (RESOLUTION)CDisplaySettings::GetInstance().ResolutionInfoSize())
+  if (resolution >= RES_DESKTOP &&
+      resolution < static_cast<RESOLUTION>(CDisplaySettings::GetInstance().ResolutionInfoSize()))
   {
     const RESOLUTION_INFO &info = CDisplaySettings::GetInstance().GetResolutionInfo(resolution);
     // also handle RES_DESKTOP resolutions with non-default refresh rates
@@ -701,31 +704,29 @@ RESOLUTION CDisplaySettings::GetResolutionForScreen()
   return RES_DESKTOP;
 }
 
-static inline bool ModeSort(const StringSettingOption& i, const StringSettingOption& j)
-{
-  return (i.value > j.value);
-}
-
 void CDisplaySettings::SettingOptionsModesFiller(const std::shared_ptr<const CSetting>& setting,
                                                  std::vector<StringSettingOption>& list,
                                                  std::string& current)
 {
-  for (auto index = (unsigned int)RES_CUSTOM; index < CDisplaySettings::GetInstance().ResolutionInfoSize(); ++index)
+  for (unsigned int index = static_cast<unsigned int>(RES_CUSTOM);
+       index < CDisplaySettings::GetInstance().ResolutionInfoSize(); ++index)
   {
-    const auto mode = CDisplaySettings::GetInstance().GetResolutionInfo(index);
+    const RESOLUTION_INFO& mode = CDisplaySettings::GetInstance().GetResolutionInfo(index);
 
     if (mode.dwFlags ^ D3DPRESENTFLAG_INTERLACED)
     {
-      auto setting = GetStringFromResolution((RESOLUTION)index, mode.fRefreshRate);
+      const std::string screenmode =
+          GetStringFromResolution(static_cast<RESOLUTION>(index), mode.fRefreshRate);
 
       list.emplace_back(
           StringUtils::Format("{}x{}{} {:0.2f}Hz", mode.iScreenWidth, mode.iScreenHeight,
                               ModeFlagsToString(mode.dwFlags, false), mode.fRefreshRate),
-          setting);
+          screenmode);
     }
   }
 
-  std::sort(list.begin(), list.end(), ModeSort);
+  std::ranges::sort(list, [](const StringSettingOption& i, const StringSettingOption& j)
+                    { return (i.value > j.value); });
 }
 
 void CDisplaySettings::SettingOptionsRefreshChangeDelaysFiller(
@@ -760,12 +761,13 @@ void CDisplaySettings::SettingOptionsRefreshRatesFiller(const SettingConstPtr& s
   std::vector<REFRESHRATE> refreshrates = CServiceBroker::GetWinSystem()->RefreshRates(resInfo.iScreenWidth, resInfo.iScreenHeight, resInfo.dwFlags);
 
   bool match = false;
-  for (std::vector<REFRESHRATE>::const_iterator refreshrate = refreshrates.begin(); refreshrate != refreshrates.end(); ++refreshrate)
+  for (const auto& refreshrate : refreshrates)
   {
-    std::string screenmode = GetStringFromResolution((RESOLUTION)refreshrate->ResInfo_Index, refreshrate->RefreshRate);
+    const std::string screenmode = GetStringFromResolution(
+        static_cast<RESOLUTION>(refreshrate.ResInfo_Index), refreshrate.RefreshRate);
     if (!match && StringUtils::EqualsNoCase(std::static_pointer_cast<const CSettingString>(setting)->GetValue(), screenmode))
       match = true;
-    list.emplace_back(StringUtils::Format("{:.2f}", refreshrate->RefreshRate), screenmode);
+    list.emplace_back(StringUtils::Format("{:.2f}", refreshrate.RefreshRate), screenmode);
   }
 
   if (!match)
@@ -787,27 +789,28 @@ void CDisplaySettings::SettingOptionsResolutionsFiller(const SettingConstPtr& se
   {
     std::map<RESOLUTION, RESOLUTION_INFO> resolutionInfos;
     std::vector<RESOLUTION_WHR> resolutions = CServiceBroker::GetWinSystem()->ScreenResolutions(info.fRefreshRate);
-    for (std::vector<RESOLUTION_WHR>::const_iterator resolution = resolutions.begin(); resolution != resolutions.end(); ++resolution)
+    for (const auto& resolution : resolutions)
     {
       const std::string resLabel =
-          StringUtils::Format("{}x{}{}{}", resolution->m_screenWidth, resolution->m_screenHeight,
-                              ModeFlagsToString(resolution->flags, false),
-                              resolution->width > resolution->m_screenWidth &&
-                                      resolution->height > resolution->m_screenHeight
+          StringUtils::Format("{}x{}{}{}", resolution.m_screenWidth, resolution.m_screenHeight,
+                              ModeFlagsToString(resolution.flags, false),
+                              resolution.width > resolution.m_screenWidth &&
+                                      resolution.height > resolution.m_screenHeight
                                   ? " (HiDPI)"
                                   : "");
-      list.emplace_back(resLabel, resolution->ResInfo_Index);
+      list.emplace_back(resLabel, resolution.ResInfo_Index);
 
-      resolutionInfos.insert(std::make_pair((RESOLUTION)resolution->ResInfo_Index, CDisplaySettings::GetInstance().GetResolutionInfo(resolution->ResInfo_Index)));
+      resolutionInfos.try_emplace(
+          static_cast<RESOLUTION>(resolution.ResInfo_Index),
+          CDisplaySettings::GetInstance().GetResolutionInfo(resolution.ResInfo_Index));
     }
 
     // ids are unique, so try to find a match by id first. Then resort to best matching resolution.
     if (!info.strId.empty())
     {
-      const auto it = std::find_if(resolutionInfos.begin(), resolutionInfos.end(),
-                                   [&](const std::pair<RESOLUTION, RESOLUTION_INFO>& resItem) {
-                                     return info.strId == resItem.second.strId;
-                                   });
+      const auto it = std::ranges::find_if(
+          resolutionInfos, [&info](const std::pair<RESOLUTION, RESOLUTION_INFO>& resItem)
+          { return info.strId == resItem.second.strId; });
       current =
           it != resolutionInfos.end()
               ? it->first
@@ -840,13 +843,13 @@ void CDisplaySettings::SettingOptionsStereoscopicModesFiller(
     const SettingConstPtr& setting, std::vector<IntegerSettingOption>& list, int& current)
 {
   CGUIComponent *gui = CServiceBroker::GetGUI();
-  if (gui != nullptr)
+  if (gui)
   {
     const CStereoscopicsManager &stereoscopicsManager = gui->GetStereoscopicsManager();
 
     for (int i = RENDER_STEREO_MODE_OFF; i < RENDER_STEREO_MODE_COUNT; i++)
     {
-      RENDER_STEREO_MODE mode = (RENDER_STEREO_MODE) i;
+      const auto mode = static_cast<RENDER_STEREO_MODE>(i);
       if (CServiceBroker::GetRenderSystem()->SupportsStereo(mode))
         list.emplace_back(stereoscopicsManager.GetLabelForStereoMode(mode), mode);
     }
@@ -863,7 +866,7 @@ void CDisplaySettings::SettingOptionsPreferredStereoscopicViewModesFiller(
   // don't add "off" to the list of preferred modes as this doesn't make sense
   for (int i = RENDER_STEREO_MODE_OFF +1; i < RENDER_STEREO_MODE_COUNT; i++)
   {
-    RENDER_STEREO_MODE mode = (RENDER_STEREO_MODE) i;
+    const auto mode = static_cast<RENDER_STEREO_MODE>(i);
     // also skip "mono" mode which is no real stereoscopic mode
     if (mode != RENDER_STEREO_MODE_MONO && CServiceBroker::GetRenderSystem()->SupportsStereo(mode))
       list.emplace_back(stereoscopicsManager.GetLabelForStereoMode(mode), mode);
@@ -874,15 +877,16 @@ void CDisplaySettings::SettingOptionsMonitorsFiller(const SettingConstPtr& setti
                                                     std::vector<StringSettingOption>& list,
                                                     std::string& current)
 {
-  auto winSystem = CServiceBroker::GetWinSystem();
+  CWinSystemBase* winSystem = CServiceBroker::GetWinSystem();
   if (!winSystem)
     return;
 
-  auto settingsComponent = CServiceBroker::GetSettingsComponent();
+  const std::shared_ptr<const CSettingsComponent> settingsComponent =
+      CServiceBroker::GetSettingsComponent();
   if (!settingsComponent)
     return;
 
-  auto settings = settingsComponent->GetSettings();
+  const std::shared_ptr<const CSettings> settings = settingsComponent->GetSettings();
   if (!settings)
     return;
 

--- a/xbmc/settings/DisplaySettings.h
+++ b/xbmc/settings/DisplaySettings.h
@@ -71,8 +71,14 @@ public:
 
   const RESOLUTION_INFO& GetCurrentResolutionInfo() const { return GetResolutionInfo(m_currentResolution); }
   RESOLUTION_INFO& GetCurrentResolutionInfo() { return GetResolutionInfo(m_currentResolution); }
-  RESOLUTION GetResFromString(const std::string &strResolution) { return GetResolutionFromString(strResolution); }
-  std::string GetStringFromRes(const RESOLUTION resolution, float refreshrate = 0.0f) { return GetStringFromResolution(resolution, refreshrate); }
+  RESOLUTION GetResFromString(const std::string& strResolution) const
+  {
+    return GetResolutionFromString(strResolution);
+  }
+  std::string GetStringFromRes(const RESOLUTION resolution, float refreshrate = 0.0f) const
+  {
+    return GetStringFromResolution(resolution, refreshrate);
+  }
 
   void ApplyCalibrations();
   void UpdateCalibrations();
@@ -146,15 +152,15 @@ private:
   // holds the real gui resolution
   RESOLUTION m_currentResolution;
 
-  typedef std::vector<RESOLUTION_INFO> ResolutionInfos;
+  using ResolutionInfos = std::vector<RESOLUTION_INFO>;
   ResolutionInfos m_resolutions;
   ResolutionInfos m_calibrations;
 
-  float m_zoomAmount;         // current zoom amount
-  float m_pixelRatio;         // current pixel ratio
-  float m_verticalShift;      // current vertical shift
-  bool  m_nonLinearStretched;   // current non-linear stretch
+  float m_zoomAmount{1.0f}; // current zoom amount
+  float m_pixelRatio{1.0f}; // current pixel ratio
+  float m_verticalShift{0.0f}; // current vertical shift
+  bool m_nonLinearStretched{false}; // current non-linear stretch
 
-  bool m_resolutionChangeAborted;
+  bool m_resolutionChangeAborted{false};
   mutable CCriticalSection m_critical;
 };

--- a/xbmc/settings/GameSettings.cpp
+++ b/xbmc/settings/GameSettings.cpp
@@ -35,7 +35,7 @@ bool CGameSettings::operator==(const CGameSettings &rhs) const
          m_rotationDegCCW == rhs.m_rotationDegCCW;
 }
 
-void CGameSettings::SetVideoFilter(const std::string &videoFilter)
+void CGameSettings::SetVideoFilter(std::string_view videoFilter)
 {
   if (videoFilter != m_videoFilter)
   {

--- a/xbmc/settings/GameSettings.h
+++ b/xbmc/settings/GameSettings.h
@@ -12,6 +12,7 @@
 #include "utils/Observer.h"
 
 #include <string>
+#include <string_view>
 
 class CGameSettings : public Observable
 {
@@ -24,11 +25,10 @@ public:
   // Restore game settings to default
   void Reset();
 
-  bool operator==(const CGameSettings &rhs) const;
-  bool operator!=(const CGameSettings &rhs) const { return !(*this == rhs); }
+  bool operator==(const CGameSettings& rhs) const;
 
   const std::string &VideoFilter() const { return m_videoFilter; }
-  void SetVideoFilter(const std::string &videoFilter);
+  void SetVideoFilter(std::string_view videoFilter);
 
   KODI::RETRO::STRETCHMODE StretchMode() const { return m_stretchMode; }
   void SetStretchMode(KODI::RETRO::STRETCHMODE stretchMode);

--- a/xbmc/settings/LibExportSettings.cpp
+++ b/xbmc/settings/LibExportSettings.cpp
@@ -15,16 +15,6 @@
 // Construction/Destruction
 //////////////////////////////////////////////////////////////////////
 
-CLibExportSettings::CLibExportSettings()
-{
-  m_exporttype = ELIBEXPORT_SINGLEFILE;
-  m_itemstoexport = ELIBEXPORT_ALBUMS + ELIBEXPORT_ALBUMARTISTS;
-  m_overwrite = false;
-  m_artwork = false;
-  m_unscraped  = false;
-  m_skipnfo = false;
-}
-
 bool CLibExportSettings::operator!=(const CLibExportSettings &right) const
 {
   if (m_exporttype != right.m_exporttype)

--- a/xbmc/settings/LibExportSettings.h
+++ b/xbmc/settings/LibExportSettings.h
@@ -38,31 +38,42 @@ enum ELIBEXPORTOPTIONS
 class CLibExportSettings
 {
 public:
-  CLibExportSettings();
+  CLibExportSettings() = default;
   ~CLibExportSettings() = default;
 
   bool operator!=(const CLibExportSettings &right) const;
+
+  const std::string& GetPath() const { return m_strPath; }
+  void SetPath(const std::string& path) { m_strPath = path; }
+  bool IsOverwrite() const { return m_overwrite; }
+  void SetOverwrite(bool set) { m_overwrite = set; }
+  bool IsArtwork() const { return m_artwork; }
+  void SetArtwork(bool set) { m_artwork = set; }
+  bool IsUnscraped() const { return m_unscraped; }
+  void SetUnscraped(bool set) { m_unscraped = set; }
+  bool IsSkipNfo() const { return m_skipnfo; }
+  void SetSkipNfo(bool set) { m_skipnfo = set; }
   bool IsItemExported(ELIBEXPORTOPTIONS item) const;
   bool IsArtists() const;
   std::vector<int> GetExportItems() const;
   std::vector<int> GetLimitedItems(int items) const;
   void ClearItems() { m_itemstoexport = 0; }
   void AddItem(ELIBEXPORTOPTIONS item) { m_itemstoexport += item; }
-  unsigned int GetItemsToExport() { return m_itemstoexport; }
+  unsigned int GetItemsToExport() const { return m_itemstoexport; }
   void SetItemsToExport(int itemstoexport) { m_itemstoexport = static_cast<unsigned int>(itemstoexport); }
-  unsigned int GetExportType() { return m_exporttype; }
+  unsigned int GetExportType() const { return m_exporttype; }
   void SetExportType(int exporttype) { m_exporttype = static_cast<unsigned int>(exporttype); }
   bool IsSingleFile() const;
   bool IsSeparateFiles() const;
   bool IsToLibFolders() const;
   bool IsArtistFoldersOnly() const;
 
-  std::string m_strPath;
-  bool m_overwrite;
-  bool m_artwork;
-  bool m_unscraped;
-  bool m_skipnfo;
 private:
-  unsigned int m_exporttype; //singlefile, separate files, to library folder
-  unsigned int m_itemstoexport;
+  std::string m_strPath;
+  bool m_overwrite{false};
+  bool m_artwork{false};
+  bool m_unscraped{false};
+  bool m_skipnfo{false};
+  unsigned int m_exporttype{ELIBEXPORT_SINGLEFILE}; //singlefile, separate files, to library folder
+  unsigned int m_itemstoexport{ELIBEXPORT_ALBUMS + ELIBEXPORT_ALBUMARTISTS};
 };

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -40,28 +40,6 @@ using namespace KODI::MESSAGING;
 
 using KODI::MESSAGING::HELPERS::DialogResponse;
 
-CMediaSettings::CMediaSettings()
-{
-  m_watchedModes["files"] = WatchedModeAll;
-  m_watchedModes["movies"] = WatchedModeAll;
-  m_watchedModes["tvshows"] = WatchedModeAll;
-  m_watchedModes["musicvideos"] = WatchedModeAll;
-  m_watchedModes["recordings"] = WatchedModeAll;
-
-  m_musicPlaylistRepeat = false;
-  m_musicPlaylistShuffle = false;
-  m_videoPlaylistRepeat = false;
-  m_videoPlaylistShuffle = false;
-
-  m_mediaStartWindowed = false;
-  m_additionalSubtitleDirectoryChecked = 0;
-
-  m_musicNeedsUpdate = 0;
-  m_videoNeedsUpdate = 0;
-}
-
-CMediaSettings::~CMediaSettings() = default;
-
 CMediaSettings& CMediaSettings::GetInstance()
 {
   static CMediaSettings sMediaSettings;
@@ -70,12 +48,12 @@ CMediaSettings& CMediaSettings::GetInstance()
 
 bool CMediaSettings::Load(const TiXmlNode *settings)
 {
-  if (settings == NULL)
+  if (!settings)
     return false;
 
   std::unique_lock lock(m_critical);
   const TiXmlElement *pElement = settings->FirstChildElement("defaultvideosettings");
-  if (pElement != NULL)
+  if (pElement)
   {
     int interlaceMethod;
     XMLUtils::GetInt(pElement, "interlacemethod", interlaceMethod, VS_INTERLACEMETHOD_NONE, VS_INTERLACEMETHOD_MAX);
@@ -129,7 +107,7 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
 
   m_defaultGameSettings.Reset();
   pElement = settings->FirstChildElement("defaultgamesettings");
-  if (pElement != nullptr)
+  if (pElement)
   {
     std::string videoFilter;
     if (XMLUtils::GetString(pElement, "videofilter", videoFilter))
@@ -149,10 +127,10 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
 
   // mymusic settings
   pElement = settings->FirstChildElement("mymusic");
-  if (pElement != NULL)
+  if (pElement)
   {
     const TiXmlElement *pChild = pElement->FirstChildElement("playlist");
-    if (pChild != NULL)
+    if (pChild)
     {
       XMLUtils::GetBoolean(pChild, "repeat", m_musicPlaylistRepeat);
       XMLUtils::GetBoolean(pChild, "shuffle", m_musicPlaylistShuffle);
@@ -172,7 +150,7 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
 
   // Read the watchmode settings for the various media views
   pElement = settings->FirstChildElement("myvideos");
-  if (pElement != NULL)
+  if (pElement)
   {
     int tmp;
     if (XMLUtils::GetInt(pElement, "watchmodemovies", tmp, (int)WatchedModeAll, (int)WatchedModeWatched))
@@ -185,7 +163,7 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
       m_watchedModes["recordings"] = static_cast<WatchedMode>(tmp);
 
     const TiXmlElement *pChild = pElement->FirstChildElement("playlist");
-    if (pChild != NULL)
+    if (pChild)
     {
       XMLUtils::GetBoolean(pChild, "repeat", m_videoPlaylistRepeat);
       XMLUtils::GetBoolean(pChild, "shuffle", m_videoPlaylistShuffle);
@@ -208,14 +186,14 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
 
 bool CMediaSettings::Save(TiXmlNode *settings) const
 {
-  if (settings == NULL)
+  if (!settings)
     return false;
 
   std::unique_lock lock(m_critical);
   // default video settings
   TiXmlElement videoSettingsNode("defaultvideosettings");
   TiXmlNode *pNode = settings->InsertEndChild(videoSettingsNode);
-  if (pNode == NULL)
+  if (!pNode)
     return false;
 
   XMLUtils::SetInt(pNode, "interlacemethod", m_defaultVideoSettings.m_InterlaceMethod);
@@ -243,13 +221,13 @@ bool CMediaSettings::Save(TiXmlNode *settings) const
   // default audio settings for dsp addons
   TiXmlElement audioSettingsNode("defaultaudiosettings");
   pNode = settings->InsertEndChild(audioSettingsNode);
-  if (pNode == NULL)
+  if (!pNode)
     return false;
 
   // Default game settings
   TiXmlElement gameSettingsNode("defaultgamesettings");
   pNode = settings->InsertEndChild(gameSettingsNode);
-  if (pNode == nullptr)
+  if (!pNode)
     return false;
 
   XMLUtils::SetString(pNode, "videofilter", m_defaultGameSettings.VideoFilter());
@@ -259,17 +237,17 @@ bool CMediaSettings::Save(TiXmlNode *settings) const
 
   // mymusic
   pNode = settings->FirstChild("mymusic");
-  if (pNode == NULL)
+  if (!pNode)
   {
     TiXmlElement videosNode("mymusic");
     pNode = settings->InsertEndChild(videosNode);
-    if (pNode == NULL)
+    if (!pNode)
       return false;
   }
 
   TiXmlElement musicPlaylistNode("playlist");
   TiXmlNode *playlistNode = pNode->InsertEndChild(musicPlaylistNode);
-  if (playlistNode == NULL)
+  if (!playlistNode)
     return false;
   XMLUtils::SetBoolean(playlistNode, "repeat", m_musicPlaylistRepeat);
   XMLUtils::SetBoolean(playlistNode, "shuffle", m_musicPlaylistShuffle);
@@ -278,11 +256,11 @@ bool CMediaSettings::Save(TiXmlNode *settings) const
 
   // myvideos
   pNode = settings->FirstChild("myvideos");
-  if (pNode == NULL)
+  if (!pNode)
   {
     TiXmlElement videosNode("myvideos");
     pNode = settings->InsertEndChild(videosNode);
-    if (pNode == NULL)
+    if (!pNode)
       return false;
   }
 
@@ -293,7 +271,7 @@ bool CMediaSettings::Save(TiXmlNode *settings) const
 
   TiXmlElement videoPlaylistNode("playlist");
   playlistNode = pNode->InsertEndChild(videoPlaylistNode);
-  if (playlistNode == NULL)
+  if (!playlistNode)
     return false;
   XMLUtils::SetBoolean(playlistNode, "repeat", m_videoPlaylistRepeat);
   XMLUtils::SetBoolean(playlistNode, "shuffle", m_videoPlaylistShuffle);
@@ -305,7 +283,7 @@ bool CMediaSettings::Save(TiXmlNode *settings) const
 
 void CMediaSettings::OnSettingAction(const std::shared_ptr<const CSetting>& setting)
 {
-  if (setting == NULL)
+  if (!setting)
     return;
 
   const std::string &settingId = setting->GetId();
@@ -376,7 +354,7 @@ void CMediaSettings::OnSettingAction(const std::shared_ptr<const CSetting>& sett
 
 void CMediaSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)
 {
-  if (setting == nullptr)
+  if (!setting)
     return;
 
   if (setting->GetId() == CSettings::SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS)

--- a/xbmc/settings/MediaSettings.h
+++ b/xbmc/settings/MediaSettings.h
@@ -19,16 +19,17 @@
 #include <map>
 #include <string>
 
-#define VOLUME_DRC_MINIMUM 0    // 0dB
-#define VOLUME_DRC_MAXIMUM 6000 // 60dB
+constexpr int VOLUME_DRC_MINIMUM = 0; // 0dB
+constexpr int VOLUME_DRC_MAXIMUM = 6000; // 60dB
 
 class TiXmlNode;
 
-typedef enum {
-  WatchedModeAll        = 0,
+enum WatchedMode
+{
+  WatchedModeAll = 0,
   WatchedModeUnwatched,
   WatchedModeWatched
-} WatchedMode;
+};
 
 class CMediaSettings : public ISettingCallback, public ISettingsHandler, public ISubSettings
 {
@@ -86,10 +87,10 @@ public:
   void SetVideoNeedsUpdate(int version) { m_videoNeedsUpdate = version; }
 
 protected:
-  CMediaSettings();
+  CMediaSettings() = default;
   CMediaSettings(const CMediaSettings&) = delete;
   CMediaSettings& operator=(CMediaSettings const&) = delete;
-  ~CMediaSettings() override;
+  ~CMediaSettings() override = default;
 
   static std::string GetWatchedContent(const std::string &content);
 
@@ -99,19 +100,25 @@ private:
   CGameSettings m_defaultGameSettings;
   CGameSettings m_currentGameSettings;
 
-  typedef std::map<std::string, WatchedMode> WatchedModes;
-  WatchedModes m_watchedModes;
+  using WatchedModes = std::map<std::string, WatchedMode, std::less<>>;
+  WatchedModes m_watchedModes{{"files", WatchedModeAll},
+                              {"movies", WatchedModeAll},
+                              {"tvshows", WatchedModeAll},
+                              {"musicvideos", WatchedModeAll},
+                              {"recordings", WatchedModeAll}};
 
-  bool m_musicPlaylistRepeat;
-  bool m_musicPlaylistShuffle;
-  bool m_videoPlaylistRepeat;
-  bool m_videoPlaylistShuffle;
+  bool m_musicPlaylistRepeat{false};
+  bool m_musicPlaylistShuffle{false};
+  bool m_videoPlaylistRepeat{false};
+  bool m_videoPlaylistShuffle{false};
 
-  bool m_mediaStartWindowed;
-  int m_additionalSubtitleDirectoryChecked;
+  bool m_mediaStartWindowed{false};
+  int m_additionalSubtitleDirectoryChecked{0};
 
-  int m_musicNeedsUpdate; ///< if a database update means an update is required (set to the version number of the db)
-  int m_videoNeedsUpdate; ///< if a database update means an update is required (set to the version number of the db)
+  int m_musicNeedsUpdate{
+      0}; ///< if a database update means an update is required (set to the version number of the db)
+  int m_videoNeedsUpdate{
+      0}; ///< if a database update means an update is required (set to the version number of the db)
 
   mutable CCriticalSection m_critical;
 };

--- a/xbmc/settings/MediaSourceSettings.h
+++ b/xbmc/settings/MediaSourceSettings.h
@@ -12,6 +12,7 @@
 #include "settings/lib/ISettingsHandler.h"
 
 #include <string>
+#include <string_view>
 
 class CProfileManager;
 
@@ -32,18 +33,24 @@ public:
 
   bool Load();
   bool Load(const std::string &file);
-  bool Save();
+  bool Save() const;
   bool Save(const std::string &file) const;
   void Clear();
 
-  std::vector<CMediaSource>* GetSources(const std::string& type);
-  const std::string& GetDefaultSource(const std::string &type) const;
-  void SetDefaultSource(const std::string &type, const std::string &source);
+  std::vector<CMediaSource>* GetSources(std::string_view type);
+  const std::string& GetDefaultSource(std::string_view type) const;
+  void SetDefaultSource(std::string_view type, std::string_view source);
 
-  bool UpdateSource(const std::string &strType, const std::string &strOldName, const std::string &strUpdateChild, const std::string &strUpdateValue);
-  bool DeleteSource(const std::string &strType, const std::string &strName, const std::string &strPath, bool virtualSource = false);
-  bool AddShare(const std::string &type, const CMediaSource &share);
-  bool UpdateShare(const std::string &type, const std::string &oldName, const CMediaSource &share);
+  bool UpdateSource(std::string_view strType,
+                    std::string_view strOldName,
+                    std::string_view strUpdateChild,
+                    const std::string& strUpdateValue);
+  bool DeleteSource(std::string_view strType,
+                    std::string_view strName,
+                    std::string_view strPath,
+                    bool virtualSource = false);
+  bool AddShare(std::string_view type, const CMediaSource& share);
+  bool UpdateShare(std::string_view type, std::string_view oldName, const CMediaSource& share);
 
 protected:
   CMediaSourceSettings();
@@ -52,7 +59,9 @@ protected:
   ~CMediaSourceSettings() override;
 
 private:
-  bool GetSource(const std::string& category, const tinyxml2::XMLNode* source, CMediaSource& share);
+  bool GetSource(const std::string& category,
+                 const tinyxml2::XMLNode* source,
+                 CMediaSource& share) const;
   void GetSources(const tinyxml2::XMLNode* rootElement,
                   const std::string& tagName,
                   std::vector<CMediaSource>& items,

--- a/xbmc/settings/PlayerSettings.cpp
+++ b/xbmc/settings/PlayerSettings.cpp
@@ -15,9 +15,9 @@ void CPlayerSettings::SettingOptionsQueueTimeSizesFiller(const SettingConstPtr& 
                                                          std::vector<IntegerSettingOption>& list,
                                                          int& current)
 {
-  const auto& secFloat = g_localizeStrings.Get(13553);
-  const auto& seconds = g_localizeStrings.Get(37129);
-  const auto& second = g_localizeStrings.Get(37128);
+  const std::string& secFloat = g_localizeStrings.Get(13553);
+  const std::string& seconds = g_localizeStrings.Get(37129);
+  const std::string& second = g_localizeStrings.Get(37128);
 
   list.emplace_back(StringUtils::Format(secFloat, 0.5), 5);
   list.emplace_back(StringUtils::Format(second, 1), 10);
@@ -31,8 +31,8 @@ void CPlayerSettings::SettingOptionsQueueDataSizesFiller(const SettingConstPtr& 
                                                          std::vector<IntegerSettingOption>& list,
                                                          int& current)
 {
-  const auto& mb = g_localizeStrings.Get(37122);
-  const auto& gb = g_localizeStrings.Get(37123);
+  const std::string& mb = g_localizeStrings.Get(37122);
+  const std::string& gb = g_localizeStrings.Get(37123);
 
   list.emplace_back(StringUtils::Format(mb, 16), 16);
   list.emplace_back(StringUtils::Format(mb, 32), 32);

--- a/xbmc/settings/ServicesSettings.cpp
+++ b/xbmc/settings/ServicesSettings.cpp
@@ -18,8 +18,8 @@ void CServicesSettings::SettingOptionsChunkSizesFiller(const SettingConstPtr& se
                                                        std::vector<IntegerSettingOption>& list,
                                                        int& current)
 {
-  const auto& kb = g_localizeStrings.Get(37121);
-  const auto& mb = g_localizeStrings.Get(37122);
+  const std::string& kb = g_localizeStrings.Get(37121);
+  const std::string& mb = g_localizeStrings.Get(37122);
 
   list.emplace_back(StringUtils::Format(kb, 16), 16);
   list.emplace_back(StringUtils::Format(kb, 32), 32);
@@ -45,8 +45,8 @@ void CServicesSettings::SettingOptionsMemorySizesFiller(const SettingConstPtr& s
                                                         std::vector<IntegerSettingOption>& list,
                                                         int& current)
 {
-  const auto& mb = g_localizeStrings.Get(37122);
-  const auto& gb = g_localizeStrings.Get(37123);
+  const std::string& mb = g_localizeStrings.Get(37122);
+  const std::string& gb = g_localizeStrings.Get(37123);
 
   list.emplace_back(StringUtils::Format(mb, 16), 16);
   list.emplace_back(StringUtils::Format(mb, 20), 20);
@@ -91,9 +91,9 @@ void CServicesSettings::SettingOptionsCacheChunkSizesFiller(const SettingConstPt
                                                             std::vector<IntegerSettingOption>& list,
                                                             int& current)
 {
-  const auto& byte = g_localizeStrings.Get(37120);
-  const auto& kb = g_localizeStrings.Get(37121);
-  const auto& mb = g_localizeStrings.Get(37122);
+  const std::string& byte = g_localizeStrings.Get(37120);
+  const std::string& kb = g_localizeStrings.Get(37121);
+  const std::string& mb = g_localizeStrings.Get(37122);
 
   list.emplace_back(StringUtils::Format(byte, 256), 256);
   list.emplace_back(StringUtils::Format(byte, 512), 512);

--- a/xbmc/settings/SettingAddon.cpp
+++ b/xbmc/settings/SettingAddon.cpp
@@ -39,13 +39,12 @@ SettingPtr CSettingAddon::Clone(const std::string &id) const
 
 bool CSettingAddon::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
-  std::unique_lock<CSharedSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
 
   if (!CSettingString::Deserialize(node, update))
     return false;
 
-  if (m_control != nullptr &&
-     (m_control->GetType() != "button" || m_control->GetFormat() != "addon"))
+  if (m_control && (m_control->GetType() != "button" || m_control->GetFormat() != "addon"))
   {
     CLog::Log(LOGERROR, "CSettingAddon: invalid <control> of \"{}\"", m_id);
     return false;
@@ -53,8 +52,8 @@ bool CSettingAddon::Deserialize(const TiXmlNode *node, bool update /* = false */
 
   bool ok = false;
   std::string strAddonType;
-  auto constraints = node->FirstChild("constraints");
-  if (constraints != nullptr)
+  const TiXmlNode* constraints = node->FirstChild("constraints");
+  if (constraints)
   {
     // get the addon type
     if (XMLUtils::GetString(constraints, "addontype", strAddonType) && !strAddonType.empty())
@@ -79,6 +78,6 @@ void CSettingAddon::copyaddontype(const CSettingAddon &setting)
 {
   CSettingString::Copy(setting);
 
-  std::unique_lock<CSharedSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   m_addonType = setting.m_addonType;
 }

--- a/xbmc/settings/SettingConditions.h
+++ b/xbmc/settings/SettingConditions.h
@@ -24,17 +24,20 @@ public:
 
   static const CProfile& GetCurrentProfile();
 
-  static const std::set<std::string>& GetSimpleConditions() { return m_simpleConditions; }
-  static const std::map<std::string, SettingConditionCheck>& GetComplexConditions() { return m_complexConditions; }
+  using SimpleConditions = std::set<std::string, std::less<>>;
+  static SimpleConditions& GetSimpleConditions() { return m_simpleConditions; }
+
+  using ComplexConditions = std::map<std::string, SettingConditionCheck, std::less<>>;
+  static const ComplexConditions& GetComplexConditions() { return m_complexConditions; }
 
   static bool Check(const std::string& condition,
                     const std::string& value = "",
-                    const std::shared_ptr<const CSetting>& setting = NULL);
+                    const std::shared_ptr<const CSetting>& setting = nullptr);
 
 private:
   // Initialization parameters
   static const CProfileManager *m_profileManager;
 
-  static std::set<std::string> m_simpleConditions;
-  static std::map<std::string, SettingConditionCheck> m_complexConditions;
+  static SimpleConditions m_simpleConditions;
+  static ComplexConditions m_complexConditions;
 };

--- a/xbmc/settings/SettingControl.cpp
+++ b/xbmc/settings/SettingControl.cpp
@@ -16,9 +16,12 @@
 
 #include <vector>
 
-const char* SHOW_ADDONS_ALL = "all";
-const char* SHOW_ADDONS_INSTALLED = "installed";
-const char* SHOW_ADDONS_INSTALLABLE = "installable";
+namespace
+{
+constexpr const char* SHOW_ADDONS_ALL = "all";
+constexpr const char* SHOW_ADDONS_INSTALLED = "installed";
+constexpr const char* SHOW_ADDONS_INSTALLABLE = "installable";
+} // unnamed namespace
 
 std::shared_ptr<ISettingControl> CSettingControlCreator::CreateControl(const std::string &controlType) const
 {
@@ -61,20 +64,20 @@ bool CSettingControlFormattedRange::Deserialize(const TiXmlNode *node, bool upda
     XMLUtils::GetInt(node, SETTING_XML_ELM_CONTROL_FORMATLABEL, m_formatLabel);
 
     // get the minimum label from <setting><constraints><minimum label="X" />
-    auto settingNode = node->Parent();
-    if (settingNode != nullptr)
+    const TiXmlNode* settingNode = node->Parent();
+    if (settingNode)
     {
-      auto constraintsNode = settingNode->FirstChild(SETTING_XML_ELM_CONSTRAINTS);
-      if (constraintsNode != nullptr)
+      const TiXmlNode* constraintsNode = settingNode->FirstChild(SETTING_XML_ELM_CONSTRAINTS);
+      if (constraintsNode)
       {
-        auto minimumNode = constraintsNode->FirstChild(SETTING_XML_ELM_MINIMUM);
-        if (minimumNode != nullptr)
+        const TiXmlNode* minimumNode = constraintsNode->FirstChild(SETTING_XML_ELM_MINIMUM);
+        if (minimumNode)
         {
-          auto minimumElem = minimumNode->ToElement();
-          if (minimumElem != nullptr)
+          const TiXmlElement* minimumElem = minimumNode->ToElement();
+          if (minimumElem && minimumElem->QueryIntAttribute(SETTING_XML_ATTR_LABEL,
+                                                            &m_minimumLabel) != TIXML_SUCCESS)
           {
-            if (minimumElem->QueryIntAttribute(SETTING_XML_ATTR_LABEL, &m_minimumLabel) != TIXML_SUCCESS)
-              m_minimumLabel = -1;
+            m_minimumLabel = -1;
           }
         }
       }
@@ -172,11 +175,11 @@ bool CSettingControlButton::Deserialize(const TiXmlNode *node, bool update /* = 
       else
         CLog::Log(LOGWARNING, "CSettingControlButton: invalid <show>");
 
-      auto show = node->FirstChildElement("show");
-      if (show != nullptr)
+      const TiXmlElement* show = node->FirstChildElement("show");
+      if (show)
       {
-        const char *strShowDetails = nullptr;
-        if ((strShowDetails = show->Attribute(SETTING_XML_ATTR_SHOW_DETAILS)) != nullptr)
+        const char* strShowDetails = show->Attribute(SETTING_XML_ATTR_SHOW_DETAILS);
+        if (strShowDetails)
         {
           if (StringUtils::EqualsNoCase(strShowDetails, "false") || StringUtils::EqualsNoCase(strShowDetails, "true"))
             m_showAddonDetails = StringUtils::EqualsNoCase(strShowDetails, "true");
@@ -186,8 +189,8 @@ bool CSettingControlButton::Deserialize(const TiXmlNode *node, bool update /* = 
 
         if (!m_showInstallableAddons)
         {
-          const char *strShowMore = nullptr;
-          if ((strShowMore = show->Attribute(SETTING_XML_ATTR_SHOW_MORE)) != nullptr)
+          const char* strShowMore = show->Attribute(SETTING_XML_ATTR_SHOW_MORE);
+          if (strShowMore)
           {
             if (StringUtils::EqualsNoCase(strShowMore, "false") || StringUtils::EqualsNoCase(strShowMore, "true"))
               m_showMoreAddons = StringUtils::EqualsNoCase(strShowMore, "true");
@@ -304,15 +307,15 @@ bool CSettingControlRange::Deserialize(const TiXmlNode *node, bool update /* = f
   if (!ISettingControl::Deserialize(node, update))
     return false;
 
-  auto formatLabel = node->FirstChildElement(SETTING_XML_ELM_CONTROL_FORMATLABEL);
-  if (formatLabel != nullptr)
+  const TiXmlElement* formatLabel = node->FirstChildElement(SETTING_XML_ELM_CONTROL_FORMATLABEL);
+  if (formatLabel)
   {
     XMLUtils::GetInt(node, SETTING_XML_ELM_CONTROL_FORMATLABEL, m_formatLabel);
     if (m_formatLabel < 0)
       return false;
 
-    auto formatValue = formatLabel->Attribute(SETTING_XML_ELM_CONTROL_FORMATVALUE);
-    if (formatValue != nullptr)
+    const char* formatValue = formatLabel->Attribute(SETTING_XML_ELM_CONTROL_FORMATVALUE);
+    if (formatValue)
     {
       if (StringUtils::IsInteger(formatValue))
         m_valueFormatLabel = (int)strtol(formatValue, nullptr, 0);

--- a/xbmc/settings/SettingControl.h
+++ b/xbmc/settings/SettingControl.h
@@ -14,20 +14,21 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <string_view>
 
-#define SETTING_XML_ELM_CONTROL_FORMATLABEL "formatlabel"
-#define SETTING_XML_ELM_CONTROL_HIDDEN "hidden"
-#define SETTING_XML_ELM_CONTROL_VERIFYNEW "verifynew"
-#define SETTING_XML_ELM_CONTROL_HEADING "heading"
-#define SETTING_XML_ELM_CONTROL_HIDEVALUE "hidevalue"
-#define SETTING_XML_ELM_CONTROL_MULTISELECT "multiselect"
-#define SETTING_XML_ELM_CONTROL_POPUP "popup"
-#define SETTING_XML_ELM_CONTROL_FORMATVALUE "value"
-#define SETTING_XML_ELM_CONTROL_ADDBUTTONLABEL "addbuttonlabel"
-#define SETTING_XML_ATTR_SHOW_MORE "more"
-#define SETTING_XML_ATTR_SHOW_DETAILS "details"
-#define SETTING_XML_ATTR_SEPARATOR_POSITION "separatorposition"
-#define SETTING_XML_ATTR_HIDE_SEPARATOR "hideseparator"
+constexpr const char* SETTING_XML_ELM_CONTROL_FORMATLABEL = "formatlabel";
+constexpr const char* SETTING_XML_ELM_CONTROL_HIDDEN = "hidden";
+constexpr const char* SETTING_XML_ELM_CONTROL_VERIFYNEW = "verifynew";
+constexpr const char* SETTING_XML_ELM_CONTROL_HEADING = "heading";
+constexpr const char* SETTING_XML_ELM_CONTROL_HIDEVALUE = "hidevalue";
+constexpr const char* SETTING_XML_ELM_CONTROL_MULTISELECT = "multiselect";
+constexpr const char* SETTING_XML_ELM_CONTROL_POPUP = "popup";
+constexpr const char* SETTING_XML_ELM_CONTROL_FORMATVALUE = "value";
+constexpr const char* SETTING_XML_ELM_CONTROL_ADDBUTTONLABEL = "addbuttonlabel";
+constexpr const char* SETTING_XML_ATTR_SHOW_MORE = "more";
+constexpr const char* SETTING_XML_ATTR_SHOW_DETAILS = "details";
+constexpr const char* SETTING_XML_ATTR_SEPARATOR_POSITION = "separatorposition";
+constexpr const char* SETTING_XML_ATTR_HIDE_SEPARATOR = "hideseparator";
 
 class CVariant;
 class TiXmlNode;
@@ -67,13 +68,14 @@ public:
   int GetFormatLabel() const { return m_formatLabel; }
   void SetFormatLabel(int formatLabel) { m_formatLabel = formatLabel; }
   const std::string& GetFormatString() const { return m_formatString; }
-  void SetFormatString(const std::string &formatString) { m_formatString = formatString; }
+  void SetFormatString(std::string_view formatString) { m_formatString = formatString; }
   int GetMinimumLabel() const { return m_minimumLabel; }
   void SetMinimumLabel(int minimumLabel) { m_minimumLabel = minimumLabel; }
 
 protected:
   CSettingControlFormattedRange() = default;
 
+private:
   int m_formatLabel = -1;
   std::string m_formatString = "{}";
   int m_minimumLabel = -1;
@@ -113,7 +115,7 @@ public:
   int GetHeading() const { return m_heading; }
   void SetHeading(int heading) { m_heading = heading; }
 
-protected:
+private:
   bool m_hidden = false;
   bool m_verifyNewValue = false;
   int m_heading = -1;
@@ -151,12 +153,12 @@ public:
 
   bool HasActionData() const { return !m_actionData.empty(); }
   const std::string& GetActionData() const { return m_actionData; }
-  void SetActionData(const std::string& actionData) { m_actionData = actionData; }
+  void SetActionData(std::string_view actionData) { m_actionData = actionData; }
 
   bool CloseDialog() const { return m_closeDialog; }
   void SetCloseDialog(bool closeDialog) { m_closeDialog = closeDialog; }
 
-protected:
+private:
   int m_heading = -1;
   bool m_hideValue = false;
 
@@ -205,7 +207,7 @@ public:
   bool UseDetails() const { return m_useDetails; }
   void SetUseDetails(bool useDetails) { m_useDetails = useDetails; }
 
-protected:
+private:
   int m_heading = -1;
   bool m_multiselect = false;
   bool m_hideValue = false;
@@ -216,11 +218,11 @@ protected:
 
 class CSettingControlSlider;
 using SettingControlSliderFormatter =
-    std::string (*)(const std::shared_ptr<const CSettingControlSlider>& control,
-                    const CVariant& value,
-                    const CVariant& minimum,
-                    const CVariant& step,
-                    const CVariant& maximum);
+    std::function<std::string(const std::shared_ptr<const CSettingControlSlider>& control,
+                              const CVariant& value,
+                              const CVariant& minimum,
+                              const CVariant& step,
+                              const CVariant& maximum)>;
 
 class CSettingControlSlider : public ISettingControl
 {
@@ -240,13 +242,13 @@ public:
   int GetFormatLabel() const { return m_formatLabel; }
   void SetFormatLabel(int formatLabel) { m_formatLabel = formatLabel; }
   const std::string& GetFormatString() const { return m_formatString; }
-  void SetFormatString(const std::string &formatString) { m_formatString = formatString; }
+  void SetFormatString(std::string_view formatString) { m_formatString = formatString; }
   std::string GetDefaultFormatString() const;
 
   const SettingControlSliderFormatter& GetFormatter() const { return m_formatter; }
-  void SetFormatter(SettingControlSliderFormatter formatter) { m_formatter = formatter; }
+  void SetFormatter(const SettingControlSliderFormatter& formatter) { m_formatter = formatter; }
 
-protected:
+private:
   int m_heading = -1;
   bool m_popup = false;
   int m_formatLabel = -1;
@@ -270,9 +272,9 @@ public:
   int GetValueFormatLabel() const { return m_valueFormatLabel; }
   void SetValueFormatLabel(int valueFormatLabel) { m_valueFormatLabel = valueFormatLabel; }
   const std::string& GetValueFormat() const { return m_valueFormat; }
-  void SetValueFormat(const std::string &valueFormat) { m_valueFormat = valueFormat; }
+  void SetValueFormat(std::string_view valueFormat) { m_valueFormat = valueFormat; }
 
-protected:
+private:
   int m_formatLabel = 21469;
   int m_valueFormatLabel = -1;
   std::string m_valueFormat = "{}";
@@ -293,7 +295,7 @@ public:
   bool IsSeparatorBelowLabel() const { return m_separatorBelowLabel; }
   void SetSeparatorBelowLabel(bool below) { m_separatorBelowLabel = below; }
 
-protected:
+private:
   bool m_separatorHidden = false;
   bool m_separatorBelowLabel = true;
 };

--- a/xbmc/settings/SettingDateTime.cpp
+++ b/xbmc/settings/SettingDateTime.cpp
@@ -13,11 +13,14 @@
 
 #include <shared_mutex>
 
-CSettingDate::CSettingDate(const std::string &id, CSettingsManager *settingsManager /* = NULL */)
+CSettingDate::CSettingDate(const std::string& id, CSettingsManager* settingsManager /* = nullptr */)
   : CSettingString(id, settingsManager)
 { }
 
-CSettingDate::CSettingDate(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager /* = NULL */)
+CSettingDate::CSettingDate(const std::string& id,
+                           int label,
+                           const std::string& value,
+                           CSettingsManager* settingsManager /* = nullptr */)
   : CSettingString(id, label, value, settingsManager)
 { }
 
@@ -32,7 +35,7 @@ SettingPtr CSettingDate::Clone(const std::string &id) const
 
 bool CSettingDate::CheckValidity(const std::string &value) const
 {
-  std::shared_lock<CSharedSection> lock(m_critical);
+  std::shared_lock lock(m_critical);
 
   if (!CSettingString::CheckValidity(value))
     return false;
@@ -50,11 +53,14 @@ bool CSettingDate::SetDate(const CDateTime& date)
   return SetValue(date.GetAsDBDate());
 }
 
-CSettingTime::CSettingTime(const std::string &id, CSettingsManager *settingsManager /* = NULL */)
+CSettingTime::CSettingTime(const std::string& id, CSettingsManager* settingsManager /* = nullptr */)
   : CSettingString(id, settingsManager)
 { }
 
-CSettingTime::CSettingTime(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager /* = NULL */)
+CSettingTime::CSettingTime(const std::string& id,
+                           int label,
+                           const std::string& value,
+                           CSettingsManager* settingsManager /* = nullptr */)
   : CSettingString(id, label, value, settingsManager)
 { }
 
@@ -69,7 +75,7 @@ SettingPtr CSettingTime::Clone(const std::string &id) const
 
 bool CSettingTime::CheckValidity(const std::string &value) const
 {
-  std::shared_lock<CSharedSection> lock(m_critical);
+  std::shared_lock lock(m_critical);
 
   if (!CSettingString::CheckValidity(value))
     return false;

--- a/xbmc/settings/SettingDateTime.h
+++ b/xbmc/settings/SettingDateTime.h
@@ -15,8 +15,11 @@ class CDateTime;
 class CSettingDate : public CSettingString
 {
 public:
-  CSettingDate(const std::string &id, CSettingsManager *settingsManager = NULL);
-  CSettingDate(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager = NULL);
+  CSettingDate(const std::string& id, CSettingsManager* settingsManager = nullptr);
+  CSettingDate(const std::string& id,
+               int label,
+               const std::string& value,
+               CSettingsManager* settingsManager = nullptr);
   CSettingDate(const std::string &id, const CSettingDate &setting);
   ~CSettingDate() override = default;
 
@@ -31,8 +34,11 @@ public:
 class CSettingTime : public CSettingString
 {
 public:
-  CSettingTime(const std::string &id, CSettingsManager *settingsManager = NULL);
-  CSettingTime(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager = NULL);
+  CSettingTime(const std::string& id, CSettingsManager* settingsManager = nullptr);
+  CSettingTime(const std::string& id,
+               int label,
+               const std::string& value,
+               CSettingsManager* settingsManager = nullptr);
   CSettingTime(const std::string &id, const CSettingTime &setting);
   ~CSettingTime() override = default;
 

--- a/xbmc/settings/SettingPath.h
+++ b/xbmc/settings/SettingPath.h
@@ -10,6 +10,7 @@
 
 #include "settings/lib/Setting.h"
 
+#include <string_view>
 #include <vector>
 
 class CFileExtensionProvider;
@@ -35,7 +36,7 @@ public:
   bool HideExtension() const { return m_hideExtension; }
   void SetHideExtension(bool hideExtension) { m_hideExtension = hideExtension; }
   std::string GetMasking(const CFileExtensionProvider& fileExtensionProvider) const;
-  void SetMasking(const std::string& masking) { m_masking = masking; }
+  void SetMasking(std::string_view masking) { m_masking = masking; }
 
 private:
   using CSettingString::copy;

--- a/xbmc/settings/SettingUtils.cpp
+++ b/xbmc/settings/SettingUtils.cpp
@@ -35,7 +35,7 @@ std::vector<CVariant> CSettingUtils::ListToValues(
 {
   std::vector<CVariant> realValues;
 
-  if (setting == NULL)
+  if (!setting)
     return realValues;
 
   for (const auto& value : values)
@@ -70,7 +70,7 @@ bool CSettingUtils::ValuesToList(const std::shared_ptr<const CSettingList>& sett
                                  const std::vector<CVariant>& values,
                                  std::vector<std::shared_ptr<CSetting>>& newValues)
 {
-  if (setting == NULL)
+  if (!setting)
     return false;
 
   int index = 0;
@@ -78,8 +78,9 @@ bool CSettingUtils::ValuesToList(const std::shared_ptr<const CSettingList>& sett
   for (const auto& value : values)
   {
     SettingPtr settingValue =
-        setting->GetDefinition()->Clone(StringUtils::Format("{}.{}", setting->GetId(), index++));
-    if (settingValue == NULL)
+        setting->GetDefinition()->Clone(StringUtils::Format("{}.{}", setting->GetId(), index));
+    index++;
+    if (!settingValue)
       return false;
 
     switch (setting->GetElementType())
@@ -128,13 +129,12 @@ bool CSettingUtils::ValuesToList(const std::shared_ptr<const CSettingList>& sett
 
 bool CSettingUtils::FindIntInList(const std::shared_ptr<const CSettingList>& settingList, int value)
 {
-  if (settingList == nullptr || settingList->GetElementType() != SettingType::Integer)
+  if (!settingList || settingList->GetElementType() != SettingType::Integer)
     return false;
 
-  const auto values = settingList->GetValue();
-  const auto matchingValue =
-      std::find_if(values.begin(), values.end(), [value](const SettingPtr& setting) {
-        return std::static_pointer_cast<CSettingInt>(setting)->GetValue() == value;
-      });
+  const SettingList& values = settingList->GetValue();
+  const auto matchingValue = std::ranges::find_if(
+      values, [value](const SettingPtr& setting)
+      { return std::static_pointer_cast<CSettingInt>(setting)->GetValue() == value; });
   return matchingValue != values.end();
 }

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -518,8 +518,6 @@ public:
   CSettings() = default;
   ~CSettings() override = default;
 
-  CSettingsManager* GetSettingsManager() const { return m_settingsManager; }
-
   // specialization of CSettingsBase
   bool Initialize() override;
 
@@ -569,7 +567,7 @@ public:
    \param file Path to an XML file
    \return True if the setting values were successfully saved, false otherwise
    */
-  bool Save(const std::string &file);
+  bool Save(const std::string& file) const;
   /*!
    \brief Saves the setting values to the given XML node.
 
@@ -586,7 +584,7 @@ public:
    \param settingId Setting identifier
    \return True if the setting was successfully loaded from the given XML node, false otherwise
    */
-  bool LoadSetting(const TiXmlNode *node, const std::string &settingId);
+  bool LoadSetting(const TiXmlNode* node, const std::string& settingId) const;
 
   // overwrite (not override) from CSettingsBase
   bool GetBool(const std::string& id) const;

--- a/xbmc/settings/SettingsBase.h
+++ b/xbmc/settings/SettingsBase.h
@@ -103,7 +103,7 @@ public:
    \brief Gets the setting with the given identifier.
 
    \param id Setting identifier
-   \return Setting object with the given identifier or NULL if the identifier is unknown
+   \return Setting object with the given identifier or nullptr if the identifier is unknown
    */
   std::shared_ptr<CSetting> GetSetting(const std::string& id) const;
   /*!
@@ -116,7 +116,7 @@ public:
    \brief Gets the setting section with the given identifier.
 
    \param section Setting section identifier
-   \return Setting section with the given identifier or NULL if the identifier is unknown
+   \return Setting section with the given identifier or nullptr if the identifier is unknown
    */
   std::shared_ptr<CSettingSection> GetSection(const std::string& section) const;
 
@@ -202,7 +202,7 @@ public:
    \param value Values to set
    \return True if setting the values was successful, false otherwise
    */
-  bool SetList(const std::string& id, const std::vector<CVariant>& value);
+  bool SetList(const std::string& id, const std::vector<CVariant>& value) const;
 
   /*!
   \brief Sets the value of the setting with the given identifier to its default.

--- a/xbmc/settings/SettingsComponent.h
+++ b/xbmc/settings/SettingsComponent.h
@@ -14,13 +14,10 @@ class CAdvancedSettings;
 class CProfileManager;
 class CSettings;
 
-namespace KODI
-{
-namespace SUBTITLES
+namespace KODI::SUBTITLES
 {
 class CSubtitlesSettings;
-} // namespace SUBTITLES
-} // namespace KODI
+} // namespace KODI::SUBTITLES
 
 class CSettingsComponent
 {
@@ -48,32 +45,27 @@ public:
    * @brief Get access to the settings subcomponent.
    * @return the settings subcomponent.
    */
-  std::shared_ptr<CSettings> GetSettings();
+  std::shared_ptr<CSettings> GetSettings() const;
 
   /*!
    * @brief Get access to the advanced settings subcomponent.
    * @return the advanced settings subcomponent.
    */
-  std::shared_ptr<CAdvancedSettings> GetAdvancedSettings();
+  std::shared_ptr<CAdvancedSettings> GetAdvancedSettings() const;
 
   /*!
    * @brief Get access to the subtitles settings subcomponent.
    * @return the subtiltles settings subcomponent.
    */
-  std::shared_ptr<KODI::SUBTITLES::CSubtitlesSettings> GetSubtitlesSettings();
+  std::shared_ptr<KODI::SUBTITLES::CSubtitlesSettings> GetSubtitlesSettings() const;
 
   /*!
    * @brief Get access to the profiles manager subcomponent.
    * @return the profiles manager subcomponent.
    */
-  std::shared_ptr<CProfileManager> GetProfileManager();
+  std::shared_ptr<CProfileManager> GetProfileManager() const;
 
 private:
-  bool InitDirectoriesLinux(bool bPlatformDirectories);
-  bool InitDirectoriesOSX(bool bPlatformDirectories);
-  bool InitDirectoriesWin32(bool bPlatformDirectories);
-  void CreateUserDirs() const;
-
   enum class State
   {
     DEINITED,

--- a/xbmc/settings/SettingsValueFlatJsonSerializer.cpp
+++ b/xbmc/settings/SettingsValueFlatJsonSerializer.cpp
@@ -23,12 +23,12 @@ CSettingsValueFlatJsonSerializer::CSettingsValueFlatJsonSerializer(bool compact 
 std::string CSettingsValueFlatJsonSerializer::SerializeValues(
   const CSettingsManager* settingsManager) const
 {
-  if (settingsManager == nullptr)
+  if (!settingsManager)
     return "";
 
   CVariant root(CVariant::VariantTypeObject);
 
-  const auto sections = settingsManager->GetSections();
+  const SettingSectionList sections = settingsManager->GetSections();
   for (const auto& section : sections)
     SerializeSection(root, section);
 
@@ -46,10 +46,10 @@ std::string CSettingsValueFlatJsonSerializer::SerializeValues(
 void CSettingsValueFlatJsonSerializer::SerializeSection(
     CVariant& parent, const std::shared_ptr<CSettingSection>& section) const
 {
-  if (section == nullptr)
+  if (!section)
     return;
 
-  const auto categories = section->GetCategories();
+  const SettingCategoryList& categories = section->GetCategories();
   for (const auto& category : categories)
     SerializeCategory(parent, category);
 }
@@ -57,10 +57,10 @@ void CSettingsValueFlatJsonSerializer::SerializeSection(
 void CSettingsValueFlatJsonSerializer::SerializeCategory(
     CVariant& parent, const std::shared_ptr<CSettingCategory>& category) const
 {
-  if (category == nullptr)
+  if (!category)
     return;
 
-  const auto groups = category->GetGroups();
+  const SettingGroupList& groups = category->GetGroups();
   for (const auto& group : groups)
     SerializeGroup(parent, group);
 }
@@ -68,10 +68,10 @@ void CSettingsValueFlatJsonSerializer::SerializeCategory(
 void CSettingsValueFlatJsonSerializer::SerializeGroup(
     CVariant& parent, const std::shared_ptr<CSettingGroup>& group) const
 {
-  if (group == nullptr)
+  if (!group)
     return;
 
-  const auto settings = group->GetSettings();
+  const SettingList& settings = group->GetSettings();
   for (const auto& setting : settings)
     SerializeSetting(parent, setting);
 }
@@ -79,14 +79,14 @@ void CSettingsValueFlatJsonSerializer::SerializeGroup(
 void CSettingsValueFlatJsonSerializer::SerializeSetting(
     CVariant& parent, const std::shared_ptr<CSetting>& setting) const
 {
-  if (setting == nullptr)
+  if (!setting)
     return;
 
   // ignore references and action settings (which don't have a value)
   if (setting->IsReference() || setting->GetType() == SettingType::Action)
     return;
 
-  const auto valueObj = SerializeSettingValue(setting);
+  const CVariant valueObj = SerializeSettingValue(setting);
   if (valueObj.isNull())
     return;
 
@@ -118,10 +118,10 @@ CVariant CSettingsValueFlatJsonSerializer::SerializeSettingValue(
       const auto settingList = std::static_pointer_cast<CSettingList>(setting);
 
       CVariant settingListValuesObj(CVariant::VariantTypeArray);
-      const auto settingListValues = settingList->GetValue();
+      const SettingList& settingListValues = settingList->GetValue();
       for (const auto& settingListValue : settingListValues)
       {
-        const auto valueObj = SerializeSettingValue(settingListValue);
+        const CVariant valueObj = SerializeSettingValue(settingListValue);
         if (!valueObj.isNull())
           settingListValuesObj.push_back(valueObj);
       }

--- a/xbmc/settings/SettingsValueFlatJsonSerializer.h
+++ b/xbmc/settings/SettingsValueFlatJsonSerializer.h
@@ -22,7 +22,7 @@ class CSettingsValueFlatJsonSerializer : public ISettingsValueSerializer
 {
 public:
   explicit CSettingsValueFlatJsonSerializer(bool compact = true);
-  ~CSettingsValueFlatJsonSerializer() = default;
+  ~CSettingsValueFlatJsonSerializer() override = default;
 
   void SetCompact(bool compact = true) { m_compact = compact; }
 

--- a/xbmc/settings/SettingsValueXmlSerializer.cpp
+++ b/xbmc/settings/SettingsValueXmlSerializer.cpp
@@ -20,17 +20,17 @@ static constexpr char SETTINGS_XML_ROOT[] = "settings";
 std::string CSettingsValueXmlSerializer::SerializeValues(
   const CSettingsManager* settingsManager) const
 {
-  if (settingsManager == nullptr)
+  if (!settingsManager)
     return "";
 
   CXBMCTinyXML xmlDoc;
   TiXmlElement rootElement(SETTINGS_XML_ROOT);
   rootElement.SetAttribute(SETTING_XML_ROOT_VERSION, settingsManager->GetVersion());
   TiXmlNode* xmlRoot = xmlDoc.InsertEndChild(rootElement);
-  if (xmlRoot == nullptr)
+  if (!xmlRoot)
     return "";
 
-  const auto sections = settingsManager->GetSections();
+  const SettingSectionList sections = settingsManager->GetSections();
   for (const auto& section : sections)
     SerializeSection(xmlRoot, section);
 
@@ -43,10 +43,10 @@ std::string CSettingsValueXmlSerializer::SerializeValues(
 void CSettingsValueXmlSerializer::SerializeSection(
     TiXmlNode* parent, const std::shared_ptr<CSettingSection>& section) const
 {
-  if (section == nullptr)
+  if (!section)
     return;
 
-  const auto categories = section->GetCategories();
+  const SettingCategoryList& categories = section->GetCategories();
   for (const auto& category : categories)
     SerializeCategory(parent, category);
 }
@@ -54,10 +54,10 @@ void CSettingsValueXmlSerializer::SerializeSection(
 void CSettingsValueXmlSerializer::SerializeCategory(
     TiXmlNode* parent, const std::shared_ptr<CSettingCategory>& category) const
 {
-  if (category == nullptr)
+  if (!category)
     return;
 
-  const auto groups = category->GetGroups();
+  const SettingGroupList& groups = category->GetGroups();
   for (const auto& group : groups)
     SerializeGroup(parent, group);
 }
@@ -65,10 +65,10 @@ void CSettingsValueXmlSerializer::SerializeCategory(
 void CSettingsValueXmlSerializer::SerializeGroup(TiXmlNode* parent,
                                                  const std::shared_ptr<CSettingGroup>& group) const
 {
-  if (group == nullptr)
+  if (!group)
     return;
 
-  const auto settings = group->GetSettings();
+  const SettingList& settings = group->GetSettings();
   for (const auto& setting : settings)
     SerializeSetting(parent, setting);
 }
@@ -76,7 +76,7 @@ void CSettingsValueXmlSerializer::SerializeGroup(TiXmlNode* parent,
 void CSettingsValueXmlSerializer::SerializeSetting(TiXmlNode* parent,
                                                    const std::shared_ptr<CSetting>& setting) const
 {
-  if (setting == nullptr)
+  if (!setting)
     return;
 
   // ignore references and action settings (which don't have a value)

--- a/xbmc/settings/SettingsValueXmlSerializer.cpp
+++ b/xbmc/settings/SettingsValueXmlSerializer.cpp
@@ -94,8 +94,9 @@ void CSettingsValueXmlSerializer::SerializeSetting(TiXmlNode* parent,
   TiXmlText value(setting->ToString());
   settingElement.InsertEndChild(value);
 
-  if (parent->InsertEndChild(settingElement) == nullptr)
-    CLog::Log(LOGWARNING,
-      "CSettingsValueXmlSerializer: unable to write <" SETTING_XML_ELM_SETTING " id=\"{}\"> tag",
-      setting->GetId());
+  if (!parent->InsertEndChild(settingElement))
+  {
+    CLog::Log(LOGWARNING, "CSettingsValueXmlSerializer: unable to write <{} id=\"{}\"> tag",
+              SETTING_XML_ELM_SETTING, setting->GetId());
+  }
 }

--- a/xbmc/settings/SettingsValueXmlSerializer.h
+++ b/xbmc/settings/SettingsValueXmlSerializer.h
@@ -22,7 +22,7 @@ class CSettingsValueXmlSerializer : public ISettingsValueSerializer
 {
 public:
   CSettingsValueXmlSerializer() = default;
-  ~CSettingsValueXmlSerializer() = default;
+  ~CSettingsValueXmlSerializer() override = default;
 
   // implementation of ISettingsValueSerializer
   std::string SerializeValues(const CSettingsManager* settingsManager) const override;

--- a/xbmc/settings/SkinSettings.cpp
+++ b/xbmc/settings/SkinSettings.cpp
@@ -22,7 +22,10 @@
 #include <mutex>
 #include <string>
 
-#define XML_SKINSETTINGS  "skinsettings"
+namespace
+{
+constexpr const char* XML_SKINSETTINGS = "skinsettings";
+} // unnamed namespace
 
 CSkinSettings::CSkinSettings()
 {
@@ -37,7 +40,7 @@ CSkinSettings& CSkinSettings::GetInstance()
   return sSkinSettings;
 }
 
-int CSkinSettings::TranslateString(const std::string &setting)
+int CSkinSettings::TranslateString(const std::string& setting) const
 {
   return g_SkinInfo->TranslateString(setting);
 }
@@ -47,12 +50,12 @@ const std::string& CSkinSettings::GetString(int setting) const
   return g_SkinInfo->GetString(setting);
 }
 
-void CSkinSettings::SetString(int setting, const std::string &label)
+void CSkinSettings::SetString(int setting, const std::string& label) const
 {
   g_SkinInfo->SetString(setting, label);
 }
 
-int CSkinSettings::TranslateBool(const std::string &setting)
+int CSkinSettings::TranslateBool(const std::string& setting) const
 {
   return g_SkinInfo->TranslateBool(setting);
 }
@@ -67,12 +70,12 @@ int CSkinSettings::GetInt(int setting) const
   return g_SkinInfo->GetInt(setting);
 }
 
-void CSkinSettings::SetBool(int setting, bool set)
+void CSkinSettings::SetBool(int setting, bool set) const
 {
   g_SkinInfo->SetBool(setting, set);
 }
 
-void CSkinSettings::Reset(const std::string &setting)
+void CSkinSettings::Reset(const std::string& setting) const
 {
   g_SkinInfo->Reset(setting);
 }
@@ -93,7 +96,7 @@ std::shared_ptr<const ADDON::CSkinSetting> CSkinSettings::GetSetting(
   return g_SkinInfo->GetSkinSetting(settingId);
 }
 
-void CSkinSettings::Reset()
+void CSkinSettings::Reset() const
 {
   g_SkinInfo->Reset();
 
@@ -104,14 +107,14 @@ void CSkinSettings::Reset()
 
 bool CSkinSettings::Load(const TiXmlNode *settings)
 {
-  if (settings == nullptr)
+  if (!settings)
     return false;
 
   const TiXmlElement *rootElement = settings->FirstChildElement(XML_SKINSETTINGS);
 
   // return true in the case skinsettings is missing. It just means that
   // it's been migrated and it's not an error
-  if (rootElement == nullptr)
+  if (!rootElement)
   {
     CLog::Log(LOGDEBUG, "CSkinSettings: no <skinsettings> tag found");
     return true;
@@ -126,7 +129,7 @@ bool CSkinSettings::Load(const TiXmlNode *settings)
 
 bool CSkinSettings::Save(TiXmlNode *settings) const
 {
-  if (settings == nullptr)
+  if (!settings)
     return false;
 
   // nothing to do here because skin settings saving has been migrated to CSkinInfo
@@ -142,7 +145,7 @@ void CSkinSettings::Clear()
 
 void CSkinSettings::MigrateSettings(const std::shared_ptr<ADDON::CSkinInfo>& skin)
 {
-  if (skin == nullptr)
+  if (!skin)
     return;
 
   std::unique_lock lock(m_critical);

--- a/xbmc/settings/SkinSettings.h
+++ b/xbmc/settings/SkinSettings.h
@@ -29,13 +29,13 @@ public:
 
   void MigrateSettings(const std::shared_ptr<ADDON::CSkinInfo>& skin);
 
-  int TranslateString(const std::string &setting);
+  int TranslateString(const std::string& setting) const;
   const std::string& GetString(int setting) const;
-  void SetString(int setting, const std::string &label);
+  void SetString(int setting, const std::string& label) const;
 
-  int TranslateBool(const std::string &setting);
+  int TranslateBool(const std::string& setting) const;
   bool GetBool(int setting) const;
-  void SetBool(int setting, bool set);
+  void SetBool(int setting, bool set) const;
 
   /*! \brief Get the skin setting value as an integer value
    * \param setting - the setting id
@@ -47,8 +47,8 @@ public:
   ADDON::CSkinSettingPtr GetSetting(const std::string& settingId);
   std::shared_ptr<const ADDON::CSkinSetting> GetSetting(const std::string& settingId) const;
 
-  void Reset(const std::string &setting);
-  void Reset();
+  void Reset(const std::string& setting) const;
+  void Reset() const;
 
 protected:
   CSkinSettings();

--- a/xbmc/settings/SubtitlesSettings.cpp
+++ b/xbmc/settings/SubtitlesSettings.cpp
@@ -48,7 +48,7 @@ CSubtitlesSettings::~CSubtitlesSettings()
 
 void CSubtitlesSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)
 {
-  if (setting == nullptr)
+  if (!setting)
     return;
 
   SetChanged();
@@ -60,113 +60,113 @@ void CSubtitlesSettings::OnSettingChanged(const std::shared_ptr<const CSetting>&
   }
 }
 
-Align CSubtitlesSettings::GetAlignment()
+Align CSubtitlesSettings::GetAlignment() const
 {
   return static_cast<Align>(m_settings->GetInt(CSettings::SETTING_SUBTITLES_ALIGN));
 }
 
-void CSubtitlesSettings::SetAlignment(Align align)
+void CSubtitlesSettings::SetAlignment(Align align) const
 {
   m_settings->SetInt(CSettings::SETTING_SUBTITLES_ALIGN, static_cast<int>(align));
 }
 
-HorizontalAlign CSubtitlesSettings::GetHorizontalAlignment()
+HorizontalAlign CSubtitlesSettings::GetHorizontalAlignment() const
 {
   return static_cast<HorizontalAlign>(
       m_settings->GetInt(CSettings::SETTING_SUBTITLES_CAPTIONSALIGN));
 }
 
-std::string CSubtitlesSettings::GetFontName()
+std::string CSubtitlesSettings::GetFontName() const
 {
   return m_settings->GetString(CSettings::SETTING_SUBTITLES_FONTNAME);
 }
 
-FontStyle CSubtitlesSettings::GetFontStyle()
+FontStyle CSubtitlesSettings::GetFontStyle() const
 {
   return static_cast<FontStyle>(m_settings->GetInt(CSettings::SETTING_SUBTITLES_STYLE));
 }
 
-int CSubtitlesSettings::GetFontSize()
+int CSubtitlesSettings::GetFontSize() const
 {
   return m_settings->GetInt(CSettings::SETTING_SUBTITLES_FONTSIZE);
 }
 
-UTILS::COLOR::Color CSubtitlesSettings::GetFontColor()
+UTILS::COLOR::Color CSubtitlesSettings::GetFontColor() const
 {
   return UTILS::COLOR::ConvertHexToColor(m_settings->GetString(CSettings::SETTING_SUBTITLES_COLOR));
 }
 
-int CSubtitlesSettings::GetFontOpacity()
+int CSubtitlesSettings::GetFontOpacity() const
 {
   return m_settings->GetInt(CSettings::SETTING_SUBTITLES_OPACITY);
 }
 
-int CSubtitlesSettings::GetBorderSize()
+int CSubtitlesSettings::GetBorderSize() const
 {
   return m_settings->GetInt(CSettings::SETTING_SUBTITLES_BORDERSIZE);
 }
 
-UTILS::COLOR::Color CSubtitlesSettings::GetBorderColor()
+UTILS::COLOR::Color CSubtitlesSettings::GetBorderColor() const
 {
   return UTILS::COLOR::ConvertHexToColor(
       m_settings->GetString(CSettings::SETTING_SUBTITLES_BORDERCOLOR));
 }
 
-int CSubtitlesSettings::GetShadowSize()
+int CSubtitlesSettings::GetShadowSize() const
 {
   return m_settings->GetInt(CSettings::SETTING_SUBTITLES_SHADOWSIZE);
 }
 
-UTILS::COLOR::Color CSubtitlesSettings::GetShadowColor()
+UTILS::COLOR::Color CSubtitlesSettings::GetShadowColor() const
 {
   return UTILS::COLOR::ConvertHexToColor(
       m_settings->GetString(CSettings::SETTING_SUBTITLES_SHADOWCOLOR));
 }
 
-int CSubtitlesSettings::GetShadowOpacity()
+int CSubtitlesSettings::GetShadowOpacity() const
 {
   return m_settings->GetInt(CSettings::SETTING_SUBTITLES_SHADOWOPACITY);
 }
 
-int CSubtitlesSettings::GetBlurSize()
+int CSubtitlesSettings::GetBlurSize() const
 {
   return m_settings->GetInt(CSettings::SETTING_SUBTITLES_BLUR);
 }
 
-int CSubtitlesSettings::GetLineSpacing()
+int CSubtitlesSettings::GetLineSpacing() const
 {
   return m_settings->GetInt(CSettings::SETTING_SUBTITLES_LINE_SPACING);
 }
 
-BackgroundType CSubtitlesSettings::GetBackgroundType()
+BackgroundType CSubtitlesSettings::GetBackgroundType() const
 {
   return static_cast<BackgroundType>(
       m_settings->GetInt(CSettings::SETTING_SUBTITLES_BACKGROUNDTYPE));
 }
 
-UTILS::COLOR::Color CSubtitlesSettings::GetBackgroundColor()
+UTILS::COLOR::Color CSubtitlesSettings::GetBackgroundColor() const
 {
   return UTILS::COLOR::ConvertHexToColor(
       m_settings->GetString(CSettings::SETTING_SUBTITLES_BGCOLOR));
 }
 
-int CSubtitlesSettings::GetBackgroundOpacity()
+int CSubtitlesSettings::GetBackgroundOpacity() const
 {
   return m_settings->GetInt(CSettings::SETTING_SUBTITLES_BGOPACITY);
 }
 
-bool CSubtitlesSettings::IsOverrideFonts()
+bool CSubtitlesSettings::IsOverrideFonts() const
 {
   return m_settings->GetBool(CSettings::SETTING_SUBTITLES_OVERRIDEFONTS);
 }
 
-OverrideStyles CSubtitlesSettings::GetOverrideStyles()
+OverrideStyles CSubtitlesSettings::GetOverrideStyles() const
 {
   return static_cast<OverrideStyles>(
       m_settings->GetInt(CSettings::SETTING_SUBTITLES_OVERRIDESTYLES));
 }
 
-float CSubtitlesSettings::GetVerticalMarginPerc()
+float CSubtitlesSettings::GetVerticalMarginPerc() const
 {
   // We return the vertical margin as percentage
   // to fit the current screen resolution

--- a/xbmc/settings/SubtitlesSettings.h
+++ b/xbmc/settings/SubtitlesSettings.h
@@ -80,127 +80,127 @@ public:
    * \brief Get subtitle alignment
    * \return The alignment
    */
-  Align GetAlignment();
+  Align GetAlignment() const;
 
   /*!
    * \brief Set the subtitle alignment
    * \param align The alignment
    */
-  void SetAlignment(Align align);
+  void SetAlignment(Align align) const;
 
   /*!
    * \brief Get horizontal text alignment
    * \return The alignment
    */
-  HorizontalAlign GetHorizontalAlignment();
+  HorizontalAlign GetHorizontalAlignment() const;
 
   /*!
    * \brief Get font name
    * \return The font name
    */
-  std::string GetFontName();
+  std::string GetFontName() const;
 
   /*!
    * \brief Get font style
    * \return The font style
    */
-  FontStyle GetFontStyle();
+  FontStyle GetFontStyle() const;
 
   /*!
    * \brief Get font size
    * \return The font size in PX
    */
-  int GetFontSize();
+  int GetFontSize() const;
 
   /*!
    * \brief Get font color
    * \return The font color
    */
-  UTILS::COLOR::Color GetFontColor();
+  UTILS::COLOR::Color GetFontColor() const;
 
   /*!
    * \brief Get font opacity
    * \return The font opacity in %
    */
-  int GetFontOpacity();
+  int GetFontOpacity() const;
 
   /*!
    * \brief Get border size
    * \return The border size in %
    */
-  int GetBorderSize();
+  int GetBorderSize() const;
 
   /*!
    * \brief Get border color
    * \return The border color
    */
-  UTILS::COLOR::Color GetBorderColor();
+  UTILS::COLOR::Color GetBorderColor() const;
 
   /*!
    * \brief Get shadow size
    * \return The shadow size in %
    */
-  int GetShadowSize();
+  int GetShadowSize() const;
 
   /*!
    * \brief Get shadow color
    * \return The shadow color
    */
-  UTILS::COLOR::Color GetShadowColor();
+  UTILS::COLOR::Color GetShadowColor() const;
 
   /*!
    * \brief Get shadow opacity
    * \return The shadow opacity in %
    */
-  int GetShadowOpacity();
+  int GetShadowOpacity() const;
 
   /*!
    * \brief Get blur size
    * \return The blur size in %
    */
-  int GetBlurSize();
+  int GetBlurSize() const;
 
   /*!
    * \brief Get line spacing
    * \return The line spacing
    */
-  int GetLineSpacing();
+  int GetLineSpacing() const;
 
   /*!
    * \brief Get background type
    * \return The background type
    */
-  BackgroundType GetBackgroundType();
+  BackgroundType GetBackgroundType() const;
 
   /*!
    * \brief Get background color
    * \return The background color
    */
-  UTILS::COLOR::Color GetBackgroundColor();
+  UTILS::COLOR::Color GetBackgroundColor() const;
 
   /*!
    * \brief Get background opacity
    * \return The background opacity in %
    */
-  int GetBackgroundOpacity();
+  int GetBackgroundOpacity() const;
 
   /*!
    * \brief Check if font override is enabled
    * \return True if fonts must be overridden, otherwise false
    */
-  bool IsOverrideFonts();
+  bool IsOverrideFonts() const;
 
   /*!
    * \brief Get override styles
    * \return The styles to be overridden
    */
-  OverrideStyles GetOverrideStyles();
+  OverrideStyles GetOverrideStyles() const;
 
   /*!
    * \brief Get the subtitle vertical margin
    * \return The vertical margin in %
    */
-  float GetVerticalMarginPerc();
+  float GetVerticalMarginPerc() const;
 
   static void SettingOptionsSubtitleFontsFiller(const std::shared_ptr<const CSetting>& setting,
                                                 std::vector<StringSettingOption>& list,

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.h
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.h
@@ -49,9 +49,6 @@ public:
                    CONTENT_TYPE content = CONTENT_NONE);
 
 protected:
-  // specializations of CGUIWindow
-  void OnInitWindow() override;
-
   // implementations of ISettingCallback
   void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
   void OnSettingAction(const std::shared_ptr<const CSetting>& setting) override;

--- a/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
@@ -77,11 +77,6 @@ bool CGUIDialogLibExportSettings::Show(CLibExportSettings& settings)
   return confirmed;
 }
 
-void CGUIDialogLibExportSettings::OnInitWindow()
-{
-  CGUIDialogSettingsManualBase::OnInitWindow();
-}
-
 void CGUIDialogLibExportSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)
 {
   if (!setting)
@@ -144,7 +139,7 @@ void CGUIDialogLibExportSettings::OnSettingChanged(const std::shared_ptr<const C
 
 void CGUIDialogLibExportSettings::OnSettingAction(const std::shared_ptr<const CSetting>& setting)
 {
-  if (setting == NULL)
+  if (!setting)
     return;
 
   CGUIDialogSettingsManualBase::OnSettingAction(setting);
@@ -174,15 +169,14 @@ void CGUIDialogLibExportSettings::OnSettingAction(const std::shared_ptr<const CS
     else
       strDirectory = "default location";
 
-    if (CGUIDialogFileBrowser::ShowAndGetDirectory(shares, g_localizeStrings.Get(661), strDirectory, true))
+    if (CGUIDialogFileBrowser::ShowAndGetDirectory(shares, g_localizeStrings.Get(661), strDirectory,
+                                                   true) &&
+        !strDirectory.empty())
     {
-      if (!strDirectory.empty())
-      {
-        m_destinationChecked = true;
-        m_settings.SetPath(strDirectory);
-        SetLabel2(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER, strDirectory);
-        SetFocus(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER);
-      }
+      m_destinationChecked = true;
+      m_settings.SetPath(strDirectory);
+      SetLabel2(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER, strDirectory);
+      SetFocus(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER);
     }
     UpdateButtons();
   }
@@ -200,8 +194,10 @@ bool CGUIDialogLibExportSettings::OnMessage(CGUIMessage& message)
         OnOK();
         return true;
       }
+      break;
     }
-    break;
+    default:
+      break;
   }
   return CGUIDialogSettingsManualBase::OnMessage(message);
 }
@@ -376,14 +372,14 @@ void CGUIDialogLibExportSettings::InitializeSettings()
   {
     // Only artists, not albums, at least album artists
     items = m_settings.GetLimitedItems(ELIBEXPORT_ALBUMARTISTS + ELIBEXPORT_SONGARTISTS + ELIBEXPORT_OTHERARTISTS);
-    if (items.size() == 0)
+    if (items.empty())
       items.emplace_back(ELIBEXPORT_ALBUMARTISTS);
   }
   else if (!m_settings.IsSingleFile())
   {
     // No songs unless single file export, at least album artists
     items = m_settings.GetLimitedItems(ELIBEXPORT_ALBUMS + ELIBEXPORT_ALBUMARTISTS + ELIBEXPORT_SONGARTISTS + ELIBEXPORT_OTHERARTISTS);
-    if (items.size() == 0)
+    if (items.empty())
       items.emplace_back(ELIBEXPORT_ALBUMARTISTS);
   }
   else
@@ -408,21 +404,21 @@ void CGUIDialogLibExportSettings::InitializeSettings()
 void CGUIDialogLibExportSettings::SetLabel2(const std::string &settingid, const std::string &label)
 {
   BaseSettingControlPtr settingControl = GetSettingControl(settingid);
-  if (settingControl != nullptr && settingControl->GetControl() != nullptr)
+  if (settingControl && settingControl->GetControl())
     SET_CONTROL_LABEL2(settingControl->GetID(), label);
 }
 
 void CGUIDialogLibExportSettings::SetLabel(const std::string &settingid, const std::string &label)
 {
   BaseSettingControlPtr settingControl = GetSettingControl(settingid);
-  if (settingControl != nullptr && settingControl->GetControl() != nullptr)
+  if (settingControl && settingControl->GetControl())
     SetControlLabel(settingControl->GetID(), label);
 }
 
 void CGUIDialogLibExportSettings::ToggleState(const std::string & settingid, bool enabled)
 {
   BaseSettingControlPtr settingControl = GetSettingControl(settingid);
-  if (settingControl != nullptr && settingControl->GetControl() != nullptr)
+  if (settingControl && settingControl->GetControl())
   {
     if (enabled)
       CONTROL_ENABLE(settingControl->GetID());
@@ -434,7 +430,7 @@ void CGUIDialogLibExportSettings::ToggleState(const std::string & settingid, boo
 void CGUIDialogLibExportSettings::SetFocus(const std::string &settingid)
 {
   BaseSettingControlPtr settingControl = GetSettingControl(settingid);
-  if (settingControl != NULL && settingControl->GetControl() != NULL)
+  if (settingControl && settingControl->GetControl())
     SET_CONTROL_FOCUS(settingControl->GetID(), 0);
 }
 
@@ -443,7 +439,7 @@ int CGUIDialogLibExportSettings::GetExportItemsFromSetting(const SettingConstPtr
   std::shared_ptr<const CSettingList> settingList = std::static_pointer_cast<const CSettingList>(setting);
   if (settingList->GetElementType() != SettingType::Integer)
   {
-    CLog::Log(LOGERROR, "CGUIDialogLibExportSettings::{} - wrong items element type", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Wrong items element type");
     return 0;
   }
   int exportitems = 0;
@@ -452,7 +448,7 @@ int CGUIDialogLibExportSettings::GetExportItemsFromSetting(const SettingConstPtr
   {
     if (!value.isInteger())
     {
-      CLog::Log(LOGERROR, "CGUIDialogLibExportSettings::{} - wrong items value type", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Wrong items value type");
       return 0;
     }
     exportitems += static_cast<int>(value.asInteger());

--- a/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
@@ -51,16 +51,19 @@ bool CGUIDialogLibExportSettings::Show(CLibExportSettings& settings)
   // Get current export settings from service broker
   const std::shared_ptr<CSettings> pSettings = CServiceBroker::GetSettingsComponent()->GetSettings();
   dialog->m_settings.SetExportType(pSettings->GetInt(CSettings::SETTING_MUSICLIBRARY_EXPORT_FILETYPE));
-  dialog->m_settings.m_strPath = pSettings->GetString(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER);
+  dialog->m_settings.SetPath(pSettings->GetString(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER));
   dialog->m_settings.SetItemsToExport(pSettings->GetInt(CSettings::SETTING_MUSICLIBRARY_EXPORT_ITEMS));
-  dialog->m_settings.m_unscraped = pSettings->GetBool(CSettings::SETTING_MUSICLIBRARY_EXPORT_UNSCRAPED);
-  dialog->m_settings.m_artwork = pSettings->GetBool(CSettings::SETTING_MUSICLIBRARY_EXPORT_ARTWORK);
-  dialog->m_settings.m_skipnfo = pSettings->GetBool(CSettings::SETTING_MUSICLIBRARY_EXPORT_SKIPNFO);
-  dialog->m_settings.m_overwrite = pSettings->GetBool(CSettings::SETTING_MUSICLIBRARY_EXPORT_OVERWRITE);
+  dialog->m_settings.SetUnscraped(
+      pSettings->GetBool(CSettings::SETTING_MUSICLIBRARY_EXPORT_UNSCRAPED));
+  dialog->m_settings.SetArtwork(pSettings->GetBool(CSettings::SETTING_MUSICLIBRARY_EXPORT_ARTWORK));
+  dialog->m_settings.SetSkipNfo(pSettings->GetBool(CSettings::SETTING_MUSICLIBRARY_EXPORT_SKIPNFO));
+  dialog->m_settings.SetOverwrite(
+      pSettings->GetBool(CSettings::SETTING_MUSICLIBRARY_EXPORT_OVERWRITE));
 
   // Ensure NFO or art output enabled when albums exported (adjust old saved settings)
-  if (dialog->m_settings.IsItemExported(ELIBEXPORT_ALBUMS) && (dialog->m_settings.m_skipnfo && !dialog->m_settings.m_artwork))
-    dialog->m_settings.m_skipnfo = false;
+  if (dialog->m_settings.IsItemExported(ELIBEXPORT_ALBUMS) &&
+      (dialog->m_settings.IsSkipNfo() && !dialog->m_settings.IsArtwork()))
+    dialog->m_settings.SetSkipNfo(false);
 
   dialog->m_destinationChecked = false;
   dialog->Open();
@@ -96,17 +99,18 @@ void CGUIDialogLibExportSettings::OnSettingChanged(const std::shared_ptr<const C
   }
   else if (settingId == CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER)
   {
-    m_settings.m_strPath = std::static_pointer_cast<const CSettingString>(setting)->GetValue();
+    m_settings.SetPath(std::static_pointer_cast<const CSettingString>(setting)->GetValue());
     UpdateButtons();
   }
   else if (settingId == CSettings::SETTING_MUSICLIBRARY_EXPORT_OVERWRITE)
-    m_settings.m_overwrite = std::static_pointer_cast<const CSettingBool>(setting)->GetValue();
+    m_settings.SetOverwrite(std::static_pointer_cast<const CSettingBool>(setting)->GetValue());
   else if (settingId == CSettings::SETTING_MUSICLIBRARY_EXPORT_ITEMS)
   {
     m_settings.SetItemsToExport(GetExportItemsFromSetting(setting));
-    if (m_settings.IsItemExported(ELIBEXPORT_ALBUMS) && (m_settings.m_skipnfo && !m_settings.m_artwork))
+    if (m_settings.IsItemExported(ELIBEXPORT_ALBUMS) &&
+        (m_settings.IsSkipNfo() && !m_settings.IsArtwork()))
     {
-      m_settings.m_skipnfo = false;
+      m_settings.SetSkipNfo(false);
       m_settingNFO->SetValue(true);
       UpdateToggles();
     }
@@ -114,22 +118,24 @@ void CGUIDialogLibExportSettings::OnSettingChanged(const std::shared_ptr<const C
   }
   else if (settingId == CSettings::SETTING_MUSICLIBRARY_EXPORT_ARTWORK)
   {
-    m_settings.m_artwork = std::static_pointer_cast<const CSettingBool>(setting)->GetValue();
-    if (m_settings.IsItemExported(ELIBEXPORT_ALBUMS) && (m_settings.m_skipnfo && !m_settings.m_artwork))
+    m_settings.SetArtwork(std::static_pointer_cast<const CSettingBool>(setting)->GetValue());
+    if (m_settings.IsItemExported(ELIBEXPORT_ALBUMS) &&
+        (m_settings.IsSkipNfo() && !m_settings.IsArtwork()))
     {
-      m_settings.m_skipnfo = false;
+      m_settings.SetSkipNfo(false);
       m_settingNFO->SetValue(true);
     }
     UpdateToggles();
   }
   else if (settingId == CSettings::SETTING_MUSICLIBRARY_EXPORT_UNSCRAPED)
-    m_settings.m_unscraped = std::static_pointer_cast<const CSettingBool>(setting)->GetValue();
+    m_settings.SetUnscraped(std::static_pointer_cast<const CSettingBool>(setting)->GetValue());
   else if (settingId == CSettings::SETTING_MUSICLIBRARY_EXPORT_SKIPNFO)
   {
-    m_settings.m_skipnfo = !std::static_pointer_cast<const CSettingBool>(setting)->GetValue();
-    if (m_settings.IsItemExported(ELIBEXPORT_ALBUMS) && (m_settings.m_skipnfo && !m_settings.m_artwork))
+    m_settings.SetSkipNfo(!std::static_pointer_cast<const CSettingBool>(setting)->GetValue());
+    if (m_settings.IsItemExported(ELIBEXPORT_ALBUMS) &&
+        (m_settings.IsSkipNfo() && !m_settings.IsArtwork()))
     {
-      m_settings.m_artwork = true;
+      m_settings.SetArtwork(true);
       m_settingArt->SetValue(true);
     }
     UpdateToggles();
@@ -152,7 +158,7 @@ void CGUIDialogLibExportSettings::OnSettingAction(const std::shared_ptr<const CS
     CServiceBroker::GetMediaManager().GetLocalDrives(shares);
     CServiceBroker::GetMediaManager().GetNetworkLocations(shares);
     CServiceBroker::GetMediaManager().GetRemovableDrives(shares);
-    std::string strDirectory = m_settings.m_strPath;
+    std::string strDirectory = m_settings.GetPath();
     if (!strDirectory.empty())
     {
       URIUtils::AddSlashAtEnd(strDirectory);
@@ -173,7 +179,7 @@ void CGUIDialogLibExportSettings::OnSettingAction(const std::shared_ptr<const CS
       if (!strDirectory.empty())
       {
         m_destinationChecked = true;
-        m_settings.m_strPath = strDirectory;
+        m_settings.SetPath(strDirectory);
         SetLabel2(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER, strDirectory);
         SetFocus(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER);
       }
@@ -224,7 +230,7 @@ void CGUIDialogLibExportSettings::OnOK()
   {
     // ELIBEXPORT_SINGLEFILE or LIBEXPORT_SEPARATEFILES
     // Check that destination folder exists
-    if (!XFILE::CDirectory::Exists(m_settings.m_strPath))
+    if (!XFILE::CDirectory::Exists(m_settings.GetPath()))
     {
       HELPERS::ShowOKDialogText(CVariant{ 38300 }, CVariant{ 38318 });
       return;
@@ -240,12 +246,12 @@ bool CGUIDialogLibExportSettings::Save()
   CLog::Log(LOGINFO, "CGUIDialogMusicExportSettings: Save() called");
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   settings->SetInt(CSettings::SETTING_MUSICLIBRARY_EXPORT_FILETYPE, m_settings.GetExportType());
-  settings->SetString(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER, m_settings.m_strPath);
+  settings->SetString(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER, m_settings.GetPath());
   settings->SetInt(CSettings::SETTING_MUSICLIBRARY_EXPORT_ITEMS, m_settings.GetItemsToExport());
-  settings->SetBool(CSettings::SETTING_MUSICLIBRARY_EXPORT_UNSCRAPED, m_settings.m_unscraped);
-  settings->SetBool(CSettings::SETTING_MUSICLIBRARY_EXPORT_OVERWRITE, m_settings.m_overwrite);
-  settings->SetBool(CSettings::SETTING_MUSICLIBRARY_EXPORT_ARTWORK, m_settings.m_artwork);
-  settings->SetBool(CSettings::SETTING_MUSICLIBRARY_EXPORT_SKIPNFO, m_settings.m_skipnfo);
+  settings->SetBool(CSettings::SETTING_MUSICLIBRARY_EXPORT_UNSCRAPED, m_settings.IsUnscraped());
+  settings->SetBool(CSettings::SETTING_MUSICLIBRARY_EXPORT_OVERWRITE, m_settings.IsOverwrite());
+  settings->SetBool(CSettings::SETTING_MUSICLIBRARY_EXPORT_ARTWORK, m_settings.IsArtwork());
+  settings->SetBool(CSettings::SETTING_MUSICLIBRARY_EXPORT_SKIPNFO, m_settings.IsSkipNfo());
   settings->Save();
 
   return true;
@@ -271,7 +277,7 @@ void CGUIDialogLibExportSettings::UpdateButtons()
   bool enableExport(true);
   if (m_settings.IsSingleFile() ||
       m_settings.IsSeparateFiles())
-    enableExport = !m_settings.m_strPath.empty();
+    enableExport = !m_settings.GetPath().empty();
 
   CONTROL_ENABLE_ON_CONDITION(CONTROL_SETTINGS_OKAY_BUTTON, enableExport);
   if (!enableExport)
@@ -281,9 +287,10 @@ void CGUIDialogLibExportSettings::UpdateButtons()
 void CGUIDialogLibExportSettings::UpdateToggles()
 {
   if (m_settings.IsSeparateFiles())
-    ToggleState(CSettings::SETTING_MUSICLIBRARY_EXPORT_UNSCRAPED, !m_settings.m_skipnfo);
+    ToggleState(CSettings::SETTING_MUSICLIBRARY_EXPORT_UNSCRAPED, !m_settings.IsSkipNfo());
 
-  if (!m_settings.IsItemExported(ELIBEXPORT_ALBUMS) && m_settings.m_skipnfo && !m_settings.m_artwork)
+  if (!m_settings.IsItemExported(ELIBEXPORT_ALBUMS) && m_settings.IsSkipNfo() &&
+      !m_settings.IsArtwork())
   {
     //"Output information to NFO files (currently exporting artist folders only)"
     SetLabel(CSettings::SETTING_MUSICLIBRARY_EXPORT_SKIPNFO, g_localizeStrings.Get(38310));
@@ -323,7 +330,7 @@ void CGUIDialogLibExportSettings::UpdateDescription()
   }
   else
   {
-    SetLabel2(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER, m_settings.m_strPath);
+    SetLabel2(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER, m_settings.GetPath());
     SetLabel(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER, g_localizeStrings.Get(38305));
   }
 }
@@ -386,11 +393,15 @@ void CGUIDialogLibExportSettings::InitializeSettings()
 
   if (m_settings.IsToLibFolders() || m_settings.IsSeparateFiles())
   {
-    m_settingNFO = AddToggle(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_SKIPNFO, 38309, SettingLevel::Basic, !m_settings.m_skipnfo);
+    m_settingNFO = AddToggle(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_SKIPNFO, 38309,
+                             SettingLevel::Basic, !m_settings.IsSkipNfo());
     if (m_settings.IsSeparateFiles())
-      AddToggle(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_UNSCRAPED, 38308, SettingLevel::Basic, m_settings.m_unscraped);
-    m_settingArt = AddToggle(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_ARTWORK, 38307, SettingLevel::Basic, m_settings.m_artwork);
-    AddToggle(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_OVERWRITE, 38311, SettingLevel::Basic, m_settings.m_overwrite);
+      AddToggle(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_UNSCRAPED, 38308,
+                SettingLevel::Basic, m_settings.IsUnscraped());
+    m_settingArt = AddToggle(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_ARTWORK, 38307,
+                             SettingLevel::Basic, m_settings.IsArtwork());
+    AddToggle(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_OVERWRITE, 38311,
+              SettingLevel::Basic, m_settings.IsOverwrite());
   }
 }
 

--- a/xbmc/settings/dialogs/GUIDialogLibExportSettings.h
+++ b/xbmc/settings/dialogs/GUIDialogLibExportSettings.h
@@ -23,9 +23,6 @@ public:
   static bool Show(CLibExportSettings& settings);
 
 protected:
-  // specializations of CGUIWindow
-  void OnInitWindow() override;
-
   // implementations of ISettingCallback
   void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
   void OnSettingAction(const std::shared_ptr<const CSetting>& setting) override;

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.h
@@ -15,20 +15,21 @@
 #include "threads/Timer.h"
 #include "utils/ILocalizer.h"
 
+#include <string_view>
 #include <vector>
 
-#define CONTROL_SETTINGS_LABEL 2
-#define CONTROL_SETTINGS_DESCRIPTION 6
+constexpr int CONTROL_SETTINGS_LABEL = 2;
+constexpr int CONTROL_SETTINGS_DESCRIPTION = 6;
 
-#define CONTROL_SETTINGS_OKAY_BUTTON 28
-#define CONTROL_SETTINGS_CANCEL_BUTTON 29
-#define CONTROL_SETTINGS_CUSTOM_BUTTON 30
+constexpr int CONTROL_SETTINGS_OKAY_BUTTON = 28;
+constexpr int CONTROL_SETTINGS_CANCEL_BUTTON = 29;
+constexpr int CONTROL_SETTINGS_CUSTOM_BUTTON = 30;
 
-#define CONTROL_SETTINGS_START_BUTTONS -200
-#define CONTROL_SETTINGS_START_CONTROL -180
+constexpr int CONTROL_SETTINGS_START_BUTTONS = -200;
+constexpr int CONTROL_SETTINGS_START_CONTROL = -180;
 
-#define SETTINGS_RESET_SETTING_ID "settings.reset"
-#define SETTINGS_EMPTY_CATEGORY_ID "categories.empty"
+constexpr const char* SETTINGS_RESET_SETTING_ID = "settings.reset";
+constexpr const char* SETTINGS_EMPTY_CATEGORY_ID = "categories.empty";
 
 class CGUIControl;
 class CGUIControlBaseSetting;
@@ -51,7 +52,7 @@ class CVariant;
 
 class ISetting;
 
-typedef std::shared_ptr<CGUIControlBaseSetting> BaseSettingControlPtr;
+using BaseSettingControlPtr = std::shared_ptr<CGUIControlBaseSetting>;
 
 class CGUIDialogSettingsBase : public CGUIDialog,
                                public CSettingControlCreator,
@@ -106,14 +107,14 @@ protected:
   virtual void UpdateSettings();
 
   /*!
-    \brief Get the name for the setting entry
+   \brief Get the name for the setting entry
 
-    Used as virtual to allow related settings dialog to give a std::string name of the setting.
-    If not used on own dialog class it handle the string from int CSetting::GetLabel(),
-    This must also be used if on related dialog no special entry is wanted.
+   Used as virtual to allow related settings dialog to give a std::string name of the setting.
+   If not used on own dialog class it handle the string from int CSetting::GetLabel(),
+   This must also be used if on related dialog no special entry is wanted.
 
-    \param pSetting Base settings class which need the name
-    \return Name used on settings dialog
+   \param pSetting Base settings class which need the name
+   \return Name used on settings dialog
    */
   virtual std::string GetSettingsLabel(const std::shared_ptr<ISetting>& pSetting);
 
@@ -136,24 +137,24 @@ protected:
   virtual void OnResetSettings();
 
   /*!
-    \brief A setting control has been interacted with by the user
+   \brief A setting control has been interacted with by the user
 
-    This method is called when the user manually interacts (clicks,
-    edits) with a setting control. It contains handling for both
-    delayed and undelayed settings and either starts the delay timer
-    or triggers the setting change which, on success, results in a
-    callback to OnSettingChanged().
+   This method is called when the user manually interacts (clicks,
+   edits) with a setting control. It contains handling for both
+   delayed and undelayed settings and either starts the delay timer
+   or triggers the setting change which, on success, results in a
+   callback to OnSettingChanged().
 
-    \param pSettingControl Setting control that has been interacted with
+   \param pSettingControl Setting control that has been interacted with
    */
   virtual void OnClick(const BaseSettingControlPtr& pSettingControl);
 
   void UpdateSettingControl(const std::string& settingId, bool updateDisplayOnly = false);
   void UpdateSettingControl(const BaseSettingControlPtr& pSettingControl,
-                            bool updateDisplayOnly = false);
+                            bool updateDisplayOnly = false) const;
   void SetControlLabel(int controlId, const CVariant& label);
 
-  BaseSettingControlPtr GetSettingControl(const std::string& setting);
+  BaseSettingControlPtr GetSettingControl(std::string_view setting);
   BaseSettingControlPtr GetSettingControl(int controlId);
 
   CGUIControl* AddSeparator(float width, int& iControlID);
@@ -164,20 +165,20 @@ protected:
   std::vector<std::shared_ptr<CSettingCategory>> m_categories;
   std::vector<BaseSettingControlPtr> m_settingControls;
 
-  int m_iSetting = 0;
-  int m_iCategory = 0;
+  int m_iSetting{0};
+  int m_iCategory{0};
   std::shared_ptr<CSettingAction> m_resetSetting;
   std::shared_ptr<CSettingCategory> m_dummyCategory;
 
-  CGUISpinControlEx* m_pOriginalSpin;
-  CGUISettingsSliderControl* m_pOriginalSlider;
-  CGUIRadioButtonControl* m_pOriginalRadioButton;
-  CGUIColorButtonControl* m_pOriginalColorButton = nullptr;
-  CGUIButtonControl* m_pOriginalCategoryButton;
-  CGUIButtonControl* m_pOriginalButton;
-  CGUIEditControl* m_pOriginalEdit;
-  CGUIImage* m_pOriginalImage;
-  CGUILabelControl* m_pOriginalGroupTitle;
+  CGUISpinControlEx* m_pOriginalSpin{nullptr};
+  CGUISettingsSliderControl* m_pOriginalSlider{nullptr};
+  CGUIRadioButtonControl* m_pOriginalRadioButton{nullptr};
+  CGUIColorButtonControl* m_pOriginalColorButton{nullptr};
+  CGUIButtonControl* m_pOriginalCategoryButton{nullptr};
+  CGUIButtonControl* m_pOriginalButton{nullptr};
+  CGUIEditControl* m_pOriginalEdit{nullptr};
+  CGUIImage* m_pOriginalImage{nullptr};
+  CGUILabelControl* m_pOriginalGroupTitle{nullptr};
   bool m_newOriginalEdit = false;
 
   BaseSettingControlPtr
@@ -185,5 +186,6 @@ protected:
   CTimer m_delayedTimer; ///< Delayed setting timer
 
   bool m_confirmed = false;
-  int m_focusedControl = 0, m_fadedControl = 0;
+  int m_focusedControlID{0};
+  int m_fadedControlID{0};
 };

--- a/xbmc/settings/dialogs/GUIDialogSettingsManagerBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManagerBase.cpp
@@ -20,7 +20,7 @@ CGUIDialogSettingsManagerBase::~CGUIDialogSettingsManagerBase() = default;
 
 std::shared_ptr<CSetting> CGUIDialogSettingsManagerBase::GetSetting(const std::string &settingId)
 {
-  assert(GetSettingsManager() != nullptr);
+  assert(GetSettingsManager());
 
   return GetSettingsManager()->GetSetting(settingId);
 }
@@ -38,7 +38,7 @@ bool CGUIDialogSettingsManagerBase::OnOkay()
 
 SettingsContainer CGUIDialogSettingsManagerBase::CreateSettings()
 {
-  assert(GetSettingsManager() != nullptr);
+  assert(GetSettingsManager());
 
   const SettingsContainer settings{CGUIDialogSettingsBase::CreateSettings()};
 
@@ -52,13 +52,13 @@ void CGUIDialogSettingsManagerBase::FreeSettingsControls()
 {
   CGUIDialogSettingsBase::FreeSettingsControls();
 
-  if (GetSettingsManager() != nullptr)
+  if (GetSettingsManager())
     GetSettingsManager()->UnregisterCallback(this);
 }
 
 std::shared_ptr<ISettingControl> CGUIDialogSettingsManagerBase::CreateControl(const std::string &controlType) const
 {
-  assert(GetSettingsManager() != nullptr);
+  assert(GetSettingsManager());
 
   return GetSettingsManager()->CreateControl(controlType);
 }

--- a/xbmc/settings/dialogs/GUIDialogSettingsManualBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManualBase.cpp
@@ -27,7 +27,7 @@ CGUIDialogSettingsManualBase::CGUIDialogSettingsManualBase(int windowId, const s
 
 CGUIDialogSettingsManualBase::~CGUIDialogSettingsManualBase()
 {
-  if (GetSettingsManager() != nullptr)
+  if (GetSettingsManager())
   {
     GetSettingsManager()->Clear();
     m_section = nullptr;
@@ -39,7 +39,7 @@ void CGUIDialogSettingsManualBase::SetupView()
 {
   InitializeSettings();
 
-  if (GetSettingsManager() != nullptr)
+  if (GetSettingsManager())
   {
     // add the created setting section to the settings manager and mark it as ready
     GetSettingsManager()->AddSection(m_section);
@@ -52,7 +52,7 @@ void CGUIDialogSettingsManualBase::SetupView()
 
 CSettingsManager* CGUIDialogSettingsManualBase::GetSettingsManager() const
 {
-  if (m_settingsManager == nullptr)
+  if (!m_settingsManager)
     m_settingsManager = new CSettingsManager();
 
   return m_settingsManager;
@@ -60,24 +60,26 @@ CSettingsManager* CGUIDialogSettingsManualBase::GetSettingsManager() const
 
 void CGUIDialogSettingsManualBase::InitializeSettings()
 {
-  if (GetSettingsManager() != nullptr)
+  if (GetSettingsManager())
   {
     GetSettingsManager()->Clear();
-    m_section = NULL;
+    m_section = nullptr;
 
     // create a std::make_shared<section
     m_section = std::make_shared<CSettingSection>(GetProperty("xmlfile").asString(), GetSettingsManager());
   }
 }
 
-SettingCategoryPtr CGUIDialogSettingsManualBase::AddCategory(const std::string &id, int label, int help /* = -1 */)
+SettingCategoryPtr CGUIDialogSettingsManualBase::AddCategory(const std::string& id,
+                                                             int label,
+                                                             int help /* = -1 */) const
 {
   if (id.empty())
-    return NULL;
+    return nullptr;
 
-  SettingCategoryPtr category = std::make_shared<CSettingCategory>(id, GetSettingsManager());
-  if (category == NULL)
-    return NULL;
+  const auto category = std::make_shared<CSettingCategory>(id, GetSettingsManager());
+  if (!category)
+    return nullptr;
 
   category->SetLabel(label);
   if (help >= 0)
@@ -93,14 +95,15 @@ SettingGroupPtr CGUIDialogSettingsManualBase::AddGroup(const SettingCategoryPtr&
                                                        bool separatorBelowLabel /* = true */,
                                                        bool hideSeparator /* = false */)
 {
-  if (category == NULL)
-    return NULL;
+  if (!category)
+    return nullptr;
 
   size_t groups = category->GetGroups().size();
 
-  SettingGroupPtr group = std::make_shared<CSettingGroup>(StringUtils::Format("{0}", groups + 1), GetSettingsManager());
-  if (group == NULL)
-    return NULL;
+  const auto group =
+      std::make_shared<CSettingGroup>(StringUtils::Format("{0}", groups + 1), GetSettingsManager());
+  if (!group)
+    return nullptr;
 
   if (label >= 0)
     group->SetLabel(label);
@@ -121,16 +124,15 @@ std::shared_ptr<CSettingBool> CGUIDialogSettingsManualBase::AddToggle(const Sett
                                                                       bool visible /* = true */,
                                                                       int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingBool> setting = std::make_shared<CSettingBool>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingBool>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetCheckmarkControl(delayed));
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -151,16 +153,16 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddEdit(
     bool visible /* = true */,
     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingInt> setting = std::make_shared<CSettingInt>(id, label, value, minimum, step, maximum, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting =
+      std::make_shared<CSettingInt>(id, label, value, minimum, step, maximum, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetEditControl("integer", delayed, false, verifyNewValue, heading));
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -181,16 +183,16 @@ std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddEdit(
     bool visible /* = true */,
     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingNumber> setting = std::make_shared<CSettingNumber>(id, label, value, minimum, step, maximum, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingNumber>(id, label, value, minimum, step, maximum,
+                                                        GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetEditControl("number", delayed, false, verifyNewValue, heading));
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -208,17 +210,16 @@ std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddEdit(const Sett
                                                                       bool visible /* = true */,
                                                                       int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingString> setting = std::make_shared<CSettingString>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingString>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetEditControl("string", delayed, hidden, false, heading));
   setting->SetAllowEmpty(allowEmpty);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -235,17 +236,16 @@ std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddIp(const Settin
                                                                     bool visible /* = true */,
                                                                     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingString> setting = std::make_shared<CSettingString>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingString>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetEditControl("ip", delayed, false, false, heading));
   setting->SetAllowEmpty(allowEmpty);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -263,17 +263,16 @@ std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddPasswordMd5(
     bool visible /* = true */,
     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingString> setting = std::make_shared<CSettingString>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingString>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetEditControl("md5", delayed, false, false, heading));
   setting->SetAllowEmpty(allowEmpty);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -289,17 +288,16 @@ std::shared_ptr<CSettingAction> CGUIDialogSettingsManualBase::AddButton(
     bool visible /* = true */,
     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingAction> setting = std::make_shared<CSettingAction>(id, label, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingAction>(id, label, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetButtonControl("action", delayed));
   setting->SetData(data);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -314,16 +312,15 @@ std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddInfoLabelButton
     bool visible /* = true */,
     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingString> setting = std::make_shared<CSettingString>(id, label, info, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingString>(id, label, info, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetButtonControl("infolabel", false));
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -346,18 +343,17 @@ std::shared_ptr<CSettingAddon> CGUIDialogSettingsManualBase::AddAddon(
     bool visible /* = true */,
     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingAddon> setting = std::make_shared<CSettingAddon>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingAddon>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetButtonControl("addon", delayed, heading, hideValue, showInstalledAddons, showInstallableAddons, showMoreAddons));
   setting->SetAddonType(addonType);
   setting->SetAllowEmpty(allowEmpty);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -378,19 +374,18 @@ std::shared_ptr<CSettingPath> CGUIDialogSettingsManualBase::AddPath(
     bool visible /* = true */,
     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingPath> setting = std::make_shared<CSettingPath>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingPath>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetButtonControl("path", delayed, heading, hideValue));
   setting->SetWritable(writable);
   setting->SetSources(sources);
   setting->SetAllowEmpty(allowEmpty);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -407,16 +402,16 @@ std::shared_ptr<CSettingDate> CGUIDialogSettingsManualBase::AddDate(const Settin
                                                                     bool visible /* = true */,
                                                                     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 || GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingDate> setting = std::make_shared<CSettingDate>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingDate>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetButtonControl("date", delayed, heading));
   setting->SetAllowEmpty(allowEmpty);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -433,16 +428,16 @@ std::shared_ptr<CSettingTime> CGUIDialogSettingsManualBase::AddTime(const Settin
                                                                     bool visible /* = true */,
                                                                     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 || GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingTime> setting = std::make_shared<CSettingTime>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingTime>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetButtonControl("time", delayed, heading));
   setting->SetAllowEmpty(allowEmpty);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -459,17 +454,16 @@ std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddSpinner(
     bool visible /* = true */,
     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 || filler == NULL ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || !filler || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingString> setting = std::make_shared<CSettingString>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingString>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetSpinnerControl("string", delayed));
   setting->SetOptionsFiller(filler);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -489,19 +483,18 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSpinner(const Sett
                                                                       bool visible /* = true */,
                                                                       int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingInt> setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetSpinnerControl("string", delayed, minimumLabel, formatLabel));
   setting->SetMinimum(minimum);
   setting->SetStep(step);
   setting->SetMaximum(maximum);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -522,19 +515,18 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSpinner(
     bool visible /* = true */,
     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingInt> setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetSpinnerControl("string", delayed, minimumLabel, -1, formatString));
   setting->SetMinimum(minimum);
   setting->SetStep(step);
   setting->SetMaximum(maximum);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -551,17 +543,16 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSpinner(
     bool visible /* = true */,
     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 || entries.empty() ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || entries.empty() || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingInt> setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetSpinnerControl("string", delayed));
   setting->SetTranslatableOptions(entries);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -578,17 +569,16 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSpinner(
     bool visible /* = true */,
     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 || entries.empty() ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || entries.empty() || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingInt> setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetSpinnerControl("string", delayed));
   setting->SetOptions(entries);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -605,17 +595,16 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSpinner(
     bool visible /* = true */,
     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 || filler == NULL ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || !filler || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingInt> setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetSpinnerControl("string", delayed));
   setting->SetOptionsFiller(filler);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -636,19 +625,18 @@ std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddSpinner(
     bool visible /* = true */,
     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingNumber> setting = std::make_shared<CSettingNumber>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingNumber>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetSpinnerControl("number", delayed, minimumLabel, formatLabel));
   setting->SetMinimum(static_cast<double>(minimum));
   setting->SetStep(static_cast<double>(step));
   setting->SetMaximum(static_cast<double>(maximum));
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -669,19 +657,18 @@ std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddSpinner(
     bool visible /* = true */,
     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingNumber> setting = std::make_shared<CSettingNumber>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingNumber>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetSpinnerControl("number", delayed, minimumLabel, -1, formatString));
   setting->SetMinimum(static_cast<double>(minimum));
   setting->SetStep(static_cast<double>(step));
   setting->SetMaximum(static_cast<double>(maximum));
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -699,17 +686,16 @@ std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddList(
     int help /* = -1 */,
     bool details /* = false */)
 {
-  if (group == NULL || id.empty() || label < 0 || filler == NULL ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || !filler || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingString> setting = std::make_shared<CSettingString>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingString>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetListControl("string", false, heading, false, nullptr, details));
   setting->SetOptionsFiller(filler);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -727,17 +713,16 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddList(
     int help /* = -1 */,
     bool details /* = false */)
 {
-  if (group == NULL || id.empty() || label < 0 || entries.empty() ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || entries.empty() || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingInt> setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetListControl("integer", false, heading, false, nullptr, details));
   setting->SetTranslatableOptions(entries);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -755,17 +740,16 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddList(
     int help /* = -1 */,
     bool details /* = false */)
 {
-  if (group == NULL || id.empty() || label < 0 || entries.empty() ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || entries.empty() || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingInt> setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetListControl("integer", false, heading, false, nullptr, details));
   setting->SetOptions(entries);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -783,17 +767,16 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddList(
     int help /* = -1 */,
     bool details /* = false */)
 {
-  if (group == NULL || id.empty() || label < 0 || filler == NULL ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || !filler || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingInt> setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetListControl("integer", false, heading, false, nullptr, details));
   setting->SetOptionsFiller(filler);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -813,33 +796,35 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(
     int help /* = -1 */,
     bool details /* = false */)
 {
-  if (group == NULL || id.empty() || label < 0 || filler == NULL ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || !filler || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingString> settingDefinition = std::make_shared<CSettingString>(id, GetSettingsManager());
-  if (settingDefinition == NULL)
-    return NULL;
+  const auto settingDefinition = std::make_shared<CSettingString>(id, GetSettingsManager());
+  if (!settingDefinition)
+    return nullptr;
 
   settingDefinition->SetOptionsFiller(filler);
 
-  std::shared_ptr<CSettingList> setting = std::make_shared<CSettingList>(id, settingDefinition, label, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting =
+      std::make_shared<CSettingList>(id, settingDefinition, label, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   std::vector<CVariant> valueList;
-  for (std::vector<std::string>::const_iterator itValue = values.begin(); itValue != values.end(); ++itValue)
-    valueList.emplace_back(*itValue);
+  for (const auto& value : values)
+    valueList.emplace_back(value);
+
   SettingList settingValues;
   if (!CSettingUtils::ValuesToList(setting, valueList, settingValues))
-    return NULL;
+    return nullptr;
+
   // setting the default will also set the actual value on an unchanged setting
   setting->SetDefault(settingValues);
 
   setting->SetControl(GetListControl("string", false, heading, true, nullptr, details));
   setting->SetMinimumItems(minimumItems);
   setting->SetMaximumItems(maximumItems);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -859,23 +844,24 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(
     int help /* = -1 */,
     bool details /* = false */)
 {
-  if (group == NULL || id.empty() || label < 0 || entries.empty() ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || entries.empty() || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingInt> settingDefinition = std::make_shared<CSettingInt>(id, GetSettingsManager());
+  const auto settingDefinition = std::make_shared<CSettingInt>(id, GetSettingsManager());
   if (settingDefinition == NULL)
     return NULL;
 
   settingDefinition->SetTranslatableOptions(entries);
 
-  std::shared_ptr<CSettingList> setting = std::make_shared<CSettingList>(id, settingDefinition, label, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting =
+      std::make_shared<CSettingList>(id, settingDefinition, label, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   std::vector<CVariant> valueList;
-  for (std::vector<int>::const_iterator itValue = values.begin(); itValue != values.end(); ++itValue)
-    valueList.emplace_back(*itValue);
+  for (const auto& value : values)
+    valueList.emplace_back(value);
+
   SettingList settingValues;
   if (!CSettingUtils::ValuesToList(setting, valueList, settingValues))
     return NULL;
@@ -885,7 +871,7 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(
   setting->SetControl(GetListControl("integer", false, heading, true, nullptr, details));
   setting->SetMinimumItems(minimumItems);
   setting->SetMaximumItems(maximumItems);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -905,33 +891,35 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(
     int help /* = -1 */,
     bool details /* = false */)
 {
-  if (group == NULL || id.empty() || label < 0 || entries.empty() ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || entries.empty() || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingInt> settingDefinition = std::make_shared<CSettingInt>(id, GetSettingsManager());
-  if (settingDefinition == NULL)
-    return NULL;
+  const auto settingDefinition = std::make_shared<CSettingInt>(id, GetSettingsManager());
+  if (!settingDefinition)
+    return nullptr;
 
   settingDefinition->SetOptions(entries);
 
-  std::shared_ptr<CSettingList> setting = std::make_shared<CSettingList>(id, settingDefinition, label, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting =
+      std::make_shared<CSettingList>(id, settingDefinition, label, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   std::vector<CVariant> valueList;
-  for (std::vector<int>::const_iterator itValue = values.begin(); itValue != values.end(); ++itValue)
-    valueList.emplace_back(*itValue);
+  for (const auto& value : values)
+    valueList.emplace_back(value);
+
   SettingList settingValues;
   if (!CSettingUtils::ValuesToList(setting, valueList, settingValues))
-    return NULL;
+    return nullptr;
+
   // setting the default will also set the actual value on an unchanged setting
   setting->SetDefault(settingValues);
 
   setting->SetControl(GetListControl("integer", false, heading, true, nullptr, details));
   setting->SetMinimumItems(minimumItems);
   setting->SetMaximumItems(maximumItems);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -952,33 +940,35 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(
     const SettingControlListValueFormatter& formatter /* = {} */,
     bool details /* = false */)
 {
-  if (group == NULL || id.empty() || label < 0 || filler == NULL ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || !filler || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingInt> settingDefinition = std::make_shared<CSettingInt>(id, GetSettingsManager());
-  if (settingDefinition == NULL)
-    return NULL;
+  const auto settingDefinition = std::make_shared<CSettingInt>(id, GetSettingsManager());
+  if (!settingDefinition)
+    return nullptr;
 
   settingDefinition->SetOptionsFiller(filler);
 
-  std::shared_ptr<CSettingList> setting = std::make_shared<CSettingList>(id, settingDefinition, label, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting =
+      std::make_shared<CSettingList>(id, settingDefinition, label, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   std::vector<CVariant> valueList;
-  for (std::vector<int>::const_iterator itValue = values.begin(); itValue != values.end(); ++itValue)
-    valueList.emplace_back(*itValue);
+  for (const auto& value : values)
+    valueList.emplace_back(value);
+
   SettingList settingValues;
   if (!CSettingUtils::ValuesToList(setting, valueList, settingValues))
-    return NULL;
+    return nullptr;
+
   // setting the default will also set the actual value on an unchanged setting
   setting->SetDefault(settingValues);
 
   setting->SetControl(GetListControl("integer", false, heading, true, formatter, details));
   setting->SetMinimumItems(minimumItems);
   setting->SetMaximumItems(maximumItems);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -998,19 +988,18 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddPercentageSlider(
     bool visible /* = true */,
     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingInt> setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetSliderControl("percentage", delayed, heading, usePopup, formatLabel));
   setting->SetMinimum(0);
   setting->SetStep(step);
   setting->SetMaximum(100);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -1030,19 +1019,18 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddPercentageSlider(
     bool visible /* = true */,
     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingInt> setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetSliderControl("percentage", delayed, heading, usePopup, -1, formatString));
   setting->SetMinimum(0);
   setting->SetStep(step);
   setting->SetMaximum(100);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -1063,19 +1051,18 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSlider(const Setti
                                                                      bool visible /* = true */,
                                                                      int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingInt> setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetSliderControl("integer", delayed, heading, usePopup, formatLabel));
   setting->SetMinimum(minimum);
   setting->SetStep(step);
   setting->SetMaximum(maximum);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -1097,19 +1084,18 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSlider(
     bool visible /* = true */,
     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingInt> setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingInt>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetSliderControl("integer", delayed, heading, usePopup, -1, formatString));
   setting->SetMinimum(minimum);
   setting->SetStep(step);
   setting->SetMaximum(maximum);
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -1131,19 +1117,18 @@ std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddSlider(
     bool visible /* = true */,
     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingNumber> setting = std::make_shared<CSettingNumber>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingNumber>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetSliderControl("number", delayed, heading, usePopup, formatLabel));
   setting->SetMinimum(static_cast<double>(minimum));
   setting->SetStep(static_cast<double>(step));
   setting->SetMaximum(static_cast<double>(maximum));
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -1165,19 +1150,18 @@ std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddSlider(
     bool visible /* = true */,
     int help /* = -1 */)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingNumber> setting = std::make_shared<CSettingNumber>(id, label, value, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting = std::make_shared<CSettingNumber>(id, label, value, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   setting->SetControl(GetSliderControl("number", delayed, heading, usePopup, -1, formatString));
   setting->SetMinimum(static_cast<double>(minimum));
   setting->SetStep(static_cast<double>(step));
   setting->SetMaximum(static_cast<double>(maximum));
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -1385,28 +1369,29 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddRange(
     bool visible,
     int help)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingInt> settingDefinition = std::make_shared<CSettingInt>(id, GetSettingsManager());
-  if (settingDefinition == NULL)
-    return NULL;
+  const auto settingDefinition = std::make_shared<CSettingInt>(id, GetSettingsManager());
+  if (!settingDefinition)
+    return nullptr;
 
   settingDefinition->SetMinimum(minimum);
   settingDefinition->SetStep(step);
   settingDefinition->SetMaximum(maximum);
 
-  std::shared_ptr<CSettingList> setting = std::make_shared<CSettingList>(id, settingDefinition, label, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting =
+      std::make_shared<CSettingList>(id, settingDefinition, label, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   std::vector<CVariant> valueList;
   valueList.emplace_back(valueLower);
   valueList.emplace_back(valueUpper);
   SettingList settingValues;
   if (!CSettingUtils::ValuesToList(setting, valueList, settingValues))
-    return NULL;
+    return nullptr;
+
   // setting the default will also set the actual value on an unchanged setting
   setting->SetDefault(settingValues);
 
@@ -1414,7 +1399,7 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddRange(
   setting->SetMinimumItems(2);
   setting->SetMaximumItems(2);
 
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
@@ -1438,28 +1423,29 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddRange(
     bool visible,
     int help)
 {
-  if (group == NULL || id.empty() || label < 0 ||
-      GetSetting(id) != NULL)
-    return NULL;
+  if (!group || id.empty() || label < 0 || GetSetting(id))
+    return nullptr;
 
-  std::shared_ptr<CSettingNumber> settingDefinition = std::make_shared<CSettingNumber>(id, GetSettingsManager());
-  if (settingDefinition == NULL)
-    return NULL;
+  const auto settingDefinition = std::make_shared<CSettingNumber>(id, GetSettingsManager());
+  if (!settingDefinition)
+    return nullptr;
 
   settingDefinition->SetMinimum(static_cast<double>(minimum));
   settingDefinition->SetStep(static_cast<double>(step));
   settingDefinition->SetMaximum(static_cast<double>(maximum));
 
-  std::shared_ptr<CSettingList> setting = std::make_shared<CSettingList>(id, settingDefinition, label, GetSettingsManager());
-  if (setting == NULL)
-    return NULL;
+  const auto setting =
+      std::make_shared<CSettingList>(id, settingDefinition, label, GetSettingsManager());
+  if (!setting)
+    return nullptr;
 
   std::vector<CVariant> valueList;
   valueList.emplace_back(valueLower);
   valueList.emplace_back(valueUpper);
   SettingList settingValues;
   if (!CSettingUtils::ValuesToList(setting, valueList, settingValues))
-    return NULL;
+    return nullptr;
+
   // setting the default will also set the actual value on an unchanged setting
   setting->SetDefault(settingValues);
 
@@ -1467,18 +1453,18 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddRange(
   setting->SetMinimumItems(2);
   setting->SetMaximumItems(2);
 
-  setSettingDetails(setting, level, visible, help);
+  SetSettingDetails(setting, level, visible, help);
 
   group->AddSetting(setting);
   return setting;
 }
 
-void CGUIDialogSettingsManualBase::setSettingDetails(const std::shared_ptr<CSetting>& setting,
+void CGUIDialogSettingsManualBase::SetSettingDetails(const std::shared_ptr<CSetting>& setting,
                                                      SettingLevel level,
                                                      bool visible,
-                                                     int help)
+                                                     int help) const
 {
-  if (setting == NULL)
+  if (!setting)
     return;
 
   if (level < SettingLevel::Basic)
@@ -1492,28 +1478,35 @@ void CGUIDialogSettingsManualBase::setSettingDetails(const std::shared_ptr<CSett
     setting->SetHelp(help);
 }
 
-std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetCheckmarkControl(bool delayed /* = false */)
+std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetCheckmarkControl(
+    bool delayed /* = false */) const
 {
-  std::shared_ptr<CSettingControlCheckmark> control = std::make_shared<CSettingControlCheckmark>();
+  const auto control = std::make_shared<CSettingControlCheckmark>();
   control->SetDelayed(delayed);
 
   return control;
 }
 
-std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetTitleControl(bool separatorBelowLabel /* = true */, bool hideSeparator /* = false */)
+std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetTitleControl(
+    bool separatorBelowLabel /* = true */, bool hideSeparator /* = false */) const
 {
-  std::shared_ptr<CSettingControlTitle> control = std::make_shared<CSettingControlTitle>();
+  const auto control = std::make_shared<CSettingControlTitle>();
   control->SetSeparatorBelowLabel(separatorBelowLabel);
   control->SetSeparatorHidden(hideSeparator);
 
   return control;
 }
 
-std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetEditControl(const std::string &format, bool delayed /* = false */, bool hidden /* = false */, bool verifyNewValue /* = false */, int heading /* = -1 */)
+std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetEditControl(
+    const std::string& format,
+    bool delayed /* = false */,
+    bool hidden /* = false */,
+    bool verifyNewValue /* = false */,
+    int heading /* = -1 */) const
 {
-  std::shared_ptr<CSettingControlEdit> control = std::make_shared<CSettingControlEdit>();
+  const auto control = std::make_shared<CSettingControlEdit>();
   if (!control->SetFormat(format))
-    return NULL;
+    return nullptr;
 
   control->SetDelayed(delayed);
   control->SetHidden(hidden);
@@ -1523,12 +1516,18 @@ std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetEditControl(co
   return control;
 }
 
-std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetButtonControl(const std::string &format, bool delayed /* = false */, int heading /* = -1 */, bool hideValue /* = false */,
-                                                                bool showInstalledAddons /* = true */, bool showInstallableAddons /* = false */, bool showMoreAddons /* = true */)
+std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetButtonControl(
+    const std::string& format,
+    bool delayed /* = false */,
+    int heading /* = -1 */,
+    bool hideValue /* = false */,
+    bool showInstalledAddons /* = true */,
+    bool showInstallableAddons /* = false */,
+    bool showMoreAddons /* = true */) const
 {
-  std::shared_ptr<CSettingControlButton> control = std::make_shared<CSettingControlButton>();
+  const auto control = std::make_shared<CSettingControlButton>();
   if (!control->SetFormat(format))
-    return NULL;
+    return nullptr;
 
   control->SetDelayed(delayed);
   control->SetHeading(heading);
@@ -1540,11 +1539,16 @@ std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetButtonControl(
   return control;
 }
 
-std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetSpinnerControl(const std::string &format, bool delayed /* = false */, int minimumLabel /* = -1 */, int formatLabel /* = -1 */, const std::string &formatString /* = "" */)
+std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetSpinnerControl(
+    const std::string& format,
+    bool delayed /* = false */,
+    int minimumLabel /* = -1 */,
+    int formatLabel /* = -1 */,
+    const std::string& formatString /* = "" */) const
 {
-  std::shared_ptr<CSettingControlSpinner> control = std::make_shared<CSettingControlSpinner>();
+  const auto control = std::make_shared<CSettingControlSpinner>();
   if (!control->SetFormat(format))
-    return NULL;
+    return nullptr;
 
   control->SetDelayed(delayed);
   if (formatLabel >= 0)
@@ -1563,11 +1567,11 @@ std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetListControl(
     int heading /* = -1 */,
     bool multiselect /* = false */,
     const SettingControlListValueFormatter& formatter /* = {} */,
-    bool details /* = false */)
+    bool details /* = false */) const
 {
-  std::shared_ptr<CSettingControlList> control = std::make_shared<CSettingControlList>();
+  const auto control = std::make_shared<CSettingControlList>();
   if (!control->SetFormat(format))
-    return NULL;
+    return nullptr;
 
   control->SetDelayed(delayed);
   control->SetHeading(heading);
@@ -1578,12 +1582,17 @@ std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetListControl(
   return control;
 }
 
-std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetSliderControl(const std::string &format, bool delayed /* = false */, int heading /* = -1 */, bool usePopup /* = false */,
-                                                                int formatLabel /* = -1 */, const std::string &formatString /* = "" */)
+std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetSliderControl(
+    const std::string& format,
+    bool delayed /* = false */,
+    int heading /* = -1 */,
+    bool usePopup /* = false */,
+    int formatLabel /* = -1 */,
+    const std::string& formatString /* = "" */) const
 {
-  std::shared_ptr<CSettingControlSlider> control = std::make_shared<CSettingControlSlider>();
+  const auto control = std::make_shared<CSettingControlSlider>();
   if (!control->SetFormat(format))
-    return NULL;
+    return nullptr;
 
   control->SetDelayed(delayed);
   if (heading >= 0)
@@ -1597,12 +1606,16 @@ std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetSliderControl(
   return control;
 }
 
-std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetRangeControl(const std::string &format, bool delayed /* = false */, int formatLabel /* = -1 */,
-                                                               int valueFormatLabel /* = -1 */, const std::string &valueFormatString /* = "" */)
+std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetRangeControl(
+    const std::string& format,
+    bool delayed /* = false */,
+    int formatLabel /* = -1 */,
+    int valueFormatLabel /* = -1 */,
+    const std::string& valueFormatString /* = "" */) const
 {
-  std::shared_ptr<CSettingControlRange> control = std::make_shared<CSettingControlRange>();
+  const auto control = std::make_shared<CSettingControlRange>();
   if (!control->SetFormat(format))
-    return NULL;
+    return nullptr;
 
   control->SetDelayed(delayed);
   if (formatLabel >= 0)

--- a/xbmc/settings/dialogs/GUIDialogSettingsManualBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManualBase.h
@@ -50,7 +50,9 @@ protected:
 
   virtual void InitializeSettings();
 
-  std::shared_ptr<CSettingCategory> AddCategory(const std::string &id, int label, int help = -1);
+  std::shared_ptr<CSettingCategory> AddCategory(const std::string& id,
+                                                int label,
+                                                int help = -1) const;
   std::shared_ptr<CSettingGroup> AddGroup(const std::shared_ptr<CSettingCategory>& category,
                                           int label = -1,
                                           int help = -1,
@@ -590,21 +592,44 @@ protected:
                                              bool visible = true,
                                              int help = -1);
 
-  std::shared_ptr<ISettingControl> GetTitleControl(bool separatorBelowLabel = true, bool hideSeparator = false);
-  std::shared_ptr<ISettingControl> GetCheckmarkControl(bool delayed = false);
-  std::shared_ptr<ISettingControl> GetEditControl(const std::string &format, bool delayed = false, bool hidden = false, bool verifyNewValue = false, int heading = -1);
-  std::shared_ptr<ISettingControl> GetButtonControl(const std::string &format, bool delayed = false, int heading = -1, bool hideValue = false, bool showInstalledAddons = true,
-    bool showInstallableAddons = false, bool showMoreAddons = true);
-  std::shared_ptr<ISettingControl> GetSpinnerControl(const std::string &format, bool delayed = false, int minimumLabel = -1, int formatLabel = -1, const std::string &formatString = "");
+  std::shared_ptr<ISettingControl> GetTitleControl(bool separatorBelowLabel = true,
+                                                   bool hideSeparator = false) const;
+  std::shared_ptr<ISettingControl> GetCheckmarkControl(bool delayed = false) const;
+  std::shared_ptr<ISettingControl> GetEditControl(const std::string& format,
+                                                  bool delayed = false,
+                                                  bool hidden = false,
+                                                  bool verifyNewValue = false,
+                                                  int heading = -1) const;
+  std::shared_ptr<ISettingControl> GetButtonControl(const std::string& format,
+                                                    bool delayed = false,
+                                                    int heading = -1,
+                                                    bool hideValue = false,
+                                                    bool showInstalledAddons = true,
+                                                    bool showInstallableAddons = false,
+                                                    bool showMoreAddons = true) const;
+  std::shared_ptr<ISettingControl> GetSpinnerControl(const std::string& format,
+                                                     bool delayed = false,
+                                                     int minimumLabel = -1,
+                                                     int formatLabel = -1,
+                                                     const std::string& formatString = "") const;
   std::shared_ptr<ISettingControl> GetListControl(
       const std::string& format,
       bool delayed = false,
       int heading = -1,
       bool multiselect = false,
       const SettingControlListValueFormatter& formatter = {},
-      bool details = false);
-  std::shared_ptr<ISettingControl> GetSliderControl(const std::string &format, bool delayed = false, int heading = -1, bool usePopup = false, int formatLabel = -1, const std::string &formatString = "");
-  std::shared_ptr<ISettingControl> GetRangeControl(const std::string &format, bool delayed = false, int formatLabel = -1, int valueFormatLabel = -1, const std::string &valueFormatString = "");
+      bool details = false) const;
+  std::shared_ptr<ISettingControl> GetSliderControl(const std::string& format,
+                                                    bool delayed = false,
+                                                    int heading = -1,
+                                                    bool usePopup = false,
+                                                    int formatLabel = -1,
+                                                    const std::string& formatString = "") const;
+  std::shared_ptr<ISettingControl> GetRangeControl(const std::string& format,
+                                                   bool delayed = false,
+                                                   int formatLabel = -1,
+                                                   int valueFormatLabel = -1,
+                                                   const std::string& valueFormatString = "") const;
 
 private:
   std::shared_ptr<CSettingList> AddRange(const std::shared_ptr<CSettingGroup>& group,
@@ -640,10 +665,10 @@ private:
                                          bool visible,
                                          int help);
 
-  void setSettingDetails(const std::shared_ptr<CSetting>& setting,
+  void SetSettingDetails(const std::shared_ptr<CSetting>& setting,
                          SettingLevel level,
                          bool visible,
-                         int help);
+                         int help) const;
 
   mutable CSettingsManager* m_settingsManager = nullptr;
   std::shared_ptr<CSettingSection> m_section;

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -23,6 +23,7 @@
 #include <set>
 #include <shared_mutex>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -71,11 +72,10 @@ public:
   void SetEnabled(bool enabled);
   bool IsDefault() const { return !m_changed; }
   const std::string& GetParent() const { return m_parentSetting; }
-  void SetParent(const std::string& parentSetting) { m_parentSetting = parentSetting; }
+  void SetParent(std::string_view parentSetting) { m_parentSetting = parentSetting; }
   SettingLevel GetLevel() const { return m_level; }
   void SetLevel(SettingLevel level) { m_level = level; }
-  std::shared_ptr<const ISettingControl> GetControl() const { return m_control; }
-  std::shared_ptr<ISettingControl> GetControl() { return m_control; }
+  std::shared_ptr<ISettingControl> GetControl() const { return m_control; }
   void SetControl(std::shared_ptr<ISettingControl> control) { m_control = std::move(control); }
   const SettingDependencies& GetDependencies() const { return m_dependencies; }
   void SetDependencies(const SettingDependencies &dependencies) { m_dependencies = dependencies; }
@@ -85,7 +85,7 @@ public:
 
   bool IsReference() const { return !m_referencedId.empty(); }
   const std::string& GetReferencedId() const { return m_referencedId; }
-  void SetReferencedId(const std::string& referencedId) { m_referencedId = referencedId; }
+  void SetReferencedId(std::string_view referencedId) { m_referencedId = referencedId; }
   void MakeReference(const std::string& referencedId = "");
 
   bool GetVisible() const { return ISetting::IsVisible(); }
@@ -146,7 +146,7 @@ template<typename TValue, SettingType TSettingType>
 class CTraitedSetting : public CSetting
 {
 public:
-  typedef TValue Value;
+  using Value = TValue;
 
   // implementation of CSetting
   SettingType GetType() const override { return TSettingType; }
@@ -192,7 +192,7 @@ public:
   void SetDefinition(std::shared_ptr<CSetting> definition) { m_definition = std::move(definition); }
 
   const std::string& GetDelimiter() const { return m_delimiter; }
-  void SetDelimiter(const std::string &delimiter) { m_delimiter = delimiter; }
+  void SetDelimiter(std::string_view delimiter) { m_delimiter = delimiter; }
   int GetMinimumItems() const { return m_minimumItems; }
   void SetMinimumItems(int minimumItems) { m_minimumItems = minimumItems; }
   int GetMaximumItems() const { return m_maximumItems; }
@@ -248,7 +248,7 @@ public:
 
   bool GetValue() const
   {
-    std::shared_lock<CSharedSection> lock(m_critical);
+    std::shared_lock lock(m_critical);
     return m_value;
   }
   bool SetValue(bool value);
@@ -296,7 +296,7 @@ public:
 
   int GetValue() const
   {
-    std::shared_lock<CSharedSection> lock(m_critical);
+    std::shared_lock lock(m_critical);
     return m_value;
   }
   bool SetValue(int value);
@@ -316,7 +316,7 @@ public:
   const IntegerSettingOptions& GetOptions() const { return m_options; }
   void SetOptions(const IntegerSettingOptions &options) { m_options = options; }
   const std::string& GetOptionsFillerName() const { return m_optionsFillerName; }
-  void SetOptionsFillerName(const std::string& optionsFillerName)
+  void SetOptionsFillerName(std::string_view optionsFillerName)
   {
     m_optionsFillerName = optionsFillerName;
   }
@@ -381,7 +381,7 @@ public:
 
   double GetValue() const
   {
-    std::shared_lock<CSharedSection> lock(m_critical);
+    std::shared_lock lock(m_critical);
     return m_value;
   }
   bool SetValue(double value);
@@ -439,7 +439,7 @@ public:
 
   virtual const std::string& GetValue() const
   {
-    std::shared_lock<CSharedSection> lock(m_critical);
+    std::shared_lock lock(m_critical);
     return m_value;
   }
   virtual bool SetValue(const std::string &value);
@@ -457,7 +457,7 @@ public:
   const StringSettingOptions& GetOptions() const { return m_options; }
   void SetOptions(const StringSettingOptions &options) { m_options = options; }
   const std::string& GetOptionsFillerName() const { return m_optionsFillerName; }
-  void SetOptionsFillerName(const std::string& optionsFillerName)
+  void SetOptionsFillerName(std::string_view optionsFillerName)
   {
     m_optionsFillerName = optionsFillerName;
   }
@@ -520,7 +520,7 @@ public:
 
   bool HasData() const { return !m_data.empty(); }
   const std::string& GetData() const { return m_data; }
-  void SetData(const std::string& data) { m_data = data; }
+  void SetData(std::string_view data) { m_data = data; }
 
 protected:
   virtual void copy(const CSettingAction& setting);

--- a/xbmc/settings/lib/SettingCategoryAccess.cpp
+++ b/xbmc/settings/lib/SettingCategoryAccess.cpp
@@ -37,5 +37,5 @@ bool CSettingCategoryAccessConditionCombination::Check() const
 CSettingCategoryAccess::CSettingCategoryAccess(CSettingsManager *settingsManager /* = nullptr */)
   : CSettingCondition(settingsManager)
 {
-  m_operation = CBooleanLogicOperationPtr(new CSettingCategoryAccessConditionCombination(m_settingsManager));
+  m_operation = std::make_shared<CSettingCategoryAccessConditionCombination>(m_settingsManager);
 }

--- a/xbmc/settings/lib/SettingCategoryAccess.h
+++ b/xbmc/settings/lib/SettingCategoryAccess.h
@@ -16,9 +16,7 @@
 class CSettingCategoryAccessCondition : public CSettingConditionItem
 {
 public:
-  explicit CSettingCategoryAccessCondition(CSettingsManager *settingsManager = nullptr)
-    : CSettingConditionItem(settingsManager)
-  { }
+  using CSettingConditionItem::CSettingConditionItem;
   ~CSettingCategoryAccessCondition() override = default;
 
   bool Check() const override;
@@ -27,9 +25,7 @@ public:
 class CSettingCategoryAccessConditionCombination : public CSettingConditionCombination
 {
 public:
-  explicit CSettingCategoryAccessConditionCombination(CSettingsManager *settingsManager = nullptr)
-    : CSettingConditionCombination(settingsManager)
-  { }
+  using CSettingConditionCombination::CSettingConditionCombination;
   ~CSettingCategoryAccessConditionCombination() override = default;
 
   bool Check() const override;

--- a/xbmc/settings/lib/SettingConditions.h
+++ b/xbmc/settings/lib/SettingConditions.h
@@ -97,6 +97,6 @@ public:
       const std::shared_ptr<const CSetting>& setting = std::shared_ptr<const CSetting>()) const;
 
 private:
-  std::map<std::string, SettingConditionCheck> m_conditions;
-  std::set<std::string> m_defines;
+  std::map<std::string, SettingConditionCheck, std::less<>> m_conditions;
+  std::set<std::string, std::less<>> m_defines;
 };

--- a/xbmc/settings/lib/SettingDefinitions.h
+++ b/xbmc/settings/lib/SettingDefinitions.h
@@ -16,53 +16,53 @@
 #include <utility>
 #include <vector>
 
-#define SETTING_XML_ROOT "settings"
-#define SETTING_XML_ROOT_VERSION "version"
+constexpr const char* SETTING_XML_ROOT = "settings";
+constexpr const char* SETTING_XML_ROOT_VERSION = "version";
 
-#define SETTING_XML_ELM_SECTION "section"
-#define SETTING_XML_ELM_CATEGORY "category"
-#define SETTING_XML_ELM_GROUP "group"
-#define SETTING_XML_ELM_SETTING "setting"
-#define SETTING_XML_ELM_VISIBLE "visible"
-#define SETTING_XML_ELM_REQUIREMENT "requirement"
-#define SETTING_XML_ELM_CONDITION "condition"
-#define SETTING_XML_ELM_ENABLED "enable"
-#define SETTING_XML_ELM_LEVEL "level"
-#define SETTING_XML_ELM_DEFAULT "default"
-#define SETTING_XML_ELM_VALUE "value"
-#define SETTING_XML_ELM_CONTROL "control"
-#define SETTING_XML_ELM_CONSTRAINTS "constraints"
-#define SETTING_XML_ELM_OPTIONS "options"
-#define SETTING_XML_ELM_OPTION "option"
-#define SETTING_XML_ELM_MINIMUM "minimum"
-#define SETTING_XML_ELM_STEP "step"
-#define SETTING_XML_ELM_MAXIMUM "maximum"
-#define SETTING_XML_ELM_ALLOWEMPTY "allowempty"
-#define SETTING_XML_ELM_ALLOWNEWOPTION "allownewoption"
-#define SETTING_XML_ELM_DEPENDENCIES "dependencies"
-#define SETTING_XML_ELM_DEPENDENCY "dependency"
-#define SETTING_XML_ELM_UPDATES "updates"
-#define SETTING_XML_ELM_UPDATE "update"
-#define SETTING_XML_ELM_ACCESS "access"
-#define SETTING_XML_ELM_DELIMITER "delimiter"
-#define SETTING_XML_ELM_MINIMUM_ITEMS "minimumitems"
-#define SETTING_XML_ELM_MAXIMUM_ITEMS "maximumitems"
-#define SETTING_XML_ELM_DATA "data"
+constexpr const char* SETTING_XML_ELM_SECTION = "section";
+constexpr const char* SETTING_XML_ELM_CATEGORY = "category";
+constexpr const char* SETTING_XML_ELM_GROUP = "group";
+constexpr const char* SETTING_XML_ELM_SETTING = "setting";
+constexpr const char* SETTING_XML_ELM_VISIBLE = "visible";
+constexpr const char* SETTING_XML_ELM_REQUIREMENT = "requirement";
+constexpr const char* SETTING_XML_ELM_CONDITION = "condition";
+constexpr const char* SETTING_XML_ELM_ENABLED = "enable";
+constexpr const char* SETTING_XML_ELM_LEVEL = "level";
+constexpr const char* SETTING_XML_ELM_DEFAULT = "default";
+constexpr const char* SETTING_XML_ELM_VALUE = "value";
+constexpr const char* SETTING_XML_ELM_CONTROL = "control";
+constexpr const char* SETTING_XML_ELM_CONSTRAINTS = "constraints";
+constexpr const char* SETTING_XML_ELM_OPTIONS = "options";
+constexpr const char* SETTING_XML_ELM_OPTION = "option";
+constexpr const char* SETTING_XML_ELM_MINIMUM = "minimum";
+constexpr const char* SETTING_XML_ELM_STEP = "step";
+constexpr const char* SETTING_XML_ELM_MAXIMUM = "maximum";
+constexpr const char* SETTING_XML_ELM_ALLOWEMPTY = "allowempty";
+constexpr const char* SETTING_XML_ELM_ALLOWNEWOPTION = "allownewoption";
+constexpr const char* SETTING_XML_ELM_DEPENDENCIES = "dependencies";
+constexpr const char* SETTING_XML_ELM_DEPENDENCY = "dependency";
+constexpr const char* SETTING_XML_ELM_UPDATES = "updates";
+constexpr const char* SETTING_XML_ELM_UPDATE = "update";
+constexpr const char* SETTING_XML_ELM_ACCESS = "access";
+constexpr const char* SETTING_XML_ELM_DELIMITER = "delimiter";
+constexpr const char* SETTING_XML_ELM_MINIMUM_ITEMS = "minimumitems";
+constexpr const char* SETTING_XML_ELM_MAXIMUM_ITEMS = "maximumitems";
+constexpr const char* SETTING_XML_ELM_DATA = "data";
 
-#define SETTING_XML_ATTR_ID "id"
-#define SETTING_XML_ATTR_REFERENCE "ref"
-#define SETTING_XML_ATTR_LABEL "label"
-#define SETTING_XML_ATTR_HELP "help"
-#define SETTING_XML_ATTR_TYPE "type"
-#define SETTING_XML_ATTR_PARENT "parent"
-#define SETTING_XML_ATTR_FORMAT "format"
-#define SETTING_XML_ATTR_DELAYED "delayed"
-#define SETTING_XML_ATTR_ON "on"
-#define SETTING_XML_ATTR_OPERATOR "operator"
-#define SETTING_XML_ATTR_NAME "name"
-#define SETTING_XML_ATTR_SETTING "setting"
-#define SETTING_XML_ATTR_BEFORE "before"
-#define SETTING_XML_ATTR_AFTER "after"
+constexpr const char* SETTING_XML_ATTR_ID = "id";
+constexpr const char* SETTING_XML_ATTR_REFERENCE = "ref";
+constexpr const char* SETTING_XML_ATTR_LABEL = "label";
+constexpr const char* SETTING_XML_ATTR_HELP = "help";
+constexpr const char* SETTING_XML_ATTR_TYPE = "type";
+constexpr const char* SETTING_XML_ATTR_PARENT = "parent";
+constexpr const char* SETTING_XML_ATTR_FORMAT = "format";
+constexpr const char* SETTING_XML_ATTR_DELAYED = "delayed";
+constexpr const char* SETTING_XML_ATTR_ON = "on";
+constexpr const char* SETTING_XML_ATTR_OPERATOR = "operator";
+constexpr const char* SETTING_XML_ATTR_NAME = "name";
+constexpr const char* SETTING_XML_ATTR_SETTING = "setting";
+constexpr const char* SETTING_XML_ATTR_BEFORE = "before";
+constexpr const char* SETTING_XML_ATTR_AFTER = "after";
 
 struct IntegerSettingOption
 {

--- a/xbmc/settings/lib/SettingDependency.h
+++ b/xbmc/settings/lib/SettingDependency.h
@@ -16,6 +16,7 @@
 #include <list>
 #include <set>
 #include <string>
+#include <string_view>
 
 enum class SettingDependencyType {
   Unknown = 0,
@@ -62,9 +63,9 @@ public:
 
 private:
   CSettingDependencyCondition(CSettingsManager* settingsManager,
-                              const std::string& strProperty,
-                              const std::string& setting,
-                              const std::string& value,
+                              std::string_view strProperty,
+                              std::string_view setting,
+                              std::string_view value,
                               SettingDependencyTarget target = SettingDependencyTarget::Unknown,
                               SettingDependencyOperator op = SettingDependencyOperator::Equals,
                               bool negated = false);
@@ -135,4 +136,4 @@ private:
 };
 
 using SettingDependencies = std::list<CSettingDependency>;
-using SettingDependencyMap = std::map<std::string, SettingDependencies>;
+using SettingDependencyMap = std::map<std::string, SettingDependencies, std::less<>>;

--- a/xbmc/settings/lib/SettingRequirement.cpp
+++ b/xbmc/settings/lib/SettingRequirement.cpp
@@ -33,5 +33,5 @@ bool CSettingRequirementConditionCombination::Check() const
 CSettingRequirement::CSettingRequirement(CSettingsManager *settingsManager /* = nullptr */)
   : CSettingCondition(settingsManager)
 {
-  m_operation = CBooleanLogicOperationPtr(new CSettingRequirementConditionCombination(m_settingsManager));
+  m_operation = std::make_shared<CSettingRequirementConditionCombination>(m_settingsManager);
 }

--- a/xbmc/settings/lib/SettingRequirement.h
+++ b/xbmc/settings/lib/SettingRequirement.h
@@ -16,9 +16,7 @@
 class CSettingRequirementCondition : public CSettingConditionItem
 {
 public:
-  explicit CSettingRequirementCondition(CSettingsManager *settingsManager = nullptr)
-    : CSettingConditionItem(settingsManager)
-  { }
+  using CSettingConditionItem::CSettingConditionItem;
   ~CSettingRequirementCondition() override = default;
 
   bool Check() const override;
@@ -27,9 +25,7 @@ public:
 class CSettingRequirementConditionCombination : public CSettingConditionCombination
 {
 public:
-  explicit CSettingRequirementConditionCombination(CSettingsManager *settingsManager = nullptr)
-    : CSettingConditionCombination(settingsManager)
-  { }
+  using CSettingConditionCombination::CSettingConditionCombination;
   ~CSettingRequirementConditionCombination() override = default;
 
   bool Check() const override;

--- a/xbmc/settings/lib/SettingUpdate.h
+++ b/xbmc/settings/lib/SettingUpdate.h
@@ -26,10 +26,7 @@ public:
   CSettingUpdate();
   virtual ~CSettingUpdate() = default;
 
-  inline bool operator<(const CSettingUpdate& rhs) const
-  {
-    return m_type < rhs.m_type && m_value < rhs.m_value;
-  }
+  auto operator<=>(const CSettingUpdate&) const = default;
 
   virtual bool Deserialize(const TiXmlNode *node);
 

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -33,7 +33,7 @@ bool ParseSettingIdentifier(const std::string& settingId, std::string& categoryT
   if (settingId.empty())
     return false;
 
-  auto parts = StringUtils::Split(settingId, Separator);
+  std::vector<std::string> parts = StringUtils::Split(settingId, Separator);
   if (parts.size() < 1 || parts.at(0).empty())
     return false;
 
@@ -80,22 +80,22 @@ uint32_t CSettingsManager::ParseVersion(const TiXmlElement* root) const
 
 bool CSettingsManager::Initialize(const TiXmlElement *root)
 {
-  std::unique_lock<CSharedSection> lock(m_critical);
-  std::unique_lock<CSharedSection> settingsLock(m_settingsCritical);
-  if (m_initialized || root == nullptr)
+  std::unique_lock lock(m_critical);
+  std::unique_lock settingsLock(m_settingsCritical);
+  if (m_initialized || !root)
     return false;
 
   if (!StringUtils::EqualsNoCase(root->ValueStr(), SETTING_XML_ROOT))
   {
-    m_logger->error("error reading settings definition: doesn't contain <" SETTING_XML_ROOT
-                    "> tag");
+    m_logger->error(StringUtils::Format(
+        "error reading settings definition: doesn't contain <{}> tag", SETTING_XML_ROOT));
     return false;
   }
 
   // try to get and check the version
   uint32_t version = ParseVersion(root);
   if (version == 0)
-    m_logger->warn("missing " SETTING_XML_ROOT_VERSION " attribute", SETTING_XML_ROOT_VERSION);
+    m_logger->warn(StringUtils::Format("missing {} attribute", SETTING_XML_ROOT_VERSION));
 
   if (MinimumSupportedVersion >= version+1)
   {
@@ -110,14 +110,14 @@ bool CSettingsManager::Initialize(const TiXmlElement *root)
     return false;
   }
 
-  auto sectionNode = root->FirstChild(SETTING_XML_ELM_SECTION);
-  while (sectionNode != nullptr)
+  const TiXmlNode* sectionNode = root->FirstChild(SETTING_XML_ELM_SECTION);
+  while (sectionNode)
   {
     std::string sectionId;
     if (CSettingSection::DeserializeIdentification(sectionNode, sectionId))
     {
       SettingSectionPtr section = nullptr;
-      auto itSection = m_sections.find(sectionId);
+      const auto itSection = m_sections.find(sectionId);
       bool update = (itSection != m_sections.end());
       if (!update)
         section = std::make_shared<CSettingSection>(sectionId, this);
@@ -143,9 +143,9 @@ bool CSettingsManager::Load(const TiXmlElement* root,
                             bool triggerEvents /* = true */,
                             LoadedSettings* loadedSettings /* = nullptr */)
 {
-  std::shared_lock<CSharedSection> lock(m_critical);
-  std::unique_lock<CSharedSection> settingsLock(m_settingsCritical);
-  if (m_loaded || root == nullptr)
+  std::shared_lock lock(m_critical);
+  std::unique_lock settingsLock(m_settingsCritical);
+  if (m_loaded || !root)
     return false;
 
   if (triggerEvents && !OnSettingsLoading())
@@ -181,11 +181,11 @@ bool CSettingsManager::Load(const TiXmlElement* root,
 bool CSettingsManager::Save(
   const ISettingsValueSerializer* serializer, std::string& serializedValues) const
 {
-  if (serializer == nullptr)
+  if (!serializer)
     return false;
 
-  std::shared_lock<CSharedSection> lock(m_critical);
-  std::shared_lock<CSharedSection> settingsLock(m_settingsCritical);
+  std::shared_lock lock(m_critical);
+  std::shared_lock settingsLock(m_settingsCritical);
   if (!m_initialized)
     return false;
 
@@ -201,7 +201,7 @@ bool CSettingsManager::Save(
 
 void CSettingsManager::Unload()
 {
-  std::unique_lock<CSharedSection> lock(m_settingsCritical);
+  std::unique_lock lock(m_settingsCritical);
   if (!m_loaded)
     return;
 
@@ -209,15 +209,15 @@ void CSettingsManager::Unload()
   // OnSettingChanging() and OnSettingChanged()
   m_loaded = false;
 
-  for (auto& setting : m_settings)
-    setting.second.setting->Reset();
+  for (const auto& [_, setting] : m_settings)
+    setting.setting->Reset();
 
   OnSettingsUnloaded();
 }
 
 void CSettingsManager::Clear()
 {
-  std::unique_lock<CSharedSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   Unload();
 
   m_settings.clear();
@@ -238,11 +238,11 @@ bool CSettingsManager::LoadSetting(const TiXmlNode *node, const std::string &set
 {
   updated = false;
 
-  if (node == nullptr)
+  if (!node)
     return false;
 
-  auto setting = GetSetting(settingId);
-  if (setting == nullptr)
+  const SettingPtr setting = GetSetting(settingId);
+  if (!setting)
     return false;
 
   return LoadSetting(node, setting, updated);
@@ -250,31 +250,31 @@ bool CSettingsManager::LoadSetting(const TiXmlNode *node, const std::string &set
 
 void CSettingsManager::SetInitialized()
 {
-  std::unique_lock<CSharedSection> lock(m_settingsCritical);
+  std::unique_lock lock(m_settingsCritical);
   if (m_initialized)
     return;
 
   m_initialized = true;
 
   // resolve any reference settings
-  for (const auto& section : m_sections)
-    ResolveReferenceSettings(section.second);
+  for (const auto& [_, section] : m_sections)
+    ResolveReferenceSettings(section);
 
   // remove any incomplete settings
   CleanupIncompleteSettings();
 
   // figure out all the dependencies between settings
-  for (const auto& setting : m_settings)
-    ResolveSettingDependencies(setting.second);
+  for (const auto& [_, setting] : m_settings)
+    ResolveSettingDependencies(setting);
 }
 
 void CSettingsManager::AddSection(const SettingSectionPtr& section)
 {
-  if (section == nullptr)
+  if (!section)
     return;
 
-  std::unique_lock<CSharedSection> lock(m_critical);
-  std::unique_lock<CSharedSection> settingsLock(m_settingsCritical);
+  std::unique_lock lock(m_critical);
+  std::unique_lock settingsLock(m_settingsCritical);
 
   section->CheckRequirements();
   m_sections[section->GetId()] = section;
@@ -315,38 +315,38 @@ bool CSettingsManager::AddSetting(const std::shared_ptr<CSetting>& setting,
                                   const std::shared_ptr<CSettingCategory>& category,
                                   const std::shared_ptr<CSettingGroup>& group)
 {
-  if (setting == nullptr || section == nullptr || category == nullptr || group == nullptr)
+  if (!setting || !section || !category || !group)
     return false;
 
-  std::unique_lock<CSharedSection> lock(m_critical);
-  std::unique_lock<CSharedSection> settingsLock(m_settingsCritical);
+  std::unique_lock lock(m_critical);
+  std::unique_lock settingsLock(m_settingsCritical);
 
   // check if a setting with the given ID already exists
   if (FindSetting(setting->GetId()) != m_settings.end())
     return false;
 
   // if the given setting has not been added to the group yet, do it now
-  auto settings = group->GetSettings();
-  if (std::find(settings.begin(), settings.end(), setting) == settings.end())
+  const SettingList& settings = group->GetSettings();
+  if (std::ranges::find(settings, setting) == settings.end())
     group->AddSetting(setting);
 
   // if the given group has not been added to the category yet, do it now
-  auto groups = category->GetGroups();
-  if (std::find(groups.begin(), groups.end(), group) == groups.end())
+  const SettingGroupList& groups = category->GetGroups();
+  if (std::ranges::find(groups, group) == groups.end())
     category->AddGroup(group);
 
   // if the given category has not been added to the section yet, do it now
-  auto categories = section->GetCategories();
-  if (std::find(categories.begin(), categories.end(), category) == categories.end())
+  const SettingCategoryList& categories = section->GetCategories();
+  if (std::ranges::find(categories, category) == categories.end())
     section->AddCategory(category);
 
   // check if the given section exists and matches
-  auto sectionPtr = GetSection(section->GetId());
-  if (sectionPtr != nullptr && sectionPtr != section)
+  const std::shared_ptr<const CSettingSection> sectionPtr = GetSection(section->GetId());
+  if (sectionPtr && sectionPtr != section)
     return false;
 
   // if the section doesn't exist yet, add it
-  if (sectionPtr == nullptr)
+  if (!sectionPtr)
     AddSection(section);
   else
   {
@@ -369,8 +369,8 @@ bool CSettingsManager::AddSetting(const std::shared_ptr<CSetting>& setting,
 void CSettingsManager::RegisterCallback(ISettingCallback* callback,
                                         const SettingsContainer& settingList)
 {
-  std::unique_lock<CSharedSection> lock(m_settingsCritical);
-  if (callback == nullptr)
+  std::unique_lock lock(m_settingsCritical);
+  if (!callback)
     return;
 
   for (const auto& setting : settingList)
@@ -382,8 +382,8 @@ void CSettingsManager::RegisterCallback(ISettingCallback* callback,
         continue;
 
       Setting tmpSetting = {};
-      std::pair<SettingMap::iterator, bool> tmpIt = InsertSetting(setting, tmpSetting);
-      itSetting = tmpIt.first;
+      const auto [it, _] = InsertSetting(setting, tmpSetting);
+      itSetting = it;
     }
 
     itSetting->second.callbacks.insert(callback);
@@ -392,40 +392,38 @@ void CSettingsManager::RegisterCallback(ISettingCallback* callback,
 
 void CSettingsManager::UnregisterCallback(ISettingCallback *callback)
 {
-  std::unique_lock<CSharedSection> lock(m_settingsCritical);
-  for (auto& setting : m_settings)
-    setting.second.callbacks.erase(callback);
+  std::unique_lock lock(m_settingsCritical);
+  for (auto& [_, setting] : m_settings)
+    setting.callbacks.erase(callback);
 }
 
 void CSettingsManager::RegisterSettingType(const std::string &settingType, ISettingCreator *settingCreator)
 {
-  std::unique_lock<CSharedSection> lock(m_critical);
-  if (settingType.empty() || settingCreator == nullptr)
+  std::unique_lock lock(m_critical);
+  if (settingType.empty() || !settingCreator)
     return;
 
-  auto creatorIt = m_settingCreators.find(settingType);
-  if (creatorIt == m_settingCreators.end())
-    m_settingCreators.insert(std::make_pair(settingType, settingCreator));
+  if (m_settingCreators.find(settingType) == m_settingCreators.end())
+    m_settingCreators.try_emplace(settingType, settingCreator);
 }
 
 void CSettingsManager::RegisterSettingControl(const std::string &controlType, ISettingControlCreator *settingControlCreator)
 {
-  if (controlType.empty() || settingControlCreator == nullptr)
+  if (controlType.empty() || !settingControlCreator)
     return;
 
-  std::unique_lock<CSharedSection> lock(m_critical);
-  auto creatorIt = m_settingControlCreators.find(controlType);
-  if (creatorIt == m_settingControlCreators.end())
-    m_settingControlCreators.insert(std::make_pair(controlType, settingControlCreator));
+  std::unique_lock lock(m_critical);
+  if (m_settingControlCreators.find(controlType) == m_settingControlCreators.end())
+    m_settingControlCreators.try_emplace(controlType, settingControlCreator);
 }
 
 void CSettingsManager::RegisterSettingsHandler(ISettingsHandler *settingsHandler, bool bFront /* = false */)
 {
-  if (settingsHandler == nullptr)
+  if (!settingsHandler)
     return;
 
-  std::unique_lock<CSharedSection> lock(m_critical);
-  if (find(m_settingsHandlers.begin(), m_settingsHandlers.end(), settingsHandler) == m_settingsHandlers.end())
+  std::unique_lock lock(m_critical);
+  if (std::ranges::find(m_settingsHandlers, settingsHandler) == m_settingsHandlers.end())
   {
     if (bFront)
       m_settingsHandlers.insert(m_settingsHandlers.begin(), settingsHandler);
@@ -436,11 +434,11 @@ void CSettingsManager::RegisterSettingsHandler(ISettingsHandler *settingsHandler
 
 void CSettingsManager::UnregisterSettingsHandler(ISettingsHandler *settingsHandler)
 {
-  if (settingsHandler == nullptr)
+  if (!settingsHandler)
     return;
 
-  std::unique_lock<CSharedSection> lock(m_critical);
-  auto it = std::find(m_settingsHandlers.begin(), m_settingsHandlers.end(), settingsHandler);
+  std::unique_lock lock(m_critical);
+  const auto it = std::ranges::find(m_settingsHandlers, settingsHandler);
   if (it != m_settingsHandlers.end())
     m_settingsHandlers.erase(it);
 }
@@ -448,42 +446,40 @@ void CSettingsManager::UnregisterSettingsHandler(ISettingsHandler *settingsHandl
 void CSettingsManager::RegisterSettingOptionsFiller(
     const std::string& identifier, const IntegerSettingOptionsFiller& optionsFiller)
 {
-  if (identifier.empty() || optionsFiller == nullptr)
+  if (identifier.empty() || !optionsFiller)
     return;
 
-  std::unique_lock<CSharedSection> lock(m_critical);
-  auto it = m_optionsFillers.find(identifier);
-  if (it != m_optionsFillers.end())
+  std::unique_lock lock(m_critical);
+  if (m_optionsFillers.contains(identifier))
     return;
 
-  m_optionsFillers.insert(std::make_pair(identifier, optionsFiller));
+  m_optionsFillers.try_emplace(identifier, optionsFiller);
 }
 
 void CSettingsManager::RegisterSettingOptionsFiller(const std::string& identifier,
                                                     const StringSettingOptionsFiller& optionsFiller)
 {
-  if (identifier.empty() || optionsFiller == nullptr)
+  if (identifier.empty() || !optionsFiller)
     return;
 
-  std::unique_lock<CSharedSection> lock(m_critical);
-  auto it = m_optionsFillers.find(identifier);
-  if (it != m_optionsFillers.end())
+  std::unique_lock lock(m_critical);
+  if (m_optionsFillers.contains(identifier))
     return;
 
-  m_optionsFillers.insert(std::make_pair(identifier, optionsFiller));
+  m_optionsFillers.try_emplace(identifier, optionsFiller);
 }
 
 void CSettingsManager::UnregisterSettingOptionsFiller(const std::string &identifier)
 {
-  std::unique_lock<CSharedSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   m_optionsFillers.erase(identifier);
 }
 
 SettingOptionsFiller CSettingsManager::GetSettingOptionsFiller(
     const std::shared_ptr<const CSetting>& setting)
 {
-  std::shared_lock<CSharedSection> lock(m_critical);
-  if (setting == nullptr)
+  std::shared_lock lock(m_critical);
+  if (!setting)
     return {};
 
   // get the option filler's identifier
@@ -497,7 +493,7 @@ SettingOptionsFiller CSettingsManager::GetSettingOptionsFiller(
     return {};
 
   // check if such an option filler is known
-  auto fillerIt = m_optionsFillers.find(filler);
+  const auto fillerIt = m_optionsFillers.find(filler);
   if (fillerIt == m_optionsFillers.end())
     return {};
 
@@ -509,7 +505,7 @@ SettingOptionsFiller CSettingsManager::GetSettingOptionsFiller(
       if (setting->GetType() != SettingType::Integer)
         return {};
 
-      if (fillerIt->second.intFiller == nullptr)
+      if (!fillerIt->second.intFiller)
         return {};
 
       break;
@@ -520,7 +516,7 @@ SettingOptionsFiller CSettingsManager::GetSettingOptionsFiller(
       if (setting->GetType() != SettingType::String)
         return {};
 
-      if (fillerIt->second.stringFiller == nullptr)
+      if (!fillerIt->second.stringFiller)
         return {};
 
       break;
@@ -540,11 +536,11 @@ bool CSettingsManager::HasSettings() const
 
 SettingPtr CSettingsManager::GetSetting(const std::string &id) const
 {
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
+  std::shared_lock lock(m_settingsCritical);
   if (id.empty())
     return nullptr;
 
-  auto setting = FindSetting(id);
+  const auto setting = FindSetting(id);
   if (setting != m_settings.end())
   {
     if (setting->second.setting->IsReference())
@@ -559,23 +555,23 @@ SettingPtr CSettingsManager::GetSetting(const std::string &id) const
 
 SettingSectionList CSettingsManager::GetSections() const
 {
-  std::shared_lock<CSharedSection> lock(m_critical);
+  std::shared_lock lock(m_critical);
   SettingSectionList sections;
-  for (const auto& section : m_sections)
-    sections.push_back(section.second);
+  for (const auto& [_, section] : m_sections)
+    sections.emplace_back(section);
 
   return sections;
 }
 
 SettingSectionPtr CSettingsManager::GetSection(std::string section) const
 {
-  std::shared_lock<CSharedSection> lock(m_critical);
+  std::shared_lock lock(m_critical);
   if (section.empty())
     return nullptr;
 
   StringUtils::ToLower(section);
 
-  auto sectionIt = m_sections.find(section);
+  const auto sectionIt = m_sections.find(section);
   if (sectionIt != m_sections.end())
     return sectionIt->second;
 
@@ -585,8 +581,8 @@ SettingSectionPtr CSettingsManager::GetSection(std::string section) const
 
 SettingDependencyMap CSettingsManager::GetDependencies(const std::string &id) const
 {
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
-  auto setting = FindSetting(id);
+  std::shared_lock lock(m_settingsCritical);
+  const auto setting = FindSetting(id);
   if (setting == m_settings.end())
     return SettingDependencyMap();
 
@@ -595,7 +591,7 @@ SettingDependencyMap CSettingsManager::GetDependencies(const std::string &id) co
 
 SettingDependencyMap CSettingsManager::GetDependencies(const SettingConstPtr& setting) const
 {
-  if (setting == nullptr)
+  if (!setting)
     return SettingDependencyMap();
 
   return GetDependencies(setting->GetId());
@@ -603,9 +599,9 @@ SettingDependencyMap CSettingsManager::GetDependencies(const SettingConstPtr& se
 
 bool CSettingsManager::GetBool(const std::string &id) const
 {
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
+  std::shared_lock lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
-  if (setting == nullptr || setting->GetType() != SettingType::Boolean)
+  if (!setting || setting->GetType() != SettingType::Boolean)
     return false;
 
   return std::static_pointer_cast<CSettingBool>(setting)->GetValue();
@@ -613,9 +609,9 @@ bool CSettingsManager::GetBool(const std::string &id) const
 
 bool CSettingsManager::SetBool(const std::string &id, bool value)
 {
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
+  std::shared_lock lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
-  if (setting == nullptr || setting->GetType() != SettingType::Boolean)
+  if (!setting || setting->GetType() != SettingType::Boolean)
     return false;
 
   return std::static_pointer_cast<CSettingBool>(setting)->SetValue(value);
@@ -623,9 +619,9 @@ bool CSettingsManager::SetBool(const std::string &id, bool value)
 
 bool CSettingsManager::ToggleBool(const std::string &id)
 {
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
+  std::shared_lock lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
-  if (setting == nullptr || setting->GetType() != SettingType::Boolean)
+  if (!setting || setting->GetType() != SettingType::Boolean)
     return false;
 
   return SetBool(id, !std::static_pointer_cast<CSettingBool>(setting)->GetValue());
@@ -633,9 +629,9 @@ bool CSettingsManager::ToggleBool(const std::string &id)
 
 int CSettingsManager::GetInt(const std::string &id) const
 {
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
+  std::shared_lock lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
-  if (setting == nullptr || setting->GetType() != SettingType::Integer)
+  if (!setting || setting->GetType() != SettingType::Integer)
     return 0;
 
   return std::static_pointer_cast<CSettingInt>(setting)->GetValue();
@@ -643,9 +639,9 @@ int CSettingsManager::GetInt(const std::string &id) const
 
 bool CSettingsManager::SetInt(const std::string &id, int value)
 {
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
+  std::shared_lock lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
-  if (setting == nullptr || setting->GetType() != SettingType::Integer)
+  if (!setting || setting->GetType() != SettingType::Integer)
     return false;
 
   return std::static_pointer_cast<CSettingInt>(setting)->SetValue(value);
@@ -653,9 +649,9 @@ bool CSettingsManager::SetInt(const std::string &id, int value)
 
 double CSettingsManager::GetNumber(const std::string &id) const
 {
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
+  std::shared_lock lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
-  if (setting == nullptr || setting->GetType() != SettingType::Number)
+  if (!setting || setting->GetType() != SettingType::Number)
     return 0.0;
 
   return std::static_pointer_cast<CSettingNumber>(setting)->GetValue();
@@ -663,9 +659,9 @@ double CSettingsManager::GetNumber(const std::string &id) const
 
 bool CSettingsManager::SetNumber(const std::string &id, double value)
 {
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
+  std::shared_lock lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
-  if (setting == nullptr || setting->GetType() != SettingType::Number)
+  if (!setting || setting->GetType() != SettingType::Number)
     return false;
 
   return std::static_pointer_cast<CSettingNumber>(setting)->SetValue(value);
@@ -673,9 +669,9 @@ bool CSettingsManager::SetNumber(const std::string &id, double value)
 
 std::string CSettingsManager::GetString(const std::string &id) const
 {
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
+  std::shared_lock lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
-  if (setting == nullptr || setting->GetType() != SettingType::String)
+  if (!setting || setting->GetType() != SettingType::String)
     return "";
 
   return std::static_pointer_cast<CSettingString>(setting)->GetValue();
@@ -683,9 +679,9 @@ std::string CSettingsManager::GetString(const std::string &id) const
 
 bool CSettingsManager::SetString(const std::string &id, const std::string &value)
 {
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
+  std::shared_lock lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
-  if (setting == nullptr || setting->GetType() != SettingType::String)
+  if (!setting || setting->GetType() != SettingType::String)
     return false;
 
   return std::static_pointer_cast<CSettingString>(setting)->SetValue(value);
@@ -693,9 +689,9 @@ bool CSettingsManager::SetString(const std::string &id, const std::string &value
 
 std::vector< std::shared_ptr<CSetting> > CSettingsManager::GetList(const std::string &id) const
 {
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
+  std::shared_lock lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
-  if (setting == nullptr || setting->GetType() != SettingType::List)
+  if (!setting || setting->GetType() != SettingType::List)
     return std::vector< std::shared_ptr<CSetting> >();
 
   return std::static_pointer_cast<CSettingList>(setting)->GetValue();
@@ -703,9 +699,9 @@ std::vector< std::shared_ptr<CSetting> > CSettingsManager::GetList(const std::st
 
 bool CSettingsManager::SetList(const std::string &id, const std::vector< std::shared_ptr<CSetting> > &value)
 {
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
+  std::shared_lock lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
-  if (setting == nullptr || setting->GetType() != SettingType::List)
+  if (!setting || setting->GetType() != SettingType::List)
     return false;
 
   return std::static_pointer_cast<CSettingList>(setting)->SetValue(value);
@@ -713,9 +709,9 @@ bool CSettingsManager::SetList(const std::string &id, const std::vector< std::sh
 
 bool CSettingsManager::SetDefault(const std::string &id)
 {
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
+  std::shared_lock lock(m_settingsCritical);
   SettingPtr setting = GetSetting(id);
-  if (setting == nullptr)
+  if (!setting)
     return false;
 
   setting->Reset();
@@ -724,14 +720,14 @@ bool CSettingsManager::SetDefault(const std::string &id)
 
 void CSettingsManager::SetDefaults()
 {
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
-  for (auto& setting : m_settings)
-    setting.second.setting->Reset();
+  std::shared_lock lock(m_settingsCritical);
+  for (const auto& [_, setting] : m_settings)
+    setting.setting->Reset();
 }
 
 void CSettingsManager::AddCondition(const std::string &condition)
 {
-  std::unique_lock<CSharedSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (condition.empty())
     return;
 
@@ -741,8 +737,8 @@ void CSettingsManager::AddCondition(const std::string &condition)
 void CSettingsManager::AddDynamicCondition(const std::string& identifier,
                                            const SettingConditionCheck& condition)
 {
-  std::unique_lock<CSharedSection> lock(m_critical);
-  if (identifier.empty() || condition == nullptr)
+  std::unique_lock lock(m_critical);
+  if (identifier.empty() || !condition)
     return;
 
   m_conditions.AddDynamicCondition(identifier, condition);
@@ -750,7 +746,7 @@ void CSettingsManager::AddDynamicCondition(const std::string& identifier,
 
 void CSettingsManager::RemoveDynamicCondition(const std::string &identifier)
 {
-  std::unique_lock<CSharedSection> lock(m_critical);
+  std::unique_lock lock(m_critical);
   if (identifier.empty())
     return;
 
@@ -759,32 +755,31 @@ void CSettingsManager::RemoveDynamicCondition(const std::string &identifier)
 
 bool CSettingsManager::Serialize(TiXmlNode *parent) const
 {
-  if (parent == nullptr)
+  if (!parent)
     return false;
 
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
+  std::shared_lock lock(m_settingsCritical);
 
-  for (const auto& setting : m_settings)
+  for (const auto& [_, setting] : m_settings)
   {
-    if (setting.second.setting->IsReference() ||
-        setting.second.setting->GetType() == SettingType::Action)
+    if (setting.setting->IsReference() || setting.setting->GetType() == SettingType::Action)
       continue;
 
     TiXmlElement settingElement(SETTING_XML_ELM_SETTING);
-    settingElement.SetAttribute(SETTING_XML_ATTR_ID, setting.second.setting->GetId());
+    settingElement.SetAttribute(SETTING_XML_ATTR_ID, setting.setting->GetId());
 
     // add the default attribute
-    if (setting.second.setting->IsDefault())
+    if (setting.setting->IsDefault())
       settingElement.SetAttribute(SETTING_XML_ELM_DEFAULT, "true");
 
     // add the value
-    TiXmlText value(setting.second.setting->ToString());
+    const TiXmlText value(setting.setting->ToString());
     settingElement.InsertEndChild(value);
 
-    if (parent->InsertEndChild(settingElement) == nullptr)
+    if (!parent->InsertEndChild(settingElement))
     {
-      m_logger->warn("unable to write <" SETTING_XML_ELM_SETTING " id=\"{}\"> tag",
-                     setting.second.setting->GetId());
+      m_logger->warn(StringUtils::Format("unable to write <{} id=\"{}\"> tag",
+                                         SETTING_XML_ELM_SETTING, setting.setting->GetId()));
       continue;
     }
   }
@@ -792,25 +787,27 @@ bool CSettingsManager::Serialize(TiXmlNode *parent) const
   return true;
 }
 
-bool CSettingsManager::Deserialize(const TiXmlNode *node, bool &updated, std::map<std::string, SettingPtr> *loadedSettings /* = nullptr */)
+bool CSettingsManager::Deserialize(const TiXmlNode* node,
+                                   bool& updated,
+                                   LoadedSettings* loadedSettings /* = nullptr */)
 {
   updated = false;
 
-  if (node == nullptr)
+  if (!node)
     return false;
 
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
+  std::shared_lock lock(m_settingsCritical);
 
   // TODO: ideally this would be done by going through all <setting> elements
   // in node but as long as we have to support the v1- format that's not possible
-  for (auto& setting : m_settings)
+  for (const auto& [settingname, setting] : m_settings)
   {
     bool settingUpdated = false;
-    if (LoadSetting(node, setting.second.setting, settingUpdated))
+    if (LoadSetting(node, setting.setting, settingUpdated))
     {
       updated |= settingUpdated;
-      if (loadedSettings != nullptr)
-        loadedSettings->insert(make_pair(setting.first, setting.second.setting));
+      if (loadedSettings)
+        loadedSettings->try_emplace(settingname, setting.setting);
     }
   }
 
@@ -819,20 +816,20 @@ bool CSettingsManager::Deserialize(const TiXmlNode *node, bool &updated, std::ma
 
 bool CSettingsManager::OnSettingChanging(const std::shared_ptr<const CSetting>& setting)
 {
-  if (setting == nullptr)
+  if (!setting)
     return false;
 
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
+  std::shared_lock settingsLock(m_settingsCritical);
   if (!m_loaded)
     return true;
 
-  auto settingIt = FindSetting(setting->GetId());
+  const auto settingIt = FindSetting(setting->GetId());
   if (settingIt == m_settings.end())
     return false;
 
   Setting settingData = settingIt->second;
   // now that we have a copy of the setting's data, we can leave the lock
-  lock.unlock();
+  settingsLock.unlock();
 
   for (auto& callback : settingData.callbacks)
   {
@@ -843,8 +840,8 @@ bool CSettingsManager::OnSettingChanging(const std::shared_ptr<const CSetting>& 
   // if this is a reference setting apply the same change to the referenced setting
   if (setting->IsReference())
   {
-    std::shared_lock<CSharedSection> lock(m_settingsCritical);
-    auto referencedSettingIt = FindSetting(setting->GetReferencedId());
+    std::shared_lock lock(m_settingsCritical);
+    const auto referencedSettingIt = FindSetting(setting->GetReferencedId());
     if (referencedSettingIt != m_settings.end())
     {
       Setting referencedSettingData = referencedSettingIt->second;
@@ -858,10 +855,10 @@ bool CSettingsManager::OnSettingChanging(const std::shared_ptr<const CSetting>& 
   {
     // if the changed setting is referenced by other settings apply the same change to the referencing settings
     std::unordered_set<SettingPtr> referenceSettings;
-    std::shared_lock<CSharedSection> lock(m_settingsCritical);
+    std::shared_lock lock(m_settingsCritical);
     for (const auto& reference : settingData.references)
     {
-      auto referenceSettingIt = FindSetting(reference);
+      const auto referenceSettingIt = FindSetting(reference);
       if (referenceSettingIt != m_settings.end())
         referenceSettings.insert(referenceSettingIt->second.setting);
     }
@@ -877,11 +874,11 @@ bool CSettingsManager::OnSettingChanging(const std::shared_ptr<const CSetting>& 
 
 void CSettingsManager::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)
 {
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
-  if (!m_loaded || setting == nullptr)
+  std::shared_lock lock(m_settingsCritical);
+  if (!m_loaded || !setting)
     return;
 
-  auto settingIt = FindSetting(setting->GetId());
+  const auto settingIt = FindSetting(setting->GetId());
   if (settingIt == m_settings.end())
     return;
 
@@ -893,21 +890,21 @@ void CSettingsManager::OnSettingChanged(const std::shared_ptr<const CSetting>& s
     callback->OnSettingChanged(setting);
 
   // now handle any settings which depend on the changed setting
-  auto dependencies = GetDependencies(setting);
-  for (const auto& deps : dependencies)
+  const SettingDependencyMap dependencies = GetDependencies(setting);
+  for (const auto& [depname, deps] : dependencies)
   {
-    for (const auto& dep : deps.second)
-      UpdateSettingByDependency(deps.first, dep);
+    for (const auto& dep : deps)
+      UpdateSettingByDependency(depname, dep);
   }
 }
 
 void CSettingsManager::OnSettingAction(const std::shared_ptr<const CSetting>& setting)
 {
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
-  if (!m_loaded || setting == nullptr)
+  std::shared_lock lock(m_settingsCritical);
+  if (!m_loaded || !setting)
     return;
 
-  auto settingIt = FindSetting(setting->GetId());
+  const auto settingIt = FindSetting(setting->GetId());
   if (settingIt == m_settings.end())
     return;
 
@@ -923,11 +920,11 @@ bool CSettingsManager::OnSettingUpdate(const SettingPtr& setting,
                                        const char* oldSettingId,
                                        const TiXmlNode* oldSettingNode)
 {
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
-  if (setting == nullptr)
+  std::shared_lock lock(m_settingsCritical);
+  if (!setting)
     return false;
 
-  auto settingIt = FindSetting(setting->GetId());
+  const auto settingIt = FindSetting(setting->GetId());
   if (settingIt == m_settings.end())
     return false;
 
@@ -945,11 +942,11 @@ bool CSettingsManager::OnSettingUpdate(const SettingPtr& setting,
 void CSettingsManager::OnSettingPropertyChanged(const std::shared_ptr<const CSetting>& setting,
                                                 const char* propertyName)
 {
-  std::shared_lock<CSharedSection> lock(m_settingsCritical);
-  if (!m_loaded || setting == nullptr)
+  std::shared_lock lock(m_settingsCritical);
+  if (!m_loaded || !setting)
     return;
 
-  auto settingIt = FindSetting(setting->GetId());
+  const auto settingIt = FindSetting(setting->GetId());
   if (settingIt == m_settings.end())
     return;
 
@@ -993,12 +990,12 @@ SettingPtr CSettingsManager::CreateSetting(const std::string &settingType, const
   {
     std::string elementType = StringUtils::Mid(settingType, 5, settingType.size() - 6);
     SettingPtr elementSetting = CreateSetting(elementType, settingId + ".definition", const_cast<CSettingsManager*>(this));
-    if (elementSetting != nullptr)
+    if (elementSetting)
       return std::make_shared<CSettingList>(settingId, elementSetting, const_cast<CSettingsManager*>(this));
   }
 
-  std::shared_lock<CSharedSection> lock(m_critical);
-  auto creator = m_settingCreators.find(settingType);
+  std::shared_lock lock(m_critical);
+  const auto creator = m_settingCreators.find(settingType);
   if (creator != m_settingCreators.end())
     return creator->second->CreateSetting(settingType, settingId, const_cast<CSettingsManager*>(this));
 
@@ -1010,9 +1007,9 @@ std::shared_ptr<ISettingControl> CSettingsManager::CreateControl(const std::stri
   if (controlType.empty())
     return nullptr;
 
-  std::shared_lock<CSharedSection> lock(m_critical);
-  auto creator = m_settingControlCreators.find(controlType);
-  if (creator != m_settingControlCreators.end() && creator->second != nullptr)
+  std::shared_lock lock(m_critical);
+  const auto creator = m_settingControlCreators.find(controlType);
+  if (creator != m_settingControlCreators.end() && creator->second)
     return creator->second->CreateControl(controlType);
 
   return nullptr;
@@ -1020,7 +1017,7 @@ std::shared_ptr<ISettingControl> CSettingsManager::CreateControl(const std::stri
 
 bool CSettingsManager::OnSettingsLoading()
 {
-  std::shared_lock<CSharedSection> lock(m_critical);
+  std::shared_lock lock(m_critical);
   for (const auto& settingsHandler : m_settingsHandlers)
   {
     if (!settingsHandler->OnSettingsLoading())
@@ -1032,40 +1029,35 @@ bool CSettingsManager::OnSettingsLoading()
 
 void CSettingsManager::OnSettingsUnloaded()
 {
-  std::shared_lock<CSharedSection> lock(m_critical);
+  std::shared_lock lock(m_critical);
   for (const auto& settingsHandler : m_settingsHandlers)
     settingsHandler->OnSettingsUnloaded();
 }
 
 void CSettingsManager::OnSettingsLoaded()
 {
-  std::shared_lock<CSharedSection> lock(m_critical);
+  std::shared_lock lock(m_critical);
   for (const auto& settingsHandler : m_settingsHandlers)
     settingsHandler->OnSettingsLoaded();
 }
 
 bool CSettingsManager::OnSettingsSaving() const
 {
-  std::shared_lock<CSharedSection> lock(m_critical);
-  for (const auto& settingsHandler : m_settingsHandlers)
-  {
-    if (!settingsHandler->OnSettingsSaving())
-      return false;
-  }
-
-  return true;
+  std::shared_lock lock(m_critical);
+  return std::ranges::all_of(m_settingsHandlers, [](const auto& settingsHandler)
+                             { return settingsHandler->OnSettingsSaving(); });
 }
 
 void CSettingsManager::OnSettingsSaved() const
 {
-  std::shared_lock<CSharedSection> lock(m_critical);
+  std::shared_lock lock(m_critical);
   for (const auto& settingsHandler : m_settingsHandlers)
     settingsHandler->OnSettingsSaved();
 }
 
 void CSettingsManager::OnSettingsCleared()
 {
-  std::shared_lock<CSharedSection> lock(m_critical);
+  std::shared_lock lock(m_critical);
   for (const auto& settingsHandler : m_settingsHandlers)
     settingsHandler->OnSettingsCleared();
 }
@@ -1074,58 +1066,61 @@ bool CSettingsManager::LoadSetting(const TiXmlNode* node, const SettingPtr& sett
 {
   updated = false;
 
-  if (node == nullptr || setting == nullptr)
+  if (!node || !setting)
     return false;
 
   if (setting->GetType() == SettingType::Action)
     return false;
 
-  auto settingId = setting->GetId();
+  std::string settingId = setting->GetId();
   if (setting->IsReference())
     settingId = setting->GetReferencedId();
 
   const TiXmlElement* settingElement = nullptr;
   // try to split the setting identifier into category and subsetting identifier (v1-)
-  std::string categoryTag, settingTag;
+  std::string categoryTag;
+  std::string settingTag;
   if (ParseSettingIdentifier(settingId, categoryTag, settingTag))
   {
-    auto categoryNode = node;
+    const TiXmlNode* categoryNode = node;
     if (!categoryTag.empty())
       categoryNode = node->FirstChild(categoryTag);
 
-    if (categoryNode != nullptr)
+    if (categoryNode)
       settingElement = categoryNode->FirstChildElement(settingTag);
   }
 
-  if (settingElement == nullptr)
+  if (!settingElement)
   {
     // check if the setting is stored using its full setting identifier (v2+)
     settingElement = node->FirstChildElement(SETTING_XML_ELM_SETTING);
-    while (settingElement != nullptr)
+    while (settingElement)
     {
-      const auto id = settingElement->Attribute(SETTING_XML_ATTR_ID);
-      if (id != nullptr && settingId.compare(id) == 0)
+      const char* id = settingElement->Attribute(SETTING_XML_ATTR_ID);
+      if (id && settingId.compare(id) == 0)
         break;
 
       settingElement = settingElement->NextSiblingElement(SETTING_XML_ELM_SETTING);
     }
   }
 
-  if (settingElement == nullptr)
+  if (!settingElement)
     return false;
 
   // check if the default="true" attribute is set for the value
-  auto isDefaultAttribute = settingElement->Attribute(SETTING_XML_ELM_DEFAULT);
-  bool isDefault = isDefaultAttribute != nullptr && StringUtils::EqualsNoCase(isDefaultAttribute, "true");
+  const char* isDefaultAttribute = settingElement->Attribute(SETTING_XML_ELM_DEFAULT);
+  const bool isDefault =
+      isDefaultAttribute && StringUtils::EqualsNoCase(isDefaultAttribute, "true");
 
-  if (!setting->FromString(settingElement->FirstChild() != nullptr ? settingElement->FirstChild()->ValueStr() : StringUtils::Empty))
+  if (!setting->FromString(settingElement->FirstChild() ? settingElement->FirstChild()->ValueStr()
+                                                        : StringUtils::Empty))
   {
     m_logger->warn("unable to read value of setting \"{}\"", settingId);
     return false;
   }
 
   // check if we need to perform any update logic for the setting
-  auto updates = setting->GetUpdates();
+  const std::set<CSettingUpdate>& updates = setting->GetUpdates();
   for (const auto& update : updates)
     updated |= UpdateSetting(node, setting, update);
 
@@ -1141,7 +1136,7 @@ bool CSettingsManager::UpdateSetting(const TiXmlNode* node,
                                      const SettingPtr& setting,
                                      const CSettingUpdate& update)
 {
-  if (node == nullptr || setting == nullptr || update.GetType() == SettingUpdateType::Unknown)
+  if (!node || !setting || update.GetType() == SettingUpdateType::Unknown)
     return false;
 
   bool updated = false;
@@ -1153,23 +1148,25 @@ bool CSettingsManager::UpdateSetting(const TiXmlNode* node,
       return false;
 
     oldSetting = update.GetValue().c_str();
-    std::string categoryTag, settingTag;
+    std::string categoryTag;
+    std::string settingTag;
     if (!ParseSettingIdentifier(oldSetting, categoryTag, settingTag))
       return false;
 
-    auto categoryNode = node;
+    const TiXmlNode* categoryNode = node;
     if (!categoryTag.empty())
     {
       categoryNode = node->FirstChild(categoryTag);
-      if (categoryNode == nullptr)
+      if (!categoryNode)
         return false;
     }
 
     oldSettingNode = categoryNode->FirstChild(settingTag);
-    if (oldSettingNode == nullptr)
+    if (!oldSettingNode)
       return false;
 
-    if (setting->FromString(oldSettingNode->FirstChild() != nullptr ? oldSettingNode->FirstChild()->ValueStr() : StringUtils::Empty))
+    if (setting->FromString(oldSettingNode->FirstChild() ? oldSettingNode->FirstChild()->ValueStr()
+                                                         : StringUtils::Empty))
       updated = true;
     else
       m_logger->warn("unable to update \"{}\" through automatically renaming from \"{}\"",
@@ -1187,11 +1184,11 @@ void CSettingsManager::UpdateSettingByDependency(const std::string &settingId, c
 
 void CSettingsManager::UpdateSettingByDependency(const std::string &settingId, SettingDependencyType dependencyType)
 {
-  auto settingIt = FindSetting(settingId);
+  const auto settingIt = FindSetting(settingId);
   if (settingIt == m_settings.end())
     return;
   SettingPtr setting = settingIt->second.setting;
-  if (setting == nullptr)
+  if (!setting)
     return;
 
   switch (dependencyType)
@@ -1208,13 +1205,13 @@ void CSettingsManager::UpdateSettingByDependency(const std::string &settingId, S
       SettingType type = setting->GetType();
       if (type == SettingType::Integer)
       {
-        auto settingInt = std::static_pointer_cast<CSettingInt>(setting);
+        const auto settingInt = std::static_pointer_cast<CSettingInt>(setting);
         if (settingInt->GetOptionsType() == SettingOptionsType::Dynamic)
           settingInt->UpdateDynamicOptions();
       }
       else if (type == SettingType::String)
       {
-        auto settingString = std::static_pointer_cast<CSettingString>(setting);
+        const auto settingString = std::static_pointer_cast<CSettingString>(setting);
         if (settingString->GetOptionsType() == SettingOptionsType::Dynamic)
           settingString->UpdateDynamicOptions();
       }
@@ -1273,11 +1270,11 @@ void CSettingsManager::AddSetting(const std::shared_ptr<CSetting>& setting)
   if (addedSetting == m_settings.end())
   {
     Setting tmpSetting = {};
-    auto tmpIt = InsertSetting(setting->GetId(), tmpSetting);
-    addedSetting = tmpIt.first;
+    const auto [it, _] = InsertSetting(setting->GetId(), tmpSetting);
+    addedSetting = it;
   }
 
-  if (addedSetting->second.setting == nullptr)
+  if (!addedSetting->second.setting)
   {
     addedSetting->second.setting = setting;
     setting->SetCallback(this);
@@ -1291,26 +1288,26 @@ void CSettingsManager::ResolveReferenceSettings(const std::shared_ptr<CSettingSe
     SettingPtr referencedSetting;
     std::unordered_set<SettingPtr> referenceSettings;
   };
-  std::map<std::string, GroupedReferenceSettings> groupedReferenceSettings;
+  std::map<std::string, GroupedReferenceSettings, std::less<>> groupedReferenceSettings;
 
   // collect and group all reference(d) settings
-  auto categories = section->GetCategories();
+  const SettingCategoryList& categories = section->GetCategories();
   for (const auto& category : categories)
   {
-    auto groups = category->GetGroups();
-    for (auto& group : groups)
+    const SettingGroupList& groups = category->GetGroups();
+    for (const auto& group : groups)
     {
-      auto settings = group->GetSettings();
+      const SettingList& settings = group->GetSettings();
       for (const auto& setting : settings)
       {
         if (setting->IsReference())
         {
-          auto referencedSettingId = setting->GetReferencedId();
+          const std::string& referencedSettingId = setting->GetReferencedId();
           auto itGroupedReferenceSetting = groupedReferenceSettings.find(referencedSettingId);
           if (itGroupedReferenceSetting == groupedReferenceSettings.end())
           {
             SettingPtr referencedSetting = nullptr;
-            auto itReferencedSetting = FindSetting(referencedSettingId);
+            const auto itReferencedSetting = FindSetting(referencedSettingId);
             if (itReferencedSetting == m_settings.end())
             {
               m_logger->warn("missing referenced setting \"{}\"", referencedSettingId);
@@ -1320,8 +1317,9 @@ void CSettingsManager::ResolveReferenceSettings(const std::shared_ptr<CSettingSe
             GroupedReferenceSettings groupedReferenceSetting;
             groupedReferenceSetting.referencedSetting = itReferencedSetting->second.setting;
 
-            itGroupedReferenceSetting = groupedReferenceSettings.insert(
-              std::make_pair(referencedSettingId, groupedReferenceSetting)).first;
+            itGroupedReferenceSetting =
+                groupedReferenceSettings.try_emplace(referencedSettingId, groupedReferenceSetting)
+                    .first;
           }
 
           itGroupedReferenceSetting->second.referenceSettings.insert(setting);
@@ -1334,16 +1332,15 @@ void CSettingsManager::ResolveReferenceSettings(const std::shared_ptr<CSettingSe
     return;
 
   // merge all reference settings into the referenced setting
-  for (const auto& groupedReferenceSetting : groupedReferenceSettings)
+  for (const auto& [settingname, setting] : groupedReferenceSettings)
   {
-    auto itReferencedSetting = FindSetting(groupedReferenceSetting.first);
+    const auto itReferencedSetting = FindSetting(settingname);
     if (itReferencedSetting == m_settings.end())
       continue;
 
-    for (const auto& referenceSetting : groupedReferenceSetting.second.referenceSettings)
+    for (const auto& referenceSetting : setting.referenceSettings)
     {
-      groupedReferenceSetting.second.referencedSetting->MergeDetails(*referenceSetting);
-
+      setting.referencedSetting->MergeDetails(*referenceSetting);
       itReferencedSetting->second.references.insert(referenceSetting->GetId());
     }
   }
@@ -1351,29 +1348,30 @@ void CSettingsManager::ResolveReferenceSettings(const std::shared_ptr<CSettingSe
   // resolve any reference settings
   for (const auto& category : categories)
   {
-    auto groups = category->GetGroups();
-    for (auto& group : groups)
+    const SettingGroupList& groups = category->GetGroups();
+    for (const auto& group : groups)
     {
-      auto settings = group->GetSettings();
+      const SettingList& settings = group->GetSettings();
       for (const auto& setting : settings)
       {
         if (setting->IsReference())
         {
-          auto referencedSettingId = setting->GetReferencedId();
+          const std::string& referencedSettingId = setting->GetReferencedId();
           auto itGroupedReferenceSetting = groupedReferenceSettings.find(referencedSettingId);
           if (itGroupedReferenceSetting != groupedReferenceSettings.end())
           {
-            const auto referencedSetting = itGroupedReferenceSetting->second.referencedSetting;
+            const SettingPtr referencedSetting =
+                itGroupedReferenceSetting->second.referencedSetting;
 
             // clone the referenced setting and copy the general properties of the reference setting
-            auto clonedReferencedSetting = referencedSetting->Clone(setting->GetId());
+            const SettingPtr clonedReferencedSetting = referencedSetting->Clone(setting->GetId());
             clonedReferencedSetting->SetReferencedId(referencedSettingId);
             clonedReferencedSetting->MergeBasics(*setting);
 
             group->ReplaceSetting(setting, clonedReferencedSetting);
 
             // update the setting
-            auto itReferenceSetting = FindSetting(setting->GetId());
+            const auto itReferenceSetting = FindSetting(setting->GetId());
             if (itReferenceSetting != m_settings.end())
               itReferenceSetting->second.setting = clonedReferencedSetting;
           }
@@ -1389,7 +1387,7 @@ void CSettingsManager::CleanupIncompleteSettings()
   for (auto setting = m_settings.begin(); setting != m_settings.end(); )
   {
     auto tmpIterator = setting++;
-    if (tmpIterator->second.setting == nullptr)
+    if (!tmpIterator->second.setting)
     {
       m_logger->warn("removing empty setting \"{}\"", tmpIterator->first);
       m_settings.erase(tmpIterator);
@@ -1399,7 +1397,7 @@ void CSettingsManager::CleanupIncompleteSettings()
 
 void CSettingsManager::ResolveSettingDependencies(const std::shared_ptr<CSetting>& setting)
 {
-  if (setting == nullptr)
+  if (!setting)
     return;
 
   ResolveSettingDependencies(FindSetting(setting->GetId())->second);
@@ -1407,31 +1405,31 @@ void CSettingsManager::ResolveSettingDependencies(const std::shared_ptr<CSetting
 
 void CSettingsManager::ResolveSettingDependencies(const Setting& setting)
 {
-  if (setting.setting == nullptr)
+  if (!setting.setting)
     return;
 
   // if the setting has a parent setting, add it to its children
-  auto parentSettingId = setting.setting->GetParent();
+  const std::string& parentSettingId = setting.setting->GetParent();
   if (!parentSettingId.empty())
   {
-    auto itParentSetting = FindSetting(parentSettingId);
+    const auto itParentSetting = FindSetting(parentSettingId);
     if (itParentSetting != m_settings.end())
       itParentSetting->second.children.insert(setting.setting->GetId());
   }
 
   // handle all dependencies of the setting
-  const auto& dependencies = setting.setting->GetDependencies();
+  const SettingDependencies& dependencies = setting.setting->GetDependencies();
   for (const auto& deps : dependencies)
   {
-    const auto settingIds = deps.GetSettings();
+    const SettingsContainer settingIds = deps.GetSettings();
     for (const auto& settingId : settingIds)
     {
-      auto settingIt = FindSetting(settingId);
+      const auto settingIt = FindSetting(settingId);
       if (settingIt == m_settings.end())
         continue;
 
       bool newDep = true;
-      auto& settingDeps = settingIt->second.dependencies[setting.setting->GetId()];
+      SettingDependencies& settingDeps = settingIt->second.dependencies[setting.setting->GetId()];
       for (const auto& dep : settingDeps)
       {
         if (dep.GetType() == deps.GetType())
@@ -1462,5 +1460,5 @@ CSettingsManager::SettingMap::iterator CSettingsManager::FindSetting(std::string
 std::pair<CSettingsManager::SettingMap::iterator, bool> CSettingsManager::InsertSetting(std::string settingId, const Setting& setting)
 {
   StringUtils::ToLower(settingId);
-  return m_settings.insert(std::make_pair(settingId, setting));
+  return m_settings.try_emplace(settingId, setting);
 }

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -138,7 +138,10 @@ bool CSettingsManager::Initialize(const TiXmlElement *root)
   return true;
 }
 
-bool CSettingsManager::Load(const TiXmlElement *root, bool &updated, bool triggerEvents /* = true */, std::map<std::string, SettingPtr> *loadedSettings /* = nullptr */)
+bool CSettingsManager::Load(const TiXmlElement* root,
+                            bool& updated,
+                            bool triggerEvents /* = true */,
+                            LoadedSettings* loadedSettings /* = nullptr */)
 {
   std::shared_lock<CSharedSection> lock(m_critical);
   std::unique_lock<CSharedSection> settingsLock(m_settingsCritical);

--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -104,6 +104,9 @@ public:
    \return True if the XML element was successfully deserialized into setting definitions, false otherwise
    */
   bool Initialize(const TiXmlElement *root);
+
+  using LoadedSettings = std::map<std::string, std::shared_ptr<CSetting>>;
+
   /*!
    \brief Loads setting values from the given XML element.
 
@@ -113,7 +116,10 @@ public:
    \param loadedSettings A list to fill with all the successfully loaded settings
    \return True if the setting values were successfully loaded, false otherwise
    */
-  bool Load(const TiXmlElement *root, bool &updated, bool triggerEvents = true, std::map<std::string, std::shared_ptr<CSetting>> *loadedSettings = nullptr);
+  bool Load(const TiXmlElement* root,
+            bool& updated,
+            bool triggerEvents = true,
+            LoadedSettings* loadedSettings = nullptr);
   /*!
    \brief Saves the setting values using the given serializer.
 

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -50,16 +50,18 @@
 
 using namespace ADDON;
 
-static std::string Localize(std::uint32_t code,
-                            ILocalizer* localizer,
-                            const std::string& addonId = "")
+namespace
 {
-  if (localizer == nullptr)
+std::string Localize(std::uint32_t code,
+                     const ILocalizer* localizer,
+                     const std::string& addonId = "")
+{
+  if (!localizer)
     return "";
 
   if (!addonId.empty())
   {
-    std::string label = g_localizeStrings.GetAddonString(addonId, code);
+    const std::string label = g_localizeStrings.GetAddonString(addonId, code);
     if (!label.empty())
       return label;
   }
@@ -68,44 +70,45 @@ static std::string Localize(std::uint32_t code,
 }
 
 template<typename TValueType>
-static CFileItemPtr GetFileItem(const std::string& label,
-                                const std::string& label2,
-                                const TValueType& value,
-                                const std::vector<std::pair<std::string, CVariant>>& properties,
-                                const std::set<TValueType>& selectedValues)
+std::shared_ptr<CFileItem> GetFileItem(
+    const std::string& label,
+    const std::string& label2,
+    const TValueType& value,
+    const std::vector<std::pair<std::string, CVariant>>& properties,
+    const std::set<TValueType>& selectedValues)
 {
-  CFileItemPtr item(new CFileItem(label));
+  auto item = std::make_shared<CFileItem>(label);
   item->SetProperty("value", value);
   item->SetLabel2(label2);
 
-  for (const auto& prop : properties)
-    item->SetProperty(prop.first, prop.second);
+  for (const auto& [propname, propval] : properties)
+    item->SetProperty(propname, propval);
 
-  if (selectedValues.find(value) != selectedValues.end())
+  if (selectedValues.contains(value))
     item->Select(true);
 
   return item;
 }
 
 template<class SettingOption>
-static bool CompareSettingOptionAseconding(const SettingOption& lhs, const SettingOption& rhs)
+bool CompareSettingOptionAseconding(const SettingOption& lhs, const SettingOption& rhs)
 {
   return StringUtils::CompareNoCase(lhs.label, rhs.label) < 0;
 }
 
 template<class SettingOption>
-static bool CompareSettingOptionDeseconding(const SettingOption& lhs, const SettingOption& rhs)
+bool CompareSettingOptionDeseconding(const SettingOption& lhs, const SettingOption& rhs)
 {
   return StringUtils::CompareNoCase(lhs.label, rhs.label) > 0;
 }
 
-static bool GetIntegerOptions(const SettingConstPtr& setting,
-                              IntegerSettingOptions& options,
-                              std::set<int>& selectedOptions,
-                              ILocalizer* localizer,
-                              bool updateOptions)
+bool GetIntegerOptions(const SettingConstPtr& setting,
+                       IntegerSettingOptions& options,
+                       std::set<int>& selectedOptions,
+                       ILocalizer* localizer,
+                       bool updateOptions)
 {
-  std::shared_ptr<const CSettingInt> pSettingInt = NULL;
+  std::shared_ptr<const CSettingInt> pSettingInt;
   if (setting->GetType() == SettingType::Integer)
     pSettingInt = std::static_pointer_cast<const CSettingInt>(setting);
   else if (setting->GetType() == SettingType::List)
@@ -173,13 +176,11 @@ static bool GetIntegerOptions(const SettingConstPtr& setting,
   switch (pSettingInt->GetOptionsSort())
   {
     case SettingOptionsSort::Ascending:
-      std::sort(options.begin(), options.end(),
-                CompareSettingOptionAseconding<IntegerSettingOption>);
+      std::ranges::sort(options, CompareSettingOptionAseconding<IntegerSettingOption>);
       break;
 
     case SettingOptionsSort::Descending:
-      std::sort(options.begin(), options.end(),
-                CompareSettingOptionDeseconding<IntegerSettingOption>);
+      std::ranges::sort(options, CompareSettingOptionDeseconding<IntegerSettingOption>);
       break;
 
     case SettingOptionsSort::NoSorting:
@@ -204,13 +205,13 @@ static bool GetIntegerOptions(const SettingConstPtr& setting,
   return true;
 }
 
-static bool GetStringOptions(const SettingConstPtr& setting,
-                             StringSettingOptions& options,
-                             std::set<std::string>& selectedOptions,
-                             ILocalizer* localizer,
-                             bool updateOptions)
+bool GetStringOptions(const SettingConstPtr& setting,
+                      StringSettingOptions& options,
+                      std::set<std::string>& selectedOptions,
+                      ILocalizer* localizer,
+                      bool updateOptions)
 {
-  std::shared_ptr<const CSettingString> pSettingString = NULL;
+  std::shared_ptr<const CSettingString> pSettingString;
   if (setting->GetType() == SettingType::String)
     pSettingString = std::static_pointer_cast<const CSettingString>(setting);
   else if (setting->GetType() == SettingType::List)
@@ -229,8 +230,8 @@ static bool GetStringOptions(const SettingConstPtr& setting,
     {
       const TranslatableStringSettingOptions& settingOptions =
           pSettingString->GetTranslatableOptions();
-      for (const auto& option : settingOptions)
-        options.emplace_back(Localize(option.first, localizer), option.second);
+      for (const auto& [id, value] : settingOptions)
+        options.emplace_back(Localize(id, localizer), value);
       break;
     }
 
@@ -261,13 +262,11 @@ static bool GetStringOptions(const SettingConstPtr& setting,
   switch (pSettingString->GetOptionsSort())
   {
     case SettingOptionsSort::Ascending:
-      std::sort(options.begin(), options.end(),
-                CompareSettingOptionAseconding<StringSettingOption>);
+      std::ranges::sort(options, CompareSettingOptionAseconding<StringSettingOption>);
       break;
 
     case SettingOptionsSort::Descending:
-      std::sort(options.begin(), options.end(),
-                CompareSettingOptionDeseconding<StringSettingOption>);
+      std::ranges::sort(options, CompareSettingOptionDeseconding<StringSettingOption>);
       break;
 
     case SettingOptionsSort::NoSorting:
@@ -291,17 +290,18 @@ static bool GetStringOptions(const SettingConstPtr& setting,
 
   return true;
 }
+} // unnamed namespace
 
 CGUIControlBaseSetting::CGUIControlBaseSetting(int id,
-                                               std::shared_ptr<CSetting> pSetting,
+                                               const std::shared_ptr<CSetting>& pSetting,
                                                ILocalizer* localizer)
-  : m_id(id), m_pSetting(std::move(pSetting)), m_localizer(localizer)
+  : m_id(id), m_pSetting(pSetting), m_localizer(localizer)
 {
 }
 
 bool CGUIControlBaseSetting::IsEnabled() const
 {
-  return m_pSetting != NULL && m_pSetting->IsEnabled();
+  return m_pSetting && m_pSetting->IsEnabled();
 }
 
 void CGUIControlBaseSetting::UpdateFromControl()
@@ -325,7 +325,7 @@ void CGUIControlBaseSetting::Update(bool fromControl, bool updateDisplayOnly)
     return;
 
   CGUIControl* control = GetControl();
-  if (control == NULL)
+  if (!control)
     return;
 
   control->SetEnabled(IsEnabled());
@@ -334,14 +334,14 @@ void CGUIControlBaseSetting::Update(bool fromControl, bool updateDisplayOnly)
   SetValid(true);
 }
 
-CGUIControlRadioButtonSetting::CGUIControlRadioButtonSetting(CGUIRadioButtonControl* pRadioButton,
-                                                             int id,
-                                                             std::shared_ptr<CSetting> pSetting,
-                                                             ILocalizer* localizer)
-  : CGUIControlBaseSetting(id, std::move(pSetting), localizer)
+CGUIControlRadioButtonSetting::CGUIControlRadioButtonSetting(
+    CGUIRadioButtonControl* pRadioButton,
+    int id,
+    const std::shared_ptr<CSetting>& pSetting,
+    ILocalizer* localizer)
+  : CGUIControlBaseSetting(id, pSetting, localizer), m_pRadioButton(pRadioButton)
 {
-  m_pRadioButton = pRadioButton;
-  if (m_pRadioButton == NULL)
+  if (!m_pRadioButton)
     return;
 
   m_pRadioButton->SetID(id);
@@ -358,7 +358,7 @@ bool CGUIControlRadioButtonSetting::OnClick()
 
 void CGUIControlRadioButtonSetting::Update(bool fromControl, bool updateDisplayOnly)
 {
-  if (fromControl || m_pRadioButton == NULL)
+  if (fromControl || !m_pRadioButton)
     return;
 
   CGUIControlBaseSetting::Update(fromControl, updateDisplayOnly);
@@ -371,9 +371,8 @@ CGUIControlColorButtonSetting::CGUIControlColorButtonSetting(
     int id,
     const std::shared_ptr<CSetting>& pSetting,
     ILocalizer* localizer)
-  : CGUIControlBaseSetting(id, pSetting, localizer)
+  : CGUIControlBaseSetting(id, pSetting, localizer), m_pColorButton(pColorControl)
 {
-  m_pColorButton = pColorControl;
   if (!m_pColorButton)
     return;
 
@@ -426,12 +425,11 @@ void CGUIControlColorButtonSetting::Update(bool fromControl, bool updateDisplayO
 
 CGUIControlSpinExSetting::CGUIControlSpinExSetting(CGUISpinControlEx* pSpin,
                                                    int id,
-                                                   std::shared_ptr<CSetting> pSetting,
+                                                   const std::shared_ptr<CSetting>& pSetting,
                                                    ILocalizer* localizer)
-  : CGUIControlBaseSetting(id, std::move(pSetting), localizer)
+  : CGUIControlBaseSetting(id, pSetting, localizer), m_pSpin(pSpin)
 {
-  m_pSpin = pSpin;
-  if (m_pSpin == NULL)
+  if (!m_pSpin)
     return;
 
   m_pSpin->SetID(id);
@@ -482,7 +480,7 @@ CGUIControlSpinExSetting::~CGUIControlSpinExSetting() = default;
 
 bool CGUIControlSpinExSetting::OnClick()
 {
-  if (m_pSpin == NULL)
+  if (!m_pSpin)
     return false;
 
   switch (m_pSetting->GetType())
@@ -494,7 +492,7 @@ bool CGUIControlSpinExSetting::OnClick()
     case SettingType::Number:
     {
       auto pSettingNumber = std::static_pointer_cast<CSettingNumber>(m_pSetting);
-      const auto& controlFormat = m_pSetting->GetControl()->GetFormat();
+      const std::string& controlFormat = m_pSetting->GetControl()->GetFormat();
       if (controlFormat == "number")
         SetValid(pSettingNumber->SetValue(static_cast<double>(m_pSpin->GetFloatValue())));
       else
@@ -518,7 +516,7 @@ bool CGUIControlSpinExSetting::OnClick()
 
 void CGUIControlSpinExSetting::Update(bool fromControl, bool updateDisplayOnly)
 {
-  if (fromControl || m_pSpin == NULL)
+  if (fromControl || !m_pSpin)
     return;
 
   CGUIControlBaseSetting::Update(fromControl, updateDisplayOnly);
@@ -535,7 +533,7 @@ void CGUIControlSpinExSetting::Update(bool fromControl, bool updateDisplayOnly)
 
 void CGUIControlSpinExSetting::FillControl(bool updateValues)
 {
-  if (m_pSpin == NULL)
+  if (!m_pSpin)
     return;
 
   if (updateValues)
@@ -624,12 +622,11 @@ void CGUIControlSpinExSetting::FillStringSettingControl(bool updateValues)
 
 CGUIControlListSetting::CGUIControlListSetting(CGUIButtonControl* pButton,
                                                int id,
-                                               std::shared_ptr<CSetting> pSetting,
+                                               const std::shared_ptr<CSetting>& pSetting,
                                                ILocalizer* localizer)
-  : CGUIControlBaseSetting(id, std::move(pSetting), localizer)
+  : CGUIControlBaseSetting(id, pSetting, localizer), m_pButton(pButton)
 {
-  m_pButton = pButton;
-  if (m_pButton == NULL)
+  if (!m_pButton)
     return;
 
   m_pButton->SetID(id);
@@ -639,13 +636,13 @@ CGUIControlListSetting::~CGUIControlListSetting() = default;
 
 bool CGUIControlListSetting::OnClick()
 {
-  if (m_pButton == NULL)
+  if (!m_pButton)
     return false;
 
   CGUIDialogSelect* dialog =
       CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(
           WINDOW_DIALOG_SELECT);
-  if (dialog == NULL)
+  if (!dialog)
     return false;
 
   CFileItemList options;
@@ -690,12 +687,12 @@ bool CGUIControlListSetting::OnClick()
       CSettingUtils::GetList(std::static_pointer_cast<const CSettingList>(m_pSetting));
     for (const auto& value : list)
     {
-      bool found = std::any_of(options.begin(), options.end(), [&](const auto& p) {
-        return p->GetProperty("value").asString() == value.asString();
-      });
+      const bool found =
+          std::ranges::any_of(options, [&value](const auto& p)
+                              { return p->GetProperty("value").asString() == value.asString(); });
       if (!found)
       {
-        CFileItemPtr item(new CFileItem(value.asString()));
+        const auto item = std::make_shared<CFileItem>(value.asString());
         item->SetProperty("value", value.asString());
         item->Select(true);
         options.Add(item);
@@ -754,7 +751,7 @@ bool CGUIControlListSetting::OnClick()
   for (int i : dialog->GetSelectedItems())
   {
     const CFileItemPtr item = options.Get(i);
-    if (item == NULL || !item->HasProperty("value"))
+    if (!item || !item->HasProperty("value"))
       return false;
 
     values.push_back(item->GetProperty("value"));
@@ -794,7 +791,7 @@ bool CGUIControlListSetting::OnClick()
 
 void CGUIControlListSetting::Update(bool fromControl, bool updateDisplayOnly)
 {
-  if (fromControl || m_pButton == NULL)
+  if (fromControl || !m_pButton)
     return;
 
   CGUIControlBaseSetting::Update(fromControl, updateDisplayOnly);
@@ -922,12 +919,12 @@ bool CGUIControlListSetting::GetStringItems(const SettingConstPtr& setting,
 
 CGUIControlButtonSetting::CGUIControlButtonSetting(CGUIButtonControl* pButton,
                                                    int id,
-                                                   std::shared_ptr<CSetting> pSetting,
+                                                   const std::shared_ptr<CSetting>& pSetting,
                                                    ILocalizer* localizer)
-  : CGUIControlBaseSetting(id, std::move(pSetting), localizer)
+  : CGUIControlBaseSetting(id, pSetting, localizer), m_pButton(pButton)
 {
-  m_pButton = pButton;
-  if (m_pButton == NULL)
+  ;
+  if (!m_pButton)
     return;
 
   m_pButton->SetID(id);
@@ -937,7 +934,7 @@ CGUIControlButtonSetting::~CGUIControlButtonSetting() = default;
 
 bool CGUIControlButtonSetting::OnClick()
 {
-  if (m_pButton == NULL)
+  if (!m_pButton)
     return false;
 
   std::shared_ptr<const ISettingControl> control = m_pSetting->GetControl();
@@ -1011,23 +1008,26 @@ bool CGUIControlButtonSetting::OnClick()
   }
   else if (controlType == "slider")
   {
-    float value, min, step, max;
+    float value;
+    float min;
+    float step;
+    float max;
     if (m_pSetting->GetType() == SettingType::Integer)
     {
       std::shared_ptr<CSettingInt> settingInt = std::static_pointer_cast<CSettingInt>(m_pSetting);
-      value = (float)settingInt->GetValue();
-      min = (float)settingInt->GetMinimum();
-      step = (float)settingInt->GetStep();
-      max = (float)settingInt->GetMaximum();
+      value = static_cast<float>(settingInt->GetValue());
+      min = static_cast<float>(settingInt->GetMinimum());
+      step = static_cast<float>(settingInt->GetStep());
+      max = static_cast<float>(settingInt->GetMaximum());
     }
     else if (m_pSetting->GetType() == SettingType::Number)
     {
       std::shared_ptr<CSettingNumber> settingNumber =
           std::static_pointer_cast<CSettingNumber>(m_pSetting);
-      value = (float)settingNumber->GetValue();
-      min = (float)settingNumber->GetMinimum();
-      step = (float)settingNumber->GetStep();
-      max = (float)settingNumber->GetMaximum();
+      value = static_cast<float>(settingNumber->GetValue());
+      min = static_cast<float>(settingNumber->GetMinimum());
+      step = static_cast<float>(settingNumber->GetStep());
+      max = static_cast<float>(settingNumber->GetMaximum());
     }
     else
       return false;
@@ -1035,7 +1035,7 @@ bool CGUIControlButtonSetting::OnClick()
     std::shared_ptr<const CSettingControlSlider> sliderControl =
         std::static_pointer_cast<const CSettingControlSlider>(control);
     CGUIDialogSlider::ShowAndGetInput(Localize(sliderControl->GetHeading()), value, min, step, max,
-                                      this, NULL);
+                                      this, nullptr);
     SetValid(true);
   }
 
@@ -1047,7 +1047,7 @@ bool CGUIControlButtonSetting::OnClick()
 
 void CGUIControlButtonSetting::Update(bool fromControl, bool updateDisplayOnly)
 {
-  if (fromControl || m_pButton == NULL)
+  if (fromControl || !m_pButton)
     return;
 
   CGUIControlBaseSetting::Update(fromControl, updateDisplayOnly);
@@ -1061,7 +1061,7 @@ void CGUIControlButtonSetting::Update(bool fromControl, bool updateDisplayOnly)
   {
     if (!std::static_pointer_cast<const CSettingControlButton>(control)->HideValue())
     {
-      auto setting = m_pSetting;
+      std::shared_ptr<CSetting> setting = m_pSetting;
       if (m_pSetting->GetType() == SettingType::List)
         setting = std::static_pointer_cast<CSettingList>(m_pSetting)->GetDefinition();
 
@@ -1168,7 +1168,7 @@ void CGUIControlButtonSetting::Update(bool fromControl, bool updateDisplayOnly)
 bool CGUIControlButtonSetting::GetPath(const std::shared_ptr<CSettingPath>& pathSetting,
                                        ILocalizer* localizer)
 {
-  if (pathSetting == NULL)
+  if (!pathSetting)
     return false;
 
   std::string path = pathSetting->GetValue();
@@ -1182,9 +1182,10 @@ bool CGUIControlButtonSetting::GetPath(const std::shared_ptr<CSettingPath>& path
       localSharesOnly = true;
     else
     {
-      std::vector<CMediaSource>* sources = CMediaSourceSettings::GetInstance().GetSources(source);
-      if (sources != NULL)
-        shares.insert(shares.end(), sources->begin(), sources->end());
+      const std::vector<CMediaSource>* mediasources =
+          CMediaSourceSettings::GetInstance().GetSources(source);
+      if (mediasources)
+        shares.insert(shares.end(), mediasources->begin(), mediasources->end());
     }
   }
 
@@ -1195,7 +1196,7 @@ bool CGUIControlButtonSetting::GetPath(const std::shared_ptr<CSettingPath>& path
   bool result = false;
   std::shared_ptr<const CSettingControlButton> control =
       std::static_pointer_cast<const CSettingControlButton>(pathSetting->GetControl());
-  const auto heading = ::Localize(control->GetHeading(), localizer);
+  const std::string heading = ::Localize(control->GetHeading(), localizer);
   if (control->GetFormat() == "file")
     result = CGUIDialogFileBrowser::ShowAndGetFile(
         shares, pathSetting->GetMasking(CServiceBroker::GetFileExtensionProvider()), heading, path,
@@ -1227,7 +1228,7 @@ bool CGUIControlButtonSetting::GetPath(const std::shared_ptr<CSettingPath>& path
 
 void CGUIControlButtonSetting::OnSliderChange(void* data, CGUISliderControl* slider)
 {
-  if (slider == NULL)
+  if (!slider)
     return;
 
   std::string strText;
@@ -1266,16 +1267,15 @@ CGUIControlEditSetting::CGUIControlEditSetting(CGUIEditControl* pEdit,
                                                int id,
                                                const std::shared_ptr<CSetting>& pSetting,
                                                ILocalizer* localizer)
-  : CGUIControlBaseSetting(id, pSetting, localizer)
+  : CGUIControlBaseSetting(id, pSetting, localizer), m_pEdit(pEdit)
 {
-  std::shared_ptr<const CSettingControlEdit> control =
-      std::static_pointer_cast<const CSettingControlEdit>(pSetting->GetControl());
-  m_pEdit = pEdit;
-  if (m_pEdit == NULL)
+  if (!m_pEdit)
     return;
 
   m_pEdit->SetID(id);
   int heading = m_pSetting->GetLabel();
+
+  const auto control = std::static_pointer_cast<const CSettingControlEdit>(pSetting->GetControl());
   if (control->GetHeading() > 0)
     heading = control->GetHeading();
   if (heading < 0)
@@ -1311,7 +1311,7 @@ CGUIControlEditSetting::~CGUIControlEditSetting() = default;
 
 bool CGUIControlEditSetting::OnClick()
 {
-  if (m_pEdit == NULL)
+  if (!m_pEdit)
     return false;
 
   // update our string
@@ -1329,18 +1329,17 @@ bool CGUIControlEditSetting::OnClick()
 
 void CGUIControlEditSetting::Update(bool fromControl, bool updateDisplayOnly)
 {
-  if (fromControl || m_pEdit == NULL)
+  if (fromControl || !m_pEdit)
     return;
 
   CGUIControlBaseSetting::Update(fromControl, updateDisplayOnly);
 
-  std::shared_ptr<const CSettingControlEdit> control =
+  const auto control =
       std::static_pointer_cast<const CSettingControlEdit>(m_pSetting->GetControl());
 
   if (control->GetFormat() == "urlencoded")
   {
-    std::shared_ptr<CSettingUrlEncodedString> urlEncodedSetting =
-        std::static_pointer_cast<CSettingUrlEncodedString>(m_pSetting);
+    const auto urlEncodedSetting = std::static_pointer_cast<CSettingUrlEncodedString>(m_pSetting);
     m_pEdit->SetLabel2(urlEncodedSetting->GetDecodedValue());
   }
   else
@@ -1349,11 +1348,11 @@ void CGUIControlEditSetting::Update(bool fromControl, bool updateDisplayOnly)
 
 bool CGUIControlEditSetting::InputValidation(const std::string& input, void* data)
 {
-  if (data == NULL)
+  if (!data)
     return true;
 
-  CGUIControlEditSetting* editControl = reinterpret_cast<CGUIControlEditSetting*>(data);
-  if (editControl->GetSetting() == NULL)
+  auto* editControl = reinterpret_cast<CGUIControlEditSetting*>(data);
+  if (!editControl->GetSetting())
     return true;
 
   editControl->SetValid(editControl->GetSetting()->CheckValidity(input));
@@ -1362,12 +1361,11 @@ bool CGUIControlEditSetting::InputValidation(const std::string& input, void* dat
 
 CGUIControlSliderSetting::CGUIControlSliderSetting(CGUISettingsSliderControl* pSlider,
                                                    int id,
-                                                   std::shared_ptr<CSetting> pSetting,
+                                                   const std::shared_ptr<CSetting>& pSetting,
                                                    ILocalizer* localizer)
-  : CGUIControlBaseSetting(id, std::move(pSetting), localizer)
+  : CGUIControlBaseSetting(id, pSetting, localizer), m_pSlider(pSlider)
 {
-  m_pSlider = pSlider;
-  if (m_pSlider == NULL)
+  if (!m_pSlider)
     return;
 
   m_pSlider->SetID(id);
@@ -1408,7 +1406,7 @@ CGUIControlSliderSetting::~CGUIControlSliderSetting() = default;
 
 bool CGUIControlSliderSetting::OnClick()
 {
-  if (m_pSlider == NULL)
+  if (!m_pSlider)
     return false;
 
   switch (m_pSetting->GetType())
@@ -1432,7 +1430,7 @@ bool CGUIControlSliderSetting::OnClick()
 
 void CGUIControlSliderSetting::Update(bool fromControl, bool updateDisplayOnly)
 {
-  if (m_pSlider == NULL)
+  if (!m_pSlider)
     return;
 
   CGUIControlBaseSetting::Update(fromControl, updateDisplayOnly);
@@ -1493,15 +1491,15 @@ std::string CGUIControlSliderSetting::GetText(const std::shared_ptr<CSetting>& s
                                               const CVariant& maximum,
                                               ILocalizer* localizer)
 {
-  if (setting == NULL || !(value.isInteger() || value.isDouble()))
+  if (!setting || !(value.isInteger() || value.isDouble()))
     return "";
 
   const auto control = std::static_pointer_cast<const CSettingControlSlider>(setting->GetControl());
-  if (control == NULL)
+  if (!control)
     return "";
 
   SettingControlSliderFormatter formatter = control->GetFormatter();
-  if (formatter != NULL)
+  if (formatter)
     return formatter(control, value, minimum, step, maximum);
 
   std::string formatString = control->GetFormatString();
@@ -1544,12 +1542,11 @@ bool CGUIControlSliderSetting::FormatText(const std::string& formatString,
 
 CGUIControlRangeSetting::CGUIControlRangeSetting(CGUISettingsSliderControl* pSlider,
                                                  int id,
-                                                 std::shared_ptr<CSetting> pSetting,
+                                                 const std::shared_ptr<CSetting>& pSetting,
                                                  ILocalizer* localizer)
-  : CGUIControlBaseSetting(id, std::move(pSetting), localizer)
+  : CGUIControlBaseSetting(id, pSetting, localizer), m_pSlider(pSlider)
 {
-  m_pSlider = pSlider;
-  if (m_pSlider == NULL)
+  if (!m_pSlider)
     return;
 
   m_pSlider->SetID(id);
@@ -1597,7 +1594,7 @@ CGUIControlRangeSetting::~CGUIControlRangeSetting() = default;
 
 bool CGUIControlRangeSetting::OnClick()
 {
-  if (m_pSlider == NULL || m_pSetting->GetType() != SettingType::List)
+  if (!m_pSlider || m_pSetting->GetType() != SettingType::List)
     return false;
 
   std::shared_ptr<CSettingList> settingList = std::static_pointer_cast<CSettingList>(m_pSetting);
@@ -1632,7 +1629,7 @@ bool CGUIControlRangeSetting::OnClick()
 
 void CGUIControlRangeSetting::Update(bool fromControl, bool updateDisplayOnly)
 {
-  if (m_pSlider == NULL || m_pSetting->GetType() != SettingType::List)
+  if (!m_pSlider || m_pSetting->GetType() != SettingType::List)
     return;
 
   CGUIControlBaseSetting::Update(fromControl, updateDisplayOnly);
@@ -1648,7 +1645,8 @@ void CGUIControlRangeSetting::Update(bool fromControl, bool updateDisplayOnly)
   const std::string& controlFormat = controlRange->GetFormat();
 
   std::string strText;
-  std::string strTextLower, strTextUpper;
+  std::string strTextLower;
+  std::string strTextUpper;
   std::string formatString =
       Localize(controlRange->GetFormatLabel() > -1 ? controlRange->GetFormatLabel() : 21469);
   std::string valueFormat = controlRange->GetValueFormat();
@@ -1659,7 +1657,8 @@ void CGUIControlRangeSetting::Update(bool fromControl, bool updateDisplayOnly)
   {
     case SettingType::Integer:
     {
-      int valueLower, valueUpper;
+      int valueLower;
+      int valueUpper;
       if (fromControl)
       {
         valueLower = m_pSlider->GetIntValue(CGUISliderControl::RangeSelectorLower);
@@ -1715,7 +1714,8 @@ void CGUIControlRangeSetting::Update(bool fromControl, bool updateDisplayOnly)
 
     case SettingType::Number:
     {
-      double valueLower, valueUpper;
+      double valueLower;
+      double valueUpper;
       if (fromControl)
       {
         valueLower =
@@ -1754,10 +1754,9 @@ void CGUIControlRangeSetting::Update(bool fromControl, bool updateDisplayOnly)
 CGUIControlSeparatorSetting::CGUIControlSeparatorSetting(CGUIImage* pImage,
                                                          int id,
                                                          ILocalizer* localizer)
-  : CGUIControlBaseSetting(id, NULL, localizer)
+  : CGUIControlBaseSetting(id, nullptr, localizer), m_pImage(pImage)
 {
-  m_pImage = pImage;
-  if (m_pImage == NULL)
+  if (!m_pImage)
     return;
 
   m_pImage->SetID(id);
@@ -1768,10 +1767,9 @@ CGUIControlSeparatorSetting::~CGUIControlSeparatorSetting() = default;
 CGUIControlGroupTitleSetting::CGUIControlGroupTitleSetting(CGUILabelControl* pLabel,
                                                            int id,
                                                            ILocalizer* localizer)
-  : CGUIControlBaseSetting(id, NULL, localizer)
+  : CGUIControlBaseSetting(id, nullptr, localizer), m_pLabel(pLabel)
 {
-  m_pLabel = pLabel;
-  if (m_pLabel == NULL)
+  if (!m_pLabel)
     return;
 
   m_pLabel->SetID(id);
@@ -1781,12 +1779,11 @@ CGUIControlGroupTitleSetting::~CGUIControlGroupTitleSetting() = default;
 
 CGUIControlLabelSetting::CGUIControlLabelSetting(CGUIButtonControl* pButton,
                                                  int id,
-                                                 std::shared_ptr<CSetting> pSetting,
+                                                 const std::shared_ptr<CSetting>& pSetting,
                                                  ILocalizer* localizer)
-  : CGUIControlBaseSetting(id, std::move(pSetting), localizer)
+  : CGUIControlBaseSetting(id, pSetting, localizer), m_pButton(pButton)
 {
-  m_pButton = pButton;
-  if (m_pButton == NULL)
+  if (!m_pButton)
     return;
 
   m_pButton->SetID(id);

--- a/xbmc/settings/windows/GUIControlSettings.h
+++ b/xbmc/settings/windows/GUIControlSettings.h
@@ -8,6 +8,13 @@
 
 #pragma once
 
+#include "guilib/GUIColorButtonControl.h"
+#include "guilib/GUIEditControl.h"
+#include "guilib/GUIImage.h"
+#include "guilib/GUILabelControl.h"
+#include "guilib/GUIRadioButtonControl.h"
+#include "guilib/GUISettingsSliderControl.h"
+#include "guilib/GUISpinControlEx.h"
 #include "guilib/ISliderCallback.h"
 #include "utils/ILocalizer.h"
 
@@ -15,16 +22,6 @@
 #include <memory>
 #include <stdlib.h>
 #include <string>
-
-class CGUIControl;
-class CGUIImage;
-class CGUISpinControlEx;
-class CGUIEditControl;
-class CGUIButtonControl;
-class CGUIRadioButtonControl;
-class CGUISettingsSliderControl;
-class CGUILabelControl;
-class CGUIColorButtonControl;
 
 class CSetting;
 class CSettingControlSlider;
@@ -37,11 +34,11 @@ class CVariant;
 class CGUIControlBaseSetting : protected ILocalizer
 {
 public:
-  CGUIControlBaseSetting(int id, std::shared_ptr<CSetting> pSetting, ILocalizer* localizer);
+  CGUIControlBaseSetting(int id, const std::shared_ptr<CSetting>& pSetting, ILocalizer* localizer);
   ~CGUIControlBaseSetting() override = default;
 
   int GetID() const { return m_id; }
-  std::shared_ptr<CSetting> GetSetting() { return m_pSetting; }
+  std::shared_ptr<CSetting> GetSetting() const { return m_pSetting; }
 
   /*!
    \brief Specifies that this setting should update after a delay
@@ -77,7 +74,7 @@ public:
 
   void SetValid(bool valid) { m_valid = valid; }
 
-  virtual CGUIControl* GetControl() { return NULL; }
+  virtual CGUIControl* GetControl() { return nullptr; }
   virtual bool OnClick() { return false; }
   void UpdateFromControl();
   void UpdateFromSetting(bool updateDisplayOnly = false);
@@ -100,15 +97,15 @@ class CGUIControlRadioButtonSetting : public CGUIControlBaseSetting
 public:
   CGUIControlRadioButtonSetting(CGUIRadioButtonControl* pRadioButton,
                                 int id,
-                                std::shared_ptr<CSetting> pSetting,
+                                const std::shared_ptr<CSetting>& pSetting,
                                 ILocalizer* localizer);
   ~CGUIControlRadioButtonSetting() override;
 
   void Select(bool bSelect);
 
-  CGUIControl* GetControl() override { return reinterpret_cast<CGUIControl*>(m_pRadioButton); }
+  CGUIControl* GetControl() override { return m_pRadioButton; }
   bool OnClick() override;
-  void Clear() override { m_pRadioButton = NULL; }
+  void Clear() override { m_pRadioButton = nullptr; }
 
 protected:
   // specialization of CGUIControlBaseSetting
@@ -129,7 +126,7 @@ public:
 
   void Select(bool bSelect);
 
-  CGUIControl* GetControl() override { return reinterpret_cast<CGUIControl*>(m_pColorButton); }
+  CGUIControl* GetControl() override { return m_pColorButton; }
   bool OnClick() override;
   void Clear() override { m_pColorButton = nullptr; }
 
@@ -146,13 +143,13 @@ class CGUIControlSpinExSetting : public CGUIControlBaseSetting
 public:
   CGUIControlSpinExSetting(CGUISpinControlEx* pSpin,
                            int id,
-                           std::shared_ptr<CSetting> pSetting,
+                           const std::shared_ptr<CSetting>& pSetting,
                            ILocalizer* localizer);
   ~CGUIControlSpinExSetting() override;
 
-  CGUIControl* GetControl() override { return reinterpret_cast<CGUIControl*>(m_pSpin); }
+  CGUIControl* GetControl() override { return m_pSpin; }
   bool OnClick() override;
-  void Clear() override { m_pSpin = NULL; }
+  void Clear() override { m_pSpin = nullptr; }
 
 protected:
   // specialization of CGUIControlBaseSetting
@@ -171,13 +168,13 @@ class CGUIControlListSetting : public CGUIControlBaseSetting
 public:
   CGUIControlListSetting(CGUIButtonControl* pButton,
                          int id,
-                         std::shared_ptr<CSetting> pSetting,
+                         const std::shared_ptr<CSetting>& pSetting,
                          ILocalizer* localizer);
   ~CGUIControlListSetting() override;
 
-  CGUIControl* GetControl() override { return reinterpret_cast<CGUIControl*>(m_pButton); }
+  CGUIControl* GetControl() override { return m_pButton; }
   bool OnClick() override;
-  void Clear() override { m_pButton = NULL; }
+  void Clear() override { m_pButton = nullptr; }
 
 protected:
   // specialization of CGUIControlBaseSetting
@@ -202,11 +199,11 @@ class CGUIControlListColorSetting : public CGUIControlBaseSetting
 public:
   CGUIControlListColorSetting(CGUIButtonControl* pButton,
                               int id,
-                              std::shared_ptr<CSetting> pSetting,
+                              const std::shared_ptr<CSetting>& pSetting,
                               ILocalizer* localizer);
   ~CGUIControlListColorSetting() override;
 
-  CGUIControl* GetControl() override { return reinterpret_cast<CGUIControl*>(m_pButton); }
+  CGUIControl* GetControl() override { return m_pButton; }
   bool OnClick() override;
   void Clear() override { m_pButton = nullptr; }
 
@@ -223,13 +220,13 @@ class CGUIControlButtonSetting : public CGUIControlBaseSetting, protected ISlide
 public:
   CGUIControlButtonSetting(CGUIButtonControl* pButton,
                            int id,
-                           std::shared_ptr<CSetting> pSetting,
+                           const std::shared_ptr<CSetting>& pSetting,
                            ILocalizer* localizer);
   ~CGUIControlButtonSetting() override;
 
-  CGUIControl* GetControl() override { return reinterpret_cast<CGUIControl*>(m_pButton); }
+  CGUIControl* GetControl() override { return m_pButton; }
   bool OnClick() override;
-  void Clear() override { m_pButton = NULL; }
+  void Clear() override { m_pButton = nullptr; }
 
   static bool GetPath(const std::shared_ptr<CSettingPath>& pathSetting, ILocalizer* localizer);
 
@@ -253,9 +250,9 @@ public:
                          ILocalizer* localizer);
   ~CGUIControlEditSetting() override;
 
-  CGUIControl* GetControl() override { return reinterpret_cast<CGUIControl*>(m_pEdit); }
+  CGUIControl* GetControl() override { return m_pEdit; }
   bool OnClick() override;
-  void Clear() override { m_pEdit = NULL; }
+  void Clear() override { m_pEdit = nullptr; }
 
 protected:
   // specialization of CGUIControlBaseSetting
@@ -272,13 +269,13 @@ class CGUIControlSliderSetting : public CGUIControlBaseSetting
 public:
   CGUIControlSliderSetting(CGUISettingsSliderControl* pSlider,
                            int id,
-                           std::shared_ptr<CSetting> pSetting,
+                           const std::shared_ptr<CSetting>& pSetting,
                            ILocalizer* localizer);
   ~CGUIControlSliderSetting() override;
 
-  CGUIControl* GetControl() override { return reinterpret_cast<CGUIControl*>(m_pSlider); }
+  CGUIControl* GetControl() override { return m_pSlider; }
   bool OnClick() override;
-  void Clear() override { m_pSlider = NULL; }
+  void Clear() override { m_pSlider = nullptr; }
 
   static std::string GetText(const std::shared_ptr<CSetting>& setting,
                              const CVariant& value,
@@ -305,13 +302,13 @@ class CGUIControlRangeSetting : public CGUIControlBaseSetting
 public:
   CGUIControlRangeSetting(CGUISettingsSliderControl* pSlider,
                           int id,
-                          std::shared_ptr<CSetting> pSetting,
+                          const std::shared_ptr<CSetting>& pSetting,
                           ILocalizer* localizer);
   ~CGUIControlRangeSetting() override;
 
-  CGUIControl* GetControl() override { return reinterpret_cast<CGUIControl*>(m_pSlider); }
+  CGUIControl* GetControl() override { return m_pSlider; }
   bool OnClick() override;
-  void Clear() override { m_pSlider = NULL; }
+  void Clear() override { m_pSlider = nullptr; }
 
 protected:
   // specialization of CGUIControlBaseSetting
@@ -327,9 +324,9 @@ public:
   CGUIControlSeparatorSetting(CGUIImage* pImage, int id, ILocalizer* localizer);
   ~CGUIControlSeparatorSetting() override;
 
-  CGUIControl* GetControl() override { return reinterpret_cast<CGUIControl*>(m_pImage); }
+  CGUIControl* GetControl() override { return m_pImage; }
   bool OnClick() override { return false; }
-  void Clear() override { m_pImage = NULL; }
+  void Clear() override { m_pImage = nullptr; }
 
 private:
   CGUIImage* m_pImage;
@@ -341,9 +338,9 @@ public:
   CGUIControlGroupTitleSetting(CGUILabelControl* pLabel, int id, ILocalizer* localizer);
   ~CGUIControlGroupTitleSetting() override;
 
-  CGUIControl* GetControl() override { return reinterpret_cast<CGUIControl*>(m_pLabel); }
+  CGUIControl* GetControl() override { return m_pLabel; }
   bool OnClick() override { return false; }
-  void Clear() override { m_pLabel = NULL; }
+  void Clear() override { m_pLabel = nullptr; }
 
 private:
   CGUILabelControl* m_pLabel;
@@ -354,12 +351,12 @@ class CGUIControlLabelSetting : public CGUIControlBaseSetting
 public:
   CGUIControlLabelSetting(CGUIButtonControl* pButton,
                           int id,
-                          std::shared_ptr<CSetting> pSetting,
+                          const std::shared_ptr<CSetting>& pSetting,
                           ILocalizer* localizer);
   ~CGUIControlLabelSetting() override = default;
 
-  CGUIControl* GetControl() override { return reinterpret_cast<CGUIControl*>(m_pButton); }
-  void Clear() override { m_pButton = NULL; }
+  CGUIControl* GetControl() override { return m_pButton; }
+  void Clear() override { m_pButton = nullptr; }
 
 private:
   CGUIButtonControl* m_pButton;

--- a/xbmc/settings/windows/GUIWindowSettings.cpp
+++ b/xbmc/settings/windows/GUIWindowSettings.cpp
@@ -10,10 +10,9 @@
 
 #include "guilib/WindowIDs.h"
 
-CGUIWindowSettings::CGUIWindowSettings(void)
-    : CGUIWindow(WINDOW_SETTINGS_MENU, "Settings.xml")
+CGUIWindowSettings::CGUIWindowSettings() : CGUIWindow(WINDOW_SETTINGS_MENU, "Settings.xml")
 {
   m_loadType = KEEP_IN_MEMORY;
 }
 
-CGUIWindowSettings::~CGUIWindowSettings(void) = default;
+CGUIWindowSettings::~CGUIWindowSettings() = default;

--- a/xbmc/settings/windows/GUIWindowSettings.h
+++ b/xbmc/settings/windows/GUIWindowSettings.h
@@ -14,6 +14,6 @@ class CGUIWindowSettings :
       public CGUIWindow
 {
 public:
-  CGUIWindowSettings(void);
-  ~CGUIWindowSettings(void) override;
+  CGUIWindowSettings();
+  ~CGUIWindowSettings() override;
 };

--- a/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
@@ -21,32 +21,39 @@
 #include "utils/log.h"
 #include "view/ViewStateSettings.h"
 
+#include <array>
 #include <string>
 
-#define SETTINGS_SYSTEM                 WINDOW_SETTINGS_SYSTEM - WINDOW_SETTINGS_START
-#define SETTINGS_SERVICE                WINDOW_SETTINGS_SERVICE - WINDOW_SETTINGS_START
-#define SETTINGS_PVR                    WINDOW_SETTINGS_MYPVR - WINDOW_SETTINGS_START
-#define SETTINGS_PLAYER                 WINDOW_SETTINGS_PLAYER - WINDOW_SETTINGS_START
-#define SETTINGS_MEDIA                  WINDOW_SETTINGS_MEDIA - WINDOW_SETTINGS_START
-#define SETTINGS_INTERFACE              WINDOW_SETTINGS_INTERFACE - WINDOW_SETTINGS_START
-#define SETTINGS_GAMES                  WINDOW_SETTINGS_MYGAMES - WINDOW_SETTINGS_START
+namespace
+{
+constexpr int SETTINGS_SYSTEM = WINDOW_SETTINGS_SYSTEM - WINDOW_SETTINGS_START;
+constexpr int SETTINGS_SERVICE = WINDOW_SETTINGS_SERVICE - WINDOW_SETTINGS_START;
+constexpr int SETTINGS_PVR = WINDOW_SETTINGS_MYPVR - WINDOW_SETTINGS_START;
+constexpr int SETTINGS_PLAYER = WINDOW_SETTINGS_PLAYER - WINDOW_SETTINGS_START;
+constexpr int SETTINGS_MEDIA = WINDOW_SETTINGS_MEDIA - WINDOW_SETTINGS_START;
+constexpr int SETTINGS_INTERFACE = WINDOW_SETTINGS_INTERFACE - WINDOW_SETTINGS_START;
+constexpr int SETTINGS_GAMES = WINDOW_SETTINGS_MYGAMES - WINDOW_SETTINGS_START;
 
-#define CONTROL_BTN_LEVELS               20
+constexpr int CONTROL_BTN_LEVELS = 20;
 
-typedef struct {
+struct SettingGroup
+{
   int id;
   std::string name;
-} SettingGroup;
+};
 
-static const SettingGroup s_settingGroupMap[] = { { SETTINGS_SYSTEM,      "system" },
-                                                  { SETTINGS_SERVICE,     "services" },
-                                                  { SETTINGS_PVR,         "pvr" },
-                                                  { SETTINGS_PLAYER,      "player" },
-                                                  { SETTINGS_MEDIA,       "media" },
-                                                  { SETTINGS_INTERFACE,   "interface" },
-                                                  { SETTINGS_GAMES,       "games" } };
-
-#define SettingGroupSize sizeof(s_settingGroupMap) / sizeof(SettingGroup)
+// clang-format off
+const std::array<SettingGroup, 7> s_settingGroupMap = {{
+  { SETTINGS_SYSTEM,      "system" },
+  { SETTINGS_SERVICE,     "services" },
+  { SETTINGS_PVR,         "pvr" },
+  { SETTINGS_PLAYER,      "player" },
+  { SETTINGS_MEDIA,       "media" },
+  { SETTINGS_INTERFACE,   "interface" },
+  { SETTINGS_GAMES,       "games" },
+}};
+// clang-format on
+} // unnamed namespace
 
 CGUIWindowSettingsCategory::CGUIWindowSettingsCategory()
     : CGUIDialogSettingsManagerBase(WINDOW_SETTINGS_SYSTEM, "SettingsCategory.xml"),
@@ -118,6 +125,9 @@ bool CGUIWindowSettingsCategory::OnMessage(CGUIMessage &message)
       }
       break;
     }
+
+    default:
+      break;
   }
 
   return CGUIDialogSettingsManagerBase::OnMessage(message);

--- a/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.h
+++ b/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.h
@@ -24,8 +24,6 @@ public:
   void DoProcess(unsigned int currentTime, CDirtyRegionList& dirtyregions) override;
   void FrameMove() override;
   void DoRender() override;
-  void AllocResources(bool forceLoad = false) override;
-  void FreeResources(bool forceUnLoad = false) override;
 
 protected:
   unsigned int FindCurrentResolution();
@@ -34,12 +32,11 @@ protected:
   void EnableControl(int iControl);
   bool UpdateFromControl(int iControl);
   void ResetCalibration();
-  unsigned int m_iCurRes;
-  std::vector<RESOLUTION> m_Res;
-  int m_iControl;
-  float m_fPixelRatioBoxHeight;
 
 private:
+  unsigned int m_iCurRes{0};
+  std::vector<RESOLUTION> m_Res;
+  int m_iControl{0};
   std::map<int, std::pair<float, float>> m_controlsSize;
   int m_subtitlesHalfSpace{0};
   int m_subtitleVerticalMargin{0};


### PR DESCRIPTION
Fixes a bunch of SonarQube findings. Many changes, almost all trivial, no functional changes intended, only modernization and optimization.

**settings/***
* Member data should be initialized in-class or in a constructor initialization list cpp:S3230
* "nullptr" should be used to denote the null pointer cpp:S4962
* "static" members should be accessed statically cpp:S2209
* STL algorithms and range-based for loops should be preferred to traditional for loops cpp:S5566
* Context-sensitive keywords should not be used as identifiers cpp:S1669
* Multiple variables should not be declared on the same line cpp:S1659
* Pointer and reference local variables should be "const" if the corresponding object is not modified cpp:S5350
* Redundant pairs of parentheses should be removed cpp:S1110
* Assignments should not be made from within conditions cpp:S1121
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* "using" should be preferred for type aliasing cpp:S5416
* Transparent function objects should be used with associative "std::string" containers cpp:S6045
* #include directives in a file should only be preceded by other preprocessor directives or comments cpp:S954
* Macros should not be used to define constants cpp:S5028
* Non-const global variables should not be used cpp:S5421
* "auto" should be used to avoid repetition of types cpp:S5827
* "try_emplace" should be used with "std::map" and "std::unordered_map" cpp:S6030
* Variables should not be shadowed cpp:S1117
* "std::string_view" should be used to pass a read-only string to a function cpp:S6009
* Redundant comparison operators should not be defined cpp:S6186
* Classes should not contain both public and private data members cpp:S5414
* Redundant class template arguments should not be used cpp:S6012
* "contains" should be used to check if a key exists in a container cpp:S6171
* Member variables should not be "protected" cpp:S3656
* "make_unique" and "make_shared" should be used to construct "unique_ptr" and "shared_ptr" cpp:S5950
* Special member function should not be defined unless a non standard behavior is required cpp:S3490
* Concise syntax should be used for concatenatable namespaces cpp:S5812
* "override" or "final" should be used instead of "virtual" cpp:S3471

**settings/dialogs**
* Macros should not be used to define constants cpp:S5028
* "nullptr" should be used to denote the null pointer cpp:S4962
* Overriding member functions should do more than simply call the same member in the base class cpp:S1185
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* Structured binding should be used cpp:S6005
* Unnecessary expensive copy should be avoided when using auto as a placeholder type cpp:S6032
* "std::source_location" should be used instead of "__FILE__", "__LINE__", and "__func__" macros cpp:S6190
* "make_unique" and "make_shared" should be used to construct "unique_ptr" and "shared_ptr" cpp:S5950
* Mergeable "if" statements should be combined cpp:S1066
* "switch" statements should cover all cases cpp:S3562
* "empty()" should be used to test for emptiness cpp:S1155
* Variables should not be shadowed cpp:S1117
* "auto" should be used to avoid repetition of types cpp:S5827
* STL algorithms and range-based for loops should be preferred to traditional for loops cpp:S5566
* Pointer and reference local variables should be "const" if the corresponding object is not modified cpp:S5350
* Assignments should not be made from within conditions cpp:S1121
* "std::string_view" should be used to pass a read-only string to a function cpp:S6009
* "using" should be preferred for type aliasing cpp:S5416
* Child class fields should not shadow parent class fields cpp:S2387
* Multiple variables should not be declared on the same line cpp:S1659

**settings/lib**
* STL algorithms and range-based for loops should be preferred to traditional for loops cpp:S5566
* "using enum" should be used in scopes with high concentration of "enum" constants cpp:S6177
* A cast shall not remove any const or volatile qualification from the type of a pointer or reference cpp:S859
* Redundant class template arguments should not be used cpp:S6012
* Variables should not be shadowed cpp:S1117
* "std::string_view" should be used to pass a read-only string to a function cpp:S6009
* "make_unique" and "make_shared" should be used to construct "unique_ptr" and "shared_ptr" cpp:S5950
* Inheriting constructors should be used cpp:S5952
* "try_emplace" should be used with "std::map" and "std::unordered_map" cpp:S6030
* "contains" should be used to check if a key exists in a container cpp:S6171
* Transparent function objects should be used with associative "std::string" containers cpp:S6045
* Unnecessary expensive copy should be avoided when using auto as a placeholder type cpp:S6032
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* Structured binding should be used cpp:S6005
* Pointer and reference local variables should be "const" if the corresponding object is not modified cpp:S5350
* Multiple variables should not be declared on the same line cpp:S1659
* Operator spaceship "<=>" should be used to define comparable types cpp:S6187

**settings/windows**
* Pointer and reference parameters should be "const" if the corresponding object is not modified cpp:S995
* "make_unique" and "make_shared" should be used to construct "unique_ptr" and "shared_ptr" cpp:S5950
* Structured binding should be used cpp:S6005
* "contains" should be used to check if a key exists in a container cpp:S6171
* "nullptr" should be used to denote the null pointer cpp:S4962
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* Member data should be initialized in-class or in a constructor initialization list cpp:S3230
* Multiple variables should not be declared on the same line cpp:S1659
* Variables should not be shadowed cpp:S1117
* "auto" should be used to avoid repetition of types cpp:S5827
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* "reinterpret_cast" should not be used cpp:S3630
* Macros should not be used to define constants cpp:S5028
* C-style array should not be used cpp:S5945
* "switch" statements should cover all cases cpp:S3562
* Overriding member functions should do more than simply call the same member in the base class cpp:S1185
* Member variables should not be "protected" cpp:S3656

@neo1973 I know this is a bit painful and boring, but would be nice if you find some time to review.