### PR TITLE
[MUSIC] Correct sql table error when querying 'albumartistsonly wth a…

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -13630,7 +13630,7 @@ bool CMusicDatabase::GetFilter(CDbUrl& musicUrl, Filter& filter, SortDescription
       songArtistSub.AppendJoin("JOIN artist ON artist.idArtist = song_artist.idArtist");
       songArtistSub.AppendWhere(PrepareSQL("artist.strArtist like '%s'", artistname.c_str()));
 
-      albumArtistSub.AppendJoin("JOIN artist ON artist.idArtist = song_artist.idArtist");
+      albumArtistSub.AppendJoin("JOIN artist ON artist.idArtist = album_artist.idArtist");
       albumArtistSub.AppendWhere(PrepareSQL("artist.strArtist like '%s'", artistname.c_str()));
     }
     if (idRole > 0)


### PR DESCRIPTION
…n artist string

## Description
Fiixes a typo when generating sql for albumartistsonly but using a string for the artist name rather than an artist ID from the database.
## Motivation and context
Current sql generates an error in the log as the song_artist table isn't available to that part of the query.  Noticed it when looking for something else.  The query fails silently in Kodi and just logs a message and as it's mainly music video related I guess no-one noticed until now.  This goes back to at least Nexus, probably further.

## How has this been tested?
Tested by running the same query before and after the change.

Log before 
```
GetAlbumsByWhere query: SELECT albumview.* FROM albumview  WHERE (albumview.bCompilation = 0) AND (EXISTS (SELECT 1 FROM song_artist JOIN song ON song.idSong = song_artist.idSong JOIN artist ON artist.idArtist = song_artist.idArtist WHERE song.idAlbum = albumview.idAlbum AND artist.strArtist like 'ZZ Top' AND song_artist.idRole = 1) OR EXISTS (SELECT 1 FROM album_artist JOIN artist ON artist.idArtist = song_artist.idArtist WHERE album_artist.idAlbum = albumview.idAlbum AND artist.strArtist like 'ZZ Top')) ORDER BY albumview.idAlbum
 error <general>: SQL: [MyMusic82.db] SQLite error SQLITE_ERROR (no such column: song_artist.idArtist)
                                                   Query: SELECT albumview.* FROM albumview  WHERE (albumview.bCompilation = 0) AND (EXISTS (SELECT 1 FROM song_artist JOIN song ON song.idSong = song_artist.idSong JOIN artist ON artist.idArtist = song_artist.idArtist WHERE song.idAlbum = albumview.idAlbum AND artist.strArtist like 'ZZ Top' AND song_artist.idRole = 1) OR EXISTS (SELECT 1 FROM album_artist JOIN artist ON artist.idArtist = song_artist.idArtist WHERE album_artist.idAlbum = albumview.idAlbum AND artist.strArtist like 'ZZ Top')) ORDER BY albumview.idAlbum
 error <general>: :GetAlbumsByWhere () failed

```

Log after
```

GetAlbumsByWhere query: SELECT albumview.* FROM albumview  WHERE (albumview.bCompilation = 0) AND (EXISTS (SELECT 1 FROM song_artist JOIN song ON song.idSong = song_artist.idSong JOIN artist ON artist.idArtist = song_artist.idArtist WHERE song.idAlbum = albumview.idAlbum AND artist.strArtist like 'ZZ Top' AND song_artist.idRole = 1) OR EXISTS (SELECT 1 FROM album_artist JOIN artist ON artist.idArtist = album_artist.idArtist WHERE album_artist.idAlbum = albumview.idAlbum AND artist.strArtist like 'ZZ Top')) ORDER BY albumview.idAlbum
 debug <general>: Custom album format = [%B]
```
## What is the effect on users?
Queries generated by the music video info dialog to search for albums don't fail and Kodi will display those albums.
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
