### PR TITLE
[Video][Bluray] Revert "Associate bookmarks with known bluray:// paths (including removable discs) when files viewed through the Video node."

### DIFF
--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -11,7 +11,6 @@
 #include "CueDocument.h"
 #include "ServiceBroker.h"
 #include "URL.h"
-#include "filesystem/BlurayDirectory.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "filesystem/MusicDatabaseDirectory.h"
@@ -31,9 +30,7 @@
 #include "utils/RegExp.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
-#include "video/VideoDatabase.h"
 #include "video/VideoFileItemClassify.h"
-#include "video/VideoInfoTag.h"
 #include "video/VideoUtils.h"
 
 #include <algorithm>
@@ -930,39 +927,6 @@ void CFileItemList::StackFiles()
       }
     }
     i++;
-  }
-}
-
-void CFileItemList::ReplaceBlurayFiles()
-{
-  for (auto& item : m_items)
-  {
-    if (URIUtils::IsBlurayPath(item->GetDynPath()))
-      continue;
-
-    const std::string path{VIDEO::UTILS::GetOpticalMediaPath(*item)};
-    if (path.empty())
-      continue;
-
-    const std::string file{CBlurayDirectory::GetBlurayPlaylistPath(*item)};
-    if (file.empty())
-      continue;
-
-    item->SetPath(path); // index.bdmv
-    item->SetFolder(false);
-
-    // The removable path encapsulated in bluray://
-    item->GetVideoInfoTag()->m_strFileNameAndPath = file;
-
-    // See if bookmark exists
-    CVideoDatabase db;
-    if (db.Open())
-    {
-      CBookmark bookmark;
-      if (db.GetResumeBookMark(file, bookmark))
-        item->GetVideoInfoTag()->SetResumePoint(bookmark);
-      db.Close();
-    }
   }
 }
 

--- a/xbmc/FileItemList.h
+++ b/xbmc/FileItemList.h
@@ -86,11 +86,6 @@ public:
    */
   void Stack(bool stackFiles = true);
 
-  /*! \brief replace any items in the list with bluray:// URLs
-   Only if these exist in the video database
-   */
-  void ReplaceBlurayFiles();
-
   SortOrder GetSortOrder() const { return m_sortDescription.sortOrder; }
   SortBy GetSortMethod() const { return m_sortDescription.sortBy; }
   void SetSortOrder(SortOrder sortOrder) { m_sortDescription.sortOrder = sortOrder; }

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -20,14 +20,11 @@
 #include "guilib/LocalizeStrings.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
-#include "storage/MediaManager.h"
-#include "utils/DiscsUtils.h"
 #include "utils/LangCodeExpander.h"
 #include "utils/RegExp.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
-#include "video/VideoDatabase.h"
 #include "video/VideoInfoTag.h"
 
 #include <algorithm>
@@ -1865,42 +1862,4 @@ const BLURAY_DISC_INFO* CBlurayDirectory::GetDiscInfo() const
   return bd_get_disc_info(m_bd);
 }
 
-std::string CBlurayDirectory::GetBlurayPlaylistPath(const CFileItem& item)
-{
-  const std::string& path{item.GetPath()};
-  if (URIUtils::IsBlurayPath(path))
-    return path; // Already a bluray playlist path
-
-  CVideoDatabase db;
-  if (!db.Open())
-    return {};
-
-  // First see if the path is a removable bluray path
-  std::string playlistPath;
-#ifdef HAS_OPTICAL_DRIVE
-  if (item.IsRemovable())
-  {
-    const CURL url{path};
-    const std::string mediaPath{
-        CServiceBroker::GetMediaManager().TranslateDevicePath(url.GetHostName())};
-    UTILS::DISCS::DiscInfo info{CServiceBroker::GetMediaManager().GetDiscInfo(mediaPath)};
-    if (!info.empty() && info.type == UTILS::DISCS::DiscType::BLURAY)
-    {
-      const std::string blurayPath{CServiceBroker::GetMediaManager().GetDiskUniqueId()};
-      playlistPath = db.GetRemovableBlurayPath(blurayPath);
-    }
-  }
-  else
-#endif
-  {
-    // See if the bluray path exists in the database
-    const std::string blurayPath{URIUtils::GetBlurayPlaylistPath(path)};
-    if (const int idPath{db.GetPathId(blurayPath)}; idPath != -1)
-      if (std::vector<std::string> files{db.GetFilesByPathId(idPath)}; !files.empty())
-        playlistPath = *files.begin();
-  }
-
-  db.Close();
-  return playlistPath;
-}
 } // namespace XFILE

--- a/xbmc/filesystem/BlurayDirectory.h
+++ b/xbmc/filesystem/BlurayDirectory.h
@@ -199,7 +199,6 @@ public:
   static std::string GetBasePath(const CURL& url);
   std::string GetBlurayTitle() const;
   std::string GetBlurayID() const;
-  static std::string GetBlurayPlaylistPath(const CFileItem& item);
 
 private:
   enum class DiscInfo : uint8_t

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -539,10 +539,9 @@ std::string URIUtils::GetBlurayAllEpisodesPath(const std::string& path)
   return AddFileToFolder(GetBlurayPath(path), "root", "episode", "all");
 }
 
-std::string URIUtils::GetBlurayPlaylistPath(const std::string& path, int playlist /* = -1 */)
+std::string URIUtils::GetBlurayPlaylistPath(const std::string& path)
 {
-  return AddFileToFolder(GetBlurayPath(path), "BDMV", "PLAYLIST",
-                         playlist != -1 ? StringUtils::Format("{:05}.mpls", playlist) : "");
+  return AddFileToFolder(GetBlurayPath(path), "BDMV", "PLAYLIST", "");
 }
 
 std::string URIUtils::GetBlurayPath(const std::string& path)
@@ -564,8 +563,6 @@ std::string URIUtils::GetBlurayPath(const std::string& path)
   }
   else if (IsBDFile(path))
     newPath = GetDiscBasePath(path);
-  else
-    newPath = path;
 
   if (!newPath.empty())
   {

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -138,10 +138,9 @@ public:
 
   /*! \brief Given a path to an .ISO or index.BDMV, returns a bluray:// path to default playlist path.
    \param path the ISO/index.BDMV path.
-   \param playlist (optional) the .mpls playlist
-   \return the bluray:// playlist path - BDMV/PLAYLIST(/xxxxx.mpls)
+   \return the bluray:// playlist path - BDMV/PLAYLIST
    */
-  static std::string GetBlurayPlaylistPath(const std::string& path, int playlist = -1);
+  static std::string GetBlurayPlaylistPath(const std::string& path);
 
   /*! \brief Given a path to an .ISO or index.BDMV, returns a bluray:// path.
    \param path the ISO/index.BDMV path.

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3618,40 +3618,6 @@ void CVideoDatabase::GetFilePathById(int idMovie, std::string& filePath, VideoDb
   }
 }
 
-std::vector<std::string> CVideoDatabase::GetFilesByPathId(int idPath)
-{
-  try
-  {
-    if (!m_pDB || !m_pDS || idPath < 0)
-      return {};
-
-    const std::string strSQL{PrepareSQL("SELECT path.strPath, files.strFileName FROM path "
-                                        "INNER JOIN files ON path.idPath=files.idPath "
-                                        "WHERE path.idPath=%i ORDER BY strFilename",
-                                        idPath)};
-
-    m_pDS->query(strSQL);
-
-    std::vector<std::string> files;
-    while (!m_pDS->eof())
-    {
-      std::string file;
-      ConstructPath(file, m_pDS->fv("strPath").get_asString(),
-                    m_pDS->fv("strFilename").get_asString());
-      files.emplace_back(file);
-      m_pDS->next();
-    }
-    m_pDS->close();
-
-    return files;
-  }
-  catch (const std::exception& e)
-  {
-    CLog::LogF(LOGERROR, "Failed with idPath {}, error {}", idPath, e.what());
-  }
-  return {};
-}
-
 //********************************************************************************************************************************
 void CVideoDatabase::GetBookMarksForFile(const std::string& strFilenameAndPath, VECBOOKMARKS& bookmarks, CBookmark::EType type /*= CBookmark::STANDARD*/, bool bAppend, long partNumber)
 {

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -582,7 +582,6 @@ public:
   bool HasMusicVideoInfo(const std::string& strFilenameAndPath);
 
   void GetFilePathById(int idMovie, std::string& filePath, VideoDbContentType iType);
-  std::vector<std::string> GetFilesByPathId(int idPath);
   std::string GetGenreById(int id) const;
   std::string GetCountryById(int id) const;
   std::string GetSetById(int id) const;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -756,9 +756,6 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
     if (!GetDirectoryItems(pathToUrl, dirItems, UseFileDirectories()))
       return false;
 
-    if (GetID() == WINDOW_VIDEO_NAV)
-      dirItems.ReplaceBlurayFiles();
-
     // assign fetched directory items
     items.Assign(dirItems);
 


### PR DESCRIPTION
Caused loading video library to be slower.

Will revise in due course.

Apologies.

This reverts commit 8c687a0bed4ed370b6e54f9c4471510b2f374f5c.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
