### PR TITLE
[addons] Misc SonarQube findings

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -551,13 +551,10 @@ bool CAddon::SettingsFromXML(const CXBMCTinyXML& doc,
     return false;
 
   // if the settings haven't been initialized yet, try it from the given XML
-  if (!SettingsInitialized(id))
+  if (!SettingsInitialized(id) && !GetSettings(id)->Initialize(doc))
   {
-    if (!GetSettings(id)->Initialize(doc))
-    {
-      CLog::Log(LOGERROR, "CAddon[{}]: failed to initialize addon settings", ID());
-      return false;
-    }
+    CLog::Log(LOGERROR, "CAddon[{}]: failed to initialize addon settings", ID());
+    return false;
   }
 
   // reset all setting values to their default value

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -88,7 +88,7 @@ public:
    *
    * **Example:**
    * ~~~~~~~~~~~~~{.cpp}
-   * // To get e.g. <extension ... name="blablabla" /> from addon.xml
+   * To get e.g. <extension ... name="blablabla" /> from addon.xml
    * std::string name = Type(ADDON_...)->GetValue("@name").asString();
    * ~~~~~~~~~~~~~
    *

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -72,7 +72,7 @@ public:
                 ADDON::AddonPtr& addon);
 
   /*! Get the addon IDs that have been set to disabled */
-  bool GetDisabled(std::map<std::string, ADDON::AddonDisabledReason>& addons);
+  bool GetDisabled(std::map<std::string, ADDON::AddonDisabledReason, std::less<>>& addons);
 
   /*! Returns all addons in the repositories with id `addonId`. */
   bool FindByAddonId(const std::string& addonId, ADDON::VECADDONS& addons) const;
@@ -181,7 +181,8 @@ public:
    * \param rulesMap target map
    * \return true on success, false otherwise
    */
-  bool GetAddonUpdateRules(std::map<std::string, std::vector<AddonUpdateRule>>& rulesMap) const;
+  bool GetAddonUpdateRules(
+      std::map<std::string, std::vector<AddonUpdateRule>, std::less<>>& rulesMap) const;
 
   /*! \brief Store an addon's package filename and that file's hash for future verification
       \param  addonID         id of the addon we're adding a package for
@@ -202,7 +203,7 @@ public:
   */
   bool GetPackageHash(const std::string& addonID,
                       const std::string& packageFileName,
-                      std::string&       hash);
+                      std::string& hash) const;
   /*! \brief Remove a package's info from the database
       \param  packageFileName filename of the package
       \return Whether or not we succeeded in removing the package
@@ -213,9 +214,9 @@ public:
   /*! Clear internal fields that shouldn't be kept around indefinitely */
   void OnPostUnInstall(const std::string& addonId);
 
-  void SyncInstalled(const std::set<std::string>& ids,
-                     const std::set<std::string>& system,
-                     const std::set<std::string>& optional);
+  void SyncInstalled(const std::set<std::string, std::less<>>& ids,
+                     const std::set<std::string, std::less<>>& system,
+                     const std::set<std::string, std::less<>>& optional);
 
   bool SetLastUpdated(const std::string& addonId, const CDateTime& dateTime);
   bool SetOrigin(const std::string& addonId, const std::string& origin);

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -193,7 +193,7 @@ public:
     bool downloadFinshed = false;
   };
 
-  typedef std::map<std::string, CDownloadJob> JobMap;
+  using JobMap = std::map<std::string, CDownloadJob, std::less<>>;
 
 private:
   // private construction, and no assignments; use the provided singleton methods
@@ -234,7 +234,6 @@ private:
   bool CheckDependencies(const ADDON::AddonPtr &addon, std::vector<std::string>& preDeps, CAddonDatabase &database, std::pair<std::string, std::string> &failedDep);
 
   void PrunePackageCache();
-  int64_t EnumeratePackageFolder(std::map<std::string, std::unique_ptr<CFileItemList>>& result);
 
   mutable CCriticalSection m_critSection;
   JobMap m_downloadJobs;

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -35,7 +35,7 @@ class IAddonMgrCallback;
 
 class CAddonInfo;
 using AddonInfoPtr = std::shared_ptr<CAddonInfo>;
-using ADDON_INFO_LIST = std::map<std::string, AddonInfoPtr>;
+using AddonInfoMap = std::map<std::string, AddonInfoPtr, std::less<>>;
 
 class IAddon;
 using AddonPtr = std::shared_ptr<IAddon>;
@@ -97,8 +97,8 @@ public:
   CEventStream<AddonEvent>& UnloadEvents() { return m_unloadEvents; }
 
   IAddonMgrCallback* GetCallbackForType(AddonType type);
-  bool RegisterAddonMgrCallback(AddonType type, IAddonMgrCallback* cb);
-  void UnregisterAddonMgrCallback(AddonType type);
+  bool RegisterAddonMgrCallback(AddonType type, IAddonMgrCallback* cb) const;
+  void UnregisterAddonMgrCallback(AddonType type) const;
 
   /*! \brief Retrieve a specific addon (of a specific type)
      \param id the id of the addon to retrieve.
@@ -120,7 +120,7 @@ public:
      */
   bool GetAddon(const std::string& id, AddonPtr& addon, OnlyEnabled onlyEnabled) const;
 
-  bool HasType(const std::string& id, AddonType type);
+  bool HasType(const std::string& id, AddonType type) const;
 
   bool HasAddons(AddonType type);
 
@@ -133,13 +133,13 @@ public:
   bool GetAddons(VECADDONS& addons) const;
 
   /*! Returns enabled add-ons with given type. */
-  bool GetAddons(VECADDONS& addons, AddonType type);
+  bool GetAddons(VECADDONS& addons, AddonType type) const;
 
   /*! Returns all installed, including disabled. */
-  bool GetInstalledAddons(VECADDONS& addons);
+  bool GetInstalledAddons(VECADDONS& addons) const;
 
   /*! Returns installed add-ons, including disabled, with given type. */
-  bool GetInstalledAddons(VECADDONS& addons, AddonType type);
+  bool GetInstalledAddons(VECADDONS& addons, AddonType type) const;
 
   bool GetDisabledAddons(VECADDONS& addons);
 
@@ -164,8 +164,8 @@ public:
      */
   bool FindInstallableById(const std::string& addonId, AddonPtr& addon);
 
-  void AddToUpdateableAddons(AddonPtr& pAddon);
-  void RemoveFromUpdateableAddons(AddonPtr& pAddon);
+  void AddToUpdateableAddons(const AddonPtr& pAddon);
+  void RemoveFromUpdateableAddons(const AddonPtr& pAddon);
   bool ReloadSettings(const std::string& addonId, AddonInstanceId instanceId);
 
   /*! Get addons with available updates */
@@ -175,7 +175,7 @@ public:
   std::vector<std::shared_ptr<IAddon>> GetOutdatedAddons() const;
 
   /*! Returns true if there is any addon with available updates, otherwise false */
-  bool HasAvailableUpdates();
+  bool HasAvailableUpdates() const;
 
   /*!
      * \brief Checks if the passed in addon is an orphaned dependency
@@ -293,7 +293,7 @@ public:
   /* \brief Checks whether an addon is installed.
      \param ID id of the addon
     */
-  bool IsAddonInstalled(const std::string& ID);
+  bool IsAddonInstalled(const std::string& ID) const;
 
   /* \brief Checks whether an addon is installed from a
      *        particular origin repo
@@ -314,7 +314,7 @@ public:
      */
   bool IsAddonInstalled(const std::string& ID,
                         const std::string& origin,
-                        const CAddonVersion& version);
+                        const CAddonVersion& version) const;
 
   /* \brief Checks whether an addon can be installed. Broken addons can't be installed.
     \param addon addon to be checked
@@ -329,7 +329,7 @@ public:
      * @param[in] id id of the addon
      * @return true if addon is bundled addon, false otherwise.
      */
-  bool IsBundledAddon(const std::string& id);
+  bool IsBundledAddon(const std::string& id) const;
 
   /*!
      * @brief Checks whether an addon is a system addon
@@ -423,7 +423,7 @@ public:
      \param addon [out] returned addon.
      \return true if addon is set, false otherwise.
      */
-  bool LoadAddonDescription(const std::string& path, AddonPtr& addon);
+  bool LoadAddonDescription(const std::string& path, AddonPtr& addon) const;
 
   bool ServicesHasStarted() const;
 
@@ -512,7 +512,7 @@ public:
                              AddonType type,
                              AddonDisabledReason disabledReason) const;
 
-  const AddonInfoPtr GetAddonInfo(const std::string& id, AddonType type) const;
+  AddonInfoPtr GetAddonInfo(const std::string& id, AddonType type) const;
 
   /*!
      * @brief Get the path where temporary add-on files are stored
@@ -521,7 +521,7 @@ public:
      *
      * @warning the folder and its contents are deleted when Kodi is closed
      */
-  const std::string& GetTempAddonBasePath() { return m_tempAddonBasePath; }
+  const std::string& GetTempAddonBasePath() const { return m_tempAddonBasePath; }
 
   AddonOriginType GetAddonOriginType(const AddonPtr& addon) const;
 
@@ -578,7 +578,7 @@ public:
      */
   bool AddonsFromRepoXML(const RepositoryDirInfo& repo,
                          const std::string& xml,
-                         std::vector<AddonInfoPtr>& addons);
+                         std::vector<AddonInfoPtr>& addons) const;
 
   /*@}}}*/
 
@@ -587,7 +587,7 @@ public:
      *        available updates and stores them into map.
      * \return map of outdated addons with their update
      */
-  std::map<std::string, AddonWithUpdate> GetAddonsWithAvailableUpdate() const;
+  std::map<std::string, AddonWithUpdate, std::less<>> GetAddonsWithAvailableUpdate() const;
 
   /*!
      * \brief Retrieves list of compatible addon versions of all origins
@@ -632,7 +632,7 @@ private:
 
   bool EnableSingle(const std::string& id);
 
-  void FindAddons(ADDON_INFO_LIST& addonmap, const std::string& path);
+  void FindAddons(AddonInfoMap& addonmap, const std::string& path) const;
 
   /*!
      * @brief Fills the the provided vector with the list of incompatible
@@ -676,16 +676,16 @@ private:
   // (migration will install any available update anyway)
   mutable std::mutex m_installAddonsMutex;
 
-  std::map<std::string, AddonDisabledReason> m_disabled;
+  std::map<std::string, AddonDisabledReason, std::less<>> m_disabled;
   static std::map<AddonType, IAddonMgrCallback*> m_managers;
   mutable CCriticalSection m_critSection;
   std::unique_ptr<CAddonDatabase> m_database;
   std::unique_ptr<CAddonUpdateRules> m_updateRules;
   CEventSource<AddonEvent> m_events;
   CBlockingEventSource<AddonEvent> m_unloadEvents;
-  std::set<std::string> m_systemAddons;
-  std::set<std::string> m_optionalSystemAddons;
-  ADDON_INFO_LIST m_installedAddons;
+  std::set<std::string, std::less<>> m_systemAddons;
+  std::set<std::string, std::less<>> m_optionalSystemAddons;
+  AddonInfoMap m_installedAddons;
 
   // Temporary path given to add-ons, whose content is deleted when Kodi is stopped
   const std::string m_tempAddonBasePath = "special://temp/addons";

--- a/xbmc/addons/AddonProvider.h
+++ b/xbmc/addons/AddonProvider.h
@@ -13,15 +13,14 @@
 #include <memory>
 
 /*
-* CAddonProvider
-* IUnknown implementation to retrieve sub-addons from already active addons
-* See Inputstream.cpp/h for an explaric use case
-*/
+ * Interface to retrieve sub-addons from already active addons
+ * See Inputstream.cpp/h for an explaric use case
+ */
 
 namespace ADDON
 {
 class CAddonInfo;
-typedef std::shared_ptr<CAddonInfo> AddonInfoPtr;
+using AddonInfoPtr = std::shared_ptr<CAddonInfo>;
 
 class IAddonProvider
 {

--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -65,8 +65,9 @@ public:
    *        checked for an update
    * \param[out] addonsWithUpdate target map
    */
-  void BuildAddonsWithUpdateList(const std::vector<std::shared_ptr<IAddon>>& installed,
-                                 std::map<std::string, AddonWithUpdate>& addonsWithUpdate) const;
+  void BuildAddonsWithUpdateList(
+      const std::vector<std::shared_ptr<IAddon>>& installed,
+      std::map<std::string, AddonWithUpdate, std::less<>>& addonsWithUpdate) const;
 
   /*!
    * \brief Checks if the origin-repository of a given addon is defined as official repo
@@ -185,9 +186,10 @@ private:
    *         its version is newer than our local version.
    *         false if the addon does NOT exist in the map or it is up to date.
    */
-  bool FindAddonAndCheckForUpdate(const std::shared_ptr<IAddon>& addonToCheck,
-                                  const std::map<std::string, std::shared_ptr<IAddon>>& map,
-                                  std::shared_ptr<IAddon>& update) const;
+  bool FindAddonAndCheckForUpdate(
+      const std::shared_ptr<IAddon>& addonToCheck,
+      const std::map<std::string, std::shared_ptr<IAddon>, std::less<>>& map,
+      std::shared_ptr<IAddon>& update) const;
 
   /*!
    * \brief Adds the latest version of an addon to the desired map
@@ -195,7 +197,7 @@ private:
    * \param map target map, e.g. latestOfficialVersions or latestPrivateVersions
    */
   void AddAddonIfLatest(const std::shared_ptr<IAddon>& addonToAdd,
-                        std::map<std::string, std::shared_ptr<IAddon>>& map) const;
+                        std::map<std::string, std::shared_ptr<IAddon>, std::less<>>& map) const;
 
   /*!
    * \brief Adds the latest version of an addon to the desired map per repository
@@ -204,10 +206,11 @@ private:
    * \param addonToAdd the addon whose latest version should be added
    * \param map target map, latestVersionsByRepo
    */
-  void AddAddonIfLatest(
-      const std::string& repoId,
-      const std::shared_ptr<IAddon>& addonToAdd,
-      std::map<std::string, std::map<std::string, std::shared_ptr<IAddon>>>& map) const;
+  void AddAddonIfLatest(const std::string& repoId,
+                        const std::shared_ptr<IAddon>& addonToAdd,
+                        std::map<std::string,
+                                 std::map<std::string, std::shared_ptr<IAddon>, std::less<>>,
+                                 std::less<>>& map) const;
 
   /*!
    * \brief Looks up an addon entry in a specific map
@@ -217,19 +220,21 @@ private:
    * \return true if the addon was found in the map, false otherwise
    */
   bool GetLatestVersionByMap(const std::string& addonId,
-                             const std::map<std::string, std::shared_ptr<IAddon>>& map,
+                             const std::map<std::string, std::shared_ptr<IAddon>, std::less<>>& map,
                              std::shared_ptr<IAddon>& addon) const;
 
   const CAddonMgr& m_addonMgr;
   CAddonDatabase m_addonDb;
-  bool m_valid{false};
 
   std::vector<std::shared_ptr<IAddon>> m_allAddons;
 
-  std::map<std::string, std::shared_ptr<IAddon>> m_latestOfficialVersions;
-  std::map<std::string, std::shared_ptr<IAddon>> m_latestPrivateVersions;
-  std::map<std::string, std::map<std::string, std::shared_ptr<IAddon>>> m_latestVersionsByRepo;
+  std::map<std::string, std::shared_ptr<IAddon>, std::less<>> m_latestOfficialVersions;
+  std::map<std::string, std::shared_ptr<IAddon>, std::less<>> m_latestPrivateVersions;
+  std::map<std::string, std::map<std::string, std::shared_ptr<IAddon>, std::less<>>, std::less<>>
+      m_latestVersionsByRepo;
   std::map<std::string, std::multimap<std::string, std::shared_ptr<IAddon>>> m_addonsByRepoMap;
+
+  bool m_valid{false};
 };
 
 }; /* namespace ADDON */

--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -44,7 +44,7 @@ CAddonStatusHandler::CAddonStatusHandler(const std::string& addonID,
                                          AddonInstanceId instanceId,
                                          ADDON_STATUS status,
                                          bool sameThread)
-  : CThread(("AddonStatus " + std::to_string(instanceId) + "@" + addonID).c_str()),
+  : CThread(StringUtils::Format("AddonStatus {}@{}", instanceId, addonID).c_str()),
     m_instanceId(instanceId)
 {
   //! @todo The status handled CAddonStatusHandler by is related to the class, not the instance
@@ -53,8 +53,8 @@ CAddonStatusHandler::CAddonStatusHandler(const std::string& addonID,
     return;
 
   CLog::Log(LOGINFO,
-            "Called Add-on status handler for '{}' of clientName:{}, clientID:{}, instanceID:{} "
-            "(same Thread={})",
+            "Called Add-on status handler for '{}' of addon name:{}, addon ID:{}, instance ID:{}, "
+            "same thread:{}",
             status, m_addon->Name(), m_addon->ID(), m_instanceId, sameThread ? "yes" : "no");
 
   m_status = status;

--- a/xbmc/addons/AddonSystemSettings.cpp
+++ b/xbmc/addons/AddonSystemSettings.cpp
@@ -96,7 +96,7 @@ void CAddonSystemSettings::OnSettingChanged(const std::shared_ptr<const CSetting
   }
 }
 
-bool CAddonSystemSettings::GetActive(AddonType type, AddonPtr& addon)
+bool CAddonSystemSettings::GetActive(AddonType type, AddonPtr& addon) const
 {
   auto it = m_activeSettings.find(type);
   if (it != m_activeSettings.end())
@@ -108,7 +108,7 @@ bool CAddonSystemSettings::GetActive(AddonType type, AddonPtr& addon)
   return false;
 }
 
-bool CAddonSystemSettings::SetActive(AddonType type, const std::string& addonID)
+bool CAddonSystemSettings::SetActive(AddonType type, const std::string& addonID) const
 {
   auto it = m_activeSettings.find(type);
   if (it != m_activeSettings.end())
@@ -125,7 +125,7 @@ bool CAddonSystemSettings::IsActive(const IAddon& addon)
   return GetActive(addon.Type(), active) && active->ID() == addon.ID();
 }
 
-bool CAddonSystemSettings::UnsetActive(const AddonInfoPtr& addon)
+bool CAddonSystemSettings::UnsetActive(const AddonInfoPtr& addon) const
 {
   auto it = m_activeSettings.find(addon->MainType());
   if (it == m_activeSettings.end())

--- a/xbmc/addons/AddonSystemSettings.h
+++ b/xbmc/addons/AddonSystemSettings.h
@@ -42,8 +42,8 @@ public:
   void OnSettingAction(const std::shared_ptr<const CSetting>& setting) override;
   void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
 
-  bool GetActive(AddonType type, AddonPtr& addon);
-  bool SetActive(AddonType type, const std::string& addonID);
+  bool GetActive(AddonType type, AddonPtr& addon) const;
+  bool SetActive(AddonType type, const std::string& addonID) const;
   bool IsActive(const IAddon& addon);
 
   /*!
@@ -65,7 +65,7 @@ public:
    * Attempt to unset addon as active. Returns true if addon is no longer active,
    * false if it could not be unset (e.g. if the addon is the default)
    */
-  bool UnsetActive(const AddonInfoPtr& addon);
+  bool UnsetActive(const AddonInfoPtr& addon) const;
 
 private:
   CAddonSystemSettings();

--- a/xbmc/addons/AddonUpdateRules.cpp
+++ b/xbmc/addons/AddonUpdateRules.cpp
@@ -35,8 +35,8 @@ bool CAddonUpdateRules::IsUpdateableByRule(const std::string& id, AddonUpdateRul
   std::unique_lock lock(m_critSection);
   const auto& updateRulesEntry = m_updateRules.find(id);
   return (updateRulesEntry == m_updateRules.end() ||
-          std::none_of(updateRulesEntry->second.begin(), updateRulesEntry->second.end(),
-                       [updateRule](AddonUpdateRule rule) { return rule == updateRule; }));
+          std::ranges::none_of(updateRulesEntry->second,
+                               [updateRule](AddonUpdateRule rule) { return rule == updateRule; }));
 }
 
 bool CAddonUpdateRules::AddUpdateRuleToList(CAddonDatabase& db,
@@ -92,8 +92,7 @@ bool CAddonUpdateRules::RemoveFromUpdateRuleslist(CAddonDatabase& db,
     }
     else if (!onlySingleRule)
     {
-      const auto& position =
-          std::find(updateRulesEntry->second.begin(), updateRulesEntry->second.end(), updateRule);
+      const auto& position = std::ranges::find(updateRulesEntry->second, updateRule);
       if (position != updateRulesEntry->second.end() && db.RemoveUpdateRuleForAddon(id, updateRule))
       {
         updateRulesEntry->second.erase(position);

--- a/xbmc/addons/AddonUpdateRules.h
+++ b/xbmc/addons/AddonUpdateRules.h
@@ -82,7 +82,7 @@ private:
                                  AddonUpdateRule updateRule);
 
   mutable CCriticalSection m_critSection;
-  std::map<std::string, std::vector<AddonUpdateRule>> m_updateRules;
+  std::map<std::string, std::vector<AddonUpdateRule>, std::less<>> m_updateRules;
 };
 
 }; /* namespace ADDON */

--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -28,35 +28,35 @@ const std::string VALID_ADDON_VERSION_CHARACTERS =
 namespace ADDON
 {
 CAddonVersion::CAddonVersion(const std::string& version)
-  : mEpoch(0), mUpstream(version.empty() ? "0.0.0" : [&version] {
+  : m_epoch(0), m_upstream(version.empty() ? "0.0.0" : [&version] {
       auto versionLowerCase = std::string(version);
       StringUtils::ToLower(versionLowerCase);
       return versionLowerCase;
     }())
 {
-  size_t pos = mUpstream.find(':');
+  size_t pos = m_upstream.find(':');
   if (pos != std::string::npos)
   {
-    mEpoch = strtol(mUpstream.c_str(), nullptr, 10);
-    mUpstream.erase(0, pos + 1);
+    m_epoch = strtol(m_upstream.c_str(), nullptr, 10);
+    m_upstream.erase(0, pos + 1);
   }
 
-  pos = mUpstream.find('-');
+  pos = m_upstream.find('-');
   if (pos != std::string::npos)
   {
-    mRevision = mUpstream.substr(pos + 1);
-    if (mRevision.find_first_not_of(VALID_ADDON_VERSION_CHARACTERS) != std::string::npos)
+    m_revision = m_upstream.substr(pos + 1);
+    if (m_revision.find_first_not_of(VALID_ADDON_VERSION_CHARACTERS) != std::string::npos)
     {
-      CLog::Log(LOGERROR, "AddonVersion: {} is not a valid revision number", mRevision);
-      mRevision = "";
+      CLog::Log(LOGERROR, "AddonVersion: {} is not a valid revision number", m_revision);
+      m_revision = "";
     }
-    mUpstream.erase(pos);
+    m_upstream.erase(pos);
   }
 
-  if (mUpstream.find_first_not_of(VALID_ADDON_VERSION_CHARACTERS) != std::string::npos)
+  if (m_upstream.find_first_not_of(VALID_ADDON_VERSION_CHARACTERS) != std::string::npos)
   {
-    CLog::Log(LOGERROR, "AddonVersion: {} is not a valid version", mUpstream);
-    mUpstream = "0.0.0";
+    CLog::Log(LOGERROR, "AddonVersion: {} is not a valid version", m_upstream);
+    m_upstream = "0.0.0";
   }
 }
 
@@ -113,14 +113,14 @@ int CAddonVersion::CompareComponent(const char* a, const char* b)
 
 bool CAddonVersion::operator<(const CAddonVersion& other) const
 {
-  if (mEpoch != other.mEpoch)
-    return mEpoch < other.mEpoch;
+  if (m_epoch != other.m_epoch)
+    return m_epoch < other.m_epoch;
 
-  int result = CompareComponent(mUpstream.c_str(), other.mUpstream.c_str());
+  int result = CompareComponent(m_upstream.c_str(), other.m_upstream.c_str());
   if (result)
     return (result < 0);
 
-  return (CompareComponent(mRevision.c_str(), other.mRevision.c_str()) < 0);
+  return (CompareComponent(m_revision.c_str(), other.m_revision.c_str()) < 0);
 }
 
 bool CAddonVersion::operator>(const CAddonVersion& other) const
@@ -130,9 +130,9 @@ bool CAddonVersion::operator>(const CAddonVersion& other) const
 
 bool CAddonVersion::operator==(const CAddonVersion& other) const
 {
-  return mEpoch == other.mEpoch &&
-         CompareComponent(mUpstream.c_str(), other.mUpstream.c_str()) == 0 &&
-         CompareComponent(mRevision.c_str(), other.mRevision.c_str()) == 0;
+  return m_epoch == other.m_epoch &&
+         CompareComponent(m_upstream.c_str(), other.m_upstream.c_str()) == 0 &&
+         CompareComponent(m_revision.c_str(), other.m_revision.c_str()) == 0;
 }
 
 bool CAddonVersion::operator!=(const CAddonVersion& other) const
@@ -152,17 +152,17 @@ bool CAddonVersion::operator>=(const CAddonVersion& other) const
 
 bool CAddonVersion::empty() const
 {
-  return mEpoch == 0 && mUpstream == "0.0.0" && mRevision.empty();
+  return m_epoch == 0 && m_upstream == "0.0.0" && m_revision.empty();
 }
 
 std::string CAddonVersion::asString() const
 {
   std::string out;
-  if (mEpoch)
-    out = StringUtils::Format("{}:", mEpoch);
-  out += mUpstream;
-  if (!mRevision.empty())
-    out += "-" + mRevision;
+  if (m_epoch)
+    out = StringUtils::Format("{}:", m_epoch);
+  out += m_upstream;
+  if (!m_revision.empty())
+    out += "-" + m_revision;
   return out;
 }
 

--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -37,7 +37,7 @@ CAddonVersion::CAddonVersion(const std::string& version)
   size_t pos = m_upstream.find(':');
   if (pos != std::string::npos)
   {
-    m_epoch = strtol(m_upstream.c_str(), nullptr, 10);
+    m_epoch = std::strtol(m_upstream.c_str(), nullptr, 10);
     m_upstream.erase(0, pos + 1);
   }
 
@@ -72,7 +72,7 @@ int CAddonVersion::CompareComponent(const char* a, const char* b)
 {
   while (*a && *b)
   {
-    while (*a && *b && !isdigit(*a) && !isdigit(*b))
+    while (*a && *b && !std::isdigit(*a) && !std::isdigit(*b))
     {
       if (*a != *b)
       {
@@ -85,18 +85,19 @@ int CAddonVersion::CompareComponent(const char* a, const char* b)
       a++;
       b++;
     }
-    if (*a && *b && (!isdigit(*a) || !isdigit(*b)))
+    if (*a && *b && (!std::isdigit(*a) || !std::isdigit(*b)))
     {
       if (*a == '~')
         return -1;
       if (*b == '~')
         return 1;
-      return isdigit(*a) ? -1 : 1;
+      return std::isdigit(*a) ? -1 : 1;
     }
 
-    char *next_a, *next_b;
-    long int num_a = strtol(a, &next_a, 10);
-    long int num_b = strtol(b, &next_b, 10);
+    char* next_a;
+    char* next_b;
+    long num_a = std::strtol(a, &next_a, 10);
+    long num_b = std::strtol(b, &next_b, 10);
     if (num_a != num_b)
       return num_a < num_b ? -1 : 1;
 
@@ -133,11 +134,6 @@ bool CAddonVersion::operator==(const CAddonVersion& other) const
   return m_epoch == other.m_epoch &&
          CompareComponent(m_upstream.c_str(), other.m_upstream.c_str()) == 0 &&
          CompareComponent(m_revision.c_str(), other.m_revision.c_str()) == 0;
-}
-
-bool CAddonVersion::operator!=(const CAddonVersion& other) const
-{
-  return !(*this == other);
 }
 
 bool CAddonVersion::operator<=(const CAddonVersion& other) const

--- a/xbmc/addons/AddonVersion.h
+++ b/xbmc/addons/AddonVersion.h
@@ -37,9 +37,9 @@ public:
 
   virtual ~CAddonVersion() = default;
 
-  int Epoch() const { return mEpoch; }
-  const std::string& Upstream() const { return mUpstream; }
-  const std::string& Revision() const { return mRevision; }
+  int Epoch() const { return m_epoch; }
+  const std::string& Upstream() const { return m_upstream; }
+  const std::string& Revision() const { return m_revision; }
 
   bool operator<(const CAddonVersion& other) const;
   bool operator>(const CAddonVersion& other) const;
@@ -53,9 +53,9 @@ public:
   static bool SplitFileName(std::string& ID, std::string& version, const std::string& filename);
 
 protected:
-  int mEpoch;
-  std::string mUpstream;
-  std::string mRevision;
+  int m_epoch;
+  std::string m_upstream;
+  std::string m_revision;
 
   static int CompareComponent(const char* a, const char* b);
 };

--- a/xbmc/addons/AddonVersion.h
+++ b/xbmc/addons/AddonVersion.h
@@ -37,7 +37,7 @@ public:
 
   virtual ~CAddonVersion() = default;
 
-  int Epoch() const { return m_epoch; }
+  long Epoch() const { return m_epoch; }
   const std::string& Upstream() const { return m_upstream; }
   const std::string& Revision() const { return m_revision; }
 
@@ -46,14 +46,13 @@ public:
   bool operator<=(const CAddonVersion& other) const;
   bool operator>=(const CAddonVersion& other) const;
   bool operator==(const CAddonVersion& other) const;
-  bool operator!=(const CAddonVersion& other) const;
   std::string asString() const;
   bool empty() const;
 
   static bool SplitFileName(std::string& ID, std::string& version, const std::string& filename);
 
-protected:
-  int m_epoch;
+private:
+  long m_epoch;
   std::string m_upstream;
   std::string m_revision;
 

--- a/xbmc/addons/AudioDecoder.cpp
+++ b/xbmc/addons/AudioDecoder.cpp
@@ -86,9 +86,7 @@ bool CAudioDecoder::Init(const CFileItem& file, unsigned int filecache)
   {
     if (channels <= 0 || sampleRate <= 0 || addonFormat == AUDIOENGINE_FMT_INVALID)
     {
-      CLog::Log(LOGERROR,
-                "CAudioDecoder::{} - Addon '{}' returned true without set of needed values",
-                __func__, ID());
+      CLog::LogF(LOGERROR, "Addon '{}' returned true without set of needed values", ID());
       return false;
     }
 

--- a/xbmc/addons/AudioDecoder.h
+++ b/xbmc/addons/AudioDecoder.h
@@ -15,9 +15,7 @@
 #include "filesystem/MusicFileDirectory.h"
 #include "music/tags/ImusicInfoTagLoader.h"
 
-namespace KODI
-{
-namespace ADDONS
+namespace KODI::ADDONS
 {
 
 class CAudioDecoder : public ADDON::IAddonInstanceHandler,
@@ -46,5 +44,4 @@ private:
   bool m_hasTags;
 };
 
-} /* namespace ADDONS */
-} /* namespace KODI */
+} // namespace KODI::ADDONS

--- a/xbmc/addons/BinaryAddonCache.cpp
+++ b/xbmc/addons/BinaryAddonCache.cpp
@@ -77,12 +77,9 @@ AddonPtr CBinaryAddonCache::GetAddonInstance(const std::string& strId, AddonType
   auto it = m_addons.find(type);
   if (it != m_addons.end())
   {
-    VECADDONS& addons = it->second;
-    auto itAddon = std::find_if(addons.begin(), addons.end(),
-      [&strId](const AddonPtr& addon)
-      {
-        return addon->ID() == strId;
-      });
+    const VECADDONS& addons = it->second;
+    const auto itAddon =
+        std::ranges::find_if(addons, [&strId](const AddonPtr& a) { return a->ID() == strId; });
 
     if (itAddon != addons.end())
       addon = *itAddon;

--- a/xbmc/addons/BinaryAddonCache.h
+++ b/xbmc/addons/BinaryAddonCache.h
@@ -36,7 +36,7 @@ public:
   void GetInstalledAddons(VECADDONS& addons, AddonType type);
   AddonPtr GetAddonInstance(const std::string& strId, AddonType type);
 
-protected:
+private:
   void Update();
   void OnEvent(const AddonEvent& event);
 

--- a/xbmc/addons/CMakeLists.txt
+++ b/xbmc/addons/CMakeLists.txt
@@ -56,6 +56,7 @@ set(HEADERS Addon.h
             IAddon.h
             IAddonManagerCallback.h
             IAddonSupportCheck.h
+            IAddonSupportList.h
             ImageDecoder.h
             ImageResource.h
             LanguageResource.h

--- a/xbmc/addons/ExtsMimeSupportList.h
+++ b/xbmc/addons/ExtsMimeSupportList.h
@@ -26,9 +26,7 @@ class CAddonInfo;
 struct AddonEvent;
 }
 
-namespace KODI
-{
-namespace ADDONS
+namespace KODI::ADDONS
 {
 
 /*!
@@ -42,8 +40,8 @@ namespace ADDONS
 class CExtsMimeSupportList : public KODI::ADDONS::IAddonSupportList
 {
 public:
-  CExtsMimeSupportList(ADDON::CAddonMgr& addonMgr);
-  ~CExtsMimeSupportList();
+  explicit CExtsMimeSupportList(ADDON::CAddonMgr& addonMgr);
+  ~CExtsMimeSupportList() override;
 
   /*!
    * @brief Filter selection values.
@@ -100,12 +98,12 @@ public:
     // List of supported file extensions by addon
     // First: Extension name
     // Second: With @ref SupportValue defined content
-    std::map<std::string, SupportValue> m_supportedExtensions;
+    std::map<std::string, SupportValue, std::less<>> m_supportedExtensions;
 
     // List of supported mimetypes by addon
     // First: Mimetype name
     // Second: With @ref SupportValue defined content
-    std::map<std::string, SupportValue> m_supportedMimetypes;
+    std::map<std::string, SupportValue, std::less<>> m_supportedMimetypes;
   };
 
   /*!
@@ -170,7 +168,7 @@ public:
   std::vector<KODI::ADDONS::AddonSupportEntry> GetSupportedExtsAndMimeTypes(
       const std::string& addonId) override;
 
-protected:
+private:
   void Update(const std::string& id);
   void OnEvent(const ADDON::AddonEvent& event);
 
@@ -183,5 +181,4 @@ protected:
   ADDON::CAddonMgr& m_addonMgr;
 };
 
-} /* namespace ADDONS */
-} /* namespace KODI */
+} // namespace KODI::ADDONS

--- a/xbmc/addons/FilesystemInstaller.h
+++ b/xbmc/addons/FilesystemInstaller.h
@@ -24,13 +24,11 @@ public:
    * @param addonId
    * @return true on success, otherwise false.
    */
-  bool InstallToFilesystem(const std::string& archive, const std::string& addonId);
+  bool InstallToFilesystem(const std::string& archive, const std::string& addonId) const;
 
-  bool UnInstallFromFilesystem(const std::string& addonPath);
+  bool UnInstallFromFilesystem(const std::string& addonPath) const;
 
 private:
-  static bool UnpackArchive(std::string path, const std::string& dest);
-
   std::string m_addonFolder;
   std::string m_tempFolder;
 };

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -65,10 +65,9 @@ constexpr AddonInstanceId ADDON_SETTINGS_ID = ADDON_SINGLETON_INSTANCE_ID;
 constexpr char const* ORIGIN_SYSTEM = "b6a50484-93a0-4afb-a01c-8d17e059feda";
 
 class IAddon;
-typedef std::shared_ptr<IAddon> AddonPtr;
-typedef std::vector<AddonPtr> VECADDONS;
-
-using InfoMap = std::map<std::string, std::string>;
+using AddonPtr = std::shared_ptr<IAddon>;
+using VECADDONS = std::vector<AddonPtr>;
+using InfoMap = std::map<std::string, std::string, std::less<>>;
 
 class IAddon : public std::enable_shared_from_this<IAddon>
 {

--- a/xbmc/addons/IAddonSupportCheck.h
+++ b/xbmc/addons/IAddonSupportCheck.h
@@ -10,9 +10,7 @@
 
 #include <string>
 
-namespace KODI
-{
-namespace ADDONS
+namespace KODI::ADDONS
 {
 
 /*!
@@ -42,5 +40,4 @@ public:
   virtual bool SupportsFile(const std::string& filename) { return true; }
 };
 
-} /* namespace ADDONS */
-} /* namespace KODI */
+} // namespace KODI::ADDONS

--- a/xbmc/addons/IAddonSupportList.h
+++ b/xbmc/addons/IAddonSupportList.h
@@ -11,9 +11,7 @@
 #include <string>
 #include <vector>
 
-namespace KODI
-{
-namespace ADDONS
+namespace KODI::ADDONS
 {
 
 /*!
@@ -74,5 +72,4 @@ public:
       const std::string& addonId) = 0;
 };
 
-} /* namespace ADDONS */
-} /* namespace KODI */
+} // namespace KODI::ADDONS

--- a/xbmc/addons/ImageDecoder.cpp
+++ b/xbmc/addons/ImageDecoder.cpp
@@ -111,11 +111,11 @@ bool CImageDecoder::LoadInfoTag(const std::string& fileName, CPictureInfoTag* ta
     tag->m_imageMetadata.height = ifcTag.height;
     tag->m_imageMetadata.exifInfo.Distance = ifcTag.distance;
     tag->m_imageMetadata.exifInfo.Orientation = ifcTag.orientation;
-    tag->m_imageMetadata.isColor = ifcTag.color == ADDON_IMG_COLOR_COLORED ? 1 : 0;
+    tag->m_imageMetadata.isColor = (ifcTag.color == ADDON_IMG_COLOR_COLORED);
     tag->m_imageMetadata.exifInfo.ApertureFNumber = ifcTag.aperture_f_number;
     tag->m_imageMetadata.exifInfo.FlashUsed = ifcTag.flash_used ? 1 : 0;
     tag->m_imageMetadata.exifInfo.LightSource = ifcTag.light_source;
-    tag->m_imageMetadata.exifInfo.FocalLength = ifcTag.focal_length;
+    tag->m_imageMetadata.exifInfo.FocalLength = static_cast<float>(ifcTag.focal_length);
     tag->m_imageMetadata.exifInfo.FocalLength35mmEquiv = ifcTag.focal_length_in_35mm_format;
     tag->m_imageMetadata.exifInfo.MeteringMode = ifcTag.metering_mode;
     tag->m_imageMetadata.exifInfo.DigitalZoomRatio = ifcTag.digital_zoom_ratio;
@@ -194,8 +194,8 @@ bool CImageDecoder::Decode(unsigned char* const pixels,
   if (!m_created || !m_ifc.imagedecoder->toAddon->decode)
     return false;
 
-  const auto it = std::find_if(KodiToAddonFormat.begin(), KodiToAddonFormat.end(),
-                               [format](auto& p) { return std::get<0>(p) == format; });
+  const auto it = std::ranges::find_if(KodiToAddonFormat,
+                                       [format](auto& p) { return std::get<0>(p) == format; });
   if (it == KodiToAddonFormat.end())
     return false;
 

--- a/xbmc/addons/ImageDecoder.h
+++ b/xbmc/addons/ImageDecoder.h
@@ -14,9 +14,7 @@
 
 class CPictureInfoTag;
 
-namespace KODI
-{
-namespace ADDONS
+namespace KODI::ADDONS
 {
 
 class CImageDecoder : public ADDON::IAddonInstanceHandler,
@@ -69,5 +67,4 @@ private:
   bool m_created{false};
 };
 
-} /* namespace ADDONS */
-} /* namespace KODI */
+} // namespace KODI::ADDONS

--- a/xbmc/addons/LanguageResource.cpp
+++ b/xbmc/addons/LanguageResource.cpp
@@ -23,7 +23,10 @@ using namespace KODI::MESSAGING;
 
 using KODI::MESSAGING::HELPERS::DialogResponse;
 
-#define LANGUAGE_ADDON_PREFIX   "resource.language."
+namespace
+{
+constexpr const char* LANGUAGE_ADDON_PREFIX = "resource.language.";
+}
 
 namespace ADDON
 {
@@ -70,16 +73,16 @@ CLanguageResource::CLanguageResource(const AddonInfoPtr& addonInfo)
      *   <token>Le</token>
      *   ...
      */
-    for (const auto& values : sorttokensElement->GetValues())
+    for (const auto& [_, addonExtensions] : sorttokensElement->GetValues())
     {
       /* Second loop goes around the row parts, e.g.
        *   separators = "'"
        *   token = Le
        */
-      std::string token = values.second.GetValue("token").asString();
-      std::string separators = values.second.GetValue("token@separators").asString();
+      const std::string token = addonExtensions.GetValue("token").asString();
       if (!token.empty())
       {
+        std::string separators = addonExtensions.GetValue("token@separators").asString();
         if (separators.empty())
           separators = " ._";
 

--- a/xbmc/addons/PluginSource.h
+++ b/xbmc/addons/PluginSource.h
@@ -11,11 +11,12 @@
 #include "addons/Addon.h"
 
 #include <set>
+#include <string_view>
 
 namespace ADDON
 {
 
-typedef std::map<std::string, std::vector<std::string>> ContentPathMap;
+using ContentPathMap = std::map<std::string, std::vector<std::string>, std::less<>>;
 
 class CPluginSource : public CAddon
 {
@@ -48,7 +49,8 @@ public:
     return m_mediaLibraryScanPaths;
   }
 
-  static Content Translate(const std::string &content);
+  static Content Translate(std::string_view content);
+
 private:
   /*! \brief Set the provided content for this plugin
    If no valid content types are passed in, we set the EXECUTABLE type

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace ADDON
@@ -32,7 +33,7 @@ struct RepositoryDirInfo
   KODI::UTILITY::CDigest::Type hashType{KODI::UTILITY::CDigest::Type::INVALID};
 };
 
-typedef std::vector<RepositoryDirInfo> RepositoryDirList;
+using RepositoryDirList = std::vector<RepositoryDirInfo>;
 
 class CRepository : public CAddon
 {
@@ -46,7 +47,7 @@ public:
     FETCH_ERROR
   };
 
-  FetchStatus FetchIfChanged(const std::string& oldChecksum,
+  FetchStatus FetchIfChanged(std::string_view oldChecksum,
                              std::string& checksum,
                              std::vector<AddonInfoPtr>& addons,
                              int& recheckAfter) const;
@@ -74,6 +75,6 @@ private:
   RepositoryDirList m_dirs;
 };
 
-typedef std::shared_ptr<CRepository> RepositoryPtr;
+using RepositoryPtr = std::shared_ptr<CRepository>;
 }
 

--- a/xbmc/addons/RepositoryUpdater.h
+++ b/xbmc/addons/RepositoryUpdater.h
@@ -101,7 +101,7 @@ private:
 
   CCriticalSection m_criticalSection;
   CTimer m_timer;
-  CEvent m_doneEvent;
+  CEvent m_doneEvent{true};
   std::vector<CRepositoryUpdateJob*> m_jobs;
   CAddonMgr& m_addonMgr;
 

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -877,7 +877,7 @@ bool PythonDetails(const std::string& ID,
                    const std::string& url,
                    const std::string& action,
                    const std::string& pathSettings,
-                   const std::unordered_map<std::string, std::string>& uniqueIDs,
+                   const CScraper::UniqueIDs& uniqueIDs,
                    T& result)
 {
   CVariant ids;
@@ -907,7 +907,7 @@ bool PythonDetails(const std::string& ID,
                    const std::string& pathSettings,
                    T& result)
 {
-  const std::unordered_map<std::string, std::string> ids;
+  const ADDON::CScraper::UniqueIDs ids;
   return PythonDetails(ID, key, url, action, pathSettings, ids, result);
 }
 } // unnamed namespace
@@ -1355,7 +1355,7 @@ VIDEO::EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile& fcurl, const CScra
 
 // takes URL; returns true and populates video details on success, false otherwise
 bool CScraper::GetVideoDetails(XFILE::CCurlFile& fcurl,
-                               const std::unordered_map<std::string, std::string>& uniqueIDs,
+                               const UniqueIDs& uniqueIDs,
                                const CScraperUrl& scurl,
                                bool fMovie /*else episode*/,
                                CVideoInfoTag& video)

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -55,19 +55,19 @@ namespace
 struct ContentMapping
 {
   const char *name;
-  CONTENT_TYPE type;
+  ADDON::ContentType type;
   int pretty;
 };
 
 // clang-format off
 const std::array<ContentMapping, 7> content = {{
-    {"unknown", CONTENT_NONE, 231},
-    {"albums", CONTENT_ALBUMS, 132},
-    {"music", CONTENT_ALBUMS, 132},
-    {"artists", CONTENT_ARTISTS, 133},
-    {"movies", CONTENT_MOVIES, 20342},
-    {"tvshows", CONTENT_TVSHOWS, 20343},
-    {"musicvideos", CONTENT_MUSICVIDEOS, 20389},
+  {"unknown",     ADDON::ContentType::NONE,        231},
+  {"albums",      ADDON::ContentType::ALBUMS,      132},
+  {"music",       ADDON::ContentType::ALBUMS,      132},
+  {"artists",     ADDON::ContentType::ARTISTS,     133},
+  {"movies",      ADDON::ContentType::MOVIES,      20342},
+  {"tvshows",     ADDON::ContentType::TVSHOWS,     20343},
+  {"musicvideos", ADDON::ContentType::MUSICVIDEOS, 20389},
 }};
 // clang-format on
 
@@ -86,7 +86,7 @@ void CheckScraperError(const TiXmlElement* pxeRoot)
 
 namespace ADDON
 {
-std::string TranslateContent(const CONTENT_TYPE &type, bool pretty /*=false*/)
+std::string TranslateContent(ContentType type, bool pretty /*=false*/)
 {
   for (const ContentMapping& map : content)
   {
@@ -101,30 +101,31 @@ std::string TranslateContent(const CONTENT_TYPE &type, bool pretty /*=false*/)
   return "";
 }
 
-CONTENT_TYPE TranslateContent(std::string_view string)
+ContentType TranslateContent(std::string_view string)
 {
   for (const ContentMapping& map : content)
   {
     if (string == map.name)
       return map.type;
   }
-  return CONTENT_NONE;
+  return ContentType::NONE;
 }
 
-AddonType ScraperTypeFromContent(const CONTENT_TYPE& content)
+AddonType ScraperTypeFromContent(ContentType content)
 {
   switch (content)
   {
     using enum ADDON::AddonType;
-    case CONTENT_ALBUMS:
+    using enum ContentType;
+    case ALBUMS:
       return SCRAPER_ALBUMS;
-    case CONTENT_ARTISTS:
+    case ARTISTS:
       return SCRAPER_ARTISTS;
-    case CONTENT_MOVIES:
+    case MOVIES:
       return SCRAPER_MOVIES;
-    case CONTENT_MUSICVIDEOS:
+    case MUSICVIDEOS:
       return SCRAPER_MUSICVIDEOS;
-    case CONTENT_TVSHOWS:
+    case TVSHOWS:
       return SCRAPER_TVSHOWS;
     default:
       return UNKNOWN;
@@ -144,20 +145,21 @@ CScraper::CScraper(const AddonInfoPtr& addonInfo, AddonType addonType)
   switch (addonType)
   {
     using enum ADDON::AddonType;
+    using enum ContentType;
     case SCRAPER_ALBUMS:
-      m_pathContent = CONTENT_ALBUMS;
+      m_pathContent = ALBUMS;
       break;
     case SCRAPER_ARTISTS:
-      m_pathContent = CONTENT_ARTISTS;
+      m_pathContent = ARTISTS;
       break;
     case SCRAPER_MOVIES:
-      m_pathContent = CONTENT_MOVIES;
+      m_pathContent = MOVIES;
       break;
     case SCRAPER_MUSICVIDEOS:
-      m_pathContent = CONTENT_MUSICVIDEOS;
+      m_pathContent = MUSICVIDEOS;
       break;
     case SCRAPER_TVSHOWS:
-      m_pathContent = CONTENT_TVSHOWS;
+      m_pathContent = TVSHOWS;
       break;
     default:
       break;
@@ -166,12 +168,12 @@ CScraper::CScraper(const AddonInfoPtr& addonInfo, AddonType addonType)
   m_isPython = URIUtils::GetExtension(addonInfo->Type(addonType)->LibPath()) == ".py";
 }
 
-bool CScraper::Supports(const CONTENT_TYPE &content) const
+bool CScraper::Supports(ContentType content) const
 {
   return Type() == ScraperTypeFromContent(content);
 }
 
-bool CScraper::SetPathSettings(CONTENT_TYPE content, const std::string &xml)
+bool CScraper::SetPathSettings(ContentType content, const std::string& xml)
 {
   m_pathContent = content;
   if (!LoadSettings(false, false))
@@ -403,7 +405,7 @@ bool CScraper::Load()
 
 bool CScraper::IsInUse() const
 {
-  if (Supports(CONTENT_ALBUMS) || Supports(CONTENT_ARTISTS))
+  if (Supports(ContentType::ALBUMS) || Supports(ContentType::ARTISTS))
   { // music scraper
     CMusicDatabase db;
     if (db.Open() && db.ScraperInUse(ID()))

--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -132,8 +132,19 @@ public:
     XFILE::CCurlFile &fcurl, const std::string &sArtist);
   KODI::VIDEO::EPISODELIST GetEpisodeList(XFILE::CCurlFile& fcurl, const CScraperUrl& scurl);
 
+  struct StringHash
+  {
+    using is_transparent = void; // Enables heterogeneous operations.
+    std::size_t operator()(std::string_view sv) const
+    {
+      std::hash<std::string_view> hasher;
+      return hasher(sv);
+    }
+  };
+  using UniqueIDs = std::unordered_map<std::string, std::string, StringHash, std::equal_to<>>;
+
   bool GetVideoDetails(XFILE::CCurlFile& fcurl,
-                       const std::unordered_map<std::string, std::string>& uniqueIDs,
+                       const UniqueIDs& uniqueIDs,
                        const CScraperUrl& scurl,
                        bool fMovie /*else episode*/,
                        CVideoInfoTag& video);

--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 class CAlbum;
@@ -28,7 +29,7 @@ class CMusicAlbumInfo;
 class CMusicArtistInfo;
 }
 
-typedef enum
+enum CONTENT_TYPE
 {
   CONTENT_MOVIES,
   CONTENT_TVSHOWS,
@@ -36,7 +37,7 @@ typedef enum
   CONTENT_ALBUMS,
   CONTENT_ARTISTS,
   CONTENT_NONE,
-} CONTENT_TYPE;
+};
 
 namespace XFILE
 {
@@ -48,10 +49,10 @@ class CScraperUrl;
 namespace ADDON
 {
 class CScraper;
-typedef std::shared_ptr<CScraper> ScraperPtr;
+using ScraperPtr = std::shared_ptr<CScraper>;
 
 std::string TranslateContent(const CONTENT_TYPE &content, bool pretty=false);
-CONTENT_TYPE TranslateContent(const std::string &string);
+CONTENT_TYPE TranslateContent(std::string_view string);
 AddonType ScraperTypeFromContent(const CONTENT_TYPE& content);
 
 // thrown as exception to signal abort or show error dialog
@@ -99,7 +100,7 @@ public:
    Any previously cached files are cleared if they have been cached for longer than the specified
    cachepersistence.
    */
-  void ClearCache();
+  void ClearCache() const;
 
   CONTENT_TYPE Content() const { return m_pathContent; }
   bool RequiresSettings() const { return m_requiressettings; }

--- a/xbmc/addons/ScreenSaver.cpp
+++ b/xbmc/addons/ScreenSaver.cpp
@@ -67,7 +67,7 @@ void CScreenSaver::Render()
     m_ifc.screensaver->toAddon->render(m_ifc.hdl);
 }
 
-void CScreenSaver::GetProperties(struct KODI_ADDON_SCREENSAVER_PROPS* props)
+void CScreenSaver::GetProperties(struct KODI_ADDON_SCREENSAVER_PROPS* props) const
 {
   if (!props)
     return;

--- a/xbmc/addons/ScreenSaver.h
+++ b/xbmc/addons/ScreenSaver.h
@@ -11,9 +11,7 @@
 #include "addons/binary-addons/AddonInstanceHandler.h"
 #include "addons/kodi-dev-kit/include/kodi/addon-instance/Screensaver.h"
 
-namespace KODI
-{
-namespace ADDONS
+namespace KODI::ADDONS
 {
 
 class CScreenSaver : public ADDON::IAddonInstanceHandler
@@ -27,8 +25,7 @@ public:
   void Render();
 
   // Addon callback functions
-  void GetProperties(struct KODI_ADDON_SCREENSAVER_PROPS* props);
+  void GetProperties(struct KODI_ADDON_SCREENSAVER_PROPS* props) const;
 };
 
-} /* namespace ADDONS */
-} /* namespace KODI */
+} // namespace KODI::ADDONS

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -120,7 +120,8 @@ void CServiceAddonManager::Stop(const std::string& addonId)
   }
 }
 
-void CServiceAddonManager::Stop(const std::map<std::string, int>::value_type& service)
+void CServiceAddonManager::Stop(
+    const std::map<std::string, int, std::less<>>::value_type& service) const
 {
   CLog::Log(LOGDEBUG, "CServiceAddonManager: stopping {}.", service.first);
   if (!CScriptInvocationManager::GetInstance().Stop(service.second))

--- a/xbmc/addons/Service.h
+++ b/xbmc/addons/Service.h
@@ -50,11 +50,11 @@ namespace ADDON
   private:
     void OnEvent(const AddonEvent& event);
 
-    void Stop(const std::map<std::string, int>::value_type& service);
+    void Stop(const std::map<std::string, int, std::less<>>::value_type& service) const;
 
     CAddonMgr& m_addonMgr;
     CCriticalSection m_criticalSection;
     /** add-on id -> script id */
-    std::map<std::string, int> m_services;
+    std::map<std::string, int, std::less<>> m_services;
   };
 }

--- a/xbmc/addons/ShaderPreset.cpp
+++ b/xbmc/addons/ShaderPreset.cpp
@@ -47,7 +47,7 @@ bool CShaderPreset::ResolveParameters(video_shader& shader)
   return m_struct.toAddon->VideoShaderResolveParameters(&m_struct, m_file, &shader);
 }
 
-void CShaderPreset::FreeShaderPreset(video_shader& shader)
+void CShaderPreset::FreeShaderPreset(video_shader& shader) const
 {
   m_struct.toAddon->VideoShaderFree(&m_struct, &shader);
 }
@@ -79,13 +79,13 @@ CShaderPresetAddon::~CShaderPresetAddon(void)
 
 bool CShaderPresetAddon::CreateAddon(void)
 {
-  std::unique_lock<CSharedSection> lock(m_dllSection);
+  std::unique_lock lock(m_dllSection);
 
   // Reset all properties to defaults
   ResetProperties();
 
   // Initialise the add-on
-  CLog::Log(LOGDEBUG, "{} - creating ShaderPreset add-on instance '{}'", __FUNCTION__, Name());
+  CLog::LogF(LOGDEBUG, "Creating ShaderPreset add-on instance '{}'", Name());
 
   if (CreateInstance() != ADDON_STATUS_OK)
     return false;
@@ -95,7 +95,7 @@ bool CShaderPresetAddon::CreateAddon(void)
 
 void CShaderPresetAddon::DestroyAddon()
 {
-  std::unique_lock<CSharedSection> lock(m_dllSection);
+  std::unique_lock lock(m_dllSection);
 
   DestroyInstance();
 }
@@ -122,8 +122,7 @@ bool CShaderPresetAddon::LoadPreset(const std::string& presetPath,
 
   if (file != nullptr)
   {
-    std::unique_ptr<CShaderPreset> shaderPresetAddon =
-        std::make_unique<CShaderPreset>(file, *m_ifc.shaderpreset);
+    const auto shaderPresetAddon = std::make_unique<CShaderPreset>(file, *m_ifc.shaderpreset);
 
     video_shader videoShader = {};
     if (shaderPresetAddon->ReadShaderPreset(videoShader))
@@ -244,10 +243,11 @@ SHADER::FilterType CShaderPresetAddon::TranslateFilterType(SHADER_FILTER_TYPE ty
 {
   switch (type)
   {
+    using enum KODI::SHADER::FilterType;
     case SHADER_FILTER_TYPE_LINEAR:
-      return SHADER::FilterType::LINEAR;
+      return LINEAR;
     case SHADER_FILTER_TYPE_NEAREST:
-      return SHADER::FilterType::NEAREST;
+      return NEAREST;
     default:
       break;
   }
@@ -259,14 +259,15 @@ SHADER::WrapType CShaderPresetAddon::TranslateWrapType(SHADER_WRAP_TYPE type)
 {
   switch (type)
   {
+    using enum KODI::SHADER::WrapType;
     case SHADER_WRAP_TYPE_BORDER:
-      return SHADER::WrapType::BORDER;
+      return BORDER;
     case SHADER_WRAP_TYPE_EDGE:
-      return SHADER::WrapType::EDGE;
+      return EDGE;
     case SHADER_WRAP_TYPE_REPEAT:
-      return SHADER::WrapType::REPEAT;
+      return REPEAT;
     case SHADER_WRAP_TYPE_MIRRORED_REPEAT:
-      return SHADER::WrapType::MIRRORED_REPEAT;
+      return MIRRORED_REPEAT;
     default:
       break;
   }
@@ -278,12 +279,13 @@ SHADER::ScaleType CShaderPresetAddon::TranslateScaleType(SHADER_SCALE_TYPE type)
 {
   switch (type)
   {
+    using enum KODI::SHADER::ScaleType;
     case SHADER_SCALE_TYPE_INPUT:
-      return SHADER::ScaleType::INPUT;
+      return INPUT;
     case SHADER_SCALE_TYPE_ABSOLUTE:
-      return SHADER::ScaleType::ABSOLUTE_SCALE;
+      return ABSOLUTE_SCALE;
     case SHADER_SCALE_TYPE_VIEWPORT:
-      return SHADER::ScaleType::VIEWPORT;
+      return VIEWPORT;
     default:
       break;
   }

--- a/xbmc/addons/ShaderPreset.h
+++ b/xbmc/addons/ShaderPreset.h
@@ -19,7 +19,7 @@
 namespace ADDON
 {
 class CAddonInfo;
-typedef std::shared_ptr<CAddonInfo> AddonInfoPtr;
+using AddonInfoPtr = std::shared_ptr<CAddonInfo>;
 
 class CShaderPreset
 {
@@ -59,7 +59,7 @@ public:
    *
    * \param shader Shader passes handle
    */
-  void FreeShaderPreset(video_shader& shader);
+  void FreeShaderPreset(video_shader& shader) const;
 
 private:
   preset_file m_file;
@@ -72,7 +72,7 @@ private:
 class CShaderPresetAddon : public IAddonInstanceHandler, public KODI::SHADER::IShaderPresetLoader
 {
 public:
-  CShaderPresetAddon(const AddonInfoPtr& addonInfo);
+  explicit CShaderPresetAddon(const AddonInfoPtr& addonInfo);
   ~CShaderPresetAddon() override;
 
   /*!

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -34,14 +34,14 @@
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
+#include <algorithm>
 #include <charconv>
+#include <chrono>
+#include <map>
 #include <memory>
-
-#define XML_SETTINGS      "settings"
-#define XML_SETTING       "setting"
-#define XML_ATTR_TYPE     "type"
-#define XML_ATTR_NAME     "name"
-#define XML_ATTR_ID       "id"
+#include <set>
+#include <string>
+#include <vector>
 
 using namespace XFILE;
 using namespace KODI::MESSAGING;
@@ -53,8 +53,15 @@ std::shared_ptr<ADDON::CSkinInfo> g_SkinInfo;
 
 namespace
 {
+constexpr const char* XML_SETTINGS = "settings";
+constexpr const char* XML_SETTING = "setting";
+constexpr const char* XML_ATTR_TYPE = "type";
+constexpr const char* XML_ATTR_NAME = "name";
+constexpr const char* XML_ATTR_ID = "id";
+
 constexpr auto DELAY = 500ms;
-}
+
+} // unnamed namespace
 
 namespace ADDON
 {
@@ -62,8 +69,7 @@ namespace ADDON
 class CSkinSettingUpdateHandler : private ITimerCallback
 {
 public:
-  CSkinSettingUpdateHandler(CAddon& addon)
-  : m_addon(addon), m_timer(this) {}
+  explicit CSkinSettingUpdateHandler(CAddon& addon) : m_addon(addon), m_timer(this) {}
   ~CSkinSettingUpdateHandler() override = default;
 
   void OnTimeout() override;
@@ -164,28 +170,28 @@ CSkinInfo::CSkinInfo(const AddonInfoPtr& addonInfo,
 
 CSkinInfo::CSkinInfo(const AddonInfoPtr& addonInfo) : CAddon(addonInfo, AddonType::SKIN)
 {
-  for (const auto& values : Type(AddonType::SKIN)->GetValues())
+  for (const auto& [name, values] : Type(AddonType::SKIN)->GetValues())
   {
-    if (values.first != "res")
+    if (name != "res")
       continue;
 
-    int width = values.second.GetValue("res@width").asInteger();
-    int height = values.second.GetValue("res@height").asInteger();
-    bool defRes = values.second.GetValue("res@default").asBoolean();
-    std::string folder = values.second.GetValue("res@folder").asString();
-    std::string strAspect = values.second.GetValue("res@aspect").asString();
+    const int width = values.GetValue("res@width").asInteger();
+    const int height = values.GetValue("res@height").asInteger();
+    const bool defRes = values.GetValue("res@default").asBoolean();
+    const std::string folder = values.GetValue("res@folder").asString();
+    const std::string strAspect = values.GetValue("res@aspect").asString();
     float aspect = 0;
 
-    std::vector<std::string> fracs = StringUtils::Split(strAspect, ':');
+    const std::vector<std::string> fracs = StringUtils::Split(strAspect, ':');
     if (fracs.size() == 2)
-      aspect = (float)(atof(fracs[0].c_str()) / atof(fracs[1].c_str()));
+      aspect = static_cast<float>(std::atof(fracs[0].c_str()) / std::atof(fracs[1].c_str()));
     if (width > 0 && height > 0)
     {
       RESOLUTION_INFO res(width, height, aspect, folder);
       res.strId = strAspect; // for skin usage, store aspect string in strId
       if (defRes)
         m_defaultRes = res;
-      m_resolutions.push_back(res);
+      m_resolutions.emplace_back(std::move(res));
     }
   }
 
@@ -204,15 +210,22 @@ CSkinInfo::~CSkinInfo() = default;
 struct closestRes
 {
   explicit closestRes(const RESOLUTION_INFO &target) : m_target(target) { };
-  bool operator()(const RESOLUTION_INFO &i, const RESOLUTION_INFO &j)
+  bool operator()(const RESOLUTION_INFO& i, const RESOLUTION_INFO& j) const
   {
-    float diff = fabs(i.DisplayRatio() - m_target.DisplayRatio()) - fabs(j.DisplayRatio() - m_target.DisplayRatio());
-    if (diff < 0) return true;
-    if (diff > 0) return false;
-    diff = fabs((float)i.iHeight - m_target.iHeight) - fabs((float)j.iHeight - m_target.iHeight);
-    if (diff < 0) return true;
-    if (diff > 0) return false;
-    return fabs((float)i.iWidth - m_target.iWidth) < fabs((float)j.iWidth - m_target.iWidth);
+    float diff = std::fabs(i.DisplayRatio() - m_target.DisplayRatio()) -
+                 std::fabs(j.DisplayRatio() - m_target.DisplayRatio());
+    if (diff < 0)
+      return true;
+    if (diff > 0)
+      return false;
+    diff = std::fabs(static_cast<float>(i.iHeight - m_target.iHeight)) -
+           std::fabs(static_cast<float>(j.iHeight - m_target.iHeight));
+    if (diff < 0)
+      return true;
+    if (diff > 0)
+      return false;
+    return std::fabs(static_cast<float>(i.iWidth - m_target.iWidth)) <
+           std::fabs(static_cast<float>(j.iWidth - m_target.iWidth));
   }
   RESOLUTION_INFO m_target;
 };
@@ -230,20 +243,22 @@ void CSkinInfo::Start()
     {
       RESOLUTION_INFO res;
       if (items[i]->IsFolder() && TranslateResolution(items[i]->GetLabel(), res))
-        m_resolutions.push_back(res);
+        m_resolutions.emplace_back(std::move(res));
     }
   }
 
   if (!m_resolutions.empty())
   {
     // find the closest resolution
-    const RESOLUTION_INFO &target = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
-    RESOLUTION_INFO& res = *std::min_element(m_resolutions.begin(), m_resolutions.end(), closestRes(target));
+    const RESOLUTION_INFO& target = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
+    const RESOLUTION_INFO& res = *std::ranges::min_element(m_resolutions, closestRes(target));
     m_currentAspect = res.strId;
   }
 }
 
-std::string CSkinInfo::GetSkinPath(const std::string& strFile, RESOLUTION_INFO *res, const std::string& strBaseDir /* = "" */) const
+std::string CSkinInfo::GetSkinPath(const std::string& strFile,
+                                   RESOLUTION_INFO* res,
+                                   std::string_view strBaseDir /* = "" */) const
 {
   if (m_resolutions.empty())
     return ""; // invalid skin
@@ -259,7 +274,7 @@ std::string CSkinInfo::GetSkinPath(const std::string& strFile, RESOLUTION_INFO *
 
   // find the closest resolution
   const RESOLUTION_INFO &target = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
-  *res = *std::min_element(m_resolutions.begin(), m_resolutions.end(), closestRes(target));
+  *res = *std::ranges::min_element(m_resolutions, closestRes(target));
 
   std::string strPath = URIUtils::AddFileToFolder(strPathToUse, res->strMode, strFile);
   if (CFileUtils::Exists(strPath))
@@ -312,16 +327,16 @@ int CSkinInfo::GetStartWindow() const
 {
   int windowID = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_LOOKANDFEEL_STARTUPWINDOW);
   assert(m_startupWindows.size());
-  for (std::vector<CStartupWindow>::const_iterator it = m_startupWindows.begin(); it != m_startupWindows.end(); ++it)
+  for (const auto& window : m_startupWindows)
   {
-    if (windowID == (*it).m_id)
+    if (windowID == window.m_id)
       return windowID;
   }
   // return our first one
   return m_startupWindows[0].m_id;
 }
 
-bool CSkinInfo::LoadStartupWindows(const AddonInfoPtr& addonInfo)
+bool CSkinInfo::LoadStartupWindows(const AddonInfoPtr& /*addonInfo*/)
 {
   m_startupWindows.clear();
   m_startupWindows.emplace_back(WINDOW_HOME, "513");
@@ -479,9 +494,9 @@ void CSkinInfo::SettingOptionsSkinColorsFiller(const SettingConstPtr& setting,
       vecColors.push_back(pItem->GetLabel().substr(0, pItem->GetLabel().size() - 4));
     }
   }
-  sort(vecColors.begin(), vecColors.end(), sortstringbyname());
-  for (int i = 0; i < (int) vecColors.size(); ++i)
-    list.emplace_back(vecColors[i], vecColors[i]);
+  std::ranges::sort(vecColors, sortstringbyname());
+  for (const auto& color : vecColors)
+    list.emplace_back(color, color);
 
   // try to find the best matching value
   for (const auto& elem : list)
@@ -581,8 +596,8 @@ void CSkinInfo::SettingOptionsSkinThemesFiller(const SettingConstPtr& setting,
   CUtil::GetSkinThemes(vecTheme);
 
   // sort the themes for GUI and list them
-  for (int i = 0; i < (int) vecTheme.size(); ++i)
-    list.emplace_back(vecTheme[i], vecTheme[i]);
+  for (const auto& theme : vecTheme)
+    list.emplace_back(theme, theme);
 
   // try to find the best matching value
   for (const auto& elem : list)
@@ -604,12 +619,12 @@ void CSkinInfo::SettingOptionsStartupWindowsFiller(const SettingConstPtr& settin
 
   const std::vector<CStartupWindow> &startupWindows = g_SkinInfo->GetStartupWindows();
 
-  for (std::vector<CStartupWindow>::const_iterator it = startupWindows.begin(); it != startupWindows.end(); ++it)
+  for (const auto& window : startupWindows)
   {
-    std::string windowName = it->m_name;
+    std::string windowName = window.m_name;
     if (StringUtils::IsNaturalNumber(windowName))
-      windowName = g_localizeStrings.Get(atoi(windowName.c_str()));
-    int windowID = it->m_id;
+      windowName = g_localizeStrings.Get(std::atoi(windowName.c_str()));
+    const int windowID = window.m_id;
 
     list.emplace_back(windowName, windowID);
 
@@ -630,18 +645,18 @@ void CSkinInfo::ToggleDebug()
 int CSkinInfo::TranslateString(const std::string &setting)
 {
   // run through and see if we have this setting
-  for (const auto& it : m_strings)
+  for (const auto& [id, settingstring] : m_strings)
   {
-    if (StringUtils::EqualsNoCase(setting, it.second->name))
-      return it.first;
+    if (StringUtils::EqualsNoCase(setting, settingstring->name))
+      return id;
   }
 
   // didn't find it - insert it
-  CSkinSettingStringPtr skinString(new CSkinSettingString());
+  auto skinString = std::make_shared<CSkinSettingString>();
   skinString->name = setting;
 
-  int number = m_bools.size() + m_strings.size();
-  m_strings.insert(std::pair<int, CSkinSettingStringPtr>(number, skinString));
+  const int number = static_cast<int>(m_bools.size() + m_strings.size());
+  m_strings.try_emplace(number, skinString);
 
   return number;
 }
@@ -667,7 +682,7 @@ const std::string& CSkinInfo::GetString(int setting) const
   return StringUtils::Empty;
 }
 
-void CSkinInfo::SetString(int setting, const std::string &label)
+void CSkinInfo::SetString(int setting, std::string_view label)
 {
   auto&& it = m_strings.find(setting);
   if (it != m_strings.end())
@@ -677,25 +692,25 @@ void CSkinInfo::SetString(int setting, const std::string &label)
     return;
   }
 
-  CLog::Log(LOGFATAL, "{}: unknown setting ({}) requested", __FUNCTION__, setting);
+  CLog::LogF(LOGFATAL, "Unknown setting ({}) requested", setting);
   assert(false);
 }
 
 int CSkinInfo::TranslateBool(const std::string &setting)
 {
   // run through and see if we have this setting
-  for (const auto& it : m_bools)
+  for (const auto& [id, settingbool] : m_bools)
   {
-    if (StringUtils::EqualsNoCase(setting, it.second->name))
-      return it.first;
+    if (StringUtils::EqualsNoCase(setting, settingbool->name))
+      return id;
   }
 
   // didn't find it - insert it
-  CSkinSettingBoolPtr skinBool(new CSkinSettingBool());
+  auto skinBool = std::make_shared<CSkinSettingBool>();
   skinBool->name = setting;
 
-  int number = m_bools.size() + m_strings.size();
-  m_bools.insert(std::pair<int, CSkinSettingBoolPtr>(number, skinBool));
+  const int number = static_cast<int>(m_bools.size() + m_strings.size());
+  m_bools.try_emplace(number, skinBool);
   m_settingsUpdateHandler->TriggerSave();
 
   return number;
@@ -721,7 +736,7 @@ void CSkinInfo::SetBool(int setting, bool set)
     return;
   }
 
-  CLog::Log(LOGFATAL, "{}: unknown setting ({}) requested", __FUNCTION__, setting);
+  CLog::LogF(LOGFATAL, "Unknown setting ({}) requested", setting);
   assert(false);
 }
 
@@ -729,8 +744,8 @@ std::set<CSkinSettingPtr> CSkinInfo::GetSkinSettings() const
 {
   std::set<CSkinSettingPtr> settings;
 
-  for (const auto& setting : m_settings)
-    settings.insert(setting.second);
+  for (const auto& [_, skinsetting] : m_settings)
+    settings.insert(skinsetting);
 
   return settings;
 }
@@ -756,22 +771,22 @@ std::shared_ptr<const CSkinSetting> CSkinInfo::GetSkinSetting(const std::string&
 void CSkinInfo::Reset(const std::string &setting)
 {
   // run through and see if we have this setting as a string
-  for (auto& it : m_strings)
+  for (const auto& [_, settingstring] : m_strings)
   {
-    if (StringUtils::EqualsNoCase(setting, it.second->name))
+    if (StringUtils::EqualsNoCase(setting, settingstring->name))
     {
-      it.second->value.clear();
+      settingstring->value.clear();
       m_settingsUpdateHandler->TriggerSave();
       return;
     }
   }
 
   // and now check for the skin bool
-  for (auto& it : m_bools)
+  for (const auto& [_, settingbool] : m_bools)
   {
-    if (StringUtils::EqualsNoCase(setting, it.second->name))
+    if (StringUtils::EqualsNoCase(setting, settingbool->name))
     {
-      it.second->value = false;
+      settingbool->value = false;
       m_settingsUpdateHandler->TriggerSave();
       return;
     }
@@ -781,11 +796,11 @@ void CSkinInfo::Reset(const std::string &setting)
 void CSkinInfo::Reset()
 {
   // clear all the settings and strings from this skin.
-  for (auto& it : m_bools)
-    it.second->value = false;
+  for (const auto& [_, settingbool] : m_bools)
+    settingbool->value = false;
 
-  for (auto& it : m_strings)
-    it.second->value.clear();
+  for (const auto& [_, settingstring] : m_strings)
+    settingstring->value.clear();
 
   m_settingsUpdateHandler->TriggerSave();
 }
@@ -817,17 +832,17 @@ CSkinSettingPtr CSkinInfo::ParseSetting(const TiXmlElement* element)
   std::string settingType = XMLUtils::GetAttribute(element, XML_ATTR_TYPE);
   CSkinSettingPtr setting;
   if (settingType == "string")
-    setting = CSkinSettingPtr(new CSkinSettingString());
+    setting = std::make_shared<CSkinSettingString>();
   else if (settingType == "bool")
-    setting = CSkinSettingPtr(new CSkinSettingBool());
+    setting = std::make_shared<CSkinSettingBool>();
   else
-    return CSkinSettingPtr();
+    return setting;
 
   if (setting == nullptr)
-    return CSkinSettingPtr();
+    return setting;
 
   if (!setting->Deserialize(element))
-    return CSkinSettingPtr();
+    return setting;
 
   return setting;
 }
@@ -861,15 +876,15 @@ bool CSkinInfo::SettingsFromXML(const CXBMCTinyXML& doc,
   {
     if (setting->GetType() == "string")
     {
-      m_settings.insert(std::make_pair(setting->name, setting));
-      m_strings.insert(
-          std::make_pair(number++, std::dynamic_pointer_cast<CSkinSettingString>(setting)));
+      m_settings.try_emplace(setting->name, setting);
+      m_strings.try_emplace(number, std::dynamic_pointer_cast<CSkinSettingString>(setting));
+      number++;
     }
     else if (setting->GetType() == "bool")
     {
-      m_settings.insert(std::make_pair(setting->name, setting));
-      m_bools.insert(
-          std::make_pair(number++, std::dynamic_pointer_cast<CSkinSettingBool>(setting)));
+      m_settings.try_emplace(setting->name, setting);
+      m_bools.try_emplace(number, std::dynamic_pointer_cast<CSkinSettingBool>(setting));
+      number++;
     }
     else
       CLog::Log(LOGWARNING, "CSkinInfo: ignoring setting of unknown type \"{}\"",
@@ -891,16 +906,16 @@ bool CSkinInfo::SettingsToXML(CXBMCTinyXML& doc, AddonInstanceId id /* = ADDON_S
   }
 
   TiXmlElement* settingsElement = settingsNode->ToElement();
-  for (const auto& it : m_bools)
+  for (const auto& [_, settingbool] : m_bools)
   {
-    if (!it.second->Serialize(settingsElement))
-      CLog::Log(LOGWARNING, "CSkinInfo: failed to save string setting \"{}\"", it.second->name);
+    if (!settingbool->Serialize(settingsElement))
+      CLog::Log(LOGWARNING, "CSkinInfo: failed to save string setting \"{}\"", settingbool->name);
   }
 
-  for (const auto& it : m_strings)
+  for (const auto& [_, settingstring] : m_strings)
   {
-    if (!it.second->Serialize(settingsElement))
-      CLog::Log(LOGWARNING, "CSkinInfo: failed to save bool setting \"{}\"", it.second->name);
+    if (!settingstring->Serialize(settingsElement))
+      CLog::Log(LOGWARNING, "CSkinInfo: failed to save bool setting \"{}\"", settingstring->name);
   }
 
   return true;
@@ -919,4 +934,4 @@ void CSkinSettingUpdateHandler::TriggerSave()
     m_timer.Start(DELAY);
 }
 
-} /*namespace ADDON*/
+} // namespace ADDON

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -16,10 +16,9 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <string_view>
 #include <utility>
 #include <vector>
-
-#define CREDIT_LINE_LENGTH 50
 
 class CSetting;
 class TiXmlElement;
@@ -48,7 +47,7 @@ protected:
   virtual bool SerializeSetting(TiXmlElement* element) const = 0;
 };
 
-typedef std::shared_ptr<CSkinSetting> CSkinSettingPtr;
+using CSkinSettingPtr = std::shared_ptr<CSkinSetting>;
 
 class CSkinSettingString : public CSkinSetting
 {
@@ -65,7 +64,7 @@ protected:
   bool SerializeSetting(TiXmlElement* element) const override;
 };
 
-typedef std::shared_ptr<CSkinSettingString> CSkinSettingStringPtr;
+using CSkinSettingStringPtr = std::shared_ptr<CSkinSettingString>;
 
 class CSkinSettingBool : public CSkinSetting
 {
@@ -82,7 +81,7 @@ protected:
   bool SerializeSetting(TiXmlElement* element) const override;
 };
 
-typedef std::shared_ptr<CSkinSettingBool> CSkinSettingBoolPtr;
+using CSkinSettingBoolPtr = std::shared_ptr<CSkinSettingBool>;
 
 class CSkinInfo : public CAddon
 {
@@ -128,7 +127,7 @@ public:
    */
   std::string GetSkinPath(const std::string& file,
                           RESOLUTION_INFO* res = nullptr,
-                          const std::string& baseDir = "") const;
+                          std::string_view baseDir = "") const;
 
   /*! \brief Return whether skin debugging is enabled
    \return true if skin debugging (set via <debugging>true</debugging> in addon.xml) is enabled.
@@ -210,7 +209,7 @@ public:
 
   int TranslateString(const std::string &setting);
   const std::string& GetString(int setting) const;
-  void SetString(int setting, const std::string &label);
+  void SetString(int setting, std::string_view label);
 
   int TranslateBool(const std::string &setting);
   bool GetBool(int setting) const;
@@ -285,7 +284,7 @@ protected:
 private:
   std::map<int, CSkinSettingStringPtr> m_strings;
   std::map<int, CSkinSettingBoolPtr> m_bools;
-  std::map<std::string, CSkinSettingPtr> m_settings;
+  std::map<std::string, CSkinSettingPtr, std::less<>> m_settings;
   std::unique_ptr<CSkinSettingUpdateHandler> m_settingsUpdateHandler;
 };
 

--- a/xbmc/addons/VFSEntry.h
+++ b/xbmc/addons/VFSEntry.h
@@ -23,18 +23,18 @@ namespace ADDON
 struct AddonEvent;
 
 class CVFSEntry;
-typedef std::shared_ptr<CVFSEntry> VFSEntryPtr;
+using VFSEntryPtr = std::shared_ptr<CVFSEntry>;
 
 class CVFSAddonCache : public CAddonDllInformer
 {
 public:
-  virtual ~CVFSAddonCache();
+  ~CVFSAddonCache() override;
   void Init();
   void Deinit();
-  const std::vector<VFSEntryPtr> GetAddonInstances();
+  std::vector<VFSEntryPtr> GetAddonInstances();
   VFSEntryPtr GetAddonInstance(const std::string& strId);
 
-protected:
+private:
   void Update(const std::string& id);
   void OnEvent(const AddonEvent& event);
   bool IsInUse(const std::string& id) override;
@@ -61,7 +61,7 @@ protected:
       int label;             //!< String ID to use as label in dialog
 
       //! \brief The constructor reads the info from an add-on info structure.
-      ProtocolInfo(const AddonInfoPtr& addonInfo);
+      explicit ProtocolInfo(const AddonInfoPtr& addonInfo);
     };
 
     //! \brief Construct from add-on properties.
@@ -72,28 +72,28 @@ protected:
     // Things that MUST be supplied by the child classes
     void* Open(const CURL& url);
     void* OpenForWrite(const CURL& url, bool bOverWrite);
-    bool Exists(const CURL& url);
-    int Stat(const CURL& url, struct __stat64* buffer);
-    ssize_t Read(void* ctx, void* lpBuf, size_t uiBufSize);
-    ssize_t Write(void* ctx, const void* lpBuf, size_t uiBufSize);
-    int64_t Seek(void* ctx, int64_t iFilePosition, int iWhence = SEEK_SET);
-    int Truncate(void* ctx, int64_t size);
-    void Close(void* ctx);
-    int64_t GetPosition(void* ctx);
-    int64_t GetLength(void* ctx);
-    int GetChunkSize(void* ctx);
-    int IoControl(void* ctx, XFILE::IOControl request, void* param);
-    bool Delete(const CURL& url);
-    bool Rename(const CURL& url, const CURL& url2);
+    bool Exists(const CURL& url) const;
+    int Stat(const CURL& url, struct __stat64* buffer) const;
+    ssize_t Read(void* ctx, void* lpBuf, size_t uiBufSize) const;
+    ssize_t Write(void* ctx, const void* lpBuf, size_t uiBufSize) const;
+    int64_t Seek(void* ctx, int64_t iFilePosition, int iWhence = SEEK_SET) const;
+    int Truncate(void* ctx, int64_t size) const;
+    void Close(void* ctx) const;
+    int64_t GetPosition(void* ctx) const;
+    int64_t GetLength(void* ctx) const;
+    int GetChunkSize(void* ctx) const;
+    int IoControl(void* ctx, XFILE::IOControl request, void* param) const;
+    bool Delete(const CURL& url) const;
+    bool Rename(const CURL& url, const CURL& url2) const;
 
-    bool GetDirectory(const CURL& url, CFileItemList& items, void* ctx);
-    bool DirectoryExists(const CURL& url);
-    bool RemoveDirectory(const CURL& url);
-    bool CreateDirectory(const CURL& url);
-    void ClearOutIdle();
-    void DisconnectAll();
+    bool GetDirectory(const CURL& url, CFileItemList& items, void* ctx) const;
+    bool DirectoryExists(const CURL& url) const;
+    bool RemoveDirectory(const CURL& url) const;
+    bool CreateDirectory(const CURL& url) const;
+    void ClearOutIdle() const;
+    void DisconnectAll() const;
 
-    bool ContainsFiles(const CURL& url, CFileItemList& items);
+    bool ContainsFiles(const CURL& url, CFileItemList& items) const;
 
     const std::string& GetProtocols() const { return m_protocols; }
     const std::string& GetExtensions() const { return m_extensions; }
@@ -102,7 +102,8 @@ protected:
     bool HasFileDirectories() const { return m_filedirectories; }
     const std::string& GetZeroconfType() const { return m_zeroconf; }
     const ProtocolInfo& GetProtocolInfo() const { return m_protocolInfo; }
-  protected:
+
+  private:
     std::string m_protocols;  //!< Protocols for VFS entry.
     std::string m_extensions; //!< Extensions for VFS entry.
     std::string m_zeroconf;   //!< Zero conf announce string for VFS protocol.
@@ -191,7 +192,8 @@ protected:
     //! \param[in] url URL of file to rename.
     //! \param[in] url2 New URL of file.
     bool Rename(const CURL& url, const CURL& url2) override;
-  protected:
+
+  private:
     void* m_context = nullptr; //!< Opaque add-on specific context for opened file.
     VFSEntryPtr m_addon; //!< Pointer to wrapped CVFSEntry.
   };
@@ -306,6 +308,11 @@ protected:
       return CVFSEntryIDirectoryWrapper::Create(url);
     }
 
+    //! \brief Return items.
+    //! \return The items.
+    const CFileItemList& GetItems() const { return m_items; }
+
+  private:
     CFileItemList m_items; //!< Internal list of items, used for cache purposes.
   };
 

--- a/xbmc/addons/Visualization.cpp
+++ b/xbmc/addons/Visualization.cpp
@@ -174,12 +174,12 @@ bool CVisualization::UpdateTrack(const KODI_ADDON_VISUALIZATION_TRACK* track)
   return false;
 }
 
-bool CVisualization::HasPresets()
+bool CVisualization::HasPresets() const
 {
   return !m_presets.empty();
 }
 
-bool CVisualization::GetPresetList(std::vector<std::string>& vecpresets)
+bool CVisualization::GetPresetList(std::vector<std::string>& vecpresets) const
 {
   vecpresets = m_presets;
   return !m_presets.empty();
@@ -216,7 +216,7 @@ void CVisualization::ClearPresets()
   m_presets.clear();
 }
 
-void CVisualization::GetProperties(struct KODI_ADDON_VISUALIZATION_PROPS* props)
+void CVisualization::GetProperties(struct KODI_ADDON_VISUALIZATION_PROPS* props) const
 {
   if (!props)
     return;

--- a/xbmc/addons/Visualization.h
+++ b/xbmc/addons/Visualization.h
@@ -11,9 +11,7 @@
 #include "addons/binary-addons/AddonInstanceHandler.h"
 #include "addons/kodi-dev-kit/include/kodi/addon-instance/Visualization.h"
 
-namespace KODI
-{
-namespace ADDONS
+namespace KODI::ADDONS
 {
 
 class CVisualization : public ADDON::IAddonInstanceHandler
@@ -36,14 +34,14 @@ public:
   bool RatePreset(bool plus_minus);
   bool UpdateAlbumart(const char* albumart);
   bool UpdateTrack(const KODI_ADDON_VISUALIZATION_TRACK* track);
-  bool HasPresets();
-  bool GetPresetList(std::vector<std::string>& vecpresets);
+  bool HasPresets() const;
+  bool GetPresetList(std::vector<std::string>& vecpresets) const;
   int GetActivePreset();
   std::string GetActivePresetName();
   bool IsLocked();
 
   // Addon callback functions
-  void GetProperties(struct KODI_ADDON_VISUALIZATION_PROPS* props);
+  void GetProperties(struct KODI_ADDON_VISUALIZATION_PROPS* props) const;
   void TransferPreset(const std::string& preset);
   void ClearPresets();
 
@@ -55,5 +53,4 @@ private:
   std::vector<std::string> m_presets; /*!< cached preset list */
 };
 
-} // namespace ADDONS
-} // namespace KODI
+} // namespace KODI::ADDONS

--- a/xbmc/addons/Webinterface.cpp
+++ b/xbmc/addons/Webinterface.cpp
@@ -15,17 +15,23 @@
 
 using namespace ADDON;
 
+namespace
+{
+constexpr const char* WEBINTERFACE_DEFAULT_ENTRY_POINT = "index.html";
+
+} // unnamed namespace
+
 CWebinterface::CWebinterface(const AddonInfoPtr& addonInfo)
   : CAddon(addonInfo, AddonType::WEB_INTERFACE), m_entryPoint(WEBINTERFACE_DEFAULT_ENTRY_POINT)
+
 {
   // determine the type of the webinterface
   std::string webinterfaceType = Type(AddonType::WEB_INTERFACE)->GetValue("@type").asString();
   if (StringUtils::EqualsNoCase(webinterfaceType, "wsgi"))
-    m_type = WebinterfaceTypeWsgi;
+    m_type = WebinterfaceType::TYPE_WSGI;
   else if (!webinterfaceType.empty() && !StringUtils::EqualsNoCase(webinterfaceType, "static") && !StringUtils::EqualsNoCase(webinterfaceType, "html"))
-    CLog::Log(LOGWARNING,
-              "CWebinterface::{}: Addon \"{}\" has specified an unsupported type \"{}\"", __func__,
-              ID(), webinterfaceType);
+    CLog::LogF(LOGWARNING, R"(Addon "{}" has specified an unsupported type "{}")", ID(),
+               webinterfaceType);
 
   // determine the entry point of the webinterface
   std::string entry = Type(AddonType::WEB_INTERFACE)->GetValue("@entry").asString();
@@ -35,7 +41,7 @@ CWebinterface::CWebinterface(const AddonInfoPtr& addonInfo)
 
 std::string CWebinterface::GetEntryPoint(const std::string &path) const
 {
-  if (m_type == WebinterfaceTypeWsgi)
+  if (m_type == WebinterfaceType::TYPE_WSGI)
     return LibPath();
 
   return URIUtils::AddFileToFolder(path, m_entryPoint);
@@ -43,7 +49,7 @@ std::string CWebinterface::GetEntryPoint(const std::string &path) const
 
 std::string CWebinterface::GetBaseLocation() const
 {
-  if (m_type == WebinterfaceTypeWsgi)
+  if (m_type == WebinterfaceType::TYPE_WSGI)
     return "/addons/" + ID();
 
   return "";

--- a/xbmc/addons/Webinterface.h
+++ b/xbmc/addons/Webinterface.h
@@ -10,29 +10,27 @@
 
 #include "addons/Addon.h"
 
-#define WEBINTERFACE_DEFAULT_ENTRY_POINT  "index.html"
-
 namespace ADDON
 {
-  typedef enum WebinterfaceType
-  {
-    WebinterfaceTypeStatic = 0,
-    WebinterfaceTypeWsgi
-  } WebinterfaceType;
+enum class WebinterfaceType
+{
+  TYPE_STATIC = 0,
+  TYPE_WSGI
+};
 
-  class CWebinterface : public CAddon
-  {
-  public:
-    explicit CWebinterface(const AddonInfoPtr& addonInfo);
+class CWebinterface : public CAddon
+{
+public:
+  explicit CWebinterface(const AddonInfoPtr& addonInfo);
 
-    WebinterfaceType GetType() const { return m_type; }
-    const std::string& EntryPoint() const { return m_entryPoint; }
+  WebinterfaceType GetType() const { return m_type; }
+  const std::string& EntryPoint() const { return m_entryPoint; }
 
-    std::string GetEntryPoint(const std::string &path) const;
-    std::string GetBaseLocation() const;
+  std::string GetEntryPoint(const std::string& path) const;
+  std::string GetBaseLocation() const;
 
-  private:
-    WebinterfaceType m_type = WebinterfaceTypeStatic;
-    std::string m_entryPoint;
-  };
+private:
+  WebinterfaceType m_type{WebinterfaceType::TYPE_STATIC};
+  std::string m_entryPoint;
+};
 }

--- a/xbmc/addons/addoninfo/AddonInfo.h
+++ b/xbmc/addons/addoninfo/AddonInfo.h
@@ -134,7 +134,7 @@ struct DependencyInfo
   }
 };
 
-typedef std::map<std::string, std::string> InfoMap;
+using InfoMap = std::map<std::string, std::string, std::less<>>;
 
 class CAddonInfoBuilder;
 

--- a/xbmc/addons/test/TestAddonDatabase.cpp
+++ b/xbmc/addons/test/TestAddonDatabase.cpp
@@ -33,8 +33,8 @@ protected:
 
     database.Connect("test", settings, true);
 
-    std::set<std::string> installed{"repository.a", "repository.b"};
-    database.SyncInstalled(installed, installed, std::set<std::string>());
+    std::set<std::string, std::less<>> installed{"repository.a", "repository.b"};
+    database.SyncInstalled(installed, installed, {});
 
     std::vector<AddonInfoPtr> addons;
     CreateAddon(addons, "foo.bar", "1.0.0");

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -270,7 +270,7 @@ void CGUIDialogContextMenu::GetContextButtons(const std::string &type, const CFi
       // Note. Temporarily disabled ability to remove plugin sources until installer is operational
 
       CURL url(share->strPath);
-      bool isAddon = ADDON::TranslateContent(url.GetProtocol()) != CONTENT_NONE;
+      bool isAddon = ADDON::TranslateContent(url.GetProtocol()) != ADDON::ContentType::NONE;
       if (!share->m_ignore && !isAddon)
         buttons.Add(CONTEXT_BUTTON_EDIT_SOURCE, 1027); // Edit Source
       if (type != "video")

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -783,7 +783,7 @@ void CAddonsDirectory::GenerateAddonListing(const CURL& path,
                                             CFileItemList& items,
                                             const std::string& label)
 {
-  std::map<std::string, AddonWithUpdate> addonsWithUpdate =
+  std::map<std::string, AddonWithUpdate, std::less<>> addonsWithUpdate =
       CServiceBroker::GetAddonMgr().GetAddonsWithAvailableUpdate();
 
   items.ClearItems();

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -110,15 +110,15 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
           CVFSEntryIFileDirectoryWrapper* wrap = new CVFSEntryIFileDirectoryWrapper(vfsAddon);
           if (wrap->ContainsFiles(url))
           {
-            if (wrap->m_items.Size() == 1)
+            if (wrap->GetItems().Size() == 1)
             {
               // one STORED file - collapse it down
-              *pItem = *wrap->m_items[0];
+              *pItem = *wrap->GetItems()[0];
             }
             else
             {
               // compressed or more than one file -> create a dir
-              pItem->SetPath(wrap->m_items.GetPath());
+              pItem->SetPath(wrap->GetItems().GetPath());
             }
 
             // Check for folder, if yes return also wrap.

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -11594,7 +11594,7 @@ bool CMusicDatabase::SetScraperAll(const std::string& strBaseDir, const ADDON::S
   int idSetting = -1;
   try
   {
-    CONTENT_TYPE content = CONTENT_NONE;
+    ADDON::ContentType content = ADDON::ContentType::NONE;
 
     // Build where clause from virtual path
     Filter extFilter;
@@ -11606,11 +11606,11 @@ bool CMusicDatabase::SetScraperAll(const std::string& strBaseDir, const ADDON::S
     std::string itemType = musicUrl.GetType();
     if (StringUtils::EqualsNoCase(itemType, "artists"))
     {
-      content = CONTENT_ARTISTS;
+      content = ADDON::ContentType::ARTISTS;
     }
     else if (StringUtils::EqualsNoCase(itemType, "albums"))
     {
-      content = CONTENT_ALBUMS;
+      content = ADDON::ContentType::ALBUMS;
     }
     else
       return false; //Only artists and albums have info settings
@@ -11625,7 +11625,7 @@ bool CMusicDatabase::SetScraperAll(const std::string& strBaseDir, const ADDON::S
 
     BeginTransaction();
     // Clear current scraper settings (0 => default scraper used)
-    if (content == CONTENT_ARTISTS)
+    if (content == ADDON::ContentType::ARTISTS)
       strSQL = "UPDATE artist SET idInfoSetting = %i ";
     else
       strSQL = "UPDATE album SET idInfoSetting = %i ";
@@ -11643,7 +11643,7 @@ bool CMusicDatabase::SetScraperAll(const std::string& strBaseDir, const ADDON::S
       m_pDS->exec(strSQL);
       idSetting = static_cast<int>(m_pDS->lastinsertid());
 
-      if (content == CONTENT_ARTISTS)
+      if (content == ADDON::ContentType::ARTISTS)
         strSQL = "UPDATE artist SET idInfoSetting = %i ";
       else
         strSQL = "UPDATE album SET idInfoSetting = %i ";
@@ -11662,7 +11662,7 @@ bool CMusicDatabase::SetScraperAll(const std::string& strBaseDir, const ADDON::S
 }
 
 bool CMusicDatabase::SetScraper(int id,
-                                const CONTENT_TYPE& content,
+                                ADDON::ContentType content,
                                 const ADDON::ScraperPtr& scraper)
 {
   if (nullptr == m_pDB)
@@ -11675,7 +11675,7 @@ bool CMusicDatabase::SetScraper(int id,
   {
     BeginTransaction();
     // Fetch current info settings for item, 0 => default is used
-    if (content == CONTENT_ARTISTS)
+    if (content == ADDON::ContentType::ARTISTS)
       strSQL = "SELECT idInfoSetting FROM artist WHERE idArtist = %i";
     else
       strSQL = "SELECT idInfoSetting FROM album WHERE idAlbum = %i";
@@ -11692,7 +11692,7 @@ bool CMusicDatabase::SetScraper(int id,
       m_pDS->exec(strSQL);
       idSetting = static_cast<int>(m_pDS->lastinsertid());
 
-      if (content == CONTENT_ARTISTS)
+      if (content == ADDON::ContentType::ARTISTS)
         strSQL = "UPDATE artist SET idInfoSetting = %i WHERE idArtist = %i";
       else
         strSQL = "UPDATE album SET idInfoSetting = %i WHERE idAlbum = %i";
@@ -11718,7 +11718,7 @@ bool CMusicDatabase::SetScraper(int id,
   return false;
 }
 
-bool CMusicDatabase::GetScraper(int id, const CONTENT_TYPE& content, ADDON::ScraperPtr& scraper)
+bool CMusicDatabase::GetScraper(int id, ADDON::ContentType content, ADDON::ScraperPtr& scraper)
 {
   std::string scraperUUID;
   std::string strSettings;
@@ -11731,7 +11731,7 @@ bool CMusicDatabase::GetScraper(int id, const CONTENT_TYPE& content, ADDON::Scra
 
     std::string strSQL;
     strSQL = "SELECT strScraperPath, strSettings FROM infosetting JOIN ";
-    if (content == CONTENT_ARTISTS)
+    if (content == ADDON::ContentType::ARTISTS)
       strSQL = strSQL + "artist ON artist.idInfoSetting = infosetting.idSetting "
                         "WHERE artist.idArtist = %i";
     else

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -669,9 +669,9 @@ public:
   /////////////////////////////////////////////////
   // Scraper
   /////////////////////////////////////////////////
-  bool SetScraper(int id, const CONTENT_TYPE& content, const ADDON::ScraperPtr& scraper);
+  bool SetScraper(int id, ADDON::ContentType content, const ADDON::ScraperPtr& scraper);
   bool SetScraperAll(const std::string& strBaseDir, const ADDON::ScraperPtr& scraper);
-  bool GetScraper(int id, const CONTENT_TYPE& content, ADDON::ScraperPtr& scraper);
+  bool GetScraper(int id, ADDON::ContentType content, ADDON::ScraperPtr& scraper);
 
   /*! \brief Check whether a given scraper is in use.
    \param scraperID the scraper to check for.

--- a/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
+++ b/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
@@ -91,13 +91,13 @@ int CGUIDialogInfoProviderSettings::Show(ADDON::ScraperPtr& scraper)
   CGUIDialogInfoProviderSettings *dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogInfoProviderSettings>(WINDOW_DIALOG_INFOPROVIDER_SETTINGS);
   if (!dialog || !scraper)
     return -1;
-  if (scraper->Content() != CONTENT_ARTISTS && scraper->Content() != CONTENT_ALBUMS)
+  if (scraper->Content() != ContentType::ARTISTS && scraper->Content() != ContentType::ALBUMS)
     return -1;
 
   dialog->m_showSingleScraper = true;
   dialog->m_singleScraperType = scraper->Content();
 
-  if (dialog->m_singleScraperType == CONTENT_ALBUMS)
+  if (dialog->m_singleScraperType == ContentType::ALBUMS)
     dialog->SetAlbumScraper(scraper);
   else
     dialog->SetArtistScraper(scraper);
@@ -111,7 +111,7 @@ int CGUIDialogInfoProviderSettings::Show(ADDON::ScraperPtr& scraper)
   unsigned int applyToItems = dialog->m_applyToItems;
   if (confirmed)
   {
-    if (dialog->m_singleScraperType == CONTENT_ALBUMS)
+    if (dialog->m_singleScraperType == ContentType::ALBUMS)
       scraper = dialog->GetAlbumScraper();
     else
     {
@@ -339,7 +339,7 @@ void CGUIDialogInfoProviderSettings::SetupView()
       ToggleState(CSettings::SETTING_MUSICLIBRARY_ARTISTSFOLDER, true);
     }
   }
-  else if (m_singleScraperType == CONTENT_ALBUMS)
+  else if (m_singleScraperType == ContentType::ALBUMS)
   {
     SetHeading(38331);
     // Album scraper
@@ -406,7 +406,7 @@ void CGUIDialogInfoProviderSettings::InitializeSettings()
   {
     TranslatableIntegerSettingOptions entries;
     entries.clear();
-    if (m_singleScraperType == CONTENT_ALBUMS)
+    if (m_singleScraperType == ContentType::ALBUMS)
     {
       entries.emplace_back(38066, INFOPROVIDER_THISITEM);
       entries.emplace_back(38067, INFOPROVIDER_ALLVIEW);
@@ -427,14 +427,14 @@ void CGUIDialogInfoProviderSettings::InitializeSettings()
     return;
   }
   std::shared_ptr<CSettingAction> subsetting;
-  if (!m_showSingleScraper || m_singleScraperType == CONTENT_ALBUMS)
+  if (!m_showSingleScraper || m_singleScraperType == ContentType::ALBUMS)
   {
     AddButton(group, CSettings::SETTING_MUSICLIBRARY_ALBUMSSCRAPER, 38334, SettingLevel::Basic); //Provider for album information
     subsetting = AddButton(group, SETTING_ALBUMSCRAPER_SETTINGS, 10004, SettingLevel::Basic); //"settings"
     if (subsetting)
       subsetting->SetParent(CSettings::SETTING_MUSICLIBRARY_ALBUMSSCRAPER);
   }
-  if (!m_showSingleScraper || m_singleScraperType == CONTENT_ARTISTS)
+  if (!m_showSingleScraper || m_singleScraperType == ContentType::ARTISTS)
   {
     AddButton(group, CSettings::SETTING_MUSICLIBRARY_ARTISTSSCRAPER, 38335, SettingLevel::Basic); //Provider for artist information
     subsetting = AddButton(group, SETTING_ARTISTSCRAPER_SETTINGS, 10004, SettingLevel::Basic); //"settings"
@@ -474,6 +474,6 @@ void CGUIDialogInfoProviderSettings::SetFocus(const std::string &settingid)
 void CGUIDialogInfoProviderSettings::ResetDefaults()
 {
   m_showSingleScraper = false;
-  m_singleScraperType = CONTENT_NONE;
+  m_singleScraperType = ContentType::NONE;
   m_applyToItems = INFOPROVIDER_THISITEM;
 }

--- a/xbmc/music/dialogs/GUIDialogInfoProviderSettings.h
+++ b/xbmc/music/dialogs/GUIDialogInfoProviderSettings.h
@@ -86,7 +86,7 @@ private:
 
   std::string m_strArtistInfoPath;
   bool m_showSingleScraper = false;
-  CONTENT_TYPE m_singleScraperType = CONTENT_NONE;
+  ADDON::ContentType m_singleScraperType = ADDON::ContentType::NONE;
   bool m_fetchInfo;
   unsigned int m_applyToItems = INFOPROVIDER_THISITEM;
 };

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -232,7 +232,7 @@ public:
     if (tag.GetType() == MediaTypeArtist)
     {
       ADDON::ScraperPtr scraper;
-      if (!database.GetScraper(m_artist.idArtist, CONTENT_ARTISTS, scraper))
+      if (!database.GetScraper(m_artist.idArtist, ADDON::ContentType::ARTISTS, scraper))
         return false;
 
       if (dlgProgress->IsCanceled())
@@ -263,7 +263,7 @@ public:
     {
       // tag.GetType == MediaTypeAlbum
       ADDON::ScraperPtr scraper;
-      if (!database.GetScraper(m_album.idAlbum, CONTENT_ALBUMS, scraper))
+      if (!database.GetScraper(m_album.idAlbum, ADDON::ContentType::ALBUMS, scraper))
         return false;
 
       if (dlgProgress->IsCanceled())

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -227,7 +227,7 @@ void CMusicInfoScanner::Process()
 
         // find album info
         ADDON::ScraperPtr scraper;
-        if (!m_musicDatabase.GetScraper(album.idAlbum, CONTENT_ALBUMS, scraper))
+        if (!m_musicDatabase.GetScraper(album.idAlbum, ContentType::ALBUMS, scraper))
           continue;
 
         UpdateDatabaseAlbumInfo(album, scraper, false);
@@ -260,7 +260,7 @@ void CMusicInfoScanner::Process()
 
         // find album info
         ADDON::ScraperPtr scraper;
-        if (!m_musicDatabase.GetScraper(artist.idArtist, CONTENT_ARTISTS, scraper) || !scraper)
+        if (!m_musicDatabase.GetScraper(artist.idArtist, ContentType::ARTISTS, scraper) || !scraper)
           continue;
 
         UpdateDatabaseArtistInfo(artist, scraper, false);

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -230,11 +230,11 @@ bool CGUIWindowMusicNav::ManageInfoProvider(const CFileItemPtr& item)
     return false;
 
   // Set things up for processing artist or albums
-  CONTENT_TYPE content = CONTENT_ALBUMS;
+  ADDON::ContentType content = ADDON::ContentType::ALBUMS;
   int id = params.GetAlbumId();
   if (id == -1)
   {
-    content = CONTENT_ARTISTS;
+    content = ADDON::ContentType::ARTISTS;
     id = params.GetArtistId();
   }
 
@@ -264,13 +264,13 @@ bool CGUIWindowMusicNav::ManageInfoProvider(const CFileItemPtr& item)
     case INFOPROVIDERAPPLYOPTIONS::INFOPROVIDER_ALLVIEW: // Change information provider for the filtered items shown on this node
       {
         msgctxt = 38069;
-        if (content == CONTENT_ARTISTS)
+        if (content == ADDON::ContentType::ARTISTS)
           msgctxt = 38068;
         if (CGUIDialogYesNo::ShowAndGetInput(CVariant{ 20195 }, msgctxt)) // Change information provider, confirm for all shown
         {
           // Set scraper for all items on current view.
           std::string strPath = "musicdb://";
-          if (content == CONTENT_ARTISTS)
+          if (content == ADDON::ContentType::ARTISTS)
             strPath += "artists";
           else
             strPath += "albums";
@@ -278,7 +278,7 @@ bool CGUIWindowMusicNav::ManageInfoProvider(const CFileItemPtr& item)
           // Items on view could be limited by navigation criteria, smart playlist rules or a filter.
           // Get these options, except ID, from item path
           CURL musicUrl(item->GetPath());  //Use CURL, as CMusicDbUrl removes "filter" option
-          if (content == CONTENT_ARTISTS)
+          if (content == ADDON::ContentType::ARTISTS)
             musicUrl.RemoveOption("artistid");
           else
             musicUrl.RemoveOption("albumid");
@@ -290,7 +290,7 @@ bool CGUIWindowMusicNav::ManageInfoProvider(const CFileItemPtr& item)
     case INFOPROVIDERAPPLYOPTIONS::INFOPROVIDER_DEFAULT: // Change information provider for all items
       {
         msgctxt = 38071;
-        if (content == CONTENT_ARTISTS)
+        if (content == ADDON::ContentType::ARTISTS)
           msgctxt = 38070;
         if (CGUIDialogYesNo::ShowAndGetInput(CVariant{20195}, msgctxt)) // Change information provider, confirm default and clear
         {
@@ -298,13 +298,13 @@ bool CGUIWindowMusicNav::ManageInfoProvider(const CFileItemPtr& item)
           scraper->SaveSettings();
           // Set default scraper
           const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-          if (content == CONTENT_ARTISTS)
+          if (content == ADDON::ContentType::ARTISTS)
             settings->SetString(CSettings::SETTING_MUSICLIBRARY_ARTISTSSCRAPER, scraper->ID());
           else
             settings->SetString(CSettings::SETTING_MUSICLIBRARY_ALBUMSSCRAPER, scraper->ID());
           settings->Save();
           // Clear all item specific settings
-          if (content == CONTENT_ARTISTS)
+          if (content == ADDON::ContentType::ARTISTS)
             result = m_musicdatabase.SetScraperAll("musicdb://artists/", nullptr);
           else
             result = m_musicdatabase.SetScraperAll("musicdb://albums/", nullptr);
@@ -329,7 +329,7 @@ bool CGUIWindowMusicNav::ManageInfoProvider(const CFileItemPtr& item)
       if (CGUIDialogYesNo::ShowAndGetInput(CVariant{20195}, CVariant{38073}))
       {
         std::string itempath = StringUtils::Format("musicdb://albums/{}/", id);
-        if (content == CONTENT_ARTISTS)
+        if (content == ADDON::ContentType::ARTISTS)
           itempath = StringUtils::Format("musicdb://artists/{}/", id);
         OnItemInfoAll(itempath, true);
       }

--- a/xbmc/network/httprequesthandler/HTTPPythonHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPPythonHandler.cpp
@@ -54,7 +54,7 @@ CHTTPPythonHandler::CHTTPPythonHandler(const HTTPRequest &request)
   // only allow requests to a non-static webinterface addon
   if (m_addon == NULL || m_addon->Type() != ADDON::AddonType::WEB_INTERFACE ||
       std::dynamic_pointer_cast<ADDON::CWebinterface>(m_addon)->GetType() ==
-          ADDON::WebinterfaceTypeStatic)
+          ADDON::WebinterfaceType::TYPE_STATIC)
   {
     m_response.type = HTTPError;
     m_response.status = MHD_HTTP_INTERNAL_SERVER_ERROR;
@@ -110,7 +110,7 @@ bool CHTTPPythonHandler::CanHandleRequest(const HTTPRequest &request) const
 
   // static webinterfaces aren't allowed to run python scripts
   ADDON::CWebinterface* webinterface = static_cast<ADDON::CWebinterface*>(addon.get());
-  if (webinterface->GetType() != ADDON::WebinterfaceTypeWsgi)
+  if (webinterface->GetType() != ADDON::WebinterfaceType::TYPE_WSGI)
     return false;
 
   return true;

--- a/xbmc/network/httprequesthandler/python/HTTPPythonWsgiInvoker.cpp
+++ b/xbmc/network/httprequesthandler/python/HTTPPythonWsgiInvoker.cpp
@@ -128,7 +128,7 @@ void CHTTPPythonWsgiInvoker::executeScript(FILE* fp, const std::string& script, 
       StringUtils::Format("CHTTPPythonWsgiInvoker[{}]", script));
 
   ADDON::CWebinterface* webinterface = static_cast<ADDON::CWebinterface*>(m_addon.get());
-  if (webinterface->GetType() != ADDON::WebinterfaceTypeWsgi)
+  if (webinterface->GetType() != ADDON::WebinterfaceType::TYPE_WSGI)
   {
     logger->error("trying to execute a non-WSGI script");
     return;

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.h
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.h
@@ -28,8 +28,8 @@ public:
   // specialization of CGUIWindow
   bool HasListItems() const override { return true; }
 
-  CONTENT_TYPE GetContent() const { return m_content; }
-  void SetContent(CONTENT_TYPE content);
+  ADDON::ContentType GetContent() const { return m_content; }
+  void SetContent(ADDON::ContentType content);
   void ResetContent();
 
   const ADDON::ScraperPtr& GetScraper() const { return m_scraper; }
@@ -43,10 +43,11 @@ public:
   bool GetNoUpdating() const { return m_noUpdating; }
   bool GetUseAllExternalAudio() const { return m_allExternalAudio; }
 
-  static bool Show(ADDON::ScraperPtr& scraper, CONTENT_TYPE content = CONTENT_NONE);
+  static bool Show(ADDON::ScraperPtr& scraper,
+                   ADDON::ContentType content = ADDON::ContentType::NONE);
   static bool Show(ADDON::ScraperPtr& scraper,
                    KODI::VIDEO::SScanSettings& settings,
-                   CONTENT_TYPE content = CONTENT_NONE);
+                   ADDON::ContentType content = ADDON::ContentType::NONE);
 
 protected:
   // implementations of ISettingCallback
@@ -70,11 +71,11 @@ private:
   /*!
   * @brief The currently selected content type
   */
-  CONTENT_TYPE m_content = CONTENT_NONE;
+  ADDON::ContentType m_content{ADDON::ContentType::NONE};
   /*!
   * @brief The selected content type at dialog creation
   */
-  CONTENT_TYPE m_originalContent = CONTENT_NONE;
+  ADDON::ContentType m_originalContent{ADDON::ContentType::NONE};
   /*!
   * @brief The currently selected scraper
   */

--- a/xbmc/video/VideoInfoDownloader.cpp
+++ b/xbmc/video/VideoInfoDownloader.cpp
@@ -147,7 +147,7 @@ bool CVideoInfoDownloader::GetArtwork(CVideoInfoTag &details)
   return m_info->GetArtwork(*m_http, details);
 }
 
-bool CVideoInfoDownloader::GetDetails(const std::unordered_map<std::string, std::string>& uniqueIDs,
+bool CVideoInfoDownloader::GetDetails(const ADDON::CScraper::UniqueIDs& uniqueIDs,
                                       const CScraperUrl& url,
                                       CVideoInfoTag& movieDetails,
                                       CGUIDialogProgress* pProgress /* = NULL */)

--- a/xbmc/video/VideoInfoDownloader.h
+++ b/xbmc/video/VideoInfoDownloader.h
@@ -54,7 +54,7 @@ public:
    */
   bool GetArtwork(CVideoInfoTag &details);
 
-  bool GetDetails(const std::unordered_map<std::string, std::string>& uniqueIDs,
+  bool GetDetails(const ADDON::CScraper::UniqueIDs& uniqueIDs,
                   const CScraperUrl& url,
                   CVideoInfoTag& movieDetails,
                   CGUIDialogProgress* pProgress = NULL);
@@ -75,7 +75,7 @@ protected:
   XFILE::CCurlFile*   m_http;
   std::string         m_movieTitle;
   int                 m_movieYear;
-  std::unordered_map<std::string, std::string> m_uniqueIDs;
+  ADDON::CScraper::UniqueIDs m_uniqueIDs;
   MOVIELIST           m_movieList;
   CVideoInfoTag       m_movieDetails;
   CScraperUrl         m_url;

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -699,7 +699,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     long lResult = -1;
     if (info2->IsPython() && CUtil::GetFilenameIdentifier(movieTitle, identifierType, identifier))
     {
-      const std::unordered_map<std::string, std::string> uniqueIDs{{identifierType, identifier}};
+      const ADDON::CScraper::UniqueIDs uniqueIDs{{identifierType, identifier}};
       if (GetDetails(pItem, uniqueIDs, url, info2,
                      (result == InfoType::COMBINED || result == InfoType::OVERRIDE) ? loader.get()
                                                                                     : nullptr,
@@ -804,7 +804,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     std::string identifier;
     if (info2->IsPython() && CUtil::GetFilenameIdentifier(movieTitle, identifierType, identifier))
     {
-      const std::unordered_map<std::string, std::string> uniqueIDs{{identifierType, identifier}};
+      const ADDON::CScraper::UniqueIDs uniqueIDs{{identifierType, identifier}};
       if (GetDetails(pItem, uniqueIDs, url, info2,
                      (result == InfoType::COMBINED || result == InfoType::OVERRIDE) ? loader.get()
                                                                                     : nullptr,
@@ -897,7 +897,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     std::string identifier;
     if (info2->IsPython() && CUtil::GetFilenameIdentifier(movieTitle, identifierType, identifier))
     {
-      const std::unordered_map<std::string, std::string> uniqueIDs{{identifierType, identifier}};
+      const ADDON::CScraper::UniqueIDs uniqueIDs{{identifierType, identifier}};
       if (GetDetails(pItem, uniqueIDs, url, info2,
                      (result == InfoType::COMBINED || result == InfoType::OVERRIDE) ? loader.get()
                                                                                     : nullptr,
@@ -2212,7 +2212,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
   }
 
   bool CVideoInfoScanner::GetDetails(CFileItem* pItem,
-                                     const std::unordered_map<std::string, std::string>& uniqueIDs,
+                                     const ADDON::CScraper::UniqueIDs& uniqueIDs,
                                      CScraperUrl& url,
                                      const ScraperPtr& scraper,
                                      IVideoInfoTagLoader* loader,

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -303,12 +303,12 @@ CVideoInfoScanner::~CVideoInfoScanner()
     SScanSettings settings;
     ScraperPtr info =
         m_database.GetScraperForPath(strDirectory, settings, foundDirectly, &m_scraperCache);
-    CONTENT_TYPE content = info ? info->Content() : CONTENT_NONE;
+    ContentType content = info ? info->Content() : ContentType::NONE;
 
     // exclude folders that match our exclude regexps
     const std::vector<std::string>& regexps =
-        content == CONTENT_TVSHOWS ? m_advancedSettings->m_tvshowExcludeFromScanRegExps
-                                   : m_advancedSettings->m_moviesExcludeFromScanRegExps;
+        content == ContentType::TVSHOWS ? m_advancedSettings->m_tvshowExcludeFromScanRegExps
+                                        : m_advancedSettings->m_moviesExcludeFromScanRegExps;
 
     if (CUtil::ExcludeFileOrFolder(strDirectory, regexps))
       return true;
@@ -317,7 +317,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       return true;
 
     bool ignoreFolder = !m_scanAll && settings.noupdate;
-    if (content == CONTENT_NONE || ignoreFolder)
+    if (content == ContentType::NONE || ignoreFolder)
       return true;
 
     if (URIUtils::IsPlugin(strDirectory) && !CPluginDirectory::IsMediaLibraryScanningAllowed(TranslateContent(content), strDirectory))
@@ -330,11 +330,11 @@ CVideoInfoScanner::~CVideoInfoScanner()
     }
 
     std::string hash, dbHash;
-    if (content == CONTENT_MOVIES ||content == CONTENT_MUSICVIDEOS)
+    if (content == ContentType::MOVIES || content == ContentType::MUSICVIDEOS)
     {
       if (m_handle)
       {
-        int str = content == CONTENT_MOVIES ? 20317:20318;
+        int str = content == ContentType::MOVIES ? 20317 : 20318;
         m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(str), info->Name()));
       }
 
@@ -390,7 +390,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
                   CURL::GetRedacted(strDirectory), dbHash, hash);
       }
     }
-    else if (content == CONTENT_TVSHOWS)
+    else if (content == ContentType::TVSHOWS)
     {
       if (m_handle)
         m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20319), info->Name()));
@@ -422,7 +422,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       foundSomething = RetrieveVideoInfo(items, settings.parent_name_root, content);
       if (foundSomething)
       {
-        if (!m_bStop && (content == CONTENT_MOVIES || content == CONTENT_MUSICVIDEOS))
+        if (!m_bStop && (content == ContentType::MOVIES || content == ContentType::MUSICVIDEOS))
         {
           m_database.SetPathHash(strDirectory, hash);
           if (m_bClean)
@@ -439,7 +439,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
                   CURL::GetRedacted(strDirectory));
       }
     }
-    else if (!StringUtils::EqualsNoCase(hash, dbHash) && (content == CONTENT_MOVIES || content == CONTENT_MUSICVIDEOS))
+    else if (!StringUtils::EqualsNoCase(hash, dbHash) &&
+             (content == ContentType::MOVIES || content == ContentType::MUSICVIDEOS))
     { // update the hash either way - we may have changed the hash to a fast version
       m_database.SetPathHash(strDirectory, hash);
     }
@@ -455,7 +456,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         break;
 
       // add video extras to library
-      if (foundSomething && content == CONTENT_MOVIES && settings.parent_name &&
+      if (foundSomething && content == ContentType::MOVIES && settings.parent_name &&
           !m_ignoreVideoExtras && IsVideoExtrasFolder(*pItem))
       {
         if (AddVideoExtras(items, content, pItem->GetPath()))
@@ -471,7 +472,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       // if we have a directory item (non-playlist) we then recurse into that folder
       // do not recurse for tv shows - we have already looked recursively for episodes
       if (pItem->IsFolder() && !pItem->IsParentFolder() && !PLAYLIST::IsPlayList(*pItem) &&
-          settings.recurse > 0 && content != CONTENT_TVSHOWS)
+          settings.recurse > 0 && content != ContentType::TVSHOWS)
       {
         if (!DoScan(pItem->GetPath()))
         {
@@ -482,7 +483,13 @@ CVideoInfoScanner::~CVideoInfoScanner()
     return !m_bStop;
   }
 
-  bool CVideoInfoScanner::RetrieveVideoInfo(CFileItemList& items, bool bDirNames, CONTENT_TYPE content, bool useLocal, CScraperUrl* pURL, bool fetchEpisodes, CGUIDialogProgress* pDlgProgress)
+  bool CVideoInfoScanner::RetrieveVideoInfo(CFileItemList& items,
+                                            bool bDirNames,
+                                            ContentType content,
+                                            bool useLocal,
+                                            CScraperUrl* pURL,
+                                            bool fetchEpisodes,
+                                            CGUIDialogProgress* pDlgProgress)
   {
     if (pDlgProgress)
     {
@@ -517,23 +524,23 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
       // Discard all exclude files defined by regExExclude
       if (CUtil::ExcludeFileOrFolder(pItem->GetPath(),
-                                     (content == CONTENT_TVSHOWS)
+                                     (content == ContentType::TVSHOWS)
                                          ? m_advancedSettings->m_tvshowExcludeFromScanRegExps
                                          : m_advancedSettings->m_moviesExcludeFromScanRegExps))
         continue;
 
-      if (info2->Content() == CONTENT_MOVIES || info2->Content() == CONTENT_MUSICVIDEOS)
+      if (info2->Content() == ContentType::MOVIES || info2->Content() == ContentType::MUSICVIDEOS)
       {
         if (m_handle)
           m_handle->SetPercentage(i*100.f/items.Size());
       }
 
       InfoRet ret = InfoRet::CANCELLED;
-      if (info2->Content() == CONTENT_TVSHOWS)
+      if (info2->Content() == ContentType::TVSHOWS)
         ret = RetrieveInfoForTvShow(pItem.get(), bDirNames, info2, useLocal, pURL, fetchEpisodes, pDlgProgress);
-      else if (info2->Content() == CONTENT_MOVIES)
+      else if (info2->Content() == ContentType::MOVIES)
         ret = RetrieveInfoForMovie(pItem.get(), bDirNames, info2, useLocal, pURL, pDlgProgress);
-      else if (info2->Content() == CONTENT_MUSICVIDEOS)
+      else if (info2->Content() == ContentType::MUSICVIDEOS)
         ret = RetrieveInfoForMusicVideo(pItem.get(), bDirNames, info2, useLocal, pURL, pDlgProgress);
       else
       {
@@ -560,15 +567,15 @@ CVideoInfoScanner::~CVideoInfoScanner()
                   CURL::GetRedacted(pItem->GetPath()));
 
         MediaType mediaType = MediaTypeMovie;
-        if (info2->Content() == CONTENT_TVSHOWS)
+        if (info2->Content() == ContentType::TVSHOWS)
           mediaType = MediaTypeTvShow;
-        else if (info2->Content() == CONTENT_MUSICVIDEOS)
+        else if (info2->Content() == ContentType::MUSICVIDEOS)
           mediaType = MediaTypeMusicVideo;
 
         auto eventLog = CServiceBroker::GetEventLog();
         if (eventLog)
         {
-          const std::string itemlogpath = (info2->Content() == CONTENT_TVSHOWS)
+          const std::string itemlogpath = (info2->Content() == ContentType::TVSHOWS)
                                               ? CURL::GetRedacted(pItem->GetPath())
                                               : URIUtils::GetFileName(pItem->GetPath());
 
@@ -586,7 +593,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         seenPaths.push_back(m_database.GetPathId(pItem->GetPath()));
     }
 
-    if (content == CONTENT_TVSHOWS && ! seenPaths.empty())
+    if (content == ContentType::TVSHOWS && !seenPaths.empty())
     {
       std::vector<std::pair<int, std::string>> libPaths;
       m_database.GetSubPaths(items.GetPath(), libPaths);
@@ -1512,7 +1519,12 @@ CVideoInfoScanner::~CVideoInfoScanner()
     return false;
   }
 
-  long CVideoInfoScanner::AddVideo(CFileItem *pItem, const CONTENT_TYPE &content, bool videoFolder /* = false */, bool useLocal /* = true */, const CVideoInfoTag *showInfo /* = NULL */, bool libraryImport /* = false */)
+  long CVideoInfoScanner::AddVideo(CFileItem* pItem,
+                                   ContentType content,
+                                   bool videoFolder /* = false */,
+                                   bool useLocal /* = true */,
+                                   const CVideoInfoTag* showInfo /* = NULL */,
+                                   bool libraryImport /* = false */)
   {
     // ensure our database is open (this can get called via other classes)
     if (!m_database.Open())
@@ -1538,7 +1550,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
     std::string strTitle(movieDetails.m_strTitle);
 
-    if (showInfo && content == CONTENT_TVSHOWS)
+    if (showInfo && content == ContentType::TVSHOWS)
     {
       strTitle = StringUtils::Format("{} - {}x{} - {}", showInfo->m_strTitle,
                                      movieDetails.m_iSeason, movieDetails.m_iEpisode, strTitle);
@@ -1566,7 +1578,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding new item to {}:{}", TranslateContent(content), CURL::GetRedacted(pItem->GetPath()));
     long lResult = -1;
 
-    if (content == CONTENT_MOVIES)
+    if (content == ContentType::MOVIES)
     {
       // find local trailer first
       std::string strTrailer = UTILS::FindTrailer(*pItem);
@@ -1616,7 +1628,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
                     movieDetails.m_strTitle, movieDetails.m_showLink[i]);
       }
     }
-    else if (content == CONTENT_TVSHOWS)
+    else if (content == ContentType::TVSHOWS)
     {
       if (pItem->IsFolder())
       {
@@ -1659,7 +1671,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         }
       }
     }
-    else if (content == CONTENT_MUSICVIDEOS)
+    else if (content == ContentType::MUSICVIDEOS)
     {
       lResult = m_database.SetDetailsForMusicVideo(movieDetails, art);
       movieDetails.m_iDbId = lResult;
@@ -1689,30 +1701,32 @@ CVideoInfoScanner::~CVideoInfoScanner()
     return lResult;
   }
 
-  std::string ContentToMediaType(CONTENT_TYPE content, bool folder)
+  std::string ContentToMediaType(ContentType content, bool folder)
   {
     switch (content)
     {
-      case CONTENT_MOVIES:
+      using enum ContentType;
+      case MOVIES:
         return MediaTypeMovie;
-      case CONTENT_MUSICVIDEOS:
+      case MUSICVIDEOS:
         return MediaTypeMusicVideo;
-      case CONTENT_TVSHOWS:
+      case TVSHOWS:
         return folder ? MediaTypeTvShow : MediaTypeEpisode;
       default:
         return "";
     }
   }
 
-  VideoDbContentType ContentToVideoDbType(CONTENT_TYPE content)
+  VideoDbContentType ContentToVideoDbType(ContentType content)
   {
     switch (content)
     {
-      case CONTENT_MOVIES:
+      using enum ContentType;
+      case MOVIES:
         return VideoDbContentType::MOVIES;
-      case CONTENT_MUSICVIDEOS:
+      case MUSICVIDEOS:
         return VideoDbContentType::MUSICVIDEOS;
-      case CONTENT_TVSHOWS:
+      case TVSHOWS:
         return VideoDbContentType::EPISODES;
       default:
         return VideoDbContentType::UNKNOWN;
@@ -1837,7 +1851,11 @@ CVideoInfoScanner::~CVideoInfoScanner()
     }
   }
 
-  void CVideoInfoScanner::GetArtwork(CFileItem *pItem, const CONTENT_TYPE &content, bool bApplyToDir, bool useLocal, const std::string &actorArtPath)
+  void CVideoInfoScanner::GetArtwork(CFileItem* pItem,
+                                     ContentType content,
+                                     bool bApplyToDir,
+                                     bool useLocal,
+                                     const std::string& actorArtPath)
   {
     int artLevel = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
         CSettings::SETTING_VIDEOLIBRARY_ARTWORK_LEVEL);
@@ -1853,7 +1871,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     // get and cache thumb images
     std::string mediaType = ContentToMediaType(content, pItem->IsFolder());
     std::vector<std::string> artTypes = CVideoThumbLoader::GetArtTypes(mediaType);
-    bool moviePartOfSet = content == CONTENT_MOVIES && !movieDetails.m_set.title.empty();
+    bool moviePartOfSet = content == ContentType::MOVIES && !movieDetails.m_set.title.empty();
     std::vector<std::string> movieSetArtTypes;
     if (moviePartOfSet)
     {
@@ -1869,7 +1887,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       if (!pItem->SkipLocalArt())
       {
         bool useFolder = false;
-        if (bApplyToDir && (content == CONTENT_MOVIES || content == CONTENT_MUSICVIDEOS))
+        if (bApplyToDir && (content == ContentType::MOVIES || content == ContentType::MUSICVIDEOS))
         {
           std::string filename = ART::GetLocalArtBaseFilename(*pItem, useFolder);
           std::string directory = URIUtils::GetDirectory(filename);
@@ -2047,7 +2065,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
           item.GetVideoInfoTag()->m_iEpisode = file->iEpisode;
           item.GetVideoInfoTag()->m_iSeason = file->iSeason;
         }
-        if (AddVideo(&item, CONTENT_TVSHOWS, file->isFolder, true, &showInfo) < 0)
+        if (AddVideo(&item, ContentType::TVSHOWS, file->isFolder, true, &showInfo) < 0)
           return InfoRet::INFO_ERROR;
         continue;
       }
@@ -2196,7 +2214,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         if (item.GetVideoInfoTag()->m_iEpisode == -1)
           item.GetVideoInfoTag()->m_iEpisode = guide->iEpisode;
 
-        if (AddVideo(&item, CONTENT_TVSHOWS, file->isFolder, useLocal, &showInfo) < 0)
+        if (AddVideo(&item, ContentType::TVSHOWS, file->isFolder, useLocal, &showInfo) < 0)
           return InfoRet::INFO_ERROR;
       }
       else
@@ -2527,7 +2545,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
   }
 
   bool CVideoInfoScanner::AddVideoExtras(CFileItemList& items,
-                                         const CONTENT_TYPE& content,
+                                         ContentType content,
                                          const std::string& path)
   {
     int dbId = -1;
@@ -2535,7 +2553,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     // get the library item which was added previously with the specified content type
     for (const auto& item : items)
     {
-      if (content == CONTENT_MOVIES && !item->IsFolder())
+      if (content == ContentType::MOVIES && !item->IsFolder())
       {
         dbId = m_database.GetMovieId(item->GetPath());
         if (dbId != -1)

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -68,7 +68,12 @@ namespace KODI::VIDEO
      \param libraryImport Whether this call belongs to a full library import or not. Defaults to false.
      \return database id of the added item, or -1 on failure.
      */
-    long AddVideo(CFileItem *pItem, const CONTENT_TYPE &content, bool videoFolder = false, bool useLocal = true, const CVideoInfoTag *showInfo = NULL, bool libraryImport = false);
+    long AddVideo(CFileItem* pItem,
+                  ADDON::ContentType content,
+                  bool videoFolder = false,
+                  bool useLocal = true,
+                  const CVideoInfoTag* showInfo = NULL,
+                  bool libraryImport = false);
 
     /*! \brief Retrieve information for a list of items and add them to the database.
      \param items list of items to retrieve info for.
@@ -80,7 +85,13 @@ namespace KODI::VIDEO
      \param pDlgProgress progress dialog to update and check for cancellation during processing.  Defaults to NULL.
      \return true if we successfully found information for some items, false otherwise
      */
-    bool RetrieveVideoInfo(CFileItemList& items, bool bDirNames, CONTENT_TYPE content, bool useLocal = true, CScraperUrl *pURL = NULL, bool fetchEpisodes = true, CGUIDialogProgress* pDlgProgress = NULL);
+    bool RetrieveVideoInfo(CFileItemList& items,
+                           bool bDirNames,
+                           ADDON::ContentType content,
+                           bool useLocal = true,
+                           CScraperUrl* pURL = NULL,
+                           bool fetchEpisodes = true,
+                           CGUIDialogProgress* pDlgProgress = NULL);
 
     static void ApplyThumbToFolder(const std::string &folder, const std::string &imdbThumb);
     static bool DownloadFailed(CGUIDialogProgress* pDlgProgress);
@@ -92,7 +103,11 @@ namespace KODI::VIDEO
      \param useLocal whether we should use local thumbs. Defaults to true.
      \param actorArtPath the path to search for actor thumbs. Defaults to empty.
      */
-    void GetArtwork(CFileItem *pItem, const CONTENT_TYPE &content, bool bApplyToDir=false, bool useLocal=true, const std::string &actorArtPath = "");
+    void GetArtwork(CFileItem* pItem,
+                    ADDON::ContentType content,
+                    bool bApplyToDir = false,
+                    bool useLocal = true,
+                    const std::string& actorArtPath = "");
 
     /*! \brief Get season thumbs for a tvshow.
      All seasons (regardless of whether the user has episodes) are added to the art map.
@@ -269,7 +284,7 @@ namespace KODI::VIDEO
     bool EnumerateSeriesFolder(CFileItem* item, EPISODELIST& episodeList);
     bool ProcessItemByVideoInfoTag(const CFileItem *item, EPISODELIST &episodeList);
 
-    bool AddVideoExtras(CFileItemList& items, const CONTENT_TYPE& content, const std::string& path);
+    bool AddVideoExtras(CFileItemList& items, ADDON::ContentType content, const std::string& path);
     bool ProcessVideoVersion(VideoDbContentType itemType, int dbId);
 
     std::pair<InfoType, std::unique_ptr<IVideoInfoTagLoader>> ReadInfoTag(

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -178,7 +178,7 @@ namespace KODI::VIDEO
      \return true if information is found, false if an error occurred, the lookup was cancelled, or no information was found.
      */
     bool GetDetails(CFileItem* pItem,
-                    const std::unordered_map<std::string, std::string>& uniqueIDs,
+                    const ADDON::CScraper::UniqueIDs& uniqueIDs,
                     CScraperUrl& url,
                     const ADDON::ScraperPtr& scraper,
                     VIDEO::IVideoInfoTagLoader* nfoFile = nullptr,

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -133,7 +133,8 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
             scraper->ID() == "metadata.local")
         {
           // get video info and art from plugin source with metadata.local scraper
-          if (scraper->Content() == CONTENT_TVSHOWS && !m_item->IsFolder() && tag->m_iIdShow < 0)
+          if (scraper->Content() == ADDON::ContentType::TVSHOWS && !m_item->IsFolder() &&
+              tag->m_iIdShow < 0)
             // preserve show_id for episode
             tag->m_iIdShow = m_item->GetVideoInfoTag()->m_iIdShow;
           pluginTag = std::move(tag);
@@ -156,11 +157,11 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
           nfoResult != CInfoScanner::InfoType::ERROR_NFO)
       {
         int heading = 20159;
-        if (scraper->Content() == CONTENT_MOVIES)
+        if (scraper->Content() == ADDON::ContentType::MOVIES)
           heading = 13346;
-        else if (scraper->Content() == CONTENT_TVSHOWS)
+        else if (scraper->Content() == ADDON::ContentType::TVSHOWS)
           heading = m_item->IsFolder() ? 20351 : 20352;
-        else if (scraper->Content() == CONTENT_MUSICVIDEOS)
+        else if (scraper->Content() == ADDON::ContentType::MUSICVIDEOS)
           heading = 20393;
         if (CGUIDialogYesNo::ShowAndGetInput(heading, 20446))
         {
@@ -173,7 +174,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
     }
 
     // no need to re-fetch the episode guide for episodes
-    if (scraper->Content() == CONTENT_TVSHOWS && !m_item->IsFolder())
+    if (scraper->Content() == ADDON::ContentType::TVSHOWS && !m_item->IsFolder())
       hasDetails = true;
 
     // if we don't have an url or need to refresh anyway do the web search
@@ -224,7 +225,8 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
             // ask the user what to do
             CGUIDialogSelect* selectDialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
             selectDialog->Reset();
-            selectDialog->SetHeading(scraper->Content() == CONTENT_TVSHOWS ? 20356 : 196);
+            selectDialog->SetHeading(scraper->Content() == ADDON::ContentType::TVSHOWS ? 20356
+                                                                                       : 196);
             for (const auto& itemResult : itemResultList)
               selectDialog->Add(itemResult.GetTitle());
             selectDialog->EnableButton(true, 413); // "Manual"
@@ -238,7 +240,11 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
             else if (selectDialog->IsButtonPressed())
             {
               // ask the user to input a title to use
-              if (!CGUIKeyboardFactory::ShowAndGetInput(itemTitle, g_localizeStrings.Get(scraper->Content() == CONTENT_TVSHOWS ? 20357 : 16009), false))
+              if (!CGUIKeyboardFactory::ShowAndGetInput(
+                      itemTitle,
+                      g_localizeStrings.Get(
+                          scraper->Content() == ADDON::ContentType::TVSHOWS ? 20357 : 16009),
+                      false))
                 return false;
 
               // go through the whole process again
@@ -268,7 +274,11 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
       if (IsModal())
       {
         // ask the user to input a title to use
-        if (!CGUIKeyboardFactory::ShowAndGetInput(itemTitle, g_localizeStrings.Get(scraper->Content() == CONTENT_TVSHOWS ? 20357 : 16009), false))
+        if (!CGUIKeyboardFactory::ShowAndGetInput(
+                itemTitle,
+                g_localizeStrings.Get(scraper->Content() == ADDON::ContentType::TVSHOWS ? 20357
+                                                                                        : 16009),
+                false))
           return false;
 
         // go through the whole process again
@@ -324,14 +334,14 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
                                      : URIUtils::GetDirectory(path));
 
     int headingLabel = 198;
-    if (scraper->Content() == CONTENT_TVSHOWS)
+    if (scraper->Content() == ADDON::ContentType::TVSHOWS)
     {
       if (m_item->IsFolder())
         headingLabel = 20353;
       else
         headingLabel = 20361;
     }
-    else if (scraper->Content() == CONTENT_MUSICVIDEOS)
+    else if (scraper->Content() == ADDON::ContentType::MUSICVIDEOS)
       headingLabel = 20394;
 
     // prepare the progress dialog for downloading all the necessary information
@@ -345,11 +355,11 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
     // remove any existing data for the item we're going to refresh
     if (origDbId > 0)
     {
-      if (scraper->Content() == CONTENT_MOVIES)
+      if (scraper->Content() == ADDON::ContentType::MOVIES)
         db.DeleteMovie(origDbId, DeleteMovieCascadeAction::DEFAULT_VERSION);
-      else if (scraper->Content() == CONTENT_MUSICVIDEOS)
+      else if (scraper->Content() == ADDON::ContentType::MUSICVIDEOS)
         db.DeleteMusicVideo(origDbId);
-      else if (scraper->Content() == CONTENT_TVSHOWS)
+      else if (scraper->Content() == ADDON::ContentType::TVSHOWS)
       {
         if (!m_item->IsFolder())
           db.DeleteEpisode(origDbId);
@@ -392,11 +402,11 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
     }
 
     // retrieve the updated information from the database
-    if (scraper->Content() == CONTENT_MOVIES)
+    if (scraper->Content() == ADDON::ContentType::MOVIES)
       db.GetMovieInfo(m_item->GetPath(), *m_item->GetVideoInfoTag());
-    else if (scraper->Content() == CONTENT_MUSICVIDEOS)
+    else if (scraper->Content() == ADDON::ContentType::MUSICVIDEOS)
       db.GetMusicVideoInfo(m_item->GetPath(), *m_item->GetVideoInfoTag());
-    else if (scraper->Content() == CONTENT_TVSHOWS)
+    else if (scraper->Content() == ADDON::ContentType::TVSHOWS)
     {
       // update tvshow/season info to get updated episode numbers
       if (m_item->IsFolder())

--- a/xbmc/video/tags/VideoTagLoaderNFO.cpp
+++ b/xbmc/video/tags/VideoTagLoaderNFO.cpp
@@ -29,7 +29,7 @@ CVideoTagLoaderNFO::CVideoTagLoaderNFO(const CFileItem& item,
                                        bool lookInFolder)
   : IVideoInfoTagLoader(item, std::move(info), lookInFolder)
 {
-  if (m_info && m_info->Content() == CONTENT_TVSHOWS && m_item.IsFolder())
+  if (m_info && m_info->Content() == ADDON::ContentType::TVSHOWS && m_item.IsFolder())
     m_path = URIUtils::AddFileToFolder(m_item.GetPath(), "tvshow.nfo");
   else
     m_path = FindNFO(m_item, lookInFolder);
@@ -46,7 +46,7 @@ CInfoScanner::InfoType CVideoTagLoaderNFO::Load(CVideoInfoTag& tag,
 {
   CNfoFile nfoReader;
   CInfoScanner::InfoType result = CInfoScanner::InfoType::NONE;
-  if (m_info && m_info->Content() == CONTENT_TVSHOWS && !m_item.IsFolder())
+  if (m_info && m_info->Content() == ADDON::ContentType::TVSHOWS && !m_item.IsFolder())
     result = nfoReader.Create(m_path, m_info, m_item.GetVideoInfoTag()->m_iEpisode);
   else if (m_info)
     result = nfoReader.Create(m_path, m_info);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -271,7 +271,7 @@ bool CGUIWindowVideoBase::OnItemInfo(const CFileItem& fileItem)
 
   m_database.Close();
 
-  if (scraper && scraper->Content() == CONTENT_TVSHOWS && foundDirectly &&
+  if (scraper && scraper->Content() == ContentType::TVSHOWS && foundDirectly &&
       !settings.parent_name_root) // dont lookup on root tvshow folder
     return true;
 
@@ -287,7 +287,7 @@ bool CGUIWindowVideoBase::OnItemInfo(const CFileItem& fileItem)
   }
   else
   {
-    if (item.IsFolder() && scraper && scraper->Content() != CONTENT_TVSHOWS)
+    if (item.IsFolder() && scraper && scraper->Content() != ContentType::TVSHOWS)
     {
       CFileItemList items;
       const std::string fileExts = CServiceBroker::GetFileExtensionProvider().GetVideoExtensions();
@@ -380,14 +380,14 @@ CGUIWindowVideoBase::ShowInfoResult CGUIWindowVideoBase::ShowInfo(
     m_database.Open(); // since we can be called from the music library
 
     const int dbId{item->HasVideoInfoTag() ? item->GetVideoInfoTag()->m_iDbId : -1};
-    if (info->Content() == CONTENT_MOVIES)
+    if (info->Content() == ContentType::MOVIES)
     {
       const int versionId{item->HasVideoInfoTag() ? item->GetVideoInfoTag()->GetAssetInfo().GetId()
                                                   : -1};
       const int fileId{item->HasVideoInfoTag() ? item->GetVideoInfoTag()->m_iFileId : -1};
       bHasInfo = m_database.GetMovieInfo(item->GetPath(), movieDetails, dbId, versionId, fileId);
     }
-    if (info->Content() == CONTENT_TVSHOWS)
+    if (info->Content() == ContentType::TVSHOWS)
     {
       if (item->IsFolder())
       {
@@ -421,7 +421,7 @@ CGUIWindowVideoBase::ShowInfoResult CGUIWindowVideoBase::ShowInfo(
         }
       }
     }
-    if (info->Content() == CONTENT_MUSICVIDEOS)
+    if (info->Content() == ContentType::MUSICVIDEOS)
     {
       bHasInfo = m_database.GetMusicVideoInfo(item->GetDynPath(), movieDetails);
     }
@@ -437,7 +437,7 @@ CGUIWindowVideoBase::ShowInfoResult CGUIWindowVideoBase::ShowInfo(
   if (bHasInfo)
   {
     // @todo add support to refresh movie version information
-    if (!info || info->Content() == CONTENT_NONE || VIDEO::IsVideoAssetFile(*item))
+    if (!info || info->Content() == ContentType::NONE || VIDEO::IsVideoAssetFile(*item))
       item->SetProperty("xxuniqueid", "xx" + movieDetails.GetUniqueID()); // disable refresh button
     item->SetProperty("CheckAutoPlayNextItem", IsActive());
     *item->GetVideoInfoTag() = movieDetails;
@@ -1148,7 +1148,7 @@ bool CGUIWindowVideoBase::GetDirectory(const std::string &strDirectory, CFileIte
   // (ideally this should be removed, and our stack regexps tidied up if necessary
   // No "normal" episodes should stack, and multi-parts should be supported)
   ADDON::ScraperPtr info = m_database.GetScraperForPath(strDirectory);
-  if (info && info->Content() == CONTENT_TVSHOWS)
+  if (info && info->Content() == ContentType::TVSHOWS)
     m_stackingAvailable = false;
 
   if (m_stackingAvailable && !items.IsStack() && CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MYVIDEOS_STACKVIDEOS))

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -782,7 +782,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
 
       if (!item->IsLiveTV() && !item->IsAddonsPath() && !URIUtils::IsUPnP(item->GetPath()))
       {
-        if (info && info->Content() != CONTENT_NONE)
+        if (info && info->Content() != ADDON::ContentType::NONE)
         {
           buttons.Add(CONTEXT_BUTTON_SET_CONTENT, 20442);
           buttons.Add(CONTEXT_BUTTON_SCAN, 13349);
@@ -864,17 +864,18 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
             !PLAYLIST::IsSmartPlayList(*item) && !item->IsLibraryFolder() && !item->IsLiveTV() &&
             !item->IsPlugin() && !item->IsAddonsPath() && !URIUtils::IsUPnP(item->GetPath()))
         {
-          if (info && info->Content() != CONTENT_NONE)
+          if (info && info->Content() != ADDON::ContentType::NONE)
             buttons.Add(CONTEXT_BUTTON_SET_CONTENT, 20442);
           else
             buttons.Add(CONTEXT_BUTTON_SET_CONTENT, 20333);
 
-          if (info && info->Content() != CONTENT_NONE)
+          if (info && info->Content() != ADDON::ContentType::NONE)
             buttons.Add(CONTEXT_BUTTON_SCAN, 13349);
         }
       }
 
-      if ((!item->HasVideoInfoTag() || item->GetVideoInfoTag()->m_iDbId == -1) && info && info->Content() != CONTENT_NONE)
+      if ((!item->HasVideoInfoTag() || item->GetVideoInfoTag()->m_iDbId == -1) && info &&
+          info->Content() != ADDON::ContentType::NONE)
         buttons.Add(CONTEXT_BUTTON_SCAN_TO_LIBRARY, 21845);
 
     }


### PR DESCRIPTION
This time it is a bunch of SonarQube findings solved by this PR. No functional changes intended, only optimizations and modernization of the code:

* Mergeable "if" statements should be combined cpp:S1066
* "/*" and "//" should not be used within comments cpp:S1103
* Structured binding should be used cpp:S6005
* "try_emplace" should be used with "std::map" and "std::unordered_map" cpp:S6030
* Transparent function objects should be used with associative "std::string" containers cpp:S6045
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* Unused function parameters should be removed cpp:S1172
* "auto" should be used to avoid repetition of types cpp:S5827
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* "auto" should be used to store a result of functions that conventionally return an iterator or a range cpp:S6234
* "std::source_location" should be used instead of `__FILE__`, `__LINE__`, and `__func__` macros cpp:S6190
* Memory should not be managed manually cpp:S5025
* "make_unique" and "make_shared" should be used to construct "unique_ptr" and "shared_ptr" cpp:S5950
* Assignments should not be made from within conditions cpp:S1121
* Multiple variables should not be declared on the same line cpp:S1659
* Mergeable "if" statements should be combined cpp:S1066
* Implicit casts should not lower precision cpp:S5276
* "using" should be preferred for type aliasing cpp:S5416
* Pointer and reference parameters should be "const" if the corresponding object is not modified cpp:S995
* Redundant class template arguments should not be used cpp:S6012
* "std::scoped_lock" should be used instead of "std::lock_guard" cpp:S5997
* Elements in a container should be erased with "std::erase" or "std::erase_if" cpp:S6165
* Return type of functions shouldn't be const qualified value cpp:S5951
* Redundant pairs of parentheses should be removed cpp:S1110
* Member variables should not be "protected" cpp:S3656
* Redundant comparison operators should not be defined cpp:S6186
* Concise syntax should be used for concatenatable namespaces cpp:S5812
* Capture by reference in lambdas used locally cpp:S5495
* "explicit" should be used on single-parameter constructors and conversion operators cpp:S1709
* "override" or "final" should be used instead of "virtual" cpp:S3471
* Integer literals should not be cast to bool cpp:S5820
* Macros should not be used to define constants cpp:S5028
* "std::string_view" should be used to pass a read-only string to a function
* C-style array should not be used cpp:S5945
* "empty()" should be used to test for emptiness cpp:S1155
* Transparent function objects should be used with associative "std::string" containers cpp:S6045
* "static" members should be accessed statically cpp:S2209

Runtime-tested on macOS and Android, latest Kodi master.

@garbear maybe you can have a look?