### PR TITLE
[Controllers] Fix disabling keyboard and mouse in game

### DIFF
--- a/xbmc/games/addons/input/GameClientInput.h
+++ b/xbmc/games/addons/input/GameClientInput.h
@@ -84,14 +84,14 @@ public:
   void CloseJoysticks(PERIPHERALS::EventLockHandlePtr& inputHandlingLock);
 
   // Keyboard functions
-  bool OpenKeyboard(const ControllerPtr& controller, const PERIPHERALS::PeripheralPtr& keyboard);
+  bool OpenKeyboard(const ControllerPtr& controller);
   bool IsKeyboardOpen() const;
-  void CloseKeyboard();
+  bool CloseKeyboard();
 
   // Mouse functions
-  bool OpenMouse(const ControllerPtr& controller, const PERIPHERALS::PeripheralPtr& mouse);
+  bool OpenMouse(const ControllerPtr& controller);
   bool IsMouseOpen() const;
-  void CloseMouse();
+  bool CloseMouse();
 
   // Agent functions
   bool HasAgent() const;

--- a/xbmc/games/agents/input/AgentInput.cpp
+++ b/xbmc/games/agents/input/AgentInput.cpp
@@ -374,11 +374,10 @@ void CAgentInput::ProcessKeyboard()
                              { return port.GetPortType() == PORT_TYPE::KEYBOARD; });
 
       // Open keyboard input
-      PERIPHERALS::PeripheralPtr keyboard = std::move(keyboards.at(0));
-      m_gameClient->Input().OpenKeyboard(it->GetActiveController().GetController(), keyboard);
+      m_gameClient->Input().OpenKeyboard(it->GetActiveController().GetController());
 
       // Save keyboard port
-      m_keyboardPort[static_cast<KEYBOARD::IKeyboardInputProvider*>(keyboard.get())] =
+      m_keyboardPort[static_cast<KEYBOARD::IKeyboardInputProvider*>(keyboards.at(0).get())] =
           it->GetAddress();
 
       SetChanged(true);
@@ -409,11 +408,10 @@ void CAgentInput::ProcessMouse()
                              { return port.GetPortType() == PORT_TYPE::MOUSE; });
 
       // Open mouse input
-      PERIPHERALS::PeripheralPtr mouse = std::move(mice.at(0));
-      m_gameClient->Input().OpenMouse(it->GetActiveController().GetController(), mouse);
+      m_gameClient->Input().OpenMouse(it->GetActiveController().GetController());
 
       // Save mouse port
-      m_mousePort[static_cast<MOUSE::IMouseInputProvider*>(mouse.get())] = it->GetAddress();
+      m_mousePort[static_cast<MOUSE::IMouseInputProvider*>(mice.at(0).get())] = it->GetAddress();
 
       SetChanged(true);
     }

--- a/xbmc/games/controllers/input/test/CMakeLists.txt
+++ b/xbmc/games/controllers/input/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES TestControllerState.cpp
             TestDefaultKeyboardTranslator.cpp
             TestDefaultMouseTranslator.cpp
+            TestPortNodeInput.cpp
 )
 
 core_add_test_library(test_games_controllers_input)

--- a/xbmc/games/controllers/input/test/TestPortNodeInput.cpp
+++ b/xbmc/games/controllers/input/test/TestPortNodeInput.cpp
@@ -1,0 +1,137 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h"
+#include "games/controllers/types/ControllerHub.h"
+#include "games/controllers/types/ControllerNode.h"
+#include "games/ports/types/PortNode.h"
+
+#include <gtest/gtest.h>
+
+using namespace KODI;
+using namespace GAME;
+
+/*!
+ * Verify that a keyboard port at the root level is returned by GetKeyboardPorts.
+ */
+TEST(TestPortNodeInput, RootKeyboard)
+{
+  // Build a hub containing a single keyboard port
+  CPortNode keyboardPort;
+  keyboardPort.SetPortType(PORT_TYPE::KEYBOARD);
+  keyboardPort.SetPortID(KEYBOARD_PORT_ID);
+  keyboardPort.SetAddress(KEYBOARD_PORT_ADDRESS);
+
+  CControllerHub hub;
+  hub.SetPorts({keyboardPort});
+
+  // Query keyboard ports
+  std::vector<std::string> keyboardPorts;
+  hub.GetKeyboardPorts(keyboardPorts);
+
+  ASSERT_EQ(keyboardPorts.size(), 1u);
+  EXPECT_EQ(keyboardPorts.front(), KEYBOARD_PORT_ADDRESS);
+}
+
+/*!
+ * Verify that a mouse port at the root level is returned by GetMousePorts.
+ */
+TEST(TestPortNodeInput, RootMouse)
+{
+  // Build a hub containing a single mouse port
+  CPortNode mousePort;
+  mousePort.SetPortType(PORT_TYPE::MOUSE);
+  mousePort.SetPortID(MOUSE_PORT_ID);
+  mousePort.SetAddress(MOUSE_PORT_ADDRESS);
+
+  CControllerHub hub;
+  hub.SetPorts({mousePort});
+
+  // Query mouse ports
+  std::vector<std::string> mousePorts;
+  hub.GetMousePorts(mousePorts);
+
+  ASSERT_EQ(mousePorts.size(), 1u);
+  EXPECT_EQ(mousePorts.front(), MOUSE_PORT_ADDRESS);
+}
+
+/*!
+ * Verify that nested keyboard ports are discovered through connected controllers.
+ */
+TEST(TestPortNodeInput, NestedKeyboard)
+{
+  // Leaf keyboard port inside a controller hub
+  CPortNode keyboardPort;
+  keyboardPort.SetPortType(PORT_TYPE::KEYBOARD);
+  keyboardPort.SetPortID(KEYBOARD_PORT_ID);
+  keyboardPort.SetAddress(std::string(DEFAULT_PORT_ADDRESS) + "/" + KEYBOARD_PORT_ID);
+
+  CControllerHub childHub;
+  childHub.SetPorts({keyboardPort});
+
+  // Controller node exposing the child hub
+  CControllerNode controllerNode;
+  controllerNode.SetHub(childHub);
+
+  // Root port connected to the controller node
+  CPortNode rootPort;
+  rootPort.SetPortType(PORT_TYPE::CONTROLLER);
+  rootPort.SetPortID(DEFAULT_PORT_ID);
+  rootPort.SetAddress(DEFAULT_PORT_ADDRESS);
+  rootPort.SetCompatibleControllers({controllerNode});
+  rootPort.SetConnected(true);
+  rootPort.SetActiveController(0);
+
+  CControllerHub rootHub;
+  rootHub.SetPorts({rootPort});
+
+  // Query keyboard ports from the root
+  std::vector<std::string> keyboardPorts;
+  rootHub.GetKeyboardPorts(keyboardPorts);
+
+  ASSERT_EQ(keyboardPorts.size(), 1u);
+  EXPECT_EQ(keyboardPorts.front(), std::string(DEFAULT_PORT_ADDRESS) + "/" + KEYBOARD_PORT_ID);
+}
+
+/*!
+ * Verify that nested mouse ports are discovered through connected controllers.
+ */
+TEST(TestPortNodeInput, NestedMouse)
+{
+  // Leaf mouse port inside a controller hub
+  CPortNode mousePort;
+  mousePort.SetPortType(PORT_TYPE::MOUSE);
+  mousePort.SetPortID(MOUSE_PORT_ID);
+  mousePort.SetAddress(std::string(DEFAULT_PORT_ADDRESS) + "/" + MOUSE_PORT_ID);
+
+  CControllerHub childHub;
+  childHub.SetPorts({mousePort});
+
+  // Controller node exposing the child hub
+  CControllerNode controllerNode;
+  controllerNode.SetHub(childHub);
+
+  // Root port connected to the controller node
+  CPortNode rootPort;
+  rootPort.SetPortType(PORT_TYPE::CONTROLLER);
+  rootPort.SetPortID(DEFAULT_PORT_ID);
+  rootPort.SetAddress(DEFAULT_PORT_ADDRESS);
+  rootPort.SetCompatibleControllers({controllerNode});
+  rootPort.SetConnected(true);
+  rootPort.SetActiveController(0);
+
+  CControllerHub rootHub;
+  rootHub.SetPorts({rootPort});
+
+  // Query mouse ports from the root
+  std::vector<std::string> mousePorts;
+  rootHub.GetMousePorts(mousePorts);
+
+  ASSERT_EQ(mousePorts.size(), 1u);
+  EXPECT_EQ(mousePorts.front(), std::string(DEFAULT_PORT_ADDRESS) + "/" + MOUSE_PORT_ID);
+}

--- a/xbmc/games/controllers/types/ControllerHub.cpp
+++ b/xbmc/games/controllers/types/ControllerHub.cpp
@@ -120,6 +120,18 @@ void CControllerHub::GetInputPorts(std::vector<std::string>& inputPorts) const
     port.GetInputPorts(inputPorts);
 }
 
+void CControllerHub::GetKeyboardPorts(std::vector<std::string>& keyboardPorts) const
+{
+  for (const CPortNode& port : m_ports)
+    port.GetKeyboardPorts(keyboardPorts);
+}
+
+void CControllerHub::GetMousePorts(std::vector<std::string>& mousePorts) const
+{
+  for (const CPortNode& port : m_ports)
+    port.GetMousePorts(mousePorts);
+}
+
 bool CControllerHub::Serialize(tinyxml2::XMLElement& controllerElement) const
 {
   // Iterate and serialize each port

--- a/xbmc/games/controllers/types/ControllerHub.h
+++ b/xbmc/games/controllers/types/ControllerHub.h
@@ -59,6 +59,20 @@ public:
    */
   void GetInputPorts(std::vector<std::string>& inputPorts) const;
 
+  /*!
+   * \brief Get a list of ports that accept keyboard input
+   *
+   * \param[out] keyboardPorts The list of keyboard ports
+   */
+  void GetKeyboardPorts(std::vector<std::string>& keyboardPorts) const;
+
+  /*!
+   * \brief Get a list of ports that accept mouse input
+   *
+   * \param[out] mousePorts The list of mouse ports
+   */
+  void GetMousePorts(std::vector<std::string>& mousePorts) const;
+
   // XML functions
   bool Serialize(tinyxml2::XMLElement& controllerElement) const;
   bool Deserialize(const tinyxml2::XMLElement& controllerElement);

--- a/xbmc/games/controllers/types/ControllerNode.cpp
+++ b/xbmc/games/controllers/types/ControllerNode.cpp
@@ -155,6 +155,16 @@ void CControllerNode::GetInputPorts(std::vector<std::string>& inputPorts) const
   m_hub->GetInputPorts(inputPorts);
 }
 
+void CControllerNode::GetKeyboardPorts(std::vector<std::string>& keyboardPorts) const
+{
+  m_hub->GetKeyboardPorts(keyboardPorts);
+}
+
+void CControllerNode::GetMousePorts(std::vector<std::string>& mousePorts) const
+{
+  m_hub->GetMousePorts(mousePorts);
+}
+
 bool CControllerNode::Serialize(tinyxml2::XMLElement& controllerElement) const
 {
   // Validate state

--- a/xbmc/games/controllers/types/ControllerNode.h
+++ b/xbmc/games/controllers/types/ControllerNode.h
@@ -116,6 +116,20 @@ public:
    */
   void GetInputPorts(std::vector<std::string>& activePorts) const;
 
+  /*!
+   * \brief Get a list of ports that accept keyboard input
+   *
+   * \param[out] keyboardPorts The list of keyboard ports
+   */
+  void GetKeyboardPorts(std::vector<std::string>& keyboardPorts) const;
+
+  /*!
+   * \brief Get a list of ports that accept mouse input
+   *
+   * \param[out] mousePorts The list of mouse ports
+   */
+  void GetMousePorts(std::vector<std::string>& mousePorts) const;
+
   // XML functions
   bool Serialize(tinyxml2::XMLElement& controllerElement) const;
   bool Deserialize(const tinyxml2::XMLElement& controllerElement);

--- a/xbmc/games/ports/types/PortNode.cpp
+++ b/xbmc/games/ports/types/PortNode.cpp
@@ -168,6 +168,34 @@ void CPortNode::GetInputPorts(std::vector<std::string>& inputPorts) const
   }
 }
 
+void CPortNode::GetKeyboardPorts(std::vector<std::string>& keyboardPorts) const
+{
+  // Base case: we're a keyboard port
+  if (GetPortType() == PORT_TYPE::KEYBOARD)
+    keyboardPorts.emplace_back(GetAddress());
+
+  // Visit children
+  if (IsConnected())
+  {
+    const CControllerNode& controller = GetActiveController();
+    controller.GetKeyboardPorts(keyboardPorts);
+  }
+}
+
+void CPortNode::GetMousePorts(std::vector<std::string>& mousePorts) const
+{
+  // Base case: we're a mouse port
+  if (GetPortType() == PORT_TYPE::MOUSE)
+    mousePorts.emplace_back(GetAddress());
+
+  // Visit children
+  if (IsConnected())
+  {
+    const CControllerNode& controller = GetActiveController();
+    controller.GetMousePorts(mousePorts);
+  }
+}
+
 void CPortNode::GetPort(CPhysicalPort& port) const
 {
   std::vector<std::string> accepts;

--- a/xbmc/games/ports/types/PortNode.h
+++ b/xbmc/games/ports/types/PortNode.h
@@ -127,6 +127,20 @@ public:
    */
   void GetInputPorts(std::vector<std::string>& inputPorts) const;
 
+  /*!
+   * \brief Get a list of ports that accept keyboard input
+   *
+   * \param[out] keyboardPorts The list of keyboard ports
+   */
+  void GetKeyboardPorts(std::vector<std::string>& keyboardPorts) const;
+
+  /*!
+   * \brief Get a list of ports that accept mouse input
+   *
+   * \param[out] mousePorts The list of mouse ports
+   */
+  void GetMousePorts(std::vector<std::string>& mousePorts) const;
+
   // XML functions
   bool Serialize(tinyxml2::XMLElement& portElement) const;
   bool Deserialize(const tinyxml2::XMLElement& portElement);

--- a/xbmc/games/ports/windows/GUIPortList.cpp
+++ b/xbmc/games/ports/windows/GUIPortList.cpp
@@ -285,9 +285,29 @@ void CGUIPortList::OnControllerSelected(const CPortNode& port, const ControllerP
     const bool bConnected = static_cast<bool>(controller);
 
     // Update the game client
-    const bool bSuccess =
-        bConnected ? m_gameClient->Input().ConnectController(port.GetAddress(), controller)
-                   : m_gameClient->Input().DisconnectController(port.GetAddress());
+    bool bSuccess = false;
+
+    switch (port.GetPortType())
+    {
+      case PORT_TYPE::CONTROLLER:
+        bSuccess = bConnected
+                       ? m_gameClient->Input().ConnectController(port.GetAddress(), controller)
+                       : m_gameClient->Input().DisconnectController(port.GetAddress());
+        break;
+      case PORT_TYPE::KEYBOARD:
+        bSuccess = bConnected ? m_gameClient->Input().OpenKeyboard(controller)
+                              : m_gameClient->Input().CloseKeyboard();
+        break;
+      case PORT_TYPE::MOUSE:
+        bSuccess = bConnected ? m_gameClient->Input().OpenMouse(controller)
+                              : m_gameClient->Input().CloseMouse();
+        break;
+      case PORT_TYPE::UNKNOWN:
+      default:
+        CLog::Log(LOGERROR, "Unknown port type \"{}\" for port ID \"{}\"",
+                  static_cast<int>(port.GetPortType()), port.GetAddress());
+        break;
+    }
 
     if (bSuccess)
     {


### PR DESCRIPTION
## Description

I added the ability to change controllers in game, with an option to disable a controller port. However, I never finished disabling keyboards or mice - it just showed an "Internal error" message.

This PR finishes the work, allowing them to be disabled, which means they provide _Kodi_ input during the game without affecting the game.

## How has this been tested?

Included in latest round of test builds: https://github.com/garbear/xbmc/releases/tag/retroplayer-22alpha1-20250616

Tested on macOS ARM.

Passes tests:

```
$ time make test ARGS="-R TestPortNodeInput --output-on-failure"

Running tests...
Test project /home/garrett/Documents/kodi-master/build
    Start 639: TestPortNodeInput.RootKeyboard
1/4 Test #639: TestPortNodeInput.RootKeyboard .....   Passed    0.11 sec
    Start 640: TestPortNodeInput.RootMouse
2/4 Test #640: TestPortNodeInput.RootMouse ........   Passed    0.10 sec
    Start 641: TestPortNodeInput.NestedKeyboard
3/4 Test #641: TestPortNodeInput.NestedKeyboard ...   Passed    0.10 sec
    Start 642: TestPortNodeInput.NestedMouse
4/4 Test #642: TestPortNodeInput.NestedMouse ......   Passed    0.10 sec

100% tests passed, 0 tests failed out of 4

Total Test time (real) =   0.42 sec
```


## What is the effect on users?

* Fixed disabling keyboard and mouse in games

## Screenshots (if appropriate):

DOSBOX with keyboard, mouse and controller:

<img width="1136" alt="Screenshot 2025-06-16 at 6 43 45 PM" src="https://github.com/user-attachments/assets/9e8d8206-03e8-4e7e-9027-191b9073274e" />

Before:

<img width="1135" alt="Screenshot 2025-06-16 at 6 52 41 PM" src="https://github.com/user-attachments/assets/66e1d98b-1fbd-4401-afc8-662c87f4f30c" />

After, disabling keyboard:

<img width="1135" alt="Screenshot 2025-06-16 at 6 43 57 PM" src="https://github.com/user-attachments/assets/51795b5e-bc45-4dab-baa4-0e2fa8affb98" />

After, disabling mouse:

<img width="1133" alt="Screenshot 2025-06-16 at 6 44 15 PM" src="https://github.com/user-attachments/assets/19d21bcf-038f-4f44-bc71-d6663786da7f" />

Now both are disabled, and input in the game opens the OSD (as it now "falls through" to Kodi as Kodi input).

<img width="1136" alt="Screenshot 2025-06-16 at 6 44 32 PM" src="https://github.com/user-attachments/assets/3c82d8f0-3ba2-4897-a793-50124b8cefad" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
