### PR TITLE
[cores/Retroplayer][games] Misc SonarQube findings.

### DIFF
--- a/xbmc/cores/RetroPlayer/RetroPlayerTypes.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayerTypes.h
@@ -8,6 +8,9 @@
 
 #pragma once
 
+#include "utils/Geometry.h"
+
+#include <array>
 #include <memory>
 #include <vector>
 
@@ -18,6 +21,11 @@ namespace RETRO
 class IRenderBufferPool;
 using RenderBufferPoolPtr = std::shared_ptr<IRenderBufferPool>;
 using RenderBufferPoolVector = std::vector<RenderBufferPoolPtr>;
+
+/*!
+ * \brief Coordinates of the 4 corners of the output viewport/window
+ */
+using ViewportCoordinates = std::array<CPoint, 4>;
 
 enum class DataAccess
 {

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferManager.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferManager.cpp
@@ -36,8 +36,7 @@ RenderBufferPoolVector CRenderBufferManager::GetPools(IRendererFactory* factory)
 
   std::unique_lock lock(m_critSection);
 
-  auto it = std::find_if(m_pools.begin(), m_pools.end(), [factory](const RenderBufferPools& pools)
-                         { return pools.factory == factory; });
+  auto it = std::ranges::find(m_pools, factory, &RenderBufferPools::factory);
 
   if (it != m_pools.end())
     bufferPools = it->pools;

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -648,9 +648,8 @@ IRenderBuffer* CRPRenderManager::GetRenderBufferForSavestate(const std::string& 
     // Get a render buffer belonging to the specified pool
     const std::vector<IRenderBuffer*>& renderBuffers = it->second;
 
-    auto it2 =
-        std::find_if(renderBuffers.begin(), renderBuffers.end(), [bufferPool](IRenderBuffer* buffer)
-                     { return buffer->GetPool() == bufferPool; });
+    auto it2 = std::ranges::find_if(renderBuffers, [bufferPool](IRenderBuffer* buffer)
+                                    { return buffer->GetPool() == bufferPool; });
 
     if (it2 != renderBuffers.end())
     {

--- a/xbmc/cores/RetroPlayer/rendering/RenderUtils.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderUtils.cpp
@@ -121,12 +121,12 @@ void CRenderUtils::CalculateStretchMode(STRETCHMODE stretchMode,
 
           if (screenWidth / (sourceFrameRatio * pixelRatio) > screenHeight)
           {
-            const int zoomFactor = static_cast<int>(screenHeight / sourceWidth);
+            const auto zoomFactor = static_cast<int>(screenHeight / sourceWidth);
             zoomAmount = (zoomFactor * sourceWidth) / screenHeight;
           }
           else
           {
-            const int zoomFactor = static_cast<int>(screenWidth / (sourceHeight * pixelRatio));
+            const auto zoomFactor = static_cast<int>(screenWidth / (sourceHeight * pixelRatio));
             zoomAmount = (zoomFactor * sourceHeight * pixelRatio) / screenWidth;
           }
 
@@ -137,12 +137,12 @@ void CRenderUtils::CalculateStretchMode(STRETCHMODE stretchMode,
 
           if (screenWidth / (sourceFrameRatio * pixelRatio) > screenHeight)
           {
-            const int zoomFactor = static_cast<int>(screenHeight / sourceHeight);
+            const auto zoomFactor = static_cast<int>(screenHeight / sourceHeight);
             zoomAmount = (zoomFactor * sourceHeight) / screenHeight;
           }
           else
           {
-            const int zoomFactor = static_cast<int>(screenWidth / (sourceWidth * pixelRatio));
+            const auto zoomFactor = static_cast<int>(screenWidth / (sourceWidth * pixelRatio));
             zoomAmount = (zoomFactor * sourceWidth * pixelRatio) / screenWidth;
           }
 
@@ -162,12 +162,12 @@ void CRenderUtils::CalculateStretchMode(STRETCHMODE stretchMode,
 
           if (screenWidth / (sourceFrameRatio * pixelRatio) > screenHeight)
           {
-            const int zoomFactor = static_cast<int>(screenHeight / sourceWidth);
+            const auto zoomFactor = static_cast<int>(screenHeight / sourceWidth);
             zoomAmount = (zoomFactor * sourceWidth) / screenHeight;
           }
           else
           {
-            const int zoomFactor = static_cast<int>(screenWidth / (sourceHeight * pixelRatio));
+            const auto zoomFactor = static_cast<int>(screenWidth / (sourceHeight * pixelRatio));
             zoomAmount = (zoomFactor * sourceHeight * pixelRatio) / screenWidth;
           }
 
@@ -179,12 +179,12 @@ void CRenderUtils::CalculateStretchMode(STRETCHMODE stretchMode,
 
           if (screenWidth / (sourceFrameRatio * pixelRatio) > screenHeight)
           {
-            const int zoomFactor = static_cast<int>(screenHeight / sourceHeight);
+            const auto zoomFactor = static_cast<int>(screenHeight / sourceHeight);
             zoomAmount = (zoomFactor * sourceHeight) / screenHeight;
           }
           else
           {
-            const int zoomFactor = static_cast<int>(screenWidth / (sourceWidth * pixelRatio));
+            const auto zoomFactor = static_cast<int>(screenWidth / (sourceWidth * pixelRatio));
             zoomAmount = (zoomFactor * sourceWidth * pixelRatio) / screenWidth;
           }
 
@@ -357,10 +357,10 @@ void CRenderUtils::CropSource(CRect& sourceRect,
   }
 }
 
-std::array<CPoint, 4> CRenderUtils::ReorderDrawPoints(const CRect& destRect,
-                                                      unsigned int orientationDegCCW)
+ViewportCoordinates CRenderUtils::ReorderDrawPoints(const CRect& destRect,
+                                                    unsigned int orientationDegCCW)
 {
-  std::array<CPoint, 4> rotatedDestCoords{};
+  ViewportCoordinates rotatedDestCoords{};
 
   switch (orientationDegCCW)
   {

--- a/xbmc/cores/RetroPlayer/rendering/RenderUtils.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderUtils.h
@@ -9,9 +9,7 @@
 #pragma once
 
 #include "cores/GameSettings.h"
-#include "utils/Geometry.h"
-
-#include <array>
+#include "cores/RetroPlayer/RetroPlayerTypes.h"
 
 namespace KODI
 {
@@ -45,8 +43,8 @@ public:
                          float destWidth,
                          float destHeight);
 
-  static std::array<CPoint, 4> ReorderDrawPoints(const CRect& destRect,
-                                                 unsigned int orientationDegCCW);
+  static ViewportCoordinates ReorderDrawPoints(const CRect& destRect,
+                                               unsigned int orientationDegCCW);
 };
 } // namespace RETRO
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/rendering/RenderVideoSettings.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderVideoSettings.h
@@ -11,6 +11,7 @@
 #include "cores/GameSettings.h"
 
 #include <string>
+#include <string_view>
 
 namespace KODI
 {
@@ -44,7 +45,7 @@ public:
   void SetRenderStretchMode(STRETCHMODE mode) { m_stretchMode = mode; }
 
   const std::string& GetShaderPreset() const { return m_shaderPreset; }
-  void SetShaderPreset(const std::string& shaderPreset) { m_shaderPreset = shaderPreset; }
+  void SetShaderPreset(std::string_view shaderPreset) { m_shaderPreset = shaderPreset; }
   void ResetShaderPreset();
 
   unsigned int GetRenderRotation() const { return m_rotationDegCCW; }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
@@ -47,11 +47,8 @@ bool CRPBaseRenderer::IsCompatible(const CRenderVideoSettings& settings) const
     shaderPreset = m_shaderPreset->GetShaderPreset();
 
   // Shader preset might not be initialized yet
-  if (!shaderPreset.empty())
-  {
-    if (settings.GetShaderPreset() != shaderPreset)
-      return false;
-  }
+  if (!shaderPreset.empty() && settings.GetShaderPreset() != shaderPreset)
+    return false;
 
   return true;
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
@@ -10,6 +10,7 @@
 
 #include "cores/GameSettings.h"
 #include "cores/RetroPlayer/rendering/RenderSettings.h"
+#include "cores/RetroPlayer/rendering/RenderUtils.h"
 #include "utils/Geometry.h"
 
 extern "C"
@@ -17,7 +18,6 @@ extern "C"
 #include <libavutil/pixfmt.h>
 }
 
-#include <array>
 #include <memory>
 #include <stdint.h>
 
@@ -95,7 +95,7 @@ protected:
 
   // Geometry properties
   CRect m_sourceRect;
-  std::array<CPoint, 4> m_rotatedDestCoords{};
+  ViewportCoordinates m_rotatedDestCoords{};
 
   // Video shaders
   void Updateshaders();

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
@@ -97,8 +97,7 @@ void CRPRendererDMAOpenGL::Render(uint8_t alpha)
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    const CPoint destPoints[4] = {m_rotatedDestCoords[0], m_rotatedDestCoords[1],
-                                  m_rotatedDestCoords[2], m_rotatedDestCoords[3]};
+    const ViewportCoordinates destPoints{m_rotatedDestCoords};
 
     SHADER::CShaderTextureGL source(sourceTexture, false);
     SHADER::CShaderTextureGL target(targetTexture, false);
@@ -171,7 +170,7 @@ void CRPRendererDMAOpenGL::Render(uint8_t alpha)
                 (colour[3] / 255.0f));
     glUniform1f(depthLoc, -1.0f);
 
-    glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+    glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
 
     glBindVertexArray(0);
     glBindBuffer(GL_ARRAY_BUFFER, 0);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
@@ -97,8 +97,7 @@ void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    const CPoint destPoints[4] = {m_rotatedDestCoords[0], m_rotatedDestCoords[1],
-                                  m_rotatedDestCoords[2], m_rotatedDestCoords[3]};
+    const ViewportCoordinates destPoints{m_rotatedDestCoords};
 
     SHADER::CShaderTextureGLES source(sourceTexture, false);
     SHADER::CShaderTextureGLES target(targetTexture, false);
@@ -178,7 +177,7 @@ void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
     glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f),
                 (colour[3] / 255.0f));
     glUniform1f(depthLoc, -1.0f);
-    glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+    glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
 
     glDisableVertexAttribArray(vertLoc);
     glDisableVertexAttribArray(loc);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
@@ -225,7 +225,7 @@ void CRPRendererGuiTexture::RenderInternal(bool clear, uint8_t alpha)
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexVBO);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * 4, idx, GL_STATIC_DRAW);
 
-  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
 
   glDisableVertexAttribArray(posLoc);
   glDisableVertexAttribArray(tex0Loc);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -318,8 +318,7 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    const CPoint destPoints[4] = {m_rotatedDestCoords[0], m_rotatedDestCoords[1],
-                                  m_rotatedDestCoords[2], m_rotatedDestCoords[3]};
+    const ViewportCoordinates destPoints{m_rotatedDestCoords};
 
     SHADER::CShaderTextureGL source(sourceTexture, false);
     SHADER::CShaderTextureGL target(targetTexture, false);
@@ -392,7 +391,7 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
                 (colour[3] / 255.0f));
     glUniform1f(depthLoc, -1.0f);
 
-    glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+    glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
 
     glBindVertexArray(0);
     glBindBuffer(GL_ARRAY_BUFFER, 0);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -290,8 +290,7 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    const CPoint destPoints[4] = {m_rotatedDestCoords[0], m_rotatedDestCoords[1],
-                                  m_rotatedDestCoords[2], m_rotatedDestCoords[3]};
+    const ViewportCoordinates destPoints{m_rotatedDestCoords};
 
     SHADER::CShaderTextureGLES source(sourceTexture, false);
     SHADER::CShaderTextureGLES target(targetTexture, false);
@@ -371,7 +370,7 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
     glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f),
                 (colour[3] / 255.0f));
     glUniform1f(depthLoc, -1.0f);
-    glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+    glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
 
     glDisableVertexAttribArray(vertLoc);
     glDisableVertexAttribArray(loc);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
@@ -295,8 +295,7 @@ bool CRPWinRenderer::SupportsScalingMethod(SCALINGMETHOD method)
 
 void CRPWinRenderer::Render(CD3DTexture& target)
 {
-  const CPoint destPoints[4] = {m_rotatedDestCoords[0], m_rotatedDestCoords[1],
-                                m_rotatedDestCoords[2], m_rotatedDestCoords[3]};
+  const ViewportCoordinates destPoints{m_rotatedDestCoords};
 
   CWinRenderBuffer* renderBuffer = static_cast<CWinRenderBuffer*>(m_renderBuffer);
   if (renderBuffer == nullptr)
@@ -313,7 +312,7 @@ void CRPWinRenderer::Render(CD3DTexture& target)
   {
     //! @todo Orientation?
     /*
-    CPoint destPoints[4];
+    ViewportCoordinates destPoints = {};
     // select destination rectangle
     if (m_renderOrientation)
     {

--- a/xbmc/cores/RetroPlayer/shaders/IShader.h
+++ b/xbmc/cores/RetroPlayer/shaders/IShader.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "ShaderTypes.h"
-#include "utils/Geometry.h"
+#include "cores/RetroPlayer/RetroPlayerTypes.h"
 
 #include <map>
 #include <stdint.h>
@@ -81,7 +81,7 @@ public:
    * \param frameCount Number of frames that have passed
    */
   virtual void PrepareParameters(
-      CPoint dest[4],
+      const RETRO::ViewportCoordinates& dest,
       IShaderTexture& sourceTexture,
       const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
       const std::vector<std::unique_ptr<IShader>>& pShaders,

--- a/xbmc/cores/RetroPlayer/shaders/IShaderLut.h
+++ b/xbmc/cores/RetroPlayer/shaders/IShaderLut.h
@@ -19,11 +19,6 @@ class CTexture;
 
 namespace KODI
 {
-namespace RETRO
-{
-class CRenderContext;
-}
-
 namespace SHADER
 {
 /*!
@@ -38,12 +33,11 @@ public:
   /*!
    * \brief Create the LUT and allocate resources
    *
-   * \param context The render context
    * \param lut The LUT information structure
    *
    * \return Returns true if successful and the LUT can be used, false otherwise
    */
-  virtual bool Create(RETRO::CRenderContext& context, const ShaderLut& lut) = 0;
+  virtual bool Create(const ShaderLut& lut) = 0;
 
   /*!
    * \brief Gets ID of LUT

--- a/xbmc/cores/RetroPlayer/shaders/IShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/shaders/IShaderPreset.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "ShaderTypes.h"
-#include "utils/Geometry.h"
+#include "cores/RetroPlayer/RetroPlayerTypes.h"
 
 #include <string>
 #include <vector>
@@ -46,7 +46,7 @@ public:
    *
    * \return Returns false if updating or rendering failed, true if both succeeded
    */
-  virtual bool RenderUpdate(const CPoint dest[],
+  virtual bool RenderUpdate(const RETRO::ViewportCoordinates& dest,
                             IShaderTexture& source,
                             IShaderTexture& target) = 0;
 

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
@@ -42,7 +42,7 @@ bool CShaderPreset::ReadPresetFile(const std::string& presetPath)
   return CServiceBroker::GetGameServices().VideoShaders().LoadPreset(presetPath, *this);
 }
 
-bool CShaderPreset::RenderUpdate(const CPoint dest[],
+bool CShaderPreset::RenderUpdate(const RETRO::ViewportCoordinates& dest,
                                  IShaderTexture& source,
                                  IShaderTexture& target)
 {
@@ -57,9 +57,9 @@ bool CShaderPreset::RenderUpdate(const CPoint dest[],
   if (!Update())
     return false;
 
-  PrepareParameters(dest, source, target);
+  PrepareParameters(dest, source);
 
-  const unsigned int numPasses = static_cast<unsigned int>(m_pShaders.size());
+  const auto numPasses = static_cast<unsigned int>(m_pShaders.size());
 
   // Apply all passes except the last one (which needs to be applied to the backbuffer)
   IShaderTexture* sourceTexture = &source;
@@ -175,17 +175,12 @@ void CShaderPreset::UpdateMVPs()
     videoShader->UpdateMVP();
 }
 
-void CShaderPreset::PrepareParameters(const CPoint dest[],
-                                      IShaderTexture& source,
-                                      IShaderTexture& target)
+void CShaderPreset::PrepareParameters(const RETRO::ViewportCoordinates& dest,
+                                      IShaderTexture& source)
 {
-  if (m_dest[0] != dest[0] || m_dest[1] != dest[1] || m_dest[2] != dest[2] || m_dest[3] != dest[3])
-  {
-    for (size_t i = 0; i < 4; ++i)
-      m_dest[i] = dest[i];
-  }
+  m_dest = dest;
 
-  const unsigned int numPasses = static_cast<unsigned int>(m_pShaders.size());
+  const auto numPasses = static_cast<unsigned int>(m_pShaders.size());
 
   // Prepare parameters for all shader passes
   for (unsigned int shaderIdx = 0; shaderIdx < numPasses; ++shaderIdx)

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.h
@@ -40,7 +40,9 @@ public:
 
   // Implementation of IShaderPreset
   bool ReadPresetFile(const std::string& presetPath) override;
-  bool RenderUpdate(const CPoint dest[], IShaderTexture& source, IShaderTexture& target) override;
+  bool RenderUpdate(const RETRO::ViewportCoordinates& dest,
+                    IShaderTexture& source,
+                    IShaderTexture& target) override;
   void SetSpeed(double speed) override { m_speed = speed; }
   void SetVideoSize(unsigned int videoWidth, unsigned int videoHeight) override;
   bool SetShaderPreset(const std::string& shaderPresetPath) override;
@@ -60,7 +62,7 @@ protected:
   bool Update();
   void UpdateViewPort(CRect viewPort);
   void UpdateMVPs();
-  void PrepareParameters(const CPoint dest[], IShaderTexture& source, IShaderTexture& target);
+  void PrepareParameters(const RETRO::ViewportCoordinates& dest, IShaderTexture& source);
   void DisposeShaders();
   bool HasPathFailed(const std::string& path) const;
   ShaderParameterMap GetShaderParameters(const std::vector<ShaderParameter>& parameters,
@@ -96,7 +98,7 @@ protected:
   float2 m_videoSize;
 
   // Array of vertices that comprise the full viewport
-  CPoint m_dest[4];
+  RETRO::ViewportCoordinates m_dest{};
 
   // Number of frames that have passed
   float m_frameCount = 0.0f;

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPresetFactory.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPresetFactory.cpp
@@ -150,7 +150,7 @@ void CShaderPresetFactory::UpdateAddons()
     }
     else
     {
-      m_failedAddons.emplace(std::move(addonId), std::move(addonPtr));
+      m_failedAddons.try_emplace(std::move(addonId), std::move(addonPtr));
     }
   }
 }

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
@@ -21,14 +21,12 @@
 using namespace KODI;
 using namespace SHADER;
 
-CShaderGL::CShaderGL(RETRO::CRenderContext& context)
-{
-}
+CShaderGL::CShaderGL() = default;
 
 CShaderGL::~CShaderGL()
 {
   glDeleteBuffers(1, &m_shaderIndexVBO);
-  glDeleteBuffers(3, m_shaderVertexVBO);
+  glDeleteBuffers(3, m_shaderVertexVBO.data());
 
   glDeleteVertexArrays(1, &m_shaderVAO);
 }
@@ -70,7 +68,7 @@ bool CShaderGL::Create(std::string shaderSource,
   GLuint fShader;
 
   vShader = glCreateShader(GL_VERTEX_SHADER);
-  glShaderSource(vShader, 1, &vertexShaderSource, NULL);
+  glShaderSource(vShader, 1, &vertexShaderSource, nullptr);
   glCompileShader(vShader);
   glGetShaderiv(vShader, GL_COMPILE_STATUS, &status);
 
@@ -85,7 +83,7 @@ bool CShaderGL::Create(std::string shaderSource,
   }
 
   fShader = glCreateShader(GL_FRAGMENT_SHADER);
-  glShaderSource(fShader, 1, &fragmentShaderSource, NULL);
+  glShaderSource(fShader, 1, &fragmentShaderSource, nullptr);
   glCompileShader(fShader);
   glGetShaderiv(fShader, GL_COMPILE_STATUS, &status);
 
@@ -132,19 +130,19 @@ bool CShaderGL::Create(std::string shaderSource,
   glGenVertexArrays(1, &m_shaderVAO);
   glBindVertexArray(m_shaderVAO);
 
-  glGenBuffers(3, m_shaderVertexVBO);
+  glGenBuffers(3, m_shaderVertexVBO.data());
 
   glBindBuffer(GL_ARRAY_BUFFER, m_shaderVertexVBO[0]);
   glEnableVertexAttribArray(0);
-  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
+  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), nullptr);
 
   glBindBuffer(GL_ARRAY_BUFFER, m_shaderVertexVBO[1]);
   glEnableVertexAttribArray(1);
-  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
+  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), nullptr);
 
   glBindBuffer(GL_ARRAY_BUFFER, m_shaderVertexVBO[2]);
   glEnableVertexAttribArray(2);
-  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 2 * sizeof(float), (void*)0);
+  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 2 * sizeof(float), nullptr);
 
   glGenBuffers(1, &m_shaderIndexVBO);
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_shaderIndexVBO);
@@ -157,7 +155,7 @@ bool CShaderGL::Create(std::string shaderSource,
 
 void CShaderGL::Render(IShaderTexture& source, IShaderTexture& target)
 {
-  CShaderTextureGL& sourceGL = static_cast<CShaderTextureGL&>(source);
+  auto& sourceGL = static_cast<CShaderTextureGL&>(source);
 
   glUseProgram(m_shaderProgram);
 
@@ -166,18 +164,18 @@ void CShaderGL::Render(IShaderTexture& source, IShaderTexture& target)
   glBindVertexArray(m_shaderVAO);
 
   glBindBuffer(GL_ARRAY_BUFFER, m_shaderVertexVBO[0]);
-  glBufferData(GL_ARRAY_BUFFER, sizeof(m_VertexCoords), m_VertexCoords, GL_STATIC_DRAW);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(m_VertexCoords), m_VertexCoords.data(), GL_STATIC_DRAW);
 
   glBindBuffer(GL_ARRAY_BUFFER, m_shaderVertexVBO[1]);
-  glBufferData(GL_ARRAY_BUFFER, sizeof(m_colors), m_colors, GL_STATIC_DRAW);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(m_colors), m_colors.data(), GL_STATIC_DRAW);
 
   glBindBuffer(GL_ARRAY_BUFFER, m_shaderVertexVBO[2]);
-  glBufferData(GL_ARRAY_BUFFER, sizeof(m_TexCoords), m_TexCoords, GL_STATIC_DRAW);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(m_TexCoords), m_TexCoords.data(), GL_STATIC_DRAW);
 
   // No need to bind the index VBO, it's part of VAO state
-  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(m_indices), m_indices, GL_STATIC_DRAW);
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(m_indices), m_indices.data(), GL_STATIC_DRAW);
 
-  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
 
   glBindVertexArray(0);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -195,7 +193,7 @@ void CShaderGL::SetSizes(const float2& prevSize,
 }
 
 void CShaderGL::PrepareParameters(
-    CPoint dest[4],
+    const RETRO::ViewportCoordinates& dest,
     IShaderTexture& sourceTexture,
     const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
     const std::vector<std::unique_ptr<IShader>>& pShaders,
@@ -295,8 +293,7 @@ void CShaderGL::UpdateUniformInputs(
 
   if (m_passIdx > 0) // Not first pass
   {
-    CShaderTextureGL& shaderTextureGL =
-        static_cast<CShaderTextureGL&>(*pShaderTextures[m_passIdx - 1]);
+    auto& shaderTextureGL = static_cast<CShaderTextureGL&>(*pShaderTextures[m_passIdx - 1]);
     m_uniformFrameInputs = GetFrameInputData(shaderTextureGL.GetTexture().GetTextureID());
   }
   else // First pass
@@ -382,8 +379,8 @@ void CShaderGL::SetShaderParameters(CGLTexture& sourceTexture)
   // Set lookup textures
   for (const std::shared_ptr<IShaderLut>& lut : m_luts)
   {
-    CGLTexture* texture = static_cast<CGLTexture*>(lut->GetTexture());
-    if (texture != nullptr)
+    auto* texture = static_cast<CGLTexture*>(lut->GetTexture());
+    if (texture)
     {
       const GLint paramLoc = glGetUniformLocation(m_shaderProgram, lut->GetID().c_str());
       glUniform1i(paramLoc, textureUnit);

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
@@ -18,17 +18,12 @@
 
 namespace KODI
 {
-namespace RETRO
-{
-class CRenderContext;
-}
-
 namespace SHADER
 {
 class CShaderGL : public IShader
 {
 public:
-  CShaderGL(RETRO::CRenderContext& context);
+  CShaderGL();
   ~CShaderGL() override;
 
   // Implementation of IShader
@@ -43,7 +38,7 @@ public:
   void SetSizes(const float2& prevSize,
                 const float2& prevTextureSize,
                 const float2& nextSize) override;
-  void PrepareParameters(CPoint dest[4],
+  void PrepareParameters(const RETRO::ViewportCoordinates& dest,
                          IShaderTexture& sourceTexture,
                          const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
                          const std::vector<std::unique_ptr<IShader>>& pShaders,
@@ -73,7 +68,7 @@ private:
                            uint64_t frameCount);
   UniformInputs GetInputData(uint64_t frameCount = 0) const;
   UniformFrameInputs GetFrameInputData(GLuint texture) const;
-  UniformFrameInputs GetFrameUniformInputs() { return m_uniformFrameInputs; }
+  UniformFrameInputs GetFrameUniformInputs() const { return m_uniformFrameInputs; }
   void GetUniformLocs();
   void SetShaderParameters(CGLTexture& sourceTexture);
 
@@ -115,10 +110,10 @@ private:
   unsigned int m_frameCountMod{0};
 
   GLuint m_shaderProgram{0};
-  GLubyte m_indices[4];
-  float m_VertexCoords[4][3];
-  float m_colors[4][3];
-  float m_TexCoords[4][2];
+  std::array<GLubyte, 4> m_indices;
+  std::array<std::array<float, 3>, 4> m_VertexCoords;
+  std::array<std::array<float, 3>, 4> m_colors;
+  std::array<std::array<float, 2>, 4> m_TexCoords;
 
   UniformInputs m_uniformInputs;
   UniformFrameInputs m_uniformFrameInputs;
@@ -132,7 +127,7 @@ private:
   GLint m_MVPMatrixLoc{-1};
 
   GLuint m_shaderVAO = GL_NONE;
-  GLuint m_shaderVertexVBO[3]{GL_NONE};
+  std::array<GLuint, 3> m_shaderVertexVBO{GL_NONE};
   GLuint m_shaderIndexVBO = GL_NONE;
 };
 } // namespace SHADER

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderLutGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderLutGL.cpp
@@ -26,9 +26,9 @@ CShaderLutGL::CShaderLutGL(std::string id, std::string path)
 {
 }
 
-bool CShaderLutGL::Create(RETRO::CRenderContext& context, const ShaderLut& lut)
+bool CShaderLutGL::Create(const ShaderLut& lut)
 {
-  std::unique_ptr<CTexture> lutTexture(CreateLUTTexture(context, lut));
+  std::unique_ptr<CTexture> lutTexture(CreateLUTTexture(lut));
   if (!lutTexture)
   {
     CLog::Log(LOGWARNING, "CShaderLutGL::Create: Couldn't create texture for LUT: {}", lut.strId);
@@ -39,11 +39,10 @@ bool CShaderLutGL::Create(RETRO::CRenderContext& context, const ShaderLut& lut)
   return true;
 }
 
-std::unique_ptr<CTexture> CShaderLutGL::CreateLUTTexture(RETRO::CRenderContext& context,
-                                                         const ShaderLut& lut)
+std::unique_ptr<CTexture> CShaderLutGL::CreateLUTTexture(const ShaderLut& lut)
 {
   std::unique_ptr<CTexture> texture = CTexture::LoadFromFile(lut.path);
-  CGLTexture* textureGL = static_cast<CGLTexture*>(texture.get());
+  auto* textureGL = static_cast<CGLTexture*>(texture.get());
 
   if (textureGL == nullptr)
   {

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderLutGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderLutGL.h
@@ -18,11 +18,6 @@
 
 namespace KODI
 {
-namespace RETRO
-{
-class CRenderContext;
-}
-
 namespace SHADER
 {
 class CTextureBase;
@@ -35,12 +30,11 @@ public:
   ~CShaderLutGL() override = default;
 
   // Implementation of IShaderLut
-  bool Create(RETRO::CRenderContext& context, const ShaderLut& lut) override;
+  bool Create(const ShaderLut& lut) override;
   CTexture* GetTexture() override { return m_texture.get(); }
 
 private:
-  static std::unique_ptr<CTexture> CreateLUTTexture(RETRO::CRenderContext& context,
-                                                    const ShaderLut& lut);
+  static std::unique_ptr<CTexture> CreateLUTTexture(const ShaderLut& lut);
 
   std::unique_ptr<CTexture> m_texture;
 };

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGL.cpp
@@ -52,11 +52,8 @@ bool CShaderTextureGL::BindFBO()
   if (renderTargetID == 0)
     return false;
 
-  if (FBO == 0)
-  {
-    if (!CreateFBO())
-      return false;
-  }
+  if (FBO == 0 && !CreateFBO())
+    return false;
 
   glBindFramebuffer(GL_FRAMEBUFFER, FBO);
   glBindTexture(GL_TEXTURE_2D, renderTargetID);
@@ -64,7 +61,7 @@ bool CShaderTextureGL::BindFBO()
 
   if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
   {
-    CLog::Log(LOGERROR, "{}: Framebuffer is not complete!", __func__);
+    CLog::LogF(LOGERROR, "Framebuffer is not complete!");
     UnbindFBO();
     return false;
   }
@@ -75,7 +72,7 @@ bool CShaderTextureGL::BindFBO()
   return true;
 }
 
-void CShaderTextureGL::UnbindFBO()
+void CShaderTextureGL::UnbindFBO() const
 {
   if (IsSRGBFramebuffer())
     glDisable(GL_FRAMEBUFFER_SRGB);

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGL.h
@@ -16,9 +16,7 @@
 
 class CGLTexture;
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 
 class CShaderTextureGL : public IShaderTexture
@@ -39,12 +37,11 @@ public:
   // Frame buffer interface
   bool CreateFBO();
   bool BindFBO();
-  void UnbindFBO();
+  void UnbindFBO() const;
 
 private:
   std::shared_ptr<CGLTexture> m_texture;
   bool m_sRgbFramebuffer{false};
   GLuint FBO{0};
 };
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderUtilsGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderUtilsGL.cpp
@@ -68,7 +68,8 @@ std::string CShaderUtilsGL::GetGLSLVersion(std::string& source)
   // Set GLSL version according to GL version
   else
   {
-    unsigned int major, minor;
+    unsigned int major{0};
+    unsigned int minor{0};
     CServiceBroker::GetRenderSystem()->GetRenderVersion(major, minor);
     version = major * 100 + minor * 10;
 

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderUtilsGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderUtilsGL.h
@@ -12,9 +12,7 @@
 
 #include "system_gl.h"
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 
 class CShaderUtilsGL
@@ -24,5 +22,4 @@ public:
   static std::string GetGLSLVersion(std::string& source);
 };
 
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
@@ -159,7 +159,7 @@ void CShaderGLES::Render(IShaderTexture& source, IShaderTexture& target)
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_shaderIndexVBO);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(m_indices), m_indices, GL_STATIC_DRAW);
 
-  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
 
   glDisableVertexAttribArray(0);
   glDisableVertexAttribArray(1);
@@ -181,7 +181,7 @@ void CShaderGLES::SetSizes(const float2& prevSize,
 }
 
 void CShaderGLES::PrepareParameters(
-    CPoint dest[4],
+    const RETRO::ViewportCoordinates& dest,
     IShaderTexture& sourceTexture,
     const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
     const std::vector<std::unique_ptr<IShader>>& pShaders,

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
@@ -43,7 +43,7 @@ public:
   void SetSizes(const float2& prevSize,
                 const float2& prevTextureSize,
                 const float2& nextSize) override;
-  void PrepareParameters(CPoint dest[4],
+  void PrepareParameters(const RETRO::ViewportCoordinates& dest,
                          IShaderTexture& sourceTexture,
                          const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
                          const std::vector<std::unique_ptr<IShader>>& pShaders,

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderLutGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderLutGLES.cpp
@@ -26,9 +26,9 @@ CShaderLutGLES::CShaderLutGLES(std::string id, std::string path)
 {
 }
 
-bool CShaderLutGLES::Create(RETRO::CRenderContext& context, const ShaderLut& lut)
+bool CShaderLutGLES::Create(const ShaderLut& lut)
 {
-  std::unique_ptr<CTexture> lutTexture(CreateLUTTexture(context, lut));
+  std::unique_ptr<CTexture> lutTexture(CreateLUTTexture(lut));
   if (!lutTexture)
   {
     CLog::Log(LOGWARNING, "CShaderLutGLES::Create: Couldn't create texture for LUT: {}", lut.strId);
@@ -39,11 +39,10 @@ bool CShaderLutGLES::Create(RETRO::CRenderContext& context, const ShaderLut& lut
   return true;
 }
 
-std::unique_ptr<CTexture> CShaderLutGLES::CreateLUTTexture(RETRO::CRenderContext& context,
-                                                           const ShaderLut& lut)
+std::unique_ptr<CTexture> CShaderLutGLES::CreateLUTTexture(const ShaderLut& lut)
 {
   std::unique_ptr<CTexture> texture = CTexture::LoadFromFile(lut.path);
-  CGLESTexture* textureGL = static_cast<CGLESTexture*>(texture.get());
+  auto* textureGL = static_cast<CGLESTexture*>(texture.get());
 
   if (textureGL == nullptr)
   {

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderLutGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderLutGLES.h
@@ -18,11 +18,6 @@
 
 namespace KODI
 {
-namespace RETRO
-{
-class CRenderContext;
-}
-
 namespace SHADER
 {
 class CTextureBase;
@@ -35,12 +30,11 @@ public:
   ~CShaderLutGLES() override = default;
 
   // Implementation of IShaderLut
-  bool Create(RETRO::CRenderContext& context, const ShaderLut& lut) override;
+  bool Create(const ShaderLut& lut) override;
   CTexture* GetTexture() override { return m_texture.get(); }
 
 private:
-  static std::unique_ptr<CTexture> CreateLUTTexture(RETRO::CRenderContext& context,
-                                                    const ShaderLut& lut);
+  static std::unique_ptr<CTexture> CreateLUTTexture(const ShaderLut& lut);
 
   std::unique_ptr<CTexture> m_texture;
 };

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.cpp
@@ -30,27 +30,26 @@ CShaderPresetGLES::CShaderPresetGLES(RETRO::CRenderContext& context,
 
 bool CShaderPresetGLES::CreateShaders()
 {
-  const unsigned int numPasses = static_cast<unsigned int>(m_passes.size());
+  const auto numPasses = static_cast<unsigned int>(m_passes.size());
 
   //! @todo Is this pass specific?
   std::vector<std::shared_ptr<IShaderLut>> passLUTsGL;
   for (unsigned int shaderIdx = 0; shaderIdx < numPasses; ++shaderIdx)
   {
     const ShaderPass& pass = m_passes[shaderIdx];
-    const unsigned int numPassLuts = static_cast<unsigned int>(pass.luts.size());
+    const auto numPassLuts = static_cast<unsigned int>(pass.luts.size());
 
     for (unsigned int i = 0; i < numPassLuts; ++i)
     {
       const ShaderLut& lutStruct = pass.luts[i];
 
-      std::shared_ptr<CShaderLutGLES> passLut =
-          std::make_shared<CShaderLutGLES>(lutStruct.strId, lutStruct.path);
-      if (passLut->Create(m_context, lutStruct))
+      auto passLut = std::make_shared<CShaderLutGLES>(lutStruct.strId, lutStruct.path);
+      if (passLut->Create(lutStruct))
         passLUTsGL.emplace_back(std::move(passLut));
     }
 
     // Create the shader
-    std::unique_ptr<CShaderGLES> videoShader = std::make_unique<CShaderGLES>(m_context);
+    auto videoShader = std::make_unique<CShaderGLES>(m_context);
 
     const std::string& shaderSource = pass.vertexSource; // Also contains fragment source
     const std::string& shaderPath = pass.sourcePath;
@@ -80,7 +79,7 @@ bool CShaderPresetGLES::CreateShaderTextures()
   float2 prevSize = m_videoSize;
   float2 prevTextureSize = m_videoSize;
 
-  const unsigned int numPasses = static_cast<unsigned int>(m_passes.size());
+  const auto numPasses = static_cast<unsigned int>(m_passes.size());
 
   for (unsigned int shaderIdx = 0; shaderIdx < numPasses; ++shaderIdx)
   {
@@ -166,9 +165,9 @@ bool CShaderPresetGLES::CreateShaderTextures()
       //
       textureSize = scaledSize; // CShaderUtils::GetOptimalTextureSize(scaledSize)
 
-      std::shared_ptr<CGLESTexture> textureGL = std::make_shared<CGLESTexture>(
-          static_cast<unsigned int>(textureSize.x), static_cast<unsigned int>(textureSize.y),
-          XB_FMT_A8R8G8B8); // Format is not used
+      auto textureGL = std::make_shared<CGLESTexture>(static_cast<unsigned int>(textureSize.x),
+                                                      static_cast<unsigned int>(textureSize.y),
+                                                      XB_FMT_A8R8G8B8); // Format is not used
 
       textureGL->CreateTextureObject();
 

--- a/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.cpp
@@ -186,7 +186,7 @@ bool CRPWinOutputShader::Create(RETRO::SCALINGMETHOD scalingMethod)
 
 void CRPWinOutputShader::Render(CD3DTexture& sourceTexture,
                                 CRect sourceRect,
-                                const CPoint points[4],
+                                const KODI::RETRO::ViewportCoordinates& points,
                                 CRect& viewPort,
                                 CD3DTexture& target,
                                 unsigned int range /* = 0 */)
@@ -199,7 +199,7 @@ void CRPWinOutputShader::Render(CD3DTexture& sourceTexture,
 void CRPWinOutputShader::PrepareParameters(unsigned int sourceWidth,
                                            unsigned int sourceHeight,
                                            CRect sourceRect,
-                                           const CPoint points[4])
+                                           const KODI::RETRO::ViewportCoordinates& points)
 {
   bool changed = false;
   for (unsigned int i = 0; i < 4 && !changed; ++i)

--- a/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.h
@@ -9,8 +9,8 @@
 #pragma once
 
 #include "cores/GameSettings.h"
+#include "cores/RetroPlayer/RetroPlayerTypes.h"
 #include "guilib/D3DResource.h"
-#include "utils/Geometry.h"
 
 #include <memory>
 #include <string>
@@ -59,7 +59,7 @@ public:
   bool Create(RETRO::SCALINGMETHOD scalingMethod);
   void Render(CD3DTexture& sourceTexture,
               CRect sourceRect,
-              const CPoint points[4],
+              const KODI::RETRO::ViewportCoordinates& points,
               CRect& viewPort,
               CD3DTexture& target,
               unsigned int range = 0);
@@ -68,18 +68,13 @@ private:
   void PrepareParameters(unsigned int sourceWidth,
                          unsigned int sourceHeight,
                          CRect sourceRect,
-                         const CPoint points[4]);
+                         const KODI::RETRO::ViewportCoordinates& points);
   void SetShaderParameters(CD3DTexture& sourceTexture, unsigned int range, CRect& viewPort);
 
   unsigned int m_sourceWidth{0};
   unsigned int m_sourceHeight{0};
-  CRect m_sourceRect{0.f, 0.f, 0.f, 0.f};
-  CPoint m_destPoints[4] = {
-      {0.f, 0.f},
-      {0.f, 0.f},
-      {0.f, 0.f},
-      {0.f, 0.f},
-  };
+  CRect m_sourceRect{};
+  KODI::RETRO::ViewportCoordinates m_destPoints{};
 };
 
 } // namespace SHADER

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.cpp
@@ -116,7 +116,7 @@ void CShaderDX::SetSizes(const float2& prevSize,
 }
 
 void CShaderDX::PrepareParameters(
-    CPoint dest[4],
+    const RETRO::ViewportCoordinates& dest,
     IShaderTexture& sourceTexture,
     const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
     const std::vector<std::unique_ptr<IShader>>& pShaders,

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.h
@@ -48,7 +48,7 @@ public:
   void SetSizes(const float2& prevSize,
                 const float2& prevTextureSize,
                 const float2& nextSize) override;
-  void PrepareParameters(CPoint dest[4],
+  void PrepareParameters(const RETRO::ViewportCoordinates& dest,
                          IShaderTexture& sourceTexture,
                          const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
                          const std::vector<std::unique_ptr<IShader>>& pShaders,

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderLutDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderLutDX.cpp
@@ -27,7 +27,7 @@ CShaderLutDX::CShaderLutDX(std::string id, std::string path)
 
 CShaderLutDX::~CShaderLutDX() = default;
 
-bool CShaderLutDX::Create(RETRO::CRenderContext& context, const ShaderLut& lut)
+bool CShaderLutDX::Create(const ShaderLut& lut)
 {
   std::unique_ptr<CTexture> lutTexture{CreateLUTexture(lut)};
   if (!lutTexture)

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderLutDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderLutDX.h
@@ -18,11 +18,6 @@
 
 namespace KODI
 {
-namespace RETRO
-{
-class CRenderContext;
-}
-
 namespace SHADER
 {
 class CTextureBase;
@@ -38,7 +33,7 @@ public:
   ~CShaderLutDX() override;
 
   // Implementation of IShaderLut
-  bool Create(RETRO::CRenderContext& context, const ShaderLut& lut) override;
+  bool Create(const ShaderLut& lut) override;
   CTexture* GetTexture() override { return m_texture.get(); }
 
 private:

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.cpp
@@ -30,7 +30,7 @@ CShaderPresetDX::CShaderPresetDX(RETRO::CRenderContext& context,
 
 bool CShaderPresetDX::CreateShaders()
 {
-  const unsigned int numPasses = static_cast<unsigned int>(m_passes.size());
+  const auto numPasses = static_cast<unsigned int>(m_passes.size());
 
   //! @todo Is this pass specific?
   for (unsigned int shaderIdx = 0; shaderIdx < numPasses; ++shaderIdx)
@@ -38,20 +38,19 @@ bool CShaderPresetDX::CreateShaders()
     std::vector<std::shared_ptr<IShaderLut>> passLUTsDX;
 
     const ShaderPass& pass = m_passes[shaderIdx];
-    const unsigned int numPassLuts = static_cast<unsigned int>(pass.luts.size());
+    const auto numPassLuts = static_cast<unsigned int>(pass.luts.size());
 
     for (unsigned int i = 0; i < numPassLuts; ++i)
     {
       const ShaderLut& lutStruct = pass.luts[i];
 
-      std::shared_ptr<CShaderLutDX> passLut =
-          std::make_shared<CShaderLutDX>(lutStruct.strId, lutStruct.path);
-      if (passLut->Create(m_context, lutStruct))
+      auto passLut = std::make_shared<CShaderLutDX>(lutStruct.strId, lutStruct.path);
+      if (passLut->Create(lutStruct))
         passLUTsDX.emplace_back(std::move(passLut));
     }
 
     // Create the shader
-    std::unique_ptr<CShaderDX> videoShader = std::make_unique<CShaderDX>(m_context);
+    auto videoShader = std::make_unique<CShaderDX>(m_context);
 
     const std::string& shaderSource = pass.vertexSource; // Also contains fragment source
     const std::string& shaderPath = pass.sourcePath;
@@ -124,7 +123,7 @@ bool CShaderPresetDX::CreateShaderTextures()
   float2 prevSize = m_videoSize;
   float2 prevTextureSize = m_videoSize;
 
-  const unsigned int numPasses = static_cast<unsigned int>(m_passes.size());
+  const auto numPasses = static_cast<unsigned int>(m_passes.size());
 
   for (unsigned int shaderIdx = 0; shaderIdx < numPasses; ++shaderIdx)
   {
@@ -203,7 +202,7 @@ bool CShaderPresetDX::CreateShaderTextures()
       //
       textureSize = scaledSize; // CShaderUtils::GetOptimalTextureSize(scaledSize)
 
-      std::shared_ptr<CD3DTexture> textureDX = std::make_shared<CD3DTexture>();
+      auto textureDX = std::make_shared<CD3DTexture>();
 
       if (!textureDX->Create(static_cast<UINT>(textureSize.x), static_cast<UINT>(textureSize.y), 1,
                              D3D11_USAGE_DEFAULT, textureFormat, nullptr, 0))

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -379,7 +379,7 @@ void CRendererDRMPRIMEGLES::Render(unsigned int flags, int index)
 
   glUniform1f(depthLoc, -1.0f);
 
-  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
 
   glDisableVertexAttribArray(vertLoc);
   glDisableVertexAttribArray(loc);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -1245,7 +1245,7 @@ void CLinuxRendererGL::RenderSinglePass(int index, int field)
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexVBO);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte)*4, idx, GL_STATIC_DRAW);
 
-  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
   VerifyGLState();
 
   glDisableVertexAttribArray(vertLoc);
@@ -1456,7 +1456,7 @@ void CLinuxRendererGL::RenderToFBO(int index, int field, bool weave /*= false*/)
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexVBO);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte)*4, idx, GL_STATIC_DRAW);
 
-  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
   VerifyGLState();
 
   glDisableVertexAttribArray(vertLoc);
@@ -1579,7 +1579,7 @@ void CLinuxRendererGL::RenderFromFBO()
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexVBO);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte)*4, idx, GL_STATIC_DRAW);
 
-  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
   VerifyGLState();
 
   glDisableVertexAttribArray(loc);
@@ -1720,7 +1720,7 @@ void CLinuxRendererGL::RenderRGB(int index, int field)
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexVBO);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte)*4, idx, GL_STATIC_DRAW);
 
-  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
 
   glBindBuffer(GL_ARRAY_BUFFER, 0);
   glDeleteBuffers(1, &vertexVBO);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
@@ -462,7 +462,7 @@ void COverlayTextureGL::Render(SRenderState& state)
 
   glUniform1f(depthLoc, -1.0f);
 
-  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
 
   glDisableVertexAttribArray(posLoc);
   glDisableVertexAttribArray(tex0Loc);

--- a/xbmc/games/GameServices.cpp
+++ b/xbmc/games/GameServices.cpp
@@ -30,7 +30,7 @@ CGameServices::CGameServices(CControllerManager& controllerManager,
     m_profileManager(profileManager),
     m_gameSettings(new CGameSettings()),
     m_agentInput(std::make_unique<CAgentInput>(peripheralManager, inputManager)),
-    m_videoShaders(new SHADER::CShaderPresetFactory(addons))
+    m_videoShaders(std::make_unique<SHADER::CShaderPresetFactory>(addons))
 {
   // Load the add-ons from the database asynchronously
   m_initializationTask =

--- a/xbmc/games/controllers/ControllerTranslator.cpp
+++ b/xbmc/games/controllers/ControllerTranslator.cpp
@@ -171,7 +171,7 @@ INPUT_TYPE CControllerTranslator::TranslateInputType(const std::string& strType)
   return INPUT_TYPE::UNKNOWN;
 }
 
-PORT_TYPE CControllerTranslator::TranslatePortType(const std::string& strPortType)
+PORT_TYPE CControllerTranslator::TranslatePortType(std::string_view strPortType)
 {
   if (strPortType == KEYBOARD_PORT_TYPE)
     return PORT_TYPE::KEYBOARD;

--- a/xbmc/games/controllers/ControllerTranslator.h
+++ b/xbmc/games/controllers/ControllerTranslator.h
@@ -12,6 +12,7 @@
 #include "input/joysticks/JoystickTypes.h"
 
 #include <string>
+#include <string_view>
 
 namespace KODI
 {
@@ -33,7 +34,7 @@ public:
   static const char* TranslateInputType(JOYSTICK::INPUT_TYPE type);
   static JOYSTICK::INPUT_TYPE TranslateInputType(const std::string& strType);
 
-  static PORT_TYPE TranslatePortType(const std::string& strPortType);
+  static PORT_TYPE TranslatePortType(std::string_view strPortType);
   static const char* TranslatePortType(PORT_TYPE portType);
 };
 

--- a/xbmc/games/controllers/input/ControllerActivity.cpp
+++ b/xbmc/games/controllers/input/ControllerActivity.cpp
@@ -130,7 +130,7 @@ void CControllerActivity::OnInputFrame()
       m_currentActivation = 1.0f;
 
     // Process mouse motion
-    for (auto& it : m_mousePointers)
+    for (const auto& it : m_mousePointers)
     {
       const MousePointer& pointer = it.second;
       if (pointer.active && !pointer.timer.IsTimePast())

--- a/xbmc/games/controllers/input/ControllerActivity.h
+++ b/xbmc/games/controllers/input/ControllerActivity.h
@@ -60,8 +60,8 @@ private:
   float m_lastActivation{0.0f};
   float m_currentActivation{0.0f};
   KEYBOARD::KeyName m_activeKey;
-  std::map<MOUSE::PointerName, MousePointer> m_mousePointers;
-  std::set<MOUSE::ButtonName> m_activeMouseButtons;
+  std::map<MOUSE::PointerName, MousePointer, std::less<>> m_mousePointers;
+  std::set<MOUSE::ButtonName, std::less<>> m_activeMouseButtons;
   bool m_bKeyPressed{false};
 };
 } // namespace GAME

--- a/xbmc/games/controllers/input/ControllerState.h
+++ b/xbmc/games/controllers/input/ControllerState.h
@@ -11,9 +11,7 @@
 #include <map>
 #include <string>
 
-namespace KODI
-{
-namespace GAME
+namespace KODI::GAME
 {
 class CController;
 
@@ -35,7 +33,6 @@ public:
     float x;
     float y;
     bool operator==(const AnalogStick& rhs) const = default;
-    bool operator!=(const AnalogStick& rhs) const = default;
   };
   struct Accelerometer
   {
@@ -43,10 +40,12 @@ public:
     float y;
     float z;
     bool operator==(const Accelerometer& rhs) const = default;
-    bool operator!=(const Accelerometer& rhs) const = default;
   };
   using Throttle = float;
   using Wheel = float;
+
+  template<typename CONTROL>
+  using ControlMap = std::map<std::string, CONTROL, std::less<>>;
 
   // Constructors
   explicit CControllerState() = default;
@@ -58,18 +57,17 @@ public:
 
   // Operators
   bool operator==(const CControllerState& rhs) const = default;
-  bool operator!=(const CControllerState& rhs) const = default;
 
   // Controller state
   const std::string& ID() const { return m_controllerId; }
 
   // Input state (const accessors)
-  const std::map<std::string, DigitalButton>& DigitalButtons() const { return m_digitalButtons; }
-  const std::map<std::string, AnalogButton>& AnalogButtons() const { return m_analogButtons; }
-  const std::map<std::string, AnalogStick>& AnalogSticks() const { return m_analogSticks; }
-  const std::map<std::string, Accelerometer>& Accelerometers() const { return m_accelerometers; }
-  const std::map<std::string, Throttle>& Throttles() const { return m_throttles; }
-  const std::map<std::string, Wheel>& Wheels() const { return m_wheels; }
+  const ControlMap<DigitalButton>& DigitalButtons() const { return m_digitalButtons; }
+  const ControlMap<AnalogButton>& AnalogButtons() const { return m_analogButtons; }
+  const ControlMap<AnalogStick>& AnalogSticks() const { return m_analogSticks; }
+  const ControlMap<Accelerometer>& Accelerometers() const { return m_accelerometers; }
+  const ControlMap<Throttle>& Throttles() const { return m_throttles; }
+  const ControlMap<Wheel>& Wheels() const { return m_wheels; }
 
   // Input state (mutable accessors)
   DigitalButton GetDigitalButton(const std::string& featureName) const;
@@ -92,13 +90,12 @@ private:
   std::string m_controllerId;
 
   // Input state
-  std::map<std::string, DigitalButton> m_digitalButtons;
-  std::map<std::string, AnalogButton> m_analogButtons;
-  std::map<std::string, AnalogStick> m_analogSticks;
-  std::map<std::string, Accelerometer> m_accelerometers;
-  std::map<std::string, Throttle> m_throttles;
-  std::map<std::string, Wheel> m_wheels;
+  ControlMap<DigitalButton> m_digitalButtons;
+  ControlMap<AnalogButton> m_analogButtons;
+  ControlMap<AnalogStick> m_analogSticks;
+  ControlMap<Accelerometer> m_accelerometers;
+  ControlMap<Throttle> m_throttles;
+  ControlMap<Wheel> m_wheels;
 };
 
-} // namespace GAME
-} // namespace KODI
+} // namespace KODI::GAME

--- a/xbmc/games/controllers/test/TestControllerDigest.cpp
+++ b/xbmc/games/controllers/test/TestControllerDigest.cpp
@@ -48,9 +48,9 @@ TEST(TestControllerDigest, SimpleTree)
   const UTILITY::CDigest::Type type = UTILITY::CDigest::Type::MD5;
 
   // Build controller
-  ADDON::AddonInfoPtr addonInfo = std::make_shared<ADDON::CAddonInfo>(
-      "game.controller.test", ADDON::AddonType::GAME_CONTROLLER);
-  ControllerPtr controller = std::make_shared<CController>(addonInfo);
+  auto addonInfo = std::make_shared<ADDON::CAddonInfo>("game.controller.test",
+                                                       ADDON::AddonType::GAME_CONTROLLER);
+  auto controller = std::make_shared<CController>(addonInfo);
 
   // Controller node containing the controller and an empty hub
   CControllerNode node;
@@ -104,13 +104,13 @@ TEST(TestControllerDigest, MultiControllerPort)
   const UTILITY::CDigest::Type type = UTILITY::CDigest::Type::MD5;
 
   // Build controllers
-  ADDON::AddonInfoPtr addonInfo1 =
+  auto addonInfo1 =
       std::make_shared<ADDON::CAddonInfo>("game.controller.one", ADDON::AddonType::GAME_CONTROLLER);
-  ControllerPtr controller1 = std::make_shared<CController>(addonInfo1);
+  auto controller1 = std::make_shared<CController>(addonInfo1);
 
-  ADDON::AddonInfoPtr addonInfo2 =
+  auto addonInfo2 =
       std::make_shared<ADDON::CAddonInfo>("game.controller.two", ADDON::AddonType::GAME_CONTROLLER);
-  ControllerPtr controller2 = std::make_shared<CController>(addonInfo2);
+  auto controller2 = std::make_shared<CController>(addonInfo2);
 
   // Controller nodes containing the controllers and empty hubs
   CControllerNode node1;
@@ -176,13 +176,13 @@ TEST(TestControllerDigest, NestedHub)
   const UTILITY::CDigest::Type type = UTILITY::CDigest::Type::MD5;
 
   // Build controllers for both levels
-  ADDON::AddonInfoPtr addonInfo1 = std::make_shared<ADDON::CAddonInfo>(
-      "game.controller.parent", ADDON::AddonType::GAME_CONTROLLER);
-  ControllerPtr controller1 = std::make_shared<CController>(addonInfo1);
+  auto addonInfo1 = std::make_shared<ADDON::CAddonInfo>("game.controller.parent",
+                                                        ADDON::AddonType::GAME_CONTROLLER);
+  auto controller1 = std::make_shared<CController>(addonInfo1);
 
-  ADDON::AddonInfoPtr addonInfo2 = std::make_shared<ADDON::CAddonInfo>(
-      "game.controller.child", ADDON::AddonType::GAME_CONTROLLER);
-  ControllerPtr controller2 = std::make_shared<CController>(addonInfo2);
+  auto addonInfo2 = std::make_shared<ADDON::CAddonInfo>("game.controller.child",
+                                                        ADDON::AddonType::GAME_CONTROLLER);
+  auto controller2 = std::make_shared<CController>(addonInfo2);
 
   // Leaf node with controller2 and empty hub
   CControllerNode nodeChild;

--- a/xbmc/games/controllers/test/TestControllerTreeXML.cpp
+++ b/xbmc/games/controllers/test/TestControllerTreeXML.cpp
@@ -50,7 +50,7 @@ TEST(TestControllerTreeXML, TranslatePortType)
 TEST(TestControllerTreeXML, SerializeSimpleTree)
 {
   // Load the default controller add-on
-  ADDON::CAddonMgr& addonManager = CServiceBroker::GetAddonMgr();
+  const ADDON::CAddonMgr& addonManager = CServiceBroker::GetAddonMgr();
   ADDON::AddonPtr addon;
   ASSERT_TRUE(addonManager.GetAddon(DEFAULT_CONTROLLER_ID, addon, ADDON::AddonType::GAME_CONTROLLER,
                                     ADDON::OnlyEnabled::CHOICE_YES));
@@ -97,11 +97,11 @@ TEST(TestControllerTreeXML, SerializeSimpleTree)
 TEST(TestControllerTreeXML, DeserializeSimpleTree)
 {
   // Build an XML document representing a controller tree
-  const char* xml = "<controller>"
-                    "<port type=\"controller\" id=\"1\">"
-                    "<accepts controller=\"game.controller.default\"/>"
-                    "</port>"
-                    "</controller>";
+  const char* xml = R"(<controller>
+                         <port type="controller" id="1">
+                           <accepts controller="game.controller.default"/>
+                         </port>
+                       </controller>)";
   std::string xmlStr{xml};
   CXBMCTinyXML2 doc;
   ASSERT_TRUE(doc.Parse(xmlStr));
@@ -129,7 +129,7 @@ TEST(TestControllerTreeXML, DeserializeSimpleTree)
 TEST(TestControllerTreeXML, SerializeDeserializeRoundTrip)
 {
   // Load the default controller add-on
-  ADDON::CAddonMgr& addonManager = CServiceBroker::GetAddonMgr();
+  const ADDON::CAddonMgr& addonManager = CServiceBroker::GetAddonMgr();
   ADDON::AddonPtr addon;
   ASSERT_TRUE(addonManager.GetAddon(DEFAULT_CONTROLLER_ID, addon, ADDON::AddonType::GAME_CONTROLLER,
                                     ADDON::OnlyEnabled::CHOICE_YES));
@@ -180,7 +180,7 @@ TEST(TestControllerTreeXML, SerializeDeserializeRoundTrip)
 TEST(TestControllerTreeXML, SerializePortInvalidType)
 {
   // Load the default controller add-on
-  ADDON::CAddonMgr& addonManager = CServiceBroker::GetAddonMgr();
+  const ADDON::CAddonMgr& addonManager = CServiceBroker::GetAddonMgr();
   ADDON::AddonPtr addon;
   ASSERT_TRUE(addonManager.GetAddon(DEFAULT_CONTROLLER_ID, addon, ADDON::AddonType::GAME_CONTROLLER,
                                     ADDON::OnlyEnabled::CHOICE_YES));
@@ -206,7 +206,7 @@ TEST(TestControllerTreeXML, SerializePortInvalidType)
 TEST(TestControllerTreeXML, SerializePortMissingID)
 {
   // Load the default controller add-on
-  ADDON::CAddonMgr& addonManager = CServiceBroker::GetAddonMgr();
+  const ADDON::CAddonMgr& addonManager = CServiceBroker::GetAddonMgr();
   ADDON::AddonPtr addon;
   ASSERT_TRUE(addonManager.GetAddon(DEFAULT_CONTROLLER_ID, addon, ADDON::AddonType::GAME_CONTROLLER,
                                     ADDON::OnlyEnabled::CHOICE_YES));
@@ -260,9 +260,9 @@ TEST(TestControllerTreeXML, SerializeControllerNodeMissingController)
 TEST(TestControllerTreeXML, DeserializePortMissingID)
 {
   // XML representing a port with a type but no id
-  const char* xml = "<port type=\"controller\">"
-                    "<accepts controller=\"game.controller.default\"/>"
-                    "</port>";
+  const char* xml = R"(<port type="controller">
+                         <accepts controller="game.controller.default"/>
+                       </port>)";
   std::string xmlStr{xml};
   CXBMCTinyXML2 doc;
   ASSERT_TRUE(doc.Parse(xmlStr));

--- a/xbmc/games/controllers/types/ControllerGrid.cpp
+++ b/xbmc/games/controllers/types/ControllerGrid.cpp
@@ -48,14 +48,14 @@ unsigned int CControllerGrid::AddPorts(const PortVec& ports, ControllerGrid& gri
 {
   unsigned int height = 0;
 
-  auto itKeyboard = std::find_if(ports.begin(), ports.end(), [](const CPortNode& port)
-                                 { return port.GetPortType() == PORT_TYPE::KEYBOARD; });
+  auto itKeyboard = std::ranges::find_if(ports, [](const CPortNode& port)
+                                         { return port.GetPortType() == PORT_TYPE::KEYBOARD; });
 
-  auto itMouse = std::find_if(ports.begin(), ports.end(), [](const CPortNode& port)
-                              { return port.GetPortType() == PORT_TYPE::MOUSE; });
+  auto itMouse = std::ranges::find_if(ports, [](const CPortNode& port)
+                                      { return port.GetPortType() == PORT_TYPE::MOUSE; });
 
-  auto itController = std::find_if(ports.begin(), ports.end(), [](const CPortNode& port)
-                                   { return port.GetPortType() == PORT_TYPE::CONTROLLER; });
+  auto itController = std::ranges::find_if(ports, [](const CPortNode& port)
+                                           { return port.GetPortType() == PORT_TYPE::CONTROLLER; });
 
   // Keyboard and mouse are not allowed to have ports because they might
   // overlap with controllers

--- a/xbmc/games/controllers/types/ControllerHub.cpp
+++ b/xbmc/games/controllers/types/ControllerHub.cpp
@@ -59,16 +59,15 @@ void CControllerHub::SetPorts(PortVec ports)
 
 bool CControllerHub::IsControllerAccepted(const std::string& controllerId) const
 {
-  return std::any_of(m_ports.begin(), m_ports.end(), [controllerId](const CPortNode& port)
-                     { return port.IsControllerAccepted(controllerId); });
+  return std::ranges::any_of(m_ports, [&controllerId](const CPortNode& port)
+                             { return port.IsControllerAccepted(controllerId); });
 }
 
 bool CControllerHub::IsControllerAccepted(const std::string& portAddress,
                                           const std::string& controllerId) const
 {
-  return std::any_of(m_ports.begin(), m_ports.end(),
-                     [portAddress, controllerId](const CPortNode& port)
-                     { return port.IsControllerAccepted(portAddress, controllerId); });
+  return std::ranges::any_of(m_ports, [&portAddress, &controllerId](const CPortNode& port)
+                             { return port.IsControllerAccepted(portAddress, controllerId); });
 }
 
 ControllerVector CControllerHub::GetControllers() const

--- a/xbmc/games/dialogs/osd/DialogGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameSaves.cpp
@@ -431,7 +431,7 @@ void CDialogGameSaves::OnRename(CFileItem& item)
   }
 }
 
-void CDialogGameSaves::OnDelete(CFileItem& item)
+void CDialogGameSaves::OnDelete(const CFileItem& item)
 {
   // "Confirm delete"
   // "Would you like to delete the selected file(s)?[CR]Warning - this action can't be undone!"

--- a/xbmc/games/dialogs/osd/DialogGameSaves.h
+++ b/xbmc/games/dialogs/osd/DialogGameSaves.h
@@ -87,7 +87,7 @@ private:
   /*!
   * \brief Called when "Delete" is selected from the context menu
   */
-  void OnDelete(CFileItem& item);
+  void OnDelete(const CFileItem& item);
 
   /*!
    * \brief Called every frame with the caption to set

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
@@ -41,13 +41,12 @@ using namespace KODI;
 using namespace GAME;
 using namespace std::chrono_literals;
 
-#define PRESETS_ADDON_NAME "game.shader.presets"
-
 namespace
 {
 
-constexpr auto ICON_VIDEO = "DefaultVideo.png";
-constexpr auto ICON_GET_MORE = "DefaultAddSource.png";
+constexpr const char* PRESETS_ADDON_NAME = "game.shader.presets";
+constexpr const char* ICON_VIDEO = "DefaultVideo.png";
+constexpr const char* ICON_GET_MORE = "DefaultAddSource.png";
 
 struct ScalingMethodProperties
 {
@@ -199,10 +198,10 @@ void CDialogGameVideoFilter::InitVideoFilters()
     if (!canLoadPreset)
       continue;
 
-    CFileItem item{videoFilter.name};
-    item.SetLabel2(videoFilter.folder);
-    item.SetProperty("game.videofilter", CVariant{videoFilter.path});
-    item.SetArt("icon", ICON_VIDEO);
+    auto item{std::make_shared<CFileItem>(videoFilter.name)};
+    item->SetLabel2(videoFilter.folder);
+    item->SetProperty("game.videofilter", CVariant{videoFilter.path});
+    item->SetArt("icon", ICON_VIDEO);
 
     m_items.Add(std::move(item));
   }
@@ -269,7 +268,7 @@ void CDialogGameVideoFilter::OnItemFocus(unsigned int index)
 
 unsigned int CDialogGameVideoFilter::GetFocusedItem() const
 {
-  ::CGameSettings& gameSettings = CMediaSettings::GetInstance().GetCurrentGameSettings();
+  const ::CGameSettings& gameSettings = CMediaSettings::GetInstance().GetCurrentGameSettings();
 
   for (int i = 0; i < m_items.Size(); i++)
   {

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
@@ -376,7 +376,7 @@ void CDialogInGameSaves::OnRename(CFileItem& focusedItem)
   }
 }
 
-void CDialogInGameSaves::OnDelete(CFileItem& focusedItem)
+void CDialogInGameSaves::OnDelete(const CFileItem& focusedItem)
 {
   // "Confirm delete"
   // "Would you like to delete the selected file(s)?[CR]Warning - this action can't be undone!"

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.h
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.h
@@ -49,7 +49,7 @@ protected:
   void OnLoad(CFileItem& focusedItem);
   void OnOverwrite(CFileItem& focusedItem);
   void OnRename(CFileItem& focusedItem);
-  void OnDelete(CFileItem& focusedItem);
+  void OnDelete(const CFileItem& focusedItem);
 
 private:
   void InitSavedGames();

--- a/xbmc/games/ports/windows/GUIPortList.cpp
+++ b/xbmc/games/ports/windows/GUIPortList.cpp
@@ -304,7 +304,7 @@ void CGUIPortList::OnControllerSelected(const CPortNode& port, const ControllerP
         break;
       case PORT_TYPE::UNKNOWN:
       default:
-        CLog::Log(LOGERROR, "Unknown port type \"{}\" for port ID \"{}\"",
+        CLog::Log(LOGERROR, R"(Unknown port type "{}" for port ID "{}")",
                   static_cast<int>(port.GetPortType()), port.GetAddress());
         break;
     }

--- a/xbmc/guilib/GUITextureGL.cpp
+++ b/xbmc/guilib/GUITextureGL.cpp
@@ -360,7 +360,7 @@ void CGUITextureGL::DrawQuad(const CRect& rect,
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexVBO);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte)*4, idx, GL_STATIC_DRAW);
 
-  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
 
   glDisableVertexAttribArray(posLoc);
   if (texture)

--- a/xbmc/pictures/SlideShowPictureGL.cpp
+++ b/xbmc/pictures/SlideShowPictureGL.cpp
@@ -111,7 +111,7 @@ void CSlideShowPicGL::Render(float* x, float* y, CTexture* pTexture, Color color
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexVBO);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * 4, idx, GL_STATIC_DRAW);
 
-  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
 
   glDisableVertexAttribArray(posLoc);
   glDisableVertexAttribArray(tex0Loc);


### PR DESCRIPTION
SonarQube moaned about several changes recently done in retroplayer/games code.

Among them:
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* "auto" should be used to avoid repetition of types cpp:S5827
* "std::string_view" should be used to pass a read-only string to a function cpp:S6009
* Mergeable "if" statements should be combined cpp:S1066
* C-style array should not be used cpp:S5945
* Concise syntax should be used for concatenatable namespaces cpp:S5812
* Unused function parameters should be removed cpp:S1172
* "try_emplace" should be used with "std::map" and "std::unordered_map" cpp:S6030
* "nullptr" should be used to denote the null pointer cpp:S4962
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* Multiple variables should not be declared on the same line cpp:S1659
* "std::source_location" should be used instead of `"__FILE__"`, `"__LINE__"`, and `"__func__"` macros cpp:S6190
* Redundant comparison operators should not be defined cpp:S6186
* Transparent function objects should be used with associative "std::string" containers cpp:S6045
* Raw string literals should be used cpp:S3628
* Pointer and reference parameters should be "const" if the corresponding object is not modified cpp:S995
* Macros should not be used to define constants cpp:S5028

Runtime-tested on macOS, no problems found.

@garbear I guess this is something you should review.