### PR TITLE
[Music] Add chapter frame reading for mp3 files to taglib.  Store the…

### DIFF
--- a/xbmc/music/Song.cpp
+++ b/xbmc/music/Song.cpp
@@ -76,6 +76,7 @@ CSong::CSong(CFileItem& item)
   iBitRate = tag.GetBitRate();
   iChannels = tag.GetNoOfChannels();
   songVideoURL = tag.GetSongVideoURL();
+  m_chapters = tag.GetChapterMarks();
 }
 
 CSong::CSong()
@@ -284,6 +285,7 @@ void CSong::Clear()
   iSampleRate = 0;
   iChannels =  0;
   songVideoURL.clear();
+  m_chapters.clear();
 
   replayGain = ReplayGain();
 }

--- a/xbmc/music/Song.h
+++ b/xbmc/music/Song.h
@@ -19,6 +19,7 @@
 #include "utils/EmbeddedArt.h"
 #include "utils/ISerializable.h"
 
+#include <chrono>
 #include <map>
 #include <string>
 #include <vector>
@@ -39,6 +40,16 @@ public:
 };
 
 class CFileItem;
+
+// Struct to store chapter information from mp3 files (could be used for m4b or mka files too)
+struct ChapterDetails
+{
+  std::string name;
+  std::chrono::milliseconds startTimeMs{0}; // All chapter timings are in milliseconds
+  std::chrono::milliseconds endTimeMs{0};
+};
+
+using ChapterMarks = std::map<int, ChapterDetails>;
 
 /*!
  \ingroup music
@@ -195,6 +206,7 @@ public:
   std::string strRecordLabel; // Record label from tag for album processing by CMusicInfoScanner::FileItemsToAlbums
   std::string strAlbumType; // (Musicbrainz release type) album type from tag for album processing by CMusicInfoScanner::FileItemsToAlbums
   std::string songVideoURL; // url to song video
+  ChapterMarks m_chapters; // map of chapter names and start and end times
 
   ReplayGain replayGain;
 private:

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -328,6 +328,11 @@ const std::string& CMusicInfoTag::GetSongVideoURL() const
   return m_songVideoURL;
 }
 
+const ChapterMarks& CMusicInfoTag::GetChapterMarks() const
+{
+  return m_chapters;
+}
+
 void CMusicInfoTag::SetURL(std::string_view strURL)
 {
   m_strURL = strURL;
@@ -784,6 +789,11 @@ void CMusicInfoTag::SetSongVideoURL(std::string_view songVideoURL)
   m_songVideoURL = songVideoURL;
 }
 
+void CMusicInfoTag::SetChapterMarks(const ChapterMarks& chapters)
+{
+  m_chapters = chapters;
+}
+
 void CMusicInfoTag::SetArtist(const CArtist& artist)
 {
   SetArtist(artist.strArtist);
@@ -1208,6 +1218,7 @@ void CMusicInfoTag::Clear()
   m_stationName.clear();
   m_stationArt.clear();
   m_songVideoURL.clear();
+  m_chapters.clear();
 }
 
 void CMusicInfoTag::AppendArtist(const std::string &artist)

--- a/xbmc/music/tags/MusicInfoTag.h
+++ b/xbmc/music/tags/MusicInfoTag.h
@@ -11,6 +11,7 @@
 #include "ReplayGain.h"
 #include "XBDateTime.h"
 #include "music/Album.h"
+#include "music/Song.h"
 #include "utils/IArchivable.h"
 #include "utils/ISerializable.h"
 #include "utils/ISortable.h"
@@ -19,7 +20,6 @@
 #include <string_view>
 #include <vector>
 
-class CSong;
 class CArtist;
 class CVariant;
 
@@ -90,6 +90,7 @@ public:
   const EmbeddedArtInfo &GetCoverArtInfo() const;
   const ReplayGain& GetReplayGain() const;
   CAlbum::ReleaseType GetAlbumReleaseType() const;
+  const ChapterMarks& GetChapterMarks() const;
 
   void SetURL(std::string_view strURL);
   void SetTitle(const std::string& strTitle);
@@ -160,6 +161,7 @@ public:
   void SetStationName(std::string_view strStationName); // name of online radio station
   void SetStationArt(std::string_view strStationArt);
   void SetSongVideoURL(std::string_view songVideoURL); // link to video of song
+  void SetChapterMarks(const ChapterMarks& chapters);
 
   /*! \brief Append a unique artist to the artist list
    Checks if we have this artist already added, and if not adds it to the songs artist list.
@@ -259,6 +261,7 @@ private:
   std::string m_stationName;
   std::string m_stationArt; // Used to fetch thumb URL for Shoutcasts
   std::string m_songVideoURL; // link to a video for a song
+  ChapterMarks m_chapters; // Ch No., name, start time, end time
 
   EmbeddedArtInfo m_coverArt; ///< art information
 

--- a/xbmc/music/tags/TagLoaderTagLib.h
+++ b/xbmc/music/tags/TagLoaderTagLib.h
@@ -10,6 +10,7 @@
 
 #include "ImusicInfoTagLoader.h"
 
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -48,7 +49,11 @@ protected:
   static void AddArtistInstrument(MUSIC_INFO::CMusicInfoTag &tag, const std::vector<std::string> &values);
   static int POPMtoXBMC(int popm);
 
-template<typename T>
-   static bool ParseTag(T *tag, EmbeddedArt *art, MUSIC_INFO::CMusicInfoTag& infoTag);
+  template<typename T>
+  static bool ParseTag(T* tag,
+                       EmbeddedArt* art,
+                       MUSIC_INFO::CMusicInfoTag& infoTag,
+                       // time in ms to the end of the current file.  Used to ensure the final
+                       // chapter (if any) extends to the end of the file.
+                       std::chrono::milliseconds totalLenMs = {});
 };
-


### PR DESCRIPTION
… chapters and times in a struct ready for processing in the music db.

## Description
This extends CTagLoaderTagLib to be able to read chapter frames in an mp3 file.  Chapter names, start and end times are stored in a struct.  The music database has fields for startoffest and endoffset as well as duration in the song table, which can be populated from this struct.

## Motivation and context
There is currently no player (that I'm aware of) that can properly play chaptered mp3 files.  I already have code to populate the music db and properly play back the file(s) although this will need updating.  However, this is a first step towards implementing the entire feature.

A second PR will add the chaptered data to the music db and allow playback and resumption in the same way that m4b audiobooks are handled.

As some team members may remember, a previous incarnation of this used a global variable to hold the file length.  I have re-written the template definition to avoid this and only pass in a file length to id3v2 as that is the only place it's needed (id3v1 does not have chapter frames).
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
The code builds and scanning in a chaptered mp3 file shows taglib reading the chapters.

Log excerpt
```

debug <general>: CTagLoaderTagLib - Chapter 1, 001 start point 0, endpoint 24985
debug <general>: CTagLoaderTagLib - Chapter 2, 002 start point 24985, endpoint 41819
debug <general>: CTagLoaderTagLib - Chapter 3, 003 start point 41819, endpoint 68917
debug <general>: CTagLoaderTagLib - Chapter 4, 004 start point 68917, endpoint 4577489
debug <general>: CTagLoaderTagLib - Chapter 5, 005 start point 4577489, endpoint 7197373
```
## What is the effect on users?
None as yet.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
