### PR TITLE
[Shaders] Add "Get more..." button to install shader add-on

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9493,17 +9493,7 @@ msgctxt "#16297"
 msgid "Smooth"
 msgstr ""
 
-#. Description of the video filter that uses jagged pixels without smoothing
-#: xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
-msgctxt "#16298"
-msgid "Shows the game's pixels without any modifications."
-msgstr ""
-
-#. Description of the video filter that smooths pixels to remove jagged edges
-#: xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
-msgctxt "#16299"
-msgid "Removes the jagged edges of pixels by evenly fading between adjacent pixels."
-msgstr ""
+#empty strings from id 16298 to 16299
 
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
 msgctxt "#16300"

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -981,11 +981,12 @@
 							<width>444</width>
 							<height>250</height>
 							<aspectratio>scale</aspectratio>
-							<texture border="4">DefaultVideo.png</texture>
+							<texture>$INFO[ListItem.Icon]</texture>
 							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
 							<bordersize>4</bordersize>
 						</control>
 						<control type="gamewindow">
+							<visible>!String.IsEmpty(ListItem.Property(game.videofilter))</visible>
 							<width>444</width>
 							<height>250</height>
 							<videofilter>$INFO[ListItem.Property(game.videofilter)]</videofilter>
@@ -1012,11 +1013,12 @@
 							<width>444</width>
 							<height>250</height>
 							<aspectratio>scale</aspectratio>
-							<texture border="4">DefaultVideo.png</texture>
+							<texture>$INFO[ListItem.Icon]</texture>
 							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
 							<bordersize>4</bordersize>
 						</control>
 						<control type="gamewindow">
+							<visible>!String.IsEmpty(ListItem.Property(game.videofilter))</visible>
 							<width>444</width>
 							<height>250</height>
 							<videofilter>$INFO[ListItem.Property(game.videofilter)]</videofilter>

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPresetFactory.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPresetFactory.cpp
@@ -145,7 +145,7 @@ void CShaderPresetFactory::UpdateAddons()
     }
     else
     {
-      m_shaderAddons.emplace(std::move(addonId), std::move(addonPtr));
+      m_failedAddons.emplace(std::move(addonId), std::move(addonPtr));
     }
   }
 }

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPresetFactory.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPresetFactory.cpp
@@ -60,6 +60,11 @@ void CShaderPresetFactory::UnregisterLoader(IShaderPresetLoader* loader)
   }
 }
 
+bool CShaderPresetFactory::HasAddons() const
+{
+  return !m_shaderAddons.empty() || !m_failedAddons.empty();
+}
+
 bool CShaderPresetFactory::LoadPreset(const std::string& presetPath, IShaderPreset& shaderPreset)
 {
   bool bSuccess = false;

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPresetFactory.h
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPresetFactory.h
@@ -53,6 +53,15 @@ public:
   void UnregisterLoader(IShaderPresetLoader* loader);
 
   /*!
+   * \brief Check if any shader preset add-ons have been loaded
+   *
+   * This includes add-ons in a failed state.
+   *
+   * \return True if any shader preset add-ons are present, false otherwise
+   */
+  bool HasAddons() const;
+
+  /*!
    * \brief Load a preset from the given path
    *
    * \param presetPath The path to the shader preset

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
@@ -40,14 +40,20 @@ struct ScalingMethodProperties
 {
   int nameIndex;
   int categoryIndex;
-  int descriptionIndex;
   RETRO::SCALINGMETHOD scalingMethod;
 };
 
 const std::vector<ScalingMethodProperties> scalingMethods = {
-    {16301, 16296, 16298, RETRO::SCALINGMETHOD::NEAREST},
-    {16302, 16297, 16299, RETRO::SCALINGMETHOD::LINEAR},
+    {16301, 16296, RETRO::SCALINGMETHOD::NEAREST},
+    {16302, 16297, RETRO::SCALINGMETHOD::LINEAR},
 };
+
+// Helper function
+void GetProperties(const CFileItem& item, std::string& videoFilter)
+{
+  videoFilter = item.GetProperty("game.videofilter").asString();
+}
+
 } // namespace
 
 CDialogGameVideoFilter::CDialogGameVideoFilter()
@@ -72,8 +78,6 @@ void CDialogGameVideoFilter::PreInit()
     CFileItemPtr item = std::make_shared<CFileItem>(g_localizeStrings.Get(231)); // "None"
     m_items.Add(std::move(item));
   }
-
-  m_bHasDescription = false;
 }
 
 void CDialogGameVideoFilter::InitScalingMethods()
@@ -91,8 +95,6 @@ void CDialogGameVideoFilter::InitScalingMethods()
             std::make_shared<CFileItem>(g_localizeStrings.Get(scalingMethodProps.nameIndex));
         item->SetLabel2(g_localizeStrings.Get(scalingMethodProps.categoryIndex));
         item->SetProperty("game.videofilter", CVariant{videoSettings.GetVideoFilter()});
-        item->SetProperty("game.videofilterdescription",
-                          CVariant{g_localizeStrings.Get(scalingMethodProps.descriptionIndex)});
         m_items.Add(std::move(item));
       }
     }
@@ -203,8 +205,7 @@ void CDialogGameVideoFilter::OnItemFocus(unsigned int index)
     CFileItemPtr item = m_items[index];
 
     std::string videoFilter;
-    std::string description;
-    GetProperties(*item, videoFilter, description);
+    GetProperties(*item, videoFilter);
 
     ::CGameSettings& gameSettings = CMediaSettings::GetInstance().GetCurrentGameSettings();
 
@@ -212,14 +213,6 @@ void CDialogGameVideoFilter::OnItemFocus(unsigned int index)
     {
       gameSettings.SetVideoFilter(videoFilter);
       gameSettings.NotifyObservers(ObservableMessageSettingsChanged);
-
-      OnDescriptionChange(description);
-      m_bHasDescription = true;
-    }
-    else if (!m_bHasDescription)
-    {
-      OnDescriptionChange(description);
-      m_bHasDescription = true;
     }
   }
 }
@@ -231,8 +224,7 @@ unsigned int CDialogGameVideoFilter::GetFocusedItem() const
   for (int i = 0; i < m_items.Size(); i++)
   {
     std::string videoFilter;
-    std::string description;
-    GetProperties(*m_items[i], videoFilter, description);
+    GetProperties(*m_items[i], videoFilter);
 
     if (videoFilter == gameSettings.VideoFilter())
     {
@@ -257,12 +249,4 @@ bool CDialogGameVideoFilter::OnClickAction()
 std::string CDialogGameVideoFilter::GetLocalizedString(uint32_t code)
 {
   return g_localizeStrings.GetAddonString(PRESETS_ADDON_NAME, code);
-}
-
-void CDialogGameVideoFilter::GetProperties(const CFileItem& item,
-                                           std::string& videoFilter,
-                                           std::string& description)
-{
-  videoFilter = item.GetProperty("game.videofilter").asString();
-  description = item.GetProperty("game.videofilterdescription").asString();
 }

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.h
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.h
@@ -34,10 +34,14 @@ protected:
   unsigned int GetFocusedItem() const override;
   void PostExit() override;
   bool OnClickAction() override;
+  void RefreshList() override;
 
 private:
   void InitScalingMethods();
   void InitVideoFilters();
+  void InitGetMoreButton();
+  void OnGetMore();
+  void OnGetMoreComplete();
 
   CFileItemList m_items;
 
@@ -49,6 +53,10 @@ private:
     std::string name;
     std::string folder;
   };
+
+  // GUI state
+  unsigned int m_focusedItemIndex{0};
+  bool m_regenerateList{false};
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.h
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.h
@@ -39,10 +39,6 @@ private:
   void InitScalingMethods();
   void InitVideoFilters();
 
-  static void GetProperties(const CFileItem& item,
-                            std::string& videoFilter,
-                            std::string& description);
-
   CFileItemList m_items;
 
   static std::string GetLocalizedString(uint32_t code);
@@ -53,9 +49,6 @@ private:
     std::string name;
     std::string folder;
   };
-
-  //! \brief Set to true when a description has first been set
-  bool m_bHasDescription = false;
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
@@ -124,7 +124,11 @@ bool CDialogGameVideoSelect::OnMessage(CGUIMessage& message)
     }
     case GUI_MSG_REFRESH_LIST:
     {
-      RefreshList();
+      if (message.GetControlId() == CONTROL_VIDEO_THUMBS)
+      {
+        RefreshList();
+        return true;
+      }
       break;
     }
     default:

--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.h
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.h
@@ -66,7 +66,7 @@ protected:
   virtual bool OnDeleteAction() { return false; }
 
   // GUI functions
-  void RefreshList();
+  virtual void RefreshList();
   void OnDescriptionChange(const std::string& description);
 
   std::shared_ptr<RETRO::CGUIGameVideoHandle> m_gameVideoHandle;

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.h
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.h
@@ -77,7 +77,7 @@ private:
 
   CFileItemList m_savestateItems;
   const CFileItemPtr m_newSaveItem;
-  unsigned int m_focusedItemIndex = false;
+  unsigned int m_focusedItemIndex{0};
 };
 } // namespace GAME
 } // namespace KODI


### PR DESCRIPTION
## Description

This PR introduces 3 fixes, then adds a new feature - the ability to install the shader preset add-on from within the game.

Clicking on the + item will install the shader add-on, then populate the list with its shaders.

## Motivation and context

Noticed a user not seeing shaders and being confused: https://forum.kodi.tv/showthread.php?tid=173361&pid=3234787#pid3234787

## Screenshots (if appropriate):

<img width="1138" alt="Screenshot 2025-06-13 at 1 09 46 PM" src="https://github.com/user-attachments/assets/dffc3535-679e-48db-994a-fdc94b68cf9e" />

## How has this been tested?

Included in latest rounds of test builds: https://github.com/garbear/xbmc/releases/tag/retroplayer-22alpha1-20250616.

Tested on macOS ARM.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
