### PR TITLE
RetroPlayer: Add integer scaling support

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -19102,7 +19102,25 @@ msgctxt "#35236"
 msgid "In this release, only controllers can be used to play games."
 msgstr ""
 
-#empty strings from id 35237 to 35248
+#. Label of thumbnail in the in-game menu for normal size with 1:1 pixel aspect ratio (PAR)
+#: xbmc/games/dialogs/osd/DialogGameStretchMode.cpp
+msgctxt "#35237"
+msgid "Normal (1:1 PAR)"
+msgstr ""
+
+#. Label of thumbnail in the in-game menu for integer underscaling
+#: xbmc/games/dialogs/osd/DialogGameStretchMode.cpp
+msgctxt "#35238"
+msgid "Integer"
+msgstr ""
+
+#. Label of thumbnail in the in-game menu for integer underscaling with 1:1 pixel aspect ratio (PAR)
+#: xbmc/games/dialogs/osd/DialogGameStretchMode.cpp
+msgctxt "#35239"
+msgid "Integer (1:1 PAR)"
+msgstr ""
+
+#empty strings from id 35240 to 35248
 
 #. Button to open the savestate manager from the game OSD
 #: addons/skin.estuary/xml/GameOSD.xml

--- a/xbmc/cores/GameSettings.h
+++ b/xbmc/cores/GameSettings.h
@@ -34,14 +34,36 @@ enum class STRETCHMODE
   Normal,
 
   /*!
+   * \brief Show the game at 1:1 PAR
+   */
+  Normal1x1,
+
+  /*!
    * \brief Stretch the game to maintain a 4:3 aspect ratio
    */
   Stretch4x3,
 
   /*!
+   * \brief Stretch the game to maintain a 16:9 aspect ratio
+   */
+  Stretch16x9,
+
+  /*!
    * \brief Stretch the game to fill the viewing area
    */
   Fullscreen,
+
+  /*!
+   * \brief Stretch the game by multiplying the original vertical size
+   *        by an integer value while keeping the original PAR
+   */
+  Integer,
+
+  /*!
+   * \brief Stretch the game by multiplying the original pixel dimensions
+   *        by an integer value at 1:1 PAR
+   */
+  Integer1x1,
 
   /*!
    * \brief Show the game at its original size (humorous for old consoles
@@ -57,8 +79,12 @@ enum class STRETCHMODE
 };
 
 constexpr const char* STRETCHMODE_NORMAL_ID = "normal";
+constexpr const char* STRETCHMODE_NORMAL_1_1_ID = "normal1:1";
 constexpr const char* STRETCHMODE_STRETCH_4_3_ID = "4:3";
+constexpr const char* STRETCHMODE_STRETCH_16_9_ID = "16:9";
 constexpr const char* STRETCHMODE_FULLSCREEN_ID = "fullscreen";
+constexpr const char* STRETCHMODE_INTEGER_ID = "integer";
+constexpr const char* STRETCHMODE_INTEGER_1_1_ID = "integer1:1";
 constexpr const char* STRETCHMODE_ORIGINAL_ID = "original";
 constexpr const char* STRETCHMODE_ZOOM_ID = "zoom";
 

--- a/xbmc/cores/RetroPlayer/RetroPlayerUtils.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerUtils.cpp
@@ -17,10 +17,18 @@ const char* CRetroPlayerUtils::StretchModeToIdentifier(STRETCHMODE stretchMode)
   {
     case STRETCHMODE::Normal:
       return STRETCHMODE_NORMAL_ID;
+    case STRETCHMODE::Normal1x1:
+      return STRETCHMODE_NORMAL_1_1_ID;
     case STRETCHMODE::Stretch4x3:
       return STRETCHMODE_STRETCH_4_3_ID;
+    case STRETCHMODE::Stretch16x9:
+      return STRETCHMODE_STRETCH_16_9_ID;
     case STRETCHMODE::Fullscreen:
       return STRETCHMODE_FULLSCREEN_ID;
+    case STRETCHMODE::Integer:
+      return STRETCHMODE_INTEGER_ID;
+    case STRETCHMODE::Integer1x1:
+      return STRETCHMODE_INTEGER_1_1_ID;
     case STRETCHMODE::Original:
       return STRETCHMODE_ORIGINAL_ID;
     case STRETCHMODE::Zoom:
@@ -36,10 +44,18 @@ STRETCHMODE CRetroPlayerUtils::IdentifierToStretchMode(const std::string& stretc
 {
   if (stretchMode == STRETCHMODE_NORMAL_ID)
     return STRETCHMODE::Normal;
+  else if (stretchMode == STRETCHMODE_NORMAL_1_1_ID)
+    return STRETCHMODE::Normal1x1;
   else if (stretchMode == STRETCHMODE_STRETCH_4_3_ID)
     return STRETCHMODE::Stretch4x3;
+  else if (stretchMode == STRETCHMODE_STRETCH_16_9_ID)
+    return STRETCHMODE::Stretch16x9;
   else if (stretchMode == STRETCHMODE_FULLSCREEN_ID)
     return STRETCHMODE::Fullscreen;
+  else if (stretchMode == STRETCHMODE_INTEGER_ID)
+    return STRETCHMODE::Integer;
+  else if (stretchMode == STRETCHMODE_INTEGER_1_1_ID)
+    return STRETCHMODE::Integer1x1;
   else if (stretchMode == STRETCHMODE_ORIGINAL_ID)
     return STRETCHMODE::Original;
   else if (stretchMode == STRETCHMODE_ZOOM_ID)

--- a/xbmc/cores/RetroPlayer/rendering/RenderUtils.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderUtils.h
@@ -26,7 +26,6 @@ public:
                                    unsigned int sourceHeight,
                                    float screenWidth,
                                    float screenHeight,
-                                   float displayAspectRatio,
                                    float& pixelRatio,
                                    float& zoomAmount);
 

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
@@ -169,10 +169,11 @@ void CRPBaseRenderer::ManageRenderArea(const IRenderBuffer& renderBuffer)
   const unsigned int sourceHeight = renderBuffer.GetHeight();
   const unsigned int sourceRotationDegCCW = renderBuffer.GetRotation();
   const float sourceFrameRatio = static_cast<float>(sourceWidth) / static_cast<float>(sourceHeight);
-  // The frame may specify a display aspect ratio to account for non-square pixels
-  const float frameAspectRatio = (renderBuffer.GetDisplayAspectRatio() > 0.0f)
-                                     ? renderBuffer.GetDisplayAspectRatio()
-                                     : sourceFrameRatio;
+  // The frame may specify a display aspect ratio to account for non-square pixels. Otherwise
+  // assume square pixels.
+  const float framePixelRatio = (renderBuffer.GetDisplayAspectRatio() > 0.0f)
+                                    ? renderBuffer.GetDisplayAspectRatio() / sourceFrameRatio
+                                    : 1.0f;
 
   const STRETCHMODE stretchMode = m_renderSettings.VideoSettings().GetRenderStretchMode();
   const unsigned int rotationDegCCW =
@@ -189,15 +190,14 @@ void CRPBaseRenderer::ManageRenderArea(const IRenderBuffer& renderBuffer)
   const CRect viewRect = m_context.GetViewWindow();
 
   // Calculate pixel ratio and zoom amount
-  float pixelRatio = 1.0f;
+  float pixelRatio = framePixelRatio;
   float zoomAmount = 1.0f;
   CRenderUtils::CalculateStretchMode(stretchMode, rotationDegCCW, sourceWidth, sourceHeight,
-                                     screenWidth, screenHeight, frameAspectRatio, pixelRatio,
-                                     zoomAmount);
+                                     screenWidth, screenHeight, pixelRatio, zoomAmount);
 
   // Calculate destination dimensions
   CRect destRect;
-  CRenderUtils::CalcNormalRenderRect(viewRect, frameAspectRatio * pixelRatio, zoomAmount, destRect);
+  CRenderUtils::CalcNormalRenderRect(viewRect, sourceFrameRatio * pixelRatio, zoomAmount, destRect);
 
   m_sourceRect.x1 = 0.0f;
   m_sourceRect.y1 = 0.0f;

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
@@ -95,8 +95,8 @@ void CShaderPreset::SetVideoSize(unsigned int videoWidth, unsigned int videoHeig
 
 bool CShaderPreset::SetShaderPreset(const std::string& shaderPresetPath)
 {
-  m_bPresetNeedsUpdate = true;
   m_presetPath = shaderPresetPath;
+  m_bPresetNeedsUpdate = true;
   return Update();
 }
 
@@ -159,13 +159,6 @@ bool CShaderPreset::Update()
   return true;
 }
 
-void CShaderPreset::UpdateViewPort()
-{
-  CRect viewPort;
-  m_context.GetViewPort(viewPort);
-  UpdateViewPort(viewPort);
-}
-
 void CShaderPreset::UpdateViewPort(CRect viewPort)
 {
   const float2 currentViewPortSize = {viewPort.Width(), viewPort.Height()};
@@ -173,7 +166,6 @@ void CShaderPreset::UpdateViewPort(CRect viewPort)
   {
     m_outputSize = currentViewPortSize;
     m_bPresetNeedsUpdate = true;
-    Update();
   }
 }
 
@@ -187,18 +179,10 @@ void CShaderPreset::PrepareParameters(const CPoint dest[],
                                       IShaderTexture& source,
                                       IShaderTexture& target)
 {
-  if (m_dest[0] != dest[0] || m_dest[1] != dest[1] || m_dest[2] != dest[2] ||
-      m_dest[3] != dest[3] || target.GetWidth() != m_outputSize.x ||
-      target.GetHeight() != m_outputSize.y)
+  if (m_dest[0] != dest[0] || m_dest[1] != dest[1] || m_dest[2] != dest[2] || m_dest[3] != dest[3])
   {
     for (size_t i = 0; i < 4; ++i)
       m_dest[i] = dest[i];
-
-    m_outputSize = {target.GetWidth(), target.GetHeight()};
-
-    // Update projection matrix and update video shaders
-    UpdateMVPs();
-    UpdateViewPort();
   }
 
   const unsigned int numPasses = static_cast<unsigned int>(m_pShaders.size());

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.h
@@ -58,7 +58,6 @@ protected:
 
   // Helper functions
   bool Update();
-  void UpdateViewPort();
   void UpdateViewPort(CRect viewPort);
   void UpdateMVPs();
   void PrepareParameters(const CPoint dest[], IShaderTexture& source, IShaderTexture& target);

--- a/xbmc/games/dialogs/osd/DialogGameStretchMode.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameStretchMode.cpp
@@ -24,10 +24,14 @@ using namespace GAME;
 const std::vector<CDialogGameStretchMode::StretchModeProperties>
     CDialogGameStretchMode::m_allStretchModes = {
         {630, RETRO::STRETCHMODE::Normal},
+        {35237, RETRO::STRETCHMODE::Normal1x1},
         //  { 631,   RETRO::STRETCHMODE::Zoom }, //! @todo RetroArch allows trimming some outer
         //  pixels
         {632, RETRO::STRETCHMODE::Stretch4x3},
+        {634, RETRO::STRETCHMODE::Stretch16x9},
         {35232, RETRO::STRETCHMODE::Fullscreen},
+        {35238, RETRO::STRETCHMODE::Integer},
+        {35239, RETRO::STRETCHMODE::Integer1x1},
         {635, RETRO::STRETCHMODE::Original},
 };
 
@@ -52,12 +56,16 @@ void CDialogGameStretchMode::PreInit()
     switch (stretchMode.stretchMode)
     {
       case RETRO::STRETCHMODE::Normal:
+      case RETRO::STRETCHMODE::Normal1x1:
       case RETRO::STRETCHMODE::Original:
         bSupported = true;
         break;
 
       case RETRO::STRETCHMODE::Stretch4x3:
+      case RETRO::STRETCHMODE::Stretch16x9:
       case RETRO::STRETCHMODE::Fullscreen:
+      case RETRO::STRETCHMODE::Integer:
+      case RETRO::STRETCHMODE::Integer1x1:
         if (m_gameVideoHandle)
         {
           bSupported = m_gameVideoHandle->SupportsRenderFeature(RETRO::RENDERFEATURE::STRETCH) ||


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR adds integer scaling support back to RetroPlayer. There are also 2 new stretch modes and some minor cleanups and improvements included.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The original integer scaling support in RetroPlayer was broken and limited to Intel GPUs only and also limited to 1:1 PAR, so it was decided to be removed in https://github.com/xbmc/xbmc/pull/26906. This PR reintroduces integer scaling support, which should work for all supported platforms and which can also utilize the game client provided aspect ratio introduced in https://github.com/xbmc/xbmc/pull/26923.

Apart from the integer scaling support this PR includes following changes:
- Changes to _CRenderUtils::CalculateStretchMode()_ function. Instead of passing _pixelRatio = 1.0_ and using it as a magic constant to modify the _displayAspectRatio_, we now compute the real _pixelRatio_ and pass it to the _CalculateStretchMode()_ instead of _displayAspectRatio_. It makes the code cleaner and it makes it easier to calculate the parameters needed for the integer scaling and for the 1:1 PAR modes.

- Fix for the _Stretch 4:3_ mode when rotated.

- Cleanups for video shaders code related to viewport and scaling changes.

The new integer scaling can be used with any video filter including the video shader presets, however, while testing this, I've found a new issue in the video shaders code. The issue is not directly related to this PR and in general, it affects all stretch modes except the _Fullscreen_, but it is most visible when the output height does not match the screen height, e.g. when using the integer scaling. The affected video shader profiles from our default selection are _CRT Glow Lanczos_ and _PSP Color_. I've found the cause for this and I am working on a fix. It can be included in this PR later or I can create a separate PR for it.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Linux / Wayland / OpenGL build.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
There are 4 new scaling methods added to options:
- **Normal (1:1 PAR)** - This is the same as _Normal_ used to be before https://github.com/xbmc/xbmc/pull/26923, so it is like _Normal_ with forced 1:1 PAR. It is useful for games with broken aspect ratio by design.

- **Stretch 16:9** - Useful for 16:9 games on non-16:9 screens. There are PSX games with native 16:9 support (e.g. Worms World Party). For such games the emulators usually report 4:3 aspect ratio, which is wrong, so the _Normal_ mode doesn't work. If you are using a non-16:9 screen (e.g. like this laptop with 16:10), then the _Fullscreen_ mode is not correct either, so you need the _Stretch 16:9_ mode.

- **Integer** - This is the integer underscaling mode, which multiplies the height of the source by an integer factor and then computes the width to keep the aspect ratio provided by the game client.

- **Integer (1:1 PAR)** - This is integer underscaling mode, which forces 1:1 PAR, so both width and height of the source are multiplied by the integer factor.

Also, the **Stretch 4:3** mode is now usable when rotated.

## Screenshots (if appropriate):
The first screenshot shows the regular integer scaling mode with the PAR provided by the game client:
![scaling_integer_kodi_01](https://github.com/user-attachments/assets/212ed156-781c-449e-80a8-a162b336159f)

This picture shows an example of a game where the forced **1:1 PAR** is needed. Note, how the _Normal_ mode is stretched to 4:3 for this game. You can tell that 1:1 PAR is the correct aspect ratio by looking at the crosshair (it should be a circle):
![scaling_kodi_03](https://github.com/user-attachments/assets/f584895a-6615-479f-baa8-8226ca3597d6)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
