### PR TITLE
webOS: fix incorrect appId used in CShellSurfaceWebOSShell when in SSH

### DIFF
--- a/xbmc/windowing/wayland/ShellSurfaceWebOSShell.cpp
+++ b/xbmc/windowing/wayland/ShellSurfaceWebOSShell.cpp
@@ -21,6 +21,7 @@ using namespace wayland;
 namespace
 {
 constexpr auto WEBOS_ACCESS_POLICY_KEYS_GUIDE = "_WEBOS_ACCESS_POLICY_KEYS_GUIDE";
+constexpr auto WEBOS_SSH_DEFAULT_APPID = "com.palm.devmode.openssh";
 } // namespace
 
 CShellSurfaceWebOSShell::CShellSurfaceWebOSShell(IShellSurfaceHandler& handler,
@@ -83,7 +84,7 @@ CShellSurfaceWebOSShell::CShellSurfaceWebOSShell(IShellSurfaceHandler& handler,
   };
 
   std::string appId = CEnvironment::getenv("APPID");
-  if (appId.empty())
+  if (appId.empty() || appId == WEBOS_SSH_DEFAULT_APPID)
   {
     appId = CCompileInfo::GetPackage();
   }


### PR DESCRIPTION
## Description
The default APPID used in ssh environment variables is 'export APPID='com.palm.devmode.openssh'

When launching kodi from ssh, the code incorrectly picks com.palm.devmode.openssh as its APPID.

```
2025-07-15 11:43:01.024 T:9781    debug <general>: Passing appId com.palm.devmode.openssh and displayAffinity 0 to wl_webos_shell
```

This overrides this behaviour by checking if APPID is set to com.palm.devmode.openssh and if it does it uses CCompileInfo::GetPackage() instead which is typically "org.xbmc.kodi"

## Motivation and context
Having issues with playback from SSH

## How has this been tested?
Tested from launcher and ssh

## What is the effect on users?
Only affects developers being able to debug from SSH

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
