### PR TITLE
[Bluray] Fix failure to compile on linux without libbluray.

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -467,8 +467,10 @@ std::string URIUtils::GetBasePath(const std::string& strPath)
   if (IsBDFile(strCheck))
     strDirectory = GetDiscBasePath(strCheck);
 
+#ifdef HAVE_LIBBLURAY
   if (IsBlurayPath(strCheck))
     strDirectory = CBlurayDirectory::GetBasePath(CURL(strCheck));
+#endif
 
   if (IsStack(strPath))
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Wrap a call to a CBlurayDirectory function in an #ifdef.
This isn't picked up by Jenkins.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Thanks to @howie-f pointing out:
```
[100%] Linking CXX executable kodi-x11
build/utils/utils.a(URIUtils.cpp.o):URIUtils.cpp:function URIUtils::GetBasePath(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&):

error: undefined reference to 'XFILE::CBlurayDirectory::GetBasePath[abi:cxx11](CURL const&)'
collect2: error: ld returned 1 exit status

gmake[2]: *** [CMakeFiles/kodi.dir/build.make:540: kodi-x11] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:5625: CMakeFiles/kodi.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2

6451b7937d811203597f902add034710a74958ab is the first bad commit
commit 6451b7937d811203597f902add034710a74958ab
Author: 78andyp <99039295+78andyp@users.noreply.github.com>
Date:   Mon May 26 22:14:11 2025 +0100

    Fix retrieval of basepath.
    
    Looking at the existing code basepath is different to the actual path of the media file, it is where the actual physical file resides (eg. for an archive:// path the basepath is the path in which the archive file itself resides not the media contained therein which the archive:// path+file points to, and for BD file structure its the movie directory not the BDMV directory with index.BDMV).

 xbmc/filesystem/BlurayDirectory.cpp |  2 +-
 xbmc/utils/URIUtils.cpp             | 16 +++++++++++++---
 xbmc/video/VideoDatabase.cpp        |  2 +-
 3 files changed, 15 insertions(+), 5 deletions(-)
```

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
