### PR TITLE
[VideoPlayer] Fix CVideoPlayer::IsLiveStream() to use player process …

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5215,9 +5215,9 @@ bool CVideoPlayer::IsRenderingVideo() const
 
 bool CVideoPlayer::IsLiveStream() const
 {
-  if (m_pInputStream)
-    return m_pInputStream->IsRealtime();
-  return false;
+  if (!m_processInfo)
+    return false;
+  return m_processInfo->IsRealtimeStream();
 }
 
 bool CVideoPlayer::Supports(EINTERLACEMETHOD method) const


### PR DESCRIPTION
…info, not to interact with the inputstream directly

Saves resources and for me it even fixes a crash while switching from one channel provided by inputstream.adaptive to another channel provided by the same IA instance. Fixes another fallout from https://github.com/xbmc/xbmc/pull/26764

Runtime-tested on macOS and Android

@lpuglia fyi