### PR TITLE
[Texturepacker] Hide some output behind verbose option

### DIFF
--- a/cmake/scripts/common/ProjectMacros.cmake
+++ b/cmake/scripts/common/ProjectMacros.cmake
@@ -12,14 +12,27 @@ function(pack_xbt input output)
   set(XBT_SOURCE_FILELIST ${XBT_SOURCE_FILELIST} PARENT_SCOPE)
 
   get_filename_component(dir ${output} DIRECTORY)
+
+  # filename of output file for logging info
+  get_filename_component(file ${output} NAME)
+
+  # Get skin name for logging info. assumes path structure <skin>/media/<output.xbt>
+  get_filename_component(skin ${dir} DIRECTORY)
+  get_filename_component(skin ${skin} NAME)
+
   if(${CORE_SYSTEM_NAME} MATCHES "windows")
     string(REPLACE "${CMAKE_BINARY_DIR}" "\$\{BUNDLEDIR\}" dir ${dir})
     string(REPLACE "${CMAKE_BINARY_DIR}" "\$\{BUNDLEDIR\}" output ${output})
   endif()
 
+  if(VERBOSE)
+    set(verbose_flag "-verbose")
+  endif()
+
   file(APPEND ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/GeneratedPackSkins.cmake
-"execute_process(COMMAND \"${CMAKE_COMMAND}\" -E make_directory ${dir})
-execute_process(COMMAND \$\{TEXTUREPACKER_EXECUTABLE\} -input ${input} -output ${output} -dupecheck)\n")
+"message(STATUS \"Packing ${file} for ${skin}\")
+execute_process(COMMAND \"${CMAKE_COMMAND}\" -E make_directory ${dir})
+execute_process(COMMAND \$\{TEXTUREPACKER_EXECUTABLE\} -input ${input} -output ${output} -dupecheck ${verbose_flag})\n")
 
     list(APPEND XBT_FILES ${output})
     set(XBT_FILES ${XBT_FILES} PARENT_SCOPE)

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -97,7 +97,7 @@ public:
 
   void EnableDupeCheck() { m_dupecheck = true; }
 
-  void EnableVerboseOutput() { decoderManager.EnableVerboseOutput(); }
+  void EnableVerboseOutput();
 
   int createBundle(const std::string& InputDir, const std::string& OutputFile);
 
@@ -122,8 +122,15 @@ private:
   std::vector<unsigned int> m_dupes;
 
   bool m_dupecheck{false};
+  bool m_verbose{false};
   unsigned int m_flags{0};
 };
+
+void TexturePacker::EnableVerboseOutput()
+{
+  decoderManager.EnableVerboseOutput();
+  m_verbose = true;
+}
 
 void TexturePacker::CreateSkeletonHeader(CXBTFWriter& xbtfWriter,
                                          const std::string& fullPath,
@@ -415,7 +422,9 @@ int TexturePacker::createBundle(const std::string& InputDir, const std::string& 
     for (unsigned int j = 0; j < frames.frameList.size(); j++)
       ReduceChannels(frames.frameList[j].rgbaImage);
 
-    printf("%s\n", output.c_str());
+    if(m_verbose)
+      printf("%s\n", output.c_str());
+
     bool skip=false;
     if (m_dupecheck)
     {
@@ -425,7 +434,9 @@ int TexturePacker::createBundle(const std::string& InputDir, const std::string& 
 
       if (CheckDupe(&ctx, i))
       {
-        printf("****  duplicate of %s\n", files[m_dupes[i]].GetPath().c_str());
+        if(m_verbose)
+          printf("****  duplicate of %s\n", files[m_dupes[i]].GetPath().c_str());
+
         file.GetFrames().insert(file.GetFrames().end(),
                                 files[m_dupes[i]].GetFrames().begin(),
                                 files[m_dupes[i]].GetFrames().end());
@@ -443,11 +454,14 @@ int TexturePacker::createBundle(const std::string& InputDir, const std::string& 
       {
         CXBTFFrame frame = CreateXBTFFrame(frames.frameList[j], writer);
         file.GetFrames().push_back(frame);
-        printf("    frame %4i (delay:%4i)                         %s%c (%d,%d @ %" PRIu64
-               " bytes)\n",
-               j, frame.GetDuration(), GetFormatString(frame.GetKDFormat()),
-               frame.HasAlpha() ? ' ' : '*', frame.GetWidth(), frame.GetHeight(),
-               frame.GetUnpackedSize());
+        if(m_verbose)
+        {
+          printf("    frame %4i (delay:%4i)                         %s%c (%d,%d @ %" PRIu64
+                 " bytes)\n",
+                 j, frame.GetDuration(), GetFormatString(frame.GetKDFormat()),
+                 frame.HasAlpha() ? ' ' : '*', frame.GetWidth(), frame.GetHeight(),
+                 frame.GetUnpackedSize());
+        }
       }
     }
     file.SetLoop(0);


### PR DESCRIPTION
## Description
Hide some output behind verbose argument

## Motivation and context
Texturepacker spams all sorts of shit that i think means nothing to most people 99% of the time.

```
<snip>
07:06:04 DefaultActor.png
07:06:04     frame    0 (delay:   0)                         R8     (256,256 @ 65536 bytes)
07:06:04 DefaultActorSolid.png
07:06:04     frame    0 (delay:   0)                         R8   * (256,392 @ 100352 bytes)
07:06:04 DefaultAddSource.png
07:06:04     frame    0 (delay:   0)                         R8     (256,256 @ 65536 bytes)
07:06:04 DefaultAddon.png
07:06:04     frame    0 (delay:   0)                         R8     (256,256 @ 65536 bytes)
07:06:04 DefaultAddonAlbumInfo.png
07:06:04     frame    0 (delay:   0)                         R8     (256,256 @ 65536 bytes)
07:06:04 DefaultAddonArtistInfo.png
07:06:04     frame    0 (delay:   0)                         R8     (256,256 @ 65536 bytes)
07:06:04 DefaultAddonAudioDSP.png
07:06:04     frame    0 (delay:   0)                         R8     (256,256 @ 65536 bytes)
07:06:04 DefaultAddonAudioDecoder.png
07:06:04     frame    0 (delay:   0)                         R8     (256,256 @ 65536 bytes)
07:06:04 DefaultAddonAudioEncoder.png
07:06:04     frame    0 (delay:   0)                         R8     (256,256 @ 65536 bytes)
<snip>
```

Hide this output behind the texturepacker ``-verbose`` option. Enable the use of the ``-verbose`` option when the core cmake project is built using the ``VERBOSE`` cmake argument for when someone does need the verbose texturepacker info.
It also adds a single status message showing that an xbt file is being created

```
-- Packing /macos/build/addons/skin.estuary/media/flat.xbt
```

## How has this been tested?
Locally build android aarch64 apk

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
