### PR TITLE
[Video] More path related refactoring for blurays, and associated tests.

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1222,6 +1222,10 @@ int CUtil::GetMatchingSource(const std::string& strPath1,
   if (checkURL.IsProtocol("stack"))
     strPath.erase(0, 8); // remove the stack protocol
 
+  // bluray://
+  if (checkURL.IsProtocol("bluray"))
+    strPath = URIUtils::GetDiscBase(checkURL.Get()); // get the actual path on disc
+
   if (checkURL.IsProtocol("shout"))
     strPath = checkURL.GetHostName();
 
@@ -1890,12 +1894,13 @@ void CUtil::GetVideoBasePathAndFileName(const std::string& videoPath,
                                         std::string& basePath,
                                         std::string& videoFileName)
 {
-  const CFileItem item(videoPath, false);
-
-  if (item.IsOpticalMediaFile() || URIUtils::IsBlurayPath(item.GetDynPath()))
+  if (URIUtils::IsOpticalMediaFile(videoPath) || URIUtils::IsBlurayPath(videoPath))
   {
+    const std::string path{URIUtils::IsBlurayPath(videoPath) ? URIUtils::GetDiscFile(videoPath)
+                                                             : videoPath};
+    CFileItem item(path, false);
+    videoFileName = item.GetMovieName();
     basePath = item.GetLocalMetadataPath();
-    videoFileName = URIUtils::ReplaceExtension(GetTitleFromPath(basePath), "");
   }
   else
   {

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -250,51 +250,51 @@ public:
    */
   static std::string GetHexString(const std::span<const uint8_t>& buf, int count);
 
+  /*! \brief Retrieves the base path and the filename of a given video.
+   *  \param[in]  videoPath The full path of the video file.
+   *  \param[out] basePath The base path of the given video.
+   *  \param[out] videoFileName The file name of the given video.
+   */
+  static void GetVideoBasePathAndFileName(const std::string& videoPath,
+                                          std::string& basePath,
+                                          std::string& videoFileName);
+
 #if !defined(TARGET_WINDOWS)
 private:
   static unsigned int s_randomSeed;
 #endif
 
-  protected:
-    /** \brief Retrieves the base path and the filename of a given video.
-    *   \param[in]  videoPath The full path of the video file.
-    *   \param[out] basePath The base path of the given video.
-    *   \param[out] videoFileName The file name of the given video..
-    */
-    static void GetVideoBasePathAndFileName(const std::string& videoPath,
-                                            std::string& basePath,
-                                            std::string& videoFileName);
-
-    /** \brief Retrieves FileItems that could contain associated files of a given video.
+protected:
+  /** \brief Retrieves FileItems that could contain associated files of a given video.
     *   \param[in]  videoPath The full path of the video file.
     *   \param[in]  item_exts A | separated string of extensions specifying the associated files.
     *   \param[in]  sub_dirs A vector of sub directory names to look for.
     *   \param[out] items A List of FileItems to scan for associated files.
     */
-    static void GetItemsToScan(const std::string& videoPath,
-                               const std::string& item_exts,
-                               const std::vector<std::string>& sub_dirs,
-                               CFileItemList& items);
+  static void GetItemsToScan(const std::string& videoPath,
+                             const std::string& item_exts,
+                             const std::vector<std::string>& sub_dirs,
+                             CFileItemList& items);
 
-    /** \brief Searches for associated files of a given video.
+  /** \brief Searches for associated files of a given video.
     *   \param[in]  videoName The name of the video file.
     *   \param[in]  items A List of FileItems to scan for associated files.
     *   \param[in]  item_exts A vector of extensions specifying the associated files.
     *   \param[out] associatedFiles A vector containing the full paths of all found associated files.
     */
-    static void ScanPathsForAssociatedItems(const std::string& videoName,
-                                            const CFileItemList& items,
-                                            const std::vector<std::string>& item_exts,
-                                            std::vector<std::string>& associatedFiles);
+  static void ScanPathsForAssociatedItems(const std::string& videoName,
+                                          const CFileItemList& items,
+                                          const std::vector<std::string>& item_exts,
+                                          std::vector<std::string>& associatedFiles);
 
-    /** \brief Searches in an archive for associated files of a given video.
+  /** \brief Searches in an archive for associated files of a given video.
     *   \param[in]  strArchivePath The full path of the archive.
     *   \param[in]  videoNameNoExt The filename of the video without extension for which associated files should be retrieved.
     *   \param[in]  item_exts A vector of extensions specifying the associated files.
     *   \param[out] associatedFiles A vector containing the full paths of all found associated files.
     */
-    static int ScanArchiveForAssociatedItems(const std::string& strArchivePath,
-                                             const std::string& videoNameNoExt,
-                                             const std::vector<std::string>& item_exts,
-                                             std::vector<std::string>& associatedFiles);
+  static int ScanArchiveForAssociatedItems(const std::string& strArchivePath,
+                                           const std::string& videoNameNoExt,
+                                           const std::vector<std::string>& item_exts,
+                                           std::vector<std::string>& associatedFiles);
 };

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -150,7 +150,7 @@ bool CGUIDialogSimpleMenu::ShowPlaylistSelection(CFileItem& item)
 
           std::string base{originalDynPath};
           if (URIUtils::IsBlurayPath(base))
-            base = URIUtils::GetBlurayFile(base);
+            base = URIUtils::GetDiscFile(base);
 
           for (const auto& it : matchingPlaylists)
           {

--- a/xbmc/filesystem/BlurayFile.cpp
+++ b/xbmc/filesystem/BlurayFile.cpp
@@ -36,6 +36,6 @@ std::string CBlurayFile::TranslatePath(const CURL& url)
 bool CBlurayFile::Exists(const CURL& url)
 {
   if (url.GetFileName() == "menu")
-    return CFile::Exists(URIUtils::GetBlurayFile(url.Get()));
+    return CFile::Exists(URIUtils::GetDiscFile(url.Get()));
   return CFile::Exists(TranslatePath(url));
 }

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -59,14 +59,20 @@ class TestFileItemMovieName : public AdvancedSettingsResetBase,
 {
 };
 
+class TestFileItemLocalMetadataPath : public AdvancedSettingsResetBase,
+                                      public WithParamInterface<TestFileData>
+{
+};
+
 const TestFileData BaseMovies[] = {
-    {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie/"},
     {"c:\\dir\\filename.avi", false, "c:\\dir\\filename.avi"},
     {"c:\\dir\\filename.avi", true, "c:\\dir\\"},
     {"/dir/filename.avi", false, "/dir/filename.avi"},
     {"/dir/filename.avi", true, "/dir/"},
     {"smb://somepath/file.avi", false, "smb://somepath/file.avi"},
     {"smb://somepath/file.avi", true, "smb://somepath/"},
+    {"smb://somepath/disc 1/file.avi", false, "smb://somepath/disc 1/file.avi"},
+    {"smb://somepath/disc 1/file.avi", true, "smb://somepath/"},
     {"stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi",
      false,
      "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi"},
@@ -116,6 +122,8 @@ const TestNameData BaseNames[] = {
     {"/movie/filename.avi", true, "movie"},
     {"smb://somepath/movie.avi", false, "movie"},
     {"smb://somepath/movie/file.avi", true, "movie"},
+    {"smb://somepath/disc 1/movie.avi", false, "movie"},
+    {"smb://somepath/movie/disc 1/file.avi", true, "movie"},
     {"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", false, "movie"},
     {"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", true, "movie"},
     {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", false, "movie"},
@@ -139,3 +147,42 @@ TEST_P(TestFileItemMovieName, GetMovieName)
 }
 
 INSTANTIATE_TEST_SUITE_P(NameMovies, TestFileItemMovieName, ValuesIn(BaseNames));
+
+const TestFileData BasePaths[] = {
+    {"c:\\dir\\", true, "c:\\dir\\"},
+    {"/dir/filename.avi", false, "/dir/"},
+    {"/dir/", true, "/dir/"},
+    {"smb://somepath/file.avi", false, "smb://somepath/"},
+    {"smb://somepath/", true, "smb://somepath/"},
+    {"smb://somepath/disc 1/file.avi", false, "smb://somepath/disc 1/"},
+    {"smb://somepath/disc 1/", true, "smb://somepath/disc 1/"},
+    {"/home/user/TV Shows/Dexter/S1/1x01.avi", false, "/home/user/TV Shows/Dexter/S1/"},
+    {"/home/user/TV Shows/Dexter/S1/", true, "/home/user/TV Shows/Dexter/S1/"},
+    {"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", false,
+     "/home/user/movies/movie/disc 1/"},
+    {"/home/user/movies/movie/BDMV/index.bdmv", false, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", false, "/home/user/movies/movie/disc 1/"},
+    {"/home/user/movies/movie/movie.iso", false, "/home/user/movies/movie/"},
+    {"/home/user/movies/movie/disc 1/movie.iso", false, "/home/user/movies/movie/disc 1/"},
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/00800.mpls",
+     false, "smb://somepath/"},
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fdisc%201%252fmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     false, "smb://somepath/disc 1/"},
+    {"bluray://smb%3a%2f%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", false, "smb://somepath/"},
+    {"bluray://smb%3a%2f%2fsomepath%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls", false,
+     "smb://somepath/disc 1/"},
+    {"/dir/filename.m3u8", true, "/dir/"},
+    {"/dir/filename.zip", true, "/dir/"},
+    {"smb://somepath/filename.rar", true, "smb://somepath/"}};
+
+TEST_P(TestFileItemLocalMetadataPath, GetLocalMetadataPath)
+{
+  CFileItem item;
+  item.SetPath(GetParam().file);
+  item.SetFolder(GetParam().use_folder);
+  EXPECT_EQ(GetParam().base, item.GetLocalMetadataPath());
+}
+
+INSTANTIATE_TEST_SUITE_P(NameMovies, TestFileItemLocalMetadataPath, ValuesIn(BasePaths));

--- a/xbmc/utils/ArtUtils.h
+++ b/xbmc/utils/ArtUtils.h
@@ -51,7 +51,12 @@ std::string GetLocalArtBaseFilename(const CFileItem& item, bool& useFolder);
  */
 std::string GetLocalFanart(const CFileItem& item);
 
-//! \brief Get the .tbn file associated with an item
+/*! \brief Get the .tbn file associated with an item.
+ Note this is used to derive the .nfo path in CVideoDatabase::ExportToXML() and for
+ bluray/dvd this is not the same as the thumbnail/art directory.
+ \param item CFileItem containing the item path.
+ \return the path to the .tbn file
+*/
 std::string GetTBNFile(const CFileItem& item);
 
 } // namespace KODI::ART

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -89,30 +89,32 @@ public:
 
   static bool IsDiscPath(const std::string& path);
 
-  /*! \brief Given a bluray:// path, return the base .ISO or folder containing the bluray file structure.
-   \param path bluray:// path.
-   \return the base .ISO or folder containing the bluray file structure.
+  /*! \brief Given a bluray:// path or disc file path (index.bdmv/video_ts.ifo), return the base .ISO or folder
+   containing the disc file structure.
+   \param path source path.
+   \return the base .ISO or folder containing the disc file structure.
    \note Used to determine file/folder to delete
    */
   static std::string GetDiscBase(const std::string& file);
 
-  /*! \brief Given a bluray:// path, return the folder containing the .ISO or bluray file structure.
-   \param path bluray:// path.
-   \return the folder containing the .ISO or bluray file structure.
+  /*! \brief Given a bluray:// path or disc file path (index.bdmv/video_ts.ifo), return the folder
+   containing the disc file structure or ISO.
+   \param path source path.
+   \return the folder containing the .ISO or disc file structure.
    */
   static std::string GetDiscBasePath(const std::string& file);
+
+  /*! \brief Given a bluray:// path, return the base .ISO or index.BDMV.
+   \param path bluray:// path.
+   \return the base .ISO or index.BDMV.
+   */
+  static std::string GetDiscFile(const std::string& path);
 
   /*! \brief Given a bluray:// path, return the underlying file path (eg. smb://, udf:// etc..)
    \param url CURL containing bluray:// path.
    \return return the underlying file path.
    */
   static std::string GetDiscUnderlyingFile(const CURL& url);
-
-  /*! \brief Given a bluray:// path, return the base .ISO or index.BDMV.
-   \param path bluray:// path.
-   \return the base .ISO or index.BDMV.
-   */
-  static std::string GetBlurayFile(const std::string& path);
 
   /*! \brief Given a path to an .ISO or index.BDMV, returns a bluray:// path to root.
    \param path the ISO/index.BDMV path.
@@ -140,21 +142,16 @@ public:
 
   /*! \brief Given a path to an .ISO or index.BDMV, returns a bluray:// path to default playlist path.
    \param path the ISO/index.BDMV path.
-   \return the bluray:// playlist path - BDMV/PLAYLIST
+   \param playlist (optional) the .mpls playlist
+   \return the bluray:// playlist path - BDMV/PLAYLIST(/xxxxx.mpls)
    */
-  static std::string GetBlurayPlaylistPath(const std::string& path);
+  static std::string GetBlurayPlaylistPath(const std::string& path, int playlist = -1);
 
-  /*! \brief Given a path to an .ISO or index.BDMV, returns a bluray:// path.
-   \param path the ISO/index.BDMV path.
-   \return the bluray:// path.
+  /*! \brief Given a path to bluray playlist (bluray://.../xxxxx.mpls), returns the playlist number.
+   \param path the bluray:// path
+   \return the playlist number
    */
-  static std::string GetBlurayPath(const std::string& path);
-
-  /*! \brief Determines if a file is from optical media (ie. index.bdmv, video_ts.ifo etc..)
-   \param file file path for determination.
-   \return true if file is from optical media
-   */
-  static bool IsOpticalMediaFile(const std::string& file);
+  static int GetBlurayPlaylistFromPath(const std::string& path);
 
   /*! \brief Get the regex for matching trailing part numbers.
    \return the regex
@@ -253,6 +250,13 @@ public:
   static bool IsDiscImage(const std::string& file);
   static bool IsDiscImageStack(const std::string& file);
   static bool IsBlurayPath(const std::string& strFile);
+
+  /*! \brief Determines if a file is from optical media (ie. index.bdmv, video_ts.ifo etc..)
+   \param file file path for determination.
+   \return true if file is from optical media
+   */
+  static bool IsOpticalMediaFile(const std::string& file);
+
   static bool IsBDFile(const std::string& file);
   static bool IsDVDFile(const std::string& file);
   static bool IsAndroidApp(const std::string& strFile);
@@ -330,6 +334,12 @@ public:
 
 private:
   static std::string resolvePath(const std::string &path);
+
+  /*! \brief Given a path to an .ISO or index.BDMV, returns a bluray:// path.
+   \param path the ISO/index.BDMV path.
+   \return the bluray:// path.
+   */
+  static std::string GetBlurayPath(const std::string& path);
 
   static const CAdvancedSettings* m_advancedSettings;
 };

--- a/xbmc/utils/test/TestArtUtils.cpp
+++ b/xbmc/utils/test/TestArtUtils.cpp
@@ -88,9 +88,17 @@ const auto local_art_filename_tests = std::array{
     ArtFilenameTest{"zip://%2fhome%2fuser%2fbar.zip/foo.avi", "/home/user/foo.avi"},
     ArtFilenameTest{"multipath://%2fhome%2fuser%2fbar%2f/%2fhome%2fuser%2ffoo%2f",
                     "/home/user/bar/", true, true},
+    ArtFilenameTest{"/home/user/foo/foo.iso", "/home/user/foo/foo.iso"},
     ArtFilenameTest{"/home/user/VIDEO_TS/VIDEO_TS.IFO", "/home/user/", false, true},
     ArtFilenameTest{"/home/user/BDMV/index.bdmv", "/home/user/", false, true},
     ArtFilenameTest{"/home/user/foo.avi", "/home/user/", false, true, true},
+    ArtFilenameTest{
+        "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/00800.mpls",
+        "smb://somepath/movie.iso"},
+    ArtFilenameTest{"bluray://smb%3a%2f%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", "smb://somepath/",
+                    false, true},
+    ArtFilenameTest{"bluray://smb%3a%2f%2fsomepath%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls",
+                    "smb://somepath/disc 1/", false, true},
 };
 
 struct FanartTest
@@ -197,7 +205,7 @@ struct LocalArtTest
 {
   std::string file;
   std::string art;
-  bool use_folder;
+  bool use_folder{false};
   std::string base;
 };
 
@@ -286,6 +294,7 @@ TEST_P(GetLocalArtBaseFilenameTest, GetLocalArtBaseFilename)
 {
   CFileItem item(GetParam().path, GetParam().isFolder);
   bool useFolder = GetParam().force_use_folder ? true : GetParam().isFolder;
+
   const std::string res = ART::GetLocalArtBaseFilename(item, useFolder);
   EXPECT_EQ(res, GetParam().result);
   EXPECT_EQ(useFolder, GetParam().result_folder);
@@ -354,7 +363,15 @@ const auto tbn_tests = std::array{
     TbnTest{"/home/user/video/", "/home/user/video.tbn", true},
     TbnTest{"/home/user/bar.xbt", "/home/user/bar.tbn", true},
     TbnTest{"zip://%2fhome%2fuser%2fbar.zip/foo.avi", "/home/user/foo.tbn"},
-    TbnTest{"stack:///home/user/foo-cd1.avi , /home/user/foo-cd2.avi", "/home/user/foo.tbn"}};
+    TbnTest{"stack:///home/user/foo-cd1.avi , /home/user/foo-cd2.avi", "/home/user/foo.tbn"},
+    TbnTest{"/home/user/BDMV/index.bdmv", "/home/user/BDMV/index.tbn"},
+    TbnTest{"/home/user/movie.iso", "/home/user/movie.tbn"},
+    TbnTest{"bluray://smb%3a%2f%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls",
+            "smb://somepath/BDMV/index.tbn"},
+    TbnTest{
+        "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/00800.mpls",
+        "smb://somepath/movie.tbn"},
+};
 
 INSTANTIATE_TEST_SUITE_P(TestArtUtils, GetTbnTest, testing::ValuesIn(tbn_tests));
 

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -664,3 +664,116 @@ TEST_F(TestURIUtils, ContainersEncodeHostnamePaths)
   EXPECT_EQ("rar://%2fpath%2fthing/my/archived/path",
             URIUtils::CreateArchivePath("rar", curl, "/my/archived/path").Get());
 }
+
+TEST_F(TestURIUtils, GetDiscBase)
+{
+  constexpr std::string_view refDir{"smb://somepath/path/"};
+  EXPECT_EQ(refDir, URIUtils::GetDiscBase("smb://somepath/path/BDMV/index.bdmv"));
+  EXPECT_EQ(refDir, URIUtils::GetDiscBase(
+                        "bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls"));
+
+  constexpr std::string_view refIso{"smb://somepath/path/movie.iso"};
+  EXPECT_EQ(refIso, URIUtils::GetDiscBase("smb://somepath/path/movie.iso"));
+  EXPECT_EQ(
+      refIso,
+      URIUtils::GetDiscBase(
+          "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+          "00800.mpls"));
+}
+
+TEST_F(TestURIUtils, GetDiscBasePath)
+{
+  constexpr std::string_view refDir{"smb://somepath/path/"};
+  EXPECT_EQ(refDir, URIUtils::GetDiscBasePath("smb://somepath/path/BDMV/index.bdmv"));
+  EXPECT_EQ(refDir, URIUtils::GetDiscBasePath(
+                        "bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls"));
+  EXPECT_EQ(refDir, URIUtils::GetDiscBasePath("smb://somepath/path/movie.iso"));
+  EXPECT_EQ(
+      refDir,
+      URIUtils::GetDiscBasePath(
+          "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+          "00800.mpls"));
+}
+
+TEST_F(TestURIUtils, GetDiscFile)
+{
+  EXPECT_EQ(
+      "smb://somepath/path/BDMV/index.bdmv",
+      URIUtils::GetDiscFile("bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls"));
+  EXPECT_EQ(
+      "smb://somepath/path/movie.iso",
+      URIUtils::GetDiscFile(
+          "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+          "00800.mpls"));
+}
+
+TEST_F(TestURIUtils, GetDiscUnderlyingFile)
+{
+  CURL url = CURL("bluray://smb%3a%2f%2fsomepath%2fpath%2f/file.ext");
+  EXPECT_EQ("smb://somepath/path/file.ext", URIUtils::GetDiscUnderlyingFile(url));
+
+  url = CURL("bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/file.ext");
+  EXPECT_EQ("udf://smb%3a%2f%2fsomepath%2fpath%2fmovie.iso/file.ext",
+            URIUtils::GetDiscUnderlyingFile(url));
+}
+
+TEST_F(TestURIUtils, GetBlurayRootPath)
+{
+  constexpr std::string_view refRoot{"bluray://smb%3a%2f%2fsomepath%2fpath%2f/root"};
+  EXPECT_EQ(refRoot, URIUtils::GetBlurayRootPath("smb://somepath/path/BDMV/index.bdmv"));
+  EXPECT_EQ(refRoot, URIUtils::GetBlurayRootPath(
+                         "bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls"));
+
+  constexpr std::string_view refIsoRoot{
+      "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/root"};
+  EXPECT_EQ(refIsoRoot, URIUtils::GetBlurayRootPath("smb://somepath/path/movie.iso"));
+  EXPECT_EQ(
+      refIsoRoot,
+      URIUtils::GetBlurayRootPath(
+          "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+          "00800.mpls"));
+}
+
+TEST_F(TestURIUtils, GetBlurayEpisodePath)
+{
+  constexpr std::string_view ref{"bluray://smb%3a%2f%2fsomepath%2fpath%2f/root/episode/3/4"};
+  EXPECT_EQ(ref, URIUtils::GetBlurayEpisodePath("smb://somepath/path/BDMV/index.bdmv", 3, 4));
+  EXPECT_EQ(ref, URIUtils::GetBlurayEpisodePath(
+                     "bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls", 3, 4));
+
+  constexpr std::string_view refIso{
+      "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/root/episode/3/4"};
+  EXPECT_EQ(refIso, URIUtils::GetBlurayEpisodePath("smb://somepath/path/movie.iso", 3, 4));
+  EXPECT_EQ(
+      refIso,
+      URIUtils::GetBlurayEpisodePath(
+          "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+          "00800.mpls",
+          3, 4));
+}
+
+TEST_F(TestURIUtils, GetBlurayPlaylistPath)
+{
+  EXPECT_EQ("bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/",
+            URIUtils::GetBlurayPlaylistPath("smb://somepath/path/BDMV/index.bdmv"));
+  EXPECT_EQ("bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls",
+            URIUtils::GetBlurayPlaylistPath("smb://somepath/path/BDMV/index.bdmv", 800));
+  EXPECT_EQ(
+      "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/",
+      URIUtils::GetBlurayPlaylistPath("smb://somepath/path/movie.iso"));
+  EXPECT_EQ(
+      "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+      "00800.mpls",
+      URIUtils::GetBlurayPlaylistPath("smb://somepath/path/movie.iso", 800));
+}
+
+TEST_F(TestURIUtils, GetBlurayPlaylistFromPath)
+{
+  EXPECT_EQ(URIUtils::GetBlurayPlaylistFromPath(
+                "bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls"),
+            800);
+  EXPECT_EQ(URIUtils::GetBlurayPlaylistFromPath(
+                "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/"
+                "PLAYLIST/00800.mpls"),
+            800);
+}

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3773,7 +3773,7 @@ void CVideoDatabase::GetEpisodesByBlurayPath(const std::string& path,
   {
     // url will be in vfs format (ie. bluray://.../episode/1/1)
     // episode database entries will either have basepath path (ie. ISO/BDMV) if not yet played ...
-    const std::string baseFileAndPath{URIUtils::GetBlurayFile(path)};
+    const std::string baseFileAndPath{URIUtils::GetDiscFile(path)};
     std::string baseFile;
     std::string basePath;
     SplitPath(baseFileAndPath, basePath, baseFile);
@@ -3827,7 +3827,7 @@ void CVideoDatabase::GetEpisodesByFileId(int idFile, std::vector<CVideoInfoTag>&
       std::string file{URIUtils::AddFileToFolder(m_pDS->fv("strPath").get_asString(),
                                                  m_pDS->fv("strFileName").get_asString())};
       if (URIUtils::IsBlurayPath(file))
-        file = URIUtils::GetBlurayFile(file);
+        file = URIUtils::GetDiscFile(file);
       fileMap.insert({file, index});
       if (episodeFile.empty() && m_pDS->fv("idFile").get_asInt() == idFile)
         episodeFile = file;
@@ -10778,7 +10778,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
 
         // if bluray:// get actual path
         if (URIUtils::IsBlurayPath(fullPath))
-          fullPath = URIUtils::GetBlurayFile(fullPath);
+          fullPath = URIUtils::GetDiscFile(fullPath);
 
         bool del = true;
         if (URIUtils::IsPlugin(fullPath))


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

I think (I hope!) I've now added tests for all routines that manipulate paths - to account for blurays (both ISO/BDMV paths and bluray:// paths where appropriate).

The same still needs to happen for zip:// and rar:// as there are some inconsistencies there - but that's for another PR.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is part of the ongoing bluray work. This has mainly arisen from the import/export work - where ensuring you are looking in the right place for art/subs/audio etc.. is important.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally - via added tests.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

There should be no functional changes at this stage. Any changes to the routines are to ensure they are consistent with the wiki (where blurays are specifically mentioned), where it would be logical to find associated files, or in keeping with tests.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed