### PR TITLE
Fix launching kodi on webOS with non standard path from SSH in a locked down jailer

### DIFF
--- a/xbmc/platform/linux/PlatformWebOS.h
+++ b/xbmc/platform/linux/PlatformWebOS.h
@@ -19,4 +19,7 @@ public:
 
 protected:
   void RegisterPowerManagement() override;
+
+private:
+  std::string GetHomePath();
 };


### PR DESCRIPTION
## Description
Kodi will fail to launch from SSH due to the jailer user not having write permissions to /media/developer on newer versions of webOS.

So instead get the HOME path from the current working directory, this allows Kodi to run again.

Note this only works if you cd into the folder where kodi is installed e.g. cd /media/developer/temp/kodi/ and then launch it from that dir. It wont work if you launch it say from /media/developer with ./temp/kodi/kodi-webos -p. In that scenario it didn't work before this patch anyway. If there's an existing function that easily locates the working directory of the binary please let me know and I'll update the PR.

## Motivation and context
While debugging kodi changes, I need to be able to run it from ssh as well as the menu.

It would crash with the following error:
```
~/temp/kodi $ ./kodi-webos -p
Could not open module param file '/sys/module/mali_kbase/parameters/large_page_conf'
XDG_RUNTIME_DIR (/tmp/xdg) is not owned by us (uid 6969), but by uid 0! (This could e.g. happen if you try to connect to a non-root PulseAudio as a root user, over the native protocol. Don't do that.)
Failed to load cookie file from cookie: No such file or directory
XDG_RUNTIME_DIR (/tmp/xdg) is not owned by us (uid 6969), but by uid 0! (This could e.g. happen if you try to connect to a non-root PulseAudio as a root user, over the native protocol. Don't do that.)
Failed to load cookie file from cookie: No such file or directory
Python path configuration:
  PYTHONHOME = '/media/developer//lib/python3'
  PYTHONPATH = '/media/developer//lib/python3:/media/developer//lib/python3/site-packages'
  program name = 'python3'
  isolated = 0
  environment = 1
  user site = 1
  safe_path = 0
  import site = 1
  is in build tree = 0
  stdlib dir = '/media/developer/lib/python3/lib/python3.12'
  sys._base_executable = '/usr/bin/python3'
  sys.base_prefix = '/media/developer//lib/python3'
  sys.base_exec_prefix = '/media/developer//lib/python3'
  sys.platlibdir = 'lib'
  sys.executable = '/usr/bin/python3'
  sys.prefix = '/media/developer//lib/python3'
  sys.exec_prefix = '/media/developer//lib/python3'
  sys.path = [
    '/media/developer/lib/python3',
    '/media/developer/lib/python3/site-packages',
    '/media/developer/lib/python3/lib/python312.zip',
    '/media/developer/lib/python3/lib/python3.12',
    '/media/developer/lib/python3/lib/python3.12/lib-dynload',
  ]
Fatal Python error: init_fs_encoding: failed to get the Python codec of the filesystem encoding
Python runtime state: core initialized
ModuleNotFoundError: No module named 'encodings'

Current thread 0xde7f90c0 (most recent call first):
  <no Python frame>
terminate called after throwing an instance of 'std::bad_variant_access'
  what():  std::visit: variant is valueless
```

With the patch applied in the commit, kodi will now run as usual from ssh, using kodi-webos -p.

This only affects newer webOS versions, as my TV only has write permission to /media/developer/temp.

Note I added the lib directory to my path:

```
export LD_LIBRARY_PATH='/media/developer/temp/kodi/lib:/lib:/usr/lib:/media/cryptofs/apps/usr/palm/services/com.palmdts.devmode.service/binaries-armv71/opt/openssh/lib/openssh:/usr/lib:/media/developer/lib'
```

## How has this been tested?
Source compiled, uploaded to a LG webOS TV C3 running webOS 24.

## What is the effect on users?
No change for users.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
