### PR TITLE
RetroPlayer: Let ApplyStateBlock() handle the VAO rebind

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -506,8 +506,6 @@ void CRPRenderManager::RenderInternal(const std::shared_ptr<CRPBaseRenderer>& re
                                       bool bClear,
                                       uint32_t alpha)
 {
-  renderer->PreRender(bClear);
-
   CSingleExit exitLock(m_renderContext.GraphicsMutex());
 
   if (renderBuffer != nullptr)

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
@@ -61,6 +61,11 @@ void CRenderContext::SetScissors(const CRect& rect)
   m_rendering->SetScissors(rect);
 }
 
+void CRenderContext::CaptureStateBlock()
+{
+  m_rendering->CaptureStateBlock();
+}
+
 void CRenderContext::ApplyStateBlock()
 {
   m_rendering->ApplyStateBlock();

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.h
@@ -60,6 +60,7 @@ public:
   void SetViewPort(const CRect& viewPort);
   void GetViewPort(CRect& viewPort);
   void SetScissors(const CRect& rect);
+  void CaptureStateBlock();
   void ApplyStateBlock();
   bool IsExtSupported(const char* extension);
 

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
@@ -123,8 +123,8 @@ void CRPBaseRenderer::RenderFrame(bool clear, uint8_t alpha)
   if (!m_bConfigured || m_renderBuffer == nullptr)
     return;
 
+  PreRender(clear);
   ManageRenderArea(*m_renderBuffer);
-
   RenderInternal(clear, alpha);
   PostRender();
 
@@ -260,15 +260,12 @@ void CRPBaseRenderer::Updateshaders()
 
 void CRPBaseRenderer::PreRender(bool clear)
 {
-  if (!m_bConfigured)
-    return;
+  m_context.CaptureStateBlock();
 
   // Clear screen
   if (clear)
     m_context.Clear(m_context.UseLimitedColor() ? UTILS::COLOR::LIMITED_BLACK
                                                 : UTILS::COLOR::BLACK);
-
-  // ManageRenderArea(*m_renderBuffer);
 }
 
 void CRPBaseRenderer::PostRender()

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
@@ -50,10 +50,6 @@ public:
   // Player functions
   bool Configure(AVPixelFormat format);
   void FrameMove();
-  /*!
-   * \brief Performs whatever necessary before rendering the frame
-   */
-  void PreRender(bool clear);
   void SetBuffer(IRenderBuffer* buffer);
   void RenderFrame(bool clear, uint8_t alpha);
 
@@ -114,12 +110,17 @@ private:
    */
   virtual void ManageRenderArea(const IRenderBuffer& renderBuffer);
 
+  void MarkDirty();
+
+  /*!
+   * \brief Performs whatever necessary before rendering the frame
+   */
+  void PreRender(bool clear);
+
   /*!
    * \brief Performs whatever necessary after a frame has been rendered
    */
   void PostRender();
-
-  void MarkDirty();
 
   // Utility functions
   void GetScreenDimensions(float& screenWidth, float& screenHeight, float& screenPixelRatio);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
@@ -84,6 +84,7 @@ void CRPRendererDMAOpenGL::Render(uint8_t alpha)
 
   Updateshaders();
 
+  // Use video shader preset
   if (m_bUseShaderPreset)
   {
     GLint filter = GL_NEAREST;
@@ -106,76 +107,75 @@ void CRPRendererDMAOpenGL::Render(uint8_t alpha)
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;
     }
-
-    return;
   }
-
-  CRect rect = m_sourceRect;
-
-  rect.x1 /= renderBuffer->GetWidth();
-  rect.x2 /= renderBuffer->GetWidth();
-  rect.y1 /= renderBuffer->GetHeight();
-  rect.y2 /= renderBuffer->GetHeight();
-
-  const uint32_t color = (alpha << 24) | 0xFFFFFF;
-
-  GLint filter = GL_NEAREST;
-  if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
-    filter = GL_LINEAR;
-
-  glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
-  glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
-  glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
-  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-  m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE);
-
-  GLubyte colour[4];
-  GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
-  PackedVertex vertex[4];
-
-  GLint uniColLoc = m_context.GUIShaderGetUniCol();
-  GLint depthLoc = m_context.GUIShaderGetDepth();
-
-  // Setup color values
-  colour[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
-  colour[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
-  colour[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
-  colour[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
-
-  for (unsigned int i = 0; i < 4; i++)
+  // Use GUI shader
+  else
   {
-    // Setup vertex position values
-    vertex[i].x = m_rotatedDestCoords[i].x;
-    vertex[i].y = m_rotatedDestCoords[i].y;
-    vertex[i].z = 0.0f;
+    CRect rect = m_sourceRect;
+
+    rect.x1 /= renderBuffer->GetWidth();
+    rect.x2 /= renderBuffer->GetWidth();
+    rect.y1 /= renderBuffer->GetHeight();
+    rect.y2 /= renderBuffer->GetHeight();
+
+    const uint32_t color = (alpha << 24) | 0xFFFFFF;
+
+    GLint filter = GL_NEAREST;
+    if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
+      filter = GL_LINEAR;
+
+    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
+    glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
+    glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
+    glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE);
+
+    GLubyte colour[4];
+    GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
+    PackedVertex vertex[4];
+
+    GLint uniColLoc = m_context.GUIShaderGetUniCol();
+    GLint depthLoc = m_context.GUIShaderGetDepth();
+
+    // Setup color values
+    colour[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
+    colour[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
+    colour[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
+    colour[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
+
+    for (unsigned int i = 0; i < 4; i++)
+    {
+      // Setup vertex position values
+      vertex[i].x = m_rotatedDestCoords[i].x;
+      vertex[i].y = m_rotatedDestCoords[i].y;
+      vertex[i].z = 0.0f;
+    }
+
+    // Setup texture coordinates
+    vertex[0].u1 = vertex[3].u1 = rect.x1;
+    vertex[0].v1 = vertex[1].v1 = rect.y1;
+    vertex[1].u1 = vertex[2].u1 = rect.x2;
+    vertex[2].v1 = vertex[3].v1 = rect.y2;
+
+    glBindVertexArray(m_mainVAO);
+
+    glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_STATIC_DRAW);
+
+    // No need to bind the index VBO, it's part of VAO state
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * 4, idx, GL_STATIC_DRAW);
+
+    glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f),
+                (colour[3] / 255.0f));
+    glUniform1f(depthLoc, -1.0f);
+
+    glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+
+    glBindVertexArray(0);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+    m_context.DisableGUIShader();
   }
-
-  // Setup texture coordinates
-  vertex[0].u1 = vertex[3].u1 = rect.x1;
-  vertex[0].v1 = vertex[1].v1 = rect.y1;
-  vertex[1].u1 = vertex[2].u1 = rect.x2;
-  vertex[2].v1 = vertex[3].v1 = rect.y2;
-
-  glBindVertexArray(m_mainVAO);
-
-  glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
-  glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_STATIC_DRAW);
-
-  // No need to bind the index VBO, it's part of VAO state
-  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * 4, idx, GL_STATIC_DRAW);
-
-  glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f),
-              (colour[3] / 255.0f));
-  glUniform1f(depthLoc, -1.0f);
-
-  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
-
-  // Unbind VAO/VBO/EBO just to be safe
-  glBindVertexArray(0);
-  glBindBuffer(GL_ARRAY_BUFFER, 0);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
-
-  m_context.DisableGUIShader();
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
@@ -84,6 +84,7 @@ void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
 
   Updateshaders();
 
+  // Use video shader preset
   if (m_bUseShaderPreset)
   {
     GLint filter = GL_NEAREST;
@@ -106,84 +107,85 @@ void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;
     }
-
-    return;
   }
-
-  CRect rect = m_sourceRect;
-
-  rect.x1 /= renderBuffer->GetWidth();
-  rect.x2 /= renderBuffer->GetWidth();
-  rect.y1 /= renderBuffer->GetHeight();
-  rect.y2 /= renderBuffer->GetHeight();
-
-  const uint32_t color = (alpha << 24) | 0xFFFFFF;
-
-  GLint filter = GL_NEAREST;
-  if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
-    filter = GL_LINEAR;
-
-  glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
-  glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
-  glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
-  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-  m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE);
-
-  GLubyte colour[4];
-  GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
-  PackedVertex vertex[4];
-
-  GLint vertLoc = m_context.GUIShaderGetPos();
-  GLint loc = m_context.GUIShaderGetCoord0();
-  GLint uniColLoc = m_context.GUIShaderGetUniCol();
-  GLint depthLoc = m_context.GUIShaderGetDepth();
-
-  // Setup color values
-  colour[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
-  colour[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
-  colour[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
-  colour[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
-
-  for (unsigned int i = 0; i < 4; i++)
+  // Use GUI shader
+  else
   {
-    // Setup vertex position values
-    vertex[i].x = m_rotatedDestCoords[i].x;
-    vertex[i].y = m_rotatedDestCoords[i].y;
-    vertex[i].z = 0.0f;
+    CRect rect = m_sourceRect;
+
+    rect.x1 /= renderBuffer->GetWidth();
+    rect.x2 /= renderBuffer->GetWidth();
+    rect.y1 /= renderBuffer->GetHeight();
+    rect.y2 /= renderBuffer->GetHeight();
+
+    const uint32_t color = (alpha << 24) | 0xFFFFFF;
+
+    GLint filter = GL_NEAREST;
+    if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
+      filter = GL_LINEAR;
+
+    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
+    glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
+    glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
+    glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE);
+
+    GLubyte colour[4];
+    GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
+    PackedVertex vertex[4];
+
+    GLint vertLoc = m_context.GUIShaderGetPos();
+    GLint loc = m_context.GUIShaderGetCoord0();
+    GLint uniColLoc = m_context.GUIShaderGetUniCol();
+    GLint depthLoc = m_context.GUIShaderGetDepth();
+
+    // Setup color values
+    colour[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
+    colour[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
+    colour[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
+    colour[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
+
+    for (unsigned int i = 0; i < 4; i++)
+    {
+      // Setup vertex position values
+      vertex[i].x = m_rotatedDestCoords[i].x;
+      vertex[i].y = m_rotatedDestCoords[i].y;
+      vertex[i].z = 0.0f;
+    }
+
+    // Setup texture coordinates
+    vertex[0].u1 = vertex[3].u1 = rect.x1;
+    vertex[0].v1 = vertex[1].v1 = rect.y1;
+    vertex[1].u1 = vertex[2].u1 = rect.x2;
+    vertex[2].v1 = vertex[3].v1 = rect.y2;
+
+    glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_STATIC_DRAW);
+
+    glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex),
+                          reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, x)));
+    glVertexAttribPointer(loc, 2, GL_FLOAT, 0, sizeof(PackedVertex),
+                          reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, u1)));
+
+    glEnableVertexAttribArray(vertLoc);
+    glEnableVertexAttribArray(loc);
+
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_mainIndexVBO);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * 4, idx, GL_STATIC_DRAW);
+
+    glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f),
+                (colour[3] / 255.0f));
+    glUniform1f(depthLoc, -1.0f);
+    glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+
+    glDisableVertexAttribArray(vertLoc);
+    glDisableVertexAttribArray(loc);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+
+    m_context.DisableGUIShader();
   }
-
-  // Setup texture coordinates
-  vertex[0].u1 = vertex[3].u1 = rect.x1;
-  vertex[0].v1 = vertex[1].v1 = rect.y1;
-  vertex[1].u1 = vertex[2].u1 = rect.x2;
-  vertex[2].v1 = vertex[3].v1 = rect.y2;
-
-  glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
-  glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_STATIC_DRAW);
-
-  glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex),
-                        reinterpret_cast<const GLuint*>(offsetof(PackedVertex, x)));
-  glVertexAttribPointer(loc, 2, GL_FLOAT, 0, sizeof(PackedVertex),
-                        reinterpret_cast<const GLuint*>(offsetof(PackedVertex, u1)));
-
-  glEnableVertexAttribArray(vertLoc);
-  glEnableVertexAttribArray(loc);
-
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_mainIndexVBO);
-  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * 4, idx, GL_STATIC_DRAW);
-
-  glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f),
-              (colour[3] / 255.0f));
-  glUniform1f(depthLoc, -1.0f);
-  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
-
-  glDisableVertexAttribArray(vertLoc);
-  glDisableVertexAttribArray(loc);
-
-  glBindBuffer(GL_ARRAY_BUFFER, 0);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
-
-  m_context.DisableGUIShader();
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -50,6 +50,8 @@ CRPRendererOpenGL::CRPRendererOpenGL(const CRenderSettings& renderSettings,
                                      std::shared_ptr<IRenderBufferPool> bufferPool)
   : CRPBaseRenderer(renderSettings, context, std::move(bufferPool))
 {
+  m_context.CaptureStateBlock();
+
   // Initialize CRPBaseRenderer
   m_shaderPreset = std::make_unique<SHADER::CShaderPresetGL>(m_context);
 
@@ -61,15 +63,16 @@ CRPRendererOpenGL::CRPRendererOpenGL(const CRenderSettings& renderSettings,
   glBindVertexArray(m_mainVAO);
 
   glGenBuffers(1, &m_mainVertexVBO);
+  glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
+
   glGenBuffers(1, &m_mainIndexVBO);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_mainIndexVBO);
 
   m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE);
   GLint vertLoc = m_context.GUIShaderGetPos();
   GLint loc = m_context.GUIShaderGetCoord0();
   m_context.DisableGUIShader();
 
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_mainIndexVBO);
-  glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
   glEnableVertexAttribArray(vertLoc);
   glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex),
                         reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, x)));
@@ -91,10 +94,10 @@ CRPRendererOpenGL::CRPRendererOpenGL(const CRenderSettings& renderSettings,
   glEnableVertexAttribArray(posLoc);
   glVertexAttribPointer(posLoc, 3, GL_FLOAT, GL_FALSE, sizeof(Svertex), 0);
 
-  // Unbind everything just to be safe
   glBindVertexArray(0);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+
+  m_context.ApplyStateBlock();
 }
 
 CRPRendererOpenGL::~CRPRendererOpenGL()
@@ -263,10 +266,8 @@ void CRPRendererOpenGL::DrawBlackBars()
 
   glDrawArrays(GL_TRIANGLES, 0, count);
 
-  // Unbind VAO/VBO/EBO just to be safe
   glBindVertexArray(0);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
   m_context.DisableGUIShader();
 }
@@ -304,6 +305,7 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
 
   Updateshaders();
 
+  // Use video shader preset
   if (m_bUseShaderPreset)
   {
     GLint filter = GL_NEAREST;
@@ -326,76 +328,75 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;
     }
-
-    return;
   }
-
-  CRect rect = m_sourceRect;
-
-  rect.x1 /= renderBuffer->GetWidth();
-  rect.x2 /= renderBuffer->GetWidth();
-  rect.y1 /= renderBuffer->GetHeight();
-  rect.y2 /= renderBuffer->GetHeight();
-
-  const uint32_t color = (alpha << 24) | 0xFFFFFF;
-
-  GLint filter = GL_NEAREST;
-  if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
-    filter = GL_LINEAR;
-
-  glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
-  glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
-  glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
-  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-  m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE);
-
-  GLubyte colour[4];
-  GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
-  PackedVertex vertex[4];
-
-  GLint uniColLoc = m_context.GUIShaderGetUniCol();
-  GLint depthLoc = m_context.GUIShaderGetDepth();
-
-  // Setup color values
-  colour[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
-  colour[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
-  colour[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
-  colour[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
-
-  for (unsigned int i = 0; i < 4; i++)
+  // Use GUI shader
+  else
   {
-    // Setup vertex position values
-    vertex[i].x = m_rotatedDestCoords[i].x;
-    vertex[i].y = m_rotatedDestCoords[i].y;
-    vertex[i].z = 0.0f;
+    CRect rect = m_sourceRect;
+
+    rect.x1 /= renderBuffer->GetWidth();
+    rect.x2 /= renderBuffer->GetWidth();
+    rect.y1 /= renderBuffer->GetHeight();
+    rect.y2 /= renderBuffer->GetHeight();
+
+    const uint32_t color = (alpha << 24) | 0xFFFFFF;
+
+    GLint filter = GL_NEAREST;
+    if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
+      filter = GL_LINEAR;
+
+    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
+    glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
+    glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
+    glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE);
+
+    GLubyte colour[4];
+    GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
+    PackedVertex vertex[4];
+
+    GLint uniColLoc = m_context.GUIShaderGetUniCol();
+    GLint depthLoc = m_context.GUIShaderGetDepth();
+
+    // Setup color values
+    colour[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
+    colour[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
+    colour[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
+    colour[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
+
+    for (unsigned int i = 0; i < 4; i++)
+    {
+      // Setup vertex position values
+      vertex[i].x = m_rotatedDestCoords[i].x;
+      vertex[i].y = m_rotatedDestCoords[i].y;
+      vertex[i].z = 0.0f;
+    }
+
+    // Setup texture coordinates
+    vertex[0].u1 = vertex[3].u1 = rect.x1;
+    vertex[0].v1 = vertex[1].v1 = rect.y1;
+    vertex[1].u1 = vertex[2].u1 = rect.x2;
+    vertex[2].v1 = vertex[3].v1 = rect.y2;
+
+    glBindVertexArray(m_mainVAO);
+
+    glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_STATIC_DRAW);
+
+    // No need to bind the index VBO, it's part of VAO state
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * 4, idx, GL_STATIC_DRAW);
+
+    glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f),
+                (colour[3] / 255.0f));
+    glUniform1f(depthLoc, -1.0f);
+
+    glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+
+    glBindVertexArray(0);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+    m_context.DisableGUIShader();
   }
-
-  // Setup texture coordinates
-  vertex[0].u1 = vertex[3].u1 = rect.x1;
-  vertex[0].v1 = vertex[1].v1 = rect.y1;
-  vertex[1].u1 = vertex[2].u1 = rect.x2;
-  vertex[2].v1 = vertex[3].v1 = rect.y2;
-
-  glBindVertexArray(m_mainVAO);
-
-  glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
-  glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_STATIC_DRAW);
-
-  // No need to bind the index VBO, it's part of VAO state
-  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * 4, idx, GL_STATIC_DRAW);
-
-  glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f),
-              (colour[3] / 255.0f));
-  glUniform1f(depthLoc, -1.0f);
-
-  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
-
-  // Unbind VAO/VBO/EBO just to be safe
-  glBindVertexArray(0);
-  glBindBuffer(GL_ARRAY_BUFFER, 0);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
-
-  m_context.DisableGUIShader();
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -52,12 +52,16 @@ CRPRendererOpenGLES::CRPRendererOpenGLES(const CRenderSettings& renderSettings,
                                          std::shared_ptr<IRenderBufferPool> bufferPool)
   : CRPBaseRenderer(renderSettings, context, std::move(bufferPool))
 {
+  m_context.CaptureStateBlock();
+
   // Initialize CRPBaseRenderer
   m_shaderPreset = std::make_unique<SHADER::CShaderPresetGLES>(m_context);
 
   glGenBuffers(1, &m_mainIndexVBO);
   glGenBuffers(1, &m_mainVertexVBO);
   glGenBuffers(1, &m_blackbarsVertexVBO);
+
+  m_context.ApplyStateBlock();
 }
 
 CRPRendererOpenGLES::~CRPRendererOpenGLES()
@@ -234,6 +238,7 @@ void CRPRendererOpenGLES::DrawBlackBars()
   glDrawArrays(GL_TRIANGLES, 0, count);
 
   glDisableVertexAttribArray(posLoc);
+
   glBindBuffer(GL_ARRAY_BUFFER, 0);
 
   m_context.DisableGUIShader();
@@ -272,6 +277,7 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
 
   Updateshaders();
 
+  // Use video shader preset
   if (m_bUseShaderPreset)
   {
     GLint filter = GL_NEAREST;
@@ -294,84 +300,85 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;
     }
-
-    return;
   }
-
-  CRect rect = m_sourceRect;
-
-  rect.x1 /= renderBuffer->GetWidth();
-  rect.x2 /= renderBuffer->GetWidth();
-  rect.y1 /= renderBuffer->GetHeight();
-  rect.y2 /= renderBuffer->GetHeight();
-
-  const uint32_t color = (alpha << 24) | 0xFFFFFF;
-
-  GLint filter = GL_NEAREST;
-  if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
-    filter = GL_LINEAR;
-
-  glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
-  glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
-  glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
-  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-  m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE_NOALPHA);
-
-  GLubyte colour[4];
-  GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
-  PackedVertex vertex[4];
-
-  GLint vertLoc = m_context.GUIShaderGetPos();
-  GLint loc = m_context.GUIShaderGetCoord0();
-  GLint uniColLoc = m_context.GUIShaderGetUniCol();
-  GLint depthLoc = m_context.GUIShaderGetDepth();
-
-  // Setup color values
-  colour[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
-  colour[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
-  colour[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
-  colour[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
-
-  for (unsigned int i = 0; i < 4; i++)
+  // Use GUI shader
+  else
   {
-    // Setup vertex position values
-    vertex[i].x = m_rotatedDestCoords[i].x;
-    vertex[i].y = m_rotatedDestCoords[i].y;
-    vertex[i].z = 0.0f;
+    CRect rect = m_sourceRect;
+
+    rect.x1 /= renderBuffer->GetWidth();
+    rect.x2 /= renderBuffer->GetWidth();
+    rect.y1 /= renderBuffer->GetHeight();
+    rect.y2 /= renderBuffer->GetHeight();
+
+    const uint32_t color = (alpha << 24) | 0xFFFFFF;
+
+    GLint filter = GL_NEAREST;
+    if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
+      filter = GL_LINEAR;
+
+    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
+    glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
+    glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
+    glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE_NOALPHA);
+
+    GLubyte colour[4];
+    GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
+    PackedVertex vertex[4];
+
+    GLint vertLoc = m_context.GUIShaderGetPos();
+    GLint loc = m_context.GUIShaderGetCoord0();
+    GLint uniColLoc = m_context.GUIShaderGetUniCol();
+    GLint depthLoc = m_context.GUIShaderGetDepth();
+
+    // Setup color values
+    colour[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
+    colour[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
+    colour[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
+    colour[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
+
+    for (unsigned int i = 0; i < 4; i++)
+    {
+      // Setup vertex position values
+      vertex[i].x = m_rotatedDestCoords[i].x;
+      vertex[i].y = m_rotatedDestCoords[i].y;
+      vertex[i].z = 0.0f;
+    }
+
+    // Setup texture coordinates
+    vertex[0].u1 = vertex[3].u1 = rect.x1;
+    vertex[0].v1 = vertex[1].v1 = rect.y1;
+    vertex[1].u1 = vertex[2].u1 = rect.x2;
+    vertex[2].v1 = vertex[3].v1 = rect.y2;
+
+    glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_STATIC_DRAW);
+
+    glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex),
+                          reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, x)));
+    glVertexAttribPointer(loc, 2, GL_FLOAT, 0, sizeof(PackedVertex),
+                          reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, u1)));
+
+    glEnableVertexAttribArray(vertLoc);
+    glEnableVertexAttribArray(loc);
+
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_mainIndexVBO);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * 4, idx, GL_STATIC_DRAW);
+
+    glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f),
+                (colour[3] / 255.0f));
+    glUniform1f(depthLoc, -1.0f);
+    glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+
+    glDisableVertexAttribArray(vertLoc);
+    glDisableVertexAttribArray(loc);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+
+    m_context.DisableGUIShader();
   }
-
-  // Setup texture coordinates
-  vertex[0].u1 = vertex[3].u1 = rect.x1;
-  vertex[0].v1 = vertex[1].v1 = rect.y1;
-  vertex[1].u1 = vertex[2].u1 = rect.x2;
-  vertex[2].v1 = vertex[3].v1 = rect.y2;
-
-  glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
-  glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_STATIC_DRAW);
-
-  glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex),
-                        reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, x)));
-  glVertexAttribPointer(loc, 2, GL_FLOAT, 0, sizeof(PackedVertex),
-                        reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, u1)));
-
-  glEnableVertexAttribArray(vertLoc);
-  glEnableVertexAttribArray(loc);
-
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_mainIndexVBO);
-  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * 4, idx, GL_STATIC_DRAW);
-
-  glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f),
-              (colour[3] / 255.0f));
-  glUniform1f(depthLoc, -1.0f);
-  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
-
-  glDisableVertexAttribArray(vertLoc);
-  glDisableVertexAttribArray(loc);
-
-  glBindBuffer(GL_ARRAY_BUFFER, 0);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
-
-  m_context.DisableGUIShader();
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
@@ -308,7 +308,7 @@ void CRPWinRenderer::Render(CD3DTexture& target)
 
   Updateshaders();
 
-  // Are we using video shaders?
+  // Use video shader preset
   if (m_bUseShaderPreset)
   {
     //! @todo Orientation?
@@ -339,7 +339,8 @@ void CRPWinRenderer::Render(CD3DTexture& target)
       m_bUseShaderPreset = false;
     }
   }
-  else // Not using video shaders, output using output shader
+  // Use output shader
+  else
   {
     CD3DTexture& intermediateTarget = renderBufferTarget->GetTexture();
 

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
@@ -35,9 +35,6 @@ CShaderPreset::CShaderPreset(RETRO::CRenderContext& context,
 CShaderPreset::~CShaderPreset()
 {
   DisposeShaders();
-
-  // The GUI is going to render after this, so apply the state required
-  m_context.ApplyStateBlock();
 }
 
 bool CShaderPreset::ReadPresetFile(const std::string& presetPath)

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
@@ -27,9 +27,9 @@ CShaderGL::CShaderGL(RETRO::CRenderContext& context)
 
 CShaderGL::~CShaderGL()
 {
-  glDeleteBuffers(1, &EBO);
-  glDeleteBuffers(3, VBO);
-  glDeleteVertexArrays(1, &VAO);
+  glDeleteBuffers(1, &m_shaderIndexVBO);
+  glDeleteBuffers(3, m_shaderVertexVBO);
+  glDeleteVertexArrays(1, &m_shaderVAO);
 }
 
 bool CShaderGL::Create(std::string shaderSource,
@@ -128,9 +128,9 @@ bool CShaderGL::Create(std::string shaderSource,
 
   GetUniformLocs();
 
-  glGenVertexArrays(1, &VAO);
-  glGenBuffers(3, VBO);
-  glGenBuffers(1, &EBO);
+  glGenVertexArrays(1, &m_shaderVAO);
+  glGenBuffers(3, m_shaderVertexVBO);
+  glGenBuffers(1, &m_shaderIndexVBO);
   return true;
 }
 
@@ -142,23 +142,23 @@ void CShaderGL::Render(IShaderTexture& source, IShaderTexture& target)
 
   SetShaderParameters(sourceGL.GetTexture());
 
-  glBindVertexArray(VAO);
-  glBindBuffer(GL_ARRAY_BUFFER, VBO[0]);
+  glBindVertexArray(m_shaderVAO);
+  glBindBuffer(GL_ARRAY_BUFFER, m_shaderVertexVBO[0]);
   glBufferData(GL_ARRAY_BUFFER, sizeof(m_VertexCoords), m_VertexCoords, GL_STATIC_DRAW);
   glEnableVertexAttribArray(0);
   glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
 
-  glBindBuffer(GL_ARRAY_BUFFER, VBO[1]);
+  glBindBuffer(GL_ARRAY_BUFFER, m_shaderVertexVBO[1]);
   glBufferData(GL_ARRAY_BUFFER, sizeof(m_colors), m_colors, GL_STATIC_DRAW);
   glEnableVertexAttribArray(1);
   glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
 
-  glBindBuffer(GL_ARRAY_BUFFER, VBO[2]);
+  glBindBuffer(GL_ARRAY_BUFFER, m_shaderVertexVBO[2]);
   glBufferData(GL_ARRAY_BUFFER, sizeof(m_TexCoords), m_TexCoords, GL_STATIC_DRAW);
   glEnableVertexAttribArray(2);
   glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 2 * sizeof(float), (void*)0);
 
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_shaderIndexVBO);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(m_indices), m_indices, GL_STATIC_DRAW);
 
   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
@@ -29,6 +29,7 @@ CShaderGL::~CShaderGL()
 {
   glDeleteBuffers(1, &m_shaderIndexVBO);
   glDeleteBuffers(3, m_shaderVertexVBO);
+
   glDeleteVertexArrays(1, &m_shaderVAO);
 }
 
@@ -129,8 +130,28 @@ bool CShaderGL::Create(std::string shaderSource,
   GetUniformLocs();
 
   glGenVertexArrays(1, &m_shaderVAO);
+  glBindVertexArray(m_shaderVAO);
+
   glGenBuffers(3, m_shaderVertexVBO);
+
+  glBindBuffer(GL_ARRAY_BUFFER, m_shaderVertexVBO[0]);
+  glEnableVertexAttribArray(0);
+  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
+
+  glBindBuffer(GL_ARRAY_BUFFER, m_shaderVertexVBO[1]);
+  glEnableVertexAttribArray(1);
+  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
+
+  glBindBuffer(GL_ARRAY_BUFFER, m_shaderVertexVBO[2]);
+  glEnableVertexAttribArray(2);
+  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 2 * sizeof(float), (void*)0);
+
   glGenBuffers(1, &m_shaderIndexVBO);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_shaderIndexVBO);
+
+  glBindVertexArray(0);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+
   return true;
 }
 
@@ -143,33 +164,23 @@ void CShaderGL::Render(IShaderTexture& source, IShaderTexture& target)
   SetShaderParameters(sourceGL.GetTexture());
 
   glBindVertexArray(m_shaderVAO);
+
   glBindBuffer(GL_ARRAY_BUFFER, m_shaderVertexVBO[0]);
   glBufferData(GL_ARRAY_BUFFER, sizeof(m_VertexCoords), m_VertexCoords, GL_STATIC_DRAW);
-  glEnableVertexAttribArray(0);
-  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
 
   glBindBuffer(GL_ARRAY_BUFFER, m_shaderVertexVBO[1]);
   glBufferData(GL_ARRAY_BUFFER, sizeof(m_colors), m_colors, GL_STATIC_DRAW);
-  glEnableVertexAttribArray(1);
-  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
 
   glBindBuffer(GL_ARRAY_BUFFER, m_shaderVertexVBO[2]);
   glBufferData(GL_ARRAY_BUFFER, sizeof(m_TexCoords), m_TexCoords, GL_STATIC_DRAW);
-  glEnableVertexAttribArray(2);
-  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 2 * sizeof(float), (void*)0);
 
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_shaderIndexVBO);
+  // No need to bind the index VBO, it's part of VAO state
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(m_indices), m_indices, GL_STATIC_DRAW);
 
   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
 
-  glDisableVertexAttribArray(0);
-  glDisableVertexAttribArray(1);
-  glDisableVertexAttribArray(2);
-
   glBindVertexArray(0);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
   glUseProgram(0);
 }

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
@@ -131,9 +131,9 @@ private:
   GLint m_InputSizeLoc{-1};
   GLint m_MVPMatrixLoc{-1};
 
-  GLuint VAO{0};
-  GLuint VBO[3]{};
-  GLuint EBO{0};
+  GLuint m_shaderVAO = GL_NONE;
+  GLuint m_shaderVertexVBO[3]{GL_NONE};
+  GLuint m_shaderIndexVBO = GL_NONE;
 };
 } // namespace SHADER
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
@@ -129,6 +129,7 @@ bool CShaderGLES::Create(std::string shaderSource,
 
   glGenBuffers(3, m_shaderVertexVBO);
   glGenBuffers(1, &m_shaderIndexVBO);
+
   return true;
 }
 

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
@@ -27,8 +27,8 @@ CShaderGLES::CShaderGLES(RETRO::CRenderContext& context)
 
 CShaderGLES::~CShaderGLES()
 {
-  glDeleteBuffers(1, &EBO);
-  glDeleteBuffers(3, VBO);
+  glDeleteBuffers(1, &m_shaderIndexVBO);
+  glDeleteBuffers(3, m_shaderVertexVBO);
 }
 
 bool CShaderGLES::Create(std::string shaderSource,
@@ -127,8 +127,8 @@ bool CShaderGLES::Create(std::string shaderSource,
 
   GetUniformLocs();
 
-  glGenBuffers(3, VBO);
-  glGenBuffers(1, &EBO);
+  glGenBuffers(3, m_shaderVertexVBO);
+  glGenBuffers(1, &m_shaderIndexVBO);
   return true;
 }
 
@@ -140,22 +140,22 @@ void CShaderGLES::Render(IShaderTexture& source, IShaderTexture& target)
 
   SetShaderParameters(sourceGL.GetTexture());
 
-  glBindBuffer(GL_ARRAY_BUFFER, VBO[0]);
+  glBindBuffer(GL_ARRAY_BUFFER, m_shaderVertexVBO[0]);
   glBufferData(GL_ARRAY_BUFFER, sizeof(m_VertexCoords), m_VertexCoords, GL_STATIC_DRAW);
   glEnableVertexAttribArray(0);
   glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
 
-  glBindBuffer(GL_ARRAY_BUFFER, VBO[1]);
+  glBindBuffer(GL_ARRAY_BUFFER, m_shaderVertexVBO[1]);
   glBufferData(GL_ARRAY_BUFFER, sizeof(m_colors), m_colors, GL_STATIC_DRAW);
   glEnableVertexAttribArray(1);
   glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
 
-  glBindBuffer(GL_ARRAY_BUFFER, VBO[2]);
+  glBindBuffer(GL_ARRAY_BUFFER, m_shaderVertexVBO[2]);
   glBufferData(GL_ARRAY_BUFFER, sizeof(m_TexCoords), m_TexCoords, GL_STATIC_DRAW);
   glEnableVertexAttribArray(2);
   glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 2 * sizeof(float), (void*)0);
 
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_shaderIndexVBO);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(m_indices), m_indices, GL_STATIC_DRAW);
 
   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
@@ -131,8 +131,8 @@ private:
   GLint m_InputSizeLoc{-1};
   GLint m_MVPMatrixLoc{-1};
 
-  GLuint VBO[3]{};
-  GLuint EBO{0};
+  GLuint m_shaderVertexVBO[3]{GL_NONE};
+  GLuint m_shaderIndexVBO = GL_NONE;
 };
 } // namespace SHADER
 } // namespace KODI


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR fixes following issues in RetroPlayer rendering:
- Invalid OpenGL state after VAO unbind, see here: https://github.com/xbmc/xbmc/pull/26435#discussion_r2116610809
- Restoring rendering state without saving it first, see here: https://github.com/xbmc/xbmc/pull/26435#issuecomment-2965471282
- Some minor cleanups, removed commented code, renamed variables for consistency etc.

I have kept the work split into 3 commits, even though the last one partially reverts the previous one, because it seems more understandable this way and the code without the last commit is fully functional as well.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've only tested it on Linux (Wayland/GL, Wayland/GLES, GBM/GL and GBM/GLES). It needs to be tested on all platforms including Windows before merge. Maybe @garbear can include this in his RP test builds?

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
I hope it can fix remaining Kodi GUI corruption issues seen after using RetroPlayer.


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
