### PR TITLE
RetroPlayer: Add SCALINGMETHOD::AUTO to supported scaling methods

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -886,7 +886,7 @@ void CRPRenderManager::SaveThumbnail(const std::string& thumbnailPath)
   if (CPicture::ScaleImage(copiedData.data(), width, height, stride, sourceFormat,
                            scaledImage.data(), scaleWidth, scaleHeight, scaleStride, outFormat))
   {
-    //! @todo rotate image by rotationCCW
+    //! @todo Rotate image by rotationCCW
     (void)rotationCCW;
 
     CPicture::CreateThumbnailFromSurface(scaledImage.data(), scaleWidth, scaleHeight, scaleStride,

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
@@ -183,7 +183,7 @@ void CRPBaseRenderer::ManageRenderArea(const IRenderBuffer& renderBuffer)
   // Get screen parameters
   float screenWidth;
   float screenHeight;
-  //! @Todo screenPixelRatio unused - Possibly due to display integer scaling according to Garbear
+  //! @todo screenPixelRatio unused - Possibly due to display integer scaling according to Garbear
   float screenPixelRatio;
 
   if (scaleMode == SCALINGMETHOD::NEAREST && stretchMode == STRETCHMODE::Original &&

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -149,7 +149,8 @@ bool CRPRendererOpenGL::Supports(RENDERFEATURE feature) const
 
 bool CRPRendererOpenGL::SupportsScalingMethod(SCALINGMETHOD method)
 {
-  return method == SCALINGMETHOD::NEAREST || method == SCALINGMETHOD::LINEAR;
+  return method == SCALINGMETHOD::AUTO || method == SCALINGMETHOD::NEAREST ||
+         method == SCALINGMETHOD::LINEAR;
 }
 
 void CRPRendererOpenGL::ClearBackBuffer()

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -109,7 +109,8 @@ bool CRPRendererOpenGLES::Supports(RENDERFEATURE feature) const
 
 bool CRPRendererOpenGLES::SupportsScalingMethod(SCALINGMETHOD method)
 {
-  return method == SCALINGMETHOD::NEAREST || method == SCALINGMETHOD::LINEAR;
+  return method == SCALINGMETHOD::AUTO || method == SCALINGMETHOD::NEAREST ||
+         method == SCALINGMETHOD::LINEAR;
 }
 
 void CRPRendererOpenGLES::ClearBackBuffer()

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
@@ -286,7 +286,8 @@ bool CRPWinRenderer::Supports(RENDERFEATURE feature) const
 
 bool CRPWinRenderer::SupportsScalingMethod(SCALINGMETHOD method)
 {
-  if (method == SCALINGMETHOD::LINEAR || method == SCALINGMETHOD::NEAREST)
+  if (method == SCALINGMETHOD::AUTO || method == SCALINGMETHOD::NEAREST ||
+      method == SCALINGMETHOD::LINEAR)
     return true;
 
   return false;

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
@@ -107,7 +107,7 @@ void CDialogGameVideoFilter::InitVideoFilters()
   std::string xmlPath;
   std::unique_ptr<CXBMCTinyXML> xml;
 
-  // TODO: Have the add-on give us the xml as a string (or parse it)
+  //! @todo Have the add-on give us the xml as a string (or parse it)
   std::string xmlFilename;
 #ifdef TARGET_WINDOWS
   xmlFilename = "ShaderPresetsHLSLP.xml";
@@ -126,7 +126,7 @@ void CDialogGameVideoFilter::InitVideoFilters()
   {
     xmlPath = URIUtils::AddFileToFolder(basePath, "resources", xmlFilename);
 
-    CLog::LogF(LOGERROR, "Looking for shader preset XML at {}", CURL::GetRedacted(xmlPath));
+    CLog::LogF(LOGDEBUG, "Looking for shader preset XML at {}", CURL::GetRedacted(xmlPath));
 
     if (XFILE::CFile::Exists(xmlPath))
     {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Adds scaling method AUTO to supported scaling methods and some styling cleanups.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Newly introduced video shaders in RetroPlayer are expected to use _SCALINGMETHOD::AUTO_, see here:
https://github.com/xbmc/xbmc/blob/2cd12e82cd6a65b8c770f7c5c31c9a793eb8ffb3/xbmc/cores/RetroPlayer/rendering/RenderVideoSettings.cpp#L70

But all renderers report only _NEAREST_ and _LINEAR_ as supported methods, so the _SCALINGMETHOD::AUTO_ is being replaced by default value here:
https://github.com/xbmc/xbmc/blob/2cd12e82cd6a65b8c770f7c5c31c9a793eb8ffb3/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp#L822

Because of that the integer scaling issue is affecting the video shaders in addition to the _NEAREST_ video filter.
More information about the issue is here: https://github.com/xbmc/xbmc/issues/26849

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've tested on Wayland/OpenGL build. The video filter is reported as _SCALINGMETHOD::AUTO_ when using video shaders. I haven't seen any new issues.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
The integer scaling issue now does not affect video shaders.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
