### PR TITLE
[utils] SonarQube finding: CEventStream, CSubscription: Replace function pointers with std::function

### DIFF
--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -56,8 +56,9 @@ void CContextMenuManager::Deinit()
 
 void CContextMenuManager::Init()
 {
-  m_addonMgr.Events().Subscribe(this, &CContextMenuManager::OnEvent);
-  CPVRContextMenuManager::GetInstance().Events().Subscribe(this, &CContextMenuManager::OnPVREvent);
+  m_addonMgr.Events().Subscribe(this, [this](const ADDON::AddonEvent& event) { OnEvent(event); });
+  CPVRContextMenuManager::GetInstance().Events().Subscribe(
+      this, [this](const PVRContextMenuEvent& event) { OnPVREvent(event); });
 
   std::unique_lock lock(m_criticalSection);
   m_items = {

--- a/xbmc/addons/BinaryAddonCache.h
+++ b/xbmc/addons/BinaryAddonCache.h
@@ -23,8 +23,6 @@ class IAddon;
 using AddonPtr = std::shared_ptr<IAddon>;
 using VECADDONS = std::vector<AddonPtr>;
 
-struct AddonEvent;
-
 class CBinaryAddonCache
 {
 public:
@@ -38,7 +36,6 @@ public:
 
 private:
   void Update();
-  void OnEvent(const AddonEvent& event);
 
   CCriticalSection m_critSection;
   std::multimap<AddonType, VECADDONS> m_addons;

--- a/xbmc/addons/ExtsMimeSupportList.cpp
+++ b/xbmc/addons/ExtsMimeSupportList.cpp
@@ -24,7 +24,23 @@ using namespace KODI::ADDONS;
 
 CExtsMimeSupportList::CExtsMimeSupportList(CAddonMgr& addonMgr) : m_addonMgr(addonMgr)
 {
-  m_addonMgr.Events().Subscribe(this, &CExtsMimeSupportList::OnEvent);
+  m_addonMgr.Events().Subscribe(
+      this,
+      [this](const AddonEvent& event)
+      {
+        if (typeid(event) == typeid(AddonEvents::Enabled) ||
+            typeid(event) == typeid(AddonEvents::Disabled) ||
+            typeid(event) == typeid(AddonEvents::ReInstalled))
+        {
+          if (m_addonMgr.HasType(event.addonId, AddonType::AUDIODECODER) ||
+              m_addonMgr.HasType(event.addonId, AddonType::IMAGEDECODER))
+            Update(event.addonId);
+        }
+        else if (typeid(event) == typeid(AddonEvents::UnInstalled))
+        {
+          Update(event.addonId);
+        }
+      });
 
   // Load all available audio decoder addons during Kodi start
   const std::vector<AddonType> types = {AddonType::AUDIODECODER, AddonType::IMAGEDECODER};
@@ -36,22 +52,6 @@ CExtsMimeSupportList::CExtsMimeSupportList(CAddonMgr& addonMgr) : m_addonMgr(add
 CExtsMimeSupportList::~CExtsMimeSupportList()
 {
   m_addonMgr.Events().Unsubscribe(this);
-}
-
-void CExtsMimeSupportList::OnEvent(const AddonEvent& event)
-{
-  if (typeid(event) == typeid(AddonEvents::Enabled) ||
-      typeid(event) == typeid(AddonEvents::Disabled) ||
-      typeid(event) == typeid(AddonEvents::ReInstalled))
-  {
-    if (m_addonMgr.HasType(event.addonId, AddonType::AUDIODECODER) ||
-        m_addonMgr.HasType(event.addonId, AddonType::IMAGEDECODER))
-      Update(event.addonId);
-  }
-  else if (typeid(event) == typeid(AddonEvents::UnInstalled))
-  {
-    Update(event.addonId);
-  }
 }
 
 void CExtsMimeSupportList::Update(const std::string& id)

--- a/xbmc/addons/ExtsMimeSupportList.h
+++ b/xbmc/addons/ExtsMimeSupportList.h
@@ -22,8 +22,6 @@ namespace ADDON
 enum class AddonType;
 class CAddonMgr;
 class CAddonInfo;
-
-struct AddonEvent;
 }
 
 namespace KODI::ADDONS
@@ -170,7 +168,6 @@ public:
 
 private:
   void Update(const std::string& id);
-  void OnEvent(const ADDON::AddonEvent& event);
 
   static SupportValues ScanAddonProperties(ADDON::AddonType type,
                                            const std::shared_ptr<ADDON::CAddonInfo>& addonInfo);

--- a/xbmc/addons/RepositoryUpdater.cpp
+++ b/xbmc/addons/RepositoryUpdater.cpp
@@ -132,7 +132,15 @@ CRepositoryUpdater::CRepositoryUpdater(CAddonMgr& addonMgr) : m_timer(this), m_a
 
 void CRepositoryUpdater::Start()
 {
-  m_addonMgr.Events().Subscribe(this, &CRepositoryUpdater::OnEvent);
+  m_addonMgr.Events().Subscribe(this,
+                                [this](const ADDON::AddonEvent& event)
+                                {
+                                  if (typeid(event) == typeid(ADDON::AddonEvents::Enabled))
+                                  {
+                                    if (m_addonMgr.HasType(event.addonId, AddonType::REPOSITORY))
+                                      ScheduleUpdate(UpdateScheduleType::First);
+                                  }
+                                });
   ScheduleUpdate(UpdateScheduleType::First);
 }
 
@@ -142,15 +150,6 @@ CRepositoryUpdater::~CRepositoryUpdater()
   CServiceBroker::GetSettingsComponent()->GetSettings()->UnregisterCallback(this);
 
   m_addonMgr.Events().Unsubscribe(this);
-}
-
-void CRepositoryUpdater::OnEvent(const ADDON::AddonEvent& event)
-{
-  if (typeid(event) == typeid(ADDON::AddonEvents::Enabled))
-  {
-    if (m_addonMgr.HasType(event.addonId, AddonType::REPOSITORY))
-      ScheduleUpdate(UpdateScheduleType::First);
-  }
 }
 
 void CRepositoryUpdater::OnJobComplete(unsigned int jobID, bool success, CJob* job)

--- a/xbmc/addons/RepositoryUpdater.h
+++ b/xbmc/addons/RepositoryUpdater.h
@@ -30,8 +30,6 @@ using RepositoryPtr = std::shared_ptr<CRepository>;
 
 class CRepositoryUpdateJob;
 
-struct AddonEvent;
-
 class CRepositoryUpdater : private ITimerCallback,
                            private IJobCallback,
                            public ISettingCallback,
@@ -94,8 +92,6 @@ private:
   void OnJobComplete(unsigned int jobID, bool success, CJob *job) override;
 
   void OnTimeout() override;
-
-  void OnEvent(const ADDON::AddonEvent& event);
 
   CDateTime ClosestNextCheck() const;
 

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -54,8 +54,9 @@ void CServiceAddonManager::OnEvent(const ADDON::AddonEvent& event)
 
 void CServiceAddonManager::Start()
 {
-  m_addonMgr.Events().Subscribe(this, &CServiceAddonManager::OnEvent);
-  m_addonMgr.UnloadEvents().Subscribe(this, &CServiceAddonManager::OnEvent);
+  m_addonMgr.Events().Subscribe(this, [this](const ADDON::AddonEvent& event) { OnEvent(event); });
+  m_addonMgr.UnloadEvents().Subscribe(this,
+                                      [this](const ADDON::AddonEvent& event) { OnEvent(event); });
   VECADDONS addons;
   if (m_addonMgr.GetAddons(addons, AddonType::SERVICE))
   {

--- a/xbmc/addons/VFSEntry.h
+++ b/xbmc/addons/VFSEntry.h
@@ -20,8 +20,6 @@
 
 namespace ADDON
 {
-struct AddonEvent;
-
 class CVFSEntry;
 using VFSEntryPtr = std::shared_ptr<CVFSEntry>;
 
@@ -36,7 +34,6 @@ public:
 
 private:
   void Update(const std::string& id);
-  void OnEvent(const AddonEvent& event);
   bool IsInUse(const std::string& id) override;
 
   CCriticalSection m_critSection;
@@ -316,4 +313,4 @@ private:
     CFileItemList m_items; //!< Internal list of items, used for cache purposes.
   };
 
-} /*namespace ADDON*/
+  } /*namespace ADDON*/

--- a/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
@@ -73,9 +73,20 @@ bool CGUIWindowAddonBrowser::OnMessage(CGUIMessage& message)
     break;
     case GUI_MSG_WINDOW_INIT:
     {
-      CServiceBroker::GetRepositoryUpdater().Events().Subscribe(this,
-                                                                &CGUIWindowAddonBrowser::OnEvent);
-      CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CGUIWindowAddonBrowser::OnEvent);
+      CServiceBroker::GetRepositoryUpdater().Events().Subscribe(
+          this,
+          [](const ADDON::CRepositoryUpdater::RepositoryUpdated& event)
+          {
+            CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE);
+            CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+          });
+      CServiceBroker::GetAddonMgr().Events().Subscribe(
+          this,
+          [](const ADDON::AddonEvent& event)
+          {
+            CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE);
+            CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+          });
 
       SetProperties();
     }
@@ -181,18 +192,6 @@ class UpdateAllowedAddons : public IRunnable
                                                        ModalJob::CHOICE_NO);
   }
 };
-
-void CGUIWindowAddonBrowser::OnEvent(const ADDON::CRepositoryUpdater::RepositoryUpdated& event)
-{
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE);
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
-}
-
-void CGUIWindowAddonBrowser::OnEvent(const ADDON::AddonEvent& event)
-{
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE);
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
-}
 
 void CGUIWindowAddonBrowser::InstallFromZip()
 {

--- a/xbmc/addons/gui/GUIWindowAddonBrowser.h
+++ b/xbmc/addons/gui/GUIWindowAddonBrowser.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "ThumbLoader.h"
-#include "addons/RepositoryUpdater.h"
 #include "windows/GUIMediaWindow.h"
 
 #include <string>
@@ -20,7 +19,6 @@ class CFileItemList;
 namespace ADDON
 {
 enum class AddonType;
-struct AddonEvent;
 }
 
 class CGUIWindowAddonBrowser : public CGUIMediaWindow
@@ -109,7 +107,5 @@ protected:
 private:
   void SetProperties();
   void UpdateStatus(const CFileItemPtr& item);
-  void OnEvent(const ADDON::CRepositoryUpdater::RepositoryUpdated& event);
-  void OnEvent(const ADDON::AddonEvent& event);
   CProgramThumbLoader m_thumbLoader;
 };

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPresetFactory.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPresetFactory.cpp
@@ -27,7 +27,17 @@ CShaderPresetFactory::CShaderPresetFactory(ADDON::CAddonMgr& addons) : m_addons(
 {
   UpdateAddons();
 
-  m_addons.Events().Subscribe(this, &CShaderPresetFactory::OnEvent);
+  m_addons.Events().Subscribe(this,
+                              [this](const ADDON::AddonEvent& event)
+                              {
+                                if (typeid(event) == typeid(ADDON::AddonEvents::Enabled) ||
+                                    typeid(event) == typeid(ADDON::AddonEvents::Disabled) ||
+                                    typeid(event) == typeid(ADDON::AddonEvents::UnInstalled) ||
+                                    typeid(event) == typeid(ADDON::AddonEvents::ReInstalled))
+                                {
+                                  UpdateAddons();
+                                }
+                              });
 }
 
 CShaderPresetFactory::~CShaderPresetFactory()
@@ -89,17 +99,6 @@ bool CShaderPresetFactory::CanLoadPreset(const std::string& presetPath)
     bSuccess = (m_loaders.contains(extension));
 
   return bSuccess;
-}
-
-void CShaderPresetFactory::OnEvent(const ADDON::AddonEvent& event)
-{
-  if (typeid(event) == typeid(ADDON::AddonEvents::Enabled) ||
-      typeid(event) == typeid(ADDON::AddonEvents::Disabled) ||
-      typeid(event) == typeid(ADDON::AddonEvents::UnInstalled) ||
-      typeid(event) == typeid(ADDON::AddonEvents::ReInstalled))
-  {
-    UpdateAddons();
-  }
 }
 
 void CShaderPresetFactory::UpdateAddons()

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPresetFactory.h
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPresetFactory.h
@@ -16,7 +16,6 @@
 
 namespace ADDON
 {
-struct AddonEvent;
 class CAddonMgr;
 class CBinaryAddonManager;
 class CShaderPresetAddon;
@@ -81,7 +80,6 @@ public:
   bool CanLoadPreset(const std::string& presetPath);
 
 private:
-  void OnEvent(const ADDON::AddonEvent& event);
   void UpdateAddons();
 
   // Construction parameters

--- a/xbmc/favourites/FavouritesUtils.cpp
+++ b/xbmc/favourites/FavouritesUtils.cpp
@@ -9,8 +9,10 @@
 #include "FavouritesUtils.h"
 
 #include "FileItem.h"
+#include "FileItemList.h"
 #include "ServiceBroker.h"
 #include "dialogs/GUIDialogFileBrowser.h"
+#include "favourites/FavouritesService.h"
 #include "favourites/FavouritesURL.h"
 #include "favourites/GUIWindowFavourites.h"
 #include "guilib/GUIComponent.h"

--- a/xbmc/favourites/GUIWindowFavourites.cpp
+++ b/xbmc/favourites/GUIWindowFavourites.cpp
@@ -9,6 +9,7 @@
 #include "GUIWindowFavourites.h"
 
 #include "FileItem.h"
+#include "favourites/FavouritesService.h"
 #include "favourites/FavouritesURL.h"
 #include "favourites/FavouritesUtils.h"
 #include "guilib/GUIMessage.h"
@@ -29,18 +30,17 @@ CGUIWindowFavourites::CGUIWindowFavourites()
 {
   m_loadType = KEEP_IN_MEMORY;
   CServiceBroker::GetFavouritesService().Events().Subscribe(
-      this, &CGUIWindowFavourites::OnFavouritesEvent);
+      this,
+      [this](const CFavouritesService::FavouritesUpdated& event)
+      {
+        CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), 0, 0);
+        CServiceBroker::GetAppMessenger()->SendGUIMessage(m);
+      });
 }
 
 CGUIWindowFavourites::~CGUIWindowFavourites()
 {
   CServiceBroker::GetFavouritesService().Events().Unsubscribe(this);
-}
-
-void CGUIWindowFavourites::OnFavouritesEvent(const CFavouritesService::FavouritesUpdated& event)
-{
-  CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), 0, 0);
-  CServiceBroker::GetAppMessenger()->SendGUIMessage(m);
 }
 
 bool CGUIWindowFavourites::OnSelect(int itemIdx)

--- a/xbmc/favourites/GUIWindowFavourites.h
+++ b/xbmc/favourites/GUIWindowFavourites.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "favourites/FavouritesService.h"
 #include "windows/GUIMediaWindow.h"
 
 class CGUIWindowFavourites : public CGUIMediaWindow
@@ -27,7 +26,6 @@ protected:
   bool Update(const std::string& strDirectory, bool updateFilterPath = true) override;
 
 private:
-  void OnFavouritesEvent(const CFavouritesService::FavouritesUpdated& event);
   bool MoveItem(int item, int amount);
   bool RemoveItem(int item);
 };

--- a/xbmc/games/agents/windows/GUIAgentControllerList.cpp
+++ b/xbmc/games/agents/windows/GUIAgentControllerList.cpp
@@ -81,7 +81,20 @@ bool CGUIAgentControllerList::Initialize(GameClientPtr gameClient)
   // Register observers
   if (m_gameClient)
     m_gameClient->Input().RegisterObserver(this);
-  CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CGUIAgentControllerList::OnEvent);
+  CServiceBroker::GetAddonMgr().Events().Subscribe(
+      this,
+      [this](const ADDON::AddonEvent& event)
+      {
+        if (typeid(event) == typeid(ADDON::AddonEvents::Enabled) || // Also called on install
+            typeid(event) == typeid(ADDON::AddonEvents::Disabled) || // Not called on uninstall
+            typeid(event) == typeid(ADDON::AddonEvents::ReInstalled) ||
+            typeid(event) == typeid(ADDON::AddonEvents::UnInstalled))
+        {
+          CGUIMessage msg(GUI_MSG_REFRESH_LIST, m_guiWindow.GetID(), CONTROL_AGENT_CONTROLLER_LIST);
+          msg.SetStringParam(event.addonId);
+          CServiceBroker::GetAppMessenger()->SendGUIMessage(msg, m_guiWindow.GetID());
+        }
+      });
   if (CServiceBroker::IsServiceManagerUp())
     CServiceBroker::GetGameServices().AgentInput().RegisterObserver(this);
 
@@ -193,19 +206,6 @@ void CGUIAgentControllerList::Notify(const Observable& obs, const ObservableMess
     }
     default:
       break;
-  }
-}
-
-void CGUIAgentControllerList::OnEvent(const ADDON::AddonEvent& event)
-{
-  if (typeid(event) == typeid(ADDON::AddonEvents::Enabled) || // Also called on install
-      typeid(event) == typeid(ADDON::AddonEvents::Disabled) || // Not called on uninstall
-      typeid(event) == typeid(ADDON::AddonEvents::ReInstalled) ||
-      typeid(event) == typeid(ADDON::AddonEvents::UnInstalled))
-  {
-    CGUIMessage msg(GUI_MSG_REFRESH_LIST, m_guiWindow.GetID(), CONTROL_AGENT_CONTROLLER_LIST);
-    msg.SetStringParam(event.addonId);
-    CServiceBroker::GetAppMessenger()->SendGUIMessage(msg, m_guiWindow.GetID());
   }
 }
 

--- a/xbmc/games/agents/windows/GUIAgentControllerList.h
+++ b/xbmc/games/agents/windows/GUIAgentControllerList.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "IAgentControllerList.h"
-#include "addons/AddonEvents.h"
 #include "games/GameTypes.h"
 #include "games/controllers/ControllerTypes.h"
 #include "utils/Observer.h"
@@ -55,9 +54,6 @@ public:
   void Notify(const Observable& obs, const ObservableMessage msg) override;
 
 private:
-  // Add-on API
-  void OnEvent(const ADDON::AddonEvent& event);
-
   // GUI functions
   void AddItem(const CAgentController& agentController);
   void CleanupItems();

--- a/xbmc/games/controllers/ControllerManager.h
+++ b/xbmc/games/controllers/ControllerManager.h
@@ -16,11 +16,6 @@
 #include <set>
 #include <string>
 
-namespace ADDON
-{
-struct AddonEvent;
-} // namespace ADDON
-
 namespace KODI
 {
 namespace GAME
@@ -87,9 +82,6 @@ public:
   std::string TranslateFeature(const std::string& controllerId, const std::string& featureName);
 
 private:
-  // Add-on event handler
-  void OnEvent(const ADDON::AddonEvent& event);
-
   // Utility functions
   ControllerPtr LoadController(const ADDON::AddonPtr& addon);
 

--- a/xbmc/games/controllers/windows/GUIControllerList.h
+++ b/xbmc/games/controllers/windows/GUIControllerList.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "IConfigurationWindow.h"
-#include "addons/AddonEvents.h"
 #include "games/GameTypes.h"
 #include "games/controllers/ControllerTypes.h"
 
@@ -61,7 +60,6 @@ private:
   bool RefreshControllers(void);
 
   void CleanupButtons(void);
-  void OnEvent(const ADDON::AddonEvent& event);
 
   // GUI stuff
   CGUIWindow* const m_guiWindow;

--- a/xbmc/games/controllers/windows/GUIControllerWindow.h
+++ b/xbmc/games/controllers/windows/GUIControllerWindow.h
@@ -47,10 +47,6 @@ private:
   void OnFeatureSelected(unsigned int featureIndex);
   void UpdateButtons(void);
 
-  // Callbacks for events
-  void OnEvent(const ADDON::CRepositoryUpdater::RepositoryUpdated& event);
-  void OnEvent(const ADDON::AddonEvent& event);
-
   // Action for the available button
   void GetMoreControllers(void);
   void GetAllControllers();

--- a/xbmc/games/ports/guicontrols/GUIActivePortList.cpp
+++ b/xbmc/games/ports/guicontrols/GUIActivePortList.cpp
@@ -58,7 +58,20 @@ bool CGUIActivePortList::Initialize(GameClientPtr gameClient)
 
   // Register observers
   m_gameClient->Input().RegisterObserver(this);
-  CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CGUIActivePortList::OnEvent);
+  CServiceBroker::GetAddonMgr().Events().Subscribe(
+      this,
+      [this](const ADDON::AddonEvent& event)
+      {
+        if (typeid(event) == typeid(ADDON::AddonEvents::Enabled) || // Also called on install
+            typeid(event) == typeid(ADDON::AddonEvents::Disabled) || // Not called on uninstall
+            typeid(event) == typeid(ADDON::AddonEvents::ReInstalled) ||
+            typeid(event) == typeid(ADDON::AddonEvents::UnInstalled))
+        {
+          CGUIMessage msg(GUI_MSG_REFRESH_LIST, m_guiWindow.GetID(), m_controlId);
+          msg.SetStringParam(event.addonId);
+          CServiceBroker::GetAppMessenger()->SendGUIMessage(msg, m_guiWindow.GetID());
+        }
+      });
 
   return true;
 }
@@ -113,19 +126,6 @@ void CGUIActivePortList::Notify(const Observable& obs, const ObservableMessage m
     break;
     default:
       break;
-  }
-}
-
-void CGUIActivePortList::OnEvent(const ADDON::AddonEvent& event)
-{
-  if (typeid(event) == typeid(ADDON::AddonEvents::Enabled) || // Also called on install
-      typeid(event) == typeid(ADDON::AddonEvents::Disabled) || // Not called on uninstall
-      typeid(event) == typeid(ADDON::AddonEvents::ReInstalled) ||
-      typeid(event) == typeid(ADDON::AddonEvents::UnInstalled))
-  {
-    CGUIMessage msg(GUI_MSG_REFRESH_LIST, m_guiWindow.GetID(), m_controlId);
-    msg.SetStringParam(event.addonId);
-    CServiceBroker::GetAppMessenger()->SendGUIMessage(msg, m_guiWindow.GetID());
   }
 }
 

--- a/xbmc/games/ports/guicontrols/GUIActivePortList.h
+++ b/xbmc/games/ports/guicontrols/GUIActivePortList.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "IActivePortList.h"
-#include "addons/AddonEvents.h"
 #include "games/GameTypes.h"
 #include "games/controllers/ControllerTypes.h"
 #include "games/ports/types/PortNode.h"
@@ -45,9 +44,6 @@ public:
   void Notify(const Observable& obs, const ObservableMessage msg) override;
 
 private:
-  // Add-on API
-  void OnEvent(const ADDON::AddonEvent& event);
-
   // GUI helpers
   void InitializeGUI();
   void DeinitializeGUI();

--- a/xbmc/games/ports/windows/GUIPortList.h
+++ b/xbmc/games/ports/windows/GUIPortList.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "IPortList.h"
-#include "addons/AddonEvents.h"
 #include "games/GameTypes.h"
 #include "games/controllers/ControllerTypes.h"
 #include "games/controllers/dialogs/ControllerSelect.h"
@@ -50,9 +49,6 @@ public:
   void ResetPorts() override;
 
 private:
-  // Add-on API
-  void OnEvent(const ADDON::AddonEvent& event);
-
   bool AddItems(const CPortNode& port, unsigned int& itemId, const std::string& itemLabel);
   void CleanupItems();
   void OnItemFocus(unsigned int itemIndex);

--- a/xbmc/guilib/listproviders/DirectoryProvider.cpp
+++ b/xbmc/guilib/listproviders/DirectoryProvider.cpp
@@ -120,33 +120,29 @@ public:
   explicit CAddonsSubscriber(ISubscriberCallback& invalidate)
     : CDirectoryProvider::CSubscriber(invalidate)
   {
-    CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CAddonsSubscriber::OnAddonEvent);
+    CServiceBroker::GetAddonMgr().Events().Subscribe(
+        this,
+        [this](const ADDON::AddonEvent& event)
+        {
+          if (typeid(event) == typeid(ADDON::AddonEvents::Enabled) ||
+              typeid(event) == typeid(ADDON::AddonEvents::Disabled) ||
+              typeid(event) == typeid(ADDON::AddonEvents::ReInstalled) ||
+              typeid(event) == typeid(ADDON::AddonEvents::UnInstalled) ||
+              typeid(event) == typeid(ADDON::AddonEvents::MetadataChanged) ||
+              typeid(event) == typeid(ADDON::AddonEvents::AutoUpdateStateChanged))
+          {
+            OnEventPublished();
+          }
+        });
+
     CServiceBroker::GetRepositoryUpdater().Events().Subscribe(
-        this, &CAddonsSubscriber::OnAddonRepositoryEvent);
+        this, [this](const ADDON::CRepositoryUpdater::RepositoryUpdated& /*event*/)
+        { OnEventPublished(); });
   }
   ~CAddonsSubscriber() override
   {
     CServiceBroker::GetRepositoryUpdater().Events().Unsubscribe(this);
     CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
-  }
-
-private:
-  void OnAddonEvent(const ADDON::AddonEvent& event)
-  {
-    if (typeid(event) == typeid(ADDON::AddonEvents::Enabled) ||
-        typeid(event) == typeid(ADDON::AddonEvents::Disabled) ||
-        typeid(event) == typeid(ADDON::AddonEvents::ReInstalled) ||
-        typeid(event) == typeid(ADDON::AddonEvents::UnInstalled) ||
-        typeid(event) == typeid(ADDON::AddonEvents::MetadataChanged) ||
-        typeid(event) == typeid(ADDON::AddonEvents::AutoUpdateStateChanged))
-    {
-      OnEventPublished();
-    }
-  }
-
-  void OnAddonRepositoryEvent(const ADDON::CRepositoryUpdater::RepositoryUpdated& event)
-  {
-    OnEventPublished();
   }
 };
 
@@ -156,7 +152,29 @@ public:
   explicit CPVRSubscriber(ISubscriberCallback& invalidate)
     : CDirectoryProvider::CSubscriber(invalidate)
   {
-    CServiceBroker::GetPVRManager().Events().Subscribe(this, &CPVRSubscriber::OnPVRManagerEvent);
+    CServiceBroker::GetPVRManager().Events().Subscribe(
+        this,
+        [this](const PVR::PVREvent& event)
+        {
+          if (event == PVR::PVREvent::ManagerStarted)
+            m_pvrStarted.test_and_set();
+          else if (event == PVR::PVREvent::ManagerStarting ||
+                   event == PVR::PVREvent::ManagerStopping ||
+                   event == PVR::PVREvent::ManagerStopped)
+            m_pvrStarted.clear();
+
+          if (!m_pvrStarted.test())
+            return;
+
+          using enum PVR::PVREvent;
+          if (event == ManagerStarted || event == ManagerStopped ||
+              event == RecordingsInvalidated || event == TimersInvalidated ||
+              event == ChannelGroupsInvalidated || event == SavedSearchesInvalidated ||
+              event == ClientsInvalidated || event == ClientsPrioritiesInvalidated)
+          {
+            OnEventPublished();
+          }
+        });
 
     if (CServiceBroker::GetPVRManager().IsStarted())
       m_pvrStarted.test_and_set();
@@ -166,27 +184,6 @@ public:
   bool IsReadyToUse() const override { return m_pvrStarted.test(); }
 
 private:
-  void OnPVRManagerEvent(const PVR::PVREvent& event)
-  {
-    if (event == PVR::PVREvent::ManagerStarted)
-      m_pvrStarted.test_and_set();
-    else if (event == PVR::PVREvent::ManagerStarting || event == PVR::PVREvent::ManagerStopping ||
-             event == PVR::PVREvent::ManagerStopped)
-      m_pvrStarted.clear();
-
-    if (!m_pvrStarted.test())
-      return;
-
-    using enum PVR::PVREvent;
-    if (event == ManagerStarted || event == ManagerStopped || event == RecordingsInvalidated ||
-        event == TimersInvalidated || event == ChannelGroupsInvalidated ||
-        event == SavedSearchesInvalidated || event == ClientsInvalidated ||
-        event == ClientsPrioritiesInvalidated)
-    {
-      OnEventPublished();
-    }
-  }
-
   std::atomic_flag m_pvrStarted{};
 };
 
@@ -197,15 +194,13 @@ public:
     : CDirectoryProvider::CSubscriber(invalidate)
   {
     CServiceBroker::GetFavouritesService().Events().Subscribe(
-        this, &CFavouritesSubscriber::OnFavouritesEvent);
+        this,
+        [this](const CFavouritesService::FavouritesUpdated& /*event*/) { OnEventPublished(); });
   }
   ~CFavouritesSubscriber() override
   {
     CServiceBroker::GetFavouritesService().Events().Unsubscribe(this);
   }
-
-private:
-  void OnFavouritesEvent(const CFavouritesService::FavouritesUpdated& event) { OnEventPublished(); }
 };
 
 std::unique_ptr<CDirectoryProvider::CSubscriber> GetSubscriber(const std::string& url,

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
@@ -17,7 +17,6 @@
 
 namespace ADDON
 {
-struct AddonEvent;
 class CAddonInfo;
 } // namespace ADDON
 
@@ -85,7 +84,6 @@ protected:
   void UnregisterRemovedDevices(const PeripheralScanResults& results) override;
 
 private:
-  void OnEvent(const ADDON::AddonEvent& event);
   void UnRegisterAddon(const std::string& addonId);
 
   void PromptEnableAddons(const std::vector<std::shared_ptr<ADDON::CAddonInfo>>& disabledAddons);

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -23,7 +23,6 @@ class CVariant;
 
 namespace ADDON
 {
-struct AddonEvent;
 class CAddonInfo;
 
 } // namespace ADDON
@@ -90,12 +89,6 @@ public:
    * @return True if the client was found, false otherwise.
    */
   bool StopClient(int clientId, bool restart);
-
-  /*!
-   * @brief Handle addon events (enable, disable, ...).
-   * @param event The addon event.
-   */
-  void OnAddonEvent(const ADDON::AddonEvent& event);
 
   /*!
    * @brief Get the number of created clients.

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -154,19 +154,16 @@ bool CPVRChannel::CreateEPG()
       }
 
       // Subscribe for EPG delete event
-      m_epg->Events().Subscribe(this, &CPVRChannel::Notify);
+      m_epg->Events().Subscribe(this,
+                                [this](const PVREvent& event)
+                                {
+                                  if (event == PVREvent::EpgDeleted)
+                                    ResetEPG();
+                                });
       return true;
     }
   }
   return false;
-}
-
-void CPVRChannel::Notify(const PVREvent& event)
-{
-  if (event == PVREvent::EpgDeleted)
-  {
-    ResetEPG();
-  }
 }
 
 void CPVRChannel::ResetEPG()

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -28,8 +28,6 @@ class CDateTime;
 
 namespace PVR
 {
-enum class PVREvent;
-
 class CPVRProvider;
 class CPVREpg;
 class CPVREpgInfoTag;
@@ -450,12 +448,6 @@ public:
    * @return the client uid of the provider or PVR_PROVIDER_INVALID_UID
    */
   int ClientProviderUid() const { return m_iClientProviderUid; }
-
-  /*!
-   * @brief CEventStream callback for PVR events.
-   * @param event The event.
-   */
-  void Notify(const PVREvent& event);
 
   /*!
    * @brief Lock the instance. No other thread gets access to this channel until Unlock was called.

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -18,8 +18,6 @@
 
 namespace PVR
 {
-enum class PVREvent;
-
 class CPVRChannel;
 class CPVRChannelGroupFactory;
 class CPVRClient;
@@ -266,8 +264,6 @@ private:
    * @return True, if data is currently valid, false otherwise.
    */
   bool HasValidDataForClients(const std::vector<std::shared_ptr<CPVRClient>>& clients) const;
-
-  void OnPVRManagerEvent(const PVR::PVREvent& event);
 
   int GetGroupClientPriority(const std::shared_ptr<const CPVRChannelGroup>& group) const;
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -182,7 +182,13 @@ bool CGUIDialogPVRChannelsOSD::OnAction(const CAction& action)
 void CGUIDialogPVRChannelsOSD::Update()
 {
   CPVRManager& pvrMgr = CServiceBroker::GetPVRManager();
-  pvrMgr.Events().Subscribe(this, &CGUIDialogPVRChannelsOSD::Notify);
+  pvrMgr.Events().Subscribe(this,
+                            [this](const PVREvent& event)
+                            {
+                              const CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), 0,
+                                                  static_cast<int>(event));
+                              CServiceBroker::GetAppMessenger()->SendGUIMessage(m);
+                            });
 
   const std::shared_ptr<const CPVRChannel> channel = pvrMgr.PlaybackState()->GetPlayingChannel();
   if (channel)
@@ -258,12 +264,6 @@ void CGUIDialogPVRChannelsOSD::GotoChannel(int iItem)
     Close();
 
   CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(*item);
-}
-
-void CGUIDialogPVRChannelsOSD::Notify(const PVREvent& event)
-{
-  const CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), 0, static_cast<int>(event));
-  CServiceBroker::GetAppMessenger()->SendGUIMessage(m);
 }
 
 void CGUIDialogPVRChannelsOSD::SaveSelectedItemPath(int iGroupID)

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
@@ -18,8 +18,6 @@
 
 namespace PVR
 {
-enum class PVREvent;
-
 class CPVRChannelGroup;
 
 class CGUIDialogPVRChannelsOSD : public CGUIDialogPVRItemsViewBase,
@@ -30,12 +28,6 @@ public:
   ~CGUIDialogPVRChannelsOSD() override;
   bool OnMessage(CGUIMessage& message) override;
   bool OnAction(const CAction& action) override;
-
-  /*!
-   * @brief CEventStream callback for PVR events.
-   * @param event The event.
-   */
-  void Notify(const PVREvent& event);
 
   // CPVRChannelNumberInputHandler implementation
   void GetChannelNumbers(std::vector<std::string>& channelNumbers) override;

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -562,7 +562,7 @@ void CPVREpgContainer::InsertFromDB(const std::shared_ptr<CPVREpg>& newEpg)
     // create a new epg table
     epg = newEpg;
     m_epgIdToEpgMap.try_emplace(epg->EpgID(), epg);
-    epg->Events().Subscribe(this, &CPVREpgContainer::Notify);
+    epg->Events().Subscribe(this, [this](const PVREvent& event) { Notify(event); });
   }
 }
 
@@ -588,7 +588,7 @@ std::shared_ptr<CPVREpg> CPVREpgContainer::CreateChannelEpg(int iEpgId, const st
     m_epgIdToEpgMap.try_emplace(iEpgId, epg);
     m_channelUidToEpgMap.try_emplace(
         {channelData->ClientId(), channelData->UniqueClientChannelId()}, epg);
-    epg->Events().Subscribe(this, &CPVREpgContainer::Notify);
+    epg->Events().Subscribe(this, [this](const PVREvent& event) { Notify(event); });
   }
   else if (epg->ChannelID() == -1)
   {

--- a/xbmc/pvr/guilib/PVRGUIActionListener.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionListener.cpp
@@ -67,26 +67,25 @@ CPVRGUIActionListener::~CPVRGUIActionListener()
 
 void CPVRGUIActionListener::Init(CPVRManager& mgr)
 {
-  mgr.Events().Subscribe(this, &CPVRGUIActionListener::OnPVRManagerEvent);
+  mgr.Events().Subscribe(this,
+                         [](const PVREvent& event)
+                         {
+                           if (event == PVREvent::AnnounceReminder)
+                           {
+                             if (g_application.IsInitialized())
+                             {
+                               // if GUI is ready, dispatch to GUI thread and handle the action there
+                               CServiceBroker::GetAppMessenger()->PostMsg(
+                                   TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                   static_cast<void*>(new CAction(ACTION_PVR_ANNOUNCE_REMINDERS)));
+                             }
+                           }
+                         });
 }
 
 void CPVRGUIActionListener::Deinit(CPVRManager& mgr)
 {
   mgr.Events().Unsubscribe(this);
-}
-
-void CPVRGUIActionListener::OnPVRManagerEvent(const PVREvent& event)
-{
-  if (event == PVREvent::AnnounceReminder)
-  {
-    if (g_application.IsInitialized())
-    {
-      // if GUI is ready, dispatch to GUI thread and handle the action there
-      CServiceBroker::GetAppMessenger()->PostMsg(
-          TMSG_GUI_ACTION, WINDOW_INVALID, -1,
-          static_cast<void*>(new CAction(ACTION_PVR_ANNOUNCE_REMINDERS)));
-    }
-  }
 }
 
 ChannelSwitchMode CPVRGUIActionListener::GetChannelSwitchMode(int iAction)

--- a/xbmc/pvr/guilib/PVRGUIActionListener.h
+++ b/xbmc/pvr/guilib/PVRGUIActionListener.h
@@ -16,7 +16,6 @@ namespace PVR
 
 class CPVRManager;
 enum class ChannelSwitchMode;
-enum class PVREvent;
 
 class CPVRGUIActionListener : public KODI::ACTION::IActionListener, public ISettingCallback
 {
@@ -33,8 +32,6 @@ public:
   // ISettingCallback implementation
   void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
   void OnSettingAction(const std::shared_ptr<const CSetting>& setting) override;
-
-  void OnPVRManagerEvent(const PVREvent& event);
 
 private:
   CPVRGUIActionListener(const CPVRGUIActionListener&) = delete;

--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
@@ -187,7 +187,8 @@ void CPVRGUIActionsChannels::RegisterChannelNumberInputHandler(
     CPVRChannelNumberInputHandler* handler)
 {
   if (handler)
-    handler->Events().Subscribe(this, &CPVRGUIActionsChannels::Notify);
+    handler->Events().Subscribe(this, [this](const PVRChannelNumberInputChangedEvent& event)
+                                { m_events.Publish(event); });
 }
 
 void CPVRGUIActionsChannels::DeregisterChannelNumberInputHandler(
@@ -195,11 +196,6 @@ void CPVRGUIActionsChannels::DeregisterChannelNumberInputHandler(
 {
   if (handler)
     handler->Events().Unsubscribe(this);
-}
-
-void CPVRGUIActionsChannels::Notify(const PVRChannelNumberInputChangedEvent& event)
-{
-  m_events.Publish(event);
 }
 
 bool CPVRGUIActionsChannels::HideChannel(const CFileItem& item) const

--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.h
@@ -72,12 +72,6 @@ public:
   void DeregisterChannelNumberInputHandler(CPVRChannelNumberInputHandler* handler);
 
   /*!
-   * @brief CEventStream callback for channel number input changes.
-   * @param event The event.
-   */
-  void Notify(const PVRChannelNumberInputChangedEvent& event);
-
-  /*!
    * @brief Hide a channel, always showing a confirmation dialog.
    * @param item containing a channel or an epg tag.
    * @return true on success, false otherwise.

--- a/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
@@ -119,7 +119,14 @@ void CPVRGUIChannelNavigator::SubscribeToShowInfoEventStream()
       .GetInfoProviders()
       .GetPlayerInfoProvider()
       .Events()
-      .Subscribe(this, &CPVRGUIChannelNavigator::Notify);
+      .Subscribe(this,
+                 [this](const PlayerShowInfoChangedEvent& event)
+                 {
+                   std::unique_lock lock(m_critSection);
+
+                   m_playerShowInfo = event.m_showInfo;
+                   CheckAndPublishPreviewAndPlayerShowInfoChangedEvent();
+                 });
 }
 
 void CPVRGUIChannelNavigator::CheckAndPublishPreviewAndPlayerShowInfoChangedEvent()
@@ -134,14 +141,6 @@ void CPVRGUIChannelNavigator::CheckAndPublishPreviewAndPlayerShowInfoChangedEven
     // inform subscribers
     m_events.Publish(PVRPreviewAndPlayerShowInfoChangedEvent(currentValue));
   }
-}
-
-void CPVRGUIChannelNavigator::Notify(const PlayerShowInfoChangedEvent& event)
-{
-  std::unique_lock lock(m_critSection);
-
-  m_playerShowInfo = event.m_showInfo;
-  CheckAndPublishPreviewAndPlayerShowInfoChangedEvent();
 }
 
 void CPVRGUIChannelNavigator::SelectNextChannel(ChannelSwitchMode eSwitchMode)

--- a/xbmc/pvr/guilib/PVRGUIChannelNavigator.h
+++ b/xbmc/pvr/guilib/PVRGUIChannelNavigator.h
@@ -13,11 +13,6 @@
 
 #include <memory>
 
-namespace KODI::GUILIB::GUIINFO
-{
-struct PlayerShowInfoChangedEvent;
-}
-
 namespace PVR
 {
 enum class ChannelSwitchMode
@@ -45,13 +40,15 @@ public:
   CPVRGUIChannelNavigator();
   virtual ~CPVRGUIChannelNavigator();
 
+  using Callback = std::function<void(const PVRPreviewAndPlayerShowInfoChangedEvent&)>;
+
   /*!
    * @brief Subscribe to the event stream for changes of channel preview and player show info.
    * @param owner The subscriber.
    * @param fn The callback function of the subscriber for the events.
    */
   template<typename A>
-  void Subscribe(A* owner, void (A::*fn)(const PVRPreviewAndPlayerShowInfoChangedEvent&))
+  void Subscribe(A* owner, const Callback& fn)
   {
     SubscribeToShowInfoEventStream();
     m_events.Subscribe(owner, fn);
@@ -66,12 +63,6 @@ public:
   {
     m_events.Unsubscribe(obj);
   }
-
-  /*!
-   * @brief CEventStream callback for player show info flag changes.
-   * @param event The event.
-   */
-  void Notify(const KODI::GUILIB::GUIINFO::PlayerShowInfoChangedEvent& event);
 
   /*!
    * @brief Select the next channel in currently playing channel group, relative to the currently

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
@@ -30,10 +30,6 @@ class CGUIInfo;
 
 namespace PVR
 {
-enum class PVREvent;
-struct PVRChannelNumberInputChangedEvent;
-struct PVRPreviewAndPlayerShowInfoChangedEvent;
-
 class CPVRGUIInfo : public KODI::GUILIB::GUIINFO::CGUIInfoProvider, private CThread
 {
 public:
@@ -42,24 +38,6 @@ public:
 
   void Start();
   void Stop();
-
-  /*!
-   * @brief CEventStream callback for PVR events.
-   * @param event The event.
-   */
-  void Notify(const PVREvent& event);
-
-  /*!
-   * @brief CEventStream callback for channel number input changes.
-   * @param event The event.
-   */
-  void Notify(const PVRChannelNumberInputChangedEvent& event);
-
-  /*!
-   * @brief CEventStream callback for channel preview and player show info changes.
-   * @param event The event.
-   */
-  void Notify(const PVRPreviewAndPlayerShowInfoChangedEvent& event);
 
   // KODI::GUILIB::GUIINFO::IGUIInfoProvider implementation
   bool InitCurrentItem(CFileItem* item) override;

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -138,7 +138,28 @@ void CPVRTimers::Start()
 {
   Stop();
 
-  CServiceBroker::GetPVRManager().Events().Subscribe(this, &CPVRTimers::Notify);
+  CServiceBroker::GetPVRManager().Events().Subscribe(
+      this,
+      [this](const PVREvent& event)
+      {
+        switch (event)
+        {
+          using enum PVREvent;
+
+          case EpgContainer:
+            CServiceBroker::GetPVRManager().TriggerTimersUpdate();
+            break;
+          case Epg:
+          case EpgItemUpdate:
+          {
+            std::unique_lock lock(m_critSection);
+            m_bReminderRulesUpdatePending = true;
+            break;
+          }
+          default:
+            break;
+        }
+      });
   Create();
 }
 
@@ -1264,27 +1285,6 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetTimerRule(
   }
 
   return {};
-}
-
-void CPVRTimers::Notify(const PVREvent& event)
-{
-  switch (event)
-  {
-    using enum PVREvent;
-
-    case EpgContainer:
-      CServiceBroker::GetPVRManager().TriggerTimersUpdate();
-      break;
-    case Epg:
-    case EpgItemUpdate:
-    {
-      std::unique_lock lock(m_critSection);
-      m_bReminderRulesUpdatePending = true;
-      break;
-    }
-    default:
-      break;
-  }
 }
 
 CDateTime CPVRTimers::GetNextEventTime() const

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -21,7 +21,6 @@ class CDateTime;
 namespace PVR
 {
 enum class TimerOperationResult;
-enum class PVREvent;
 
 class CPVRChannel;
 class CPVRClient;
@@ -265,12 +264,6 @@ public:
      * @brief Update the channel pointers.
      */
   void UpdateChannels();
-
-  /*!
-     * @brief CEventStream callback for PVR events.
-     * @param event The event.
-     */
-  void Notify(const PVREvent& event);
 
   /*!
    * @brief Get a timer tag given it's unique ID

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -146,7 +146,12 @@ CGUIWindowPVRBase::CGUIWindowPVRBase(bool bRadio, int id, const std::string& xml
   // prevent removable drives to appear in directory listing (base class default behavior).
   m_rootDir.AllowNonLocalSources(false);
 
-  CServiceBroker::GetPVRManager().Events().Subscribe(this, &CGUIWindowPVRBase::Notify);
+  CServiceBroker::GetPVRManager().Events().Subscribe(this,
+                                                     [this](const PVREvent& event)
+                                                     {
+                                                       // call virtual event handler function
+                                                       NotifyEvent(event);
+                                                     });
 }
 
 CGUIWindowPVRBase::~CGUIWindowPVRBase()
@@ -161,12 +166,6 @@ void CGUIWindowPVRBase::UpdateSelectedItemPath()
 {
   CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().SetSelectedChannelPath(
       m_bRadio, m_viewControl.GetSelectedItemPath());
-}
-
-void CGUIWindowPVRBase::Notify(const PVREvent& event)
-{
-  // call virtual event handler function
-  NotifyEvent(event);
 }
 
 void CGUIWindowPVRBase::NotifyEvent(const PVREvent& event)
@@ -562,7 +561,12 @@ void CGUIWindowPVRBase::SetChannelGroup(const std::shared_ptr<CPVRChannelGroup>&
         m_channelGroup->Events().Unsubscribe(this);
       m_channelGroup = group;
       // we need to register the window to receive changes from the new group
-      m_channelGroup->Events().Subscribe(this, &CGUIWindowPVRBase::Notify);
+      m_channelGroup->Events().Subscribe(this,
+                                         [this](const PVREvent& event)
+                                         {
+                                           // call virtual event handler function
+                                           NotifyEvent(event);
+                                         });
       if (bUpdate)
         updateChannelGroup = m_channelGroup;
     }

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -55,7 +55,6 @@ public:
    * @brief CEventStream callback for PVR events.
    * @param event The event.
    */
-  void Notify(const PVREvent& event);
   virtual void NotifyEvent(const PVREvent& event);
 
   bool ActivatePreviousChannelGroup();

--- a/xbmc/utils/EventStream.h
+++ b/xbmc/utils/EventStream.h
@@ -13,6 +13,7 @@
 #include "threads/CriticalSection.h"
 
 #include <algorithm>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <vector>
@@ -22,11 +23,12 @@ template<typename Event>
 class CEventStream
 {
 public:
+  using EventHandler = std::function<void(const Event&)>;
 
   template<typename A>
-  void Subscribe(A* owner, void (A::*fn)(const Event&))
+  void Subscribe(A* owner, const EventHandler& eventHandler)
   {
-    auto subscription = std::make_shared<detail::CSubscription<Event, A>>(owner, fn);
+    auto subscription = std::make_shared<detail::CSubscription<Event, A>>(owner, eventHandler);
     std::unique_lock lock(m_criticalSection);
     m_subscriptions.emplace_back(std::move(subscription));
   }

--- a/xbmc/utils/FileExtensionProvider.h
+++ b/xbmc/utils/FileExtensionProvider.h
@@ -17,7 +17,6 @@ namespace ADDON
 {
 enum class AddonType;
 class CAddonMgr;
-struct AddonEvent;
 }
 
 class CAdvancedSettings;
@@ -75,8 +74,6 @@ private:
   std::string GetAddonFileFolderExtensions(ADDON::AddonType type) const;
   void SetAddonExtensions();
   void SetAddonExtensions(ADDON::AddonType type);
-
-  void OnAddonEvent(const ADDON::AddonEvent& event);
 
   // Construction properties
   std::shared_ptr<CAdvancedSettings> m_advancedSettings;


### PR DESCRIPTION
SonarQube suggests to modernize `CEventStream` and `CSubsription` interfaces to use `std::function` instead of function pointers. Nice side effect of my implementation: Better encapsulation. Less functions need to be exposed in class declarations (header files).

Runtime-tested for quite some time. Seems to do what it is supposed to do.

No idea who could review this. It's getting more and more complicated to find somebody for PR reviews...