### PR TITLE
[VideoDatabase][Bluray] Fix bluray versions not showing after creation.

### DIFF
--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -156,7 +156,7 @@ bool CGUIDialogSimpleMenu::ShowPlaylistSelection(CFileItem& item)
           {
             // Revert file to base file (BDMV/ISO)
             database.BeginTransaction();
-            if (database.SetFileForMedia(base, it.mediaType, it.idMedia, it.idFile))
+            if (database.SetFileForMedia(base, it.mediaType, it.idMedia, it.idFile) > 0)
               database.CommitTransaction();
             else
               database.RollbackTransaction();

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -218,9 +218,13 @@ void CSaveFileState::DoWork(CFileItem& item,
           videodatabase.BeginTransaction();
           // tag->m_iFileId contains the idFile originally played and may be different to the idFile
           // in the movie table entry if it's a non-default video version
-          if (videodatabase.SetFileForMedia(item.GetDynPath(), item.GetVideoContentType(),
-                                            tag->m_iDbId, tag->m_iFileId))
+          const int newFileId{videodatabase.SetFileForMedia(
+              item.GetDynPath(), item.GetVideoContentType(), tag->m_iDbId, tag->m_iFileId)};
+          if (newFileId > 0)
+          {
             videodatabase.CommitTransaction();
+            item.GetVideoInfoTag()->m_iFileId = newFileId;
+          }
           else
             videodatabase.RollbackTransaction();
         }

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -663,10 +663,10 @@ public:
                            const KODI::ART::Artwork& artwork,
                            int idShow,
                            int idEpisode = -1);
-  bool SetFileForMedia(const std::string& fileAndPath,
-                       VideoDbContentType type,
-                       int mediaId,
-                       int oldIdFile);
+  int SetFileForMedia(const std::string& fileAndPath,
+                      VideoDbContentType type,
+                      int mediaId,
+                      int oldIdFile);
   int SetDetailsForMusicVideo(CVideoInfoTag& details,
                               const KODI::ART::Artwork& artwork,
                               int idMVideo = -1);
@@ -1388,9 +1388,9 @@ protected:
                              int max,
                              const T& offsets) const;
 
-  bool SetFileForEpisode(const std::string& fileAndPath, int idEpisode, int oldIdFile);
-  bool SetFileForMovie(const std::string& fileAndPath, int idMovie, int oldIdFile);
-  bool SetFileForUnknown(const std::string& fileAndPath, int oldIdFile);
+  int SetFileForEpisode(const std::string& fileAndPath, int idEpisode, int oldIdFile);
+  int SetFileForMovie(const std::string& fileAndPath, int idMovie, int oldIdFile);
+  int SetFileForUnknown(const std::string& fileAndPath, int oldIdFile);
 
 private:
   void CreateTables() override;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Save FileId when altered by CVideoDatabase:: SetFileForMedia() to avoid need for GetFileId() in GetStreamDetails() which caused a m_pDS clash with GetMovieByWhere() and bluray versions not showing.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Needed as part of adding bluray movie versions. Without there m_pDS was overwritten in a sub-function and bluray versions were not shown in the library.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
