### PR TITLE
Factor out common definition of ArtMap

### DIFF
--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "utils/ArtUtils.h"
+
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -67,7 +69,7 @@ typedef std::shared_ptr<IAddon> AddonPtr;
 typedef std::vector<AddonPtr> VECADDONS;
 
 using InfoMap = std::map<std::string, std::string>;
-using ArtMap = std::map<std::string, std::string>;
+using ArtMap = KODI::ART::ArtMap;
 
 class IAddon : public std::enable_shared_from_this<IAddon>
 {

--- a/xbmc/addons/addoninfo/AddonInfo.h
+++ b/xbmc/addons/addoninfo/AddonInfo.h
@@ -10,6 +10,7 @@
 
 #include "XBDateTime.h"
 #include "addons/AddonVersion.h"
+#include "utils/ArtUtils.h"
 
 #include <map>
 #include <memory>
@@ -134,7 +135,7 @@ struct DependencyInfo
 };
 
 typedef std::map<std::string, std::string> InfoMap;
-typedef std::map<std::string, std::string> ArtMap;
+using ArtMap = KODI::ART::ArtMap;
 
 class CAddonInfoBuilder;
 

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -99,7 +99,7 @@ const std::wstring& CGUIListItem::GetSortLabel() const
 
 void CGUIListItem::SetArt(const std::string &type, const std::string &url)
 {
-  ART::ArtMap::const_iterator i = m_art.find(type);
+  auto i = m_art.find(type);
   if (i == m_art.end() || i->second != url)
   {
     m_art[type] = url;
@@ -133,13 +133,13 @@ void CGUIListItem::AppendArt(const ART::ArtMap& art, const std::string& prefix)
 
 std::string CGUIListItem::GetArt(const std::string &type) const
 {
-  ART::ArtMap::const_iterator i = m_art.find(type);
+  auto i = m_art.find(type);
   if (i != m_art.end())
     return i->second;
   i = m_artFallbacks.find(type);
   if (i != m_artFallbacks.end())
   {
-    ART::ArtMap::const_iterator j = m_art.find(i->second);
+    auto j = m_art.find(i->second);
     if (j != m_art.end())
       return j->second;
   }

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -16,6 +16,8 @@
 
 #include <utility>
 
+using namespace KODI;
+
 bool CGUIListItem::icompare::operator()(const std::string &s1, const std::string &s2) const
 {
   return StringUtils::CompareNoCase(s1, s2) < 0;
@@ -97,7 +99,7 @@ const std::wstring& CGUIListItem::GetSortLabel() const
 
 void CGUIListItem::SetArt(const std::string &type, const std::string &url)
 {
-  ArtMap::iterator i = m_art.find(type);
+  ART::ArtMap::const_iterator i = m_art.find(type);
   if (i == m_art.end() || i->second != url)
   {
     m_art[type] = url;
@@ -105,7 +107,7 @@ void CGUIListItem::SetArt(const std::string &type, const std::string &url)
   }
 }
 
-void CGUIListItem::SetArt(const ArtMap &art)
+void CGUIListItem::SetArt(const ART::ArtMap& art)
 {
   m_art = art;
   SetInvalid();
@@ -123,7 +125,7 @@ void CGUIListItem::ClearArt()
   SetProperty("libraryartfilled", false);
 }
 
-void CGUIListItem::AppendArt(const ArtMap &art, const std::string &prefix)
+void CGUIListItem::AppendArt(const ART::ArtMap& art, const std::string& prefix)
 {
   for (const auto& i : art)
     SetArt(prefix.empty() ? i.first : prefix + '.' + i.first, i.second);
@@ -131,20 +133,20 @@ void CGUIListItem::AppendArt(const ArtMap &art, const std::string &prefix)
 
 std::string CGUIListItem::GetArt(const std::string &type) const
 {
-  ArtMap::const_iterator i = m_art.find(type);
+  ART::ArtMap::const_iterator i = m_art.find(type);
   if (i != m_art.end())
     return i->second;
   i = m_artFallbacks.find(type);
   if (i != m_artFallbacks.end())
   {
-    ArtMap::const_iterator j = m_art.find(i->second);
+    ART::ArtMap::const_iterator j = m_art.find(i->second);
     if (j != m_art.end())
       return j->second;
   }
   return "";
 }
 
-const CGUIListItem::ArtMap &CGUIListItem::GetArt() const
+const ART::ArtMap& CGUIListItem::GetArt() const
 {
   return m_art;
 }

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -13,6 +13,8 @@
 \brief
 */
 
+#include "utils/ArtUtils.h"
+
 #include <map>
 #include <memory>
 #include <string>
@@ -29,7 +31,7 @@ class CVariant;
 class CGUIListItem
 {
 public:
-  typedef std::map<std::string, std::string> ArtMap;
+  using ArtMap = KODI::ART::ArtMap;
 
   ///
   /// @ingroup controls python_xbmcgui_listitem

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -25,6 +25,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/ArtUtils.h"
 #include "utils/SortUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -1002,7 +1003,7 @@ JSONRPC_STATUS CAudioLibrary::SetSongDetails(const std::string &method, ITranspo
   if (ParameterNotNull(parameterObject, "art"))
   {
     // Get current artwork
-    std::map<std::string, std::string> artwork;
+    KODI::ART::ArtMap artwork;
     musicdatabase.GetArtForItem(song.idSong, MediaTypeSong, artwork);
 
     std::set<std::string> removedArtwork;

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -300,9 +300,8 @@ JSONRPC_STATUS CAudioLibrary::GetAlbums(const std::string &method, ITransportLay
         }
         if (bFetchArt)
         {
-          CGUIListItem::ArtMap artMap = item.GetArt();
           CVariant artObj(CVariant::VariantTypeObject);
-          for (const auto& artIt : artMap)
+          for (const auto& artIt : item.GetArt())
           {
             if (!artIt.second.empty())
               artObj[artIt.first] = IMAGE_FILES::URLFromFile(artIt.second);
@@ -466,9 +465,8 @@ JSONRPC_STATUS CAudioLibrary::GetSongs(const std::string &method, ITransportLaye
         }
         if (bFetchArt)
         {
-          CGUIListItem::ArtMap artMap = item.GetArt();
           CVariant artObj(CVariant::VariantTypeObject);
-          for (const auto& artIt : artMap)
+          for (const auto& artIt : item.GetArt())
           {
             if (!artIt.second.empty())
               artObj[artIt.first] = IMAGE_FILES::URLFromFile(artIt.second);

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -189,9 +189,8 @@ bool CFileItemHandler::GetField(const std::string& field,
         fetchedArt = true;
       }
 
-      CGUIListItem::ArtMap artMap = item->GetArt();
       CVariant artObj(CVariant::VariantTypeObject);
-      for (const auto& artIt : artMap)
+      for (const auto& artIt : item->GetArt())
       {
         if (!artIt.second.empty())
           artObj[artIt.first] = IMAGE_FILES::URLFromFile(artIt.second);

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -261,7 +261,7 @@ JSONRPC_STATUS CFileOperations::SetFileDetails(const std::string &method, ITrans
   CVideoLibrary::UpdateResumePoint(parameterObject, infos, videodatabase);
 
   videodatabase.GetFileInfo("", infos, fileId);
-  CJSONRPCUtils::NotifyItemUpdated(infos, std::map<std::string, std::string>{});
+  CJSONRPCUtils::NotifyItemUpdated(infos, KODI::ART::ArtMap{});
   return ACK;
 }
 

--- a/xbmc/interfaces/json-rpc/JSONRPC.cpp
+++ b/xbmc/interfaces/json-rpc/JSONRPC.cpp
@@ -387,8 +387,7 @@ void CJSONRPCUtils::NotifyItemUpdated(const std::shared_ptr<CFileItem>& item)
   wm.SendThreadMessage(message);
 }
 
-void CJSONRPCUtils::NotifyItemUpdated(const CVideoInfoTag& info,
-                                      const std::map<std::string, std::string>& artwork)
+void CJSONRPCUtils::NotifyItemUpdated(const CVideoInfoTag& info, const KODI::ART::ArtMap& artwork)
 {
   CFileItemPtr msgItem(new CFileItem(info));
   if (!artwork.empty())

--- a/xbmc/interfaces/json-rpc/JSONRPCUtils.h
+++ b/xbmc/interfaces/json-rpc/JSONRPCUtils.h
@@ -10,6 +10,7 @@
 
 #include "IClient.h"
 #include "ITransportLayer.h"
+#include "utils/ArtUtils.h"
 
 #include <map>
 #include <memory>
@@ -160,7 +161,6 @@ namespace JSONRPC
   public:
     static void NotifyItemUpdated();
     static void NotifyItemUpdated(const std::shared_ptr<CFileItem>& item);
-    static void NotifyItemUpdated(const CVideoInfoTag& info,
-                                  const std::map<std::string, std::string>& artwork);
+    static void NotifyItemUpdated(const CVideoInfoTag& info, const KODI::ART::ArtMap& artwork);
   };
 }

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -15,6 +15,7 @@
 #include "Util.h"
 #include "imagefiles/ImageFileURL.h"
 #include "messaging/ApplicationMessenger.h"
+#include "utils/ArtUtils.h"
 #include "utils/SortUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -614,7 +615,7 @@ JSONRPC_STATUS CVideoLibrary::SetMovieDetails(const std::string &method, ITransp
     return InvalidParams;
 
   // get artwork
-  std::map<std::string, std::string> artwork;
+  KODI::ART::ArtMap artwork;
   videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
 
   int playcount = infos.GetPlayCount();
@@ -661,7 +662,7 @@ JSONRPC_STATUS CVideoLibrary::SetMovieSetDetails(const std::string &method, ITra
   }
 
   // get artwork
-  std::map<std::string, std::string> artwork;
+  KODI::ART::ArtMap artwork;
   videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
 
   std::set<std::string> removedArtwork;
@@ -691,10 +692,10 @@ JSONRPC_STATUS CVideoLibrary::SetTVShowDetails(const std::string &method, ITrans
     return InvalidParams;
 
   // get artwork
-  std::map<std::string, std::string> artwork;
+  KODI::ART::ArtMap artwork;
   videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
 
-  std::map<int, std::map<std::string, std::string> > seasonArt;
+  std::map<int, KODI::ART::ArtMap> seasonArt;
   videodatabase.GetTvShowSeasonArt(infos.m_iDbId, seasonArt);
 
   std::set<std::string> removedArtwork;
@@ -732,7 +733,7 @@ JSONRPC_STATUS CVideoLibrary::SetSeasonDetails(const std::string &method, ITrans
   }
 
   // get artwork
-  std::map<std::string, std::string> artwork;
+  KODI::ART::ArtMap artwork;
   videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
 
   std::set<std::string> removedArtwork;
@@ -775,7 +776,7 @@ JSONRPC_STATUS CVideoLibrary::SetEpisodeDetails(const std::string &method, ITran
   }
 
   // get artwork
-  std::map<std::string, std::string> artwork;
+  KODI::ART::ArtMap artwork;
   videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
 
   int playcount = infos.GetPlayCount();
@@ -822,7 +823,7 @@ JSONRPC_STATUS CVideoLibrary::SetMusicVideoDetails(const std::string &method, IT
   }
 
   // get artwork
-  std::map<std::string, std::string> artwork;
+  KODI::ART::ArtMap artwork;
   videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
 
   int playcount = infos.GetPlayCount();
@@ -1208,7 +1209,11 @@ void CVideoLibrary::UpdateVideoTagField(const CVariant& parameterObject, const s
   }
 }
 
-void CVideoLibrary::UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTag& details, std::map<std::string, std::string> &artwork, std::set<std::string> &removedArtwork, std::set<std::string> &updatedDetails)
+void CVideoLibrary::UpdateVideoTag(const CVariant& parameterObject,
+                                   CVideoInfoTag& details,
+                                   KODI::ART::ArtMap& artwork,
+                                   std::set<std::string>& removedArtwork,
+                                   std::set<std::string>& updatedDetails)
 {
   if (ParameterNotNull(parameterObject, "title"))
     details.SetTitle(parameterObject["title"].asString());

--- a/xbmc/interfaces/json-rpc/VideoLibrary.h
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.h
@@ -10,6 +10,7 @@
 
 #include "FileItemHandler.h"
 #include "JSONRPC.h"
+#include "utils/ArtUtils.h"
 #include "utils/DatabaseUtils.h"
 
 #include <memory>
@@ -89,7 +90,11 @@ namespace JSONRPC
     static int RequiresAdditionalDetails(const MediaType& mediaType, const CVariant &parameterObject);
     static JSONRPC_STATUS HandleItems(const char *idProperty, const char *resultName, CFileItemList &items, const CVariant &parameterObject, CVariant &result, bool limit = true);
     static JSONRPC_STATUS RemoveVideo(const CVariant &parameterObject);
-    static void UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTag &details, std::map<std::string, std::string> &artwork, std::set<std::string> &removedArtwork, std::set<std::string>& updatedDetails);
+    static void UpdateVideoTag(const CVariant& parameterObject,
+                               CVideoInfoTag& details,
+                               KODI::ART::ArtMap& artwork,
+                               std::set<std::string>& removedArtwork,
+                               std::set<std::string>& updatedDetails);
     static void UpdateVideoTagField(const CVariant& parameterObject, const std::string& fieldName, std::vector<std::string>& fieldValue, std::set<std::string>& updatedDetails);
   };
 }

--- a/xbmc/music/Album.h
+++ b/xbmc/music/Album.h
@@ -16,6 +16,7 @@
 #include "Artist.h"
 #include "Song.h"
 #include "XBDateTime.h"
+#include "utils/ArtUtils.h"
 #include "utils/ScraperUrl.h"
 
 #include <map>
@@ -154,7 +155,7 @@ public:
   std::vector<std::string> moods;
   std::vector<std::string> styles;
   std::vector<std::string> themes;
-  std::map<std::string, std::string> art;
+  KODI::ART::ArtMap art;
   std::string strReview;
   std::string strLabel;
   std::string strType;

--- a/xbmc/music/Artist.h
+++ b/xbmc/music/Artist.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "XBDateTime.h"
+#include "utils/ArtUtils.h"
 #include "utils/ScraperUrl.h"
 #include "utils/StringUtils.h"
 
@@ -120,7 +121,7 @@ public:
   std::vector<std::string> yearsActive;
   std::string strPath;
   CScraperUrl thumbURL; // Data for available remote art
-  std::map<std::string, std::string> art;  // Current artwork - thumb, fanart etc.
+  KODI::ART::ArtMap art; // Current artwork - thumb, fanart etc.
   std::vector<CDiscoAlbum> discography;
   CDateTime dateAdded; // From related file creation or modification times, or when (re-)scanned
   CDateTime dateUpdated; // Time db record Last modified

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -12039,7 +12039,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
             {
               // Save art in album folder
               // Note thumb resolution may be lower than original when overwriting
-              std::map<std::string, std::string> artwork;
+              ART::ArtMap artwork;
               std::string savedArtfile;
               if (GetArtForItem(album.idAlbum, MediaTypeAlbum, artwork))
               {
@@ -12129,7 +12129,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
         // Include discography when not folders only
         GetArtist(artistId, artist, !artistfoldersonly);
         std::string strPath;
-        std::map<std::string, std::string> artwork;
+        ART::ArtMap artwork;
         if (settings.IsSingleFile())
         {
           // Save artist to xml, and old path (common to music files) if it has one
@@ -12889,7 +12889,7 @@ void CMusicDatabase::SetItemUpdated(int mediaId, const std::string& mediaType)
 
 void CMusicDatabase::SetArtForItem(int mediaId,
                                    const std::string& mediaType,
-                                   const std::map<std::string, std::string>& art)
+                                   const ART::ArtMap& art)
 {
   for (const auto& i : art)
     SetArtForItem(mediaId, mediaType, i.first, i.second);
@@ -13053,9 +13053,7 @@ bool CMusicDatabase::GetArtForItem(
   return false;
 }
 
-bool CMusicDatabase::GetArtForItem(int mediaId,
-                                   const std::string& mediaType,
-                                   std::map<std::string, std::string>& art)
+bool CMusicDatabase::GetArtForItem(int mediaId, const std::string& mediaType, ART::ArtMap& art)
 {
   try
   {

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -18,6 +18,7 @@
 #include "addons/Scraper.h"
 #include "dbwrappers/Database.h"
 #include "settings/LibExportSettings.h"
+#include "utils/ArtUtils.h"
 #include "utils/SortUtils.h"
 
 #include <utility>
@@ -750,10 +751,7 @@ public:
    \param art a map of <type, url> where type is "thumb", "fanart", etc. and url is the original url of the art.
    \sa GetArtForItem
    */
-  void SetArtForItem(int mediaId,
-                     const std::string& mediaType,
-                     const std::map<std::string, std::string>& art);
-
+  void SetArtForItem(int mediaId, const std::string& mediaType, const KODI::ART::ArtMap& art);
 
   /*! \brief Fetch all related art for a database item.
   Fetches multiple pieces of art for a database item including that for related media types
@@ -786,9 +784,7 @@ public:
    \return true if art is retrieved, false if no art is found.
    \sa SetArtForItem
    */
-  bool GetArtForItem(int mediaId,
-                     const std::string& mediaType,
-                     std::map<std::string, std::string>& art);
+  bool GetArtForItem(int mediaId, const std::string& mediaType, KODI::ART::ArtMap& art);
 
   /*! \brief Fetch art for a database item.
    Fetches a single piece of art for a database item.

--- a/xbmc/music/MusicThumbLoader.cpp
+++ b/xbmc/music/MusicThumbLoader.cpp
@@ -12,11 +12,13 @@
 #include "imagefiles/ImageFileURL.h"
 #include "music/infoscanner/MusicInfoScanner.h"
 #include "music/tags/MusicInfoTag.h"
+#include "utils/ArtUtils.h"
 #include "utils/StringUtils.h"
 #include "video/VideoThumbLoader.h"
 
 #include <utility>
 
+using namespace KODI;
 using namespace MUSIC_INFO;
 
 CMusicThumbLoader::CMusicThumbLoader() : CThumbLoader()
@@ -269,8 +271,8 @@ bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
   {
     std::string fanartfallback;
     std::string artname;
-    std::map<std::string, std::string> artmap;
-    std::map<std::string, std::string> discartmap;
+    ART::ArtMap artmap;
+    ART::ArtMap discartmap;
     for (auto artitem : art)
     {
       /* Add art to artmap, naming according to media type.
@@ -327,11 +329,10 @@ bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
     // Process specific disc art when we have some
     for (const auto& discart : discartmap)
     {
-      std::map<std::string, std::string>::iterator it;
       if (tag.GetType() == MediaTypeAlbum)
       {
         // Insert or replace album art with specific disc art
-        it = artmap.find(discart.first);
+        auto it = artmap.find(discart.first);
         if (it != artmap.end())
           it->second = discart.second;
         else
@@ -343,7 +344,7 @@ bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
         // (Fallback approach is used to fill missing thumbs).
         if (discart.first == "thumb")
         {
-          it = artmap.find("album.thumb");
+          auto it = artmap.find("album.thumb");
           if (it != artmap.end())
             // Replace "album.thumb" already set as fallback
             it->second = discart.second;
@@ -358,7 +359,7 @@ bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
         {
           // Apply disc art as song art when not have that type (fallback does not apply).
           // Art of other types could been set via JSON, or in future read from metadata
-          it = artmap.find(discart.first);
+          auto it = artmap.find(discart.first);
           if (it == artmap.end())
             artmap.insert(discart);
         }

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -40,6 +40,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "threads/IRunnable.h"
+#include "utils/ArtUtils.h"
 #include "utils/FileUtils.h"
 #include "utils/JobManager.h"
 #include "utils/StringUtils.h"
@@ -234,7 +235,7 @@ void AddCurrentArtTypes(std::vector<std::string>& artTypes,
                         const CMusicInfoTag& tag,
                         CMusicDatabase& db)
 {
-  std::map<std::string, std::string> currentArt;
+  ART::ArtMap currentArt;
   db.GetArtForItem(tag.GetDatabaseId(), tag.GetType(), currentArt);
   for (const auto& art : currentArt)
   {

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -776,8 +776,7 @@ void CGUIDialogMusicInfo::OnGetArt()
   if (bHasArt)
   {
     // Check if that type of art is actually a fallback, e.g. artist fanart
-    ART::ArtMap::const_iterator i = primeArt.find(type);
-    bFallback = (i == primeArt.end());
+    bFallback = (primeArt.find(type) == primeArt.end());
   }
 
   // Build list of possible images of that art type

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -770,13 +770,13 @@ void CGUIDialogMusicInfo::OnGetArt()
     return; // Cancelled
 
   CFileItemList items;
-  CGUIListItem::ArtMap primeArt = m_item->GetArt(); // art without fallbacks
+  ART::ArtMap primeArt = m_item->GetArt(); // art without fallbacks
   bool bHasArt = m_item->HasArt(type);
   bool bFallback(false);
   if (bHasArt)
   {
     // Check if that type of art is actually a fallback, e.g. artist fanart
-    CGUIListItem::ArtMap::const_iterator i = primeArt.find(type);
+    ART::ArtMap::const_iterator i = primeArt.find(type);
     bFallback = (i == primeArt.end());
   }
 

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -339,13 +339,13 @@ void CGUIDialogSongInfo::OnGetArt()
     return; // Cancelled
 
   CFileItemList items;
-  CGUIListItem::ArtMap primeArt = m_song->GetArt(); // Song art without fallbacks
+  ART::ArtMap primeArt = m_song->GetArt(); // Song art without fallbacks
   bool bHasArt = m_song->HasArt(type);
   bool bFallback(false);
   if (bHasArt)
   {
     // Check if that type of art is actually a fallback, e.g. album thumb or artist fanart
-    CGUIListItem::ArtMap::const_iterator i = primeArt.find(type);
+    ART::ArtMap::const_iterator i = primeArt.find(type);
     bFallback = (i == primeArt.end());
   }
 
@@ -361,7 +361,7 @@ void CGUIDialogSongInfo::OnGetArt()
   }
   else if (m_song->HasArt("thumb"))
   { // For missing art of that type add the thumb (when it exists and not a fallback)
-    CGUIListItem::ArtMap::const_iterator i = primeArt.find("thumb");
+    ART::ArtMap::const_iterator i = primeArt.find("thumb");
     if (i != primeArt.end())
     {
       CFileItemPtr item(new CFileItem("thumb://Thumb", false));

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -345,8 +345,7 @@ void CGUIDialogSongInfo::OnGetArt()
   if (bHasArt)
   {
     // Check if that type of art is actually a fallback, e.g. album thumb or artist fanart
-    ART::ArtMap::const_iterator i = primeArt.find(type);
-    bFallback = (i == primeArt.end());
+    bFallback = (primeArt.find(type) == primeArt.end());
   }
 
   // Build list of possible images of that art type
@@ -361,8 +360,7 @@ void CGUIDialogSongInfo::OnGetArt()
   }
   else if (m_song->HasArt("thumb"))
   { // For missing art of that type add the thumb (when it exists and not a fallback)
-    ART::ArtMap::const_iterator i = primeArt.find("thumb");
-    if (i != primeArt.end())
+    if (primeArt.find("thumb") != primeArt.end())
     {
       CFileItemPtr item(new CFileItem("thumb://Thumb", false));
       item->SetArt("thumb", m_song->GetArt("thumb"));

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1973,7 +1973,7 @@ bool CMusicInfoScanner::AddArtistArtwork(CArtist& artist, const std::string& art
   if (artist.art.empty())
     m_musicDatabase.GetArtForItem(artist.idArtist, MediaTypeArtist, artist.art);
 
-  std::map<std::string, std::string> addedart;
+  ART::ArtMap addedart;
   std::string strArt;
 
   // Handle thumb separately, can be from multiple configurable file names
@@ -2046,7 +2046,7 @@ bool CMusicInfoScanner::AddAlbumArtwork(CAlbum& album)
       replaceThumb = true;
   }
 
-  std::map<std::string, std::string> addedart;
+  ART::ArtMap addedart;
   std::string strArt;
 
   // Fetch local art from album folder
@@ -2159,7 +2159,7 @@ std::vector<CVariant> CMusicInfoScanner::GetArtWhitelist(const MediaType& mediaT
   return whitelistarttypes;
 }
 
-bool CMusicInfoScanner::AddLocalArtwork(std::map<std::string, std::string>& art,
+bool CMusicInfoScanner::AddLocalArtwork(ART::ArtMap& art,
                                         const std::string& mediaType,
                                         const std::string& mediaName,
                                         const std::string& artfolder,
@@ -2255,7 +2255,7 @@ bool CMusicInfoScanner::AddLocalArtwork(std::map<std::string, std::string>& art,
   return art.size() > 0;
 }
 
-bool CMusicInfoScanner::AddRemoteArtwork(std::map<std::string, std::string>& art,
+bool CMusicInfoScanner::AddRemoteArtwork(ART::ArtMap& art,
                                          const std::string& mediaType,
                                          const CScraperUrl& thumbURL)
 {

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -182,7 +182,7 @@ protected:
   \param artfolder [in] path of folder containing local image files
   \return true when art is added
   */
-  bool AddLocalArtwork(std::map<std::string, std::string>& art,
+  bool AddLocalArtwork(KODI::ART::ArtMap& art,
                        const std::string& mediaType,
                        const std::string& mediaName,
                        const std::string& artfolder,
@@ -197,7 +197,7 @@ protected:
   \param thumbURL [in] URLs for potential remote artwork (provided by scrapers)
   \return true when art is added
   */
-  bool AddRemoteArtwork(std::map<std::string, std::string>& art,
+  bool AddRemoteArtwork(KODI::ART::ArtMap& art,
                         const std::string& mediaType,
                         const CScraperUrl& thumbURL);
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -826,7 +826,7 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
       std::string dirType = MediaTypeArtist;
       if (params.GetAlbumId() > 0)
         dirType = MediaTypeAlbum;
-      std::map<std::string, std::string> artmap;
+      ART::ArtMap artmap;
       for (auto artitem : art)
       {
         std::string artname;

--- a/xbmc/utils/ArtUtils.h
+++ b/xbmc/utils/ArtUtils.h
@@ -8,12 +8,17 @@
 
 #pragma once
 
+#include "utils/ArtUtils.h"
+
+#include <map>
 #include <string>
 
 class CFileItem;
 
 namespace KODI::ART
 {
+
+typedef std::map<std::string, std::string> ArtMap;
 
 //! \brief Set default icon for item.
 void FillInDefaultIcon(CFileItem& item);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -46,7 +46,6 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
-#include "utils/ArtUtils.h"
 #include "utils/FileUtils.h"
 #include "utils/GroupUtils.h"
 #include "utils/LabelFormatter.h"
@@ -2616,12 +2615,15 @@ std::string CVideoDatabase::GetValueString(const CVideoInfoTag &details, int min
 }
 
 //********************************************************************************************************************************
-int CVideoDatabase::SetDetailsForItem(CVideoInfoTag& details, const std::map<std::string, std::string> &artwork)
+int CVideoDatabase::SetDetailsForItem(CVideoInfoTag& details, const ART::ArtMap& artwork)
 {
   return SetDetailsForItem(details.m_iDbId, details.m_type, details, artwork);
 }
 
-int CVideoDatabase::SetDetailsForItem(int id, const MediaType& mediaType, CVideoInfoTag& details, const std::map<std::string, std::string> &artwork)
+int CVideoDatabase::SetDetailsForItem(int id,
+                                      const MediaType& mediaType,
+                                      CVideoInfoTag& details,
+                                      const ART::ArtMap& artwork)
 {
   if (mediaType == MediaTypeNone)
     return -1;
@@ -2632,7 +2634,7 @@ int CVideoDatabase::SetDetailsForItem(int id, const MediaType& mediaType, CVideo
     return SetDetailsForMovieSet(details, artwork, id);
   else if (mediaType == MediaTypeTvShow)
   {
-    std::map<int, std::map<std::string, std::string> > seasonArtwork;
+    std::map<int, ART::ArtMap> seasonArtwork;
     if (!UpdateDetailsForTvShow(id, details, artwork, seasonArtwork))
       return -1;
 
@@ -2649,7 +2651,7 @@ int CVideoDatabase::SetDetailsForItem(int id, const MediaType& mediaType, CVideo
 }
 
 int CVideoDatabase::SetDetailsForMovie(CVideoInfoTag& details,
-                                       const std::map<std::string, std::string>& artwork,
+                                       const ART::ArtMap& artwork,
                                        int idMovie /* = -1 */)
 {
   const auto filePath = details.GetPath();
@@ -2768,7 +2770,10 @@ int CVideoDatabase::SetDetailsForMovie(CVideoInfoTag& details,
   return -1;
 }
 
-int CVideoDatabase::UpdateDetailsForMovie(int idMovie, CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, const std::set<std::string> &updatedDetails)
+int CVideoDatabase::UpdateDetailsForMovie(int idMovie,
+                                          CVideoInfoTag& details,
+                                          const ART::ArtMap& artwork,
+                                          const std::set<std::string>& updatedDetails)
 {
   if (idMovie < 0)
     return idMovie;
@@ -2864,7 +2869,9 @@ int CVideoDatabase::UpdateDetailsForMovie(int idMovie, CVideoInfoTag& details, c
   return -1;
 }
 
-int CVideoDatabase::SetDetailsForMovieSet(const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, int idSet /* = -1 */)
+int CVideoDatabase::SetDetailsForMovieSet(const CVideoInfoTag& details,
+                                          const ART::ArtMap& artwork,
+                                          int idSet /* = -1 */)
 {
   if (details.m_strTitle.empty())
     return -1;
@@ -2910,9 +2917,12 @@ int CVideoDatabase::GetMatchingTvShow(const CVideoInfoTag &details)
   return id;
 }
 
-int CVideoDatabase::SetDetailsForTvShow(const std::vector<std::pair<std::string, std::string> > &paths,
-    CVideoInfoTag& details, const std::map<std::string, std::string> &artwork,
-    const std::map<int, std::map<std::string, std::string> > &seasonArt, int idTvShow /*= -1 */)
+int CVideoDatabase::SetDetailsForTvShow(
+    const std::vector<std::pair<std::string, std::string>>& paths,
+    CVideoInfoTag& details,
+    const ART::ArtMap& artwork,
+    const std::map<int, ART::ArtMap>& seasonArt,
+    int idTvShow /*= -1 */)
 {
 
   /*
@@ -2951,8 +2961,10 @@ int CVideoDatabase::SetDetailsForTvShow(const std::vector<std::pair<std::string,
   return idTvShow;
 }
 
-bool CVideoDatabase::UpdateDetailsForTvShow(int idTvShow, CVideoInfoTag &details,
-    const std::map<std::string, std::string> &artwork, const std::map<int, std::map<std::string, std::string>> &seasonArt)
+bool CVideoDatabase::UpdateDetailsForTvShow(int idTvShow,
+                                            CVideoInfoTag& details,
+                                            const ART::ArtMap& artwork,
+                                            const std::map<int, ART::ArtMap>& seasonArt)
 {
   BeginTransaction();
 
@@ -2985,7 +2997,7 @@ bool CVideoDatabase::UpdateDetailsForTvShow(int idTvShow, CVideoInfoTag &details
       continue;
 
     season.SetSortTitle(namedSeason.second);
-    SetDetailsForSeason(season, std::map<std::string, std::string>(), idTvShow, seasonId);
+    SetDetailsForSeason(season, ART::ArtMap{}, idTvShow, seasonId);
   }
 
   SetArtForItem(idTvShow, MediaTypeTvShow, artwork);
@@ -3016,8 +3028,10 @@ bool CVideoDatabase::UpdateDetailsForTvShow(int idTvShow, CVideoInfoTag &details
   return false;
 }
 
-int CVideoDatabase::SetDetailsForSeason(const CVideoInfoTag& details, const std::map<std::string,
-    std::string> &artwork, int idShow, int idSeason /* = -1 */)
+int CVideoDatabase::SetDetailsForSeason(const CVideoInfoTag& details,
+                                        const ART::ArtMap& artwork,
+                                        int idShow,
+                                        int idSeason /* = -1 */)
 {
   if (idShow < 0 || details.m_iSeason < -1)
     return -1;
@@ -3215,7 +3229,7 @@ bool CVideoDatabase::DeleteFile(int idFile)
 }
 
 int CVideoDatabase::SetDetailsForEpisode(CVideoInfoTag& details,
-                                         const std::map<std::string, std::string>& artwork,
+                                         const ART::ArtMap& artwork,
                                          int idShow,
                                          int idEpisode /* = -1 */)
 {
@@ -3332,7 +3346,7 @@ int CVideoDatabase::AddSeason(int showID, int season, const std::string& name /*
 }
 
 int CVideoDatabase::SetDetailsForMusicVideo(CVideoInfoTag& details,
-                                            const std::map<std::string, std::string>& artwork,
+                                            const ART::ArtMap& artwork,
                                             int idMVideo /* = -1 */)
 {
   const auto filePath = details.GetPath();
@@ -5283,9 +5297,7 @@ void CVideoDatabase::UpdateArtForItem(int mediaId, const MediaType& mediaType)
   AnnounceUpdate(mediaType, mediaId);
 }
 
-bool CVideoDatabase::SetArtForItem(int mediaId,
-                                   const MediaType& mediaType,
-                                   const std::map<std::string, std::string>& art)
+bool CVideoDatabase::SetArtForItem(int mediaId, const MediaType& mediaType, const ART::ArtMap& art)
 {
   for (const auto& i : art)
     if (!SetArtForItem(mediaId, mediaType, i.first, i.second))
@@ -5338,9 +5350,7 @@ bool CVideoDatabase::SetArtForItem(int mediaId,
   }
 }
 
-bool CVideoDatabase::GetArtForItem(int mediaId,
-                                   const MediaType& mediaType,
-                                   std::map<std::string, std::string>& art)
+bool CVideoDatabase::GetArtForItem(int mediaId, const MediaType& mediaType, ART::ArtMap& art)
 {
   try
   {
@@ -5523,7 +5533,7 @@ std::string CVideoDatabase::GetTvShowNamedSeasonById(int tvshowId, int seasonId)
                         PrepareSQL("season=%i AND idShow=%i", seasonId, tvshowId));
 }
 
-bool CVideoDatabase::GetTvShowSeasonArt(int showId, std::map<int, std::map<std::string, std::string> > &seasonArt)
+bool CVideoDatabase::GetTvShowSeasonArt(int showId, std::map<int, ART::ArtMap>& seasonArt)
 {
   try
   {
@@ -5537,7 +5547,7 @@ bool CVideoDatabase::GetTvShowSeasonArt(int showId, std::map<int, std::map<std::
 
     for (const auto &i : seasons)
     {
-      std::map<std::string, std::string> art;
+      ART::ArtMap art;
       GetArtForItem(i.second, MediaTypeSeason, art);
       seasonArt.insert(std::make_pair(i.first,art));
     }
@@ -11179,7 +11189,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
       // strip paths to make them relative
       if (StringUtils::StartsWith(movie.m_strTrailer, movie.m_strPath))
         movie.m_strTrailer = movie.m_strTrailer.substr(movie.m_strPath.size());
-      std::map<std::string, std::string> artwork;
+      ART::ArtMap artwork;
       if (GetArtForItem(movie.m_iDbId, movie.m_type, artwork) && !artwork.empty() && singleFile)
       {
         TiXmlElement additionalNode("art");
@@ -11302,7 +11312,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
             movieSetsDir, CUtil::MakeLegalFileName(title, LegalPath::WIN32_COMPAT));
         if (CDirectory::Exists(itemPath) || CDirectory::Create(itemPath))
         {
-          std::map<std::string, std::string> artwork;
+          ART::ArtMap artwork;
           GetArtForItem(m_pDS->fv("idSet").get_asInt(), MediaTypeVideoCollection, artwork);
           for (const auto& art : artwork)
           {
@@ -11332,7 +11342,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
     while (!m_pDS->eof())
     {
       CVideoInfoTag movie = GetDetailsForMusicVideo(m_pDS, VideoDbDetailsAll);
-      std::map<std::string, std::string> artwork;
+      ART::ArtMap artwork;
       if (GetArtForItem(movie.m_iDbId, movie.m_type, artwork) && !artwork.empty() && singleFile)
       {
         TiXmlElement additionalNode("art");
@@ -11424,10 +11434,10 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
       CVideoInfoTag tvshow = GetDetailsForTvShow(m_pDS, VideoDbDetailsAll);
       GetTvShowNamedSeasons(tvshow.m_iDbId, tvshow.m_namedSeasons);
 
-      std::map<int, std::map<std::string, std::string> > seasonArt;
+      std::map<int, ART::ArtMap> seasonArt;
       GetTvShowSeasonArt(tvshow.m_iDbId, seasonArt);
 
-      std::map<std::string, std::string> artwork;
+      ART::ArtMap artwork;
       if (GetArtForItem(tvshow.m_iDbId, tvshow.m_type, artwork) && !artwork.empty() && singleFile)
       {
         TiXmlElement additionalNode("art");
@@ -11537,7 +11547,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
       while (!pDS->eof())
       {
         CVideoInfoTag episode = GetDetailsForEpisode(pDS, VideoDbDetailsAll);
-        std::map<std::string, std::string> artwork;
+        ART::ArtMap artwork;
         if (GetArtForItem(episode.m_iDbId, MediaTypeEpisode, artwork) && !artwork.empty() &&
             singleFile)
         {
@@ -11811,7 +11821,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
                                                      LegalPath::WIN32_COMPAT));
           if (CDirectory::Exists(setPath))
           {
-            ArtMap setArt;
+            ART::ArtMap setArt;
             CFileItem artItem(setPath, true);
             for (const auto& artType : CVideoThumbLoader::GetArtTypes(MediaTypeVideoCollection))
             {
@@ -11858,7 +11868,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
         showItem.SetArt(artItem.GetArt());
         int showID = scanner.AddVideo(&showItem, CONTENT_TVSHOWS, useFolders, true, NULL, true);
         // season artwork
-        std::map<int, std::map<std::string, std::string> > seasonArt;
+        std::map<int, ART::ArtMap> seasonArt;
         artItem.GetVideoInfoTag()->m_strPath = artPath;
         scanner.GetSeasonThumbs(*artItem.GetVideoInfoTag(), seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason), true);
         for (const auto &i : seasonArt)
@@ -13240,7 +13250,7 @@ bool CVideoDatabase::SetVideoVersionDefaultArt(int dbId, int idFrom, VideoDbCont
   MediaType mediaType;
   VideoContentTypeToString(type, mediaType);
 
-  std::map<std::string, std::string> art;
+  ART::ArtMap art;
   if (GetArtForItem(idFrom, mediaType, art))
   {
     for (const auto& it : art)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -11811,7 +11811,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
                                                      LegalPath::WIN32_COMPAT));
           if (CDirectory::Exists(setPath))
           {
-            CGUIListItem::ArtMap setArt;
+            ArtMap setArt;
             CFileItem artItem(setPath, true);
             for (const auto& artType : CVideoThumbLoader::GetArtTypes(MediaTypeVideoCollection))
             {

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -12,6 +12,7 @@
 #include "VideoInfoTag.h"
 #include "addons/Scraper.h"
 #include "dbwrappers/Database.h"
+#include "utils/ArtUtils.h"
 #include "utils/SortUtils.h"
 #include "utils/UrlOptions.h"
 
@@ -608,13 +609,18 @@ public:
   void GetEpisodesByFile(const std::string& strFilenameAndPath, std::vector<CVideoInfoTag>& episodes);
   void GetEpisodesByFileId(int idFile, std::vector<CVideoInfoTag>& episodes);
 
-  int SetDetailsForItem(CVideoInfoTag& details, const std::map<std::string, std::string> &artwork);
-  int SetDetailsForItem(int id, const MediaType& mediaType, CVideoInfoTag& details, const std::map<std::string, std::string> &artwork);
+  int SetDetailsForItem(CVideoInfoTag& details, const KODI::ART::ArtMap& artwork);
+  int SetDetailsForItem(int id,
+                        const MediaType& mediaType,
+                        CVideoInfoTag& details,
+                        const KODI::ART::ArtMap& artwork);
 
   int SetDetailsForMovie(CVideoInfoTag& details,
-                         const std::map<std::string, std::string>& artwork,
+                         const KODI::ART::ArtMap& artwork,
                          int idMovie = -1);
-  int SetDetailsForMovieSet(const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, int idSet = -1);
+  int SetDetailsForMovieSet(const CVideoInfoTag& details,
+                            const KODI::ART::ArtMap& artwork,
+                            int idSet = -1);
 
   /*! \brief add a tvshow to the library, setting metadata detail
    First checks for whether this TV Show is already in the database (based on idTvShow, or via GetMatchingTvShow)
@@ -626,11 +632,21 @@ public:
    \param idTvShow the database id of the tvshow if known (defaults to -1)
    \return the id of the tvshow.
    */
-  int SetDetailsForTvShow(const std::vector< std::pair<std::string, std::string> > &paths, CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, const std::map<int, std::map<std::string, std::string> > &seasonArt, int idTvShow = -1);
-  bool UpdateDetailsForTvShow(int idTvShow, CVideoInfoTag &details, const std::map<std::string, std::string> &artwork, const std::map<int, std::map<std::string, std::string> > &seasonArt);
-  int SetDetailsForSeason(const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, int idShow, int idSeason = -1);
+  int SetDetailsForTvShow(const std::vector<std::pair<std::string, std::string>>& paths,
+                          CVideoInfoTag& details,
+                          const KODI::ART::ArtMap& artwork,
+                          const std::map<int, KODI::ART::ArtMap>& seasonArt,
+                          int idTvShow = -1);
+  bool UpdateDetailsForTvShow(int idTvShow,
+                              CVideoInfoTag& details,
+                              const KODI::ART::ArtMap& artwork,
+                              const std::map<int, KODI::ART::ArtMap>& seasonArt);
+  int SetDetailsForSeason(const CVideoInfoTag& details,
+                          const KODI::ART::ArtMap& artwork,
+                          int idShow,
+                          int idSeason = -1);
   int SetDetailsForEpisode(CVideoInfoTag& details,
-                           const std::map<std::string, std::string>& artwork,
+                           const KODI::ART::ArtMap& artwork,
                            int idShow,
                            int idEpisode = -1);
   bool SetFileForMedia(const std::string& fileAndPath,
@@ -638,7 +654,7 @@ public:
                        int mediaId,
                        int oldIdFile);
   int SetDetailsForMusicVideo(CVideoInfoTag& details,
-                              const std::map<std::string, std::string>& artwork,
+                              const KODI::ART::ArtMap& artwork,
                               int idMVideo = -1);
   bool SetStreamDetailsForFile(const CStreamDetails& details,
                                const std::string& strFileNameAndPath);
@@ -673,7 +689,10 @@ public:
   bool SetSingleValue(const std::string &table, const std::string &fieldName, const std::string &strValue,
                       const std::string &conditionName = "", int conditionValue = -1);
 
-  int UpdateDetailsForMovie(int idMovie, CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, const std::set<std::string> &updatedDetails);
+  int UpdateDetailsForMovie(int idMovie,
+                            CVideoInfoTag& details,
+                            const KODI::ART::ArtMap& artwork,
+                            const std::set<std::string>& updatedDetails);
 
   /*!
    * \brief Remove a movie from the library.
@@ -1072,12 +1091,8 @@ public:
                      const MediaType& mediaType,
                      const std::string& artType,
                      const std::string& url);
-  bool SetArtForItem(int mediaId,
-                     const MediaType& mediaType,
-                     const std::map<std::string, std::string>& art);
-  bool GetArtForItem(int mediaId,
-                     const MediaType& mediaType,
-                     std::map<std::string, std::string>& art);
+  bool SetArtForItem(int mediaId, const MediaType& mediaType, const KODI::ART::ArtMap& art);
+  bool GetArtForItem(int mediaId, const MediaType& mediaType, KODI::ART::ArtMap& art);
   std::string GetArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType);
 
   void UpdateArtForItem(int mediaId, const MediaType& mediaType);
@@ -1108,7 +1123,7 @@ public:
    */
   std::string GetTvShowNamedSeasonById(int tvshowId, int seasonId);
 
-  bool GetTvShowSeasonArt(int mediaId, std::map<int, std::map<std::string, std::string> > &seasonArt);
+  bool GetTvShowSeasonArt(int mediaId, std::map<int, KODI::ART::ArtMap>& seasonArt);
   bool GetArtTypes(const MediaType &mediaType, std::vector<std::string> &artTypes);
 
   /*! \brief Fetch the distinct types of available-but-unassigned art held in the

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1698,9 +1698,11 @@ CVideoInfoScanner::~CVideoInfoScanner()
     return CDirectory::Exists(path) ? path : "";
   }
 
-  void CVideoInfoScanner::AddLocalItemArtwork(CGUIListItem::ArtMap& itemArt,
-    const std::vector<std::string>& wantedArtTypes, const std::string& itemPath,
-    bool addAll, bool exactName)
+  void CVideoInfoScanner::AddLocalItemArtwork(ArtMap& itemArt,
+                                              const std::vector<std::string>& wantedArtTypes,
+                                              const std::string& itemPath,
+                                              bool addAll,
+                                              bool exactName)
   {
     std::string path = URIUtils::GetDirectory(itemPath);
     if (path.empty())
@@ -1772,7 +1774,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     movieDetails.m_fanart.Unpack();
     movieDetails.m_strPictureURL.Parse();
 
-    CGUIListItem::ArtMap art = pItem->GetArt();
+    ArtMap art = pItem->GetArt();
 
     // get and cache thumb images
     std::string mediaType = ContentToMediaType(content, pItem->m_bIsFolder);
@@ -1814,7 +1816,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         std::string movieSetInfoPath = GetMovieSetInfoFolder(movieDetails.m_set.title);
         if (!movieSetInfoPath.empty())
         {
-          CGUIListItem::ArtMap movieSetArt;
+          ArtMap movieSetArt;
           AddLocalItemArtwork(movieSetArt, movieSetArtTypes, movieSetInfoPath, addAll, exactName);
           for (const auto& artItem : movieSetArt)
           {

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -925,7 +925,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
     if (ret == InfoRet::ADDED)
     {
-      std::map<int, std::map<std::string, std::string>> seasonArt;
+      std::map<int, ART::ArtMap> seasonArt;
       m_database.GetTvShowSeasonArt(showID, seasonArt);
 
       const bool updateSeasonArt{
@@ -1557,7 +1557,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         for (std::vector<std::string>::const_iterator i = multipath.begin(); i != multipath.end(); ++i)
           paths.emplace_back(*i, URIUtils::GetParentPath(*i));
 
-        std::map<int, std::map<std::string, std::string> > seasonArt;
+        std::map<int, ART::ArtMap> seasonArt;
 
         if (!libraryImport)
           GetSeasonThumbs(movieDetails, seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason), useLocal && !pItem->IsPlugin());
@@ -1698,7 +1698,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     return CDirectory::Exists(path) ? path : "";
   }
 
-  void CVideoInfoScanner::AddLocalItemArtwork(ArtMap& itemArt,
+  void CVideoInfoScanner::AddLocalItemArtwork(ART::ArtMap& itemArt,
                                               const std::vector<std::string>& wantedArtTypes,
                                               const std::string& itemPath,
                                               bool addAll,
@@ -1774,7 +1774,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     movieDetails.m_fanart.Unpack();
     movieDetails.m_strPictureURL.Parse();
 
-    ArtMap art = pItem->GetArt();
+    ART::ArtMap art = pItem->GetArt();
 
     // get and cache thumb images
     std::string mediaType = ContentToMediaType(content, pItem->m_bIsFolder);
@@ -1816,7 +1816,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         std::string movieSetInfoPath = GetMovieSetInfoFolder(movieDetails.m_set.title);
         if (!movieSetInfoPath.empty())
         {
-          ArtMap movieSetArt;
+          ART::ArtMap movieSetArt;
           AddLocalItemArtwork(movieSetArt, movieSetArtTypes, movieSetInfoPath, addAll, exactName);
           for (const auto& artItem : movieSetArt)
           {
@@ -2291,8 +2291,10 @@ CVideoInfoScanner::~CVideoInfoScanner()
     return "";
   }
 
-  void CVideoInfoScanner::GetSeasonThumbs(const CVideoInfoTag &show,
-      std::map<int, std::map<std::string, std::string>> &seasonArt, const std::vector<std::string> &artTypes, bool useLocal)
+  void CVideoInfoScanner::GetSeasonThumbs(const CVideoInfoTag& show,
+                                          std::map<int, ART::ArtMap>& seasonArt,
+                                          const std::vector<std::string>& artTypes,
+                                          bool useLocal)
   {
     int artLevel = CServiceBroker::GetSettingsComponent()->GetSettings()->
       GetInt(CSettings::SETTING_VIDEOLIBRARY_ARTWORK_LEVEL);
@@ -2332,7 +2334,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         if (it != seasonArt.end() && !it->second.empty())
           continue;
 
-        std::map<std::string, std::string> art;
+        ART::ArtMap art;
         std::string basePath;
         if (season == -1)
           basePath = "season-all";

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -100,7 +100,10 @@ namespace KODI::VIDEO
      \param art      artwork map to which season thumbs are added.
      \param useLocal whether to use local thumbs, defaults to true
      */
-    static void GetSeasonThumbs(const CVideoInfoTag &show, std::map<int, std::map<std::string, std::string> > &art, const std::vector<std::string> &artTypes, bool useLocal = true);
+    static void GetSeasonThumbs(const CVideoInfoTag& show,
+                                std::map<int, KODI::ART::ArtMap>& art,
+                                const std::vector<std::string>& artTypes,
+                                bool useLocal = true);
     static std::string GetImage(const CScraperUrl::SUrlEntry &image, const std::string& itemPath);
 
     bool EnumerateEpisodeItem(const CFileItem *item, EPISODELIST& episodeList);

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -12,6 +12,7 @@
 #include "VideoDatabase.h"
 #include "addons/Scraper.h"
 #include "guilib/GUIListItem.h"
+#include "utils/ArtUtils.h"
 
 #include <set>
 #include <string>
@@ -283,9 +284,11 @@ namespace KODI::VIDEO
     CVideoDatabase::ScraperCache m_scraperCache;
 
   private:
-    static void AddLocalItemArtwork(CGUIListItem::ArtMap& itemArt,
-      const std::vector<std::string>& wantedArtTypes, const std::string& itemPath,
-      bool addAll, bool exactName);
+    static void AddLocalItemArtwork(ART::ArtMap& itemArt,
+                                    const std::vector<std::string>& wantedArtTypes,
+                                    const std::string& itemPath,
+                                    bool addAll,
+                                    bool exactName);
 
     /*! \brief Retrieve the art type for an image from the given size.
      \param width the width of the image.

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -212,7 +212,7 @@ bool CVideoThumbLoader::LoadItemCached(CFileItem* pItem)
   }
 
   // if we have no art, look for it all
-  std::map<std::string, std::string> artwork = pItem->GetArt();
+  ArtMap artwork = pItem->GetArt();
   if (artwork.empty())
   {
     std::vector<std::string> artTypes = GetArtTypes(pItem->HasVideoInfoTag() ? pItem->GetVideoInfoTag()->m_type : "");
@@ -254,7 +254,7 @@ bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
       pItem->HasVideoInfoTag() && pItem->GetProperty("libraryartfilled").asBoolean();
   if (!isLibraryItem || !libraryArtFilled)
   {
-    std::map<std::string, std::string> artwork = pItem->GetArt();
+    ArtMap artwork = pItem->GetArt();
     std::vector<std::string> artTypes =
         GetArtTypes(pItem->HasVideoInfoTag() ? pItem->GetVideoInfoTag()->m_type : "");
     if (find(artTypes.begin(), artTypes.end(), "thumb") == artTypes.end())
@@ -357,7 +357,7 @@ bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
 bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
 {
   CVideoInfoTag &tag = *item.GetVideoInfoTag();
-  std::map<std::string, std::string> artwork;
+  ArtMap artwork;
   // Video item can be an album - either a 
   // a) search result with full details including music library album id, or 
   // b) musicvideo album that needs matching to a music album, storing id as well as fetch art.

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -45,6 +45,7 @@
 #include "settings/lib/Setting.h"
 #include "storage/MediaManager.h"
 #include "threads/IRunnable.h"
+#include "utils/ArtUtils.h"
 #include "utils/FileUtils.h"
 #include "utils/SortUtils.h"
 #include "utils/StringUtils.h"
@@ -816,7 +817,7 @@ void AddCurrentArtTypes(std::vector<std::string>& artTypes,
                         const CVideoInfoTag& tag,
                         CVideoDatabase& db)
 {
-  std::map<std::string, std::string> currentArt;
+  ART::ArtMap currentArt;
 
   if (tag.GetAssetInfo().GetId() >= 0)
     db.GetArtForAsset(tag.m_iFileId, ArtFallbackOptions::NONE, currentArt);
@@ -1255,7 +1256,7 @@ bool CGUIDialogVideoInfo::UpdateVideoItemTitle(const std::shared_ptr<CFileItem>&
   if (mediaType == MediaTypeSeason)
   {
     detail.m_strSortTitle = title;
-    std::map<std::string, std::string> artwork;
+    ART::ArtMap artwork;
     database.SetDetailsForSeason(detail, artwork, detail.m_iIdShow, detail.m_iDbId);
   }
   else
@@ -1612,7 +1613,7 @@ bool CGUIDialogVideoInfo::GetSetForMovie(const CFileItem* movieItem,
     if (!CGUIKeyboardFactory::ShowAndGetInput(newSetTitle, CVariant{g_localizeStrings.Get(20468)}, false))
       return false;
     int idSet = videodb.AddSet(newSetTitle);
-    std::map<std::string, std::string> movieArt, setArt;
+    ART::ArtMap movieArt, setArt;
     if (!videodb.GetArtForItem(idSet, MediaTypeVideoCollection, setArt))
     {
       videodb.GetArtForItem(movieItem->GetVideoInfoTag()->m_iDbId, MediaTypeMovie, movieArt);

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -26,6 +26,7 @@
 #include "messaging/helpers/DialogOKHelper.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/ArtUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -107,7 +108,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
   do
   {
     std::unique_ptr<CVideoInfoTag> pluginTag;
-    std::unique_ptr<CGUIListItem::ArtMap> pluginArt;
+    std::unique_ptr<ART::ArtMap> pluginArt;
 
     if (!ignoreNfo)
     {

--- a/xbmc/video/tags/VideoTagLoaderPlugin.cpp
+++ b/xbmc/video/tags/VideoTagLoaderPlugin.cpp
@@ -12,9 +12,11 @@
 #include "FileItemList.h"
 #include "URL.h"
 #include "filesystem/PluginDirectory.h"
+#include "utils/ArtUtils.h"
 
 #include <memory>
 
+using namespace KODI;
 using namespace XFILE;
 
 CVideoTagLoaderPlugin::CVideoTagLoaderPlugin(const CFileItem& item, bool forceRefresh)
@@ -27,7 +29,7 @@ CVideoTagLoaderPlugin::CVideoTagLoaderPlugin(const CFileItem& item, bool forceRe
     m_tag = std::make_unique<CVideoInfoTag>(*m_item.GetVideoInfoTag());
   auto& art = item.GetArt();
   if (!art.empty())
-    m_art = std::make_unique<CGUIListItem::ArtMap>(art);
+    m_art = std::make_unique<ART::ArtMap>(art);
 }
 
 bool CVideoTagLoaderPlugin::HasInfo() const
@@ -53,7 +55,7 @@ CInfoScanner::InfoType CVideoTagLoaderPlugin::Load(CVideoInfoTag& tag,
     if (!items.IsEmpty())
     {
       const CFileItemPtr &item = items[0];
-      m_art = std::make_unique<CGUIListItem::ArtMap>(item->GetArt());
+      m_art = std::make_unique<ART::ArtMap>(item->GetArt());
       if (item->HasVideoInfoTag())
       {
         tag = *item->GetVideoInfoTag();

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -443,7 +443,7 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
         // grab the show thumb
         CVideoInfoTag details;
         m_database.GetTvShowInfo("", details, params.GetTvShowId());
-        std::map<std::string, std::string> art;
+        ART::ArtMap art;
         if (m_database.GetArtForItem(details.m_iDbId, details.m_type, art) && !art.empty())
         {
           items.AppendArt(art, details.m_type);
@@ -481,7 +481,7 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
           else
             seasonID = items[firstIndex]->GetVideoInfoTag()->m_iIdSeason;
 
-          ArtMap seasonArt;
+          ART::ArtMap seasonArt;
           if (seasonID > -1 && m_database.GetArtForItem(seasonID, MediaTypeSeason, seasonArt) &&
               !seasonArt.empty())
           {
@@ -498,7 +498,7 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
       {
         if (params.GetSetId() > 0)
         {
-          ArtMap setArt;
+          ART::ArtMap setArt;
           if (m_database.GetArtForItem(params.GetSetId(), MediaTypeVideoCollection, setArt) &&
               !setArt.empty())
           {

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -37,6 +37,7 @@
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/ArtUtils.h"
 #include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -480,7 +481,7 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
           else
             seasonID = items[firstIndex]->GetVideoInfoTag()->m_iIdSeason;
 
-          CGUIListItem::ArtMap seasonArt;
+          ArtMap seasonArt;
           if (seasonID > -1 && m_database.GetArtForItem(seasonID, MediaTypeSeason, seasonArt) &&
               !seasonArt.empty())
           {
@@ -497,7 +498,7 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
       {
         if (params.GetSetId() > 0)
         {
-          CGUIListItem::ArtMap setArt;
+          ArtMap setArt;
           if (m_database.GetArtForItem(params.GetSetId(), MediaTypeVideoCollection, setArt) &&
               !setArt.empty())
           {


### PR DESCRIPTION
## Description
Use a common definition of the type ArtMap.

## Motivation and context
My initial interest was to change the key of ArtMap to use an enum to reduce string comparisons in the lookup. It was discovered however that the definition of ArtMap was typedef'ed in multiple locations and there was also many instances of inline declarations. 

## How has this been tested?
Building and unit tests

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
