### PR TITLE
VAAPI: remove obsolete deinterlacing workaround

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -601,7 +601,6 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
     return false;
   }
 
-  m_vaapiConfig.driverIsMesa = StringUtils::StartsWith(vaQueryVendorString(m_vaapiConfig.context->GetDisplay()), "Mesa");
   m_vaapiConfig.vidWidth = avctx->width;
   m_vaapiConfig.vidHeight = avctx->height;
   m_vaapiConfig.outWidth = avctx->width;
@@ -2224,27 +2223,14 @@ void COutput::InitCycle()
     }
     if (!m_pp)
     {
-      const bool preferVaapiRender = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(SETTING_VIDEOPLAYER_PREFERVAAPIRENDER);
-      // For 1080p/i or below, always use CVppPostproc even when not deinterlacing
-      // Reason is: mesa cannot dynamically switch surfaces between use for VAAPI post-processing
-      // and use for direct export, so we run into trouble if we or the user want to switch
-      // deinterlacing on/off mid-stream.
-      // See also: https://bugs.freedesktop.org/show_bug.cgi?id=105145
-      const bool alwaysInsertVpp = m_config.driverIsMesa &&
-                                   ((m_config.vidWidth * m_config.vidHeight) <= (1920 * 1080)) &&
-                                   interlaced;
+      const bool preferVaapiRender = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          SETTING_VIDEOPLAYER_PREFERVAAPIRENDER);
 
       m_config.stats->SetVpp(false);
       if (!preferVaapiRender)
       {
         CLog::Log(LOGDEBUG, LOGVIDEO, "VAAPI output: Initializing ffmpeg postproc");
         m_pp = new CFFmpegPostproc();
-      }
-      else if (alwaysInsertVpp)
-      {
-        CLog::Log(LOGDEBUG, LOGVIDEO, "VAAPI output: Initializing vaapi postproc");
-        m_pp = new CVppPostproc();
-        m_config.stats->SetVpp(true);
       }
       else
       {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -194,8 +194,7 @@ struct CVaapiConfig
   VADisplay dpy;
   VAProfile profile;
   VAConfigAttrib attrib;
-  CProcessInfo *processInfo;
-  bool driverIsMesa;
+  CProcessInfo* processInfo;
   int bitDepth;
   // VA fourcc requested for the surface pool. Carried through to processed
   // pictures so the renderer can pick its sampling path per-fourcc without


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This removes the workaround for AMD radeonsi mesa driver. It is no longer needed as the mesa [issue](https://gitlab.freedesktop.org/mesa/mesa/-/issues/1304) was [fixed](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/32095). I tested the dynamic switching of VAAPI deinterlacing on AMD Oland GPU and it works as expected.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
