### PR TITLE
Fixed use-after-free of Wayland Connection on webOS

### DIFF
--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -139,10 +139,7 @@ CWinSystemWayland::CWinSystemWayland()
   m_winEvents = std::make_unique<CWinEventsWayland>();
 }
 
-CWinSystemWayland::~CWinSystemWayland() noexcept
-{
-  DestroyWindowSystem();
-}
+CWinSystemWayland::~CWinSystemWayland() noexcept = default;
 
 bool CWinSystemWayland::InitWindowSystem()
 {

--- a/xbmc/windowing/wayland/WinSystemWaylandWebOS.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandWebOS.cpp
@@ -62,6 +62,19 @@ bool CWinSystemWaylandWebOS::InitWindowSystem()
   return true;
 }
 
+bool CWinSystemWaylandWebOS::DestroyWindowSystem()
+{
+  m_exportedSurface = wayland::webos_exported_t{};
+  m_webosForeign = wayland::webos_foreign_t{};
+
+  if (m_webosRegistry)
+  {
+    m_webosRegistry->UnbindSingletons();
+  }
+  m_webosRegistry.reset();
+  return CWinSystemWayland::DestroyWindowSystem();
+}
+
 bool CWinSystemWaylandWebOS::CreateNewWindow(const std::string& name,
                                              bool fullScreen,
                                              RESOLUTION_INFO& res)
@@ -83,18 +96,6 @@ bool CWinSystemWaylandWebOS::CreateNewWindow(const std::string& name,
   }
 
   return true;
-}
-
-CWinSystemWaylandWebOS::~CWinSystemWaylandWebOS() noexcept
-{
-  m_exportedSurface = wayland::webos_exported_t{};
-  m_webosForeign = wayland::webos_foreign_t{};
-
-  if (m_webosRegistry)
-  {
-    m_webosRegistry->UnbindSingletons();
-  }
-  m_webosRegistry.reset();
 }
 
 bool CWinSystemWaylandWebOS::HasCursor()

--- a/xbmc/windowing/wayland/WinSystemWaylandWebOS.h
+++ b/xbmc/windowing/wayland/WinSystemWaylandWebOS.h
@@ -23,6 +23,8 @@ class CWinSystemWaylandWebOS : public CWinSystemWayland
 public:
   bool InitWindowSystem() override;
 
+  bool DestroyWindowSystem() override;
+
   /**
    * Gets the exported window name. May return an empty string on non wayland-webos-foreign devices (pre webOS 5)
    * @return Exported window name
@@ -44,7 +46,6 @@ public:
 
   IShellSurface* CreateShellSurface(const std::string& name) override;
   bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override;
-  ~CWinSystemWaylandWebOS() noexcept override;
   bool HasCursor() override;
   void OnConfigure(std::uint32_t serial, CSizeInt size, IShellSurface::StateBitset state) override;
 


### PR DESCRIPTION
## Description
This PR fixed heap-use-after-free upon quitting.

## Motivation and context
On webOS, everytime Kodi quits, it crashes. With AddressSanitizer enabled, reason of the crash can be found.

<details>

<summary>ASAN log output</summary>

```
==29742==ERROR: AddressSanitizer: heap-use-after-free on address 0xee974830 at pc 0xf7307f70 bp 0xffd28fdc sp 0xffd28fd4
READ of size 4 at 0xee974830 thread T0
    #0 0xf7307f6c in wl_proxy_marshal_array_flags (/media/developer/lib/libwayland-client.so.0+0x7f6c)
    #1 0xf730822c in wl_proxy_marshal_array_constructor_versioned (/media/developer/lib/libwayland-client.so.0+0x822c)
    #2 0xf7308288 in wl_proxy_marshal_array_constructor (/media/developer/lib/libwayland-client.so.0+0x8288)
    #3 0xf7308658 in wl_proxy_marshal (/media/developer/lib/libwayland-client.so.0+0x8658)
    #4 0x300c3f4 in wayland::proxy_t::proxy_release() /home/mariotaku/Projects/webosbrew/xbmc-workspace/xbmc/tools/depends/target/waylandpp/arm-webos-linux-gnueabi-debug/src/wayland-client.cpp:351
    #5 0x300c4c4 in wayland::proxy_t::~proxy_t() /home/mariotaku/Projects/webosbrew/xbmc-workspace/xbmc/tools/depends/target/waylandpp/arm-webos-linux-gnueabi-debug/src/wayland-client.cpp:332
    #6 0x1721190 in KODI::WINDOWING::WAYLAND::CWinSystemWaylandWebOS::~CWinSystemWaylandWebOS() (/media/developer/apps/usr/palm/applications/org.xbmc.kodi/kodi-webos+0x1721190)

0xee974830 is located 48 bytes inside of 208-byte region [0xee974800,0xee9748d0)
freed by thread T0 here:
    #0 0xf75029e8 in free.part.0 (/media/developer/lib/libasan.so.8.0.0+0xbb9e8)
    #1 0x300c440 in wayland::proxy_t::proxy_release() /home/mariotaku/Projects/webosbrew/xbmc-workspace/xbmc/tools/depends/target/waylandpp/arm-webos-linux-gnueabi-debug/src/wayland-client.cpp:359
    #2 0x300c4c4 in wayland::proxy_t::~proxy_t() /home/mariotaku/Projects/webosbrew/xbmc-workspace/xbmc/tools/depends/target/waylandpp/arm-webos-linux-gnueabi-debug/src/wayland-client.cpp:332

previously allocated by thread T0 here:
    #0 0xf7503578 in calloc (/media/developer/lib/libasan.so.8.0.0+0xbc578)
    #1 0xf7308b6c in wl_display_connect_to_fd (/media/developer/lib/libwayland-client.so.0+0x8b6c)
    #2 0xf730920c in wl_display_connect (/media/developer/lib/libwayland-client.so.0+0x920c)
    #3 0x300caec in wayland::display_t::display_t(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/mariotaku/Projects/webosbrew/xbmc-workspace/xbmc/tools/depends/target/waylandpp/arm-webos-linux-gnueabi-debug/src/wayland-client.cpp:475
    #4 0x16f3220 in std::__detail::_MakeUniq<wayland::display_t>::__single_object std::make_unique<wayland::display_t>() (/media/developer/apps/usr/palm/applications/org.xbmc.kodi/kodi-webos+0x16f3220)
    #5 0x16f3168 in KODI::WINDOWING::WAYLAND::CConnection::CConnection() (/media/developer/apps/usr/palm/applications/org.xbmc.kodi/kodi-webos+0x16f3168)
    #6 0x1717b18 in std::__detail::_MakeUniq<KODI::WINDOWING::WAYLAND::CConnection>::__single_object std::make_unique<KODI::WINDOWING::WAYLAND::CConnection>() (/media/developer/apps/usr/palm/applications/org.xbmc.kodi/kodi-webos+0x1717b18)
    #7 0x17169d0 in KODI::WINDOWING::WAYLAND::CWinSystemWayland::InitWindowSystem() (/media/developer/apps/usr/palm/applications/org.xbmc.kodi/kodi-webos+0x17169d0)
    #8 0x17212bc in KODI::WINDOWING::WAYLAND::CWinSystemWaylandWebOS::InitWindowSystem() (/media/developer/apps/usr/palm/applications/org.xbmc.kodi/kodi-webos+0x17212bc)
    #9 0x171e64c in KODI::WINDOWING::WAYLAND::CWinSystemWaylandEGLContext::InitWindowSystemEGL(int, int) (/media/developer/apps/usr/palm/applications/org.xbmc.kodi/kodi-webos+0x171e64c)
    #10 0x171edc0 in KODI::WINDOWING::WAYLAND::CWinSystemWaylandEGLContextGLES::InitWindowSystem() (/media/developer/apps/usr/palm/applications/org.xbmc.kodi/kodi-webos+0x171edc0)
    #11 0x110ede0 in CApplication::CreateGUI() (/media/developer/apps/usr/palm/applications/org.xbmc.kodi/kodi-webos+0x110ede0)
    #12 0xff7508 in XBMC_Run (/media/developer/apps/usr/palm/applications/org.xbmc.kodi/kodi-webos+0xff7508)
    #13 0xc91510 in main (/media/developer/apps/usr/palm/applications/org.xbmc.kodi/kodi-webos+0xc91510)
    #14 0xf6cf1982 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #15 0xf6cf1a2c in __libc_start_main_impl /usr/src/debug/lib32-glibc/2.35-r0/git/csu/libc-start.c:389

SUMMARY: AddressSanitizer: heap-use-after-free (/media/developer/lib/libwayland-client.so.0+0x7f6c) in wl_proxy_marshal_array_flags
Shadow bytes around the buggy address:
  0xee974580: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0xee974600: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0xee974680: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0xee974700: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0xee974780: fd fd fd fd fa fa fa fa fa fa fa fa fa fa fa fa
=>0xee974800: fd fd fd fd fd fd[fd]fd fd fd fd fd fd fd fd fd
  0xee974880: fd fd fd fd fd fd fd fd fd fd fa fa fa fa fa fa
  0xee974900: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0xee974980: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0xee974a00: 00 00 00 00 00 00 fa fa fa fa fa fa fa fa fa fa
  0xee974a80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==29742==ABORTING
```
</details>

In destructor of `CWinSystemWaylandWebOS`, it tries to destroy `wayland::webos_exported_t`, while wayland connection was already destroyed in `DestroyWindowSystem`. This causes the crash.

## How has this been tested?

1. Launching Kodi, without playing anything
1.1. Quit Kodi
1.2. Ensure the progress quits without crashing
2. Launching Kodi, and play some video
2.1. Quit Kodi
2.2. Ensure the progress quits without crashing

## What is the effect on users?
It doesn't crash anymore on quit.

## Screenshots (if appropriate):
Not applicable.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
