### PR TITLE
[FileItem][FileItemList] SonarQube findings

### DIFF
--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -327,23 +327,30 @@ bool CAutorun::RunDisc(IDirectory* pDir,
             int ecount = 0;
             // calculate average size of elements above 1gb
             for (int j = 0; j < items.Size(); j++)
-              if (items[j]->m_dwSize > 1000000000)
+            {
+              const int64_t size{items[j]->GetSize()};
+              if (size > 1000000000)
               {
                 ecount++;
-                asize = asize + items[j]->m_dwSize;
+                asize = asize + size;
               }
+            }
             if (ecount > 0)
               asize = asize / ecount;
             // Put largest files in alphabetical order to top of new list.
             for (int j = 0; j < items.Size(); j++)
-              if (items[j]->m_dwSize >= asize)
+            {
+              if (items[j]->GetSize() >= asize)
                 sitems.Add (items[j]);
+            }
             // Sort *.evo files by size.
             items.Sort(SortBySize, SortOrderDescending);
             // Add other files with descending size to bottom of new list.
             for (int j = 0; j < items.Size(); j++)
-              if (items[j]->m_dwSize < asize)
+            {
+              if (items[j]->GetSize() < asize)
                 sitems.Add (items[j]);
+            }
             // Replace list with optimized list.
             items.Clear();
             items.Copy (sitems);

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -477,7 +477,7 @@ CFileItem& CFileItem::operator=(const CFileItem& item)
   m_lEndOffset = item.m_lEndOffset;
   m_strDVDLabel = item.m_strDVDLabel;
   m_strTitle = item.m_strTitle;
-  m_iprogramCount = item.m_iprogramCount;
+  m_programCount = item.m_programCount;
   m_idepth = item.m_idepth;
   m_iLockMode = item.m_iLockMode;
   m_strLockCode = item.m_strLockCode;
@@ -508,7 +508,7 @@ void CFileItem::Archive(CArchive& ar)
     ar << m_dwSize;
     ar << m_strDVDLabel;
     ar << m_strTitle;
-    ar << m_iprogramCount;
+    ar << m_programCount;
     ar << m_idepth;
     ar << m_lStartOffset;
     ar << m_lStartPartNumber;
@@ -566,7 +566,7 @@ void CFileItem::Archive(CArchive& ar)
     ar >> m_dwSize;
     ar >> m_strDVDLabel;
     ar >> m_strTitle;
-    ar >> m_iprogramCount;
+    ar >> m_programCount;
     ar >> m_idepth;
     ar >> m_lStartOffset;
     ar >> m_lStartPartNumber;
@@ -658,7 +658,7 @@ void CFileItem::ToSortable(SortItem &sortable, Field field) const
       sortable[FieldEndOffset] = m_lEndOffset;
       break;
     case FieldProgramCount:
-      sortable[FieldProgramCount] = m_iprogramCount;
+      sortable[FieldProgramCount] = m_programCount;
       break;
     case FieldBitrate:
       sortable[FieldBitrate] = m_dwSize;

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -81,40 +81,30 @@ using namespace GAME;
 
 CFileItem::CFileItem(const CSong& song)
 {
-  Initialize();
   SetFromSong(song);
 }
 
 CFileItem::CFileItem(const CSong& song, const CMusicInfoTag& music)
 {
-  Initialize();
   SetFromSong(song);
   *GetMusicInfoTag() = music;
 }
 
-CFileItem::CFileItem(const CURL &url, const CAlbum& album)
+CFileItem::CFileItem(const CURL& url, const CAlbum& album) : m_strPath(url.Get())
 {
-  Initialize();
-
-  m_strPath = url.Get();
   URIUtils::AddSlashAtEnd(m_strPath);
   SetFromAlbum(album);
 }
 
-CFileItem::CFileItem(const std::string &path, const CAlbum& album)
+CFileItem::CFileItem(std::string_view path, const CAlbum& album) : m_strPath(path)
 {
-  Initialize();
-
-  m_strPath = path;
   URIUtils::AddSlashAtEnd(m_strPath);
   SetFromAlbum(album);
 }
 
-CFileItem::CFileItem(const CMusicInfoTag& music)
+CFileItem::CFileItem(const CMusicInfoTag& music) : m_strPath(music.GetURL())
 {
-  Initialize();
   SetLabel(music.GetTitle());
-  m_strPath = music.GetURL();
   m_bIsFolder = URIUtils::HasSlashAtEnd(m_strPath);
   *GetMusicInfoTag() = music;
   ART::FillInDefaultIcon(*this);
@@ -123,7 +113,6 @@ CFileItem::CFileItem(const CMusicInfoTag& music)
 
 CFileItem::CFileItem(const CVideoInfoTag& movie)
 {
-  Initialize();
   SetFromVideoInfoTag(movie);
 }
 
@@ -144,13 +133,9 @@ void CFileItem::FillMusicInfoTag(const std::shared_ptr<const CPVREpgInfoTag>& ta
 }
 
 CFileItem::CFileItem(const std::shared_ptr<CPVREpgInfoTag>& tag)
+  : m_strPath(tag->Path()), m_bCanQueue(false), m_epgInfoTag(tag)
 {
-  Initialize();
-
   m_bIsFolder = false;
-  m_epgInfoTag = tag;
-  m_strPath = tag->Path();
-  m_bCanQueue = false;
   SetLabel(CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().GetTitleForEpgTag(tag));
   m_dateTime = tag->StartAsLocalTime();
 
@@ -179,20 +164,16 @@ CFileItem::CFileItem(const std::shared_ptr<CPVREpgInfoTag>& tag)
 }
 
 CFileItem::CFileItem(const std::shared_ptr<PVR::CPVREpgSearchFilter>& filter)
+  : m_strPath(filter->GetPath()), m_bCanQueue(false), m_epgSearchFilter(filter)
 {
-  Initialize();
-
   m_bIsFolder = true;
-  m_epgSearchFilter = filter;
-  m_strPath = filter->GetPath();
-  m_bCanQueue = false;
   SetLabel(filter->GetTitle());
 
-  const CDateTime lastExec = filter->GetLastExecutedDateTime();
+  const CDateTime& lastExec = filter->GetLastExecutedDateTime();
   if (lastExec.IsValid())
     m_dateTime.SetFromUTCDateTime(lastExec);
 
-  const std::string iconPath = filter->GetIconPath();
+  const std::string& iconPath = filter->GetIconPath();
   if (!iconPath.empty())
     SetArt("icon", iconPath);
   else
@@ -205,16 +186,12 @@ CFileItem::CFileItem(const std::shared_ptr<PVR::CPVREpgSearchFilter>& filter)
 }
 
 CFileItem::CFileItem(const std::shared_ptr<CPVRChannelGroupMember>& channelGroupMember)
+  : m_strPath(channelGroupMember->Path()),
+    m_bCanQueue(false),
+    m_pvrChannelGroupMemberInfoTag(channelGroupMember)
 {
-  Initialize();
-
-  const std::shared_ptr<const CPVRChannel> channel = channelGroupMember->Channel();
-
-  m_pvrChannelGroupMemberInfoTag = channelGroupMember;
-
-  m_strPath = channelGroupMember->Path();
   m_bIsFolder = false;
-  m_bCanQueue = false;
+  const std::shared_ptr<const CPVRChannel> channel = channelGroupMember->Channel();
   SetLabel(channel->ChannelName());
 
   if (!channel->IconPath().empty())
@@ -240,16 +217,12 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRChannelGroupMember>& channelGroup
 }
 
 CFileItem::CFileItem(const std::shared_ptr<CPVRRecording>& record)
+  : m_strPath(record->m_strFileNameAndPath), m_pvrRecordingInfoTag(record)
 {
-  Initialize();
-
   m_bIsFolder = false;
-  m_pvrRecordingInfoTag = record;
-  m_strPath = record->m_strFileNameAndPath;
   SetLabel(record->m_strTitle);
   m_dateTime = record->RecordingTimeAsLocalTime();
   m_dwSize = record->GetSizeInBytes();
-  m_bCanQueue = true;
 
   // Set art
   if (!record->IconPath().empty())
@@ -278,15 +251,13 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRRecording>& record)
 }
 
 CFileItem::CFileItem(const std::shared_ptr<CPVRTimerInfoTag>& timer)
+  : m_strPath(timer->Path()),
+    m_dateTime(timer->StartAsLocalTime()),
+    m_bCanQueue(false),
+    m_pvrTimerInfoTag(timer)
 {
-  Initialize();
-
   m_bIsFolder = timer->IsTimerRule();
-  m_pvrTimerInfoTag = timer;
-  m_strPath = timer->Path();
   SetLabel(timer->Title());
-  m_dateTime = timer->StartAsLocalTime();
-  m_bCanQueue = false;
 
   if (!timer->ChannelIcon().empty())
     SetArt("icon", timer->ChannelIcon());
@@ -301,15 +272,11 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRTimerInfoTag>& timer)
   FillInMimeType(false);
 }
 
-CFileItem::CFileItem(const std::string& path, const std::shared_ptr<CPVRProvider>& provider)
+CFileItem::CFileItem(std::string_view path, const std::shared_ptr<CPVRProvider>& provider)
+  : m_strPath(path), m_bCanQueue(false), m_pvrProviderInfoTag(provider)
 {
-  Initialize();
-
-  m_strPath = path;
   m_bIsFolder = true;
-  m_pvrProviderInfoTag = provider;
   SetLabel(provider->GetName());
-  m_bCanQueue = false;
 
   // Set art
   if (!provider->GetIconPath().empty())
@@ -326,91 +293,66 @@ CFileItem::CFileItem(const std::string& path, const std::shared_ptr<CPVRProvider
   FillInMimeType(false);
 }
 
-CFileItem::CFileItem(const CArtist& artist)
+CFileItem::CFileItem(const CArtist& artist) : m_strPath(artist.strArtist)
 {
-  Initialize();
   SetLabel(artist.strArtist);
-  m_strPath = artist.strArtist;
   m_bIsFolder = true;
   URIUtils::AddSlashAtEnd(m_strPath);
   GetMusicInfoTag()->SetArtist(artist);
   FillInMimeType(false);
 }
 
-CFileItem::CFileItem(const CGenre& genre)
+CFileItem::CFileItem(const CGenre& genre) : m_strPath(genre.strGenre)
 {
-  Initialize();
   SetLabel(genre.strGenre);
-  m_strPath = genre.strGenre;
   m_bIsFolder = true;
   URIUtils::AddSlashAtEnd(m_strPath);
   GetMusicInfoTag()->SetGenre(genre.strGenre);
   FillInMimeType(false);
 }
 
-CFileItem::CFileItem(const CFileItem& item)
-  : CGUIListItem(item),
-    m_musicInfoTag(NULL),
-    m_videoInfoTag(NULL),
-    m_pictureInfoTag(NULL),
-    m_gameInfoTag(NULL)
+CFileItem::CFileItem(const CFileItem& item) : CGUIListItem(item)
 {
   *this = item;
 }
 
-CFileItem::CFileItem(const CGUIListItem& item)
+CFileItem::CFileItem(const CGUIListItem& item) : CGUIListItem(item)
 {
-  Initialize();
-  // not particularly pretty, but it gets around the issue of Initialize() defaulting
-  // parameters in the CGUIListItem base class.
-  *static_cast<CGUIListItem*>(this) = item;
-
   FillInMimeType(false);
 }
 
-CFileItem::CFileItem(void)
-{
-  Initialize();
-}
+CFileItem::CFileItem() = default;
 
 CFileItem::CFileItem(const std::string& strLabel)
 {
-  Initialize();
   SetLabel(strLabel);
 }
 
 CFileItem::CFileItem(const char* strLabel)
 {
-  Initialize();
   SetLabel(std::string(strLabel));
 }
 
-CFileItem::CFileItem(const CURL& path, bool bIsFolder)
+CFileItem::CFileItem(const CURL& path, bool bIsFolder) : m_strPath(path.Get())
 {
-  Initialize();
-  m_strPath = path.Get();
   m_bIsFolder = bIsFolder;
   if (m_bIsFolder && !m_strPath.empty() && !IsFileFolder())
     URIUtils::AddSlashAtEnd(m_strPath);
   FillInMimeType(false);
 }
 
-CFileItem::CFileItem(const std::string& strPath, bool bIsFolder)
+CFileItem::CFileItem(std::string_view strPath, bool bIsFolder) : m_strPath(strPath)
 {
-  Initialize();
-  m_strPath = strPath;
   m_bIsFolder = bIsFolder;
   if (m_bIsFolder && !m_strPath.empty() && !IsFileFolder())
     URIUtils::AddSlashAtEnd(m_strPath);
   FillInMimeType(false);
 }
 
-CFileItem::CFileItem(const CMediaSource& share)
+CFileItem::CFileItem(const CMediaSource& share) : m_strPath(share.strPath)
 {
-  Initialize();
   m_bIsFolder = true;
   m_bIsShareOrDrive = true;
-  m_strPath = share.strPath;
   if (!IsRSS()) // no slash at end for rss feeds
     URIUtils::AddSlashAtEnd(m_strPath);
   std::string label = share.strName;
@@ -429,33 +371,28 @@ CFileItem::CFileItem(const CMediaSource& share)
   FillInMimeType(false);
 }
 
-CFileItem::CFileItem(std::shared_ptr<const ADDON::IAddon> addonInfo) : m_addonInfo(std::move(addonInfo))
+CFileItem::CFileItem(const std::shared_ptr<const ADDON::IAddon>& addonInfo) : m_addonInfo(addonInfo)
 {
-  Initialize();
 }
 
-CFileItem::CFileItem(const EventPtr& eventLogEntry)
+CFileItem::CFileItem(const std::shared_ptr<const IEvent>& eventLogEntry)
+  : m_dateTime(eventLogEntry->GetDateTime()), m_eventLogEntry(eventLogEntry)
 {
-  Initialize();
-
-  m_eventLogEntry = eventLogEntry;
   SetLabel(eventLogEntry->GetLabel());
-  m_dateTime = eventLogEntry->GetDateTime();
   if (!eventLogEntry->GetIcon().empty())
     SetArt("icon", eventLogEntry->GetIcon());
 }
 
-CFileItem::~CFileItem(void)
+CFileItem::~CFileItem()
 {
   delete m_musicInfoTag;
+  m_musicInfoTag = nullptr;
   delete m_videoInfoTag;
+  m_videoInfoTag = nullptr;
   delete m_pictureInfoTag;
+  m_pictureInfoTag = nullptr;
   delete m_gameInfoTag;
-
-  m_musicInfoTag = NULL;
-  m_videoInfoTag = NULL;
-  m_pictureInfoTag = NULL;
-  m_gameInfoTag = NULL;
+  m_gameInfoTag = nullptr;
 }
 
 CFileItem& CFileItem::operator=(const CFileItem& item)
@@ -484,7 +421,7 @@ CFileItem& CFileItem::operator=(const CFileItem& item)
   else
   {
     delete m_musicInfoTag;
-    m_musicInfoTag = NULL;
+    m_musicInfoTag = nullptr;
   }
 
   if (item.m_videoInfoTag)
@@ -497,7 +434,7 @@ CFileItem& CFileItem::operator=(const CFileItem& item)
   else
   {
     delete m_videoInfoTag;
-    m_videoInfoTag = NULL;
+    m_videoInfoTag = nullptr;
   }
 
   if (item.m_pictureInfoTag)
@@ -510,7 +447,7 @@ CFileItem& CFileItem::operator=(const CFileItem& item)
   else
   {
     delete m_pictureInfoTag;
-    m_pictureInfoTag = NULL;
+    m_pictureInfoTag = nullptr;
   }
 
   if (item.m_gameInfoTag)
@@ -523,7 +460,7 @@ CFileItem& CFileItem::operator=(const CFileItem& item)
   else
   {
     delete m_gameInfoTag;
-    m_gameInfoTag = NULL;
+    m_gameInfoTag = nullptr;
   }
 
   m_epgInfoTag = item.m_epgInfoTag;
@@ -553,70 +490,6 @@ CFileItem& CFileItem::operator=(const CFileItem& item)
   m_bIsAlbum = item.m_bIsAlbum;
   m_doContentLookup = item.m_doContentLookup;
   return *this;
-}
-
-void CFileItem::Initialize()
-{
-  m_musicInfoTag = NULL;
-  m_videoInfoTag = NULL;
-  m_pictureInfoTag = NULL;
-  m_gameInfoTag = NULL;
-  m_bLabelPreformatted = false;
-  m_bIsAlbum = false;
-  m_dwSize = 0;
-  m_bIsParentFolder = false;
-  m_bIsShareOrDrive = false;
-  m_iDriveType = SourceType::UNKNOWN;
-  m_lStartOffset = 0;
-  m_lStartPartNumber = 1;
-  m_lEndOffset = 0;
-  m_iprogramCount = 0;
-  m_idepth = 1;
-  m_iLockMode = LockMode::EVERYONE;
-  m_iBadPwdCount = 0;
-  m_iHasLock = LOCK_STATE_NO_LOCK;
-  m_bCanQueue = true;
-  m_specialSort = SortSpecialNone;
-  m_doContentLookup = true;
-}
-
-void CFileItem::Reset()
-{
-  // CGUIListItem members...
-  m_strLabel2.clear();
-  SetLabel("");
-  FreeIcons();
-  m_overlayIcon = ICON_OVERLAY_NONE;
-  m_bSelected = false;
-  m_bIsFolder = false;
-
-  m_strDVDLabel.clear();
-  m_strTitle.clear();
-  m_strPath.clear();
-  m_strDynPath.clear();
-  m_dateTime.Reset();
-  m_strLockCode.clear();
-  m_mimetype.clear();
-  delete m_musicInfoTag;
-  m_musicInfoTag=NULL;
-  delete m_videoInfoTag;
-  m_videoInfoTag=NULL;
-  m_epgInfoTag.reset();
-  m_epgSearchFilter.reset();
-  m_pvrChannelGroupMemberInfoTag.reset();
-  m_pvrRecordingInfoTag.reset();
-  m_pvrTimerInfoTag.reset();
-  m_pvrProviderInfoTag.reset();
-  delete m_pictureInfoTag;
-  m_pictureInfoTag=NULL;
-  delete m_gameInfoTag;
-  m_gameInfoTag = NULL;
-  m_extrainfo.clear();
-  ClearProperties();
-  m_eventLogEntry.reset();
-
-  Initialize();
-  SetInvalid();
 }
 
 void CFileItem::Archive(CArchive& ar)
@@ -757,8 +630,8 @@ void CFileItem::Serialize(CVariant& value) const
   if (!m_mapProperties.empty())
   {
     auto& customProperties = value["customproperties"];
-    for (const auto& prop : m_mapProperties)
-      customProperties[prop.first] = prop.second;
+    for (const auto& [propname, propval] : m_mapProperties)
+      customProperties[propname] = propval;
   }
 }
 
@@ -852,9 +725,8 @@ void CFileItem::ToSortable(SortItem &sortable, Field field) const
 
 void CFileItem::ToSortable(SortItem &sortable, const Fields &fields) const
 {
-  Fields::const_iterator it;
-  for (it = fields.begin(); it != fields.end(); ++it)
-    ToSortable(sortable, *it);
+  for (const auto& field : fields)
+    ToSortable(sortable, field);
 
   /* FieldLabel is used as a fallback by all sorters and therefore has to be present as well */
   sortable[FieldLabel] = GetLabel();
@@ -871,7 +743,9 @@ bool CFileItem::Exists(bool bUseCache /* = true */) const
 
   if (VIDEO::IsVideoDb(*this) && HasVideoInfoTag())
   {
-    CFileItem dbItem(m_bIsFolder ? GetVideoInfoTag()->m_strPath : GetVideoInfoTag()->m_strFileNameAndPath, m_bIsFolder);
+    const CFileItem dbItem(m_bIsFolder ? GetVideoInfoTag()->m_strPath
+                                       : GetVideoInfoTag()->m_strFileNameAndPath,
+                           m_bIsFolder);
     return dbItem.Exists();
   }
 
@@ -1013,12 +887,13 @@ bool CFileItem::IsFileFolder(FileFolderType types) const
         (PLAYLIST::IsPlayList(*this) &&
          CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_playlistAsFolders) ||
         IsAPK() || IsZIP() || IsRAR() || IsRSS() || MUSIC::IsAudioBook(*this) ||
-        IsType(".ogg|.oga|.xbt")
 #if defined(TARGET_ANDROID)
-        || IsType(".apk")
+        IsType(".apk") ||
 #endif
-    )
-    return true;
+        IsType(".ogg|.oga|.xbt"))
+    {
+      return true;
+    }
   }
 
   if (CServiceBroker::IsAddonInterfaceUp() &&
@@ -1233,7 +1108,9 @@ void CFileItem::CleanString()
     return;
 
   std::string strLabel = GetLabel();
-  std::string strTitle, strTitleAndYear, strYear;
+  std::string strTitle;
+  std::string strTitleAndYear;
+  std::string strYear;
   CUtil::CleanString(strLabel, strTitle, strTitleAndYear, strYear, true);
   SetLabel(strTitleAndYear);
 }
@@ -1301,7 +1178,7 @@ void CFileItem::FillInMimeType(bool lookup /*= true*/)
       // make sure there are no options set in mime-type
       // mime-type can look like "video/x-ms-asf ; charset=utf8"
       size_t i = m_mimetype.find(';');
-      if(i != std::string::npos)
+      if (i != std::string::npos)
         m_mimetype.erase(i, m_mimetype.length() - i);
       StringUtils::Trim(m_mimetype);
     }
@@ -1724,7 +1601,7 @@ void CFileItem::SetURL(const CURL& url)
   m_strPath = url.Get();
 }
 
-const CURL CFileItem::GetURL() const
+CURL CFileItem::GetURL() const
 {
   CURL url(m_strPath);
   return url;
@@ -1745,7 +1622,7 @@ void CFileItem::SetDynURL(const CURL& url)
   m_strDynPath = url.Get();
 }
 
-const CURL CFileItem::GetDynURL() const
+CURL CFileItem::GetDynURL() const
 {
   if (!m_strDynPath.empty())
   {
@@ -1767,12 +1644,12 @@ const std::string &CFileItem::GetDynPath() const
     return m_strPath;
 }
 
-void CFileItem::SetDynPath(const std::string &path)
+void CFileItem::SetDynPath(std::string_view path)
 {
   m_strDynPath = path;
 }
 
-void CFileItem::SetCueDocument(const CCueDocumentPtr& cuePtr)
+void CFileItem::SetCueDocument(const std::shared_ptr<CCueDocument>& cuePtr)
 {
   m_cueDocument = cuePtr;
 }
@@ -1786,14 +1663,13 @@ void CFileItem::LoadEmbeddedCue()
   const std::string embeddedCue = tag.GetCueSheet();
   if (!embeddedCue.empty())
   {
-    CCueDocumentPtr cuesheet(new CCueDocument);
+    const auto cuesheet{std::make_shared<CCueDocument>()};
     if (cuesheet->ParseTag(embeddedCue))
     {
-      std::vector<std::string> MediaFileVec;
-      cuesheet->GetMediaFiles(MediaFileVec);
-      for (std::vector<std::string>::iterator itMedia = MediaFileVec.begin();
-           itMedia != MediaFileVec.end(); ++itMedia)
-        cuesheet->UpdateMediaFile(*itMedia, GetPath());
+      std::vector<std::string> mediaFiles;
+      cuesheet->GetMediaFiles(mediaFiles);
+      for (const auto& mediaFile : mediaFiles)
+        cuesheet->UpdateMediaFile(mediaFile, GetPath());
       SetCueDocument(cuesheet);
     }
     // Clear cuesheet tag having added it to item
@@ -1803,7 +1679,7 @@ void CFileItem::LoadEmbeddedCue()
 
 bool CFileItem::HasCueDocument() const
 {
-  return (m_cueDocument.get() != nullptr);
+  return (m_cueDocument != nullptr);
 }
 
 bool CFileItem::LoadTracksFromCueDocument(CFileItemList& scannedItems)
@@ -1933,7 +1809,7 @@ std::string CFileItem::FindLocalArt(const std::string &artFile, bool useFolder) 
   }
   if ((useFolder || (m_bIsFolder && !IsFileFolder())) && !artFile.empty())
   {
-    std::string thumb2 = ART::GetLocalArt(*this, artFile, true);
+    const std::string thumb2 = ART::GetLocalArt(*this, artFile, true);
     if (!thumb2.empty() && thumb2 != thumb && CFile::Exists(thumb2))
       return thumb2;
   }
@@ -1952,7 +1828,7 @@ std::string CFileItem::GetMovieName(bool bUseFolderNames /* = false */) const
     return m_pvrRecordingInfoTag->m_strTitle;
   else if (URIUtils::IsPVRRecording(m_strPath))
   {
-    std::string title = CPVRRecording::GetTitleFromURL(m_strPath);
+    const std::string title = CPVRRecording::GetTitleFromURL(m_strPath);
     if (!title.empty())
       return title;
   }
@@ -2034,25 +1910,23 @@ bool CFileItem::LoadMusicTag()
     musicDatabase.Close();
   }
   // load tag from file
-  CLog::Log(LOGDEBUG, "{}: loading tag information for file: {}", __FUNCTION__, m_strPath);
-  CMusicInfoTagLoaderFactory factory;
-  std::unique_ptr<IMusicInfoTagLoader> pLoader (factory.CreateLoader(*this));
-  if (pLoader)
-  {
-    if (pLoader->Load(m_strPath, *GetMusicInfoTag()))
-      return true;
-  }
+  CLog::LogF(LOGDEBUG, "Loading tag information for file: {}", m_strPath);
+  const std::unique_ptr<IMusicInfoTagLoader> pLoader{
+      CMusicInfoTagLoaderFactory::CreateLoader(*this)};
+  if (pLoader && pLoader->Load(m_strPath, *GetMusicInfoTag()))
+    return true;
+
   // no tag - try some other things
   if (MUSIC::IsCDDA(*this))
   {
     // we have the tracknumber...
-    int iTrack = GetMusicInfoTag()->GetTrackNumber();
+    const int iTrack = GetMusicInfoTag()->GetTrackNumber();
     if (iTrack >= 1)
     {
       std::string strText = g_localizeStrings.Get(554); // "Track"
       if (!strText.empty() && strText[strText.size() - 1] != ' ')
         strText += " ";
-      std::string strTrack = StringUtils::Format((strText + "{}"), iTrack);
+      const std::string strTrack = StringUtils::Format((strText + "{}"), iTrack);
       GetMusicInfoTag()->SetTitle(strTrack);
       GetMusicInfoTag()->SetLoaded(true);
       return true;
@@ -2179,35 +2053,32 @@ bool CFileItem::LoadDetails()
   if (PLAYLIST::IsPlayList(*this) && IsType(".strm"))
   {
     const std::unique_ptr<PLAYLIST::CPlayList> playlist(PLAYLIST::CPlayListFactory::Create(*this));
-    if (playlist)
+    if (playlist && playlist->Load(GetPath()) && playlist->size() == 1)
     {
-      if (playlist->Load(GetPath()) && playlist->size() == 1)
+      const auto item{(*playlist)[0]};
+      if (VIDEO::IsVideo(*item))
       {
-        const auto item{(*playlist)[0]};
-        if (VIDEO::IsVideo(*item))
+        CVideoDatabase db;
+        if (!db.Open())
         {
-          CVideoDatabase db;
-          if (!db.Open())
-          {
-            CLog::LogF(LOGERROR, "Error opening video database");
-            return false;
-          }
-
-          CVideoInfoTag tag;
-          if (db.LoadVideoInfo(GetDynPath(), tag))
-          {
-            UpdateInfo(*item);
-            *GetVideoInfoTag() = tag;
-            return true;
-          }
+          CLog::LogF(LOGERROR, "Error opening video database");
+          return false;
         }
-        else if (MUSIC::IsAudio(*item))
+
+        CVideoInfoTag tag;
+        if (db.LoadVideoInfo(GetDynPath(), tag))
         {
-          if (item->LoadMusicTag())
-          {
-            UpdateInfo(*item);
-            return true;
-          }
+          UpdateInfo(*item);
+          *GetVideoInfoTag() = tag;
+          return true;
+        }
+      }
+      else if (MUSIC::IsAudio(*item))
+      {
+        if (item->LoadMusicTag())
+        {
+          UpdateInfo(*item);
+          return true;
         }
       }
     }
@@ -2287,7 +2158,7 @@ bool CFileItem::LoadDetails()
 bool CFileItem::HasVideoInfoTag() const
 {
   // Note: CPVRRecording is derived from CVideoInfoTag
-  return m_pvrRecordingInfoTag.get() != nullptr || m_videoInfoTag != nullptr;
+  return m_pvrRecordingInfoTag != nullptr || m_videoInfoTag != nullptr;
 }
 
 CVideoInfoTag* CFileItem::GetVideoInfoTag()
@@ -2336,7 +2207,7 @@ bool CFileItem::HasPVRChannelInfoTag() const
   return m_pvrChannelGroupMemberInfoTag && m_pvrChannelGroupMemberInfoTag->Channel() != nullptr;
 }
 
-const std::shared_ptr<PVR::CPVRChannel> CFileItem::GetPVRChannelInfoTag() const
+std::shared_ptr<PVR::CPVRChannel> CFileItem::GetPVRChannelInfoTag() const
 {
   return m_pvrChannelGroupMemberInfoTag ? m_pvrChannelGroupMemberInfoTag->Channel()
                                         : std::shared_ptr<CPVRChannel>();
@@ -2344,28 +2215,29 @@ const std::shared_ptr<PVR::CPVRChannel> CFileItem::GetPVRChannelInfoTag() const
 
 VideoDbContentType CFileItem::GetVideoContentType() const
 {
-  VideoDbContentType type = VideoDbContentType::MOVIES;
+  using enum VideoDbContentType;
+
+  VideoDbContentType type = MOVIES;
   if (HasVideoInfoTag())
   {
     const auto& tag{GetVideoInfoTag()};
     if (tag->m_type == MediaTypeTvShow)
-      type = VideoDbContentType::TVSHOWS;
+      type = TVSHOWS;
     if (tag->m_type == MediaTypeEpisode)
-      return VideoDbContentType::EPISODES;
+      return EPISODES;
     if (tag->m_type == MediaTypeMusicVideo)
-      return VideoDbContentType::MUSICVIDEOS;
+      return MUSICVIDEOS;
     if (tag->m_type == MediaTypeAlbum)
-      return VideoDbContentType::MUSICALBUMS;
+      return MUSICALBUMS;
     if (tag->m_strFileNameAndPath.starts_with("bluray://removable"))
       // cannot tell if a removable bluray is a movie or a tv show
-      return VideoDbContentType::UNKNOWN;
+      return UNKNOWN;
   }
 
-  CVideoDatabaseDirectory dir;
   VIDEODATABASEDIRECTORY::CQueryParams params;
-  dir.GetQueryParams(m_strPath, params);
+  CVideoDatabaseDirectory::GetQueryParams(m_strPath, params);
   if (params.GetSetId() != -1 && params.GetMovieId() == -1) // movie set
-    return VideoDbContentType::MOVIE_SETS;
+    return MOVIE_SETS;
 
   return type;
 }
@@ -2396,16 +2268,16 @@ bool CFileItem::IsResumePointSet() const
 
 double CFileItem::GetCurrentResumeTime() const
 {
-  return lrint(GetResumePoint().timeInSeconds);
+  return static_cast<double>(std::lrint(GetResumePoint().timeInSeconds));
 }
 
 bool CFileItem::GetCurrentResumeTimeAndPartNumber(int64_t& startOffset, int& partNumber) const
 {
-  CBookmark resumePoint(GetResumePoint());
+  const CBookmark resumePoint(GetResumePoint());
   if (resumePoint.IsSet())
   {
-    startOffset = llrint(resumePoint.timeInSeconds);
-    partNumber = resumePoint.partNumber;
+    startOffset = std::llrint(resumePoint.timeInSeconds);
+    partNumber = static_cast<int>(resumePoint.partNumber);
     return true;
   }
   return false;

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -478,7 +478,7 @@ CFileItem& CFileItem::operator=(const CFileItem& item)
   m_strDVDLabel = item.m_strDVDLabel;
   m_strTitle = item.m_strTitle;
   m_programCount = item.m_programCount;
-  m_idepth = item.m_idepth;
+  m_depth = item.m_depth;
   m_iLockMode = item.m_iLockMode;
   m_strLockCode = item.m_strLockCode;
   m_iHasLock = item.m_iHasLock;
@@ -509,7 +509,7 @@ void CFileItem::Archive(CArchive& ar)
     ar << m_strDVDLabel;
     ar << m_strTitle;
     ar << m_programCount;
-    ar << m_idepth;
+    ar << m_depth;
     ar << m_lStartOffset;
     ar << m_lStartPartNumber;
     ar << m_lEndOffset;
@@ -567,7 +567,7 @@ void CFileItem::Archive(CArchive& ar)
     ar >> m_strDVDLabel;
     ar >> m_strTitle;
     ar >> m_programCount;
-    ar >> m_idepth;
+    ar >> m_depth;
     ar >> m_lStartOffset;
     ar >> m_lStartPartNumber;
     ar >> m_lEndOffset;

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -359,10 +359,7 @@ CFileItem::CFileItem(const CMediaSource& share) : m_strPath(share.strPath)
   if (!share.strStatus.empty())
     label = StringUtils::Format("{} ({})", share.strName, share.strStatus);
   SetLabel(label);
-  m_iLockMode = share.GetLockMode();
-  m_strLockCode = share.GetLockCode();
-  m_lockState = share.GetLockState();
-  m_iBadPwdCount = share.GetBadPwdCount();
+  m_lockInfo = share.GetLockInfo();
   m_iDriveType = share.m_iDriveType;
   SetArt("thumb", share.m_strThumbnailImage);
   SetLabelPreformatted(true);
@@ -479,10 +476,7 @@ CFileItem& CFileItem::operator=(const CFileItem& item)
   m_strTitle = item.m_strTitle;
   m_programCount = item.m_programCount;
   m_depth = item.m_depth;
-  m_iLockMode = item.m_iLockMode;
-  m_strLockCode = item.m_strLockCode;
-  m_lockState = item.m_lockState;
-  m_iBadPwdCount = item.m_iBadPwdCount;
+  m_lockInfo = item.m_lockInfo;
   m_bCanQueue=item.m_bCanQueue;
   m_mimetype = item.m_mimetype;
   m_extrainfo = item.m_extrainfo;
@@ -513,10 +507,9 @@ void CFileItem::Archive(CArchive& ar)
     ar << m_lStartOffset;
     ar << m_lStartPartNumber;
     ar << m_lEndOffset;
-    ar << static_cast<int>(m_iLockMode);
-    ar << m_strLockCode;
-    ar << m_iBadPwdCount;
-
+    ar << static_cast<int>(m_lockInfo.GetMode());
+    ar << m_lockInfo.GetCode();
+    ar << m_lockInfo.GetBadPasswordCount();
     ar << m_bCanQueue;
     ar << m_mimetype;
     ar << m_extrainfo;
@@ -573,10 +566,12 @@ void CFileItem::Archive(CArchive& ar)
     ar >> m_lEndOffset;
     int temp;
     ar >> temp;
-    m_iLockMode = static_cast<LockMode>(temp);
-    ar >> m_strLockCode;
-    ar >> m_iBadPwdCount;
-
+    m_lockInfo.SetMode(static_cast<LockMode>(temp));
+    std::string tempstr;
+    ar >> tempstr;
+    m_lockInfo.SetCode(tempstr);
+    ar >> temp;
+    m_lockInfo.SetBadPasswordCount(temp);
     ar >> m_bCanQueue;
     ar >> m_mimetype;
     ar >> m_extrainfo;

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -359,10 +359,10 @@ CFileItem::CFileItem(const CMediaSource& share) : m_strPath(share.strPath)
   if (!share.strStatus.empty())
     label = StringUtils::Format("{} ({})", share.strName, share.strStatus);
   SetLabel(label);
-  m_iLockMode = share.m_iLockMode;
-  m_strLockCode = share.m_strLockCode;
-  m_iHasLock = share.m_iHasLock;
-  m_iBadPwdCount = share.m_iBadPwdCount;
+  m_iLockMode = share.GetLockMode();
+  m_strLockCode = share.GetLockCode();
+  m_lockState = share.GetLockState();
+  m_iBadPwdCount = share.GetBadPwdCount();
   m_iDriveType = share.m_iDriveType;
   SetArt("thumb", share.m_strThumbnailImage);
   SetLabelPreformatted(true);
@@ -481,7 +481,7 @@ CFileItem& CFileItem::operator=(const CFileItem& item)
   m_depth = item.m_depth;
   m_iLockMode = item.m_iLockMode;
   m_strLockCode = item.m_strLockCode;
-  m_iHasLock = item.m_iHasLock;
+  m_lockState = item.m_lockState;
   m_iBadPwdCount = item.m_iBadPwdCount;
   m_bCanQueue=item.m_bCanQueue;
   m_mimetype = item.m_mimetype;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -212,6 +212,10 @@ public:
   VideoDbContentType GetVideoContentType() const;
   bool IsLabelPreformatted() const { return m_bLabelPreformatted; }
   void SetLabelPreformatted(bool bYesNo) { m_bLabelPreformatted=bYesNo; }
+  bool IsShareOrDrive() const { return m_bIsShareOrDrive; }
+  void SetIsShareOrDrive(bool set) { m_bIsShareOrDrive = set; }
+  SourceType GetDriveType() const { return m_iDriveType; }
+  void SetDriveType(SourceType driveType) { m_iDriveType = driveType; }
   bool SortsOnTop() const { return m_specialSort == SortSpecialOnTop; }
   bool SortsOnBottom() const { return m_specialSort == SortSpecialOnBottom; }
   void SetSpecialSort(SortSpecial sort) { m_specialSort = sort; }
@@ -500,10 +504,6 @@ public:
    */
   void SetFromSong(const CSong &song);
 
-  bool m_bIsShareOrDrive{false}; ///< is this a root share/drive
-  /// If \e m_bIsShareOrDrive is \e true, use to get the share type.
-  /// Types see: CMediaSource::m_iDriveType
-  SourceType m_iDriveType{SourceType::UNKNOWN};
   CDateTime m_dateTime;             ///< file creation date & time
   int64_t m_dwSize{0}; ///< file size (0 for folders)
   std::string m_strDVDLabel;
@@ -541,6 +541,11 @@ private:
 
   std::string m_strPath;            ///< complete path to item
   std::string m_strDynPath;
+
+  bool m_bIsShareOrDrive{false}; ///< is this a root share/drive
+  /// If \e m_bIsShareOrDrive is \e true, use to get the share type.
+  /// Types see: CMediaSource::m_iDriveType
+  SourceType m_iDriveType{SourceType::UNKNOWN};
 
   SortSpecial m_specialSort{SortSpecialNone};
   bool m_bIsParentFolder{false};

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -17,6 +17,7 @@
 #include "SourceType.h"
 #include "XBDateTime.h"
 #include "guilib/GUIListItem.h"
+#include "media/MediaLockState.h"
 #include "utils/IArchivable.h"
 #include "utils/ISerializable.h"
 #include "utils/ISortable.h"
@@ -24,28 +25,35 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 
+class CAlbum;
+class CArtist;
+class CBookmark;
+class CCueDocument;
+class CFileItemList;
+class CGenre;
 class CMediaSource;
-enum class VideoDbContentType;
+class CPictureInfoTag;
+class CSong;
+class CURL;
+class CVariant;
+class CVideoInfoTag;
+class IEvent;
 
 namespace ADDON
 {
 class IAddon;
 }
 
+namespace KODI::GAME
+{
+class CGameInfoTag;
+}
+
 namespace MUSIC_INFO
 {
-  class CMusicInfoTag;
-}
-class CVideoInfoTag;
-class CPictureInfoTag;
-
-namespace KODI
-{
-namespace GAME
-{
-  class CGameInfoTag;
-}
+class CMusicInfoTag;
 }
 
 namespace PVR
@@ -59,25 +67,7 @@ class CPVRRecording;
 class CPVRTimerInfoTag;
 }
 
-class CAlbum;
-class CArtist;
-class CSong;
-class CGenre;
-
-class CURL;
-class CVariant;
-
-class CFileItemList;
-class CCueDocument;
-typedef std::shared_ptr<CCueDocument> CCueDocumentPtr;
-
-class IEvent;
-typedef std::shared_ptr<const IEvent> EventPtr;
-
-/* special startoffset used to indicate that we wish to resume */
-#define STARTOFFSET_RESUME (-1)
-
-class CBookmark;
+enum class VideoDbContentType;
 
 enum class FileFolderType
 {
@@ -90,6 +80,9 @@ enum class FileFolderType
   MASK_ONBROWSE = ALWAYS | ONCLICK | ONBROWSE,
 };
 
+/* special startoffset used to indicate that we wish to resume */
+constexpr int STARTOFFSET_RESUME = -1;
+
 /*!
   \brief Represents a file on a share
   \sa CFileItemList
@@ -98,17 +91,17 @@ class CFileItem :
   public CGUIListItem, public IArchivable, public ISerializable, public ISortable
 {
 public:
-  CFileItem(void);
+  CFileItem();
   CFileItem(const CFileItem& item);
   explicit CFileItem(const CGUIListItem& item);
   explicit CFileItem(const std::string& strLabel);
   explicit CFileItem(const char* strLabel);
   CFileItem(const CURL& path, bool bIsFolder);
-  CFileItem(const std::string& strPath, bool bIsFolder);
+  CFileItem(std::string_view strPath, bool bIsFolder);
   explicit CFileItem(const CSong& song);
   CFileItem(const CSong& song, const MUSIC_INFO::CMusicInfoTag& music);
   CFileItem(const CURL &path, const CAlbum& album);
-  CFileItem(const std::string &path, const CAlbum& album);
+  CFileItem(std::string_view path, const CAlbum& album);
   explicit CFileItem(const CArtist& artist);
   explicit CFileItem(const CGenre& genre);
   explicit CFileItem(const MUSIC_INFO::CMusicInfoTag& music);
@@ -118,31 +111,27 @@ public:
   explicit CFileItem(const std::shared_ptr<PVR::CPVRChannelGroupMember>& channelGroupMember);
   explicit CFileItem(const std::shared_ptr<PVR::CPVRRecording>& record);
   explicit CFileItem(const std::shared_ptr<PVR::CPVRTimerInfoTag>& timer);
-  explicit CFileItem(const std::string& path, const std::shared_ptr<PVR::CPVRProvider>& provider);
+  explicit CFileItem(const std::string_view path,
+                     const std::shared_ptr<PVR::CPVRProvider>& provider);
   explicit CFileItem(const CMediaSource& share);
-  explicit CFileItem(std::shared_ptr<const ADDON::IAddon> addonInfo);
-  explicit CFileItem(const EventPtr& eventLogEntry);
+  explicit CFileItem(const std::shared_ptr<const ADDON::IAddon>& addonInfo);
+  explicit CFileItem(const std::shared_ptr<const IEvent>& eventLogEntry);
 
-  ~CFileItem(void) override;
+  ~CFileItem() override;
   CGUIListItem* Clone() const override { return new CFileItem(*this); }
 
-  const CURL GetURL() const;
+  CURL GetURL() const;
   void SetURL(const CURL& url);
   bool IsURL(const CURL& url) const;
   const std::string& GetPath() const { return m_strPath; }
-  void SetPath(const std::string& path) { m_strPath = path; }
+  void SetPath(std::string_view path) { m_strPath = path; }
   bool IsPath(const std::string& path, bool ignoreURLOptions = false) const;
 
-  const CURL GetDynURL() const;
+  CURL GetDynURL() const;
   void SetDynURL(const CURL& url);
   const std::string &GetDynPath() const;
-  void SetDynPath(const std::string &path);
+  void SetDynPath(std::string_view path);
 
-  /*! \brief reset class to it's default values as per construction.
-   Free's all allocated memory.
-   \sa Initialize
-   */
-  void Reset();
   CFileItem& operator=(const CFileItem& item);
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;
@@ -227,10 +216,7 @@ public:
   bool SortsOnBottom() const { return m_specialSort == SortSpecialOnBottom; }
   void SetSpecialSort(SortSpecial sort) { m_specialSort = sort; }
 
-  inline bool HasMusicInfoTag() const
-  {
-    return m_musicInfoTag != NULL;
-  }
+  inline bool HasMusicInfoTag() const { return m_musicInfoTag != nullptr; }
 
   MUSIC_INFO::CMusicInfoTag* GetMusicInfoTag();
 
@@ -245,19 +231,13 @@ public:
 
   const CVideoInfoTag* GetVideoInfoTag() const;
 
-  inline bool HasEPGInfoTag() const
-  {
-    return m_epgInfoTag.get() != NULL;
-  }
+  inline bool HasEPGInfoTag() const { return m_epgInfoTag.get() != nullptr; }
 
-  inline const std::shared_ptr<PVR::CPVREpgInfoTag> GetEPGInfoTag() const
-  {
-    return m_epgInfoTag;
-  }
+  inline std::shared_ptr<PVR::CPVREpgInfoTag> GetEPGInfoTag() const { return m_epgInfoTag; }
 
   bool HasEPGSearchFilter() const { return m_epgSearchFilter != nullptr; }
 
-  const std::shared_ptr<PVR::CPVREpgSearchFilter> GetEPGSearchFilter() const
+  inline std::shared_ptr<PVR::CPVREpgSearchFilter> GetEPGSearchFilter() const
   {
     return m_epgSearchFilter;
   }
@@ -267,37 +247,31 @@ public:
     return m_pvrChannelGroupMemberInfoTag.get() != nullptr;
   }
 
-  inline const std::shared_ptr<PVR::CPVRChannelGroupMember> GetPVRChannelGroupMemberInfoTag() const
+  inline std::shared_ptr<PVR::CPVRChannelGroupMember> GetPVRChannelGroupMemberInfoTag() const
   {
     return m_pvrChannelGroupMemberInfoTag;
   }
 
   bool HasPVRChannelInfoTag() const;
-  const std::shared_ptr<PVR::CPVRChannel> GetPVRChannelInfoTag() const;
+  std::shared_ptr<PVR::CPVRChannel> GetPVRChannelInfoTag() const;
 
-  inline bool HasPVRRecordingInfoTag() const
-  {
-    return m_pvrRecordingInfoTag.get() != NULL;
-  }
+  inline bool HasPVRRecordingInfoTag() const { return m_pvrRecordingInfoTag != nullptr; }
 
-  inline const std::shared_ptr<PVR::CPVRRecording> GetPVRRecordingInfoTag() const
+  inline std::shared_ptr<PVR::CPVRRecording> GetPVRRecordingInfoTag() const
   {
     return m_pvrRecordingInfoTag;
   }
 
-  inline bool HasPVRTimerInfoTag() const
-  {
-    return m_pvrTimerInfoTag != NULL;
-  }
+  inline bool HasPVRTimerInfoTag() const { return m_pvrTimerInfoTag != nullptr; }
 
-  inline const std::shared_ptr<PVR::CPVRTimerInfoTag> GetPVRTimerInfoTag() const
+  inline std::shared_ptr<PVR::CPVRTimerInfoTag> GetPVRTimerInfoTag() const
   {
     return m_pvrTimerInfoTag;
   }
 
   inline bool HasPVRProviderInfoTag() const { return m_pvrProviderInfoTag != nullptr; }
 
-  inline const std::shared_ptr<PVR::CPVRProvider> GetPVRProviderInfoTag() const
+  inline std::shared_ptr<PVR::CPVRProvider> GetPVRProviderInfoTag() const
   {
     return m_pvrProviderInfoTag;
   }
@@ -362,10 +336,7 @@ public:
    */
   void SetEndOffset(const int64_t offset) { m_lEndOffset = offset; }
 
-  inline bool HasPictureInfoTag() const
-  {
-    return m_pictureInfoTag != NULL;
-  }
+  inline bool HasPictureInfoTag() const { return m_pictureInfoTag != nullptr; }
 
   inline const CPictureInfoTag* GetPictureInfoTag() const
   {
@@ -373,12 +344,9 @@ public:
   }
 
   bool HasAddonInfo() const { return m_addonInfo != nullptr; }
-  const std::shared_ptr<const ADDON::IAddon> GetAddonInfo() const { return m_addonInfo; }
+  inline std::shared_ptr<const ADDON::IAddon> GetAddonInfo() const { return m_addonInfo; }
 
-  inline bool HasGameInfoTag() const
-  {
-    return m_gameInfoTag != NULL;
-  }
+  inline bool HasGameInfoTag() const { return m_gameInfoTag != nullptr; }
 
   KODI::GAME::CGameInfoTag* GetGameInfoTag();
 
@@ -454,7 +422,7 @@ public:
   const std::string& GetMimeType() const { return m_mimetype; }
 
   /* sets the mime-type if known beforehand */
-  void SetMimeType(const std::string& mimetype) { m_mimetype = mimetype; } ;
+  void SetMimeType(std::string_view mimetype) { m_mimetype = mimetype; }
 
   /*! \brief Resolve the MIME type based on file extension or a web lookup
    If m_mimetype is already set (non-empty), this function has no effect. For
@@ -467,7 +435,7 @@ public:
   \brief Some sources do not support HTTP HEAD request to determine i.e. mime type
   \return false if HEAD requests have to be avoided
   */
-  bool ContentLookup() { return m_doContentLookup; }
+  bool ContentLookup() const { return m_doContentLookup; }
 
   /*!
    \brief (Re)set the mime-type for internet files if allowed (m_doContentLookup)
@@ -482,7 +450,7 @@ public:
   void SetContentLookup(bool enable) { m_doContentLookup = enable; }
 
   /* general extra info about the contents of the item, not for display */
-  void SetExtraInfo(const std::string& info) { m_extrainfo = info; }
+  void SetExtraInfo(std::string_view info) { m_extrainfo = info; }
   const std::string& GetExtraInfo() const { return m_extrainfo; }
 
   /*! \brief Update an item with information from another item
@@ -532,34 +500,28 @@ public:
    */
   void SetFromSong(const CSong &song);
 
-  bool m_bIsShareOrDrive;    ///< is this a root share/drive
+  bool m_bIsShareOrDrive{false}; ///< is this a root share/drive
   /// If \e m_bIsShareOrDrive is \e true, use to get the share type.
   /// Types see: CMediaSource::m_iDriveType
-  SourceType m_iDriveType;
+  SourceType m_iDriveType{SourceType::UNKNOWN};
   CDateTime m_dateTime;             ///< file creation date & time
-  int64_t m_dwSize;             ///< file size (0 for folders)
+  int64_t m_dwSize{0}; ///< file size (0 for folders)
   std::string m_strDVDLabel;
   std::string m_strTitle;
-  int m_iprogramCount;
-  int m_idepth;
-  int m_lStartPartNumber;
-  LockMode m_iLockMode;
+  int m_iprogramCount{0};
+  int m_idepth{1};
+  int m_lStartPartNumber{1};
+  LockMode m_iLockMode{LockMode::EVERYONE};
   std::string m_strLockCode;
-  int m_iHasLock; // 0 - no lock 1 - lock, but unlocked 2 - locked
-  int m_iBadPwdCount;
+  int m_iHasLock{LOCK_STATE_NO_LOCK};
+  int m_iBadPwdCount{0};
 
-  void SetCueDocument(const CCueDocumentPtr& cuePtr);
+  void SetCueDocument(const std::shared_ptr<CCueDocument>& cuePtr);
   void LoadEmbeddedCue();
   bool HasCueDocument() const;
   bool LoadTracksFromCueDocument(CFileItemList& scannedItems);
 
 private:
-  /*! \brief initialize all members of this class (not CGUIListItem members) to default values.
-   Called from constructors, and from Reset()
-   \sa Reset, CGUIListItem
-   */
-  void Initialize();
-
   /*! \brief Recalculate item's MIME type if it is not set or is set to "application/octet-stream".
    Resolve the MIME type based on file extension or a web lookup.
    \sa FillInMimeType
@@ -580,34 +542,34 @@ private:
   std::string m_strPath;            ///< complete path to item
   std::string m_strDynPath;
 
-  SortSpecial m_specialSort;
-  bool m_bIsParentFolder;
-  bool m_bCanQueue;
-  bool m_bLabelPreformatted;
+  SortSpecial m_specialSort{SortSpecialNone};
+  bool m_bIsParentFolder{false};
+  bool m_bCanQueue{true};
+  bool m_bLabelPreformatted{false};
   std::string m_mimetype;
   std::string m_extrainfo;
-  bool m_doContentLookup;
-  MUSIC_INFO::CMusicInfoTag* m_musicInfoTag;
-  CVideoInfoTag* m_videoInfoTag;
+  bool m_doContentLookup{true};
+  MUSIC_INFO::CMusicInfoTag* m_musicInfoTag{nullptr};
+  CVideoInfoTag* m_videoInfoTag{nullptr};
   std::shared_ptr<PVR::CPVREpgInfoTag> m_epgInfoTag;
   std::shared_ptr<PVR::CPVREpgSearchFilter> m_epgSearchFilter;
   std::shared_ptr<PVR::CPVRRecording> m_pvrRecordingInfoTag;
   std::shared_ptr<PVR::CPVRTimerInfoTag> m_pvrTimerInfoTag;
   std::shared_ptr<PVR::CPVRChannelGroupMember> m_pvrChannelGroupMemberInfoTag;
   std::shared_ptr<PVR::CPVRProvider> m_pvrProviderInfoTag;
-  CPictureInfoTag* m_pictureInfoTag;
+  CPictureInfoTag* m_pictureInfoTag{nullptr};
   std::shared_ptr<const ADDON::IAddon> m_addonInfo;
-  KODI::GAME::CGameInfoTag* m_gameInfoTag;
-  EventPtr m_eventLogEntry;
-  bool m_bIsAlbum;
-  int64_t m_lStartOffset;
-  int64_t m_lEndOffset;
+  KODI::GAME::CGameInfoTag* m_gameInfoTag{nullptr};
+  std::shared_ptr<const IEvent> m_eventLogEntry;
+  bool m_bIsAlbum{false};
+  int64_t m_lStartOffset{0};
+  int64_t m_lEndOffset{0};
 
-  CCueDocumentPtr m_cueDocument;
+  std::shared_ptr<CCueDocument> m_cueDocument;
 };
 
 /*!
   \brief A shared pointer to CFileItem
   \sa CFileItem
   */
-typedef std::shared_ptr<CFileItem> CFileItemPtr;
+using CFileItemPtr = std::shared_ptr<CFileItem>;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -13,14 +13,13 @@
  \brief
  */
 
-#include "LockMode.h"
 #include "SourceType.h"
 #include "XBDateTime.h"
 #include "guilib/GUIListItem.h"
-#include "media/MediaLockState.h"
 #include "utils/IArchivable.h"
 #include "utils/ISerializable.h"
 #include "utils/ISortable.h"
+#include "utils/LockInfo.h"
 #include "utils/SortUtils.h"
 #include "utils/XTimeUtils.h"
 
@@ -88,8 +87,7 @@ constexpr int STARTOFFSET_RESUME = -1;
   \brief Represents a file on a share
   \sa CFileItemList
   */
-class CFileItem :
-  public CGUIListItem, public IArchivable, public ISerializable, public ISortable
+class CFileItem : public CGUIListItem, public IArchivable, public ISerializable, public ISortable
 {
 public:
   CFileItem();
@@ -234,15 +232,6 @@ public:
   void SetDepth(int depth) { m_depth = depth; }
   int GetStartPartNumber() const { return m_lStartPartNumber; }
   void SetStartPartNumber(int number) { m_lStartPartNumber = number; }
-  LockMode GetLockMode() const { return m_iLockMode; }
-  void SetLockMode(LockMode mode) { m_iLockMode = mode; }
-  const std::string& GetLockCode() const { return m_strLockCode; }
-  void SetLockCode(std::string_view code) { m_strLockCode = code; }
-  int GetLockState() const { return m_lockState; }
-  void SetLockState(int state) { m_lockState = state; }
-  int GetBadPwdCount() const { return m_iBadPwdCount; }
-  void ResetBadPwdCount() { m_iBadPwdCount = 0; }
-  void IncrementBadPwdCount() { m_iBadPwdCount++; }
   bool SortsOnTop() const { return m_specialSort == SortSpecialOnTop; }
   bool SortsOnBottom() const { return m_specialSort == SortSpecialOnBottom; }
   void SetSpecialSort(SortSpecial sort) { m_specialSort = sort; }
@@ -531,6 +520,18 @@ public:
    */
   void SetFromSong(const CSong &song);
 
+  /*!
+  \brief Retrieve item's lock information, like lock code, lock mode, etc.
+  \return The lock information
+  */
+  KODI::UTILS::CLockInfo& GetLockInfo() { return m_lockInfo; }
+
+  /*!
+  \brief Retrieve item's lock information, like lock code, lock mode, etc.
+  \return The lock information
+  */
+  const KODI::UTILS::CLockInfo& GetLockInfo() const { return m_lockInfo; }
+
   void SetCueDocument(const std::shared_ptr<CCueDocument>& cuePtr);
   void LoadEmbeddedCue();
   bool HasCueDocument() const;
@@ -568,10 +569,7 @@ private:
   int m_programCount{0};
   int m_depth{1};
   int m_lStartPartNumber{1};
-  LockMode m_iLockMode{LockMode::EVERYONE};
-  std::string m_strLockCode;
-  int m_lockState{LOCK_STATE_NO_LOCK};
-  int m_iBadPwdCount{0};
+  KODI::UTILS::CLockInfo m_lockInfo;
   SortSpecial m_specialSort{SortSpecialNone};
   bool m_bIsParentFolder{false};
   bool m_bCanQueue{true};

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -222,6 +222,8 @@ public:
   void SetDateTime(time_t dateTime) { m_dateTime = dateTime; }
   void SetDateTime(KODI::TIME::SystemTime dateTime) { m_dateTime = dateTime; }
   void SetDateTime(KODI::TIME::FileTime dateTime) { m_dateTime = dateTime; }
+  int64_t GetSize() const { return m_dwSize; }
+  void SetSize(int64_t size) { m_dwSize = size; }
   bool SortsOnTop() const { return m_specialSort == SortSpecialOnTop; }
   bool SortsOnBottom() const { return m_specialSort == SortSpecialOnBottom; }
   void SetSpecialSort(SortSpecial sort) { m_specialSort = sort; }
@@ -510,7 +512,6 @@ public:
    */
   void SetFromSong(const CSong &song);
 
-  int64_t m_dwSize{0}; ///< file size (0 for folders)
   std::string m_strDVDLabel;
   std::string m_strTitle;
   int m_iprogramCount{0};
@@ -552,6 +553,7 @@ private:
   /// Types see: CMediaSource::m_iDriveType
   SourceType m_iDriveType{SourceType::UNKNOWN};
   CDateTime m_dateTime; ///< file creation date & time
+  int64_t m_dwSize{0}; ///< file size (0 for folders)
 
   SortSpecial m_specialSort{SortSpecialNone};
   bool m_bIsParentFolder{false};

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -232,6 +232,8 @@ public:
   void SetProgramCount(int count) { m_programCount = count; }
   int GetDepth() const { return m_depth; }
   void SetDepth(int depth) { m_depth = depth; }
+  int GetStartPartNumber() const { return m_lStartPartNumber; }
+  void SetStartPartNumber(int number) { m_lStartPartNumber = number; }
   bool SortsOnTop() const { return m_specialSort == SortSpecialOnTop; }
   bool SortsOnBottom() const { return m_specialSort == SortSpecialOnBottom; }
   void SetSpecialSort(SortSpecial sort) { m_specialSort = sort; }
@@ -520,7 +522,6 @@ public:
    */
   void SetFromSong(const CSong &song);
 
-  int m_lStartPartNumber{1};
   LockMode m_iLockMode{LockMode::EVERYONE};
   std::string m_strLockCode;
   int m_iHasLock{LOCK_STATE_NO_LOCK};
@@ -562,6 +563,7 @@ private:
   std::string m_strTitle;
   int m_programCount{0};
   int m_depth{1};
+  int m_lStartPartNumber{1};
 
   SortSpecial m_specialSort{SortSpecialNone};
   bool m_bIsParentFolder{false};

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -213,6 +213,8 @@ public:
   VideoDbContentType GetVideoContentType() const;
   bool IsLabelPreformatted() const { return m_bLabelPreformatted; }
   void SetLabelPreformatted(bool bYesNo) { m_bLabelPreformatted=bYesNo; }
+  const std::string& GetDVDLabel() const { return m_strDVDLabel; }
+  void SetDVDLabel(std::string_view label) { m_strDVDLabel = label; }
   bool IsShareOrDrive() const { return m_bIsShareOrDrive; }
   void SetIsShareOrDrive(bool set) { m_bIsShareOrDrive = set; }
   SourceType GetDriveType() const { return m_iDriveType; }
@@ -512,7 +514,6 @@ public:
    */
   void SetFromSong(const CSong &song);
 
-  std::string m_strDVDLabel;
   std::string m_strTitle;
   int m_iprogramCount{0};
   int m_idepth{1};
@@ -554,6 +555,7 @@ private:
   SourceType m_iDriveType{SourceType::UNKNOWN};
   CDateTime m_dateTime; ///< file creation date & time
   int64_t m_dwSize{0}; ///< file size (0 for folders)
+  std::string m_strDVDLabel;
 
   SortSpecial m_specialSort{SortSpecialNone};
   bool m_bIsParentFolder{false};

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -22,6 +22,7 @@
 #include "utils/ISerializable.h"
 #include "utils/ISortable.h"
 #include "utils/SortUtils.h"
+#include "utils/XTimeUtils.h"
 
 #include <memory>
 #include <string>
@@ -216,6 +217,11 @@ public:
   void SetIsShareOrDrive(bool set) { m_bIsShareOrDrive = set; }
   SourceType GetDriveType() const { return m_iDriveType; }
   void SetDriveType(SourceType driveType) { m_iDriveType = driveType; }
+  const CDateTime& GetDateTime() const { return m_dateTime; }
+  void SetDateTime(const CDateTime& dateTime) { m_dateTime = dateTime; }
+  void SetDateTime(time_t dateTime) { m_dateTime = dateTime; }
+  void SetDateTime(KODI::TIME::SystemTime dateTime) { m_dateTime = dateTime; }
+  void SetDateTime(KODI::TIME::FileTime dateTime) { m_dateTime = dateTime; }
   bool SortsOnTop() const { return m_specialSort == SortSpecialOnTop; }
   bool SortsOnBottom() const { return m_specialSort == SortSpecialOnBottom; }
   void SetSpecialSort(SortSpecial sort) { m_specialSort = sort; }
@@ -504,7 +510,6 @@ public:
    */
   void SetFromSong(const CSong &song);
 
-  CDateTime m_dateTime;             ///< file creation date & time
   int64_t m_dwSize{0}; ///< file size (0 for folders)
   std::string m_strDVDLabel;
   std::string m_strTitle;
@@ -546,6 +551,7 @@ private:
   /// If \e m_bIsShareOrDrive is \e true, use to get the share type.
   /// Types see: CMediaSource::m_iDriveType
   SourceType m_iDriveType{SourceType::UNKNOWN};
+  CDateTime m_dateTime; ///< file creation date & time
 
   SortSpecial m_specialSort{SortSpecialNone};
   bool m_bIsParentFolder{false};

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -226,6 +226,8 @@ public:
   void SetDateTime(KODI::TIME::FileTime dateTime) { m_dateTime = dateTime; }
   int64_t GetSize() const { return m_dwSize; }
   void SetSize(int64_t size) { m_dwSize = size; }
+  const std::string& GetTitle() const { return m_strTitle; }
+  void SetTitle(std::string_view title) { m_strTitle = title; }
   bool SortsOnTop() const { return m_specialSort == SortSpecialOnTop; }
   bool SortsOnBottom() const { return m_specialSort == SortSpecialOnBottom; }
   void SetSpecialSort(SortSpecial sort) { m_specialSort = sort; }
@@ -514,7 +516,6 @@ public:
    */
   void SetFromSong(const CSong &song);
 
-  std::string m_strTitle;
   int m_iprogramCount{0};
   int m_idepth{1};
   int m_lStartPartNumber{1};
@@ -556,6 +557,7 @@ private:
   CDateTime m_dateTime; ///< file creation date & time
   int64_t m_dwSize{0}; ///< file size (0 for folders)
   std::string m_strDVDLabel;
+  std::string m_strTitle;
 
   SortSpecial m_specialSort{SortSpecialNone};
   bool m_bIsParentFolder{false};

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -230,6 +230,8 @@ public:
   void SetTitle(std::string_view title) { m_strTitle = title; }
   int GetProgramCount() const { return m_programCount; }
   void SetProgramCount(int count) { m_programCount = count; }
+  int GetDepth() const { return m_depth; }
+  void SetDepth(int depth) { m_depth = depth; }
   bool SortsOnTop() const { return m_specialSort == SortSpecialOnTop; }
   bool SortsOnBottom() const { return m_specialSort == SortSpecialOnBottom; }
   void SetSpecialSort(SortSpecial sort) { m_specialSort = sort; }
@@ -518,7 +520,6 @@ public:
    */
   void SetFromSong(const CSong &song);
 
-  int m_idepth{1};
   int m_lStartPartNumber{1};
   LockMode m_iLockMode{LockMode::EVERYONE};
   std::string m_strLockCode;
@@ -560,6 +561,7 @@ private:
   std::string m_strDVDLabel;
   std::string m_strTitle;
   int m_programCount{0};
+  int m_depth{1};
 
   SortSpecial m_specialSort{SortSpecialNone};
   bool m_bIsParentFolder{false};

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -234,6 +234,15 @@ public:
   void SetDepth(int depth) { m_depth = depth; }
   int GetStartPartNumber() const { return m_lStartPartNumber; }
   void SetStartPartNumber(int number) { m_lStartPartNumber = number; }
+  LockMode GetLockMode() const { return m_iLockMode; }
+  void SetLockMode(LockMode mode) { m_iLockMode = mode; }
+  const std::string& GetLockCode() const { return m_strLockCode; }
+  void SetLockCode(std::string_view code) { m_strLockCode = code; }
+  int GetLockState() const { return m_lockState; }
+  void SetLockState(int state) { m_lockState = state; }
+  int GetBadPwdCount() const { return m_iBadPwdCount; }
+  void ResetBadPwdCount() { m_iBadPwdCount = 0; }
+  void IncrementBadPwdCount() { m_iBadPwdCount++; }
   bool SortsOnTop() const { return m_specialSort == SortSpecialOnTop; }
   bool SortsOnBottom() const { return m_specialSort == SortSpecialOnBottom; }
   void SetSpecialSort(SortSpecial sort) { m_specialSort = sort; }
@@ -522,11 +531,6 @@ public:
    */
   void SetFromSong(const CSong &song);
 
-  LockMode m_iLockMode{LockMode::EVERYONE};
-  std::string m_strLockCode;
-  int m_iHasLock{LOCK_STATE_NO_LOCK};
-  int m_iBadPwdCount{0};
-
   void SetCueDocument(const std::shared_ptr<CCueDocument>& cuePtr);
   void LoadEmbeddedCue();
   bool HasCueDocument() const;
@@ -564,7 +568,10 @@ private:
   int m_programCount{0};
   int m_depth{1};
   int m_lStartPartNumber{1};
-
+  LockMode m_iLockMode{LockMode::EVERYONE};
+  std::string m_strLockCode;
+  int m_lockState{LOCK_STATE_NO_LOCK};
+  int m_iBadPwdCount{0};
   SortSpecial m_specialSort{SortSpecialNone};
   bool m_bIsParentFolder{false};
   bool m_bCanQueue{true};

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -228,6 +228,8 @@ public:
   void SetSize(int64_t size) { m_dwSize = size; }
   const std::string& GetTitle() const { return m_strTitle; }
   void SetTitle(std::string_view title) { m_strTitle = title; }
+  int GetProgramCount() const { return m_programCount; }
+  void SetProgramCount(int count) { m_programCount = count; }
   bool SortsOnTop() const { return m_specialSort == SortSpecialOnTop; }
   bool SortsOnBottom() const { return m_specialSort == SortSpecialOnBottom; }
   void SetSpecialSort(SortSpecial sort) { m_specialSort = sort; }
@@ -516,7 +518,6 @@ public:
    */
   void SetFromSong(const CSong &song);
 
-  int m_iprogramCount{0};
   int m_idepth{1};
   int m_lStartPartNumber{1};
   LockMode m_iLockMode{LockMode::EVERYONE};
@@ -558,6 +559,7 @@ private:
   int64_t m_dwSize{0}; ///< file size (0 for folders)
   std::string m_strDVDLabel;
   std::string m_strTitle;
+  int m_programCount{0};
 
   SortSpecial m_specialSort{SortSpecialNone};
   bool m_bIsParentFolder{false};

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -554,7 +554,7 @@ void CFileItemList::FilterCueItems()
     { // see if it's a .CUE sheet
       if (MUSIC::IsCUESheet(*pItem))
       {
-        CCueDocumentPtr cuesheet(new CCueDocument);
+        const auto cuesheet(std::make_shared<CCueDocument>());
         if (cuesheet->ParseFile(pItem->GetPath()))
         {
           std::vector<std::string> MediaFileVec;

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -845,10 +845,10 @@ void CFileItemList::StackFiles()
                   {
                     stackName = Title1 + Ignore1 + Extension1;
                     stack.push_back(i);
-                    size += item1->m_dwSize;
+                    size += item1->GetSize();
                   }
                   stack.push_back(j);
-                  size += item2->m_dwSize;
+                  size += item2->GetSize();
                 }
                 else // Sequel
                 {
@@ -917,7 +917,7 @@ void CFileItemList::StackFiles()
           URIUtils::RemoveExtension(stackName);
 
         item1->SetLabel(stackName);
-        item1->m_dwSize = size;
+        item1->SetSize(size);
         break;
       }
     }

--- a/xbmc/FileItemList.h
+++ b/xbmc/FileItemList.h
@@ -18,6 +18,7 @@
 
 #include <map>
 #include <string>
+#include <string_view>
 #include <vector>
 
 /*!
@@ -38,16 +39,14 @@ public:
   explicit CFileItemList(const std::string& strPath);
   ~CFileItemList() override;
   void Archive(CArchive& ar) override;
-  CFileItemPtr operator[](int iItem);
-  const CFileItemPtr operator[](int iItem) const;
-  CFileItemPtr operator[](const std::string& strPath);
-  const CFileItemPtr operator[](const std::string& strPath) const;
+  CFileItemPtr operator[](int iItem) const;
+  CFileItemPtr operator[](const std::string& strPath) const;
   void Clear();
   void ClearItems();
   void Add(CFileItemPtr item);
   void Add(CFileItem&& item);
   void AddFront(const CFileItemPtr& pItem, int itemPosition);
-  void Remove(CFileItem* pItem);
+  void Remove(const CFileItem* pItem);
   void Remove(int iItem);
   CFileItemPtr Get(int iItem) const;
   const auto& GetList() const { return m_items; }
@@ -163,7 +162,7 @@ public:
   void SetSortIgnoreFolders(bool sort) { m_sortIgnoreFolders = sort; }
   bool GetReplaceListing() const { return m_replaceListing; }
   void SetReplaceListing(bool replace);
-  void SetContent(const std::string& content) { m_content = content; }
+  void SetContent(std::string_view content) { m_content = content; }
   const std::string& GetContent() const { return m_content; }
 
   void ClearSortState();
@@ -199,7 +198,7 @@ private:
   void StackFolders();
 
   std::vector<std::shared_ptr<CFileItem>> m_items;
-  std::map<std::string, std::shared_ptr<CFileItem>> m_map;
+  std::map<std::string, std::shared_ptr<CFileItem>, std::less<>> m_map;
   bool m_ignoreURLOptions = false;
   bool m_fastLookup = false;
   SortDescription m_sortDescription;

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -11832,13 +11832,19 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int co
         return strFile;
       }
       case LISTITEM_DATE:
-        if (item->m_dateTime.IsValid())
-          return item->m_dateTime.GetAsLocalizedDate();
+      {
+        const CDateTime& dateTime{item->GetDateTime()};
+        if (dateTime.IsValid())
+          return dateTime.GetAsLocalizedDate();
         break;
+      }
       case LISTITEM_DATETIME:
-        if (item->m_dateTime.IsValid())
-          return item->m_dateTime.GetAsLocalizedDateTime();
+      {
+        const CDateTime& dateTime{item->GetDateTime()};
+        if (dateTime.IsValid())
+          return dateTime.GetAsLocalizedDateTime();
         break;
+      }
       case LISTITEM_SIZE:
         if (!item->m_bIsFolder || item->m_dwSize)
           return StringUtils::SizeToString(item->m_dwSize);
@@ -11893,14 +11899,16 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int co
       }
       case LISTITEM_STARTTIME:
       {
-        if (item->m_dateTime.IsValid())
-          return item->m_dateTime.GetAsLocalizedTime("", false);
+        const CDateTime& dateTime{item->GetDateTime()};
+        if (dateTime.IsValid())
+          return dateTime.GetAsLocalizedTime("", false);
         break;
       }
       case LISTITEM_STARTDATE:
       {
-        if (item->m_dateTime.IsValid())
-          return item->m_dateTime.GetAsLocalizedDate(true);
+        const CDateTime& dateTime{item->GetDateTime()};
+        if (dateTime.IsValid())
+          return dateTime.GetAsLocalizedDate(true);
         break;
       }
       case LISTITEM_CURRENTITEM:

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -11663,7 +11663,7 @@ std::string CGUIInfoManager::GetImage(int info, int contextWindow, std::string *
 
 void CGUIInfoManager::ResetCurrentItem()
 {
-  m_currentFile->Reset();
+  m_currentFile = std::make_unique<CFileItem>();
   m_infoProviders.InitCurrentItem(nullptr);
 }
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -11850,7 +11850,7 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int co
           return StringUtils::SizeToString(item->GetSize());
         break;
       case LISTITEM_PROGRAM_COUNT:
-        return std::to_string(item->m_iprogramCount);
+        return std::to_string(item->GetProgramCount());
       case LISTITEM_ACTUAL_ICON:
         return item->GetArt("icon");
       case LISTITEM_ICON:

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -11846,8 +11846,8 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int co
         break;
       }
       case LISTITEM_SIZE:
-        if (!item->m_bIsFolder || item->m_dwSize)
-          return StringUtils::SizeToString(item->m_dwSize);
+        if (!item->m_bIsFolder || item->GetSize())
+          return StringUtils::SizeToString(item->GetSize());
         break;
       case LISTITEM_PROGRAM_COUNT:
         return std::to_string(item->m_iprogramCount);

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -57,22 +57,24 @@ bool CGUIPassword::IsItemUnlocked(T pItem,
   if (profileManager->GetMasterProfile().getLockMode() == LockMode::EVERYONE)
     return true;
 
-  while (pItem->GetLockState() > LOCK_STATE_LOCK_BUT_UNLOCKED)
+  while (pItem->GetLockInfo().GetState() > LOCK_STATE_LOCK_BUT_UNLOCKED)
   {
     int iResult = 0; // init to user succeeded state, doing this to optimize switch statement below
     if (!g_passwordManager.bMasterUser) // Check if we are the MasterUser!
     {
+      const KODI::UTILS::CLockInfo& lockInfo{pItem->GetLockInfo()};
       if (0 != CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
                    CSettings::SETTING_MASTERLOCK_MAXRETRIES) &&
-          pItem->GetBadPwdCount() >= CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
-                                         CSettings::SETTING_MASTERLOCK_MAXRETRIES))
+          lockInfo.GetBadPasswordCount() >=
+              CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                  CSettings::SETTING_MASTERLOCK_MAXRETRIES))
       {
         // user previously exhausted all retries, show access denied error
         HELPERS::ShowOKDialogText(CVariant{12345}, CVariant{12346});
         return false;
       }
       // show the appropriate lock dialog
-      iResult = VerifyPassword(pItem->GetLockMode(), pItem->GetLockCode(), strHeading);
+      iResult = VerifyPassword(lockInfo.GetMode(), lockInfo.GetCode(), strHeading);
     }
     switch (iResult)
     {
@@ -83,11 +85,12 @@ bool CGUIPassword::IsItemUnlocked(T pItem,
     case 0:
       {
         // password entry succeeded
-        pItem->ResetBadPwdCount();
-        pItem->SetLockState(LOCK_STATE_LOCK_BUT_UNLOCKED);
+        KODI::UTILS::CLockInfo& lockInfo{pItem->GetLockInfo()};
+        lockInfo.ResetBadPasswordCount();
+        lockInfo.SetState(LOCK_STATE_LOCK_BUT_UNLOCKED);
         g_passwordManager.LockSource(strType, strLabel, false);
-        CMediaSourceSettings::GetInstance().UpdateSource(strType, strLabel, "badpwdcount",
-                                                         std::to_string(pItem->GetBadPwdCount()));
+        CMediaSourceSettings::GetInstance().UpdateSource(
+            strType, strLabel, "badpwdcount", std::to_string(lockInfo.GetBadPasswordCount()));
         CMediaSourceSettings::GetInstance().Save();
 
         // a mediasource has been unlocked successfully
@@ -98,11 +101,12 @@ bool CGUIPassword::IsItemUnlocked(T pItem,
     case 1:
       {
         // password entry failed
+        KODI::UTILS::CLockInfo& lockInfo{pItem->GetLockInfo()};
         if (0 != CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
                      CSettings::SETTING_MASTERLOCK_MAXRETRIES))
-          pItem->IncrementBadPwdCount();
-        CMediaSourceSettings::GetInstance().UpdateSource(strType, strLabel, "badpwdcount",
-                                                         std::to_string(pItem->GetBadPwdCount()));
+          lockInfo.IncrementBadPasswordCount();
+        CMediaSourceSettings::GetInstance().UpdateSource(
+            strType, strLabel, "badpwdcount", std::to_string(lockInfo.GetBadPasswordCount()));
         CMediaSourceSettings::GetInstance().Save();
         break;
       }
@@ -514,9 +518,9 @@ bool CGUIPassword::LockSource(const std::string& strType, const std::string& str
   {
     if (it->strName == strName)
     {
-      if (it->GetLockState() > LOCK_STATE_NO_LOCK)
+      if (it->GetLockInfo().GetState() > LOCK_STATE_NO_LOCK)
       {
-        it->SetLockState(bState ? LOCK_STATE_LOCKED : LOCK_STATE_LOCK_BUT_UNLOCKED);
+        it->GetLockInfo().SetState(bState ? LOCK_STATE_LOCKED : LOCK_STATE_LOCK_BUT_UNLOCKED);
         bResult = true;
       }
       break;
@@ -536,8 +540,11 @@ void CGUIPassword::LockSources(bool lock)
   {
     std::vector<CMediaSource>* shares = CMediaSourceSettings::GetInstance().GetSources(strType);
     for (std::vector<CMediaSource>::iterator it = shares->begin(); it != shares->end(); ++it)
-      if (it->GetLockMode() != LockMode::EVERYONE)
-        it->SetLockState(lock ? LOCK_STATE_LOCKED : LOCK_STATE_LOCK_BUT_UNLOCKED);
+    {
+      KODI::UTILS::CLockInfo& lockInfo{it->GetLockInfo()};
+      if (lockInfo.GetMode() != LockMode::EVERYONE)
+        lockInfo.SetState(lock ? LOCK_STATE_LOCKED : LOCK_STATE_LOCK_BUT_UNLOCKED);
+    }
   }
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
   CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
@@ -551,14 +558,17 @@ void CGUIPassword::RemoveSourceLocks()
   {
     std::vector<CMediaSource>* shares = CMediaSourceSettings::GetInstance().GetSources(strType);
     for (std::vector<CMediaSource>::iterator it = shares->begin(); it != shares->end(); ++it)
-      if (it->GetLockMode() != LockMode::EVERYONE) // remove old info
+    {
+      KODI::UTILS::CLockInfo& lockInfo{it->GetLockInfo()};
+      if (lockInfo.GetMode() != LockMode::EVERYONE) // remove old info
       {
-        it->SetLockState(LOCK_STATE_NO_LOCK);
-        it->SetLockMode(LockMode::EVERYONE);
+        lockInfo.SetState(LOCK_STATE_NO_LOCK);
+        lockInfo.SetMode(LockMode::EVERYONE);
 
         // remove locks from xml
         CMediaSourceSettings::GetInstance().UpdateSource(strType, it->strName, "lockmode", "0");
       }
+    }
   }
   CMediaSourceSettings::GetInstance().Save();
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0, GUI_MSG_UPDATE_SOURCES);
@@ -587,7 +597,7 @@ bool CGUIPassword::IsDatabasePathUnlocked(const std::string& strPath,
   int iIndex = CUtil::GetMatchingSource(strPath, sources, bName);
 
   if (iIndex > -1 && iIndex < static_cast<int>(sources.size()))
-    if (sources[iIndex].GetLockState() < LOCK_STATE_LOCKED)
+    if (sources[iIndex].GetLockInfo().GetState() < LOCK_STATE_LOCKED)
       return true;
 
   return false;
@@ -635,7 +645,7 @@ bool CGUIPassword::IsMediaFileUnlocked(const std::string& type, const std::strin
   int iIndex = CUtil::GetMatchingSource(fileBasePath, *sources, isSourceName);
 
   if (iIndex > -1 && iIndex < static_cast<int>(sources->size()))
-    return (*sources)[iIndex].GetLockState() < LOCK_STATE_LOCKED;
+    return (*sources)[iIndex].GetLockInfo().GetState() < LOCK_STATE_LOCKED;
 
   return true;
 }

--- a/xbmc/MediaSource.cpp
+++ b/xbmc/MediaSource.cpp
@@ -44,7 +44,7 @@ void CMediaSource::FromNameAndPaths(const std::string& name, const std::vector<s
   m_iLockMode = LockMode::EVERYONE;
   m_strLockCode = "0";
   m_iBadPwdCount = 0;
-  m_iHasLock = LOCK_STATE_NO_LOCK;
+  m_lockState = LOCK_STATE_NO_LOCK;
   m_allowSharing = true;
 
   if (URIUtils::IsMultiPath(strPath))

--- a/xbmc/MediaSource.cpp
+++ b/xbmc/MediaSource.cpp
@@ -41,10 +41,7 @@ void CMediaSource::FromNameAndPaths(const std::string& name, const std::vector<s
   }
 
   strName = name;
-  m_iLockMode = LockMode::EVERYONE;
-  m_strLockCode = "0";
-  m_iBadPwdCount = 0;
-  m_lockState = LOCK_STATE_NO_LOCK;
+  m_lockInfo = {};
   m_allowSharing = true;
 
   if (URIUtils::IsMultiPath(strPath))

--- a/xbmc/MediaSource.h
+++ b/xbmc/MediaSource.h
@@ -8,9 +8,8 @@
 
 #pragma once
 
-#include "LockMode.h"
 #include "SourceType.h"
-#include "media/MediaLockState.h"
+#include "utils/LockInfo.h"
 
 #include <string>
 #include <vector>
@@ -27,16 +26,9 @@ public:
 
   void FromNameAndPaths(const std::string& name, const std::vector<std::string>& paths);
   bool IsWritable() const;
-  int GetLockState() const { return m_lockState; }
-  void SetLockState(int state) { m_lockState = state; }
-  LockMode GetLockMode() const { return m_iLockMode; }
-  void SetLockMode(LockMode mode) { m_iLockMode = mode; }
-  const std::string& GetLockCode() const { return m_strLockCode; }
-  void SetLockCode(std::string_view code) { m_strLockCode = code; }
-  int GetBadPwdCount() const { return m_iBadPwdCount; }
-  void SetBadPwdCount(int count) { m_iBadPwdCount = count; }
-  void ResetBadPwdCount() { m_iBadPwdCount = 0; }
-  void IncrementBadPwdCount() { m_iBadPwdCount++; }
+
+  KODI::UTILS::CLockInfo& GetLockInfo() { return m_lockInfo; }
+  const KODI::UTILS::CLockInfo& GetLockInfo() const { return m_lockInfo; }
 
   std::string strName; ///< Name of the share, can be chosen freely.
   std::string strStatus; ///< Status of the share (eg has disk etc.)
@@ -60,38 +52,14 @@ public:
   */
   SourceType m_iDriveType = SourceType::UNKNOWN;
 
+  KODI::UTILS::CLockInfo m_lockInfo;
+
   std::string
       m_strThumbnailImage; ///< Path to a thumbnail image for the share, or blank for default
 
   std::vector<std::string> vecPaths;
   bool m_ignore = false; /// <Do not store in xml
   bool m_allowSharing = true; /// <Allow browsing of source from UPnP / WebServer
-
-private:
-  /*!
-  \brief The type of Lock UI to show when accessing the media source.
-
-  Value can be:
-  - LockMode::EVERYONE \n
-  Default value.  No lock UI is shown, user can freely access the source.
-  - LockMode::NUMERIC \n
-  Lock code is entered via OSD numpad or IrDA remote buttons.
-  - LockMode::GAMEPAD \n
-  Lock code is entered via XBOX gamepad buttons.
-  - LockMode::QWERTY \n
-  Lock code is entered via OSD keyboard or PC USB keyboard.
-  - LockMode::SAMBA \n
-  Lock code is entered via OSD keyboard or PC USB keyboard and passed directly to SMB for authentication.
-  - LockMode::EEPROM_PARENTAL \n
-  Lock code is retrieved from XBOX EEPROM and entered via XBOX gamepad or remote.
-  - LockMode::UNKNOWN \n
-  Value is unknown or unspecified.
-  */
-  LockMode m_iLockMode{LockMode::EVERYONE};
-  std::string m_strLockCode;  ///< Input code for Lock UI to verify, can be chosen freely.
-  int m_lockState{LOCK_STATE_NO_LOCK};
-  int m_iBadPwdCount{
-      0}; ///< Number of wrong passwords user has entered since share was last unlocked
 };
 
 void AddOrReplace(std::vector<CMediaSource>& sources, const std::vector<CMediaSource>& extras);

--- a/xbmc/MediaSource.h
+++ b/xbmc/MediaSource.h
@@ -27,6 +27,17 @@ public:
 
   void FromNameAndPaths(const std::string& name, const std::vector<std::string>& paths);
   bool IsWritable() const;
+  int GetLockState() const { return m_lockState; }
+  void SetLockState(int state) { m_lockState = state; }
+  LockMode GetLockMode() const { return m_iLockMode; }
+  void SetLockMode(LockMode mode) { m_iLockMode = mode; }
+  const std::string& GetLockCode() const { return m_strLockCode; }
+  void SetLockCode(std::string_view code) { m_strLockCode = code; }
+  int GetBadPwdCount() const { return m_iBadPwdCount; }
+  void SetBadPwdCount(int count) { m_iBadPwdCount = count; }
+  void ResetBadPwdCount() { m_iBadPwdCount = 0; }
+  void IncrementBadPwdCount() { m_iBadPwdCount++; }
+
   std::string strName; ///< Name of the share, can be chosen freely.
   std::string strStatus; ///< Status of the share (eg has disk etc.)
   std::string strDiskUniqueId; ///< removable:// + DVD Label + DVD ID for resume point storage, if available
@@ -49,6 +60,14 @@ public:
   */
   SourceType m_iDriveType = SourceType::UNKNOWN;
 
+  std::string
+      m_strThumbnailImage; ///< Path to a thumbnail image for the share, or blank for default
+
+  std::vector<std::string> vecPaths;
+  bool m_ignore = false; /// <Do not store in xml
+  bool m_allowSharing = true; /// <Allow browsing of source from UPnP / WebServer
+
+private:
   /*!
   \brief The type of Lock UI to show when accessing the media source.
 
@@ -68,16 +87,11 @@ public:
   - LockMode::UNKNOWN \n
   Value is unknown or unspecified.
   */
-  LockMode m_iLockMode = LockMode::EVERYONE;
+  LockMode m_iLockMode{LockMode::EVERYONE};
   std::string m_strLockCode;  ///< Input code for Lock UI to verify, can be chosen freely.
-  int m_iHasLock = LOCK_STATE_NO_LOCK;
-  int m_iBadPwdCount = 0; ///< Number of wrong passwords user has entered since share was last unlocked
-
-  std::string m_strThumbnailImage; ///< Path to a thumbnail image for the share, or blank for default
-
-  std::vector<std::string> vecPaths;
-  bool m_ignore = false; /// <Do not store in xml
-  bool m_allowSharing = true; /// <Allow browsing of source from UPnP / WebServer
+  int m_lockState{LOCK_STATE_NO_LOCK};
+  int m_iBadPwdCount{
+      0}; ///< Number of wrong passwords user has entered since share was last unlocked
 };
 
 void AddOrReplace(std::vector<CMediaSource>& sources, const std::vector<CMediaSource>& extras);

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -555,7 +555,7 @@ void CPlayListPlayer::SetShuffle(Id playlistId, bool bYesNo, bool bNotify /* = f
     int iOrder = -1;
     CPlayList& playlist = GetPlaylist(playlistId);
     if (m_iCurrentSong >= 0 && m_iCurrentSong < playlist.size())
-      iOrder = playlist[m_iCurrentSong]->m_iprogramCount;
+      iOrder = playlist[m_iCurrentSong]->GetProgramCount();
 
     // shuffle or unshuffle as necessary
     if (bYesNo)

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -326,8 +326,12 @@ std::string CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false *
   {
     CRSSDirectory dir;
     CFileItemList items;
-    if(dir.GetDirectory(url, items) && !items.m_strTitle.empty())
-      return items.m_strTitle;
+    if (dir.GetDirectory(url, items))
+    {
+      const std::string& title{items.GetTitle()};
+      if (!title.empty())
+        return title;
+    }
   }
 
   // Shoutcast

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -561,7 +561,7 @@ void CAddonInstaller::PrunePackageCache()
   int i = 0;
   while (size > limit && i < items.Size())
   {
-    size -= items[i]->m_dwSize;
+    size -= items[i]->GetSize();
     db.RemovePackage(items[i]->GetPath());
     CFileUtils::DeleteItem(items[i++]);
   }
@@ -580,7 +580,7 @@ void CAddonInstaller::PrunePackageCache()
     i = 0;
     while (size > limit && i < items.Size())
     {
-      size -= items[i]->m_dwSize;
+      size -= items[i]->GetSize();
       db.RemovePackage(items[i]->GetPath());
       CFileUtils::DeleteItem(items[i++]);
     }
@@ -622,7 +622,7 @@ int64_t CAddonInstaller::EnumeratePackageFolder(
     if (items[i]->m_bIsFolder)
       continue;
 
-    size += items[i]->m_dwSize;
+    size += items[i]->GetSize();
     std::string pack,dummy;
     CAddonVersion::SplitFileName(pack, dummy, items[i]->GetLabel());
     result.try_emplace(pack, std::make_unique<CFileItemList>());

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -208,7 +208,7 @@ void CScraper::ClearCache()
     for (int i = 0; i < items.Size(); ++i)
     {
       // wipe cache
-      if (items[i]->m_dateTime + m_persistence <= CDateTime::GetCurrentDateTime())
+      if (items[i]->GetDateTime() + m_persistence <= CDateTime::GetCurrentDateTime())
         CFile::Delete(items[i]->GetDynPath());
     }
   }

--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -506,7 +506,7 @@ static void VFSDirEntriesToCFileItemList(int num_entries,
     item->SetDateTime(entries[i].date_time);
     item->m_bIsFolder = entries[i].folder;
     if (entries[i].title)
-      item->m_strTitle = entries[i].title;
+      item->SetTitle(entries[i].title);
     for (unsigned int j=0;j<entries[i].num_props;++j)
     {
       if (StringUtils::CompareNoCase(entries[i].properties[j].name, "propmisusepreformatted") == 0)

--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -502,7 +502,7 @@ static void VFSDirEntriesToCFileItemList(int num_entries,
     CFileItemPtr item(new CFileItem());
     item->SetLabel(entries[i].label);
     item->SetPath(entries[i].path);
-    item->m_dwSize = entries[i].size;
+    item->SetSize(entries[i].size);
     item->SetDateTime(entries[i].date_time);
     item->m_bIsFolder = entries[i].folder;
     if (entries[i].title)

--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -503,7 +503,7 @@ static void VFSDirEntriesToCFileItemList(int num_entries,
     item->SetLabel(entries[i].label);
     item->SetPath(entries[i].path);
     item->m_dwSize = entries[i].size;
-    item->m_dateTime = entries[i].date_time;
+    item->SetDateTime(entries[i].date_time);
     item->m_bIsFolder = entries[i].folder;
     if (entries[i].title)
       item->m_strTitle = entries[i].title;

--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -239,7 +239,7 @@ static void CFileItemListToVFSDirEntries(VFSDirEntry* entries, const CFileItemLi
   {
     entries[i].label = strdup(items[i]->GetLabel().c_str());
     entries[i].path = strdup(items[i]->GetPath().c_str());
-    entries[i].size = items[i]->m_dwSize;
+    entries[i].size = items[i]->GetSize();
     entries[i].folder = items[i]->m_bIsFolder;
     items[i]->GetDateTime().GetAsTime(entries[i].date_time);
   }

--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -241,7 +241,7 @@ static void CFileItemListToVFSDirEntries(VFSDirEntry* entries, const CFileItemLi
     entries[i].path = strdup(items[i]->GetPath().c_str());
     entries[i].size = items[i]->m_dwSize;
     entries[i].folder = items[i]->m_bIsFolder;
-    items[i]->m_dateTime.GetAsTime(entries[i].date_time);
+    items[i]->GetDateTime().GetAsTime(entries[i].date_time);
   }
 }
 

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -1874,7 +1874,7 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
 
 void CApplication::ResetCurrentItem()
 {
-  m_itemCurrentFile->Reset();
+  m_itemCurrentFile = std::make_unique<CFileItem>();
   if (m_pGUI)
     m_pGUI->GetInfoManager().ResetCurrentItem();
 }

--- a/xbmc/application/ApplicationStackHelper.cpp
+++ b/xbmc/application/ApplicationStackHelper.cpp
@@ -92,7 +92,7 @@ std::optional<int64_t> CApplicationStackHelper::InitializeStackStartPartAndOffse
   if (m_currentStackIsDiscImageStack)
   {
     // first assume values passed to the stack
-    int selectedFile = item.m_lStartPartNumber;
+    int selectedFile = item.GetStartPartNumber();
     startoffset = item.GetStartOffset();
 
     // check if we instructed the stack to resume from default

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -846,7 +846,7 @@ extern "C"
       strncpy(data->name,vecDirsOpen[iDirSlot].items[0]->GetLabel().c_str(), size);
       if (size)
         data->name[size - 1] = '\0';
-      data->size = static_cast<_fsize_t>(vecDirsOpen[iDirSlot].items[0]->m_dwSize);
+      data->size = static_cast<_fsize_t>(vecDirsOpen[iDirSlot].items[0]->GetSize());
       data->time_write = 0;
       data->time_access = 0;
       vecDirsOpen[iDirSlot].curr_index = 0;
@@ -903,7 +903,7 @@ extern "C"
       strncpy(data->name,vecDirsOpen[found].items[iItem+1]->GetLabel().c_str(), size);
       if (size)
         data->name[size - 1] = '\0';
-      data->size = static_cast<_fsize_t>(vecDirsOpen[found].items[iItem+1]->m_dwSize);
+      data->size = static_cast<_fsize_t>(vecDirsOpen[found].items[iItem + 1]->GetSize());
       vecDirsOpen[found].curr_index++;
       return 0;
     }

--- a/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
@@ -182,7 +182,7 @@ void CSavestateDatabase::GetSavestateItem(const ISavestate& savestate,
   item.SetProperty(SAVESTATE_CAPTION, savestate.Caption());
   item.SetProperty(SAVESTATE_GAME_CLIENT, savestate.GameClientID());
   item.SetProperty(SAVESTATE_GAME_CLIENT_VERSION, savestate.GameClientVersion());
-  item.m_dateTime = dateUTC;
+  item.SetDateTime(dateUTC);
 }
 
 std::unique_ptr<ISavestate> CSavestateDatabase::RenameSavestate(const std::string& savestatePath,

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -182,13 +182,14 @@ bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)
         if (iItem < 0) break;
         CFileItemPtr pItem = (*m_vecItems)[iItem];
         if ((iAction == ACTION_SELECT_ITEM || iAction == ACTION_MOUSE_LEFT_CLICK) &&
-           (!m_multipleSelection || pItem->m_bIsShareOrDrive || pItem->m_bIsFolder))
+            (!m_multipleSelection || pItem->IsShareOrDrive() || pItem->m_bIsFolder))
         {
           OnClick(iItem);
           return true;
         }
-        else if ((iAction == ACTION_HIGHLIGHT_ITEM || iAction == ACTION_MOUSE_LEFT_CLICK || iAction == ACTION_SELECT_ITEM) &&
-                (m_multipleSelection && !pItem->m_bIsShareOrDrive && !pItem->m_bIsFolder))
+        else if ((iAction == ACTION_HIGHLIGHT_ITEM || iAction == ACTION_MOUSE_LEFT_CLICK ||
+                  iAction == ACTION_SELECT_ITEM) &&
+                 (m_multipleSelection && !pItem->IsShareOrDrive() && !pItem->m_bIsFolder))
         {
           pItem->Select(!pItem->IsSelected());
           CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), message.GetSenderId(), iItem + 1);
@@ -379,7 +380,7 @@ void CGUIDialogFileBrowser::Update(const std::string &strDirectory)
         CFileItemPtr pItem(new CFileItem(".."));
         pItem->SetPath(strParentPath);
         pItem->m_bIsFolder = true;
-        pItem->m_bIsShareOrDrive = false;
+        pItem->SetIsShareOrDrive(false);
         items.AddFront(pItem, 0);
       }
     }
@@ -389,7 +390,7 @@ void CGUIDialogFileBrowser::Update(const std::string &strDirectory)
       // add parent path to the virtual directory
       CFileItemPtr pItem(new CFileItem(".."));
       pItem->SetPath("");
-      pItem->m_bIsShareOrDrive = false;
+      pItem->SetIsShareOrDrive(false);
       pItem->m_bIsFolder = true;
       items.AddFront(pItem, 0);
       strParentPath = "";
@@ -548,9 +549,9 @@ void CGUIDialogFileBrowser::OnClick(int iItem)
       OnEditMediaSource(pItem.get());
       return;
     }
-    if ( pItem->m_bIsShareOrDrive )
+    if (pItem->IsShareOrDrive())
     {
-      if (!HaveDiscOrConnection(pItem->m_iDriveType))
+      if (!HaveDiscOrConnection(pItem->GetDriveType()))
         return ;
     }
     Update(strPath);

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -1023,7 +1023,7 @@ std::shared_ptr<CFileItem> GetFileItem(const CURL& url,
   item->GetVideoInfoTag()->SetDuration(duration);
   item->SetProperty("bluray_playlist", title.playlist);
   const std::string buf{StringUtils::Format(label, title.playlist)};
-  item->m_strTitle = buf;
+  item->SetTitle(buf);
   item->SetLabel(buf);
   const std::string chap{StringUtils::Format(g_localizeStrings.Get(25007), title.chapters.size(),
                                              StringUtils::SecondsToTimeString(duration))};

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -1028,7 +1028,7 @@ std::shared_ptr<CFileItem> GetFileItem(const CURL& url,
   const std::string chap{StringUtils::Format(g_localizeStrings.Get(25007), title.chapters.size(),
                                              StringUtils::SecondsToTimeString(duration))};
   item->SetLabel2(chap);
-  item->m_dwSize = 0;
+  item->SetSize(0);
   item->SetArt("icon", "DefaultVideo.png");
 
   // Generate streamdetails

--- a/xbmc/filesystem/CDDADirectory.cpp
+++ b/xbmc/filesystem/CDDADirectory.cpp
@@ -64,7 +64,7 @@ bool CCDDADirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
     struct __stat64 s64;
     if (CFile::Stat(pItem->GetPath(), &s64) == 0)
-      pItem->m_dwSize = s64.st_size;
+      pItem->SetSize(s64.st_size);
 
     items.Add(pItem);
   }

--- a/xbmc/filesystem/DAVDirectory.cpp
+++ b/xbmc/filesystem/DAVDirectory.cpp
@@ -60,7 +60,7 @@ void CDAVDirectory::ParseResponse(const tinyxml2::XMLElement* element, CFileItem
               if (CDAVCommon::ValueWithoutNamespace(propChild, "getcontentlength") &&
                   !propChild->NoChildren())
               {
-                item.m_dwSize = strtoll(propChild->FirstChild()->Value(), NULL, 10);
+                item.SetSize(std::strtoll(propChild->FirstChild()->Value(), nullptr, 10));
               }
               else if (CDAVCommon::ValueWithoutNamespace(propChild, "getlastmodified") &&
                        !propChild->NoChildren())

--- a/xbmc/filesystem/DAVDirectory.cpp
+++ b/xbmc/filesystem/DAVDirectory.cpp
@@ -67,20 +67,20 @@ void CDAVDirectory::ParseResponse(const tinyxml2::XMLElement* element, CFileItem
               {
                 struct tm timeDate = {};
                 strptime(propChild->FirstChild()->Value(), "%a, %d %b %Y %T", &timeDate);
-                item.m_dateTime = mktime(&timeDate);
+                item.SetDateTime(std::mktime(&timeDate));
               }
               else if (CDAVCommon::ValueWithoutNamespace(propChild, "displayname") &&
                        !propChild->NoChildren())
               {
                 item.SetLabel(CURL::Decode(propChild->FirstChild()->Value()));
               }
-              else if (!item.m_dateTime.IsValid() &&
+              else if (!item.GetDateTime().IsValid() &&
                        CDAVCommon::ValueWithoutNamespace(propChild, "creationdate") &&
                        !propChild->NoChildren())
               {
                 struct tm timeDate = {};
                 strptime(propChild->FirstChild()->Value(), "%Y-%m-%dT%T", &timeDate);
-                item.m_dateTime = mktime(&timeDate);
+                item.SetDateTime(std::mktime(&timeDate));
               }
               else if (CDAVCommon::ValueWithoutNamespace(propChild, "resourcetype"))
               {

--- a/xbmc/filesystem/Directorization.h
+++ b/xbmc/filesystem/Directorization.h
@@ -131,7 +131,7 @@ namespace XFILE
       item->SetPath(itemPath);
       item->m_bIsFolder = isFolder;
       if (isFolder)
-        item->m_dwSize = 0;
+        item->SetSize(0);
 
       items.Add(item);
     }

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -760,7 +760,7 @@ void CDiscDirectoryHelper::GenerateItem(const CURL& url,
   else
     /* Episode xx - title */
     buf = StringUtils::Format(g_localizeStrings.Get(21349), tag.m_iEpisode, tag.GetTitle());
-  item->m_strTitle = buf;
+  item->SetTitle(buf);
   item->SetLabel(buf);
 
   item->SetLabel2(StringUtils::Format(

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -768,7 +768,7 @@ void CDiscDirectoryHelper::GenerateItem(const CURL& url,
       g_localizeStrings.Get(180) /* Duration */,
       StringUtils::SecondsToTimeString(static_cast<int>(duration.count() / 1000)),
       g_localizeStrings.Get(24026) /* Languages */, langs));
-  item->m_dwSize = 0;
+  item->SetSize(0);
   item->SetArt("icon", "DefaultVideo.png");
 }
 

--- a/xbmc/filesystem/FTPDirectory.cpp
+++ b/xbmc/filesystem/FTPDirectory.cpp
@@ -93,7 +93,7 @@ bool CFTPDirectory::GetDirectory(const CURL& url2, CFileItemList &items)
       pItem->SetPath(url.Get());
 
       pItem->m_dwSize = parse.getSize();
-      pItem->m_dateTime=parse.getTime();
+      pItem->SetDateTime(parse.getTime());
 
       items.Add(pItem);
     }

--- a/xbmc/filesystem/FTPDirectory.cpp
+++ b/xbmc/filesystem/FTPDirectory.cpp
@@ -92,7 +92,7 @@ bool CFTPDirectory::GetDirectory(const CURL& url2, CFileItemList &items)
       url.SetFileName(filePath);
       pItem->SetPath(url.Get());
 
-      pItem->m_dwSize = parse.getSize();
+      pItem->SetSize(parse.getSize());
       pItem->SetDateTime(parse.getTime());
 
       items.Add(pItem);

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -170,7 +170,7 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
     CDirectory::GetDirectory(zipURL, items, strMask, DIR_FLAG_DEFAULTS);
     if (items.Size() == 0) // no files
       pItem->m_bIsFolder = true;
-    else if (items.Size() == 1 && items[0]->m_idepth == 0 && !items[0]->m_bIsFolder)
+    else if (items.Size() == 1 && items[0]->GetDepth() == 0 && !items[0]->m_bIsFolder)
     {
       // one STORED file - collapse it down
       *pItem = *items[0];
@@ -191,7 +191,7 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
     CDirectory::GetDirectory(zipURL, items, strMask, DIR_FLAG_DEFAULTS);
     if (items.Size() == 0) // no files
       pItem->m_bIsFolder = true;
-    else if (items.Size() == 1 && items[0]->m_idepth == 0 && !items[0]->m_bIsFolder)
+    else if (items.Size() == 1 && items[0]->GetDepth() == 0 && !items[0]->m_bIsFolder)
     {
       // one STORED file - collapse it down
       *pItem = *items[0];

--- a/xbmc/filesystem/HTTPDirectory.cpp
+++ b/xbmc/filesystem/HTTPDirectory.cpp
@@ -249,7 +249,10 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
         if (!day.empty() && monthNum > 0 && !year.empty())
         {
-          pItem->m_dateTime = CDateTime(atoi(year.c_str()), monthNum, atoi(day.c_str()), atoi(hour.c_str()), atoi(minute.c_str()), 0);
+          const CDateTime dt{std::atoi(year.c_str()),   monthNum,
+                             std::atoi(day.c_str()),    std::atoi(hour.c_str()),
+                             std::atoi(minute.c_str()), 0};
+          pItem->SetDateTime(dt);
         }
 
         if (!pItem->m_bIsFolder)

--- a/xbmc/filesystem/HTTPDirectory.cpp
+++ b/xbmc/filesystem/HTTPDirectory.cpp
@@ -269,7 +269,7 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
             else if (strUnit == "G")
               Size = Size * 1024 * 1024 * 1024;
 
-            pItem->m_dwSize = (int64_t)Size;
+            pItem->SetSize(static_cast<int64_t>(Size));
           }
           else if (reSize.RegFind(strMetadata.c_str()) >= 0)
           {
@@ -283,14 +283,14 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
             else if (strUnit == "G")
               Size = Size * 1024 * 1024 * 1024;
 
-            pItem->m_dwSize = (int64_t)Size;
+            pItem->SetSize(static_cast<int64_t>(Size));
           }
           else
           if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bHTTPDirectoryStatFilesize) // As a fallback get the size by stat-ing the file (slow)
           {
             CCurlFile file;
             file.Open(url);
-            pItem->m_dwSize=file.GetLength();
+            pItem->SetSize(file.GetLength());
             file.Close();
           }
         }

--- a/xbmc/filesystem/ISO9660Directory.cpp
+++ b/xbmc/filesystem/ISO9660Directory.cpp
@@ -63,7 +63,7 @@ bool CISO9660Directory::GetDirectory(const CURL& url, CFileItemList& items)
         CFileItemPtr pItem(new CFileItem(filename));
         pItem->SetPath(strRoot + filename);
         pItem->m_bIsFolder = false;
-        pItem->m_dwSize = file->p_stat->size;
+        pItem->SetSize(file->p_stat->size);
         items.Add(pItem);
       }
     }

--- a/xbmc/filesystem/LibraryDirectory.cpp
+++ b/xbmc/filesystem/LibraryDirectory.cpp
@@ -126,7 +126,7 @@ bool CLibraryDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       item->SetLabel(label);
       if (!icon.empty() && CServiceBroker::GetGUI()->GetTextureManager().HasTexture(icon))
         item->SetArt("icon", icon);
-      item->m_iprogramCount = order;
+      item->SetProgramCount(order);
       items.Add(item);
     }
   }

--- a/xbmc/filesystem/MusicDatabaseDirectory.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory.cpp
@@ -75,7 +75,7 @@ bool CMusicDatabaseDirectory::GetDirectory(const CURL& url, CFileItemList &items
   }
 
   items.SetPath(path);
-  items.m_dwSize = -1;  // No size
+  items.SetSize(-1); // No size
 
   std::unique_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
 

--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -285,7 +285,7 @@ bool CNFSDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
       CFileItemPtr pItem(new CFileItem(tmpDirent.name));
       pItem->SetDateTime(localTime);
-      pItem->m_dwSize = iSize;
+      pItem->SetSize(iSize);
 
       if (bIsDir)
       {

--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -65,7 +65,7 @@ bool CNFSDirectory::GetDirectoryFromExportList(const std::string& strPath, CFile
     std::string path(nonConstStrPath + currentExport);
     URIUtils::AddSlashAtEnd(path);
     pItem->SetPath(path);
-    pItem->m_dateTime = 0;
+    pItem->SetDateTime(0);
 
     pItem->m_bIsFolder = true;
     items.Add(pItem);
@@ -89,7 +89,7 @@ bool CNFSDirectory::GetServerList(CFileItemList &items)
       CFileItemPtr pItem(new CFileItem(currentExport));
       std::string path("nfs://" + currentExport);
       URIUtils::AddSlashAtEnd(path);
-      pItem->m_dateTime=0;
+      pItem->SetDateTime(0);
 
       pItem->SetPath(path);
       pItem->m_bIsFolder = true;
@@ -284,7 +284,7 @@ bool CNFSDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       KODI::TIME::FileTimeToLocalFileTime(&fileTime, &localTime);
 
       CFileItemPtr pItem(new CFileItem(tmpDirent.name));
-      pItem->m_dateTime=localTime;
+      pItem->SetDateTime(localTime);
       pItem->m_dwSize = iSize;
 
       if (bIsDir)

--- a/xbmc/filesystem/PlaylistDirectory.cpp
+++ b/xbmc/filesystem/PlaylistDirectory.cpp
@@ -41,7 +41,7 @@ bool CPlaylistDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     CFileItemPtr item = playlist[i];
     item->SetProperty("playlistposition", i);
     item->SetProperty("playlisttype", static_cast<int>(playlistId));
-    //item->m_iprogramCount = i; // the programCount is set as items are added!
+    //item->SetProgramCount(i); // the programCount is set as items are added!
     items.Add(item);
   }
 

--- a/xbmc/filesystem/PlaylistFileDirectory.cpp
+++ b/xbmc/filesystem/PlaylistFileDirectory.cpp
@@ -37,7 +37,7 @@ namespace XFILE
       for (int i = 0; i < playlist.size(); ++i)
       {
         CFileItemPtr item = playlist[i];
-        item->m_iprogramCount = i;  // hack for playlist order
+        item->SetProgramCount(i); //! @todo remove this hack for playlist order
         items.Add(item);
       }
     }

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -82,7 +82,7 @@ bool CPluginDirectory::StartScript(const std::string& strPath, bool resume)
   }
 
   // clear out our status variables
-  m_fileResult->Reset();
+  m_fileResult = std::make_unique<CFileItem>();
   m_listItems->Clear();
   m_listItems->SetPath(strPath);
   m_listItems->SetLabel(addon->Name());

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -149,8 +149,8 @@ static void ParseItemMRSS(CFileItem* item,
     if(text.empty())
       return;
 
-    if(text.length() > item->m_strTitle.length())
-      item->m_strTitle = text;
+    if (text.length() > item->GetTitle().length())
+      item->SetTitle(text);
   }
   else if(name == "description")
   {
@@ -262,8 +262,8 @@ static void ParseItemRSS(CFileItem* item,
   std::string text = GetValue(item_child);
   if (name == "title")
   {
-    if(text.length() > item->m_strTitle.length())
-      item->m_strTitle = text;
+    if (text.length() > item->GetTitle().length())
+      item->SetTitle(text);
   }
   else if (name == "pubDate")
   {
@@ -554,8 +554,9 @@ static void ParseItem(CFileItem* item, tinyxml2::XMLElement* root, const std::st
       item->m_bIsFolder = false;
   }
 
-  if(!item->m_strTitle.empty())
-    item->SetLabel(item->m_strTitle);
+  const std::string& title{item->GetTitle()};
+  if (!title.empty())
+    item->SetLabel(title);
 
   if(item->HasVideoInfoTag())
   {

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -535,7 +535,7 @@ static void ParseItem(CFileItem* item, tinyxml2::XMLElement* root, const std::st
   {
     item->SetMimeType(best->mime);
     item->SetPath(best->path);
-    item->m_dwSize  = best->size;
+    item->SetSize(best->size);
 
     if(best->duration)
       item->SetProperty("duration", StringUtils::SecondsToTimeString(best->duration));

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -267,8 +267,7 @@ static void ParseItemRSS(CFileItem* item,
   }
   else if (name == "pubDate")
   {
-    CDateTime pubDate(ParseDate(text));
-    item->m_dateTime = pubDate;
+    item->SetDateTime(ParseDate(text));
   }
   else if (name == "link")
   {

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -319,7 +319,7 @@ namespace XFILE
     for (int i = 0; i < items.Size(); i++)
     {
       CFileItemPtr item = items[i];
-      item->m_iprogramCount = i;  // hack for playlist order
+      item->SetProgramCount(i); //! @todo remove this hack for playlist order
       item->SetProperty("playlist_type_hint", static_cast<int>(playlistTypeHint));
     }
 

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -92,7 +92,7 @@ bool CSourcesDirectory::GetDirectory(const std::vector<CMediaSource>& sources, C
       strIcon = "DefaultHardDisk.png";
 
     pItem->SetArt("icon", strIcon);
-    if (share.GetLockState() == LOCK_STATE_LOCKED &&
+    if (share.GetLockInfo().IsLocked() &&
         m_profileManager->GetMasterProfile().getLockMode() != LockMode::EVERYONE)
       pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_LOCKED);
     else

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -92,7 +92,7 @@ bool CSourcesDirectory::GetDirectory(const std::vector<CMediaSource>& sources, C
       strIcon = "DefaultHardDisk.png";
 
     pItem->SetArt("icon", strIcon);
-    if (share.m_iHasLock == LOCK_STATE_LOCKED &&
+    if (share.GetLockState() == LOCK_STATE_LOCKED &&
         m_profileManager->GetMasterProfile().getLockMode() != LockMode::EVERYONE)
       pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_LOCKED);
     else

--- a/xbmc/filesystem/UDFDirectory.cpp
+++ b/xbmc/filesystem/UDFDirectory.cpp
@@ -89,7 +89,7 @@ bool CUDFDirectory::GetDirectory(const CURL& url, CFileItemList& items)
       CFileItemPtr pItem(new CFileItem(filename));
       pItem->SetPath(strRoot + filename);
       pItem->m_bIsFolder = false;
-      pItem->m_dwSize = udfread_file_size(file);
+      pItem->SetSize(udfread_file_size(file));
       items.Add(pItem);
 
       udfread_file_close(file);

--- a/xbmc/filesystem/VideoDatabaseDirectory.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -96,7 +96,7 @@ bool CVideoDatabaseDirectory::GetDirectory(const CURL& url, CFileItemList &items
 {
   std::string path = CLegacyPathTranslation::TranslateVideoDbPath(url);
   items.SetPath(path);
-  items.m_dwSize = -1;  // No size
+  items.SetSize(-1); // No size
   std::unique_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
 
   if (!pNode)

--- a/xbmc/filesystem/XbtDirectory.cpp
+++ b/xbmc/filesystem/XbtDirectory.cpp
@@ -23,7 +23,7 @@ static CFileItemPtr XBTFFileToFileItem(const CXBTFFile& entry, const std::string
 {
   CFileItemPtr item(new CFileItem(label));
   if (!isFolder)
-    item->m_dwSize = static_cast<int64_t>(entry.GetUnpackedSize());
+    item->SetSize(static_cast<int64_t>(entry.GetUnpackedSize()));
 
   return item;
 }

--- a/xbmc/filesystem/ZeroconfDirectory.cpp
+++ b/xbmc/filesystem/ZeroconfDirectory.cpp
@@ -140,7 +140,7 @@ bool GetDirectoryFromTxtRecords(const CZeroconfBrowser::ZeroconfService& zerocon
       item->SetLabelPreformatted(true);
       //just set the default folder icon
       ART::FillInDefaultIcon(*item);
-      item->m_bIsShareOrDrive=true;
+      item->SetIsShareOrDrive(true);
       items.Add(item);
       ret = true;
     }

--- a/xbmc/filesystem/ZipDirectory.cpp
+++ b/xbmc/filesystem/ZipDirectory.cpp
@@ -27,7 +27,7 @@ namespace XFILE
     if (!isFolder)
     {
       item->SetSize(entry.usize);
-      item->m_idepth = entry.method;
+      item->SetDepth(entry.method);
     }
 
     return item;

--- a/xbmc/filesystem/ZipDirectory.cpp
+++ b/xbmc/filesystem/ZipDirectory.cpp
@@ -26,7 +26,7 @@ namespace XFILE
     CFileItemPtr item(new CFileItem(label));
     if (!isFolder)
     {
-      item->m_dwSize = entry.usize;
+      item->SetSize(entry.usize);
       item->m_idepth = entry.method;
     }
 

--- a/xbmc/filesystem/test/TestHTTPDirectory.cpp
+++ b/xbmc/filesystem/test/TestHTTPDirectory.cpp
@@ -183,19 +183,19 @@ protected:
     ASSERT_EQ(items.GetObjectCount(), SAMPLE_ITEM_COUNT);
 
     // folders
-    ASSERT_EQ(items[0]->m_dwSize, SAMPLE_ITEM_1_SIZE);
-    ASSERT_EQ(items[1]->m_dwSize, SAMPLE_ITEM_2_SIZE);
+    ASSERT_EQ(items[0]->GetSize(), SAMPLE_ITEM_1_SIZE);
+    ASSERT_EQ(items[1]->GetSize(), SAMPLE_ITEM_2_SIZE);
 
     // files - due to K/M/G conversions provided by some formats, allow for
     // non-zero values that are less than or equal to the expected file size
-    ASSERT_NE(items[2]->m_dwSize, 0);
-    ASSERT_LE(items[2]->m_dwSize, SAMPLE_ITEM_3_SIZE);
-    ASSERT_NE(items[3]->m_dwSize, 0);
-    ASSERT_LE(items[3]->m_dwSize, SAMPLE_ITEM_4_SIZE);
-    ASSERT_NE(items[4]->m_dwSize, 0);
-    ASSERT_LE(items[4]->m_dwSize, SAMPLE_ITEM_5_SIZE);
-    ASSERT_NE(items[5]->m_dwSize, 0);
-    ASSERT_LE(items[5]->m_dwSize, SAMPLE_ITEM_6_SIZE);
+    ASSERT_NE(items[2]->GetSize(), 0);
+    ASSERT_LE(items[2]->GetSize(), SAMPLE_ITEM_3_SIZE);
+    ASSERT_NE(items[3]->GetSize(), 0);
+    ASSERT_LE(items[3]->GetSize(), SAMPLE_ITEM_4_SIZE);
+    ASSERT_NE(items[4]->GetSize(), 0);
+    ASSERT_LE(items[4]->GetSize(), SAMPLE_ITEM_5_SIZE);
+    ASSERT_NE(items[5]->GetSize(), 0);
+    ASSERT_LE(items[5]->GetSize(), SAMPLE_ITEM_6_SIZE);
   }
 
   void CheckFileItems(CFileItemList const& items)

--- a/xbmc/filesystem/test/TestHTTPDirectory.cpp
+++ b/xbmc/filesystem/test/TestHTTPDirectory.cpp
@@ -170,12 +170,12 @@ protected:
   {
     ASSERT_EQ(items.GetObjectCount(), SAMPLE_ITEM_COUNT);
 
-    ASSERT_STREQ(items[0]->m_dateTime.GetAsDBDateTime().c_str(), SAMPLE_ITEM_1_DATETIME);
-    ASSERT_STREQ(items[1]->m_dateTime.GetAsDBDateTime().c_str(), SAMPLE_ITEM_2_DATETIME);
-    ASSERT_STREQ(items[2]->m_dateTime.GetAsDBDateTime().c_str(), SAMPLE_ITEM_3_DATETIME);
-    ASSERT_STREQ(items[3]->m_dateTime.GetAsDBDateTime().c_str(), SAMPLE_ITEM_4_DATETIME);
-    ASSERT_STREQ(items[4]->m_dateTime.GetAsDBDateTime().c_str(), SAMPLE_ITEM_5_DATETIME);
-    ASSERT_STREQ(items[5]->m_dateTime.GetAsDBDateTime().c_str(), SAMPLE_ITEM_6_DATETIME);
+    ASSERT_STREQ(items[0]->GetDateTime().GetAsDBDateTime().c_str(), SAMPLE_ITEM_1_DATETIME);
+    ASSERT_STREQ(items[1]->GetDateTime().GetAsDBDateTime().c_str(), SAMPLE_ITEM_2_DATETIME);
+    ASSERT_STREQ(items[2]->GetDateTime().GetAsDBDateTime().c_str(), SAMPLE_ITEM_3_DATETIME);
+    ASSERT_STREQ(items[3]->GetDateTime().GetAsDBDateTime().c_str(), SAMPLE_ITEM_4_DATETIME);
+    ASSERT_STREQ(items[4]->GetDateTime().GetAsDBDateTime().c_str(), SAMPLE_ITEM_5_DATETIME);
+    ASSERT_STREQ(items[5]->GetDateTime().GetAsDBDateTime().c_str(), SAMPLE_ITEM_6_DATETIME);
   }
 
   void CheckFileItemSizes(CFileItemList const& items)

--- a/xbmc/filesystem/test/TestHTTPDirectory.cpp
+++ b/xbmc/filesystem/test/TestHTTPDirectory.cpp
@@ -111,7 +111,7 @@ protected:
     source.vecPaths.push_back(m_sourcePath);
     source.m_allowSharing = true;
     source.m_iDriveType = SourceType::LOCAL;
-    source.SetLockMode(LockMode::EVERYONE);
+    source.GetLockInfo().SetMode(LockMode::EVERYONE);
     source.m_ignore = true;
 
     CMediaSourceSettings::GetInstance().AddShare("videos", source);

--- a/xbmc/filesystem/test/TestHTTPDirectory.cpp
+++ b/xbmc/filesystem/test/TestHTTPDirectory.cpp
@@ -111,7 +111,7 @@ protected:
     source.vecPaths.push_back(m_sourcePath);
     source.m_allowSharing = true;
     source.m_iDriveType = SourceType::LOCAL;
-    source.m_iLockMode = LockMode::EVERYONE;
+    source.SetLockMode(LockMode::EVERYONE);
     source.m_ignore = true;
 
     CMediaSourceSettings::GetInstance().AddShare("videos", source);

--- a/xbmc/games/windows/GUIWindowGames.cpp
+++ b/xbmc/games/windows/GUIWindowGames.cpp
@@ -334,7 +334,8 @@ std::string CGUIWindowGames::GetStartFolder(const std::string& dir)
   int iIndex = CUtil::GetMatchingSource(dir, shares, bIsSourceName);
   if (iIndex >= 0)
   {
-    if (iIndex < static_cast<int>(shares.size()) && shares[iIndex].m_iHasLock == LOCK_STATE_LOCKED)
+    if (iIndex < static_cast<int>(shares.size()) &&
+        shares[iIndex].GetLockState() == LOCK_STATE_LOCKED)
     {
       CFileItem item(shares[iIndex]);
       if (!g_passwordManager.IsItemUnlocked(&item, "games"))

--- a/xbmc/games/windows/GUIWindowGames.cpp
+++ b/xbmc/games/windows/GUIWindowGames.cpp
@@ -334,8 +334,7 @@ std::string CGUIWindowGames::GetStartFolder(const std::string& dir)
   int iIndex = CUtil::GetMatchingSource(dir, shares, bIsSourceName);
   if (iIndex >= 0)
   {
-    if (iIndex < static_cast<int>(shares.size()) &&
-        shares[iIndex].GetLockState() == LOCK_STATE_LOCKED)
+    if (iIndex < static_cast<int>(shares.size()) && shares[iIndex].GetLockInfo().IsLocked())
     {
       CFileItem item(shares[iIndex]);
       if (!g_passwordManager.IsItemUnlocked(&item, "games"))

--- a/xbmc/guilib/GUIStaticItem.cpp
+++ b/xbmc/guilib/GUIStaticItem.cpp
@@ -45,7 +45,7 @@ CGUIStaticItem::CGUIStaticItem(const TiXmlElement *item, int parentID) : CFileIt
     m_info.emplace_back(thumb, "thumb");
   if (!icon.IsConstant())
     m_info.emplace_back(icon, "icon");
-  m_iprogramCount = id ? atoi(id) : 0;
+  SetProgramCount(id ? std::atoi(id) : 0);
   // add any properties
   const TiXmlElement *property = item->FirstChildElement("property");
   while (property)

--- a/xbmc/guilib/guiinfo/GUIControlsGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/GUIControlsGUIInfo.cpp
@@ -594,7 +594,9 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
         if (control && control->IsContainer())
         {
           const CFileItemPtr item = std::static_pointer_cast<CFileItem>(static_cast<const IGUIContainer*>(control)->GetListItem(0));
-          if (item && item->m_iprogramCount == info.GetData2())  // programcount used to store item id
+          if (item &&
+              item->GetProgramCount() ==
+                  info.GetData2()) //! @todo remove hack to use programcount to store item id
           {
             value = true;
             return true;

--- a/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
@@ -175,9 +175,10 @@ bool CPicturesGUIInfo::GetLabel(std::string& value, const CFileItem *item, int c
       }
       case SLIDESHOW_FILE_DATE:
       {
-        if (m_currentSlide->m_dateTime.IsValid())
+        const CDateTime& dateTime{m_currentSlide->GetDateTime()};
+        if (dateTime.IsValid())
         {
-          value = m_currentSlide->m_dateTime.GetAsLocalizedDate();
+          value = dateTime.GetAsLocalizedDate();
           return true;
         }
         break;

--- a/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
@@ -166,9 +166,9 @@ bool CPicturesGUIInfo::GetLabel(std::string& value, const CFileItem *item, int c
       }
       case SLIDESHOW_FILE_SIZE:
       {
-        if (!m_currentSlide->m_bIsFolder || m_currentSlide->m_dwSize)
+        if (!m_currentSlide->m_bIsFolder || m_currentSlide->GetSize())
         {
-          value = StringUtils::SizeToString(m_currentSlide->m_dwSize);
+          value = StringUtils::SizeToString(m_currentSlide->GetSize());
           return true;
         }
         break;

--- a/xbmc/guilib/listproviders/StaticProvider.cpp
+++ b/xbmc/guilib/listproviders/StaticProvider.cpp
@@ -112,7 +112,7 @@ int CStaticListProvider::GetDefaultItem() const
       if (!i->IsVisible())
         continue;
 
-      if (i->m_iprogramCount == m_defaultItem)
+      if (i->GetProgramCount() == m_defaultItem)
         return offset;
 
       offset++;

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -46,7 +46,7 @@ JSONRPC_STATUS CFileOperations::GetRootDirectory(const std::string &method, ITra
     for (unsigned int i = 0; i < (unsigned int)sources->size(); i++)
     {
       // Do not show sources which are locked
-      if (sources->at(i).m_iHasLock == LOCK_STATE_LOCKED)
+      if (sources->at(i).GetLockState() == LOCK_STATE_LOCKED)
         continue;
 
       items.Add(std::make_shared<CFileItem>(sources->at(i)));

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -46,7 +46,7 @@ JSONRPC_STATUS CFileOperations::GetRootDirectory(const std::string &method, ITra
     for (unsigned int i = 0; i < (unsigned int)sources->size(); i++)
     {
       // Do not show sources which are locked
-      if (sources->at(i).GetLockState() == LOCK_STATE_LOCKED)
+      if (sources->at(i).GetLockInfo().IsLocked())
         continue;
 
       items.Add(std::make_shared<CFileItem>(sources->at(i)));

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -991,7 +991,7 @@ namespace XBMCAddon
 
     void ListItem::setSizeRaw(int64_t size)
     {
-      item->m_dwSize = size;
+      item->SetSize(size);
     }
 
     void ListItem::setDateTimeRaw(const std::string& dateTime)

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -986,7 +986,7 @@ namespace XBMCAddon
 
     void ListItem::setCountRaw(int count)
     {
-      item->m_iprogramCount = count;
+      item->SetProgramCount(count);
     }
 
     void ListItem::setSizeRaw(int64_t size)

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -111,8 +111,9 @@ namespace XBMCAddon
       String ret;
       {
         XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
-        if (item->m_dateTime.IsValid())
-          ret = item->m_dateTime.GetAsW3CDateTime();
+        const CDateTime& dateTime{item->GetDateTime()};
+        if (dateTime.IsValid())
+          ret = dateTime.GetAsW3CDateTime();
       }
 
       return ret;
@@ -1000,10 +1001,16 @@ namespace XBMCAddon
         int year = strtol(dateTime.substr(dateTime.size() - 4).c_str(), nullptr, 10);
         int month = strtol(dateTime.substr(3, 4).c_str(), nullptr, 10);
         int day = strtol(dateTime.substr(0, 2).c_str(), nullptr, 10);
-        item->m_dateTime.SetDate(year, month, day);
+        CDateTime dt{item->GetDateTime()};
+        dt.SetDate(year, month, day);
+        item->SetDateTime(dt);
       }
       else
-        item->m_dateTime.SetFromW3CDateTime(dateTime);
+      {
+        CDateTime dt;
+        dt.SetFromW3CDateTime(dateTime);
+        item->SetDateTime(dt);
+      }
     }
 
     void ListItem::setIsFolderRaw(bool isFolder)

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -976,7 +976,7 @@ namespace XBMCAddon
 
     void ListItem::setTitleRaw(std::string title)
     {
-      item->m_strTitle = std::move(title);
+      item->SetTitle(std::move(title));
     }
 
     void ListItem::setPathRaw(const std::string& path)

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -6334,8 +6334,8 @@ bool CMusicDatabase::GetSongsFullByWhere(
           songId = record->at(song_idSong).get_asInt();
           CFileItemPtr item(new CFileItem);
           GetFileItemFromDataset(record, item.get(), musicUrl);
-          // HACK for sorting by database returned order
-          item->m_iprogramCount = ++count;
+          //! @todo remove hack to use program count for sorting by database returned order
+          item->SetProgramCount(++count);
           // Set icon now to avoid slow per item processing in FillInDefaultIcon later
           item->SetProperty("icon_never_overlay", true);
           item->SetArt("icon", "DefaultAudio.png");
@@ -6475,8 +6475,8 @@ bool CMusicDatabase::GetSongsByWhere(
       {
         CFileItemPtr item(new CFileItem);
         GetFileItemFromDataset(record, item.get(), musicUrl);
-        // HACK for sorting by database returned order
-        item->m_iprogramCount = ++count;
+        //! @todo remove hack to use program count for sorting by database returned order
+        item->SetProgramCount(++count);
         items.Add(item);
       }
       catch (...)

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -179,7 +179,8 @@ bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
   {
     // first check the cached item
     CFileItemPtr mapItem = (*m_mapFileItems)[pItem->GetPath()];
-    if (mapItem && mapItem->m_dateTime==pItem->m_dateTime && mapItem->HasMusicInfoTag() && mapItem->GetMusicInfoTag()->Loaded())
+    if (mapItem && mapItem->HasMusicInfoTag() && mapItem->GetMusicInfoTag()->Loaded() &&
+        mapItem->GetDateTime() == pItem->GetDateTime())
     { // Query map if we previously cached the file on HD
       *pItem->GetMusicInfoTag() = *mapItem->GetMusicInfoTag();
       if (mapItem->HasArt("thumb"))

--- a/xbmc/music/MusicThumbLoader.cpp
+++ b/xbmc/music/MusicThumbLoader.cpp
@@ -53,7 +53,7 @@ bool CMusicThumbLoader::LoadItem(CFileItem* pItem)
 
 bool CMusicThumbLoader::LoadItemCached(CFileItem* pItem)
 {
-  if (pItem->m_bIsShareOrDrive)
+  if (pItem->IsShareOrDrive())
     return false;
 
   if (pItem->HasMusicInfoTag() && !pItem->GetProperty("libraryartfilled").asBoolean())
@@ -97,7 +97,7 @@ bool CMusicThumbLoader::LoadItemCached(CFileItem* pItem)
 
 bool CMusicThumbLoader::LoadItemLookup(CFileItem* pItem)
 {
-  if (pItem->m_bIsShareOrDrive)
+  if (pItem->IsShareOrDrive())
     return false;
 
   if (pItem->HasMusicInfoTag() && pItem->GetMusicInfoTag()->GetType() == MediaTypeArtist) // No fallback for artist

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -534,7 +534,7 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
   if (item->m_bIsFolder)
   {
     // Check if we add a locked share
-    if (item->m_bIsShareOrDrive)
+    if (item->IsShareOrDrive())
     {
       if (!g_passwordManager.IsItemUnlocked(item.get(), "music"))
         return;

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1277,7 +1277,8 @@ int CMusicInfoScanner::GetPathHash(const CFileItemList &items, std::string &hash
   {
     const CFileItemPtr pItem = items[i];
     digest.Update(pItem->GetPath());
-    digest.Update((unsigned char *)&pItem->m_dwSize, sizeof(pItem->m_dwSize));
+    const int64_t size{pItem->GetSize()};
+    digest.Update(&size, sizeof(size));
     KODI::TIME::FileTime time{};
     pItem->GetDateTime().GetAsTimeStamp(time);
     digest.Update(&time, sizeof(time));

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1278,8 +1278,9 @@ int CMusicInfoScanner::GetPathHash(const CFileItemList &items, std::string &hash
     const CFileItemPtr pItem = items[i];
     digest.Update(pItem->GetPath());
     digest.Update((unsigned char *)&pItem->m_dwSize, sizeof(pItem->m_dwSize));
-    KODI::TIME::FileTime time = pItem->m_dateTime;
-    digest.Update((unsigned char*)&time, sizeof(KODI::TIME::FileTime));
+    KODI::TIME::FileTime time{};
+    pItem->GetDateTime().GetAsTimeStamp(time);
+    digest.Update(&time, sizeof(time));
     if (MUSIC::IsAudio(*pItem) && !PLAYLIST::IsPlayList(*pItem) && !pItem->IsNFO())
       count++;
   }

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1865,7 +1865,8 @@ CInfoScanner::InfoRet CMusicInfoScanner::DownloadArtistInfo(
                 strTemp = StringUtils::Format("[{}] {}", genres, strTemp);
             }
             item.SetLabel(strTemp);
-            item.m_idepth = i; // use this to hold the index of the album in the scraper
+            item.SetDepth(
+                i); //! @todo remove hack to use this to hold the index of the album in the scraper
             pDlg->Add(item);
           }
           pDlg->Open();
@@ -1891,7 +1892,7 @@ CInfoScanner::InfoRet CMusicInfoScanner::DownloadArtistInfo(
             newArtist.strArtist = strNewArtist;
             return DownloadArtistInfo(newArtist, info, artistInfo, bUseScrapedMBID, pDialog);
           }
-          iSelectedArtist = pDlg->GetSelectedFileItem()->m_idepth;
+          iSelectedArtist = pDlg->GetSelectedFileItem()->GetDepth();
         }
       }
     }

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -510,12 +510,12 @@ void CGUIWindowMusicPlayList::OnItemLoaded(CFileItem* pItem)
     else if (pItem->GetLabel().empty()) // pls labels come in preformatted
     {
       // FIXME: get the position of the item in the playlist
-      //        currently it is hacked into m_iprogramCount
+      //        currently it is hacked into program count
 
       // No music info and it's not CDDA so we'll just show the filename
       std::string str;
       str = CUtil::GetTitleFromPath(pItem->GetPath());
-      str = StringUtils::Format("{:02}. {} ", pItem->m_iprogramCount, str);
+      str = StringUtils::Format("{:02}. {} ", pItem->GetProgramCount(), str);
       pItem->SetLabel(str);
     }
   }

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -184,20 +184,20 @@ bool CGUIWindowMusicPlaylistEditor::GetDirectory(const std::string &strDirectory
     CFileItemPtr files(new CFileItem("sources://music/", true));
     files->SetLabel(g_localizeStrings.Get(744));
     files->SetLabelPreformatted(true);
-    files->m_bIsShareOrDrive = true;
+    files->SetIsShareOrDrive(true);
     items.Add(files);
 
     CFileItemPtr mdb(new CFileItem("library://music/", true));
     mdb->SetLabel(g_localizeStrings.Get(14022));
     mdb->SetLabelPreformatted(true);
-    mdb->m_bIsShareOrDrive = true;
+    mdb->SetIsShareOrDrive(true);
     items.SetPath("");
     items.Add(mdb);
 
     CFileItemPtr vdb(new CFileItem("videodb://musicvideos/", true));
     vdb->SetLabel(g_localizeStrings.Get(20389));
     vdb->SetLabelPreformatted(true);
-    vdb->m_bIsShareOrDrive = true;
+    vdb->SetIsShareOrDrive(true);
     items.SetPath("");
     items.Add(vdb);
 

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
@@ -57,7 +57,7 @@ CHTTPVfsHandler::CHTTPVfsHandler(const HTTPRequest &request)
               break;
 
             // don't allow access to locked / disabled sharing sources
-            if (source.m_iHasLock == LOCK_STATE_LOCKED || !source.m_allowSharing)
+            if (source.GetLockState() == LOCK_STATE_LOCKED || !source.m_allowSharing)
               continue;
 
             for (const auto& path : source.vecPaths)
@@ -80,7 +80,7 @@ CHTTPVfsHandler::CHTTPVfsHandler(const HTTPRequest &request)
           CServiceBroker::GetMediaManager().GetRemovableDrives(removableSources);
           int sourceIndex = CUtil::GetMatchingSource(realPath, removableSources, isSource);
           if (sourceIndex >= 0 && sourceIndex < static_cast<int>(removableSources.size()) &&
-              removableSources.at(sourceIndex).m_iHasLock != LOCK_STATE_LOCKED &&
+              removableSources.at(sourceIndex).GetLockState() != LOCK_STATE_LOCKED &&
               removableSources.at(sourceIndex).m_allowSharing)
             accessible = true;
         }

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
@@ -57,7 +57,7 @@ CHTTPVfsHandler::CHTTPVfsHandler(const HTTPRequest &request)
               break;
 
             // don't allow access to locked / disabled sharing sources
-            if (source.GetLockState() == LOCK_STATE_LOCKED || !source.m_allowSharing)
+            if (source.GetLockInfo().IsLocked() || !source.m_allowSharing)
               continue;
 
             for (const auto& path : source.vecPaths)
@@ -80,7 +80,7 @@ CHTTPVfsHandler::CHTTPVfsHandler(const HTTPRequest &request)
           CServiceBroker::GetMediaManager().GetRemovableDrives(removableSources);
           int sourceIndex = CUtil::GetMatchingSource(realPath, removableSources, isSource);
           if (sourceIndex >= 0 && sourceIndex < static_cast<int>(removableSources.size()) &&
-              removableSources.at(sourceIndex).GetLockState() != LOCK_STATE_LOCKED &&
+              !removableSources.at(sourceIndex).GetLockInfo().IsLocked() &&
               removableSources.at(sourceIndex).m_allowSharing)
             accessible = true;
         }

--- a/xbmc/network/test/TestWebServer.cpp
+++ b/xbmc/network/test/TestWebServer.cpp
@@ -96,7 +96,7 @@ protected:
     source.vecPaths.push_back(sourcePath);
     source.m_allowSharing = true;
     source.m_iDriveType = SourceType::LOCAL;
-    source.SetLockMode(LockMode::EVERYONE);
+    source.GetLockInfo().SetMode(LockMode::EVERYONE);
     source.m_ignore = true;
 
     CMediaSourceSettings::GetInstance().AddShare("videos", source);

--- a/xbmc/network/test/TestWebServer.cpp
+++ b/xbmc/network/test/TestWebServer.cpp
@@ -96,7 +96,7 @@ protected:
     source.vecPaths.push_back(sourcePath);
     source.m_allowSharing = true;
     source.m_iDriveType = SourceType::LOCAL;
-    source.m_iLockMode = LockMode::EVERYONE;
+    source.SetLockMode(LockMode::EVERYONE);
     source.m_ignore = true;
 
     CMediaSourceSettings::GetInstance().AddShare("videos", source);

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -567,9 +567,11 @@ PLT_MediaObject* BuildObject(CFileItem& item,
       resource.m_Size = (NPT_LargeSize)-1;
 
     // set date
-    if (object->m_Date.IsEmpty() && item.m_dateTime.IsValid())
+    if (object->m_Date.IsEmpty())
     {
-      object->m_Date = item.m_dateTime.GetAsW3CDate().c_str();
+      const CDateTime& dateTime{item.GetDateTime()};
+      if (dateTime.IsValid())
+        object->m_Date = dateTime.GetAsW3CDate().c_str();
     }
 
     if (upnp_server)
@@ -1241,7 +1243,7 @@ std::shared_ptr<CFileItem> BuildObject(PLT_MediaObject* entry,
     KODI::TIME::SystemTime time = {};
     sscanf(entry->m_Description.date, "%hu-%hu-%huT%hu:%hu:%hu", &time.year, &time.month, &time.day,
            &time.hour, &time.minute, &time.second);
-    pItem->m_dateTime = time;
+    pItem->SetDateTime(time);
   }
 
   // if there is a thumbnail available set it here

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -1159,7 +1159,7 @@ std::shared_ptr<CFileItem> BuildObject(PLT_MediaObject* entry,
 
   CFileItemPtr pItem(new CFileItem((const char*)entry->m_Title));
   pItem->SetLabelPreformatted(true);
-  pItem->m_strTitle = (const char*)entry->m_Title;
+  pItem->SetTitle(static_cast<const char*>(entry->m_Title));
   pItem->m_bIsFolder = entry->IsContainer();
 
   // if it's a container, format a string as upnp://uuid/object_id

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -562,7 +562,7 @@ PLT_MediaObject* BuildObject(CFileItem& item,
       resource.m_Duration = -1;
 
     // Set the resource file size
-    resource.m_Size = item.m_dwSize;
+    resource.m_Size = item.GetSize();
     if (resource.m_Size == 0)
       resource.m_Size = (NPT_LargeSize)-1;
 
@@ -1215,7 +1215,7 @@ std::shared_ptr<CFileItem> BuildObject(PLT_MediaObject* entry,
       // set metadata
       if (resource.m_Size != (NPT_LargeSize)-1)
       {
-        pItem->m_dwSize = resource.m_Size;
+        pItem->SetSize(resource.m_Size);
       }
       res = &resource;
     }

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -314,7 +314,7 @@ bool CGUIWindowPictures::ShowPicture(int iItem, bool startSlideShow)
     return MEDIA_DETECT::CAutorun::PlayDiscAskResume(m_vecItems->Get(iItem)->GetPath());
 #endif
 
-  if (pItem->m_bIsShareOrDrive)
+  if (pItem->IsShareOrDrive())
     return false;
 
   //! @todo this should be reactive, based on a given event app player should stop the playback

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -605,7 +605,8 @@ std::string CGUIWindowPictures::GetStartFolder(const std::string &dir)
   int iIndex = CUtil::GetMatchingSource(dir, shares, bIsSourceName);
   if (iIndex > -1)
   {
-    if (iIndex < static_cast<int>(shares.size()) && shares[iIndex].m_iHasLock == LOCK_STATE_LOCKED)
+    if (iIndex < static_cast<int>(shares.size()) &&
+        shares[iIndex].GetLockState() == LOCK_STATE_LOCKED)
     {
       CFileItem item(shares[iIndex]);
       if (!g_passwordManager.IsItemUnlocked(&item,"pictures"))

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -605,8 +605,7 @@ std::string CGUIWindowPictures::GetStartFolder(const std::string &dir)
   int iIndex = CUtil::GetMatchingSource(dir, shares, bIsSourceName);
   if (iIndex > -1)
   {
-    if (iIndex < static_cast<int>(shares.size()) &&
-        shares[iIndex].GetLockState() == LOCK_STATE_LOCKED)
+    if (iIndex < static_cast<int>(shares.size()) && shares[iIndex].GetLockInfo().IsLocked())
     {
       CFileItem item(shares[iIndex]);
       if (!g_passwordManager.IsItemUnlocked(&item,"pictures"))

--- a/xbmc/pictures/PictureInfoLoader.cpp
+++ b/xbmc/pictures/PictureInfoLoader.cpp
@@ -64,7 +64,7 @@ bool CPictureInfoLoader::LoadItemCached(CFileItem* pItem)
 
   // Check the cached item
   CFileItemPtr mapItem = (*m_mapFileItems)[pItem->GetPath()];
-  if (mapItem && mapItem->m_dateTime==pItem->m_dateTime && mapItem->HasPictureInfoTag())
+  if (mapItem && mapItem->HasPictureInfoTag() && mapItem->GetDateTime() == pItem->GetDateTime())
   { // Query map if we previously cached the file on HD
     *pItem->GetPictureInfoTag() = *mapItem->GetPictureInfoTag();
     pItem->SetArt("thumb", mapItem->GetArt("thumb"));

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -64,8 +64,7 @@ bool CPictureThumbLoader::LoadItem(CFileItem* pItem)
 
 bool CPictureThumbLoader::LoadItemCached(CFileItem* pItem)
 {
-  if (pItem->m_bIsShareOrDrive
-  ||  pItem->IsParentFolder())
+  if (pItem->IsShareOrDrive() || pItem->IsParentFolder())
     return false;
 
   if (pItem->HasArt("thumb") && m_regenerateThumbs)
@@ -128,8 +127,8 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
       return;
     }
   }
-  if ((pItem->m_bIsFolder || pItem->IsCBR() || pItem->IsCBZ()) && !pItem->m_bIsShareOrDrive
-      && !pItem->IsParentFolder() && !pItem->IsPath("add"))
+  if ((pItem->m_bIsFolder || pItem->IsCBR() || pItem->IsCBZ()) && !pItem->IsShareOrDrive() &&
+      !pItem->IsParentFolder() && !pItem->IsPath("add"))
   {
     // first check for a folder.jpg
     std::string thumb = "folder.jpg";

--- a/xbmc/platform/android/filesystem/APKDirectory.cpp
+++ b/xbmc/platform/android/filesystem/APKDirectory.cpp
@@ -71,7 +71,7 @@ bool CAPKDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       g_charsetConverter.unknownToUTF8(test_name);
       CFileItemPtr pItem(new CFileItem(test_name));
       pItem->m_dwSize    = sb.size;
-      pItem->m_dateTime  = sb.mtime;
+      pItem->SetDateTime(sb.mtime);
       pItem->m_bIsFolder = dir_marker > 0 ;
       pItem->SetPath(host + "/" + test_name);
       pItem->SetLabel(test_name.substr(path.size()));

--- a/xbmc/platform/android/filesystem/APKDirectory.cpp
+++ b/xbmc/platform/android/filesystem/APKDirectory.cpp
@@ -70,7 +70,7 @@ bool CAPKDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     {
       g_charsetConverter.unknownToUTF8(test_name);
       CFileItemPtr pItem(new CFileItem(test_name));
-      pItem->m_dwSize    = sb.size;
+      pItem->SetSize(sb.size);
       pItem->SetDateTime(sb.mtime);
       pItem->m_bIsFolder = dir_marker > 0 ;
       pItem->SetPath(host + "/" + test_name);

--- a/xbmc/platform/android/filesystem/AndroidAppDirectory.cpp
+++ b/xbmc/platform/android/filesystem/AndroidAppDirectory.cpp
@@ -51,7 +51,7 @@ bool CAndroidAppDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       pItem->SetPath(path);
       pItem->SetLabel(i.packageLabel);
       pItem->SetArt("thumb", path+".png");
-      pItem->m_dwSize = -1;  // No size
+      pItem->SetSize(-1); // No size
       items.Add(pItem);
     }
     return true;

--- a/xbmc/platform/darwin/tvos/filesystem/TVOSDirectory.cpp
+++ b/xbmc/platform/darwin/tvos/filesystem/TVOSDirectory.cpp
@@ -95,7 +95,7 @@ bool CTVOSDirectory::GetDirectory(const CURL& url, CFileItemList& items)
         KODI::TIME::FileTime fileTime, localTime;
         KODI::TIME::TimeTToFileTime(buffer.st_mtime, &fileTime);
         KODI::TIME::FileTimeToLocalFileTime(&fileTime, &localTime);
-        pItem->m_dateTime = localTime;
+        pItem->SetDateTime(localTime);
         // all this to get the file size
         pItem->m_dwSize = buffer.st_size;
       }

--- a/xbmc/platform/darwin/tvos/filesystem/TVOSDirectory.cpp
+++ b/xbmc/platform/darwin/tvos/filesystem/TVOSDirectory.cpp
@@ -97,7 +97,7 @@ bool CTVOSDirectory::GetDirectory(const CURL& url, CFileItemList& items)
         KODI::TIME::FileTimeToLocalFileTime(&fileTime, &localTime);
         pItem->SetDateTime(localTime);
         // all this to get the file size
-        pItem->m_dwSize = buffer.st_size;
+        pItem->SetSize(buffer.st_size);
       }
     }
     items.Add(pItem);

--- a/xbmc/platform/posix/filesystem/PosixDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/PosixDirectory.cpp
@@ -90,7 +90,7 @@ bool CPosixDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         pItem->SetDateTime(localTime);
 
         if (!pItem->m_bIsFolder)
-          pItem->m_dwSize = buffer.st_size;
+          pItem->SetSize(buffer.st_size);
       }
     }
     items.Add(pItem);

--- a/xbmc/platform/posix/filesystem/PosixDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/PosixDirectory.cpp
@@ -87,7 +87,7 @@ bool CPosixDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         KODI::TIME::FileTime fileTime, localTime;
         KODI::TIME::TimeTToFileTime(buffer.st_mtime, &fileTime);
         KODI::TIME::FileTimeToLocalFileTime(&fileTime, &localTime);
-        pItem->m_dateTime = localTime;
+        pItem->SetDateTime(localTime);
 
         if (!pItem->m_bIsFolder)
           pItem->m_dwSize = buffer.st_size;

--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -234,7 +234,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         CFileItemPtr pItem(new CFileItem(strFile));
         pItem->SetPath(strRoot + aDir.name);
         pItem->m_bIsFolder = false;
-        pItem->m_dwSize = iSize;
+        pItem->SetSize(iSize);
         pItem->SetDateTime(localTime);
         if (hidden)
           pItem->SetProperty("file:hidden", true);

--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -224,7 +224,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         URIUtils::AddSlashAtEnd(path);
         pItem->SetPath(path);
         pItem->m_bIsFolder = true;
-        pItem->m_dateTime=localTime;
+        pItem->SetDateTime(localTime);
         if (hidden)
           pItem->SetProperty("file:hidden", true);
         items.Add(pItem);
@@ -235,7 +235,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         pItem->SetPath(strRoot + aDir.name);
         pItem->m_bIsFolder = false;
         pItem->m_dwSize = iSize;
-        pItem->m_dateTime=localTime;
+        pItem->SetDateTime(localTime);
         if (hidden)
           pItem->SetProperty("file:hidden", true);
         items.Add(pItem);

--- a/xbmc/platform/win10/filesystem/WinLibraryDirectory.cpp
+++ b/xbmc/platform/win10/filesystem/WinLibraryDirectory.cpp
@@ -134,7 +134,7 @@ bool CWinLibraryDirectory::GetDirectory(const CURL& url, CFileItemList& items)
     KODI::TIME::FileTime fileTime2;
     fileTime2.highDateTime = fileTime1.dwHighDateTime;
     fileTime2.lowDateTime = fileTime1.dwLowDateTime;
-    pItem->m_dateTime = fileTime2;
+    pItem->SetDateTime(fileTime2);
     if (!pItem->m_bIsFolder)
       pItem->m_dwSize = static_cast<int64_t>(props.Size());
 

--- a/xbmc/platform/win10/filesystem/WinLibraryDirectory.cpp
+++ b/xbmc/platform/win10/filesystem/WinLibraryDirectory.cpp
@@ -117,7 +117,7 @@ bool CWinLibraryDirectory::GetDirectory(const CURL& url, CFileItemList& items)
     IStorageItemProperties storageItemProperties = item.as<IStorageItemProperties>();
     if (item != nullptr)
     {
-      pItem->m_strTitle = FromW(storageItemProperties.DisplayName().c_str());
+      pItem->SetTitle(FromW(storageItemProperties.DisplayName().c_str()));
     }
 
     if (pItem->m_bIsFolder)

--- a/xbmc/platform/win10/filesystem/WinLibraryDirectory.cpp
+++ b/xbmc/platform/win10/filesystem/WinLibraryDirectory.cpp
@@ -136,7 +136,7 @@ bool CWinLibraryDirectory::GetDirectory(const CURL& url, CFileItemList& items)
     fileTime2.lowDateTime = fileTime1.dwLowDateTime;
     pItem->SetDateTime(fileTime2);
     if (!pItem->m_bIsFolder)
-      pItem->m_dwSize = static_cast<int64_t>(props.Size());
+      pItem->SetSize(static_cast<int64_t>(props.Size()));
 
     items.Add(pItem);
   }

--- a/xbmc/platform/win32/filesystem/Win32Directory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32Directory.cpp
@@ -103,7 +103,7 @@ bool CWin32Directory::GetDirectory(const CURL& url, CFileItemList &items)
       pItem->SetDateTime(0);
 
     if (!pItem->m_bIsFolder)
-        pItem->m_dwSize = (__int64(findData.nFileSizeHigh) << 32) + findData.nFileSizeLow;
+      pItem->SetSize((__int64(findData.nFileSizeHigh) << 32) + findData.nFileSizeLow);
 
     items.Add(pItem);
   } while (FindNextFileW(hSearch, &findData));

--- a/xbmc/platform/win32/filesystem/Win32Directory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32Directory.cpp
@@ -98,9 +98,9 @@ bool CWin32Directory::GetDirectory(const CURL& url, CFileItemList &items)
     fileTime.highDateTime = findData.ftLastWriteTime.dwHighDateTime;
     KODI::TIME::FileTime localTime;
     if (KODI::TIME::FileTimeToLocalFileTime(&fileTime, &localTime) == TRUE)
-      pItem->m_dateTime = localTime;
+      pItem->SetDateTime(localTime);
     else
-      pItem->m_dateTime = 0;
+      pItem->SetDateTime(0);
 
     if (!pItem->m_bIsFolder)
         pItem->m_dwSize = (__int64(findData.nFileSizeHigh) << 32) + findData.nFileSizeLow;

--- a/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
@@ -184,7 +184,7 @@ bool CWin32SMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       pItem->SetDateTime(dt);
     }
     if (!pItem->m_bIsFolder)
-        pItem->m_dwSize = (__int64(findData.nFileSizeHigh) << 32) + findData.nFileSizeLow;
+      pItem->SetSize((__int64(findData.nFileSizeHigh) << 32) + findData.nFileSizeLow);
 
     items.Add(pItem);
   } while (FindNextFileW(hSearch, &findData));

--- a/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
@@ -176,10 +176,13 @@ bool CWin32SMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     fileTime.highDateTime = findData.ftLastWriteTime.dwHighDateTime;
     KODI::TIME::FileTime localTime;
     if (KODI::TIME::FileTimeToLocalFileTime(&fileTime, &localTime) == TRUE)
-      pItem->m_dateTime = localTime;
+      pItem->SetDateTime(localTime);
     else
-      pItem->m_dateTime.SetValid(false);
-
+    {
+      CDateTime dt{pItem->GetDateTime()};
+      dt.SetValid(false);
+      pItem->SetDateTime(dt);
+    }
     if (!pItem->m_bIsFolder)
         pItem->m_dwSize = (__int64(findData.nFileSizeHigh) << 32) + findData.nFileSizeLow;
 

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -176,7 +176,7 @@ bool CPlayListM3U::Load(const std::string& strFileName)
         if (iStartOffset != 0 || iEndOffset != 0)
         {
           newItem->SetStartOffset(iStartOffset);
-          newItem->m_lStartPartNumber = 1;
+          newItem->SetStartPartNumber(1);
           newItem->SetProperty("item_start", iStartOffset);
           newItem->SetEndOffset(iEndOffset);
           // Prevent load message from file and override offset set here

--- a/xbmc/playlists/PlayListXML.cpp
+++ b/xbmc/playlists/PlayListXML.cpp
@@ -138,9 +138,7 @@ bool CPlayListXML::Load( const std::string& strFileName )
 
        if ( !lockpass.empty() )
        {
-         newItem->SetLockCode(lockpass);
-         newItem->SetLockState(LOCK_STATE_LOCKED);
-         newItem->SetLockMode(LockMode::NUMERIC);
+         newItem->GetLockInfo().Set(LockMode::NUMERIC, lockpass, LOCK_STATE_LOCKED);
        }
 
        Add(newItem);
@@ -187,8 +185,9 @@ void CPlayListXML::Save(const std::string& strFileName) const
       write += StringUtils::Format("    <channel>{}</channel>",
                                    item->GetProperty("remotechannel").asString());
 
-    if (item->GetLockState() > LOCK_STATE_NO_LOCK)
-      write += StringUtils::Format("    <lockpassword>{}<lockpassword>", item->GetLockCode());
+    if (item->GetLockInfo().GetState() > LOCK_STATE_NO_LOCK)
+      write +=
+          StringUtils::Format("    <lockpassword>{}<lockpassword>", item->GetLockInfo().GetCode());
 
     write += StringUtils::Format("  </stream>\n\n" );
   }

--- a/xbmc/playlists/PlayListXML.cpp
+++ b/xbmc/playlists/PlayListXML.cpp
@@ -138,9 +138,9 @@ bool CPlayListXML::Load( const std::string& strFileName )
 
        if ( !lockpass.empty() )
        {
-         newItem->m_strLockCode = lockpass;
-         newItem->m_iHasLock = LOCK_STATE_LOCKED;
-         newItem->m_iLockMode = LockMode::NUMERIC;
+         newItem->SetLockCode(lockpass);
+         newItem->SetLockState(LOCK_STATE_LOCKED);
+         newItem->SetLockMode(LockMode::NUMERIC);
        }
 
        Add(newItem);
@@ -187,8 +187,8 @@ void CPlayListXML::Save(const std::string& strFileName) const
       write += StringUtils::Format("    <channel>{}</channel>",
                                    item->GetProperty("remotechannel").asString());
 
-    if (item->m_iHasLock > LOCK_STATE_NO_LOCK)
-      write += StringUtils::Format("    <lockpassword>{}<lockpassword>", item->m_strLockCode);
+    if (item->GetLockState() > LOCK_STATE_NO_LOCK)
+      write += StringUtils::Format("    <lockpassword>{}<lockpassword>", item->GetLockCode());
 
     write += StringUtils::Format("  </stream>\n\n" );
   }

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -274,8 +274,8 @@ void CPowerManager::StorePlayerState()
       m_lastPlayedFileItem->SetStartOffset(m_lastPlayedFileItem->GetStartOffset() +
                                            stackHelper->GetCurrentStackPartStartTimeMs());
     // in case of iso stack, keep track of part number
-    m_lastPlayedFileItem->m_lStartPartNumber =
-        stackHelper->IsPlayingISOStack() ? stackHelper->GetCurrentPartNumber() + 1 : 1;
+    m_lastPlayedFileItem->SetStartPartNumber(
+        stackHelper->IsPlayingISOStack() ? stackHelper->GetCurrentPartNumber() + 1 : 1);
     // for iso and iso stacks, keep track of playerstate
     m_lastPlayedFileItem->SetProperty("savedplayerstate", appPlayer->GetPlayerState());
     CLog::Log(LOGDEBUG,

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -160,7 +160,8 @@ std::string CGUIWindowPrograms::GetStartFolder(const std::string &dir)
   int iIndex = CUtil::GetMatchingSource(dir, shares, bIsSourceName);
   if (iIndex > -1)
   {
-    if (iIndex < static_cast<int>(shares.size()) && shares[iIndex].m_iHasLock == LOCK_STATE_LOCKED)
+    if (iIndex < static_cast<int>(shares.size()) &&
+        shares[iIndex].GetLockState() == LOCK_STATE_LOCKED)
     {
       CFileItem item(shares[iIndex]);
       if (!g_passwordManager.IsItemUnlocked(&item,"programs"))

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -160,8 +160,7 @@ std::string CGUIWindowPrograms::GetStartFolder(const std::string &dir)
   int iIndex = CUtil::GetMatchingSource(dir, shares, bIsSourceName);
   if (iIndex > -1)
   {
-    if (iIndex < static_cast<int>(shares.size()) &&
-        shares[iIndex].GetLockState() == LOCK_STATE_LOCKED)
+    if (iIndex < static_cast<int>(shares.size()) && shares[iIndex].GetLockInfo().IsLocked())
     {
       CFileItem item(shares[iIndex]);
       if (!g_passwordManager.IsItemUnlocked(&item,"programs"))

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -431,7 +431,7 @@ void GetGetRecordingsSubDirectories(const CPVRRecordingsPath& recParentPath,
       item->SetPath(strFilePath);
       item->SetLabel(strCurrent);
       item->SetLabelPreformatted(true);
-      item->m_dateTime = recording->RecordingTimeAsLocalTime();
+      item->SetDateTime(recording->RecordingTimeAsLocalTime());
       item->SetProperty("totalepisodes", 0);
       item->SetProperty("watchedepisodes", 0);
       item->SetProperty("unwatchedepisodes", 0);
@@ -445,8 +445,8 @@ void GetGetRecordingsSubDirectories(const CPVRRecordingsPath& recParentPath,
     else
     {
       item = results.Get(strFilePath);
-      if (item->m_dateTime < recording->RecordingTimeAsLocalTime())
-        item->m_dateTime = recording->RecordingTimeAsLocalTime();
+      if (item->GetDateTime() < recording->RecordingTimeAsLocalTime())
+        item->SetDateTime(recording->RecordingTimeAsLocalTime());
     }
 
     item->IncrementProperty("totalepisodes", 1);
@@ -505,8 +505,9 @@ bool CPVRGUIDirectory::GetRecordingsDirectoryInfo(CFileItem& item)
       if (!recording)
         continue;
 
-      if (item.m_dateTime.IsValid() || (item.m_dateTime < recording->RecordingTimeAsLocalTime()))
-        item.m_dateTime = recording->RecordingTimeAsLocalTime();
+      const CDateTime& dateTime{item.GetDateTime()};
+      if (dateTime.IsValid() || (dateTime < recording->RecordingTimeAsLocalTime()))
+        item.SetDateTime(recording->RecordingTimeAsLocalTime());
 
       item.IncrementProperty("totalepisodes", 1);
 

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -473,7 +473,7 @@ void GetGetRecordingsSubDirectories(const CPVRRecordingsPath& recParentPath,
   {
     int64_t size = item->GetProperty("sizeinbytes").asInteger();
     item->ClearProperty("sizeinbytes");
-    item->m_dwSize = size; // We'll also sort recording folders by size
+    item->SetSize(size); // We'll also sort recording folders by size
     if (size > 0)
       item->SetProperty("recordingsize", StringUtils::SizeToString(size));
   }

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -711,7 +711,7 @@ bool CPVRGUIDirectory::GetChannelGroupsDirectory(bool bRadio,
     for (const auto& group : groups)
     {
       item = std::make_shared<CFileItem>(group->GetPath().AsString(), true);
-      item->m_strTitle = group->GroupName();
+      item->SetTitle(group->GroupName());
       item->SetLabel(group->GroupName());
       results.Add(item);
     }

--- a/xbmc/settings/MediaSourceSettings.cpp
+++ b/xbmc/settings/MediaSourceSettings.cpp
@@ -206,11 +206,11 @@ bool CMediaSourceSettings::UpdateSource(std::string_view strType,
       if (strUpdateChild == "name")
         share.strName = strUpdateValue;
       else if (strUpdateChild == "lockmode")
-        share.m_iLockMode = static_cast<LockMode>(std::strtol(strUpdateValue.c_str(), nullptr, 10));
+        share.SetLockMode(static_cast<LockMode>(std::strtol(strUpdateValue.c_str(), nullptr, 10)));
       else if (strUpdateChild == "lockcode")
-        share.m_strLockCode = strUpdateValue;
+        share.SetLockCode(strUpdateValue);
       else if (strUpdateChild == "badpwdcount")
-        share.m_iBadPwdCount = (int)std::strtol(strUpdateValue.c_str(), nullptr, 10);
+        share.SetBadPwdCount(static_cast<int>(std::strtol(strUpdateValue.c_str(), nullptr, 10)));
       else if (strUpdateChild == "thumbnail")
         share.m_strThumbnailImage = strUpdateValue;
       else if (strUpdateChild == "path")
@@ -418,21 +418,21 @@ bool CMediaSourceSettings::GetSource(const std::string& category,
 
   share.FromNameAndPaths(name, verifiedPaths);
 
-  share.m_iBadPwdCount = 0;
+  share.ResetBadPwdCount();
   if (lockModeElement)
   {
-    share.m_iLockMode =
-        static_cast<LockMode>(std::strtol(lockModeElement->FirstChild()->Value(), nullptr, 10));
-    share.m_iHasLock = LOCK_STATE_LOCKED;
+    share.SetLockMode(
+        static_cast<LockMode>(std::strtol(lockModeElement->FirstChild()->Value(), nullptr, 10)));
+    share.SetLockState(LOCK_STATE_LOCKED);
   }
 
   if (lockCodeElement && lockCodeElement->FirstChild())
-    share.m_strLockCode = lockCodeElement->FirstChild()->Value();
+    share.SetLockCode(lockCodeElement->FirstChild()->Value());
 
   if (badPwdCountElement && badPwdCountElement->FirstChild())
   {
-    share.m_iBadPwdCount =
-        static_cast<int>(std::strtol(badPwdCountElement->FirstChild()->Value(), nullptr, 10));
+    share.SetBadPwdCount(
+        static_cast<int>(std::strtol(badPwdCountElement->FirstChild()->Value(), nullptr, 10)));
   }
 
   if (thumbnailNodeElement && thumbnailNodeElement->FirstChild())
@@ -516,11 +516,11 @@ bool CMediaSourceSettings::SetSources(tinyxml2::XMLNode* root,
     for (const auto& path : share.vecPaths)
       XMLUtils::SetPath(sourceElement, "path", path);
 
-    if (share.m_iHasLock)
+    if (share.GetLockState())
     {
-      XMLUtils::SetInt(sourceElement, "lockmode", static_cast<int>(share.m_iLockMode));
-      XMLUtils::SetString(sourceElement, "lockcode", share.m_strLockCode);
-      XMLUtils::SetInt(sourceElement, "badpwdcount", share.m_iBadPwdCount);
+      XMLUtils::SetInt(sourceElement, "lockmode", static_cast<int>(share.GetLockMode()));
+      XMLUtils::SetString(sourceElement, "lockcode", share.GetLockCode());
+      XMLUtils::SetInt(sourceElement, "badpwdcount", share.GetBadPwdCount());
     }
 
     if (!share.m_strThumbnailImage.empty())

--- a/xbmc/test/TestMediaSource.cpp
+++ b/xbmc/test/TestMediaSource.cpp
@@ -20,8 +20,13 @@ CMediaSource createRef(const std::string& path,
                        const std::string& name,
                        SourceType type = SourceType::LOCAL)
 {
-  return CMediaSource{name, "", "",     path,  type, LockMode::EVERYONE, "", 0,
-                      0,    "", {path}, false, false};
+  CMediaSource source;
+  source.strPath = path;
+  source.strName = name;
+  source.m_iDriveType = type;
+  source.vecPaths = {path};
+  source.m_allowSharing = false;
+  return source;
 }
 
 CMediaSource createRefv(const std::string& path,
@@ -29,8 +34,13 @@ CMediaSource createRefv(const std::string& path,
                         const std::string& name,
                         SourceType type)
 {
-  return CMediaSource{name, "", "",    path,  type, LockMode::EVERYONE, "", 0,
-                      0,    "", paths, false, false};
+  CMediaSource source;
+  source.strPath = path;
+  source.strName = name;
+  source.m_iDriveType = type;
+  source.vecPaths = paths;
+  source.m_allowSharing = false;
+  return source;
 }
 
 struct FromNameAndPathDef

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -139,6 +139,7 @@ set(HEADERS ActorProtocol.h
             LangCodeExpander.h
             LegacyPathTranslation.h
             Locale.h
+            LockInfo.h
             log.h
             logtypes.h
             Map.h

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -149,7 +149,7 @@ bool CFileUtils::RemoteAccessAllowed(const std::string &strPath)
     std::vector<CMediaSource>* sources = CMediaSourceSettings::GetInstance().GetSources(sourceName);
     int sourceIndex = CUtil::GetMatchingSource(realPath, *sources, isSource);
     if (sourceIndex >= 0 && sourceIndex < static_cast<int>(sources->size()) &&
-        sources->at(sourceIndex).GetLockState() != LOCK_STATE_LOCKED &&
+        !sources->at(sourceIndex).GetLockInfo().IsLocked() &&
         sources->at(sourceIndex).m_allowSharing)
       return true;
   }
@@ -160,8 +160,7 @@ bool CFileUtils::RemoteAccessAllowed(const std::string &strPath)
   //! @todo Make sharing of auto-mounted sources user configurable
   int sourceIndex = CUtil::GetMatchingSource(realPath, sources, isSource);
   if (sourceIndex >= 0 && sourceIndex < static_cast<int>(sources.size()) &&
-      sources.at(sourceIndex).GetLockState() != LOCK_STATE_LOCKED &&
-      sources.at(sourceIndex).m_allowSharing)
+      !sources.at(sourceIndex).GetLockInfo().IsLocked() && sources.at(sourceIndex).m_allowSharing)
     return true;
 
   return false;

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -149,7 +149,7 @@ bool CFileUtils::RemoteAccessAllowed(const std::string &strPath)
     std::vector<CMediaSource>* sources = CMediaSourceSettings::GetInstance().GetSources(sourceName);
     int sourceIndex = CUtil::GetMatchingSource(realPath, *sources, isSource);
     if (sourceIndex >= 0 && sourceIndex < static_cast<int>(sources->size()) &&
-        sources->at(sourceIndex).m_iHasLock != LOCK_STATE_LOCKED &&
+        sources->at(sourceIndex).GetLockState() != LOCK_STATE_LOCKED &&
         sources->at(sourceIndex).m_allowSharing)
       return true;
   }
@@ -160,7 +160,7 @@ bool CFileUtils::RemoteAccessAllowed(const std::string &strPath)
   //! @todo Make sharing of auto-mounted sources user configurable
   int sourceIndex = CUtil::GetMatchingSource(realPath, sources, isSource);
   if (sourceIndex >= 0 && sourceIndex < static_cast<int>(sources.size()) &&
-      sources.at(sourceIndex).m_iHasLock != LOCK_STATE_LOCKED &&
+      sources.at(sourceIndex).GetLockState() != LOCK_STATE_LOCKED &&
       sources.at(sourceIndex).m_allowSharing)
     return true;
 

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -261,7 +261,7 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
       value = StringUtils::Format("{:.1f}", movie->GetRating().rating);
     break;
   case 'C': // programs count
-    value = std::to_string(item->m_iprogramCount);
+    value = std::to_string(item->GetProgramCount());
     break;
   case 'c': // relevance
     value = std::to_string(movie->m_relevance);

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -267,7 +267,7 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     value = std::to_string(movie->m_relevance);
     break;
   case 'K':
-    value = item->m_strTitle;
+    value = item->GetTitle();
     break;
   case 'M':
     if (movie && movie->m_iEpisode > 0)

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -229,14 +229,17 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
         nDuration = movie->GetDuration();
       if (nDuration > 0)
         value = StringUtils::SecondsToTimeString(nDuration, (nDuration >= 3600) ? TIME_FORMAT_H_MM_SS : TIME_FORMAT_MM_SS);
-      else if (item->m_dwSize > 0)
-        value = StringUtils::SizeToString(item->m_dwSize);
+      else if (item->GetSize() > 0)
+        value = StringUtils::SizeToString(item->GetSize());
     }
     break;
   case 'I': // size
-    if( (item->m_bIsFolder && item->m_dwSize != 0) || item->m_dwSize >= 0 )
-      value = StringUtils::SizeToString(item->m_dwSize);
+  {
+    const int64_t size{item->GetSize()};
+    if ((item->m_bIsFolder && size != 0) || size >= 0)
+      value = StringUtils::SizeToString(item->GetSize());
     break;
+  }
   case 'J': // date
   {
     const CDateTime& dateTime{item->GetDateTime()};
@@ -312,8 +315,12 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
       value = std::to_string(movie->GetPlayCount());
     break;
   case 'X': // Bitrate
-    if( !item->m_bIsFolder && item->m_dwSize != 0 )
-      value = StringUtils::Format("{} kbps", item->m_dwSize);
+    if (!item->m_bIsFolder)
+    {
+      const int64_t size{item->GetSize()};
+      if (size != 0)
+        value = StringUtils::Format("{} kbps", size);
+    }
     break;
    case 'W': // Listeners
     if( !item->m_bIsFolder && music && music->GetListeners() != 0 )

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -238,13 +238,19 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
       value = StringUtils::SizeToString(item->m_dwSize);
     break;
   case 'J': // date
-    if (item->m_dateTime.IsValid())
-      value = item->m_dateTime.GetAsLocalizedDate();
+  {
+    const CDateTime& dateTime{item->GetDateTime()};
+    if (dateTime.IsValid())
+      value = dateTime.GetAsLocalizedDate();
     break;
+  }
   case 'Q': // time
-    if (item->m_dateTime.IsValid())
-      value = item->m_dateTime.GetAsLocalizedTime("", false);
+  {
+    const CDateTime& dateTime{item->GetDateTime()};
+    if (dateTime.IsValid())
+      value = dateTime.GetAsLocalizedTime("", false);
     break;
+  }
   case 'R': // rating
     if (music && music->GetRating() != 0.f)
       value = StringUtils::Format("{:.1f}", music->GetRating());
@@ -334,9 +340,12 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     }
     break;
   case 'd': // date and time
-    if (item->m_dateTime.IsValid())
-      value = item->m_dateTime.GetAsLocalizedDateTime();
+  {
+    const CDateTime& dateTime{item->GetDateTime()};
+    if (dateTime.IsValid())
+      value = dateTime.GetAsLocalizedDateTime();
     break;
+  }
   case 'p': // Last played
     if (movie && movie->m_lastPlayed.IsValid())
       value = movie->m_lastPlayed.GetAsLocalizedDate();

--- a/xbmc/utils/LockInfo.h
+++ b/xbmc/utils/LockInfo.h
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "LockMode.h"
+#include "media/MediaLockState.h"
+
+#include <string>
+#include <string_view>
+
+namespace KODI::UTILS
+{
+class CLockInfo
+{
+public:
+  CLockInfo() = default;
+
+  /*!
+  \brief The type of Lock UI to show when accessing the media source.
+
+  Value can be:
+  - LockMode::EVERYONE \n
+  Default value.  No lock UI is shown, user can freely access the source.
+  - LockMode::NUMERIC \n
+  Lock code is entered via OSD numpad or IrDA remote buttons.
+  - LockMode::GAMEPAD \n
+  Lock code is entered via XBOX gamepad buttons.
+  - LockMode::QWERTY \n
+  Lock code is entered via OSD keyboard or PC USB keyboard.
+  - LockMode::SAMBA \n
+  Lock code is entered via OSD keyboard or PC USB keyboard and passed directly to SMB for authentication.
+  - LockMode::EEPROM_PARENTAL \n
+  Lock code is retrieved from XBOX EEPROM and entered via XBOX gamepad or remote.
+  - LockMode::UNKNOWN \n
+  Value is unknown or unspecified.
+  */
+  LockMode GetMode() const { return m_mode; }
+  void SetMode(LockMode mode) { m_mode = mode; }
+
+  const std::string& GetCode() const { return m_code; }
+  void SetCode(std::string_view code) { m_code = code; }
+
+  MediaLockState GetState() const { return m_state; }
+  void SetState(MediaLockState state) { m_state = state; }
+
+  int GetBadPasswordCount() const { return m_badPasswordCount; }
+  void SetBadPasswordCount(int count) { m_badPasswordCount = count; }
+  void ResetBadPasswordCount() { m_badPasswordCount = 0; }
+  void IncrementBadPasswordCount() { m_badPasswordCount++; }
+
+  void Set(LockMode mode, std::string_view code, MediaLockState state)
+  {
+    m_mode = mode;
+    m_code = code;
+    m_state = state;
+  }
+
+  bool IsLocked() const { return m_state == LOCK_STATE_LOCKED; }
+
+private:
+  LockMode m_mode{LockMode::EVERYONE};
+  std::string m_code;
+  MediaLockState m_state{LOCK_STATE_NO_LOCK};
+  int m_badPasswordCount{0};
+};
+} // namespace KODI::UTILS

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -355,15 +355,15 @@ bool URIUtils::GetParentPath(const std::string& strPath, std::string& strParent)
       GetParentPath(url2.Get(), strParent);
     else
       strParent = url2.Get();
-    for( int i=1;i<items.Size();++i)
+    for (const auto& item : items)
     {
-      items[i]->m_strDVDLabel = GetDirectory(items[i]->GetPath());
+      item->SetDVDLabel(GetDirectory(item->GetPath()));
       if (HasParentInHostname(url2))
-        items[i]->SetPath(GetParentPath(items[i]->m_strDVDLabel));
+        item->SetPath(GetParentPath(item->GetDVDLabel()));
       else
-        items[i]->SetPath(items[i]->m_strDVDLabel);
+        item->SetPath(item->GetDVDLabel());
 
-      GetCommonPath(strParent,items[i]->GetPath());
+      GetCommonPath(strParent, item->GetPath());
     }
     return true;
   }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4844,7 +4844,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForTvShow(const dbiplus::sql_record* con
 
   if (item != NULL)
   {
-    item->m_dateTime = details.GetPremiered();
+    item->SetDateTime(details.GetPremiered());
     item->SetProperty("totalseasons", details.m_iSeason);
     item->SetProperty("totalepisodes", details.m_iEpisode);
     item->SetProperty("numepisodes", details.m_iEpisode); // will be changed later to reflect watchmode setting
@@ -8998,7 +8998,7 @@ bool CVideoDatabase::GetEpisodesByWhere(const std::string& strBaseDir, const Fil
 
         pItem->SetOverlayImage(episode.GetPlayCount() > 0 ? CGUIListItem::ICON_OVERLAY_WATCHED
                                                           : CGUIListItem::ICON_OVERLAY_UNWATCHED);
-        pItem->m_dateTime = episode.m_firstAired;
+        pItem->SetDateTime(episode.m_firstAired);
         items.Add(pItem);
       }
     }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -12754,7 +12754,7 @@ void CVideoDatabase::GetVideoVersions(VideoDbContentType itemType,
         infoTag.m_fanart = videoItem.GetVideoInfoTag()->m_fanart;
 
         auto item(std::make_shared<CFileItem>(infoTag));
-        item->m_strTitle = name;
+        item->SetTitle(name);
         item->SetLabel(name);
 
         CVideoDbUrl itemUrl;
@@ -12827,7 +12827,7 @@ void CVideoDatabase::GetDefaultVideoVersion(VideoDbContentType itemType, int dbI
         infoTag.m_strTitle = name;
 
         item.SetFromVideoInfoTag(infoTag);
-        item.m_strTitle = name;
+        item.SetTitle(name);
         item.SetLabel(name);
       }
     }
@@ -13214,7 +13214,7 @@ bool CVideoDatabase::GetVideoVersionTypes(VideoDbContentType idContent,
       item->GetVideoInfoTag()->GetAssetInfo().SetTitle(name);
       item->GetVideoInfoTag()->m_strTitle = name;
 
-      item->m_strTitle = name;
+      item->SetTitle(name);
       item->SetLabel(name);
 
       items.Add(item);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2196,8 +2196,9 @@ CVideoInfoScanner::~CVideoInfoScanner()
       {
         // allow plugin to calculate hash itself using strings rather than binary data for size and date
         // according to ListItem.setInfo() documentation date format should be "d.m.Y"
-        if (pItem->m_dwSize)
-          digest.Update(std::to_string(pItem->m_dwSize));
+        const int64_t size{pItem->GetSize()};
+        if (size)
+          digest.Update(std::to_string(size));
 
         const CDateTime& dateTime{pItem->GetDateTime()};
         if (dateTime.IsValid())
@@ -2206,7 +2207,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
       }
       else
       {
-        digest.Update(&pItem->m_dwSize, sizeof(pItem->m_dwSize));
+        const int64_t size{pItem->GetSize()};
+        digest.Update(&size, sizeof(size));
         KODI::TIME::FileTime time{};
         pItem->GetDateTime().GetAsTimeStamp(time);
         digest.Update(&time, sizeof(time));

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2198,16 +2198,18 @@ CVideoInfoScanner::~CVideoInfoScanner()
         // according to ListItem.setInfo() documentation date format should be "d.m.Y"
         if (pItem->m_dwSize)
           digest.Update(std::to_string(pItem->m_dwSize));
-        if (pItem->m_dateTime.IsValid())
-          digest.Update(StringUtils::Format("{:02}.{:02}.{:04}", pItem->m_dateTime.GetDay(),
-                                            pItem->m_dateTime.GetMonth(),
-                                            pItem->m_dateTime.GetYear()));
+
+        const CDateTime& dateTime{pItem->GetDateTime()};
+        if (dateTime.IsValid())
+          digest.Update(StringUtils::Format("{:02}.{:02}.{:04}", dateTime.GetDay(),
+                                            dateTime.GetMonth(), dateTime.GetYear()));
       }
       else
       {
         digest.Update(&pItem->m_dwSize, sizeof(pItem->m_dwSize));
-        KODI::TIME::FileTime time = pItem->m_dateTime;
-        digest.Update(&time, sizeof(KODI::TIME::FileTime));
+        KODI::TIME::FileTime time{};
+        pItem->GetDateTime().GetAsTimeStamp(time);
+        digest.Update(&time, sizeof(time));
       }
       if (IsVideo(*pItem) && !PLAYLIST::IsPlayList(*pItem) && !pItem->IsNFO())
         count++;

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -175,8 +175,7 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
 
 bool CVideoThumbLoader::LoadItemCached(CFileItem* pItem)
 {
-  if (pItem->m_bIsShareOrDrive
-  ||  pItem->IsParentFolder())
+  if (pItem->IsShareOrDrive() || pItem->IsParentFolder())
     return false;
 
   m_videoDatabase->Open();
@@ -235,7 +234,7 @@ bool CVideoThumbLoader::LoadItemCached(CFileItem* pItem)
 
 bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
 {
-  if (pItem->m_bIsShareOrDrive || pItem->IsParentFolder() || pItem->GetPath() == "add")
+  if (pItem->IsShareOrDrive() || pItem->IsParentFolder() || pItem->GetPath() == "add")
     return false;
 
   if (pItem->HasVideoInfoTag() && !pItem->GetVideoInfoTag()->m_type.empty() &&

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -305,7 +305,7 @@ void CGUIDialogVideoManager::Remove()
 void CGUIDialogVideoManager::Rename()
 {
   const int idAsset{
-      ChooseVideoAsset(m_videoAsset, GetVideoAssetType(), m_selectedVideoAsset->m_strTitle)};
+      ChooseVideoAsset(m_videoAsset, GetVideoAssetType(), m_selectedVideoAsset->GetTitle())};
   if (idAsset != -1)
   {
     //! @todo db refactor: should not be version, but asset

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -154,7 +154,7 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
     }
 
     // Check if we add a locked share
-    if (!item->IsPVR() && item->m_bIsShareOrDrive)
+    if (!item->IsPVR() && item->IsShareOrDrive())
     {
       if (!g_passwordManager.IsItemUnlocked(item.get(), "video"))
         return;

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -118,7 +118,7 @@ SortDescription GetSortDescription(const CGUIViewState& state, const CFileItemLi
       // check whether at least one item has actually a valid date set
       for (const auto& item : items)
       {
-        if (item->m_dateTime.IsValid())
+        if (item->GetDateTime().IsValid())
         {
           // fallback, if neither ByEpisode nor ByYear is available
           sortDescDate = sortDescription;

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -362,7 +362,7 @@ void AddItemToPlayListAndPlay(const std::shared_ptr<CFileItem>& itemToQueue,
     {
       if (queuedItem->IsSamePath(itemToPlay.get()))
       {
-        queuedItem->m_lStartPartNumber = itemToPlay->m_lStartPartNumber;
+        queuedItem->SetStartPartNumber(itemToPlay->GetStartPartNumber());
         break;
       }
       pos++;

--- a/xbmc/video/guilib/VideoPlayActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.cpp
@@ -178,12 +178,12 @@ void CVideoPlayActionProcessor::SetResumeData()
 {
   if (m_chosenStackPart)
   {
-    m_item->m_lStartPartNumber = m_chosenStackPart;
+    m_item->SetStartPartNumber(m_chosenStackPart);
     m_item->SetStartOffset(VIDEO::UTILS::GetStackPartResumeOffset(*m_item, m_chosenStackPart));
   }
   else
   {
-    m_item->m_lStartPartNumber = 1;
+    m_item->SetStartPartNumber(1);
     m_item->SetStartOffset(STARTOFFSET_RESUME);
   }
 }
@@ -192,12 +192,12 @@ void CVideoPlayActionProcessor::SetStartData()
 {
   if (m_chosenStackPart)
   {
-    m_item->m_lStartPartNumber = m_chosenStackPart;
+    m_item->SetStartPartNumber(m_chosenStackPart);
     m_item->SetStartOffset(VIDEO::UTILS::GetStackPartStartOffset(*m_item, m_chosenStackPart));
   }
   else
   {
-    m_item->m_lStartPartNumber = 1;
+    m_item->SetStartPartNumber(1);
     m_item->SetStartOffset(0);
   }
 }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -220,7 +220,7 @@ bool CGUIWindowVideoBase::OnMessage(CGUIMessage& message)
 
 bool CGUIWindowVideoBase::OnItemInfo(const CFileItem& fileItem)
 {
-  if (fileItem.IsParentFolder() || fileItem.m_bIsShareOrDrive || fileItem.IsPath("add") ||
+  if (fileItem.IsParentFolder() || fileItem.IsShareOrDrive() || fileItem.IsPath("add") ||
       (PLAYLIST::IsPlayList(fileItem) && !URIUtils::HasExtension(fileItem.GetDynPath(), ".strm")))
     return false;
 

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -792,7 +792,7 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
     CFileItemPtr pItem(new CFileItem(".."));
     pItem->SetPath(strParentPath);
     pItem->m_bIsFolder = true;
-    pItem->m_bIsShareOrDrive = false;
+    pItem->SetIsShareOrDrive(false);
     items.AddFront(pItem, 0);
   }
 
@@ -1078,14 +1078,14 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
 
   if (pItem->m_bIsFolder)
   {
-    if ( pItem->m_bIsShareOrDrive )
+    if (pItem->IsShareOrDrive())
     {
       const std::string& strLockType=m_guiState->GetLockType();
       if (profileManager->GetMasterProfile().getLockMode() != LockMode::EVERYONE)
         if (!strLockType.empty() && !g_passwordManager.IsItemUnlocked(pItem.get(), strLockType))
             return true;
 
-      if (!HaveDiscOrConnection(pItem->GetPath(), pItem->m_iDriveType))
+      if (!HaveDiscOrConnection(pItem->GetPath(), pItem->GetDriveType()))
         return true;
     }
 
@@ -1232,7 +1232,7 @@ bool CGUIMediaWindow::HaveDiscOrConnection(const std::string& strPath, SourceTyp
  */
 void CGUIMediaWindow::ShowShareErrorMessage(CFileItem* pItem) const
 {
-  if (!pItem->m_bIsShareOrDrive)
+  if (!pItem->IsShareOrDrive())
     return;
 
   int idMessageText = 0;
@@ -1240,7 +1240,7 @@ void CGUIMediaWindow::ShowShareErrorMessage(CFileItem* pItem) const
 
   if (url.IsProtocol("smb") && url.GetHostName().empty()) //  smb workgroup
     idMessageText = 15303; // Workgroup not found
-  else if (pItem->m_iDriveType == SourceType::REMOTE || URIUtils::IsRemote(pItem->GetPath()))
+  else if (pItem->GetDriveType() == SourceType::REMOTE || URIUtils::IsRemote(pItem->GetPath()))
     idMessageText = 15301; // Could not connect to network server
   else
     idMessageText = 15300; // Path not found or invalid
@@ -1365,13 +1365,13 @@ void CGUIMediaWindow::RestoreSelectedItemFromHistory()
  */
 void CGUIMediaWindow::GetDirectoryHistoryString(const CFileItem* pItem, std::string& strHistoryString) const
 {
-  if (pItem->m_bIsShareOrDrive)
+  if (pItem->IsShareOrDrive())
   {
     // We are in the virtual directory
 
     // History string of the DVD drive
     // must be handled separately
-    if (pItem->m_iDriveType == SourceType::OPTICAL_DISC)
+    if (pItem->GetDriveType() == SourceType::OPTICAL_DISC)
     {
       // Remove disc label from item label
       // and use as history string, m_strPath
@@ -1996,7 +1996,7 @@ void CGUIMediaWindow::OnFilterItems(const std::string &filter)
     CFileItemPtr pItem(new CFileItem(".."));
     pItem->SetPath(m_history.GetParentPath());
     pItem->m_bIsFolder = true;
-    pItem->m_bIsShareOrDrive = false;
+    pItem->SetIsShareOrDrive(false);
     m_vecItems->AddFront(pItem, 0);
   }
 

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -350,7 +350,7 @@ void CGUIWindowFileManager::OnSort(int iList)
   for (int i = 0; i < m_vecItems[iList]->Size(); i++)
   {
     CFileItemPtr pItem = m_vecItems[iList]->Get(i);
-    if (pItem->m_bIsFolder && (!pItem->m_dwSize || pItem->IsPath("add")))
+    if (pItem->m_bIsFolder && (!pItem->GetSize() || pItem->IsPath("add")))
       pItem->SetLabel2("");
     else
       pItem->SetFileSizeLabel();
@@ -364,7 +364,7 @@ void CGUIWindowFileManager::OnSort(int iList)
         auto freeSpace = space(pItem->GetPath(), ec);
         if (ec.value() == 0)
         {
-          pItem->m_dwSize = freeSpace.free;
+          pItem->SetSize(freeSpace.free);
           pItem->SetFileSizeLabel();
         }
       }
@@ -374,7 +374,7 @@ void CGUIWindowFileManager::OnSort(int iList)
         auto freeSpace = space(pItem->GetPath(), ec);
         if (ec.value() == 0)
         {
-          pItem->m_dwSize = freeSpace.capacity;
+          pItem->SetSize(freeSpace.capacity);
           pItem->SetFileSizeLabel();
         }
       }
@@ -433,7 +433,7 @@ void CGUIWindowFileManager::UpdateItemCounts()
       if (item->IsSelected())
       {
         selectedCount++;
-        selectedSize += item->m_dwSize;
+        selectedSize += item->GetSize();
       }
       totalCount++;
     }
@@ -1136,7 +1136,7 @@ void CGUIWindowFileManager::OnPopupMenu(int list, int item, bool bContextDriven 
         int64_t folderSize = CalculateFolderSize(pItem2->GetPath(), progress);
         if (folderSize >= 0)
         {
-          pItem2->m_dwSize = folderSize;
+          pItem2->SetSize(folderSize);
           if (folderSize == 0)
             pItem2->SetLabel2(StringUtils::SizeToString(folderSize));
           else
@@ -1205,7 +1205,7 @@ int64_t CGUIWindowFileManager::CalculateFolderSize(const std::string &strDirecto
       totalSize += folderSize;
     }
     else // file
-      totalSize += items[i]->m_dwSize;
+      totalSize += items[i]->GetSize();
   }
   return totalSize;
 }

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -356,7 +356,7 @@ void CGUIWindowFileManager::OnSort(int iList)
       pItem->SetFileSizeLabel();
 
     // Set free space on disc
-    if (pItem->m_bIsShareOrDrive)
+    if (pItem->IsShareOrDrive())
     {
       if (pItem->IsHD())
       {
@@ -511,7 +511,7 @@ bool CGUIWindowFileManager::Update(int iList, const std::string &strDirectory)
     CFileItemPtr pItem(new CFileItem(".."));
     pItem->SetPath(m_rootDir.IsSource(strDirectory) ? "" : strParentPath);
     pItem->m_bIsFolder = true;
-    pItem->m_bIsShareOrDrive = false;
+    pItem->SetIsShareOrDrive(false);
     m_vecItems[iList]->AddFront(pItem, 0);
   }
 
@@ -606,8 +606,7 @@ void CGUIWindowFileManager::OnClick(int iList, int iItem)
   {
     // save path + drive type because of the possible refresh
     std::string strPath = pItem->GetPath();
-    auto iDriveType = pItem->m_iDriveType;
-    if (pItem->m_bIsShareOrDrive)
+    if (pItem->IsShareOrDrive())
     {
       if ( !g_passwordManager.IsItemUnlocked( pItem.get(), "files" ) )
       {
@@ -615,7 +614,7 @@ void CGUIWindowFileManager::OnClick(int iList, int iItem)
         return ;
       }
 
-      if ( !HaveDiscOrConnection( strPath, iDriveType ) )
+      if (!HaveDiscOrConnection(strPath, pItem->GetDriveType()))
         return ;
     }
     if (!Update(iList, strPath))
@@ -733,7 +732,7 @@ void CGUIWindowFileManager::OnMark(int iList, int iItem)
 {
   CFileItemPtr pItem = m_vecItems[iList]->Get(iItem);
 
-  if (!pItem->m_bIsShareOrDrive)
+  if (!pItem->IsShareOrDrive())
   {
     if (!pItem->IsParentFolder())
     {
@@ -892,13 +891,13 @@ void CGUIWindowFileManager::GoParentFolder(int iList)
 /// \param strHistoryString History string build as return value
 void CGUIWindowFileManager::GetDirectoryHistoryString(const CFileItem* pItem, std::string& strHistoryString)
 {
-  if (pItem->m_bIsShareOrDrive)
+  if (pItem->IsShareOrDrive())
   {
     // We are in the virtual directory
 
     // History string of the DVD drive
     // must be handled separately
-    if (pItem->m_iDriveType == SourceType::OPTICAL_DISC)
+    if (pItem->GetDriveType() == SourceType::OPTICAL_DISC)
     {
       // Remove disc label from item label
       // and use as history string, m_strPath
@@ -1236,7 +1235,7 @@ void CGUIWindowFileManager::ShowShareErrorMessage(CFileItem* pItem)
 
   if (url.IsProtocol("smb") && url.GetHostName().empty()) //  smb workgroup
     idMessageText = 15303; // Workgroup not found
-  else if (pItem->m_iDriveType == SourceType::REMOTE || URIUtils::IsRemote(pItem->GetPath()))
+  else if (pItem->GetDriveType() == SourceType::REMOTE || URIUtils::IsRemote(pItem->GetPath()))
     idMessageText = 15301; // Could not connect to network server
   else
     idMessageText = 15300; // Path not found or invalid


### PR DESCRIPTION
No functional changes intended, only modernization and optimization of class `CFileItem` and `CFileItemList`.

**CFileItem**
* Concise syntax should be used for concatenatable namespaces cpp:S5812
* "using" should be preferred for type aliasing cpp:S5416
* "std::string_view" should be used to pass a read-only string to a function cpp:S6009
* Macros should not be used to define constants cpp:S5028
* "nullptr" should be used to denote the null pointer cpp:S4962
* Return type of functions shouldn't be const qualified value cpp:S5951
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* Member data should be initialized in-class or in a constructor initialization list cpp:S3230
* Structured binding should be used cpp:S6005
* Loop variables should be declared in the minimal possible scope cpp:S5955
* A conditionally executed single line should be denoted by indentation cpp:S3973
* Multiple variables should not be declared on the same line cpp:S1659
* "make_unique" and "make_shared" should be used to construct "unique_ptr" and "shared_ptr" cpp:S5950
* STL algorithms and range-based for loops should be preferred to traditional for loops cpp:S5566
* "std::source_location" should be used instead of "`__FILE__`", "`__LINE__`", and "`__func__`" macros cpp:S6190
* "static" members should be accessed statically cpp:S2209
* Mergeable "if" statements should be combined cpp:S1066
* "using enum" should be used in scopes with high concentration of "enum" constants cpp:S6177
* Classes should not contain both public and private data members cpp:S5414

**CFileItemList**
* "empty()" should be used to test for emptiness cpp:S1155
* "std::string_view" should be used to pass a read-only string to a function cpp:S6009
* Transparent function objects should be used with associative "std::string" containers cpp:S6045
* Return type of functions shouldn't be const qualified value cpp:S5951
* "try_emplace" should be used with "std::map" and "std::unordered_map" cpp:S6030
* "contains" should be used to check if a key exists in a container cpp:S6171
* Pointer and reference parameters should be "const" if the corresponding object is not modified cpp:S995
* "make_unique" and "make_shared" should be used to construct "unique_ptr" and "shared_ptr" cpp:S5950
* "auto" should be used to avoid repetition of types cpp:S5827
* Pointer and reference local variables should be "const" if the corresponding object is not modified cpp:S5350
* "auto" should be used to store a result of functions that conventionally return an iterator or a range cpp:S6234
* "std::source_location" should be used instead of "`__FILE__`", "`__LINE__`", and "`__func__`" macros cpp:S6190
* Multiple variables should not be declared on the same line cpp:S1659
* "static" members should be accessed statically cpp:S2209

Runtime-tested on macOS and Android, latest kodi master. No regressions found.

@neo1973 @garbear maybe something for you to review?