### PR TITLE
[addons] Fix scraper contenttype logging

### DIFF
--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -936,7 +936,7 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl,
 
   CLog::LogF(LOGDEBUG,
              "Searching for '{}' using {} scraper (path: '{}', content: '{}', version: '{}')",
-             sTitle, Name(), Path(), ADDON::TranslateContent(Content()), Version().asString());
+             sTitle, Name(), Path(), Content(), Version().asString());
 
   std::vector<CScraperUrl> vcscurl;
   if (IsNoop())
@@ -1077,8 +1077,7 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl,
 {
   CLog::LogF(LOGDEBUG,
              "Searching for '{} - {}' using {} scraper (path: '{}', content: '{}', version: '{}')",
-             sArtist, sAlbum, Name(), Path(), ADDON::TranslateContent(Content()),
-             Version().asString());
+             sArtist, sAlbum, Name(), Path(), Content(), Version().asString());
 
   std::vector<CMusicAlbumInfo> vcali;
   if (IsNoop())
@@ -1177,7 +1176,7 @@ std::vector<CMusicArtistInfo> CScraper::FindArtist(CCurlFile &fcurl, const std::
 {
   CLog::LogF(LOGDEBUG,
              "Searching for '{}' using {} scraper (file: '{}', content: '{}', version: '{}')",
-             sArtist, Name(), Path(), ADDON::TranslateContent(Content()), Version().asString());
+             sArtist, Name(), Path(), Content(), Version().asString());
 
   std::vector<CMusicArtistInfo> vcari;
   if (IsNoop())
@@ -1265,8 +1264,7 @@ VIDEO::EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile& fcurl, const CScra
     return vcep;
 
   CLog::LogF(LOGDEBUG, "Searching '{}' using {} scraper (file: '{}', content: '{}', version: '{}')",
-             scurl.GetFirstThumbUrl(), Name(), Path(), ADDON::TranslateContent(Content()),
-             Version().asString());
+             scurl.GetFirstThumbUrl(), Name(), Path(), Content(), Version().asString());
 
   if (m_isPython)
   {
@@ -1365,7 +1363,7 @@ bool CScraper::GetVideoDetails(XFILE::CCurlFile& fcurl,
   CLog::LogF(LOGDEBUG,
              "Reading {} '{}' using {} scraper (file: '{}', content: '{}', version: '{}')",
              fMovie ? MediaTypeMovie : MediaTypeEpisode, scurl.GetFirstThumbUrl(), Name(), Path(),
-             ADDON::TranslateContent(Content()), Version().asString());
+             Content(), Version().asString());
 
   video.Reset();
 
@@ -1409,8 +1407,7 @@ bool CScraper::GetVideoDetails(XFILE::CCurlFile& fcurl,
 bool CScraper::GetAlbumDetails(CCurlFile &fcurl, const CScraperUrl &scurl, CAlbum &album)
 {
   CLog::LogF(LOGDEBUG, "Reading '{}' using {} scraper (file: '{}', content: '{}', version: '{}')",
-             scurl.GetFirstThumbUrl(), Name(), Path(), ADDON::TranslateContent(Content()),
-             Version().asString());
+             scurl.GetFirstThumbUrl(), Name(), Path(), Content(), Version().asString());
 
   if (m_isPython)
     return PythonDetails(ID(), "url", scurl.GetFirstThumbUrl(),
@@ -1446,8 +1443,7 @@ bool CScraper::GetArtistDetails(CCurlFile &fcurl,
 
   CLog::LogF(LOGDEBUG,
              "Reading '{}' ('{}') using {} scraper (file: '{}', content: '{}', version: '{}')",
-             scurl.GetFirstThumbUrl(), sSearch, Name(), Path(), ADDON::TranslateContent(Content()),
-             Version().asString());
+             scurl.GetFirstThumbUrl(), sSearch, Name(), Path(), Content(), Version().asString());
 
   if (m_isPython)
     return PythonDetails(ID(), "url", scurl.GetFirstThumbUrl(),
@@ -1484,8 +1480,7 @@ bool CScraper::GetArtwork(XFILE::CCurlFile &fcurl, CVideoInfoTag &details)
 
   CLog::LogF(LOGDEBUG,
              "Reading artwork for '{}' using {} scraper (file: '{}', content: '{}', version: '{}')",
-             details.GetUniqueID(), Name(), Path(), ADDON::TranslateContent(Content()),
-             Version().asString());
+             details.GetUniqueID(), Name(), Path(), Content(), Version().asString());
 
   if (m_isPython)
     return PythonDetails(ID(), "id", details.GetUniqueID(),

--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -199,7 +199,7 @@ template<>
 struct fmt::formatter<ADDON::ContentType> : fmt::formatter<std::string_view>
 {
   template<typename FormatContext>
-  constexpr auto format(const ADDON::ContentType& type, FormatContext& ctx)
+  constexpr auto format(const ADDON::ContentType& type, FormatContext& ctx) const
   {
     return fmt::formatter<std::string_view>::format(enumToSV(type), ctx);
   }

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -405,7 +405,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       CLog::Log(
           LOGINFO,
           "VideoInfoScanner: Plugin '{}' does not support media library scanning for '{}' content",
-          CURL::GetRedacted(strDirectory), TranslateContent(content));
+          CURL::GetRedacted(strDirectory), content);
       return true;
     }
 
@@ -815,7 +815,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       return retVal < 0 ? InfoRet::CANCELLED : InfoRet::NOT_FOUND;
 
     CLog::Log(LOGDEBUG, "VideoInfoScanner: Fetching url '{}' using {} scraper (content: '{}')",
-              url.GetFirstThumbUrl(), info2->Name(), TranslateContent(info2->Content()));
+              url.GetFirstThumbUrl(), info2->Name(), info2->Content());
     const std::unordered_map<std::string, std::string> uniqueIDs{{identifierType, identifier}};
 
     if (GetDetails(pItem, {}, url, info2,
@@ -912,7 +912,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       return retVal < 0 ? InfoRet::CANCELLED : InfoRet::NOT_FOUND;
 
     CLog::Log(LOGDEBUG, "VideoInfoScanner: Fetching url '{}' using {} scraper (content: '{}')",
-              url.GetFirstThumbUrl(), info2->Name(), TranslateContent(info2->Content()));
+              url.GetFirstThumbUrl(), info2->Name(), info2->Content());
 
     if (GetDetails(pItem, {}, url, info2,
                    (result == InfoType::COMBINED || result == InfoType::OVERRIDE) ? loader.get()
@@ -1002,7 +1002,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       return retVal < 0 ? InfoRet::CANCELLED : InfoRet::NOT_FOUND;
 
     CLog::Log(LOGDEBUG, "VideoInfoScanner: Fetching url '{}' using {} scraper (content: '{}')",
-              url.GetFirstThumbUrl(), info2->Name(), TranslateContent(info2->Content()));
+              url.GetFirstThumbUrl(), info2->Name(), info2->Content());
 
     if (GetDetails(pItem, {}, url, info2,
                    (result == InfoType::COMBINED || result == InfoType::OVERRIDE) ? loader.get()
@@ -1655,7 +1655,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
       }
     }
 
-    CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding new item to {}:{}", TranslateContent(content), CURL::GetRedacted(pItem->GetPath()));
+    CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding new item to {}:{}", content,
+              CURL::GetRedacted(pItem->GetPath()));
     long lResult = -1;
 
     if (content == ContentType::MOVIES)


### PR DESCRIPTION
First commit fixes #26959 
Second commit is cleanup after introduction of custom fmt logger for enum class `ADDONS::ContentType`.

Runtime-tested on macOS, latest Kodi master.

@vpeter4 fyi
@garbear @neo1973 could you review, please. 