### PR TITLE
[VideoInfoScanner] Removed unused class variables. Moved private stat…

### DIFF
--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -294,26 +294,9 @@ namespace KODI::VIDEO
     bool m_scanAll;
     bool m_ignoreVideoVersions{false};
     bool m_ignoreVideoExtras{false};
-    std::string m_strStartDir;
     CVideoDatabase m_database;
-    std::set<std::string> m_pathsToCount;
     std::set<int> m_pathsToClean;
     std::shared_ptr<CAdvancedSettings> m_advancedSettings;
     CVideoDatabase::ScraperCache m_scraperCache;
-
-  private:
-    static void AddLocalItemArtwork(KODI::ART::Artwork& itemArt,
-                                    const std::vector<std::string>& wantedArtTypes,
-                                    const std::string& itemPath,
-                                    bool addAll,
-                                    bool exactName);
-
-    /*! \brief Retrieve the art type for an image from the given size.
-     \param width the width of the image.
-     \param height the height of the image.
-     \return "poster" if the aspect ratio is at most 4:5, "banner" if the aspect ratio
-             is at least 1:4, "thumb" otherwise.
-     */
-    static std::string GetArtTypeFromSize(unsigned int width, unsigned int height);
   };
   } // namespace KODI::VIDEO


### PR DESCRIPTION
Removed unused class variables. Moved private static methods to free functions inside the translation unit where they are used.

## Description
Clean up of VideoInfoScanner

## Motivation and context
General clean-up of code

## How has this been tested?
It builds

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
