### PR TITLE
Retroplayer: Remove hardware integer scaling support

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24008,15 +24008,9 @@ msgctxt "#39150"
 msgid "Limit the music video artwork fetched locally or applied from scraper remote art results to just those art types in the whitelist"
 msgstr ""
 
-#. Display Hardware scaling filter setting toggle
-msgctxt "#39151"
-msgid "Display hardware scaling filter"
-msgstr ""
+#empty string id 39151
 
-#. Description
-msgctxt "#39152"
-msgid "Integer scaling (IS) is a Nearest-Neighbor(NN) upscaling technique using Display Engine"
-msgstr ""
+#empty string id 39152
 
 #: xbmc/windows/GUIWindowSystemInfo.cpp
 msgctxt "#39153"

--- a/system/settings/linux.xml
+++ b/system/settings/linux.xml
@@ -215,9 +215,9 @@
           <visible>false</visible>
         </setting>
         <setting id="videoscreen.hwscalingfilter" type="boolean" label="39151" help="39152">
-          <visible>false</visible>
+          <visible>true</visible>
           <level>3</level>
-          <default>true</default>
+          <default>false</default>
           <control type="toggle" />
         </setting>
         <setting id="videoscreen.limitguisize" type="integer" label="37021" help="36548">

--- a/system/settings/linux.xml
+++ b/system/settings/linux.xml
@@ -214,12 +214,6 @@
         <setting id="videoscreen.fakefullscreen">
           <visible>false</visible>
         </setting>
-        <setting id="videoscreen.hwscalingfilter" type="boolean" label="39151" help="39152">
-          <visible>true</visible>
-          <level>3</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
         <setting id="videoscreen.limitguisize" type="integer" label="37021" help="36548">
           <visible>false</visible>
           <level>3</level>

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -369,38 +369,6 @@ void CRPRenderManager::RenderWindow(bool bClear, const RESOLUTION_INFO& coordsRe
 
   m_renderContext.SetRenderingResolution(m_renderContext.GetVideoResolution(), false);
 
-  if (!m_bDisplayScaleSet && m_renderContext.DisplayHardwareScalingEnabled())
-  {
-    // If the renderer has a render buffer, get the dimensions
-    const unsigned int sourceWidth = (renderBuffer != nullptr ? renderBuffer->GetWidth() : 0);
-    const unsigned int sourceHeight = (renderBuffer != nullptr ? renderBuffer->GetHeight() : 0);
-
-    // Get render video settings for the fullscreen window
-    CRenderVideoSettings renderVideoSettings = GetEffectiveSettings(nullptr);
-
-    // Get the scaling mode of the render video settings
-    const SCALINGMETHOD scaleMode = renderVideoSettings.GetScalingMethod();
-    const STRETCHMODE stretchMode = renderVideoSettings.GetRenderStretchMode();
-
-    // Update display with video dimensions for integer scaling
-    if (scaleMode == SCALINGMETHOD::NEAREST && stretchMode == STRETCHMODE::Original &&
-        sourceWidth > 0 && sourceHeight > 0)
-    {
-      RESOLUTION_INFO gameRes = m_renderContext.GetResInfo();
-      gameRes.Overscan.left = 0;
-      gameRes.Overscan.top = 0;
-      gameRes.Overscan.right = sourceWidth;
-      gameRes.Overscan.bottom = sourceHeight;
-      gameRes.iWidth = sourceWidth;
-      gameRes.iHeight = sourceHeight;
-      gameRes.iScreenWidth = sourceWidth;
-      gameRes.iScreenHeight = sourceHeight;
-
-      m_renderContext.UpdateDisplayHardwareScaling(gameRes);
-      m_bDisplayScaleSet = true;
-    }
-  }
-
   RenderInternal(renderer, renderBuffer, bClear, 255);
 
   m_renderContext.SetRenderingResolution(coordsRes, false);

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -265,9 +265,6 @@ private:
   std::set<std::string> m_failedShaderPresets;
   std::atomic<bool> m_bFlush = {false};
 
-  // Windowing state
-  bool m_bDisplayScaleSet = false;
-
   // Playback parameters
   std::atomic<double> m_speed = {1.0};
 

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
@@ -220,16 +220,6 @@ bool CRenderContext::UseLimitedColor()
   return m_windowing->UseLimitedColor();
 }
 
-bool CRenderContext::DisplayHardwareScalingEnabled()
-{
-  return m_windowing->DisplayHardwareScalingEnabled();
-}
-
-void CRenderContext::UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo)
-{
-  return m_windowing->UpdateDisplayHardwareScaling(resInfo);
-}
-
 int CRenderContext::GetScreenWidth()
 {
   return m_graphicsContext.GetWidth();

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.h
@@ -77,8 +77,6 @@ public:
 
   // Windowing functions
   bool UseLimitedColor();
-  bool DisplayHardwareScalingEnabled();
-  void UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo);
 
   // Graphics functions
   int GetScreenWidth();

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
@@ -175,7 +175,6 @@ void CRPBaseRenderer::ManageRenderArea(const IRenderBuffer& renderBuffer)
   const float sourceAspectRatio =
       static_cast<float>(sourceWidth) / static_cast<float>(sourceHeight);
 
-  const SCALINGMETHOD scaleMode = m_renderSettings.VideoSettings().GetScalingMethod();
   const STRETCHMODE stretchMode = m_renderSettings.VideoSettings().GetRenderStretchMode();
   const unsigned int rotationDegCCW =
       (sourceRotationDegCCW + m_renderSettings.VideoSettings().GetRenderRotation()) % 360;
@@ -185,18 +184,7 @@ void CRPBaseRenderer::ManageRenderArea(const IRenderBuffer& renderBuffer)
   float screenHeight;
   //! @todo screenPixelRatio unused - Possibly due to display integer scaling according to Garbear
   float screenPixelRatio;
-
-  if (scaleMode == SCALINGMETHOD::NEAREST && stretchMode == STRETCHMODE::Original &&
-      m_context.DisplayHardwareScalingEnabled())
-  {
-    screenWidth = sourceWidth;
-    screenHeight = sourceHeight;
-    screenPixelRatio = 1.0;
-  }
-  else
-  {
-    GetScreenDimensions(screenWidth, screenHeight, screenPixelRatio);
-  }
+  GetScreenDimensions(screenWidth, screenHeight, screenPixelRatio);
 
   // Entire target rendering area for the video (including black bars)
   const CRect viewRect = m_context.GetViewWindow();

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -67,8 +67,6 @@ public:
   virtual bool DestroyWindow(){ return false; }
   virtual bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) = 0;
   virtual bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) = 0;
-  virtual bool DisplayHardwareScalingEnabled() { return false; }
-  virtual void UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo) { }
   virtual void SetDirtyRegions(const CDirtyRegionList& dirtyRegionsList) {}
   virtual int GetBufferAge() { return 2; }
   virtual bool MoveWindow(int topLeft, int topRight){return false;}

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -257,27 +257,6 @@ bool CWinSystemGbm::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   return result;
 }
 
-bool CWinSystemGbm::DisplayHardwareScalingEnabled()
-{
-  auto drmAtomic = std::dynamic_pointer_cast<CDRMAtomic>(m_DRM);
-  if (drmAtomic && drmAtomic->DisplayHardwareScalingEnabled())
-    return true;
-
-  return false;
-}
-
-void CWinSystemGbm::UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo)
-{
-  if (!DisplayHardwareScalingEnabled())
-    return;
-
-  //! @todo The PR that made the res struct constant was abandoned due to drama.
-  // It should be const-corrected and changed here.
-  RESOLUTION_INFO& resMutable = const_cast<RESOLUTION_INFO&>(resInfo);
-
-  SetFullScreen(true, resMutable, false);
-}
-
 void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
 {
   if (m_videoLayerBridge && !videoLayer)

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -46,8 +46,6 @@ public:
 
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
-  bool DisplayHardwareScalingEnabled() override;
-  void UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo) override;
 
   void FlipPage(bool rendered, bool videoLayer, bool async);
 

--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
@@ -12,8 +12,6 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "settings/Settings.h"
-#include "settings/SettingsComponent.h"
-#include "settings/lib/Setting.h"
 #include "utils/log.h"
 
 #include <errno.h>
@@ -24,46 +22,6 @@
 #include <unistd.h>
 
 using namespace KODI::WINDOWING::GBM;
-
-namespace
-{
-
-const auto SETTING_VIDEOSCREEN_HW_SCALING_FILTER = "videoscreen.hwscalingfilter";
-
-uint32_t GetScalingFactor(uint32_t srcWidth,
-                          uint32_t srcHeight,
-                          uint32_t destWidth,
-                          uint32_t destHeight)
-{
-  uint32_t factor_W = destWidth / srcWidth;
-  uint32_t factor_H = destHeight / srcHeight;
-  if (factor_W != factor_H)
-    return (factor_W < factor_H) ? factor_W : factor_H;
-  return factor_W;
-}
-
-} // namespace
-
-bool CDRMAtomic::SetScalingFilter(CDRMObject* object, const char* name, const char* type)
-{
-  std::optional<uint64_t> scalingFilter = m_gui_plane->GetPropertyValue(name, type);
-  if (!scalingFilter)
-    return false;
-
-  if (!AddProperty(object, name, scalingFilter.value()))
-    return false;
-
-  uint32_t mar_scale_factor =
-      GetScalingFactor(m_width, m_height, m_mode->hdisplay, m_mode->vdisplay);
-  uint32_t diff_w = m_mode->hdisplay - (mar_scale_factor * m_width);
-  uint32_t diff_h = m_mode->vdisplay - (mar_scale_factor * m_height);
-  AddProperty(object, "CRTC_X", (diff_w / 2));
-  AddProperty(object, "CRTC_Y", (diff_h / 2));
-  AddProperty(object, "CRTC_W", (mar_scale_factor * m_width));
-  AddProperty(object, "CRTC_H", (mar_scale_factor * m_height));
-
-  return true;
-}
 
 void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool videoLayer)
 {
@@ -102,17 +60,10 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
     AddProperty(m_gui_plane, "SRC_Y", 0);
     AddProperty(m_gui_plane, "SRC_W", m_width << 16);
     AddProperty(m_gui_plane, "SRC_H", m_height << 16);
-    if (DisplayHardwareScalingEnabled())
-    {
-      SetScalingFilter(m_gui_plane, "SCALING_FILTER", "Nearest Neighbor");
-    }
-    else
-    {
-      AddProperty(m_gui_plane, "CRTC_X", 0);
-      AddProperty(m_gui_plane, "CRTC_Y", 0);
-      AddProperty(m_gui_plane, "CRTC_W", m_mode->hdisplay);
-      AddProperty(m_gui_plane, "CRTC_H", m_mode->vdisplay);
-    }
+    AddProperty(m_gui_plane, "CRTC_X", 0);
+    AddProperty(m_gui_plane, "CRTC_Y", 0);
+    AddProperty(m_gui_plane, "CRTC_W", m_mode->hdisplay);
+    AddProperty(m_gui_plane, "CRTC_H", m_mode->vdisplay);
 
     if (m_inFenceFd != -1)
     {
@@ -236,13 +187,6 @@ bool CDRMAtomic::InitDrm()
 
   CLog::Log(LOGDEBUG, "CDRMAtomic::{} - initialized atomic DRM", __FUNCTION__);
 
-  if (m_gui_plane->SupportsProperty("SCALING_FILTER"))
-  {
-    const std::shared_ptr<CSettings> settings =
-        CServiceBroker::GetSettingsComponent()->GetSettings();
-    settings->GetSetting(SETTING_VIDEOSCREEN_HW_SCALING_FILTER)->SetVisible(true);
-  }
-
   return true;
 }
 
@@ -269,16 +213,6 @@ bool CDRMAtomic::SetActive(bool active)
 bool CDRMAtomic::AddProperty(CDRMObject* object, const char* name, uint64_t value)
 {
   return m_req->AddProperty(object, name, value);
-}
-
-bool CDRMAtomic::DisplayHardwareScalingEnabled()
-{
-  auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-
-  if (settings && settings->GetBool(SETTING_VIDEOSCREEN_HW_SCALING_FILTER))
-    return true;
-
-  return false;
 }
 
 CDRMAtomic::CDRMAtomicRequest::CDRMAtomicRequest() : m_atomicRequest(drmModeAtomicAlloc())

--- a/xbmc/windowing/gbm/drm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
@@ -34,12 +34,8 @@ public:
   void DestroyDrm() override;
   bool AddProperty(CDRMObject* object, const char* name, uint64_t value);
 
-  bool DisplayHardwareScalingEnabled();
-
 private:
   void DrmAtomicCommit(int fb_id, int flags, bool rendered, bool videoLayer);
-
-  bool SetScalingFilter(CDRMObject* object, const char* name, const char* type);
 
   bool m_need_modeset;
   bool m_active = true;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR enables the hardware integer scaling support and sets the default to false.

EDIT: After the discussion we've decided to remove the hardware integer scaling support for now.
- the feature is currently broken and seems abandoned by the original author
- it cannot support non-square pixels
- only works on a very small subset of supported platforms

We hope to introduce a new version soon as a replacement.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The integer scaling support was added in 2020 by https://github.com/xbmc/xbmc/pull/18194 and https://github.com/xbmc/xbmc/pull/18567. It was merged and then temporarily disabled by https://github.com/xbmc/xbmc/pull/18491 (commits f7366b572f49a0a606359e9f1cc3b750e52905aa and afe54ef9cc8fb16a81f66996b174511889a1cd3c) until kernel patches are accepted.

Unfortunately, it was not disabled completely. Now, with the kernel support merged and adopted by the LibreELEC, we have reports of issues caused by the not fully disabled parts of this feature:
https://github.com/xbmc/xbmc/issues/26849
https://github.com/xbmc/xbmc/pull/18194#issuecomment-2954074098

Lets re-enable the feature, so users can at least disable it in settings.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
