### PR TITLE
[VideoDatabase] Better interface for `VideoContentTypeToString`

### DIFF
--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -82,15 +82,9 @@ void CopyVideoTagInfoToObject(CFileItem& item, CVariant& object)
   }
 
   if (!tag.m_type.empty())
-  {
     objItem["type"] = tag.m_type;
-  }
   else
-  {
-    std::string type;
-    CVideoDatabase::VideoContentTypeToString(item.GetVideoContentType(), type);
-    objItem["type"] = type;
-  }
+    objItem["type"] = CVideoDatabase::VideoContentTypeToString(item.GetVideoContentType());
 
   if (id <= 0)
   {

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3710,25 +3710,7 @@ void CVideoDatabase::DeleteResumeBookMark(const CFileItem& item)
     std::string sql = PrepareSQL("delete from bookmark where idFile=%i and type=%i", fileID, CBookmark::RESUME);
     m_pDS->exec(sql);
 
-    const VideoDbContentType iType = item.GetVideoContentType();
-    std::string content;
-    switch (iType)
-    {
-      case VideoDbContentType::MOVIES:
-        content = MediaTypeMovie;
-        break;
-      case VideoDbContentType::EPISODES:
-        content = MediaTypeEpisode;
-        break;
-      case VideoDbContentType::TVSHOWS:
-        content = MediaTypeTvShow;
-        break;
-      case VideoDbContentType::MUSICVIDEOS:
-        content = MediaTypeMusicVideo;
-        break;
-      default:
-        break;
-    }
+    const MediaType content = VideoContentTypeToString(item.GetVideoContentType());
 
     if (!content.empty())
     {
@@ -12977,13 +12959,10 @@ bool CVideoDatabase::ConvertVideoToVersion(VideoDbContentType itemType,
                                            VideoAssetType assetType)
 {
   int idFile = -1;
-  MediaType mediaType;
-  VideoContentTypeToString(itemType, mediaType);
+  const MediaType mediaType = VideoContentTypeToString(itemType);
 
   if (itemType == VideoDbContentType::MOVIES)
-  {
     idFile = GetFileIdByMovie(dbIdSource);
-  }
   else
     return false;
 
@@ -12999,7 +12978,7 @@ bool CVideoDatabase::ConvertVideoToVersion(VideoDbContentType itemType,
 
     // version-level art doesn't need any change.
     // 'movie' art is converted to 'videoversion' art.
-    SetVideoVersionDefaultArt(idFile, dbIdSource, itemType);
+    SetVideoVersionDefaultArt(idFile, dbIdSource, mediaType);
 
     if (itemType == VideoDbContentType::MOVIES)
       DeleteMovie(dbIdSource, DeleteMovieCascadeAction::ALL_ASSETS,
@@ -13136,8 +13115,7 @@ bool CVideoDatabase::AddVideoAsset(VideoDbContentType itemType,
   if (itemType != VideoDbContentType::MOVIES)
     return false;
 
-  MediaType mediaType;
-  VideoContentTypeToString(itemType, mediaType);
+  MediaType mediaType = VideoContentTypeToString(itemType);
 
   int idFile = AddFile(item.GetPath());
   if (idFile < 0)
@@ -13357,11 +13335,8 @@ std::string CVideoDatabase::GetVideoVersionById(int id)
   return GetSingleValue(PrepareSQL("SELECT name FROM videoversiontype WHERE id=%i", id), *m_pDS2);
 }
 
-bool CVideoDatabase::SetVideoVersionDefaultArt(int dbId, int idFrom, VideoDbContentType type)
+bool CVideoDatabase::SetVideoVersionDefaultArt(int dbId, int idFrom, const MediaType& mediaType)
 {
-  MediaType mediaType;
-  VideoContentTypeToString(type, mediaType);
-
   KODI::ART::Artwork art;
   if (GetArtForItem(idFrom, mediaType, art))
   {

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1094,24 +1094,20 @@ public:
   */
   unsigned int GetRandomMusicVideoIDs(const std::string& strWhere, std::vector<std::pair<int, int> > &songIDs);
 
-  static void VideoContentTypeToString(VideoDbContentType type, std::string& out)
+  static MediaType VideoContentTypeToString(VideoDbContentType type)
   {
     switch (type)
     {
       case VideoDbContentType::MOVIES:
-        out = MediaTypeMovie;
-        break;
+        return MediaTypeMovie;
       case VideoDbContentType::TVSHOWS:
-        out = MediaTypeTvShow;
-        break;
+        return MediaTypeTvShow;
       case VideoDbContentType::EPISODES:
-        out = MediaTypeEpisode;
-        break;
+        return MediaTypeEpisode;
       case VideoDbContentType::MUSICVIDEOS:
-        out = MediaTypeMusicVideo;
-        break;
+        return MediaTypeMusicVideo;
       default:
-        break;
+        return {};
     }
   }
 
@@ -1243,7 +1239,7 @@ public:
   bool GetVideoVersionTypes(VideoDbContentType idContent,
                             VideoAssetType asset,
                             CFileItemList& items);
-  bool SetVideoVersionDefaultArt(int dbId, int idFrom, VideoDbContentType type);
+  bool SetVideoVersionDefaultArt(int dbId, int idFrom, const MediaType& mediaType);
   void InitializeVideoVersionTypeTable(int schemaVersion);
   void UpdateVideoVersionTypeTable();
   bool GetVideoVersionsNav(const std::string& strBaseDir,


### PR DESCRIPTION
## Description
Change `VideoContentTypeToString`  to return a `MediaType` instead of passing one in to the function as an "out-parameter"

`SetVideoDefaultArt` calls VideoContentTypeToString which it neednt do if the `MediaType` is passed directly to this function.

## Motivation and context
Optimization

## How has this been tested?
Building and unit tests

## What is the effect on users?
Optimized library scans when different versions of movies are found.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
