### PR TITLE
BP #26921 Fix CVideoInfoScanner strHash mismatch between linux and win32 platform

### DIFF
--- a/xbmc/platform/win32/filesystem/Win32File.cpp
+++ b/xbmc/platform/win32/filesystem/Win32File.cpp
@@ -466,6 +466,11 @@ int CWin32File::Stat(const CURL& url, struct __stat64* statData)
     return -1;
   }
 
+  // -- BP PR-26921
+  // stat of directories requires the removal of the trailing slash
+  if (pathnameW.back() == L'\\')
+    pathnameW.pop_back();
+
   if (pathnameW.length() <= 6) // 6 is length of "\\?\x:"
     return -1; // pathnameW is empty or points to device ("\\?\x:"), on win32 stat() for devices is not supported
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Backport of PR #26921 and https://github.com/xbmc/xbmc/pull/26104

This include the fix in Win32File.cpp concerning FindFirstFileExW() correct path format. It's mandatory for the fix related in issue #26909.

A backport of the trailling slash cutting in [Win32File.cpp](https://github.com/xbmc/xbmc/pull/26926/files#diff-839b3b86c928d75b83e7ec7f36f3e5096e08173437d4cf25ba6dfc300eacb34f) is needed too but already in Piers/master branch at the moment of the original patch.
This solve an unhandled error (FindFirstFileExW()) in Omega version of the fasthash on windows platform.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Same as original PR #26921

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
