### PR TITLE
[addons] Fix crash in CVFSAddonCache::Init().

### DIFF
--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -67,10 +67,10 @@ void CVFSAddonCache::Init()
     auto vfs = std::make_shared<CVFSEntry>(addonInfo);
     vfs->Addon()->RegisterInformer(this);
 
-    m_addonsInstances.emplace_back(std::move(vfs));
-
     if (!vfs->GetZeroconfType().empty())
       CZeroconfBrowser::GetInstance()->AddServiceType(vfs->GetZeroconfType());
+
+    m_addonsInstances.emplace_back(std::move(vfs));
   }
 }
 


### PR DESCRIPTION
Fixes #26965

Fallout from 628b22a20e7921ab6118ae57e96ad665b672ca6a

Runtime-tested on macOS, with and without VFS add-ons installed. Working again.

@neo1973 maybe you want to have a look. Accessing an object after it was `std::moved` is not a good idea, right?