### PR TITLE
[Video] Fix GetMovieName(), GetMovieBasePath() and GetBasePath() to better handle optical media, bluray:// paths and Disc n subdirectories. Add tests.

### DIFF
--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -62,17 +62,25 @@ public:
   static std::string GetTitleFromPath(const CURL& url, bool bIsFolder = false);
   static std::string GetTitleFromPath(const std::string& strFileNameAndPath, bool bIsFolder = false);
 
-  /*! \brief Return the disc number in case the last segment of given path ends with 'Disc n'.
-   Will look for 'Disc', 'Disk' and the locale specific spelling.
-   \return the disc number as string if found, empty string otherwise.
+  /*! \brief Return the part number in case the last segment of given path ends with
+   'Disc', 'Disk' and the locale specific spelling, as well as 'CD', and 'DVD'
+   \return the part number as string if found, empty string otherwise.
    */
-  static std::string GetDiscNumberFromPath(const std::string& path);
+  static std::string GetPartNumberFromPath(std::string path);
 
-  /*! \brief Remove last segment of the given path if it matches 'Disc n'.
-   Will look for 'Disc', 'Disk' and the locale specific spelling.
-   \return the given path with last segment removed if it matches 'Disc n', unchanged path otherwise.
+  enum class PreserveFileName : bool
+  {
+    REMOVE,
+    KEEP
+  };
+
+  /*! \brief Remove last segment of the given path if it matches with
+   'Disc', 'Disk' and the locale specific spelling, as well as 'CD', and 'DVD' along with any disc folders
+   (ie. BDMV or VIDEO_TS).
+   \return the given path with last segment removed if it matches, unchanged path otherwise.
    */
-  static std::string RemoveTrailingDiscNumberSegmentFromPath(std::string path);
+  static std::string RemoveTrailingPartNumberSegmentFromPath(std::string path,
+                                                             PreserveFileName preserveFileName);
 
   static void GetQualifiedFilename(const std::string &strBasePath, std::string &strFilename);
   static void RunShortcut(const char* szPath);

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -1670,7 +1670,7 @@ std::string CBlurayDirectory::GetBasePath(const CURL& url)
 
   const CURL url2(url.GetHostName()); // strip bluray://
   if (url2.IsProtocol("udf")) // ISO
-    return url2.GetHostName(); // strip udf://
+    return URIUtils::GetDirectory(url2.GetHostName()); // strip udf://
   return url2.Get(); // BDMV
 }
 

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -27,6 +27,13 @@ struct TestFileData
   const char *base;
 };
 
+struct TestNameData
+{
+  const char* file;
+  bool use_folder;
+  const char* name;
+};
+
 class AdvancedSettingsResetBase : public Test
 {
 public:
@@ -47,6 +54,50 @@ class TestFileItemBasePath : public AdvancedSettingsResetBase,
 {
 };
 
+class TestFileItemMovieName : public AdvancedSettingsResetBase,
+                              public WithParamInterface<TestNameData>
+{
+};
+
+const TestFileData BaseMovies[] = {
+    {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie/"},
+    {"c:\\dir\\filename.avi", false, "c:\\dir\\filename.avi"},
+    {"c:\\dir\\filename.avi", true, "c:\\dir\\"},
+    {"/dir/filename.avi", false, "/dir/filename.avi"},
+    {"/dir/filename.avi", true, "/dir/"},
+    {"smb://somepath/file.avi", false, "smb://somepath/file.avi"},
+    {"smb://somepath/file.avi", true, "smb://somepath/"},
+    {"stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi",
+     false,
+     "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi"},
+    {"stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi",
+     true, "/path/to/movie_name/"},
+    {"/home/user/TV Shows/Dexter/S1/1x01.avi", false, "/home/user/TV Shows/Dexter/S1/1x01.avi"},
+    {"/home/user/TV Shows/Dexter/S1/1x01.avi", true, "/home/user/TV Shows/Dexter/S1/"},
+    {"zip://g%3a%5cmultimedia%5cmovies%5cSphere%2ezip/Sphere.avi", true,
+     "g:\\multimedia\\movies\\"},
+    {"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", true, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", true, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/BDMV/index.bdmv", false, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/BDMV/index.bdmv", true, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", false, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", true, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/movie.iso", false, "/home/user/movies/movie/movie.iso"},
+    {"/home/user/movies/movie/file.iso", true, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/movie.iso", false, "/home/user/movies/movie/disc 1/movie.iso"},
+    {"/home/user/movies/movie/disc 1/file.iso", true, "/home/user/movies/movie/"},
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/00800.mpls",
+     true, "smb://somepath/"},
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fDisc%201%252fmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     true, "smb://somepath/"},
+    {"bluray://smb%3a%2f%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", true, "smb://somepath/"},
+    {"bluray://smb%3a%2f%2fsomepath%2fDisc%201%2f/BDMV/PLAYLIST/00800.mpls", true,
+     "smb://somepath/"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie.zip/BDMV/index.bdmv", true, "smb://somepath/"}};
+
 TEST_P(TestFileItemBasePath, GetBaseMoviePath)
 {
   CFileItem item;
@@ -56,20 +107,35 @@ TEST_P(TestFileItemBasePath, GetBaseMoviePath)
   EXPECT_EQ(compare, path);
 }
 
-const TestFileData BaseMovies[] = {{ "c:\\dir\\filename.avi", false, "c:\\dir\\filename.avi" },
-                                   { "c:\\dir\\filename.avi", true,  "c:\\dir\\" },
-                                   { "/dir/filename.avi", false, "/dir/filename.avi" },
-                                   { "/dir/filename.avi", true,  "/dir/" },
-                                   { "smb://somepath/file.avi", false, "smb://somepath/file.avi" },
-                                   { "smb://somepath/file.avi", true, "smb://somepath/" },
-                                   { "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi", false, "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi" },
-                                   { "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi", true,  "/path/to/movie_name/" },
-                                   { "/home/user/TV Shows/Dexter/S1/1x01.avi", false, "/home/user/TV Shows/Dexter/S1/1x01.avi" },
-                                   { "/home/user/TV Shows/Dexter/S1/1x01.avi", true, "/home/user/TV Shows/Dexter/S1/" },
-                                   { "zip://g%3a%5cmultimedia%5cmovies%5cSphere%2ezip/Sphere.avi", true, "g:\\multimedia\\movies\\" },
-                                   { "/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie_name/" },
-                                   { "/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", true, "/home/user/movies/movie_name/" },
-                                   { "/home/user/movies/movie_name/BDMV/index.bdmv", false, "/home/user/movies/movie_name/" },
-                                   { "/home/user/movies/movie_name/BDMV/index.bdmv", true, "/home/user/movies/movie_name/" }};
-
 INSTANTIATE_TEST_SUITE_P(BaseNameMovies, TestFileItemBasePath, ValuesIn(BaseMovies));
+
+const TestNameData BaseNames[] = {
+    {"c:\\dir\\movie.avi", false, "movie"},
+    {"c:\\movie\\filename.avi", true, "movie"},
+    {"/dir/movie.avi", false, "movie"},
+    {"/movie/filename.avi", true, "movie"},
+    {"smb://somepath/movie.avi", false, "movie"},
+    {"smb://somepath/movie/file.avi", true, "movie"},
+    {"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", false, "movie"},
+    {"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", true, "movie"},
+    {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", false, "movie"},
+    {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", true, "movie"},
+    {"/home/user/movies/movie/BDMV/index.bdmv", false, "movie"},
+    {"/home/user/movies/movie/BDMV/index.bdmv", true, "movie"},
+    {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", false, "movie"},
+    {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", true, "movie"},
+    {"/home/user/movies/movie.iso", false, "movie"},
+    {"/home/user/movies/movie/file.iso", true, "movie"},
+    {"/home/user/movies/disc 1/movie.iso", false, "movie"},
+    {"/home/user/movies/movie/disc 1/file.iso", true, "movie"}};
+
+TEST_P(TestFileItemMovieName, GetMovieName)
+{
+  CFileItem item;
+  item.SetPath(GetParam().file);
+  std::string path = CURL(item.GetMovieName(GetParam().use_folder)).Get();
+  std::string compare = CURL(GetParam().name).Get();
+  EXPECT_EQ(compare, path);
+}
+
+INSTANTIATE_TEST_SUITE_P(NameMovies, TestFileItemMovieName, ValuesIn(BaseNames));

--- a/xbmc/test/TestUtil.cpp
+++ b/xbmc/test/TestUtil.cpp
@@ -277,3 +277,70 @@ const TestUtilSplitParamsData valuesSplitParams[] = {
 };
 
 INSTANTIATE_TEST_SUITE_P(SP, TestUtilSplitParams, ValuesIn(valuesSplitParams));
+
+struct TestDiscData
+{
+  const char* file;
+  const char* number;
+};
+
+class TestDiscNumbers : public Test, public WithParamInterface<TestDiscData>
+{
+};
+
+const TestDiscData BaseFiles[] = {{"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", ""},
+                                  {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", "1"},
+                                  {"/home/user/movies/movie/BDMV/index.bdmv", ""},
+                                  {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", "1"},
+                                  {"/home/user/movies/movie.iso", ""},
+                                  {"/home/user/movies/movie/file.iso", ""},
+                                  {"/home/user/movies/disc 1/movie.iso", "1"},
+                                  {"/home/user/movies/movie/disc 1/file.iso", "1"},
+                                  {"/home/user/movies/movie.avi", ""},
+                                  {"/home/user/movies/movie/file.avi", ""},
+                                  {"/home/user/movies/movie/disc 1/file.avi", "1"},
+                                  {"/home/user/movies/movie/disk 1/file.avi", "1"},
+                                  {"/home/user/movies/movie/cd 1/file.avi", "1"},
+                                  {"/home/user/movies/movie/dvd 1/file.avi", "1"}};
+
+TEST_P(TestDiscNumbers, GetDiscNumbers)
+{
+  const std::string discNum = CUtil::GetPartNumberFromPath(GetParam().file);
+  const std::string compare = GetParam().number;
+  EXPECT_EQ(compare, discNum);
+}
+
+INSTANTIATE_TEST_SUITE_P(DiscNumbers, TestDiscNumbers, ValuesIn(BaseFiles));
+
+struct TestRemoveData
+{
+  const char* path;
+  const char* result;
+};
+
+class TestRemoveDiscNumbers : public Test, public WithParamInterface<TestRemoveData>
+{
+};
+
+const TestRemoveData BasePaths[] = {
+    {"/home/user/movies/movie/video_ts/", "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/video_ts/", "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/BDMV/", "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/file.iso", "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/file.iso", "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/file.avi", "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/file.avi", "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disk 1/file.avi", "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/cd 1/file.avi", "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/dvd 1/file.avi", "/home/user/movies/movie/"}};
+
+TEST_P(TestRemoveDiscNumbers, RemoveDiscNumbers)
+{
+  const std::string path = CUtil::RemoveTrailingPartNumberSegmentFromPath(
+      GetParam().path, CUtil::PreserveFileName::REMOVE);
+  const std::string compare = GetParam().result;
+  EXPECT_EQ(compare, path);
+}
+
+INSTANTIATE_TEST_SUITE_P(RemoveDiscNumbers, TestRemoveDiscNumbers, ValuesIn(BasePaths));

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -17,6 +17,7 @@
 #include "filesystem/MultiPathDirectory.h"
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/StackDirectory.h"
+#include "guilib/LocalizeStrings.h"
 #include "network/DNSNameCache.h"
 #include "network/Network.h"
 #include "pvr/channels/PVRChannelsPath.h"
@@ -480,6 +481,14 @@ std::string URIUtils::GetBasePath(const std::string& strPath)
   return strDirectory;
 }
 
+bool URIUtils::IsDiscPath(const std::string& path)
+{
+  std::string folder{path};
+  RemoveSlashAtEnd(folder);
+  folder = GetFileName(folder);
+  return StringUtils::EqualsNoCase(folder, "VIDEO_TS") || StringUtils::EqualsNoCase(folder, "BDMV");
+}
+
 std::string URIUtils::GetDiscBase(const std::string& file)
 {
   std::string discFile;
@@ -583,6 +592,16 @@ std::string URIUtils::GetBlurayPath(const std::string& path)
   }
 
   return newPath;
+}
+
+std::string URIUtils::GetTrailingPartNumberRegex()
+{
+  // Build regex inserting local specific spelling of disc (xxx)
+  // \/?:cd|dvd|xxx|dis[ck][ _.-]*([0-9]+)$
+  std::string localeDiscStr{StringUtils::Format("{} ", g_localizeStrings.Get(427))};
+  if (!localeDiscStr.empty())
+    localeDiscStr += "|";
+  return {R"([\\\/](?:cd|dvd|)" + localeDiscStr + R"(dis[ck])[ _.-]*(\d{1,3})$)"};
 }
 
 std::string URLEncodePath(const std::string& strPath)

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -13,6 +13,7 @@
 #include "ServiceBroker.h"
 #include "StringUtils.h"
 #include "URL.h"
+#include "filesystem/BlurayDirectory.h"
 #include "filesystem/MultiPathDirectory.h"
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/StackDirectory.h"
@@ -450,16 +451,24 @@ bool URIUtils::GetParentPath(const std::string& strPath, std::string& strParent)
 
 std::string URIUtils::GetBasePath(const std::string& strPath)
 {
-  std::string strCheck(strPath);
+  std::string strCheck{strPath};
   if (IsStack(strPath))
     strCheck = CStackDirectory::GetFirstStackedFile(strPath);
 
   std::string strDirectory = GetDirectory(strCheck);
+
   if (IsInRAR(strCheck))
   {
-    std::string strPath=strDirectory;
-    GetParentPath(strPath, strDirectory);
+    std::string path{strDirectory};
+    GetParentPath(path, strDirectory);
   }
+
+  if (IsBDFile(strCheck))
+    strDirectory = GetDiscBasePath(strCheck);
+
+  if (IsBlurayPath(strCheck))
+    strDirectory = CBlurayDirectory::GetBasePath(CURL(strCheck));
+
   if (IsStack(strPath))
   {
     strCheck = strDirectory;
@@ -467,6 +476,7 @@ std::string URIUtils::GetBasePath(const std::string& strPath)
     if (GetFileName(strCheck).size() == 3 && StringUtils::StartsWithNoCase(GetFileName(strCheck), "cd"))
       strDirectory = GetDirectory(strCheck);
   }
+
   return strDirectory;
 }
 

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -87,6 +87,8 @@ public:
    */
   static std::string GetBasePath(const std::string& strPath);
 
+  static bool IsDiscPath(const std::string& path);
+
   /*! \brief Given a bluray:// path, return the base .ISO or folder containing the bluray file structure.
    \param path bluray:// path.
    \return the base .ISO or folder containing the bluray file structure.
@@ -153,6 +155,11 @@ public:
    \return true if file is from optical media
    */
   static bool IsOpticalMediaFile(const std::string& file);
+
+  /*! \brief Get the regex for matching trailing part numbers.
+   \return the regex
+   */
+  static std::string GetTrailingPartNumberRegex();
 
   /* \brief Change the base path of a URL: fromPath/fromFile -> toPath/toFile
     Handles changes in path separator and filename URL encoding if necessary to derive toFile.

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -183,6 +183,36 @@ TEST_F(TestURIUtils, GetParentPath)
   EXPECT_STREQ(ref.c_str(), var.c_str());
 }
 
+TEST_F(TestURIUtils, GetBasePath)
+{
+  std::string ref, var;
+
+  ref = "smb://somepath/path/";
+
+  var = URIUtils::GetBasePath("smb://somepath/path/movie.avi");
+  EXPECT_STREQ(ref.c_str(), var.c_str());
+
+  var = URIUtils::GetBasePath("smb://somepath/path/BDMV/index.bdmv");
+  EXPECT_STREQ(ref.c_str(), var.c_str());
+
+  var = URIUtils::GetBasePath("bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls");
+  EXPECT_STREQ(ref.c_str(), var.c_str());
+
+  var = URIUtils::GetBasePath(
+      "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+      "00800.mpls");
+  EXPECT_STREQ(ref.c_str(), var.c_str());
+
+  ref = "smb://somepath/path/disc 1/";
+
+  var = URIUtils::GetBasePath("smb://somepath/path/disc 1/movie.avi");
+  EXPECT_STREQ(ref.c_str(), var.c_str());
+
+  var = URIUtils::GetBasePath(
+      "bluray://smb%3a%2f%2fsomepath%2fpath%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls");
+  EXPECT_STREQ(ref.c_str(), var.c_str());
+}
+
 TEST_F(TestURIUtils, SubstitutePath)
 {
   std::string from, to, ref, var;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4351,7 +4351,7 @@ std::string CVideoDatabase::GetFileBasePathById(int idFile)
 
     if (!m_pDS->eof())
     {
-      return m_pDS->fv("strPath").get_asString();
+      return URIUtils::GetBasePath(m_pDS->fv("strPath").get_asString());
     }
     m_pDS->close();
   }

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1574,8 +1574,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         movieDetails.m_strTrailer = strTrailer;
 
       // Deal with 'Disc n' subdirectories
-      const std::string discNum{
-          CUtil::GetDiscNumberFromPath(URIUtils::GetParentPath(movieDetails.m_strFileNameAndPath))};
+      const std::string discNum{CUtil::GetPartNumberFromPath(movieDetails.m_strFileNameAndPath)};
       if (!discNum.empty())
       {
         if (movieDetails.m_set.title.empty())


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Probably easiest to look at the tests and see if they are what you would expect.

Looking at the existing code - basepath is different to the actual path of the media file, it is where the actual physical file resides.

There are also issues with the handling of bluray:// paths and Disc n paths in terms of movie name derivation from the path.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When adding bluray movie nfo support several scenarios came to light during testing where the movie name was not being properly derived from the path.

This fixes that.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tests.
Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
