### PR TITLE
[Android] Enable displaying recommended content on Projectivy Launcher

### DIFF
--- a/tools/android/packaging/xbmc/src/Main.java.in
+++ b/tools/android/packaging/xbmc/src/Main.java.in
@@ -23,6 +23,8 @@ import android.view.WindowInsetsController;
 import android.widget.RelativeLayout;
 
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 
 public class Main extends NativeActivity implements Choreographer.FrameCallback
 {
@@ -49,6 +51,12 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
   }
   private ArrayList<DelayedIntent> mDelayedIntents = new ArrayList<>();
   private boolean mPaused = true;
+
+  // Launchers that support the Recommended Content API
+  private final Set<String> mRecommendedLaunchers = new HashSet<String>() {{
+    add("com.google.android.tvlauncher"); // Android TV Stock
+    add("com.spocky.projengmenu"); // Projectivy Launcher
+  }};
 
   native void _onNewIntent(Intent intent);
 
@@ -125,7 +133,7 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
     if (getPackageManager().hasSystemFeature(FEATURE_LEANBACK))
     {
       if (Build.VERSION.SDK_INT >= VERSION_CODES.O
-          && getLauncherName().equals("com.google.android.tvlauncher"))
+          && mRecommendedLaunchers.contains(getLauncherName()))
       {
         TvUtil.scheduleSyncingChannel(this);
       }
@@ -267,7 +275,7 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
 
     if (getPackageManager().hasSystemFeature(FEATURE_LEANBACK)
         && Build.VERSION.SDK_INT >= VERSION_CODES.O
-        && getLauncherName().equals("com.google.android.tvlauncher")) {
+        && mRecommendedLaunchers.contains(getLauncherName())) {
       TvUtil.scheduleSyncingChannel(this);
     }
 


### PR DESCRIPTION
## Description
Enable the feature to display recommended content on the Android TV home screen using channels on devices running the [Projectivy Launcher.](https://play.google.com/store/apps/details?id=com.spocky.projengmenu)

To avoid unnecessary overhead of creating and syncing content in Kodi, this feature was only enabled for devices running the stock Android TV launcher, as it's the only one that implements the Content Recommendation API.

This PR enables this feature for Projectivy Launcher as it also implements this API.

## Motivation and context
Fix #26802

## How has this been tested?
Install this launcher and check that it displays the content suggested by Kodi

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
