### PR TITLE
RetroPlayer: Fix video shaders scaling

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
@@ -183,7 +183,7 @@ void CRPBaseRenderer::ManageRenderArea(const IRenderBuffer& renderBuffer)
   float screenPixelRatio;
   GetScreenDimensions(screenWidth, screenHeight, screenPixelRatio);
 
-  // Entire target rendering area for the video (including black bars)
+  // Get target rendering area for the game view window (including black bars)
   const CRect viewRect = m_context.GetViewWindow();
 
   // Calculate pixel ratio and zoom amount
@@ -192,9 +192,41 @@ void CRPBaseRenderer::ManageRenderArea(const IRenderBuffer& renderBuffer)
   CRenderUtils::CalculateStretchMode(stretchMode, rotationDegCCW, sourceWidth, sourceHeight,
                                      screenWidth, screenHeight, pixelRatio, zoomAmount);
 
-  // Calculate destination dimensions
+  // Calculate destination rectangle for the game view window
   CRect destRect;
   CRenderUtils::CalcNormalRenderRect(viewRect, sourceFrameRatio * pixelRatio, zoomAmount, destRect);
+
+  // Calculate destination rectangle size for the fullscreen game window (needed for video shaders)
+  CRect fullDestRect;
+  CRect viewPort;
+  m_context.GetViewPort(viewPort);
+
+  if (viewPort == viewRect)
+  {
+    fullDestRect = destRect;
+  }
+  else
+  {
+    CRenderUtils::CalcNormalRenderRect(viewPort, sourceFrameRatio * pixelRatio, zoomAmount,
+                                       fullDestRect);
+  }
+
+  switch (rotationDegCCW)
+  {
+    case 90:
+    case 270:
+    {
+      m_fullDestWidth = fullDestRect.Height();
+      m_fullDestHeight = fullDestRect.Width();
+      break;
+    }
+    default:
+    {
+      m_fullDestWidth = fullDestRect.Width();
+      m_fullDestHeight = fullDestRect.Height();
+      break;
+    }
+  }
 
   m_sourceRect.x1 = 0.0f;
   m_sourceRect.y1 = 0.0f;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
@@ -95,6 +95,8 @@ protected:
 
   // Geometry properties
   CRect m_sourceRect;
+  float m_fullDestWidth{0.0f};
+  float m_fullDestHeight{0.0f};
   ViewportCoordinates m_rotatedDestCoords{};
 
   // Video shaders

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
@@ -55,6 +55,8 @@ CRPRendererDMAOpenGL::CRPRendererDMAOpenGL(const CRenderSettings& renderSettings
 
 void CRPRendererDMAOpenGL::Render(uint8_t alpha)
 {
+  const ViewportCoordinates dest{m_rotatedDestCoords};
+
   auto renderBuffer = static_cast<CRenderBufferDMA*>(m_renderBuffer);
   assert(renderBuffer != nullptr);
 
@@ -97,11 +99,9 @@ void CRPRendererDMAOpenGL::Render(uint8_t alpha)
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    const ViewportCoordinates destPoints{m_rotatedDestCoords};
-
     SHADER::CShaderTextureGL source(sourceTexture, false);
     SHADER::CShaderTextureGL target(targetTexture, false);
-    if (!m_shaderPreset->RenderUpdate(destPoints, source, target))
+    if (!m_shaderPreset->RenderUpdate(dest, {m_fullDestWidth, m_fullDestHeight}, source, target))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
@@ -55,6 +55,8 @@ CRPRendererDMAOpenGLES::CRPRendererDMAOpenGLES(const CRenderSettings& renderSett
 
 void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
 {
+  const ViewportCoordinates dest{m_rotatedDestCoords};
+
   auto renderBuffer = static_cast<CRenderBufferDMA*>(m_renderBuffer);
   assert(renderBuffer != nullptr);
 
@@ -97,11 +99,9 @@ void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    const ViewportCoordinates destPoints{m_rotatedDestCoords};
-
     SHADER::CShaderTextureGLES source(sourceTexture, false);
     SHADER::CShaderTextureGLES target(targetTexture, false);
-    if (!m_shaderPreset->RenderUpdate(destPoints, source, target))
+    if (!m_shaderPreset->RenderUpdate(dest, {m_fullDestWidth, m_fullDestHeight}, source, target))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -274,8 +274,9 @@ void CRPRendererOpenGL::DrawBlackBars()
 
 void CRPRendererOpenGL::Render(uint8_t alpha)
 {
-  CRenderBufferOpenGL* renderBuffer = static_cast<CRenderBufferOpenGL*>(m_renderBuffer);
+  const ViewportCoordinates dest{m_rotatedDestCoords};
 
+  auto renderBuffer = static_cast<CRenderBufferOpenGL*>(m_renderBuffer);
   if (renderBuffer == nullptr)
     return;
 
@@ -318,11 +319,9 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    const ViewportCoordinates destPoints{m_rotatedDestCoords};
-
     SHADER::CShaderTextureGL source(sourceTexture, false);
     SHADER::CShaderTextureGL target(targetTexture, false);
-    if (!m_shaderPreset->RenderUpdate(destPoints, source, target))
+    if (!m_shaderPreset->RenderUpdate(dest, {m_fullDestWidth, m_fullDestHeight}, source, target))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -246,8 +246,9 @@ void CRPRendererOpenGLES::DrawBlackBars()
 
 void CRPRendererOpenGLES::Render(uint8_t alpha)
 {
-  CRenderBufferOpenGLES* renderBuffer = static_cast<CRenderBufferOpenGLES*>(m_renderBuffer);
+  const ViewportCoordinates dest{m_rotatedDestCoords};
 
+  auto renderBuffer = static_cast<CRenderBufferOpenGLES*>(m_renderBuffer);
   if (renderBuffer == nullptr)
     return;
 
@@ -290,11 +291,9 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    const ViewportCoordinates destPoints{m_rotatedDestCoords};
-
     SHADER::CShaderTextureGLES source(sourceTexture, false);
     SHADER::CShaderTextureGLES target(targetTexture, false);
-    if (!m_shaderPreset->RenderUpdate(destPoints, source, target))
+    if (!m_shaderPreset->RenderUpdate(dest, {m_fullDestWidth, m_fullDestHeight}, source, target))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
@@ -295,9 +295,9 @@ bool CRPWinRenderer::SupportsScalingMethod(SCALINGMETHOD method)
 
 void CRPWinRenderer::Render(CD3DTexture& target)
 {
-  const ViewportCoordinates destPoints{m_rotatedDestCoords};
+  const ViewportCoordinates dest{m_rotatedDestCoords};
 
-  CWinRenderBuffer* renderBuffer = static_cast<CWinRenderBuffer*>(m_renderBuffer);
+  auto renderBuffer = static_cast<CWinRenderBuffer*>(m_renderBuffer);
   if (renderBuffer == nullptr)
     return;
 
@@ -310,29 +310,11 @@ void CRPWinRenderer::Render(CD3DTexture& target)
   // Use video shader preset
   if (m_bUseShaderPreset)
   {
-    //! @todo Orientation?
-    /*
-    ViewportCoordinates destPoints = {};
-    // select destination rectangle
-    if (m_renderOrientation)
-    {
-      for (size_t i = 0; i < 4; ++i)
-        destPoints[i] = m_rotatedDestCoords[i];
-    }
-    else
-    {
-      CRect destRect = m_context.StereoCorrection(m_renderSettings.Geometry().Dimensions());
-      destPoints[0] = { destRect.x1, destRect.y1 };
-      destPoints[1] = { destRect.x2, destRect.y1 };
-      destPoints[2] = { destRect.x2, destRect.y2 };
-      destPoints[3] = { destRect.x1, destRect.y2 };
-    }
-    */
-
     SHADER::CShaderTextureDXRef targetTexture{target};
 
     // Render shaders and ouput to display
-    if (!m_shaderPreset->RenderUpdate(destPoints, *renderBufferTarget, targetTexture))
+    if (!m_shaderPreset->RenderUpdate(dest, {m_fullDestWidth, m_fullDestHeight},
+                                      *renderBufferTarget, targetTexture))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;
@@ -355,7 +337,7 @@ void CRPWinRenderer::Render(CD3DTexture& target)
     // Use the picked output shader to render to the target
     if (outputShader != nullptr)
     {
-      outputShader->Render(intermediateTarget, m_sourceRect, destPoints, viewPort, target,
+      outputShader->Render(intermediateTarget, m_sourceRect, dest, viewPort, target,
                            m_context.UseLimitedColor() ? 1 : 0);
     }
   }

--- a/xbmc/cores/RetroPlayer/shaders/IShader.h
+++ b/xbmc/cores/RetroPlayer/shaders/IShader.h
@@ -33,7 +33,6 @@ public:
    * \param shaderPath Full path to the shader file
    * \param shaderParameters Struct with all parameters pertaining to the shader
    * \param luts Look-up textures pertaining to the shader
-   * \param viewPortSize Size of the window/viewport
    * \param passIdx Index of the video shader pass
    * \param frameCountMod Modulo applied to the frame count before sendign it to the shader
    *
@@ -43,7 +42,6 @@ public:
                       std::string shaderPath,
                       ShaderParameterMap shaderParameters,
                       std::vector<std::shared_ptr<IShaderLut>> luts,
-                      float2 viewPortSize,
                       unsigned int passIdx,
                       unsigned int frameCountMod = 0) = 0;
 
@@ -72,7 +70,8 @@ public:
    * Updates any internal state needed to ensure that correct data is passed to
    * the shader when rendering.
    *
-   * \param dest Coordinates of the 4 corners of the output viewport/window
+   * \param dest Coordinates of the 4 corners of the destination rectangle
+   * \param fullDestSize Destination rectangle size for the fullscreen game window
    * \param sourceTexture Source texture of the first shader pass
    * \param pShaderTextures Intermediate textures used for all shader passes
    * \param pShaders All shader passes
@@ -80,6 +79,7 @@ public:
    */
   virtual void PrepareParameters(
       const RETRO::ViewportCoordinates& dest,
+      const float2 fullDestSize,
       IShaderTexture& sourceTexture,
       const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
       const std::vector<std::unique_ptr<IShader>>& pShaders,

--- a/xbmc/cores/RetroPlayer/shaders/IShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/shaders/IShaderPreset.h
@@ -38,13 +38,15 @@ public:
   /*!
    * \brief Updates state if needed and renderes the preset to the target texture
    *
-   * \param dest Coordinates of the 4 corners of the output viewport/window
+   * \param dest Coordinates of the 4 corners of the destination rectangle
+   * \param fullDestSize Destination rectangle size for the fullscreen game window
    * \param source The source of the video frame, in its original resolution (unscaled)
    * \param target The target texture that the final result will be rendered to
    *
    * \return Returns false if updating or rendering failed, true if both succeeded
    */
   virtual bool RenderUpdate(const RETRO::ViewportCoordinates& dest,
+                            const float2 fullDestSize,
                             IShaderTexture& source,
                             IShaderTexture& target) = 0;
 

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.h
@@ -41,6 +41,7 @@ public:
   // Implementation of IShaderPreset
   bool ReadPresetFile(const std::string& presetPath) override;
   bool RenderUpdate(const RETRO::ViewportCoordinates& dest,
+                    const float2 fullDestSize,
                     IShaderTexture& source,
                     IShaderTexture& target) override;
   void SetSpeed(double speed) override { m_speed = speed; }
@@ -60,10 +61,14 @@ protected:
 
   // Helper functions
   bool Update();
-  void UpdateViewPort(CRect viewPort);
+  void UpdateViewPort(CRect viewPort, const float2 fullDestSize);
   void UpdateMVPs();
   void PrepareParameters(const RETRO::ViewportCoordinates& dest, IShaderTexture& source);
+  void CalculateScaledSize(const KODI::SHADER::ShaderPass& pass,
+                           const float2& prevSize,
+                           float2& scaledSize);
   void DisposeShaders();
+  void DisposeShaderTextures();
   bool HasPathFailed(const std::string& path) const;
   ShaderParameterMap GetShaderParameters(const std::vector<ShaderParameter>& parameters,
                                          const std::string& sourceStr) const;
@@ -91,17 +96,20 @@ protected:
   // Was the shader preset changed during the last frame?
   bool m_bPresetNeedsUpdate = true;
 
-  // Size of the viewport
+  // Resolution of the output viewport
   float2 m_outputSize;
+
+  // Resolution of the destination rectangle for the fullscreen game window
+  float2 m_fullDestSize;
 
   // Size of the actual source video data (ie. 160x144 for the Game Boy)
   float2 m_videoSize;
 
   // Number of frames that have passed
-  float m_frameCount = 0.0f;
+  float m_frameCount{0.0f};
 
   // Playback speed
-  double m_speed = 1.0;
+  double m_speed{1.0};
 };
 
 } // namespace SHADER

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
@@ -34,7 +34,6 @@ bool CShaderGL::Create(std::string shaderSource,
                        std::string shaderPath,
                        ShaderParameterMap shaderParameters,
                        std::vector<std::shared_ptr<IShaderLut>> luts,
-                       float2 viewPortSize,
                        unsigned int passIdx,
                        unsigned int frameCountMod)
 {
@@ -48,7 +47,6 @@ bool CShaderGL::Create(std::string shaderSource,
   m_shaderPath = std::move(shaderPath);
   m_shaderParameters = std::move(shaderParameters);
   m_luts = std::move(luts);
-  m_viewportSize = viewPortSize;
   m_passIdx = passIdx;
   m_frameCountMod = frameCountMod;
   m_shaderProgram = glCreateProgram();
@@ -193,6 +191,7 @@ void CShaderGL::SetSizes(const float2& prevSize,
 
 void CShaderGL::PrepareParameters(
     const RETRO::ViewportCoordinates& dest,
+    const float2 fullDestSize,
     IShaderTexture& sourceTexture,
     const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
     const std::vector<std::unique_ptr<IShader>>& pShaders,
@@ -232,7 +231,7 @@ void CShaderGL::PrepareParameters(
     m_VertexCoords[3][1] = dest[0].y - m_outputSize.y / 2;
 
     // Set destination rectangle size for the last pass
-    m_destSize = {dest[2].x - dest[0].x, dest[2].y - dest[0].y};
+    m_destSize = fullDestSize;
   }
 
   // bottom left z, tu, tv, r, g, b

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
@@ -29,7 +29,6 @@ public:
               std::string shaderPath,
               ShaderParameterMap shaderParameters,
               std::vector<std::shared_ptr<IShaderLut>> luts,
-              float2 viewPortSize,
               unsigned int passIdx,
               unsigned int frameCountMod = 0) override;
   void Render(IShaderTexture& source, IShaderTexture& target) override;
@@ -37,6 +36,7 @@ public:
                 const float2& prevTextureSize,
                 const float2& nextSize) override;
   void PrepareParameters(const RETRO::ViewportCoordinates& dest,
+                         const float2 fullDestSize,
                          IShaderTexture& sourceTexture,
                          const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
                          const std::vector<std::unique_ptr<IShader>>& pShaders,
@@ -94,9 +94,6 @@ private:
   // Resolution of the destination rectangle of the shader
   float2 m_destSize;
 
-  // Resolution of the viewport/window
-  float2 m_viewportSize;
-
   // Projection matrix
   std::array<std::array<GLfloat, 4>, 4> m_MVP;
 
@@ -124,8 +121,8 @@ private:
   GLint m_InputSizeLoc{-1};
   GLint m_MVPMatrixLoc{-1};
 
-  GLuint m_shaderVAO = GL_NONE;
+  GLuint m_shaderVAO{GL_NONE};
   std::array<GLuint, 3> m_shaderVertexVBO{GL_NONE};
-  GLuint m_shaderIndexVBO = GL_NONE;
+  GLuint m_shaderIndexVBO{GL_NONE};
 };
 } // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.cpp
@@ -56,8 +56,8 @@ bool CShaderPresetGL::CreateShaders()
     // Get only the parameters belonging to this specific shader
     ShaderParameterMap passParameters = GetShaderParameters(pass.parameters, pass.vertexSource);
 
-    if (!videoShader->Create(shaderSource, shaderPath, passParameters, passLUTsGL, m_outputSize,
-                             shaderIdx, pass.frameCountMod))
+    if (!videoShader->Create(shaderSource, shaderPath, passParameters, passLUTsGL, shaderIdx,
+                             pass.frameCountMod))
     {
       CLog::Log(LOGERROR, "CShaderPresetGL::CreateShaders: Couldn't create a video shader");
       return false;
@@ -88,36 +88,7 @@ bool CShaderPresetGL::CreateShaderTextures()
     // Resolve final texture resolution, taking scale type and scale multiplier into account
     float2 scaledSize;
     float2 textureSize;
-    switch (pass.fbo.scaleX.scaleType)
-    {
-      case ScaleType::ABSOLUTE_SCALE:
-        scaledSize.x = static_cast<float>(pass.fbo.scaleX.abs);
-        break;
-      case ScaleType::VIEWPORT:
-        scaledSize.x =
-            pass.fbo.scaleX.scale != 0.0f ? pass.fbo.scaleX.scale * m_outputSize.x : m_outputSize.x;
-        break;
-      case ScaleType::INPUT:
-      default:
-        scaledSize.x =
-            pass.fbo.scaleX.scale != 0.0f ? pass.fbo.scaleX.scale * prevSize.x : prevSize.x;
-        break;
-    }
-    switch (pass.fbo.scaleY.scaleType)
-    {
-      case ScaleType::ABSOLUTE_SCALE:
-        scaledSize.y = static_cast<float>(pass.fbo.scaleY.abs);
-        break;
-      case ScaleType::VIEWPORT:
-        scaledSize.y =
-            pass.fbo.scaleY.scale != 0.0f ? pass.fbo.scaleY.scale * m_outputSize.y : m_outputSize.y;
-        break;
-      case ScaleType::INPUT:
-      default:
-        scaledSize.y =
-            pass.fbo.scaleY.scale != 0.0f ? pass.fbo.scaleY.scale * prevSize.y : prevSize.y;
-        break;
-    }
+    CalculateScaledSize(pass, prevSize, scaledSize);
 
     if (shaderIdx + 1 == numPasses)
     {

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
@@ -32,7 +32,6 @@ bool CShaderGLES::Create(std::string shaderSource,
                          std::string shaderPath,
                          ShaderParameterMap shaderParameters,
                          std::vector<std::shared_ptr<IShaderLut>> luts,
-                         float2 viewPortSize,
                          unsigned int passIdx,
                          unsigned int frameCountMod)
 {
@@ -46,7 +45,6 @@ bool CShaderGLES::Create(std::string shaderSource,
   m_shaderPath = std::move(shaderPath);
   m_shaderParameters = std::move(shaderParameters);
   m_luts = std::move(luts);
-  m_viewportSize = viewPortSize;
   m_passIdx = passIdx;
   m_frameCountMod = frameCountMod;
   m_shaderProgram = glCreateProgram();
@@ -179,6 +177,7 @@ void CShaderGLES::SetSizes(const float2& prevSize,
 
 void CShaderGLES::PrepareParameters(
     const RETRO::ViewportCoordinates& dest,
+    const float2 fullDestSize,
     IShaderTexture& sourceTexture,
     const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
     const std::vector<std::unique_ptr<IShader>>& pShaders,
@@ -218,7 +217,7 @@ void CShaderGLES::PrepareParameters(
     m_VertexCoords[3][1] = dest[0].y - m_outputSize.y / 2;
 
     // Set destination rectangle size for the last pass
-    m_destSize = {dest[2].x - dest[0].x, dest[2].y - dest[0].y};
+    m_destSize = fullDestSize;
   }
 
   // bottom left z, tu, tv, r, g, b

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
@@ -29,7 +29,6 @@ public:
               std::string shaderPath,
               ShaderParameterMap shaderParameters,
               std::vector<std::shared_ptr<IShaderLut>> luts,
-              float2 viewPortSize,
               unsigned int passIdx,
               unsigned int frameCountMod = 0) override;
   void Render(IShaderTexture& source, IShaderTexture& target) override;
@@ -37,6 +36,7 @@ public:
                 const float2& prevTextureSize,
                 const float2& nextSize) override;
   void PrepareParameters(const RETRO::ViewportCoordinates& dest,
+                         const float2 fullDestSize,
                          IShaderTexture& sourceTexture,
                          const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
                          const std::vector<std::unique_ptr<IShader>>& pShaders,
@@ -94,9 +94,6 @@ private:
   // Resolution of the destination rectangle of the shader
   float2 m_destSize;
 
-  // Resolution of the viewport/window
-  float2 m_viewportSize;
-
   // Projection matrix
   std::array<std::array<GLfloat, 4>, 4> m_MVP;
 
@@ -125,6 +122,6 @@ private:
   GLint m_MVPMatrixLoc{-1};
 
   std::array<GLuint, 3> m_shaderVertexVBO{GL_NONE};
-  GLuint m_shaderIndexVBO = GL_NONE;
+  GLuint m_shaderIndexVBO{GL_NONE};
 };
 } // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.cpp
@@ -56,8 +56,8 @@ bool CShaderPresetGLES::CreateShaders()
     // Get only the parameters belonging to this specific shader
     ShaderParameterMap passParameters = GetShaderParameters(pass.parameters, pass.vertexSource);
 
-    if (!videoShader->Create(shaderSource, shaderPath, passParameters, passLUTsGL, m_outputSize,
-                             shaderIdx, pass.frameCountMod))
+    if (!videoShader->Create(shaderSource, shaderPath, passParameters, passLUTsGL, shaderIdx,
+                             pass.frameCountMod))
     {
       CLog::Log(LOGERROR, "CShaderPresetGLES::CreateShaders: Couldn't create a video shader");
       return false;
@@ -88,36 +88,7 @@ bool CShaderPresetGLES::CreateShaderTextures()
     // Resolve final texture resolution, taking scale type and scale multiplier into account
     float2 scaledSize;
     float2 textureSize;
-    switch (pass.fbo.scaleX.scaleType)
-    {
-      case ScaleType::ABSOLUTE_SCALE:
-        scaledSize.x = static_cast<float>(pass.fbo.scaleX.abs);
-        break;
-      case ScaleType::VIEWPORT:
-        scaledSize.x =
-            pass.fbo.scaleX.scale != 0.0f ? pass.fbo.scaleX.scale * m_outputSize.x : m_outputSize.x;
-        break;
-      case ScaleType::INPUT:
-      default:
-        scaledSize.x =
-            pass.fbo.scaleX.scale != 0.0f ? pass.fbo.scaleX.scale * prevSize.x : prevSize.x;
-        break;
-    }
-    switch (pass.fbo.scaleY.scaleType)
-    {
-      case ScaleType::ABSOLUTE_SCALE:
-        scaledSize.y = static_cast<float>(pass.fbo.scaleY.abs);
-        break;
-      case ScaleType::VIEWPORT:
-        scaledSize.y =
-            pass.fbo.scaleY.scale != 0.0f ? pass.fbo.scaleY.scale * m_outputSize.y : m_outputSize.y;
-        break;
-      case ScaleType::INPUT:
-      default:
-        scaledSize.y =
-            pass.fbo.scaleY.scale != 0.0f ? pass.fbo.scaleY.scale * prevSize.y : prevSize.y;
-        break;
-    }
+    CalculateScaledSize(pass, prevSize, scaledSize);
 
     if (shaderIdx + 1 == numPasses)
     {

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.cpp
@@ -35,7 +35,6 @@ bool CShaderDX::Create(std::string shaderSource,
                        std::string shaderPath,
                        ShaderParameterMap shaderParameters,
                        std::vector<std::shared_ptr<IShaderLut>> luts,
-                       float2 viewPortSize,
                        unsigned int passIdx,
                        unsigned int frameCountMod)
 {
@@ -49,7 +48,6 @@ bool CShaderDX::Create(std::string shaderSource,
   m_shaderPath = std::move(shaderPath);
   m_shaderParameters = std::move(shaderParameters);
   m_luts = std::move(luts);
-  m_viewportSize = viewPortSize;
   m_passIdx = passIdx;
   m_frameCountMod = frameCountMod;
   //m_pSampler = reinterpret_cast<ID3D11SamplerState*>(sampler);
@@ -107,6 +105,7 @@ void CShaderDX::SetSizes(const float2& prevSize,
 
 void CShaderDX::PrepareParameters(
     const RETRO::ViewportCoordinates& dest,
+    const float2 fullDestSize,
     IShaderTexture& sourceTexture,
     const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
     const std::vector<std::unique_ptr<IShader>>& pShaders,
@@ -149,7 +148,7 @@ void CShaderDX::PrepareParameters(
     v[3].y = dest[3].y - m_outputSize.y / 2;
 
     // Set destination rectangle size for the last pass
-    m_destSize = {dest[2].x - dest[0].x, dest[2].y - dest[0].y};
+    m_destSize = fullDestSize;
   }
 
   // top left

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.h
@@ -34,7 +34,6 @@ public:
               std::string shaderPath,
               ShaderParameterMap shaderParameters,
               std::vector<std::shared_ptr<IShaderLut>> luts,
-              float2 viewPortSize,
               unsigned int passIdx,
               unsigned int frameCountMod = 0) override;
   void Render(IShaderTexture& source, IShaderTexture& target) override;
@@ -42,6 +41,7 @@ public:
                 const float2& prevTextureSize,
                 const float2& nextSize) override;
   void PrepareParameters(const RETRO::ViewportCoordinates& dest,
+                         const float2 fullDestSize,
                          IShaderTexture& sourceTexture,
                          const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
                          const std::vector<std::unique_ptr<IShader>>& pShaders,
@@ -113,9 +113,6 @@ private:
 
   // Resolution of the destination rectangle of the shader
   float2 m_destSize;
-
-  // Resolution of the viewport/window
-  float2 m_viewportSize;
 
   // Projection matrix
   DirectX::XMFLOAT4X4 m_MVP{};

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.cpp
@@ -58,7 +58,7 @@ bool CShaderPresetDX::CreateShaders()
     ShaderParameterMap passParameters = GetShaderParameters(pass.parameters, pass.vertexSource);
 
     if (!videoShader->Create(shaderSource, shaderPath, std::move(passParameters),
-                             std::move(passLUTsDX), m_outputSize, shaderIdx, pass.frameCountMod))
+                             std::move(passLUTsDX), shaderIdx, pass.frameCountMod))
     {
       CLog::Log(LOGERROR, "CShaderPresetDX::CreateShaders: Couldn't create a video shader");
       return false;
@@ -126,41 +126,12 @@ bool CShaderPresetDX::CreateShaderTextures()
 
   for (unsigned int shaderIdx = 0; shaderIdx < numPasses; ++shaderIdx)
   {
-    const ShaderPass& pass = m_passes[shaderIdx];
+    const auto& pass = m_passes[shaderIdx];
 
     // Resolve final texture resolution, taking scale type and scale multiplier into account
     float2 scaledSize;
     float2 textureSize;
-    switch (pass.fbo.scaleX.scaleType)
-    {
-      case ScaleType::ABSOLUTE_SCALE:
-        scaledSize.x = static_cast<float>(pass.fbo.scaleX.abs);
-        break;
-      case ScaleType::VIEWPORT:
-        scaledSize.x =
-            pass.fbo.scaleX.scale != 0.0f ? pass.fbo.scaleX.scale * m_outputSize.x : m_outputSize.x;
-        break;
-      case ScaleType::INPUT:
-      default:
-        scaledSize.x =
-            pass.fbo.scaleX.scale != 0.0f ? pass.fbo.scaleX.scale * prevSize.x : prevSize.x;
-        break;
-    }
-    switch (pass.fbo.scaleY.scaleType)
-    {
-      case ScaleType::ABSOLUTE_SCALE:
-        scaledSize.y = static_cast<float>(pass.fbo.scaleY.abs);
-        break;
-      case ScaleType::VIEWPORT:
-        scaledSize.y =
-            pass.fbo.scaleY.scale != 0.0f ? pass.fbo.scaleY.scale * m_outputSize.y : m_outputSize.y;
-        break;
-      case ScaleType::INPUT:
-      default:
-        scaledSize.y =
-            pass.fbo.scaleY.scale != 0.0f ? pass.fbo.scaleY.scale * prevSize.y : prevSize.y;
-        break;
-    }
+    CalculateScaledSize(pass, prevSize, scaledSize);
 
     if (shaderIdx + 1 == numPasses)
     {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR aims to fix 3 remaining scaling issues in the video shaders code:
1. Video shader presets, in which at least one shader pass is using the viewport scaling, are not displayed properly, when the stretch mode is set to anything else but the _Fullscreen_.
2. Almost none of the video shader presets are usable when rotated.
3. Thumbnails are not rendered correctly (mostly for presets, which use absolute positioning).

I will add screenshots for each of the issues.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I'm going to use a picture for better understanding of the cause for the issues:

<img width="1920" height="1200" alt="scaling_integer_kodi_01" src="https://github.com/user-attachments/assets/35caa6f2-d1ad-4815-a613-e2253f021dbc" />

For a reference, these are the variable names, which are being used through out the code, mapped to the rectangles in the picture:
_viewPort_ - is always the big red rectangle, even when rendering the thumbnail
_viewRect_ - is the red rectangle (the small one, if rendering thumbnail, for the main game window the _viewRect_ = _viewPort_)
_destRect_ - is the green rectangle (the small one, if rendering thumbnail)

The video shader preset can specify `scale_type = viewport` for individual shader passes. In such case, it expects to get the size of the green rectangle (we should create a texture of that size and render the pass to it). However, we are currently using the size of the big red rectangle (_m_outputSize = viewPort_) here:
https://github.com/xbmc/xbmc/blob/495b3e84360da0a3727053ea599a6038b8d9534e/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.cpp#L98
The output then gets scaled down to the green rectangle in the last shader pass and that's where the issue comes from.

For the main game window it is easy to fix. We can simply pass the size of the green rectangle to the preset and use it instead of the red one. We just need to "un-rotate" it, because the _destRect_ is already rotated, but the video shader needs the size before rotation.

It gets more tricky when rendering the live thumbnails. For the thumbnails, we want to pass the size of the big green rectangle instead of the small one.
There are more reasons for this:
- We get better looking thumbnails. If we pass the size of the small rectangle, the output of the shader is different (the difference can be huge for some presets, see the screenshots).
- We don't want to be re-creating the shader pass textures between rendering of the main window and the thumbnail for performance reasons (we don't want to call _CShaderPreset::Update()_ with _m_bPresetNeedsUpdate_ set to _true_ twice per frame).

This can be done. We can compute the size of the big green rectangle even when rendering the small thumbnail (in such case we need to compute both the small and big green rectangles, they are going to be the same when rendering the fullscreen game window).

I've already tried this and it works nicely for the _Video filter_ selection screen. Thumbnails look good, all video shaders in the fullscreen window are rendered correctly (even rotated) and no _CShaderPreset::Update()_ calls between frames are needed, so the performance is also good.

However, this solution doesn't work nice when rendering the _Stretch mode_ and _Rotation_ selection screens with thumbnails, because there are different green rectangle sizes for each of the thumbnails, so we need to re-create the shader textures for each of the thumbnails. Even if we optimize the _CShaderPreset::Update()_ function to only re-create the textures (we don't need to recompile the shader programs), it will probably still be a performance issue (we should do this optimization nevertheless).

So the question is, what do we want to do?

I can think of more possible solutions:
1. Remove live thumbnails for the _Stretch mode_ and _Rotation_ screens. We can simply replace them with the default video icon. The content is exactly the same for all thumbnails for these screens, they are only used for representing changes in orientation and size, so in some cases the icon can be even better then the real image. In such case we would keep live thumbnails for the _Video filter_ screen and for save states, which should work nice and makes sense.

2. Another possible solution would be to create individual _CShaderPreset_ objects for each of the views / thumbnails and avoid re-using of the same preset object for rendering of the main window and each of the thumbnails. This way each thumbnail would have each own preset with each own textures with individual parameters, which don't need to be changed during rendering. But this solution would possibly require changes in the design beyond my capabilities.

3. This would be a trade-off solution. We can initialize the target size of the shader with the full viewport size and then only update it, if we are rendering the fullscreen game window. This way we make sure that the main game screen is always rendered correctly for all stretch modes and even for all rotated modes, we also get no _CShaderPreset::Update()_ calls initiated by rendering of a thumbnail, so no performance issues, but we sacrifice the quality of thumbnails for video shader presets, because they are going to be rendered with wrong sizes internally and then stretched to the final destination rectangle. The difference is not visible for every preset, but for some of them the result is very strange and what you see on the thumbnail, is not what you actually get, when you select it, because in that moment the sizes are updated by the main window and the thumbnail is changed.

The solution 3 is implemented by the current commit, because I wanted to test, how it would work. You can try it yourself. All shaders should be rendered correctly in the main game window now (including when rotated), but the thumbnails are not. To test the most weird behavior, select one of the last 3 shader presets and try changing the stretch mode.

The code currently work for both OpenGL and GLES, but the Windows version is not completed yet.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):
The sceenshots show the 3 issues in the current master compared to the desired look after this PR.

Broken scaling of video shader presets, which are using the viewport scaling. In this case the _CRT Glow Lanczos_ used with _Integer_ scaling (note how the CRT scanlines are distorted):
<img width="1920" height="1200" alt="screenshot00002" src="https://github.com/user-attachments/assets/7df720c7-f45b-4685-8e52-5470fc32f88b" />
And the correct version after this PR:
<img width="1920" height="1200" alt="screenshot00010" src="https://github.com/user-attachments/assets/9aa97e7d-ea41-4c2a-8ed8-d350b1bec962" />

Wrong scaling of almost any shader when rotated. In this case rotated _CRT EasyMode Halation_:
<img width="1920" height="1200" alt="screenshot00007" src="https://github.com/user-attachments/assets/7f6b6334-9e8f-46fe-9ec9-9c327ec48d6a" />
And the correct version after this PR:
<img width="1920" height="1200" alt="screenshot00008" src="https://github.com/user-attachments/assets/ee6b69d2-83e1-4ff4-aa09-dc83e4d29941" />

Bad thumbnails for the last 3 shaders + broken _PSP Color_ preset:
<img width="1920" height="1200" alt="screenshot00004" src="https://github.com/user-attachments/assets/1b18acb9-35aa-489e-becc-a24e0af1fdea" />
And the correct version after this PR:
<img width="1920" height="1200" alt="screenshot00011" src="https://github.com/user-attachments/assets/52a9fcb9-3f4d-455a-b403-aca30a35eaa7" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
