### PR TITLE
[VideoDB] Improve TV Show Match from NFO/Scraper

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -302,6 +302,9 @@ void CVideoDatabase::CreateAnalytics()
 
   m_pDS->exec(PrepareSQL("CREATE INDEX ix_movie_title ON movie (c%02d(255))", VIDEODB_ID_TITLE));
 
+  m_pDS->exec(PrepareSQL("CREATE INDEX ix_tvshow_title ON tvshow (c%02d(255), c%02d(10))",
+                         VIDEODB_ID_TV_TITLE, VIDEODB_ID_TV_PREMIERED));
+
   CreateLinkIndex("tag");
   CreateForeignLinkIndex("director", "actor");
   CreateForeignLinkIndex("writer", "actor");
@@ -7011,7 +7014,7 @@ void CVideoDatabase::UpdateTables(int iVersion)
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 136;
+  return 137;
 }
 
 bool CVideoDatabase::LookupByFolders(const std::string &path, bool shows)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2985,11 +2985,18 @@ int CVideoDatabase::GetMatchingTvShow(const CVideoInfoTag& details) const
   // first try matching on uniqueid, then on title + year
   int id = -1;
   if (details.HasUniqueID())
-    id = GetDbId(PrepareSQL("SELECT media_id FROM uniqueid "
+  {
+    //! @todo better handling when no default uniqueid is defined ("unknown" - legacy nfo)
+    //! @todo loop through the non-default uniqueid when no match is found
+
+    id = GetDbId(PrepareSQL("SELECT uniqueid.media_id FROM uniqueid "
                             "JOIN tvshow ON uniqueid.media_id=tvshow.idShow "
                             "WHERE uniqueid.media_type='%s' "
-                            "AND uniqueid.value='%s'",
-                            MediaTypeTvShow, details.GetUniqueID().c_str()));
+                            "AND uniqueid.value='%s' "
+                            "AND uniqueid.type='%s' ",
+                            MediaTypeTvShow, details.GetUniqueID().c_str(),
+                            details.GetDefaultUniqueID().c_str()));
+  }
   if (id < 0)
     id = GetDbId(PrepareSQL("SELECT idShow FROM tvshow WHERE c%02d='%s' AND c%02d='%s'",
                             VIDEODB_ID_TV_TITLE, details.m_strTitle.c_str(),

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2984,10 +2984,16 @@ int CVideoDatabase::GetMatchingTvShow(const CVideoInfoTag& details) const
 {
   // first try matching on uniqueid, then on title + year
   int id = -1;
-  if (!details.HasUniqueID())
-    id = GetDbId(PrepareSQL("SELECT idShow FROM tvshow JOIN uniqueid ON uniqueid.media_id=tvshow.idShow AND uniqueid.media_type='tvshow' WHERE uniqueid.value='%s'", details.GetUniqueID().c_str()));
+  if (details.HasUniqueID())
+    id = GetDbId(PrepareSQL("SELECT media_id FROM uniqueid "
+                            "JOIN tvshow ON uniqueid.media_id=tvshow.idShow "
+                            "WHERE uniqueid.media_type='%s' "
+                            "AND uniqueid.value='%s'",
+                            MediaTypeTvShow, details.GetUniqueID().c_str()));
   if (id < 0)
-    id = GetDbId(PrepareSQL("SELECT idShow FROM tvshow WHERE c%02d='%s' AND c%02d='%s'", VIDEODB_ID_TV_TITLE, details.m_strTitle.c_str(), VIDEODB_ID_TV_PREMIERED, details.GetPremiered().GetAsDBDate().c_str()));
+    id = GetDbId(PrepareSQL("SELECT idShow FROM tvshow WHERE c%02d='%s' AND c%02d='%s'",
+                            VIDEODB_ID_TV_TITLE, details.m_strTitle.c_str(),
+                            VIDEODB_ID_TV_PREMIERED, details.GetPremiered().GetAsDBDate().c_str()));
   return id;
 }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

A few improvements and fixes of CVideoDatabase::GetMatchingTvShow() used indirectly by VideoInfoScanner.

- Added index for the match by show name + date path (with the required DB bump)
- Fixed the inverted logic that made the match by uniqueid always fail
- Use the source type (ex tmdb) as well as the value in the match by uniqueid to avoid matching a different show that shares the same value at a different metadata provider (ex. 76479 is The Boys (2019) at tmdb but One Step Beyond at tvdb)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Was investigating the addition of a tv show season in a different path/source than the previous seasons and found that the match by unique id was broken and that the match by name used a table scan.

note: this code path is avoided altogether in the most common case of adding new seasons to the same path as the previous ones.

The match by uniqueid is more accurate than the match by name.
I left alone the cases of legacy nfo (missing tags) and uniqueid records ("unknown" type for records that predate Kodi v17/scraper updates) and they fall back on the match by name, same as has been happening since Kodi v17 when the match by uniqueid was accidentally broken by the PR that added them (PR 10000).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Scanned new season with/without tvshow.nfo, manipulated nfo tags to exercise the match by uniqueid and the match by name,

Sqlite and MariaDB.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Slightly faster and more accurate library scan for tv show seasons added to a different path than the previous seasons.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
