### PR TITLE
[tools/depends][target] pythonmodule-pil cleanup webos path install

### DIFF
--- a/tools/depends/target/pythonmodule-pil/Makefile
+++ b/tools/depends/target/pythonmodule-pil/Makefile
@@ -21,8 +21,6 @@ else ifeq ($(OS),darwin_embedded)
   PILPATH=$(PREFIX)/share/$(APP_NAME)/addons/script.module.pil
   PILPATHLIB=$(PILPATH)/lib
   PYTHONPATH=$(PILPATH):$(PYTHON_SITE_PKG)
-else ifeq ($(TARGET_PLATFORM),webos)
-  PILPATHLIB=$(PYTHON_SITE_PKG)/..
 endif
 
 SED_FLAG=-i
@@ -89,7 +87,7 @@ else ifeq ($(OS),darwin_embedded)
 	cd $(PILPATHLIB) && unzip -o ../pillow-*.egg
 	cd $(PILPATH) && rm -rf pillow-*.egg
 else ifeq ($(TARGET_PLATFORM),webos)
-	cd $(PILPATHLIB) && unzip -o $(PILPATH)/pillow-*.egg && rm -f $(PILPATH)/pillow-*.egg
+	cd $(PILPATH) && unzip -o $(PILPATH)/pillow-*.egg && rm -f $(PILPATH)/pillow-*.egg
 endif
 	touch $@
 


### PR DESCRIPTION
## Description
Clean paths that are not valid/necessary for webos

## Motivation and context
c1a5399fb90b1fd35dbb9e0f3769c1e1d46b12d7 set unique paths for webos for use with loader patching. The patching was removed later in 30498d89f3fb96d07fbbb777becf744d5fb9e4e6 but paths were left altered.
Removing this should put the extracted egg in the site-package folder

## How has this been tested?
It isnt. @sundermann maybe?

## What is the effect on users?
I guess PIL is working currently, i havent seen any report otherwise, so should be N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
