### PR TITLE
[CURL] Reduce the number of constructions of CURL objects.

### DIFF
--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -14,6 +14,7 @@
  */
 
 #include "SourceType.h"
+#include "URL.h"
 #include "XBDateTime.h"
 #include "guilib/GUIListItem.h"
 #include "utils/IArchivable.h"
@@ -24,6 +25,7 @@
 #include "utils/XTimeUtils.h"
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -36,7 +38,6 @@ class CGenre;
 class CMediaSource;
 class CPictureInfoTag;
 class CSong;
-class CURL;
 class CVariant;
 class CVideoInfoTag;
 class IEvent;
@@ -119,14 +120,14 @@ public:
   ~CFileItem() override;
   CGUIListItem* Clone() const override { return new CFileItem(*this); }
 
-  CURL GetURL() const;
+  const CURL& GetURL() const;
   void SetURL(const CURL& url);
   bool IsURL(const CURL& url) const;
-  const std::string& GetPath() const { return m_strPath; }
-  void SetPath(std::string_view path) { m_strPath = path; }
+  const std::string& GetPath() const;
+  void SetPath(std::string_view path);
   bool IsPath(const std::string& path, bool ignoreURLOptions = false) const;
 
-  CURL GetDynURL() const;
+  const CURL& GetDynURL() const;
   void SetDynURL(const CURL& url);
   const std::string &GetDynPath() const;
   void SetDynPath(std::string_view path);
@@ -555,6 +556,8 @@ private:
    */
   void FillMusicInfoTag(const std::shared_ptr<const PVR::CPVREpgInfoTag>& tag);
 
+  mutable std::optional<CURL> m_urlPath;
+  mutable std::optional<CURL> m_urlDynPath;
   std::string m_strPath;            ///< complete path to item
   std::string m_strDynPath;
 

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -81,8 +81,7 @@ void CFileItemList::SetFastLookup(bool fastLookup)
     m_map.clear();
     for (const auto& pItem : m_items)
     {
-      m_map.try_emplace(m_ignoreURLOptions ? CURL(pItem->GetPath()).GetWithoutOptions()
-                                           : pItem->GetPath(),
+      m_map.try_emplace(m_ignoreURLOptions ? pItem->GetURL().GetWithoutOptions() : pItem->GetPath(),
                         pItem);
     }
   }
@@ -133,8 +132,8 @@ void CFileItemList::Add(CFileItemPtr pItem)
   std::unique_lock lock(m_lock);
   if (m_fastLookup)
   {
-    m_map.try_emplace(
-        m_ignoreURLOptions ? CURL(pItem->GetPath()).GetWithoutOptions() : pItem->GetPath(), pItem);
+    m_map.try_emplace(m_ignoreURLOptions ? pItem->GetURL().GetWithoutOptions() : pItem->GetPath(),
+                      pItem);
   }
   m_items.emplace_back(std::move(pItem));
 }
@@ -145,8 +144,7 @@ void CFileItemList::Add(CFileItem&& item)
   auto ptr = std::make_shared<CFileItem>(std::move(item));
   if (m_fastLookup)
   {
-    m_map.try_emplace(
-        m_ignoreURLOptions ? CURL(ptr->GetPath()).GetWithoutOptions() : ptr->GetPath(), ptr);
+    m_map.try_emplace(m_ignoreURLOptions ? ptr->GetURL().GetWithoutOptions() : ptr->GetPath(), ptr);
   }
   m_items.emplace_back(std::move(ptr));
 }
@@ -164,8 +162,8 @@ void CFileItemList::AddFront(const CFileItemPtr& pItem, int itemPosition)
   }
   if (m_fastLookup)
   {
-    m_map.try_emplace(
-        m_ignoreURLOptions ? CURL(pItem->GetPath()).GetWithoutOptions() : pItem->GetPath(), pItem);
+    m_map.try_emplace(m_ignoreURLOptions ? pItem->GetURL().GetWithoutOptions() : pItem->GetPath(),
+                      pItem);
   }
 }
 
@@ -179,8 +177,7 @@ void CFileItemList::Remove(const CFileItem* pItem)
     m_items.erase(it);
     if (m_fastLookup)
     {
-      m_map.erase(m_ignoreURLOptions ? CURL(pItem->GetPath()).GetWithoutOptions()
-                                     : pItem->GetPath());
+      m_map.erase(m_ignoreURLOptions ? pItem->GetURL().GetWithoutOptions() : pItem->GetPath());
     }
   }
 }
@@ -200,8 +197,7 @@ void CFileItemList::Remove(int iItem)
     CFileItemPtr pItem = *(m_items.begin() + iItem);
     if (m_fastLookup)
     {
-      m_map.erase(m_ignoreURLOptions ? CURL(pItem->GetPath()).GetWithoutOptions()
-                                     : pItem->GetPath());
+      m_map.erase(m_ignoreURLOptions ? pItem->GetURL().GetWithoutOptions() : pItem->GetPath());
     }
     m_items.erase(m_items.begin() + iItem);
   }

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -11878,7 +11878,7 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int co
       case LISTITEM_THUMB:
         return item->GetThumbHideIfUnwatched(item);
       case LISTITEM_FOLDERPATH:
-        return CURL(item->GetPath()).GetWithoutUserDetails();
+        return item->GetURL().GetWithoutUserDetails();
       case LISTITEM_FOLDERNAME:
       case LISTITEM_PATH:
       {

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -748,7 +748,8 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
 
   // lookup host in DNS cache
   std::string resolvedHost;
-  if (CServiceBroker::GetDNSNameCache()->GetCached(url2.GetHostName(), resolvedHost))
+  const std::shared_ptr<CDNSNameCache> dnsCache = CServiceBroker::GetDNSNameCache();
+  if (dnsCache && dnsCache->GetCached(url2.GetHostName(), resolvedHost))
   {
     struct curl_slist* tempCache;
     int entryPort = url2.GetPort();

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1377,7 +1377,7 @@ void CXBMCApp::onNewIntent(CJNIIntent intent)
       CFileItem* item = new CFileItem(targetFile, false);
       if (IsVideoDb(*item))
       {
-        *(item->GetVideoInfoTag()) = XFILE::CVideoDatabaseFile::GetVideoTag(CURL(item->GetPath()));
+        *(item->GetVideoInfoTag()) = XFILE::CVideoDatabaseFile::GetVideoTag(item->GetURL());
         item->SetPath(item->GetVideoInfoTag()->m_strFileNameAndPath);
       }
       CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, 0, 0, static_cast<void*>(item));

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -186,3 +186,67 @@ TEST_P(TestFileItemLocalMetadataPath, GetLocalMetadataPath)
 }
 
 INSTANTIATE_TEST_SUITE_P(NameMovies, TestFileItemLocalMetadataPath, ValuesIn(BasePaths));
+
+TEST(TestFileItem, TestSimplePathSet)
+{
+  CFileItem item;
+  item.SetPath("/local/path/regular/file.txt");
+  item.SetDynPath("/local/path/dynamic/file.txt");
+
+  EXPECT_EQ("/local/path/regular/file.txt", item.GetURL().Get());
+  EXPECT_EQ("/local/path/dynamic/file.txt", item.GetDynURL().Get());
+}
+
+TEST(TestFileItem, TestLabel)
+{
+  CFileItem item("My Item Label");
+  item.SetPath("/local/path/file.txt");
+
+  EXPECT_EQ("My Item Label", item.GetLabel());
+  EXPECT_EQ("/local/path/file.txt", item.GetURL().Get());
+  EXPECT_EQ("/local/path/file.txt", item.GetDynURL().Get());
+}
+
+TEST(TestFileItem, TestCURLConstructor)
+{
+  CFileItem folderItem(CURL("/local/path/file.txt"), true);
+
+  EXPECT_EQ("", folderItem.GetLabel());
+  EXPECT_EQ("/local/path/file.txt/", folderItem.GetURL().Get());
+  EXPECT_EQ("/local/path/file.txt/", folderItem.GetDynURL().Get());
+
+  CFileItem fileItem(CURL("/local/path/file.txt"), false);
+
+  EXPECT_EQ("", fileItem.GetLabel());
+  EXPECT_EQ("/local/path/file.txt", fileItem.GetURL().Get());
+  EXPECT_EQ("/local/path/file.txt", fileItem.GetDynURL().Get());
+}
+
+TEST(TestFileItem, TestAssignment)
+{
+  CFileItem itemToCopy("My Item Label");
+  itemToCopy.SetPath("/local/path/file.txt");
+
+  CFileItem item("Alternative Label");
+  item = itemToCopy;
+
+  EXPECT_EQ("My Item Label", item.GetLabel());
+  EXPECT_EQ("/local/path/file.txt", item.GetURL().Get());
+  EXPECT_EQ("/local/path/file.txt", item.GetDynURL().Get());
+}
+
+TEST(TestFileItem, MimeType)
+{
+  CFileItem item("Internet Movies List");
+  item.SetPath("http://testdomain.com/api/movies");
+
+  item.FillInMimeType(true);
+  EXPECT_EQ("Internet Movies List", item.GetLabel());
+  EXPECT_EQ("http://testdomain.com/api/movies", item.GetURL().Get());
+  EXPECT_EQ("http://testdomain.com/api/movies", item.GetDynURL().Get());
+
+  item.FillInMimeType(false);
+  EXPECT_EQ("Internet Movies List", item.GetLabel());
+  EXPECT_EQ("http://testdomain.com/api/movies", item.GetURL().Get());
+  EXPECT_EQ("http://testdomain.com/api/movies", item.GetDynURL().Get());
+}

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -160,7 +160,7 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
             CFileItem item(path, URIUtils::HasSlashAtEnd(path));
             if (VIDEO::IsVideoDb(item))
             {
-              *(item.GetVideoInfoTag()) = XFILE::CVideoDatabaseFile::GetVideoTag(CURL(item.GetPath()));
+              *(item.GetVideoInfoTag()) = XFILE::CVideoDatabaseFile::GetVideoTag(item.GetURL());
               if (!item.GetVideoInfoTag()->IsEmpty())
               {
                 item.SetPath(item.GetVideoInfoTag()->m_strFileNameAndPath);


### PR DESCRIPTION
## Description
CURL objects are very expensive to create. The constructor calls `CURL::Parse` on every construction of a new object which analyses the string and parses it into many smaller strings; causing many allocations. Cache the `CURL` object on the `FileItem` object and invalidate the cache each time the `FileItem` path is modified.

The primary goal of this PR to make `FileItem::GetURL()` a cheap operation.

## Motivation and context
See description.

## How has this been tested?
Existing test suite.
Extra tests added.
Running Kodi with these changes.

## What is the effect on users?
More responsive GUI

## Screenshots (if appropriate):
If you trace these calls up the callstack the majority of these calls are originating from `CFileItem` where the `CURL` object is cached
![image](https://github.com/user-attachments/assets/223c2191-78f5-4a70-97be-d811a422a565)

Below, I have tried highlighting all the callers of `CURL::CURL` where the caller has a CURL object already, or where the caller has access to a `CFileItem` from which to request the associated `CURL` object. 
![curl_callers](https://github.com/user-attachments/assets/806537ac-4ee3-479f-b19f-854f6df48b6c)

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
