### PR TITLE
[Games] Add class for controller state

### DIFF
--- a/xbmc/games/controllers/input/CMakeLists.txt
+++ b/xbmc/games/controllers/input/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES ControllerActivity.cpp
+            ControllerState.cpp
             DefaultButtonMap.cpp
             DefaultKeyboardTranslator.cpp
             DefaultMouseTranslator.cpp
@@ -8,6 +9,7 @@ set(SOURCES ControllerActivity.cpp
 )
 
 set(HEADERS ControllerActivity.h
+            ControllerState.h
             DefaultButtonMap.h
             DefaultKeyboardTranslator.h
             DefaultMouseTranslator.h

--- a/xbmc/games/controllers/input/ControllerState.cpp
+++ b/xbmc/games/controllers/input/ControllerState.cpp
@@ -1,0 +1,142 @@
+/*
+ *  Copyright (C) 2022-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ControllerState.h"
+
+#include "games/controllers/Controller.h"
+#include "games/controllers/input/PhysicalFeature.h"
+#include "input/joysticks/JoystickTypes.h"
+
+using namespace KODI;
+using namespace GAME;
+
+CControllerState::CControllerState(const CController& controller) : m_controllerId(controller.ID())
+{
+  for (const auto& feature : controller.Features())
+  {
+    const std::string& featureName = feature.Name();
+
+    switch (feature.Type())
+    {
+      case JOYSTICK::FEATURE_TYPE::SCALAR:
+        switch (feature.InputType())
+        {
+          case JOYSTICK::INPUT_TYPE::DIGITAL:
+            SetDigitalButton(featureName, false);
+            break;
+          case JOYSTICK::INPUT_TYPE::ANALOG:
+            SetAnalogButton(featureName, 0.0f);
+            break;
+          default:
+            break;
+        }
+        break;
+      case JOYSTICK::FEATURE_TYPE::ANALOG_STICK:
+        SetAnalogStick(featureName, {0.0f, 0.0f});
+        break;
+      case JOYSTICK::FEATURE_TYPE::ACCELEROMETER:
+        SetAccelerometer(featureName, {0.0f, 0.0f, 0.0f});
+        break;
+      case JOYSTICK::FEATURE_TYPE::WHEEL:
+        SetWheel(featureName, 0.0f);
+        break;
+      case JOYSTICK::FEATURE_TYPE::THROTTLE:
+        SetThrottle(featureName, 0.0f);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+CControllerState::DigitalButton CControllerState::GetDigitalButton(
+    const std::string& featureName) const
+{
+  auto it = m_digitalButtons.find(featureName);
+  if (it != m_digitalButtons.end())
+    return it->second;
+
+  return false;
+}
+
+CControllerState::AnalogButton CControllerState::GetAnalogButton(
+    const std::string& featureName) const
+{
+  auto it = m_analogButtons.find(featureName);
+  if (it != m_analogButtons.end())
+    return it->second;
+
+  return 0.0f;
+}
+
+CControllerState::AnalogStick CControllerState::GetAnalogStick(const std::string& featureName) const
+{
+  auto it = m_analogSticks.find(featureName);
+  if (it != m_analogSticks.end())
+    return it->second;
+
+  return {};
+}
+
+CControllerState::Accelerometer CControllerState::GetAccelerometer(
+    const std::string& featureName) const
+{
+  auto it = m_accelerometers.find(featureName);
+  if (it != m_accelerometers.end())
+    return it->second;
+
+  return {};
+}
+
+CControllerState::Throttle CControllerState::GetThrottle(const std::string& featureName) const
+{
+  auto it = m_throttles.find(featureName);
+  if (it != m_throttles.end())
+    return it->second;
+
+  return 0.0f;
+}
+
+CControllerState::Wheel CControllerState::GetWheel(const std::string& featureName) const
+{
+  auto it = m_wheels.find(featureName);
+  if (it != m_wheels.end())
+    return it->second;
+
+  return 0.0f;
+}
+
+void CControllerState::SetDigitalButton(const std::string& featureName, DigitalButton state)
+{
+  m_digitalButtons[featureName] = state;
+}
+
+void CControllerState::SetAnalogButton(const std::string& featureName, AnalogButton state)
+{
+  m_analogButtons[featureName] = state;
+}
+
+void CControllerState::SetAnalogStick(const std::string& featureName, AnalogStick state)
+{
+  m_analogSticks[featureName] = state;
+}
+
+void CControllerState::SetAccelerometer(const std::string& featureName, Accelerometer state)
+{
+  m_accelerometers[featureName] = state;
+}
+
+void CControllerState::SetThrottle(const std::string& featureName, Throttle state)
+{
+  m_throttles[featureName] = state;
+}
+
+void CControllerState::SetWheel(const std::string& featureName, Wheel state)
+{
+  m_wheels[featureName] = state;
+}

--- a/xbmc/games/controllers/input/ControllerState.h
+++ b/xbmc/games/controllers/input/ControllerState.h
@@ -1,0 +1,104 @@
+/*
+ *  Copyright (C) 2022-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+
+namespace KODI
+{
+namespace GAME
+{
+class CController;
+
+/*!
+ * \ingroup games
+ *
+ * \brief Stores the input state of a controller
+ */
+class CControllerState
+{
+public:
+  /*
+   * Public types
+   */
+  using DigitalButton = bool;
+  using AnalogButton = float;
+  struct AnalogStick
+  {
+    float x;
+    float y;
+    bool operator==(const AnalogStick& rhs) const = default;
+    bool operator!=(const AnalogStick& rhs) const = default;
+  };
+  struct Accelerometer
+  {
+    float x;
+    float y;
+    float z;
+    bool operator==(const Accelerometer& rhs) const = default;
+    bool operator!=(const Accelerometer& rhs) const = default;
+  };
+  using Throttle = float;
+  using Wheel = float;
+
+  // Constructors
+  explicit CControllerState() = default;
+  explicit CControllerState(const CControllerState& controllerState) = default;
+  explicit CControllerState(const CController& controller);
+
+  // Destructor
+  ~CControllerState() = default;
+
+  // Operators
+  bool operator==(const CControllerState& rhs) const = default;
+  bool operator!=(const CControllerState& rhs) const = default;
+
+  // Controller state
+  const std::string& ID() const { return m_controllerId; }
+
+  // Input state (const accessors)
+  const std::map<std::string, DigitalButton>& DigitalButtons() const { return m_digitalButtons; }
+  const std::map<std::string, AnalogButton>& AnalogButtons() const { return m_analogButtons; }
+  const std::map<std::string, AnalogStick>& AnalogSticks() const { return m_analogSticks; }
+  const std::map<std::string, Accelerometer>& Accelerometers() const { return m_accelerometers; }
+  const std::map<std::string, Throttle>& Throttles() const { return m_throttles; }
+  const std::map<std::string, Wheel>& Wheels() const { return m_wheels; }
+
+  // Input state (mutable accessors)
+  DigitalButton GetDigitalButton(const std::string& featureName) const;
+  AnalogButton GetAnalogButton(const std::string& featureName) const;
+  AnalogStick GetAnalogStick(const std::string& featureName) const;
+  Accelerometer GetAccelerometer(const std::string& featureName) const;
+  Throttle GetThrottle(const std::string& featureName) const;
+  Wheel GetWheel(const std::string& featureName) const;
+
+  // Input state (mutators)
+  void SetDigitalButton(const std::string& featureName, DigitalButton state);
+  void SetAnalogButton(const std::string& featureName, AnalogButton state);
+  void SetAnalogStick(const std::string& featureName, AnalogStick state);
+  void SetAccelerometer(const std::string& featureName, Accelerometer state);
+  void SetThrottle(const std::string& featureName, Throttle state);
+  void SetWheel(const std::string& featureName, Wheel state);
+
+private:
+  // Controller state
+  std::string m_controllerId;
+
+  // Input state
+  std::map<std::string, DigitalButton> m_digitalButtons;
+  std::map<std::string, AnalogButton> m_analogButtons;
+  std::map<std::string, AnalogStick> m_analogSticks;
+  std::map<std::string, Accelerometer> m_accelerometers;
+  std::map<std::string, Throttle> m_throttles;
+  std::map<std::string, Wheel> m_wheels;
+};
+
+} // namespace GAME
+} // namespace KODI

--- a/xbmc/games/controllers/input/test/CMakeLists.txt
+++ b/xbmc/games/controllers/input/test/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(SOURCES TestDefaultKeyboardTranslator.cpp
+set(SOURCES TestControllerState.cpp
+            TestDefaultKeyboardTranslator.cpp
             TestDefaultMouseTranslator.cpp
 )
 

--- a/xbmc/games/controllers/input/test/TestControllerState.cpp
+++ b/xbmc/games/controllers/input/test/TestControllerState.cpp
@@ -1,0 +1,258 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "addons/addoninfo/AddonInfo.h"
+#include "addons/addoninfo/AddonInfoBuilder.h"
+#include "addons/addoninfo/AddonType.h"
+#include "games/controllers/Controller.h"
+#include "games/controllers/input/ControllerState.h"
+
+#include <gtest/gtest.h>
+
+using namespace KODI;
+using namespace GAME;
+
+//
+// Spec: Should store and return controller state for all feature types
+//
+TEST(TestControllerState, SetAndGet)
+{
+  CControllerState state;
+
+  state.SetDigitalButton("a", true);
+  state.SetAnalogButton("b", 0.5f);
+  state.SetAnalogStick("stick", {1.0f, -1.0f});
+  state.SetAccelerometer("accel", {0.1f, 0.2f, 0.3f});
+  state.SetThrottle("thr", 0.8f);
+  state.SetWheel("wheel", -0.25f);
+
+  EXPECT_TRUE(state.GetDigitalButton("a"));
+  EXPECT_FLOAT_EQ(state.GetAnalogButton("b"), 0.5f);
+  EXPECT_EQ(state.GetAnalogStick("stick"), (CControllerState::AnalogStick{1.0f, -1.0f}));
+  EXPECT_EQ(state.GetAccelerometer("accel"), (CControllerState::Accelerometer{0.1f, 0.2f, 0.3f}));
+  EXPECT_FLOAT_EQ(state.GetThrottle("thr"), 0.8f);
+  EXPECT_FLOAT_EQ(state.GetWheel("wheel"), -0.25f);
+}
+
+//
+// Spec: Copy constructor should duplicate ID and feature state
+//
+TEST(TestControllerState, CopyConstructor)
+{
+  using namespace ADDON;
+
+  // Create a minimal controller so the state has an ID
+  AddonInfoPtr addon =
+      CAddonInfoBuilder::Generate("test.controller", ADDON::AddonType::GAME_CONTROLLER);
+  CController controller(addon);
+
+  CControllerState original(controller);
+  original.SetDigitalButton("btn", true);
+  original.SetAnalogButton("analog", 0.5f);
+  original.SetAnalogStick("stick", {0.1f, -0.1f});
+  original.SetAccelerometer("accel", {1.0f, 2.0f, 3.0f});
+  original.SetThrottle("thr", 0.8f);
+  original.SetWheel("wheel", -0.25f);
+
+  CControllerState copy(original);
+
+  // Modifying the original should not change the copy
+  original.SetDigitalButton("btn", false);
+  original.SetAnalogButton("analog", 0.0f);
+  original.SetAnalogStick("stick", {0.0f, 0.0f});
+  original.SetAccelerometer("accel", {0.0f, 0.0f, 0.0f});
+  original.SetThrottle("thr", 0.0f);
+  original.SetWheel("wheel", 0.0f);
+
+  EXPECT_TRUE(copy.GetDigitalButton("btn"));
+  EXPECT_FLOAT_EQ(copy.GetAnalogButton("analog"), 0.5f);
+  EXPECT_EQ(copy.GetAnalogStick("stick"), (CControllerState::AnalogStick{0.1f, -0.1f}));
+  EXPECT_EQ(copy.GetAccelerometer("accel"), (CControllerState::Accelerometer{1.0f, 2.0f, 3.0f}));
+  EXPECT_FLOAT_EQ(copy.GetThrottle("thr"), 0.8f);
+  EXPECT_FLOAT_EQ(copy.GetWheel("wheel"), -0.25f);
+  EXPECT_EQ(copy.ID(), "test.controller");
+}
+
+//
+// Spec: States with identical values should compare equal
+//
+TEST(TestControllerState, EqualityOperator)
+{
+  using namespace ADDON;
+
+  // Give both states an ID
+  AddonInfoPtr addon =
+      CAddonInfoBuilder::Generate("test.controller", ADDON::AddonType::GAME_CONTROLLER);
+  CController controller(addon);
+
+  CControllerState state1(controller);
+  state1.SetDigitalButton("btn", true);
+  state1.SetAnalogButton("analog", 1.0f);
+  state1.SetAnalogStick("stick", {0.1f, 0.2f});
+  state1.SetAccelerometer("accel", {9.8f, 0.0f, 0.0f});
+  state1.SetThrottle("thr", 0.75f);
+  state1.SetWheel("wheel", -0.25f);
+
+  CControllerState state2(state1);
+  EXPECT_EQ(state1, state2);
+  EXPECT_FALSE(state1 != state2);
+  EXPECT_EQ(state2.ID(), "test.controller");
+}
+
+//
+// Spec: Unknown features should return default values
+//
+TEST(TestControllerState, DefaultValues)
+{
+  CControllerState state;
+
+  EXPECT_FALSE(state.GetDigitalButton("missing"));
+  EXPECT_FLOAT_EQ(state.GetAnalogButton("missing"), 0.0f);
+  EXPECT_EQ(state.GetAnalogStick("missing"), (CControllerState::AnalogStick{}));
+  EXPECT_EQ(state.GetAccelerometer("missing"), (CControllerState::Accelerometer{}));
+  EXPECT_FLOAT_EQ(state.GetThrottle("missing"), 0.0f);
+  EXPECT_FLOAT_EQ(state.GetWheel("missing"), 0.0f);
+  EXPECT_TRUE(state.ID().empty());
+}
+
+//
+// Spec: States with different values should not compare equal
+//
+TEST(TestControllerState, Inequality)
+{
+  using namespace ADDON;
+
+  // Give states an ID and set all feature types
+  AddonInfoPtr addon =
+      CAddonInfoBuilder::Generate("base.controller", ADDON::AddonType::GAME_CONTROLLER);
+  CController controller(addon);
+
+  CControllerState state1(controller);
+  state1.SetDigitalButton("btn", true);
+  state1.SetAnalogButton("analog", 1.0f);
+  state1.SetAnalogStick("stick", {0.0f, 1.0f});
+  state1.SetAccelerometer("accel", {1.0f, 2.0f, 3.0f});
+  state1.SetThrottle("thr", 0.5f);
+  state1.SetWheel("wheel", -0.5f);
+
+  CControllerState state2(state1);
+  state2.SetDigitalButton("btn", false);
+  EXPECT_TRUE(state1 != state2);
+
+  state2 = state1;
+  state2.SetAnalogButton("analog", 0.0f);
+  EXPECT_TRUE(state1 != state2);
+
+  state2 = state1;
+  state2.SetAnalogStick("stick", {0.0f, 0.0f});
+  EXPECT_TRUE(state1 != state2);
+
+  state2 = state1;
+  state2.SetAccelerometer("accel", {0.0f, 0.0f, 0.0f});
+  EXPECT_TRUE(state1 != state2);
+
+  state2 = state1;
+  state2.SetThrottle("thr", 1.0f);
+  EXPECT_TRUE(state1 != state2);
+
+  state2 = state1;
+  state2.SetWheel("wheel", 0.0f);
+  EXPECT_TRUE(state1 != state2);
+
+  // Different controller ID
+  AddonInfoPtr addon2 =
+      CAddonInfoBuilder::Generate("other.controller", ADDON::AddonType::GAME_CONTROLLER);
+  CController controller2(addon2);
+  CControllerState state3(controller2);
+  state3.SetDigitalButton("btn", true);
+  state3.SetAnalogButton("analog", 1.0f);
+  state3.SetAnalogStick("stick", {0.0f, 1.0f});
+  state3.SetAccelerometer("accel", {1.0f, 2.0f, 3.0f});
+  state3.SetThrottle("thr", 0.5f);
+  state3.SetWheel("wheel", -0.5f);
+  EXPECT_TRUE(state1 != state3);
+}
+
+//
+// Spec: Should handle multiple inputs across all feature types
+//
+TEST(TestControllerState, MultipleInputs)
+{
+  CControllerState state;
+
+  // Two digital buttons
+  state.SetDigitalButton("a", true);
+  state.SetDigitalButton("b", false);
+
+  // Two analog buttons
+  state.SetAnalogButton("c", -0.5f);
+  state.SetAnalogButton("d", 0.25f);
+
+  // Two analog sticks
+  state.SetAnalogStick("stick1", {0.1f, 0.2f});
+  state.SetAnalogStick("stick2", {-1.0f, 1.0f});
+
+  // Two accelerometers
+  state.SetAccelerometer("accel1", {1.0f, 2.0f, 3.0f});
+  state.SetAccelerometer("accel2", {-1.0f, -2.0f, -3.0f});
+
+  // Additional throttle and wheel
+  state.SetThrottle("thr1", 0.5f);
+  state.SetWheel("wheel1", 0.75f);
+
+  EXPECT_TRUE(state.GetDigitalButton("a"));
+  EXPECT_FALSE(state.GetDigitalButton("b"));
+  EXPECT_FLOAT_EQ(state.GetAnalogButton("c"), -0.5f);
+  EXPECT_FLOAT_EQ(state.GetAnalogButton("d"), 0.25f);
+  EXPECT_EQ(state.GetAnalogStick("stick1"), (CControllerState::AnalogStick{0.1f, 0.2f}));
+  EXPECT_EQ(state.GetAnalogStick("stick2"), (CControllerState::AnalogStick{-1.0f, 1.0f}));
+  EXPECT_EQ(state.GetAccelerometer("accel1"), (CControllerState::Accelerometer{1.0f, 2.0f, 3.0f}));
+  EXPECT_EQ(state.GetAccelerometer("accel2"),
+            (CControllerState::Accelerometer{-1.0f, -2.0f, -3.0f}));
+  EXPECT_FLOAT_EQ(state.GetThrottle("thr1"), 0.5f);
+  EXPECT_FLOAT_EQ(state.GetWheel("wheel1"), 0.75f);
+
+  EXPECT_EQ(state.DigitalButtons().size(), 2u);
+  EXPECT_EQ(state.AnalogButtons().size(), 2u);
+  EXPECT_EQ(state.AnalogSticks().size(), 2u);
+  EXPECT_EQ(state.Accelerometers().size(), 2u);
+  EXPECT_EQ(state.Throttles().size(), 1u);
+  EXPECT_EQ(state.Wheels().size(), 1u);
+}
+
+//
+// Spec: Latest value should overwrite previous state
+//
+TEST(TestControllerState, OverwriteValues)
+{
+  CControllerState state;
+
+  state.SetDigitalButton("btn", true);
+  state.SetDigitalButton("btn", false);
+  EXPECT_FALSE(state.GetDigitalButton("btn"));
+
+  state.SetAnalogButton("analog", 0.0f);
+  state.SetAnalogButton("analog", 1.0f);
+  EXPECT_FLOAT_EQ(state.GetAnalogButton("analog"), 1.0f);
+
+  state.SetAnalogStick("stick", {0.0f, 0.0f});
+  state.SetAnalogStick("stick", {0.5f, -0.5f});
+  EXPECT_EQ(state.GetAnalogStick("stick"), (CControllerState::AnalogStick{0.5f, -0.5f}));
+
+  state.SetAccelerometer("accel", {0.0f, 0.0f, 0.0f});
+  state.SetAccelerometer("accel", {1.0f, 1.0f, 1.0f});
+  EXPECT_EQ(state.GetAccelerometer("accel"), (CControllerState::Accelerometer{1.0f, 1.0f, 1.0f}));
+
+  state.SetThrottle("thr", 0.0f);
+  state.SetThrottle("thr", 0.9f);
+  EXPECT_FLOAT_EQ(state.GetThrottle("thr"), 0.9f);
+
+  state.SetWheel("wheel", 0.0f);
+  state.SetWheel("wheel", -0.25f);
+  EXPECT_FLOAT_EQ(state.GetWheel("wheel"), -0.25f);
+}


### PR DESCRIPTION
## Description

As title says, this PR adds a class for tracking controller state. This is analogous to `ControllerActivity.cpp/h` (https://github.com/xbmc/xbmc/tree/master/xbmc/games/controllers/input), but deals with storing state instead of handling state changes.

No runtime changes, as code is currently only hooked up to test cases.

## Motivation and context

Broken out from Smart Home PR: https://github.com/xbmc/xbmc/pull/21183.

I was working on a project I call RetroEngine, and noticed that the controller state code looked very familiar... Indeed, I took it straight from #21183, which I wrote back in 2022. It hasn't changed in the last 3 years, so I decided to back it by extensive tests and upstream it to pay down tech debt on _both_ Smart Home and RetroEngine at the same time.

## How has this been tested?

Passes included test cases:

```
$ make test ARGS="-R TestControllerState"

Running tests...
Test project /home/garrett/Documents/kodi-master/build
    Start 630: TestControllerState.SetAndGet
1/7 Test #630: TestControllerState.SetAndGet ..........   Passed    0.09 sec
    Start 631: TestControllerState.CopyConstructor
2/7 Test #631: TestControllerState.CopyConstructor ....   Passed    0.07 sec
    Start 632: TestControllerState.EqualityOperator
3/7 Test #632: TestControllerState.EqualityOperator ...   Passed    0.07 sec
    Start 633: TestControllerState.DefaultValues
4/7 Test #633: TestControllerState.DefaultValues ......   Passed    0.07 sec
    Start 634: TestControllerState.Inequality
5/7 Test #634: TestControllerState.Inequality .........   Passed    0.07 sec
    Start 635: TestControllerState.MultipleInputs
6/7 Test #635: TestControllerState.MultipleInputs .....   Passed    0.07 sec
    Start 636: TestControllerState.OverwriteValues
7/7 Test #636: TestControllerState.OverwriteValues ....   Passed    0.07 sec

100% tests passed, 0 tests failed out of 7
```

Test builds coming soon.

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
