### PR TITLE
[AnnouncementManager] Refactor large method into 4 smaller functions

### DIFF
--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -898,6 +898,11 @@ void CVideoInfoTag::ToSortable(SortItem& sortable, Field field) const
   }
 }
 
+int CVideoInfoTag::GetDatabaseId() const
+{
+  return m_iDbId;
+}
+
 CRating CVideoInfoTag::GetRating(std::string type) const
 {
   if (type.empty())

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -77,6 +77,7 @@ public:
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;
   void ToSortable(SortItem& sortable, Field field) const override;
+  int GetDatabaseId() const;
   CRating GetRating(std::string type = "") const;
   const std::string& GetDefaultRating() const;
   std::string GetUniqueID(std::string type = "") const;


### PR DESCRIPTION
## Description
`AnnouncementManager::DoAnnounce` is doing a large amount of work if `CFileItem` is non-null. Alternatively, it is simply forwarding the parameters to the another method if it is null.

The work being done when the `FileItem` is non-null has been factored out into smaller functions and the implementation of `AnnouncementManager::DoAnnounce` reduced to a simpler if/else forwarding method.

## Motivation and context
Clean up.

## How has this been tested?
Connected to TCP port 9090 using netcat while running the build. This streams JSON data which originate from announcements.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
