### PR TITLE
[VideoInfoTag][MusicInfoTag] Misc SonarQube findings

### DIFF
--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -375,7 +375,7 @@ namespace XBMCAddon
       setUniqueIDRaw(infoTag, uniqueID, type, isDefault);
     }
 
-    void InfoTagVideo::setUniqueIDs(const std::map<String, String>& uniqueIDs,
+    void InfoTagVideo::setUniqueIDs(const std::map<String, String, std::less<>>& uniqueIDs,
                                     const String& defaultUniqueID /* = "" */)
     {
       XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
@@ -760,7 +760,7 @@ namespace XBMCAddon
     }
 
     void InfoTagVideo::setUniqueIDsRaw(CVideoInfoTag* infoTag,
-                                       std::map<String, String> uniqueIDs,
+                                       std::map<String, String, std::less<>> uniqueIDs,
                                        const String& defaultUniqueID /* = "" */)
     {
       infoTag->SetUniqueIDs(uniqueIDs);

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -1727,7 +1727,7 @@ namespace XBMCAddon
       ///
       setUniqueIDs(...);
 #else
-      void setUniqueIDs(const std::map<String, String>& uniqueIDs,
+      void setUniqueIDs(const std::map<String, String, std::less<>>& uniqueIDs,
                         const String& defaultuniqueid = "");
 #endif
 
@@ -2711,7 +2711,7 @@ namespace XBMCAddon
                                  const String& type = "",
                                  bool isDefault = false);
       static void setUniqueIDsRaw(CVideoInfoTag* infoTag,
-                                  std::map<String, String> uniqueIDs,
+                                  std::map<String, String, std::less<>> uniqueIDs,
                                   const String& defaultUniqueID = "");
       static void setYearRaw(CVideoInfoTag* infoTag, int year);
       static void setEpisodeRaw(CVideoInfoTag* infoTag, int episode);

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -161,7 +161,7 @@ namespace XBMCAddon
       if (!item)
         return;
 
-      std::map<String, String> uniqueIDs;
+      std::map<String, String, std::less<>> uniqueIDs;
       for (const auto& it : dictionary)
         uniqueIDs.emplace(it.first, it.second);
 

--- a/xbmc/media/MediaType.h
+++ b/xbmc/media/MediaType.h
@@ -10,8 +10,10 @@
 
 #include <map>
 #include <string>
+#include <string_view>
 
 using MediaType = std::string;
+using MediaType_view = std::string_view;
 
 #define MediaTypeNone             ""
 #define MediaTypeMusic            "music"

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -80,7 +80,7 @@ const std::vector<std::string>& CMusicInfoTag::GetArtist() const
   return m_artist;
 }
 
-const std::string CMusicInfoTag::GetArtistString() const
+std::string CMusicInfoTag::GetArtistString() const
 {
   if (!m_strArtistDesc.empty())
     return m_strArtistDesc;
@@ -115,7 +115,7 @@ const std::string& CMusicInfoTag::GetOriginalDate() const
   return m_strOriginalDate;
 }
 
-const std::string MUSIC_INFO::CMusicInfoTag::GetOriginalYear() const
+std::string MUSIC_INFO::CMusicInfoTag::GetOriginalYear() const
 {
   return StringUtils::Left(m_strOriginalDate, 4);
 }
@@ -130,7 +130,7 @@ const std::vector<std::string>& CMusicInfoTag::GetAlbumArtist() const
   return m_albumArtist;
 }
 
-const std::string CMusicInfoTag::GetAlbumArtistString() const
+std::string CMusicInfoTag::GetAlbumArtistString() const
 {
   if (!m_strAlbumArtistDesc.empty())
     return m_strAlbumArtistDesc;
@@ -301,7 +301,7 @@ const std::string& CMusicInfoTag::GetReleaseDate() const
   return m_strReleaseDate;
 }
 
-const std::string MUSIC_INFO::CMusicInfoTag::GetReleaseYear() const
+std::string MUSIC_INFO::CMusicInfoTag::GetReleaseYear() const
 {
   return StringUtils::Left(m_strReleaseDate, 4);
 }
@@ -328,7 +328,7 @@ const std::string& CMusicInfoTag::GetSongVideoURL() const
   return m_songVideoURL;
 }
 
-void CMusicInfoTag::SetURL(const std::string& strURL)
+void CMusicInfoTag::SetURL(std::string_view strURL)
 {
   m_strURL = strURL;
 }
@@ -361,17 +361,17 @@ void CMusicInfoTag::SetArtist(const std::vector<std::string>& artists, bool Fill
   }
 }
 
-void CMusicInfoTag::SetArtistDesc(const std::string& strArtistDesc)
+void CMusicInfoTag::SetArtistDesc(std::string_view strArtistDesc)
 {
   m_strArtistDesc = strArtistDesc;
 }
 
-void CMusicInfoTag::SetArtistSort(const std::string& strArtistsort)
+void CMusicInfoTag::SetArtistSort(std::string_view strArtistsort)
 {
   m_strArtistSort = strArtistsort;
 }
 
-void CMusicInfoTag::SetComposerSort(const std::string& strComposerSort)
+void CMusicInfoTag::SetComposerSort(std::string_view strComposerSort)
 {
   m_strComposerSort = strComposerSort;
 }
@@ -407,12 +407,12 @@ void CMusicInfoTag::SetAlbumArtist(const std::vector<std::string>& albumArtists,
     SetAlbumArtistDesc(StringUtils::Join(albumArtists, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator));
 }
 
-void CMusicInfoTag::SetAlbumArtistDesc(const std::string& strAlbumArtistDesc)
+void CMusicInfoTag::SetAlbumArtistDesc(std::string_view strAlbumArtistDesc)
 {
   m_strAlbumArtistDesc = strAlbumArtistDesc;
 }
 
-void CMusicInfoTag::SetAlbumArtistSort(const std::string& strAlbumArtistSort)
+void CMusicInfoTag::SetAlbumArtistSort(std::string_view strAlbumArtistSort)
 {
   m_strAlbumArtistSort = strAlbumArtistSort;
 }
@@ -447,7 +447,7 @@ void CMusicInfoTag::SetYear(int year)
     m_strReleaseDate.clear();
 }
 
-void CMusicInfoTag::SetDatabaseId(int id, const std::string &type)
+void CMusicInfoTag::SetDatabaseId(int id, std::string_view type)
 {
   m_iDbId = id;
   m_type = type;
@@ -463,7 +463,7 @@ void CMusicInfoTag::SetDiscNumber(int iDiscNumber)
   m_iTrack = (m_iTrack & 0xffff) | (iDiscNumber << 16);
 }
 
-void CMusicInfoTag::SetDiscSubtitle(const std::string& strDiscSubtitle)
+void CMusicInfoTag::SetDiscSubtitle(std::string_view strDiscSubtitle)
 {
   m_strDiscSubtitle = strDiscSubtitle;
 }
@@ -473,19 +473,19 @@ void CMusicInfoTag::SetTotalDiscs(int iDiscTotal)
   m_iDiscTotal = iDiscTotal;
 }
 
-void CMusicInfoTag::SetReleaseDate(const std::string& strReleaseDate)
+void CMusicInfoTag::SetReleaseDate(std::string_view strReleaseDate)
 {
   // Date in ISO8601 YYYY, YYYY-MM or YYYY-MM-DD
   m_strReleaseDate = strReleaseDate;
 }
 
-void CMusicInfoTag::SetOriginalDate(const std::string& strOriginalDate)
+void CMusicInfoTag::SetOriginalDate(std::string_view strOriginalDate)
 {
   // Date in ISO8601 YYYY, YYYY-MM or YYYY-MM-DD
   m_strOriginalDate = strOriginalDate;
 }
 
-void CMusicInfoTag::AddOriginalDate(const std::string& strDateYear)
+void CMusicInfoTag::AddOriginalDate(std::string_view strDateYear)
 {
   // Avoid overwriting YYYY-MM or YYYY-MM-DD (from DATE tag) with just YYYY (from YEAR tag)
   if (strDateYear.size() > m_strOriginalDate.size())
@@ -539,27 +539,27 @@ void CMusicInfoTag::SetSampleRate(int samplerate)
   m_samplerate = samplerate;
 }
 
-void CMusicInfoTag::SetComment(const std::string& comment)
+void CMusicInfoTag::SetComment(std::string_view comment)
 {
   m_strComment = comment;
 }
 
-void CMusicInfoTag::SetMood(const std::string& mood)
+void CMusicInfoTag::SetMood(std::string_view mood)
 {
   m_strMood = mood;
 }
 
-void CMusicInfoTag::SetRecordLabel(const std::string& publisher)
+void CMusicInfoTag::SetRecordLabel(std::string_view publisher)
 {
   m_strRecordLabel = publisher;
 }
 
-void CMusicInfoTag::SetCueSheet(const std::string& cueSheet)
+void CMusicInfoTag::SetCueSheet(std::string_view cueSheet)
 {
   m_cuesheet = cueSheet;
 }
 
-void CMusicInfoTag::SetLyrics(const std::string& lyrics)
+void CMusicInfoTag::SetLyrics(std::string_view lyrics)
 {
   m_strLyrics = lyrics;
 }
@@ -662,7 +662,7 @@ void CMusicInfoTag::SetBPM(int bpm)
   m_iBPM = bpm;
 }
 
-void CMusicInfoTag::SetStationName(const std::string& strStationName)
+void CMusicInfoTag::SetStationName(std::string_view strStationName)
 {
   m_stationName = strStationName;
 }
@@ -707,7 +707,7 @@ const std::string &CMusicInfoTag::GetMusicBrainzReleaseType() const
   return m_strMusicBrainzReleaseType;
 }
 
-void CMusicInfoTag::SetMusicBrainzTrackID(const std::string& strTrackID)
+void CMusicInfoTag::SetMusicBrainzTrackID(std::string_view strTrackID)
 {
   m_strMusicBrainzTrackID = strTrackID;
 }
@@ -722,7 +722,7 @@ void CMusicInfoTag::SetMusicBrainzArtistHints(const std::vector<std::string>& mu
   m_musicBrainzArtistHints = musicBrainzArtistHints;
 }
 
-void CMusicInfoTag::SetMusicBrainzAlbumID(const std::string& strAlbumID)
+void CMusicInfoTag::SetMusicBrainzAlbumID(std::string_view strAlbumID)
 {
   m_strMusicBrainzAlbumID = strAlbumID;
 }
@@ -737,14 +737,14 @@ void CMusicInfoTag::SetMusicBrainzAlbumArtistHints(const std::vector<std::string
     m_musicBrainzAlbumArtistHints = musicBrainzAlbumArtistHints;
 }
 
-void MUSIC_INFO::CMusicInfoTag::SetMusicBrainzReleaseGroupID(const std::string & strReleaseGroupID)
+void MUSIC_INFO::CMusicInfoTag::SetMusicBrainzReleaseGroupID(std::string_view strReleaseGroupID)
 {
   m_strMusicBrainzReleaseGroupID = strReleaseGroupID;
 }
 
-void CMusicInfoTag::SetMusicBrainzReleaseType(const std::string& ReleaseType)
+void CMusicInfoTag::SetMusicBrainzReleaseType(std::string_view releaseType)
 {
-  m_strMusicBrainzReleaseType = ReleaseType;
+  m_strMusicBrainzReleaseType = releaseType;
 }
 
 void CMusicInfoTag::SetCoverArtInfo(size_t size, const std::string &mimeType)
@@ -762,24 +762,24 @@ void CMusicInfoTag::SetAlbumReleaseType(CAlbum::ReleaseType releaseType)
   m_albumReleaseType = releaseType;
 }
 
-void CMusicInfoTag::SetType(const MediaType& mediaType)
+void CMusicInfoTag::SetType(MediaType_view mediaType)
 {
   m_type = mediaType;
 }
 
 // This is the Musicbrainz release status tag. See https://musicbrainz.org/doc/Release#Status
 
-void CMusicInfoTag::SetAlbumReleaseStatus(const std::string& ReleaseStatus)
+void CMusicInfoTag::SetAlbumReleaseStatus(std::string_view ReleaseStatus)
 {
   m_strReleaseStatus = ReleaseStatus;
 }
 
-void CMusicInfoTag::SetStationArt(const std::string& strStationArt)
+void CMusicInfoTag::SetStationArt(std::string_view strStationArt)
 {
   m_stationArt = strStationArt;
 }
 
-void CMusicInfoTag::SetSongVideoURL(const std::string& songVideoURL)
+void CMusicInfoTag::SetSongVideoURL(std::string_view songVideoURL)
 {
   m_songVideoURL = songVideoURL;
 }
@@ -945,7 +945,7 @@ void CMusicInfoTag::Serialize(CVariant& value) const
     contributor["name"] = role.GetArtist();
     contributor["role"] = role.GetRoleDesc();
     contributor["roleid"] = role.GetRoleId();
-    contributor["artistid"] = (int)(role.GetArtistId());
+    contributor["artistid"] = role.GetArtistId();
     value["contributors"].push_back(contributor);
   }
   value["displaycomposer"] = GetArtistStringForRole("composer");   //TCOM
@@ -1055,7 +1055,7 @@ void CMusicInfoTag::Archive(CArchive& ar)
     ar << m_lastPlayed;
     ar << m_dateAdded;
     ar << m_strComment;
-    ar << (int)m_musicRoles.size();
+    ar << static_cast<int>(m_musicRoles.size());
     for (const auto& credit : m_musicRoles)
     {
       ar << credit.GetRoleId();
@@ -1212,73 +1212,77 @@ void CMusicInfoTag::Clear()
 
 void CMusicInfoTag::AppendArtist(const std::string &artist)
 {
-  for (unsigned int index = 0; index < m_artist.size(); index++)
+  for (const auto& artistEntry : m_artist)
   {
-    if (StringUtils::EqualsNoCase(artist, m_artist.at(index)))
+    if (StringUtils::EqualsNoCase(artist, artistEntry))
       return;
   }
 
-  m_artist.push_back(artist);
+  m_artist.emplace_back(artist);
 }
 
 void CMusicInfoTag::AppendAlbumArtist(const std::string &albumArtist)
 {
-  for (unsigned int index = 0; index < m_albumArtist.size(); index++)
+  for (const auto& artistEntry : m_albumArtist)
   {
-    if (StringUtils::EqualsNoCase(albumArtist, m_albumArtist.at(index)))
+    if (StringUtils::EqualsNoCase(albumArtist, artistEntry))
       return;
   }
 
-  m_albumArtist.push_back(albumArtist);
+  m_albumArtist.emplace_back(albumArtist);
 }
 
 void CMusicInfoTag::AppendGenre(const std::string &genre)
 {
-  for (unsigned int index = 0; index < m_genre.size(); index++)
+  for (const auto& genreEntry : m_genre)
   {
-    if (StringUtils::EqualsNoCase(genre, m_genre.at(index)))
+    if (StringUtils::EqualsNoCase(genre, genreEntry))
       return;
   }
 
   m_genre.push_back(genre);
 }
 
-void CMusicInfoTag::AddArtistRole(const std::string& Role, const std::string& strArtist)
+void CMusicInfoTag::AddArtistRole(const std::string& role, const std::string& strArtist)
 {
-  if (!strArtist.empty() && !Role.empty())
-    AddArtistRole(Role, StringUtils::Split(strArtist, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator));
+  if (!strArtist.empty() && !role.empty())
+    AddArtistRole(
+        role,
+        StringUtils::Split(
+            strArtist,
+            CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator));
 }
 
-void CMusicInfoTag::AddArtistRole(const std::string& Role, const std::vector<std::string>& artists)
+void CMusicInfoTag::AddArtistRole(const std::string& role, const std::vector<std::string>& artists)
 {
-  for (unsigned int index = 0; index < artists.size(); index++)
+  for (const auto& artist : artists)
   {
-    CMusicRole ArtistCredit(Role, Trim(artists.at(index)));
+    CMusicRole artistCredit{role, Trim(artist)};
     //Prevent duplicate entries
-    auto credit = find(m_musicRoles.begin(), m_musicRoles.end(), ArtistCredit);
+    const auto credit = std::ranges::find(m_musicRoles, artistCredit);
     if (credit == m_musicRoles.end())
-      m_musicRoles.push_back(ArtistCredit);
+      m_musicRoles.emplace_back(artistCredit);
   }
 }
 
-void CMusicInfoTag::AppendArtistRole(const CMusicRole& ArtistRole)
+void CMusicInfoTag::AppendArtistRole(const CMusicRole& artistRole)
 {
   //Append contributor, no check for duplicates as from database
-  m_musicRoles.push_back(ArtistRole);
+  m_musicRoles.emplace_back(artistRole);
 }
 
-const std::string CMusicInfoTag::GetArtistStringForRole(const std::string& strRole) const
+std::string CMusicInfoTag::GetArtistStringForRole(const std::string& strRole) const
 {
   std::vector<std::string> artistvector;
   for (const auto& credit : m_musicRoles)
   {
     if (StringUtils::EqualsNoCase(credit.GetRoleDesc(), strRole))
-      artistvector.push_back(credit.GetArtist());
+      artistvector.emplace_back(credit.GetArtist());
   }
   return StringUtils::Join(artistvector, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);
 }
 
-const std::string CMusicInfoTag::GetContributorsText() const
+std::string CMusicInfoTag::GetContributorsText() const
 {
   std::string strLabel;
   for (const auto& credit : m_musicRoles)
@@ -1288,7 +1292,7 @@ const std::string CMusicInfoTag::GetContributorsText() const
   return StringUtils::TrimRight(strLabel, "\n");
 }
 
-const std::string CMusicInfoTag::GetContributorsAndRolesText() const
+std::string CMusicInfoTag::GetContributorsAndRolesText() const
 {
   std::string strLabel;
   for (const auto& credit : m_musicRoles)

--- a/xbmc/music/tags/MusicInfoTag.h
+++ b/xbmc/music/tags/MusicInfoTag.h
@@ -8,10 +8,6 @@
 
 #pragma once
 
-class CSong;
-class CArtist;
-class CVariant;
-
 #include "ReplayGain.h"
 #include "XBDateTime.h"
 #include "music/Album.h"
@@ -20,7 +16,12 @@ class CVariant;
 #include "utils/ISortable.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
+
+class CSong;
+class CArtist;
+class CVariant;
 
 namespace MUSIC_INFO
 {
@@ -34,12 +35,12 @@ public:
   const std::string& GetURL() const;
   const std::vector<std::string>& GetArtist() const;
   const std::string& GetArtistSort() const;
-  const std::string GetArtistString() const;
+  std::string GetArtistString() const;
   const std::string& GetComposerSort() const;
   const std::string& GetAlbum() const;
   int GetAlbumId() const;
   const std::vector<std::string>& GetAlbumArtist() const;
-  const std::string GetAlbumArtistString() const;
+  std::string GetAlbumArtistString() const;
   const std::string& GetAlbumArtistSort() const;
   const std::vector<std::string>& GetGenre() const;
   int GetTrackNumber() const;
@@ -49,9 +50,9 @@ public:
   int GetDuration() const;  // may be set even if Loaded() returns false
   int GetYear() const;
   const std::string& GetReleaseDate() const;
-  const std::string GetReleaseYear() const;
+  std::string GetReleaseYear() const;
   const std::string& GetOriginalDate() const;
-  const std::string GetOriginalYear() const;
+  std::string GetOriginalYear() const;
   int GetDatabaseId() const;
   const std::string &GetType() const;
   const std::string& GetDiscSubtitle() const;
@@ -90,25 +91,25 @@ public:
   const ReplayGain& GetReplayGain() const;
   CAlbum::ReleaseType GetAlbumReleaseType() const;
 
-  void SetURL(const std::string& strURL);
+  void SetURL(std::string_view strURL);
   void SetTitle(const std::string& strTitle);
   void SetArtist(const std::string& strArtist);
   void SetArtist(const std::vector<std::string>& artists, bool FillDesc = false);
-  void SetArtistDesc(const std::string& strArtistDesc);
-  void SetArtistSort(const std::string& strArtistsort);
-  void SetComposerSort(const std::string& strComposerSort);
+  void SetArtistDesc(std::string_view strArtistDesc);
+  void SetArtistSort(std::string_view strArtistsort);
+  void SetComposerSort(std::string_view strComposerSort);
   void SetAlbum(const std::string& strAlbum);
   void SetAlbumId(const int iAlbumId);
   void SetAlbumArtist(const std::string& strAlbumArtist);
   void SetAlbumArtist(const std::vector<std::string>& albumArtists, bool FillDesc = false);
-  void SetAlbumArtistDesc(const std::string& strAlbumArtistDesc);
-  void SetAlbumArtistSort(const std::string& strAlbumArtistSort);
+  void SetAlbumArtistDesc(std::string_view strAlbumArtistDesc);
+  void SetAlbumArtistSort(std::string_view strAlbumArtistSort);
   void SetGenre(const std::string& strGenre, bool bTrim = false);
   void SetGenre(const std::vector<std::string>& genres, bool bTrim = false);
   void SetYear(int year);
-  void SetOriginalDate(const std::string& strOriginalDate);
-  void SetReleaseDate(const std::string& strReleaseDate);
-  void SetDatabaseId(int id, const std::string &type);
+  void SetOriginalDate(std::string_view strOriginalDate);
+  void SetReleaseDate(std::string_view strReleaseDate);
+  void SetDatabaseId(int id, std::string_view type);
   void SetTrackNumber(int iTrack);
   void SetDiscNumber(int iDiscNumber);
   void SetTrackAndDiscNumber(int iTrackAndDisc);
@@ -117,19 +118,19 @@ public:
   void SetArtist(const CArtist& artist);
   void SetAlbum(const CAlbum& album);
   void SetSong(const CSong& song);
-  void SetMusicBrainzTrackID(const std::string& strTrackID);
+  void SetMusicBrainzTrackID(std::string_view strTrackID);
   void SetMusicBrainzArtistID(const std::vector<std::string>& musicBrainzArtistId);
   void SetMusicBrainzArtistHints(const std::vector<std::string>& musicBrainzArtistHints);
-  void SetMusicBrainzAlbumID(const std::string& strAlbumID);
+  void SetMusicBrainzAlbumID(std::string_view strAlbumID);
   void SetMusicBrainzAlbumArtistID(const std::vector<std::string>& musicBrainzAlbumArtistId);
   void SetMusicBrainzAlbumArtistHints(const std::vector<std::string>& musicBrainzAlbumArtistHints);
-  void SetMusicBrainzReleaseGroupID(const std::string& strReleaseGroupID);
-  void SetMusicBrainzReleaseType(const std::string& ReleaseType);
-  void SetComment(const std::string& comment);
-  void SetMood(const std::string& mood);
-  void SetRecordLabel(const std::string& publisher);
-  void SetLyrics(const std::string& lyrics);
-  void SetCueSheet(const std::string& cueSheet);
+  void SetMusicBrainzReleaseGroupID(std::string_view strReleaseGroupID);
+  void SetMusicBrainzReleaseType(std::string_view releaseType);
+  void SetComment(std::string_view comment);
+  void SetMood(std::string_view mood);
+  void SetRecordLabel(std::string_view publisher);
+  void SetLyrics(std::string_view lyrics);
+  void SetCueSheet(std::string_view cueSheet);
   void SetRating(float rating);
   void SetUserrating(int rating);
   void SetVotes(int votes);
@@ -148,17 +149,17 @@ public:
   void SetCoverArtInfo(size_t size, const std::string &mimeType);
   void SetReplayGain(const ReplayGain& aGain);
   void SetAlbumReleaseType(CAlbum::ReleaseType releaseType);
-  void SetType(const MediaType& mediaType);
-  void SetDiscSubtitle(const std::string& strDiscSubtitle);
+  void SetType(MediaType_view mediaType);
+  void SetDiscSubtitle(std::string_view strDiscSubtitle);
   void SetTotalDiscs(int iDiscTotal);
   void SetBPM(int iBPM);
   void SetBitRate(int bitrate);
   void SetNoOfChannels(int channels);
   void SetSampleRate(int samplerate);
-  void SetAlbumReleaseStatus(const std::string& strReleaseStatus);
-  void SetStationName(const std::string& strStationName); // name of online radio station
-  void SetStationArt(const std::string& strStationArt);
-  void SetSongVideoURL(const std::string& songVideoURL); // link to video of song
+  void SetAlbumReleaseStatus(std::string_view strReleaseStatus);
+  void SetStationName(std::string_view strStationName); // name of online radio station
+  void SetStationArt(std::string_view strStationArt);
+  void SetSongVideoURL(std::string_view songVideoURL); // link to video of song
 
   /*! \brief Append a unique artist to the artist list
    Checks if we have this artist already added, and if not adds it to the songs artist list.
@@ -177,15 +178,15 @@ public:
    \param genre genre to add.
    */
   void AppendGenre(const std::string &genre);
-  void AddOriginalDate(const std::string& strDateYear);
+  void AddOriginalDate(std::string_view strDateYear);
   void AddReleaseDate(const std::string& strDateYear, bool isMonth = false);
 
-  void AddArtistRole(const std::string& Role, const std::string& strArtist);
-  void AddArtistRole(const std::string& Role, const std::vector<std::string>& artists);
-  void AppendArtistRole(const CMusicRole& ArtistRole);
-  const std::string GetArtistStringForRole(const std::string& strRole) const;
-  const std::string GetContributorsText() const;
-  const std::string GetContributorsAndRolesText() const;
+  void AddArtistRole(const std::string& role, const std::string& strArtist);
+  void AddArtistRole(const std::string& role, const std::vector<std::string>& artists);
+  void AppendArtistRole(const CMusicRole& artistRole);
+  std::string GetArtistStringForRole(const std::string& strRole) const;
+  std::string GetContributorsText() const;
+  std::string GetContributorsAndRolesText() const;
   const VECMUSICROLES &GetContributors() const;
   void SetContributors(const VECMUSICROLES& contributors);
   bool HasContributors() const { return !m_musicRoles.empty(); }
@@ -196,7 +197,7 @@ public:
 
   void Clear();
 
-protected:
+private:
   /*! \brief Trim whitespace off the given string
    \param value string to trim
    \return trimmed value, with spaces removed from left and right, as well as carriage returns from the right.

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -437,7 +437,7 @@ NPT_Result PopulateObjectFromTag(CVideoInfoTag& tag,
   for (unsigned int index = 0; index < tag.m_genre.size(); index++)
     object.m_Affiliation.genres.Add(tag.m_genre.at(index).c_str());
 
-  for (CVideoInfoTag::iCast it = tag.m_cast.begin(); it != tag.m_cast.end(); ++it)
+  for (auto it = tag.m_cast.begin(); it != tag.m_cast.end(); ++it)
   {
     object.m_People.actors.Add(it->strName.c_str(), it->strRole.c_str());
   }

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -61,8 +61,6 @@ namespace dbiplus
 #endif
 #endif
 
-typedef std::vector<CVideoInfoTag> VECMOVIES;
-
 namespace KODI::VIDEO
 {
   class IVideoInfoScannerObserver;
@@ -490,7 +488,7 @@ public:
   {
   public:
     std::string name;
-    VECMOVIES movies;
+    std::vector<CVideoInfoTag> movies;
     DatabaseResults results;
   };
 

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -121,14 +121,14 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const std::string &tag, bool savePathI
   if (!m_ratings.empty())
   {
     TiXmlElement ratings("ratings");
-    for (const auto& it : m_ratings)
+    for (const auto& [name, value] : m_ratings)
     {
       TiXmlElement rating("rating");
-      rating.SetAttribute("name", it.first.c_str());
-      XMLUtils::SetFloat(&rating, "value", it.second.rating);
-      XMLUtils::SetInt(&rating, "votes", it.second.votes);
+      rating.SetAttribute("name", name.c_str());
+      XMLUtils::SetFloat(&rating, "value", value.rating);
+      XMLUtils::SetInt(&rating, "votes", value.votes);
       rating.SetAttribute("max", 10);
-      if (it.first == m_strDefaultRating)
+      if (name == m_strDefaultRating)
         rating.SetAttribute("default", "true");
       ratings.InsertEndChild(rating);
     }
@@ -206,14 +206,13 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const std::string &tag, bool savePathI
   }
 
   XMLUtils::SetString(movie, "id", GetUniqueID());
-  for (const auto& uniqueid : m_uniqueIDs)
+  for (const auto& [type, value] : m_uniqueIDs)
   {
     TiXmlElement uniqueID("uniqueid");
-    uniqueID.SetAttribute("type", uniqueid.first);
-    if (uniqueid.first == m_strDefaultUniqueID)
+    uniqueID.SetAttribute("type", type);
+    if (type == m_strDefaultUniqueID)
       uniqueID.SetAttribute("default", "true");
-    TiXmlText value(uniqueid.second);
-    uniqueID.InsertEndChild(value);
+    uniqueID.InsertEndChild(TiXmlText(value));
 
     movie->InsertEndChild(uniqueID);
   }
@@ -280,25 +279,24 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const std::string &tag, bool savePathI
   }  /* if has stream details */
 
   // cast
-  for (iCast it = m_cast.begin(); it != m_cast.end(); ++it)
+  for (auto it = m_cast.begin(); it != m_cast.end(); ++it)
   {
     // add a <actor> tag
     TiXmlElement cast("actor");
-    TiXmlNode *node = movie->InsertEndChild(cast);
-    XMLUtils::SetString(node, "name", it->strName);
-    XMLUtils::SetString(node, "role", it->strRole);
-    XMLUtils::SetInt(node, "order", it->order);
-    XMLUtils::SetString(node, "thumb", it->thumbUrl.GetFirstUrlByType().m_url);
+    TiXmlNode* actornode = movie->InsertEndChild(cast);
+    XMLUtils::SetString(actornode, "name", it->strName);
+    XMLUtils::SetString(actornode, "role", it->strRole);
+    XMLUtils::SetInt(actornode, "order", it->order);
+    XMLUtils::SetString(actornode, "thumb", it->thumbUrl.GetFirstUrlByType().m_url);
   }
   XMLUtils::SetStringArray(movie, "artist", m_artist);
   XMLUtils::SetStringArray(movie, "showlink", m_showLink);
 
-  for (const auto& namedSeason : m_namedSeasons)
+  for (const auto& [number, value] : m_namedSeasons)
   {
     TiXmlElement season("namedseason");
-    season.SetAttribute("number", namedSeason.first);
-    TiXmlText value(namedSeason.second);
-    season.InsertEndChild(value);
+    season.SetAttribute("number", number);
+    season.InsertEndChild(TiXmlText(value));
     movie->InsertEndChild(season);
   }
 
@@ -412,7 +410,7 @@ void CVideoInfoTag::Merge(CVideoInfoTag& other)
   {
     m_uniqueIDs = other.m_uniqueIDs;
     m_strDefaultUniqueID = other.m_strDefaultUniqueID;
-  };
+  }
   if (other.m_iSpecialSortSeason != -1)
     m_iSpecialSortSeason = other.m_iSpecialSortSeason;
   if (other.m_iSpecialSortEpisode != -1)
@@ -422,7 +420,7 @@ void CVideoInfoTag::Merge(CVideoInfoTag& other)
   {
     m_ratings = other.m_ratings;
     m_strDefaultRating = other.m_strDefaultRating;
-  };
+  }
   if (other.m_iIdRating != -1)
     m_iIdRating = other.m_iIdRating;
   if (other.m_iUserRating)
@@ -506,16 +504,15 @@ void CVideoInfoTag::Archive(CArchive& ar)
     ar << m_strSortTitle;
     ar << m_studio;
     ar << m_strTrailer;
-    ar << (int)m_cast.size();
-    for (unsigned int i=0;i<m_cast.size();++i)
+    ar << static_cast<int>(m_cast.size());
+    for (const auto& castEntry : m_cast)
     {
-      ar << m_cast[i].strName;
-      ar << m_cast[i].strRole;
-      ar << m_cast[i].order;
-      ar << m_cast[i].thumb;
-      ar << m_cast[i].thumbUrl.GetData();
+      ar << castEntry.strName;
+      ar << castEntry.strRole;
+      ar << castEntry.order;
+      ar << castEntry.thumb;
+      ar << castEntry.thumbUrl.GetData();
     }
-
     ar << m_set.title;
     ar << m_set.id;
     ar << m_set.overview;
@@ -544,20 +541,20 @@ void CVideoInfoTag::Archive(CArchive& ar)
     ar << m_iTop250;
     ar << m_iSeason;
     ar << m_iEpisode;
-    ar << (int)m_uniqueIDs.size();
-    for (const auto& i : m_uniqueIDs)
+    ar << static_cast<int>(m_uniqueIDs.size());
+    for (const auto& [id, value] : m_uniqueIDs)
     {
-      ar << i.first;
-      ar << (i.first == m_strDefaultUniqueID);
-      ar << i.second;
+      ar << id;
+      ar << (id == m_strDefaultUniqueID);
+      ar << value;
     }
-    ar << (int)m_ratings.size();
-    for (const auto& i : m_ratings)
+    ar << static_cast<int>(m_ratings.size());
+    for (const auto& [name, value] : m_ratings)
     {
-      ar << i.first;
-      ar << (i.first == m_strDefaultRating);
-      ar << i.second.rating;
-      ar << i.second.votes;
+      ar << name;
+      ar << (name == m_strDefaultRating);
+      ar << value.rating;
+      ar << value.votes;
     }
     ar << m_iUserRating;
     ar << m_iDbId;
@@ -569,10 +566,10 @@ void CVideoInfoTag::Archive(CArchive& ar)
     ar << dynamic_cast<IArchivable&>(m_streamDetails);
     ar << m_showLink;
     ar << static_cast<int>(m_namedSeasons.size());
-    for (const auto& namedSeason : m_namedSeasons)
+    for (const auto& [number, name] : m_namedSeasons)
     {
-      ar << namedSeason.first;
-      ar << namedSeason.second;
+      ar << number;
+      ar << name;
     }
     ar << m_EpBookmark.playerState;
     ar << m_EpBookmark.timeInSeconds;
@@ -610,7 +607,7 @@ void CVideoInfoTag::Archive(CArchive& ar)
     int iCastSize;
     ar >> iCastSize;
     m_cast.reserve(iCastSize);
-    for (int i=0;i<iCastSize;++i)
+    for (int i = 0; i < iCastSize; ++i)
     {
       SActorInfo info;
       ar >> info.strName;
@@ -620,9 +617,8 @@ void CVideoInfoTag::Archive(CArchive& ar)
       std::string strXml;
       ar >> strXml;
       info.thumbUrl.ParseFromData(strXml);
-      m_cast.push_back(info);
+      m_cast.emplace_back(std::move(info));
     }
-
     ar >> m_set.title;
     ar >> m_set.id;
     ar >> m_set.overview;
@@ -689,7 +685,6 @@ void CVideoInfoTag::Archive(CArchive& ar)
     ar >> m_iTrack;
     ar >> dynamic_cast<IArchivable&>(m_streamDetails);
     ar >> m_showLink;
-
     int namedSeasonSize;
     ar >> namedSeasonSize;
     for (int i = 0; i < namedSeasonSize; ++i)
@@ -698,7 +693,7 @@ void CVideoInfoTag::Archive(CArchive& ar)
       ar >> seasonNumber;
       std::string seasonName;
       ar >> seasonName;
-      m_namedSeasons.insert(std::make_pair(seasonNumber, seasonName));
+      m_namedSeasons.try_emplace(seasonNumber, seasonName);
     }
     ar >> m_EpBookmark.playerState;
     ar >> m_EpBookmark.timeInSeconds;
@@ -737,15 +732,15 @@ void CVideoInfoTag::Serialize(CVariant& value) const
   value["studio"] = m_studio;
   value["trailer"] = m_strTrailer;
   value["cast"] = CVariant(CVariant::VariantTypeArray);
-  for (unsigned int i = 0; i < m_cast.size(); ++i)
+  for (const auto& person : m_cast)
   {
     CVariant actor;
-    actor["name"] = m_cast[i].strName;
-    actor["role"] = m_cast[i].strRole;
-    actor["order"] = m_cast[i].order;
-    if (!m_cast[i].thumb.empty())
-      actor["thumbnail"] = IMAGE_FILES::URLFromFile(m_cast[i].thumb);
-    value["cast"].push_back(actor);
+    actor["name"] = person.strName;
+    actor["role"] = person.strRole;
+    actor["order"] = person.order;
+    if (!person.thumb.empty())
+      actor["thumbnail"] = IMAGE_FILES::URLFromFile(person.thumb);
+    value["cast"].push_back(std::move(actor));
   }
   value["set"] = m_set.title;
   value["setid"] = m_set.id;
@@ -781,15 +776,15 @@ void CVideoInfoTag::Serialize(CVariant& value) const
     value["uniqueid"][i.first] = i.second;
 
   value["rating"] = GetRating().rating;
-  CVariant ratings = CVariant(CVariant::VariantTypeObject);
-  for (const auto& i : m_ratings)
+  CVariant ratings{CVariant::VariantTypeObject};
+  for (const auto& [name, value] : m_ratings)
   {
     CVariant rating;
-    rating["rating"] = i.second.rating;
-    rating["votes"] = i.second.votes;
-    rating["default"] = i.first == m_strDefaultRating;
+    rating["rating"] = value.rating;
+    rating["votes"] = value.votes;
+    rating["default"] = (name == m_strDefaultRating);
 
-    ratings[i.first] = rating;
+    ratings[name] = rating;
   }
   value["ratings"] = ratings;
   value["userrating"] = m_iUserRating;
@@ -798,7 +793,7 @@ void CVideoInfoTag::Serialize(CVariant& value) const
   value["track"] = m_iTrack;
   value["showlink"] = m_showLink;
   m_streamDetails.Serialize(value["streamdetails"]);
-  CVariant resume = CVariant(CVariant::VariantTypeObject);
+  CVariant resume{CVariant::VariantTypeObject};
   resume["position"] = m_resumePoint.timeInSeconds;
   resume["total"] = m_resumePoint.totalTimeInSeconds;
   value["resume"] = resume;
@@ -856,7 +851,16 @@ void CVideoInfoTag::ToSortable(SortItem& sortable, Field field) const
   }
   case FieldTvShowStatus:             sortable[FieldTvShowStatus] = m_strStatus; break;
   case FieldProductionCode:           sortable[FieldProductionCode] = m_strProductionCode; break;
-  case FieldAirDate:                  sortable[FieldAirDate] = m_firstAired.IsValid() ? m_firstAired.GetAsDBDate() : (m_premiered.IsValid() ? m_premiered.GetAsDBDate() : StringUtils::Empty); break;
+  case FieldAirDate:
+  {
+    if (m_firstAired.IsValid())
+      sortable[FieldAirDate] = m_firstAired.GetAsDBDate();
+    else if (m_premiered.IsValid())
+      sortable[FieldAirDate] = m_premiered.GetAsDBDate();
+    else
+      sortable[FieldAirDate] = StringUtils::Empty;
+    break;
+  }
   case FieldTvShowTitle:              sortable[FieldTvShowTitle] = m_strShowTitle; break;
   case FieldAlbum:                    sortable[FieldAlbum] = m_strAlbum; break;
   case FieldArtist:                   sortable[FieldArtist] = m_artist; break;
@@ -958,7 +962,7 @@ std::string CVideoInfoTag::GetUniqueID(std::string type) const
   return uniqueid->second;
 }
 
-const std::map<std::string, std::string>& CVideoInfoTag::GetUniqueIDs() const
+const std::map<std::string, std::string, std::less<>>& CVideoInfoTag::GetUniqueIDs() const
 {
   return m_uniqueIDs;
 }
@@ -978,7 +982,7 @@ std::string CVideoInfoTag::GetCast(const std::string& separator,
 {
   const std::string sep{separator.empty() ? "\n" : separator};
   std::string strLabel;
-  for (iCast it = m_cast.begin(); it != m_cast.end(); ++it)
+  for (auto it = m_cast.begin(); it != m_cast.end(); ++it)
   {
     std::string character;
     if (it->strRole.empty() || !bIncludeRole)
@@ -1022,7 +1026,8 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
         r.votes = StringUtils::ReturnDigits(value);
       int max_value = 10;
       if ((child->QueryIntAttribute("max", &max_value) == TIXML_SUCCESS) && max_value >= 1)
-        r.rating = r.rating / max_value * 10; // Normalise the Movie Rating to between 1 and 10
+        r.rating = r.rating / static_cast<float>(max_value) *
+                   10.0f; // Normalise the Movie Rating to between 1 and 10
       SetRating(r, name);
       bool isDefault = false;
       // guard against assert in tinyxml
@@ -1040,7 +1045,8 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
     int max_value = 10;
     const TiXmlElement* rElement = movie->FirstChildElement("rating");
     if (rElement && (rElement->QueryIntAttribute("max", &max_value) == TIXML_SUCCESS) && max_value >= 1)
-      r.rating = r.rating / max_value * 10; // Normalise the Movie Rating to between 1 and 10
+      r.rating = r.rating / static_cast<float>(max_value) *
+                 10.0f; // Normalise the Movie Rating to between 1 and 10
     SetRating(r, "default");
     m_strDefaultRating = "default";
   }
@@ -1184,7 +1190,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
   if (prioritise && iThumbCount && iThumbCount != m_strPictureURL.GetUrls().size())
   {
     auto thumbUrls = m_strPictureURL.GetUrls();
-    rotate(thumbUrls.begin(), thumbUrls.begin() + iThumbCount, thumbUrls.end());
+    std::ranges::rotate(thumbUrls, thumbUrls.begin() + iThumbCount);
     m_strPictureURL.SetUrls(thumbUrls);
     m_strPictureURL.SetData(xmlAdd);
   }
@@ -1220,7 +1226,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
       std::string seasonName = namedSeason->FirstChild()->ValueStr();
       if (!seasonName.empty() &&
           namedSeason->Attribute("number", &seasonNumber) != nullptr)
-        m_namedSeasons.insert(std::make_pair(seasonNumber, seasonName));
+        m_namedSeasons.try_emplace(seasonNumber, seasonName);
     }
 
     namedSeason = namedSeason->NextSiblingElement("namedseason");
@@ -1242,16 +1248,16 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
         info.strRole = StringUtils::Trim(value);
 
       XMLUtils::GetInt(node, "order", info.order);
-      const TiXmlElement* thumb = node->FirstChildElement("thumb");
-      while (thumb)
+      const TiXmlElement* thumbnode = node->FirstChildElement("thumb");
+      while (thumbnode)
       {
-        info.thumbUrl.ParseAndAppendUrl(thumb);
-        thumb = thumb->NextSiblingElement("thumb");
+        info.thumbUrl.ParseAndAppendUrl(thumbnode);
+        thumbnode = thumbnode->NextSiblingElement("thumb");
       }
       const char* clear=node->Attribute("clear");
       if (clear && StringUtils::CompareNoCase(clear, "true"))
         m_cast.clear();
-      m_cast.push_back(info);
+      m_cast.emplace_back(std::move(info));
     }
     node = node->NextSiblingElement("actor");
   }
@@ -1296,14 +1302,14 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
   while (node)
   {
     const TiXmlNode* pNode = node->FirstChild("name");
-    const char* pValue=NULL;
+    const char* pValue{nullptr};
     if (pNode && pNode->FirstChild())
       pValue = pNode->FirstChild()->Value();
     else if (node->FirstChild())
       pValue = node->FirstChild()->Value();
     if (pValue)
     {
-      const char* clear=node->Attribute("clear");
+      const char* clear = node->Attribute("clear");
       if (clear && StringUtils::CompareNoCase(clear, "true") == 0)
         artist.clear();
       std::vector<std::string> newArtists = StringUtils::Split(pValue, itemSeparator);
@@ -1320,10 +1326,10 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
     const TiXmlNode *nodeStreamDetails = node->FirstChild("streamdetails");
     if (nodeStreamDetails)
     {
-      const TiXmlNode *nodeDetail = NULL;
+      const TiXmlNode* nodeDetail{nullptr};
       while ((nodeDetail = nodeStreamDetails->IterateChildren("audio", nodeDetail)))
       {
-        CStreamDetailAudio *p = new CStreamDetailAudio();
+        auto* p = new CStreamDetailAudio();
         if (XMLUtils::GetString(nodeDetail, "codec", value))
           p->m_strCodec = StringUtils::Trim(value);
 
@@ -1335,10 +1341,10 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
         StringUtils::ToLower(p->m_strLanguage);
         m_streamDetails.AddStream(p);
       }
-      nodeDetail = NULL;
+      nodeDetail = nullptr;
       while ((nodeDetail = nodeStreamDetails->IterateChildren("video", nodeDetail)))
       {
-        CStreamDetailVideo *p = new CStreamDetailVideo();
+        auto* p = new CStreamDetailVideo();
         if (XMLUtils::GetString(nodeDetail, "codec", value))
           p->m_strCodec = StringUtils::Trim(value);
 
@@ -1359,10 +1365,10 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
         StringUtils::ToLower(p->m_strHdrType);
         m_streamDetails.AddStream(p);
       }
-      nodeDetail = NULL;
+      nodeDetail = nullptr;
       while ((nodeDetail = nodeStreamDetails->IterateChildren("subtitle", nodeDetail)))
       {
-        CStreamDetailSubtitle *p = new CStreamDetailSubtitle();
+        auto* p = new CStreamDetailSubtitle();
         if (XMLUtils::GetString(nodeDetail, "language", value))
           p->m_strLanguage = StringUtils::Trim(value);
         StringUtils::ToLower(p->m_strLanguage);
@@ -1417,9 +1423,9 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
     const TiXmlElement *playerstate = resume->FirstChildElement("playerstate");
     if (playerstate)
     {
-      const TiXmlElement *value = playerstate->FirstChildElement();
-      if (value)
-        m_resumePoint.playerState << *value;
+      const TiXmlElement* state = playerstate->FirstChildElement();
+      if (state)
+        m_resumePoint.playerState << *state;
     }
   }
 
@@ -1463,14 +1469,14 @@ unsigned int CVideoInfoTag::GetStaticDuration() const
 
 unsigned int CVideoInfoTag::GetDurationFromMinuteString(const std::string &runtime)
 {
-  unsigned int duration = (unsigned int)str2uint64(runtime);
+  auto duration = static_cast<unsigned int>(str2uint64(runtime));
   if (!duration)
   { // failed for some reason, or zero
-    duration = strtoul(runtime.c_str(), NULL, 10);
-    CLog::Log(LOGWARNING, "{} <runtime> should be in minutes. Interpreting '{}' as {} minutes",
-              __FUNCTION__, runtime, duration);
+    duration = static_cast<unsigned int>(std::strtoul(runtime.c_str(), nullptr, 10));
+    CLog::LogF(LOGWARNING, "<runtime> should be in minutes. Interpreting '{}' as {} minutes",
+               runtime, duration);
   }
-  return duration*60;
+  return duration * 60;
 }
 
 void CVideoInfoTag::SetBasePath(std::string basePath)
@@ -1533,7 +1539,7 @@ void CVideoInfoTag::SetSortTitle(std::string sortTitle)
   m_strSortTitle = Trim(std::move(sortTitle));
 }
 
-void CVideoInfoTag::SetPictureURL(CScraperUrl &pictureURL)
+void CVideoInfoTag::SetPictureURL(const CScraperUrl& pictureURL)
 {
   m_strPictureURL = pictureURL;
 }
@@ -1625,7 +1631,7 @@ void CVideoInfoTag::SetArtist(std::vector<std::string> artist)
   m_artist = Trim(std::move(artist));
 }
 
-void CVideoInfoTag::SetUniqueIDs(std::map<std::string, std::string> uniqueIDs)
+void CVideoInfoTag::SetUniqueIDs(std::map<std::string, std::string, std::less<>> uniqueIDs)
 {
   for (const auto& uniqueid : uniqueIDs)
   {
@@ -1720,7 +1726,9 @@ void CVideoInfoTag::SetShowLink(std::vector<std::string> showLink)
   m_showLink = Trim(std::move(showLink));
 }
 
-void CVideoInfoTag::SetUniqueID(const std::string& uniqueid, const std::string& type /* = "" */, bool isDefaultID /* = false */)
+void CVideoInfoTag::SetUniqueID(std::string_view uniqueid,
+                                const std::string& type /* = "" */,
+                                bool isDefaultID /* = false */)
 {
   if (uniqueid.empty())
     return;
@@ -1755,16 +1763,14 @@ void CVideoInfoTag::SetUserrating(int userrating)
   m_iUserRating = userrating;
 }
 
-std::string CVideoInfoTag::Trim(std::string &&value)
+std::string CVideoInfoTag::Trim(std::string&& value) const
 {
   return StringUtils::Trim(value);
 }
 
-std::vector<std::string> CVideoInfoTag::Trim(std::vector<std::string>&& items)
+std::vector<std::string> CVideoInfoTag::Trim(std::vector<std::string>&& items) const
 {
-  std::for_each(items.begin(), items.end(), [](std::string &str){
-    str = StringUtils::Trim(str);
-  });
+  std::ranges::for_each(items, [](std::string& str) { str = StringUtils::Trim(str); });
   return std::move(items);
 }
 
@@ -1846,7 +1852,7 @@ void CVideoInfoTag::CAssetInfo::Archive(CArchive& ar)
   }
 }
 
-void CVideoInfoTag::CAssetInfo::Save(TiXmlNode* movie)
+void CVideoInfoTag::CAssetInfo::Save(TiXmlNode* movie) const
 {
   XMLUtils::SetString(movie, "videoassettitle", m_title);
   XMLUtils::SetInt(movie, "videoassetid", m_id);
@@ -1866,7 +1872,7 @@ void CVideoInfoTag::CAssetInfo::ParseNative(const TiXmlElement* movie)
   m_type = static_cast<VideoAssetType>(assetType);
 }
 
-void CVideoInfoTag::CAssetInfo::Merge(CAssetInfo& other)
+void CVideoInfoTag::CAssetInfo::Merge(const CAssetInfo& other)
 {
   if (!other.m_title.empty())
     m_title = other.m_title;

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -17,6 +17,7 @@
 #include "video/Bookmark.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 class CArchive;
@@ -36,7 +37,7 @@ struct SActorInfo
   std::string strRole;
   CScraperUrl thumbUrl;
   std::string thumb;
-  int        order = -1;
+  int order{-1};
 };
 
 class CRating
@@ -48,13 +49,13 @@ public:
   float rating = 0.0f;
   int votes = 0;
 };
-typedef std::map<std::string, CRating> RatingMap;
+using RatingMap = std::map<std::string, CRating, std::less<>>;
 
 class CVideoInfoTag : public IArchivable, public ISerializable, public ISortable
 {
 public:
   CVideoInfoTag() { Reset(); }
-  virtual ~CVideoInfoTag() = default;
+  ~CVideoInfoTag() override = default;
   virtual void Reset();
   /* \brief Load information to a videoinfotag from an XML element
    There are three types of tags supported:
@@ -72,7 +73,10 @@ public:
    \sa ParseNative
    */
   bool Load(const TiXmlElement *element, bool append = false, bool prioritise = false);
-  bool Save(TiXmlNode *node, const std::string &tag, bool savePathInfo = true, const TiXmlElement *additionalNode = NULL);
+  bool Save(TiXmlNode* node,
+            const std::string& tag,
+            bool savePathInfo = true,
+            const TiXmlElement* additionalNode = nullptr);
   void Merge(CVideoInfoTag& other);
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;
@@ -80,7 +84,7 @@ public:
   CRating GetRating(std::string type = "") const;
   const std::string& GetDefaultRating() const;
   std::string GetUniqueID(std::string type = "") const;
-  const std::map<std::string, std::string>& GetUniqueIDs() const;
+  const std::map<std::string, std::string, std::less<>>& GetUniqueIDs() const;
   const std::string& GetDefaultUniqueID() const;
   bool HasUniqueID() const;
   virtual bool HasYear() const;
@@ -132,14 +136,14 @@ public:
   std::string const& GetTitle() const;
   void SetTitle(std::string title);
   void SetSortTitle(std::string sortTitle);
-  void SetPictureURL(CScraperUrl &pictureURL);
+  void SetPictureURL(const CScraperUrl& pictureURL);
   void SetRating(float rating, int votes, const std::string& type = "", bool def = false);
   void SetRating(CRating rating, const std::string& type = "", bool def = false);
   void SetRating(float rating, const std::string& type = "", bool def = false);
   void RemoveRating(const std::string& type);
   void SetRatings(RatingMap ratings, const std::string& defaultRating = "");
   void SetVotes(int votes, const std::string& type = "");
-  void SetUniqueIDs(std::map<std::string, std::string> uniqueIDs);
+  void SetUniqueIDs(std::map<std::string, std::string, std::less<>> uniqueIDs);
   void SetPremiered(const CDateTime& premiered);
   void SetPremieredFromDBDate(const std::string& premieredString);
   virtual void SetYear(int year);
@@ -159,7 +163,7 @@ public:
   void SetStudio(std::vector<std::string> studio);
   void SetAlbum(std::string album);
   void SetShowLink(std::vector<std::string> showLink);
-  void SetUniqueID(const std::string& uniqueid, const std::string& type = "", bool def = false);
+  void SetUniqueID(std::string_view uniqueid, const std::string& type = "", bool def = false);
   void RemoveUniqueID(const std::string& type);
   void SetNamedSeasons(std::map<int, std::string> namedSeasons);
   void SetUserrating(int userrating);
@@ -225,7 +229,7 @@ public:
      * @brief Store all data to XML.
      * @param movie The XML element to write the data to.
      */
-    void Save(TiXmlNode* movie);
+    void Save(TiXmlNode* movie) const;
 
     /*!
      * @brief Restore all data from XML.
@@ -237,7 +241,7 @@ public:
      * @brief Merge in all valid data from another asset info.
      * @param other The other asset info.
      */
-    void Merge(CAssetInfo& other);
+    void Merge(const CAssetInfo& other);
 
     /*!
      * @brief Serialize all data.
@@ -360,8 +364,7 @@ public:
   std::string m_strTitle;
   std::string m_strSortTitle;
   std::vector<std::string> m_artist;
-  std::vector< SActorInfo > m_cast;
-  typedef std::vector< SActorInfo >::const_iterator iCast;
+  std::vector<SActorInfo> m_cast;
   struct SetInfo //!< Struct holding information about a movie set
   {
     std::string title; //!< Title of the movie set
@@ -427,9 +430,9 @@ private:
 
   std::string m_strDefaultRating;
   std::string m_strDefaultUniqueID;
-  std::map<std::string, std::string> m_uniqueIDs;
-  std::string Trim(std::string &&value);
-  std::vector<std::string> Trim(std::vector<std::string> &&items);
+  std::map<std::string, std::string, std::less<>> m_uniqueIDs;
+  std::string Trim(std::string&& value) const;
+  std::vector<std::string> Trim(std::vector<std::string>&& items) const;
 
   int m_playCount;
   CBookmark m_resumePoint;

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -442,5 +442,3 @@ private:
 
   bool m_updateSetOverview{true};
 };
-
-typedef std::vector<CVideoInfoTag> VECMOVIES;

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -375,7 +375,7 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
       m_castList->Add(item);
     }
     // get performers in the music video (added as actors)
-    for (CVideoInfoTag::iCast it = m_movieItem->GetVideoInfoTag()->m_cast.begin();
+    for (auto it = m_movieItem->GetVideoInfoTag()->m_cast.begin();
          it != m_movieItem->GetVideoInfoTag()->m_cast.end(); ++it)
     {
       // Check to see if we have already added this performer as the artist and skip adding if so
@@ -416,7 +416,8 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
   }
   else
   { // movie/show/season/episode
-    for (CVideoInfoTag::iCast it = m_movieItem->GetVideoInfoTag()->m_cast.begin(); it != m_movieItem->GetVideoInfoTag()->m_cast.end(); ++it)
+    for (auto it = m_movieItem->GetVideoInfoTag()->m_cast.begin();
+         it != m_movieItem->GetVideoInfoTag()->m_cast.end(); ++it)
     {
       CFileItemPtr item(new CFileItem(it->strName));
       if (!it->thumb.empty())


### PR DESCRIPTION
Even more boring SonarQube stuff here. No functional changes intended, only optimizations and modernization of code.

Like always: There may be still some more findings in the touched files. I'm currently concentrating on low hanging fruits only.

**VideoInfoTag**
* Transparent function objects should be used with associative "std::string" containers cpp:S6045
* "using" should be preferred for type aliasing cpp:S5416
* "override" or "final" should be used instead of "virtual" cpp:S3471
* "nullptr" should be used to denote the null pointer cpp:S4962
* Structured binding should be used cpp:S6005
* Variables should not be shadowed cpp:S1117
* Empty statements should be removed cpp:S1116
* STL algorithms and range-based for loops should be preferred to traditional for loops cpp:S5566
* "try_emplace" should be used with "std::map" and "std::unordered_map" cpp:S6030
* Conditional operators should not be nested cpp:S3358
* "auto" should be used to store a result of functions that conventionally return an iterator or a range cpp:S6234
* Implicit casts should not lower precision cpp:S5276
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* "std::source_location" should be used instead of "__FILE__", "__LINE__", and "__func__" macros cpp:S6190
* Pointer and reference parameters should be "const" if the corresponding object is not modified cpp:S995
* "std::string_view" should be used to pass a read-only string to a function cpp:S6009

**MusicInfoTag**
* #include directives in a file should only be preceded by other preprocessor directives or comments cpp:S954
* Member variables should not be "protected" cpp:S3656
* "final" classes should not have "protected" members cpp:S2156
* "std::string_view" should be used to pass a read-only string to a function cpp:S6009
* Redundant casts should not be used cpp:S1905
* STL algorithms and range-based for loops should be preferred to traditional for loops cpp:S5566
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197

Runtime-tested on macOS and Android, latest Kodi master. No regressions found.

@neo1973 @garbear maybe you are in the mood to review this.