### PR TITLE
[Estuary] Fix 'Ends at' no longer shown in movie OSD info.

### DIFF
--- a/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
+++ b/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
@@ -249,7 +249,7 @@
 						<shadowcolor>text_shadow</shadowcolor>
 						<height>100</height>
 						<width>auto</width>
-						<visible>!Player.IsLive + Player.HasVideo + ![Player.HasGame | VideoPlayer.HasEpg] !String.IsEmpty(Player.Duration)</visible>
+						<visible>!Player.IsLive + Player.HasVideo + ![Player.HasGame | VideoPlayer.HasEpg] + !String.IsEmpty(Player.Duration)</visible>
 					</control>
 					<control type="label">
 						<label>$LOCALIZE[31081]</label>


### PR DESCRIPTION
#26764 introduced a skin xml syntax error preventing "Ends at"  displayed in video OSD. 

Runtime-tested on macOS and Android, latest Kodi master.

I guess I will merge this right away as the mistake is more than obvious.

@lpuglia fyi