### PR TITLE
[CURL] Trying to test functions which call DNSCache::Lookup failed du…

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -870,7 +870,8 @@ bool URIUtils::IsHostOnLAN(const std::string& host, LanCheckMode lanCheckMode)
   if(address == INADDR_NONE)
   {
     std::string ip;
-    if (CServiceBroker::GetDNSNameCache()->Lookup(host, ip))
+    auto cache = CServiceBroker::GetDNSNameCache();
+    if (cache && cache->Lookup(host, ip))
       address = ntohl(inet_addr(ip.c_str()));
   }
 


### PR DESCRIPTION
…ring testing.

Check if the cache service is available before trying to use it. Safter for the test environment.


## Description
Fixed issue found in testing when a service is unavailable. Check the service is non-null before calling its methods.

## Motivation and context
Tests failed when I was adding to them

## How has this been tested?
Unit test

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [X] **None of the above** (please explain below)
Safter test Environment

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
