### PR TITLE
[VideoDatabase][MusicDatabase][DatabaseUtils] Misc SonarQube findings

### DIFF
--- a/xbmc/InfoScanner.h
+++ b/xbmc/InfoScanner.h
@@ -65,7 +65,7 @@ protected:
   //! \brief Protected constructor to only allow subclass instances.
   CInfoScanner() = default;
 
-  std::set<std::string> m_pathsToScan; //!< Set of paths to scan
+  std::set<std::string, std::less<>> m_pathsToScan; //!< Set of paths to scan
   bool m_showDialog = false; //!< Whether or not to show progress bar dialog
   CGUIDialogProgressBarHandle* m_handle = nullptr; //!< Progress bar handle
   bool m_bRunning = false; //!< Whether or not scanner is running

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -1190,9 +1190,9 @@ const std::string& CLangInfo::GetSpeedUnitString(CSpeed::Unit speedUnit)
   return g_localizeStrings.Get(SPEED_UNIT_STRINGS + speedUnit);
 }
 
-std::set<std::string> CLangInfo::GetSortTokens() const
+CLangInfo::Tokens CLangInfo::GetSortTokens() const
 {
-  std::set<std::string> sortTokens = m_sortTokens;
+  Tokens sortTokens = m_sortTokens;
   for (const auto& t : CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_vecTokens)
     sortTokens.insert(t);
 

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -191,14 +191,14 @@ public:
   void SetCurrentRegion(const std::string& strName);
   const std::string& GetCurrentRegion() const;
 
-  std::set<std::string> GetSortTokens() const;
+  using Tokens = std::set<std::string, std::less<>>;
+  Tokens GetSortTokens() const;
 
   static std::string GetLanguagePath() { return "resource://"; }
   static std::string GetLanguagePath(const std::string &language);
   static std::string GetLanguageInfoPath(const std::string &language);
   bool UseLocaleCollation();
 
-  using Tokens = std::set<std::string, std::less<>>;
   static void LoadTokens(const TiXmlNode* pTokens, Tokens& vecTokens);
 
   static void SettingOptionsLanguageNamesFiller(const std::shared_ptr<const CSetting>& setting,
@@ -315,7 +315,7 @@ protected:
   std::string m_strDVDMenuLanguage;
   std::string m_strDVDAudioLanguage;
   std::string m_strDVDSubtitleLanguage;
-  std::set<std::string> m_sortTokens;
+  Tokens m_sortTokens;
 
   std::string m_shortDateFormat;
   std::string m_longDateFormat;

--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -105,7 +105,7 @@ bool CPartyModeManager::Enable(PartyModeContext context /*= PARTYMODECONTEXT_MUS
     CMusicDatabase db;
     if (db.Open())
     {
-      std::set<std::string> playlists;
+      std::set<std::string, std::less<>> playlists;
       if (playlistLoaded)
       {
         playlist.SetType("songs");
@@ -139,7 +139,7 @@ bool CPartyModeManager::Enable(PartyModeContext context /*= PARTYMODECONTEXT_MUS
     CVideoDatabase db;
     if (db.Open())
     {
-      std::set<std::string> playlists;
+      std::set<std::string, std::less<>> playlists;
       if (playlistLoaded)
       {
         playlist.SetType("musicvideos");

--- a/xbmc/addons/LanguageResource.h
+++ b/xbmc/addons/LanguageResource.h
@@ -36,7 +36,7 @@ public:
   const std::string& GetDvdAudioLanguage() const { return m_dvdLanguageAudio; }
   const std::string& GetDvdSubtitleLanguage() const { return m_dvdLanguageSubtitle; }
 
-  const std::set<std::string>& GetSortTokens() const { return m_sortTokens; }
+  const std::set<std::string, std::less<>>& GetSortTokens() const { return m_sortTokens; }
 
   static std::string GetAddonId(const std::string& locale);
 
@@ -53,7 +53,7 @@ private:
   std::string m_dvdLanguageAudio;
   std::string m_dvdLanguageSubtitle;
 
-  std::set<std::string> m_sortTokens;
+  std::set<std::string, std::less<>> m_sortTokens;
 };
 
 }

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -671,7 +671,7 @@ int CGUIDialogMediaFilter::GetItems(const Filter &filter, std::vector<std::strin
     if (!videodb.Open())
       return -1;
 
-    std::set<std::string> playlists;
+    std::set<std::string, std::less<>> playlists;
     CDatabase::Filter dbfilter;
     dbfilter.where = tmpFilter.GetWhereClause(videodb, playlists);
 
@@ -702,7 +702,7 @@ int CGUIDialogMediaFilter::GetItems(const Filter &filter, std::vector<std::strin
     if (!musicdb.Open())
       return -1;
 
-    std::set<std::string> playlists;
+    std::set<std::string, std::less<>> playlists;
     CDatabase::Filter dbfilter;
     dbfilter.where = tmpFilter.GetWhereClause(musicdb, playlists);
 

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -805,19 +805,19 @@ void CGUIDialogMediaFilter::GetRange(const Filter &filter, int &min, int &interv
       if (m_mediaType == "movies")
       {
         table = "movie_view";
-        year = DatabaseUtils::GetField(FieldYear, MediaTypeMovie, DatabaseQueryPartWhere);
+        year = DatabaseUtils::GetField(FieldYear, MediaTypeMovie, DatabaseQueryPart::WHERE);
       }
       else if (m_mediaType == "tvshows")
       {
         table = "tvshow_view";
         year = StringUtils::Format(
             "strftime(\"%%Y\", {})",
-            DatabaseUtils::GetField(FieldYear, MediaTypeTvShow, DatabaseQueryPartWhere));
+            DatabaseUtils::GetField(FieldYear, MediaTypeTvShow, DatabaseQueryPart::WHERE));
       }
       else if (m_mediaType == "musicvideos")
       {
         table = "musicvideo_view";
-        year = DatabaseUtils::GetField(FieldYear, MediaTypeMusicVideo, DatabaseQueryPartWhere);
+        year = DatabaseUtils::GetField(FieldYear, MediaTypeMusicVideo, DatabaseQueryPart::WHERE);
       }
 
       CDatabase::Filter filter;
@@ -835,8 +835,13 @@ void CGUIDialogMediaFilter::GetRange(const Filter &filter, int &min, int &interv
         return;
 
       CDatabase::Filter filter;
-      filter.where = DatabaseUtils::GetField(FieldYear, CMediaTypes::FromString(m_mediaType), DatabaseQueryPartWhere) + " > 0";
-      GetMinMax(table, DatabaseUtils::GetField(FieldYear, CMediaTypes::FromString(m_mediaType), DatabaseQueryPartSelect), min, max, filter);
+      filter.where = DatabaseUtils::GetField(FieldYear, CMediaTypes::FromString(m_mediaType),
+                                             DatabaseQueryPart::WHERE) +
+                     " > 0";
+      GetMinMax(table,
+                DatabaseUtils::GetField(FieldYear, CMediaTypes::FromString(m_mediaType),
+                                        DatabaseQueryPart::SELECT),
+                min, max, filter);
     }
   }
   else if (filter.field == FieldAirDate)

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeInProgressTvShows.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeInProgressTvShows.cpp
@@ -43,7 +43,7 @@ bool CDirectoryNodeInProgressTvShows::GetContent(CFileItemList& items) const
   int details = items.HasProperty("set_videodb_details")
                     ? items.GetProperty("set_videodb_details").asInteger32()
                     : VideoDbDetailsNone;
-  bool bSuccess = videodatabase.GetInProgressTvShowsNav(BuildPath(), items, 0, details);
+  bool bSuccess = videodatabase.GetInProgressTvShowsNav(BuildPath(), items, details);
 
   videodatabase.Close();
 

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -69,7 +69,7 @@ void CopyVideoTagInfoToObject(CFileItem& item, CVariant& object)
         path = videoInfoTagPath;
       else
         path = item.GetPath();
-      if (videodatabase.LoadVideoInfo(path, tag, VideoDbDetailsNone))
+      if (videodatabase.LoadVideoInfo(path, tag))
         id = tag.GetDatabaseId();
 
       videodatabase.Close();

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -58,7 +58,7 @@ static int CleanLibrary(const std::vector<std::string>& params)
         if (!content.empty() || !directory.empty())
         {
           CVideoDatabase db;
-          std::set<std::string> contentPaths;
+          std::set<std::string, std::less<>> contentPaths;
           if (db.Open())
           {
             if (!directory.empty())

--- a/xbmc/interfaces/json-rpc/ApplicationOperations.cpp
+++ b/xbmc/interfaces/json-rpc/ApplicationOperations.cpp
@@ -152,7 +152,7 @@ JSONRPC_STATUS CApplicationOperations::GetPropertyValue(const std::string &prope
   else if (property == "sorttokens")
   {
     result = CVariant(CVariant::VariantTypeArray); // Ensure no tokens returns as []
-    std::set<std::string> sortTokens = g_langInfo.GetSortTokens();
+    const CLangInfo::Tokens sortTokens = g_langInfo.GetSortTokens();
     for (const auto& token : sortTokens)
       result.append(token);
   }

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -154,7 +154,7 @@ JSONRPC_STATUS CAudioLibrary::GetArtists(const std::string &method, ITransportLa
     return InvalidParams;
 
   int total;
-  std::set<std::string> fields;
+  std::set<std::string, std::less<>> fields;
   if (parameterObject.isMember("properties") && parameterObject["properties"].isArray())
   {
     for (CVariant::const_iterator_array field = parameterObject["properties"].begin_array();
@@ -255,7 +255,7 @@ JSONRPC_STATUS CAudioLibrary::GetAlbums(const std::string &method, ITransportLay
     return InvalidParams;
 
   int total;
-  std::set<std::string> fields;
+  std::set<std::string, std::less<>> fields;
   if (parameterObject.isMember("properties") && parameterObject["properties"].isArray())
   {
     for (CVariant::const_iterator_array field = parameterObject["properties"].begin_array();
@@ -405,7 +405,7 @@ JSONRPC_STATUS CAudioLibrary::GetSongs(const std::string &method, ITransportLaye
     return InvalidParams;
 
   int total;
-  std::set<std::string> fields;
+  std::set<std::string, std::less<>> fields;
   if (parameterObject.isMember("properties") && parameterObject["properties"].isArray())
   {
     for (CVariant::const_iterator_array field = parameterObject["properties"].begin_array();
@@ -796,7 +796,7 @@ JSONRPC_STATUS CAudioLibrary::SetArtistDetails(const std::string &method, ITrans
     // Get current artwork
     musicdatabase.GetArtForItem(artist.idArtist, MediaTypeArtist, artist.art);
 
-    std::set<std::string> removedArtwork;
+    std::set<std::string, std::less<>> removedArtwork;
     CVariant art = parameterObject["art"];
     for (CVariant::const_iterator_map artIt = art.begin_map(); artIt != art.end_map(); ++artIt)
     {
@@ -902,7 +902,7 @@ JSONRPC_STATUS CAudioLibrary::SetAlbumDetails(const std::string &method, ITransp
     // Get current artwork
     musicdatabase.GetArtForItem(album.idAlbum, MediaTypeAlbum, album.art);
 
-    std::set<std::string> removedArtwork;
+    std::set<std::string, std::less<>> removedArtwork;
     CVariant art = parameterObject["art"];
     for (CVariant::const_iterator_map artIt = art.begin_map(); artIt != art.end_map(); ++artIt)
     {
@@ -1008,7 +1008,7 @@ JSONRPC_STATUS CAudioLibrary::SetSongDetails(const std::string &method, ITranspo
     KODI::ART::Artwork artwork;
     musicdatabase.GetArtForItem(song.idSong, MediaTypeSong, artwork);
 
-    std::set<std::string> removedArtwork;
+    std::set<std::string, std::less<>> removedArtwork;
     CVariant art = parameterObject["art"];
     for (CVariant::const_iterator_map artIt = art.begin_map(); artIt != art.end_map(); ++artIt)
     {

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -620,8 +620,8 @@ JSONRPC_STATUS CVideoLibrary::SetMovieDetails(const std::string &method, ITransp
   int playcount = infos.GetPlayCount();
   CDateTime lastPlayed = infos.m_lastPlayed;
 
-  std::set<std::string> removedArtwork;
-  std::set<std::string> updatedDetails;
+  std::set<std::string, std::less<>> removedArtwork;
+  std::set<std::string, std::less<>> updatedDetails;
   UpdateVideoTag(parameterObject, infos, artwork, removedArtwork, updatedDetails);
 
   if (videodatabase.UpdateDetailsForMovie(id, infos, artwork, updatedDetails) <= 0)
@@ -664,8 +664,8 @@ JSONRPC_STATUS CVideoLibrary::SetMovieSetDetails(const std::string &method, ITra
   KODI::ART::Artwork artwork;
   videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
 
-  std::set<std::string> removedArtwork;
-  std::set<std::string> updatedDetails;
+  std::set<std::string, std::less<>> removedArtwork;
+  std::set<std::string, std::less<>> updatedDetails;
   UpdateVideoTag(parameterObject, infos, artwork, removedArtwork, updatedDetails);
 
   if (videodatabase.SetDetailsForMovieSet(infos, artwork, id) <= 0)
@@ -697,8 +697,8 @@ JSONRPC_STATUS CVideoLibrary::SetTVShowDetails(const std::string &method, ITrans
   KODI::ART::SeasonsArtwork seasonArt;
   videodatabase.GetTvShowSeasonArt(infos.m_iDbId, seasonArt);
 
-  std::set<std::string> removedArtwork;
-  std::set<std::string> updatedDetails;
+  std::set<std::string, std::less<>> removedArtwork;
+  std::set<std::string, std::less<>> updatedDetails;
   UpdateVideoTag(parameterObject, infos, artwork, removedArtwork, updatedDetails);
 
   // we need to manually remove tags/taglinks for now because they aren't replaced
@@ -735,8 +735,8 @@ JSONRPC_STATUS CVideoLibrary::SetSeasonDetails(const std::string &method, ITrans
   KODI::ART::Artwork artwork;
   videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
 
-  std::set<std::string> removedArtwork;
-  std::set<std::string> updatedDetails;
+  std::set<std::string, std::less<>> removedArtwork;
+  std::set<std::string, std::less<>> updatedDetails;
   UpdateVideoTag(parameterObject, infos, artwork, removedArtwork, updatedDetails);
   if (ParameterNotNull(parameterObject, "title"))
     infos.SetSortTitle(parameterObject["title"].asString());
@@ -781,8 +781,8 @@ JSONRPC_STATUS CVideoLibrary::SetEpisodeDetails(const std::string &method, ITran
   int playcount = infos.GetPlayCount();
   CDateTime lastPlayed = infos.m_lastPlayed;
 
-  std::set<std::string> removedArtwork;
-  std::set<std::string> updatedDetails;
+  std::set<std::string, std::less<>> removedArtwork;
+  std::set<std::string, std::less<>> updatedDetails;
   UpdateVideoTag(parameterObject, infos, artwork, removedArtwork, updatedDetails);
 
   if (videodatabase.SetDetailsForEpisode(infos, artwork, tvshowid, id) <= 0)
@@ -828,8 +828,8 @@ JSONRPC_STATUS CVideoLibrary::SetMusicVideoDetails(const std::string &method, IT
   int playcount = infos.GetPlayCount();
   CDateTime lastPlayed = infos.m_lastPlayed;
 
-  std::set<std::string> removedArtwork;
-  std::set<std::string> updatedDetails;
+  std::set<std::string, std::less<>> removedArtwork;
+  std::set<std::string, std::less<>> updatedDetails;
   UpdateVideoTag(parameterObject, infos, artwork, removedArtwork, updatedDetails);
 
   // we need to manually remove tags/taglinks for now because they aren't replaced
@@ -1199,7 +1199,10 @@ void CVideoLibrary::UpdateResumePoint(const CVariant &parameterObject, CVideoInf
   }
 }
 
-void CVideoLibrary::UpdateVideoTagField(const CVariant& parameterObject, const std::string& fieldName, std::vector<std::string>& fieldValue, std::set<std::string>& updatedDetails)
+void CVideoLibrary::UpdateVideoTagField(const CVariant& parameterObject,
+                                        const std::string& fieldName,
+                                        std::vector<std::string>& fieldValue,
+                                        std::set<std::string, std::less<>>& updatedDetails)
 {
   if (ParameterNotNull(parameterObject, fieldName))
   {
@@ -1211,8 +1214,8 @@ void CVideoLibrary::UpdateVideoTagField(const CVariant& parameterObject, const s
 void CVideoLibrary::UpdateVideoTag(const CVariant& parameterObject,
                                    CVideoInfoTag& details,
                                    KODI::ART::Artwork& artwork,
-                                   std::set<std::string>& removedArtwork,
-                                   std::set<std::string>& updatedDetails)
+                                   std::set<std::string, std::less<>>& removedArtwork,
+                                   std::set<std::string, std::less<>>& updatedDetails)
 {
   if (ParameterNotNull(parameterObject, "title"))
     details.SetTitle(parameterObject["title"].asString());

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -432,7 +432,9 @@ JSONRPC_STATUS CVideoLibrary::GetInProgressTVShows(const std::string &method, IT
     return InternalError;
 
   CFileItemList items;
-  if (!videodatabase.GetInProgressTvShowsNav("videodb://inprogresstvshows/", items, 0, RequiresAdditionalDetails(MediaTypeTvShow, parameterObject)))
+  if (!videodatabase.GetInProgressTvShowsNav(
+          "videodb://inprogresstvshows/", items,
+          RequiresAdditionalDetails(MediaTypeTvShow, parameterObject)))
     return InternalError;
 
   return HandleItems("tvshowid", "tvshows", items, parameterObject, result, false);

--- a/xbmc/interfaces/json-rpc/VideoLibrary.h
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.h
@@ -93,8 +93,11 @@ namespace JSONRPC
     static void UpdateVideoTag(const CVariant& parameterObject,
                                CVideoInfoTag& details,
                                KODI::ART::Artwork& artwork,
-                               std::set<std::string>& removedArtwork,
-                               std::set<std::string>& updatedDetails);
-    static void UpdateVideoTagField(const CVariant& parameterObject, const std::string& fieldName, std::vector<std::string>& fieldValue, std::set<std::string>& updatedDetails);
+                               std::set<std::string, std::less<>>& removedArtwork,
+                               std::set<std::string, std::less<>>& updatedDetails);
+    static void UpdateVideoTagField(const CVariant& parameterObject,
+                                    const std::string& fieldName,
+                                    std::vector<std::string>& fieldValue,
+                                    std::set<std::string, std::less<>>& updatedDetails);
   };
 }

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -13323,7 +13323,7 @@ bool CMusicDatabase::GetFilter(CDbUrl& musicUrl, Filter& filter, SortDescription
     if (!xsp.LoadFromJson(option->second.asString()))
       return false;
 
-    std::set<std::string> playlists;
+    std::set<std::string, std::less<>> playlists;
     std::string xspWhere;
     xspWhere = xsp.GetWhereClause(*this, playlists);
     hasRoleRules = xsp.GetType() == "artists" &&
@@ -13909,7 +13909,7 @@ bool CMusicDatabase::GetFilter(CDbUrl& musicUrl, Filter& filter, SortDescription
     // check if the filter playlist matches the item type
     if (xspFilter.GetType() == type)
     {
-      std::set<std::string> playlists;
+      std::set<std::string, std::less<>> playlists;
       filter.AppendWhere(xspFilter.GetWhereClause(*this, playlists));
     }
     // remove the filter if it doesn't match the item type

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -65,7 +65,13 @@
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
+#include <array>
+#include <chrono>
 #include <inttypes.h>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 using namespace KODI;
 using namespace XFILE;
@@ -76,15 +82,17 @@ using namespace MUSIC_INFO;
 using ADDON::AddonPtr;
 using KODI::MESSAGING::HELPERS::DialogResponse;
 
-#define RECENTLY_PLAYED_LIMIT 25
-#define MIN_FULL_SEARCH_LENGTH 3
-
 #ifdef HAS_OPTICAL_DRIVE
 using namespace CDDB;
 using namespace MEDIA_DETECT;
 #endif
 
-static void AnnounceRemove(const std::string& content, int id)
+namespace
+{
+constexpr unsigned int RECENTLY_PLAYED_LIMIT = 25;
+constexpr size_t MIN_FULL_SEARCH_LENGTH = 3;
+
+void AnnounceRemove(const std::string& content, int id)
 {
   CVariant data;
   data["type"] = content;
@@ -94,7 +102,7 @@ static void AnnounceRemove(const std::string& content, int id)
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "OnRemove", data);
 }
 
-static void AnnounceUpdate(const std::string& content, int id, bool added = false)
+void AnnounceUpdate(const std::string& content, int id, bool added = false)
 {
   CVariant data;
   data["type"] = content;
@@ -105,13 +113,11 @@ static void AnnounceUpdate(const std::string& content, int id, bool added = fals
     data["added"] = true;
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "OnUpdate", data);
 }
+} // unnamed namespace
 
-CMusicDatabase::CMusicDatabase(void)
-{
-  m_translateBlankArtist = true;
-}
+CMusicDatabase::CMusicDatabase() = default;
 
-CMusicDatabase::~CMusicDatabase(void)
+CMusicDatabase::~CMusicDatabase()
 {
   EmptyCache();
 }
@@ -249,7 +255,7 @@ void CMusicDatabase::CreateTables()
 
 void CMusicDatabase::CreateAnalytics()
 {
-  CLog::Log(LOGINFO, "{} - creating indices", __FUNCTION__);
+  CLog::Log(LOGINFO, "creating indices");
   m_pDS->exec("CREATE INDEX idxAlbum ON album(strAlbum(255))");
   m_pDS->exec("CREATE INDEX idxAlbum_1 ON album(bCompilation)");
   m_pDS->exec("CREATE UNIQUE INDEX idxAlbum_2 ON album(strMusicBrainzAlbumID(36))");
@@ -324,7 +330,7 @@ void CMusicDatabase::CreateAnalytics()
      the trigger (to avoid recursion), but can set NEW column values before insert or update.
      Meanwhile SQLite triggers cannot set NEW column values in that way, but can update same table.
      Recursion avoided using WHEN but SQLite has PRAGMA recursive-triggers off by default anyway.
-    // ! @todo: once on SQLite v3.31 we could use a generated column for dateModified as real
+     @todo: once on SQLite v3.31 we could use a generated column for dateModified as real
   */
   bool bisMySQL = StringUtils::EqualsNoCase(
       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_databaseMusic.type, "mysql");
@@ -701,7 +707,7 @@ void CMusicDatabase::CreateNativeDBFunctions()
 
 void CMusicDatabase::SplitPath(const std::string& strFileNameAndPath,
                                std::string& strPath,
-                               std::string& strFileName)
+                               std::string& strFileName) const
 {
   URIUtils::Split(strFileNameAndPath, strPath, strFileName);
   // Keep protocol options as part of the path
@@ -816,8 +822,8 @@ bool CMusicDatabase::AddAlbum(CAlbum& album, int idSource)
     AddAlbumSources(album.idAlbum, album.strPath);
   }
 
-  for (const auto& albumArt : album.art)
-    SetArtForItem(album.idAlbum, MediaTypeAlbum, albumArt.first, albumArt.second);
+  for (const auto& [type, url] : album.art)
+    SetArtForItem(album.idAlbum, MediaTypeAlbum, type, url);
 
   // Set album disc total
   m_pDS->exec(
@@ -888,8 +894,7 @@ bool CMusicDatabase::UpdateAlbum(CAlbum& album)
       if (numDiscs >= 2)
       {
         canBeBoxset = true;
-        int discValue;
-        for (discValue = 1; discValue <= numDiscs; discValue++)
+        for (int discValue = 1; discValue <= numDiscs; discValue++)
         {
           strSQL =
               PrepareSQL("SELECT DISTINCT strDiscSubtitle FROM song WHERE song.idAlbum = %i AND "
@@ -909,8 +914,8 @@ bool CMusicDatabase::UpdateAlbum(CAlbum& album)
       }
       if (!canBeBoxset && album.bBoxedSet)
       {
-        CLog::Log(LOGINFO, "{} : Album with id [{}] does not meet the requirements for a boxset.",
-                  __FUNCTION__, album.idAlbum);
+        CLog::Log(LOGINFO, "Album with id [{}] does not meet the requirements for a boxset.",
+                  album.idAlbum);
         album.bBoxedSet = false;
       }
     }
@@ -982,7 +987,7 @@ bool CMusicDatabase::UpdateAlbum(CAlbum& album)
   return true;
 }
 
-void CMusicDatabase::NormaliseSongDates(std::string& strRelease, std::string& strOriginal)
+void CMusicDatabase::NormaliseSongDates(std::string& strRelease, std::string& strOriginal) const
 {
   // Validate we have ISO8601 format date strings YYYY, YYYY-MM, or YYYY-MM-DD
   int iDate;
@@ -1043,7 +1048,8 @@ int CMusicDatabase::AddSong(const int idSong,
     if (nullptr == m_pDS)
       return -1;
 
-    std::string strPath, strFileName;
+    std::string strPath;
+    std::string strFileName;
     SplitPath(strPathAndFileName, strPath, strFileName);
     int idPath = AddPath(strPath);
 
@@ -1127,7 +1133,7 @@ int CMusicDatabase::AddSong(const int idSong,
                              strComment.c_str(), strMood.c_str(), replayGain.Get().c_str());
       m_pDS->exec(strSQL);
       if (idSong <= 0)
-        idNew = (int)m_pDS->lastinsertid();
+        idNew = static_cast<int>(m_pDS->lastinsertid());
       else
         idNew = idSong;
     }
@@ -1219,7 +1225,7 @@ bool CMusicDatabase::GetSong(int idSong, CSong& song)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idSong);
+    CLog::LogF(LOGERROR, "({}) failed", idSong);
   }
 
   return false;
@@ -1287,7 +1293,7 @@ int CMusicDatabase::UpdateSong(int idSong,
                                const std::string& strPathAndFileName,
                                const std::string& strComment,
                                const std::string& strMood,
-                               const std::string& strThumb,
+                               const std::string& /*strThumb*/, //! @todo implement or remove.
                                const std::string& artistDisp,
                                const std::string& artistSort,
                                const std::vector<std::string>& genres,
@@ -1314,7 +1320,8 @@ int CMusicDatabase::UpdateSong(int idSong,
     return -1;
 
   std::string strSQL;
-  std::string strPath, strFileName;
+  std::string strPath;
+  std::string strFileName;
   SplitPath(strPathAndFileName, strPath, strFileName);
   int idPath = AddPath(strPath);
 
@@ -1437,7 +1444,7 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum,
       strSQL += ")";
       m_pDS->exec(strSQL);
 
-      return (int)m_pDS->lastinsertid();
+      return static_cast<int>(m_pDS->lastinsertid());
     }
     else
     {
@@ -1484,7 +1491,7 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed with query ({})", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "failed with query ({})", strSQL);
   }
 
   return -1;
@@ -1662,7 +1669,7 @@ bool CMusicDatabase::GetAlbum(int idAlbum, CAlbum& album, bool getSongs /* = tru
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idAlbum);
+    CLog::LogF(LOGERROR, "({}) failed", idAlbum);
   }
 
   return false;
@@ -1675,7 +1682,7 @@ bool CMusicDatabase::ClearAlbumLastScrapedTime(int idAlbum)
   return ExecuteQuery(strSQL);
 }
 
-bool CMusicDatabase::HasAlbumBeenScraped(int idAlbum)
+bool CMusicDatabase::HasAlbumBeenScraped(int idAlbum) const
 {
   std::string strSQL =
       PrepareSQL("SELECT idAlbum FROM album WHERE idAlbum = %i AND lastScraped IS NULL", idAlbum);
@@ -1713,15 +1720,15 @@ int CMusicDatabase::AddGenre(std::string& strGenre)
                           strGenre.c_str());
       m_pDS->exec(strSQL);
 
-      int idGenre = (int)m_pDS->lastinsertid();
-      m_genreCache.insert(std::pair<std::string, int>(strGenre, idGenre));
+      const int idGenre = static_cast<int>(m_pDS->lastinsertid());
+      m_genreCache.try_emplace(strGenre, idGenre);
       return idGenre;
     }
     else
     {
       int idGenre = m_pDS->fv("idGenre").get_asInt();
       strGenre = m_pDS->fv("strGenre").get_asString();
-      m_genreCache.insert(std::pair<std::string, int>(strGenre, idGenre));
+      m_genreCache.try_emplace(strGenre, idGenre);
       m_pDS->close();
       return idGenre;
     }
@@ -1758,7 +1765,7 @@ bool CMusicDatabase::UpdateArtist(const CArtist& artist)
                artist.strBiography, //
                artist.strDied, //
                artist.strDisbanded, //
-               StringUtils::Join(artist.yearsActive, itemSeparator).c_str(), //
+               StringUtils::Join(artist.yearsActive, itemSeparator), //
                artist.thumbURL.GetData());
 
   DeleteArtistDiscography(artist.idArtist);
@@ -1808,9 +1815,8 @@ int CMusicDatabase::AddArtist(const std::string& strArtist,
       m_pDS->close();
       return -1;
     }
-    std::string strArtistName, strArtistSort;
-    strArtistName = m_pDS->fv("strArtist").get_asString();
-    strArtistSort = m_pDS->fv("strSortName").get_asString();
+    const std::string strArtistName{m_pDS->fv("strArtist").get_asString()};
+    const std::string strArtistSort{m_pDS->fv("strSortName").get_asString()};
     m_pDS->close();
 
     if (!strArtistSort.empty())
@@ -1923,8 +1929,7 @@ int CMusicDatabase::AddArtist(const std::string& strArtist,
                           strArtist.c_str(), strMusicBrainzArtistID.c_str(), bScrapedMBID);
 
     m_pDS->exec(strSQL);
-    int idArtist = (int)m_pDS->lastinsertid();
-    return idArtist;
+    return static_cast<int>(m_pDS->lastinsertid());
   }
   catch (...)
   {
@@ -1964,8 +1969,8 @@ int CMusicDatabase::UpdateArtist(int idArtist,
   int idArtistMbid = GetArtistFromMBID(strMusicBrainzArtistID, artistname);
   if (idArtistMbid > 0 && idArtistMbid != idArtist)
   {
-    CLog::Log(LOGDEBUG, "{0}: Updating {4} (Id: {5}) mbid {1} already assigned to {2} (Id: {3})",
-              __FUNCTION__, strMusicBrainzArtistID, artistname, idArtistMbid, strArtist, idArtist);
+    CLog::LogF(LOGDEBUG, "Updating {} (Id: {}) mbid {} already assigned to {} (Id: {})", strArtist,
+               idArtist, strMusicBrainzArtistID, artistname, idArtistMbid);
     useMBIDNull = true;
     isScrapedMBID = false;
   }
@@ -2024,8 +2029,8 @@ bool CMusicDatabase::UpdateArtistScrapedMBID(int idArtist,
   int idArtistMbid = GetArtistFromMBID(strMusicBrainzArtistID, artistname);
   if (idArtistMbid > 0 && idArtistMbid != idArtist)
   {
-    CLog::Log(LOGDEBUG, "{0}: Artist mbid {1} already assigned to {2} (Id: {3})", __FUNCTION__,
-              strMusicBrainzArtistID, artistname, idArtistMbid);
+    CLog::LogF(LOGDEBUG, "Artist mbid {} already assigned to {} (Id: {})", strMusicBrainzArtistID,
+               artistname, idArtistMbid);
     return false;
   }
 
@@ -2129,7 +2134,7 @@ bool CMusicDatabase::GetArtist(int idArtist, CArtist& artist, bool fetchAll /* =
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idArtist);
+    CLog::LogF(LOGERROR, "({}) failed", idArtist);
   }
 
   return false;
@@ -2159,20 +2164,20 @@ bool CMusicDatabase::GetArtistExists(int idArtist)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idArtist);
+    CLog::LogF(LOGERROR, "({}) failed", idArtist);
   }
 
   return false;
 }
 
-int CMusicDatabase::GetLastArtist()
+int CMusicDatabase::GetLastArtist() const
 {
   std::string strSQL = "SELECT MAX(idArtist) FROM artist";
   std::string lastArtist = GetSingleValue(strSQL);
   if (lastArtist.empty())
     return -1;
 
-  return static_cast<int>(strtol(lastArtist.c_str(), NULL, 10));
+  return static_cast<int>(std::strtol(lastArtist.c_str(), nullptr, 10));
 }
 
 int CMusicDatabase::GetArtistFromMBID(const std::string& strMusicBrainzArtistID,
@@ -2203,12 +2208,12 @@ int CMusicDatabase::GetArtistFromMBID(const std::string& strMusicBrainzArtistID,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "CMusicDatabase::{0} - failed to execute {1}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "failed to execute {}", strSQL);
   }
   return -1;
 }
 
-bool CMusicDatabase::HasArtistBeenScraped(int idArtist)
+bool CMusicDatabase::HasArtistBeenScraped(int idArtist) const
 {
   std::string strSQL = PrepareSQL(
       "SELECT idArtist FROM artist WHERE idArtist = %i AND lastScraped IS NULL", idArtist);
@@ -2418,10 +2423,10 @@ bool CMusicDatabase::GetArtistDiscography(int idArtist, CFileItemList& items)
       std::string strAlbum = m_pDS->fv("strAlbum").get_asString();
       if (!strAlbum.empty())
       {
-        CFileItemPtr pItem(new CFileItem(strAlbum));
+        auto pItem{std::make_shared<CFileItem>(strAlbum)};
         pItem->SetLabel2(m_pDS->fv("strYear").get_asString());
         pItem->GetMusicInfoTag()->SetDatabaseId(idAlbum, MediaTypeAlbum);
-        items.Add(pItem);
+        items.Add(std::move(pItem));
       }
       m_pDS->next();
     }
@@ -2437,7 +2442,7 @@ bool CMusicDatabase::GetArtistDiscography(int idArtist, CFileItemList& items)
   {
     m_pDS->exec("DROP TABLE tempDisco");
     m_pDS->exec("DROP TABLE tempAlbum");
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -2551,13 +2556,10 @@ void CMusicDatabase::AddSongContributors(int idSong,
   {
     std::string strSortName;
     //Identify composer sort name if we have it
-    if (countComposer < composerSort.size())
+    if (countComposer < composerSort.size() && credit.GetRoleDesc().compare("Composer") == 0)
     {
-      if (credit.GetRoleDesc().compare("Composer") == 0)
-      {
-        strSortName = composerSort[countComposer];
-        countComposer++;
-      }
+      strSortName = composerSort[countComposer];
+      countComposer++;
     }
     AddSongContributor(idSong, credit.GetRoleDesc(), credit.GetArtist(), strSortName);
   }
@@ -2587,7 +2589,7 @@ int CMusicDatabase::GetRoleByName(const std::string& strRole)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return -1;
 }
@@ -2626,7 +2628,7 @@ bool CMusicDatabase::GetRolesByArtist(int idArtist, CFileItem* item)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idArtist);
+    CLog::LogF(LOGERROR, "({}) failed", idArtist);
   }
   return false;
 }
@@ -2688,7 +2690,7 @@ bool CMusicDatabase::AddSongGenres(int idSong, const std::vector<std::string>& g
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) {} failed", __FUNCTION__, idSong, strSQL);
+    CLog::LogF(LOGERROR, "({}) {} failed", idSong, strSQL);
   }
   return false;
 }
@@ -2717,7 +2719,7 @@ bool CMusicDatabase::GetAlbumsByArtist(int idArtist, std::vector<int>& albums)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idArtist);
+    CLog::LogF(LOGERROR, "({}) failed", idArtist);
   }
   return false;
 }
@@ -2767,7 +2769,7 @@ bool CMusicDatabase::GetArtistsByAlbum(int idAlbum, CFileItem* item)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idAlbum);
+    CLog::LogF(LOGERROR, "({}) failed", idAlbum);
   }
   return false;
 }
@@ -2804,7 +2806,7 @@ bool CMusicDatabase::GetArtistsByAlbum(int idAlbum, std::vector<std::string>& ar
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idAlbum);
+    CLog::LogF(LOGERROR, "({}) failed", idAlbum);
   }
   return false;
 };
@@ -2835,7 +2837,7 @@ bool CMusicDatabase::GetSongsByArtist(int idArtist, std::vector<int>& songs)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idArtist);
+    CLog::LogF(LOGERROR, "({}) failed", idArtist);
   }
   return false;
 };
@@ -2866,7 +2868,7 @@ bool CMusicDatabase::GetArtistsBySong(int idSong, std::vector<int>& artists)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idSong);
+    CLog::LogF(LOGERROR, "({}) failed", idSong);
   }
   return false;
 }
@@ -2925,7 +2927,7 @@ bool CMusicDatabase::GetGenresByArtist(int idArtist, CFileItem* item)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idArtist);
+    CLog::LogF(LOGERROR, "({}) failed", idArtist);
   }
   return false;
 }
@@ -2967,7 +2969,7 @@ bool CMusicDatabase::GetGenresByAlbum(int idAlbum, CFileItem* item)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idAlbum);
+    CLog::LogF(LOGERROR, "({}) failed", idAlbum);
   }
   return false;
 }
@@ -2998,12 +3000,12 @@ bool CMusicDatabase::GetGenresBySong(int idSong, std::vector<int>& genres)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idSong);
+    CLog::LogF(LOGERROR, "({}) failed", idSong);
   }
   return false;
 }
 
-bool CMusicDatabase::GetIsAlbumArtist(int idArtist, CFileItem* item)
+bool CMusicDatabase::GetIsAlbumArtist(int idArtist, CFileItem* item) const
 {
   try
   {
@@ -3016,7 +3018,7 @@ bool CMusicDatabase::GetIsAlbumArtist(int idArtist, CFileItem* item)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idArtist);
+    CLog::LogF(LOGERROR, "({}) failed", idArtist);
   }
   return false;
 }
@@ -3051,14 +3053,14 @@ int CMusicDatabase::AddPath(const std::string& strPath1)
                           strPath.c_str());
       m_pDS->exec(strSQL);
 
-      int idPath = (int)m_pDS->lastinsertid();
-      m_pathCache.insert(std::pair<std::string, int>(strPath, idPath));
+      const auto idPath = static_cast<int>(m_pDS->lastinsertid());
+      m_pathCache.try_emplace(strPath, idPath);
       return idPath;
     }
     else
     {
       int idPath = m_pDS->fv("idPath").get_asInt();
-      m_pathCache.insert(std::pair<std::string, int>(strPath, idPath));
+      m_pathCache.try_emplace(strPath, idPath);
       m_pDS->close();
       return idPath;
     }
@@ -3077,7 +3079,7 @@ CSong CMusicDatabase::GetSongFromDataset()
 }
 
 CSong CMusicDatabase::GetSongFromDataset(const dbiplus::sql_record* const record,
-                                         int offset /* = 0 */)
+                                         int offset /* = 0 */) const
 {
   CSong song;
   song.idSong = record->at(offset + song_idSong).get_asInt();
@@ -3133,7 +3135,7 @@ void CMusicDatabase::GetFileItemFromDataset(CFileItem* item, const CMusicDbUrl& 
 
 void CMusicDatabase::GetFileItemFromDataset(const dbiplus::sql_record* const record,
                                             CFileItem* item,
-                                            const CMusicDbUrl& baseUrl)
+                                            const CMusicDbUrl& baseUrl) const
 {
   // get the artist string from songview (not the song_artist and artist tables)
   item->GetMusicInfoTag()->SetArtistDesc(record->at(song_strArtists).get_asString());
@@ -3203,7 +3205,8 @@ void CMusicDatabase::GetFileItemFromDataset(const dbiplus::sql_record* const rec
   }
 }
 
-void CMusicDatabase::GetFileItemFromArtistCredits(VECARTISTCREDITS& artistCredits, CFileItem* item)
+void CMusicDatabase::GetFileItemFromArtistCredits(VECARTISTCREDITS& artistCredits,
+                                                  CFileItem* item) const
 {
   // Populate fileitem with artists from vector of artist credits
   std::vector<std::string> musicBrainzID;
@@ -3213,7 +3216,7 @@ void CMusicDatabase::GetFileItemFromArtistCredits(VECARTISTCREDITS& artistCredit
   // When "missing tag" artist, it is the only artist when present.
   if (artistCredits.begin()->GetArtistId() == BLANKARTIST_ID)
   {
-    artistidObj.push_back((int)BLANKARTIST_ID);
+    artistidObj.push_back(BLANKARTIST_ID);
     songartists.push_back(StringUtils::Empty);
   }
   else
@@ -3242,7 +3245,7 @@ CAlbum CMusicDatabase::GetAlbumFromDataset(dbiplus::Dataset* pDS,
 
 CAlbum CMusicDatabase::GetAlbumFromDataset(const dbiplus::sql_record* const record,
                                            int offset /* = 0 */,
-                                           bool imageURL /* = false*/)
+                                           bool imageURL /* = false*/) const
 {
   const std::string itemSeparator =
       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator;
@@ -3291,7 +3294,7 @@ CAlbum CMusicDatabase::GetAlbumFromDataset(const dbiplus::sql_record* const reco
 }
 
 CArtistCredit CMusicDatabase::GetArtistCreditFromDataset(const dbiplus::sql_record* const record,
-                                                         int offset /* = 0 */)
+                                                         int offset /* = 0 */) const
 {
   CArtistCredit artistCredit;
   artistCredit.idArtist = record->at(offset + artistCredit_idArtist).get_asInt();
@@ -3307,7 +3310,7 @@ CArtistCredit CMusicDatabase::GetArtistCreditFromDataset(const dbiplus::sql_reco
 }
 
 CMusicRole CMusicDatabase::GetArtistRoleFromDataset(const dbiplus::sql_record* const record,
-                                                    int offset /* = 0 */)
+                                                    int offset /* = 0 */) const
 {
   CMusicRole ArtistRole(record->at(offset + artistCredit_idRole).get_asInt(),
                         record->at(offset + artistCredit_strRole).get_asString(),
@@ -3325,7 +3328,7 @@ CArtist CMusicDatabase::GetArtistFromDataset(dbiplus::Dataset* pDS,
 
 CArtist CMusicDatabase::GetArtistFromDataset(const dbiplus::sql_record* const record,
                                              int offset /* = 0 */,
-                                             bool needThumb /* = true */)
+                                             bool needThumb /* = true */) const
 {
   const std::string itemSeparator =
       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator;
@@ -3389,7 +3392,8 @@ bool CMusicDatabase::GetSongByFileName(const std::string& strFileNameAndPath,
   if (nullptr == m_pDS)
     return false;
 
-  std::string strPath, strFileName;
+  std::string strPath;
+  std::string strFileName;
   SplitPath(strFileNameAndPath, strPath, strFileName);
   URIUtils::AddSlashAtEnd(strPath);
 
@@ -3434,7 +3438,7 @@ int CMusicDatabase::GetAlbumIdByPath(const std::string& strPath)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, strPath);
+    CLog::LogF(LOGERROR, "({}) failed", strPath);
   }
 
   return -1;
@@ -3465,7 +3469,7 @@ int CMusicDatabase::GetSongByArtistAndAlbumAndTitle(const std::string& strArtist
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({},{},{}) failed", __FUNCTION__, strArtist, strAlbum, strTitle);
+    CLog::LogF(LOGERROR, "({},{},{}) failed", strArtist, strAlbum, strTitle);
   }
 
   return -1;
@@ -3504,14 +3508,14 @@ bool CMusicDatabase::SearchArtists(const std::string& search, CFileItemList& art
     while (!m_pDS->eof())
     {
       std::string path = StringUtils::Format("musicdb://artists/{}/", m_pDS->fv(0).get_asInt());
-      CFileItemPtr pItem(new CFileItem(path, true));
+      auto pItem{std::make_shared<CFileItem>(path, true)};
       std::string label = StringUtils::Format("[{}] {}", artistLabel, m_pDS->fv(1).get_asString());
       pItem->SetLabel(label);
       // sort label is stored in the title tag
       label = StringUtils::Format("A {}", m_pDS->fv(1).get_asString());
       pItem->GetMusicInfoTag()->SetTitle(label);
       pItem->GetMusicInfoTag()->SetDatabaseId(m_pDS->fv(0).get_asInt(), MediaTypeArtist);
-      artists.Add(pItem);
+      artists.Add(std::move(pItem));
       m_pDS->next();
     }
 
@@ -3520,7 +3524,7 @@ bool CMusicDatabase::SearchArtists(const std::string& search, CFileItemList& art
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
 
   return false;
@@ -3544,7 +3548,7 @@ bool CMusicDatabase::GetTop100(const std::string& strBaseDir, CFileItemList& ite
                          "ORDER BY iTimesPlayed DESC "
                          "LIMIT 100";
 
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     if (!m_pDS->query(strSQL))
       return false;
     int iRowsFound = m_pDS->num_rows();
@@ -3556,9 +3560,9 @@ bool CMusicDatabase::GetTop100(const std::string& strBaseDir, CFileItemList& ite
     items.Reserve(iRowsFound);
     while (!m_pDS->eof())
     {
-      CFileItemPtr item(new CFileItem);
+      auto item{std::make_shared<CFileItem>()};
       GetFileItemFromDataset(item.get(), baseUrl);
-      items.Add(item);
+      items.Add(std::move(item));
       m_pDS->next();
     }
 
@@ -3567,7 +3571,7 @@ bool CMusicDatabase::GetTop100(const std::string& strBaseDir, CFileItemList& ite
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
 
   return false;
@@ -3592,7 +3596,7 @@ bool CMusicDatabase::GetTop100Albums(VECALBUMS& albums)
                          "ORDER BY albumview.iTimesPlayed DESC LIMIT 100) "
                          "ORDER BY albumview.iTimesPlayed DESC, albumartistview.iOrder";
 
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     if (!m_pDS->query(strSQL))
       return false;
     int iRowsFound = m_pDS->num_rows();
@@ -3624,7 +3628,7 @@ bool CMusicDatabase::GetTop100Albums(VECALBUMS& albums)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
 
   return false;
@@ -3667,9 +3671,9 @@ bool CMusicDatabase::GetTop100AlbumSongs(const std::string& strBaseDir, CFileIte
     items.Reserve(iRowsFound);
     while (!m_pDS->eof())
     {
-      CFileItemPtr item(new CFileItem);
+      auto item{std::make_shared<CFileItem>()};
       GetFileItemFromDataset(item.get(), baseUrl);
-      items.Add(item);
+      items.Add(std::move(item));
       m_pDS->next();
     }
 
@@ -3679,7 +3683,7 @@ bool CMusicDatabase::GetTop100AlbumSongs(const std::string& strBaseDir, CFileIte
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -3708,7 +3712,7 @@ bool CMusicDatabase::GetRecentlyPlayedAlbums(VECALBUMS& albums)
                    CAlbum::ReleaseTypeToString(CAlbum::Album).c_str(), RECENTLY_PLAYED_LIMIT);
 
     auto queryStart = std::chrono::steady_clock::now();
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     if (!m_pDS->query(strSQL))
       return false;
 
@@ -3744,14 +3748,14 @@ bool CMusicDatabase::GetRecentlyPlayedAlbums(VECALBUMS& albums)
     auto end = std::chrono::steady_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
-    CLog::Log(LOGDEBUG, "{0}: Time to fill list with albums {1}ms query took {2}ms", __FUNCTION__,
-              duration.count(), queryDuration.count());
+    CLog::LogF(LOGDEBUG, "Time to fill list with albums {}ms query took {}ms", duration.count(),
+               queryDuration.count());
 
     return true;
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
 
   return false;
@@ -3814,9 +3818,9 @@ bool CMusicDatabase::GetRecentlyPlayedAlbumSongs(const std::string& strBaseDir,
           artistCredits.clear();
         }
         songId = record->at(song_idSong).get_asInt();
-        CFileItemPtr item(new CFileItem);
+        auto item{std::make_shared<CFileItem>()};
         GetFileItemFromDataset(record, item.get(), baseUrl);
-        items.Add(item);
+        items.Add(std::move(item));
       }
       // Get song artist credits and contributors
       if (idSongArtistRole == ROLE_ARTIST)
@@ -3840,7 +3844,7 @@ bool CMusicDatabase::GetRecentlyPlayedAlbumSongs(const std::string& strBaseDir,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -3870,7 +3874,7 @@ bool CMusicDatabase::GetRecentlyAddedAlbums(VECALBUMS& albums, unsigned int limi
                                ->GetAdvancedSettings()
                                ->m_iMusicLibraryRecentlyAddedItems);
 
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     if (!m_pDS->query(strSQL))
       return false;
     int iRowsFound = m_pDS->num_rows();
@@ -3901,7 +3905,7 @@ bool CMusicDatabase::GetRecentlyAddedAlbums(VECALBUMS& albums, unsigned int limi
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
 
   return false;
@@ -3967,9 +3971,9 @@ bool CMusicDatabase::GetRecentlyAddedAlbumSongs(const std::string& strBaseDir,
           artistCredits.clear();
         }
         songId = record->at(song_idSong).get_asInt();
-        CFileItemPtr item(new CFileItem);
+        auto item{std::make_shared<CFileItem>()};
         GetFileItemFromDataset(record, item.get(), baseUrl);
-        items.Add(item);
+        items.Add(std::move(item));
       }
       // Get song artist credits and contributors
       if (idSongArtistRole == ROLE_ARTIST)
@@ -3993,7 +3997,7 @@ bool CMusicDatabase::GetRecentlyAddedAlbumSongs(const std::string& strBaseDir,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -4016,7 +4020,7 @@ void CMusicDatabase::IncrementPlayCount(const CFileItem& item)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, item.GetPath());
+    CLog::LogF(LOGERROR, "({}) failed", item.GetPath());
   }
 }
 
@@ -4047,7 +4051,7 @@ bool CMusicDatabase::GetSongsByPath(const std::string& strPath1,
                                     strPath.c_str());
     if (!m_pDS->query(strSQL))
       return false;
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -4064,7 +4068,7 @@ bool CMusicDatabase::GetSongsByPath(const std::string& strPath1,
       if (!filename.empty() && filename != song.strFileName)
       {
         // Save songs for previous filename
-        songmap.insert(std::make_pair(filename, songs));
+        songmap.try_emplace(filename, songs);
         songs.clear();
       }
       filename = song.strFileName;
@@ -4072,12 +4076,12 @@ bool CMusicDatabase::GetSongsByPath(const std::string& strPath1,
       m_pDS->next();
     }
     m_pDS->close(); // cleanup recordset data
-    songmap.insert(std::make_pair(filename, songs)); // Save songs for last filename
+    songmap.try_emplace(filename, songs); // Save songs for last filename
     return true;
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, strPath);
+    CLog::LogF(LOGERROR, "({}) failed", strPath);
   }
 
   return false;
@@ -4096,21 +4100,21 @@ bool CMusicDatabase::Search(const std::string& search, CFileItemList& items)
   SearchArtists(search, items);
   auto end = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-  CLog::Log(LOGDEBUG, "{} Artist search in {} ms", __FUNCTION__, duration.count());
+  CLog::LogF(LOGDEBUG, "Artist search in {} ms", duration.count());
 
   start = std::chrono::steady_clock::now();
   // then albums that match
   SearchAlbums(search, items);
   end = std::chrono::steady_clock::now();
   duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-  CLog::Log(LOGDEBUG, "{} Album search in {} ms", __FUNCTION__, duration.count());
+  CLog::LogF(LOGDEBUG, "Album search in {} ms", duration.count());
 
   start = std::chrono::steady_clock::now();
   // and finally songs
   SearchSongs(search, items);
   end = std::chrono::steady_clock::now();
   duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-  CLog::Log(LOGDEBUG, "{} Songs search in {} ms", __FUNCTION__, duration.count());
+  CLog::LogF(LOGDEBUG, "Songs search in {} ms", duration.count());
 
   return true;
 }
@@ -4145,9 +4149,9 @@ bool CMusicDatabase::SearchSongs(const std::string& search, CFileItemList& items
 
     while (!m_pDS->eof())
     {
-      CFileItemPtr item(new CFileItem);
+      auto item{std::make_shared<CFileItem>()};
       GetFileItemFromDataset(item.get(), baseUrl);
-      items.Add(item);
+      items.Add(std::move(item));
       m_pDS->next();
     }
 
@@ -4156,7 +4160,7 @@ bool CMusicDatabase::SearchSongs(const std::string& search, CFileItemList& items
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
 
   return false;
@@ -4189,13 +4193,13 @@ bool CMusicDatabase::SearchAlbums(const std::string& search, CFileItemList& albu
     {
       CAlbum album = GetAlbumFromDataset(m_pDS.get());
       std::string path = StringUtils::Format("musicdb://albums/{}/", album.idAlbum);
-      CFileItemPtr pItem(new CFileItem(path, album));
+      auto pItem{std::make_shared<CFileItem>(path, album)};
       std::string label = StringUtils::Format("[{}] {}", albumLabel, album.strAlbum);
       pItem->SetLabel(label);
       // sort label is stored in the title tag
       label = StringUtils::Format("B {}", album.strAlbum);
       pItem->GetMusicInfoTag()->SetTitle(label);
-      albums.Add(pItem);
+      albums.Add(std::move(pItem));
       m_pDS->next();
     }
     m_pDS->close(); // cleanup recordset data
@@ -4203,7 +4207,7 @@ bool CMusicDatabase::SearchAlbums(const std::string& search, CFileItemList& albu
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -4429,7 +4433,7 @@ bool CMusicDatabase::CleanupPaths()
   return false;
 }
 
-bool CMusicDatabase::InsideScannedPath(const std::string& path)
+bool CMusicDatabase::InsideScannedPath(const std::string& path) const
 {
   std::string sql = PrepareSQL("SELECT idPath FROM path WHERE SUBSTR(strPath,1,%i)='%s' LIMIT 1",
                                path.size(), path.c_str());
@@ -4570,7 +4574,7 @@ int CMusicDatabase::Cleanup(CGUIDialogProgress* progressDialog /*= nullptr*/)
   int ret;
   std::chrono::seconds duration;
   auto time = std::chrono::steady_clock::now();
-  CLog::Log(LOGINFO, "{}: Starting musicdatabase cleanup ..", __FUNCTION__);
+  CLog::Log(LOGINFO, "Starting musicdatabase cleanup ...");
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "OnCleanStarted");
 
   SetLibraryLastCleaned();
@@ -4710,8 +4714,7 @@ int CMusicDatabase::Cleanup(CGUIDialogProgress* progressDialog /*= nullptr*/)
 
   duration =
       std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - time);
-  CLog::Log(LOGINFO, "{}: Cleaning musicdatabase done. Operation took {}s", __FUNCTION__,
-            duration.count());
+  CLog::Log(LOGINFO, "Cleaning musicdatabase done. Operation took {}s", duration.count());
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "OnCleanFinished");
 
   if (!Compress(false))
@@ -4728,7 +4731,7 @@ error:
   return ret;
 }
 
-bool CMusicDatabase::TrimImageURLs(std::string& strImage, const size_t space)
+bool CMusicDatabase::TrimImageURLs(std::string& strImage, const size_t space) const
 {
   if (strImage.length() > space)
   {
@@ -4742,7 +4745,7 @@ bool CMusicDatabase::TrimImageURLs(std::string& strImage, const size_t space)
   return true;
 }
 
-bool CMusicDatabase::LookupCDDBInfo(bool bRequery /*=false*/)
+bool CMusicDatabase::LookupCDDBInfo(bool bRequery /*=false*/) const
 {
 #ifdef HAS_OPTICAL_DRIVE
   if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
@@ -4755,7 +4758,7 @@ bool CMusicDatabase::LookupCDDBInfo(bool bRequery /*=false*/)
 
   // Get information for the inserted disc
   CCdInfo* pCdInfo = CServiceBroker::GetMediaManager().GetCdInfo();
-  if (pCdInfo == NULL)
+  if (!pCdInfo)
     return false;
 
   // If the disc has no tracks, we are finished here.
@@ -4863,7 +4866,7 @@ bool CMusicDatabase::LookupCDDBInfo(bool bRequery /*=false*/)
 #endif
 }
 
-void CMusicDatabase::DeleteCDDBInfo()
+void CMusicDatabase::DeleteCDDBInfo() const
 {
 #ifdef HAS_OPTICAL_DRIVE
   CFileItemList items;
@@ -4882,21 +4885,22 @@ void CMusicDatabase::DeleteCDDBInfo()
     pDlg->Reset();
 
     std::map<uint32_t, std::string> mapCDDBIds;
-    for (int i = 0; i < items.Size(); ++i)
+    for (const auto& i : items)
     {
-      if (items[i]->IsFolder())
+      if (i->IsFolder())
         continue;
 
-      std::string strFile = URIUtils::GetFileName(items[i]->GetPath());
+      std::string strFile = URIUtils::GetFileName(i->GetPath());
       strFile.erase(strFile.size() - 5, 5);
-      uint32_t lDiscId = strtoul(strFile.c_str(), NULL, 16);
+      const auto lDiscId = static_cast<uint32_t>(std::strtoul(strFile.c_str(), nullptr, 16));
       Xcddb cddb;
       cddb.setCacheDir(m_profileManager.GetCDDBFolder());
 
       if (!cddb.queryCache(lDiscId))
         continue;
 
-      std::string strDiskTitle, strDiskArtist;
+      std::string strDiskTitle;
+      std::string strDiskArtist;
       cddb.getDiskTitle(strDiskTitle);
       cddb.getDiskArtist(strDiskArtist);
 
@@ -4907,7 +4911,7 @@ void CMusicDatabase::DeleteCDDBInfo()
         str = strDiskTitle + " - " + strDiskArtist;
 
       pDlg->Add(str);
-      mapCDDBIds.insert(std::pair<uint32_t, std::string>(lDiscId, str));
+      mapCDDBIds.try_emplace(lDiscId, str);
     }
 
     pDlg->Sort();
@@ -4922,11 +4926,11 @@ void CMusicDatabase::DeleteCDDBInfo()
     }
 
     std::string strSelectedAlbum = pDlg->GetSelectedFileItem()->GetLabel();
-    for (const auto& i : mapCDDBIds)
+    for (const auto& [discId, discTitle] : mapCDDBIds)
     {
-      if (i.second == strSelectedAlbum)
+      if (discTitle == strSelectedAlbum)
       {
-        std::string strFile = StringUtils::Format("{:x}.cddb", (unsigned int)i.first);
+        const std::string strFile = StringUtils::Format("{:x}.cddb", discId);
         CFile::Delete(URIUtils::AddFileToFolder(m_profileManager.GetCDDBFolder(), strFile));
         break;
       }
@@ -4936,7 +4940,7 @@ void CMusicDatabase::DeleteCDDBInfo()
 #endif
 }
 
-void CMusicDatabase::Clean()
+void CMusicDatabase::Clean() const
 {
   // If we are scanning for music info in the background,
   // other writing access to the database is prohibited.
@@ -5026,7 +5030,7 @@ bool CMusicDatabase::GetGenresNav(const std::string& strBaseDir,
              strSQLExtra;
 
     // run query
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
 
     if (!m_pDS->query(strSQL))
       return false;
@@ -5039,9 +5043,9 @@ bool CMusicDatabase::GetGenresNav(const std::string& strBaseDir,
 
     if (countOnly)
     {
-      CFileItemPtr pItem(new CFileItem());
+      auto pItem{std::make_shared<CFileItem>()};
       pItem->SetProperty("total", iRowsFound == 1 ? m_pDS->fv(0).get_asInt() : iRowsFound);
-      items.Add(pItem);
+      items.Add(std::move(pItem));
 
       m_pDS->close();
       return true;
@@ -5050,7 +5054,7 @@ bool CMusicDatabase::GetGenresNav(const std::string& strBaseDir,
     // get data from returned rows
     while (!m_pDS->eof())
     {
-      CFileItemPtr pItem(new CFileItem(m_pDS->fv("genre.strGenre").get_asString()));
+      auto pItem{std::make_shared<CFileItem>(m_pDS->fv("genre.strGenre").get_asString())};
       pItem->GetMusicInfoTag()->SetGenre(m_pDS->fv("genre.strGenre").get_asString());
       pItem->GetMusicInfoTag()->SetDatabaseId(m_pDS->fv("genre.idGenre").get_asInt(), "genre");
 
@@ -5060,7 +5064,7 @@ bool CMusicDatabase::GetGenresNav(const std::string& strBaseDir,
       pItem->SetPath(itemUrl.ToString());
 
       pItem->SetFolder(true);
-      items.Add(pItem);
+      items.Add(std::move(pItem));
 
       m_pDS->next();
     }
@@ -5072,7 +5076,7 @@ bool CMusicDatabase::GetGenresNav(const std::string& strBaseDir,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -5143,7 +5147,7 @@ bool CMusicDatabase::GetSourcesNav(const std::string& strBaseDir,
              strSQLExtra;
 
     // run query
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
 
     if (!m_pDS->query(strSQL))
       return false;
@@ -5156,9 +5160,9 @@ bool CMusicDatabase::GetSourcesNav(const std::string& strBaseDir,
 
     if (countOnly)
     {
-      CFileItemPtr pItem(new CFileItem());
+      auto pItem{std::make_shared<CFileItem>()};
       pItem->SetProperty("total", iRowsFound == 1 ? m_pDS->fv(0).get_asInt() : iRowsFound);
-      items.Add(pItem);
+      items.Add(std::move(pItem));
 
       m_pDS->close();
       return true;
@@ -5167,7 +5171,7 @@ bool CMusicDatabase::GetSourcesNav(const std::string& strBaseDir,
     // get data from returned rows
     while (!m_pDS->eof())
     {
-      CFileItemPtr pItem(new CFileItem(m_pDS->fv("source.strName").get_asString()));
+      auto pItem{std::make_shared<CFileItem>(m_pDS->fv("source.strName").get_asString())};
       pItem->GetMusicInfoTag()->SetTitle(m_pDS->fv("source.strName").get_asString());
       pItem->GetMusicInfoTag()->SetDatabaseId(m_pDS->fv("source.idSource").get_asInt(), "source");
 
@@ -5178,7 +5182,7 @@ bool CMusicDatabase::GetSourcesNav(const std::string& strBaseDir,
       pItem->SetPath(itemUrl.ToString());
 
       pItem->SetFolder(true);
-      items.Add(pItem);
+      items.Add(std::move(pItem));
 
       m_pDS->next();
     }
@@ -5190,7 +5194,7 @@ bool CMusicDatabase::GetSourcesNav(const std::string& strBaseDir,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -5233,7 +5237,7 @@ bool CMusicDatabase::GetYearsNav(const std::string& strBaseDir,
       return false;
 
     // run query
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     if (!m_pDS->query(strSQL))
       return false;
     int iRowsFound = m_pDS->num_rows();
@@ -5246,7 +5250,7 @@ bool CMusicDatabase::GetYearsNav(const std::string& strBaseDir,
     // get data from returned rows
     while (!m_pDS->eof())
     {
-      CFileItemPtr pItem(new CFileItem(m_pDS->fv(0).get_asString()));
+      auto pItem{std::make_shared<CFileItem>(m_pDS->fv(0).get_asString())};
       pItem->GetMusicInfoTag()->SetYear(m_pDS->fv(0).get_asInt());
       if (useOriginalYears)
         pItem->GetMusicInfoTag()->SetDatabaseId(-1, "originalyear");
@@ -5261,7 +5265,7 @@ bool CMusicDatabase::GetYearsNav(const std::string& strBaseDir,
       pItem->SetPath(itemUrl.ToString());
 
       pItem->SetFolder(true);
-      items.Add(pItem);
+      items.Add(std::move(pItem));
 
       m_pDS->next();
     }
@@ -5273,7 +5277,7 @@ bool CMusicDatabase::GetYearsNav(const std::string& strBaseDir,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -5303,7 +5307,7 @@ bool CMusicDatabase::GetRolesNav(const std::string& strBaseDir,
       return false;
 
     // run query
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     if (!m_pDS->query(strSQL))
       return false;
     int iRowsFound = m_pDS->num_rows();
@@ -5317,7 +5321,7 @@ bool CMusicDatabase::GetRolesNav(const std::string& strBaseDir,
     while (!m_pDS->eof())
     {
       std::string labelValue = m_pDS->fv("role.strRole").get_asString();
-      CFileItemPtr pItem(new CFileItem(labelValue));
+      auto pItem{std::make_shared<CFileItem>(labelValue)};
       pItem->GetMusicInfoTag()->SetTitle(labelValue);
       pItem->GetMusicInfoTag()->SetDatabaseId(m_pDS->fv("role.idRole").get_asInt(), "role");
       CMusicDbUrl itemUrl = musicUrl;
@@ -5327,7 +5331,7 @@ bool CMusicDatabase::GetRolesNav(const std::string& strBaseDir,
       pItem->SetPath(itemUrl.ToString());
 
       pItem->SetFolder(true);
-      items.Add(pItem);
+      items.Add(std::move(pItem));
 
       m_pDS->next();
     }
@@ -5339,7 +5343,7 @@ bool CMusicDatabase::GetRolesNav(const std::string& strBaseDir,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -5396,7 +5400,7 @@ bool CMusicDatabase::GetCommonNav(const std::string& strBaseDir,
       return false;
 
     // run query
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     if (!m_pDS->query(strSQL))
       return false;
 
@@ -5409,9 +5413,9 @@ bool CMusicDatabase::GetCommonNav(const std::string& strBaseDir,
 
     if (countOnly)
     {
-      CFileItemPtr pItem(new CFileItem());
+      auto pItem{std::make_shared<CFileItem>()};
       pItem->SetProperty("total", iRowsFound == 1 ? m_pDS->fv(0).get_asInt() : iRowsFound);
-      items.Add(pItem);
+      items.Add(std::move(pItem));
 
       m_pDS->close();
       return true;
@@ -5421,7 +5425,7 @@ bool CMusicDatabase::GetCommonNav(const std::string& strBaseDir,
     while (!m_pDS->eof())
     {
       std::string labelValue = m_pDS->fv(labelField.c_str()).get_asString();
-      CFileItemPtr pItem(new CFileItem(labelValue));
+      auto pItem{std::make_shared<CFileItem>(labelValue)};
 
       CMusicDbUrl itemUrl = musicUrl;
       std::string strDir = StringUtils::Format("{}/", labelValue);
@@ -5429,7 +5433,7 @@ bool CMusicDatabase::GetCommonNav(const std::string& strBaseDir,
       pItem->SetPath(itemUrl.ToString());
 
       pItem->SetFolder(true);
-      items.Add(pItem);
+      items.Add(std::move(pItem));
 
       m_pDS->next();
     }
@@ -5442,7 +5446,7 @@ bool CMusicDatabase::GetCommonNav(const std::string& strBaseDir,
   catch (...)
   {
     m_pDS->close();
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
 
   return false;
@@ -5503,7 +5507,7 @@ bool CMusicDatabase::GetArtistsNav(const std::string& strBaseDir,
   catch (...)
   {
     m_pDS->close();
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -5578,9 +5582,9 @@ bool CMusicDatabase::GetArtistsByWhere(
     }
     if (countOnly)
     {
-      CFileItemPtr pItem(new CFileItem());
+      auto pItem{std::make_shared<CFileItem>()};
       pItem->SetProperty("total", total);
-      items.Add(pItem);
+      items.Add(std::move(pItem));
 
       m_pDS->close();
       return true;
@@ -5612,7 +5616,7 @@ bool CMusicDatabase::GetArtistsByWhere(
     strSQL = "SELECT " + strFields + " FROM artistview " + strSQLExtra;
 
     // run query
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     auto queryStart = std::chrono::steady_clock::now();
     if (!m_pDS->query(strSQL))
       return false;
@@ -5647,13 +5651,13 @@ bool CMusicDatabase::GetArtistsByWhere(
     const dbiplus::query_data& data = m_pDS->get_result_set().records;
     for (const auto& i : results)
     {
-      unsigned int targetRow = (unsigned int)i.at(FieldRow).asInteger();
+      const auto targetRow = static_cast<unsigned int>(i.at(FieldRow).asInteger());
       const dbiplus::sql_record* const record = data.at(targetRow);
 
       try
       {
         CArtist artist = GetArtistFromDataset(record, false);
-        CFileItemPtr pItem(new CFileItem(artist));
+        auto pItem{std::make_shared<CFileItem>(artist)};
 
         CMusicDbUrl itemUrl = musicUrl;
         std::string path = StringUtils::Format("{}/", artist.idArtist);
@@ -5666,13 +5670,12 @@ bool CMusicDatabase::GetArtistsByWhere(
         pItem->SetArt("icon", "DefaultArtist.png");
 
         SetPropertiesFromArtist(*pItem, artist);
-        items.Add(pItem);
+        items.Add(std::move(pItem));
       }
       catch (...)
       {
         m_pDS->close();
-        CLog::Log(LOGERROR, "{} - out of memory getting listing (got {})", __FUNCTION__,
-                  items.Size());
+        CLog::LogF(LOGERROR, "out of memory getting listing (got {})", items.Size());
       }
     }
     // cleanup
@@ -5681,15 +5684,15 @@ bool CMusicDatabase::GetArtistsByWhere(
     auto end = std::chrono::steady_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
-    CLog::Log(LOGDEBUG, "{0}: Time to fill list with artists {1} ms query took {2} ms",
-              __FUNCTION__, duration.count(), queryDuration.count());
+    CLog::LogF(LOGDEBUG, "Time to fill list with artists {} ms query took {} ms", duration.count(),
+               queryDuration.count());
 
     return true;
   }
   catch (...)
   {
     m_pDS->close();
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -5723,7 +5726,7 @@ bool CMusicDatabase::GetAlbumFromSong(int idSong, CAlbum& album)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -5807,9 +5810,9 @@ bool CMusicDatabase::GetAlbumsByWhere(
     }
     if (countOnly)
     {
-      CFileItemPtr pItem(new CFileItem());
+      auto pItem{std::make_shared<CFileItem>()};
       pItem->SetProperty("total", total);
-      items.Add(pItem);
+      items.Add(std::move(pItem));
 
       m_pDS->close();
       return true;
@@ -5847,7 +5850,7 @@ bool CMusicDatabase::GetAlbumsByWhere(
     strSQL = "SELECT " + strFields + " FROM albumview " + strSQLExtra;
 
     // run query
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     auto querytime = std::chrono::steady_clock::now();
     if (!m_pDS->query(strSQL))
       return false;
@@ -5882,7 +5885,7 @@ bool CMusicDatabase::GetAlbumsByWhere(
     const dbiplus::query_data& data = m_pDS->get_result_set().records;
     for (const auto& i : results)
     {
-      unsigned int targetRow = (unsigned int)i.at(FieldRow).asInteger();
+      const auto targetRow = static_cast<unsigned int>(i.at(FieldRow).asInteger());
       const dbiplus::sql_record* const record = data.at(targetRow);
 
       try
@@ -5891,17 +5894,16 @@ bool CMusicDatabase::GetAlbumsByWhere(
         std::string path = StringUtils::Format("{}/", record->at(album_idAlbum).get_asInt());
         itemUrl.AppendPath(path);
 
-        CFileItemPtr pItem(new CFileItem(itemUrl.ToString(), GetAlbumFromDataset(record)));
+        auto pItem{std::make_shared<CFileItem>(itemUrl.ToString(), GetAlbumFromDataset(record))};
         // Set icon now to avoid slow per item processing in FillInDefaultIcon later
         pItem->SetProperty("icon_never_overlay", true);
         pItem->SetArt("icon", "DefaultAlbumCover.png");
-        items.Add(pItem);
+        items.Add(std::move(pItem));
       }
       catch (...)
       {
         m_pDS->close();
-        CLog::Log(LOGERROR, "{} - out of memory getting listing (got {})", __FUNCTION__,
-                  items.Size());
+        CLog::LogF(LOGERROR, "out of memory getting listing (got {})", items.Size());
       }
     }
     // cleanup
@@ -5910,15 +5912,15 @@ bool CMusicDatabase::GetAlbumsByWhere(
     auto end = std::chrono::steady_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
-    CLog::Log(LOGDEBUG, "{0}: Time to fill list with albums {1}ms query took {2}ms", __FUNCTION__,
-              duration.count(), queryDuration.count());
+    CLog::LogF(LOGDEBUG, "Time to fill list with albums {}ms query took {}ms", duration.count(),
+               queryDuration.count());
 
     return true;
   }
   catch (...)
   {
     m_pDS->close();
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, filter.where);
+    CLog::LogF(LOGERROR, "({}) failed", filter.where);
   }
   return false;
 }
@@ -6025,7 +6027,7 @@ bool CMusicDatabase::GetDiscsByWhere(CMusicDbUrl& musicUrl,
              strSQLExtra;
 
     // run query
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     auto queryStart = std::chrono::steady_clock::now();
     if (!m_pDS->query(strSQL))
       return false;
@@ -6065,7 +6067,7 @@ bool CMusicDatabase::GetDiscsByWhere(CMusicDbUrl& musicUrl,
     const dbiplus::query_data& data = m_pDS->get_result_set().records;
     for (const auto& i : results)
     {
-      unsigned int targetRow = static_cast<unsigned int>(i.at(FieldRow).asInteger());
+      const auto targetRow = static_cast<unsigned int>(i.at(FieldRow).asInteger());
       const dbiplus::sql_record* const record = data.at(targetRow);
       try
       {
@@ -6098,7 +6100,7 @@ bool CMusicDatabase::GetDiscsByWhere(CMusicDbUrl& musicUrl,
           itemUrl.AddOption("disctitle", strDiscSubtitle.c_str());
         else
           itemUrl.AddOption("discid", discnum);
-        CFileItemPtr pItem(new CFileItem(itemUrl.ToString(), album));
+        auto pItem{std::make_shared<CFileItem>(itemUrl.ToString(), album)};
         pItem->SetLabel2(record->at(0).get_asString()); // GUI show label2 for disc sort order??
         pItem->GetMusicInfoTag()->SetDiscNumber(discnum);
         pItem->GetMusicInfoTag()->SetTitle(strDiscSubtitle);
@@ -6106,13 +6108,12 @@ bool CMusicDatabase::GetDiscsByWhere(CMusicDbUrl& musicUrl,
         // Set icon now to avoid slow per item processing in FillInDefaultIcon later
         pItem->SetProperty("icon_never_overlay", true);
         pItem->SetArt("icon", "DefaultAlbumCover.png");
-        items.Add(pItem);
+        items.Add(std::move(pItem));
       }
       catch (...)
       {
         m_pDS->close();
-        CLog::Log(LOGERROR, "{} - out of memory getting listing (got {})", __FUNCTION__,
-                  items.Size());
+        CLog::LogF(LOGERROR, "out of memory getting listing (got {})", items.Size());
       }
     }
 
@@ -6127,15 +6128,15 @@ bool CMusicDatabase::GetDiscsByWhere(CMusicDbUrl& musicUrl,
     auto end = std::chrono::steady_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
-    CLog::Log(LOGDEBUG, "{0}: Time to fill list with discs {1}ms query took {2}ms", __FUNCTION__,
-              duration.count(), queryDuration.count());
+    CLog::LogF(LOGDEBUG, "Time to fill list with discs {}ms query took {}ms", duration.count(),
+               queryDuration.count());
 
     return true;
   }
   catch (...)
   {
     m_pDS->close();
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, filter.where);
+    CLog::LogF(LOGERROR, "({}) failed", filter.where);
   }
 
   return false;
@@ -6281,7 +6282,7 @@ bool CMusicDatabase::GetSongsFullByWhere(
     else
       strSQL = "SELECT " + strFields + " FROM songview " + strSQLExtra;
 
-    CLog::Log(LOGDEBUG, "{} query = {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query = {}", strSQL);
     auto queryStart = std::chrono::steady_clock::now();
     // run query
     if (!m_pDS->query(strSQL))
@@ -6320,7 +6321,7 @@ bool CMusicDatabase::GetSongsFullByWhere(
     int count = 0;
     for (const auto& i : results)
     {
-      unsigned int targetRow = (unsigned int)i.at(FieldRow).asInteger();
+      const auto targetRow = static_cast<unsigned int>(i.at(FieldRow).asInteger());
       const dbiplus::sql_record* const record = data.at(targetRow);
 
       try
@@ -6334,7 +6335,7 @@ bool CMusicDatabase::GetSongsFullByWhere(
             artistCredits.clear();
           }
           songId = record->at(song_idSong).get_asInt();
-          CFileItemPtr item(new CFileItem);
+          auto item{std::make_shared<CFileItem>()};
           GetFileItemFromDataset(record, item.get(), musicUrl);
           //! @todo remove hack to use program count for sorting by database returned order
           count++;
@@ -6342,7 +6343,7 @@ bool CMusicDatabase::GetSongsFullByWhere(
           // Set icon now to avoid slow per item processing in FillInDefaultIcon later
           item->SetProperty("icon_never_overlay", true);
           item->SetArt("icon", "DefaultAudio.png");
-          items.Add(item);
+          items.Add(std::move(item));
         }
         // Get song artist credits and contributors
         if (artistData)
@@ -6358,7 +6359,7 @@ bool CMusicDatabase::GetSongsFullByWhere(
       catch (...)
       {
         m_pDS->close();
-        CLog::Log(LOGERROR, "{}: out of memory loading query: {}", __FUNCTION__, filter.where);
+        CLog::LogF(LOGERROR, "out of memory loading query: {}", filter.where);
         return (items.Size() > 0);
       }
     }
@@ -6383,8 +6384,8 @@ bool CMusicDatabase::GetSongsFullByWhere(
     auto end = std::chrono::steady_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
-    CLog::Log(LOGDEBUG, "{0}: Time to fill list with songs {1}ms query took {2}ms", __FUNCTION__,
-              duration.count(), queryDuration.count());
+    CLog::LogF(LOGDEBUG, "Time to fill list with songs {}ms query took {}ms", duration.count(),
+               queryDuration.count());
 
     return true;
   }
@@ -6392,7 +6393,7 @@ bool CMusicDatabase::GetSongsFullByWhere(
   {
     // cleanup
     m_pDS->close();
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, filter.where);
+    CLog::LogF(LOGERROR, "({}) failed", filter.where);
   }
   return false;
 }
@@ -6443,7 +6444,7 @@ bool CMusicDatabase::GetSongsByWhere(
                                     : "songview.*") +
              strSQLExtra;
 
-    CLog::Log(LOGDEBUG, "{} query = {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query = {}", strSQL);
     // run query
     if (!m_pDS->query(strSQL))
       return false;
@@ -6471,23 +6472,23 @@ bool CMusicDatabase::GetSongsByWhere(
     int count = 0;
     for (const auto& i : results)
     {
-      unsigned int targetRow = (unsigned int)i.at(FieldRow).asInteger();
+      const auto targetRow = static_cast<unsigned int>(i.at(FieldRow).asInteger());
       const dbiplus::sql_record* const record = data.at(targetRow);
 
       try
       {
-        CFileItemPtr item(new CFileItem);
+        auto item{std::make_shared<CFileItem>()};
         GetFileItemFromDataset(record, item.get(), musicUrl);
         //! @todo remove hack to use program count for sorting by database returned order
         count++;
         item->SetProgramCount(count);
-        items.Add(item);
+        items.Add(std::move(item));
       }
       catch (...)
       {
         m_pDS->close();
-        CLog::Log(LOGERROR, "{}: out of memory loading query: {}", __FUNCTION__, filter.where);
-        return (items.Size() > 0);
+        CLog::LogF(LOGERROR, "out of memory loading query: {}", filter.where);
+        return !items.IsEmpty();
       }
     }
 
@@ -6499,7 +6500,7 @@ bool CMusicDatabase::GetSongsByWhere(
   {
     // cleanup
     m_pDS->close();
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, filter.where);
+    CLog::LogF(LOGERROR, "({}) failed", filter.where);
   }
   return false;
 }
@@ -6540,17 +6541,20 @@ bool CMusicDatabase::GetSongsNav(const std::string& strBaseDir,
   return GetSongsFullByWhere(musicUrl.ToString(), filter, items, sortDescription, true);
 }
 
+namespace
+{
 // clang-format off
-typedef struct
+struct TranslateJSONField
 {
   std::string fieldJSON;  // Field name in JSON schema
   std::string formatJSON; // Format in JSON schema
   bool bSimple;           // Fetch field directly to JSON output
   std::string fieldDB;    // Name of field in db query
   std::string SQL;        // SQL for scalar subqueries or field alias
-} translateJSONField;
+};
 
-static const translateJSONField JSONtoDBArtist[] = {
+// clang-format off
+const std::array<TranslateJSONField, 35> JSONtoDBArtist = {{
   // Table and single value join fields
   { "artist",                    "string", true,  "strArtist",              "" }, // Label field at top
   { "sortname",                  "string", true,  "strSortname",            "" },
@@ -6591,17 +6595,16 @@ static const translateJSONField JSONtoDBArtist[] = {
   { "thumbnail",                 "string", false, "",                       "" },
   { "fanart",                    "string", false, "",                       "" }
   /*
-    Sources and genre are related via album, and so the dataset only contains source and genre
-    pairs that exist, rather than all the genres being repeated for every source. We can not only
-    look at genres for the first source, and genre can be out of order.
+   Sources and genre are related via album, and so the dataset only contains source and genre
+   pairs that exist, rather than all the genres being repeated for every source. We can not only
+   look at genres for the first source, and genre can be out of order.
    */
-};
+}};
 // clang-format on
-
-static const size_t NUM_ARTIST_FIELDS = sizeof(JSONtoDBArtist) / sizeof(translateJSONField);
+} // unnamed namespace
 
 bool CMusicDatabase::GetArtistsByWhereJSON(
-    const std::set<std::string>& fields,
+    const std::set<std::string, std::less<>>& fields,
     const std::string& baseDir,
     CVariant& result,
     int& total,
@@ -6676,7 +6679,7 @@ bool CMusicDatabase::GetArtistsByWhereJSON(
     // Setup fields to query, and album field number mapping
     // Find first join field (isSong) in JSONtoDBArtist for offset
     int index_firstjoin = -1;
-    for (unsigned int i = 0; i < NUM_ARTIST_FIELDS; i++)
+    for (unsigned int i = 0; i < std::size(JSONtoDBArtist); i++)
     {
       if (JSONtoDBArtist[i].fieldDB == "isSong")
       {
@@ -6695,7 +6698,7 @@ bool CMusicDatabase::GetArtistsByWhereJSON(
     dbfieldindex.emplace_back(0); // Output "artist"
 
     // Check each optional artist db field that could be retrieved (not "artist")
-    for (unsigned int i = 1; i < NUM_ARTIST_FIELDS; i++)
+    for (unsigned int i = 1; i < std::size(JSONtoDBArtist); i++)
     {
       bool foundJSON = fields.contains(JSONtoDBArtist[i].fieldJSON);
       if (JSONtoDBArtist[i].bSimple)
@@ -6981,7 +6984,7 @@ bool CMusicDatabase::GetArtistsByWhereJSON(
       strSQL = "SELECT a1.*, " + joinLayout.GetFields() + " FROM " + strSQL + strSQLJoin;
     }
 
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     // run query
     auto start = std::chrono::steady_clock::now();
 
@@ -6991,7 +6994,7 @@ bool CMusicDatabase::GetArtistsByWhereJSON(
     auto end = std::chrono::steady_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
-    CLog::Log(LOGDEBUG, "{} - query took {} ms", __FUNCTION__, duration.count());
+    CLog::LogF(LOGDEBUG, "query took {} ms", duration.count());
 
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound <= 0)
@@ -7274,13 +7277,15 @@ bool CMusicDatabase::GetArtistsByWhereJSON(
   catch (...)
   {
     m_pDS->close();
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
 
+namespace
+{
 // clang-format off
-static const translateJSONField JSONtoDBAlbum[] = {
+const std::array<TranslateJSONField, 35> JSONtoDBAlbum = {{
   // albumview (inc scalar subquery fields use in filter rules)
   { "title",                     "string", true,  "strAlbum",               "" },  // Label field at top
   { "description",               "string", true,  "strReview",              "" },
@@ -7314,10 +7319,10 @@ static const translateJSONField JSONtoDBAlbum[] = {
   { "year",                     "integer", true,  "iYear",                  "CAST(<datefield> AS INTEGER) AS iYear" }, //From strReleaseDate or strOrigReleaseDate
   { "sourceid",                  "string", true,  "sourceid",               "(SELECT GROUP_CONCAT(album_source.idSource SEPARATOR '; ') FROM album_source WHERE album_source.idAlbum = albumview.idAlbum) AS sources" },
   { "songgenres",                 "array", true,  "songgenres",             "(SELECT GROUP_CONCAT(DISTINCT CONCAT(genre.idGenre, ',', REPLACE(genre.strGenre, ',', '-'))) FROM song "
-      "JOIN song_genre ON song.idSong = song_genre.idSong JOIN genre ON song_genre.idGenre = genre.idGenre WHERE song.idAlbum = albumview.idAlbum) AS songgenres" } ,
+    "JOIN song_genre ON song.idSong = song_genre.idSong JOIN genre ON song_genre.idGenre = genre.idGenre WHERE song.idAlbum = albumview.idAlbum) AS songgenres" } ,
   // Single value JOIN fields
   { "thumbnail",                  "image", true,  "thumbnail",              "art.url AS thumbnail" }, // or (SELECT art.url FROM art WHERE art.media_id = album.idAlbum AND art.media_type = "album" AND art.type = "thumb") as url
-  // JOIN fields (multivalue), same order as _JoinToAlbumFields
+                                                                                                      // JOIN fields (multivalue), same order as _JoinToAlbumFields
   { "artistid",                   "array", false, "idArtist",               "album_artist.idArtist AS idArtist" },
   { "artist",                     "array", false, "strArtist",              "artist.strArtist AS strArtist" },
   { "musicbrainzalbumartistid",   "array", false, "strArtistMBID",          "artist.strMusicBrainzArtistID AS strArtistMBID" },
@@ -7331,14 +7336,13 @@ static const translateJSONField JSONtoDBAlbum[] = {
    have to be repeated) and these fields can be used by filter rules.
    Using this view is no slower than the album table as these scalar fields are
    only calculated (slowing query) when field is in field list.
-  */
-};
+   */
+}};
 // clang-format on
-
-static const size_t NUM_ALBUM_FIELDS = sizeof(JSONtoDBAlbum) / sizeof(translateJSONField);
+} //unnamed namespace
 
 bool CMusicDatabase::GetAlbumsByWhereJSON(
-    const std::set<std::string>& fields,
+    const std::set<std::string, std::less<>>& fields,
     const std::string& baseDir,
     CVariant& result,
     int& total,
@@ -7389,7 +7393,7 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(
     // Setup fields to query, and album field number mapping
     // Find idArtist in JSONtoDBAlbum, offset of first join field
     int index_idArtist = -1;
-    for (unsigned int i = 0; i < NUM_ALBUM_FIELDS; i++)
+    for (unsigned int i = 0; i < std::size(JSONtoDBAlbum); i++)
     {
       if (JSONtoDBAlbum[i].fieldDB == "idArtist")
       {
@@ -7409,7 +7413,7 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(
       dbfieldindex.emplace_back(-1); // fetch but not output
 
     // Check each optional album db field that could be retrieved (not label)
-    for (unsigned int i = 1; i < NUM_ALBUM_FIELDS; i++)
+    for (unsigned int i = 1; i < std::size(JSONtoDBAlbum); i++)
     {
       bool foundJSON = fields.contains(JSONtoDBAlbum[i].fieldJSON);
       if (JSONtoDBAlbum[i].bSimple)
@@ -7531,7 +7535,7 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(
     else
       StringUtils::Replace(strSQL, "<datefield>", "strOrigReleaseDate");
 
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     // run query
     auto start = std::chrono::steady_clock::now();
 
@@ -7541,7 +7545,7 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(
     auto end = std::chrono::steady_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
-    CLog::Log(LOGDEBUG, "{} - query took {} ms", __FUNCTION__, duration.count());
+    CLog::LogF(LOGDEBUG, "query took {} ms", duration.count());
 
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound <= 0)
@@ -7676,13 +7680,15 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(
   catch (...)
   {
     m_pDS->close();
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
 
+namespace
+{
 // clang-format off
-static const translateJSONField JSONtoDBSong[] = {
+const std::array<TranslateJSONField, 54> JSONtoDBSong = {{
   // table and single value join fields
   { "title",                     "string", true,  "strTitle",               "" }, // Label field at top
   { "albumid",                  "integer", true,  "song.idAlbum",           "" },
@@ -7744,14 +7750,14 @@ static const translateJSONField JSONtoDBSong[] = {
   { "disc",                     "integer", true,  "disc",                   "(iTrack >> 16) AS disc" },
   { "sourceid",                  "string", true,  "sourceid",               "(SELECT GROUP_CONCAT(album_source.idSource SEPARATOR '; ') FROM album_source WHERE album_source.idAlbum = song.idAlbum) AS sources" },
   /*
-  Song "thumbnail", "fanart" and "art" fields of JSON schema are fetched using
-  thumbloader and separate queries to allow for fallback strategy
-  "lyrics"?? Can be set for an item (by addons) but not held in db so
-  AudioLibrary.GetSongs() never fills this field despite being in schema
+   Song "thumbnail", "fanart" and "art" fields of JSON schema are fetched using
+   thumbloader and separate queries to allow for fallback strategy
+   "lyrics"?? Can be set for an item (by addons) but not held in db so
+   AudioLibrary.GetSongs() never fills this field despite being in schema
 
    FROM ( SELECT * FROM song
-     JOIN album ON album.idAlbum = song.idAlbum
-     JOIN path ON path.idPath = song.idPath) AS sv
+   JOIN album ON album.idAlbum = song.idAlbum
+   JOIN path ON path.idPath = song.idPath) AS sv
    JOIN album_artist ON album_artist.idAlbum = song.idAlbum
    JOIN artist AS albumartist ON albumartist.idArtist = album_artist.idArtist
    JOIN song_artist ON song_artist.idSong = song.idSong
@@ -7759,14 +7765,13 @@ static const translateJSONField JSONtoDBSong[] = {
    JOIN role ON song_artist.idRole = role.idRole
    LEFT JOIN song_genre ON song.idSong = song_genre.idSong
 
-  */
-};
+   */
+}};
 // clang-format on
-
-static const size_t NUM_SONG_FIELDS = sizeof(JSONtoDBSong) / sizeof(translateJSONField);
+} // unnamed namespace
 
 bool CMusicDatabase::GetSongsByWhereJSON(
-    const std::set<std::string>& fields,
+    const std::set<std::string, std::less<>>& fields,
     const std::string& baseDir,
     CVariant& result,
     int& total,
@@ -7847,7 +7852,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(
     // Setup fields to query, and song field number mapping
     // Find idAlbumArtist in JSONtoDBSong, offset of first join field
     int index_idAlbumArtist = -1;
-    for (unsigned int i = 0; i < NUM_SONG_FIELDS; i++)
+    for (unsigned int i = 0; i < std::size(JSONtoDBSong); i++)
     {
       if (JSONtoDBSong[i].fieldDB == "idAlbumArtist")
       {
@@ -7868,7 +7873,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(
     std::vector<std::string> rolefieldlist;
     std::vector<int> roleidlist;
     // Check each optional db field that could be retrieved (not label)
-    for (unsigned int i = 1; i < NUM_SONG_FIELDS; i++)
+    for (unsigned int i = 1; i < std::size(JSONtoDBSong); i++)
     {
       bool foundJSON = fields.contains(JSONtoDBSong[i].fieldJSON);
       if (JSONtoDBSong[i].bSimple)
@@ -8115,7 +8120,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(
     else
       StringUtils::Replace(strSQL, "<datefield>", "song.strOrigReleaseDate");
 
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
 
     // Run query
     auto start = std::chrono::steady_clock::now();
@@ -8126,7 +8131,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(
     auto end = std::chrono::steady_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
-    CLog::Log(LOGDEBUG, "{} - query took {} ms", __FUNCTION__, duration.count());
+    CLog::LogF(LOGDEBUG, "query took {} ms", duration.count());
 
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound <= 0)
@@ -8352,7 +8357,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(
   catch (...)
   {
     m_pDS->close();
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -8472,7 +8477,7 @@ std::string CMusicDatabase::AlphanumericSortSQL(const std::string& strField,
 
 void CMusicDatabase::UpdateTables(int version)
 {
-  CLog::Log(LOGINFO, "{} - updating tables", __FUNCTION__);
+  CLog::Log(LOGINFO, "updating tables");
   if (version < 34)
   {
     m_pDS->exec("ALTER TABLE artist ADD strMusicBrainzArtistID text\n");
@@ -8844,7 +8849,7 @@ void CMusicDatabase::UpdateTables(int version)
                             "FROM artist WHERE artist.idArtist = %i",
                             BLANKARTIST_ID);
         m_pDS->exec(strSQL);
-        int idArtist = (int)m_pDS->lastinsertid();
+        const auto idArtist = static_cast<int>(m_pDS->lastinsertid());
         //No triggers, so can delete artist without effecting other tables.
         strSQL = PrepareSQL("DELETE FROM artist WHERE artist.idArtist = %i", BLANKARTIST_ID);
         m_pDS->exec(strSQL);
@@ -9482,7 +9487,7 @@ int CMusicDatabase::GetMusicNeedsTagScan()
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return -1;
 }
@@ -9604,7 +9609,7 @@ unsigned int CMusicDatabase::GetRandomSongIDs(const Filter& filter,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, filter.where);
+    CLog::LogF(LOGERROR, "({}) failed", filter.where);
   }
   return 0;
 }
@@ -9637,7 +9642,7 @@ int CMusicDatabase::GetSongsCount(const Filter& filter)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, filter.where);
+    CLog::LogF(LOGERROR, "({}) failed", filter.where);
   }
   return 0;
 }
@@ -9705,7 +9710,7 @@ bool CMusicDatabase::GetAlbumPaths(int idAlbum, std::vector<std::pair<std::strin
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "CMusicDatabase::{} - failed to execute {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "failed to execute {}", strSQL);
   }
 
   return false;
@@ -9737,7 +9742,7 @@ int CMusicDatabase::GetDiscnumberForPathID(int idPath)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "CMusicDatabase::{} - failed to execute {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "failed to execute {}", strSQL);
   }
   return result;
 }
@@ -9812,7 +9817,7 @@ bool CMusicDatabase::GetOldArtistPath(int idArtist, std::string& basePath)
       const std::string strValue = GetSingleValue(strSQL, *m_pDS2);
       if (!strValue.empty())
       {
-        int countartists = static_cast<int>(strtol(strValue.c_str(), NULL, 10));
+        int countartists = static_cast<int>(std::strtol(strValue.c_str(), nullptr, 10));
         if (countartists == 0)
           return true;
       }
@@ -9820,7 +9825,7 @@ bool CMusicDatabase::GetOldArtistPath(int idArtist, std::string& basePath)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   basePath.clear();
   return false;
@@ -9904,7 +9909,7 @@ bool CMusicDatabase::GetAlbumFolder(const CAlbum& album,
   const std::string strValue = GetSingleValue(strSQL, *m_pDS2);
   if (strValue.empty())
     return false;
-  int countalbum = static_cast<int>(strtol(strValue.c_str(), NULL, 10));
+  int countalbum = static_cast<int>(std::strtol(strValue.c_str(), nullptr, 10));
   if (countalbum > 1 && !album.strMusicBrainzAlbumID.empty())
   { // Only one of the duplicate albums can be without mbid
     strFolder += "_" + album.strMusicBrainzAlbumID.substr(0, 4);
@@ -9939,7 +9944,7 @@ bool CMusicDatabase::GetArtistFolderName(const std::string& strArtist,
   const std::string strValue = GetSingleValue(strSQL, *m_pDS2);
   if (strValue.empty())
     return false;
-  int countartist = static_cast<int>(strtol(strValue.c_str(), NULL, 10));
+  int countartist = static_cast<int>(std::strtol(strValue.c_str(), nullptr, 10));
   if (countartist > 1)
     strFolder += "_" + strMusicBrainzArtistID.substr(0, 4);
   return !strFolder.empty();
@@ -10024,7 +10029,7 @@ int CMusicDatabase::AddSource(const std::string& strName,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed with query ({})", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "failed with query ({})", strSQL);
     RollbackTransaction();
   }
 
@@ -10093,7 +10098,7 @@ int CMusicDatabase::UpdateSource(const std::string& strOldName,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed with query ({})", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "failed with query ({})", strSQL);
     RollbackTransaction();
   }
 
@@ -10145,7 +10150,7 @@ int CMusicDatabase::GetSourceFromPath(const std::string& strPath1)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} path: {} ({}) failed", __FUNCTION__, strSQL, strPath1);
+    CLog::LogF(LOGERROR, "path: {} ({}) failed", strSQL, strPath1);
   }
 
   return -1;
@@ -10222,7 +10227,7 @@ bool CMusicDatabase::AddAlbumSources(int idAlbum, const std::string& strPath)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} path: {} ({}) failed", __FUNCTION__, strSQL, strPath);
+    CLog::LogF(LOGERROR, "path: {} ({}) failed", strSQL, strPath);
   }
 
   return false;
@@ -10287,7 +10292,7 @@ bool CMusicDatabase::CheckSources(std::vector<CMediaSource>& sources)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -10327,7 +10332,7 @@ bool CMusicDatabase::MigrateSources()
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
   return false;
 }
@@ -10352,7 +10357,7 @@ bool CMusicDatabase::UpdateSources()
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -10372,7 +10377,7 @@ bool CMusicDatabase::GetSources(CFileItemList& items)
         "FROM source JOIN source_path ON source.idSource = source_path.idSource "
         "ORDER BY source.idSource, source_path.idPath";
 
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     if (!m_pDS->query(strSQL))
       return false;
     int iRowsFound = m_pDS->num_rows();
@@ -10397,7 +10402,7 @@ bool CMusicDatabase::GetSources(CFileItemList& items)
           sourcePaths.clear();
         }
         idSource = m_pDS->fv("source.idSource").get_asInt();
-        CFileItemPtr pItem(new CFileItem(m_pDS->fv("source.strName").get_asString()));
+        auto pItem{std::make_shared<CFileItem>(m_pDS->fv("source.strName").get_asString())};
         pItem->GetMusicInfoTag()->SetDatabaseId(idSource, "source");
         // Set tag URL for "file" property in AudioLibary processing
         pItem->GetMusicInfoTag()->SetURL(m_pDS->fv("source.strMultipath").get_asString());
@@ -10405,7 +10410,7 @@ bool CMusicDatabase::GetSources(CFileItemList& items)
         pItem->SetPath(m_pDS->fv("source.strMultiPath").get_asString());
 
         pItem->SetFolder(true);
-        items.Add(pItem);
+        items.Add(std::move(pItem));
       }
       // Get path data
       sourcePaths.push_back(m_pDS->fv("source_path.strPath").get_asString());
@@ -10426,7 +10431,7 @@ bool CMusicDatabase::GetSources(CFileItemList& items)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -10483,7 +10488,7 @@ bool CMusicDatabase::GetSourcesByArtist(int idArtist, CFileItem* item)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idArtist);
+    CLog::LogF(LOGERROR, "({}) failed", idArtist);
   }
   return false;
 }
@@ -10551,7 +10556,7 @@ bool CMusicDatabase::GetSourcesByAlbum(int idAlbum, CFileItem* item)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idAlbum);
+    CLog::LogF(LOGERROR, "({}) failed", idAlbum);
   }
   return false;
 }
@@ -10600,7 +10605,7 @@ bool CMusicDatabase::GetSourcesBySong(int idSong, const std::string& strPath1, C
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idSong);
+    CLog::LogF(LOGERROR, "({}) failed", idSong);
   }
   return false;
 }
@@ -10629,7 +10634,7 @@ int CMusicDatabase::GetSourceByName(const std::string& strSource)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return -1;
 }
@@ -10666,7 +10671,7 @@ int CMusicDatabase::GetArtistByName(const std::string& strArtist)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return -1;
 }
@@ -10703,7 +10708,7 @@ int CMusicDatabase::GetArtistByMatch(const CArtist& artist)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "CMusicDatabase::{} - failed to execute {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "failed to execute {}", strSQL);
   }
   return -1;
 }
@@ -10738,7 +10743,7 @@ bool CMusicDatabase::GetArtistFromSong(int idSong, CArtist& artist)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -10798,7 +10803,7 @@ int CMusicDatabase::GetAlbumByName(const std::string& strAlbum, const std::strin
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return -1;
 }
@@ -10842,7 +10847,7 @@ bool CMusicDatabase::GetMatchingMusicVideoAlbum(const std::string& strAlbum,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -10869,11 +10874,11 @@ bool CMusicDatabase::SearchAlbumsByArtistName(const std::string& strArtist, CFil
     {
       CAlbum album = GetAlbumFromDataset(m_pDS.get());
       std::string path = StringUtils::Format("musicdb://albums/{}/", album.idAlbum);
-      CFileItemPtr pItem(new CFileItem(path, album));
+      auto pItem{std::make_shared<CFileItem>(path, album)};
       std::string label =
           StringUtils::Format("{} ({})", album.strAlbum, pItem->GetMusicInfoTag()->GetYear());
       pItem->SetLabel(label);
-      items.Add(pItem);
+      items.Add(std::move(pItem));
       m_pDS->next();
     }
     m_pDS->close(); // cleanup recordset data
@@ -10881,7 +10886,7 @@ bool CMusicDatabase::SearchAlbumsByArtistName(const std::string& strArtist, CFil
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -10929,7 +10934,7 @@ int CMusicDatabase::GetAlbumByMatch(const CAlbum& album)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "CMusicDatabase::{} - failed to execute {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "failed to execute {}", strSQL);
   }
   return -1;
 }
@@ -10988,7 +10993,7 @@ bool CMusicDatabase::UpdateArtistSortNames(int idArtist /*=-1*/)
                    "AND album_artist.idAlbum = album.idAlbum)",
                    idArtist);
   ExecuteQuery(strSQL);
-  CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+  CLog::LogF(LOGDEBUG, "query: {}", strSQL);
 
   if (bisMySQL)
     strSQL = "(SELECT GROUP_CONCAT("
@@ -11016,12 +11021,12 @@ bool CMusicDatabase::UpdateArtistSortNames(int idArtist /*=-1*/)
                          "AND song_artist.idSong = song.idSong AND song_artist.idRole = 1)",
                          idArtist);
   ExecuteQuery(strSQL);
-  CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+  CLog::LogF(LOGDEBUG, "query: {}", strSQL);
 
   if (CommitMultipleExecute())
     return true;
   else
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   return false;
 }
 
@@ -11056,7 +11061,7 @@ int CMusicDatabase::GetGenreByName(const std::string& strGenre)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return -1;
 }
@@ -11095,7 +11100,7 @@ bool CMusicDatabase::GetGenresJSON(CFileItemList& items, bool bSources)
     strSQL = PrepareSQL(strSQL, extFilter.fields.c_str()) + strSQLExtra;
 
     // run query
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
 
     if (!m_pDS->query(strSQL))
       return false;
@@ -11125,13 +11130,13 @@ bool CMusicDatabase::GetGenresJSON(CFileItemList& items, bool bSources)
         }
         idGenre = m_pDS->fv("genre.idGenre").get_asInt();
         std::string strGenre = m_pDS->fv("genre.strGenre").get_asString();
-        CFileItemPtr pItem(new CFileItem(strGenre));
+        auto pItem{std::make_shared<CFileItem>(strGenre)};
         pItem->GetMusicInfoTag()->SetTitle(strGenre);
         pItem->GetMusicInfoTag()->SetGenre(strGenre);
         pItem->GetMusicInfoTag()->SetDatabaseId(idGenre, "genre");
         pItem->SetPath(StringUtils::Format("musicdb://genres/{}/", idGenre));
         pItem->SetFolder(true);
-        items.Add(pItem);
+        items.Add(std::move(pItem));
       }
       // Get source data
       if (bSources)
@@ -11155,7 +11160,7 @@ bool CMusicDatabase::GetGenresJSON(CFileItemList& items, bool bSources)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
   return false;
 }
@@ -11248,7 +11253,7 @@ bool CMusicDatabase::SetPathHash(const std::string& path, const std::string& has
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}, {}) failed", __FUNCTION__, path, hash);
+    CLog::LogF(LOGERROR, "({}, {}) failed", path, hash);
   }
 
   return false;
@@ -11272,7 +11277,7 @@ bool CMusicDatabase::GetPathHash(const std::string& path, std::string& hash)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, path);
+    CLog::LogF(LOGERROR, "({}) failed", path);
   }
 
   return false;
@@ -11373,7 +11378,7 @@ bool CMusicDatabase::RemoveSongsFromPath(const std::string& path1, MAPSONGS& son
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, path);
+    CLog::LogF(LOGERROR, "({}) failed", path);
   }
   return false;
 }
@@ -11422,7 +11427,7 @@ bool CMusicDatabase::GetPaths(std::set<std::string, std::less<>>& paths)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -11446,7 +11451,7 @@ bool CMusicDatabase::SetSongUserrating(const std::string& filePath, int userrati
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({},{}) failed", __FUNCTION__, filePath, userrating);
+    CLog::LogF(LOGERROR, "({},{}) failed", filePath, userrating);
   }
   return false;
 }
@@ -11467,7 +11472,7 @@ bool CMusicDatabase::SetSongUserrating(int idSong, int userrating)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({},{}) failed", __FUNCTION__, idSong, userrating);
+    CLog::LogF(LOGERROR, "({},{}) failed", idSong, userrating);
   }
   return false;
 }
@@ -11490,7 +11495,7 @@ bool CMusicDatabase::SetAlbumUserrating(const int idAlbum, int userrating)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({},{}) failed", __FUNCTION__, idAlbum, userrating);
+    CLog::LogF(LOGERROR, "({},{}) failed", idAlbum, userrating);
   }
   return false;
 }
@@ -11517,7 +11522,7 @@ bool CMusicDatabase::SetSongVotes(const std::string& filePath, int votes)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({},{}) failed", __FUNCTION__, filePath, votes);
+    CLog::LogF(LOGERROR, "({},{}) failed", filePath, votes);
   }
   return false;
 }
@@ -11562,7 +11567,7 @@ int CMusicDatabase::GetSongIDFromPath(const std::string& filePath)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, filePath);
+    CLog::LogF(LOGERROR, "({}) failed", filePath);
   }
   return -1;
 }
@@ -11654,7 +11659,7 @@ bool CMusicDatabase::SetScraperAll(const std::string& strBaseDir, const ADDON::S
   catch (...)
   {
     RollbackTransaction();
-    CLog::Log(LOGERROR, "{} - ({}, {}) failed", __FUNCTION__, strBaseDir, strSQL);
+    CLog::LogF(LOGERROR, "({}, {}) failed", strBaseDir, strSQL);
   }
   return false;
 }
@@ -11711,7 +11716,7 @@ bool CMusicDatabase::SetScraper(int id,
   catch (...)
   {
     RollbackTransaction();
-    CLog::Log(LOGERROR, "{} - ({}, {}) failed", __FUNCTION__, id, strSQL);
+    CLog::LogF(LOGERROR, "({}, {}) failed", id, strSQL);
   }
   return false;
 }
@@ -11764,7 +11769,7 @@ bool CMusicDatabase::GetScraper(int id, const CONTENT_TYPE& content, ADDON::Scra
               ADDON::ScraperTypeFromContent(content), addon))
       {
         scraper = std::dynamic_pointer_cast<ADDON::CScraper>(addon);
-        return scraper != NULL;
+        return scraper != nullptr;
       }
       else
         return false;
@@ -11774,7 +11779,7 @@ bool CMusicDatabase::GetScraper(int id, const CONTENT_TYPE& content, ADDON::Scra
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} -({}, {} {}) failed", __FUNCTION__, id, scraperUUID, strSettings);
+    CLog::LogF(LOGERROR, "({}, {} {}) failed", id, scraperUUID, strSettings);
   }
   return false;
 }
@@ -11801,7 +11806,7 @@ bool CMusicDatabase::ScraperInUse(const std::string& scraperID) const
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, scraperID);
+    CLog::LogF(LOGERROR, "({}) failed", scraperID);
   }
   return false;
 }
@@ -11924,7 +11929,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
     CXBMCTinyXML xmlDoc;
     TiXmlDeclaration decl("1.0", "UTF-8", "yes");
     xmlDoc.InsertEndChild(decl);
-    TiXmlNode* pMain = NULL;
+    TiXmlNode* pMain = nullptr;
     if ((settings.IsToLibFolders() || settings.IsSeparateFiles()) && !artistfoldersonly)
       pMain = &xmlDoc;
     else if (settings.IsSingleFile())
@@ -11941,7 +11946,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
                                       CAlbum::ReleaseTypeToString(CAlbum::Album).c_str());
       if (!settings.IsUnscraped())
         strSQL += "AND lastScraped IS NOT NULL";
-      CLog::Log(LOGDEBUG, "CMusicDatabase::{} - {}", __FUNCTION__, strSQL);
+      CLog::LogF(LOGDEBUG, "{}", strSQL);
       m_pDS->query(strSQL);
 
       int total = m_pDS->num_rows();
@@ -11978,14 +11983,11 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
             // Most albums are under a unique folder, but if songs from various albums are mixed then
             // avoid overwriting by not allow NFO and art to be exported
             if (strAlbumPath.empty())
-              CLog::Log(LOGDEBUG,
-                        "CMusicDatabase::{} - Not exporting album {} as unique path not found",
-                        __FUNCTION__, album.strAlbum);
+              CLog::LogF(LOGDEBUG, "Not exporting album {} as unique path not found",
+                         album.strAlbum);
             else if (!CDirectory::Exists(strAlbumPath))
-              CLog::Log(
-                  LOGDEBUG,
-                  "CMusicDatabase::{} - Not exporting album {} as found path {} does not exist",
-                  __FUNCTION__, album.strAlbum, strAlbumPath);
+              CLog::LogF(LOGDEBUG, "Not exporting album {} as found path {} does not exist",
+                         album.strAlbum, strAlbumPath);
             else
             {
               strPath = strAlbumPath;
@@ -12008,9 +12010,8 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
                 pathfound = CDirectory::Create(strPath);
             }
             if (!pathfound)
-              CLog::Log(LOGDEBUG,
-                        "CMusicDatabase::{} - Not exporting album {} as could not create {}",
-                        __FUNCTION__, album.strAlbum, strPath);
+              CLog::LogF(LOGDEBUG, "Not exporting album {} as could not create {}", album.strAlbum,
+                         strPath);
             else
             {
               std::string strAlbumFolder;
@@ -12023,9 +12024,8 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
                   pathfound = CDirectory::Create(strPath);
               }
               if (!pathfound)
-                CLog::Log(LOGDEBUG,
-                          "CMusicDatabase::{} - Not exporting album {} as could not create {}",
-                          __FUNCTION__, album.strAlbum, strPath);
+                CLog::LogF(LOGDEBUG, "Not exporting album {} as could not create {}",
+                           album.strAlbum, strPath);
             }
           }
           if (pathfound)
@@ -12039,8 +12039,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
               {
                 if (!xmlDoc.SaveFile(nfoFile))
                 {
-                  CLog::Log(LOGERROR, "CMusicDatabase::{}: Album nfo export failed! ('{}')",
-                            __FUNCTION__, nfoFile);
+                  CLog::LogF(LOGERROR, "Album nfo export failed! ('{}')", nfoFile);
                   CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
                                                         g_localizeStrings.Get(20302),
                                                         CURL::GetRedacted(nfoFile));
@@ -12123,7 +12122,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
 
       std::string strSQL = "SELECT idArtist FROM artist";
       BuildSQL(strSQL, filter, strSQL);
-      CLog::Log(LOGDEBUG, "CMusicDatabase::{} - {}", __FUNCTION__, strSQL);
+      CLog::LogF(LOGDEBUG, "{}", strSQL);
 
       m_pDS->query(strSQL);
       int total = m_pDS->num_rows();
@@ -12169,9 +12168,8 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
               pathfound = CDirectory::Create(strPath);
           }
           if (!pathfound)
-            CLog::Log(LOGDEBUG,
-                      "CMusicDatabase::{} - Not exporting artist {} as could not create {}",
-                      __FUNCTION__, artist.strArtist, strPath);
+            CLog::LogF(LOGDEBUG, "Not exporting artist {} as could not create {}", artist.strArtist,
+                       strPath);
           else
           {
             if (!artistfoldersonly)
@@ -12184,8 +12182,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
                 {
                   if (!xmlDoc.SaveFile(nfoFile))
                   {
-                    CLog::Log(LOGERROR, "CMusicDatabase::{}: Artist nfo export failed! ('{}')",
-                              __FUNCTION__, nfoFile);
+                    CLog::LogF(LOGERROR, "Artist nfo export failed! ('{}')", nfoFile);
                     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
                                                           g_localizeStrings.Get(20302),
                                                           CURL::GetRedacted(nfoFile));
@@ -12244,7 +12241,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "CMusicDatabase::{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
     iFailCount++;
   }
 
@@ -12269,7 +12266,7 @@ bool CMusicDatabase::ExportSongHistory(TiXmlNode* pNode, CGUIDialogProgress* pro
         "FROM song JOIN album on album.idAlbum = song.idAlbum "
         "WHERE iTimesPlayed > 0 OR rating > 0 or userrating > 0";
 
-    CLog::Log(LOGDEBUG, "{0} - {1}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "{}", strSQL);
     m_pDS->query(strSQL);
 
     int total = m_pDS->num_rows();
@@ -12321,7 +12318,7 @@ bool CMusicDatabase::ExportSongHistory(TiXmlNode* pNode, CGUIDialogProgress* pro
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{0} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -12383,8 +12380,8 @@ void CMusicDatabase::ImportFromXML(const std::string& xmlFile, CGUIDialogProgres
           UpdateArtist(artist);
         }
         else
-          CLog::Log(LOGDEBUG, "{} - Not import additional artist data as {} not found",
-                    __FUNCTION__, importedArtist.strArtist);
+          CLog::LogF(LOGDEBUG, "Not import additional artist data as {} not found",
+                     importedArtist.strArtist);
         current++;
       }
       else if (StringUtils::CompareNoCase(entry->Value(), "album", 5) == 0)
@@ -12402,8 +12399,8 @@ void CMusicDatabase::ImportFromXML(const std::string& xmlFile, CGUIDialogProgres
           UpdateAlbum(album); //Will replace song artists if present in xml
         }
         else
-          CLog::Log(LOGDEBUG, "{} - Not import additional album data as {} not found", __FUNCTION__,
-                    importedAlbum.strAlbum);
+          CLog::LogF(LOGDEBUG, "Not import additional album data as {} not found",
+                     importedAlbum.strAlbum);
 
         current++;
       }
@@ -12433,7 +12430,7 @@ void CMusicDatabase::ImportFromXML(const std::string& xmlFile, CGUIDialogProgres
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
     RollbackTransaction();
   }
   if (progressDialog)
@@ -12564,8 +12561,7 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile,
       }
     }
 
-    CLog::Log(LOGINFO, "{0}: Create temporary HistSong table and insert {1} records", __FUNCTION__,
-              total);
+    CLog::Log(LOGINFO, "Create temporary HistSong table and insert {} records", total);
     /* Can not use CREATE TEMPORARY TABLE as MySQL does not support updates of
        song table using correlated subqueries to a temp table. An updatable join
        to temp table would work in MySQL but SQLite not support updatable joins.
@@ -12693,8 +12689,7 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile,
     // Log how many songs matched
     const int unmatched =
         GetSingleValueInt("SELECT COUNT(1) FROM HistSong WHERE idSong < 0", *m_pDS);
-    CLog::Log(LOGINFO, "{0}: Importing song history {1} of {2} songs matched", __FUNCTION__,
-              total - unmatched, total);
+    CLog::Log(LOGINFO, "Importing song history {} of {} songs matched", total - unmatched, total);
 
     if (progressDialog)
     {
@@ -12773,7 +12768,7 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
     RollbackTransaction();
     if (bHistSongExists)
       m_pDS->exec("DROP TABLE HistSong");
@@ -12899,8 +12894,7 @@ void CMusicDatabase::SetItemUpdated(int mediaId, const std::string& mediaType)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "CMusicDatabase::{0} ({1}, {2}) - failed to execute {3}", __FUNCTION__,
-              mediaId, mediaType, strSQL);
+    CLog::LogF(LOGERROR, "({}, {}) - failed to execute {}", mediaId, mediaType, strSQL);
   }
 }
 
@@ -12950,8 +12944,7 @@ void CMusicDatabase::SetArtForItem(int mediaId,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}, '{}', '{}', '{}') failed", __FUNCTION__, mediaId, mediaType,
-              artType, url);
+    CLog::LogF(LOGERROR, "({}, '{}', '{}', '{}') failed", mediaId, mediaType, artType, url);
   }
 }
 
@@ -13065,7 +13058,7 @@ bool CMusicDatabase::GetArtForItem(
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
   return false;
 }
@@ -13094,7 +13087,7 @@ bool CMusicDatabase::GetArtForItem(int mediaId,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, mediaId);
+    CLog::LogF(LOGERROR, "({}) failed", mediaId);
   }
   return false;
 }
@@ -13123,7 +13116,7 @@ bool CMusicDatabase::RemoveArtForItem(int mediaId,
 
 bool CMusicDatabase::RemoveArtForItem(int mediaId,
                                       const MediaType& mediaType,
-                                      const std::set<std::string>& artTypes)
+                                      const std::set<std::string, std::less<>>& artTypes)
 {
   bool result = true;
   for (const auto& i : artTypes)
@@ -13163,7 +13156,7 @@ bool CMusicDatabase::GetArtTypes(const MediaType& mediaType, std::vector<std::st
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, mediaType);
+    CLog::LogF(LOGERROR, "({}) failed", mediaType);
   }
   return false;
 }
@@ -14032,7 +14025,7 @@ std::vector<std::string> CMusicDatabase::GetUsedImages(
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}, failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return {};
 }

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -13237,7 +13237,7 @@ int CMusicDatabase::GetOrderFilter(const std::string& type,
       if (it == FieldYear)
         strField = "iYear";
       else
-        strField = DatabaseUtils::GetField(it, type, DatabaseQueryPartSelect);
+        strField = DatabaseUtils::GetField(it, type, DatabaseQueryPart::SELECT);
       if (!strField.empty())
         orderfields.emplace_back(strField);
     }

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -11392,7 +11392,7 @@ void CMusicDatabase::CheckArtistLinksChanged()
   }
 }
 
-bool CMusicDatabase::GetPaths(std::set<std::string>& paths)
+bool CMusicDatabase::GetPaths(std::set<std::string, std::less<>>& paths)
 {
   try
   {

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5640,7 +5640,7 @@ bool CMusicDatabase::GetArtistsByWhere(
     results.reserve(iRowsFound);
     // Populate results field vector from dataset
     FieldList fields;
-    if (!DatabaseUtils::GetDatabaseResults(MediaTypeArtist, fields, m_pDS, results))
+    if (!DatabaseUtils::GetDatabaseResults(MediaTypeArtist, fields, *m_pDS, results))
       return false;
     // Store item list sort order
     items.SetSortMethod(sortDescription.sortBy);
@@ -5874,7 +5874,7 @@ bool CMusicDatabase::GetAlbumsByWhere(
     results.reserve(iRowsFound);
     // Populate results field vector from dataset
     FieldList fields;
-    if (!DatabaseUtils::GetDatabaseResults(MediaTypeAlbum, fields, m_pDS, results))
+    if (!DatabaseUtils::GetDatabaseResults(MediaTypeAlbum, fields, *m_pDS, results))
       return false;
     // Store item list sort order
     items.SetSortMethod(sorting.sortBy);
@@ -6055,7 +6055,7 @@ bool CMusicDatabase::GetDiscsByWhere(CMusicDbUrl& musicUrl,
     // Need guaranteed ordering for dataset processing to group by disc title
     // so apply sort later to fileitems list rather than dataset
     sorting.sortBy = SortByNone;
-    if (!SortUtils::SortFromDataset(sorting, MediaTypeAlbum, m_pDS, results))
+    if (!SortUtils::SortFromDataset(sorting, MediaTypeAlbum, *m_pDS, results))
       return false;
 
     // Get data from returned rows, note possibly multiple albums although usually only one
@@ -6306,7 +6306,7 @@ bool CMusicDatabase::GetSongsFullByWhere(
     results.reserve(iRowsFound);
     // Populate results field vector from dataset
     FieldList fields;
-    if (!DatabaseUtils::GetDatabaseResults(MediaTypeSong, fields, m_pDS, results))
+    if (!DatabaseUtils::GetDatabaseResults(MediaTypeSong, fields, *m_pDS, results))
       return false;
     // Store item list sort order
     items.SetSortMethod(sorting.sortBy);
@@ -6463,7 +6463,7 @@ bool CMusicDatabase::GetSongsByWhere(
 
     DatabaseResults results;
     results.reserve(iRowsFound);
-    if (!SortUtils::SortFromDataset(sorting, MediaTypeSong, m_pDS, results))
+    if (!SortUtils::SortFromDataset(sorting, MediaTypeSong, *m_pDS, results))
       return false;
 
     // get data from returned rows

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -433,7 +433,7 @@ public:
   /////////////////////////////////////////////////
   int AddPath(const std::string& strPath);
 
-  bool GetPaths(std::set<std::string>& paths);
+  bool GetPaths(std::set<std::string, std::less<>>& paths);
   bool SetPathHash(const std::string& path, const std::string& hash);
   bool GetPathHash(const std::string& path, std::string& hash);
   bool GetAlbumPaths(int idAlbum, std::vector<std::pair<std::string, int>>& paths);

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -347,10 +347,10 @@ public:
                                   std::string& strReview);
   bool SearchAlbumsByArtistName(const std::string& strArtist, CFileItemList& items);
   int GetAlbumByMatch(const CAlbum& album);
-  std::string GetAlbumById(int id);
+  std::string GetAlbumById(int id) const;
   std::string GetAlbumDiscTitle(int idAlbum, int idDisc);
   bool SetAlbumUserrating(const int idAlbum, int userrating);
-  int GetAlbumDiscsCount(int idAlbum);
+  int GetAlbumDiscsCount(int idAlbum) const;
 
   /////////////////////////////////////////////////
   // Artist CRUD
@@ -398,13 +398,13 @@ public:
   bool AddArtistVideoLinks(const CArtist& artist);
   bool DeleteArtistVideoLinks(const int idArtist);
 
-  std::string GetArtistById(int id);
+  std::string GetArtistById(int id) const;
   int GetArtistByName(const std::string& strArtist);
   int GetArtistByMatch(const CArtist& artist);
   bool GetArtistFromSong(int idSong, CArtist& artist);
-  bool IsSongArtist(int idSong, int idArtist);
-  bool IsSongAlbumArtist(int idSong, int idArtist);
-  std::string GetRoleById(int id);
+  bool IsSongArtist(int idSong, int idArtist) const;
+  bool IsSongAlbumArtist(int idSong, int idArtist) const;
+  std::string GetRoleById(int id) const;
 
   /*! \brief Propagate artist sort name into the concatenated artist sort name strings
   held for songs and albums
@@ -454,13 +454,13 @@ public:
   bool GetSourcesByAlbum(int idAlbum, CFileItem* item);
   bool GetSourcesBySong(int idSong, const std::string& strPath, CFileItem* item);
   int GetSourceByName(const std::string& strSource);
-  std::string GetSourceById(int id);
+  std::string GetSourceById(int id) const;
 
   /////////////////////////////////////////////////
   // Genres
   /////////////////////////////////////////////////
   int AddGenre(std::string& strGenre);
-  std::string GetGenreById(int id);
+  std::string GetGenreById(int id) const;
   int GetGenreByName(const std::string& strGenre);
 
   /////////////////////////////////////////////////
@@ -521,18 +521,18 @@ public:
   /////////////////////////////////////////////////
   // Compilations
   /////////////////////////////////////////////////
-  int GetCompilationAlbumsCount();
+  int GetCompilationAlbumsCount() const;
 
   ////////////////////////////////////////////////
   // Boxsets
   ////////////////////////////////////////////////
-  bool IsAlbumBoxset(int idAlbum);
-  int GetBoxsetsCount();
+  bool IsAlbumBoxset(int idAlbum) const;
+  int GetBoxsetsCount() const;
 
   int GetSinglesCount();
 
-  int GetArtistCountForRole(int role);
-  int GetArtistCountForRole(const std::string& strRole);
+  int GetArtistCountForRole(int role) const;
+  int GetArtistCountForRole(const std::string& strRole) const;
 
   /*! \brief Increment the playcount of an item
    Increments the playcount and updates the last played date
@@ -848,19 +848,19 @@ public:
   */
   void SetMusicTagScanVersion(int version = 0);
 
-  std::string GetLibraryLastUpdated();
+  std::string GetLibraryLastUpdated() const;
   void SetLibraryLastUpdated();
-  std::string GetLibraryLastCleaned();
+  std::string GetLibraryLastCleaned() const;
   void SetLibraryLastCleaned();
-  std::string GetArtistLinksUpdated();
+  std::string GetArtistLinksUpdated() const;
   void SetArtistLinksUpdated();
-  std::string GetGenresLastAdded();
-  std::string GetSongsLastAdded();
-  std::string GetAlbumsLastAdded();
-  std::string GetArtistsLastAdded();
-  std::string GetSongsLastModified();
-  std::string GetAlbumsLastModified();
-  std::string GetArtistsLastModified();
+  std::string GetGenresLastAdded() const;
+  std::string GetSongsLastAdded() const;
+  std::string GetAlbumsLastAdded() const;
+  std::string GetArtistsLastAdded() const;
+  std::string GetSongsLastModified() const;
+  std::string GetAlbumsLastModified() const;
+  std::string GetArtistsLastModified() const;
 
   /*!
    * @brief Check the passed in list of images if used in this database. Used to clean the image cache.
@@ -902,7 +902,7 @@ private:
                                            int offset = 0) const;
   CMusicRole GetArtistRoleFromDataset(const dbiplus::sql_record* const record,
                                       int offset = 0) const;
-  std::string GetMediaDateFromFile(const std::string& strFileNameAndPath);
+  std::string GetMediaDateFromFile(const std::string& strFileNameAndPath) const;
   void GetFileItemFromDataset(CFileItem* item, const CMusicDbUrl& baseUrl);
   void GetFileItemFromDataset(const dbiplus::sql_record* const record,
                               CFileItem* item,
@@ -931,7 +931,7 @@ private:
   \param strField original name or title field that articles could be removed from
   \return SQL string e.g.  WHEN strField LIKE 'the_' ESCAPE '_' THEN SUBSTR(strArtist, 5)
   */
-  std::string GetIgnoreArticleSQL(const std::string& strField);
+  std::string GetIgnoreArticleSQL(const std::string& strField) const;
 
   /*! \brief Build SQL for sort name scalar subquery from sort attributes and ignore article list.
   \param strAlias alias name of scalar subquery field
@@ -956,12 +956,12 @@ private:
   CASE WHEN CAST(strTitle AS INTEGER) = 0 THEN 100000000
   ELSE CAST(strTitle AS INTEGER) END DESC, strTitle COLLATE NOCASE DESC
   */
-  std::string AlphanumericSortSQL(const std::string& strField, const SortOrder& sortOrder);
+  std::string AlphanumericSortSQL(const std::string& strField, const SortOrder& sortOrder) const;
 
   /*! \brief Checks that source table matches sources.xml
   returns true when they do
   */
-  bool CheckSources(std::vector<CMediaSource>& sources);
+  bool CheckSources(const std::vector<CMediaSource>& sources);
 
   /*! \brief Initially fills source table from sources.xml for use only at
   migration of db from an earlier version than 72

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -21,6 +21,9 @@
 #include "utils/Artwork.h"
 #include "utils/SortUtils.h"
 
+#include <map>
+#include <set>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -32,40 +35,21 @@ class TiXmlNode;
 namespace dbiplus
 {
 class field_value;
-typedef std::vector<field_value> sql_record;
+using sql_record = std::vector<field_value>;
 } // namespace dbiplus
-
-#include <set>
-#include <string>
 
 // return codes of Cleaning up the Database
 // numbers are strings from strings.po
-#define ERROR_OK 317
-#define ERROR_CANCEL 0
-#define ERROR_DATABASE 315
-#define ERROR_REORG_SONGS 319
-#define ERROR_REORG_ARTIST 321
-#define ERROR_REORG_OTHER 323
-#define ERROR_REORG_PATH 325
-#define ERROR_REORG_ALBUM 327
-#define ERROR_WRITING_CHANGES 329
-#define ERROR_COMPRESSING 332
-
-#define NUM_SONGS_BEFORE_COMMIT 500
-
-/*!
- \ingroup music
- \brief A set of std::string objects, used for CMusicDatabase
- \sa ISETPATHS, CMusicDatabase
- */
-typedef std::set<std::string> SETPATHS;
-
-/*!
- \ingroup music
- \brief The SETPATHS iterator
- \sa SETPATHS, CMusicDatabase
- */
-typedef std::set<std::string>::iterator ISETPATHS;
+constexpr int ERROR_OK = 317;
+constexpr int ERROR_CANCEL = 0;
+constexpr int ERROR_DATABASE = 315;
+constexpr int ERROR_REORG_SONGS = 319;
+constexpr int ERROR_REORG_ARTIST = 321;
+constexpr int ERROR_REORG_OTHER = 323;
+constexpr int ERROR_REORG_PATH = 325;
+constexpr int ERROR_REORG_ALBUM = 327;
+constexpr int ERROR_WRITING_CHANGES = 329;
+constexpr int ERROR_COMPRESSING = 332;
 
 /*!
 \ingroup music
@@ -73,13 +57,13 @@ typedef std::set<std::string>::iterator ISETPATHS;
 \sa CMusicDatabase::GetArtForItem()
 */
 
-typedef struct
+struct ArtForThumbLoader
 {
   std::string mediaType;
   std::string artType;
   std::string prefix;
   std::string url;
-} ArtForThumbLoader;
+};
 
 class CGUIDialogProgress;
 class CFileItemList;
@@ -103,16 +87,16 @@ class CMusicDatabase : public CDatabase
   friend class TestDatabaseUtilsHelper;
 
 public:
-  CMusicDatabase(void);
-  ~CMusicDatabase(void) override;
+  CMusicDatabase();
+  ~CMusicDatabase() override;
 
   bool Open() override;
   bool CommitTransaction() override;
   void EmptyCache();
-  void Clean();
+  void Clean() const;
   int Cleanup(CGUIDialogProgress* progressDialog = nullptr);
-  bool LookupCDDBInfo(bool bRequery = false);
-  void DeleteCDDBInfo();
+  bool LookupCDDBInfo(bool bRequery = false) const;
+  void DeleteCDDBInfo() const;
 
   /////////////////////////////////////////////////
   // Song CRUD
@@ -338,7 +322,7 @@ public:
                   CAlbum::ReleaseType releaseType,
                   bool bScrapedMBID);
   bool ClearAlbumLastScrapedTime(int idAlbum);
-  bool HasAlbumBeenScraped(int idAlbum);
+  bool HasAlbumBeenScraped(int idAlbum) const;
 
   /////////////////////////////////////////////////
   // Audiobook
@@ -350,7 +334,7 @@ public:
   /*! \brief Checks if the given path is inside a folder that has already been scanned into the library
    \param path the path we want to check
    */
-  bool InsideScannedPath(const std::string& path);
+  bool InsideScannedPath(const std::string& path) const;
 
   //// Misc Album
   int GetAlbumIdByPath(const std::string& path);
@@ -382,7 +366,7 @@ public:
                 bool bScrapedMBID = false);
   bool GetArtist(int idArtist, CArtist& artist, bool fetchAll = false);
   bool GetArtistExists(int idArtist);
-  int GetLastArtist();
+  int GetLastArtist() const;
   int GetArtistFromMBID(const std::string& strMusicBrainzArtistID, std::string& artistname);
   int UpdateArtist(int idArtist,
                    const std::string& strArtist,
@@ -404,9 +388,9 @@ public:
                    const std::string& strYearsActive,
                    const std::string& strImage);
   bool UpdateArtistScrapedMBID(int idArtist, const std::string& strMusicBrainzArtistID);
-  bool GetTranslateBlankArtist() { return m_translateBlankArtist; }
+  bool GetTranslateBlankArtist() const { return m_translateBlankArtist; }
   void SetTranslateBlankArtist(bool translate) { m_translateBlankArtist = translate; }
-  bool HasArtistBeenScraped(int idArtist);
+  bool HasArtistBeenScraped(int idArtist) const;
   bool ClearArtistLastScrapedTime(int idArtist);
   int AddArtistDiscography(int idArtist, const CDiscoAlbum& discoAlbum);
   bool DeleteArtistDiscography(int idArtist);
@@ -515,7 +499,7 @@ public:
   bool GetGenresByAlbum(int idAlbum, CFileItem* item);
 
   bool GetGenresByArtist(int idArtist, CFileItem* item);
-  bool GetIsAlbumArtist(int idArtist, CFileItem* item);
+  bool GetIsAlbumArtist(int idArtist, CFileItem* item) const;
 
   /////////////////////////////////////////////////
   // Top 100
@@ -666,17 +650,17 @@ public:
   // JSON-RPC
   /////////////////////////////////////////////////
   bool GetGenresJSON(CFileItemList& items, bool bSources = false);
-  bool GetArtistsByWhereJSON(const std::set<std::string>& fields,
+  bool GetArtistsByWhereJSON(const std::set<std::string, std::less<>>& fields,
                              const std::string& baseDir,
                              CVariant& result,
                              int& total,
                              const SortDescription& sortDescription = SortDescription());
-  bool GetAlbumsByWhereJSON(const std::set<std::string>& fields,
+  bool GetAlbumsByWhereJSON(const std::set<std::string, std::less<>>& fields,
                             const std::string& baseDir,
                             CVariant& result,
                             int& total,
                             const SortDescription& sortDescription = SortDescription());
-  bool GetSongsByWhereJSON(const std::set<std::string>& fields,
+  bool GetSongsByWhereJSON(const std::set<std::string, std::less<>>& fields,
                            const std::string& baseDir,
                            CVariant& result,
                            int& total,
@@ -816,7 +800,7 @@ public:
   */
   bool RemoveArtForItem(int mediaId,
                         const MediaType& mediaType,
-                        const std::set<std::string>& artTypes);
+                        const std::set<std::string, std::less<>>& artTypes);
 
   /*! \brief Fetch the distinct types of art held in the database for a type of media.
   \param mediaType the type of media, which corresponds to the table the item resides in (song/artist/album).
@@ -886,9 +870,6 @@ public:
   std::vector<std::string> GetUsedImages(const std::vector<std::string>& imagesToCheck) const;
 
 protected:
-  std::map<std::string, int> m_genreCache;
-  std::map<std::string, int> m_pathCache;
-
   void CreateTables() override;
   void CreateAnalytics() override;
   int GetMinSchemaVersion() const override { return 32; }
@@ -905,26 +886,28 @@ private:
 
   void SplitPath(const std::string& strFileNameAndPath,
                  std::string& strPath,
-                 std::string& strFileName);
+                 std::string& strFileName) const;
 
   CSong GetSongFromDataset();
-  CSong GetSongFromDataset(const dbiplus::sql_record* const record, int offset = 0);
+  CSong GetSongFromDataset(const dbiplus::sql_record* const record, int offset = 0) const;
   CArtist GetArtistFromDataset(dbiplus::Dataset* pDS, int offset = 0, bool needThumb = true);
   CArtist GetArtistFromDataset(const dbiplus::sql_record* const record,
                                int offset = 0,
-                               bool needThumb = true);
+                               bool needThumb = true) const;
   CAlbum GetAlbumFromDataset(dbiplus::Dataset* pDS, int offset = 0, bool imageURL = false);
   CAlbum GetAlbumFromDataset(const dbiplus::sql_record* const record,
                              int offset = 0,
-                             bool imageURL = false);
-  CArtistCredit GetArtistCreditFromDataset(const dbiplus::sql_record* const record, int offset = 0);
-  CMusicRole GetArtistRoleFromDataset(const dbiplus::sql_record* const record, int offset = 0);
+                             bool imageURL = false) const;
+  CArtistCredit GetArtistCreditFromDataset(const dbiplus::sql_record* const record,
+                                           int offset = 0) const;
+  CMusicRole GetArtistRoleFromDataset(const dbiplus::sql_record* const record,
+                                      int offset = 0) const;
   std::string GetMediaDateFromFile(const std::string& strFileNameAndPath);
   void GetFileItemFromDataset(CFileItem* item, const CMusicDbUrl& baseUrl);
   void GetFileItemFromDataset(const dbiplus::sql_record* const record,
                               CFileItem* item,
-                              const CMusicDbUrl& baseUrl);
-  void GetFileItemFromArtistCredits(VECARTISTCREDITS& artistCredits, CFileItem* item);
+                              const CMusicDbUrl& baseUrl) const;
+  void GetFileItemFromArtistCredits(VECARTISTCREDITS& artistCredits, CFileItem* item) const;
 
   bool DeleteRemovedLinks();
 
@@ -941,8 +924,8 @@ private:
   bool SearchAlbums(const std::string& search, CFileItemList& albums);
   bool SearchSongs(const std::string& strSearch, CFileItemList& songs);
   int GetSongIDFromPath(const std::string& filePath);
-  void NormaliseSongDates(std::string& strRelease, std::string& strOriginal);
-  bool TrimImageURLs(std::string& strImage, const size_t space);
+  void NormaliseSongDates(std::string& strRelease, std::string& strOriginal) const;
+  bool TrimImageURLs(std::string& strImage, const size_t space) const;
 
   /*! \brief Build SQL  for sort subquery from ignore article token list
   \param strField original name or title field that articles could be removed from
@@ -986,11 +969,14 @@ private:
   */
   bool MigrateSources();
 
-  bool m_translateBlankArtist;
+  std::map<std::string, int, std::less<>> m_genreCache;
+  std::map<std::string, int, std::less<>> m_pathCache;
+  bool m_translateBlankArtist{true};
 
   // Fields should be ordered as they
   // appear in the songview
-  static enum _SongFields {
+  enum SongFields
+  {
     song_idSong = 0,
     song_strArtists,
     song_strArtistSort,
@@ -1033,11 +1019,12 @@ private:
     song_dateNew,
     song_dateModified,
     song_enumCount // end of the enum, do not add past here
-  } SongFields;
+  };
 
   // Fields should be ordered as they
   // appear in the albumview
-  static enum _AlbumFields {
+  enum AlbumFields
+  {
     album_idAlbum = 0,
     album_strAlbum,
     album_strMusicBrainzAlbumID,
@@ -1071,11 +1058,12 @@ private:
     album_dtLastPlayed,
     album_iAlbumDuration,
     album_enumCount // end of the enum, do not add past here
-  } AlbumFields;
+  };
 
   // Fields should be ordered as they
   // appear in the songartistview/albumartistview
-  static enum _ArtistCreditFields {
+  enum ArtistCreditFields
+  {
     // used for GetAlbum to get the cascaded album/song artist credits
     artistCredit_idEntity = 0, // can be idSong or idAlbum depending on context
     artistCredit_idArtist,
@@ -1086,11 +1074,12 @@ private:
     artistCredit_strMusicBrainzArtistID,
     artistCredit_iOrder,
     artistCredit_enumCount
-  } ArtistCreditFields;
+  };
 
   // Fields should be ordered as they
   // appear in the artistview
-  static enum _ArtistFields {
+  enum ArtistFields
+  {
     artist_idArtist = 0,
     artist_strArtist,
     artist_strSortName,
@@ -1115,10 +1104,11 @@ private:
     artist_dateNew,
     artist_dateModified,
     artist_enumCount // end of the enum, do not add past here
-  } ArtistFields;
+  };
 
   // Fields fetched by GetArtistsByWhereJSON,  order same as in JSONtoDBArtist
-  static enum _JoinToArtistFields {
+  enum JoinToArtistFields
+  {
     joinToArtist_isSong = 0,
     joinToArtist_idSourceAlbum,
     joinToArtist_idSourceSong,
@@ -1136,18 +1126,20 @@ private:
     joinToArtist_thumbnail,
     joinToArtist_fanart,
     joinToArtist_enumCount // end of the enum, do not add past here
-  } JoinToArtistFields;
+  };
 
   // Fields fetched by GetAlbumsByWhereJSON,  order same as in JSONtoDBAlbum
-  static enum _JoinToAlbumFields {
+  enum JoinToAlbumFields
+  {
     joinToAlbum_idArtist = 0,
     joinToAlbum_strArtist,
     joinToAlbum_strArtistMBID,
     joinToAlbum_enumCount // end of the enum, do not add past here
-  } JoinToAlbumFields;
+  };
 
   // Fields fetched by GetSongsByWhereJSON,  order same as in JSONtoDBSong
-  static enum _JoinToSongFields {
+  enum JoinToSongFields
+  {
     // Used by GetSongsByWhereJSON
     joinToSongs_idAlbumArtist = 0,
     joinToSongs_strAlbumArtist,
@@ -1163,5 +1155,5 @@ private:
     joinToSongs_idGenre,
     joinToSongs_iOrderGenre,
     joinToSongs_enumCount // end of the enum, do not add past here
-  } JoinToSongFields;
+  };
 };

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -1157,7 +1157,10 @@ std::string CSmartPlaylistRule::GetField(int field, const std::string &type) con
   return "";
 }
 
-std::string CSmartPlaylistRuleCombination::GetWhereClause(const CDatabase &db, const std::string& strType, std::set<std::string> &referencedPlaylists) const
+std::string CSmartPlaylistRuleCombination::GetWhereClause(
+    const CDatabase& db,
+    const std::string& strType,
+    std::set<std::string, std::less<>>& referencedPlaylists) const
 {
   std::string rule;
 
@@ -1627,7 +1630,8 @@ bool CSmartPlaylist::IsMusicType(const std::string &type)
          type == "songs" || type == "mixed";
 }
 
-std::string CSmartPlaylist::GetWhereClause(const CDatabase &db, std::set<std::string> &referencedPlaylists) const
+std::string CSmartPlaylist::GetWhereClause(
+    const CDatabase& db, std::set<std::string, std::less<>>& referencedPlaylists) const
 {
   return m_ruleCombination.GetWhereClause(db, GetType(), referencedPlaylists);
 }

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -1153,7 +1153,8 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
 std::string CSmartPlaylistRule::GetField(int field, const std::string &type) const
 {
   if (field >= FieldUnknown && field < FieldMax)
-    return DatabaseUtils::GetField((Field)field, CMediaTypes::FromString(type), DatabaseQueryPartWhere);
+    return DatabaseUtils::GetField(static_cast<Field>(field), CMediaTypes::FromString(type),
+                                   DatabaseQueryPart::WHERE);
   return "";
 }
 

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -87,9 +87,9 @@ public:
   CSmartPlaylistRuleCombination() = default;
   ~CSmartPlaylistRuleCombination() override = default;
 
-  std::string GetWhereClause(const CDatabase &db,
+  std::string GetWhereClause(const CDatabase& db,
                              const std::string& strType,
-                             std::set<std::string> &referencedPlaylists) const;
+                             std::set<std::string, std::less<>>& referencedPlaylists) const;
   void GetVirtualFolders(const std::string& strType,
                          std::vector<std::string>& virtualFolders) const;
 };
@@ -159,7 +159,8 @@ public:
    \param referencedPlaylists a set of playlists to know when we reach a cycle
    \param needWhere whether we need to prepend the where clause with "WHERE "
    */
-  std::string GetWhereClause(const CDatabase &db, std::set<std::string> &referencedPlaylists) const;
+  std::string GetWhereClause(const CDatabase& db,
+                             std::set<std::string, std::less<>>& referencedPlaylists) const;
   void GetVirtualFolders(std::vector<std::string> &virtualFolders) const;
 
   std::string GetSaveLocation() const;

--- a/xbmc/utils/DatabaseUtils.cpp
+++ b/xbmc/utils/DatabaseUtils.cpp
@@ -183,7 +183,7 @@ std::string DatabaseUtils::GetField(Field field, const MediaType &mediaType, Dat
     else if (field == FieldTitle)
     {
       // We need some extra logic to get the title value if sorttitle isn't set
-      if (queryPart == DatabaseQueryPartOrderBy)
+      if (queryPart == DatabaseQueryPart::ORDER_BY)
         result = StringUtils::Format("CASE WHEN length(movie_view.c{:02}) > 0 THEN "
                                      "movie_view.c{:02} ELSE movie_view.c{:02} END",
                                      VIDEODB_ID_SORTTITLE, VIDEODB_ID_SORTTITLE, VIDEODB_ID_TITLE);
@@ -243,7 +243,7 @@ std::string DatabaseUtils::GetField(Field field, const MediaType &mediaType, Dat
     else if (field == FieldTitle)
     {
       // We need some extra logic to get the title value if sorttitle isn't set
-      if (queryPart == DatabaseQueryPartOrderBy)
+      if (queryPart == DatabaseQueryPart::ORDER_BY)
         result = StringUtils::Format("CASE WHEN length(tvshow_view.c{:02}) > 0 THEN "
                                      "tvshow_view.c{:02} ELSE tvshow_view.c{:02} END",
                                      VIDEODB_ID_TV_SORTTITLE, VIDEODB_ID_TV_SORTTITLE,
@@ -325,7 +325,7 @@ std::string DatabaseUtils::GetField(Field field, const MediaType &mediaType, Dat
       return result;
   }
 
-  if (field == FieldRandom && queryPart == DatabaseQueryPartOrderBy)
+  if (field == FieldRandom && queryPart == DatabaseQueryPart::ORDER_BY)
     return "RANDOM()";
 
   return "";
@@ -377,7 +377,7 @@ bool DatabaseUtils::GetSelectFields(const Fields &fields, const MediaType &media
     if (field == FieldLabel)
       continue;
 
-    if (GetField(field, mediaType, DatabaseQueryPartSelect).empty())
+    if (GetField(field, mediaType, DatabaseQueryPart::SELECT).empty())
     {
       CLog::Log(LOGDEBUG, "DatabaseUtils::GetSortFieldList: unknown field {}", field);
       continue;

--- a/xbmc/utils/DatabaseUtils.cpp
+++ b/xbmc/utils/DatabaseUtils.cpp
@@ -438,12 +438,15 @@ bool DatabaseUtils::GetFieldValue(const dbiplus::field_value &fieldValue, CVaria
   return false;
 }
 
-bool DatabaseUtils::GetDatabaseResults(const MediaType &mediaType, const FieldList &fields, const std::unique_ptr<dbiplus::Dataset> &dataset, DatabaseResults &results)
+bool DatabaseUtils::GetDatabaseResults(const MediaType& mediaType,
+                                       const FieldList& fields,
+                                       dbiplus::Dataset& dataset,
+                                       DatabaseResults& results)
 {
-  if (dataset->num_rows() == 0)
+  if (dataset.num_rows() == 0)
     return true;
 
-  const dbiplus::result_set &resultSet = dataset->get_result_set();
+  const dbiplus::result_set& resultSet = dataset.get_result_set();
   const unsigned int offset = static_cast<unsigned int>(results.size());
 
   if (fields.empty())

--- a/xbmc/utils/DatabaseUtils.h
+++ b/xbmc/utils/DatabaseUtils.h
@@ -11,7 +11,6 @@
 #include "media/MediaType.h"
 
 #include <map>
-#include <memory>
 #include <set>
 #include <string>
 #include <vector>
@@ -180,7 +179,10 @@ public:
   static bool GetSelectFields(const Fields &fields, const MediaType &mediaType, FieldList &selectFields);
 
   static bool GetFieldValue(const dbiplus::field_value &fieldValue, CVariant &variantValue);
-  static bool GetDatabaseResults(const MediaType &mediaType, const FieldList &fields, const std::unique_ptr<dbiplus::Dataset> &dataset, DatabaseResults &results);
+  static bool GetDatabaseResults(const MediaType& mediaType,
+                                 const FieldList& fields,
+                                 dbiplus::Dataset& dataset,
+                                 DatabaseResults& results);
 
   static std::string BuildLimitClause(int end, int start = 0);
   static std::string BuildLimitClauseOnly(int end, int start = 0);

--- a/xbmc/utils/DatabaseUtils.h
+++ b/xbmc/utils/DatabaseUtils.h
@@ -25,7 +25,7 @@ namespace dbiplus
   class field_value;
 }
 
-typedef enum
+enum Field
 {
   // special fields used during sorting
   FieldUnknown = -1,
@@ -154,19 +154,20 @@ typedef enum
   FieldHasVideoVersions,
   FieldHasVideoExtras,
   FieldMax
-} Field;
+};
 
-typedef std::set<Field> Fields;
-typedef std::vector<Field> FieldList;
+using Fields = std::set<Field>;
+using FieldList = std::vector<Field>;
 
-typedef enum {
+enum DatabaseQueryPart
+{
   DatabaseQueryPartSelect,
   DatabaseQueryPartWhere,
   DatabaseQueryPartOrderBy,
-} DatabaseQueryPart;
+};
 
-typedef std::map<Field, CVariant> DatabaseResult;
-typedef std::vector<DatabaseResult> DatabaseResults;
+using DatabaseResult = std::map<Field, CVariant>;
+using DatabaseResults = std::vector<DatabaseResult>;
 
 class DatabaseUtils
 {

--- a/xbmc/utils/DatabaseUtils.h
+++ b/xbmc/utils/DatabaseUtils.h
@@ -158,11 +158,11 @@ enum Field
 using Fields = std::set<Field>;
 using FieldList = std::vector<Field>;
 
-enum DatabaseQueryPart
+enum class DatabaseQueryPart
 {
-  DatabaseQueryPartSelect,
-  DatabaseQueryPartWhere,
-  DatabaseQueryPartOrderBy,
+  SELECT,
+  WHERE,
+  ORDER_BY,
 };
 
 using DatabaseResult = std::map<Field, CVariant>;

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -1077,7 +1077,10 @@ void SortUtils::Sort(const SortDescription &sortDescription, SortItems& items)
   Sort(sortDescription.sortBy, sortDescription.sortOrder, sortDescription.sortAttributes, items, sortDescription.limitEnd, sortDescription.limitStart);
 }
 
-bool SortUtils::SortFromDataset(const SortDescription &sortDescription, const MediaType &mediaType, const std::unique_ptr<dbiplus::Dataset> &dataset, DatabaseResults &results)
+bool SortUtils::SortFromDataset(const SortDescription& sortDescription,
+                                const MediaType& mediaType,
+                                dbiplus::Dataset& dataset,
+                                DatabaseResults& results)
 {
   FieldList fields;
   if (!DatabaseUtils::GetSelectFields(SortUtils::GetFieldsForSorting(sortDescription.sortBy), mediaType, fields))

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -1134,7 +1134,7 @@ const Fields& SortUtils::GetFieldsForSorting(SortBy sortBy)
 
 std::string SortUtils::RemoveArticles(const std::string &label)
 {
-  std::set<std::string> sortTokens = g_langInfo.GetSortTokens();
+  const CLangInfo::Tokens sortTokens = g_langInfo.GetSortTokens();
   for (std::set<std::string>::const_iterator token = sortTokens.begin(); token != sortTokens.end(); ++token)
   {
     if (token->size() < label.size() && StringUtils::StartsWithNoCase(label, *token))

--- a/xbmc/utils/SortUtils.h
+++ b/xbmc/utils/SortUtils.h
@@ -216,7 +216,10 @@ public:
   static void Sort(SortBy sortBy, SortOrder sortOrder, SortAttribute attributes, SortItems& items, int limitEnd = -1, int limitStart = 0);
   static void Sort(const SortDescription &sortDescription, DatabaseResults& items);
   static void Sort(const SortDescription &sortDescription, SortItems& items);
-  static bool SortFromDataset(const SortDescription &sortDescription, const MediaType &mediaType, const std::unique_ptr<dbiplus::Dataset> &dataset, DatabaseResults &results);
+  static bool SortFromDataset(const SortDescription& sortDescription,
+                              const MediaType& mediaType,
+                              dbiplus::Dataset& dataset,
+                              DatabaseResults& results);
 
   static void GetFieldsForSQLSort(const MediaType& mediaType, SortBy sortMethod, FieldList& fields);
   static const Fields& GetFieldsForSorting(SortBy sortBy);

--- a/xbmc/utils/test/TestDatabaseUtils.cpp
+++ b/xbmc/utils/test/TestDatabaseUtils.cpp
@@ -101,12 +101,10 @@ TEST(TestDatabaseUtils, GetField_None)
   std::string refstr, varstr;
 
   refstr = "";
-  varstr = DatabaseUtils::GetField(FieldNone, MediaTypeNone,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldNone, MediaTypeNone, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  varstr = DatabaseUtils::GetField(FieldNone, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldNone, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 }
 
@@ -115,102 +113,82 @@ TEST(TestDatabaseUtils, GetField_MediaTypeAlbum)
   std::string refstr, varstr;
 
   refstr = "albumview.idAlbum";
-  varstr = DatabaseUtils::GetField(FieldId, MediaTypeAlbum,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldId, MediaTypeAlbum, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "albumview.strAlbum";
-  varstr = DatabaseUtils::GetField(FieldAlbum, MediaTypeAlbum,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldAlbum, MediaTypeAlbum, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "albumview.strArtists";
-  varstr = DatabaseUtils::GetField(FieldArtist, MediaTypeAlbum,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldArtist, MediaTypeAlbum, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "albumview.strArtists";
-  varstr = DatabaseUtils::GetField(FieldAlbumArtist, MediaTypeAlbum,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldAlbumArtist, MediaTypeAlbum, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "albumview.strGenres";
-  varstr = DatabaseUtils::GetField(FieldGenre, MediaTypeAlbum,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldGenre, MediaTypeAlbum, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "albumview.strReleaseDate";
-  varstr = DatabaseUtils::GetField(FieldYear, MediaTypeAlbum,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldYear, MediaTypeAlbum, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-refstr = "albumview.strOrigReleaseDate";
-  varstr = DatabaseUtils::GetField(FieldOrigYear, MediaTypeAlbum,
-                                   DatabaseQueryPartSelect);
+  refstr = "albumview.strOrigReleaseDate";
+  varstr = DatabaseUtils::GetField(FieldOrigYear, MediaTypeAlbum, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "albumview.strMoods";
-  varstr = DatabaseUtils::GetField(FieldMoods, MediaTypeAlbum,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldMoods, MediaTypeAlbum, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "albumview.strStyles";
-  varstr = DatabaseUtils::GetField(FieldStyles, MediaTypeAlbum,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldStyles, MediaTypeAlbum, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "albumview.strThemes";
-  varstr = DatabaseUtils::GetField(FieldThemes, MediaTypeAlbum,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldThemes, MediaTypeAlbum, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "albumview.strReview";
-  varstr = DatabaseUtils::GetField(FieldReview, MediaTypeAlbum,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldReview, MediaTypeAlbum, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "albumview.strLabel";
-  varstr = DatabaseUtils::GetField(FieldMusicLabel, MediaTypeAlbum,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldMusicLabel, MediaTypeAlbum, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "albumview.strType";
-  varstr = DatabaseUtils::GetField(FieldAlbumType, MediaTypeAlbum,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldAlbumType, MediaTypeAlbum, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "albumview.fRating";
-  varstr = DatabaseUtils::GetField(FieldRating, MediaTypeAlbum,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldRating, MediaTypeAlbum, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "albumview.iVotes";
-  varstr = DatabaseUtils::GetField(FieldVotes, MediaTypeAlbum,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldVotes, MediaTypeAlbum, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "albumview.iUserrating";
-  varstr = DatabaseUtils::GetField(FieldUserRating, MediaTypeAlbum,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldUserRating, MediaTypeAlbum, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "albumview.dateAdded";
-  varstr = DatabaseUtils::GetField(FieldDateAdded, MediaTypeAlbum,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldDateAdded, MediaTypeAlbum, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "";
-  varstr = DatabaseUtils::GetField(FieldNone, MediaTypeAlbum,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldNone, MediaTypeAlbum, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "albumview.strAlbum";
-  varstr = DatabaseUtils::GetField(FieldAlbum, MediaTypeAlbum,
-                                   DatabaseQueryPartWhere);
+  varstr = DatabaseUtils::GetField(FieldAlbum, MediaTypeAlbum, DatabaseQueryPart::WHERE);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  varstr = DatabaseUtils::GetField(FieldAlbum, MediaTypeAlbum,
-                                   DatabaseQueryPartOrderBy);
+  varstr = DatabaseUtils::GetField(FieldAlbum, MediaTypeAlbum, DatabaseQueryPart::ORDER_BY);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 }
 
@@ -219,117 +197,94 @@ TEST(TestDatabaseUtils, GetField_MediaTypeSong)
   std::string refstr, varstr;
 
   refstr = "songview.idSong";
-  varstr = DatabaseUtils::GetField(FieldId, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldId, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.strTitle";
-  varstr = DatabaseUtils::GetField(FieldTitle, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldTitle, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.iTrack";
-  varstr = DatabaseUtils::GetField(FieldTrackNumber, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldTrackNumber, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.iDuration";
-  varstr = DatabaseUtils::GetField(FieldTime, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldTime, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.strFilename";
-  varstr = DatabaseUtils::GetField(FieldFilename, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldFilename, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.iTimesPlayed";
-  varstr = DatabaseUtils::GetField(FieldPlaycount, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldPlaycount, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.iStartOffset";
-  varstr = DatabaseUtils::GetField(FieldStartOffset, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldStartOffset, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.iEndOffset";
-  varstr = DatabaseUtils::GetField(FieldEndOffset, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldEndOffset, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.lastPlayed";
-  varstr = DatabaseUtils::GetField(FieldLastPlayed, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldLastPlayed, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.rating";
-  varstr = DatabaseUtils::GetField(FieldRating, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldRating, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.votes";
-  varstr = DatabaseUtils::GetField(FieldVotes, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldVotes, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.userrating";
-  varstr = DatabaseUtils::GetField(FieldUserRating, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldUserRating, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.comment";
-  varstr = DatabaseUtils::GetField(FieldComment, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldComment, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.strReleaseDate";
-  varstr = DatabaseUtils::GetField(FieldYear, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldYear, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.strOrigReleaseDate";
-  varstr = DatabaseUtils::GetField(FieldOrigYear, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldOrigYear, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.strAlbum";
-  varstr = DatabaseUtils::GetField(FieldAlbum, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldAlbum, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.strPath";
-  varstr = DatabaseUtils::GetField(FieldPath, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldPath, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.strArtists";
-  varstr = DatabaseUtils::GetField(FieldArtist, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldArtist, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.strArtists";
-  varstr = DatabaseUtils::GetField(FieldAlbumArtist, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldAlbumArtist, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.strGenres";
-  varstr = DatabaseUtils::GetField(FieldGenre, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldGenre, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.dateAdded";
-  varstr = DatabaseUtils::GetField(FieldDateAdded, MediaTypeSong,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldDateAdded, MediaTypeSong, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "songview.strPath";
-  varstr = DatabaseUtils::GetField(FieldPath, MediaTypeSong,
-                                   DatabaseQueryPartWhere);
+  varstr = DatabaseUtils::GetField(FieldPath, MediaTypeSong, DatabaseQueryPart::WHERE);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  varstr = DatabaseUtils::GetField(FieldPath, MediaTypeSong,
-                                   DatabaseQueryPartOrderBy);
+  varstr = DatabaseUtils::GetField(FieldPath, MediaTypeSong, DatabaseQueryPart::ORDER_BY);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 }
 
@@ -338,98 +293,81 @@ TEST(TestDatabaseUtils, GetField_MediaTypeMusicVideo)
   std::string refstr, varstr;
 
   refstr = "musicvideo_view.idMVideo";
-  varstr = DatabaseUtils::GetField(FieldId, MediaTypeMusicVideo,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldId, MediaTypeMusicVideo, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_TITLE);
-  varstr = DatabaseUtils::GetField(FieldTitle, MediaTypeMusicVideo,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldTitle, MediaTypeMusicVideo, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_RUNTIME);
-  varstr = DatabaseUtils::GetField(FieldTime, MediaTypeMusicVideo,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldTime, MediaTypeMusicVideo, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_DIRECTOR);
-  varstr = DatabaseUtils::GetField(FieldDirector, MediaTypeMusicVideo,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldDirector, MediaTypeMusicVideo, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_STUDIOS);
-  varstr = DatabaseUtils::GetField(FieldStudio, MediaTypeMusicVideo,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldStudio, MediaTypeMusicVideo, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_PLOT);
-  varstr = DatabaseUtils::GetField(FieldPlot, MediaTypeMusicVideo,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldPlot, MediaTypeMusicVideo, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_ALBUM);
-  varstr = DatabaseUtils::GetField(FieldAlbum, MediaTypeMusicVideo,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldAlbum, MediaTypeMusicVideo, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_ARTIST);
-  varstr = DatabaseUtils::GetField(FieldArtist, MediaTypeMusicVideo,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldArtist, MediaTypeMusicVideo, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_GENRE);
-  varstr = DatabaseUtils::GetField(FieldGenre, MediaTypeMusicVideo,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldGenre, MediaTypeMusicVideo, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("musicvideo_view.c{:02}", VIDEODB_ID_MUSICVIDEO_TRACK);
-  varstr = DatabaseUtils::GetField(FieldTrackNumber, MediaTypeMusicVideo,
-                                   DatabaseQueryPartSelect);
+  varstr =
+      DatabaseUtils::GetField(FieldTrackNumber, MediaTypeMusicVideo, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "musicvideo_view.strFilename";
-  varstr = DatabaseUtils::GetField(FieldFilename, MediaTypeMusicVideo,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldFilename, MediaTypeMusicVideo, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "musicvideo_view.strPath";
-  varstr = DatabaseUtils::GetField(FieldPath, MediaTypeMusicVideo,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldPath, MediaTypeMusicVideo, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "musicvideo_view.playCount";
-  varstr = DatabaseUtils::GetField(FieldPlaycount, MediaTypeMusicVideo,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldPlaycount, MediaTypeMusicVideo, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "musicvideo_view.lastPlayed";
-  varstr = DatabaseUtils::GetField(FieldLastPlayed, MediaTypeMusicVideo,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldLastPlayed, MediaTypeMusicVideo, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "musicvideo_view.dateAdded";
-  varstr = DatabaseUtils::GetField(FieldDateAdded, MediaTypeMusicVideo,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldDateAdded, MediaTypeMusicVideo, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "";
-  varstr = DatabaseUtils::GetField(FieldVideoResolution, MediaTypeMusicVideo,
-                                   DatabaseQueryPartSelect);
+  varstr =
+      DatabaseUtils::GetField(FieldVideoResolution, MediaTypeMusicVideo, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "musicvideo_view.strPath";
-  varstr = DatabaseUtils::GetField(FieldPath, MediaTypeMusicVideo,
-                                   DatabaseQueryPartWhere);
+  varstr = DatabaseUtils::GetField(FieldPath, MediaTypeMusicVideo, DatabaseQueryPart::WHERE);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "musicvideo_view.strPath";
-  varstr = DatabaseUtils::GetField(FieldPath, MediaTypeMusicVideo,
-                                   DatabaseQueryPartOrderBy);
+  varstr = DatabaseUtils::GetField(FieldPath, MediaTypeMusicVideo, DatabaseQueryPart::ORDER_BY);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "musicvideo_view.userrating";
-  varstr = DatabaseUtils::GetField(FieldUserRating, MediaTypeMusicVideo,
-    DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldUserRating, MediaTypeMusicVideo, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 }
 
@@ -438,130 +376,105 @@ TEST(TestDatabaseUtils, GetField_MediaTypeMovie)
   std::string refstr, varstr;
 
   refstr = "movie_view.idMovie";
-  varstr = DatabaseUtils::GetField(FieldId, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldId, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_TITLE);
-  varstr = DatabaseUtils::GetField(FieldTitle, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldTitle, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("CASE WHEN length(movie_view.c{:02}) > 0 THEN movie_view.c{:02} "
                                "ELSE movie_view.c{:02} END",
                                VIDEODB_ID_SORTTITLE, VIDEODB_ID_SORTTITLE, VIDEODB_ID_TITLE);
-  varstr = DatabaseUtils::GetField(FieldTitle, MediaTypeMovie,
-                                   DatabaseQueryPartOrderBy);
+  varstr = DatabaseUtils::GetField(FieldTitle, MediaTypeMovie, DatabaseQueryPart::ORDER_BY);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_PLOT);
-  varstr = DatabaseUtils::GetField(FieldPlot, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldPlot, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_PLOTOUTLINE);
-  varstr = DatabaseUtils::GetField(FieldPlotOutline, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldPlotOutline, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_TAGLINE);
-  varstr = DatabaseUtils::GetField(FieldTagline, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldTagline, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "movie_view.votes";
-  varstr = DatabaseUtils::GetField(FieldVotes, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldVotes, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "movie_view.rating";
-  varstr = DatabaseUtils::GetField(FieldRating, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldRating, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_CREDITS);
-  varstr = DatabaseUtils::GetField(FieldWriter, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldWriter, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_SORTTITLE);
-  varstr = DatabaseUtils::GetField(FieldSortTitle, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldSortTitle, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_RUNTIME);
-  varstr = DatabaseUtils::GetField(FieldTime, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldTime, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_MPAA);
-  varstr = DatabaseUtils::GetField(FieldMPAA, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldMPAA, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_TOP250);
-  varstr = DatabaseUtils::GetField(FieldTop250, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldTop250, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_GENRE);
-  varstr = DatabaseUtils::GetField(FieldGenre, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldGenre, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_DIRECTOR);
-  varstr = DatabaseUtils::GetField(FieldDirector, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldDirector, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_STUDIOS);
-  varstr = DatabaseUtils::GetField(FieldStudio, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldStudio, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_TRAILER);
-  varstr = DatabaseUtils::GetField(FieldTrailer, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldTrailer, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("movie_view.c{:02}", VIDEODB_ID_COUNTRY);
-  varstr = DatabaseUtils::GetField(FieldCountry, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldCountry, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "movie_view.strFilename";
-  varstr = DatabaseUtils::GetField(FieldFilename, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldFilename, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "movie_view.strPath";
-  varstr = DatabaseUtils::GetField(FieldPath, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldPath, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "movie_view.playCount";
-  varstr = DatabaseUtils::GetField(FieldPlaycount, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldPlaycount, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "movie_view.lastPlayed";
-  varstr = DatabaseUtils::GetField(FieldLastPlayed, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldLastPlayed, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "movie_view.dateAdded";
-  varstr = DatabaseUtils::GetField(FieldDateAdded, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldDateAdded, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "movie_view.userrating";
-  varstr = DatabaseUtils::GetField(FieldUserRating, MediaTypeMovie,
-    DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldUserRating, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "";
-  varstr = DatabaseUtils::GetField(FieldRandom, MediaTypeMovie,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldRandom, MediaTypeMovie, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 }
 
@@ -570,101 +483,84 @@ TEST(TestDatabaseUtils, GetField_MediaTypeTvShow)
   std::string refstr, varstr;
 
   refstr = "tvshow_view.idShow";
-  varstr = DatabaseUtils::GetField(FieldId, MediaTypeTvShow,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldId, MediaTypeTvShow, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr =
       StringUtils::Format("CASE WHEN length(tvshow_view.c{:02}) > 0 THEN tvshow_view.c{:02} "
                           "ELSE tvshow_view.c{:02} END",
                           VIDEODB_ID_TV_SORTTITLE, VIDEODB_ID_TV_SORTTITLE, VIDEODB_ID_TV_TITLE);
-  varstr = DatabaseUtils::GetField(FieldTitle, MediaTypeTvShow,
-                                   DatabaseQueryPartOrderBy);
+  varstr = DatabaseUtils::GetField(FieldTitle, MediaTypeTvShow, DatabaseQueryPart::ORDER_BY);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_TITLE);
-  varstr = DatabaseUtils::GetField(FieldTitle, MediaTypeTvShow,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldTitle, MediaTypeTvShow, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_PLOT);
-  varstr = DatabaseUtils::GetField(FieldPlot, MediaTypeTvShow,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldPlot, MediaTypeTvShow, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_STATUS);
-  varstr = DatabaseUtils::GetField(FieldTvShowStatus, MediaTypeTvShow,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldTvShowStatus, MediaTypeTvShow, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "tvshow_view.votes";
-  varstr = DatabaseUtils::GetField(FieldVotes, MediaTypeTvShow,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldVotes, MediaTypeTvShow, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "tvshow_view.rating";
-  varstr = DatabaseUtils::GetField(FieldRating, MediaTypeTvShow,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldRating, MediaTypeTvShow, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_PREMIERED);
-  varstr = DatabaseUtils::GetField(FieldYear, MediaTypeTvShow,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldYear, MediaTypeTvShow, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_GENRE);
-  varstr = DatabaseUtils::GetField(FieldGenre, MediaTypeTvShow,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldGenre, MediaTypeTvShow, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_MPAA);
-  varstr = DatabaseUtils::GetField(FieldMPAA, MediaTypeTvShow,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldMPAA, MediaTypeTvShow, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_STUDIOS);
-  varstr = DatabaseUtils::GetField(FieldStudio, MediaTypeTvShow,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldStudio, MediaTypeTvShow, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("tvshow_view.c{:02}", VIDEODB_ID_TV_SORTTITLE);
-  varstr = DatabaseUtils::GetField(FieldSortTitle, MediaTypeTvShow,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldSortTitle, MediaTypeTvShow, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "tvshow_view.strPath";
-  varstr = DatabaseUtils::GetField(FieldPath, MediaTypeTvShow,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldPath, MediaTypeTvShow, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "tvshow_view.dateAdded";
-  varstr = DatabaseUtils::GetField(FieldDateAdded, MediaTypeTvShow,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldDateAdded, MediaTypeTvShow, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "tvshow_view.totalSeasons";
-  varstr = DatabaseUtils::GetField(FieldSeason, MediaTypeTvShow,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldSeason, MediaTypeTvShow, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "tvshow_view.totalCount";
-  varstr = DatabaseUtils::GetField(FieldNumberOfEpisodes, MediaTypeTvShow,
-                                   DatabaseQueryPartSelect);
+  varstr =
+      DatabaseUtils::GetField(FieldNumberOfEpisodes, MediaTypeTvShow, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "tvshow_view.watchedcount";
-  varstr = DatabaseUtils::GetField(FieldNumberOfWatchedEpisodes,
-                                   MediaTypeTvShow, DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldNumberOfWatchedEpisodes, MediaTypeTvShow,
+                                   DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "tvshow_view.userrating";
-  varstr = DatabaseUtils::GetField(FieldUserRating, MediaTypeTvShow,
-    DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldUserRating, MediaTypeTvShow, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "";
-  varstr = DatabaseUtils::GetField(FieldRandom, MediaTypeTvShow,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldRandom, MediaTypeTvShow, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 }
 
@@ -673,113 +569,91 @@ TEST(TestDatabaseUtils, GetField_MediaTypeEpisode)
   std::string refstr, varstr;
 
   refstr = "episode_view.idEpisode";
-  varstr = DatabaseUtils::GetField(FieldId, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldId, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_TITLE);
-  varstr = DatabaseUtils::GetField(FieldTitle, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldTitle, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_PLOT);
-  varstr = DatabaseUtils::GetField(FieldPlot, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldPlot, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "episode_view.votes";
-  varstr = DatabaseUtils::GetField(FieldVotes, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldVotes, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "episode_view.rating";
-  varstr = DatabaseUtils::GetField(FieldRating, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldRating, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_CREDITS);
-  varstr = DatabaseUtils::GetField(FieldWriter, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldWriter, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_AIRED);
-  varstr = DatabaseUtils::GetField(FieldAirDate, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldAirDate, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_RUNTIME);
-  varstr = DatabaseUtils::GetField(FieldTime, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldTime, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_DIRECTOR);
-  varstr = DatabaseUtils::GetField(FieldDirector, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldDirector, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_SEASON);
-  varstr = DatabaseUtils::GetField(FieldSeason, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldSeason, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = StringUtils::Format("episode_view.c{:02}", VIDEODB_ID_EPISODE_EPISODE);
-  varstr = DatabaseUtils::GetField(FieldEpisodeNumber, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldEpisodeNumber, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "episode_view.strFilename";
-  varstr = DatabaseUtils::GetField(FieldFilename, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldFilename, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "episode_view.strPath";
-  varstr = DatabaseUtils::GetField(FieldPath, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldPath, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "episode_view.playCount";
-  varstr = DatabaseUtils::GetField(FieldPlaycount, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldPlaycount, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "episode_view.lastPlayed";
-  varstr = DatabaseUtils::GetField(FieldLastPlayed, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldLastPlayed, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "episode_view.dateAdded";
-  varstr = DatabaseUtils::GetField(FieldDateAdded, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldDateAdded, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "episode_view.strTitle";
-  varstr = DatabaseUtils::GetField(FieldTvShowTitle, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldTvShowTitle, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "episode_view.premiered";
-  varstr = DatabaseUtils::GetField(FieldYear, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldYear, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "episode_view.mpaa";
-  varstr = DatabaseUtils::GetField(FieldMPAA, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldMPAA, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "episode_view.strStudio";
-  varstr = DatabaseUtils::GetField(FieldStudio, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldStudio, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "episode_view.userrating";
-  varstr = DatabaseUtils::GetField(FieldUserRating, MediaTypeEpisode,
-    DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldUserRating, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "";
-  varstr = DatabaseUtils::GetField(FieldRandom, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldRandom, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 }
 
@@ -788,18 +662,15 @@ TEST(TestDatabaseUtils, GetField_FieldRandom)
   std::string refstr, varstr;
 
   refstr = "";
-  varstr = DatabaseUtils::GetField(FieldRandom, MediaTypeEpisode,
-                                   DatabaseQueryPartSelect);
+  varstr = DatabaseUtils::GetField(FieldRandom, MediaTypeEpisode, DatabaseQueryPart::SELECT);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "";
-  varstr = DatabaseUtils::GetField(FieldRandom, MediaTypeEpisode,
-                                   DatabaseQueryPartWhere);
+  varstr = DatabaseUtils::GetField(FieldRandom, MediaTypeEpisode, DatabaseQueryPart::WHERE);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "RANDOM()";
-  varstr = DatabaseUtils::GetField(FieldRandom, MediaTypeEpisode,
-                                   DatabaseQueryPartOrderBy);
+  varstr = DatabaseUtils::GetField(FieldRandom, MediaTypeEpisode, DatabaseQueryPart::ORDER_BY);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8784,7 +8784,7 @@ bool CVideoDatabase::GetMoviesByWhere(const std::string& strBaseDir, const Filte
     DatabaseResults results;
     results.reserve(iRowsFound);
 
-    if (!SortUtils::SortFromDataset(sortDescription, MediaTypeMovie, m_pDS, results))
+    if (!SortUtils::SortFromDataset(sortDescription, MediaTypeMovie, *m_pDS, results))
       return false;
 
     // get data from returned rows
@@ -8931,7 +8931,7 @@ bool CVideoDatabase::GetTvShowsByWhere(const std::string& strBaseDir, const Filt
 
     DatabaseResults results;
     results.reserve(iRowsFound);
-    if (!SortUtils::SortFromDataset(sorting, MediaTypeTvShow, m_pDS, results))
+    if (!SortUtils::SortFromDataset(sorting, MediaTypeTvShow, *m_pDS, results))
       return false;
 
     // get data from returned rows
@@ -9060,7 +9060,7 @@ bool CVideoDatabase::GetEpisodesByWhere(const std::string& strBaseDir, const Fil
 
     DatabaseResults results;
     results.reserve(iRowsFound);
-    if (!SortUtils::SortFromDataset(sorting, MediaTypeEpisode, m_pDS, results))
+    if (!SortUtils::SortFromDataset(sorting, MediaTypeEpisode, *m_pDS, results))
       return false;
 
     // get data from returned rows
@@ -10034,7 +10034,7 @@ bool CVideoDatabase::GetMusicVideosByWhere(const std::string &baseDir, const Fil
 
     DatabaseResults results;
     results.reserve(iRowsFound);
-    if (!SortUtils::SortFromDataset(sorting, MediaTypeMusicVideo, m_pDS, results))
+    if (!SortUtils::SortFromDataset(sorting, MediaTypeMusicVideo, *m_pDS, results))
       return false;
 
     // get data from returned rows

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -16,10 +16,14 @@
 #include "utils/SortUtils.h"
 #include "utils/UrlOptions.h"
 
+#include <array>
+#include <functional>
 #include <memory>
 #include <set>
 #include <stdexcept>
+#include <string>
 #include <string_view>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -41,7 +45,7 @@ enum class VideoAssetType;
 namespace dbiplus
 {
   class field_value;
-  typedef std::vector<field_value> sql_record;
+  using sql_record = std::vector<field_value>;
 }
 
 #ifndef my_offsetof
@@ -84,95 +88,97 @@ enum VideoDbDetails
 
 // these defines are based on how many columns we have and which column certain data is going to be in
 // when we do GetDetailsForMovie()
-#define VIDEODB_MAX_COLUMNS 24
-#define VIDEODB_DETAILS_FILEID      1
+constexpr int VIDEODB_MAX_COLUMNS = 24;
+constexpr int VIDEODB_DETAILS_FILEID = 1;
 
-#define VIDEODB_DETAILS_MOVIE_SET_ID            VIDEODB_MAX_COLUMNS + 2
-#define VIDEODB_DETAILS_MOVIE_USER_RATING       VIDEODB_MAX_COLUMNS + 3
-#define VIDEODB_DETAILS_MOVIE_PREMIERED         VIDEODB_MAX_COLUMNS + 4
-#define VIDEODB_DETAILS_MOVIE_SET_NAME          VIDEODB_MAX_COLUMNS + 5
-#define VIDEODB_DETAILS_MOVIE_SET_OVERVIEW      VIDEODB_MAX_COLUMNS + 6
-#define VIDEODB_DETAILS_MOVIE_FILE              VIDEODB_MAX_COLUMNS + 7
-#define VIDEODB_DETAILS_MOVIE_PATH              VIDEODB_MAX_COLUMNS + 8
-#define VIDEODB_DETAILS_MOVIE_PLAYCOUNT         VIDEODB_MAX_COLUMNS + 9
-#define VIDEODB_DETAILS_MOVIE_LASTPLAYED        VIDEODB_MAX_COLUMNS + 10
-#define VIDEODB_DETAILS_MOVIE_DATEADDED         VIDEODB_MAX_COLUMNS + 11
-#define VIDEODB_DETAILS_MOVIE_RESUME_TIME       VIDEODB_MAX_COLUMNS + 12
-#define VIDEODB_DETAILS_MOVIE_TOTAL_TIME        VIDEODB_MAX_COLUMNS + 13
-#define VIDEODB_DETAILS_MOVIE_PLAYER_STATE      VIDEODB_MAX_COLUMNS + 14
-#define VIDEODB_DETAILS_MOVIE_RATING            VIDEODB_MAX_COLUMNS + 15
-#define VIDEODB_DETAILS_MOVIE_VOTES             VIDEODB_MAX_COLUMNS + 16
-#define VIDEODB_DETAILS_MOVIE_RATING_TYPE       VIDEODB_MAX_COLUMNS + 17
-#define VIDEODB_DETAILS_MOVIE_UNIQUEID_VALUE    VIDEODB_MAX_COLUMNS + 18
-#define VIDEODB_DETAILS_MOVIE_UNIQUEID_TYPE     VIDEODB_MAX_COLUMNS + 19
-#define VIDEODB_DETAILS_MOVIE_HASVERSIONS       VIDEODB_MAX_COLUMNS + 20
-#define VIDEODB_DETAILS_MOVIE_HASEXTRAS VIDEODB_MAX_COLUMNS + 21
-#define VIDEODB_DETAILS_MOVIE_ISDEFAULTVERSION VIDEODB_MAX_COLUMNS + 22
-#define VIDEODB_DETAILS_MOVIE_VERSION_FILEID VIDEODB_MAX_COLUMNS + 23
-#define VIDEODB_DETAILS_MOVIE_VERSION_TYPEID VIDEODB_MAX_COLUMNS + 24
-#define VIDEODB_DETAILS_MOVIE_VERSION_TYPENAME VIDEODB_MAX_COLUMNS + 25
-#define VIDEODB_DETAILS_MOVIE_VERSION_ITEMTYPE VIDEODB_MAX_COLUMNS + 26
+// clang-format off
+constexpr int VIDEODB_DETAILS_MOVIE_SET_ID              = VIDEODB_MAX_COLUMNS + 2;
+constexpr int VIDEODB_DETAILS_MOVIE_USER_RATING         = VIDEODB_MAX_COLUMNS + 3;
+constexpr int VIDEODB_DETAILS_MOVIE_PREMIERED           = VIDEODB_MAX_COLUMNS + 4;
+constexpr int VIDEODB_DETAILS_MOVIE_SET_NAME            = VIDEODB_MAX_COLUMNS + 5;
+constexpr int VIDEODB_DETAILS_MOVIE_SET_OVERVIEW        = VIDEODB_MAX_COLUMNS + 6;
+constexpr int VIDEODB_DETAILS_MOVIE_FILE                = VIDEODB_MAX_COLUMNS + 7;
+constexpr int VIDEODB_DETAILS_MOVIE_PATH                = VIDEODB_MAX_COLUMNS + 8;
+constexpr int VIDEODB_DETAILS_MOVIE_PLAYCOUNT           = VIDEODB_MAX_COLUMNS + 9;
+constexpr int VIDEODB_DETAILS_MOVIE_LASTPLAYED          = VIDEODB_MAX_COLUMNS + 10;
+constexpr int VIDEODB_DETAILS_MOVIE_DATEADDED           = VIDEODB_MAX_COLUMNS + 11;
+constexpr int VIDEODB_DETAILS_MOVIE_RESUME_TIME         = VIDEODB_MAX_COLUMNS + 12;
+constexpr int VIDEODB_DETAILS_MOVIE_TOTAL_TIME          = VIDEODB_MAX_COLUMNS + 13;
+constexpr int VIDEODB_DETAILS_MOVIE_PLAYER_STATE        = VIDEODB_MAX_COLUMNS + 14;
+constexpr int VIDEODB_DETAILS_MOVIE_RATING              = VIDEODB_MAX_COLUMNS + 15;
+constexpr int VIDEODB_DETAILS_MOVIE_VOTES               = VIDEODB_MAX_COLUMNS + 16;
+constexpr int VIDEODB_DETAILS_MOVIE_RATING_TYPE         = VIDEODB_MAX_COLUMNS + 17;
+constexpr int VIDEODB_DETAILS_MOVIE_UNIQUEID_VALUE      = VIDEODB_MAX_COLUMNS + 18;
+constexpr int VIDEODB_DETAILS_MOVIE_UNIQUEID_TYPE       = VIDEODB_MAX_COLUMNS + 19;
+constexpr int VIDEODB_DETAILS_MOVIE_HASVERSIONS         = VIDEODB_MAX_COLUMNS + 20;
+constexpr int VIDEODB_DETAILS_MOVIE_HASEXTRAS           = VIDEODB_MAX_COLUMNS + 21;
+constexpr int VIDEODB_DETAILS_MOVIE_ISDEFAULTVERSION    = VIDEODB_MAX_COLUMNS + 22;
+constexpr int VIDEODB_DETAILS_MOVIE_VERSION_FILEID      = VIDEODB_MAX_COLUMNS + 23;
+constexpr int VIDEODB_DETAILS_MOVIE_VERSION_TYPEID      = VIDEODB_MAX_COLUMNS + 24;
+constexpr int VIDEODB_DETAILS_MOVIE_VERSION_TYPENAME    = VIDEODB_MAX_COLUMNS + 25;
+constexpr int VIDEODB_DETAILS_MOVIE_VERSION_ITEMTYPE    = VIDEODB_MAX_COLUMNS + 26;
 
-#define VIDEODB_DETAILS_EPISODE_TVSHOW_ID       VIDEODB_MAX_COLUMNS + 2
-#define VIDEODB_DETAILS_EPISODE_USER_RATING     VIDEODB_MAX_COLUMNS + 3
-#define VIDEODB_DETAILS_EPISODE_SEASON_ID       VIDEODB_MAX_COLUMNS + 4
-#define VIDEODB_DETAILS_EPISODE_FILE            VIDEODB_MAX_COLUMNS + 5
-#define VIDEODB_DETAILS_EPISODE_PATH            VIDEODB_MAX_COLUMNS + 6
-#define VIDEODB_DETAILS_EPISODE_PLAYCOUNT       VIDEODB_MAX_COLUMNS + 7
-#define VIDEODB_DETAILS_EPISODE_LASTPLAYED      VIDEODB_MAX_COLUMNS + 8
-#define VIDEODB_DETAILS_EPISODE_DATEADDED       VIDEODB_MAX_COLUMNS + 9
-#define VIDEODB_DETAILS_EPISODE_TVSHOW_NAME     VIDEODB_MAX_COLUMNS + 10
-#define VIDEODB_DETAILS_EPISODE_TVSHOW_GENRE    VIDEODB_MAX_COLUMNS + 11
-#define VIDEODB_DETAILS_EPISODE_TVSHOW_STUDIO   VIDEODB_MAX_COLUMNS + 12
-#define VIDEODB_DETAILS_EPISODE_TVSHOW_AIRED    VIDEODB_MAX_COLUMNS + 13
-#define VIDEODB_DETAILS_EPISODE_TVSHOW_MPAA     VIDEODB_MAX_COLUMNS + 14
-#define VIDEODB_DETAILS_EPISODE_RESUME_TIME     VIDEODB_MAX_COLUMNS + 15
-#define VIDEODB_DETAILS_EPISODE_TOTAL_TIME      VIDEODB_MAX_COLUMNS + 16
-#define VIDEODB_DETAILS_EPISODE_PLAYER_STATE    VIDEODB_MAX_COLUMNS + 17
-#define VIDEODB_DETAILS_EPISODE_RATING          VIDEODB_MAX_COLUMNS + 18
-#define VIDEODB_DETAILS_EPISODE_VOTES           VIDEODB_MAX_COLUMNS + 19
-#define VIDEODB_DETAILS_EPISODE_RATING_TYPE     VIDEODB_MAX_COLUMNS + 20
-#define VIDEODB_DETAILS_EPISODE_UNIQUEID_VALUE  VIDEODB_MAX_COLUMNS + 21
-#define VIDEODB_DETAILS_EPISODE_UNIQUEID_TYPE   VIDEODB_MAX_COLUMNS + 22
+constexpr int VIDEODB_DETAILS_EPISODE_TVSHOW_ID         = VIDEODB_MAX_COLUMNS + 2;
+constexpr int VIDEODB_DETAILS_EPISODE_USER_RATING       = VIDEODB_MAX_COLUMNS + 3;
+constexpr int VIDEODB_DETAILS_EPISODE_SEASON_ID         = VIDEODB_MAX_COLUMNS + 4;
+constexpr int VIDEODB_DETAILS_EPISODE_FILE              = VIDEODB_MAX_COLUMNS + 5;
+constexpr int VIDEODB_DETAILS_EPISODE_PATH              = VIDEODB_MAX_COLUMNS + 6;
+constexpr int VIDEODB_DETAILS_EPISODE_PLAYCOUNT         = VIDEODB_MAX_COLUMNS + 7;
+constexpr int VIDEODB_DETAILS_EPISODE_LASTPLAYED        = VIDEODB_MAX_COLUMNS + 8;
+constexpr int VIDEODB_DETAILS_EPISODE_DATEADDED         = VIDEODB_MAX_COLUMNS + 9;
+constexpr int VIDEODB_DETAILS_EPISODE_TVSHOW_NAME       = VIDEODB_MAX_COLUMNS + 10;
+constexpr int VIDEODB_DETAILS_EPISODE_TVSHOW_GENRE      = VIDEODB_MAX_COLUMNS + 11;
+constexpr int VIDEODB_DETAILS_EPISODE_TVSHOW_STUDIO     = VIDEODB_MAX_COLUMNS + 12;
+constexpr int VIDEODB_DETAILS_EPISODE_TVSHOW_AIRED      = VIDEODB_MAX_COLUMNS + 13;
+constexpr int VIDEODB_DETAILS_EPISODE_TVSHOW_MPAA       = VIDEODB_MAX_COLUMNS + 14;
+constexpr int VIDEODB_DETAILS_EPISODE_RESUME_TIME       = VIDEODB_MAX_COLUMNS + 15;
+constexpr int VIDEODB_DETAILS_EPISODE_TOTAL_TIME        = VIDEODB_MAX_COLUMNS + 16;
+constexpr int VIDEODB_DETAILS_EPISODE_PLAYER_STATE      = VIDEODB_MAX_COLUMNS + 17;
+constexpr int VIDEODB_DETAILS_EPISODE_RATING            = VIDEODB_MAX_COLUMNS + 18;
+constexpr int VIDEODB_DETAILS_EPISODE_VOTES             = VIDEODB_MAX_COLUMNS + 19;
+constexpr int VIDEODB_DETAILS_EPISODE_RATING_TYPE       = VIDEODB_MAX_COLUMNS + 20;
+constexpr int VIDEODB_DETAILS_EPISODE_UNIQUEID_VALUE    = VIDEODB_MAX_COLUMNS + 21;
+constexpr int VIDEODB_DETAILS_EPISODE_UNIQUEID_TYPE     = VIDEODB_MAX_COLUMNS + 22;
 
-#define VIDEODB_DETAILS_TVSHOW_USER_RATING      VIDEODB_MAX_COLUMNS + 1
-#define VIDEODB_DETAILS_TVSHOW_DURATION         VIDEODB_MAX_COLUMNS + 2
-#define VIDEODB_DETAILS_TVSHOW_PARENTPATHID     VIDEODB_MAX_COLUMNS + 3
-#define VIDEODB_DETAILS_TVSHOW_PATH             VIDEODB_MAX_COLUMNS + 4
-#define VIDEODB_DETAILS_TVSHOW_DATEADDED        VIDEODB_MAX_COLUMNS + 5
-#define VIDEODB_DETAILS_TVSHOW_LASTPLAYED       VIDEODB_MAX_COLUMNS + 6
-#define VIDEODB_DETAILS_TVSHOW_NUM_EPISODES     VIDEODB_MAX_COLUMNS + 7
-#define VIDEODB_DETAILS_TVSHOW_NUM_WATCHED      VIDEODB_MAX_COLUMNS + 8
-#define VIDEODB_DETAILS_TVSHOW_NUM_SEASONS      VIDEODB_MAX_COLUMNS + 9
-#define VIDEODB_DETAILS_TVSHOW_RATING           VIDEODB_MAX_COLUMNS + 10
-#define VIDEODB_DETAILS_TVSHOW_VOTES            VIDEODB_MAX_COLUMNS + 11
-#define VIDEODB_DETAILS_TVSHOW_RATING_TYPE      VIDEODB_MAX_COLUMNS + 12
-#define VIDEODB_DETAILS_TVSHOW_UNIQUEID_VALUE   VIDEODB_MAX_COLUMNS + 13
-#define VIDEODB_DETAILS_TVSHOW_UNIQUEID_TYPE    VIDEODB_MAX_COLUMNS + 14
-#define VIDEODB_DETAILS_TVSHOW_NUM_INPROGRESS VIDEODB_MAX_COLUMNS + 15
+constexpr int VIDEODB_DETAILS_TVSHOW_USER_RATING        = VIDEODB_MAX_COLUMNS + 1;
+constexpr int VIDEODB_DETAILS_TVSHOW_DURATION           = VIDEODB_MAX_COLUMNS + 2;
+constexpr int VIDEODB_DETAILS_TVSHOW_PARENTPATHID       = VIDEODB_MAX_COLUMNS + 3;
+constexpr int VIDEODB_DETAILS_TVSHOW_PATH               = VIDEODB_MAX_COLUMNS + 4;
+constexpr int VIDEODB_DETAILS_TVSHOW_DATEADDED          = VIDEODB_MAX_COLUMNS + 5;
+constexpr int VIDEODB_DETAILS_TVSHOW_LASTPLAYED         = VIDEODB_MAX_COLUMNS + 6;
+constexpr int VIDEODB_DETAILS_TVSHOW_NUM_EPISODES       = VIDEODB_MAX_COLUMNS + 7;
+constexpr int VIDEODB_DETAILS_TVSHOW_NUM_WATCHED        = VIDEODB_MAX_COLUMNS + 8;
+constexpr int VIDEODB_DETAILS_TVSHOW_NUM_SEASONS        = VIDEODB_MAX_COLUMNS + 9;
+constexpr int VIDEODB_DETAILS_TVSHOW_RATING             = VIDEODB_MAX_COLUMNS + 10;
+constexpr int VIDEODB_DETAILS_TVSHOW_VOTES              = VIDEODB_MAX_COLUMNS + 11;
+constexpr int VIDEODB_DETAILS_TVSHOW_RATING_TYPE        = VIDEODB_MAX_COLUMNS + 12;
+constexpr int VIDEODB_DETAILS_TVSHOW_UNIQUEID_VALUE     = VIDEODB_MAX_COLUMNS + 13;
+constexpr int VIDEODB_DETAILS_TVSHOW_UNIQUEID_TYPE      = VIDEODB_MAX_COLUMNS + 14;
+constexpr int VIDEODB_DETAILS_TVSHOW_NUM_INPROGRESS     = VIDEODB_MAX_COLUMNS + 15;
 
-#define VIDEODB_DETAILS_MUSICVIDEO_USER_RATING  VIDEODB_MAX_COLUMNS + 2
-#define VIDEODB_DETAILS_MUSICVIDEO_PREMIERED    VIDEODB_MAX_COLUMNS + 3
-#define VIDEODB_DETAILS_MUSICVIDEO_FILE         VIDEODB_MAX_COLUMNS + 4
-#define VIDEODB_DETAILS_MUSICVIDEO_PATH         VIDEODB_MAX_COLUMNS + 5
-#define VIDEODB_DETAILS_MUSICVIDEO_PLAYCOUNT    VIDEODB_MAX_COLUMNS + 6
-#define VIDEODB_DETAILS_MUSICVIDEO_LASTPLAYED   VIDEODB_MAX_COLUMNS + 7
-#define VIDEODB_DETAILS_MUSICVIDEO_DATEADDED    VIDEODB_MAX_COLUMNS + 8
-#define VIDEODB_DETAILS_MUSICVIDEO_RESUME_TIME  VIDEODB_MAX_COLUMNS + 9
-#define VIDEODB_DETAILS_MUSICVIDEO_TOTAL_TIME   VIDEODB_MAX_COLUMNS + 10
-#define VIDEODB_DETAILS_MUSICVIDEO_PLAYER_STATE VIDEODB_MAX_COLUMNS + 11
-#define VIDEODB_DETAILS_MUSICVIDEO_UNIQUEID_VALUE VIDEODB_MAX_COLUMNS + 12
-#define VIDEODB_DETAILS_MUSICVIDEO_UNIQUEID_TYPE VIDEODB_MAX_COLUMNS + 13
+constexpr int VIDEODB_DETAILS_MUSICVIDEO_USER_RATING    = VIDEODB_MAX_COLUMNS + 2;
+constexpr int VIDEODB_DETAILS_MUSICVIDEO_PREMIERED      = VIDEODB_MAX_COLUMNS + 3;
+constexpr int VIDEODB_DETAILS_MUSICVIDEO_FILE           = VIDEODB_MAX_COLUMNS + 4;
+constexpr int VIDEODB_DETAILS_MUSICVIDEO_PATH           = VIDEODB_MAX_COLUMNS + 5;
+constexpr int VIDEODB_DETAILS_MUSICVIDEO_PLAYCOUNT      = VIDEODB_MAX_COLUMNS + 6;
+constexpr int VIDEODB_DETAILS_MUSICVIDEO_LASTPLAYED     = VIDEODB_MAX_COLUMNS + 7;
+constexpr int VIDEODB_DETAILS_MUSICVIDEO_DATEADDED      = VIDEODB_MAX_COLUMNS + 8;
+constexpr int VIDEODB_DETAILS_MUSICVIDEO_RESUME_TIME    = VIDEODB_MAX_COLUMNS + 9;
+constexpr int VIDEODB_DETAILS_MUSICVIDEO_TOTAL_TIME     = VIDEODB_MAX_COLUMNS + 10;
+constexpr int VIDEODB_DETAILS_MUSICVIDEO_PLAYER_STATE   = VIDEODB_MAX_COLUMNS + 11;
+constexpr int VIDEODB_DETAILS_MUSICVIDEO_UNIQUEID_VALUE = VIDEODB_MAX_COLUMNS + 12;
+constexpr int VIDEODB_DETAILS_MUSICVIDEO_UNIQUEID_TYPE  = VIDEODB_MAX_COLUMNS + 13;
 
-#define VIDEODB_TYPE_UNUSED 0
-#define VIDEODB_TYPE_STRING 1
-#define VIDEODB_TYPE_INT 2
-#define VIDEODB_TYPE_FLOAT 3
-#define VIDEODB_TYPE_BOOL 4
-#define VIDEODB_TYPE_COUNT 5
-#define VIDEODB_TYPE_STRINGARRAY 6
-#define VIDEODB_TYPE_DATE 7
-#define VIDEODB_TYPE_DATETIME 8
+constexpr int VIDEODB_TYPE_UNUSED       = 0;
+constexpr int VIDEODB_TYPE_STRING       = 1;
+constexpr int VIDEODB_TYPE_INT          = 2;
+constexpr int VIDEODB_TYPE_FLOAT        = 3;
+constexpr int VIDEODB_TYPE_BOOL         = 4;
+constexpr int VIDEODB_TYPE_COUNT        = 5;
+constexpr int VIDEODB_TYPE_STRINGARRAY  = 6;
+constexpr int VIDEODB_TYPE_DATE         = 7;
+constexpr int VIDEODB_TYPE_DATETIME     = 8;
+// clang-format on
 
 enum class VideoDbContentType
 {
@@ -219,7 +225,7 @@ private:
   }
 };
 
-typedef enum // this enum MUST match the offset struct further down!! and make sure to keep min and max at -1 and sizeof(offsets)
+enum VIDEODB_IDS // this enum MUST match the offset struct further down!! and make sure to keep min and max at -1 and sizeof(offsets)
 {
   VIDEODB_ID_MIN = -1,
   VIDEODB_ID_TITLE = 0,
@@ -247,14 +253,16 @@ typedef enum // this enum MUST match the offset struct further down!! and make s
   VIDEODB_ID_BASEPATH = 22,
   VIDEODB_ID_PARENTPATHID = 23,
   VIDEODB_ID_MAX
-} VIDEODB_IDS;
+};
 
-const struct SDbTableOffsets
+struct SDbTableOffsets
 {
-  int type;
-  size_t offset;
-} DbMovieOffsets[] =
-{
+  int type{VIDEODB_TYPE_UNUSED};
+  size_t offset{0};
+};
+
+// clang-format off
+const std::array<SDbTableOffsets, 24> DbMovieOffsets = {{
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strTitle) },
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strPlot) },
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strPlotOutline) },
@@ -279,9 +287,10 @@ const struct SDbTableOffsets
   { VIDEODB_TYPE_STRINGARRAY, my_offsetof(CVideoInfoTag,m_country) },
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_basePath) },
   { VIDEODB_TYPE_INT, my_offsetof(CVideoInfoTag,m_parentPathID) }
-};
+}};
+// clang-format on
 
-typedef enum // this enum MUST match the offset struct further down!! and make sure to keep min and max at -1 and sizeof(offsets)
+enum VIDEODB_TV_IDS // this enum MUST match the offset struct further down!! and make sure to keep min and max at -1 and sizeof(offsets)
 {
   VIDEODB_ID_TV_MIN = -1,
   VIDEODB_ID_TV_TITLE = 0,
@@ -302,10 +311,10 @@ typedef enum // this enum MUST match the offset struct further down!! and make s
   VIDEODB_ID_TV_SORTTITLE = 15,
   VIDEODB_ID_TV_TRAILER = 16,
   VIDEODB_ID_TV_MAX
-} VIDEODB_TV_IDS;
+};
 
-const struct SDbTableOffsets DbTvShowOffsets[] =
-{
+// clang-format off
+const std::array<SDbTableOffsets, 17> DbTvShowOffsets = {{
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strTitle) },
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strPlot) },
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strStatus) },
@@ -323,10 +332,11 @@ const struct SDbTableOffsets DbTvShowOffsets[] =
   { VIDEODB_TYPE_STRINGARRAY, my_offsetof(CVideoInfoTag,m_studio)},
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strSortTitle)},
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strTrailer)}
-};
+}};
+// clang-format on
 
 //! @todo is this comment valid for seasons? There is no offset structure or am I wrong?
-typedef enum // this enum MUST match the offset struct further down!! and make sure to keep min and max at -1 and sizeof(offsets)
+enum VIDEODB_SEASON_IDS // this enum MUST match the offset struct further down!! and make sure to keep min and max at -1 and sizeof(offsets)
 {
   VIDEODB_ID_SEASON_MIN = -1,
   VIDEODB_ID_SEASON_ID = 0,
@@ -346,9 +356,9 @@ typedef enum // this enum MUST match the offset struct further down!! and make s
   VIDEODB_ID_SEASON_PREMIERED = 14,
   VIDEODB_ID_SEASON_EPISODES_INPROGRESS = 15,
   VIDEODB_ID_SEASON_MAX
-} VIDEODB_SEASON_IDS;
+};
 
-typedef enum // this enum MUST match the offset struct further down!! and make sure to keep min and max at -1 and sizeof(offsets)
+enum VIDEODB_EPISODE_IDS // this enum MUST match the offset struct further down!! and make sure to keep min and max at -1 and sizeof(offsets)
 {
   VIDEODB_ID_EPISODE_MIN = -1,
   VIDEODB_ID_EPISODE_TITLE = 0,
@@ -373,10 +383,10 @@ typedef enum // this enum MUST match the offset struct further down!! and make s
   VIDEODB_ID_EPISODE_PARENTPATHID = 19,
   VIDEODB_ID_EPISODE_IDENT_ID = 20,
   VIDEODB_ID_EPISODE_MAX
-} VIDEODB_EPISODE_IDS;
+};
 
-const struct SDbTableOffsets DbEpisodeOffsets[] =
-{
+// clang-format off
+const std::array<SDbTableOffsets, 21> DbEpisodeOffsets = {{
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strTitle) },
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strPlot) },
   { VIDEODB_TYPE_UNUSED, 0 }, // unused
@@ -398,9 +408,10 @@ const struct SDbTableOffsets DbEpisodeOffsets[] =
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_basePath) },
   { VIDEODB_TYPE_INT, my_offsetof(CVideoInfoTag,m_parentPathID) },
   { VIDEODB_TYPE_INT, my_offsetof(CVideoInfoTag,m_iIdUniqueID) }
-};
+}};
+// clang-format on
 
-typedef enum // this enum MUST match the offset struct further down!! and make sure to keep min and max at -1 and sizeof(offsets)
+enum VIDEODB_MUSICVIDEO_IDS // this enum MUST match the offset struct further down!! and make sure to keep min and max at -1 and sizeof(offsets)
 {
   VIDEODB_ID_MUSICVIDEO_MIN = -1,
   VIDEODB_ID_MUSICVIDEO_TITLE = 0,
@@ -420,10 +431,10 @@ typedef enum // this enum MUST match the offset struct further down!! and make s
   VIDEODB_ID_MUSICVIDEO_PARENTPATHID = 14,
   VIDEODB_ID_MUSICVIDEO_IDENT_ID = 15,
   VIDEODB_ID_MUSICVIDEO_MAX
-} VIDEODB_MUSICVIDEO_IDS;
+};
 
-const struct SDbTableOffsets DbMusicVideoOffsets[] =
-{
+// clang-format off
+const std::array<SDbTableOffsets, 16> DbMusicVideoOffsets = {{
   { VIDEODB_TYPE_STRING, my_offsetof(class CVideoInfoTag,m_strTitle) },
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strPictureURL.m_data) },
   { VIDEODB_TYPE_UNUSED, 0 }, // unused
@@ -440,7 +451,8 @@ const struct SDbTableOffsets DbMusicVideoOffsets[] =
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_basePath) },
   { VIDEODB_TYPE_INT, my_offsetof(CVideoInfoTag,m_parentPathID) },
   { VIDEODB_TYPE_INT, my_offsetof(CVideoInfoTag,m_iIdUniqueID)}
-};
+}};
+// clang-format on
 
 enum class ArtFallbackOptions
 {
@@ -583,14 +595,18 @@ public:
   int GetTvShowForEpisode(int idEpisode);
   int GetSeasonForEpisode(int idEpisode);
 
-  bool LoadVideoInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details, int getDetails = VideoDbDetailsAll);
+  bool LoadVideoInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details);
   bool GetMovieInfo(const std::string& strFilenameAndPath,
                     CVideoInfoTag& details,
                     int idMovie = -1,
                     int idVersion = -1,
                     int idFile = -1,
                     int getDetails = VideoDbDetailsAll);
-  bool GetTvShowInfo(const std::string& strPath, CVideoInfoTag& details, int idTvShow = -1, CFileItem* item = NULL, int getDetails = VideoDbDetailsAll);
+  bool GetTvShowInfo(const std::string& strPath,
+                     CVideoInfoTag& details,
+                     int idTvShow = -1,
+                     CFileItem* item = nullptr,
+                     int getDetails = VideoDbDetailsAll);
   bool GetSeasonInfo(const std::string& path, int season, CVideoInfoTag& details, CFileItem* item);
   bool GetSeasonInfo(int idSeason, CVideoInfoTag& details, CFileItem* item);
   bool GetSeasonInfo(int idSeason, CVideoInfoTag& details, bool allDetails = true);
@@ -692,7 +708,7 @@ public:
   int UpdateDetailsForMovie(int idMovie,
                             CVideoInfoTag& details,
                             const KODI::ART::Artwork& artwork,
-                            const std::set<std::string>& updatedDetails);
+                            const std::set<std::string, std::less<>>& updatedDetails);
 
   /*!
    * \brief Remove a movie from the library.
@@ -711,7 +727,7 @@ public:
   void DeleteMusicVideo(int idMusicVideo, bool bKeepId = false);
   void DeleteDetailsForTvShow(int idTvShow);
   void DeleteStreamDetails(int idFile);
-  void RemoveContentForPath(const std::string& strPath,CGUIDialogProgress *progress = NULL);
+  void RemoveContentForPath(const std::string& strPath, CGUIDialogProgress* progress = nullptr);
   void UpdateFanart(const CFileItem& item, VideoDbContentType type);
   void DeleteSet(int idSet);
   void DeleteTag(int idTag, VideoDbContentType mediaType);
@@ -805,7 +821,17 @@ public:
   CVideoInfoTag GetDetailsByTypeAndId(VideoDbContentType type, int id);
 
   // scraper settings
-  using ScraperCache = std::unordered_map<std::string, ADDON::ScraperPtr>;
+  struct StringHash
+  {
+    using is_transparent = void; // Enables heterogeneous operations.
+    std::size_t operator()(std::string_view sv) const
+    {
+      std::hash<std::string_view> hasher;
+      return hasher(sv);
+    }
+  };
+  using ScraperCache =
+      std::unordered_map<std::string, ADDON::ScraperPtr, StringHash, std::equal_to<>>;
   void SetScraperForPath(const std::string& filePath,
                          const ADDON::ScraperPtr& info,
                          const KODI::VIDEO::SScanSettings& settings);
@@ -820,7 +846,7 @@ public:
    \param strPath path to start searching in.
    \param settings [out] scan settings for this folder.
    \param foundDirectly [out] true if a scraper was found directly for strPath, false if it was in a parent path.
-   \return A ScraperPtr containing the scraper information. Returns NULL if a trivial (Content == CONTENT_NONE)
+   \return A ScraperPtr containing the scraper information. Returns nullptr if a trivial (Content == CONTENT_NONE)
            scraper or no scraper is found.
    */
   ADDON::ScraperPtr GetScraperForPath(const std::string& strPath,
@@ -855,7 +881,7 @@ public:
   // scanning hashes and paths scanned
   bool SetPathHash(const std::string &path, const std::string &hash);
   bool GetPathHash(const std::string &path, std::string &hash);
-  bool GetPaths(std::set<std::string> &paths);
+  bool GetPaths(std::set<std::string, std::less<>>& paths);
   bool GetPathsForTvShow(int idShow, std::set<int>& paths);
 
   /*! \brief return the paths linked to a tvshow.
@@ -979,7 +1005,9 @@ public:
   bool HasContent(VideoDbContentType type);
   bool HasSets() const;
 
-  void CleanDatabase(CGUIDialogProgressBarHandle* handle = NULL, const std::set<int>& paths = std::set<int>(), bool showProgress = true);
+  void CleanDatabase(CGUIDialogProgressBarHandle* handle = nullptr,
+                     const std::set<int>& paths = std::set<int>(),
+                     bool showProgress = true);
 
   /*! \brief Add a file to the database, if necessary
    If the file is already in the database, we simply return its id.
@@ -1109,7 +1137,9 @@ public:
   bool GetArtForAsset(int assetId, ArtFallbackOptions fallback, KODI::ART::Artwork& art);
   bool HasArtForItem(int mediaId, const MediaType &mediaType);
   bool RemoveArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType);
-  bool RemoveArtForItem(int mediaId, const MediaType &mediaType, const std::set<std::string> &artTypes);
+  bool RemoveArtForItem(int mediaId,
+                        const MediaType& mediaType,
+                        const std::set<std::string, std::less<>>& artTypes);
   bool GetTvShowSeasons(int showId, std::map<int, int> &seasons);
   bool GetTvShowNamedSeasons(int showId, std::map<int, std::string> &seasons);
 
@@ -1271,7 +1301,10 @@ protected:
 
   int AddToTable(const std::string& table, const std::string& firstField, const std::string& secondField, const std::string& value);
   int UpdateRatings(int mediaId, const char *mediaType, const RatingMap& values, const std::string& defaultRating);
-  int AddRatings(int mediaId, const char *mediaType, const RatingMap& values, const std::string& defaultRating);
+  int AddRatings(int mediaId,
+                 const char* mediaType,
+                 const RatingMap& values,
+                 std::string_view defaultRating);
   int UpdateUniqueIDs(int mediaId, const char *mediaType, const CVideoInfoTag& details);
   int AddUniqueIDs(int mediaId, const char *mediaType, const CVideoInfoTag& details);
   int AddActor(const std::string& strActor, const std::string& thumbURL, const std::string &thumb = "");
@@ -1296,8 +1329,16 @@ protected:
 
   // link functions - these two do all the work
   void AddLinkToActor(int mediaId, const char *mediaType, int actorId, const std::string &role, int order);
-  void AddToLinkTable(int mediaId, const std::string& mediaType, const std::string& table, int valueId, const char *foreignKey = NULL);
-  void RemoveFromLinkTable(int mediaId, const std::string& mediaType, const std::string& table, int valueId, const char *foreignKey = NULL);
+  void AddToLinkTable(int mediaId,
+                      const std::string& mediaType,
+                      const std::string& table,
+                      int valueId,
+                      const char* foreignKey = nullptr);
+  void RemoveFromLinkTable(int mediaId,
+                           const std::string& mediaType,
+                           const std::string& table,
+                           int valueId,
+                           const char* foreignKey = nullptr);
 
   void AddLinksToItem(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);
   void UpdateLinksToItem(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);
@@ -1308,8 +1349,12 @@ protected:
 
   CVideoInfoTag GetDetailsForMovie(std::unique_ptr<dbiplus::Dataset> &pDS, int getDetails = VideoDbDetailsNone);
   CVideoInfoTag GetDetailsForMovie(const dbiplus::sql_record* const record, int getDetails = VideoDbDetailsNone);
-  CVideoInfoTag GetDetailsForTvShow(std::unique_ptr<dbiplus::Dataset> &pDS, int getDetails = VideoDbDetailsNone, CFileItem* item = NULL);
-  CVideoInfoTag GetDetailsForTvShow(const dbiplus::sql_record* const record, int getDetails = VideoDbDetailsNone, CFileItem* item = NULL);
+  CVideoInfoTag GetDetailsForTvShow(std::unique_ptr<dbiplus::Dataset>& pDS,
+                                    int getDetails = VideoDbDetailsNone,
+                                    CFileItem* item = nullptr);
+  CVideoInfoTag GetDetailsForTvShow(const dbiplus::sql_record* const record,
+                                    int getDetails = VideoDbDetailsNone,
+                                    CFileItem* item = nullptr);
   CVideoInfoTag GetBasicDetailsForEpisode(std::unique_ptr<dbiplus::Dataset> &pDS);
   CVideoInfoTag GetBasicDetailsForEpisode(const dbiplus::sql_record* const record);
   CVideoInfoTag GetDetailsForEpisode(std::unique_ptr<dbiplus::Dataset> &pDS, int getDetails = VideoDbDetailsNone);
@@ -1333,9 +1378,19 @@ protected:
   void GetRatings(int media_id, const std::string &media_type, RatingMap &ratings);
   void GetUniqueIDs(int media_id, const std::string &media_type, CVideoInfoTag& details);
 
-  void GetDetailsFromDB(std::unique_ptr<dbiplus::Dataset> &pDS, int min, int max, const SDbTableOffsets *offsets, CVideoInfoTag &details, int idxOffset = 2);
-  void GetDetailsFromDB(const dbiplus::sql_record* const record, int min, int max, const SDbTableOffsets *offsets, CVideoInfoTag &details, int idxOffset = 2);
-  std::string GetValueString(const CVideoInfoTag &details, int min, int max, const SDbTableOffsets *offsets) const;
+  template<typename T>
+  void GetDetailsFromDB(const dbiplus::sql_record* const record,
+                        int min,
+                        int max,
+                        const T& offsets,
+                        CVideoInfoTag& details,
+                        int idxOffset = 2);
+
+  template<typename T>
+  std::string GetValueString(const CVideoInfoTag& details,
+                             int min,
+                             int max,
+                             const T& offsets) const;
 
   bool SetFileForEpisode(const std::string& fileAndPath, int idEpisode, int oldIdFile);
   bool SetFileForMovie(const std::string& fileAndPath, int idMovie, int oldIdFile);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -506,8 +506,8 @@ public:
     DatabaseResults results;
   };
 
-  CVideoDatabase(void);
-  ~CVideoDatabase(void) override;
+  CVideoDatabase();
+  ~CVideoDatabase() override;
 
   bool Open() override;
   bool CommitTransaction() override;
@@ -584,16 +584,16 @@ public:
   bool HasMusicVideoInfo(const std::string& strFilenameAndPath);
 
   void GetFilePathById(int idMovie, std::string& filePath, VideoDbContentType iType);
-  std::string GetGenreById(int id);
-  std::string GetCountryById(int id);
-  std::string GetSetById(int id);
-  std::string GetTagById(int id);
-  std::string GetPersonById(int id);
-  std::string GetStudioById(int id);
-  std::string GetTvShowTitleById(int id);
-  std::string GetMusicVideoAlbumById(int id);
-  int GetTvShowForEpisode(int idEpisode);
-  int GetSeasonForEpisode(int idEpisode);
+  std::string GetGenreById(int id) const;
+  std::string GetCountryById(int id) const;
+  std::string GetSetById(int id) const;
+  std::string GetTagById(int id) const;
+  std::string GetPersonById(int id) const;
+  std::string GetStudioById(int id) const;
+  std::string GetTvShowTitleById(int id) const;
+  std::string GetMusicVideoAlbumById(int id) const;
+  int GetTvShowForEpisode(int idEpisode) const;
+  int GetSeasonForEpisode(int idEpisode) const;
 
   bool LoadVideoInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details);
   bool GetMovieInfo(const std::string& strFilenameAndPath,
@@ -619,7 +619,7 @@ public:
   int GetPathId(const std::string& strPath);
   int GetTvShowId(const std::string& strPath);
   int GetEpisodeId(const std::string& strFilenameAndPath, int idEpisode=-1, int idSeason=-1); // idEpisode, idSeason are used for multipart episodes as hints
-  int GetSeasonId(int idShow, int season);
+  int GetSeasonId(int idShow, int season) const;
 
   void GetEpisodesByBlurayPath(const std::string& path, std::vector<CVideoInfoTag>& episodes);
   void GetEpisodesByFile(const std::string& strFilenameAndPath, std::vector<CVideoInfoTag>& episodes);
@@ -999,7 +999,9 @@ public:
   bool GetRecentlyAddedMoviesNav(const std::string& strBaseDir, CFileItemList& items, unsigned int limit=0, int getDetails = VideoDbDetailsNone);
   bool GetRecentlyAddedEpisodesNav(const std::string& strBaseDir, CFileItemList& items, unsigned int limit=0, int getDetails = VideoDbDetailsNone);
   bool GetRecentlyAddedMusicVideosNav(const std::string& strBaseDir, CFileItemList& items, unsigned int limit=0, int getDetails = VideoDbDetailsNone);
-  bool GetInProgressTvShowsNav(const std::string& strBaseDir, CFileItemList& items, unsigned int limit=0, int getDetails = VideoDbDetailsNone);
+  bool GetInProgressTvShowsNav(const std::string& strBaseDir,
+                               CFileItemList& items,
+                               int getDetails = VideoDbDetailsNone);
 
   bool HasContent();
   bool HasContent(VideoDbContentType type);
@@ -1062,7 +1064,7 @@ public:
                          const std::string& tvshowDir = "") const;
   void ImportFromXML(const std::string &path);
   void DumpToDummyFiles(const std::string &path);
-  bool ImportArtFromXML(const TiXmlNode* node, KODI::ART::Artwork& artwork);
+  bool ImportArtFromXML(const TiXmlNode* node, KODI::ART::Artwork& artwork) const;
 
   // smart playlists and main retrieval work in these functions
   bool GetMoviesByWhere(const std::string& strBaseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription = SortDescription(), int getDetails = VideoDbDetailsNone);
@@ -1123,7 +1125,7 @@ public:
   bool GetArtForItem(int mediaId, const MediaType& mediaType, KODI::ART::Artwork& art);
   std::string GetArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType);
 
-  void UpdateArtForItem(int mediaId, const MediaType& mediaType);
+  void UpdateArtForItem(int mediaId, const MediaType& mediaType) const;
 
   /*!
    * \brief Retrieve all art for the given video asset, with optional fallback to the art of the
@@ -1149,7 +1151,7 @@ public:
    * \param seasonId The season id for which to search the named title.
    * \return The named title if found, otherwise empty.
    */
-  std::string GetTvShowNamedSeasonById(int tvshowId, int seasonId);
+  std::string GetTvShowNamedSeasonById(int tvshowId, int seasonId) const;
 
   bool GetTvShowSeasonArt(int mediaId, KODI::ART::SeasonsArtwork& seasonArt);
   bool GetArtTypes(const MediaType &mediaType, std::vector<std::string> &artTypes);
@@ -1347,19 +1349,19 @@ protected:
 
   void AddCast(int mediaId, const char *mediaType, const std::vector<SActorInfo> &cast);
 
-  CVideoInfoTag GetDetailsForMovie(std::unique_ptr<dbiplus::Dataset> &pDS, int getDetails = VideoDbDetailsNone);
+  CVideoInfoTag GetDetailsForMovie(dbiplus::Dataset& pDS, int getDetails = VideoDbDetailsNone);
   CVideoInfoTag GetDetailsForMovie(const dbiplus::sql_record* const record, int getDetails = VideoDbDetailsNone);
-  CVideoInfoTag GetDetailsForTvShow(std::unique_ptr<dbiplus::Dataset>& pDS,
+  CVideoInfoTag GetDetailsForTvShow(dbiplus::Dataset& pDS,
                                     int getDetails = VideoDbDetailsNone,
                                     CFileItem* item = nullptr);
   CVideoInfoTag GetDetailsForTvShow(const dbiplus::sql_record* const record,
                                     int getDetails = VideoDbDetailsNone,
                                     CFileItem* item = nullptr);
-  CVideoInfoTag GetBasicDetailsForEpisode(std::unique_ptr<dbiplus::Dataset> &pDS);
+  CVideoInfoTag GetBasicDetailsForEpisode(dbiplus::Dataset& pDS);
   CVideoInfoTag GetBasicDetailsForEpisode(const dbiplus::sql_record* const record);
-  CVideoInfoTag GetDetailsForEpisode(std::unique_ptr<dbiplus::Dataset> &pDS, int getDetails = VideoDbDetailsNone);
+  CVideoInfoTag GetDetailsForEpisode(dbiplus::Dataset& pDS, int getDetails = VideoDbDetailsNone);
   CVideoInfoTag GetDetailsForEpisode(const dbiplus::sql_record* const record, int getDetails = VideoDbDetailsNone);
-  CVideoInfoTag GetDetailsForMusicVideo(std::unique_ptr<dbiplus::Dataset> &pDS, int getDetails = VideoDbDetailsNone);
+  CVideoInfoTag GetDetailsForMusicVideo(dbiplus::Dataset& pDS, int getDetails = VideoDbDetailsNone);
   CVideoInfoTag GetDetailsForMusicVideo(const dbiplus::sql_record* const record, int getDetails = VideoDbDetailsNone);
   bool GetPeopleNav(const std::string& strBaseDir,
                     CFileItemList& items,
@@ -1384,7 +1386,7 @@ protected:
                         int max,
                         const T& offsets,
                         CVideoInfoTag& details,
-                        int idxOffset = 2);
+                        int idxOffset = 2) const;
 
   template<typename T>
   std::string GetValueString(const CVideoInfoTag& details,
@@ -1413,7 +1415,7 @@ private:
    \param query the SQL that will retrieve a database id.
    \return -1 if not found, else a valid database id (i.e. > 0)
    */
-  int GetDbId(const std::string &query);
+  int GetDbId(const std::string& query) const;
 
   /*! \brief Run a query on the main dataset and return the number of rows
    If no rows are found we close the dataset and return 0.
@@ -1422,8 +1424,20 @@ private:
    */
   int RunQuery(const std::string &sql);
 
-  void AppendIdLinkFilter(const char* field, const char *table, const MediaType& mediaType, const char *view, const char *viewKey, const CUrlOptions::UrlOptions& options, Filter &filter);
-  void AppendLinkFilter(const char* field, const char *table, const MediaType& mediaType, const char *view, const char *viewKey, const CUrlOptions::UrlOptions& options, Filter &filter);
+  void AppendIdLinkFilter(const char* field,
+                          const char* table,
+                          const MediaType& mediaType,
+                          const char* view,
+                          const char* viewKey,
+                          const CUrlOptions::UrlOptions& options,
+                          Filter& filter) const;
+  void AppendLinkFilter(const char* field,
+                        const char* table,
+                        const MediaType& mediaType,
+                        const char* view,
+                        const char* viewKey,
+                        const CUrlOptions::UrlOptions& options,
+                        Filter& filter) const;
 
   /*! \brief Determine whether the path is using lookup using folders
    \param path the path to check
@@ -1452,8 +1466,12 @@ private:
   virtual int GetExportVersion() const { return 1; }
   const char* GetBaseDBName() const override { return "MyVideos"; }
 
-  void ConstructPath(std::string& strDest, const std::string& strPath, const std::string& strFileName);
-  void SplitPath(const std::string& strFileNameAndPath, std::string& strPath, std::string& strFileName);
+  void ConstructPath(std::string& strDest,
+                     const std::string& strPath,
+                     const std::string& strFileName) const;
+  void SplitPath(const std::string& strFileNameAndPath,
+                 std::string& strPath,
+                 std::string& strFileName) const;
   void InvalidatePathHash(const std::string& strPath);
 
   /*! \brief Get a safe filename from a given string


### PR DESCRIPTION
More boring SonarQube stuff here. No functional changes intended, only optimizations and modernization of code.

Like always: There may be still some more findings in the touched files. I'm currently concentrating on low hanging fruits only.

**VideoDatabase**
* "using" should be preferred for type aliasing cpp:S5416
* Macros should not be used to define constants cpp:S5028
* C-style array should not be used cpp:S5945
* Types and variables should be declared in separate statements cpp:S3646
* "nullptr" should be used to denote the null pointer cpp:S4962
* Transparent function objects should be used with associative "std::string" containers cpp:S6045
* "std::source_location" should be used instead of "__FILE__", "__LINE__", and "__func__" macros cpp:S6190
* Multiple variables should not be declared on the same line cpp:S1659
* Variables should not be shadowed cpp:S1117
* "auto" should be used to avoid repetition of types cpp:S5827
* "std::string_view" should be used to pass a read-only string to a function cpp:S6009
* Structured binding should be used cpp:S6005
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* Unused function parameters should be removed cpp:S1172
* "make_unique" and "make_shared" should be used to construct "unique_ptr" and "shared_ptr" cpp:S5950
* "switch" statements should cover all cases cpp:S3562
* "contains" should be used to check if a key exists in a container cpp:S6171
* Calls to c_str() should not implicitly recreate strings or string_views cpp:S7121
* Redundant casts should not be used cpp:S1905
* STL algorithms and range-based for loops should be preferred to traditional for loops cpp:S5566
* Capture by reference in lambdas used locally cpp:S5495
* "try_emplace" should be used with "std::map" and "std::unordered_map" cpp:S6030
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* Member data should be initialized in-class or in a constructor initialization list cpp:S3230
* Redundant pairs of parentheses should be removed cpp:S1110
* "empty()" should be used to test for emptiness cpp:S1155
* Two branches in a conditional structure should not have exactly the same implementation cpp:S1871
* Unused assignments should be removed cpp:S1854
* "static" members should be accessed statically cpp:S2209

**MusicDatabase**
* "using" should be preferred for type aliasing cpp:S5416
* #include directives in a file should only be preceded by other preprocessor directives or comments cpp:S954
* Macros should not be used to define constants cpp:S5028
* Member variables should not be "protected" cpp:S3656
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* Transparent function objects should be used with associative "std::string" containers cpp:S6045
* Types and variables should be declared in separate statements cpp:S3646
* Member data should be initialized in-class or in a constructor initialization list cpp:S3230
* "std::source_location" should be used instead of "__FILE__", "__LINE__", and "__func__" macros cpp:S6190
* "/*" and "//" should not be used within comments cpp:S1103
* Structured binding should be used cpp:S6005
* Loop variables should be declared in the minimal possible scope cpp:S5955
* Multiple variables should not be declared on the same line cpp:S1659
(* "std::string_view" should be used to pass a read-only string to a function cpp:S6009)
* Multiple variables should not be declared on the same line cpp:S1659
* "auto" should be used to avoid repetition of types cpp:S5827
* "try_emplace" should be used with "std::map" and "std::unordered_map" cpp:S6030
* Calls to c_str() should not implicitly recreate strings or string_views cpp:S7121
* "nullptr" should be used to denote the null pointer cpp:S4962
* "make_unique" and "make_shared" should be used to construct "unique_ptr" and "shared_ptr" cpp:S5950
* Mergeable "if" statements should be combined cpp:S1066
* Redundant casts should not be used cpp:S1905
* "std::size" should be used to determine the size of arrays cpp:S7127
* STL algorithms and range-based for loops should be preferred to traditional for loops cpp:S5566
* Pointer and reference parameters should be "const" if the corresponding object is not modified cpp:S995
* "static" members should be accessed statically cpp:S2209

**DatabaseUtils**
* "using" should be preferred for type aliasing cpp:S5416
* "using enum" should be used in scopes with high concentration of "enum" constants cpp:S6177
* STL algorithms and range-based for loops should be preferred to traditional for loops cpp:S5566
* Two branches in a conditional structure should not have exactly the same implementation cpp:S1871
* Implicit casts should not lower precision cpp:S5276
* Assignments should not be made from within conditions cpp:S1121

Runtime-tested on macOS and Android, latest Kodi master. No regressions found.

@neo1973 @garbear maybe you are in the mood to review this.