### PR TITLE
[cmake] FindPython add SEARCH_QUIET to find_package calls

### DIFF
--- a/cmake/modules/FindPython.cmake
+++ b/cmake/modules/FindPython.cmake
@@ -51,14 +51,14 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
   if(Python3_FOUND)
     if(KODI_DEPENDSBUILD)
       set(EXPAT_USE_STATIC_LIBS TRUE)
-      find_package(EXPAT REQUIRED)
+      find_package(EXPAT REQUIRED ${SEARCH_QUIET})
 
       find_library(FFI_LIBRARY ffi REQUIRED)
       find_library(GMP_LIBRARY gmp REQUIRED)
 
-      find_package(Iconv REQUIRED)
-      find_package(Intl REQUIRED)
-      find_package(LibLZMA REQUIRED)
+      find_package(Iconv REQUIRED ${SEARCH_QUIET})
+      find_package(Intl REQUIRED ${SEARCH_QUIET})
+      find_package(LibLZMA REQUIRED ${SEARCH_QUIET})
 
       if(NOT CORE_SYSTEM_NAME STREQUAL android)
         set(PYTHON_DEP_LIBRARIES pthread dl util)


### PR DESCRIPTION
## Description
Quiet some find_package calls in the FindPython module

## Motivation and context
Quiet some logging unless desired with VERBOSE_FIND

## How has this been tested?
Locally.

Before
```
<snip>
-- External TexturePacker for KODI_DEPENDSBUILD will be executed during build: /Users/Shared/xbmc-depends/arm-darwin24.5.0-native/bin/TexturePacker
-- Found EXPAT: /Users/Shared/xbmc-depends/appletvos18.5_arm64-target-debug/lib/libexpat.a (found version "2.6.3")
-- Performing Test Iconv_IS_BUILT_IN
-- Performing Test Iconv_IS_BUILT_IN - Failed
-- Found Intl: /Users/Shared/xbmc-depends/appletvos18.5_arm64-target-debug/lib/libintl.a (found version "0.22.4")
-- Looking for lzma_auto_decoder in /Users/Shared/xbmc-depends/appletvos18.5_arm64-target-debug/lib/liblzma.a
-- Looking for lzma_auto_decoder in /Users/Shared/xbmc-depends/appletvos18.5_arm64-target-debug/lib/liblzma.a - found
-- Looking for lzma_easy_encoder in /Users/Shared/xbmc-depends/appletvos18.5_arm64-target-debug/lib/liblzma.a
-- Looking for lzma_easy_encoder in /Users/Shared/xbmc-depends/appletvos18.5_arm64-target-debug/lib/liblzma.a - found
-- Looking for lzma_lzma_preset in /Users/Shared/xbmc-depends/appletvos18.5_arm64-target-debug/lib/liblzma.a
-- Looking for lzma_lzma_preset in /Users/Shared/xbmc-depends/appletvos18.5_arm64-target-debug/lib/liblzma.a - found
-- Found LibLZMA: /Users/Shared/xbmc-depends/appletvos18.5_arm64-target-debug/lib/liblzma.a (found version "5.4.1")
-- Could NOT find ZLIB (missing: ZLIB_LIBRARY) (found version "1.2.12")
-- Found Threads: TRUE
<snip>
```

After
```
<snip>
-- External TexturePacker for KODI_DEPENDSBUILD will be executed during build: /Users/Shared/xbmc-depends/arm-darwin24.5.0-native/bin/TexturePacker
-- Performing Test Iconv_IS_BUILT_IN
-- Performing Test Iconv_IS_BUILT_IN - Failed
-- Found ZLIB: /Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS18.5.sdk/usr/lib/libz.tbd (found version "1.2.12")
-- Found Threads: TRUE
<snip>
```

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
