### PR TITLE
[video] SonarQube finding: Make CVideoActionProcessorBase members m_item and m_userCancelled private.

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -147,7 +147,7 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonPlay(const CGUIMessage& message)
           KODI::VIDEO::GUILIB::CVideoPlayActionProcessor proc{
               std::make_shared<CFileItem>(recording)};
           proc.ProcessDefaultAction();
-          if (proc.UserCancelled())
+          if (proc.GetUserCancelled())
             Open();
         }
       }

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
@@ -66,7 +66,7 @@ bool CGUIDialogPVRRecordingInfo::OnClickButtonPlay(const CGUIMessage& message)
     {
       KODI::VIDEO::GUILIB::CVideoPlayActionProcessor proc{m_recordItem};
       proc.ProcessDefaultAction();
-      if (proc.UserCancelled())
+      if (proc.GetUserCancelled())
         Open();
     }
 

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -791,7 +791,7 @@ void CGUIDialogVideoInfo::Play(bool resume)
       // play button acts according to default play action setting
       KODI::VIDEO::GUILIB::CVideoPlayActionProcessor proc{m_movieItem};
       proc.ProcessDefaultAction();
-      if (proc.UserCancelled())
+      if (proc.GetUserCancelled())
       {
         // The Resume dialog was closed without any choice
         SetMovie(m_movieItem.get()); // restore cast list, which was cleared on dialog close

--- a/xbmc/video/guilib/VideoActionProcessorBase.h
+++ b/xbmc/video/guilib/VideoActionProcessorBase.h
@@ -28,7 +28,8 @@ public:
   bool UserCancelled() const { return m_userCancelled; }
   void SetUserCancelled(bool set) { m_userCancelled = set; }
 
-  std::shared_ptr<CFileItem> GetItem() const { return m_item; }
+  std::shared_ptr<CFileItem> GetItem() { return m_item; }
+  std::shared_ptr<const CFileItem> GetItem() const { return m_item; }
 
 protected:
   virtual Action GetDefaultAction() = 0;

--- a/xbmc/video/guilib/VideoActionProcessorBase.h
+++ b/xbmc/video/guilib/VideoActionProcessorBase.h
@@ -25,7 +25,7 @@ public:
   bool ProcessDefaultAction();
   bool ProcessAction(Action action);
 
-  bool UserCancelled() const { return m_userCancelled; }
+  bool GetUserCancelled() const { return m_userCancelled; }
   void SetUserCancelled(bool set) { m_userCancelled = set; }
 
   std::shared_ptr<CFileItem> GetItem() { return m_item; }

--- a/xbmc/video/guilib/VideoActionProcessorBase.h
+++ b/xbmc/video/guilib/VideoActionProcessorBase.h
@@ -26,15 +26,18 @@ public:
   bool ProcessAction(Action action);
 
   bool UserCancelled() const { return m_userCancelled; }
+  void SetUserCancelled(bool set) { m_userCancelled = set; }
+
+  std::shared_ptr<CFileItem> GetItem() const { return m_item; }
 
 protected:
   virtual Action GetDefaultAction() = 0;
   virtual bool Process(Action action) = 0;
 
-  std::shared_ptr<CFileItem> m_item;
-  bool m_userCancelled{false};
-
 private:
   CVideoActionProcessorBase() = delete;
+
+  std::shared_ptr<CFileItem> m_item;
+  bool m_userCancelled{false};
 };
 } // namespace KODI::VIDEO::GUILIB

--- a/xbmc/video/guilib/VideoPlayActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.cpp
@@ -49,7 +49,7 @@ bool CVideoPlayActionProcessor::Process(Action action)
 {
   if (m_chooseStackPart && m_chosenStackPart == 0)
   {
-    if (!URIUtils::IsStack(m_item->GetDynPath()))
+    if (!URIUtils::IsStack(GetItem()->GetDynPath()))
     {
       CLog::LogF(LOGERROR, "Invalid item (not a stack)!");
       return true; // done
@@ -58,7 +58,7 @@ bool CVideoPlayActionProcessor::Process(Action action)
     m_chosenStackPart = ChooseStackPart();
     if (m_chosenStackPart < 1)
     {
-      m_userCancelled = true;
+      SetUserCancelled(true);
       return true; // User cancelled the select menu. We're done.
     }
   }
@@ -70,7 +70,7 @@ bool CVideoPlayActionProcessor::Process(Action action)
       const Action selectedAction = ChoosePlayOrResume();
       if (selectedAction < 0)
       {
-        m_userCancelled = true;
+        SetUserCancelled(true);
         return true; // User cancelled the select menu. We're done.
       }
 
@@ -99,20 +99,20 @@ Action CVideoPlayActionProcessor::ChoosePlayOrResume() const
 {
   if (m_chosenStackPart)
   {
-    const int64_t offset{VIDEO::UTILS::GetStackPartResumeOffset(*m_item, m_chosenStackPart)};
+    const int64_t offset{VIDEO::UTILS::GetStackPartResumeOffset(*GetItem(), m_chosenStackPart)};
     if (offset > 0)
       return ChoosePlayOrResume(VIDEO::UTILS::GetResumeString(offset, m_chosenStackPart));
   }
-  else if (URIUtils::IsStack(m_item->GetDynPath()))
+  else if (URIUtils::IsStack(GetItem()->GetDynPath()))
   {
-    const auto [offset, partNumber] = VIDEO::UTILS::GetStackResumeOffsetAndPartNumber(*m_item);
+    const auto [offset, partNumber] = VIDEO::UTILS::GetStackResumeOffsetAndPartNumber(*GetItem());
     if (offset > 0)
       return ChoosePlayOrResume(VIDEO::UTILS::GetResumeString(offset, partNumber));
   }
   else
   {
     const VIDEO::UTILS::ResumeInformation resumeInfo{
-        VIDEO::UTILS::GetItemResumeInformation(*m_item)};
+        VIDEO::UTILS::GetItemResumeInformation(*GetItem())};
     if (resumeInfo.isResumable)
       return ChoosePlayOrResume(
           VIDEO::UTILS::GetResumeString(resumeInfo.startOffset, resumeInfo.partNumber));
@@ -147,7 +147,7 @@ Action CVideoPlayActionProcessor::ChoosePlayOrResume(const CFileItem& item)
 unsigned int CVideoPlayActionProcessor::ChooseStackPart() const
 {
   CFileItemList parts;
-  XFILE::CDirectory::GetDirectory(m_item->GetDynPath(), parts, "", XFILE::DIR_FLAG_DEFAULTS);
+  XFILE::CDirectory::GetDirectory(GetItem()->GetDynPath(), parts, "", XFILE::DIR_FLAG_DEFAULTS);
 
   if (parts.IsEmpty())
   {
@@ -176,29 +176,31 @@ unsigned int CVideoPlayActionProcessor::ChooseStackPart() const
 
 void CVideoPlayActionProcessor::SetResumeData() const
 {
+  const auto item{GetItem()};
   if (m_chosenStackPart)
   {
-    m_item->SetStartPartNumber(m_chosenStackPart);
-    m_item->SetStartOffset(VIDEO::UTILS::GetStackPartResumeOffset(*m_item, m_chosenStackPart));
+    item->SetStartPartNumber(m_chosenStackPart);
+    item->SetStartOffset(VIDEO::UTILS::GetStackPartResumeOffset(*item, m_chosenStackPart));
   }
   else
   {
-    m_item->SetStartPartNumber(1);
-    m_item->SetStartOffset(STARTOFFSET_RESUME);
+    item->SetStartPartNumber(1);
+    item->SetStartOffset(STARTOFFSET_RESUME);
   }
 }
 
 void CVideoPlayActionProcessor::SetStartData() const
 {
+  const auto item{GetItem()};
   if (m_chosenStackPart)
   {
-    m_item->SetStartPartNumber(m_chosenStackPart);
-    m_item->SetStartOffset(VIDEO::UTILS::GetStackPartStartOffset(*m_item, m_chosenStackPart));
+    item->SetStartPartNumber(m_chosenStackPart);
+    item->SetStartOffset(VIDEO::UTILS::GetStackPartStartOffset(*item, m_chosenStackPart));
   }
   else
   {
-    m_item->SetStartPartNumber(1);
-    m_item->SetStartOffset(0);
+    item->SetStartPartNumber(1);
+    item->SetStartOffset(0);
   }
 }
 
@@ -213,12 +215,12 @@ bool CVideoPlayActionProcessor::OnPlaySelected()
   std::string player;
   if (m_choosePlayer)
   {
-    const std::vector<std::string> players{CPlayerUtils::GetPlayersForItem(*m_item)};
+    const std::vector<std::string> players{CPlayerUtils::GetPlayersForItem(*GetItem())};
     const CPlayerCoreFactory& playerCoreFactory{CServiceBroker::GetPlayerCoreFactory()};
     player = playerCoreFactory.SelectPlayerDialog(players);
     if (player.empty())
     {
-      m_userCancelled = true;
+      SetUserCancelled(true);
       return true; // User cancelled player selection. We're done.
     }
   }
@@ -229,7 +231,7 @@ bool CVideoPlayActionProcessor::OnPlaySelected()
 
 void CVideoPlayActionProcessor::Play(const std::string& player) const
 {
-  auto item{m_item};
+  auto item{GetItem()};
   if (item->IsFolder() && item->HasVideoVersions())
   {
     //! @todo get rid of "videos with versions as folder" hack!

--- a/xbmc/video/guilib/VideoPlayActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.cpp
@@ -174,7 +174,7 @@ unsigned int CVideoPlayActionProcessor::ChooseStackPart() const
   return dialog->GetSelectedItem() + 1; // part numbers are 1-based
 }
 
-void CVideoPlayActionProcessor::SetResumeData() const
+void CVideoPlayActionProcessor::SetResumeData()
 {
   const auto item{GetItem()};
   if (m_chosenStackPart)
@@ -189,7 +189,7 @@ void CVideoPlayActionProcessor::SetResumeData() const
   }
 }
 
-void CVideoPlayActionProcessor::SetStartData() const
+void CVideoPlayActionProcessor::SetStartData()
 {
   const auto item{GetItem()};
   if (m_chosenStackPart)
@@ -229,7 +229,7 @@ bool CVideoPlayActionProcessor::OnPlaySelected()
   return true;
 }
 
-void CVideoPlayActionProcessor::Play(const std::string& player) const
+void CVideoPlayActionProcessor::Play(const std::string& player)
 {
   auto item{GetItem()};
   if (item->IsFolder() && item->HasVideoVersions())

--- a/xbmc/video/guilib/VideoPlayActionProcessor.h
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.h
@@ -38,9 +38,9 @@ private:
   unsigned int ChooseStackPart() const;
   Action ChoosePlayOrResume() const;
   static Action ChoosePlayOrResume(const std::string& resumeString);
-  void SetResumeData() const;
-  void SetStartData() const;
-  void Play(const std::string& player) const;
+  void SetResumeData();
+  void SetStartData();
+  void Play(const std::string& player);
 
   bool m_chooseStackPart{false};
   bool m_choosePlayer{false};

--- a/xbmc/video/guilib/VideoSelectActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoSelectActionProcessor.cpp
@@ -52,9 +52,10 @@ bool CVideoSelectActionProcessor::Process(Action action)
 
     case ACTION_INFO:
     {
-      if (GetDefaultAction() == ACTION_INFO && !KODI::VIDEO::IsVideoDb(*m_item) &&
-          !m_item->IsPlugin() && !m_item->IsScript() && !m_item->IsPVR() &&
-          !KODI::VIDEO::UTILS::HasItemVideoDbInformation(*m_item))
+      const auto item{GetItem()};
+      if (GetDefaultAction() == ACTION_INFO && !KODI::VIDEO::IsVideoDb(*item) &&
+          !item->IsPlugin() && !item->IsScript() && !item->IsPVR() &&
+          !KODI::VIDEO::UTILS::HasItemVideoDbInformation(*item))
       {
         // For items without info fall back to default play action.
         return Process(ACTION_PLAY);
@@ -72,24 +73,24 @@ bool CVideoSelectActionProcessor::Process(Action action)
 bool CVideoSelectActionProcessor::OnPlaySelected()
 {
   // Execute default play action.
-  CVideoPlayActionProcessor proc(m_item);
+  CVideoPlayActionProcessor proc(GetItem());
   return proc.ProcessDefaultAction();
 }
 
 bool CVideoSelectActionProcessor::OnQueueSelected()
 {
-  VIDEO::UTILS::QueueItem(m_item, VIDEO::UTILS::QueuePosition::POSITION_END);
+  VIDEO::UTILS::QueueItem(GetItem(), VIDEO::UTILS::QueuePosition::POSITION_END);
   return true;
 }
 
 bool CVideoSelectActionProcessor::OnInfoSelected()
 {
-  return KODI::UTILS::GUILIB::CGUIContentUtils::ShowInfoForItem(*m_item);
+  return KODI::UTILS::GUILIB::CGUIContentUtils::ShowInfoForItem(*GetItem());
 }
 
 bool CVideoSelectActionProcessor::OnChooseSelected()
 {
-  CONTEXTMENU::ShowFor(m_item, CContextMenuManager::MAIN);
+  CONTEXTMENU::ShowFor(GetItem(), CContextMenuManager::MAIN);
   return true;
 }
 

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -582,9 +582,9 @@ public:
   }
 
 protected:
-  bool OnResumeSelected() override { return m_window.PlayItem(m_item, m_player); }
+  bool OnResumeSelected() override { return m_window.PlayItem(GetItem(), m_player); }
 
-  bool OnPlaySelected() override { return m_window.PlayItem(m_item, m_player); }
+  bool OnPlaySelected() override { return m_window.PlayItem(GetItem(), m_player); }
 
 private:
   CGUIWindowVideoBase& m_window;
@@ -608,23 +608,24 @@ public:
 protected:
   bool OnPlaySelected() override
   {
-    CVideoPlayActionProcessor proc{m_window, m_item, m_player};
+    CVideoPlayActionProcessor proc{m_window, GetItem(), m_player};
     return proc.ProcessDefaultAction();
   }
 
   bool OnQueueSelected() override
   {
-    m_window.OnQueueItem(m_item, m_itemIndex);
+    m_window.OnQueueItem(GetItem(), m_itemIndex);
     return true;
   }
 
-  bool OnInfoSelected() override { return m_window.OnItemInfo(*m_item); }
+  bool OnInfoSelected() override { return m_window.OnItemInfo(*GetItem()); }
 
   bool OnChooseSelected() override
   {
     // window only shows the default version, so no window specific context menu items available
-    if (m_item->HasVideoVersions() && !m_item->GetVideoInfoTag()->IsDefaultVideoVersion())
-      return CONTEXTMENU::ShowFor(m_item, CContextMenuManager::MAIN);
+    const auto item{GetItem()};
+    if (item->HasVideoVersions() && !item->GetVideoInfoTag()->IsDefaultVideoVersion())
+      return CONTEXTMENU::ShowFor(item, CContextMenuManager::MAIN);
 
     m_window.OnPopupMenu(m_itemIndex);
     return true;

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -396,8 +396,9 @@ protected:
 
     const auto playlistItem{playlistPlayer.GetPlaylist(PLAYLIST::Id::TYPE_VIDEO)[m_itemIndex]};
     playlistItem->SetStartOffset(STARTOFFSET_RESUME);
-    if (playlistItem->HasVideoInfoTag() && m_item->HasVideoInfoTag())
-      playlistItem->GetVideoInfoTag()->SetResumePoint(m_item->GetVideoInfoTag()->GetResumePoint());
+    if (playlistItem->HasVideoInfoTag() && GetItem()->HasVideoInfoTag())
+      playlistItem->GetVideoInfoTag()->SetResumePoint(
+          GetItem()->GetVideoInfoTag()->GetResumePoint());
 
     playlistPlayer.Play(m_itemIndex, m_player);
     return true;


### PR DESCRIPTION
SonarQube suggests to make members `m_item` and `m_userCancelled` of class `CVideoActionProcessorBase` private.

Runtime-tested for quite some time. Seems to do what it is supposed to do.

It's getting more and more complicated to find somebody for PR reviews... maybe @enen92 ?