### PR TITLE
[URLUtils] Added consistency checks between `URLUtils` and `CURL::Parse`

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -65,7 +65,6 @@ void CURL::Parse(std::string strURL1)
   // first need 2 check if this is a protocol or just a normal drive & path
   if (strURL.empty())
     return;
-  if (strURL == "?") return;
 
   // form is format 1 or 2
   // format 1: protocol://[domain;][username:password]@hostname[:port]/directoryandfile

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -863,6 +863,13 @@ TEST_F(TestURIUtils, CheckConsistencyBetweenFileNameUtilities)
   { return URIUtils_Split(CURL(in).GetFileName()); };
 
   {
+    EXPECT_EQ("?", CURL("?").GetFileName());
+
+    EXPECT_EQ("?", URIUtils::GetFileName("?"));
+    EXPECT_EQ("?", CURL_FileName_URIUtils_Split("?"));
+    EXPECT_EQ("?", URIUtils_Split("?"));
+  }
+  {
     EXPECT_EQ("", URIUtils_Split("C:"));
 
     EXPECT_EQ("", URIUtils::GetFileName("C:"));


### PR DESCRIPTION
Fixed found issues found between the two implementations.

## Description
- Fixed CURL parsing. A question mark may be a valid filename.
- Fixed inconsistency when getting filename from a windows drive spec.

## Motivation and context
Inconsistencies found while adding tests.

## How has this been tested?
Added tests

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
