### PR TITLE
[GUILIstItem] SonarQube findings

### DIFF
--- a/xbmc/AutoSwitch.cpp
+++ b/xbmc/AutoSwitch.cpp
@@ -160,7 +160,7 @@ bool CAutoSwitch::ByFolderThumbPercentage(bool hideParentDirItems, int percent, 
     return false;
 
   const int numThumbs = std::ranges::count_if(
-      vecItems, [](const auto& item) { return item->m_bIsFolder && item->HasArt("thumb"); });
+      vecItems, [](const auto& item) { return item->IsFolder() && item->HasArt("thumb"); });
   return numThumbs >= 0.01f * percent * (numItems - fileCount);
 }
 

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -207,7 +207,7 @@ bool CAutorun::RunDisc(IDirectory* pDir,
     for (const auto& pItem : vecItems)
     {
       // is the current item a (non system) folder?
-      if (pItem->m_bIsFolder && pItem->GetPath() != "." && pItem->GetPath() != "..")
+      if (pItem->IsFolder() && pItem->GetPath() != "." && pItem->GetPath() != "..")
       {
         std::string name = pItem->GetPath();
         URIUtils::RemoveSlashAtEnd(name);
@@ -442,7 +442,7 @@ bool CAutorun::RunDisc(IDirectory* pDir,
     for (int i = 0; i < tempItems.Size(); i++)
     {
       CFileItemPtr pItem = tempItems[i];
-      if (!pItem->m_bIsFolder && IsVideo(*pItem))
+      if (!pItem->IsFolder() && IsVideo(*pItem))
       {
         bPlaying = true;
         if (pItem->IsStack())
@@ -483,7 +483,7 @@ bool CAutorun::RunDisc(IDirectory* pDir,
     for (int i = 0; i < vecItems.Size(); i++)
     {
       CFileItemPtr pItem = vecItems[i];
-      if (!pItem->m_bIsFolder && MUSIC::IsAudio(*pItem))
+      if (!pItem->IsFolder() && MUSIC::IsAudio(*pItem))
       {
         nAddedToPlaylist++;
         CServiceBroker::GetPlaylistPlayer().Add(PLAYLIST::Id::TYPE_MUSIC, pItem);
@@ -497,7 +497,7 @@ bool CAutorun::RunDisc(IDirectory* pDir,
     for (int i = 0; i < vecItems.Size(); i++)
     {
       CFileItemPtr pItem = vecItems[i];
-      if (!pItem->m_bIsFolder && pItem->IsPicture())
+      if (!pItem->IsFolder() && pItem->IsPicture())
       {
         bPlaying = true;
         std::string strExec = StringUtils::Format("RecursiveSlideShow({})", strDrive);
@@ -514,7 +514,7 @@ bool CAutorun::RunDisc(IDirectory* pDir,
     for (int i = 0; i < vecItems.Size(); i++)
     {
       CFileItemPtr  pItem = vecItems[i];
-      if (pItem->m_bIsFolder)
+      if (pItem->IsFolder())
       {
         if (pItem->GetPath() != "." && pItem->GetPath() != ".." )
         {

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -599,6 +599,7 @@ void CFileItem::Archive(CArchive& ar)
 
 void CFileItem::Serialize(CVariant& value) const
 {
+  //! @todo Why is this commented out? The implementation exists but will never be called.
   //CGUIListItem::Serialize(value["CGUIListItem"]);
 
   value["strPath"] = m_strPath;
@@ -622,10 +623,12 @@ void CFileItem::Serialize(CVariant& value) const
   if (m_gameInfoTag)
     (*m_gameInfoTag).Serialize(value["gameInfoTag"]);
 
-  if (!m_mapProperties.empty())
+  //! @todo Why is property map the only CGUIListItem property which gets serialized?
+  //! Why is this implemented here and not in CGUIListItem?
+  if (HasProperties())
   {
     auto& customProperties = value["customproperties"];
-    for (const auto& [propname, propval] : m_mapProperties)
+    for (const auto& [propname, propval] : GetProperties())
       customProperties[propname] = propval;
   }
 }

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1550,7 +1550,7 @@ void CFileItem::SetFromAlbum(const CAlbum &album)
   if (!album.strAlbum.empty())
     SetLabel(album.strAlbum);
   SetFolder(true);
-  m_strLabel2 = album.GetAlbumArtistString();
+  SetLabel2(album.GetAlbumArtistString());
   GetMusicInfoTag()->SetAlbum(album);
 
   if (album.art.empty())

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -105,7 +105,7 @@ CFileItem::CFileItem(std::string_view path, const CAlbum& album) : m_strPath(pat
 CFileItem::CFileItem(const CMusicInfoTag& music) : m_strPath(music.GetURL())
 {
   SetLabel(music.GetTitle());
-  m_bIsFolder = URIUtils::HasSlashAtEnd(m_strPath);
+  SetFolder(URIUtils::HasSlashAtEnd(m_strPath));
   *GetMusicInfoTag() = music;
   ART::FillInDefaultIcon(*this);
   FillInMimeType(false);
@@ -135,7 +135,7 @@ void CFileItem::FillMusicInfoTag(const std::shared_ptr<const CPVREpgInfoTag>& ta
 CFileItem::CFileItem(const std::shared_ptr<CPVREpgInfoTag>& tag)
   : m_strPath(tag->Path()), m_bCanQueue(false), m_epgInfoTag(tag)
 {
-  m_bIsFolder = false;
+  SetFolder(false);
   SetLabel(CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().GetTitleForEpgTag(tag));
   m_dateTime = tag->StartAsLocalTime();
 
@@ -166,7 +166,7 @@ CFileItem::CFileItem(const std::shared_ptr<CPVREpgInfoTag>& tag)
 CFileItem::CFileItem(const std::shared_ptr<PVR::CPVREpgSearchFilter>& filter)
   : m_strPath(filter->GetPath()), m_bCanQueue(false), m_epgSearchFilter(filter)
 {
-  m_bIsFolder = true;
+  SetFolder(true);
   SetLabel(filter->GetTitle());
 
   const CDateTime& lastExec = filter->GetLastExecutedDateTime();
@@ -190,7 +190,7 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRChannelGroupMember>& channelGroup
     m_bCanQueue(false),
     m_pvrChannelGroupMemberInfoTag(channelGroupMember)
 {
-  m_bIsFolder = false;
+  SetFolder(false);
   const std::shared_ptr<const CPVRChannel> channel = channelGroupMember->Channel();
   SetLabel(channel->ChannelName());
 
@@ -219,7 +219,7 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRChannelGroupMember>& channelGroup
 CFileItem::CFileItem(const std::shared_ptr<CPVRRecording>& record)
   : m_strPath(record->m_strFileNameAndPath), m_pvrRecordingInfoTag(record)
 {
-  m_bIsFolder = false;
+  SetFolder(false);
   SetLabel(record->m_strTitle);
   m_dateTime = record->RecordingTimeAsLocalTime();
   m_dwSize = record->GetSizeInBytes();
@@ -256,7 +256,7 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRTimerInfoTag>& timer)
     m_bCanQueue(false),
     m_pvrTimerInfoTag(timer)
 {
-  m_bIsFolder = timer->IsTimerRule();
+  SetFolder(timer->IsTimerRule());
   SetLabel(timer->Title());
 
   if (!timer->ChannelIcon().empty())
@@ -275,7 +275,7 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRTimerInfoTag>& timer)
 CFileItem::CFileItem(std::string_view path, const std::shared_ptr<CPVRProvider>& provider)
   : m_strPath(path), m_bCanQueue(false), m_pvrProviderInfoTag(provider)
 {
-  m_bIsFolder = true;
+  SetFolder(true);
   SetLabel(provider->GetName());
 
   // Set art
@@ -296,7 +296,7 @@ CFileItem::CFileItem(std::string_view path, const std::shared_ptr<CPVRProvider>&
 CFileItem::CFileItem(const CArtist& artist) : m_strPath(artist.strArtist)
 {
   SetLabel(artist.strArtist);
-  m_bIsFolder = true;
+  SetFolder(true);
   URIUtils::AddSlashAtEnd(m_strPath);
   GetMusicInfoTag()->SetArtist(artist);
   FillInMimeType(false);
@@ -305,7 +305,7 @@ CFileItem::CFileItem(const CArtist& artist) : m_strPath(artist.strArtist)
 CFileItem::CFileItem(const CGenre& genre) : m_strPath(genre.strGenre)
 {
   SetLabel(genre.strGenre);
-  m_bIsFolder = true;
+  SetFolder(true);
   URIUtils::AddSlashAtEnd(m_strPath);
   GetMusicInfoTag()->SetGenre(genre.strGenre);
   FillInMimeType(false);
@@ -335,23 +335,23 @@ CFileItem::CFileItem(const char* strLabel)
 
 CFileItem::CFileItem(const CURL& path, bool bIsFolder) : m_strPath(path.Get())
 {
-  m_bIsFolder = bIsFolder;
-  if (m_bIsFolder && !m_strPath.empty() && !IsFileFolder())
+  SetFolder(bIsFolder);
+  if (bIsFolder && !m_strPath.empty() && !IsFileFolder())
     URIUtils::AddSlashAtEnd(m_strPath);
   FillInMimeType(false);
 }
 
 CFileItem::CFileItem(std::string_view strPath, bool bIsFolder) : m_strPath(strPath)
 {
-  m_bIsFolder = bIsFolder;
-  if (m_bIsFolder && !m_strPath.empty() && !IsFileFolder())
+  SetFolder(bIsFolder);
+  if (bIsFolder && !m_strPath.empty() && !IsFileFolder())
     URIUtils::AddSlashAtEnd(m_strPath);
   FillInMimeType(false);
 }
 
 CFileItem::CFileItem(const CMediaSource& share) : m_strPath(share.strPath)
 {
-  m_bIsFolder = true;
+  SetFolder(true);
   m_bIsShareOrDrive = true;
   if (!IsRSS()) // no slash at end for rss feeds
     URIUtils::AddSlashAtEnd(m_strPath);
@@ -727,7 +727,7 @@ void CFileItem::ToSortable(SortItem &sortable, const Fields &fields) const
   sortable[FieldLabel] = GetLabel();
   /* FieldSortSpecial and FieldFolder are required in conjunction with all other sorters as well */
   sortable[FieldSortSpecial] = m_specialSort;
-  sortable[FieldFolder] = m_bIsFolder;
+  sortable[FieldFolder] = IsFolder();
 }
 
 bool CFileItem::Exists(bool bUseCache /* = true */) const
@@ -738,9 +738,9 @@ bool CFileItem::Exists(bool bUseCache /* = true */) const
 
   if (VIDEO::IsVideoDb(*this) && HasVideoInfoTag())
   {
-    const CFileItem dbItem(m_bIsFolder ? GetVideoInfoTag()->m_strPath
-                                       : GetVideoInfoTag()->m_strFileNameAndPath,
-                           m_bIsFolder);
+    const CFileItem dbItem(IsFolder() ? GetVideoInfoTag()->m_strPath
+                                      : GetVideoInfoTag()->m_strFileNameAndPath,
+                           IsFolder());
     return dbItem.Exists();
   }
 
@@ -752,7 +752,7 @@ bool CFileItem::Exists(bool bUseCache /* = true */) const
   if (URIUtils::IsStack(strPath))
     strPath = CStackDirectory::GetFirstStackedFile(strPath);
 
-  if (m_bIsFolder)
+  if (IsFolder())
     return CDirectory::Exists(strPath, bUseCache);
   else
     return CFile::Exists(strPath, bUseCache);
@@ -1068,7 +1068,7 @@ bool CFileItem::IsHD() const
 
 bool CFileItem::IsVirtualDirectoryRoot() const
 {
-  return (m_bIsFolder && m_strPath.empty());
+  return (IsFolder() && m_strPath.empty());
 }
 
 bool CFileItem::IsRemovable() const
@@ -1089,7 +1089,7 @@ bool CFileItem::IsReadOnly() const
 
 void CFileItem::RemoveExtension()
 {
-  if (m_bIsFolder)
+  if (IsFolder())
     return;
 
   std::string strLabel = GetLabel();
@@ -1115,7 +1115,7 @@ void CFileItem::SetLabel(const std::string &strLabel)
   if (strLabel == "..")
   {
     m_bIsParentFolder = true;
-    m_bIsFolder = true;
+    SetFolder(true);
     m_specialSort = SortSpecialOnTop;
     SetLabelPreformatted(true);
   }
@@ -1124,7 +1124,7 @@ void CFileItem::SetLabel(const std::string &strLabel)
 
 void CFileItem::SetFileSizeLabel()
 {
-  if(m_bIsFolder && m_dwSize == 0)
+  if (IsFolder() && m_dwSize == 0)
     SetLabel2("");
   else
     SetLabel2(StringUtils::SizeToString(m_dwSize));
@@ -1150,7 +1150,7 @@ void CFileItem::FillInMimeType(bool lookup /*= true*/)
   //! @todo adapt this to use CMime::GetMimeType()
   if (m_mimetype.empty())
   {
-    if (m_bIsFolder)
+    if (IsFolder())
       m_mimetype = "x-directory/normal";
     else if (HasPVRChannelInfoTag())
       m_mimetype = GetPVRChannelInfoTag()->MimeType();
@@ -1458,12 +1458,12 @@ void CFileItem::SetFromVideoInfoTag(const CVideoInfoTag &video)
   {
     m_strPath = video.m_strPath;
     URIUtils::AddSlashAtEnd(m_strPath);
-    m_bIsFolder = true;
+    SetFolder(true);
   }
   else
   {
     m_strPath = video.m_strFileNameAndPath;
-    m_bIsFolder = false;
+    SetFolder(false);
   }
 
   if (m_videoInfoTag)
@@ -1549,7 +1549,7 @@ void CFileItem::SetFromAlbum(const CAlbum &album)
 {
   if (!album.strAlbum.empty())
     SetLabel(album.strAlbum);
-  m_bIsFolder = true;
+  SetFolder(true);
   m_strLabel2 = album.GetAlbumArtistString();
   GetMusicInfoTag()->SetAlbum(album);
 
@@ -1705,14 +1705,14 @@ std::string CFileItem::GetUserMusicThumb(bool alwaysCheckRemote /* = false */, b
     return fileThumb;
 
   // Fall back to folder thumb, if requested
-  if (!m_bIsFolder && fallbackToFolder)
+  if (!IsFolder() && fallbackToFolder)
   {
     CFileItem item(URIUtils::GetDirectory(m_strPath), true);
     return item.GetUserMusicThumb(alwaysCheckRemote);
   }
 
   // if a folder, check for folder.jpg
-  if (m_bIsFolder && !IsFileFolder() &&
+  if (IsFolder() && !IsFileFolder() &&
       (!NETWORK::IsRemote(*this) || alwaysCheckRemote ||
        CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
            CSettings::SETTING_MUSICFILES_FINDREMOTETHUMBS)))
@@ -1796,13 +1796,13 @@ std::string CFileItem::FindLocalArt(const std::string &artFile, bool useFolder) 
     return "";
 
   std::string thumb;
-  if (!m_bIsFolder)
+  if (!IsFolder())
   {
     thumb = ART::GetLocalArt(*this, artFile, false);
     if (!thumb.empty() && CFile::Exists(thumb))
       return thumb;
   }
-  if ((useFolder || (m_bIsFolder && !IsFileFolder())) && !artFile.empty())
+  if ((useFolder || (IsFolder() && !IsFileFolder())) && !artFile.empty())
   {
     const std::string thumb2 = ART::GetLocalArt(*this, artFile, true);
     if (!thumb2.empty() && thumb2 != thumb && CFile::Exists(thumb2))
@@ -1850,7 +1850,7 @@ std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
     return GetLocalMetadataPath();
 
   if (bUseFolderNames &&
-      (!m_bIsFolder || URIUtils::IsInArchive(m_strPath) || URIUtils::IsBlurayPath(m_strPath) ||
+      (!IsFolder() || URIUtils::IsInArchive(m_strPath) || URIUtils::IsBlurayPath(m_strPath) ||
        (HasVideoInfoTag() && GetVideoInfoTag()->m_iDbId > 0 &&
         !CMediaTypes::IsContainer(GetVideoInfoTag()->m_type))))
   {
@@ -1875,7 +1875,7 @@ std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
 
 std::string CFileItem::GetLocalMetadataPath() const
 {
-  if (m_bIsFolder && !IsFileFolder())
+  if (IsFolder() && !IsFileFolder())
     return m_strPath;
 
   if (URIUtils::IsBlurayPath(GetDynPath()) || VIDEO::IsDVDFile(*this) || VIDEO::IsBDFile(*this))
@@ -2112,7 +2112,7 @@ bool CFileItem::LoadDetails()
     }
     else if (params.GetAlbumId() >= 0)
     {
-      m_bIsFolder = true;
+      SetFolder(true);
       CAlbum album;
       if (db.GetAlbum(params.GetAlbumId(), album, false))
       {
@@ -2122,7 +2122,7 @@ bool CFileItem::LoadDetails()
     }
     else if (params.GetArtistId() >= 0)
     {
-      m_bIsFolder = true;
+      SetFolder(true);
       CArtist artist;
       if (db.GetArtist(params.GetArtistId(), artist, false))
       {
@@ -2280,7 +2280,7 @@ bool CFileItem::GetCurrentResumeTimeAndPartNumber(int64_t& startOffset, int& par
 
 bool CFileItem::IsResumable() const
 {
-  if (m_bIsFolder)
+  if (IsFolder())
   {
     int64_t watched = 0;
     int64_t inprogress = 0;

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -219,14 +219,21 @@ void CFileItemList::Assign(const CFileItemList& itemlist, bool append)
   std::unique_lock lock(m_lock);
   if (!append)
     Clear();
+
   Append(itemlist);
+
+  //! @todo Is it intentional not to copy CFileItem properties, except path, label and property map?
+  //! This is different from CFileItemList::Copy. Why?
   SetPath(itemlist.GetPath());
   SetLabel(itemlist.GetLabel());
+  SetProperties(itemlist.GetProperties());
+
+  //! @todo Is it intentional not to copy m_ignoreURLOptions, m_fastLookup, m_sortIgnoreFolders, m_content?
+  //! This is (partly) different from CFileItemList::Copy. Why?
   m_sortDetails = itemlist.m_sortDetails;
   m_sortDescription = itemlist.m_sortDescription;
   m_replaceListing = itemlist.m_replaceListing;
   m_content = itemlist.m_content;
-  m_mapProperties = itemlist.m_mapProperties;
   m_cacheToDisc = itemlist.m_cacheToDisc;
 }
 
@@ -235,10 +242,10 @@ bool CFileItemList::Copy(const CFileItemList& items, bool copyItems /* = true */
   // assign all CFileItem parts
   *static_cast<CFileItem*>(this) = static_cast<const CFileItem&>(items);
 
+  //! @todo Is it intentional not to copy m_ignoreURLOptions, m_fastLookup ?
   // assign the rest of the CFileItemList properties
   m_replaceListing = items.m_replaceListing;
   m_content = items.m_content;
-  m_mapProperties = items.m_mapProperties;
   m_cacheToDisc = items.m_cacheToDisc;
   m_sortDetails = items.m_sortDetails;
   m_sortDescription = items.m_sortDescription;

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -511,7 +511,7 @@ int CFileItemList::GetFolderCount() const
 {
   std::unique_lock lock(m_lock);
   return static_cast<int>(
-      std::ranges::count_if(m_items, [](const auto& pItem) { return pItem->m_bIsFolder; }));
+      std::ranges::count_if(m_items, [](const auto& pItem) { return pItem->IsFolder(); }));
 }
 
 int CFileItemList::GetObjectCount() const
@@ -529,7 +529,7 @@ int CFileItemList::GetFileCount() const
 {
   std::unique_lock lock(m_lock);
   return static_cast<int>(
-      std::ranges::count_if(m_items, [](const auto& pItem) { return !pItem->m_bIsFolder; }));
+      std::ranges::count_if(m_items, [](const auto& pItem) { return !pItem->IsFolder(); }));
 }
 
 int CFileItemList::GetSelectedCount() const
@@ -546,7 +546,7 @@ void CFileItemList::FilterCueItems()
   std::vector<std::string> itemstodelete;
   for (const auto& pItem : m_items)
   {
-    if (!pItem->m_bIsFolder)
+    if (!pItem->IsFolder())
     { // see if it's a .CUE sheet
       if (MUSIC::IsCUESheet(*pItem))
       {
@@ -681,7 +681,7 @@ void CFileItemList::StackFolders()
   for (const auto& item : m_items)
   {
     // combined the folder checks
-    if (item->m_bIsFolder)
+    if (item->IsFolder())
     {
       // only check known fast sources?
       // NOTES:
@@ -711,7 +711,7 @@ void CFileItemList::StackFolders()
             int index = -1;
             for (int j = 0; j < items.Size(); j++)
             {
-              if (!items[j]->m_bIsFolder)
+              if (!items[j]->IsFolder())
               {
                 nFiles++;
                 index = j;
@@ -735,7 +735,7 @@ void CFileItemList::StackFolders()
           if (!dvdPath.empty())
           {
             // NOTE: should this be done for the CD# folders too?
-            item->m_bIsFolder = false;
+            item->SetFolder(false);
             item->SetPath(dvdPath);
             item->SetLabel2("");
             item->SetLabelPreformatted(true);
@@ -774,7 +774,7 @@ void CFileItemList::StackFiles()
     CFileItemPtr item1 = Get(i);
 
     // skip folders, nfo files, playlists
-    if (item1->m_bIsFolder || item1->IsParentFolder() || item1->IsNFO() ||
+    if (item1->IsFolder() || item1->IsParentFolder() || item1->IsNFO() ||
         PLAYLIST::IsPlayList(*item1))
     {
       // increment index
@@ -811,7 +811,7 @@ void CFileItemList::StackFiles()
           const CFileItemPtr item2 = Get(j);
 
           // skip folders, nfo files, playlists
-          if (item2->m_bIsFolder || item2->IsParentFolder() || item2->IsNFO() ||
+          if (item2->IsFolder() || item2->IsParentFolder() || item2->IsNFO() ||
               PLAYLIST::IsPlayList(*item2))
           {
             // increment index
@@ -907,7 +907,7 @@ void CFileItemList::StackFiles()
         // clean up list
         for (size_t k = 1; k < stack.size(); k++)
           Remove(i + 1);
-        // item->m_bIsFolder = true;  // don't treat stacked files as folders
+        // item->SetFolder(true);  // don't treat stacked files as folders
         // the label may be in a different char set from the filename (eg over smb
         // the label is converted from utf8, but the filename is not)
         if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -11855,7 +11855,7 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int co
         break;
       }
       case LISTITEM_SIZE:
-        if (!item->m_bIsFolder || item->GetSize())
+        if (!item->IsFolder() || item->GetSize())
           return StringUtils::SizeToString(item->GetSize());
         break;
       case LISTITEM_PROGRAM_COUNT:
@@ -11966,7 +11966,7 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int contextWindow, i
       case LISTITEM_ISSELECTED:
         return item->IsSelected();
       case LISTITEM_IS_FOLDER:
-        return item->m_bIsFolder;
+        return item->IsFolder();
       case LISTITEM_IS_PARENTFOLDER:
       {
         if (item->IsFileItem())

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -124,7 +124,7 @@ bool CGUIPassword::IsItemUnlocked(CFileItem* pItem, const std::string& strType)
 {
   const std::string strLabel = pItem->GetLabel();
   std::string strHeading;
-  if (pItem->m_bIsFolder)
+  if (pItem->IsFolder())
     strHeading = g_localizeStrings.Get(12325); // "Locked! Enter code..."
   else
     strHeading = g_localizeStrings.Get(12348); // "Item locked"

--- a/xbmc/ThumbLoader.cpp
+++ b/xbmc/ThumbLoader.cpp
@@ -112,7 +112,7 @@ std::string CProgramThumbLoader::GetLocalThumb(const CFileItem &item)
     return "";
 
   // look for the thumb
-  if (item.m_bIsFolder)
+  if (item.IsFolder())
   {
     const std::string folderThumb = ART::GetFolderThumb(item);
     if (CFileUtils::Exists(folderThumb))

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -777,7 +777,7 @@ void CUtil::RemoveTempFiles()
 
   for (const auto &item : items)
   {
-    if (item->m_bIsFolder)
+    if (item->IsFolder())
       continue;
     XFILE::CFile::Delete(item->GetPath());
   }
@@ -790,7 +790,7 @@ void CUtil::ClearSubtitles()
   CDirectory::GetDirectory("special://temp/",items, "", DIR_FLAG_DEFAULTS);
   for (const auto &item : items)
   {
-    if (!item->m_bIsFolder)
+    if (!item->IsFolder())
     {
       if (item->GetPath().find("subtitle") != std::string::npos ||
           item->GetPath().find("vobsub_queue") != std::string::npos)
@@ -1439,7 +1439,7 @@ void CUtil::DeleteDirectoryCache(const std::string &prefix)
 
   for (const auto &item : items)
   {
-    if (item->m_bIsFolder)
+    if (item->IsFolder())
       continue;
     std::string fileName = URIUtils::GetFileName(item->GetPath());
     if (StringUtils::StartsWith(fileName, prefix))
@@ -1454,7 +1454,7 @@ void CUtil::GetRecursiveListing(const std::string& strPath, CFileItemList& items
   CDirectory::GetDirectory(strPath,myItems,strMask,flags);
   for (const auto &item : myItems)
   {
-    if (item->m_bIsFolder)
+    if (item->IsFolder())
       CUtil::GetRecursiveListing(item->GetPath(),items,strMask,flags);
     else
       items.Add(item);
@@ -1467,7 +1467,7 @@ void CUtil::GetRecursiveDirsListing(const std::string& strPath, CFileItemList& i
   CDirectory::GetDirectory(strPath,myItems,"",flags);
   for (const auto &i : myItems)
   {
-    if (i->m_bIsFolder && !i->IsPath(".."))
+    if (i->IsFolder() && !i->IsPath(".."))
     {
       item.Add(i);
       CUtil::GetRecursiveDirsListing(i->GetPath(),item,flags);
@@ -1628,7 +1628,7 @@ void CUtil::GetSkinThemes(std::vector<std::string>& vecTheme)
   // Search for Themes in the Current skin!
   for (const auto &pItem : items)
   {
-    if (!pItem->m_bIsFolder)
+    if (!pItem->IsFolder())
     {
       std::string strExtension = URIUtils::GetExtension(pItem->GetPath());
       std::string strLabel = pItem->GetLabel();
@@ -1963,7 +1963,7 @@ void CUtil::ScanPathsForAssociatedItems(const std::string& videoName,
 {
   for (const auto &pItem : items)
   {
-    if (pItem->m_bIsFolder)
+    if (pItem->IsFolder())
       continue;
 
     std::string strCandidate = URIUtils::GetFileName(pItem->GetPath());

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -125,7 +125,7 @@ std::string CAddon::Icon() const
   return m_addonInfo->Icon();
 }
 
-ArtMap CAddon::Art() const
+KODI::ART::Artwork CAddon::Art() const
 {
   return m_addonInfo->Art();
 }

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -109,7 +109,7 @@ public:
   std::string Author() const override;
   std::string ChangeLog() const override;
   std::string Icon() const override;
-  ArtMap Art() const override;
+  KODI::ART::Artwork Art() const override;
   std::vector<std::string> Screenshots() const override;
   std::string Disclaimer() const override;
   AddonLifecycleState LifecycleState() const override;

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -15,6 +15,7 @@
 #include "addons/addoninfo/AddonType.h"
 #include "dbwrappers/dataset.h"
 #include "filesystem/SpecialProtocol.h"
+#include "utils/Artwork.h"
 #include "utils/JSONVariantParser.h"
 #include "utils/JSONVariantWriter.h"
 #include "utils/StringUtils.h"
@@ -126,7 +127,7 @@ void CAddonDatabaseSerializer::DeserializeMetadata(const std::string& document,
   builder.SetPath(variant["path"].asString());
   builder.SetIcon(variant["icon"].asString());
 
-  std::map<std::string, std::string> art;
+  KODI::ART::Artwork art;
   for (auto it = variant["art"].begin_map(); it != variant["art"].end_map(); ++it)
     art.emplace(it->first, it->second.asString());
   builder.SetArt(std::move(art));

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -418,8 +418,8 @@ bool CAddonInstaller::InstallFromZip(const std::string &path)
   CURL pathToUrl(path);
   CURL zipDir = URIUtils::CreateArchivePath("zip", pathToUrl, "");
   auto eventLog = CServiceBroker::GetEventLog();
-  if (!CDirectory::GetDirectory(zipDir, items, "", DIR_FLAG_DEFAULTS) ||
-      items.Size() != 1 || !items[0]->m_bIsFolder)
+  if (!CDirectory::GetDirectory(zipDir, items, "", DIR_FLAG_DEFAULTS) || items.Size() != 1 ||
+      !items[0]->IsFolder())
   {
     if (eventLog)
       eventLog->AddWithNotification(EventPtr(
@@ -429,7 +429,7 @@ bool CAddonInstaller::InstallFromZip(const std::string &path)
     CLog::Log(
         LOGERROR,
         "CAddonInstaller: installing addon failed '{}' - itemsize: {}, first item is folder: {}",
-        CURL::GetRedacted(path), items.Size(), items[0]->m_bIsFolder);
+        CURL::GetRedacted(path), items.Size(), items[0]->IsFolder());
     return false;
   }
 
@@ -619,7 +619,7 @@ int64_t CAddonInstaller::EnumeratePackageFolder(
   int64_t size = 0;
   for (int i = 0; i < items.Size(); i++)
   {
-    if (items[i]->m_bIsFolder)
+    if (items[i]->IsFolder())
       continue;
 
     size += items[i]->GetSize();
@@ -776,7 +776,7 @@ bool CAddonInstallJob::DoWork()
       CFileItemList archivedFiles;
       AddonPtr temp;
       if (!CDirectory::GetDirectory(archive, archivedFiles, "", DIR_FLAG_DEFAULTS) ||
-          archivedFiles.Size() != 1 || !archivedFiles[0]->m_bIsFolder ||
+          archivedFiles.Size() != 1 || !archivedFiles[0]->IsFolder() ||
           !CServiceBroker::GetAddonMgr().LoadAddonDescription(archivedFiles[0]->GetPath(), temp))
       {
         CLog::Log(LOGERROR, "CAddonInstallJob[{}]: invalid package {}", m_addon->ID(), package);

--- a/xbmc/addons/FilesystemInstaller.cpp
+++ b/xbmc/addons/FilesystemInstaller.cpp
@@ -94,7 +94,7 @@ bool CFilesystemInstaller::UnpackArchive(std::string path, const std::string& de
   if (!CDirectory::GetDirectory(path, files, "", DIR_FLAG_DEFAULTS))
     return false;
 
-  if (files.Size() == 1 && files[0]->m_bIsFolder)
+  if (files.Size() == 1 && files[0]->IsFolder())
   {
     path = files[0]->GetPath();
     files.Clear();

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "utils/Artwork.h"
+
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -67,7 +69,6 @@ typedef std::shared_ptr<IAddon> AddonPtr;
 typedef std::vector<AddonPtr> VECADDONS;
 
 using InfoMap = std::map<std::string, std::string>;
-using ArtMap = std::map<std::string, std::string>;
 
 class IAddon : public std::enable_shared_from_this<IAddon>
 {
@@ -90,7 +91,7 @@ public:
   virtual std::string LibPath() const = 0;
   virtual std::string ChangeLog() const = 0;
   virtual std::string FanArt() const = 0;
-  virtual ArtMap Art() const = 0;
+  virtual KODI::ART::Artwork Art() const = 0;
   virtual std::vector<std::string> Screenshots() const = 0;
   virtual std::string Author() const = 0;
   virtual std::string Icon() const = 0;

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -229,7 +229,7 @@ void CSkinInfo::Start()
     for (int i = 0; i < items.Size(); i++)
     {
       RESOLUTION_INFO res;
-      if (items[i]->m_bIsFolder && TranslateResolution(items[i]->GetLabel(), res))
+      if (items[i]->IsFolder() && TranslateResolution(items[i]->GetLabel(), res))
         m_resolutions.push_back(res);
     }
   }
@@ -474,7 +474,7 @@ void CSkinInfo::SettingOptionsSkinColorsFiller(const SettingConstPtr& setting,
   for (int i = 0; i < items.Size(); ++i)
   {
     CFileItemPtr pItem = items[i];
-    if (!pItem->m_bIsFolder && !StringUtils::EqualsNoCase(pItem->GetLabel(), "defaults.xml"))
+    if (!pItem->IsFolder() && !StringUtils::EqualsNoCase(pItem->GetLabel(), "defaults.xml"))
     { // not the default one
       vecColors.push_back(pItem->GetLabel().substr(0, pItem->GetLabel().size() - 4));
     }

--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -504,7 +504,7 @@ static void VFSDirEntriesToCFileItemList(int num_entries,
     item->SetPath(entries[i].path);
     item->SetSize(entries[i].size);
     item->SetDateTime(entries[i].date_time);
-    item->m_bIsFolder = entries[i].folder;
+    item->SetFolder(entries[i].folder);
     if (entries[i].title)
       item->SetTitle(entries[i].title);
     for (unsigned int j=0;j<entries[i].num_props;++j)

--- a/xbmc/addons/addoninfo/AddonInfo.h
+++ b/xbmc/addons/addoninfo/AddonInfo.h
@@ -10,6 +10,7 @@
 
 #include "XBDateTime.h"
 #include "addons/AddonVersion.h"
+#include "utils/Artwork.h"
 
 #include <map>
 #include <memory>
@@ -134,7 +135,6 @@ struct DependencyInfo
 };
 
 typedef std::map<std::string, std::string> InfoMap;
-typedef std::map<std::string, std::string> ArtMap;
 
 class CAddonInfoBuilder;
 
@@ -222,7 +222,7 @@ public:
   const std::string& ProfilePath() const { return m_profilePath; }
   const std::string& ChangeLog() const { return GetTranslatedText(m_changelog); }
   const std::string& Icon() const { return m_icon; }
-  const ArtMap& Art() const { return m_art; }
+  const KODI::ART::Artwork& Art() const { return m_art; }
   const std::vector<std::string>& Screenshots() const { return m_screenshots; }
   const std::string& Disclaimer() const { return GetTranslatedText(m_disclaimer); }
   const std::vector<DependencyInfo>& GetDependencies() const { return m_dependencies; }
@@ -284,7 +284,7 @@ private:
   std::string m_profilePath;
   std::unordered_map<std::string, std::string> m_changelog;
   std::string m_icon;
-  ArtMap m_art;
+  KODI::ART::Artwork m_art;
   std::vector<std::string> m_screenshots;
   std::unordered_map<std::string, std::string> m_disclaimer;
   std::vector<DependencyInfo> m_dependencies;

--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -108,7 +108,7 @@ void CAddonInfoBuilderFromDB::SetArt(const std::string& type, std::string value)
   m_addonInfo->m_art[type] = std::move(value);
 }
 
-void CAddonInfoBuilderFromDB::SetArt(std::map<std::string, std::string> art)
+void CAddonInfoBuilderFromDB::SetArt(KODI::ART::Artwork art)
 {
   m_addonInfo->m_art = std::move(art);
 }

--- a/xbmc/addons/addoninfo/AddonInfoBuilder.h
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "addons/IAddon.h"
+#include "utils/Artwork.h"
 
 #include <map>
 #include <memory>
@@ -91,7 +92,7 @@ public:
   void SetEMail(std::string email);
   void SetIcon(std::string icon);
   void SetArt(const std::string& type, std::string value);
-  void SetArt(std::map<std::string, std::string> art);
+  void SetArt(KODI::ART::Artwork art);
   void SetScreenshots(std::vector<std::string> screenshots);
   void SetChangelog(std::string changelog);
   void SetLifecycleState(AddonLifecycleState state, std::string description);

--- a/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
@@ -239,7 +239,7 @@ bool CGUIWindowAddonBrowser::OnClick(int iItem, const std::string& player)
     CGUIDialogBusy::Wait(&updater, 100, true);
     return true;
   }
-  if (!item->m_bIsFolder)
+  if (!item->IsFolder())
   {
     // cancel a downloading job
     if (item->HasProperty("Addon.Downloading"))
@@ -345,7 +345,7 @@ bool CGUIWindowAddonBrowser::GetDirectory(const std::string& strDirectory, CFile
 
 void CGUIWindowAddonBrowser::UpdateStatus(const CFileItemPtr& item)
 {
-  if (!item || item->m_bIsFolder)
+  if (!item || item->IsFolder())
     return;
 
   unsigned int percent;

--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -240,7 +240,7 @@ static void CFileItemListToVFSDirEntries(VFSDirEntry* entries, const CFileItemLi
     entries[i].label = strdup(items[i]->GetLabel().c_str());
     entries[i].path = strdup(items[i]->GetPath().c_str());
     entries[i].size = items[i]->GetSize();
-    entries[i].folder = items[i]->m_bIsFolder;
+    entries[i].folder = items[i]->IsFolder();
     items[i]->GetDateTime().GetAsTime(entries[i].date_time);
   }
 }

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -1724,7 +1724,7 @@ void CAddonSettings::FileEnumSettingOptionsFiller(const std::shared_ptr<const CS
   // process the matching files/directories
   for (const auto& item : items)
   {
-    if ((masking == "/" && item->m_bIsFolder) || !item->m_bIsFolder)
+    if ((masking == "/" && item->IsFolder()) || !item->IsFolder())
     {
       if (settingPath->HideExtension())
         item->RemoveExtension();

--- a/xbmc/application/ApplicationSkinHandling.cpp
+++ b/xbmc/application/ApplicationSkinHandling.cpp
@@ -276,7 +276,7 @@ bool CApplicationSkinHandling::LoadCustomWindows()
     {
       for (const auto& item : items)
       {
-        if (item->m_bIsFolder)
+        if (item->IsFolder())
           continue;
 
         std::string skinFile = URIUtils::GetFileName(item->GetPath());

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -255,7 +255,7 @@ std::unique_ptr<CTexture> CDVDFileInfo::ExtractThumbToTexture(const CFileItem& f
 
 bool CDVDFileInfo::CanExtract(const CFileItem& fileItem)
 {
-  if (fileItem.m_bIsFolder)
+  if (fileItem.IsFolder())
     return false;
 
   if ((URIUtils::IsPVR(fileItem.GetPath()) &&

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -118,7 +118,7 @@ void CDVDSubtitlesLibass::Configure()
   }
   for (const auto& item : items)
   {
-    if (item->m_bIsFolder)
+    if (item->IsFolder())
       continue;
     const std::string filepath = item->GetPath();
     const std::string fileName = item->GetLabel();

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -59,7 +59,7 @@ CGUIDialogFileBrowser::CGUIDialogFileBrowser()
   m_Directory = new CFileItem;
   m_vecItems = new CFileItemList;
   m_bConfirmed = false;
-  m_Directory->m_bIsFolder = true;
+  m_Directory->SetFolder(true);
   m_browsingForFolders = 0;
   m_browsingForImages = false;
   m_useFileDirectories = false;
@@ -182,14 +182,14 @@ bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)
         if (iItem < 0) break;
         CFileItemPtr pItem = (*m_vecItems)[iItem];
         if ((iAction == ACTION_SELECT_ITEM || iAction == ACTION_MOUSE_LEFT_CLICK) &&
-            (!m_multipleSelection || pItem->IsShareOrDrive() || pItem->m_bIsFolder))
+            (!m_multipleSelection || pItem->IsShareOrDrive() || pItem->IsFolder()))
         {
           OnClick(iItem);
           return true;
         }
         else if ((iAction == ACTION_HIGHLIGHT_ITEM || iAction == ACTION_MOUSE_LEFT_CLICK ||
                   iAction == ACTION_SELECT_ITEM) &&
-                 (m_multipleSelection && !pItem->IsShareOrDrive() && !pItem->m_bIsFolder))
+                 (m_multipleSelection && !pItem->IsShareOrDrive() && !pItem->IsFolder()))
         {
           pItem->Select(!pItem->IsSelected());
           CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), message.GetSenderId(), iItem + 1);
@@ -379,7 +379,7 @@ void CGUIDialogFileBrowser::Update(const std::string &strDirectory)
       {
         CFileItemPtr pItem(new CFileItem(".."));
         pItem->SetPath(strParentPath);
-        pItem->m_bIsFolder = true;
+        pItem->SetFolder(true);
         pItem->SetIsShareOrDrive(false);
         items.AddFront(pItem, 0);
       }
@@ -391,7 +391,7 @@ void CGUIDialogFileBrowser::Update(const std::string &strDirectory)
       CFileItemPtr pItem(new CFileItem(".."));
       pItem->SetPath("");
       pItem->SetIsShareOrDrive(false);
-      pItem->m_bIsFolder = true;
+      pItem->SetFolder(true);
       items.AddFront(pItem, 0);
       strParentPath = "";
     }
@@ -411,7 +411,7 @@ void CGUIDialogFileBrowser::Update(const std::string &strDirectory)
   if (m_browsingForFolders)
   {
     for (int i=0;i<m_vecItems->Size();++i)
-      if (!(*m_vecItems)[i]->m_bIsFolder)
+      if (!(*m_vecItems)[i]->IsFolder())
       {
         m_vecItems->Remove(i);
         i--;
@@ -434,14 +434,14 @@ void CGUIDialogFileBrowser::Update(const std::string &strDirectory)
   { // we are in the virtual directory - add the "Add Network Location" item
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(1032)));
     pItem->SetPath("net://");
-    pItem->m_bIsFolder = true;
+    pItem->SetFolder(true);
     m_vecItems->Add(pItem);
   }
   if (m_Directory->GetPath().empty() && !m_addSourceType.empty())
   {
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(21359)));
     pItem->SetPath("source://");
-    pItem->m_bIsFolder = true;
+    pItem->SetFolder(true);
     m_vecItems->Add(pItem);
   }
 
@@ -498,7 +498,8 @@ void CGUIDialogFileBrowser::FrameMove()
       std::string safePath = url.GetWithoutUserDetails();
       SET_CONTROL_LABEL(CONTROL_LABEL_PATH, safePath);
     }
-    if ((!m_browsingForFolders && (*m_vecItems)[item]->m_bIsFolder) || ((*m_vecItems)[item]->GetPath() == "image://Browse"))
+    if ((!m_browsingForFolders && (*m_vecItems)[item]->IsFolder()) ||
+        ((*m_vecItems)[item]->GetPath() == "image://Browse"))
     {
       CONTROL_DISABLE(CONTROL_OK);
     }
@@ -532,7 +533,7 @@ void CGUIDialogFileBrowser::OnClick(int iItem)
   CFileItemPtr pItem = (*m_vecItems)[iItem];
   std::string strPath = pItem->GetPath();
 
-  if (pItem->m_bIsFolder)
+  if (pItem->IsFolder())
   {
     if (pItem->GetPath() == "net://")
     { // special "Add Network Location" item

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -132,7 +132,7 @@ bool CGUIDialogSimpleMenu::ShowPlaylistSelection(CFileItem& item)
     }
 
     // If item is not folder (ie. all titles)
-    if (!item_new->m_bIsFolder)
+    if (!item_new->IsFolder())
     {
       if (!usedPlaylists.empty())
       {

--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -257,7 +257,7 @@ bool CFavouritesService::AddOrRemove(const CFileItem& item, int contextWindow)
       // create our new favourite item
       const auto favourite{std::make_shared<CFileItem>(item.GetLabel())};
       if (item.GetLabel().empty())
-        favourite->SetLabel(CUtil::GetTitleFromPath(item.GetPath(), item.m_bIsFolder));
+        favourite->SetLabel(CUtil::GetTitleFromPath(item.GetPath(), item.IsFolder()));
       favourite->SetArt("thumb", ContentUtils::GetPreferredArtImage(item));
       const std::string favUrl{CFavouritesURL(item, contextWindow).GetURL()};
       favourite->SetPath(favUrl);

--- a/xbmc/favourites/GUIWindowFavourites.cpp
+++ b/xbmc/favourites/GUIWindowFavourites.cpp
@@ -61,7 +61,7 @@ bool CGUIWindowFavourites::OnSelect(int itemIdx)
     return false;
 
   // video select action setting is for files only, except exec func is playmedia...
-  if (targetItem->HasVideoInfoTag() && (!targetItem->m_bIsFolder || isPlayMedia))
+  if (targetItem->HasVideoInfoTag() && (!targetItem->IsFolder() || isPlayMedia))
   {
     KODI::VIDEO::GUILIB::CVideoSelectActionProcessor proc{targetItem};
     if (proc.ProcessDefaultAction())
@@ -88,7 +88,7 @@ bool CGUIWindowFavourites::OnAction(const CAction& action)
     const auto item{std::make_shared<CFileItem>(*targetItem)};
 
     // video play action setting is for files and folders...
-    if (item->HasVideoInfoTag() || (item->m_bIsFolder && VIDEO::UTILS::IsItemPlayable(*item)))
+    if (item->HasVideoInfoTag() || (item->IsFolder() && VIDEO::UTILS::IsItemPlayable(*item)))
     {
       KODI::VIDEO::GUILIB::CVideoPlayActionProcessor proc{item};
       if (proc.ProcessDefaultAction())

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -171,7 +171,7 @@ static void GenerateTypeListing(const CURL& path,
         CURL itemPath = path;
         itemPath.SetFileName(CAddonInfo::TranslateType(type, false));
         item->SetPath(itemPath.Get());
-        item->m_bIsFolder = true;
+        item->SetFolder(true);
         std::string thumb = CAddonInfo::TranslateIconType(type);
         if (!thumb.empty() && CServiceBroker::GetGUI()->GetTextureManager().HasTexture(thumb))
           item->SetArt("thumb", thumb);
@@ -194,7 +194,7 @@ static void GenerateGameListing(const CURL& path, const VECADDONS& addons, CFile
       CURL itemPath = path;
       itemPath.SetFileName(CAddonInfo::TranslateType(AddonType::GAME_CONTROLLER, false));
       item->SetPath(itemPath.Get());
-      item->m_bIsFolder = true;
+      item->SetFolder(true);
       std::string thumb = CAddonInfo::TranslateIconType(AddonType::GAME_CONTROLLER);
       if (!thumb.empty() && CServiceBroker::GetGUI()->GetTextureManager().HasTexture(thumb))
         item->SetArt("thumb", thumb);
@@ -211,7 +211,7 @@ static void GenerateGameListing(const CURL& path, const VECADDONS& addons, CFile
       CURL itemPath = path;
       itemPath.SetFileName(CATEGORY_EMULATORS);
       item->SetPath(itemPath.Get());
-      item->m_bIsFolder = true;
+      item->SetFolder(true);
       std::string thumb = CAddonInfo::TranslateIconType(AddonType::GAMEDLL);
       if (!thumb.empty() && CServiceBroker::GetGUI()->GetTextureManager().HasTexture(thumb))
         item->SetArt("thumb", thumb);
@@ -228,7 +228,7 @@ static void GenerateGameListing(const CURL& path, const VECADDONS& addons, CFile
       CURL itemPath = path;
       itemPath.SetFileName(CATEGORY_STANDALONE_GAMES);
       item->SetPath(itemPath.Get());
-      item->m_bIsFolder = true;
+      item->SetFolder(true);
       std::string thumb = CAddonInfo::TranslateIconType(AddonType::GAMEDLL);
       if (!thumb.empty() && CServiceBroker::GetGUI()->GetTextureManager().HasTexture(thumb))
         item->SetArt("thumb", thumb);
@@ -245,7 +245,7 @@ static void GenerateGameListing(const CURL& path, const VECADDONS& addons, CFile
       CURL itemPath = path;
       itemPath.SetFileName(CATEGORY_GAME_PROVIDERS);
       item->SetPath(itemPath.Get());
-      item->m_bIsFolder = true;
+      item->SetFolder(true);
       std::string thumb = CAddonInfo::TranslateIconType(AddonType::GAMEDLL);
       if (!thumb.empty() && CServiceBroker::GetGUI()->GetTextureManager().HasTexture(thumb))
         item->SetArt("thumb", thumb);
@@ -262,7 +262,7 @@ static void GenerateGameListing(const CURL& path, const VECADDONS& addons, CFile
       CURL itemPath = path;
       itemPath.SetFileName(CATEGORY_GAME_RESOURCES);
       item->SetPath(itemPath.Get());
-      item->m_bIsFolder = true;
+      item->SetFolder(true);
       std::string thumb = CAddonInfo::TranslateIconType(AddonType::GAMEDLL);
       if (!thumb.empty() && CServiceBroker::GetGUI()->GetTextureManager().HasTexture(thumb))
         item->SetArt("thumb", thumb);
@@ -279,7 +279,7 @@ static void GenerateGameListing(const CURL& path, const VECADDONS& addons, CFile
       CURL itemPath = path;
       itemPath.SetFileName(CATEGORY_GAME_SUPPORT_ADDONS);
       item->SetPath(itemPath.Get());
-      item->m_bIsFolder = true;
+      item->SetFolder(true);
       std::string thumb = CAddonInfo::TranslateIconType(AddonType::GAMEDLL);
       if (!thumb.empty() && CServiceBroker::GetGUI()->GetTextureManager().HasTexture(thumb))
         item->SetArt("thumb", thumb);
@@ -297,7 +297,7 @@ static void GenerateMainCategoryListing(const CURL& path, const VECADDONS& addon
   {
     CFileItemPtr item(new CFileItem(g_localizeStrings.Get(24993)));
     item->SetPath(URIUtils::AddFileToFolder(path.Get(), CATEGORY_INFO_PROVIDERS));
-    item->m_bIsFolder = true;
+    item->SetFolder(true);
     const std::string thumb = "DefaultAddonInfoProvider.png";
     if (CServiceBroker::GetGUI()->GetTextureManager().HasTexture(thumb))
       item->SetArt("thumb", thumb);
@@ -307,7 +307,7 @@ static void GenerateMainCategoryListing(const CURL& path, const VECADDONS& addon
   {
     CFileItemPtr item(new CFileItem(g_localizeStrings.Get(24997)));
     item->SetPath(URIUtils::AddFileToFolder(path.Get(), CATEGORY_LOOK_AND_FEEL));
-    item->m_bIsFolder = true;
+    item->SetFolder(true);
     const std::string thumb = "DefaultAddonLookAndFeel.png";
     if (CServiceBroker::GetGUI()->GetTextureManager().HasTexture(thumb))
       item->SetArt("thumb", thumb);
@@ -317,7 +317,7 @@ static void GenerateMainCategoryListing(const CURL& path, const VECADDONS& addon
   {
     CFileItemPtr item(new CFileItem(CAddonInfo::TranslateType(AddonType::GAME, true)));
     item->SetPath(URIUtils::AddFileToFolder(path.Get(), CATEGORY_GAME_ADDONS));
-    item->m_bIsFolder = true;
+    item->SetFolder(true);
     const std::string thumb = CAddonInfo::TranslateIconType(AddonType::GAME);
     if (CServiceBroker::GetGUI()->GetTextureManager().HasTexture(thumb))
       item->SetArt("thumb", thumb);
@@ -452,7 +452,7 @@ static void UserInstalledAddons(const CURL& path, CFileItemList &items)
 
     //"All" node
     CFileItemPtr item(new CFileItem());
-    item->m_bIsFolder = true;
+    item->SetFolder(true);
     CURL itemPath = path;
     itemPath.SetFileName("all");
     item->SetPath(itemPath.Get());
@@ -855,7 +855,7 @@ CFileItemPtr CAddonsDirectory::FileItemFromAddon(const AddonPtr &addon,
     return CFileItemPtr();
 
   CFileItemPtr item(new CFileItem(addon));
-  item->m_bIsFolder = folder;
+  item->SetFolder(folder);
   item->SetPath(path);
 
   std::string strLabel(addon->Name());

--- a/xbmc/filesystem/CDDADirectory.cpp
+++ b/xbmc/filesystem/CDDADirectory.cpp
@@ -58,7 +58,7 @@ bool CCDDADirectory::GetDirectory(const CURL& url, CFileItemList &items)
     std::string strLabel = StringUtils::Format("Track {:02}", i);
 
     CFileItemPtr pItem(new CFileItem(strLabel));
-    pItem->m_bIsFolder = false;
+    pItem->SetFolder(false);
     std::string path = StringUtils::Format("cdda://local/{:02}.cdda", i);
     pItem->SetPath(path);
 

--- a/xbmc/filesystem/DAVDirectory.cpp
+++ b/xbmc/filesystem/DAVDirectory.cpp
@@ -86,7 +86,7 @@ void CDAVDirectory::ParseResponse(const tinyxml2::XMLElement* element, CFileItem
               {
                 if (CDAVCommon::ValueWithoutNamespace(propChild->FirstChild(), "collection"))
                 {
-                  item.m_bIsFolder = true;
+                  item.SetFolder(true);
                 }
               }
             }
@@ -156,7 +156,7 @@ bool CDAVDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         item.SetLabel(CURL::Decode(URIUtils::GetFileName(name)));
       }
 
-      if (item.m_bIsFolder)
+      if (item.IsFolder())
         URIUtils::AddSlashAtEnd(itemPath);
 
       // Add back protocol options

--- a/xbmc/filesystem/Directorization.h
+++ b/xbmc/filesystem/Directorization.h
@@ -129,7 +129,7 @@ namespace XFILE
       // convert the entry into a CFileItem
       CFileItemPtr item = converter(entry.second, label, itemPath, isFolder);
       item->SetPath(itemPath);
-      item->m_bIsFolder = isFolder;
+      item->SetFolder(isFolder);
       if (isFolder)
         item->SetSize(0);
 

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -264,7 +264,7 @@ bool CDirectory::GetDirectory(const CURL& url,
       for (int i = 0; i < items.Size(); ++i)
       {
         CFileItemPtr item = items[i];
-        if (!item->m_bIsFolder && !pDirectory->IsAllowed(item->GetURL()))
+        if (!item->IsFolder() && !pDirectory->IsAllowed(item->GetURL()))
         {
           items.Remove(i);
           i--; // don't confuse loop
@@ -328,14 +328,14 @@ bool CDirectory::EnumerateDirectory(
   // process all files
   for (const auto& item : items)
   {
-    if (!item->m_bIsFolder)
+    if (!item->IsFolder())
       callback(item);
   }
 
   // process all directories
   for (const auto& item : items)
   {
-    if (item->m_bIsFolder && filter(item))
+    if (item->IsFolder() && filter(item))
     {
       if (!fileOnly)
         callback(item);
@@ -474,17 +474,16 @@ void CDirectory::FilterFileDirectories(CFileItemList &items, const std::string &
     CFileItemPtr pItem=items[i];
     auto mode =
         expandImages && pItem->IsDiscImage() ? FileFolderType::ONBROWSE : FileFolderType::ALWAYS;
-    if (!pItem->m_bIsFolder && pItem->IsFileFolder(mode))
+    if (!pItem->IsFolder() && pItem->IsFileFolder(mode))
     {
       std::unique_ptr<IFileDirectory> pDirectory(CFileDirectoryFactory::Create(pItem->GetURL(),pItem.get(),mask));
       if (pDirectory)
-        pItem->m_bIsFolder = true;
-      else
-        if (pItem->m_bIsFolder)
-        {
-          items.Remove(i);
-          i--; // don't confuse loop
-        }
+        pItem->SetFolder(true);
+      else if (pItem->IsFolder())
+      {
+        items.Remove(i);
+        i--; // don't confuse loop
+      }
     }
   }
 }

--- a/xbmc/filesystem/FTPDirectory.cpp
+++ b/xbmc/filesystem/FTPDirectory.cpp
@@ -83,9 +83,9 @@ bool CFTPDirectory::GetDirectory(const CURL& url2, CFileItemList &items)
 
       CFileItemPtr pItem(new CFileItem(name));
 
-      pItem->m_bIsFolder = parse.getFlagtrycwd() != 0;
+      pItem->SetFolder(parse.getFlagtrycwd() != 0);
       std::string filePath = path + name;
-      if (pItem->m_bIsFolder)
+      if (pItem->IsFolder())
         URIUtils::AddSlashAtEnd(filePath);
 
       /* qualify the url with host and all */

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -50,7 +50,7 @@ CFileDirectoryFactory::CFileDirectoryFactory(void) = default;
 
 CFileDirectoryFactory::~CFileDirectoryFactory(void) = default;
 
-// return NULL + set pItem->m_bIsFolder to remove it completely from list.
+// return NULL + set pItem->IsFolder() to remove it completely from list.
 IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem, const std::string& strMask)
 {
   if (url.IsProtocol("stack")) // disqualify stack as we need to work with each of the parts instead
@@ -123,13 +123,13 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
 
             // Check for folder, if yes return also wrap.
             // Needed to fix for e.g. RAR files with only one file inside
-            pItem->m_bIsFolder = URIUtils::HasSlashAtEnd(pItem->GetPath());
-            if (pItem->m_bIsFolder)
+            pItem->SetFolder(URIUtils::HasSlashAtEnd(pItem->GetPath()));
+            if (pItem->IsFolder())
               return wrap;
           }
           else
           {
-            pItem->m_bIsFolder = true;
+            pItem->SetFolder(true);
           }
 
           delete wrap;
@@ -169,8 +169,8 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
     CFileItemList items;
     CDirectory::GetDirectory(zipURL, items, strMask, DIR_FLAG_DEFAULTS);
     if (items.Size() == 0) // no files
-      pItem->m_bIsFolder = true;
-    else if (items.Size() == 1 && items[0]->GetDepth() == 0 && !items[0]->m_bIsFolder)
+      pItem->SetFolder(true);
+    else if (items.Size() == 1 && items[0]->GetDepth() == 0 && !items[0]->IsFolder())
     {
       // one STORED file - collapse it down
       *pItem = *items[0];
@@ -190,8 +190,8 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
     CFileItemList items;
     CDirectory::GetDirectory(zipURL, items, strMask, DIR_FLAG_DEFAULTS);
     if (items.Size() == 0) // no files
-      pItem->m_bIsFolder = true;
-    else if (items.Size() == 1 && items[0]->GetDepth() == 0 && !items[0]->m_bIsFolder)
+      pItem->SetFolder(true);
+    else if (items.Size() == 1 && items[0]->GetDepth() == 0 && !items[0]->IsFolder())
     {
       // one STORED file - collapse it down
       *pItem = *items[0];

--- a/xbmc/filesystem/HTTPDirectory.cpp
+++ b/xbmc/filesystem/HTTPDirectory.cpp
@@ -190,7 +190,7 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         pItem->SetURL(url2);
 
         if(URIUtils::HasSlashAtEnd(pItem->GetPath(), true))
-          pItem->m_bIsFolder = true;
+          pItem->SetFolder(true);
 
         std::string day, month, year, hour, minute;
         int monthNum = 0;
@@ -255,7 +255,7 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
           pItem->SetDateTime(dt);
         }
 
-        if (!pItem->m_bIsFolder)
+        if (!pItem->IsFolder())
         {
           if (reSizeHtml.RegFind(strMetadata.c_str()) >= 0)
           {

--- a/xbmc/filesystem/ISO9660Directory.cpp
+++ b/xbmc/filesystem/ISO9660Directory.cpp
@@ -54,7 +54,7 @@ bool CISO9660Directory::GetDirectory(const CURL& url, CFileItemList& items)
           std::string strDir(strRoot + filename);
           URIUtils::AddSlashAtEnd(strDir);
           pItem->SetPath(strDir);
-          pItem->m_bIsFolder = true;
+          pItem->SetFolder(true);
           items.Add(pItem);
         }
       }
@@ -62,7 +62,7 @@ bool CISO9660Directory::GetDirectory(const CURL& url, CFileItemList& items)
       {
         CFileItemPtr pItem(new CFileItem(filename));
         pItem->SetPath(strRoot + filename);
-        pItem->m_bIsFolder = false;
+        pItem->SetFolder(false);
         pItem->SetSize(file->p_stat->size);
         items.Add(pItem);
       }

--- a/xbmc/filesystem/LibraryDirectory.cpp
+++ b/xbmc/filesystem/LibraryDirectory.cpp
@@ -95,7 +95,7 @@ bool CLibraryDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   {
     const TiXmlElement *node = NULL;
     std::string xml = nodes[i]->GetPath();
-    if (nodes[i]->m_bIsFolder)
+    if (nodes[i]->IsFolder())
       node = LoadXML(URIUtils::AddFileToFolder(xml, "index.xml"));
     else
     {

--- a/xbmc/filesystem/MultiPathDirectory.cpp
+++ b/xbmc/filesystem/MultiPathDirectory.cpp
@@ -246,14 +246,14 @@ void CMultiPathDirectory::MergeItems(CFileItemList &items)
   int i = 0;
 
   // if first item in the sorted list is a file, just abort
-  if (!items.Get(i)->m_bIsFolder)
+  if (!items.Get(i)->IsFolder())
     return;
 
   while (i + 1 < items.Size())
   {
     // there are no more folders left, so exit the loop
     CFileItemPtr pItem1 = items.Get(i);
-    if (!pItem1->m_bIsFolder)
+    if (!pItem1->IsFolder())
       break;
 
     std::vector<int> stack;

--- a/xbmc/filesystem/MusicDatabaseDirectory.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory.cpp
@@ -86,7 +86,7 @@ bool CMusicDatabaseDirectory::GetDirectory(const CURL& url, CFileItemList &items
   for (int i=0;i<items.Size();++i)
   {
     CFileItemPtr item = items[i];
-    if (item->m_bIsFolder && !item->HasArt("icon") && !item->HasArt("thumb"))
+    if (item->IsFolder() && !item->HasArt("icon") && !item->HasArt("thumb"))
     {
       std::string strImage = GetIcon(item->GetPath());
       if (!strImage.empty() && CServiceBroker::GetGUI()->GetTextureManager().HasTexture(strImage))

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -79,7 +79,7 @@ bool CDirectoryNodeOverview::GetContent(CFileItemList& items) const
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(OverviewChildren[i].label)));
     std::string strDir = StringUtils::Format("{}/", OverviewChildren[i].id);
     pItem->SetPath(BuildPath() + strDir);
-    pItem->m_bIsFolder = true;
+    pItem->SetFolder(true);
     pItem->SetCanQueue(false);
     items.Add(pItem);
   }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.cpp
@@ -50,7 +50,7 @@ bool CDirectoryNodeTop100::GetContent(CFileItemList& items) const
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(node.label)));
     std::string strDir = StringUtils::Format("{}/", node.id);
     pItem->SetPath(BuildPath() + strDir);
-    pItem->m_bIsFolder = true;
+    pItem->SetFolder(true);
     items.Add(pItem);
   }
 

--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -66,8 +66,7 @@ bool CNFSDirectory::GetDirectoryFromExportList(const std::string& strPath, CFile
     URIUtils::AddSlashAtEnd(path);
     pItem->SetPath(path);
     pItem->SetDateTime(0);
-
-    pItem->m_bIsFolder = true;
+    pItem->SetFolder(true);
     items.Add(pItem);
   }
 
@@ -90,9 +89,8 @@ bool CNFSDirectory::GetServerList(CFileItemList &items)
       std::string path("nfs://" + currentExport);
       URIUtils::AddSlashAtEnd(path);
       pItem->SetDateTime(0);
-
       pItem->SetPath(path);
-      pItem->m_bIsFolder = true;
+      pItem->SetFolder(true);
       items.Add(pItem);
       ret = true; //added at least one entry
   }
@@ -290,11 +288,11 @@ bool CNFSDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       if (bIsDir)
       {
         URIUtils::AddSlashAtEnd(path);
-        pItem->m_bIsFolder = true;
+        pItem->SetFolder(true);
       }
       else
       {
-        pItem->m_bIsFolder = false;
+        pItem->SetFolder(false);
       }
 
       if (strName[0] == '.')

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -549,9 +549,9 @@ static void ParseItem(CFileItem* item, tinyxml2::XMLElement* root, const std::st
 
     if(StringUtils::StartsWithNoCase(item->GetPath(), "rss://")
       || StringUtils::StartsWithNoCase(item->GetPath(), "rsss://"))
-      item->m_bIsFolder = true;
+      item->SetFolder(true);
     else
-      item->m_bIsFolder = false;
+      item->SetFolder(false);
   }
 
   const std::string& title{item->GetTitle()};

--- a/xbmc/filesystem/StackDirectory.cpp
+++ b/xbmc/filesystem/StackDirectory.cpp
@@ -38,7 +38,7 @@ namespace XFILE
     {
       CFileItemPtr item(new CFileItem(i));
       item->SetPath(i);
-      item->m_bIsFolder = false;
+      item->SetFolder(false);
       items.Add(item);
     }
     return true;

--- a/xbmc/filesystem/UDFDirectory.cpp
+++ b/xbmc/filesystem/UDFDirectory.cpp
@@ -73,7 +73,7 @@ bool CUDFDirectory::GetDirectory(const CURL& url, CFileItemList& items)
         std::string strDir(strRoot + filename);
         URIUtils::AddSlashAtEnd(strDir);
         pItem->SetPath(strDir);
-        pItem->m_bIsFolder = true;
+        pItem->SetFolder(true);
 
         items.Add(pItem);
       }
@@ -88,7 +88,7 @@ bool CUDFDirectory::GetDirectory(const CURL& url, CFileItemList& items)
 
       CFileItemPtr pItem(new CFileItem(filename));
       pItem->SetPath(strRoot + filename);
-      pItem->m_bIsFolder = false;
+      pItem->SetFolder(false);
       pItem->SetSize(udfread_file_size(file));
       items.Add(pItem);
 

--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -207,7 +207,7 @@ CUPnPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
             CFileItemPtr pItem(new CFileItem((const char*)name));
             pItem->SetPath(std::string((const char*) "upnp://" + uuid + "/"));
-            pItem->m_bIsFolder = true;
+            pItem->SetFolder(true);
             pItem->SetArt("thumb", (const char*)(*device)->GetIconUrl("image/png"));
 
             items.Add(pItem);

--- a/xbmc/filesystem/VideoDatabaseDirectory.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -106,7 +106,7 @@ bool CVideoDatabaseDirectory::GetDirectory(const CURL& url, CFileItemList &items
   for (int i=0;i<items.Size();++i)
   {
     CFileItemPtr item = items[i];
-    if (item->m_bIsFolder && !item->HasArt("icon") && !item->HasArt("thumb"))
+    if (item->IsFolder() && !item->HasArt("icon") && !item->HasArt("thumb"))
     {
       std::string strImage = GetIcon(item->GetPath());
       if (!strImage.empty() && CServiceBroker::GetGUI()->GetTextureManager().HasTexture(strImage))

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
@@ -64,7 +64,7 @@ bool CDirectoryNodeMusicVideosOverview::GetContent(CFileItemList& items) const
     itemUrl.AppendPath(strDir);
     pItem->SetPath(itemUrl.ToString());
 
-    pItem->m_bIsFolder = true;
+    pItem->SetFolder(true);
     pItem->SetCanQueue(false);
     pItem->SetSpecialSort(SortSpecialOnTop);
     items.Add(pItem);

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
@@ -63,7 +63,7 @@ bool CDirectoryNodeTvShowsOverview::GetContent(CFileItemList& items) const
     itemUrl.AppendPath(strDir);
     pItem->SetPath(itemUrl.ToString());
 
-    pItem->m_bIsFolder = true;
+    pItem->SetFolder(true);
     pItem->SetCanQueue(false);
     items.Add(pItem);
   }

--- a/xbmc/filesystem/test/TestHTTPDirectory.cpp
+++ b/xbmc/filesystem/test/TestHTTPDirectory.cpp
@@ -144,14 +144,14 @@ protected:
     ASSERT_EQ(items.GetObjectCount(), SAMPLE_ITEM_COUNT);
 
     // folders
-    ASSERT_TRUE(items[0]->m_bIsFolder);
-    ASSERT_TRUE(items[1]->m_bIsFolder);
+    ASSERT_TRUE(items[0]->IsFolder());
+    ASSERT_TRUE(items[1]->IsFolder());
 
     // files
-    ASSERT_FALSE(items[2]->m_bIsFolder);
-    ASSERT_FALSE(items[3]->m_bIsFolder);
-    ASSERT_FALSE(items[4]->m_bIsFolder);
-    ASSERT_FALSE(items[5]->m_bIsFolder);
+    ASSERT_FALSE(items[2]->IsFolder());
+    ASSERT_FALSE(items[3]->IsFolder());
+    ASSERT_FALSE(items[4]->IsFolder());
+    ASSERT_FALSE(items[5]->IsFolder());
   }
 
   void CheckFileItemLabels(CFileItemList const& items)

--- a/xbmc/games/windows/GUIWindowGames.cpp
+++ b/xbmc/games/windows/GUIWindowGames.cpp
@@ -147,7 +147,7 @@ bool CGUIWindowGames::OnClick(int iItem, const std::string& player /* = "" */)
   CFileItemPtr item = m_vecItems->Get(iItem);
   if (item)
   {
-    if (!item->m_bIsFolder)
+    if (!item->IsFolder())
     {
       PlayGame(*item);
       return true;
@@ -236,7 +236,7 @@ bool CGUIWindowGames::GetDirectory(const std::string& strDirectory, CFileItemLis
   for (int i = 0; i < items.Size(); ++i)
   {
     CFileItemPtr item = items[i];
-    if (item->m_bIsFolder || !item->IsFileFolder(FileFolderType::ALWAYS))
+    if (item->IsFolder() || !item->IsFileFolder(FileFolderType::ALWAYS))
       continue;
 
     const std::string originalPath = item->GetPath();
@@ -258,7 +258,7 @@ bool CGUIWindowGames::GetDirectory(const std::string& strDirectory, CFileItemLis
       // Check if file folder contains games or subfolders
       if (std::any_of(fileFolderItems.begin(), fileFolderItems.end(),
                       [](const CFileItemPtr& fileFolderItem) {
-                        return fileFolderItem->m_bIsFolder ||
+                        return fileFolderItem->IsFolder() ||
                                CGameUtils::HasGameExtension(fileFolderItem->GetPath());
                       }))
       {
@@ -266,7 +266,7 @@ bool CGUIWindowGames::GetDirectory(const std::string& strDirectory, CFileItemLis
       }
 
       // If the file folder contains no games, turn it back into a regular file
-      item->m_bIsFolder = false;
+      item->SetFolder(false);
       item->SetPath(originalPath);
     }
     else
@@ -311,7 +311,7 @@ bool CGUIWindowGames::GetDirectory(const std::string& strDirectory, CFileItemLis
   // Ensure a game info tag is created so that files are recognized as games
   for (const CFileItemPtr& item : items)
   {
-    if (!item->m_bIsFolder)
+    if (!item->IsFolder())
       item->GetGameInfoTag();
   }
 
@@ -377,9 +377,9 @@ bool CGUIWindowGames::PlayGame(const CFileItem& item)
 
   // Dereference file folders. The check here assumes all "is folder" items
   // passed CanPlay(), e.g. are definitely file folders.
-  if (itemCopy.m_bIsFolder)
+  if (itemCopy.IsFolder())
   {
-    itemCopy.m_bIsFolder = false;
+    itemCopy.SetFolder(false);
     itemCopy.SetPath(itemCopy.GetURL().GetHostName());
     itemCopy.GetGameInfoTag();
   }
@@ -392,7 +392,7 @@ bool CGUIWindowGames::CanPlay(const CFileItem& item) const
   if (item.IsGame())
     return true;
 
-  if (item.m_bIsFolder)
+  if (item.IsFolder())
   {
     // Check for file folders
     CURL url{item.GetPath()};

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -944,7 +944,7 @@ std::string CGUIBaseContainer::GetDescription() const
   if (item >= 0 && item < (int)m_items.size())
   {
     std::shared_ptr<CGUIListItem> pItem = m_items[item];
-    if (pItem->m_bIsFolder)
+    if (pItem->IsFolder())
       strLabel = StringUtils::Format("[{}]", pItem->GetLabel());
     else
       strLabel = pItem->GetLabel();
@@ -1496,7 +1496,7 @@ std::string CGUIBaseContainer::GetLabel(int info) const
       int numItems = 0;
       for (const auto& item : m_items)
       {
-        if (!item->m_bIsFolder)
+        if (!item->IsFolder())
           numItems++;
       }
       label = std::to_string(numItems);

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -562,7 +562,7 @@ void GUIFontManager::SettingOptionsFontsFiller(const SettingConstPtr& setting,
 
   for (const auto& item : items)
   {
-    if (item->m_bIsFolder)
+    if (item->IsFolder())
       continue;
 
     list.emplace_back(item->GetLabel(), item->GetLabel());
@@ -645,7 +645,7 @@ void GUIFontManager::LoadUserFonts()
   for (auto& item : dirItems)
   {
     std::string filepath = item->GetPath();
-    if (item->m_bIsFolder)
+    if (item->IsFolder())
       continue;
 
     std::set<std::string> familyNames;

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -204,6 +204,7 @@ CGUIListItem& CGUIListItem::operator =(const CGUIListItem& item)
   m_mapProperties = item.m_mapProperties;
   m_art = item.m_art;
   m_artFallbacks = item.m_artFallbacks;
+  m_currentItem = item.m_currentItem;
   SetInvalid();
   return *this;
 }
@@ -236,6 +237,7 @@ void CGUIListItem::Archive(CArchive &ar)
       ar << type;
       ar << url;
     }
+    ar << m_currentItem;
   }
   else
   {
@@ -277,6 +279,7 @@ void CGUIListItem::Archive(CArchive &ar)
       ar >> value;
       m_artFallbacks.try_emplace(key, value);
     }
+    ar >> m_currentItem;
     SetInvalid();
   }
 }
@@ -293,6 +296,8 @@ void CGUIListItem::Serialize(CVariant& value) const
 
   for (const auto& [type, url] : m_art)
     value["art"][type] = url;
+
+  value["current"] = m_currentItem;
 }
 
 void CGUIListItem::FreeIcons()

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -427,6 +427,11 @@ void CGUIListItem::AppendProperties(const CGUIListItem &item)
     SetProperty(propname, propvalue);
 }
 
+void CGUIListItem::SetProperties(const PropertyMap& props)
+{
+  m_mapProperties = props;
+}
+
 void CGUIListItem::SetCurrentItem(unsigned int position)
 {
   m_currentItem = position;

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -97,7 +97,7 @@ const std::wstring& CGUIListItem::GetSortLabel() const
 
 void CGUIListItem::SetArt(const std::string &type, const std::string &url)
 {
-  ArtMap::iterator i = m_art.find(type);
+  const auto i = m_art.find(type);
   if (i == m_art.end() || i->second != url)
   {
     m_art[type] = url;
@@ -105,7 +105,7 @@ void CGUIListItem::SetArt(const std::string &type, const std::string &url)
   }
 }
 
-void CGUIListItem::SetArt(const ArtMap &art)
+void CGUIListItem::SetArt(const KODI::ART::Artwork& art)
 {
   m_art = art;
   SetInvalid();
@@ -123,7 +123,7 @@ void CGUIListItem::ClearArt()
   SetProperty("libraryartfilled", false);
 }
 
-void CGUIListItem::AppendArt(const ArtMap &art, const std::string &prefix)
+void CGUIListItem::AppendArt(const KODI::ART::Artwork& art, const std::string& prefix)
 {
   for (const auto& i : art)
     SetArt(prefix.empty() ? i.first : prefix + '.' + i.first, i.second);
@@ -131,20 +131,20 @@ void CGUIListItem::AppendArt(const ArtMap &art, const std::string &prefix)
 
 std::string CGUIListItem::GetArt(const std::string &type) const
 {
-  ArtMap::const_iterator i = m_art.find(type);
+  auto i = m_art.find(type);
   if (i != m_art.end())
     return i->second;
   i = m_artFallbacks.find(type);
   if (i != m_artFallbacks.end())
   {
-    ArtMap::const_iterator j = m_art.find(i->second);
+    const auto j = m_art.find(i->second);
     if (j != m_art.end())
       return j->second;
   }
   return "";
 }
 
-const CGUIListItem::ArtMap &CGUIListItem::GetArt() const
+const KODI::ART::Artwork& CGUIListItem::GetArt() const
 {
   return m_art;
 }

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -16,7 +16,8 @@
 
 #include <utility>
 
-bool CGUIListItem::icompare::operator()(const std::string &s1, const std::string &s2) const
+bool CGUIListItem::CaseInsensitiveCompare::operator()(const std::string_view& s1,
+                                                      const std::string_view& s2) const
 {
   return StringUtils::CompareNoCase(s1, s2) < 0;
 }
@@ -27,25 +28,14 @@ CGUIListItem::CGUIListItem(const CGUIListItem& item)
   SetInvalid();
 }
 
-CGUIListItem::CGUIListItem(void)
-{
-  m_bIsFolder = false;
-  m_bSelected = false;
-  m_overlayIcon = ICON_OVERLAY_NONE;
-  m_currentItem = 1;
-}
+CGUIListItem::CGUIListItem() = default;
 
-CGUIListItem::CGUIListItem(const std::string& strLabel):
-  m_strLabel(strLabel)
+CGUIListItem::CGUIListItem(const std::string& strLabel) : m_strLabel(strLabel)
 {
-  m_bIsFolder = false;
   SetSortLabel(strLabel);
-  m_bSelected = false;
-  m_overlayIcon = ICON_OVERLAY_NONE;
-  m_currentItem = 1;
 }
 
-CGUIListItem::~CGUIListItem(void)
+CGUIListItem::~CGUIListItem()
 {
   FreeMemory();
 }
@@ -65,8 +55,7 @@ const std::string& CGUIListItem::GetLabel() const
   return m_strLabel;
 }
 
-
-void CGUIListItem::SetLabel2(const std::string& strLabel2)
+void CGUIListItem::SetLabel2(std::string_view strLabel2)
 {
   if (m_strLabel2 == strLabel2)
     return;
@@ -81,7 +70,7 @@ const std::string& CGUIListItem::GetLabel2() const
 
 void CGUIListItem::SetSortLabel(const std::string &label)
 {
-  g_charsetConverter.utf8ToW(label, m_sortLabel, false);
+  CCharsetConverter::utf8ToW(label, m_sortLabel, false);
   // no need to invalidate - this is never shown in the UI
 }
 
@@ -95,7 +84,7 @@ const std::wstring& CGUIListItem::GetSortLabel() const
   return m_sortLabel;
 }
 
-void CGUIListItem::SetArt(const std::string &type, const std::string &url)
+void CGUIListItem::SetArt(const std::string& type, std::string_view url)
 {
   const auto i = m_art.find(type);
   if (i == m_art.end() || i->second != url)
@@ -111,7 +100,7 @@ void CGUIListItem::SetArt(const KODI::ART::Artwork& art)
   SetInvalid();
 }
 
-void CGUIListItem::SetArtFallback(const std::string &from, const std::string &to)
+void CGUIListItem::SetArtFallback(const std::string& from, std::string_view to)
 {
   m_artFallbacks[from] = to;
 }
@@ -125,8 +114,8 @@ void CGUIListItem::ClearArt()
 
 void CGUIListItem::AppendArt(const KODI::ART::Artwork& art, const std::string& prefix)
 {
-  for (const auto& i : art)
-    SetArt(prefix.empty() ? i.first : prefix + '.' + i.first, i.second);
+  for (const auto& [type, url] : art)
+    SetArt(prefix.empty() ? type : prefix + '.' + type, url);
 }
 
 std::string CGUIListItem::GetArt(const std::string &type) const
@@ -134,6 +123,7 @@ std::string CGUIListItem::GetArt(const std::string &type) const
   auto i = m_art.find(type);
   if (i != m_art.end())
     return i->second;
+
   i = m_artFallbacks.find(type);
   if (i != m_artFallbacks.end())
   {
@@ -158,6 +148,7 @@ void CGUIListItem::SetOverlayImage(GUIIconOverlay icon)
 {
   if (m_overlayIcon == icon)
     return;
+
   m_overlayIcon = icon;
   SetInvalid();
 }
@@ -200,7 +191,9 @@ bool CGUIListItem::IsSelected() const
 
 CGUIListItem& CGUIListItem::operator =(const CGUIListItem& item)
 {
-  if (&item == this) return * this;
+  if (&item == this)
+    return *this;
+
   m_strLabel2 = item.m_strLabel2;
   m_strLabel = item.m_strLabel;
   m_sortLabel = item.m_sortLabel;
@@ -225,23 +218,23 @@ void CGUIListItem::Archive(CArchive &ar)
     ar << m_sortLabel;
     ar << m_bSelected;
     ar << m_overlayIcon;
-    ar << (int)m_mapProperties.size();
-    for (const auto& it : m_mapProperties)
+    ar << static_cast<int>(m_mapProperties.size());
+    for (const auto& [name, value] : m_mapProperties)
     {
-      ar << it.first;
-      ar << it.second;
+      ar << name;
+      ar << value;
     }
-    ar << (int)m_art.size();
-    for (const auto& i : m_art)
+    ar << static_cast<int>(m_art.size());
+    for (const auto& [type, url] : m_art)
     {
-      ar << i.first;
-      ar << i.second;
+      ar << type;
+      ar << url;
     }
-    ar << (int)m_artFallbacks.size();
-    for (const auto& i : m_artFallbacks)
+    ar << static_cast<int>(m_artFallbacks.size());
+    for (const auto& [type, url] : m_artFallbacks)
     {
-      ar << i.first;
-      ar << i.second;
+      ar << type;
+      ar << url;
     }
   }
   else
@@ -269,23 +262,25 @@ void CGUIListItem::Archive(CArchive &ar)
     ar >> mapSize;
     for (int i = 0; i < mapSize; i++)
     {
-      std::string key, value;
+      std::string key;
+      std::string value;
       ar >> key;
       ar >> value;
-      m_art.insert(make_pair(key, value));
+      m_art.try_emplace(key, value);
     }
     ar >> mapSize;
     for (int i = 0; i < mapSize; i++)
     {
-      std::string key, value;
+      std::string key;
+      std::string value;
       ar >> key;
       ar >> value;
-      m_artFallbacks.insert(make_pair(key, value));
+      m_artFallbacks.try_emplace(key, value);
     }
     SetInvalid();
   }
 }
-void CGUIListItem::Serialize(CVariant &value)
+void CGUIListItem::Serialize(CVariant& value) const
 {
   value["isFolder"] = m_bIsFolder;
   value["strLabel"] = m_strLabel;
@@ -293,12 +288,11 @@ void CGUIListItem::Serialize(CVariant &value)
   value["sortLabel"] = m_sortLabel;
   value["selected"] = m_bSelected;
 
-  for (const auto& it : m_mapProperties)
-  {
-    value["properties"][it.first] = it.second;
-  }
-  for (const auto& it : m_art)
-    value["art"][it.first] = it.second;
+  for (const auto& [propname, propvalue] : m_mapProperties)
+    value["properties"][propname] = propvalue;
+
+  for (const auto& [type, url] : m_art)
+    value["art"][type] = url;
 }
 
 void CGUIListItem::FreeIcons()
@@ -344,16 +338,19 @@ CGUIListItemLayout *CGUIListItem::GetFocusedLayout()
 
 void CGUIListItem::SetInvalid()
 {
-  if (m_layout) m_layout->SetInvalid();
-  if (m_focusedLayout) m_focusedLayout->SetInvalid();
+  if (m_layout)
+    m_layout->SetInvalid();
+
+  if (m_focusedLayout)
+    m_focusedLayout->SetInvalid();
 }
 
 void CGUIListItem::SetProperty(const std::string &strKey, const CVariant &value)
 {
-  PropertyMap::iterator iter = m_mapProperties.find(strKey);
+  const auto iter = m_mapProperties.find(strKey);
   if (iter == m_mapProperties.end())
   {
-    m_mapProperties.insert(make_pair(strKey, value));
+    m_mapProperties.try_emplace(strKey, value);
     SetInvalid();
   }
   else if (iter->second != value)
@@ -365,9 +362,9 @@ void CGUIListItem::SetProperty(const std::string &strKey, const CVariant &value)
 
 const CVariant &CGUIListItem::GetProperty(const std::string &strKey) const
 {
-  PropertyMap::const_iterator iter = m_mapProperties.find(strKey);
-  static CVariant nullVariant = CVariant(CVariant::VariantTypeNull);
+  static CVariant nullVariant{CVariant::VariantTypeNull};
 
+  const auto iter = m_mapProperties.find(strKey);
   if (iter == m_mapProperties.end())
     return nullVariant;
 
@@ -376,16 +373,12 @@ const CVariant &CGUIListItem::GetProperty(const std::string &strKey) const
 
 bool CGUIListItem::HasProperty(const std::string &strKey) const
 {
-  PropertyMap::const_iterator iter = m_mapProperties.find(strKey);
-  if (iter == m_mapProperties.end())
-    return false;
-
-  return true;
+  return m_mapProperties.contains(strKey);
 }
 
 void CGUIListItem::ClearProperty(const std::string &strKey)
 {
-  PropertyMap::iterator iter = m_mapProperties.find(strKey);
+  const auto iter = m_mapProperties.find(strKey);
   if (iter != m_mapProperties.end())
   {
     m_mapProperties.erase(iter);
@@ -425,8 +418,8 @@ void CGUIListItem::IncrementProperty(const std::string &strKey, double dVal)
 
 void CGUIListItem::AppendProperties(const CGUIListItem &item)
 {
-  for (const auto& i : item.m_mapProperties)
-    SetProperty(i.first, i.second);
+  for (const auto& [propname, propvalue] : item.m_mapProperties)
+    SetProperty(propname, propvalue);
 }
 
 void CGUIListItem::SetCurrentItem(unsigned int position)

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -177,7 +177,6 @@ public:
   unsigned int GetCurrentItem() const;
 
 protected:
-  std::string m_strLabel2;     // text of column2
   GUIIconOverlay m_overlayIcon{ICON_OVERLAY_NONE}; // type of overlay icon
 
   std::unique_ptr<CGUIListItemLayout> m_layout;
@@ -196,8 +195,9 @@ protected:
 
 private:
   bool m_bIsFolder{false}; ///< is item a folder or a file
-  std::wstring m_sortLabel;    // text for sorting. Need to be UTF16 for proper sorting
-  std::string m_strLabel;      // text of column1
+  std::wstring m_sortLabel; // text for sorting. Need to be UTF16 for proper sorting
+  std::string m_strLabel; // text of column1
+  std::string m_strLabel2; // text of column2
 
   KODI::ART::Artwork m_art;
   KODI::ART::Artwork m_artFallbacks;

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -177,7 +177,6 @@ public:
   unsigned int GetCurrentItem() const;
 
 protected:
-  bool m_bSelected{false}; // item is selected or not
   unsigned int m_currentItem{1}; // current item number within container (starting at 1)
 
   struct CaseInsensitiveCompare
@@ -197,6 +196,7 @@ private:
   GUIIconOverlay m_overlayIcon{ICON_OVERLAY_NONE}; // type of overlay icon
   std::unique_ptr<CGUIListItemLayout> m_layout;
   std::unique_ptr<CGUIListItemLayout> m_focusedLayout;
+  bool m_bSelected{false}; // item is selected or not
 
   KODI::ART::Artwork m_art;
   KODI::ART::Artwork m_artFallbacks;

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -18,6 +18,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 
 //  Forward
 class CGUIListItemLayout;
@@ -46,10 +47,10 @@ public:
                       };
   /// @}
 
-  CGUIListItem(void);
+  CGUIListItem();
   explicit CGUIListItem(const CGUIListItem& item);
   explicit CGUIListItem(const std::string& strLabel);
-  virtual ~CGUIListItem(void);
+  virtual ~CGUIListItem();
   virtual CGUIListItem* Clone() const { return new CGUIListItem(*this); }
 
   CGUIListItem& operator =(const CGUIListItem& item);
@@ -57,7 +58,7 @@ public:
   virtual void SetLabel(const std::string& strLabel);
   const std::string& GetLabel() const;
 
-  void SetLabel2(const std::string& strLabel);
+  void SetLabel2(std::string_view strLabel);
   const std::string& GetLabel2() const;
 
   void SetOverlayImage(GUIIconOverlay icon);
@@ -67,7 +68,7 @@ public:
    \param type type of art to set.
    \param url the url of the art.
    */
-  void SetArt(const std::string &type, const std::string &url);
+  void SetArt(const std::string& type, std::string_view url);
 
   /*! \brief set artwork for an item
    \param art a type:url map for artwork
@@ -87,7 +88,7 @@ public:
    \param to the type to fallback to
    \sa SetArt
    */
-  void SetArtFallback(const std::string &from, const std::string &to);
+  void SetArtFallback(const std::string& from, std::string_view to);
 
   /*! \brief clear art on an item
    \sa SetArt
@@ -134,7 +135,7 @@ public:
   void FreeMemory(bool immediately = false);
   void SetInvalid();
 
-  bool m_bIsFolder;     ///< is item a folder or a file
+  bool m_bIsFolder{false}; ///< is item a folder or a file
 
   void SetProperty(const std::string &strKey, const CVariant &value);
 
@@ -152,11 +153,11 @@ public:
   void AppendProperties(const CGUIListItem &item);
 
   void Archive(CArchive& ar);
-  void Serialize(CVariant& value);
+  void Serialize(CVariant& value) const;
 
-  bool       HasProperty(const std::string &strKey) const;
+  bool HasProperty(const std::string& strKey) const;
   bool HasProperties() const { return !m_mapProperties.empty(); }
-  void       ClearProperty(const std::string &strKey);
+  void ClearProperty(const std::string& strKey);
 
   const CVariant &GetProperty(const std::string &strKey) const;
 
@@ -176,20 +177,22 @@ public:
 
 protected:
   std::string m_strLabel2;     // text of column2
-  GUIIconOverlay m_overlayIcon; // type of overlay icon
+  GUIIconOverlay m_overlayIcon{ICON_OVERLAY_NONE}; // type of overlay icon
 
   std::unique_ptr<CGUIListItemLayout> m_layout;
   std::unique_ptr<CGUIListItemLayout> m_focusedLayout;
-  bool m_bSelected;     // item is selected or not
-  unsigned int m_currentItem; // current item number within container (starting at 1)
+  bool m_bSelected{false}; // item is selected or not
+  unsigned int m_currentItem{1}; // current item number within container (starting at 1)
 
-  struct icompare
+  struct CaseInsensitiveCompare
   {
-    bool operator()(const std::string &s1, const std::string &s2) const;
+    using is_transparent = void; // Enables heterogeneous operations.
+    bool operator()(const std::string_view& s1, const std::string_view& s2) const;
   };
 
-  typedef std::map<std::string, CVariant, icompare> PropertyMap;
+  using PropertyMap = std::map<std::string, CVariant, CaseInsensitiveCompare>;
   PropertyMap m_mapProperties;
+
 private:
   std::wstring m_sortLabel;    // text for sorting. Need to be UTF16 for proper sorting
   std::string m_strLabel;      // text of column1

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -61,6 +61,9 @@ public:
   void SetLabel2(std::string_view strLabel);
   const std::string& GetLabel2() const;
 
+  void SetFolder(bool isFolder) { m_bIsFolder = isFolder; }
+  bool IsFolder() const { return m_bIsFolder; }
+
   void SetOverlayImage(GUIIconOverlay icon);
   std::string GetOverlayImage() const;
 
@@ -135,8 +138,6 @@ public:
   void FreeMemory(bool immediately = false);
   void SetInvalid();
 
-  bool m_bIsFolder{false}; ///< is item a folder or a file
-
   void SetProperty(const std::string &strKey, const CVariant &value);
 
   void IncrementProperty(const std::string &strKey, int nVal);
@@ -194,6 +195,7 @@ protected:
   PropertyMap m_mapProperties;
 
 private:
+  bool m_bIsFolder{false}; ///< is item a folder or a file
   std::wstring m_sortLabel;    // text for sorting. Need to be UTF16 for proper sorting
   std::string m_strLabel;      // text of column1
 

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -162,6 +162,17 @@ public:
 
   const CVariant &GetProperty(const std::string &strKey) const;
 
+  struct CaseInsensitiveCompare
+  {
+    using is_transparent = void; // Enables heterogeneous operations.
+    bool operator()(const std::string_view& s1, const std::string_view& s2) const;
+  };
+
+  using PropertyMap = std::map<std::string, CVariant, CaseInsensitiveCompare>;
+  const PropertyMap& GetProperties() const { return m_mapProperties; }
+
+  void SetProperties(const PropertyMap& props);
+
   /*! \brief Set the current item number within it's container
    Our container classes will set this member with the items position
    in the container starting at 1.
@@ -176,16 +187,6 @@ public:
    */
   unsigned int GetCurrentItem() const;
 
-protected:
-  struct CaseInsensitiveCompare
-  {
-    using is_transparent = void; // Enables heterogeneous operations.
-    bool operator()(const std::string_view& s1, const std::string_view& s2) const;
-  };
-
-  using PropertyMap = std::map<std::string, CVariant, CaseInsensitiveCompare>;
-  PropertyMap m_mapProperties;
-
 private:
   bool m_bIsFolder{false}; ///< is item a folder or a file
   std::wstring m_sortLabel; // text for sorting. Need to be UTF16 for proper sorting
@@ -196,6 +197,8 @@ private:
   std::unique_ptr<CGUIListItemLayout> m_focusedLayout;
   bool m_bSelected{false}; // item is selected or not
   unsigned int m_currentItem{1}; // current item number within container (starting at 1)
+
+  PropertyMap m_mapProperties;
 
   KODI::ART::Artwork m_art;
   KODI::ART::Artwork m_artFallbacks;

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -177,8 +177,6 @@ public:
   unsigned int GetCurrentItem() const;
 
 protected:
-  std::unique_ptr<CGUIListItemLayout> m_layout;
-  std::unique_ptr<CGUIListItemLayout> m_focusedLayout;
   bool m_bSelected{false}; // item is selected or not
   unsigned int m_currentItem{1}; // current item number within container (starting at 1)
 
@@ -197,6 +195,8 @@ private:
   std::string m_strLabel; // text of column1
   std::string m_strLabel2; // text of column2
   GUIIconOverlay m_overlayIcon{ICON_OVERLAY_NONE}; // type of overlay icon
+  std::unique_ptr<CGUIListItemLayout> m_layout;
+  std::unique_ptr<CGUIListItemLayout> m_focusedLayout;
 
   KODI::ART::Artwork m_art;
   KODI::ART::Artwork m_artFallbacks;

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -177,8 +177,6 @@ public:
   unsigned int GetCurrentItem() const;
 
 protected:
-  GUIIconOverlay m_overlayIcon{ICON_OVERLAY_NONE}; // type of overlay icon
-
   std::unique_ptr<CGUIListItemLayout> m_layout;
   std::unique_ptr<CGUIListItemLayout> m_focusedLayout;
   bool m_bSelected{false}; // item is selected or not
@@ -198,6 +196,7 @@ private:
   std::wstring m_sortLabel; // text for sorting. Need to be UTF16 for proper sorting
   std::string m_strLabel; // text of column1
   std::string m_strLabel2; // text of column2
+  GUIIconOverlay m_overlayIcon{ICON_OVERLAY_NONE}; // type of overlay icon
 
   KODI::ART::Artwork m_art;
   KODI::ART::Artwork m_artFallbacks;

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -13,6 +13,8 @@
 \brief
 */
 
+#include "utils/Artwork.h"
+
 #include <map>
 #include <memory>
 #include <string>
@@ -29,8 +31,6 @@ class CVariant;
 class CGUIListItem
 {
 public:
-  typedef std::map<std::string, std::string> ArtMap;
-
   ///
   /// @ingroup controls python_xbmcgui_listitem
   /// @defgroup kodi_guilib_listitem_iconoverlay Overlay icon types
@@ -73,14 +73,14 @@ public:
    \param art a type:url map for artwork
    \sa GetArt
    */
-  void SetArt(const ArtMap &art);
+  void SetArt(const KODI::ART::Artwork& art);
 
   /*! \brief append artwork to an item
    \param art a type:url map for artwork
    \param prefix a prefix for the art, if applicable.
    \sa GetArt
    */
-  void AppendArt(const ArtMap &art, const std::string &prefix = "");
+  void AppendArt(const KODI::ART::Artwork& art, const std::string& prefix = "");
 
   /*! \brief set a fallback image for art
    \param from the type to fallback from
@@ -105,7 +105,7 @@ public:
    \return a type:url map for artwork
    \sa SetArt
    */
-  const ArtMap &GetArt() const;
+  const KODI::ART::Artwork& GetArt() const;
 
   /*! \brief Check whether an item has a particular piece of art
    Equivalent to !GetArt(type).empty()
@@ -194,7 +194,6 @@ private:
   std::wstring m_sortLabel;    // text for sorting. Need to be UTF16 for proper sorting
   std::string m_strLabel;      // text of column1
 
-  ArtMap m_art;
-  ArtMap m_artFallbacks;
+  KODI::ART::Artwork m_art;
+  KODI::ART::Artwork m_artFallbacks;
 };
-

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -177,8 +177,6 @@ public:
   unsigned int GetCurrentItem() const;
 
 protected:
-  unsigned int m_currentItem{1}; // current item number within container (starting at 1)
-
   struct CaseInsensitiveCompare
   {
     using is_transparent = void; // Enables heterogeneous operations.
@@ -197,6 +195,7 @@ private:
   std::unique_ptr<CGUIListItemLayout> m_layout;
   std::unique_ptr<CGUIListItemLayout> m_focusedLayout;
   bool m_bSelected{false}; // item is selected or not
+  unsigned int m_currentItem{1}; // current item number within container (starting at 1)
 
   KODI::ART::Artwork m_art;
   KODI::ART::Artwork m_artFallbacks;

--- a/xbmc/guilib/guiinfo/GUIControlsGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/GUIControlsGUIInfo.cpp
@@ -440,8 +440,8 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
         const CFileItemList& items = window->CurrentDirectory();
         for (const auto& item : items)
         {
-          if ((!item->m_bIsFolder && info.GetInfo() == CONTAINER_HASFILES) ||
-              (item->m_bIsFolder && !item->IsParentFolder() &&
+          if ((!item->IsFolder() && info.GetInfo() == CONTAINER_HASFILES) ||
+              (item->IsFolder() && !item->IsParentFolder() &&
                info.GetInfo() == CONTAINER_HASFOLDERS))
           {
             value = true;

--- a/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
@@ -166,7 +166,7 @@ bool CPicturesGUIInfo::GetLabel(std::string& value, const CFileItem *item, int c
       }
       case SLIDESHOW_FILE_SIZE:
       {
-        if (!m_currentSlide->m_bIsFolder || m_currentSlide->GetSize())
+        if (!m_currentSlide->IsFolder() || m_currentSlide->GetSize())
         {
           value = StringUtils::SizeToString(m_currentSlide->GetSize());
           return true;

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -521,7 +521,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_PATH:
         if (VIDEO::IsVideoDb(*item))
         {
-          if (item->m_bIsFolder)
+          if (item->IsFolder())
             value = tag->m_strPath;
           else
             URIUtils::GetParentPath(tag->m_strFileNameAndPath, value);

--- a/xbmc/guilib/listproviders/DirectoryProvider.cpp
+++ b/xbmc/guilib/listproviders/DirectoryProvider.cpp
@@ -637,7 +637,7 @@ bool CDirectoryProvider::OnClick(const std::shared_ptr<CGUIListItem>& item)
   const bool isPlayMedia{exec.GetFunction() == "playmedia"};
 
   // video select action setting is for files only, except exec func is playmedia...
-  if (targetItem->HasVideoInfoTag() && (!targetItem->m_bIsFolder || isPlayMedia))
+  if (targetItem->HasVideoInfoTag() && (!targetItem->IsFolder() || isPlayMedia))
   {
     const std::string targetWindow{GetTarget(*targetItem)};
     if (!targetWindow.empty())
@@ -670,7 +670,7 @@ bool CDirectoryProvider::OnPlay(const std::shared_ptr<CGUIListItem>& item)
 
   // video play action setting is for files and folders...
   if (targetItem->HasVideoInfoTag() ||
-      (targetItem->m_bIsFolder && VIDEO::UTILS::IsItemPlayable(*targetItem)))
+      (targetItem->IsFolder() && VIDEO::UTILS::IsItemPlayable(*targetItem)))
   {
     KODI::VIDEO::GUILIB::CVideoPlayActionProcessor proc{targetItem};
     if (proc.ProcessDefaultAction())

--- a/xbmc/input/keymaps/ButtonTranslator.cpp
+++ b/xbmc/input/keymaps/ButtonTranslator.cpp
@@ -89,7 +89,7 @@ bool CButtonTranslator::Load()
       files.Sort(SortByFile, SortOrderAscending);
       for (int fileIndex = 0; fileIndex < files.Size(); ++fileIndex)
       {
-        if (!files[fileIndex]->m_bIsFolder)
+        if (!files[fileIndex]->IsFolder())
           success |= LoadKeymap(files[fileIndex]->GetPath());
       }
 
@@ -108,7 +108,7 @@ bool CButtonTranslator::Load()
           files.Sort(SortByFile, SortOrderAscending);
           for (int fileIndex = 0; fileIndex < files.Size(); ++fileIndex)
           {
-            if (!files[fileIndex]->m_bIsFolder)
+            if (!files[fileIndex]->IsFolder())
               success |= LoadKeymap(files[fileIndex]->GetPath());
           }
         }

--- a/xbmc/interfaces/builtins/AddonBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AddonBuiltins.cpp
@@ -92,7 +92,7 @@ static int RunPlugin(const std::vector<std::string>& params)
   if (!params.empty())
   {
     CFileItem item(params[0]);
-    if (!item.m_bIsFolder)
+    if (!item.IsFolder())
     {
       item.SetPath(params[0]);
       XFILE::CPluginDirectory::RunScriptWithParams(item.GetPath(), false);

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -516,7 +516,7 @@ int PlayOrQueueMedia(const std::vector<std::string>& params,
   for (unsigned int i = 1 ; i < params.size() ; i++)
   {
     if (StringUtils::EqualsNoCase(params[i], "isdir"))
-      item.m_bIsFolder = true;
+      item.SetFolder(true);
     else if (params[i] == "1") // set fullscreen or windowed
       CMediaSettings::GetInstance().SetMediaStartWindowed(true);
     else if (StringUtils::EqualsNoCase(params[i], "resume"))
@@ -554,7 +554,7 @@ int PlayOrQueueMedia(const std::vector<std::string>& params,
     }
   }
 
-  if (!item.m_bIsFolder && item.IsPlugin())
+  if (!item.IsFolder() && item.IsPlugin())
     item.SetProperty("IsPlayable", true);
 
   if (forcePlay && askToResume)
@@ -572,7 +572,7 @@ int PlayOrQueueMedia(const std::vector<std::string>& params,
     }
   }
 
-  if (!forcePlay /* queue */ || item.m_bIsFolder || PLAYLIST::IsPlayList(item))
+  if (!forcePlay /* queue */ || item.IsFolder() || PLAYLIST::IsPlayList(item))
   {
     CFileItemList items;
     GetItemsForPlayList(std::make_shared<CFileItem>(item), items);

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -25,6 +25,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/Artwork.h"
 #include "utils/SortUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -300,7 +301,7 @@ JSONRPC_STATUS CAudioLibrary::GetAlbums(const std::string &method, ITransportLay
         }
         if (bFetchArt)
         {
-          CGUIListItem::ArtMap artMap = item.GetArt();
+          const KODI::ART::Artwork& artMap = item.GetArt();
           CVariant artObj(CVariant::VariantTypeObject);
           for (const auto& artIt : artMap)
           {
@@ -466,7 +467,7 @@ JSONRPC_STATUS CAudioLibrary::GetSongs(const std::string &method, ITransportLaye
         }
         if (bFetchArt)
         {
-          CGUIListItem::ArtMap artMap = item.GetArt();
+          const KODI::ART::Artwork& artMap = item.GetArt();
           CVariant artObj(CVariant::VariantTypeObject);
           for (const auto& artIt : artMap)
           {
@@ -1004,7 +1005,7 @@ JSONRPC_STATUS CAudioLibrary::SetSongDetails(const std::string &method, ITranspo
   if (ParameterNotNull(parameterObject, "art"))
   {
     // Get current artwork
-    std::map<std::string, std::string> artwork;
+    KODI::ART::Artwork artwork;
     musicdatabase.GetArtForItem(song.idSong, MediaTypeSong, artwork);
 
     std::set<std::string> removedArtwork;

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -428,7 +428,7 @@ void CFileItemHandler::HandleFileItem(const char* ID,
           std::string type = item->GetMusicInfoTag()->GetType();
           if (type == MediaTypeAlbum || type == MediaTypeSong || type == MediaTypeArtist)
             object["type"] = type;
-          else if (!item->m_bIsFolder)
+          else if (!item->IsFolder())
             object["type"] = MediaTypeSong;
         }
         else if (item->HasVideoInfoTag() && !item->GetVideoInfoTag()->m_type.empty())
@@ -445,7 +445,7 @@ void CFileItemHandler::HandleFileItem(const char* ID,
 
         if (fields.contains("filetype"))
         {
-          if (item->m_bIsFolder)
+          if (item->IsFolder())
             object["filetype"] = "directory";
           else
             object["filetype"] = "file";

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -28,6 +28,7 @@
 #include "pvr/recordings/PVRRecordings.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/timers/PVRTimers.h"
+#include "utils/Artwork.h"
 #include "utils/FileUtils.h"
 #include "utils/ISerializable.h"
 #include "utils/SortUtils.h"
@@ -189,7 +190,7 @@ bool CFileItemHandler::GetField(const std::string& field,
         fetchedArt = true;
       }
 
-      CGUIListItem::ArtMap artMap = item->GetArt();
+      const KODI::ART::Artwork& artMap = item->GetArt();
       CVariant artObj(CVariant::VariantTypeObject);
       for (const auto& artIt : artMap)
       {

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -22,6 +22,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/Artwork.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
@@ -261,7 +262,7 @@ JSONRPC_STATUS CFileOperations::SetFileDetails(const std::string &method, ITrans
   CVideoLibrary::UpdateResumePoint(parameterObject, infos, videodatabase);
 
   videodatabase.GetFileInfo("", infos, fileId);
-  CJSONRPCUtils::NotifyItemUpdated(infos, std::map<std::string, std::string>{});
+  CJSONRPCUtils::NotifyItemUpdated(infos, KODI::ART::Artwork{});
   return ACK;
 }
 

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -334,7 +334,7 @@ bool CFileOperations::FillFileItem(
 
         item->SetLabel(label);
         item->SetPath(strFilename);
-        item->m_bIsFolder = isDir;
+        item->SetFolder(isDir);
       }
       else
         *item = *originalItem;
@@ -391,7 +391,7 @@ bool CFileOperations::FillFileItemList(const CVariant &parameterObject, CFileIte
           if (CUtil::ExcludeFileOrFolder(items[i]->GetPath(), regexps))
             continue;
 
-          if (items[i]->m_bIsFolder)
+          if (items[i]->IsFolder())
             filteredDirectories.Add(items[i]);
           else if ((media == "video" && items[i]->HasVideoInfoTag()) ||
                    (media == "music" && items[i]->HasMusicInfoTag()))

--- a/xbmc/interfaces/json-rpc/JSONRPC.cpp
+++ b/xbmc/interfaces/json-rpc/JSONRPC.cpp
@@ -387,8 +387,7 @@ void CJSONRPCUtils::NotifyItemUpdated(const std::shared_ptr<CFileItem>& item)
   wm.SendThreadMessage(message);
 }
 
-void CJSONRPCUtils::NotifyItemUpdated(const CVideoInfoTag& info,
-                                      const std::map<std::string, std::string>& artwork)
+void CJSONRPCUtils::NotifyItemUpdated(const CVideoInfoTag& info, const KODI::ART::Artwork& artwork)
 {
   CFileItemPtr msgItem(new CFileItem(info));
   if (!artwork.empty())

--- a/xbmc/interfaces/json-rpc/JSONRPCUtils.h
+++ b/xbmc/interfaces/json-rpc/JSONRPCUtils.h
@@ -10,6 +10,7 @@
 
 #include "IClient.h"
 #include "ITransportLayer.h"
+#include "utils/Artwork.h"
 
 #include <map>
 #include <memory>
@@ -160,7 +161,6 @@ namespace JSONRPC
   public:
     static void NotifyItemUpdated();
     static void NotifyItemUpdated(const std::shared_ptr<CFileItem>& item);
-    static void NotifyItemUpdated(const CVideoInfoTag& info,
-                                  const std::map<std::string, std::string>& artwork);
+    static void NotifyItemUpdated(const CVideoInfoTag& info, const KODI::ART::Artwork& artwork);
   };
 }

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -614,7 +614,7 @@ JSONRPC_STATUS CVideoLibrary::SetMovieDetails(const std::string &method, ITransp
     return InvalidParams;
 
   // get artwork
-  std::map<std::string, std::string> artwork;
+  KODI::ART::Artwork artwork;
   videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
 
   int playcount = infos.GetPlayCount();
@@ -661,7 +661,7 @@ JSONRPC_STATUS CVideoLibrary::SetMovieSetDetails(const std::string &method, ITra
   }
 
   // get artwork
-  std::map<std::string, std::string> artwork;
+  KODI::ART::Artwork artwork;
   videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
 
   std::set<std::string> removedArtwork;
@@ -691,10 +691,10 @@ JSONRPC_STATUS CVideoLibrary::SetTVShowDetails(const std::string &method, ITrans
     return InvalidParams;
 
   // get artwork
-  std::map<std::string, std::string> artwork;
+  KODI::ART::Artwork artwork;
   videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
 
-  std::map<int, std::map<std::string, std::string> > seasonArt;
+  KODI::ART::SeasonsArtwork seasonArt;
   videodatabase.GetTvShowSeasonArt(infos.m_iDbId, seasonArt);
 
   std::set<std::string> removedArtwork;
@@ -732,7 +732,7 @@ JSONRPC_STATUS CVideoLibrary::SetSeasonDetails(const std::string &method, ITrans
   }
 
   // get artwork
-  std::map<std::string, std::string> artwork;
+  KODI::ART::Artwork artwork;
   videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
 
   std::set<std::string> removedArtwork;
@@ -775,7 +775,7 @@ JSONRPC_STATUS CVideoLibrary::SetEpisodeDetails(const std::string &method, ITran
   }
 
   // get artwork
-  std::map<std::string, std::string> artwork;
+  KODI::ART::Artwork artwork;
   videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
 
   int playcount = infos.GetPlayCount();
@@ -822,7 +822,7 @@ JSONRPC_STATUS CVideoLibrary::SetMusicVideoDetails(const std::string &method, IT
   }
 
   // get artwork
-  std::map<std::string, std::string> artwork;
+  KODI::ART::Artwork artwork;
   videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
 
   int playcount = infos.GetPlayCount();
@@ -1208,7 +1208,11 @@ void CVideoLibrary::UpdateVideoTagField(const CVariant& parameterObject, const s
   }
 }
 
-void CVideoLibrary::UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTag& details, std::map<std::string, std::string> &artwork, std::set<std::string> &removedArtwork, std::set<std::string> &updatedDetails)
+void CVideoLibrary::UpdateVideoTag(const CVariant& parameterObject,
+                                   CVideoInfoTag& details,
+                                   KODI::ART::Artwork& artwork,
+                                   std::set<std::string>& removedArtwork,
+                                   std::set<std::string>& updatedDetails)
 {
   if (ParameterNotNull(parameterObject, "title"))
     details.SetTitle(parameterObject["title"].asString());

--- a/xbmc/interfaces/json-rpc/VideoLibrary.h
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.h
@@ -10,6 +10,7 @@
 
 #include "FileItemHandler.h"
 #include "JSONRPC.h"
+#include "utils/Artwork.h"
 #include "utils/DatabaseUtils.h"
 
 #include <memory>
@@ -89,7 +90,11 @@ namespace JSONRPC
     static int RequiresAdditionalDetails(const MediaType& mediaType, const CVariant &parameterObject);
     static JSONRPC_STATUS HandleItems(const char *idProperty, const char *resultName, CFileItemList &items, const CVariant &parameterObject, CVariant &result, bool limit = true);
     static JSONRPC_STATUS RemoveVideo(const CVariant &parameterObject);
-    static void UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTag &details, std::map<std::string, std::string> &artwork, std::set<std::string> &removedArtwork, std::set<std::string>& updatedDetails);
+    static void UpdateVideoTag(const CVariant& parameterObject,
+                               CVideoInfoTag& details,
+                               KODI::ART::Artwork& artwork,
+                               std::set<std::string>& removedArtwork,
+                               std::set<std::string>& updatedDetails);
     static void UpdateVideoTagField(const CVariant& parameterObject, const std::string& fieldName, std::vector<std::string>& fieldValue, std::set<std::string>& updatedDetails);
   };
 }

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -314,7 +314,7 @@ namespace XBMCAddon
     bool ListItem::isFolder() const
     {
       XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
-      return item->m_bIsFolder;
+      return item->IsFolder();
     }
 
     String ListItem::getUniqueID(const char* key)
@@ -1015,7 +1015,7 @@ namespace XBMCAddon
 
     void ListItem::setIsFolderRaw(bool isFolder)
     {
-      item->m_bIsFolder = isFolder;
+      item->SetFolder(isFolder);
     }
 
     void ListItem::setStartOffsetRaw(double startOffset)

--- a/xbmc/interfaces/legacy/ModuleXbmcplugin.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmcplugin.cpp
@@ -25,7 +25,7 @@ namespace XBMCAddon
         throw new XBMCAddon::WrongTypeException("None not allowed as argument for listitem");
       AddonClass::Ref<xbmcgui::ListItem> pListItem(listItem);
       pListItem->item->SetPath(url);
-      pListItem->item->m_bIsFolder = isFolder;
+      pListItem->item->SetFolder(isFolder);
 
       // call the directory class to add our item
       return XFILE::CPluginDirectory::AddItem(handle, pListItem->item.get(), totalItems);
@@ -42,7 +42,7 @@ namespace XBMCAddon
         const XBMCAddon::xbmcgui::ListItem* pListItem = item.second();
         bool bIsFolder = item.GetNumValuesSet() > 2 ? item.third() : false;
         pListItem->item->SetPath(url);
-        pListItem->item->m_bIsFolder = bIsFolder;
+        pListItem->item->SetFolder(bIsFolder);
         fitems.Add(pListItem->item);
       }
 

--- a/xbmc/music/Album.h
+++ b/xbmc/music/Album.h
@@ -16,6 +16,7 @@
 #include "Artist.h"
 #include "Song.h"
 #include "XBDateTime.h"
+#include "utils/Artwork.h"
 #include "utils/ScraperUrl.h"
 
 #include <map>
@@ -154,7 +155,7 @@ public:
   std::vector<std::string> moods;
   std::vector<std::string> styles;
   std::vector<std::string> themes;
-  std::map<std::string, std::string> art;
+  KODI::ART::Artwork art;
   std::string strReview;
   std::string strLabel;
   std::string strType;

--- a/xbmc/music/Artist.h
+++ b/xbmc/music/Artist.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "XBDateTime.h"
+#include "utils/Artwork.h"
 #include "utils/ScraperUrl.h"
 #include "utils/StringUtils.h"
 
@@ -120,7 +121,7 @@ public:
   std::vector<std::string> yearsActive;
   std::string strPath;
   CScraperUrl thumbURL; // Data for available remote art
-  std::map<std::string, std::string> art;  // Current artwork - thumb, fanart etc.
+  KODI::ART::Artwork art; // Current artwork - thumb, fanart etc.
   std::vector<CDiscoAlbum> discography;
   CDateTime dateAdded; // From related file creation or modification times, or when (re-)scanned
   CDateTime dateUpdated; // Time db record Last modified

--- a/xbmc/music/ContextMenus.cpp
+++ b/xbmc/music/ContextMenus.cpp
@@ -52,7 +52,7 @@ bool CMusicInfo::IsVisible(const CFileItem& item) const
   if (CMusicInfoBase::IsVisible(item))
     return true;
 
-  if (item.m_bIsFolder)
+  if (item.IsFolder())
     return false;
 
   const auto* tag{item.GetMusicInfoTag()};
@@ -61,7 +61,7 @@ bool CMusicInfo::IsVisible(const CFileItem& item) const
 
 bool CMusicBrowse::IsVisible(const CFileItem& item) const
 {
-  return ((item.m_bIsFolder || item.IsFileFolder(FileFolderType::MASK_ONBROWSE)) &&
+  return ((item.IsFolder() || item.IsFileFolder(FileFolderType::MASK_ONBROWSE)) &&
           MUSIC_UTILS::IsItemPlayable(item));
 }
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -4884,7 +4884,7 @@ void CMusicDatabase::DeleteCDDBInfo()
     std::map<uint32_t, std::string> mapCDDBIds;
     for (int i = 0; i < items.Size(); ++i)
     {
-      if (items[i]->m_bIsFolder)
+      if (items[i]->IsFolder())
         continue;
 
       std::string strFile = URIUtils::GetFileName(items[i]->GetPath());
@@ -5059,7 +5059,7 @@ bool CMusicDatabase::GetGenresNav(const std::string& strBaseDir,
       itemUrl.AppendPath(strDir);
       pItem->SetPath(itemUrl.ToString());
 
-      pItem->m_bIsFolder = true;
+      pItem->SetFolder(true);
       items.Add(pItem);
 
       m_pDS->next();
@@ -5177,7 +5177,7 @@ bool CMusicDatabase::GetSourcesNav(const std::string& strBaseDir,
       itemUrl.AddOption("sourceid", m_pDS->fv("source.idSource").get_asInt());
       pItem->SetPath(itemUrl.ToString());
 
-      pItem->m_bIsFolder = true;
+      pItem->SetFolder(true);
       items.Add(pItem);
 
       m_pDS->next();
@@ -5260,7 +5260,7 @@ bool CMusicDatabase::GetYearsNav(const std::string& strBaseDir,
         itemUrl.AddOption("useoriginalyear", true);
       pItem->SetPath(itemUrl.ToString());
 
-      pItem->m_bIsFolder = true;
+      pItem->SetFolder(true);
       items.Add(pItem);
 
       m_pDS->next();
@@ -5326,7 +5326,7 @@ bool CMusicDatabase::GetRolesNav(const std::string& strBaseDir,
       itemUrl.AddOption("roleid", m_pDS->fv("role.idRole").get_asInt());
       pItem->SetPath(itemUrl.ToString());
 
-      pItem->m_bIsFolder = true;
+      pItem->SetFolder(true);
       items.Add(pItem);
 
       m_pDS->next();
@@ -5428,7 +5428,7 @@ bool CMusicDatabase::GetCommonNav(const std::string& strBaseDir,
       itemUrl.AppendPath(strDir);
       pItem->SetPath(itemUrl.ToString());
 
-      pItem->m_bIsFolder = true;
+      pItem->SetFolder(true);
       items.Add(pItem);
 
       m_pDS->next();
@@ -10402,7 +10402,7 @@ bool CMusicDatabase::GetSources(CFileItemList& items)
         // Set item path as source URL encoded multipath too
         pItem->SetPath(m_pDS->fv("source.strMultiPath").get_asString());
 
-        pItem->m_bIsFolder = true;
+        pItem->SetFolder(true);
         items.Add(pItem);
       }
       // Get path data
@@ -11128,7 +11128,7 @@ bool CMusicDatabase::GetGenresJSON(CFileItemList& items, bool bSources)
         pItem->GetMusicInfoTag()->SetGenre(strGenre);
         pItem->GetMusicInfoTag()->SetDatabaseId(idGenre, "genre");
         pItem->SetPath(StringUtils::Format("musicdb://genres/{}/", idGenre));
-        pItem->m_bIsFolder = true;
+        pItem->SetFolder(true);
         items.Add(pItem);
       }
       // Get source data

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -12050,7 +12050,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
             {
               // Save art in album folder
               // Note thumb resolution may be lower than original when overwriting
-              std::map<std::string, std::string> artwork;
+              KODI::ART::Artwork artwork;
               std::string savedArtfile;
               if (GetArtForItem(album.idAlbum, MediaTypeAlbum, artwork))
               {
@@ -12140,7 +12140,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
         // Include discography when not folders only
         GetArtist(artistId, artist, !artistfoldersonly);
         std::string strPath;
-        std::map<std::string, std::string> artwork;
+        KODI::ART::Artwork artwork;
         if (settings.IsSingleFile())
         {
           // Save artist to xml, and old path (common to music files) if it has one
@@ -12904,7 +12904,7 @@ void CMusicDatabase::SetItemUpdated(int mediaId, const std::string& mediaType)
 
 void CMusicDatabase::SetArtForItem(int mediaId,
                                    const std::string& mediaType,
-                                   const std::map<std::string, std::string>& art)
+                                   const KODI::ART::Artwork& art)
 {
   for (const auto& i : art)
     SetArtForItem(mediaId, mediaType, i.first, i.second);
@@ -13070,7 +13070,7 @@ bool CMusicDatabase::GetArtForItem(
 
 bool CMusicDatabase::GetArtForItem(int mediaId,
                                    const std::string& mediaType,
-                                   std::map<std::string, std::string>& art)
+                                   KODI::ART::Artwork& art)
 {
   try
   {

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -18,6 +18,7 @@
 #include "addons/Scraper.h"
 #include "dbwrappers/Database.h"
 #include "settings/LibExportSettings.h"
+#include "utils/Artwork.h"
 #include "utils/SortUtils.h"
 
 #include <utility>
@@ -750,10 +751,7 @@ public:
    \param art a map of <type, url> where type is "thumb", "fanart", etc. and url is the original url of the art.
    \sa GetArtForItem
    */
-  void SetArtForItem(int mediaId,
-                     const std::string& mediaType,
-                     const std::map<std::string, std::string>& art);
-
+  void SetArtForItem(int mediaId, const std::string& mediaType, const KODI::ART::Artwork& art);
 
   /*! \brief Fetch all related art for a database item.
   Fetches multiple pieces of art for a database item including that for related media types
@@ -786,9 +784,7 @@ public:
    \return true if art is retrieved, false if no art is found.
    \sa SetArtForItem
    */
-  bool GetArtForItem(int mediaId,
-                     const std::string& mediaType,
-                     std::map<std::string, std::string>& art);
+  bool GetArtForItem(int mediaId, const std::string& mediaType, KODI::ART::Artwork& art);
 
   /*! \brief Fetch art for a database item.
    Fetches a single piece of art for a database item.

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -76,7 +76,7 @@ void CMusicInfoLoader::OnLoaderStart()
 
 bool CMusicInfoLoader::LoadAdditionalTagInfo(CFileItem* pItem)
 {
-  if (!pItem || (pItem->m_bIsFolder && !MUSIC::IsAudio(*pItem)) || PLAYLIST::IsPlayList(*pItem) ||
+  if (!pItem || (pItem->IsFolder() && !MUSIC::IsAudio(*pItem)) || PLAYLIST::IsPlayList(*pItem) ||
       pItem->IsNFO() || NETWORK::IsInternetStream(*pItem))
     return false;
 
@@ -150,7 +150,7 @@ bool CMusicInfoLoader::LoadItem(CFileItem* pItem)
 
 bool CMusicInfoLoader::LoadItemCached(CFileItem* pItem)
 {
-  if ((pItem->m_bIsFolder && !MUSIC::IsAudio(*pItem)) || PLAYLIST::IsPlayList(*pItem) ||
+  if ((pItem->IsFolder() && !MUSIC::IsAudio(*pItem)) || PLAYLIST::IsPlayList(*pItem) ||
       PLAYLIST::IsSmartPlayList(*pItem) ||
       StringUtils::StartsWithNoCase(pItem->GetPath(), "newplaylist://") ||
       StringUtils::StartsWithNoCase(pItem->GetPath(), "newsmartplaylist://") || pItem->IsNFO() ||
@@ -165,10 +165,10 @@ bool CMusicInfoLoader::LoadItemCached(CFileItem* pItem)
 
 bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
 {
-  if (m_pProgressCallback && !pItem->m_bIsFolder)
+  if (m_pProgressCallback && !pItem->IsFolder())
     m_pProgressCallback->SetProgressAdvance();
 
-  if ((pItem->m_bIsFolder && !MUSIC::IsAudio(*pItem)) || //
+  if ((pItem->IsFolder() && !MUSIC::IsAudio(*pItem)) || //
       PLAYLIST::IsPlayList(*pItem) || PLAYLIST::IsSmartPlayList(*pItem) || //
       StringUtils::StartsWithNoCase(pItem->GetPath(), "newplaylist://") || //
       StringUtils::StartsWithNoCase(pItem->GetPath(), "newsmartplaylist://") || //

--- a/xbmc/music/MusicThumbLoader.cpp
+++ b/xbmc/music/MusicThumbLoader.cpp
@@ -12,6 +12,7 @@
 #include "imagefiles/ImageFileURL.h"
 #include "music/infoscanner/MusicInfoScanner.h"
 #include "music/tags/MusicInfoTag.h"
+#include "utils/Artwork.h"
 #include "utils/StringUtils.h"
 #include "video/VideoThumbLoader.h"
 
@@ -269,8 +270,8 @@ bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
   {
     std::string fanartfallback;
     std::string artname;
-    std::map<std::string, std::string> artmap;
-    std::map<std::string, std::string> discartmap;
+    KODI::ART::Artwork artmap;
+    KODI::ART::Artwork discartmap;
     for (auto artitem : art)
     {
       /* Add art to artmap, naming according to media type.

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -509,7 +509,7 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
   if (item->IsParentFolder() || !item->CanQueue() || item->IsRAR() || item->IsZIP())
     return;
 
-  if (MUSIC::IsMusicDb(*item) && item->m_bIsFolder && !item->IsParentFolder())
+  if (MUSIC::IsMusicDb(*item) && item->IsFolder() && !item->IsParentFolder())
   {
     // we have a music database folder, just grab the "all" item underneath it
     XFILE::CMusicDatabaseDirectory dir;
@@ -532,7 +532,7 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
     }
   }
 
-  if (item->m_bIsFolder)
+  if (item->IsFolder())
   {
     // Check if we add a locked share
     if (item->IsShareOrDrive())
@@ -559,7 +559,7 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
         if (i->IsLabelPreformatted())
           continue;
 
-        if (i->m_bIsFolder)
+        if (i->IsFolder())
           folderFormatter.FormatLabels(i.get());
         else
           fileFormatter.FormatLabels(i.get());
@@ -728,7 +728,7 @@ void PlayItem(const std::shared_ptr<CFileItem>& itemIn,
     item->SetCanQueue(true);
   }
 
-  if (item->m_bIsFolder)
+  if (item->IsFolder())
   {
     AddItemToPlayListAndPlay(item, nullptr, player);
   }
@@ -918,7 +918,7 @@ bool IsItemPlayable(const CFileItem& item)
     if (StringUtils::StartsWith(item.GetPath(), StringUtils::Format("{}/music/", path)))
       return true;
 
-    if (!item.m_bIsFolder && !item.HasMusicInfoTag())
+    if (!item.IsFolder() && !item.HasMusicInfoTag())
     {
       // Unknown location. Type cannot be determined for non-folder items.
       return false;
@@ -928,7 +928,7 @@ bool IsItemPlayable(const CFileItem& item)
   if (IsNonExistingUserPartyModePlaylist(item))
     return false;
 
-  if (item.m_bIsFolder &&
+  if (item.IsFolder() &&
       (MUSIC::IsMusicDb(item) || StringUtils::StartsWithNoCase(item.GetPath(), "library://music/")))
   {
     // Exclude top level nodes - eg can't play 'genres' just a specific genre etc
@@ -948,11 +948,11 @@ bool IsItemPlayable(const CFileItem& item)
   {
     return true;
   }
-  else if (!item.m_bIsFolder && MUSIC::IsAudio(item) && !IsEmptyMusicItem(item))
+  else if (!item.IsFolder() && MUSIC::IsAudio(item) && !IsEmptyMusicItem(item))
   {
     return true;
   }
-  else if (item.m_bIsFolder && !item.IsPlugin() && !item.IsScript())
+  else if (item.IsFolder() && !item.IsPlugin() && !item.IsScript())
   {
     // Not a music-specific folder (just file:// or nfs://). Allow play if context is Music window.
     if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_MUSIC_NAV &&

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -40,6 +40,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "threads/IRunnable.h"
+#include "utils/Artwork.h"
 #include "utils/FileUtils.h"
 #include "utils/JobManager.h"
 #include "utils/StringUtils.h"
@@ -234,7 +235,7 @@ void AddCurrentArtTypes(std::vector<std::string>& artTypes,
                         const CMusicInfoTag& tag,
                         CMusicDatabase& db)
 {
-  std::map<std::string, std::string> currentArt;
+  KODI::ART::Artwork currentArt;
   db.GetArtForItem(tag.GetDatabaseId(), tag.GetType(), currentArt);
   for (const auto& art : currentArt)
   {

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -42,6 +42,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
+#include "utils/Artwork.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/FileUtils.h"
 #include "utils/ProgressJob.h"
@@ -770,13 +771,13 @@ void CGUIDialogMusicInfo::OnGetArt()
     return; // Cancelled
 
   CFileItemList items;
-  CGUIListItem::ArtMap primeArt = m_item->GetArt(); // art without fallbacks
+  const KODI::ART::Artwork& primeArt = m_item->GetArt(); // art without fallbacks
   bool bHasArt = m_item->HasArt(type);
   bool bFallback(false);
   if (bHasArt)
   {
     // Check if that type of art is actually a fallback, e.g. artist fanart
-    CGUIListItem::ArtMap::const_iterator i = primeArt.find(type);
+    const auto i = primeArt.find(type);
     bFallback = (i == primeArt.end());
   }
 

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -985,7 +985,7 @@ void CGUIDialogMusicInfo::ShowFor(CFileItem* pItem)
     StringUtils::StartsWithNoCase(pItem->GetPath(), "musicsearch://"))
     return; // nothing to do
 
-  if (!pItem->m_bIsFolder)
+  if (!pItem->IsFolder())
   { // Show Song information dialog
     CGUIDialogSongInfo::ShowFor(pItem);
     return;

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -30,6 +30,7 @@
 #include "settings/MediaSourceSettings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
+#include "utils/Artwork.h"
 #include "utils/FileUtils.h"
 
 using namespace KODI;
@@ -339,13 +340,13 @@ void CGUIDialogSongInfo::OnGetArt()
     return; // Cancelled
 
   CFileItemList items;
-  CGUIListItem::ArtMap primeArt = m_song->GetArt(); // Song art without fallbacks
+  KODI::ART::Artwork primeArt = m_song->GetArt(); // Song art without fallbacks
   bool bHasArt = m_song->HasArt(type);
   bool bFallback(false);
   if (bHasArt)
   {
     // Check if that type of art is actually a fallback, e.g. album thumb or artist fanart
-    CGUIListItem::ArtMap::const_iterator i = primeArt.find(type);
+    auto i = primeArt.find(type);
     bFallback = (i == primeArt.end());
   }
 
@@ -361,7 +362,7 @@ void CGUIDialogSongInfo::OnGetArt()
   }
   else if (m_song->HasArt("thumb"))
   { // For missing art of that type add the thumb (when it exists and not a fallback)
-    CGUIListItem::ArtMap::const_iterator i = primeArt.find("thumb");
+    auto i = primeArt.find("thumb");
     if (i != primeArt.end())
     {
       CFileItemPtr item(new CFileItem("thumb://Thumb", false));

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -492,7 +492,7 @@ void CGUIDialogSongInfo::OnSetUserrating()
 
 void CGUIDialogSongInfo::ShowFor(CFileItem* pItem)
 {
-  if (pItem->m_bIsFolder)
+  if (pItem->IsFolder())
     return;
   if (!MUSIC::IsMusicDb(*pItem))
     pItem->LoadMusicTag();

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -557,7 +557,7 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
     if (m_bStop)
       break;
     // if we have a directory item (non-playlist) we then recurse into that folder
-    if (pItem->m_bIsFolder && !pItem->IsParentFolder() && !PLAYLIST::IsPlayList(*pItem))
+    if (pItem->IsFolder() && !pItem->IsParentFolder() && !PLAYLIST::IsPlayList(*pItem))
     {
       std::string strPath=pItem->GetPath();
       if (!DoScan(strPath))
@@ -584,7 +584,7 @@ CInfoScanner::InfoRet CMusicInfoScanner::ScanTags(const CFileItemList& items,
     if (CUtil::ExcludeFileOrFolder(pItem->GetPath(), regexps))
       continue;
 
-    if (pItem->m_bIsFolder || PLAYLIST::IsPlayList(*pItem) || pItem->IsPicture() ||
+    if (pItem->IsFolder() || PLAYLIST::IsPlayList(*pItem) || pItem->IsPicture() ||
         MUSIC::IsLyrics(*pItem))
       continue;
 
@@ -2196,7 +2196,7 @@ bool CMusicInfoScanner::AddLocalArtwork(std::map<std::string, std::string>& art,
 
   for (const auto& artFile : availableArtFiles)
   {
-    if (artFile->m_bIsFolder)
+    if (artFile->IsFolder())
       continue;
     std::string strCandidate = URIUtils::GetFileName(artFile->GetPath());
     // Strip media name
@@ -2338,7 +2338,7 @@ int CMusicInfoScanner::CountFiles(const CFileItemList& items, bool recursive)
   {
     const CFileItemPtr pItem = items[i];
 
-    if (recursive && pItem->m_bIsFolder)
+    if (recursive && pItem->IsFolder())
       count += CountFilesRecursively(pItem->GetPath());
     else if (MUSIC::IsAudio(*pItem) && !PLAYLIST::IsPlayList(*pItem) && !pItem->IsNFO())
       ++count;

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -271,7 +271,7 @@ bool CGUIWindowMusicBase::OnAction(const CAction &action)
   if (action.GetID() == ACTION_SCAN_ITEM)
   {
     int item = m_viewControl.GetSelectedItem();
-    if (item > -1 && m_vecItems->Get(item)->m_bIsFolder)
+    if (item > -1 && m_vecItems->Get(item)->IsFolder())
       OnScan(item);
 
     return true;
@@ -357,7 +357,7 @@ void CGUIWindowMusicBase::RetrieveMusicInfo()
   for (int i = 0; i < m_vecItems->Size(); ++i)
   {
     CFileItemPtr pItem = (*m_vecItems)[i];
-    if (pItem->m_bIsFolder || PLAYLIST::IsPlayList(*pItem) || pItem->IsPicture() ||
+    if (pItem->IsFolder() || PLAYLIST::IsPlayList(*pItem) || pItem->IsPicture() ||
         MUSIC::IsLyrics(*pItem) || VIDEO::IsVideo(*pItem))
       continue;
 
@@ -629,7 +629,7 @@ void CGUIWindowMusicBase::PlayItem(int iItem)
   }
 
   // if its a folder, build a playlist
-  if (pItem->m_bIsFolder && !pItem->IsPlugin())
+  if (pItem->IsFolder() && !pItem->IsPlugin())
   {
     // make a copy so that we can alter the queue state
     CFileItemPtr item(new CFileItem(*m_vecItems->Get(iItem)));
@@ -857,7 +857,7 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
       newPlaylist->SetLabel(g_localizeStrings.Get(16035));
       newPlaylist->SetLabelPreformatted(true);
       newPlaylist->SetArt("icon", "DefaultPartyMode.png");
-      newPlaylist->m_bIsFolder = true;
+      newPlaylist->SetFolder(true);
       items.Add(newPlaylist);
 
       newPlaylist = std::make_shared<CFileItem>("newplaylist://", false);
@@ -993,7 +993,7 @@ void CGUIWindowMusicBase::OnScan(int iItem, bool bPromptRescan /*= false*/)
   std::string strPath;
   if (iItem < 0 || iItem >= m_vecItems->Size())
     strPath = m_vecItems->GetPath();
-  else if (m_vecItems->Get(iItem)->m_bIsFolder)
+  else if (m_vecItems->Get(iItem)->IsFolder())
     strPath = m_vecItems->Get(iItem)->GetPath();
   else
   { //! @todo MUSICDB - should we allow scanning a single item into the database?

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -61,6 +61,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
+#include "utils/Artwork.h"
 #include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -826,7 +827,7 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
       std::string dirType = MediaTypeArtist;
       if (params.GetAlbumId() > 0)
         dirType = MediaTypeAlbum;
-      std::map<std::string, std::string> artmap;
+      KODI::ART::Artwork artmap;
       for (auto artitem : art)
       {
         std::string artname;
@@ -840,7 +841,7 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
             StringUtils::Replace(artitem.prefix, "albumartist", "artist");
           artname = artitem.prefix + "." + artitem.artType;
         }
-      artmap.insert(std::make_pair(artname, artitem.url));
+        artmap.insert(std::make_pair(artname, artitem.url));
       }
       items.SetArt(artmap);
     }

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -210,9 +210,8 @@ bool CGUIWindowMusicNav::OnAction(const CAction& action)
   {
     int item = m_viewControl.GetSelectedItem();
     CMusicDatabaseDirectory dir;
-    if (item > -1 && m_vecItems->Get(item)->m_bIsFolder
-                  && (m_vecItems->Get(item)->IsAlbum()||
-                      dir.IsArtistDir(m_vecItems->Get(item)->GetPath())))
+    if (item > -1 && m_vecItems->Get(item)->IsFolder() &&
+        (m_vecItems->Get(item)->IsAlbum() || dir.IsArtistDir(m_vecItems->Get(item)->GetPath())))
     {
       OnContextButton(item,CONTEXT_BUTTON_INFO);
       return true;
@@ -356,7 +355,7 @@ bool CGUIWindowMusicNav::OnClick(int iItem, const std::string &player /* = "" */
     }
     return true;
   }
-  if (MUSIC::IsMusicDb(*item) && !item->m_bIsFolder)
+  if (MUSIC::IsMusicDb(*item) && !item->IsFolder())
     m_musicdatabase.SetPropertiesForFileItem(*item);
 
   if (PLAYLIST::IsPlayList(*item) &&
@@ -619,7 +618,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
           !inPlaylists &&
           !NETWORK::IsInternetStream(*m_vecItems) && // Not playlists locations or streams
           !item->IsPath("add") && !item->IsParentFolder() && // Not ".." and "Add items
-          item->m_bIsFolder && // Folders only, but playlists can be folders too
+          item->IsFolder() && // Folders only, but playlists can be folders too
           !URIUtils::IsLibraryContent(item->GetPath()) && // database folder or .xsp files
           !URIUtils::IsSpecial(item->GetPath()) && !item->IsPlugin() && !item->IsScript() &&
           !PLAYLIST::IsPlayList(
@@ -635,7 +634,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
 
       if (!item->IsParentFolder() && !dir.IsAllItem(item->GetPath()))
       {
-        if (item->m_bIsFolder && !VIDEO::IsVideoDb(*item) && !item->IsPlugin() &&
+        if (item->IsFolder() && !VIDEO::IsVideoDb(*item) && !item->IsPlugin() &&
             !StringUtils::StartsWithNoCase(item->GetPath(), "musicsearch://"))
         {
           if (item->IsAlbum())
@@ -681,7 +680,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
           if (database.GetMatchingMusicVideo(item->GetMusicInfoTag()->GetArtistString(), item->GetMusicInfoTag()->GetAlbum(), item->GetMusicInfoTag()->GetTitle()) > -1)
             buttons.Add(CONTEXT_BUTTON_PLAY_OTHER, 20401);
         }
-        if (item->HasVideoInfoTag() && !item->m_bIsFolder)
+        if (item->HasVideoInfoTag() && !item->IsFolder())
         {
           if ((profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !item->IsPlugin())
           {
@@ -827,7 +826,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   case CONTEXT_BUTTON_DELETE:
     if (PLAYLIST::IsPlayList(*item) || PLAYLIST::IsSmartPlayList(*item))
     {
-      item->m_bIsFolder = false;
+      item->SetFolder(false);
       CFileUtils::DeleteItemWithConfirm(item);
     }
     else if (!VIDEO::IsVideoDb(*item))

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -89,7 +89,7 @@ bool CGUIWindowMusicPlaylistEditor::OnClick(int iItem, const std::string& player
   if (item->IsFileFolder(FileFolderType::MASK_ONBROWSE))
     return Update(item->GetPath());
   // Avoid playback (default click behaviour) of media files
-  if (!item->m_bIsFolder)
+  if (!item->IsFolder())
     return false;
 
   return CGUIWindowMusicBase::OnClick(iItem, player);

--- a/xbmc/music/windows/MusicFileItemListModifier.cpp
+++ b/xbmc/music/windows/MusicFileItemListModifier.cpp
@@ -107,7 +107,7 @@ void CMusicFileItemListModifier::AddQueuingFolder(CFileItemList& items)
 
   if (pItem)
   {
-    pItem->m_bIsFolder = true;
+    pItem->SetFolder(true);
     pItem->SetSpecialSort(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bMusicLibraryAllItemsOnBottom ? SortSpecialOnBottom : SortSpecialOnTop);
     pItem->SetCanQueue(false);
     pItem->SetLabelPreformatted(true);

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -239,7 +239,7 @@ void ClearPhotoAssetCache()
   for (int i = 0; i < items.Size(); ++i)
   {
     CFileItemPtr pItem = items[i];
-    if (!pItem->m_bIsFolder)
+    if (!pItem->IsFolder())
     {
       if (StringUtils::StartsWithNoCase(pItem->GetLabel(), "airplayasset") &&
           (StringUtils::EndsWithNoCase(pItem->GetLabel(), ".jpg") ||

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -519,7 +519,7 @@ PLT_MediaObject* BuildObject(CFileItem& item,
     rooturi = NPT_HttpUrl("localhost", upnp_server->GetPort(), "/");
   }
 
-  if (!item.m_bIsFolder)
+  if (!item.IsFolder())
   {
     object = new PLT_MediaItem();
     object->m_ObjectID = EncodeObjectId(item.GetPath());
@@ -752,7 +752,7 @@ PLT_MediaObject* BuildObject(CFileItem& item,
     if (!item.GetLabel().empty())
     {
       std::string title = item.GetLabel();
-      if (PLAYLIST::IsPlayList(item) || !item.m_bIsFolder)
+      if (PLAYLIST::IsPlayList(item) || !item.IsFolder())
         URIUtils::RemoveExtension(title);
       object->m_Title = title.c_str();
     }
@@ -1160,10 +1160,10 @@ std::shared_ptr<CFileItem> BuildObject(PLT_MediaObject* entry,
   CFileItemPtr pItem(new CFileItem((const char*)entry->m_Title));
   pItem->SetLabelPreformatted(true);
   pItem->SetTitle(static_cast<const char*>(entry->m_Title));
-  pItem->m_bIsFolder = entry->IsContainer();
+  pItem->SetFolder(entry->IsContainer());
 
   // if it's a container, format a string as upnp://uuid/object_id
-  if (pItem->m_bIsFolder)
+  if (pItem->IsFolder())
   {
 
     // look for metadata

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -291,7 +291,7 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
   if (path.StartsWith("virtualpath://upnproot"))
   {
     path.TrimRight("/");
-    item->m_bIsFolder = true;
+    item->SetFolder(true);
     if (path.StartsWith("virtualpath://"))
     {
       object = new PLT_MediaContainer;
@@ -327,7 +327,7 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
       {
         item->SetLabel("Music Library");
         item->SetLabelPreformatted(true);
-        item->m_bIsFolder = true;
+        item->SetFolder(true);
       }
       else
       {
@@ -348,14 +348,14 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
           }
           else if (params.GetAlbumId() >= 0)
           {
-            item->m_bIsFolder = true;
+            item->SetFolder(true);
             CAlbum album;
             if (db.GetAlbum(params.GetAlbumId(), album, false))
               item->GetMusicInfoTag()->SetAlbum(album);
           }
           else if (params.GetArtistId() >= 0)
           {
-            item->m_bIsFolder = true;
+            item->SetFolder(true);
             CArtist artist;
             if (db.GetArtist(params.GetArtistId(), artist, false))
               item->GetMusicInfoTag()->SetArtist(artist);
@@ -365,7 +365,7 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
         // all items apart from songs (artists, albums, etc) are folders
         if (!item->HasMusicInfoTag() || item->GetMusicInfoTag()->GetType() != MediaTypeSong)
         {
-          item->m_bIsFolder = true;
+          item->SetFolder(true);
         }
 
         if (item->GetLabel().empty())
@@ -386,7 +386,7 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
       {
         item->SetLabel("Video Library");
         item->SetLabelPreformatted(true);
-        item->m_bIsFolder = true;
+        item->SetFolder(true);
       }
       else
       {
@@ -425,7 +425,7 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
         {
           // for tvshows and seasons, iEpisode and playCount are
           // invalid
-          item->m_bIsFolder = true;
+          item->SetFolder(true);
           item->GetVideoInfoTag()->m_iEpisode = (int)item->GetProperty("totalepisodes").asInteger();
           item->GetVideoInfoTag()->SetPlayCount(
               static_cast<int>(item->GetProperty("watchedepisodes").asInteger()));
@@ -433,7 +433,7 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
         // if this is an item in the library without a playable path it most be a folder
         else if (item->GetVideoInfoTag()->m_strFileNameAndPath.empty())
         {
-          item->m_bIsFolder = true;
+          item->SetFolder(true);
         }
 
         // try to grab title from tag
@@ -458,17 +458,17 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
     // all playlist types are folders
     else if (PLAYLIST::IsPlayList(*item) || PLAYLIST::IsSmartPlayList(*item))
     {
-      item->m_bIsFolder = true;
+      item->SetFolder(true);
     }
     // audio and not a playlist -> song, so it's not a folder
     else if (MUSIC::IsAudio(*item))
     {
-      item->m_bIsFolder = false;
+      item->SetFolder(true);
     }
     // any other type of item -> delegate to CDirectory
     else
     {
-      item->m_bIsFolder = CDirectory::Exists(item->GetPath());
+      item->SetFolder(CDirectory::Exists(item->GetPath()));
     }
 
     // not a virtual path directory, new system

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -328,7 +328,7 @@ bool CGUIWindowPictures::ShowPicture(int iItem, bool startSlideShow)
   bool bShowVideos = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_PICTURES_SHOWVIDEOS);
   for (const auto& pItem : *m_vecItems)
   {
-    if (!pItem->m_bIsFolder &&
+    if (!pItem->IsFolder() &&
         !(URIUtils::IsRAR(pItem->GetPath()) || URIUtils::IsZIP(pItem->GetPath())) &&
         (pItem->IsPicture() || (bShowVideos && VIDEO::IsVideo(*pItem))))
     {
@@ -450,13 +450,15 @@ void CGUIWindowPictures::GetContextButtons(int itemNumber, CContextButtons &butt
     {
       if (item)
       {
-        if (!(item->m_bIsFolder || item->IsZIP() || item->IsRAR() || item->IsCBZ() || item->IsCBR() || item->IsScript()))
+        if (!(item->IsFolder() || item->IsZIP() || item->IsRAR() || item->IsCBZ() ||
+              item->IsCBR() || item->IsScript()))
         {
           if (item->IsPicture())
             buttons.Add(CONTEXT_BUTTON_INFO, 13406); // picture info
-          buttons.Add(CONTEXT_BUTTON_VIEW_SLIDESHOW, item->m_bIsFolder ? 13317 : 13422);      // View Slideshow
+          buttons.Add(CONTEXT_BUTTON_VIEW_SLIDESHOW,
+                      item->IsFolder() ? 13317 : 13422); // View Slideshow
         }
-        if (item->m_bIsFolder)
+        if (item->IsFolder())
           buttons.Add(CONTEXT_BUTTON_RECURSIVE_SLIDESHOW, 13318);     // Recursive Slideshow
 
         if (!m_thumbLoader.IsLoading())
@@ -486,7 +488,7 @@ bool CGUIWindowPictures::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   switch (button)
   {
   case CONTEXT_BUTTON_VIEW_SLIDESHOW:
-    if (item && item->m_bIsFolder)
+    if (item && item->IsFolder())
       OnSlideShow(item->GetPath());
     else
       ShowPicture(itemNumber, true);
@@ -582,7 +584,8 @@ void CGUIWindowPictures::OnItemInfo(int itemNumber)
     CGUIDialogAddonInfo::ShowForItem(item);
     return;
   }
-  if (item->m_bIsFolder || item->IsZIP() || item->IsRAR() || item->IsCBZ() || item->IsCBR() || !item->IsPicture())
+  if (item->IsFolder() || item->IsZIP() || item->IsRAR() || item->IsCBZ() || item->IsCBR() ||
+      !item->IsPicture())
     return;
   CGUIDialogPictureInfo *pictureInfo = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogPictureInfo>(WINDOW_DIALOG_PICTURE_INFO);
   if (pictureInfo)

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -1386,11 +1386,12 @@ void CGUIWindowSlideShow::AddItems(const std::string &strPath, path_set *recursi
   for (int i = 0; i < items.Size(); i++)
   {
     CFileItemPtr item = items[i];
-    if (item->m_bIsFolder && recursivePaths)
+    if (item->IsFolder() && recursivePaths)
     {
       AddItems(item->GetPath(), recursivePaths);
     }
-    else if (!item->m_bIsFolder && !URIUtils::IsRAR(item->GetPath()) && !URIUtils::IsZIP(item->GetPath()))
+    else if (!item->IsFolder() && !URIUtils::IsRAR(item->GetPath()) &&
+             !URIUtils::IsZIP(item->GetPath()))
     { // add to the slideshow
       Add(item.get());
     }

--- a/xbmc/pictures/PictureInfoLoader.cpp
+++ b/xbmc/pictures/PictureInfoLoader.cpp
@@ -76,7 +76,7 @@ bool CPictureInfoLoader::LoadItemCached(CFileItem* pItem)
 
 bool CPictureInfoLoader::LoadItemLookup(CFileItem* pItem)
 {
-  if (m_pProgressCallback && !pItem->m_bIsFolder)
+  if (m_pProgressCallback && !pItem->IsFolder())
     m_pProgressCallback->SetProgressAdvance();
 
   if (!pItem->IsPicture() || pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBR() || pItem->IsCBZ() ||

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -127,7 +127,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
       return;
     }
   }
-  if ((pItem->m_bIsFolder || pItem->IsCBR() || pItem->IsCBZ()) && !pItem->IsShareOrDrive() &&
+  if ((pItem->IsFolder() || pItem->IsCBR() || pItem->IsCBZ()) && !pItem->IsShareOrDrive() &&
       !pItem->IsParentFolder() && !pItem->IsPath("add"))
   {
     // first check for a folder.jpg
@@ -184,7 +184,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
           for (int i=0;i<items.Size();++i)
           {
             CFileItemPtr item = items[i];
-            if (item->m_bIsFolder)
+            if (item->IsFolder())
             {
               ProcessFoldersAndArchives(item.get());
               pItem->SetArt("thumb", items[i]->GetArt("thumb"));

--- a/xbmc/platform/android/filesystem/APKDirectory.cpp
+++ b/xbmc/platform/android/filesystem/APKDirectory.cpp
@@ -72,7 +72,7 @@ bool CAPKDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       CFileItemPtr pItem(new CFileItem(test_name));
       pItem->SetSize(sb.size);
       pItem->SetDateTime(sb.mtime);
-      pItem->m_bIsFolder = dir_marker > 0 ;
+      pItem->SetFolder(dir_marker > 0);
       pItem->SetPath(host + "/" + test_name);
       pItem->SetLabel(test_name.substr(path.size()));
       items.Add(pItem);

--- a/xbmc/platform/android/filesystem/AndroidAppDirectory.cpp
+++ b/xbmc/platform/android/filesystem/AndroidAppDirectory.cpp
@@ -45,7 +45,7 @@ bool CAndroidAppDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       if (i.packageName == className.c_str())
         continue;
       CFileItemPtr pItem(new CFileItem(i.packageName));
-      pItem->m_bIsFolder = false;
+      pItem->SetFolder(false);
       std::string path =
           StringUtils::Format("androidapp://{}/{}/{}", url.GetHostName(), dirname, i.packageName);
       pItem->SetPath(path);

--- a/xbmc/platform/darwin/tvos/filesystem/TVOSDirectory.cpp
+++ b/xbmc/platform/darwin/tvos/filesystem/TVOSDirectory.cpp
@@ -80,7 +80,7 @@ bool CTVOSDirectory::GetDirectory(const CURL& url, CFileItemList& items)
   {
     CFileItemPtr pItem(new CFileItem(URIUtils::GetFileName(path)));
     // we only save files to persistent storage
-    pItem->m_bIsFolder = false;
+    pItem->SetFolder(false);
     // path must a full path, with no protocol
     // or they will not get intercepted in CFileFactory
     pItem->SetPath(path);

--- a/xbmc/platform/posix/filesystem/PosixDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/PosixDirectory.cpp
@@ -67,12 +67,12 @@ bool CPosixDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
     if (entry->d_type == DT_DIR || (bStat && S_ISDIR(buffer.st_mode)))
     {
-      pItem->m_bIsFolder = true;
+      pItem->SetFolder(true);
       URIUtils::AddSlashAtEnd(itemPath);
     }
     else
     {
-      pItem->m_bIsFolder = false;
+      pItem->SetFolder(false);
     }
 
     if (StringUtils::StartsWith(entry->d_name, "."))
@@ -89,7 +89,7 @@ bool CPosixDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         KODI::TIME::FileTimeToLocalFileTime(&fileTime, &localTime);
         pItem->SetDateTime(localTime);
 
-        if (!pItem->m_bIsFolder)
+        if (!pItem->IsFolder())
           pItem->SetSize(buffer.st_size);
       }
     }

--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -223,7 +223,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         path = URIUtils::AddFileToFolder(path,aDir.name);
         URIUtils::AddSlashAtEnd(path);
         pItem->SetPath(path);
-        pItem->m_bIsFolder = true;
+        pItem->SetFolder(true);
         pItem->SetDateTime(localTime);
         if (hidden)
           pItem->SetProperty("file:hidden", true);
@@ -233,7 +233,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       {
         CFileItemPtr pItem(new CFileItem(strFile));
         pItem->SetPath(strRoot + aDir.name);
-        pItem->m_bIsFolder = false;
+        pItem->SetFolder(false);
         pItem->SetSize(iSize);
         pItem->SetDateTime(localTime);
         if (hidden)

--- a/xbmc/platform/posix/filesystem/SMBWSDiscovery.cpp
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscovery.cpp
@@ -91,7 +91,7 @@ bool CWSDiscoveryPosix::GetServerList(CFileItemList& items)
 
       CFileItemPtr pItem = std::make_shared<CFileItem>(host);
       pItem->SetPath("smb://" + host + '/');
-      pItem->m_bIsFolder = true;
+      pItem->SetFolder(true);
       items.Add(pItem);
     }
   }

--- a/xbmc/platform/win10/filesystem/WinLibraryDirectory.cpp
+++ b/xbmc/platform/win10/filesystem/WinLibraryDirectory.cpp
@@ -112,15 +112,14 @@ bool CWinLibraryDirectory::GetDirectory(const CURL& url, CFileItemList& items)
     std::string itemName = FromW(item.Name().c_str());
 
     CFileItemPtr pItem(new CFileItem(itemName));
-    pItem->m_bIsFolder =
-        (item.Attributes() & FileAttributes::Directory) == FileAttributes::Directory;
+    pItem->SetFolder((item.Attributes() & FileAttributes::Directory) == FileAttributes::Directory);
     IStorageItemProperties storageItemProperties = item.as<IStorageItemProperties>();
     if (item != nullptr)
     {
       pItem->SetTitle(FromW(storageItemProperties.DisplayName().c_str()));
     }
 
-    if (pItem->m_bIsFolder)
+    if (pItem->IsFolder())
       pItem->SetPath(path + itemName + "/");
     else
       pItem->SetPath(path + itemName);
@@ -135,7 +134,7 @@ bool CWinLibraryDirectory::GetDirectory(const CURL& url, CFileItemList& items)
     fileTime2.highDateTime = fileTime1.dwHighDateTime;
     fileTime2.lowDateTime = fileTime1.dwLowDateTime;
     pItem->SetDateTime(fileTime2);
-    if (!pItem->m_bIsFolder)
+    if (!pItem->IsFolder())
       pItem->SetSize(static_cast<int64_t>(props.Size()));
 
     items.Add(pItem);

--- a/xbmc/platform/win32/filesystem/Win32Directory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32Directory.cpp
@@ -81,8 +81,8 @@ bool CWin32Directory::GetDirectory(const CURL& url, CFileItemList &items)
 
     CFileItemPtr pItem(new CFileItem(itemName));
 
-    pItem->m_bIsFolder = ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0);
-    if (pItem->m_bIsFolder)
+    pItem->SetFolder((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0);
+    if (pItem->IsFolder())
       pItem->SetPath(pathWithSlash + itemName + '\\');
     else
       pItem->SetPath(pathWithSlash + itemName);
@@ -102,7 +102,7 @@ bool CWin32Directory::GetDirectory(const CURL& url, CFileItemList &items)
     else
       pItem->SetDateTime(0);
 
-    if (!pItem->m_bIsFolder)
+    if (!pItem->IsFolder())
       pItem->SetSize((__int64(findData.nFileSizeHigh) << 32) + findData.nFileSizeLow);
 
     items.Add(pItem);

--- a/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
@@ -159,8 +159,8 @@ bool CWin32SMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
     CFileItemPtr pItem(new CFileItem(itemName));
 
-    pItem->m_bIsFolder = ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0);
-    if (pItem->m_bIsFolder)
+    pItem->SetFolder((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0);
+    if (pItem->IsFolder())
       pItem->SetPath(pathWithSlash + itemName + '/');
     else
       pItem->SetPath(pathWithSlash + itemName);
@@ -183,7 +183,7 @@ bool CWin32SMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       dt.SetValid(false);
       pItem->SetDateTime(dt);
     }
-    if (!pItem->m_bIsFolder)
+    if (!pItem->IsFolder())
       pItem->SetSize((__int64(findData.nFileSizeHigh) << 32) + findData.nFileSizeLow);
 
     items.Add(pItem);
@@ -471,7 +471,7 @@ static bool localGetNetworkResources(struct _NETRESOURCEW* basePathToScanPtr, co
               {
                 CFileItemPtr pItem(new CFileItem(remoteNameUtf8));
                 pItem->SetPath(urlPrefixForItems + remoteNameUtf8 + '/');
-                pItem->m_bIsFolder = true;
+                pItem->SetFolder(true);
                 items.Add(pItem);
               }
               else
@@ -505,7 +505,7 @@ static bool localGetNetworkResources(struct _NETRESOURCEW* basePathToScanPtr, co
                 {
                   CFileItemPtr pItem(new CFileItem(shareNameUtf8));
                   pItem->SetPath(urlPrefixForItems + shareNameUtf8 + '/');
-                  pItem->m_bIsFolder = true;
+                  pItem->SetFolder(true);
                   if (curResource.dwDisplayType == RESOURCEDISPLAYTYPE_SHAREADMIN)
                     pItem->SetProperty("file:hidden", true);
 
@@ -617,7 +617,7 @@ static bool localGetShares(const std::wstring& serverNameToScan, const std::stri
           {
             CFileItemPtr pItem(new CFileItem(shareNameUtf8));
             pItem->SetPath(urlPrefixForItems + shareNameUtf8 + '/');
-            pItem->m_bIsFolder = true;
+            pItem->SetFolder(true);
             if ((curShare.shi1_type & STYPE_SPECIAL) != 0 || shareNameUtf8.back() == '$')
               pItem->SetProperty("file:hidden", true);
 
@@ -655,7 +655,7 @@ static bool localGetServers(const std::string& urlPrefixForItems, CFileItemList&
       {
         CFileItemPtr pItem = std::make_shared<CFileItem>(shareNameUtf8);
         pItem->SetPath(urlPrefixForItems + shareNameUtf8 + '/');
-        pItem->m_bIsFolder = true;
+        pItem->SetFolder(true);
         items.Add(pItem);
       }
     }

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -505,7 +505,7 @@ bool CProfileManager::DeleteProfile(unsigned int index)
   CFileItemPtr item =
       std::make_shared<CFileItem>(URIUtils::AddFileToFolder(GetUserDataFolder(), strDirectory));
   item->SetPath(URIUtils::AddFileToFolder(GetUserDataFolder(), strDirectory + "/"));
-  item->m_bIsFolder = true;
+  item->SetFolder(true);
   item->Select(true);
 
   CGUIComponent *gui = CServiceBroker::GetGUI();

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -140,7 +140,8 @@ bool CGUIWindowPrograms::OnPlayMedia(int iItem, const std::string&)
     return MEDIA_DETECT::CAutorun::PlayDiscAskResume(m_vecItems->Get(iItem)->GetPath());
 #endif
 
-  if (pItem->m_bIsFolder) return false;
+  if (pItem->IsFolder())
+    return false;
 
   return false;
 }

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -388,7 +388,7 @@ std::string DeleteRecording::GetLabel(const CFileItem& item) const
   if (recording && recording->IsDeleted())
     return g_localizeStrings.Get(19291); // Delete permanently
 
-  if (recording || item.m_bIsFolder)
+  if (recording || item.IsFolder())
     return g_localizeStrings.Get(117); // Delete
 
   return g_localizeStrings.Get(19357); // Delete recording
@@ -410,7 +410,7 @@ bool DeleteRecording::IsVisible(const CFileItem& item) const
     return true;
 
   // recordings folder?
-  if (item.m_bIsFolder && pvrMgr.Clients()->AnyClientSupportingRecordingsDelete())
+  if (item.IsFolder() && pvrMgr.Clients()->AnyClientSupportingRecordingsDelete())
   {
     const CPVRRecordingsPath path(item.GetPath());
     return path.IsValid() && !path.IsRecordingsRoot();
@@ -447,7 +447,7 @@ bool UndeleteRecording::Execute(const CFileItemPtr& item) const
 bool DeleteWatchedRecordings::IsVisible(const CFileItem& item) const
 {
   // recordings folder?
-  if (item.m_bIsFolder && !item.IsParentFolder() && CPVRRecordingsPath(item.GetPath()).IsValid())
+  if (item.IsFolder() && !item.IsParentFolder() && CPVRRecordingsPath(item.GetPath()).IsValid())
     return item.GetProperty("watchedepisodes").asInteger() > 0;
 
   return false;
@@ -666,8 +666,7 @@ bool PVRClientMenuHook::IsVisible(const CFileItem& item) const
     return false;
 
   if (m_hook.IsAllHook())
-    return !item.m_bIsFolder &&
-           !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER);
+    return !item.IsFolder() && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER);
   else if (m_hook.IsEpgHook())
     return item.IsEPG();
   else if (m_hook.IsChannelHook())

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
@@ -87,7 +87,7 @@ bool CPVRGUIActionsPlayback::PlayRecording(const CFileItem& item) const
     return true;
   }
 
-  if (!item.m_bIsFolder && VIDEO::UTILS::IsAutoPlayNextItem(item))
+  if (!item.IsFolder() && VIDEO::UTILS::IsAutoPlayNextItem(item))
   {
     // recursively add items located in the same folder as item to play list, starting with item
     std::string parentPath{item.GetProperty("ParentPath").asString()};
@@ -157,7 +157,7 @@ bool CPVRGUIActionsPlayback::PlayEpgTag(
 
 bool CPVRGUIActionsPlayback::SwitchToChannel(const CFileItem& item) const
 {
-  if (item.m_bIsFolder)
+  if (item.IsFolder())
     return false;
 
   std::shared_ptr<CPVRRecording> recording;

--- a/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
@@ -118,7 +118,7 @@ private:
   bool DoRun(const std::shared_ptr<CFileItem>& item) override
   {
     CFileItemList items;
-    if (item->m_bIsFolder)
+    if (item->IsFolder())
     {
       CUtil::GetRecursiveListing(item->GetPath(), items, "", XFILE::DIR_FLAG_NO_FILE_INFO);
     }
@@ -273,7 +273,7 @@ bool CPVRGUIActionsRecordings::CanEditRecording(const CFileItem& item) const
 
 bool CPVRGUIActionsRecordings::DeleteRecording(const CFileItem& item) const
 {
-  if (!item.m_bIsFolder && !item.HasPVRRecordingInfoTag())
+  if (!item.IsFolder() && !item.HasPVRRecordingInfoTag())
   {
     const std::shared_ptr<CPVRRecording> recording{CPVRItem(item).GetRecording()};
     if (recording)
@@ -282,7 +282,7 @@ bool CPVRGUIActionsRecordings::DeleteRecording(const CFileItem& item) const
       return false;
   }
 
-  if ((!item.IsPVRRecording() && !item.m_bIsFolder) || item.IsParentFolder())
+  if ((!item.IsPVRRecording() && !item.IsFolder()) || item.IsParentFolder())
     return false;
 
   if (!ConfirmDeleteRecording(item))
@@ -301,18 +301,17 @@ bool CPVRGUIActionsRecordings::ConfirmDeleteRecording(const CFileItem& item) con
 {
   return CGUIDialogYesNo::ShowAndGetInput(
       CVariant{122}, // "Confirm delete"
-      item.m_bIsFolder
-          ? CVariant{19113} // "Delete all recordings in this folder?"
-          : item.GetPVRRecordingInfoTag()->IsDeleted()
-                ? CVariant{19294}
-                // "Remove this deleted recording from trash? This operation cannot be reverted."
-                : CVariant{19112}, // "Delete this recording?"
+      item.IsFolder() ? CVariant{19113} // "Delete all recordings in this folder?"
+      : item.GetPVRRecordingInfoTag()->IsDeleted()
+          ? CVariant{19294}
+          // "Remove this deleted recording from trash? This operation cannot be reverted."
+          : CVariant{19112}, // "Delete this recording?"
       CVariant{""}, CVariant{item.GetLabel()});
 }
 
 bool CPVRGUIActionsRecordings::DeleteWatchedRecordings(const CFileItem& item) const
 {
-  if (!item.m_bIsFolder || item.IsParentFolder())
+  if (!item.IsFolder() || item.IsParentFolder())
     return false;
 
   if (!ConfirmDeleteWatchedRecordings(item))

--- a/xbmc/pvr/guilib/PVRGUIActionsUtils.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsUtils.cpp
@@ -55,7 +55,7 @@ std::shared_ptr<CFileItem> LoadRecordingFileOrFolderItem(const CFileItem& item)
     if (item.HasPVRRecordingInfoTag() || item.HasProperty("watchedepisodes"))
       return std::make_shared<CFileItem>(item); // already loaded
 
-    if (item.m_bIsFolder)
+    if (item.IsFolder())
     {
       CFileItem loadedItem{item};
       if (CPVRGUIDirectory::GetRecordingsDirectoryInfo(loadedItem))

--- a/xbmc/pvr/windows/GUIWindowPVRProviders.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRProviders.cpp
@@ -128,7 +128,7 @@ bool CGUIWindowPVRProvidersBase::OnMessage(CGUIMessage& message)
                 }
               }
 
-              if (item->m_bIsFolder)
+              if (item->IsFolder())
               {
                 // Folders and ".." folders in subfolders are handled by base class.
                 ret = false;

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -142,7 +142,7 @@ bool CGUIWindowPVRRecordingsBase::OnAction(const CAction& action)
     bool bUnWatched = false;
     if (pItem->HasPVRRecordingInfoTag())
       bUnWatched = pItem->GetPVRRecordingInfoTag()->GetPlayCount() == 0;
-    else if (pItem->m_bIsFolder)
+    else if (pItem->IsFolder())
       bUnWatched = pItem->GetProperty("unwatchedepisodes").asInteger() > 0;
     else
       return false;
@@ -307,7 +307,7 @@ bool CGUIWindowPVRRecordingsBase::OnMessage(CGUIMessage& message)
                 KODI::VIDEO::GUILIB::CVideoPlayActionProcessor proc{item};
                 bReturn = proc.ProcessDefaultAction();
               }
-              else if (item->m_bIsFolder)
+              else if (item->IsFolder())
               {
                 // recording folders and ".." folders in subfolders are handled by base class.
                 bReturn = false;
@@ -416,7 +416,7 @@ void CGUIWindowPVRRecordingsBase::OnPrepareFileItems(CFileItemList& items)
   CFileItemList files;
   for (const auto& item : items)
   {
-    if (!item->m_bIsFolder)
+    if (!item->IsFolder())
       files.Add(item);
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
@@ -135,7 +135,7 @@ bool CGUIWindowPVRTimersBase::OnMessage(CGUIMessage& message)
             case ACTION_MOUSE_LEFT_CLICK:
             {
               CFileItemPtr item(m_vecItems->Get(iItem));
-              if (item->m_bIsFolder && (message.GetParam1() != ACTION_SHOW_INFO))
+              if (item->IsFolder() && (message.GetParam1() != ACTION_SHOW_INFO))
               {
                 m_currentFileItem = item;
                 bReturn = false; // folders are handled by base class

--- a/xbmc/utils/ArtUtils.cpp
+++ b/xbmc/utils/ArtUtils.cpp
@@ -54,7 +54,7 @@ void FillInDefaultIcon(CFileItem& item)
 
   if (item.GetArt("icon").empty())
   {
-    if (!item.m_bIsFolder)
+    if (!item.IsFolder())
     {
       /* To reduce the average runtime of this code, this list should
        * be ordered with most frequently seen types first.  Also bear
@@ -231,7 +231,7 @@ std::string GetLocalArtBaseFilename(const CFileItem& item, bool& useFolder)
     useFolder = true;
     strFile = item.GetLocalMetadataPath();
   }
-  else if (useFolder && !(item.m_bIsFolder && !item.IsFileFolder()))
+  else if (useFolder && !(item.IsFolder() && !item.IsFileFolder()))
   {
     file = strFile.empty() ? item.GetPath() : strFile;
     strFile = URIUtils::GetDirectory(file);
@@ -249,9 +249,9 @@ std::string GetLocalFanart(const CFileItem& item)
   {
     if (!item.HasVideoInfoTag())
       return ""; // nothing can be done
-    CFileItem dbItem(item.m_bIsFolder ? item.GetVideoInfoTag()->m_strPath
-                                      : item.GetVideoInfoTag()->m_strFileNameAndPath,
-                     item.m_bIsFolder);
+    CFileItem dbItem(item.IsFolder() ? item.GetVideoInfoTag()->m_strPath
+                                     : item.GetVideoInfoTag()->m_strFileNameAndPath,
+                     item.IsFolder());
     return GetLocalFanart(dbItem);
   }
 
@@ -307,11 +307,10 @@ std::string GetLocalFanart(const CFileItem& item)
   std::vector<std::string> fanarts = {"fanart"};
 
   file = URIUtils::ReplaceExtension(file, "-fanart");
-  fanarts.insert(item.m_bIsFolder ? fanarts.end() : fanarts.begin(), URIUtils::GetFileName(file));
+  fanarts.insert(item.IsFolder() ? fanarts.end() : fanarts.begin(), URIUtils::GetFileName(file));
 
   if (!file2.empty())
-    fanarts.insert(item.m_bIsFolder ? fanarts.end() : fanarts.begin(),
-                   URIUtils::GetFileName(file2));
+    fanarts.insert(item.IsFolder() ? fanarts.end() : fanarts.begin(), URIUtils::GetFileName(file2));
 
   for (const auto& fanart : fanarts)
   {
@@ -362,12 +361,12 @@ std::string GetTBNFile(const CFileItem& item)
   CURL url(file);
   file = url.GetFileName();
 
-  if (item.m_bIsFolder && !item.IsFileFolder())
+  if (item.IsFolder() && !item.IsFileFolder())
     URIUtils::RemoveSlashAtEnd(file);
 
   if (!file.empty())
   {
-    if (item.m_bIsFolder && !item.IsFileFolder())
+    if (item.IsFolder() && !item.IsFileFolder())
       thumbFile = file + ".tbn"; // folder, so just add ".tbn"
     else
       thumbFile = URIUtils::ReplaceExtension(file, ".tbn");

--- a/xbmc/utils/Artwork.h
+++ b/xbmc/utils/Artwork.h
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+
+namespace KODI::ART
+{
+/*!
+ * \brief A container for artwork. key: artwork type, value: URL of artwork file
+ */
+using Artwork = std::map<std::string, std::string, std::less<>>;
+
+/*!
+ * \brief A container for artwork for multipe seasons. key: season number, value: artwork
+ */
+using SeasonsArtwork = std::map<int, Artwork>;
+
+} // namespace KODI::ART

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -84,6 +84,7 @@ set(HEADERS ActorProtocol.h
             AliasShortcutUtils.h
             Archive.h
             ArtUtils.h
+            Artwork.h
             Base64.h
             BitstreamConverter.h
             BitstreamReader.h

--- a/xbmc/utils/ExecString.cpp
+++ b/xbmc/utils/ExecString.cpp
@@ -48,7 +48,7 @@ CExecString::CExecString(const std::string& function,
 
   m_params.emplace_back(StringUtils::Paramify(target.GetPath()));
 
-  if (target.m_bIsFolder)
+  if (target.IsFolder())
     m_params.emplace_back("isdir");
 
   if (!param.empty())
@@ -105,7 +105,7 @@ bool CExecString::Parse(const CFileItem& item, const std::string& contextWindow)
     const CURL url(item.GetPath());
     Parse(CURL::Decode(url.GetHostName()));
   }
-  else if (item.m_bIsFolder &&
+  else if (item.IsFolder() &&
            (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_playlistAsFolders ||
             !(PLAYLIST::IsSmartPlayList(item) || PLAYLIST::IsPlayList(item))))
   {

--- a/xbmc/utils/FileOperationJob.cpp
+++ b/xbmc/utils/FileOperationJob.cpp
@@ -163,7 +163,7 @@ bool CFileOperationJob::DoProcess(FileAction action,
         // get filename from label instead of path
         strFileName = pItem->GetLabel();
 
-        if (!pItem->m_bIsFolder && !URIUtils::HasExtension(strFileName))
+        if (!pItem->IsFolder() && !URIUtils::HasExtension(strFileName))
         {
           // FIXME: for now we only work well if the url has the extension
           // we should map the content type to the extension otherwise
@@ -177,7 +177,7 @@ bool CFileOperationJob::DoProcess(FileAction action,
       if (!strDestFile.empty()) // only do this if we have a destination
         strnewDestFile = URIUtils::ChangeBasePath(pItem->GetPath(), strFileName, strDestFile); // Convert (URL) encoding + slashes (if source / target differ)
 
-      if (pItem->m_bIsFolder)
+      if (pItem->IsFolder())
       {
         // in ActionReplace mode all subdirectories will be removed by the below
         // DoProcessFolder(ActionDelete) call as well, so ActionCopy is enough when

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -43,7 +43,7 @@ bool CFileUtils::DeleteItem(const std::string &strPath)
 {
   CFileItemPtr item(new CFileItem(strPath));
   item->SetPath(strPath);
-  item->m_bIsFolder = URIUtils::HasSlashAtEnd(strPath);
+  item->SetFolder(URIUtils::HasSlashAtEnd(strPath));
   item->Select(true);
   return DeleteItem(item);
 }

--- a/xbmc/utils/FontUtils.cpp
+++ b/xbmc/utils/FontUtils.cpp
@@ -233,7 +233,7 @@ void ClearTemporaryFonts()
                            DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_BYPASS_CACHE | DIR_FLAG_GET_HIDDEN);
   for (const auto& item : items)
   {
-    if (item->m_bIsFolder)
+    if (item->IsFolder())
       continue;
 
     CFile::Delete(item->GetPath());

--- a/xbmc/utils/GroupUtils.cpp
+++ b/xbmc/utils/GroupUtils.cpp
@@ -85,7 +85,7 @@ bool GroupUtils::Group(GroupBy groupBy, const std::string &baseDir, const CFileI
         videoUrl.AddOptions((*set->second.begin())->GetURL().GetOptions());
         pItem->SetPath(videoUrl.ToString());
       }
-      pItem->m_bIsFolder = true;
+      pItem->SetFolder(true);
 
       CVideoInfoTag* setInfo = pItem->GetVideoInfoTag();
       setInfo->m_strPath = pItem->GetPath();

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -142,7 +142,7 @@ void CLabelFormatter::FormatLabel(CFileItem *item) const
   std::string maskedLabel = GetContent(0, item);
   if (!maskedLabel.empty())
     item->SetLabel(maskedLabel);
-  else if (!item->m_bIsFolder && m_hideFileExtensions)
+  else if (!item->IsFolder() && m_hideFileExtensions)
     item->RemoveExtension();
 }
 
@@ -210,14 +210,14 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     }
     break;
   case 'F': // filename
-    value = CUtil::GetTitleFromPath(item->GetPath(), item->m_bIsFolder && !item->IsFileFolder());
+    value = CUtil::GetTitleFromPath(item->GetPath(), item->IsFolder() && !item->IsFileFolder());
     break;
   case 'L':
     value = item->GetLabel();
     // is the label the actual file or folder name?
     if (value == URIUtils::GetFileName(item->GetPath()))
     { // label is the same as filename, clean it up as appropriate
-      value = CUtil::GetTitleFromPath(item->GetPath(), item->m_bIsFolder && !item->IsFileFolder());
+      value = CUtil::GetTitleFromPath(item->GetPath(), item->IsFolder() && !item->IsFileFolder());
     }
     break;
   case 'D':
@@ -236,7 +236,7 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
   case 'I': // size
   {
     const int64_t size{item->GetSize()};
-    if ((item->m_bIsFolder && size != 0) || size >= 0)
+    if ((item->IsFolder() && size != 0) || size >= 0)
       value = StringUtils::SizeToString(item->GetSize());
     break;
   }
@@ -315,7 +315,7 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
       value = std::to_string(movie->GetPlayCount());
     break;
   case 'X': // Bitrate
-    if (!item->m_bIsFolder)
+    if (!item->IsFolder())
     {
       const int64_t size{item->GetSize()};
       if (size != 0)
@@ -323,11 +323,11 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     }
     break;
    case 'W': // Listeners
-    if( !item->m_bIsFolder && music && music->GetListeners() != 0 )
-      value =
-          StringUtils::Format("{} {}", music->GetListeners(),
-                              g_localizeStrings.Get(music->GetListeners() == 1 ? 20454 : 20455));
-    break;
+     if (!item->IsFolder() && music && music->GetListeners() != 0)
+       value =
+           StringUtils::Format("{} {}", music->GetListeners(),
+                               g_localizeStrings.Get(music->GetListeners() == 1 ? 20454 : 20455));
+     break;
   case 'a': // Date Added
     if (movie && movie->m_dateAdded.IsValid())
       value = movie->m_dateAdded.GetAsLocalizedDate();

--- a/xbmc/utils/test/TestFileOperationJob.cpp
+++ b/xbmc/utils/test/TestFileOperationJob.cpp
@@ -27,7 +27,7 @@ TEST(TestFileOperationJob, ActionCopy)
 
   CFileItemPtr item(new CFileItem(tmpfilepath));
   item->SetPath(tmpfilepath);
-  item->m_bIsFolder = false;
+  item->SetFolder(false);
   item->Select(true);
   items.Add(item);
 
@@ -61,7 +61,7 @@ TEST(TestFileOperationJob, ActionMove)
 
   CFileItemPtr item(new CFileItem(tmpfilepath));
   item->SetPath(tmpfilepath);
-  item->m_bIsFolder = false;
+  item->SetFolder(false);
   item->Select(true);
   items.Add(item);
 
@@ -97,7 +97,7 @@ TEST(TestFileOperationJob, ActionDelete)
 
   CFileItemPtr item(new CFileItem(tmpfilepath));
   item->SetPath(tmpfilepath);
-  item->m_bIsFolder = false;
+  item->SetFolder(false);
   item->Select(true);
   items.Add(item);
 
@@ -122,7 +122,7 @@ TEST(TestFileOperationJob, ActionDelete)
   items.Clear();
   CFileItemPtr item2(new CFileItem(destfile));
   item2->SetPath(destfile);
-  item2->m_bIsFolder = false;
+  item2->SetFolder(false);
   item2->Select(true);
   items.Add(item2);
 
@@ -149,7 +149,7 @@ TEST(TestFileOperationJob, ActionReplace)
 
   CFileItemPtr item(new CFileItem(tmpfilepath));
   item->SetPath(tmpfilepath);
-  item->m_bIsFolder = false;
+  item->SetFolder(false);
   item->Select(true);
   items.Add(item);
 
@@ -197,7 +197,7 @@ TEST(TestFileOperationJob, ActionCreateFolder)
 
   CFileItemPtr item(new CFileItem(destpath));
   item->SetPath(destpath);
-  item->m_bIsFolder = true;
+  item->SetFolder(true);
   item->Select(true);
   items.Add(item);
 
@@ -233,7 +233,7 @@ TEST(TestFileOperationJob, ActionDeleteFolder)
 
   CFileItemPtr item(new CFileItem(destpath));
   item->SetPath(destpath);
-  item->m_bIsFolder = true;
+  item->SetFolder(true);
   item->Select(true);
   items.Add(item);
 
@@ -265,7 +265,7 @@ TEST(TestFileOperationJob, GetFunctions)
 
   CFileItemPtr item(new CFileItem(tmpfilepath));
   item->SetPath(tmpfilepath);
-  item->m_bIsFolder = false;
+  item->SetFolder(false);
   item->Select(true);
   items.Add(item);
 

--- a/xbmc/utils/test/TestFileUtils.cpp
+++ b/xbmc/utils/test/TestFileUtils.cpp
@@ -23,7 +23,7 @@ TEST(TestFileUtils, DeleteItem_CFileItemPtr)
 
   CFileItemPtr item(new CFileItem(tmpfilepath));
   item->SetPath(tmpfilepath);
-  item->m_bIsFolder = false;
+  item->SetFolder(false);
   item->Select(true);
   tmpfile->Close();  //Close tmpfile before we try to delete it
   EXPECT_TRUE(CFileUtils::DeleteItem(item));

--- a/xbmc/utils/test/TestLabelFormatter.cpp
+++ b/xbmc/utils/test/TestLabelFormatter.cpp
@@ -40,7 +40,7 @@ TEST_F(TestLabelFormatter, FormatLabel)
 
   CFileItemPtr item(new CFileItem(tmpfilepath));
   item->SetPath(tmpfilepath);
-  item->m_bIsFolder = false;
+  item->SetFolder(false);
   item->Select(true);
 
   formatter.FormatLabel(item.get());
@@ -60,7 +60,7 @@ TEST_F(TestLabelFormatter, FormatLabel2)
 
   CFileItemPtr item(new CFileItem(tmpfilepath));
   item->SetPath(tmpfilepath);
-  item->m_bIsFolder = false;
+  item->SetFolder(false);
   item->Select(true);
 
   formatter.FormatLabel2(item.get());

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -65,7 +65,7 @@ bool CVideoInfo::IsVisible(const CFileItem& item) const
   if (CVideoInfoBase::IsVisible(item))
     return true;
 
-  if (item.m_bIsFolder)
+  if (item.IsFolder())
     return false;
 
   if (item.IsPVRRecording())
@@ -82,7 +82,7 @@ bool CVideoRemoveResumePoint::IsVisible(const CFileItem& itemIn) const
     return false;
 
   // Folders don't have a resume point
-  return !item.m_bIsFolder && VIDEO::UTILS::GetItemResumeInformation(item).isResumable;
+  return !item.IsFolder() && VIDEO::UTILS::GetItemResumeInformation(item).isResumable;
 }
 
 bool CVideoRemoveResumePoint::Execute(const std::shared_ptr<CFileItem>& item) const
@@ -96,10 +96,10 @@ bool CVideoMarkWatched::IsVisible(const CFileItem& item) const
   if (item.IsDeleted()) // e.g. trashed pvr recording
     return false;
 
-  if (item.m_bIsFolder && item.IsPlugin()) // we cannot manage plugin folder's watched state
+  if (item.IsFolder() && item.IsPlugin()) // we cannot manage plugin folder's watched state
     return false;
 
-  if (item.m_bIsFolder)
+  if (item.IsFolder())
   {
     if (item.HasProperty("watchedepisodes") && item.HasProperty("totalepisodes"))
     {
@@ -136,10 +136,10 @@ bool CVideoMarkUnWatched::IsVisible(const CFileItem& item) const
   if (item.IsDeleted()) // e.g. trashed pvr recording
     return false;
 
-  if (item.m_bIsFolder && item.IsPlugin()) // we cannot manage plugin folder's watched state
+  if (item.IsFolder() && item.IsPlugin()) // we cannot manage plugin folder's watched state
     return false;
 
-  if (item.m_bIsFolder)
+  if (item.IsFolder())
   {
     if (item.HasProperty("watchedepisodes"))
     {
@@ -172,7 +172,7 @@ bool CVideoMarkUnWatched::Execute(const std::shared_ptr<CFileItem>& item) const
 
 bool CVideoBrowse::IsVisible(const CFileItem& item) const
 {
-  return ((item.m_bIsFolder || item.IsFileFolder(FileFolderType::MASK_ONBROWSE)) &&
+  return ((item.IsFolder() || item.IsFileFolder(FileFolderType::MASK_ONBROWSE)) &&
           VIDEO::UTILS::IsItemPlayable(item));
 }
 
@@ -240,7 +240,7 @@ void SetPathAndPlay(const std::shared_ptr<CFileItem>& item, PlayMode mode)
     const auto itemCopy{std::make_shared<CFileItem>(*item)};
     if (VIDEO::IsVideoDb(*itemCopy))
     {
-      if (!itemCopy->m_bIsFolder)
+      if (!itemCopy->IsFolder())
       {
         itemCopy->SetProperty("original_listitem_url", item->GetPath());
         itemCopy->SetPath(item->GetVideoInfoTag()->m_strFileNameAndPath);
@@ -248,7 +248,7 @@ void SetPathAndPlay(const std::shared_ptr<CFileItem>& item, PlayMode mode)
       else if (itemCopy->HasVideoInfoTag() && itemCopy->GetVideoInfoTag()->IsDefaultVideoVersion())
       {
         //! @todo get rid of "videos with versions as folder" hack!
-        itemCopy->m_bIsFolder = false;
+        itemCopy->SetFolder(false);
       }
     }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2616,12 +2616,15 @@ std::string CVideoDatabase::GetValueString(const CVideoInfoTag &details, int min
 }
 
 //********************************************************************************************************************************
-int CVideoDatabase::SetDetailsForItem(CVideoInfoTag& details, const std::map<std::string, std::string> &artwork)
+int CVideoDatabase::SetDetailsForItem(CVideoInfoTag& details, const KODI::ART::Artwork& artwork)
 {
   return SetDetailsForItem(details.m_iDbId, details.m_type, details, artwork);
 }
 
-int CVideoDatabase::SetDetailsForItem(int id, const MediaType& mediaType, CVideoInfoTag& details, const std::map<std::string, std::string> &artwork)
+int CVideoDatabase::SetDetailsForItem(int id,
+                                      const MediaType& mediaType,
+                                      CVideoInfoTag& details,
+                                      const KODI::ART::Artwork& artwork)
 {
   if (mediaType == MediaTypeNone)
     return -1;
@@ -2632,7 +2635,7 @@ int CVideoDatabase::SetDetailsForItem(int id, const MediaType& mediaType, CVideo
     return SetDetailsForMovieSet(details, artwork, id);
   else if (mediaType == MediaTypeTvShow)
   {
-    std::map<int, std::map<std::string, std::string> > seasonArtwork;
+    KODI::ART::SeasonsArtwork seasonArtwork;
     if (!UpdateDetailsForTvShow(id, details, artwork, seasonArtwork))
       return -1;
 
@@ -2649,7 +2652,7 @@ int CVideoDatabase::SetDetailsForItem(int id, const MediaType& mediaType, CVideo
 }
 
 int CVideoDatabase::SetDetailsForMovie(CVideoInfoTag& details,
-                                       const std::map<std::string, std::string>& artwork,
+                                       const KODI::ART::Artwork& artwork,
                                        int idMovie /* = -1 */)
 {
   const auto filePath = details.GetPath();
@@ -2768,7 +2771,10 @@ int CVideoDatabase::SetDetailsForMovie(CVideoInfoTag& details,
   return -1;
 }
 
-int CVideoDatabase::UpdateDetailsForMovie(int idMovie, CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, const std::set<std::string> &updatedDetails)
+int CVideoDatabase::UpdateDetailsForMovie(int idMovie,
+                                          CVideoInfoTag& details,
+                                          const KODI::ART::Artwork& artwork,
+                                          const std::set<std::string>& updatedDetails)
 {
   if (idMovie < 0)
     return idMovie;
@@ -2864,7 +2870,9 @@ int CVideoDatabase::UpdateDetailsForMovie(int idMovie, CVideoInfoTag& details, c
   return -1;
 }
 
-int CVideoDatabase::SetDetailsForMovieSet(const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, int idSet /* = -1 */)
+int CVideoDatabase::SetDetailsForMovieSet(const CVideoInfoTag& details,
+                                          const KODI::ART::Artwork& artwork,
+                                          int idSet /* = -1 */)
 {
   if (details.m_strTitle.empty())
     return -1;
@@ -2910,9 +2918,12 @@ int CVideoDatabase::GetMatchingTvShow(const CVideoInfoTag &details)
   return id;
 }
 
-int CVideoDatabase::SetDetailsForTvShow(const std::vector<std::pair<std::string, std::string> > &paths,
-    CVideoInfoTag& details, const std::map<std::string, std::string> &artwork,
-    const std::map<int, std::map<std::string, std::string> > &seasonArt, int idTvShow /*= -1 */)
+int CVideoDatabase::SetDetailsForTvShow(
+    const std::vector<std::pair<std::string, std::string>>& paths,
+    CVideoInfoTag& details,
+    const KODI::ART::Artwork& artwork,
+    const KODI::ART::SeasonsArtwork& seasonArt,
+    int idTvShow /*= -1 */)
 {
 
   /*
@@ -2951,8 +2962,10 @@ int CVideoDatabase::SetDetailsForTvShow(const std::vector<std::pair<std::string,
   return idTvShow;
 }
 
-bool CVideoDatabase::UpdateDetailsForTvShow(int idTvShow, CVideoInfoTag &details,
-    const std::map<std::string, std::string> &artwork, const std::map<int, std::map<std::string, std::string>> &seasonArt)
+bool CVideoDatabase::UpdateDetailsForTvShow(int idTvShow,
+                                            CVideoInfoTag& details,
+                                            const KODI::ART::Artwork& artwork,
+                                            const KODI::ART::SeasonsArtwork& seasonArt)
 {
   BeginTransaction();
 
@@ -2985,7 +2998,7 @@ bool CVideoDatabase::UpdateDetailsForTvShow(int idTvShow, CVideoInfoTag &details
       continue;
 
     season.SetSortTitle(namedSeason.second);
-    SetDetailsForSeason(season, std::map<std::string, std::string>(), idTvShow, seasonId);
+    SetDetailsForSeason(season, KODI::ART::Artwork(), idTvShow, seasonId);
   }
 
   SetArtForItem(idTvShow, MediaTypeTvShow, artwork);
@@ -3016,8 +3029,10 @@ bool CVideoDatabase::UpdateDetailsForTvShow(int idTvShow, CVideoInfoTag &details
   return false;
 }
 
-int CVideoDatabase::SetDetailsForSeason(const CVideoInfoTag& details, const std::map<std::string,
-    std::string> &artwork, int idShow, int idSeason /* = -1 */)
+int CVideoDatabase::SetDetailsForSeason(const CVideoInfoTag& details,
+                                        const KODI::ART::Artwork& artwork,
+                                        int idShow,
+                                        int idSeason /* = -1 */)
 {
   if (idShow < 0 || details.m_iSeason < -1)
     return -1;
@@ -3215,7 +3230,7 @@ bool CVideoDatabase::DeleteFile(int idFile)
 }
 
 int CVideoDatabase::SetDetailsForEpisode(CVideoInfoTag& details,
-                                         const std::map<std::string, std::string>& artwork,
+                                         const KODI::ART::Artwork& artwork,
                                          int idShow,
                                          int idEpisode /* = -1 */)
 {
@@ -3332,7 +3347,7 @@ int CVideoDatabase::AddSeason(int showID, int season, const std::string& name /*
 }
 
 int CVideoDatabase::SetDetailsForMusicVideo(CVideoInfoTag& details,
-                                            const std::map<std::string, std::string>& artwork,
+                                            const KODI::ART::Artwork& artwork,
                                             int idMVideo /* = -1 */)
 {
   const auto filePath = details.GetPath();
@@ -5285,7 +5300,7 @@ void CVideoDatabase::UpdateArtForItem(int mediaId, const MediaType& mediaType)
 
 bool CVideoDatabase::SetArtForItem(int mediaId,
                                    const MediaType& mediaType,
-                                   const std::map<std::string, std::string>& art)
+                                   const KODI::ART::Artwork& art)
 {
   for (const auto& i : art)
     if (!SetArtForItem(mediaId, mediaType, i.first, i.second))
@@ -5338,9 +5353,7 @@ bool CVideoDatabase::SetArtForItem(int mediaId,
   }
 }
 
-bool CVideoDatabase::GetArtForItem(int mediaId,
-                                   const MediaType& mediaType,
-                                   std::map<std::string, std::string>& art)
+bool CVideoDatabase::GetArtForItem(int mediaId, const MediaType& mediaType, KODI::ART::Artwork& art)
 {
   try
   {
@@ -5369,7 +5382,7 @@ bool CVideoDatabase::GetArtForItem(int mediaId,
 
 bool CVideoDatabase::GetArtForAsset(int assetId,
                                     ArtFallbackOptions fallback,
-                                    std::map<std::string, std::string>& art)
+                                    KODI::ART::Artwork& art)
 {
   try
   {
@@ -5526,7 +5539,7 @@ std::string CVideoDatabase::GetTvShowNamedSeasonById(int tvshowId, int seasonId)
                         PrepareSQL("season=%i AND idShow=%i", seasonId, tvshowId));
 }
 
-bool CVideoDatabase::GetTvShowSeasonArt(int showId, std::map<int, std::map<std::string, std::string> > &seasonArt)
+bool CVideoDatabase::GetTvShowSeasonArt(int showId, KODI::ART::SeasonsArtwork& seasonArt)
 {
   try
   {
@@ -5540,7 +5553,7 @@ bool CVideoDatabase::GetTvShowSeasonArt(int showId, std::map<int, std::map<std::
 
     for (const auto &i : seasons)
     {
-      std::map<std::string, std::string> art;
+      KODI::ART::Artwork art;
       GetArtForItem(i.second, MediaTypeSeason, art);
       seasonArt.insert(std::make_pair(i.first,art));
     }
@@ -11182,7 +11195,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
       // strip paths to make them relative
       if (StringUtils::StartsWith(movie.m_strTrailer, movie.m_strPath))
         movie.m_strTrailer = movie.m_strTrailer.substr(movie.m_strPath.size());
-      std::map<std::string, std::string> artwork;
+      KODI::ART::Artwork artwork;
       if (GetArtForItem(movie.m_iDbId, movie.m_type, artwork) && !artwork.empty() && singleFile)
       {
         TiXmlElement additionalNode("art");
@@ -11305,7 +11318,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
             movieSetsDir, CUtil::MakeLegalFileName(title, LegalPath::WIN32_COMPAT));
         if (CDirectory::Exists(itemPath) || CDirectory::Create(itemPath))
         {
-          std::map<std::string, std::string> artwork;
+          KODI::ART::Artwork artwork;
           GetArtForItem(m_pDS->fv("idSet").get_asInt(), MediaTypeVideoCollection, artwork);
           for (const auto& art : artwork)
           {
@@ -11335,7 +11348,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
     while (!m_pDS->eof())
     {
       CVideoInfoTag movie = GetDetailsForMusicVideo(m_pDS, VideoDbDetailsAll);
-      std::map<std::string, std::string> artwork;
+      KODI::ART::Artwork artwork;
       if (GetArtForItem(movie.m_iDbId, movie.m_type, artwork) && !artwork.empty() && singleFile)
       {
         TiXmlElement additionalNode("art");
@@ -11427,10 +11440,10 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
       CVideoInfoTag tvshow = GetDetailsForTvShow(m_pDS, VideoDbDetailsAll);
       GetTvShowNamedSeasons(tvshow.m_iDbId, tvshow.m_namedSeasons);
 
-      std::map<int, std::map<std::string, std::string> > seasonArt;
+      KODI::ART::SeasonsArtwork seasonArt;
       GetTvShowSeasonArt(tvshow.m_iDbId, seasonArt);
 
-      std::map<std::string, std::string> artwork;
+      KODI::ART::Artwork artwork;
       if (GetArtForItem(tvshow.m_iDbId, tvshow.m_type, artwork) && !artwork.empty() && singleFile)
       {
         TiXmlElement additionalNode("art");
@@ -11540,7 +11553,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
       while (!pDS->eof())
       {
         CVideoInfoTag episode = GetDetailsForEpisode(pDS, VideoDbDetailsAll);
-        std::map<std::string, std::string> artwork;
+        KODI::ART::Artwork artwork;
         if (GetArtForItem(episode.m_iDbId, MediaTypeEpisode, artwork) && !artwork.empty() &&
             singleFile)
         {
@@ -11814,7 +11827,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
                                                      LegalPath::WIN32_COMPAT));
           if (CDirectory::Exists(setPath))
           {
-            CGUIListItem::ArtMap setArt;
+            KODI::ART::Artwork setArt;
             CFileItem artItem(setPath, true);
             for (const auto& artType : CVideoThumbLoader::GetArtTypes(MediaTypeVideoCollection))
             {
@@ -11861,7 +11874,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
         showItem.SetArt(artItem.GetArt());
         int showID = scanner.AddVideo(&showItem, CONTENT_TVSHOWS, useFolders, true, NULL, true);
         // season artwork
-        std::map<int, std::map<std::string, std::string> > seasonArt;
+        KODI::ART::SeasonsArtwork seasonArt;
         artItem.GetVideoInfoTag()->m_strPath = artPath;
         scanner.GetSeasonThumbs(*artItem.GetVideoInfoTag(), seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason), true);
         for (const auto &i : seasonArt)
@@ -11910,7 +11923,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
     progress->Close();
 }
 
-bool CVideoDatabase::ImportArtFromXML(const TiXmlNode *node, std::map<std::string, std::string> &artwork)
+bool CVideoDatabase::ImportArtFromXML(const TiXmlNode* node, KODI::ART::Artwork& artwork)
 {
   if (!node) return false;
   const TiXmlNode *art = node->FirstChild();
@@ -13246,7 +13259,7 @@ bool CVideoDatabase::SetVideoVersionDefaultArt(int dbId, int idFrom, VideoDbCont
   MediaType mediaType;
   VideoContentTypeToString(type, mediaType);
 
-  std::map<std::string, std::string> art;
+  KODI::ART::Artwork art;
   if (GetArtForItem(idFrom, mediaType, art))
   {
     for (const auto& it : art)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -6919,7 +6919,7 @@ bool CVideoDatabase::GetPlayCounts(const std::string &strPath, CFileItemList &it
     {
       for (auto& item : items)
       {
-        if (!item || item->m_bIsFolder || !item->GetProperty("IsPlayable").asBoolean())
+        if (!item || item->IsFolder() || !item->GetProperty("IsPlayable").asBoolean())
           continue;
 
         std::string path, filename;
@@ -7496,7 +7496,7 @@ bool CVideoDatabase::GetNavCommon(const std::string& strBaseDir,
         itemUrl.AppendPath(path);
         pItem->SetPath(itemUrl.ToString());
 
-        pItem->m_bIsFolder = true;
+        pItem->SetFolder(true);
         if (idContent == VideoDbContentType::MOVIES || idContent == VideoDbContentType::MUSICVIDEOS)
           pItem->GetVideoInfoTag()->SetPlayCount(i.second.second);
         if (!items.Contains(pItem->GetPath()))
@@ -7519,7 +7519,7 @@ bool CVideoDatabase::GetNavCommon(const std::string& strBaseDir,
         itemUrl.AppendPath(path);
         pItem->SetPath(itemUrl.ToString());
 
-        pItem->m_bIsFolder = true;
+        pItem->SetFolder(true);
         pItem->SetLabelPreformatted(true);
         if (idContent == VideoDbContentType::MOVIES || idContent == VideoDbContentType::MUSICVIDEOS)
         { // fv(3) is the number of videos watched, fv(2) is the total number.  We set the playcount
@@ -7722,7 +7722,7 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const std::string& strBaseDir, CFile
       }
       itemUrl.AppendPath(path);
       pItem->SetPath(itemUrl.ToString());
-      pItem->m_bIsFolder = isAlbum;
+      pItem->SetFolder(isAlbum);
       pItem->SetLabelPreformatted(true);
 
       if (!items.Contains(pItem->GetPath()))
@@ -7744,7 +7744,7 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const std::string& strBaseDir, CFile
     {
       CVideoInfoTag details;
 
-      if (items[i]->m_bIsFolder)
+      if (items[i]->IsFolder())
       {
         details.SetPath(items[i]->GetPath());
         details.m_strAlbum = idData.front().first;
@@ -8039,7 +8039,7 @@ bool CVideoDatabase::GetPeopleNav(const std::string& strBaseDir,
         itemUrl.AppendPath(path);
         pItem->SetPath(itemUrl.ToString());
 
-        pItem->m_bIsFolder=true;
+        pItem->SetFolder(true);
         pItem->GetVideoInfoTag()->SetPlayCount(i.second.playcount);
         pItem->GetVideoInfoTag()->m_strPictureURL.ParseFromData(i.second.thumb);
         pItem->GetVideoInfoTag()->m_iDbId = i.first;
@@ -8067,7 +8067,7 @@ bool CVideoDatabase::GetPeopleNav(const std::string& strBaseDir,
           itemUrl.AppendPath(path);
           pItem->SetPath(itemUrl.ToString());
 
-          pItem->m_bIsFolder=true;
+          pItem->SetFolder(true);
           pItem->GetVideoInfoTag()->m_strPictureURL.ParseFromData(m_pDS->fv(2).get_asString());
           pItem->GetVideoInfoTag()->m_iDbId = m_pDS->fv(0).get_asInt();
           pItem->GetVideoInfoTag()->m_type = type;
@@ -8225,7 +8225,7 @@ bool CVideoDatabase::GetYearsNav(const std::string& strBaseDir,
         itemUrl.AppendPath(path);
         pItem->SetPath(itemUrl.ToString());
 
-        pItem->m_bIsFolder=true;
+        pItem->SetFolder(true);
         if (idContent == VideoDbContentType::MOVIES || idContent == VideoDbContentType::MUSICVIDEOS)
           pItem->GetVideoInfoTag()->SetPlayCount(i.second.second);
         items.Add(pItem);
@@ -8261,7 +8261,7 @@ bool CVideoDatabase::GetYearsNav(const std::string& strBaseDir,
         itemUrl.AppendPath(path);
         pItem->SetPath(itemUrl.ToString());
 
-        pItem->m_bIsFolder=true;
+        pItem->SetFolder(true);
         if (idContent == VideoDbContentType::MOVIES || idContent == VideoDbContentType::MUSICVIDEOS)
         {
           // fv(2) is the number of videos watched, fv(1) is the total number.  We set the playcount
@@ -8399,7 +8399,7 @@ bool CVideoDatabase::GetSeasonsByWhere(const std::string& strBaseDir, const Filt
         itemUrl.AppendPath(strDir);
         pItem->SetPath(itemUrl.ToString());
 
-        pItem->m_bIsFolder = true;
+        pItem->SetFolder(true);
         pItem->GetVideoInfoTag()->m_strTitle = strLabel;
         if (!name.empty())
           pItem->GetVideoInfoTag()->m_strSortTitle = name;
@@ -8751,7 +8751,7 @@ bool CVideoDatabase::GetMoviesByWhere(const std::string& strBaseDir, const Filte
             static std::string hybridFolderPath{
                 std::to_string(static_cast<int>(VideoAssetType::VERSIONSANDEXTRASFOLDER)) + "/"};
             item->SetProperty("IsHybridFolder", true);
-            item->m_bIsFolder = true;
+            item->SetFolder(true);
             itemUrl.AppendPath(hybridFolderPath);
           }
         }
@@ -9517,7 +9517,7 @@ void CVideoDatabase::GetMovieGenresByName(const std::string& strSearch, CFileIte
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
       std::string strDir = StringUtils::Format("{}/", m_pDS->fv(0).get_asInt());
       pItem->SetPath("videodb://movies/genres/"+ strDir);
-      pItem->m_bIsFolder=true;
+      pItem->SetFolder(true);
       items.Add(pItem);
       m_pDS->next();
     }
@@ -9561,7 +9561,7 @@ void CVideoDatabase::GetMovieCountriesByName(const std::string& strSearch, CFile
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
       std::string strDir = StringUtils::Format("{}/", m_pDS->fv(0).get_asInt());
       pItem->SetPath("videodb://movies/genres/"+ strDir);
-      pItem->m_bIsFolder=true;
+      pItem->SetFolder(true);
       items.Add(pItem);
       m_pDS->next();
     }
@@ -9604,7 +9604,7 @@ void CVideoDatabase::GetTvShowGenresByName(const std::string& strSearch, CFileIt
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
       std::string strDir = StringUtils::Format("{}/", m_pDS->fv(0).get_asInt());
       pItem->SetPath("videodb://tvshows/genres/"+ strDir);
-      pItem->m_bIsFolder=true;
+      pItem->SetFolder(true);
       items.Add(pItem);
       m_pDS->next();
     }
@@ -9647,7 +9647,7 @@ void CVideoDatabase::GetMovieActorsByName(const std::string& strSearch, CFileIte
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
       std::string strDir = StringUtils::Format("{}/", m_pDS->fv(0).get_asInt());
       pItem->SetPath("videodb://movies/actors/"+ strDir);
-      pItem->m_bIsFolder=true;
+      pItem->SetFolder(true);
       items.Add(pItem);
       m_pDS->next();
     }
@@ -9690,7 +9690,7 @@ void CVideoDatabase::GetTvShowsActorsByName(const std::string& strSearch, CFileI
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
       std::string strDir = StringUtils::Format("{}/", m_pDS->fv(0).get_asInt());
       pItem->SetPath("videodb://tvshows/actors/"+ strDir);
-      pItem->m_bIsFolder=true;
+      pItem->SetFolder(true);
       items.Add(pItem);
       m_pDS->next();
     }
@@ -9736,7 +9736,7 @@ void CVideoDatabase::GetMusicVideoArtistsByName(const std::string& strSearch, CF
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
       std::string strDir = StringUtils::Format("{}/", m_pDS->fv(0).get_asInt());
       pItem->SetPath("videodb://musicvideos/artists/"+ strDir);
-      pItem->m_bIsFolder=true;
+      pItem->SetFolder(true);
       items.Add(pItem);
       m_pDS->next();
     }
@@ -9779,7 +9779,7 @@ void CVideoDatabase::GetMusicVideoGenresByName(const std::string& strSearch, CFi
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
       std::string strDir = StringUtils::Format("{}/", m_pDS->fv(0).get_asInt());
       pItem->SetPath("videodb://musicvideos/genres/"+ strDir);
-      pItem->m_bIsFolder=true;
+      pItem->SetFolder(true);
       items.Add(pItem);
       m_pDS->next();
     }
@@ -9837,7 +9837,7 @@ void CVideoDatabase::GetMusicVideoAlbumsByName(const std::string& strSearch, CFi
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(0).get_asString()));
       std::string strDir = std::to_string(m_pDS->fv(1).get_asInt());
       pItem->SetPath("videodb://musicvideos/titles/"+ strDir);
-      pItem->m_bIsFolder=false;
+      pItem->SetFolder(false);
       items.Add(pItem);
       m_pDS->next();
     }
@@ -9882,7 +9882,7 @@ void CVideoDatabase::GetMusicVideosByAlbum(const std::string& strSearch, CFileIt
           StringUtils::Format("3/2/{}", m_pDS->fv("musicvideo.idMVideo").get_asInt());
 
       pItem->SetPath("videodb://"+ strDir);
-      pItem->m_bIsFolder=false;
+      pItem->SetFolder(false);
       items.Add(pItem);
       m_pDS->next();
     }
@@ -10130,7 +10130,7 @@ void CVideoDatabase::GetMoviesByName(const std::string& strSearch, CFileItemList
       else
         path = StringUtils::Format("videodb://movies/sets/{}/{}", setId, movieId);
       pItem->SetPath(path);
-      pItem->m_bIsFolder=false;
+      pItem->SetFolder(false);
       items.Add(pItem);
       m_pDS->next();
     }
@@ -10175,7 +10175,7 @@ void CVideoDatabase::GetTvShowsByName(const std::string& strSearch, CFileItemLis
           StringUtils::Format("tvshows/titles/{}/", m_pDS->fv("tvshow.idShow").get_asInt());
 
       pItem->SetPath("videodb://"+ strDir);
-      pItem->m_bIsFolder=true;
+      pItem->SetFolder(true);
       pItem->GetVideoInfoTag()->m_iDbId = m_pDS->fv("tvshow.idShow").get_asInt();
       items.Add(pItem);
       m_pDS->next();
@@ -10221,7 +10221,7 @@ void CVideoDatabase::GetEpisodesByName(const std::string& strSearch, CFileItemLi
                                              m_pDS->fv("episode.idShow").get_asInt(),
                                              m_pDS->fv(2).get_asInt(), m_pDS->fv(0).get_asInt());
       pItem->SetPath(path);
-      pItem->m_bIsFolder=false;
+      pItem->SetFolder(false);
       items.Add(pItem);
       m_pDS->next();
     }
@@ -10270,7 +10270,7 @@ void CVideoDatabase::GetMusicVideosByName(const std::string& strSearch, CFileIte
           StringUtils::Format("3/2/{}", m_pDS->fv("musicvideo.idMVideo").get_asInt());
 
       pItem->SetPath("videodb://"+ strDir);
-      pItem->m_bIsFolder=false;
+      pItem->SetFolder(false);
       items.Add(pItem);
       m_pDS->next();
     }
@@ -10322,7 +10322,7 @@ void CVideoDatabase::GetEpisodesByPlot(const std::string& strSearch, CFileItemLi
                                              m_pDS->fv("episode.idShow").get_asInt(),
                                              m_pDS->fv(2).get_asInt(), m_pDS->fv(0).get_asInt());
       pItem->SetPath(path);
-      pItem->m_bIsFolder=false;
+      pItem->SetFolder(false);
       items.Add(pItem);
       m_pDS->next();
     }
@@ -10367,7 +10367,7 @@ void CVideoDatabase::GetMoviesByPlot(const std::string& strSearch, CFileItemList
       std::string path =
           StringUtils::Format("videodb://movies/titles/{}", m_pDS->fv(0).get_asInt());
       pItem->SetPath(path);
-      pItem->m_bIsFolder=false;
+      pItem->SetFolder(false);
 
       items.Add(pItem);
       m_pDS->next();
@@ -10414,7 +10414,7 @@ void CVideoDatabase::GetMovieDirectorsByName(const std::string& strSearch, CFile
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
 
       pItem->SetPath("videodb://movies/directors/"+ strDir);
-      pItem->m_bIsFolder=true;
+      pItem->SetFolder(true);
       items.Add(pItem);
       m_pDS->next();
     }
@@ -10459,7 +10459,7 @@ void CVideoDatabase::GetTvShowsDirectorsByName(const std::string& strSearch, CFi
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
 
       pItem->SetPath("videodb://tvshows/directors/"+ strDir);
-      pItem->m_bIsFolder=true;
+      pItem->SetFolder(true);
       items.Add(pItem);
       m_pDS->next();
     }
@@ -10504,7 +10504,7 @@ void CVideoDatabase::GetMusicVideoDirectorsByName(const std::string& strSearch, 
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
 
       pItem->SetPath("videodb://musicvideos/albums/"+ strDir);
-      pItem->m_bIsFolder=true;
+      pItem->SetFolder(true);
       items.Add(pItem);
       m_pDS->next();
     }

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -12,6 +12,7 @@
 #include "VideoInfoTag.h"
 #include "addons/Scraper.h"
 #include "dbwrappers/Database.h"
+#include "utils/Artwork.h"
 #include "utils/SortUtils.h"
 #include "utils/UrlOptions.h"
 
@@ -608,13 +609,18 @@ public:
   void GetEpisodesByFile(const std::string& strFilenameAndPath, std::vector<CVideoInfoTag>& episodes);
   void GetEpisodesByFileId(int idFile, std::vector<CVideoInfoTag>& episodes);
 
-  int SetDetailsForItem(CVideoInfoTag& details, const std::map<std::string, std::string> &artwork);
-  int SetDetailsForItem(int id, const MediaType& mediaType, CVideoInfoTag& details, const std::map<std::string, std::string> &artwork);
+  int SetDetailsForItem(CVideoInfoTag& details, const KODI::ART::Artwork& artwork);
+  int SetDetailsForItem(int id,
+                        const MediaType& mediaType,
+                        CVideoInfoTag& details,
+                        const KODI::ART::Artwork& artwork);
 
   int SetDetailsForMovie(CVideoInfoTag& details,
-                         const std::map<std::string, std::string>& artwork,
+                         const KODI::ART::Artwork& artwork,
                          int idMovie = -1);
-  int SetDetailsForMovieSet(const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, int idSet = -1);
+  int SetDetailsForMovieSet(const CVideoInfoTag& details,
+                            const KODI::ART::Artwork& artwork,
+                            int idSet = -1);
 
   /*! \brief add a tvshow to the library, setting metadata detail
    First checks for whether this TV Show is already in the database (based on idTvShow, or via GetMatchingTvShow)
@@ -626,11 +632,21 @@ public:
    \param idTvShow the database id of the tvshow if known (defaults to -1)
    \return the id of the tvshow.
    */
-  int SetDetailsForTvShow(const std::vector< std::pair<std::string, std::string> > &paths, CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, const std::map<int, std::map<std::string, std::string> > &seasonArt, int idTvShow = -1);
-  bool UpdateDetailsForTvShow(int idTvShow, CVideoInfoTag &details, const std::map<std::string, std::string> &artwork, const std::map<int, std::map<std::string, std::string> > &seasonArt);
-  int SetDetailsForSeason(const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, int idShow, int idSeason = -1);
+  int SetDetailsForTvShow(const std::vector<std::pair<std::string, std::string>>& paths,
+                          CVideoInfoTag& details,
+                          const KODI::ART::Artwork& artwork,
+                          const KODI::ART::SeasonsArtwork& seasonArt,
+                          int idTvShow = -1);
+  bool UpdateDetailsForTvShow(int idTvShow,
+                              CVideoInfoTag& details,
+                              const KODI::ART::Artwork& artwork,
+                              const KODI::ART::SeasonsArtwork& seasonArt);
+  int SetDetailsForSeason(const CVideoInfoTag& details,
+                          const KODI::ART::Artwork& artwork,
+                          int idShow,
+                          int idSeason = -1);
   int SetDetailsForEpisode(CVideoInfoTag& details,
-                           const std::map<std::string, std::string>& artwork,
+                           const KODI::ART::Artwork& artwork,
                            int idShow,
                            int idEpisode = -1);
   bool SetFileForMedia(const std::string& fileAndPath,
@@ -638,7 +654,7 @@ public:
                        int mediaId,
                        int oldIdFile);
   int SetDetailsForMusicVideo(CVideoInfoTag& details,
-                              const std::map<std::string, std::string>& artwork,
+                              const KODI::ART::Artwork& artwork,
                               int idMVideo = -1);
   bool SetStreamDetailsForFile(const CStreamDetails& details,
                                const std::string& strFileNameAndPath);
@@ -673,7 +689,10 @@ public:
   bool SetSingleValue(const std::string &table, const std::string &fieldName, const std::string &strValue,
                       const std::string &conditionName = "", int conditionValue = -1);
 
-  int UpdateDetailsForMovie(int idMovie, CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, const std::set<std::string> &updatedDetails);
+  int UpdateDetailsForMovie(int idMovie,
+                            CVideoInfoTag& details,
+                            const KODI::ART::Artwork& artwork,
+                            const std::set<std::string>& updatedDetails);
 
   /*!
    * \brief Remove a movie from the library.
@@ -1015,7 +1034,7 @@ public:
                          const std::string& tvshowDir = "") const;
   void ImportFromXML(const std::string &path);
   void DumpToDummyFiles(const std::string &path);
-  bool ImportArtFromXML(const TiXmlNode *node, std::map<std::string, std::string> &artwork);
+  bool ImportArtFromXML(const TiXmlNode* node, KODI::ART::Artwork& artwork);
 
   // smart playlists and main retrieval work in these functions
   bool GetMoviesByWhere(const std::string& strBaseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription = SortDescription(), int getDetails = VideoDbDetailsNone);
@@ -1072,12 +1091,8 @@ public:
                      const MediaType& mediaType,
                      const std::string& artType,
                      const std::string& url);
-  bool SetArtForItem(int mediaId,
-                     const MediaType& mediaType,
-                     const std::map<std::string, std::string>& art);
-  bool GetArtForItem(int mediaId,
-                     const MediaType& mediaType,
-                     std::map<std::string, std::string>& art);
+  bool SetArtForItem(int mediaId, const MediaType& mediaType, const KODI::ART::Artwork& art);
+  bool GetArtForItem(int mediaId, const MediaType& mediaType, KODI::ART::Artwork& art);
   std::string GetArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType);
 
   void UpdateArtForItem(int mediaId, const MediaType& mediaType);
@@ -1091,9 +1106,7 @@ public:
    * \param art collection of the retrieved art
    * \return 
   */
-  bool GetArtForAsset(int assetId,
-                      ArtFallbackOptions fallback,
-                      std::map<std::string, std::string>& art);
+  bool GetArtForAsset(int assetId, ArtFallbackOptions fallback, KODI::ART::Artwork& art);
   bool HasArtForItem(int mediaId, const MediaType &mediaType);
   bool RemoveArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType);
   bool RemoveArtForItem(int mediaId, const MediaType &mediaType, const std::set<std::string> &artTypes);
@@ -1108,7 +1121,7 @@ public:
    */
   std::string GetTvShowNamedSeasonById(int tvshowId, int seasonId);
 
-  bool GetTvShowSeasonArt(int mediaId, std::map<int, std::map<std::string, std::string> > &seasonArt);
+  bool GetTvShowSeasonArt(int mediaId, KODI::ART::SeasonsArtwork& seasonArt);
   bool GetArtTypes(const MediaType &mediaType, std::vector<std::string> &artTypes);
 
   /*! \brief Fetch the distinct types of available-but-unassigned art held in the

--- a/xbmc/video/VideoFileItemClassify.cpp
+++ b/xbmc/video/VideoFileItemClassify.cpp
@@ -29,9 +29,9 @@ bool IsDiscStub(const CFileItem& item)
 {
   if (IsVideoDb(item) && item.HasVideoInfoTag())
   {
-    CFileItem dbItem(item.m_bIsFolder ? item.GetVideoInfoTag()->m_strPath
-                                      : item.GetVideoInfoTag()->m_strFileNameAndPath,
-                     item.m_bIsFolder);
+    CFileItem dbItem(item.IsFolder() ? item.GetVideoInfoTag()->m_strPath
+                                     : item.GetVideoInfoTag()->m_strFileNameAndPath,
+                     item.IsFolder());
     return IsDiscStub(dbItem);
   }
 
@@ -93,7 +93,7 @@ bool IsVideo(const CFileItem& item)
     return false;
 
   // TV recordings are videos...
-  if (!item.m_bIsFolder && URIUtils::IsPVRTVRecordingFileOrFolder(item.GetPath()))
+  if (!item.IsFolder() && URIUtils::IsPVRTVRecordingFileOrFolder(item.GetPath()))
     return true;
 
   // ... all other PVR items are not.
@@ -121,7 +121,7 @@ bool IsVideo(const CFileItem& item)
 
 bool IsVideoAssetFile(const CFileItem& item)
 {
-  if (item.m_bIsFolder || !IsVideoDb(item))
+  if (item.IsFolder() || !IsVideoDb(item))
     return false;
 
   // @todo better encoding of video assets as path, they won't always be tied with movies.
@@ -136,7 +136,7 @@ bool IsVideoDb(const CFileItem& item)
 
 bool IsVideoExtrasFolder(const CFileItem& item)
 {
-  return item.m_bIsFolder &&
+  return item.IsFolder() &&
          StringUtils::EqualsNoCase(URIUtils::GetFileOrFolderName(item.GetPath()), "extras");
 }
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -925,7 +925,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
     if (ret == InfoRet::ADDED)
     {
-      std::map<int, std::map<std::string, std::string>> seasonArt;
+      KODI::ART::SeasonsArtwork seasonArt;
       m_database.GetTvShowSeasonArt(showID, seasonArt);
 
       const bool updateSeasonArt{
@@ -939,7 +939,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
           loader.GetArtwork(showInfo);
         }
         GetSeasonThumbs(showInfo, seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason), useLocal && !item->IsPlugin());
-        for (std::map<int, std::map<std::string, std::string> >::const_iterator i = seasonArt.begin(); i != seasonArt.end(); ++i)
+        for (auto i = seasonArt.begin(); i != seasonArt.end(); ++i)
         {
           int seasonID = m_database.AddSeason(showID, i->first);
           m_database.SetArtForItem(seasonID, MediaTypeSeason, i->second);
@@ -1448,7 +1448,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       GetArtwork(pItem, content, videoFolder, useLocal && !pItem->IsPlugin(), showInfo ? showInfo->m_strPath : "");
 
     // ensure the art map isn't completely empty by specifying an empty thumb
-    std::map<std::string, std::string> art = pItem->GetArt();
+    KODI::ART::Artwork art = pItem->GetArt();
     if (art.empty())
       art["thumb"] = "";
 
@@ -1557,7 +1557,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         for (std::vector<std::string>::const_iterator i = multipath.begin(); i != multipath.end(); ++i)
           paths.emplace_back(*i, URIUtils::GetParentPath(*i));
 
-        std::map<int, std::map<std::string, std::string> > seasonArt;
+        KODI::ART::SeasonsArtwork seasonArt;
 
         if (!libraryImport)
           GetSeasonThumbs(movieDetails, seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason), useLocal && !pItem->IsPlugin());
@@ -1698,9 +1698,11 @@ CVideoInfoScanner::~CVideoInfoScanner()
     return CDirectory::Exists(path) ? path : "";
   }
 
-  void CVideoInfoScanner::AddLocalItemArtwork(CGUIListItem::ArtMap& itemArt,
-    const std::vector<std::string>& wantedArtTypes, const std::string& itemPath,
-    bool addAll, bool exactName)
+  void CVideoInfoScanner::AddLocalItemArtwork(KODI::ART::Artwork& itemArt,
+                                              const std::vector<std::string>& wantedArtTypes,
+                                              const std::string& itemPath,
+                                              bool addAll,
+                                              bool exactName)
   {
     std::string path = URIUtils::GetDirectory(itemPath);
     if (path.empty())
@@ -1772,7 +1774,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     movieDetails.m_fanart.Unpack();
     movieDetails.m_strPictureURL.Parse();
 
-    CGUIListItem::ArtMap art = pItem->GetArt();
+    KODI::ART::Artwork art = pItem->GetArt();
 
     // get and cache thumb images
     std::string mediaType = ContentToMediaType(content, pItem->m_bIsFolder);
@@ -1814,7 +1816,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         std::string movieSetInfoPath = GetMovieSetInfoFolder(movieDetails.m_set.title);
         if (!movieSetInfoPath.empty())
         {
-          CGUIListItem::ArtMap movieSetArt;
+          KODI::ART::Artwork movieSetArt;
           AddLocalItemArtwork(movieSetArt, movieSetArtTypes, movieSetInfoPath, addAll, exactName);
           for (const auto& artItem : movieSetArt)
           {
@@ -2293,8 +2295,10 @@ CVideoInfoScanner::~CVideoInfoScanner()
     return "";
   }
 
-  void CVideoInfoScanner::GetSeasonThumbs(const CVideoInfoTag &show,
-      std::map<int, std::map<std::string, std::string>> &seasonArt, const std::vector<std::string> &artTypes, bool useLocal)
+  void CVideoInfoScanner::GetSeasonThumbs(const CVideoInfoTag& show,
+                                          KODI::ART::SeasonsArtwork& seasonArt,
+                                          const std::vector<std::string>& artTypes,
+                                          bool useLocal)
   {
     int artLevel = CServiceBroker::GetSettingsComponent()->GetSettings()->
       GetInt(CSettings::SETTING_VIDEOLIBRARY_ARTWORK_LEVEL);
@@ -2330,11 +2334,11 @@ CVideoInfoScanner::~CVideoInfoScanner()
       for (int season = -1; season <= maxSeasons; season++)
       {
         // skip if we already have some art
-        std::map<int, std::map<std::string, std::string>>::const_iterator it = seasonArt.find(season);
+        const auto it = seasonArt.find(season);
         if (it != seasonArt.end() && !it->second.empty())
           continue;
 
-        std::map<std::string, std::string> art;
+        KODI::ART::Artwork art;
         std::string basePath;
         if (season == -1)
           basePath = "season-all";
@@ -2358,7 +2362,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       std::string aspect = url.m_aspect;
       if (aspect.empty())
         aspect = "thumb";
-      std::map<std::string, std::string>& art = seasonArt[url.m_season];
+      KODI::ART::Artwork& art = seasonArt[url.m_season];
       if ((addAll || CVideoThumbLoader::IsArtTypeInWhitelist(aspect, artTypes, exactName)) &&
           !art.contains(aspect))
       {

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -12,6 +12,7 @@
 #include "VideoDatabase.h"
 #include "addons/Scraper.h"
 #include "guilib/GUIListItem.h"
+#include "utils/Artwork.h"
 
 #include <set>
 #include <string>
@@ -99,7 +100,10 @@ namespace KODI::VIDEO
      \param art      artwork map to which season thumbs are added.
      \param useLocal whether to use local thumbs, defaults to true
      */
-    static void GetSeasonThumbs(const CVideoInfoTag &show, std::map<int, std::map<std::string, std::string> > &art, const std::vector<std::string> &artTypes, bool useLocal = true);
+    static void GetSeasonThumbs(const CVideoInfoTag& show,
+                                KODI::ART::SeasonsArtwork& art,
+                                const std::vector<std::string>& artTypes,
+                                bool useLocal = true);
     static std::string GetImage(const CScraperUrl::SUrlEntry &image, const std::string& itemPath);
 
     bool EnumerateEpisodeItem(const CFileItem *item, EPISODELIST& episodeList);
@@ -283,9 +287,11 @@ namespace KODI::VIDEO
     CVideoDatabase::ScraperCache m_scraperCache;
 
   private:
-    static void AddLocalItemArtwork(CGUIListItem::ArtMap& itemArt,
-      const std::vector<std::string>& wantedArtTypes, const std::string& itemPath,
-      bool addAll, bool exactName);
+    static void AddLocalItemArtwork(KODI::ART::Artwork& itemArt,
+                                    const std::vector<std::string>& wantedArtTypes,
+                                    const std::string& itemPath,
+                                    bool addAll,
+                                    bool exactName);
 
     /*! \brief Retrieve the art type for an image from the given size.
      \param width the width of the image.

--- a/xbmc/video/VideoItemArtworkHandler.cpp
+++ b/xbmc/video/VideoItemArtworkHandler.cpp
@@ -112,7 +112,7 @@ std::string CVideoItemArtworkHandler::GetLocalArt() const
 
 std::string CVideoItemArtworkHandler::GetDefaultIcon() const
 {
-  return m_item->m_bIsFolder ? "DefaultFolder.png" : "DefaultPicture.png";
+  return m_item->IsFolder() ? "DefaultFolder.png" : "DefaultPicture.png";
 }
 
 void CVideoItemArtworkHandler::AddItemPathToFileBrowserSources(std::vector<CMediaSource>& sources)

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -184,7 +184,7 @@ bool CVideoThumbLoader::LoadItemCached(CFileItem* pItem)
   {
     if ((pItem->HasVideoInfoTag() &&
          pItem->GetVideoInfoTag()->m_iFileId >= 0) // file (or maybe folder) is in the database
-        || (!pItem->m_bIsFolder &&
+        || (!pItem->IsFolder() &&
             VIDEO::IsVideo(
                 *pItem))) // Some other video file for which we haven't yet got any database details
     {
@@ -291,7 +291,7 @@ bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
   }
 
   // We can only extract flags/thumbs for file-like items
-  if (!pItem->m_bIsFolder && VIDEO::IsVideo(*pItem))
+  if (!pItem->IsFolder() && VIDEO::IsVideo(*pItem))
   {
     const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
     if (!pItem->HasArt("thumb"))
@@ -524,7 +524,7 @@ std::string CVideoThumbLoader::GetLocalArt(const CFileItem &item, const std::str
                                        static_cast<int>(CacheBufferMode::ALL)
                                  : false;
 
-  if (item.m_bIsFolder && (NETWORK::IsStreamedFilesystem(item) || cacheAll))
+  if (item.IsFolder() && (NETWORK::IsStreamedFilesystem(item) || cacheAll))
   {
     CFileItemList items; // Dummy list
     CDirectory::GetDirectory(item.GetPath(), items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
@@ -540,7 +540,8 @@ std::string CVideoThumbLoader::GetLocalArt(const CFileItem &item, const std::str
   if (art.empty() && (type.empty() || type == "thumb"))
   { // backward compatibility
     art = item.FindLocalArt("", false);
-    if (art.empty() && (checkFolder || (item.m_bIsFolder && !item.IsFileFolder()) || item.IsOpticalMediaFile()))
+    if (art.empty() &&
+        (checkFolder || (item.IsFolder() && !item.IsFileFolder()) || item.IsOpticalMediaFile()))
     { // try movie.tbn
       art = item.FindLocalArt("movie.tbn", true);
       if (art.empty()) // try folder.jpg
@@ -565,7 +566,7 @@ std::string CVideoThumbLoader::GetEmbeddedThumbURL(const CFileItem &item)
 void CVideoThumbLoader::DetectAndAddMissingItemData(CFileItem &item)
 {
   // @todo remove exception for hybrid movie/folder of versions
-  if (item.m_bIsFolder && !item.GetProperty("IsHybridFolder").asBoolean(false))
+  if (item.IsFolder() && !item.GetProperty("IsHybridFolder").asBoolean(false))
     return;
 
   if (item.HasVideoInfoTag())

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -211,7 +211,7 @@ bool CVideoThumbLoader::LoadItemCached(CFileItem* pItem)
   }
 
   // if we have no art, look for it all
-  std::map<std::string, std::string> artwork = pItem->GetArt();
+  KODI::ART::Artwork artwork = pItem->GetArt();
   if (artwork.empty())
   {
     std::vector<std::string> artTypes = GetArtTypes(pItem->HasVideoInfoTag() ? pItem->GetVideoInfoTag()->m_type : "");
@@ -253,7 +253,7 @@ bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
       pItem->HasVideoInfoTag() && pItem->GetProperty("libraryartfilled").asBoolean();
   if (!isLibraryItem || !libraryArtFilled)
   {
-    std::map<std::string, std::string> artwork = pItem->GetArt();
+    KODI::ART::Artwork artwork = pItem->GetArt();
     std::vector<std::string> artTypes =
         GetArtTypes(pItem->HasVideoInfoTag() ? pItem->GetVideoInfoTag()->m_type : "");
     if (find(artTypes.begin(), artTypes.end(), "thumb") == artTypes.end())
@@ -356,7 +356,7 @@ bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
 bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
 {
   CVideoInfoTag &tag = *item.GetVideoInfoTag();
-  std::map<std::string, std::string> artwork;
+  KODI::ART::Artwork artwork;
   // Video item can be an album - either a 
   // a) search result with full details including music library album id, or 
   // b) musicvideo album that needs matching to a music album, storing id as well as fetch art.
@@ -446,7 +446,7 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
       // For episodes and seasons, we want to set fanart for that of the show
       if (!item.HasArt("tvshow.fanart") && tag.m_iIdShow >= 0)
       {
-        const ArtMap& artmap = GetArtFromCache(MediaTypeTvShow, tag.m_iIdShow);
+        const KODI::ART::Artwork& artmap = GetArtFromCache(MediaTypeTvShow, tag.m_iIdShow);
         if (!artmap.empty())
         {
           item.AppendArt(artmap, MediaTypeTvShow);
@@ -457,14 +457,14 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
 
       if (tag.m_type == MediaTypeEpisode && !item.HasArt("season.poster") && tag.m_iSeason > -1)
       {
-        const ArtMap& artmap = GetArtFromCache(MediaTypeSeason, tag.m_iIdSeason);
+        const KODI::ART::Artwork& artmap = GetArtFromCache(MediaTypeSeason, tag.m_iIdSeason);
         if (!artmap.empty())
           item.AppendArt(artmap, MediaTypeSeason);
       }
     }
     else if (tag.m_type == MediaTypeMovie && tag.m_set.id >= 0 && !item.HasArt("set.fanart"))
     {
-      const ArtMap& artmap = GetArtFromCache(MediaTypeVideoCollection, tag.m_set.id);
+      const KODI::ART::Artwork& artmap = GetArtFromCache(MediaTypeVideoCollection, tag.m_set.id);
       if (!artmap.empty())
         item.AppendArt(artmap, MediaTypeVideoCollection);
     }
@@ -622,13 +622,14 @@ void CVideoThumbLoader::DetectAndAddMissingItemData(CFileItem &item)
     item.SetProperty("stereomode", CStereoscopicsManager::NormalizeStereoMode(stereoMode));
 }
 
-const ArtMap& CVideoThumbLoader::GetArtFromCache(const std::string &mediaType, const int id)
+const KODI::ART::Artwork& CVideoThumbLoader::GetArtFromCache(const std::string& mediaType,
+                                                             const int id)
 {
   std::pair<MediaType, int> key = std::make_pair(mediaType, id);
   auto it = m_artCache.find(key);
   if (it == m_artCache.end())
   {
-    ArtMap newart;
+    KODI::ART::Artwork newart;
     m_videoDatabase->GetArtForItem(id, mediaType, newart);
     it = m_artCache.insert(std::make_pair(key, std::move(newart))).first;
   }

--- a/xbmc/video/VideoThumbLoader.h
+++ b/xbmc/video/VideoThumbLoader.h
@@ -10,6 +10,7 @@
 
 #include "FileItem.h"
 #include "ThumbLoader.h"
+#include "utils/Artwork.h"
 
 #include <map>
 #include <vector>
@@ -18,8 +19,7 @@ class CStreamDetails;
 class CVideoDatabase;
 class EmbeddedArt;
 
-using ArtMap = std::map<std::string, std::string>;
-using ArtCache = std::map<std::pair<MediaType, int>, ArtMap>;
+using ArtCache = std::map<std::pair<MediaType, int>, KODI::ART::Artwork>;
 
 class CVideoThumbLoader : public CThumbLoader
 {
@@ -83,5 +83,5 @@ protected:
    */
   void DetectAndAddMissingItemData(CFileItem &item);
 
-  const ArtMap& GetArtFromCache(const std::string &mediaType, const int id);
+  const KODI::ART::Artwork& GetArtFromCache(const std::string& mediaType, const int id);
 };

--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -394,7 +394,7 @@ ResumeInformation GetItemResumeInformation(const CFileItem& item)
     return resumeInfo;
   }
 
-  if (item.m_bIsFolder && item.IsResumable())
+  if (item.IsFolder() && item.IsResumable())
   {
     ResumeInformation resumeInfo;
     resumeInfo.isResumable = true;

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -45,6 +45,7 @@
 #include "settings/lib/Setting.h"
 #include "storage/MediaManager.h"
 #include "threads/IRunnable.h"
+#include "utils/Artwork.h"
 #include "utils/FileUtils.h"
 #include "utils/SortUtils.h"
 #include "utils/StringUtils.h"
@@ -816,7 +817,7 @@ void AddCurrentArtTypes(std::vector<std::string>& artTypes,
                         const CVideoInfoTag& tag,
                         CVideoDatabase& db)
 {
-  std::map<std::string, std::string> currentArt;
+  KODI::ART::Artwork currentArt;
 
   if (tag.GetAssetInfo().GetId() >= 0)
     db.GetArtForAsset(tag.m_iFileId, ArtFallbackOptions::NONE, currentArt);
@@ -1255,7 +1256,7 @@ bool CGUIDialogVideoInfo::UpdateVideoItemTitle(const std::shared_ptr<CFileItem>&
   if (mediaType == MediaTypeSeason)
   {
     detail.m_strSortTitle = title;
-    std::map<std::string, std::string> artwork;
+    KODI::ART::Artwork artwork;
     database.SetDetailsForSeason(detail, artwork, detail.m_iIdShow, detail.m_iDbId);
   }
   else
@@ -1612,7 +1613,8 @@ bool CGUIDialogVideoInfo::GetSetForMovie(const CFileItem* movieItem,
     if (!CGUIKeyboardFactory::ShowAndGetInput(newSetTitle, CVariant{g_localizeStrings.Get(20468)}, false))
       return false;
     int idSet = videodb.AddSet(newSetTitle);
-    std::map<std::string, std::string> movieArt, setArt;
+    KODI::ART::Artwork movieArt;
+    KODI::ART::Artwork setArt;
     if (!videodb.GetArtForItem(idSet, MediaTypeVideoCollection, setArt))
     {
       videodb.GetArtForItem(movieItem->GetVideoInfoTag()->m_iDbId, MediaTypeMovie, movieArt);

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1087,13 +1087,13 @@ int CGUIDialogVideoInfo::ManageVideoItem(const std::shared_ptr<CFileItem>& item)
     buttons.Add(CONTEXT_BUTTON_SET_ART, 13511);
 
   // movie sets
-  if (item->m_bIsFolder && type == MediaTypeVideoCollection)
+  if (item->IsFolder() && type == MediaTypeVideoCollection)
   {
     buttons.Add(CONTEXT_BUTTON_MOVIESET_ADD_REMOVE_ITEMS, 20465);
   }
 
   // tags
-  if (item->m_bIsFolder && type == "tag")
+  if (item->IsFolder() && type == "tag")
   {
     CVideoDbUrl videoUrl;
     if (videoUrl.FromString(item->GetPath()))
@@ -1415,7 +1415,7 @@ bool CGUIDialogVideoInfo::DeleteVideoItem(const std::shared_ptr<CFileItem>& item
     if (URIUtils::IsBlurayPath(strDeletePath) || VIDEO::IsDVDFile(*item) || VIDEO::IsBDFile(*item))
       strDeletePath = URIUtils::GetDiscBase(strDeletePath);
     if (URIUtils::HasSlashAtEnd(strDeletePath))
-      item->m_bIsFolder = true;
+      item->SetFolder(true);
 
     // check if the file/directory can be deleted
     if (CUtil::SupportsWriteFileOperations(strDeletePath))
@@ -1424,7 +1424,7 @@ bool CGUIDialogVideoInfo::DeleteVideoItem(const std::shared_ptr<CFileItem>& item
 
       // HACK: stacked files need to be treated as folders in order to be deleted
       if (item->IsStack())
-        item->m_bIsFolder = true;
+        item->SetFolder(true);
 
       CFileUtils::DeleteItemWithConfirm(item);
     }

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -140,7 +140,7 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
   if (item->IsParentFolder() || !item->CanQueue() || item->IsRAR() || item->IsZIP())
     return;
 
-  if (item->m_bIsFolder)
+  if (item->IsFolder())
   {
     if (!item->IsPlugin())
     {
@@ -184,7 +184,7 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
         if (i->IsLabelPreformatted())
           continue;
 
-        if (i->m_bIsFolder)
+        if (i->IsFolder())
           folderFormatter.FormatLabels(i.get());
         else
           fileFormatter.FormatLabels(i.get());
@@ -270,7 +270,7 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
     bool fetchedPlayCounts = false;
     for (const auto& i : items)
     {
-      if (i->m_bIsFolder)
+      if (i->IsFolder())
       {
         std::string path = i->GetPath();
         URIUtils::RemoveSlashAtEnd(path);
@@ -401,7 +401,7 @@ void PlayItem(
     item->SetCanQueue(true);
   }
 
-  if (item->m_bIsFolder && !item->IsPlugin())
+  if (item->IsFolder() && !item->IsPlugin())
   {
     AddItemToPlayListAndPlay(item, nullptr, player);
   }
@@ -532,7 +532,7 @@ bool IsItemPlayable(const CFileItem& item)
     return true;
 
   // Include Live TV
-  if (!item.m_bIsFolder && (item.IsLiveTV() || item.IsEPG()))
+  if (!item.IsFolder() && (item.IsLiveTV() || item.IsEPG()))
     return true;
 
   // Exclude all music library items
@@ -568,7 +568,7 @@ bool IsItemPlayable(const CFileItem& item)
         StringUtils::StartsWith(item.GetPath(), StringUtils::Format("{}/mixed/", path)))
       return true;
 
-    if (!item.m_bIsFolder && !item.HasVideoInfoTag())
+    if (!item.IsFolder() && !item.HasVideoInfoTag())
     {
       // Unknown location. Type cannot be determined for non-folder items.
       return false;
@@ -578,7 +578,7 @@ bool IsItemPlayable(const CFileItem& item)
   if (IsNonExistingUserPartyModePlaylist(item))
     return false;
 
-  if (item.m_bIsFolder &&
+  if (item.IsFolder() &&
       (IsVideoDb(item) || StringUtils::StartsWithNoCase(item.GetPath(), "library://video/")))
   {
     // Exclude top level nodes - eg can't play 'genres' just a specific genre etc
@@ -601,12 +601,12 @@ bool IsItemPlayable(const CFileItem& item)
   {
     return true;
   }
-  else if ((!item.m_bIsFolder && IsVideo(item) && !IsEmptyVideoItem(item)) || item.IsDVD() ||
+  else if ((!item.IsFolder() && IsVideo(item) && !IsEmptyVideoItem(item)) || item.IsDVD() ||
            MUSIC::IsCDDA(item))
   {
     return true;
   }
-  else if (item.m_bIsFolder && !item.IsPlugin() && !item.IsScript())
+  else if (item.IsFolder() && !item.IsPlugin() && !item.IsScript())
   {
     // Not a video-specific folder (like file:// or nfs://). Allow play if context is Video window.
     if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_VIDEO_NAV &&

--- a/xbmc/video/guilib/VideoPlayActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.cpp
@@ -230,11 +230,11 @@ bool CVideoPlayActionProcessor::OnPlaySelected()
 void CVideoPlayActionProcessor::Play(const std::string& player)
 {
   auto item{m_item};
-  if (item->m_bIsFolder && item->HasVideoVersions())
+  if (item->IsFolder() && item->HasVideoVersions())
   {
     //! @todo get rid of "videos with versions as folder" hack!
     item = std::make_shared<CFileItem>(*item);
-    item->m_bIsFolder = false;
+    item->SetFolder(false);
   }
 
   item->SetProperty("playlist_type_hint", static_cast<int>(KODI::PLAYLIST::Id::TYPE_VIDEO));

--- a/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
@@ -55,7 +55,7 @@ bool CVideoLibraryMarkWatchedJob::Work(CVideoDatabase &db)
   CFileItemList items;
   items.Add(std::make_shared<CFileItem>(*m_item));
 
-  if (m_item->m_bIsFolder)
+  if (m_item->IsFolder())
     CUtil::GetRecursiveListing(m_item->GetPath(), items, "", XFILE::DIR_FLAG_NO_FILE_INFO);
 
   std::vector<CFileItemPtr> markItems;

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -133,7 +133,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
             scraper->ID() == "metadata.local")
         {
           // get video info and art from plugin source with metadata.local scraper
-          if (scraper->Content() == CONTENT_TVSHOWS && !m_item->m_bIsFolder && tag->m_iIdShow < 0)
+          if (scraper->Content() == CONTENT_TVSHOWS && !m_item->IsFolder() && tag->m_iIdShow < 0)
             // preserve show_id for episode
             tag->m_iIdShow = m_item->GetVideoInfoTag()->m_iIdShow;
           pluginTag = std::move(tag);
@@ -159,7 +159,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
         if (scraper->Content() == CONTENT_MOVIES)
           heading = 13346;
         else if (scraper->Content() == CONTENT_TVSHOWS)
-          heading = m_item->m_bIsFolder ? 20351 : 20352;
+          heading = m_item->IsFolder() ? 20351 : 20352;
         else if (scraper->Content() == CONTENT_MUSICVIDEOS)
           heading = 20393;
         if (CGUIDialogYesNo::ShowAndGetInput(heading, 20446))
@@ -173,7 +173,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
     }
 
     // no need to re-fetch the episode guide for episodes
-    if (scraper->Content() == CONTENT_TVSHOWS && !m_item->m_bIsFolder)
+    if (scraper->Content() == CONTENT_TVSHOWS && !m_item->IsFolder())
       hasDetails = true;
 
     // if we don't have an url or need to refresh anyway do the web search
@@ -194,8 +194,8 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
       {
         CFileItemList items;
         items.Add(m_item);
-        items.SetPath(m_item->m_bIsFolder ? URIUtils::GetParentPath(m_item->GetPath())
-                                          : URIUtils::GetDirectory(m_item->GetPath()));
+        items.SetPath(m_item->IsFolder() ? URIUtils::GetParentPath(m_item->GetPath())
+                                         : URIUtils::GetDirectory(m_item->GetPath()));
         VIDEO::CVideoInfoScanner scanner;
         if (scanner.RetrieveVideoInfo(items, scanSettings.parent_name, scraper->Content(),
                                       !ignoreNfo, nullptr, m_refreshAll, GetProgressDialog()))
@@ -320,12 +320,13 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
       items.Add(std::make_shared<CFileItem>(*m_item));
 
     // set the proper path of the list of items to lookup
-    items.SetPath(m_item->m_bIsFolder ? URIUtils::GetParentPath(path) : URIUtils::GetDirectory(path));
+    items.SetPath(m_item->IsFolder() ? URIUtils::GetParentPath(path)
+                                     : URIUtils::GetDirectory(path));
 
     int headingLabel = 198;
     if (scraper->Content() == CONTENT_TVSHOWS)
     {
-      if (m_item->m_bIsFolder)
+      if (m_item->IsFolder())
         headingLabel = 20353;
       else
         headingLabel = 20361;
@@ -350,7 +351,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
         db.DeleteMusicVideo(origDbId);
       else if (scraper->Content() == CONTENT_TVSHOWS)
       {
-        if (!m_item->m_bIsFolder)
+        if (!m_item->IsFolder())
           db.DeleteEpisode(origDbId);
         else if (m_item->GetVideoInfoTag()->m_type == MediaTypeSeason)
           db.DeleteSeason(origDbId);
@@ -398,7 +399,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
     else if (scraper->Content() == CONTENT_TVSHOWS)
     {
       // update tvshow/season info to get updated episode numbers
-      if (m_item->m_bIsFolder)
+      if (m_item->IsFolder())
       {
         // Note: don't use any database ids (m_iDbId, m_idSeason, m_IdShow) of m_item's video
         // info tag here. The db information might have been deleted and recreated afterwards,

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -26,6 +26,7 @@
 #include "messaging/helpers/DialogOKHelper.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/Artwork.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -107,7 +108,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
   do
   {
     std::unique_ptr<CVideoInfoTag> pluginTag;
-    std::unique_ptr<CGUIListItem::ArtMap> pluginArt;
+    std::unique_ptr<KODI::ART::Artwork> pluginArt;
 
     if (!ignoreNfo)
     {

--- a/xbmc/video/jobs/VideoLibraryResetResumePointJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryResetResumePointJob.cpp
@@ -53,7 +53,7 @@ bool CVideoLibraryResetResumePointJob::Work(CVideoDatabase &db)
   CFileItemList items;
   items.Add(std::make_shared<CFileItem>(*m_item));
 
-  if (m_item->m_bIsFolder)
+  if (m_item->IsFolder())
     CUtil::GetRecursiveListing(m_item->GetPath(), items, "", XFILE::DIR_FLAG_NO_FILE_INFO);
 
   std::vector<CFileItemPtr> resetItems;

--- a/xbmc/video/tags/VideoTagLoaderNFO.cpp
+++ b/xbmc/video/tags/VideoTagLoaderNFO.cpp
@@ -29,7 +29,7 @@ CVideoTagLoaderNFO::CVideoTagLoaderNFO(const CFileItem& item,
                                        bool lookInFolder)
   : IVideoInfoTagLoader(item, std::move(info), lookInFolder)
 {
-  if (m_info && m_info->Content() == CONTENT_TVSHOWS && m_item.m_bIsFolder)
+  if (m_info && m_info->Content() == CONTENT_TVSHOWS && m_item.IsFolder())
     m_path = URIUtils::AddFileToFolder(m_item.GetPath(), "tvshow.nfo");
   else
     m_path = FindNFO(m_item, lookInFolder);
@@ -46,7 +46,7 @@ CInfoScanner::InfoType CVideoTagLoaderNFO::Load(CVideoInfoTag& tag,
 {
   CNfoFile nfoReader;
   CInfoScanner::InfoType result = CInfoScanner::InfoType::NONE;
-  if (m_info && m_info->Content() == CONTENT_TVSHOWS && !m_item.m_bIsFolder)
+  if (m_info && m_info->Content() == CONTENT_TVSHOWS && !m_item.IsFolder())
     result = nfoReader.Create(m_path, m_info, m_item.GetVideoInfoTag()->m_iEpisode);
   else if (m_info)
     result = nfoReader.Create(m_path, m_info);
@@ -96,7 +96,7 @@ std::string CVideoTagLoaderNFO::FindNFO(const CFileItem& item,
 {
   std::string nfoFile;
   // Find a matching .nfo file
-  if (!item.m_bIsFolder)
+  if (!item.IsFolder())
   {
     if (URIUtils::IsInRAR(item.GetPath())) // we have a rarred item - we want to check outside the rars
     {
@@ -168,13 +168,13 @@ std::string CVideoTagLoaderNFO::FindNFO(const CFileItem& item,
     }
   }
   // folders (or stacked dvds) can take any nfo file if there's a unique one
-  if (item.m_bIsFolder || item.IsOpticalMediaFile() || (movieFolder && nfoFile.empty()))
+  if (item.IsFolder() || item.IsOpticalMediaFile() || (movieFolder && nfoFile.empty()))
   {
     // see if there is a unique nfo file in this folder, and if so, use that
     CFileItemList items;
     CDirectory dir;
     std::string strPath;
-    if (item.m_bIsFolder)
+    if (item.IsFolder())
       strPath = item.GetPath();
     else
       strPath = URIUtils::GetDirectory(item.GetPath());

--- a/xbmc/video/tags/VideoTagLoaderPlugin.cpp
+++ b/xbmc/video/tags/VideoTagLoaderPlugin.cpp
@@ -27,7 +27,7 @@ CVideoTagLoaderPlugin::CVideoTagLoaderPlugin(const CFileItem& item, bool forceRe
     m_tag = std::make_unique<CVideoInfoTag>(*m_item.GetVideoInfoTag());
   auto& art = item.GetArt();
   if (!art.empty())
-    m_art = std::make_unique<CGUIListItem::ArtMap>(art);
+    m_art = std::make_unique<KODI::ART::Artwork>(art);
 }
 
 bool CVideoTagLoaderPlugin::HasInfo() const
@@ -53,7 +53,7 @@ CInfoScanner::InfoType CVideoTagLoaderPlugin::Load(CVideoInfoTag& tag,
     if (!items.IsEmpty())
     {
       const CFileItemPtr &item = items[0];
-      m_art = std::make_unique<CGUIListItem::ArtMap>(item->GetArt());
+      m_art = std::make_unique<KODI::ART::Artwork>(item->GetArt());
       if (item->HasVideoInfoTag())
       {
         tag = *item->GetVideoInfoTag();

--- a/xbmc/video/tags/VideoTagLoaderPlugin.h
+++ b/xbmc/video/tags/VideoTagLoaderPlugin.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "IVideoInfoTagLoader.h"
+#include "utils/Artwork.h"
 #include "video/VideoInfoTag.h"
 
 #include <map>
@@ -33,12 +34,10 @@ public:
                               bool prioritise,
                               std::vector<EmbeddedArt>* = nullptr) override;
 
-  inline std::unique_ptr<std::map<std::string, std::string>>& GetArt()
-  {
-    return m_art;
-  }
+  inline std::unique_ptr<KODI::ART::Artwork>& GetArt() { return m_art; }
+
 protected:
   std::unique_ptr<CVideoInfoTag> m_tag;
-  std::unique_ptr<std::map<std::string, std::string>> m_art;
+  std::unique_ptr<KODI::ART::Artwork> m_art;
   bool m_force_refresh;
 };

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -708,7 +708,7 @@ void CGUIWindowVideoNav::OnDeleteItem(const CFileItemPtr& pItem)
       CGUIWindowVideoBase::OnDeleteItem(pItem);
   }
   else if (StringUtils::StartsWithNoCase(pItem->GetPath(), "videodb://movies/sets/") &&
-           pItem->GetPath().size() > 22 && pItem->m_bIsFolder)
+           pItem->GetPath().size() > 22 && pItem->IsFolder())
   {
     CGUIDialogYesNo* pDialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogYesNo>(WINDOW_DIALOG_YES_NO);
 
@@ -737,7 +737,7 @@ void CGUIWindowVideoNav::OnDeleteItem(const CFileItemPtr& pItem)
   else if (m_vecItems->IsPath(CUtil::VideoPlaylistsLocation()) ||
            m_vecItems->IsPath("special://videoplaylists/"))
   {
-    pItem->m_bIsFolder = false;
+    pItem->SetFolder(false);
     CFileUtils::DeleteItemWithConfirm(pItem);
   }
   else
@@ -842,7 +842,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
         {
           buttons.Add(CONTEXT_BUTTON_SCAN, 13349);
         }
-        if (node == NodeType::ACTOR && !dir.IsAllItem(item->GetPath()) && item->m_bIsFolder)
+        if (node == NodeType::ACTOR && !dir.IsAllItem(item->GetPath()) && item->IsFolder())
         {
           buttons.Add(CONTEXT_BUTTON_SET_ART, 13511); // Choose art
         }
@@ -860,7 +860,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
           buttons.Add(CONTEXT_BUTTON_RENAME, 118);
         }
         // add "Set/Change content" to folders
-        if (item->m_bIsFolder && !VIDEO::IsVideoDb(*item) && !PLAYLIST::IsPlayList(*item) &&
+        if (item->IsFolder() && !VIDEO::IsVideoDb(*item) && !PLAYLIST::IsPlayList(*item) &&
             !PLAYLIST::IsSmartPlayList(*item) && !item->IsLibraryFolder() && !item->IsLiveTV() &&
             !item->IsPlugin() && !item->IsAddonsPath() && !URIUtils::IsUPnP(item->GetPath()))
         {

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -37,6 +37,7 @@
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/Artwork.h"
 #include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -441,7 +442,7 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
         // grab the show thumb
         CVideoInfoTag details;
         m_database.GetTvShowInfo("", details, params.GetTvShowId());
-        std::map<std::string, std::string> art;
+        KODI::ART::Artwork art;
         if (m_database.GetArtForItem(details.m_iDbId, details.m_type, art) && !art.empty())
         {
           items.AppendArt(art, details.m_type);
@@ -479,7 +480,7 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
           else
             seasonID = items[firstIndex]->GetVideoInfoTag()->m_iIdSeason;
 
-          CGUIListItem::ArtMap seasonArt;
+          KODI::ART::Artwork seasonArt;
           if (seasonID > -1 && m_database.GetArtForItem(seasonID, MediaTypeSeason, seasonArt) &&
               !seasonArt.empty())
           {
@@ -496,7 +497,7 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
       {
         if (params.GetSetId() > 0)
         {
-          CGUIListItem::ArtMap setArt;
+          KODI::ART::Artwork setArt;
           if (m_database.GetArtForItem(params.GetSetId(), MediaTypeVideoCollection, setArt) &&
               !setArt.empty())
           {

--- a/xbmc/video/windows/VideoFileItemListModifier.cpp
+++ b/xbmc/video/windows/VideoFileItemListModifier.cpp
@@ -136,7 +136,7 @@ void CVideoFileItemListModifier::AddQueuingFolder(CFileItemList& items)
 
   if (pItem)
   {
-    pItem->m_bIsFolder = true;
+    pItem->SetFolder(true);
     pItem->SetSpecialSort(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bVideoLibraryAllItemsOnBottom ? SortSpecialOnBottom : SortSpecialOnTop);
     pItem->SetCanQueue(false);
     items.Add(pItem);

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -691,7 +691,7 @@ void CGUIMediaWindow::FormatItemLabels(CFileItemList &items, const LABEL_MASKS &
     if (pItem->IsLabelPreformatted())
       continue;
 
-    if (pItem->m_bIsFolder)
+    if (pItem->IsFolder())
       folderFormatter.FormatLabels(pItem.get());
     else
       fileFormatter.FormatLabels(pItem.get());
@@ -791,7 +791,7 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
   {
     CFileItemPtr pItem(new CFileItem(".."));
     pItem->SetPath(strParentPath);
-    pItem->m_bIsFolder = true;
+    pItem->SetFolder(true);
     pItem->SetIsShareOrDrive(false);
     items.AddFront(pItem, 0);
   }
@@ -920,7 +920,7 @@ bool CGUIMediaWindow::Update(const std::string &strDirectory, bool updateFilterP
     pItem->SetArt("icon", "DefaultAddSource.png");
     pItem->SetLabel(strLabel);
     pItem->SetLabelPreformatted(true);
-    pItem->m_bIsFolder = true;
+    pItem->SetFolder(true);
     pItem->SetSpecialSort(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_addSourceOnTop ?
                                              SortSpecialOnTop : SortSpecialOnBottom);
     m_vecItems->Add(pItem);
@@ -1048,14 +1048,14 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
     return true;
   }
 
-  if (!pItem->m_bIsFolder && pItem->IsFileFolder(FileFolderType::MASK_ONCLICK))
+  if (!pItem->IsFolder() && pItem->IsFileFolder(FileFolderType::MASK_ONCLICK))
   {
     XFILE::IFileDirectory *pFileDirectory = nullptr;
     pFileDirectory = XFILE::CFileDirectoryFactory::Create(pItem->GetURL(), pItem.get(), "");
     if(pFileDirectory)
-      pItem->m_bIsFolder = true;
-    else if(pItem->m_bIsFolder)
-      pItem->m_bIsFolder = false;
+      pItem->SetFolder(true);
+    else if (pItem->IsFolder())
+      pItem->SetFolder(false);
     delete pFileDirectory;
   }
 
@@ -1076,7 +1076,7 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
     }
   }
 
-  if (pItem->m_bIsFolder)
+  if (pItem->IsFolder())
   {
     if (pItem->IsShareOrDrive())
     {
@@ -1540,7 +1540,7 @@ bool CGUIMediaWindow::OnPlayAndQueueMedia(const CFileItemPtr& item, const std::s
     playlist.Copy(*m_vecItems, true);
     playlist.erase(std::remove_if(playlist.begin(), playlist.end(),
                                   [](const std::shared_ptr<CFileItem>& i)
-                                  { return i->IsZIP() || i->IsRAR() || i->m_bIsFolder; }),
+                                  { return i->IsZIP() || i->IsRAR() || i->IsFolder(); }),
                    playlist.end());
 
     // Chosen item
@@ -1622,7 +1622,7 @@ void CGUIMediaWindow::UpdateFileList()
     for (int i = 0; i < m_vecItems->Size(); i++)
     {
       CFileItemPtr pItem = m_vecItems->Get(i);
-      if (pItem->m_bIsFolder)
+      if (pItem->IsFolder())
         continue;
 
       if (!PLAYLIST::IsPlayList(*pItem) && !pItem->IsZIP() && !pItem->IsRAR())
@@ -1642,7 +1642,7 @@ void CGUIMediaWindow::OnDeleteItem(int iItem)
   CFileItemPtr item = m_vecItems->Get(iItem);
 
   if (PLAYLIST::IsPlayList(*item))
-    item->m_bIsFolder = false;
+    item->SetFolder(false);
 
   const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
@@ -1959,7 +1959,7 @@ void CGUIMediaWindow::OnFilterItems(const std::string &filter)
     CFileItemPtr pItem = m_vecItems->Get(index);
     // if the item is a folder we need to copy the path of
     // the filtered item to be able to keep the applied filters
-    if (pItem->m_bIsFolder)
+    if (pItem->IsFolder())
     {
       CURL itemUrl(pItem->GetPath());
       if (!filterOption.empty())
@@ -1976,7 +1976,7 @@ void CGUIMediaWindow::OnFilterItems(const std::string &filter)
     // to be able to select the same item as before we need to adjust
     // the path of the item i.e. add or remove the "filter=" URL option
     // but that's only necessary for folder items
-    if (currentItem.get() && currentItem->m_bIsFolder)
+    if (currentItem.get() && currentItem->IsFolder())
     {
       CURL curUrl(currentItemPath), newUrl(m_strFilterPath);
       if (newUrl.HasOption("filter"))
@@ -1995,7 +1995,7 @@ void CGUIMediaWindow::OnFilterItems(const std::string &filter)
   {
     CFileItemPtr pItem(new CFileItem(".."));
     pItem->SetPath(m_history.GetParentPath());
-    pItem->m_bIsFolder = true;
+    pItem->SetFolder(true);
     pItem->SetIsShareOrDrive(false);
     m_vecItems->AddFront(pItem, 0);
   }

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -123,8 +123,8 @@ CGUIWindowFileManager::CGUIWindowFileManager(void)
   m_vecItems[1] = new CFileItemList;
   m_Directory[0]->SetPath("?");
   m_Directory[1]->SetPath("?");
-  m_Directory[0]->m_bIsFolder = true;
-  m_Directory[1]->m_bIsFolder = true;
+  m_Directory[0]->SetFolder(true);
+  m_Directory[1]->SetFolder(true);
   bCheckShareConnectivity = true;
   m_loadType = KEEP_IN_MEMORY;
 }
@@ -227,8 +227,8 @@ bool CGUIWindowFileManager::OnMessage(CGUIMessage& message)
       {
         m_Directory[0]->SetPath("?");
         m_Directory[1]->SetPath("?");
-        m_Directory[0]->m_bIsFolder = true;
-        m_Directory[1]->m_bIsFolder = true;
+        m_Directory[0]->SetFolder(true);
+        m_Directory[1]->SetFolder(true);
         return true;
       }
 
@@ -350,7 +350,7 @@ void CGUIWindowFileManager::OnSort(int iList)
   for (int i = 0; i < m_vecItems[iList]->Size(); i++)
   {
     CFileItemPtr pItem = m_vecItems[iList]->Get(i);
-    if (pItem->m_bIsFolder && (!pItem->GetSize() || pItem->IsPath("add")))
+    if (pItem->IsFolder() && (!pItem->GetSize() || pItem->IsPath("add")))
       pItem->SetLabel2("");
     else
       pItem->SetFileSizeLabel();
@@ -502,7 +502,7 @@ bool CGUIWindowFileManager::Update(int iList, const std::string &strDirectory)
     pItem->SetArt("icon", "DefaultAddSource.png");
     pItem->SetLabel(strLabel);
     pItem->SetLabelPreformatted(true);
-    pItem->m_bIsFolder = true;
+    pItem->SetFolder(true);
     pItem->SetSpecialSort(SortSpecialOnBottom);
     m_vecItems[iList]->Add(pItem);
   }
@@ -510,7 +510,7 @@ bool CGUIWindowFileManager::Update(int iList, const std::string &strDirectory)
   {
     CFileItemPtr pItem(new CFileItem(".."));
     pItem->SetPath(m_rootDir.IsSource(strDirectory) ? "" : strParentPath);
-    pItem->m_bIsFolder = true;
+    pItem->SetFolder(true);
     pItem->SetIsShareOrDrive(false);
     m_vecItems[iList]->AddFront(pItem, 0);
   }
@@ -591,18 +591,18 @@ void CGUIWindowFileManager::OnClick(int iList, int iItem)
     return;
   }
 
-  if (!pItem->m_bIsFolder && pItem->IsFileFolder(FileFolderType::MASK_ALL))
+  if (!pItem->IsFolder() && pItem->IsFileFolder(FileFolderType::MASK_ALL))
   {
     XFILE::IFileDirectory *pFileDirectory = NULL;
     pFileDirectory = XFILE::CFileDirectoryFactory::Create(pItem->GetURL(), pItem.get(), "");
     if(pFileDirectory)
-      pItem->m_bIsFolder = true;
-    else if(pItem->m_bIsFolder)
-      pItem->m_bIsFolder = false;
+      pItem->SetFolder(true);
+    else if (pItem->IsFolder())
+      pItem->SetFolder(false);
     delete pFileDirectory;
   }
 
-  if (pItem->m_bIsFolder)
+  if (pItem->IsFolder())
   {
     // save path + drive type because of the possible refresh
     std::string strPath = pItem->GetPath();
@@ -1077,13 +1077,13 @@ void CGUIWindowFileManager::OnPopupMenu(int list, int item, bool bContextDriven 
   }
   if (CanNewFolder(list))
     choices.Add(CONTROL_BTNNEWFOLDER, 20309);
-  if (item >= 0 && pItem->m_bIsFolder && !pItem->IsParentFolder())
+  if (item >= 0 && pItem->IsFolder() && !pItem->IsParentFolder())
     choices.Add(CONTROL_BTNCALCSIZE, 13393);
   choices.Add(CONTROL_BTNSWITCHMEDIA, 523);
   if (CServiceBroker::GetJobManager()->IsProcessing("filemanager"))
     choices.Add(CONTROL_BTNCANCELJOB, 167);
 
-  if (!pItem->m_bIsFolder)
+  if (!pItem->IsFolder())
     choices.Add(CONTROL_BTNVIEW, 39104);
 
   int btnid = CGUIDialogContextMenu::ShowAndGetChoice(choices);
@@ -1131,7 +1131,7 @@ void CGUIWindowFileManager::OnPopupMenu(int list, int item, bool bContextDriven 
     for (int i=0; i<m_vecItems[list]->Size(); ++i)
     {
       CFileItemPtr pItem2=m_vecItems[list]->Get(i);
-      if (pItem2->m_bIsFolder && pItem2->IsSelected())
+      if (pItem2->IsFolder() && pItem2->IsSelected())
       {
         int64_t folderSize = CalculateFolderSize(pItem2->GetPath(), progress);
         if (folderSize >= 0)
@@ -1198,7 +1198,7 @@ int64_t CGUIWindowFileManager::CalculateFolderSize(const std::string &strDirecto
   rootDir.GetDirectory(pathToUrl, items, false, false);
   for (int i=0; i < items.Size(); i++)
   {
-    if (items[i]->m_bIsFolder && !items[i]->IsParentFolder()) // folder
+    if (items[i]->IsFolder() && !items[i]->IsParentFolder()) // folder
     {
       int64_t folderSize = CalculateFolderSize(items[i]->GetPath(), pProgress);
       if (folderSize < 0) return -1;


### PR DESCRIPTION
More SonarQube findings fixed in this PR...

GUIListItem - ArtWork
* Transparent function objects should be used with associative "std::string" containers cpp:S6045
* "using" should be preferred for type aliasing cpp:S5416

GUIListItem - misc
* Transparent function objects should be used with associative "std::string" containers cpp:S6045
* "using" should be preferred for type aliasing cpp:S5416
* Member data should be initialized in-class or in a constructor initialization list cpp:S3230
* "std::string_view" should be used to pass a read-only string to a function cpp:S6009
* "static" members should be accessed statically cpp:S2209
* Structured binding should be used cpp:S6005
* Multiple variables should not be declared on the same line cpp:S1659
* "try_emplace" should be used with "std::map" and "std::unordered_map" cpp:S6030
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* "auto" should be used to avoid repetition of types cpp:S5827

GUIListItem - encapsulate member m_bIsFolder
* Classes should not contain both public and private data members cpp:S5414

GUIListItem - extra commits for encapsulating more members
* Member variables should not be "protected" cpp:S3656

Runtime-tested on macOS and Android, latest Kodi master

NO idea who could review this, maybe @neo1973 
