### PR TITLE
Random SonarQube findings which were introduced lately, episode 2.

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -558,7 +558,7 @@ bool CAddonInstaller::HasJob(const std::string& ID) const
   return m_downloadJobs.contains(ID);
 }
 
-void CAddonInstaller::PrunePackageCache()
+void CAddonInstaller::PrunePackageCache() const
 {
   std::map<std::string, std::unique_ptr<CFileItemList>, std::less<>> packs;
   int64_t size = EnumeratePackageFolder(packs);
@@ -1157,7 +1157,7 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const RepositoryP
   }
 
   SetText(g_localizeStrings.Get(24086));
-  SetProgress(100.0f * (totalSteps - 1.0f) / totalSteps);
+  SetProgress(100.0f * (static_cast<float>(totalSteps) - 1.0f) / static_cast<float>(totalSteps));
 
   CFilesystemInstaller fsInstaller;
   if (!fsInstaller.InstallToFilesystem(installFrom, m_addon->ID()))

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -162,6 +162,61 @@ int64_t EnumeratePackageFolder(
 
   return size;
 }
+
+void PrunePackageCache()
+{
+  std::map<std::string, std::unique_ptr<CFileItemList>, std::less<>> packs;
+  int64_t size = EnumeratePackageFolder(packs);
+  const auto limit =
+      static_cast<int64_t>(
+          CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_addonPackageFolderSize) *
+      1024 * 1024;
+  if (size < limit)
+    return;
+
+  // Prune packages
+  // 1. Remove the largest packages, leaving at least 2 for each add-on
+  CFileItemList items;
+  CAddonDatabase db;
+  db.Open();
+  for (const auto& [_, files] : packs)
+  {
+    files->Sort(SortByLabel, SortOrderDescending);
+    for (int j = 2; j < files->Size(); j++)
+      items.Add(std::make_shared<CFileItem>(*files->Get(j)));
+  }
+
+  items.Sort(SortBySize, SortOrderDescending);
+  int i = 0;
+  while (size > limit && i < items.Size())
+  {
+    size -= items[i]->GetSize();
+    db.RemovePackage(items[i]->GetPath());
+    CFileUtils::DeleteItem(items[i]);
+    i++;
+  }
+
+  if (size > limit)
+  {
+    // 2. Remove the oldest packages (leaving least 1 for each add-on)
+    items.Clear();
+    for (const auto& [_, files] : packs)
+    {
+      if (files->Size() > 1)
+        items.Add(std::make_shared<CFileItem>(*files->Get(1)));
+    }
+
+    items.Sort(SortByDate, SortOrderAscending);
+    i = 0;
+    while (size > limit && i < items.Size())
+    {
+      size -= items[i]->GetSize();
+      db.RemovePackage(items[i]->GetPath());
+      CFileUtils::DeleteItem(items[i]);
+      i++;
+    }
+  }
+}
 } // unnamed namespace
 
 CAddonInstaller::CAddonInstaller() : m_idle(true)
@@ -556,58 +611,6 @@ bool CAddonInstaller::HasJob(const std::string& ID) const
 {
   std::unique_lock lock(m_critSection);
   return m_downloadJobs.contains(ID);
-}
-
-void CAddonInstaller::PrunePackageCache() const
-{
-  std::map<std::string, std::unique_ptr<CFileItemList>, std::less<>> packs;
-  int64_t size = EnumeratePackageFolder(packs);
-  int64_t limit = static_cast<int64_t>(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_addonPackageFolderSize) * 1024 * 1024;
-  if (size < limit)
-    return;
-
-  // Prune packages
-  // 1. Remove the largest packages, leaving at least 2 for each add-on
-  CFileItemList items;
-  CAddonDatabase db;
-  db.Open();
-  for (const auto& [_, files] : packs)
-  {
-    files->Sort(SortByLabel, SortOrderDescending);
-    for (int j = 2; j < files->Size(); j++)
-      items.Add(std::make_shared<CFileItem>(*files->Get(j)));
-  }
-
-  items.Sort(SortBySize, SortOrderDescending);
-  int i = 0;
-  while (size > limit && i < items.Size())
-  {
-    size -= items[i]->GetSize();
-    db.RemovePackage(items[i]->GetPath());
-    CFileUtils::DeleteItem(items[i]);
-    i++;
-  }
-
-  if (size > limit)
-  {
-    // 2. Remove the oldest packages (leaving least 1 for each add-on)
-    items.Clear();
-    for (const auto& [_, files] : packs)
-    {
-      if (files->Size() > 1)
-        items.Add(std::make_shared<CFileItem>(*files->Get(1)));
-    }
-
-    items.Sort(SortByDate, SortOrderAscending);
-    i = 0;
-    while (size > limit && i < items.Size())
-    {
-      size -= items[i]->GetSize();
-      db.RemovePackage(items[i]->GetPath());
-      CFileUtils::DeleteItem(items[i]);
-      i++;
-    }
-  }
 }
 
 void CAddonInstaller::InstallAddons(const VECADDONS& addons,

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -233,8 +233,6 @@ private:
    */
   bool CheckDependencies(const ADDON::AddonPtr &addon, std::vector<std::string>& preDeps, CAddonDatabase &database, std::pair<std::string, std::string> &failedDep);
 
-  void PrunePackageCache() const;
-
   mutable CCriticalSection m_critSection;
   JobMap m_downloadJobs;
   CEvent m_idle;

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -233,7 +233,7 @@ private:
    */
   bool CheckDependencies(const ADDON::AddonPtr &addon, std::vector<std::string>& preDeps, CAddonDatabase &database, std::pair<std::string, std::string> &failedDep);
 
-  void PrunePackageCache();
+  void PrunePackageCache() const;
 
   mutable CCriticalSection m_critSection;
   JobMap m_downloadJobs;

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -375,12 +375,12 @@ bool CAddonMgr::GetInstalledAddons(VECADDONS& addons, AddonType type) const
   return GetAddonsInternal(type, addons, OnlyEnabled::CHOICE_NO, CheckIncompatible::CHOICE_NO);
 }
 
-bool CAddonMgr::GetDisabledAddons(VECADDONS& addons)
+bool CAddonMgr::GetDisabledAddons(VECADDONS& addons) const
 {
   return CAddonMgr::GetDisabledAddons(addons, AddonType::UNKNOWN);
 }
 
-bool CAddonMgr::GetDisabledAddons(VECADDONS& addons, AddonType type)
+bool CAddonMgr::GetDisabledAddons(VECADDONS& addons, AddonType type) const
 {
   VECADDONS all;
   if (GetInstalledAddons(all, type))
@@ -964,7 +964,7 @@ bool CAddonMgr::CanAddonBeDisabled(const std::string& ID)
   return true;
 }
 
-bool CAddonMgr::CanAddonBeEnabled(const std::string& id)
+bool CAddonMgr::CanAddonBeEnabled(const std::string& id) const
 {
   return !id.empty() && IsAddonInstalled(id);
 }
@@ -1013,7 +1013,7 @@ bool CAddonMgr::IsAddonInstalled(const std::string& ID,
   return false;
 }
 
-bool CAddonMgr::CanAddonBeInstalled(const AddonPtr& addon)
+bool CAddonMgr::CanAddonBeInstalled(const AddonPtr& addon) const
 {
   return addon != nullptr && addon->LifecycleState() != AddonLifecycleState::BROKEN &&
          !IsAddonInstalled(addon->ID());

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -141,9 +141,9 @@ public:
   /*! Returns installed add-ons, including disabled, with given type. */
   bool GetInstalledAddons(VECADDONS& addons, AddonType type) const;
 
-  bool GetDisabledAddons(VECADDONS& addons);
+  bool GetDisabledAddons(VECADDONS& addons) const;
 
-  bool GetDisabledAddons(VECADDONS& addons, AddonType type);
+  bool GetDisabledAddons(VECADDONS& addons, AddonType type) const;
 
   /*! Get all installable addons */
   bool GetInstallableAddons(VECADDONS& addons);
@@ -288,7 +288,7 @@ public:
      */
   bool CanAddonBeDisabled(const std::string& ID);
 
-  bool CanAddonBeEnabled(const std::string& id);
+  bool CanAddonBeEnabled(const std::string& id) const;
 
   /* \brief Checks whether an addon is installed.
      \param ID id of the addon
@@ -319,7 +319,7 @@ public:
   /* \brief Checks whether an addon can be installed. Broken addons can't be installed.
     \param addon addon to be checked
     */
-  bool CanAddonBeInstalled(const AddonPtr& addon);
+  bool CanAddonBeInstalled(const AddonPtr& addon) const;
 
   bool CanUninstall(const AddonPtr& addon);
 

--- a/xbmc/addons/AddonSystemSettings.cpp
+++ b/xbmc/addons/AddonSystemSettings.cpp
@@ -119,7 +119,7 @@ bool CAddonSystemSettings::SetActive(AddonType type, const std::string& addonID)
   return false;
 }
 
-bool CAddonSystemSettings::IsActive(const IAddon& addon)
+bool CAddonSystemSettings::IsActive(const IAddon& addon) const
 {
   AddonPtr active;
   return GetActive(addon.Type(), active) && active->ID() == addon.ID();

--- a/xbmc/addons/AddonSystemSettings.h
+++ b/xbmc/addons/AddonSystemSettings.h
@@ -44,7 +44,7 @@ public:
 
   bool GetActive(AddonType type, AddonPtr& addon) const;
   bool SetActive(AddonType type, const std::string& addonID) const;
-  bool IsActive(const IAddon& addon);
+  bool IsActive(const IAddon& addon) const;
 
   /*!
    * Gets Kodi addon auto update mode

--- a/xbmc/addons/ExtsMimeSupportList.cpp
+++ b/xbmc/addons/ExtsMimeSupportList.cpp
@@ -104,7 +104,7 @@ CExtsMimeSupportList::SupportValues CExtsMimeSupportList::ScanAddonProperties(
     // `<extension name=".zwdsp">`
     // `  <description>30246</description>`
     // `</extension>`
-    for (const auto& [type, addonExtensions] : support->GetElements())
+    for (const auto& [extensionType, addonExtensions] : support->GetElements())
     {
       std::string name = addonExtensions.GetValue("@name").asString();
       if (name.empty())
@@ -117,18 +117,18 @@ CExtsMimeSupportList::SupportValues CExtsMimeSupportList::ScanAddonProperties(
                                           addonExtensions.GetValue("icon").asString())
               : "";
 
-      if (type == "extension")
+      if (extensionType == "extension")
       {
         if (name[0] != '.')
           name.insert(name.begin(), '.');
-        values.m_supportedExtensions.try_emplace(name, SupportValue(description, icon));
+        values.m_supportedExtensions.try_emplace(name, description, icon);
       }
-      else if (type == "mimetype")
+      else if (extensionType == "mimetype")
       {
-        values.m_supportedMimetypes.try_emplace(name, SupportValue(description, icon));
+        values.m_supportedMimetypes.try_emplace(name, description, icon);
         const std::string extension = addonExtensions.GetValue("extension").asString();
         if (!extension.empty())
-          values.m_supportedExtensions.try_emplace(extension, SupportValue(description, icon));
+          values.m_supportedExtensions.try_emplace(extension, description, icon);
       }
     }
 
@@ -143,10 +143,10 @@ CExtsMimeSupportList::SupportValues CExtsMimeSupportList::ScanAddonProperties(
         {
           if (name[0] != '.')
             name.insert(name.begin(), '.');
-          values.m_supportedExtensions.try_emplace(name, SupportValue(-1, ""));
+          values.m_supportedExtensions.try_emplace(name, -1, "");
         }
         else if (extName == "mimetype@name")
-          values.m_supportedMimetypes.try_emplace(name, SupportValue(-1, ""));
+          values.m_supportedMimetypes.try_emplace(name, -1, "");
       }
     }
   }
@@ -155,7 +155,7 @@ CExtsMimeSupportList::SupportValues CExtsMimeSupportList::ScanAddonProperties(
   // By them addon no more need to add itself on his addon.xml
   if (values.m_hasTracks)
     values.m_supportedExtensions.try_emplace(
-        "." + values.m_codecName + KODI_ADDON_AUDIODECODER_TRACK_EXT, SupportValue(-1, ""));
+        "." + values.m_codecName + KODI_ADDON_AUDIODECODER_TRACK_EXT, -1, "");
 
   return values;
 }
@@ -257,8 +257,7 @@ std::vector<AddonSupportEntry> CExtsMimeSupportList::GetSupportedExtsAndMimeType
 {
   std::vector<AddonSupportEntry> list;
 
-  const auto it = std::ranges::find_if(m_supportedList.begin(), m_supportedList.end(),
-                                       [&addonId](const SupportValues& v)
+  const auto it = std::ranges::find_if(m_supportedList, [&addonId](const SupportValues& v)
                                        { return v.m_addonInfo->ID() == addonId; });
   if (it == m_supportedList.end())
     return list;

--- a/xbmc/addons/RepositoryUpdater.cpp
+++ b/xbmc/addons/RepositoryUpdater.cpp
@@ -226,8 +226,8 @@ void CRepositoryUpdater::CheckForUpdates(const ADDON::RepositoryPtr& repo, bool 
     return;
   }
 
-  const auto job = std::ranges::find_if(m_jobs, [&](CRepositoryUpdateJob* job)
-                                        { return job->GetAddon()->ID() == repo->ID(); });
+  const auto job = std::ranges::find_if(m_jobs, [&repo](const CRepositoryUpdateJob* updateJob)
+                                        { return updateJob->GetAddon()->ID() == repo->ID(); });
 
   if (job == m_jobs.end())
   {

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -655,7 +655,7 @@ int CSkinInfo::TranslateString(const std::string &setting)
   auto skinString = std::make_shared<CSkinSettingString>();
   skinString->name = setting;
 
-  const int number = static_cast<int>(m_bools.size() + m_strings.size());
+  const auto number = static_cast<int>(m_bools.size() + m_strings.size());
   m_strings.try_emplace(number, skinString);
 
   return number;
@@ -709,7 +709,7 @@ int CSkinInfo::TranslateBool(const std::string &setting)
   auto skinBool = std::make_shared<CSkinSettingBool>();
   skinBool->name = setting;
 
-  const int number = static_cast<int>(m_bools.size() + m_strings.size());
+  const auto number = static_cast<int>(m_bools.size() + m_strings.size());
   m_bools.try_emplace(number, skinBool);
   m_settingsUpdateHandler->TriggerSave();
 
@@ -835,14 +835,9 @@ CSkinSettingPtr CSkinInfo::ParseSetting(const TiXmlElement* element)
     setting = std::make_shared<CSkinSettingString>();
   else if (settingType == "bool")
     setting = std::make_shared<CSkinSettingBool>();
-  else
-    return setting;
 
-  if (setting == nullptr)
-    return setting;
-
-  if (!setting->Deserialize(element))
-    return setting;
+  if (setting)
+    setting->Deserialize(element);
 
   return setting;
 }

--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -91,8 +91,8 @@ VFSEntryPtr CVFSAddonCache::GetAddonInstance(const std::string& strId)
 
   std::unique_lock lock(m_critSection);
 
-  const auto itAddon = std::ranges::find_if(m_addonsInstances, [&strId](const VFSEntryPtr& addon)
-                                            { return addon->ID() == strId; });
+  const auto itAddon = std::ranges::find_if(m_addonsInstances, [&strId](const VFSEntryPtr& a)
+                                            { return a->ID() == strId; });
 
   if (itAddon != m_addonsInstances.end())
     addon = *itAddon;
@@ -170,35 +170,36 @@ void CVFSAddonCache::Update(const std::string& id)
 class CVFSURLWrapper
 {
   public:
-    explicit CVFSURLWrapper(const CURL& url2)
+    explicit CVFSURLWrapper(const CURL& url)
     {
-      m_strings.push_back(url2.Get());
-      m_strings.push_back(url2.GetDomain());
-      m_strings.push_back(url2.GetHostName());
-      m_strings.push_back(url2.GetFileName());
-      m_strings.push_back(url2.GetOptions());
-      m_strings.push_back(url2.GetUserName());
-      m_strings.push_back(url2.GetPassWord());
-      m_strings.push_back(url2.GetRedacted());
-      m_strings.push_back(url2.GetShareName());
-      m_strings.push_back(url2.GetProtocol());
+      m_strings.emplace_back(url.Get());
+      m_strings.emplace_back(url.GetDomain());
+      m_strings.emplace_back(url.GetHostName());
+      m_strings.emplace_back(url.GetFileName());
+      m_strings.emplace_back(url.GetOptions());
+      m_strings.emplace_back(url.GetUserName());
+      m_strings.emplace_back(url.GetPassWord());
+      m_strings.emplace_back(url.GetRedacted());
+      m_strings.emplace_back(url.GetShareName());
+      m_strings.emplace_back(url.GetProtocol());
 
-      url.url = m_strings[0].c_str();
-      url.domain = m_strings[1].c_str();
-      url.hostname = m_strings[2].c_str();
-      url.filename = m_strings[3].c_str();
-      url.port = url2.GetPort();
-      url.options = m_strings[4].c_str();
-      url.username = m_strings[5].c_str();
-      url.password = m_strings[6].c_str();
-      url.redacted = m_strings[7].c_str();
-      url.sharename = m_strings[8].c_str();
-      url.protocol = m_strings[9].c_str();
+      m_url.url = m_strings[0].c_str();
+      m_url.domain = m_strings[1].c_str();
+      m_url.hostname = m_strings[2].c_str();
+      m_url.filename = m_strings[3].c_str();
+      m_url.port = url.GetPort();
+      m_url.options = m_strings[4].c_str();
+      m_url.username = m_strings[5].c_str();
+      m_url.password = m_strings[6].c_str();
+      m_url.redacted = m_strings[7].c_str();
+      m_url.sharename = m_strings[8].c_str();
+      m_url.protocol = m_strings[9].c_str();
     }
 
-    VFSURL url;
+    const VFSURL& GetURL() const { return m_url; }
 
   private:
+    VFSURL m_url;
     std::vector<std::string> m_strings;
 };
 
@@ -256,7 +257,7 @@ void* CVFSEntry::Open(const CURL& url)
     return nullptr;
 
   CVFSURLWrapper url2(url);
-  return m_ifc.vfs->toAddon->open(m_ifc.vfs, &url2.url);
+  return m_ifc.vfs->toAddon->open(m_ifc.vfs, &url2.GetURL());
 }
 
 void* CVFSEntry::OpenForWrite(const CURL& url, bool bOverWrite)
@@ -265,7 +266,7 @@ void* CVFSEntry::OpenForWrite(const CURL& url, bool bOverWrite)
     return nullptr;
 
   CVFSURLWrapper url2(url);
-  return m_ifc.vfs->toAddon->open_for_write(m_ifc.vfs, &url2.url, bOverWrite);
+  return m_ifc.vfs->toAddon->open_for_write(m_ifc.vfs, &url2.GetURL(), bOverWrite);
 }
 
 bool CVFSEntry::Exists(const CURL& url) const
@@ -274,7 +275,7 @@ bool CVFSEntry::Exists(const CURL& url) const
     return false;
 
   CVFSURLWrapper url2(url);
-  return m_ifc.vfs->toAddon->exists(m_ifc.vfs, &url2.url);
+  return m_ifc.vfs->toAddon->exists(m_ifc.vfs, &url2.GetURL());
 }
 
 int CVFSEntry::Stat(const CURL& url, struct __stat64* buffer) const
@@ -285,7 +286,7 @@ int CVFSEntry::Stat(const CURL& url, struct __stat64* buffer) const
 
   CVFSURLWrapper url2(url);
   STAT_STRUCTURE statBuffer = {};
-  ret = m_ifc.vfs->toAddon->stat(m_ifc.vfs, &url2.url, &statBuffer);
+  ret = m_ifc.vfs->toAddon->stat(m_ifc.vfs, &url2.GetURL(), &statBuffer);
 
   *buffer = {};
   buffer->st_dev = statBuffer.deviceId;
@@ -438,7 +439,7 @@ bool CVFSEntry::Delete(const CURL& url) const
     return false;
 
   CVFSURLWrapper url2(url);
-  return m_ifc.vfs->toAddon->delete_it(m_ifc.vfs, &url2.url);
+  return m_ifc.vfs->toAddon->delete_it(m_ifc.vfs, &url2.GetURL());
 }
 
 bool CVFSEntry::Rename(const CURL& url, const CURL& url2) const
@@ -448,7 +449,7 @@ bool CVFSEntry::Rename(const CURL& url, const CURL& url2) const
 
   CVFSURLWrapper url3(url);
   CVFSURLWrapper url4(url2);
-  return m_ifc.vfs->toAddon->rename(m_ifc.vfs, &url3.url, &url4.url);
+  return m_ifc.vfs->toAddon->rename(m_ifc.vfs, &url3.GetURL(), &url4.GetURL());
 }
 
 void CVFSEntry::ClearOutIdle() const
@@ -469,7 +470,7 @@ bool CVFSEntry::DirectoryExists(const CURL& url) const
     return false;
 
   CVFSURLWrapper url2(url);
-  return m_ifc.vfs->toAddon->directory_exists(m_ifc.vfs, &url2.url);
+  return m_ifc.vfs->toAddon->directory_exists(m_ifc.vfs, &url2.GetURL());
 }
 
 bool CVFSEntry::RemoveDirectory(const CURL& url) const
@@ -478,7 +479,7 @@ bool CVFSEntry::RemoveDirectory(const CURL& url) const
     return false;
 
   CVFSURLWrapper url2(url);
-  return m_ifc.vfs->toAddon->remove_directory(m_ifc.vfs, &url2.url);
+  return m_ifc.vfs->toAddon->remove_directory(m_ifc.vfs, &url2.GetURL());
 }
 
 bool CVFSEntry::CreateDirectory(const CURL& url) const
@@ -487,7 +488,7 @@ bool CVFSEntry::CreateDirectory(const CURL& url) const
     return false;
 
   CVFSURLWrapper url2(url);
-  return m_ifc.vfs->toAddon->create_directory(m_ifc.vfs, &url2.url);
+  return m_ifc.vfs->toAddon->create_directory(m_ifc.vfs, &url2.GetURL());
 }
 
 namespace
@@ -535,8 +536,8 @@ bool CVFSEntry::GetDirectory(const CURL& url, CFileItemList& items, void* ctx) c
   VFSDirEntry* entries = nullptr;
   int num_entries = 0;
   CVFSURLWrapper url2(url);
-  bool ret =
-      m_ifc.vfs->toAddon->get_directory(m_ifc.vfs, &url2.url, &entries, &num_entries, &callbacks);
+  bool ret = m_ifc.vfs->toAddon->get_directory(m_ifc.vfs, &url2.GetURL(), &entries, &num_entries,
+                                               &callbacks);
   if (ret)
   {
     VFSDirEntriesToCFileItemList(num_entries, entries, items);
@@ -557,8 +558,8 @@ bool CVFSEntry::ContainsFiles(const CURL& url, CFileItemList& items) const
   CVFSURLWrapper url2(url);
   char rootpath[ADDON_STANDARD_STRING_LENGTH];
   rootpath[0] = 0;
-  bool ret =
-      m_ifc.vfs->toAddon->contains_files(m_ifc.vfs, &url2.url, &entries, &num_entries, rootpath);
+  bool ret = m_ifc.vfs->toAddon->contains_files(m_ifc.vfs, &url2.GetURL(), &entries, &num_entries,
+                                                rootpath);
   if (!ret)
     return false;
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/tools/StringUtils.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/tools/StringUtils.h
@@ -1465,7 +1465,8 @@ public:
   /// --------------------------------------------------------------------------
   /// Example:
   /// ~~~~~~~~~~~~~{.cpp}
-  /// std::string ref, var;
+  /// std::string ref;
+  /// std::string var;
   ///
   /// ref = "8378 787464";
   /// var = "test string";
@@ -2925,7 +2926,8 @@ public:
   /// ~~~~~~~~~~~~~{.cpp}
   /// #include <kodi/tools/StringUtils.h>
   ///
-  /// std::string ref, var;
+  /// std::string ref;
+  /// std::string var;
   ///
   /// ref = "21:30:55";
   /// var = kodi::tools::StringUtils::SecondsToTimeString(77455);

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -1702,7 +1702,7 @@ bool CAddonSettings::ParseOldConditionExpression(std::string str, ConditionExpre
 
 void CAddonSettings::FileEnumSettingOptionsFiller(const std::shared_ptr<const CSetting>& setting,
                                                   std::vector<StringSettingOption>& list,
-                                                  std::string& current)
+                                                  std::string& /*current*/)
 {
   if (setting == nullptr)
     return;

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -983,25 +983,25 @@ void CStrAccum::VXPrintf(MYSQL* conn,
       switch (c)
       {
         case '-':
-          flag_leftjustify = 1;
+          flag_leftjustify = true;
           break;
         case '+':
-          flag_plussign = 1;
+          flag_plussign = true;
           break;
         case ' ':
-          flag_blanksign = 1;
+          flag_blanksign = true;
           break;
         case '#':
-          flag_alternateform = 1;
+          flag_alternateform = true;
           break;
         case '!':
-          flag_altform2 = 1;
+          flag_altform2 = true;
           break;
         case '0':
-          flag_zeropad = 1;
+          flag_zeropad = true;
           break;
         default:
-          done = 1;
+          done = true;
           break;
       }
     } while (!done && (c = (*++fmt)) != 0);
@@ -1012,7 +1012,7 @@ void CStrAccum::VXPrintf(MYSQL* conn,
       width = va_arg(ap, int);
       if (width < 0)
       {
-        flag_leftjustify = 1;
+        flag_leftjustify = true;
         width = -width;
       }
       c = *++fmt;
@@ -1057,21 +1057,21 @@ void CStrAccum::VXPrintf(MYSQL* conn,
     /* Get the conversion type modifier */
     if (c == 'l')
     {
-      flag_long = 1;
+      flag_long = true;
       c = *++fmt;
       if (c == 'l')
       {
-        flag_longlong = 1;
+        flag_longlong = true;
         c = *++fmt;
       }
       else
       {
-        flag_longlong = 0;
+        flag_longlong = false;
       }
     }
     else
     {
-      flag_long = flag_longlong = 0;
+      flag_long = flag_longlong = false;
     }
     /* Fetch the info entry for the field */
     infop = fmtinfo.data();
@@ -1096,7 +1096,7 @@ void CStrAccum::VXPrintf(MYSQL* conn,
       break;
     }
 
-    zExtra = 0;
+    zExtra = nullptr;
 
     /* Limit the precision to prevent overflowing buf[] during conversion */
     if (precision > etBUFSIZE - 40 && (infop->flags & FLAG_STRING) == 0)
@@ -1636,9 +1636,8 @@ bool CStrAccum::Append(const char* z, int n)
 
 size_t ci_find(std::string_view where, std::string_view what)
 {
-  const auto found =
-      std::ranges::search(where.cbegin(), where.cend(), what.cbegin(), what.cend(),
-                          [](char l, char r) { return std::tolower(l) == std::tolower(r); });
+  const auto found = std::ranges::search(where, what, [](char l, char r)
+                                         { return std::tolower(l) == std::tolower(r); });
   if (found.empty())
     return std::string::npos;
   else

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -413,7 +413,7 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
     // nothing to add
   }
   if (CGUIDialogFileBrowser::ShowAndGetSource(path, allowNetworkShares,
-                                              extraShares.empty() ? NULL : &extraShares))
+                                              extraShares.empty() ? nullptr : &extraShares))
   {
     if (item < m_paths->Size()) // if the skin does funky things, m_paths may have been cleared
       m_paths->Get(item)->SetPath(path);

--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -205,12 +205,12 @@ CUPnPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
             NPT_String name = (*device)->GetFriendlyName();
             NPT_String uuid = (*device)->GetUUID();
 
-            CFileItemPtr pItem(new CFileItem((const char*)name));
-            pItem->SetPath(std::string((const char*) "upnp://" + uuid + "/"));
+            auto pItem{std::make_shared<CFileItem>(static_cast<const char*>(name))};
+            pItem->SetPath(std::string_view(static_cast<const char*>("upnp://" + uuid + "/")));
             pItem->SetFolder(true);
-            pItem->SetArt("thumb", (const char*)(*device)->GetIconUrl("image/png"));
+            pItem->SetArt("thumb", static_cast<const char*>((*device)->GetIconUrl("image/png")));
 
-            items.Add(pItem);
+            items.Add(std::move(pItem));
 
             ++device;
         }
@@ -316,13 +316,14 @@ CUPnPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
             std::string id;
             if ((*entry)->m_ReferenceID.IsEmpty())
-                id = (const char*) (*entry)->m_ObjectID;
+              id = static_cast<const char*>((*entry)->m_ObjectID);
             else
-                id = (const char*) (*entry)->m_ReferenceID;
+              id = static_cast<const char*>((*entry)->m_ReferenceID);
 
             id = CURL::Encode(id);
             URIUtils::AddSlashAtEnd(id);
-            pItem->SetPath(std::string((const char*) "upnp://" + uuid + "/" + id.c_str()));
+            pItem->SetPath(
+                std::string_view(static_cast<const char*>("upnp://" + uuid + "/" + id.c_str())));
 
             items.Add(pItem);
 

--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -42,7 +42,6 @@ CGUIImage::CGUIImage(const CGUIImage& left)
     m_info(left.m_info),
     m_textureCurrent(left.m_textureCurrent->Clone()),
     m_textureNext(left.m_textureNext->Clone()),
-    m_currentFallback(),
     m_imageFilterInfo(left.m_imageFilterInfo),
     m_imageFilter(left.m_imageFilter),
     m_diffuseFilterInfo(left.m_diffuseFilterInfo),

--- a/xbmc/guilib/GUIVisualisationControl.cpp
+++ b/xbmc/guilib/GUIVisualisationControl.cpp
@@ -82,7 +82,7 @@ CGUIVisualisationControl::CGUIVisualisationControl(const CGUIVisualisationContro
   ControlType = GUICONTROL_VISUALISATION;
 }
 
-std::string CGUIVisualisationControl::Name()
+std::string CGUIVisualisationControl::Name() const
 {
   if (m_instance == nullptr)
     return "";
@@ -309,7 +309,7 @@ void CGUIVisualisationControl::UpdateTrack()
   m_instance->UpdateTrack(&track);
 }
 
-bool CGUIVisualisationControl::IsLocked()
+bool CGUIVisualisationControl::IsLocked() const
 {
   if (m_instance && m_alreadyStarted)
     return m_instance->IsLocked();
@@ -317,7 +317,7 @@ bool CGUIVisualisationControl::IsLocked()
   return false;
 }
 
-bool CGUIVisualisationControl::HasPresets()
+bool CGUIVisualisationControl::HasPresets() const
 {
   if (m_instance && m_alreadyStarted)
     return m_instance->HasPresets();
@@ -325,7 +325,7 @@ bool CGUIVisualisationControl::HasPresets()
   return false;
 }
 
-int CGUIVisualisationControl::GetActivePreset()
+int CGUIVisualisationControl::GetActivePreset() const
 {
   if (m_instance && m_alreadyStarted)
     return m_instance->GetActivePreset();
@@ -339,7 +339,7 @@ void CGUIVisualisationControl::SetPreset(int idx)
     m_instance->LoadPreset(idx);
 }
 
-std::string CGUIVisualisationControl::GetActivePresetName()
+std::string CGUIVisualisationControl::GetActivePresetName() const
 {
   if (m_instance && m_alreadyStarted)
     return m_instance->GetActivePresetName();
@@ -347,7 +347,7 @@ std::string CGUIVisualisationControl::GetActivePresetName()
   return "";
 }
 
-bool CGUIVisualisationControl::GetPresetList(std::vector<std::string>& vecpresets)
+bool CGUIVisualisationControl::GetPresetList(std::vector<std::string>& vecpresets) const
 {
   if (m_instance && m_alreadyStarted)
     return m_instance->GetPresetList(vecpresets);

--- a/xbmc/guilib/GUIVisualisationControl.h
+++ b/xbmc/guilib/GUIVisualisationControl.h
@@ -65,14 +65,14 @@ public:
   bool CanFocus() const override { return false; }
   bool CanFocusFromPoint(const CPoint& point) const override;
 
-  std::string Name();
+  std::string Name() const;
   void UpdateTrack();
-  bool HasPresets();
+  bool HasPresets() const;
   void SetPreset(int idx);
-  bool IsLocked();
-  int GetActivePreset();
-  std::string GetActivePresetName();
-  bool GetPresetList(std::vector<std::string>& vecpresets);
+  bool IsLocked() const;
+  int GetActivePreset() const;
+  std::string GetActivePresetName() const;
+  bool GetPresetList(std::vector<std::string>& vecpresets) const;
 
 private:
   bool InitVisualization();

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -90,7 +90,7 @@ void CTextureArray::SetScalingMethod(TEXTURE_SCALING scalingMethod)
 {
   m_scalingMethod = scalingMethod;
 
-  for (std::shared_ptr<CTexture>& texture : m_textures)
+  for (const std::shared_ptr<CTexture>& texture : m_textures)
     texture->SetScalingMethod(m_scalingMethod);
 }
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -1720,7 +1720,7 @@ int CMusicDatabase::AddGenre(std::string& strGenre)
                           strGenre.c_str());
       m_pDS->exec(strSQL);
 
-      const int idGenre = static_cast<int>(m_pDS->lastinsertid());
+      const auto idGenre = static_cast<int>(m_pDS->lastinsertid());
       m_genreCache.try_emplace(strGenre, idGenre);
       return idGenre;
     }
@@ -3238,7 +3238,7 @@ void CMusicDatabase::GetFileItemFromArtistCredits(VECARTISTCREDITS& artistCredit
 
 CAlbum CMusicDatabase::GetAlbumFromDataset(dbiplus::Dataset* pDS,
                                            int offset /* = 0 */,
-                                           bool imageURL /* = false*/)
+                                           bool imageURL /* = false*/) const
 {
   return GetAlbumFromDataset(pDS->get_sql_record(), offset, imageURL);
 }
@@ -3321,7 +3321,7 @@ CMusicRole CMusicDatabase::GetArtistRoleFromDataset(const dbiplus::sql_record* c
 
 CArtist CMusicDatabase::GetArtistFromDataset(dbiplus::Dataset* pDS,
                                              int offset /* = 0 */,
-                                             bool needThumb /* = true */)
+                                             bool needThumb /* = true */) const
 {
   return GetArtistFromDataset(pDS->get_sql_record(), offset, needThumb);
 }
@@ -8411,7 +8411,7 @@ std::string CMusicDatabase::GetIgnoreArticleSQL(const std::string& strField) con
 std::string CMusicDatabase::SortnameBuildSQL(const std::string& strAlias,
                                              const SortAttribute& sortAttributes,
                                              const std::string& strField,
-                                             const std::string& strSortField)
+                                             const std::string& strSortField) const
 {
   /*
   Build SQL for sort name scalar subquery from sort attributes and ignore article list.
@@ -11161,7 +11161,7 @@ bool CMusicDatabase::GetGenresJSON(CFileItemList& items, bool bSources)
   return false;
 }
 
-std::string CMusicDatabase::GetAlbumDiscTitle(int idAlbum, int idDisc)
+std::string CMusicDatabase::GetAlbumDiscTitle(int idAlbum, int idDisc) const
 {
   // Get disc node title from ids allowing for "*all"
   std::string disctitle;
@@ -11849,7 +11849,7 @@ bool CMusicDatabase::GetItems(const std::string& strBaseDir,
   return false;
 }
 
-std::string CMusicDatabase::GetItemById(const std::string& itemType, int id)
+std::string CMusicDatabase::GetItemById(const std::string& itemType, int id) const
 {
   if (StringUtils::EqualsNoCase(itemType, "genres"))
     return GetGenreById(id);

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -348,7 +348,7 @@ public:
   bool SearchAlbumsByArtistName(const std::string& strArtist, CFileItemList& items);
   int GetAlbumByMatch(const CAlbum& album);
   std::string GetAlbumById(int id) const;
-  std::string GetAlbumDiscTitle(int idAlbum, int idDisc);
+  std::string GetAlbumDiscTitle(int idAlbum, int idDisc) const;
   bool SetAlbumUserrating(const int idAlbum, int userrating);
   int GetAlbumDiscsCount(int idAlbum) const;
 
@@ -691,7 +691,7 @@ public:
                 CFileItemList& items,
                 const Filter& filter = Filter(),
                 const SortDescription& sortDescription = SortDescription());
-  std::string GetItemById(const std::string& itemType, int id);
+  std::string GetItemById(const std::string& itemType, int id) const;
 
   /////////////////////////////////////////////////
   // XML
@@ -890,11 +890,11 @@ private:
 
   CSong GetSongFromDataset();
   CSong GetSongFromDataset(const dbiplus::sql_record* const record, int offset = 0) const;
-  CArtist GetArtistFromDataset(dbiplus::Dataset* pDS, int offset = 0, bool needThumb = true);
+  CArtist GetArtistFromDataset(dbiplus::Dataset* pDS, int offset = 0, bool needThumb = true) const;
   CArtist GetArtistFromDataset(const dbiplus::sql_record* const record,
                                int offset = 0,
                                bool needThumb = true) const;
-  CAlbum GetAlbumFromDataset(dbiplus::Dataset* pDS, int offset = 0, bool imageURL = false);
+  CAlbum GetAlbumFromDataset(dbiplus::Dataset* pDS, int offset = 0, bool imageURL = false) const;
   CAlbum GetAlbumFromDataset(const dbiplus::sql_record* const record,
                              int offset = 0,
                              bool imageURL = false) const;
@@ -947,7 +947,7 @@ private:
   std::string SortnameBuildSQL(const std::string& strAlias,
                                const SortAttribute& sortAttributes,
                                const std::string& strField,
-                               const std::string& strSortField);
+                               const std::string& strSortField) const;
 
   /*! \brief Build SQL for sorting field naturally and case-insensitively (in SQLite).
   \param strField field name

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -294,7 +294,7 @@ void CMusicInfoLoader::LoadCache(const std::string& strFileName, CFileItemList& 
   }
 }
 
-void CMusicInfoLoader::SaveCache(const std::string& strFileName, CFileItemList& items)
+void CMusicInfoLoader::SaveCache(const std::string& strFileName, const CFileItemList& items)
 {
   int iSize = items.Size();
 

--- a/xbmc/music/MusicInfoLoader.h
+++ b/xbmc/music/MusicInfoLoader.h
@@ -32,7 +32,8 @@ protected:
   void OnLoaderStart() override;
   void OnLoaderFinish() override;
   void LoadCache(const std::string& strFileName, CFileItemList& items);
-  void SaveCache(const std::string& strFileName, CFileItemList& items);
+  void SaveCache(const std::string& strFileName, const CFileItemList& items);
+
 protected:
   std::string m_strCacheFileName;
   CFileItemList* m_mapFileItems;

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -76,7 +76,7 @@ public:
   bool HasSongExtraArtChanged(const CFileItemPtr& pSongItem,
                               const std::string& type,
                               const int itemID,
-                              CMusicDatabase& db)
+                              const CMusicDatabase& db)
   {
     if (!pSongItem->HasMusicInfoTag())
       return false;

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -625,7 +625,9 @@ static bool SortSongsByTrack(const CSong& song, const CSong& song2)
   return song.iTrack < song2.iTrack;
 }
 
-void CMusicInfoScanner::FileItemsToAlbums(CFileItemList& items, VECALBUMS& albums, MAPSONGS* songsMap /* = NULL */)
+void CMusicInfoScanner::FileItemsToAlbums(const CFileItemList& items,
+                                          VECALBUMS& albums,
+                                          MAPSONGS* songsMap /* = nullptr */)
 {
   /*
    * Step 1: Convert the FileItems into Songs.

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -51,7 +51,9 @@ public:
    \param songs [in/out] list of songs to categorise - albumartist field may be altered.
    \param albums [out] albums found within these songs.
    */
-  static void FileItemsToAlbums(CFileItemList& items, VECALBUMS& albums, MAPSONGS* songsMap = NULL);
+  static void FileItemsToAlbums(const CFileItemList& items,
+                                VECALBUMS& albums,
+                                MAPSONGS* songsMap = nullptr);
 
   /*! \brief Scrape additional album information and update the music database with it.
   Given an album, search for it using the given scraper.

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -1124,7 +1124,7 @@ void CTagLoaderTagLib::SetDiscSubtitle(CMusicInfoTag& tag, const std::vector<std
   if (values.size() == 1)
     tag.SetDiscSubtitle(values[0]);
   else
-    tag.SetDiscSubtitle(std::string());
+    tag.SetDiscSubtitle(std::string_view());
 }
 
 void CTagLoaderTagLib::AddArtistRole(CMusicInfoTag &tag, const std::vector<std::string> &values)

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -1366,7 +1366,7 @@ bool GetResource(const PLT_MediaObject* entry, CFileItem& item)
     // if this is an image fill the thumb of the item
     if (StringUtils::StartsWithNoCase(resource.m_ProtocolInfo.GetContentType().GetChars(), "image"))
     {
-      item.SetArt("thumb", std::string(resource.m_Uri));
+      item.SetArt("thumb", std::string_view(resource.m_Uri));
     }
   }
   else

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -792,7 +792,7 @@ NPT_Result CUPnPServer::OnBrowseDirectChildren(PLT_ActionReference& action,
     return NPT_FAILURE;
   }
 
-  items.SetPath(std::string(parent_id));
+  items.SetPath(std::string_view(parent_id));
 
   // guard against loading while saving to the same cache file
   // as CArchive currently performs no locking itself

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -251,9 +251,8 @@ PeripheralBusPtr CPeripherals::GetBusWithDevice(const std::string& strLocation) 
 {
   std::unique_lock lock(m_critSectionBusses);
 
-  const auto& bus =
-      std::find_if(m_busses.cbegin(), m_busses.cend(), [&strLocation](const PeripheralBusPtr& bus)
-                   { return bus->HasPeripheral(strLocation); });
+  const auto& bus = std::ranges::find_if(m_busses, [&strLocation](const PeripheralBusPtr& bus)
+                                         { return bus->HasPeripheral(strLocation); });
   if (bus != m_busses.cend())
     return *bus;
 

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -479,9 +479,8 @@ void CPeripheralBusAddon::PromptEnableAddons(
   // True if the user confirms enabling the disabled peripheral add-on
   bool bAccepted = false;
 
-  auto itAddon =
-      std::find_if(disabledAddons.begin(), disabledAddons.end(), [](const AddonInfoPtr& addonInfo)
-                   { return CPeripheralAddon::ProvidesJoysticks(addonInfo); });
+  auto itAddon = std::ranges::find_if(disabledAddons, [](const AddonInfoPtr& addonInfo)
+                                      { return CPeripheralAddon::ProvidesJoysticks(addonInfo); });
 
   if (itAddon != disabledAddons.end())
   {

--- a/xbmc/playlists/PlayListURL.cpp
+++ b/xbmc/playlists/PlayListURL.cpp
@@ -56,8 +56,8 @@ bool CPlayListURL::Load(const std::string& strFileName)
         StringUtils::RemoveCRLF(strLine);
         if (StringUtils::StartsWith(strLine, "URL="))
         {
-          CFileItemPtr newItem(new CFileItem(strLine.substr(4), false));
-          Add(newItem);
+          auto newItem{std::make_shared<CFileItem>(strLine.substr(4), false)};
+          Add(std::move(newItem));
         }
       }
     }

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -932,9 +932,9 @@ void CDisplaySettings::SettingOptionsCmsModesFiller(const SettingConstPtr& /*set
 #endif
 }
 
-void CDisplaySettings::SettingOptionsCmsWhitepointsFiller(const SettingConstPtr& setting,
+void CDisplaySettings::SettingOptionsCmsWhitepointsFiller(const SettingConstPtr& /*setting*/,
                                                           std::vector<IntegerSettingOption>& list,
-                                                          int& current)
+                                                          int& /*current*/)
 {
   list.emplace_back(g_localizeStrings.Get(36586), CMS_WHITEPOINT_D65);
   list.emplace_back(g_localizeStrings.Get(36587), CMS_WHITEPOINT_D93);

--- a/xbmc/settings/MediaSourceSettings.cpp
+++ b/xbmc/settings/MediaSourceSettings.cpp
@@ -449,7 +449,7 @@ bool CMediaSourceSettings::GetSource(const std::string& category,
 void CMediaSourceSettings::GetSources(const tinyxml2::XMLNode* rootElement,
                                       const std::string& tagName,
                                       std::vector<CMediaSource>& items,
-                                      std::string& defaultString)
+                                      std::string& defaultString) const
 {
 
   defaultString = "";

--- a/xbmc/settings/MediaSourceSettings.h
+++ b/xbmc/settings/MediaSourceSettings.h
@@ -65,7 +65,7 @@ private:
   void GetSources(const tinyxml2::XMLNode* rootElement,
                   const std::string& tagName,
                   std::vector<CMediaSource>& items,
-                  std::string& defaultString);
+                  std::string& defaultString) const;
   bool SetSources(tinyxml2::XMLNode* rootNode,
                   const char* section,
                   const std::vector<CMediaSource>& shares,

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -53,9 +53,9 @@ bool AddonHasSettings(const std::string& condition,
   return addon->CanHaveAddonOrInstanceSettings();
 }
 
-bool CheckMasterLock(const std::string& condition,
+bool CheckMasterLock(const std::string& /*condition*/,
                      const std::string& value,
-                     const SettingConstPtr& setting)
+                     const SettingConstPtr& /*setting*/)
 {
   return g_passwordManager.IsMasterLockUnlocked(StringUtils::EqualsNoCase(value, "true"));
 }

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -228,7 +228,7 @@ void CGUIDialogContentSettings::OnSettingAction(const std::shared_ptr<const CSet
         return;
 
       const auto& [_, selected] = labels.at(newSelected);
-      m_content = static_cast<ContentType>(selected);
+      m_content = selected;
 
       AddonPtr scraperAddon;
       if (!CAddonSystemSettings::GetInstance().GetActive(ADDON::ScraperTypeFromContent(m_content),

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -892,7 +892,7 @@ void CGUIDialogSettingsBase::OnClick(const BaseSettingControlPtr& pSettingContro
 }
 
 void CGUIDialogSettingsBase::UpdateSettingControl(const std::string& settingId,
-                                                  bool updateDisplayOnly /* = false */)
+                                                  bool updateDisplayOnly /* = false */) const
 {
   if (settingId.empty())
     return;

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.h
@@ -149,7 +149,7 @@ protected:
    */
   virtual void OnClick(const BaseSettingControlPtr& pSettingControl);
 
-  void UpdateSettingControl(const std::string& settingId, bool updateDisplayOnly = false);
+  void UpdateSettingControl(const std::string& settingId, bool updateDisplayOnly = false) const;
   void UpdateSettingControl(const BaseSettingControlPtr& pSettingControl,
                             bool updateDisplayOnly = false) const;
   void SetControlLabel(int controlId, const CVariant& label);

--- a/xbmc/settings/dialogs/GUIDialogSettingsManualBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManualBase.cpp
@@ -93,7 +93,7 @@ SettingGroupPtr CGUIDialogSettingsManualBase::AddGroup(const SettingCategoryPtr&
                                                        int label /* = -1 */,
                                                        int help /* = -1 */,
                                                        bool separatorBelowLabel /* = true */,
-                                                       bool hideSeparator /* = false */)
+                                                       bool hideSeparator /* = false */) const
 {
   if (!category)
     return nullptr;

--- a/xbmc/settings/dialogs/GUIDialogSettingsManualBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManualBase.h
@@ -57,7 +57,7 @@ protected:
                                           int label = -1,
                                           int help = -1,
                                           bool separatorBelowLabel = true,
-                                          bool hideSeparator = false);
+                                          bool hideSeparator = false) const;
   // checkmark control
   std::shared_ptr<CSettingBool> AddToggle(const std::shared_ptr<CSettingGroup>& group,
                                           const std::string& id,

--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -946,7 +946,7 @@ bool CSettingInt::Deserialize(const TiXmlNode *node, bool update /* = false */)
             if (optionElement->QueryStringAttribute(SETTING_XML_ATTR_LABEL, &label) ==
                 TIXML_SUCCESS)
             {
-              const int val =
+              const auto val =
                   static_cast<int>(std::strtol(optionElement->FirstChild()->Value(), nullptr, 10));
               m_options.emplace_back(label, val);
             }

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -208,7 +208,7 @@ bool GetIntegerOptions(const SettingConstPtr& setting,
 bool GetStringOptions(const SettingConstPtr& setting,
                       StringSettingOptions& options,
                       std::set<std::string>& selectedOptions,
-                      ILocalizer* localizer,
+                      const ILocalizer* localizer,
                       bool updateOptions)
 {
   std::shared_ptr<const CSettingString> pSettingString;
@@ -1163,7 +1163,7 @@ void CGUIControlButtonSetting::Update(bool fromControl, bool updateDisplayOnly)
 }
 
 bool CGUIControlButtonSetting::GetPath(const std::shared_ptr<CSettingPath>& pathSetting,
-                                       ILocalizer* localizer)
+                                       const ILocalizer* localizer)
 {
   if (!pathSetting)
     return false;
@@ -1486,7 +1486,7 @@ std::string CGUIControlSliderSetting::GetText(const std::shared_ptr<CSetting>& s
                                               const CVariant& minimum,
                                               const CVariant& step,
                                               const CVariant& maximum,
-                                              ILocalizer* localizer)
+                                              const ILocalizer* localizer)
 {
   if (!setting || !(value.isInteger() || value.isDouble()))
     return "";

--- a/xbmc/settings/windows/GUIControlSettings.h
+++ b/xbmc/settings/windows/GUIControlSettings.h
@@ -228,7 +228,8 @@ public:
   bool OnClick() override;
   void Clear() override { m_pButton = nullptr; }
 
-  static bool GetPath(const std::shared_ptr<CSettingPath>& pathSetting, ILocalizer* localizer);
+  static bool GetPath(const std::shared_ptr<CSettingPath>& pathSetting,
+                      const ILocalizer* localizer);
 
 protected:
   // specialization of CGUIControlBaseSetting
@@ -282,7 +283,7 @@ public:
                              const CVariant& minimum,
                              const CVariant& step,
                              const CVariant& maximum,
-                             ILocalizer* localizer);
+                             const ILocalizer* localizer);
 
 protected:
   // specialization of CGUIControlBaseSetting

--- a/xbmc/utils/DatabaseUtils.cpp
+++ b/xbmc/utils/DatabaseUtils.cpp
@@ -447,7 +447,7 @@ bool DatabaseUtils::GetDatabaseResults(const MediaType& mediaType,
     return true;
 
   const dbiplus::result_set& resultSet = dataset.get_result_set();
-  const unsigned int offset = static_cast<unsigned int>(results.size());
+  const auto offset = static_cast<unsigned int>(results.size());
 
   if (fields.empty())
   {

--- a/xbmc/utils/test/TestStringUtils.cpp
+++ b/xbmc/utils/test/TestStringUtils.cpp
@@ -468,7 +468,8 @@ TEST(TestStringUtils, utf8_strlen)
 
 TEST(TestStringUtils, SecondsToTimeString)
 {
-  std::string ref, var;
+  std::string ref;
+  std::string var;
 
   ref = "21:30:55";
   var = StringUtils::SecondsToTimeString(77455);
@@ -513,7 +514,8 @@ TEST(TestStringUtils, IsInteger)
 
 TEST(TestStringUtils, SizeToString)
 {
-  std::string ref, var;
+  std::string ref;
+  std::string var;
 
   ref = "2.00 GB";
   var = StringUtils::SizeToString(2147483647);
@@ -587,7 +589,8 @@ TEST(TestStringUtils, DateStringToYYYYMMDD)
 
 TEST(TestStringUtils, WordToDigits)
 {
-  std::string ref, var;
+  std::string ref;
+  std::string var;
 
   ref = "8378 787464";
   var = "test string";

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -84,7 +84,8 @@ TEST_F(TestURIUtils, GetFileName)
 
 TEST_F(TestURIUtils, RemoveExtension)
 {
-  std::string ref, var;
+  std::string ref;
+  std::string var;
 
   /* NOTE: CSettings need to be set to find other extensions. */
   ref = "/path/to/file";
@@ -95,7 +96,8 @@ TEST_F(TestURIUtils, RemoveExtension)
 
 TEST_F(TestURIUtils, ReplaceExtension)
 {
-  std::string ref, var;
+  std::string ref;
+  std::string var;
 
   ref = "/path/to/file.xsd";
   var = URIUtils::ReplaceExtension("/path/to/file.xml", ".xsd");
@@ -104,7 +106,10 @@ TEST_F(TestURIUtils, ReplaceExtension)
 
 TEST_F(TestURIUtils, Split)
 {
-  std::string refpath, reffile, varpath, varfile;
+  std::string refpath;
+  std::string reffile;
+  std::string varpath;
+  std::string varfile;
 
   refpath = "/path/to/";
   reffile = "movie.avi";
@@ -162,7 +167,8 @@ TEST_F(TestURIUtils, SplitPathLocal)
 
 TEST_F(TestURIUtils, GetCommonPath)
 {
-  std::string ref, var;
+  std::string ref;
+  std::string var;
 
   ref = "/path/";
   var = "/path/2/movie.avi";
@@ -172,7 +178,8 @@ TEST_F(TestURIUtils, GetCommonPath)
 
 TEST_F(TestURIUtils, GetParentPath)
 {
-  std::string ref, var;
+  std::string ref;
+  std::string var;
 
   ref = "/path/to/";
   var = URIUtils::GetParentPath("/path/to/movie.avi");
@@ -185,7 +192,8 @@ TEST_F(TestURIUtils, GetParentPath)
 
 TEST_F(TestURIUtils, GetBasePath)
 {
-  std::string ref, var;
+  std::string ref;
+  std::string var;
 
   ref = "smb://somepath/path/";
 
@@ -215,7 +223,10 @@ TEST_F(TestURIUtils, GetBasePath)
 
 TEST_F(TestURIUtils, SubstitutePath)
 {
-  std::string from, to, ref, var;
+  std::string from;
+  std::string to;
+  std::string ref;
+  std::string var;
 
   from = "C:\\My Videos";
   to = "https://myserver/some%20other%20path";
@@ -480,7 +491,8 @@ TEST_F(TestURIUtils, IsBlurayPath)
 
 TEST_F(TestURIUtils, AddSlashAtEnd)
 {
-  std::string ref, var;
+  std::string ref;
+  std::string var;
 
   ref = "bluray://path/to/file/";
   var = "bluray://path/to/file/";
@@ -496,7 +508,8 @@ TEST_F(TestURIUtils, HasSlashAtEnd)
 
 TEST_F(TestURIUtils, RemoveSlashAtEnd)
 {
-  std::string ref, var;
+  std::string ref;
+  std::string var;
 
   ref = "bluray://path/to/file";
   var = "bluray://path/to/file/";
@@ -506,7 +519,8 @@ TEST_F(TestURIUtils, RemoveSlashAtEnd)
 
 TEST_F(TestURIUtils, CreateArchivePath)
 {
-  std::string ref, var;
+  std::string ref;
+  std::string var;
 
   ref = "zip://%2fpath%2fto%2f/file";
   var = URIUtils::CreateArchivePath("zip", CURL("/path/to/"), "file").Get();

--- a/xbmc/video/SetInfoTag.cpp
+++ b/xbmc/video/SetInfoTag.cpp
@@ -23,17 +23,17 @@ void CSetInfoTag::Reset()
   m_art.clear();
 }
 
-bool CSetInfoTag::Load(const TiXmlElement* element, bool append, bool prioritise)
+bool CSetInfoTag::Load(const TiXmlElement* element, bool append, bool /*prioritise*/)
 {
   if (!element)
     return false;
   if (!append)
     Reset();
-  ParseNative(element, prioritise);
+  ParseNative(element);
   return true;
 }
 
-void CSetInfoTag::ParseNative(const TiXmlElement* set, bool prioritise)
+void CSetInfoTag::ParseNative(const TiXmlElement* set)
 {
   std::string value;
 
@@ -52,24 +52,24 @@ void CSetInfoTag::ParseNative(const TiXmlElement* set, bool prioritise)
       std::string type{picture->ValueStr()};
       std::string url{picture->GetText()};
       if (!type.empty() && !url.empty())
-        m_art.insert({type, url});
+        m_art.try_emplace(type, url);
     }
 }
 
-void CSetInfoTag::SetOverview(const std::string& overview)
+void CSetInfoTag::SetOverview(std::string_view overview)
 {
   m_overview = overview;
   m_overview = StringUtils::Trim(m_overview);
   m_updateSetOverview = true;
 }
 
-void CSetInfoTag::SetTitle(const std::string& title)
+void CSetInfoTag::SetTitle(std::string_view title)
 {
   m_title = title;
   m_title = StringUtils::Trim(m_title);
 }
 
-void CSetInfoTag::SetOriginalTitle(const std::string& title)
+void CSetInfoTag::SetOriginalTitle(std::string_view title)
 {
   m_originalTitle = title;
 }
@@ -104,8 +104,7 @@ void CSetInfoTag::Copy(const CSetInfoTag& other)
 
 bool CSetInfoTag::Save(TiXmlNode* node,
                        const std::string& tag,
-                       bool savePathInfo,
-                       const TiXmlElement* additionalNode /* =nullptr */)
+                       const TiXmlElement* additionalNode /* =nullptr */) const
 {
   if (!node)
     return false;
@@ -125,7 +124,7 @@ bool CSetInfoTag::Save(TiXmlNode* node,
   if (HasArt())
   {
     TiXmlElement art("art");
-    for (auto& [type, url] : m_art)
+    for (const auto& [type, url] : m_art)
     {
       XMLUtils::SetString(&art, type.c_str(), url);
     }

--- a/xbmc/video/SetInfoTag.h
+++ b/xbmc/video/SetInfoTag.h
@@ -11,6 +11,7 @@
 #include "VideoThumbLoader.h"
 
 #include <string>
+#include <string_view>
 
 class TiXmlNode;
 class TiXmlElement;
@@ -32,18 +33,18 @@ public:
   bool IsEmpty() const;
 
   int GetID() const { return m_id; }
-  void SetID(int id) { m_id = id; }
+  void SetID(int setId) { m_id = setId; }
 
-  void SetOverview(const std::string& overview);
+  void SetOverview(std::string_view overview);
   bool HasOverview() const { return !m_overview.empty(); }
   std::string GetOverview() const { return m_overview; }
   bool GetUpdateSetOverview() const { return m_updateSetOverview; }
 
-  void SetTitle(const std::string& title);
+  void SetTitle(std::string_view title);
   bool HasTitle() const { return !m_title.empty(); }
   std::string GetTitle() const { return m_title; }
 
-  void SetOriginalTitle(const std::string& title);
+  void SetOriginalTitle(std::string_view title);
   bool HasOriginalTitle() const { return !m_originalTitle.empty(); }
   std::string GetOriginalTitle() const { return m_originalTitle; }
 
@@ -55,8 +56,7 @@ public:
   void Copy(const CSetInfoTag& other);
   bool Save(TiXmlNode* node,
             const std::string& tag,
-            bool savePathInfo = true,
-            const TiXmlElement* additionalNode = nullptr);
+            const TiXmlElement* additionalNode = nullptr) const;
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;
 
@@ -73,8 +73,7 @@ private:
    See Load for a description of the available tag types.
 
    \param element    the root XML element to parse.
-   \param prioritise whether additive tags should be replaced (or prepended) by the content of the tags, or appended to.
    \sa Load
    */
-  void ParseNative(const TiXmlElement* set, bool prioritise);
+  void ParseNative(const TiXmlElement* set);
 };

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -644,7 +644,7 @@ public:
 
   int SetDetailsForItem(CVideoInfoTag& details, const KODI::ART::Artwork& artwork);
   int SetDetailsForItem(int id,
-                        const MediaType& mediaType,
+                        MediaType_view mediaType,
                         CVideoInfoTag& details,
                         const KODI::ART::Artwork& artwork);
 
@@ -1343,7 +1343,7 @@ protected:
    \param show the details of the show to check for.
    \return the show id if found, else -1.
    */
-  int GetMatchingTvShow(const CVideoInfoTag &show);
+  int GetMatchingTvShow(const CVideoInfoTag& show) const;
 
   // link functions - these two do all the work
   void AddLinkToActor(int mediaId, const char *mediaType, int actorId, const std::string &role, int order);
@@ -1375,8 +1375,8 @@ protected:
   CVideoInfoTag GetDetailsForTvShow(const dbiplus::sql_record* const record,
                                     int getDetails = VideoDbDetailsNone,
                                     CFileItem* item = nullptr);
-  CVideoInfoTag GetBasicDetailsForEpisode(dbiplus::Dataset& pDS);
-  CVideoInfoTag GetBasicDetailsForEpisode(const dbiplus::sql_record* const record);
+  CVideoInfoTag GetBasicDetailsForEpisode(dbiplus::Dataset& pDS) const;
+  CVideoInfoTag GetBasicDetailsForEpisode(const dbiplus::sql_record* const record) const;
   CVideoInfoTag GetDetailsForEpisode(dbiplus::Dataset& pDS, int getDetails = VideoDbDetailsNone);
   CVideoInfoTag GetDetailsForEpisode(const dbiplus::sql_record* const record, int getDetails = VideoDbDetailsNone);
   CVideoInfoTag GetDetailsForMusicVideo(dbiplus::Dataset& pDS, int getDetails = VideoDbDetailsNone);
@@ -1411,7 +1411,7 @@ protected:
                         int max,
                         const T& offsets,
                         CSetInfoTag& details,
-                        int idxOffset);
+                        int idxOffset) const;
 
   template<typename T>
   std::string GetValueString(const CVideoInfoTag& details,

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -64,14 +64,14 @@ namespace KODI::VIDEO
      \param set CSetInfoTag to add to the database.
      \return true if successful, false otherwise.
      */
-    bool AddSet(CSetInfoTag* set);
+    bool AddSet(const CSetInfoTag& set);
 
     /*! \brief Add an item to the database.
      \param pItem item to add to the database.
      \param content content type of the item.
      \param videoFolder whether the video is represented by a folder (single movie per folder). Defaults to false.
      \param useLocal whether to use local information for artwork etc.
-     \param showInfo pointer to CVideoInfoTag details for the show if this is an episode. Defaults to NULL.
+     \param showInfo pointer to CVideoInfoTag details for the show if this is an episode. Defaults to nullptr.
      \param libraryImport Whether this call belongs to a full library import or not. Defaults to false.
      \return database id of the added item, or -1 on failure.
      */
@@ -79,7 +79,7 @@ namespace KODI::VIDEO
                   ADDON::ContentType content,
                   bool videoFolder = false,
                   bool useLocal = true,
-                  const CVideoInfoTag* showInfo = NULL,
+                  const CVideoInfoTag* showInfo = nullptr,
                   bool libraryImport = false);
 
     /*! \brief Retrieve information for a list of items and add them to the database.
@@ -87,18 +87,18 @@ namespace KODI::VIDEO
      \param bDirNames whether we should use folder or file names for lookups.
      \param content type of content to retrieve.
      \param useLocal should local data (.nfo and art) be used. Defaults to true.
-     \param pURL an optional URL to use to retrieve online info.  Defaults to NULL.
+     \param pURL an optional URL to use to retrieve online info.  Defaults to nullptr.
      \param fetchEpisodes whether we are fetching episodes with shows. Defaults to true.
-     \param pDlgProgress progress dialog to update and check for cancellation during processing.  Defaults to NULL.
+     \param pDlgProgress progress dialog to update and check for cancellation during processing.  Defaults to nullptr.
      \return true if we successfully found information for some items, false otherwise
      */
-    bool RetrieveVideoInfo(CFileItemList& items,
+    bool RetrieveVideoInfo(const CFileItemList& items,
                            bool bDirNames,
                            ADDON::ContentType content,
                            bool useLocal = true,
-                           CScraperUrl* pURL = NULL,
+                           CScraperUrl* pURL = nullptr,
                            bool fetchEpisodes = true,
-                           CGUIDialogProgress* pDlgProgress = NULL);
+                           CGUIDialogProgress* pDlgProgress = nullptr);
 
     static void ApplyThumbToFolder(const std::string &folder, const std::string &imdbThumb);
     static bool DownloadFailed(CGUIDialogProgress* pDlgProgress);
@@ -201,8 +201,8 @@ namespace KODI::VIDEO
      \param uniqueIDs Unique IDs for additional information for scrapers.
      \param url URL to use to retrieve online details.
      \param scraper Scraper that handles parsing the online data.
-     \param nfoFile if set, we override the online data with the locally supplied data. Defaults to NULL.
-     \param pDialog progress dialog to update and check for cancellation during processing. Defaults to NULL.
+     \param nfoFile if set, we override the online data with the locally supplied data. Defaults to nullptr.
+     \param pDialog progress dialog to update and check for cancellation during processing. Defaults to nullptr.
      \return true if information is found, false if an error occurred, the lookup was cancelled, or no information was found.
      */
     bool GetDetails(CFileItem* pItem,
@@ -284,7 +284,7 @@ namespace KODI::VIDEO
      \param files the episode files to process.
      \param scraper scraper to use for finding online info
      \param showInfo information for the show.
-     \param pDlgProcess progress dialog to update during processing.  Defaults to NULL.
+     \param pDlgProcess progress dialog to update during processing.  Defaults to nullptr.
      \return InfoRet::ERROR on failure, InfoRet::CANCELLED on cancellation,
      InfoRet::NOT_FOUND if an episode isn't found, or InfoRet::ADDED if all episodes are added.
      */

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -767,14 +767,14 @@ void CVideoInfoTag::Serialize(CVariant& value) const
 
   value["rating"] = GetRating().rating;
   CVariant ratings{CVariant::VariantTypeObject};
-  for (const auto& [name, value] : m_ratings)
+  for (const auto& [ratingname, ratingvalue] : m_ratings)
   {
     CVariant rating;
-    rating["rating"] = value.rating;
-    rating["votes"] = value.votes;
-    rating["default"] = (name == m_strDefaultRating);
+    rating["rating"] = ratingvalue.rating;
+    rating["votes"] = ratingvalue.votes;
+    rating["default"] = (ratingname == m_strDefaultRating);
 
-    ratings[name] = rating;
+    ratings[ratingname] = rating;
   }
   value["ratings"] = ratings;
   value["userrating"] = m_iUserRating;

--- a/xbmc/video/tags/ISetInfoTagLoader.h
+++ b/xbmc/video/tags/ISetInfoTagLoader.h
@@ -25,7 +25,7 @@ class ISetInfoTagLoader
 public:
   //! \brief Constructor
   //! \param title The title of the set to load info for
-  ISetInfoTagLoader(const std::string title) : m_title(title) {}
+  explicit ISetInfoTagLoader(const std::string& title) : m_title(title) {}
   virtual ~ISetInfoTagLoader() = default;
 
   //! \brief Returns true if we have info to provide.

--- a/xbmc/video/tags/SetTagLoaderNFO.h
+++ b/xbmc/video/tags/SetTagLoaderNFO.h
@@ -16,7 +16,7 @@
 class CSetTagLoaderNFO : public KODI::VIDEO::ISetInfoTagLoader
 {
 public:
-  CSetTagLoaderNFO(const std::string& title);
+  explicit CSetTagLoaderNFO(const std::string& title);
 
   ~CSetTagLoaderNFO() override = default;
 
@@ -25,7 +25,7 @@ public:
 
   //! \brief Load "tag" from nfo file.
   //! \brief tag Tag to load info into
-  CInfoScanner::InfoType Load(CSetInfoTag& tag, bool prioritise = false) override;
+  CInfoScanner::InfoType Load(CSetInfoTag& tag, bool prioritise) override;
 
 protected:
   std::string m_path; //!< Path to nfo file

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -842,9 +842,11 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
         {
           buttons.Add(CONTEXT_BUTTON_SCAN, 13349);
         }
-        if (node == NodeType::ACTOR && !dir.IsAllItem(item->GetPath()) && item->IsFolder())
+        else if (node == NodeType::ACTOR)
         {
-          buttons.Add(CONTEXT_BUTTON_SET_ART, 13511); // Choose art
+          // Add 'Choose art' for all not 'all items' folders
+          if (item->IsFolder() && !CVideoDatabaseDirectory::IsAllItem(item->GetPath()))
+            buttons.Add(CONTEXT_BUTTON_SET_ART, 13511); // Choose art
         }
       }
 

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -48,21 +48,6 @@ RESOLUTION_INFO::RESOLUTION_INFO(int width, int height, float aspect, const std:
   dwFlags = iSubtitles = 0;
 }
 
-RESOLUTION_INFO::RESOLUTION_INFO(const RESOLUTION_INFO& res)
-  : Overscan(res.Overscan),
-    guiInsets(res.guiInsets),
-    strMode(res.strMode),
-    strOutput(res.strOutput),
-    strId(res.strId)
-{
-  bFullScreen = res.bFullScreen;
-  iWidth = res.iWidth; iHeight = res.iHeight;
-  iScreenWidth = res.iScreenWidth; iScreenHeight = res.iScreenHeight;
-  iSubtitles = res.iSubtitles; dwFlags = res.dwFlags;
-  fPixelRatio = res.fPixelRatio; fRefreshRate = res.fRefreshRate;
-  iBlanking = res.iBlanking;
-}
-
 float RESOLUTION_INFO::DisplayRatio() const
 {
   return iWidth * fPixelRatio / iHeight;

--- a/xbmc/windowing/Resolution.h
+++ b/xbmc/windowing/Resolution.h
@@ -113,8 +113,6 @@ struct RESOLUTION_INFO
 public:
   RESOLUTION_INFO(int width = 1280, int height = 720, float aspect = 0, const std::string &mode = "");
   float DisplayRatio() const;
-  RESOLUTION_INFO(const RESOLUTION_INFO& res);
-  RESOLUTION_INFO& operator=(const RESOLUTION_INFO&) = default;
 };
 
 class CResolutionUtils

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -86,7 +86,9 @@ constexpr auto ColorimetryMap = make_map<KODI::UTILS::Colorimetry, std::string_v
 } // namespace
 
 CWinSystemGbm::CWinSystemGbm()
-  : m_DRM(nullptr), m_GBM(new CGBMUtils), m_libinput(new CLibInputHandler)
+  : m_DRM(nullptr),
+    m_GBM(std::make_unique<CGBMUtils>()),
+    m_libinput(std::make_unique<CLibInputHandler>())
 {
   m_dpms = std::make_shared<CGBMDPMSSupport>();
   m_libinput->Start();


### PR DESCRIPTION
Addresses a bunch of issues detected by SonarQube in code that was added / touched between June 1 and July 12

* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* Implicit casts should not lower precision cpp:S5276
* Variables should not be shadowed cpp:S1117
* Objects should not be created solely to be passed as arguments to functions that perform delegated object creation cpp:S6011
* "std::move" should only be used where moving can happen cpp:S5415
* "auto" should be used to avoid repetition of types cpp:S5827
* All branches in a conditional structure should not have exactly the same implementation cpp:S3923
* Classes should not contain both public and private data members cpp:S5414
* Unused function parameters should be removed cpp:S1172
* Integer literals should not be cast to bool cpp:S5820
* "nullptr" should be used to denote the null pointer cpp:S4962
* Unnecessary expensive copy should be avoided when using auto as a placeholder type cpp:S6032
* Pointer and reference parameters should be "const" if the corresponding object is not modified cpp:S995
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* "make_unique" and "make_shared" should be used to construct "unique_ptr" and "shared_ptr" cpp:S5950
* Redundant casts should not be used cpp:S1905
* Multiple variables should not be declared on the same line cpp:S1659
* "try_emplace" should be used with "std::map" and "std::unordered_map" cpp:S6030
* "std::string_view" should be used to pass a read-only string to a function cpp:S6009
* "switch" statements should cover all cases cpp:S3562
* Mergeable "if" statements should be combined cpp:S1066
* Variables should not be shadowed cpp:S1117
* STL algorithms and range-based for loops should be preferred to traditional for loops cpp:S5566
* "explicit" should be used on single-parameter constructors and conversion operators cpp:S1709
* Parameters in an overriding virtual function shall either use the same default arguments as the function they override, or else shall not specify any default arguments cpp:S1006
* "static" members should be accessed statically cpp:S2209
* "std::source_location" should be used instead of `"__FILE__"`, `"__LINE__"`, and `"__func__"` macros cpp:S6190

Runtime-tested n macOS and Android, no issues found.

Any reviewers welcome.
