### PR TITLE
[guilib] Two fixes for Nearest Neighbor image filter

### DIFF
--- a/xbmc/GUILargeTextureManager.h
+++ b/xbmc/GUILargeTextureManager.h
@@ -10,6 +10,7 @@
 
 #include "guilib/AspectRatio.h"
 #include "guilib/TextureManager.h"
+#include "guilib/TextureScaling.h"
 #include "jobs/IJobCallback.h"
 #include "jobs/Job.h"
 #include "threads/CriticalSection.h"
@@ -36,7 +37,8 @@ public:
                unsigned int targetWidth,
                unsigned int targetHeight,
                CAspectRatio::AspectRatio aspectRatio,
-               const bool useCache);
+               const bool useCache,
+               TEXTURE_SCALING scalingMethod);
   ~CImageLoader() override;
 
   /*!
@@ -52,6 +54,7 @@ private:
   unsigned int m_targetWidth; ///< target width of the image
   unsigned int m_targetHeight; ///< target height of the image
   CAspectRatio::AspectRatio m_aspectRatio; ///< aspect ratio mode of the image
+  TEXTURE_SCALING m_scalingMethod{TEXTURE_SCALING::LINEAR};
 };
 
 /*!
@@ -100,7 +103,8 @@ public:
                 unsigned int height,
                 CAspectRatio::AspectRatio aspectRatio,
                 bool firstRequest,
-                bool useCache = true);
+                bool useCache = true,
+                TEXTURE_SCALING scalingMethod = TEXTURE_SCALING::LINEAR);
 
   /*!
    \brief Request a texture to be unloaded.
@@ -119,7 +123,8 @@ public:
                     unsigned int width,
                     unsigned int height,
                     CAspectRatio::AspectRatio aspectRatio,
-                    bool immediately = false);
+                    bool immediately = false,
+                    TEXTURE_SCALING scalingMethod = TEXTURE_SCALING::LINEAR);
 
   /*!
    \brief Cleanup images that are no longer in use.
@@ -139,7 +144,8 @@ private:
     explicit CLargeTexture(const std::string& path,
                            unsigned int targetWidth,
                            unsigned int targetHeight,
-                           CAspectRatio::AspectRatio aspectRatio);
+                           CAspectRatio::AspectRatio aspectRatio,
+                           TEXTURE_SCALING scalingMethod);
     virtual ~CLargeTexture();
 
     void AddRef();
@@ -152,6 +158,7 @@ private:
     unsigned int GetTargetWidth() const { return m_targetWidth; }
     unsigned int GetTargetHeight() const { return m_targetHeight; }
     CAspectRatio::AspectRatio GetAspectRatio() const { return m_aspectRatio; }
+    TEXTURE_SCALING GetScalingMethod() const { return m_scalingMethod; }
 
   private:
     static const unsigned int TIME_TO_DELETE = 2000;
@@ -162,6 +169,7 @@ private:
     unsigned int m_targetWidth;
     unsigned int m_targetHeight;
     CAspectRatio::AspectRatio m_aspectRatio;
+    TEXTURE_SCALING m_scalingMethod;
     unsigned int m_timeToDelete;
   };
 
@@ -169,7 +177,8 @@ private:
                   unsigned int width,
                   unsigned int height,
                   CAspectRatio::AspectRatio aspectRatio,
-                  bool useCache = true);
+                  bool useCache = true,
+                  TEXTURE_SCALING scalingMethod = TEXTURE_SCALING::LINEAR);
 
   std::vector< std::pair<unsigned int, CLargeTexture *> > m_queued;
   std::vector<CLargeTexture *> m_allocated;

--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -156,6 +156,16 @@ bool CFFmpegImage::LoadImageFromMemory(unsigned char* buffer, unsigned int bufSi
   return !(m_pFrame == nullptr);
 }
 
+bool CFFmpegImage::LoadImageFromMemory(unsigned char* buffer,
+                                       unsigned int bufSize,
+                                       unsigned int width,
+                                       unsigned int height,
+                                       TEXTURE_SCALING scalingMethod)
+{
+  SetScalingMethod(scalingMethod);
+  return LoadImageFromMemory(buffer, bufSize, width, height);
+}
+
 bool CFFmpegImage::Initialize(unsigned char* buffer, size_t bufSize)
 {
   int bufferSize = 4096;
@@ -509,8 +519,9 @@ bool CFFmpegImage::DecodeFrame(AVFrame* frame, unsigned int width, unsigned int 
   AVColorRange range = frame->color_range;
   AVPixelFormat pixFormat = ConvertFormats(frame);
 
+  int swsFlags = (m_scalingMethod == TEXTURE_SCALING::NEAREST) ? SWS_POINT : SWS_BICUBIC;
   SwsContext* context = sws_getContext(m_originalWidth, m_originalHeight, pixFormat, width, height,
-                                       AV_PIX_FMT_RGB32, SWS_BICUBIC, NULL, NULL, NULL);
+                                       AV_PIX_FMT_RGB32, swsFlags, NULL, NULL, NULL);
 
   if (range == AVCOL_RANGE_JPEG)
   {

--- a/xbmc/guilib/FFmpegImage.h
+++ b/xbmc/guilib/FFmpegImage.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "guilib/TextureScaling.h"
 #include "iimage.h"
 
 #include <cstdint>
@@ -62,6 +63,11 @@ public:
 
   bool LoadImageFromMemory(unsigned char* buffer, unsigned int bufSize,
                            unsigned int width, unsigned int height) override;
+  bool LoadImageFromMemory(unsigned char* buffer,
+                           unsigned int bufSize,
+                           unsigned int width,
+                           unsigned int height,
+                           TEXTURE_SCALING scalingMethod) override;
   bool Decode(unsigned char * const pixels, unsigned int width, unsigned int height,
               unsigned int pitch, unsigned int format) override;
   bool CreateThumbnailFromSurface(unsigned char* bufferin, unsigned int width,
@@ -72,6 +78,8 @@ public:
   void ReleaseThumbnailBuffer() override;
 
   bool Initialize(unsigned char* buffer, size_t bufSize);
+
+  void SetScalingMethod(TEXTURE_SCALING method) { m_scalingMethod = method; }
 
   std::shared_ptr<Frame> ReadFrame();
 
@@ -94,4 +102,5 @@ private:
 
   AVFrame* m_pFrame;
   uint8_t* m_outputBuffer;
+  TEXTURE_SCALING m_scalingMethod{TEXTURE_SCALING::LINEAR};
 };

--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -375,7 +375,7 @@ bool CGUITexture::AllocResources()
       }
       if (CServiceBroker::GetGUI()->GetLargeTextureManager().GetImage(
               m_info.filename, texture, m_requestWidth, m_requestHeight, m_aspect.ratio,
-              !IsAllocated(), m_use_cache))
+              !IsAllocated(), m_use_cache, m_scalingMethod))
       {
         m_isAllocated = LARGE;
 
@@ -524,7 +524,7 @@ void CGUITexture::FreeResources(bool immediately /* = false */)
   {
     CServiceBroker::GetGUI()->GetLargeTextureManager().ReleaseImage(
         m_info.filename, m_requestWidth, m_requestHeight, m_aspect.ratio,
-        immediately || (m_isAllocated == LARGE_FAILED));
+        immediately || (m_isAllocated == LARGE_FAILED), m_scalingMethod);
     m_requestWidth = REQUEST_SIZE_UNSET;
     m_requestHeight = REQUEST_SIZE_UNSET;
     CServiceBroker::GetGUI()->GetTextureCallbackManager().UnregisterOnWindowResizeCallback(*this);

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -106,7 +106,8 @@ std::unique_ptr<CTexture> CTexture::LoadFromFile(const std::string& texturePath,
                                                  unsigned int idealWidth,
                                                  unsigned int idealHeight,
                                                  CAspectRatio::AspectRatio aspectRatio,
-                                                 const std::string& strMimeType)
+                                                 const std::string& strMimeType,
+                                                 TEXTURE_SCALING scalingMethod)
 {
 #if defined(TARGET_ANDROID)
   CURL url(texturePath);
@@ -131,7 +132,8 @@ std::unique_ptr<CTexture> CTexture::LoadFromFile(const std::string& texturePath,
   }
 #endif
   std::unique_ptr<CTexture> texture = CTexture::CreateTexture();
-  if (texture->LoadFromFileInternal(texturePath, idealWidth, idealHeight, aspectRatio, strMimeType))
+  if (texture->LoadFromFileInternal(texturePath, idealWidth, idealHeight, aspectRatio, strMimeType,
+                                    scalingMethod))
     return texture;
   return {};
 }
@@ -141,11 +143,12 @@ std::unique_ptr<CTexture> CTexture::LoadFromFileInMemory(unsigned char* buffer,
                                                          const std::string& mimeType,
                                                          unsigned int idealWidth,
                                                          unsigned int idealHeight,
-                                                         CAspectRatio::AspectRatio aspectRatio)
+                                                         CAspectRatio::AspectRatio aspectRatio,
+                                                         TEXTURE_SCALING scalingMethod)
 {
   std::unique_ptr<CTexture> texture = CTexture::CreateTexture();
-  if (texture->LoadFromFileInMem(buffer, bufferSize, mimeType, idealWidth, idealHeight,
-                                 aspectRatio))
+  if (texture->LoadFromFileInMem(buffer, bufferSize, mimeType, idealWidth, idealHeight, aspectRatio,
+                                 scalingMethod))
     return texture;
   return {};
 }
@@ -154,7 +157,8 @@ bool CTexture::LoadFromFileInternal(const std::string& texturePath,
                                     unsigned int idealWidth,
                                     unsigned int idealHeight,
                                     CAspectRatio::AspectRatio aspectRatio,
-                                    const std::string& strMimeType)
+                                    const std::string& strMimeType,
+                                    TEXTURE_SCALING scalingMethod)
 {
   if (URIUtils::HasExtension(texturePath, ".dds"))
   { // special case for DDS images
@@ -213,7 +217,8 @@ bool CTexture::LoadFromFileInternal(const std::string& texturePath,
   else
     pImage = ImageFactory::CreateLoaderFromMimeType(strMimeType);
 
-  if (!LoadIImage(pImage, buf.data(), buf.size(), idealWidth, idealHeight, aspectRatio))
+  if (!LoadIImage(pImage, buf.data(), buf.size(), idealWidth, idealHeight, aspectRatio,
+                  scalingMethod))
   {
     CLog::Log(LOGDEBUG, "{} - Load of {} failed.", __FUNCTION__, CURL::GetRedacted(texturePath));
     delete pImage;
@@ -229,13 +234,14 @@ bool CTexture::LoadFromFileInMem(unsigned char* buffer,
                                  const std::string& mimeType,
                                  unsigned int idealWidth,
                                  unsigned int idealHeight,
-                                 CAspectRatio::AspectRatio aspectRatio)
+                                 CAspectRatio::AspectRatio aspectRatio,
+                                 TEXTURE_SCALING scalingMethod)
 {
   if (!buffer || !size)
     return false;
 
   IImage* pImage = ImageFactory::CreateLoaderFromMimeType(mimeType);
-  if (!LoadIImage(pImage, buffer, size, idealWidth, idealHeight, aspectRatio))
+  if (!LoadIImage(pImage, buffer, size, idealWidth, idealHeight, aspectRatio, scalingMethod))
   {
     delete pImage;
     return false;
@@ -249,13 +255,14 @@ bool CTexture::LoadIImage(IImage* pImage,
                           unsigned int bufSize,
                           unsigned int idealWidth,
                           unsigned int idealHeight,
-                          CAspectRatio::AspectRatio aspectRatio)
+                          CAspectRatio::AspectRatio aspectRatio,
+                          TEXTURE_SCALING scalingMethod)
 {
   if (pImage == nullptr)
     return false;
 
   unsigned int maxTextureSize = CServiceBroker::GetRenderSystem()->GetMaxTextureSize();
-  if (!pImage->LoadImageFromMemory(buffer, bufSize, maxTextureSize, maxTextureSize))
+  if (!pImage->LoadImageFromMemory(buffer, bufSize, maxTextureSize, maxTextureSize, scalingMethod))
     return false;
 
   if (pImage->Width() == 0 || pImage->Height() == 0)

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -54,6 +54,12 @@ CTexture::~CTexture()
   m_pixels = NULL;
 }
 
+void CTexture::SetScalingMethod(TEXTURE_SCALING scalingMethod)
+{
+  m_scalingMethod = scalingMethod;
+  ApplyScalingMethod();
+}
+
 void CTexture::Update(unsigned int width,
                       unsigned int height,
                       unsigned int pitch,

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -46,6 +46,7 @@ public:
    \param idealHeight the ideal height of the texture (defaults to 0, no ideal height).
    \param aspectRatio the aspect ratio mode of the texture (defaults to "center").
    \param strMimeType mimetype of the given texture if available (defaults to empty)
+   \param scalingMethod the image filter to apply when scaling
    \return a CTexture std::unique_ptr to the created texture - nullptr if the texture failed to load.
    */
   static std::unique_ptr<CTexture> LoadFromFile(
@@ -53,7 +54,8 @@ public:
       unsigned int idealWidth = 0,
       unsigned int idealHeight = 0,
       CAspectRatio::AspectRatio aspectRatio = CAspectRatio::CENTER,
-      const std::string& strMimeType = "");
+      const std::string& strMimeType = "",
+      TEXTURE_SCALING scalingMethod = TEXTURE_SCALING::LINEAR);
 
   /*! \brief Load a texture from a file in memory
    Loads a texture from a file in memory, restricting in size if needed based on maxHeight and maxWidth.
@@ -64,6 +66,7 @@ public:
    \param idealWidth the ideal width of the texture (defaults to 0, no ideal width).
    \param idealHeight the ideal height of the texture (defaults to 0, no ideal height).
    \param aspectRatio the aspect ratio mode of the texture (defaults to "center").
+   \param scalingMethod the image filter to apply when scaling
    \return a CTexture std::unique_ptr to the created texture - nullptr if the texture failed to load.
    */
   static std::unique_ptr<CTexture> LoadFromFileInMemory(
@@ -72,7 +75,8 @@ public:
       const std::string& mimeType,
       unsigned int idealWidth = 0,
       unsigned int idealHeight = 0,
-      CAspectRatio::AspectRatio aspectRatio = CAspectRatio::CENTER);
+      CAspectRatio::AspectRatio aspectRatio = CAspectRatio::CENTER,
+      TEXTURE_SCALING scalingMethod = TEXTURE_SCALING::LINEAR);
 
   bool LoadFromMemory(unsigned int width,
                       unsigned int height,
@@ -168,16 +172,19 @@ protected:
                          const std::string& mimeType,
                          unsigned int idealWidth,
                          unsigned int idealHeight,
-                         CAspectRatio::AspectRatio aspectRatio);
+                         CAspectRatio::AspectRatio aspectRatio,
+                         TEXTURE_SCALING scalingMethod);
   bool LoadFromFileInternal(const std::string& texturePath,
                             unsigned int idealWidth,
                             unsigned int idealHeight,
                             CAspectRatio::AspectRatio aspectRatio,
-                            const std::string& strMimeType = "");
+                            const std::string& strMimeType = "",
+                            TEXTURE_SCALING scalingMethod = TEXTURE_SCALING::LINEAR);
   bool LoadIImage(IImage* pImage,
                   unsigned char* buffer,
                   unsigned int bufSize,
                   unsigned int idealWidth,
                   unsigned int idealHeight,
-                  CAspectRatio::AspectRatio aspectRatio);
+                  CAspectRatio::AspectRatio aspectRatio,
+                  TEXTURE_SCALING scalingMethod);
 };

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -120,13 +120,20 @@ public:
   virtual void CreateTextureObject() = 0;
   virtual void DestroyTextureObject() = 0;
   virtual void LoadToGPU() = 0;
-  /*! 
+  /*!
    * \brief Blocks execution until the previous GFX commands have been processed.
    */
   virtual void SyncGPU(){};
   virtual void BindToUnit(unsigned int unit) = 0;
 
-  /*! 
+  /*!
+   * \brief Set texture filtering method and update GPU state if needed
+   *
+   * \param scalingMethod the scaling method to use for the texture
+   */
+  virtual void SetScalingMethod(TEXTURE_SCALING scalingMethod);
+
+  /*!
    * \brief Checks if the processing pipeline can handle the texture format/swizzle
    \param format the format of the texture.
    \return true if the texturing pipeline supports the format
@@ -141,6 +148,21 @@ private:
   CTexture(const CTexture& copy) = delete;
 
 protected:
+  /*!
+   * \brief Apply the currently-selected texture scaling method to the GPU state
+   *
+   * This is called automatically by SetScalingMethod() once the desired
+   * TEXTURE_SCALING value has been stored in \a m_scalingMethod.  Concrete
+   * subclasses (e.g., CGLTexture, CGLESTexture, CDXTexture) should override this
+   * method to bind the underlying texture object and update its filtering
+   * parameters (GL_LINEAR / GL_NEAREST, mip-map variants, etc.) so that the
+   * texture is rendered with the correct magnification and minification filters.
+   *
+   * Classes that do not keep a GPU-resident texture (or whose platform handles
+   * filtering externally) may leave the base implementation empty.
+   */
+  virtual void ApplyScalingMethod() {}
+
   bool LoadFromFileInMem(unsigned char* buffer,
                          size_t size,
                          const std::string& mimeType,

--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -333,3 +333,26 @@ GLuint CGLTexture::GetTextureID() const
 {
   return m_texture;
 }
+
+void CGLTexture::ApplyScalingMethod()
+{
+  if (!m_loadedToGPU || m_texture == 0)
+    return;
+
+  glBindTexture(GL_TEXTURE_2D, m_texture);
+
+  GLenum filter = (m_scalingMethod == TEXTURE_SCALING::NEAREST ? GL_NEAREST : GL_LINEAR);
+
+  if (IsMipmapped())
+  {
+    GLenum mipmapFilter = (m_scalingMethod == TEXTURE_SCALING::NEAREST ? GL_LINEAR_MIPMAP_NEAREST
+                                                                       : GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipmapFilter);
+  }
+  else
+  {
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
+  }
+
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
+}

--- a/xbmc/guilib/TextureGL.h
+++ b/xbmc/guilib/TextureGL.h
@@ -53,6 +53,9 @@ public:
   GLuint GetTextureID() const;
 
 protected:
+  // Implementation of CTexture
+  void ApplyScalingMethod() override;
+
   void SetSwizzle();
   TextureFormat GetFormatGL(KD_TEX_FMT textureFormat);
 

--- a/xbmc/guilib/TextureGLES.cpp
+++ b/xbmc/guilib/TextureGLES.cpp
@@ -487,3 +487,26 @@ GLuint CGLESTexture::GetTextureID() const
 {
   return m_texture;
 }
+
+void CGLESTexture::ApplyScalingMethod()
+{
+  if (!m_loadedToGPU || m_texture == 0)
+    return;
+
+  glBindTexture(GL_TEXTURE_2D, m_texture);
+
+  GLenum filter = (m_scalingMethod == TEXTURE_SCALING::NEAREST ? GL_NEAREST : GL_LINEAR);
+
+  if (IsMipmapped())
+  {
+    GLenum mipmapFilter = (m_scalingMethod == TEXTURE_SCALING::NEAREST ? GL_LINEAR_MIPMAP_NEAREST
+                                                                       : GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipmapFilter);
+  }
+  else
+  {
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
+  }
+
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
+}

--- a/xbmc/guilib/TextureGLES.h
+++ b/xbmc/guilib/TextureGLES.h
@@ -45,6 +45,9 @@ public:
   GLuint GetTextureID() const;
 
 protected:
+  // Implementation of CTexture
+  void ApplyScalingMethod() override;
+
   void SetSwizzle(bool swapRB);
   void SwapBlueRedSwizzle(GLint& component);
   TextureFormat GetFormatGLES20(KD_TEX_FMT textureFormat);

--- a/xbmc/guilib/iimage.h
+++ b/xbmc/guilib/iimage.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "guilib/TextureScaling.h"
+
 #include <string>
 
 class IImage
@@ -25,6 +27,25 @@ public:
    \return true if the image could be loaded
    */
   virtual bool LoadImageFromMemory(unsigned char* buffer, unsigned int bufSize, unsigned int width, unsigned int height)=0;
+
+  /*!
+   \brief Load an image from memory with an explicit scaling method
+   \param buffer The memory location where the image data can be found
+   \param bufSize The size of the buffer
+   \param width The ideal width of the texture
+   \param height The ideal height of the texture
+   \param scalingMethod Scaling algorithm to use while decoding
+   \return true if the image could be loaded
+   */
+  virtual bool LoadImageFromMemory(unsigned char* buffer,
+                                   unsigned int bufSize,
+                                   unsigned int width,
+                                   unsigned int height,
+                                   TEXTURE_SCALING scalingMethod)
+  {
+    return LoadImageFromMemory(buffer, bufSize, width, height);
+  }
+
   /*!
    \brief Decodes the previously loaded image data to the output buffer in 32 bit raw bits
    \param pixels The output buffer


### PR DESCRIPTION
## Description

After merging https://github.com/xbmc/xbmc/pull/24395, I found some cases (read: most cases) where NN filtering is broken. Indeed, NN only worked for local files on Windows. Network files, or any files on GL, were drawn with linear filtering.

There are actually 3 separate bugs that are fixed:

### 1. Fixed NN scaling on GL platforms

The problem was if the scaling method changed after the initial upload - which is a common path for GUI textures - the CPU flag flipped, but the texture object that the driver already owns kept its old filter state.

We fix this by putting the update in a dedicated setter, which guarantees every caller goes through the same path and that we never forget to re-sync the GPU state.

### 2. Fixed NN scaling for remote images

Because the second image used a `resource://` URL, Kodi mistakenly thought it was remote, so it used the Large Texture Manager, which scales images with ffmpeg.

The scaling method wasn't passed through to the large texture manager, so remote (ffmpeg scaled) images didn't inherit the NN option.

Fixed by having ffmpeg respect the scaling method set by the skin.

### ~3. Consider `resource://` files as local images to bypass the large texture manager~

~While this doesn't fix any NN issue, it fixes a root cause that made NN broken for _different_ issues.~

## Motivation and context

Getting the Player Manager WIP to work after merging NN in https://github.com/xbmc/xbmc/pull/24395.

## What is the effect on users?

* Fixed "`nearest`" image filter for skin textures

## How has this been tested?

I added two images to the home screen: A local skin image, and a `resource://` image:

```xml
<control type="image">
	<texture>qrcode.png</texture>
	<aspectratio>keep</aspectratio>
	<imagefilter>nearest</imagefilter>
	<top>15%</top>
	<bottom>50%</bottom>
	<left>15%</left>
	<right>15%</right>
</control>
<control type="image">
	<texture>resource://resource.avatar.opengameart/avatars/Mr._Man/01x/001.png</texture>
	<aspectratio>keep</aspectratio>
	<imagefilter>nearest</imagefilter>
	<top>50%</top>
	<bottom>15%</bottom>
	<left>15%</left>
	<right>15%</right>
</control>
```

Without any fixes, both are linear on GL platforms:

<img width="1136" alt="Screenshot 2025-06-18 at 5 24 56 PM" src="https://github.com/user-attachments/assets/fcf06f68-45f8-4084-9b96-8d8f1d9c478d" />

With the ffmpeg fix, large texture manager textures for remote images works:

<img width="1138" alt="Screenshot 2025-06-18 at 5 26 35 PM" src="https://github.com/user-attachments/assets/aa6c29ad-7bb1-4098-83b6-e83e0d33c96f" />

With just the GL fix (and ffmpeg still linear), local textures work on macOS:

<img width="1136" alt="Screenshot 2025-06-18 at 5 27 54 PM" src="https://github.com/user-attachments/assets/6500626e-128b-43fa-9ab3-cd47c7530efc" />

Then with the `resource://` fix, the large texture manager is successfully bypassed:

<img width="1138" alt="Screenshot 2025-06-18 at 5 28 56 PM" src="https://github.com/user-attachments/assets/fcb39a05-c579-491a-bb82-90d008340160" />

## Screenshots

My current progress on the Player Manager, with avatars in all their pixelated glory:

<img width="1136" alt="Screenshot 2025-06-18 at 6 08 13 PM" src="https://github.com/user-attachments/assets/cde16df8-cd8d-4da1-ac54-029f509a11bd" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
