### PR TITLE
[cmake] FindZLIB limit ZLIB_USE_STATIC_LIBS to depends build platforms

### DIFF
--- a/cmake/modules/FindZLIB.cmake
+++ b/cmake/modules/FindZLIB.cmake
@@ -26,8 +26,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
   # Darwin platforms link against toolchain provided zlib regardless
   # They will fail when searching for static. All other platforms, prefer static
   # if possible (requires cmake 3.24+ otherwise variable is a no-op)
-  # Windows still uses dynamic lib for zlib for other purposes, dont mix
-  if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin" AND NOT (WIN32 OR WINDOWS_STORE))
+  if(KODI_DEPENDSBUILD AND NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
     set(ZLIB_USE_STATIC_LIBS ON)
   endif()
 


### PR DESCRIPTION
## Description
Limit use of ZLIB_USE_STATIC_LIBS to depends platforms

## Motivation and context
https://github.com/xbmc/xbmc/pull/26797#issuecomment-2988059611

## How has this been tested?
N/A

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
