### PR TITLE
webOS: move dummy.c out of kodi source path

### DIFF
--- a/cmake/modules/FindAcbAPI.cmake
+++ b/cmake/modules/FindAcbAPI.cmake
@@ -38,8 +38,8 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
                                                                      INTERFACE_INCLUDE_DIRECTORIES "${ACBAPI_INCLUDE_DIR}")
 
     # creates an empty library to install on webOS 5+ devices
-    file(TOUCH dummy.c)
-    add_library(AcbAPI SHARED dummy.c)
+    file(TOUCH ${CMAKE_CURRENT_BINARY_DIR}/dummy.c)
+    add_library(AcbAPI SHARED ${CMAKE_CURRENT_BINARY_DIR}/dummy.c)
     set_target_properties(AcbAPI PROPERTIES VERSION 1.0.0 SOVERSION 1)
   else()
     if(AcbAPI_FIND_REQUIRED)


### PR DESCRIPTION
## Description
Adds dummy.c to gitignore generated by FindAcbAPI.cmake. It keeps making its way into my PRs..

Revised: moves dummy.c to cmake binary path, out of the source directory.

## Motivation and context
Keeps getting added to my PRs

## How has this been tested?
Added to gitignore, now its ignored.

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
