### PR TITLE
[DirectoryCache] Reduce construction of expensive CURL objects.

### DIFF
--- a/xbmc/application/ApplicationSkinHandling.cpp
+++ b/xbmc/application/ApplicationSkinHandling.cpp
@@ -16,6 +16,7 @@
 #include "PlayListPlayer.h"
 #include "ServiceBroker.h"
 #include "TextureCache.h"
+#include "URL.h"
 #include "addons/AddonManager.h"
 #include "addons/AddonVersion.h"
 #include "addons/Skin.h"
@@ -130,7 +131,7 @@ bool CApplicationSkinHandling::LoadSkin(const std::string& skinID)
 
   CLog::Log(LOGINFO, "  load fonts for skin...");
   CServiceBroker::GetWinSystem()->GetGfxContext().SetMediaDir(skin->Path());
-  g_directoryCache.ClearSubPaths(skin->Path());
+  g_directoryCache.ClearSubPaths(CURL(skin->Path()));
 
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   CServiceBroker::GetGUI()->GetColorManager().Load(

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -172,14 +172,15 @@ bool CDirectory::GetDirectory(const CURL& url,
       return false;
 
     // check our cache for this path
-    if (g_directoryCache.GetDirectory(realURL.Get(), items, (hints.flags & DIR_FLAG_READ_CACHE) == DIR_FLAG_READ_CACHE))
+    if (g_directoryCache.GetDirectory(realURL, items,
+                                      (hints.flags & DIR_FLAG_READ_CACHE) == DIR_FLAG_READ_CACHE))
       items.SetURL(url);
     else
     {
       // need to clear the cache (in case the directory fetch fails)
       // and (re)fetch the folder
       if (!(hints.flags & DIR_FLAG_BYPASS_CACHE))
-        g_directoryCache.ClearDirectory(realURL.Get());
+        g_directoryCache.ClearDirectory(realURL);
 
       pDirectory->SetFlags(hints.flags);
 
@@ -254,7 +255,7 @@ bool CDirectory::GetDirectory(const CURL& url,
 
       // cache the directory, if necessary
       if (!(hints.flags & DIR_FLAG_BYPASS_CACHE))
-        g_directoryCache.SetDirectory(realURL.Get(), items, pDirectory->GetCacheType(url));
+        g_directoryCache.SetDirectory(realURL, items, pDirectory->GetCacheType(url));
     }
 
     // now filter for allowed files
@@ -390,7 +391,7 @@ bool CDirectory::Exists(const CURL& url, bool bUseCache /* = true */)
       bool bPathInCache;
       std::string realPath(realURL.Get());
       URIUtils::AddSlashAtEnd(realPath);
-      if (g_directoryCache.FileExists(realPath, bPathInCache))
+      if (g_directoryCache.FileExists(CURL(realPath), bPathInCache))
         return true;
       if (bPathInCache)
         return false;
@@ -433,7 +434,7 @@ bool CDirectory::Remove(const CURL& url)
     if (pDirectory)
       if(pDirectory->Remove(authUrl))
       {
-        g_directoryCache.ClearFile(realURL.Get());
+        g_directoryCache.ClearFile(realURL);
         return true;
       }
   }
@@ -456,7 +457,7 @@ bool CDirectory::RemoveRecursive(const CURL& url)
     if (pDirectory)
       if(pDirectory->RemoveRecursive(authUrl))
       {
-        g_directoryCache.ClearFile(realURL.Get());
+        g_directoryCache.ClearFile(realURL);
         return true;
       }
   }

--- a/xbmc/filesystem/DirectoryCache.h
+++ b/xbmc/filesystem/DirectoryCache.h
@@ -15,7 +15,7 @@
 #include <memory>
 #include <set>
 
-class CFileItem;
+class CURL;
 
 namespace XFILE
 {
@@ -43,14 +43,14 @@ namespace XFILE
   public:
     CDirectoryCache(void);
     virtual ~CDirectoryCache(void);
-    bool GetDirectory(const std::string& strPath, CFileItemList &items, bool retrieveAll = false);
-    void SetDirectory(const std::string& strPath, const CFileItemList& items, CacheType cacheType);
-    void ClearDirectory(const std::string& strPath);
-    void ClearFile(const std::string& strFile);
-    void ClearSubPaths(const std::string& strPath);
+    bool GetDirectory(const CURL& url, CFileItemList& items, bool retrieveAll = false);
+    void SetDirectory(const CURL& url, const CFileItemList& items, CacheType cacheType);
+    void ClearDirectory(const CURL& url);
+    void ClearFile(const CURL& url);
+    void ClearSubPaths(const CURL& url);
     void Clear();
-    void AddFile(const std::string& strFile);
-    bool FileExists(const std::string& strPath, bool& bInCache);
+    void AddFile(const CURL& url);
+    bool FileExists(const CURL& url, bool& foundInCache);
 #ifdef _DEBUG
     void PrintStats() const;
 #endif

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -268,7 +268,7 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
     if (url2.IsProtocol("apk") || url2.IsProtocol("zip") )
       url2.SetOptions("");
 
-    if (!g_directoryCache.FileExists(url2.Get(), bPathInCache) )
+    if (!g_directoryCache.FileExists(url2, bPathInCache))
     {
       if (bPathInCache)
         return false;
@@ -421,7 +421,7 @@ bool CFile::OpenForWrite(const CURL& file, bool bOverWrite)
     if (m_pFile && m_pFile->OpenForWrite(authUrl, bOverWrite))
     {
       // add this file to our directory cache (if it's stored)
-      g_directoryCache.AddFile(url.Get());
+      g_directoryCache.AddFile(url);
       return true;
     }
     return false;
@@ -460,7 +460,7 @@ bool CFile::Exists(const CURL& file, bool bUseCache /* = true */)
     if (bUseCache)
     {
       bool bPathInCache;
-      if (g_directoryCache.FileExists(url.Get(), bPathInCache))
+      if (g_directoryCache.FileExists(url, bPathInCache))
         return true;
       if (bPathInCache)
         return false;
@@ -491,7 +491,7 @@ bool CFile::Exists(const CURL& file, bool bUseCache /* = true */)
           if (bUseCache)
           {
             bool bPathInCache;
-            if (g_directoryCache.FileExists(pNewUrl->Get(), bPathInCache))
+            if (g_directoryCache.FileExists(*pNewUrl, bPathInCache))
               return true;
             if (bPathInCache)
               return false;
@@ -908,7 +908,7 @@ bool CFile::Delete(const CURL& file)
 
     if(pFile->Delete(authUrl))
     {
-      g_directoryCache.ClearFile(url.Get());
+      g_directoryCache.ClearFile(url);
       return true;
     }
   }
@@ -946,8 +946,8 @@ bool CFile::Rename(const CURL& file, const CURL& newFile)
 
     if(pFile->Rename(authUrl, authUrlNew))
     {
-      g_directoryCache.ClearFile(url.Get());
-      g_directoryCache.AddFile(urlnew.Get());
+      g_directoryCache.ClearFile(url);
+      g_directoryCache.AddFile(urlnew);
       return true;
     }
   }

--- a/xbmc/video/VideoGeneratedImageFileLoader.cpp
+++ b/xbmc/video/VideoGeneratedImageFileLoader.cpp
@@ -51,7 +51,7 @@ void SetupRarOptions(CFileItem& item, const std::string& path)
     item.GetVideoInfoTag()->m_strFileNameAndPath = url.Get();
   else
     item.SetPath(url.Get());
-  g_directoryCache.ClearDirectory(url.GetWithoutFilename());
+  g_directoryCache.ClearDirectory(CURL(url.GetWithoutFilename()));
 }
 } // namespace
 


### PR DESCRIPTION
## Description
`CDirectoryCache` interface accepts paths as `std::string` and every method then converts the string into a `CURL` object. This is expensive as it needs to parse the string.

Most callers of these methods are converting to a `std::string` from a `CURL` object just to match the interface of the cache.

Changing the interface to accept a `CURL` object, which the callers primarily have already, we can avoid these extra string parsing.

## Motivation and context
Profiling and optimization

## How has this been tested?
Building
Existing Unit Tests
Manual Run

## What is the effect on users?
Speed-up

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
