### PR TITLE
Set APP_ID if not supplied by webOS launcher

### DIFF
--- a/xbmc/platform/linux/PlatformWebOS.cpp
+++ b/xbmc/platform/linux/PlatformWebOS.cpp
@@ -8,6 +8,7 @@
 
 #include "PlatformWebOS.h"
 
+#include "CompileInfo.h"
 #include "ServiceBroker.h"
 #include "filesystem/SpecialProtocol.h"
 #include "powermanagement/LunaPowerManagement.h"
@@ -43,6 +44,7 @@ bool CPlatformWebOS::InitStageOne()
   // $HOME is set to the ipk dir and $LD_LIBRARY_PATH is lib
   const auto HOME = GetHomePath();
 
+  setenv("APPID", CCompileInfo::GetPackage(), 0);
   setenv("XDG_RUNTIME_DIR", "/tmp/xdg", 1);
   setenv("XKB_CONFIG_ROOT", "/usr/share/X11/xkb", 1);
   setenv("WAYLAND_DISPLAY", "wayland-0", 1);

--- a/xbmc/windowing/wayland/ShellSurfaceWebOSShell.cpp
+++ b/xbmc/windowing/wayland/ShellSurfaceWebOSShell.cpp
@@ -82,7 +82,7 @@ CShellSurfaceWebOSShell::CShellSurfaceWebOSShell(IShellSurfaceHandler& handler,
     m_handler.OnClose();
   };
 
-  std::string appId = CEnvironment::getenv("APP_ID");
+  std::string appId = CEnvironment::getenv("APPID");
   if (appId.empty())
   {
     appId = CCompileInfo::GetPackage();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Sets APPID which is normally set by the menu launcher, but is missing on SSH, causing video playback to fail. Fix courtesy of @sundermann 

Also fix correct usage in xbmc/windowing/wayland/ShellSurfaceWebOSShell.cpp

## Motivation and context
Fixes playback of video when kodi launched from ssh

## How has this been tested?
Without this fix, playback from ssh does not work.
Tested with this fix from SSH
Tested with this fix from webOS menu

Both working.

## What is the effect on users?
Developers can debug from SSH

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
