### PR TITLE
[Bluray] fix build ENABLE_BLURAY=NO && ENABLE_OPTICAL=YES

### DIFF
--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -642,7 +642,9 @@ bool CMediaManager::HasMediaBlurayPlaylist(const std::string& devicePath)
 
 void CMediaManager::ResetBlurayPlaylistStatus()
 {
+#ifdef HAVE_LIBBLURAY
   m_hasBlurayPlaylist = HasBlurayPlaylist::UNKNOWN;
+#endif
 }
 
 std::string CMediaManager::GetDiscPath()


### PR DESCRIPTION
## Description
by coincidence i stumbled across another build error when `ENABLE_BLURAY=NO` and `ENABLE_OPTICAL=YES` which is a valid combination.

```
[ 98%] Built target utils
/home/fhw/xbmc/xbmc/storage/MediaManager.cpp: In member function ‘void CMediaManager::ResetBlurayPlaylistStatus()’:
/home/fhw/xbmc/xbmc/storage/MediaManager.cpp:645:3: error: ‘m_hasBlurayPlaylist’ was not declared in this scope; did you mean ‘HasBlurayPlaylist’?
  645 |   m_hasBlurayPlaylist = HasBlurayPlaylist::UNKNOWN;
      |   ^~~~~~~~~~~~~~~~~~~
      |   HasBlurayPlaylist
gmake[2]: *** [build/storage/CMakeFiles/storage.dir/build.make:90: build/storage/CMakeFiles/storage.dir/MediaManager.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:10491: build/storage/CMakeFiles/storage.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```

let's wrap it in `ifdef HAVE_LIBBLURAY` so `CMediaManager::ResetBlurayPlaylistStatus()` will just do nothing.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

