### PR TITLE
Prevent unnecessary calls to `strlen`

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -51,7 +51,7 @@ namespace
 {
 struct InfoMap
 {
-  const char* str{nullptr};
+  std::string_view str{};
   int val{0};
 };
 

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -295,7 +295,7 @@ void CURL::Parse(std::string strURL1)
     if (!m_strHostName.empty() && !m_strFileName.empty())
     {
       m_strFileName = StringUtils::Format("{}/{}", m_strHostName, m_strFileName);
-      m_strHostName = "";
+      m_strHostName.clear();
     }
     else
     {
@@ -303,7 +303,7 @@ void CURL::Parse(std::string strURL1)
         m_strFileName = m_strHostName + "/";
       else
         m_strFileName = m_strHostName;
-      m_strHostName = "";
+      m_strHostName.clear();
     }
   }
 
@@ -705,7 +705,7 @@ std::string CURL::Encode(std::string_view strURLData)
   return strResult;
 }
 
-bool CURL::IsProtocolEqual(const std::string &protocol, const char *type)
+bool CURL::IsProtocolEqual(const std::string& protocol, std::string_view type)
 {
   /*
    NOTE: We're currently using == here as m_strProtocol is assigned as lower-case in SetProtocol(),
@@ -713,9 +713,7 @@ bool CURL::IsProtocolEqual(const std::string &protocol, const char *type)
    We possibly shouldn't do this (as CURL(foo).Get() != foo, though there are other reasons for this as well)
    but it handles the requirements of RFC-1738 which allows the scheme to be case-insensitive.
    */
-  if (type)
-    return protocol == type;
-  return false;
+  return protocol == type;
 }
 
 void CURL::GetOptions(std::map<std::string, std::string> &options) const

--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -132,10 +132,7 @@ public:
    \param type a lower-case scheme name, e.g. "smb".
    \return true if the url is of the given scheme, false otherwise.
    */
-  bool IsProtocol(const char *type) const
-  {
-    return IsProtocolEqual(m_strProtocol, type);
-  }
+  bool IsProtocol(std::string_view type) const { return IsProtocolEqual(m_strProtocol, type); }
 
   /*! \brief Check whether a URL protocol is a given URL scheme.
    Both parameters MUST be lower-case.  Typically this would be called using
@@ -144,7 +141,7 @@ public:
    \param type a lower-case scheme name, e.g. "smb".
    \return true if the url is of the given scheme, false otherwise.
    */
-  static bool IsProtocolEqual(const std::string& protocol, const char *type);
+  static bool IsProtocolEqual(const std::string& protocol, std::string_view type);
 
   /*! \brief Check whether a URL is a given filetype.
    Comparison is effectively case-insensitive as both the parameter
@@ -152,10 +149,7 @@ public:
    \param type a lower-case filetype, e.g. "mp3".
    \return true if the url is of the given filetype, false otherwise.
    */
-  bool IsFileType(const char *type) const
-  {
-    return m_strFileType == type;
-  }
+  bool IsFileType(std::string_view type) const { return m_strFileType == type; }
 
   void GetOptions(std::map<std::string, std::string> &options) const;
   bool HasOption(const std::string &key) const;

--- a/xbmc/dbwrappers/dataset.cpp
+++ b/xbmc/dbwrappers/dataset.cpp
@@ -526,18 +526,9 @@ const char* Dataset::fieldName(int n)
     return nullptr;
 }
 
-char* Dataset::str_toLower(char* s)
-{
-  for (char* p = s; *p; p++)
-    *p = static_cast<char>(std::tolower(*p));
-
-  return s;
-}
-
 int Dataset::fieldIndex(const char* fn)
 {
-  std::string name(fn);
-  const auto it = name2indexMap.find(str_toLower(name.data()));
+  const auto it = name2indexMap.find(StringUtils::ToLower(fn));
   if (it != name2indexMap.end())
     return (*it).second;
   else

--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -273,9 +273,6 @@ protected:
   /* Returns old field value (for :OLD) */
   virtual field_value f_old(const char* f);
 
-  /* fast string tolower helper */
-  char* str_toLower(char* s);
-
 public:
   /* constructor */
   Dataset();

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -1965,7 +1965,7 @@ bool MysqlDataset::query(const std::string& query)
         case MYSQL_TYPE_NULL:
         default:
           CLog::Log(LOGDEBUG, "MYSQL: Unknown field type: {}", fields[i].type);
-          v.set_asString("");
+          v.set_asString("", 0);
           v.set_isNull();
           break;
       }

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -1752,7 +1752,8 @@ void MysqlDataset::fill_fields()
     {
       (*fields_object)[i].props = result.record_header[i];
       std::string name = result.record_header[i].name;
-      name2indexMap.try_emplace(str_toLower(name.data()), static_cast<unsigned int>(i));
+      StringUtils::ToLower(name);
+      name2indexMap.try_emplace(std::move(name), static_cast<unsigned int>(i));
     }
   }
 

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -188,7 +188,7 @@ int callback(void* res_ptr, int ncol, char** result, char** cols)
       dbiplus::field_value& v = rec->at(i);
       if (!result[i])
       {
-        v.set_asString("");
+        v.set_asString("", 0);
         v.set_isNull();
       }
       else
@@ -971,7 +971,7 @@ bool SqliteDataset::query(const std::string& query)
           break;
         case SQLITE_NULL:
         default:
-          v.set_asString("");
+          v.set_asString("", 0);
           v.set_isNull();
           break;
       }

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -805,7 +805,8 @@ void SqliteDataset::fill_fields()
     {
       (*fields_object)[i].props = result.record_header[i];
       std::string name = result.record_header[i].name;
-      name2indexMap.try_emplace(str_toLower(name.data()), static_cast<unsigned int>(i));
+      StringUtils::ToLower(name);
+      name2indexMap.try_emplace(std::move(name), static_cast<unsigned int>(i));
     }
   }
 

--- a/xbmc/guilib/guiinfo/GUIInfoLabel.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoLabel.cpp
@@ -296,7 +296,7 @@ enum class InfoFormat
 
 struct InfoFormatData
 {
-  const char* str{nullptr};
+  std::string_view str{};
   InfoFormat val{0};
 };
 
@@ -333,7 +333,7 @@ void CGUIInfoLabel::Parse(const std::string& label,
       if (pos2 != std::string::npos && pos2 < pos1)
       {
         pos1 = pos2;
-        len = strlen(infoformat.str);
+        len = infoformat.str.length();
         format = infoformat.val;
       }
     }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Small adjustments that eliminate a bunch of calls to `strlen`. For my  test case of starting Kodi, performing a library refresh on an already up-to-date library and then stopping Kodi, this reduces the number of `strlen` calls from 4.9 million to 3 million. This was with a GCC release build in Linux.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Small performance improvement.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Runtime tested with the above test scenario.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Small performance improvement on slow devices.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
