### PR TITLE
[VideoPlayer][Bluray] Fix #26943 -  on bluray resume audio/subs (inc external subs) language is not restored.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -28,6 +28,7 @@
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 #include "video/VideoFileItemClassify.h"
+#include "video/VideoInfoTag.h"
 
 #include <functional>
 #include <limits>
@@ -86,6 +87,17 @@ void CDVDInputStreamBluray::Abort()
 bool CDVDInputStreamBluray::IsEOF()
 {
   return false;
+}
+
+BLURAY_TITLE_INFO* CDVDInputStreamBluray::GetTitleFromState(const std::string& xmlstate)
+{
+  BlurayState blurayState;
+  if (!m_blurayStateSerializer.XMLToBlurayState(blurayState, xmlstate))
+  {
+    CLog::LogF(LOGWARNING, "Failed to deserialize Bluray state");
+    return nullptr;
+  }
+  return bd_get_playlist_info(m_bd, blurayState.playlistId, 0);
 }
 
 BLURAY_TITLE_INFO* CDVDInputStreamBluray::GetTitleLongest()
@@ -328,9 +340,8 @@ bool CDVDInputStreamBluray::Open()
   }
   else if (resumable && m_item.GetStartOffset() == STARTOFFSET_RESUME && m_item.IsResumable())
   {
-    // resuming a bluray for which we have a saved state - the playlist will be open later on SetState
     m_navmode = false;
-    return true;
+    m_titleInfo = GetTitleFromState(m_item.GetVideoInfoTag()->GetResumePoint().playerState);
   }
   else
   {

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -132,6 +132,7 @@ public:
   void OverlayCallbackARGB(const struct bd_argb_overlay_s * const);
 #endif
 
+  BLURAY_TITLE_INFO* GetTitleFromState(const std::string& xmlstate);
   BLURAY_TITLE_INFO* GetTitleLongest();
   BLURAY_TITLE_INFO* GetTitleFile(const std::string& name);
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -995,8 +995,10 @@ void CVideoPlayer::CloseDemuxer()
 void CVideoPlayer::OpenDefaultStreams(bool reset)
 {
   // if input stream dictate, we will open later
-  if (m_dvd.iSelectedAudioStream >= 0 ||
-      m_dvd.iSelectedSPUStream >= 0)
+  // unless we are loading a bluray playlist directly in which case set now
+  const bool noBlurayMenu{m_pInputStream->IsStreamType(DVDSTREAM_TYPE_BLURAY) &&
+                          m_State.menuType == MenuType::NONE};
+  if (!noBlurayMenu && (m_dvd.iSelectedAudioStream >= 0 || m_dvd.iSelectedSPUStream >= 0))
     return;
 
   bool valid;
@@ -1130,6 +1132,9 @@ void CVideoPlayer::OpenDefaultStreams(bool reset)
       }
     }
   }
+
+  if (noBlurayMenu)
+    SynchronizeDemuxer();
 }
 
 bool CVideoPlayer::ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream)
@@ -1355,15 +1360,19 @@ void CVideoPlayer::Prepare()
   }
 
   bool discStateRestored = false;
-  if (std::shared_ptr<CDVDInputStream::IMenus> ptr = std::dynamic_pointer_cast<CDVDInputStream::IMenus>(m_pInputStream))
+  if (std::shared_ptr<CDVDInputStream::IMenus> ptr =
+          std::dynamic_pointer_cast<CDVDInputStream::IMenus>(m_pInputStream))
   {
-    CLog::Log(LOGINFO, "VideoPlayer: playing a file with menu's");
+    CLog::Log(LOGINFO, "VideoPlayer: playing a file with menus");
 
-    if (!m_playerOptions.state.empty())
+    if (!m_playerOptions.state.empty() && !(m_pInputStream->IsStreamType(DVDSTREAM_TYPE_BLURAY) &&
+                                            m_State.menuType == MenuType::NONE))
+
     {
       discStateRestored = ptr->SetState(m_playerOptions.state);
     }
-    else if(std::shared_ptr<CDVDInputStreamNavigator> nav = std::dynamic_pointer_cast<CDVDInputStreamNavigator>(m_pInputStream))
+    else if (std::shared_ptr<CDVDInputStreamNavigator> nav =
+                 std::dynamic_pointer_cast<CDVDInputStreamNavigator>(m_pInputStream))
     {
       nav->EnableSubtitleStream(m_processInfo->GetVideoSettings().m_SubtitleOn);
     }
@@ -5398,6 +5407,15 @@ void CVideoPlayer::UpdateContentState()
       m_content.m_subtitleIndex = m_SelectionStreams.TypeIndexOf(
           STREAM_SUBTITLE, STREAM_SOURCE_NAV, -1, nav->GetActiveSubtitleStream());
     }
+  }
+
+  if (m_pInputStream->IsStreamType(DVDSTREAM_TYPE_BLURAY) && m_State.menuType == MenuType::NATIVE)
+  {
+    // Update settings with changes made in bluray menu
+    CVideoSettings settings{m_processInfo->GetVideoSettings()};
+    settings.m_AudioStream = m_content.m_audioIndex;
+    settings.m_SubtitleStream = m_content.m_subtitleIndex;
+    m_processInfo->SetVideoSettings(settings);
   }
 }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1054,6 +1054,8 @@ int CVideoDatabase::AddFile(const std::string& strFileNameAndPath,
 
 int CVideoDatabase::AddFile(const CFileItem& item)
 {
+  if (URIUtils::IsBlurayPath(item.GetDynPath()))
+    return AddFile(item.GetDynPath());
   if (IsVideoDb(item) && item.HasVideoInfoTag())
   {
     const auto videoInfoTag = item.GetVideoInfoTag();
@@ -1244,6 +1246,10 @@ int CVideoDatabase::GetFileId(const std::string& strFilenameAndPath)
 int CVideoDatabase::GetFileId(const CFileItem &item)
 {
   int fileId = -1;
+
+  if (URIUtils::IsBlurayPath(item.GetDynPath()))
+    return GetFileId(item.GetDynPath());
+
   if (item.HasVideoInfoTag())
     fileId = GetFileId(*item.GetVideoInfoTag());
 
@@ -3177,6 +3183,7 @@ int CVideoDatabase::SetFileForEpisode(const std::string& fileAndPath, int idEpis
   try
   {
     m_pDS->exec(PrepareSQL("UPDATE episode SET idFile=%i WHERE idEpisode=%i", idFile, idEpisode));
+    m_pDS->exec(PrepareSQL("UPDATE settings SET idFile=%i WHERE idFile=%i", idFile, oldIdFile));
     return DeleteFile(oldIdFile) ? idFile : -1;
   }
   catch (...)
@@ -3215,6 +3222,9 @@ int CVideoDatabase::SetFileForMovie(const std::string& fileAndPath, int idMovie,
                      idFile, oldIdFile, idFile);
     m_pDS->exec(sql);
 
+    sql = PrepareSQL("UPDATE settings SET idFile=%i WHERE idFile=%i", idFile, oldIdFile);
+    m_pDS->exec(sql);
+
     return DeleteFile(oldIdFile) ? idFile : -1;
   }
   catch (...)
@@ -3239,6 +3249,9 @@ int CVideoDatabase::SetFileForUnknown(const std::string& fileAndPath, int oldIdF
         PrepareSQL("UPDATE streamdetails SET idFile=%i WHERE idFile=%i AND NOT EXISTS (SELECT 1 "
                    "FROM streamdetails WHERE idFile=%i)",
                    idFile, oldIdFile, idFile)};
+    m_pDS->exec(sql);
+
+    sql = PrepareSQL("UPDATE settings SET idFile=%i WHERE idFile=%i", idFile, oldIdFile);
     m_pDS->exec(sql);
 
     return DeleteFile(oldIdFile) ? idFile : -1;
@@ -7161,8 +7174,6 @@ int CVideoDatabase::GetPlayCount(const std::string& strFilenameAndPath)
 
 int CVideoDatabase::GetPlayCount(const CFileItem &item)
 {
-  if (URIUtils::IsBlurayPath(item.GetDynPath()))
-    return GetPlayCount(GetFileId(item.GetDynPath()));
   return GetPlayCount(GetFileId(item));
 }
 
@@ -7234,10 +7245,8 @@ void CVideoDatabase::UpdateFanart(const CFileItem& item, VideoDbContentType type
 CDateTime CVideoDatabase::SetPlayCount(const CFileItem& item, int count, const CDateTime& date)
 {
   int id{-1};
-  if (URIUtils::IsBlurayPath(item.GetDynPath()))
-    id = AddFile(item.GetDynPath());
-  else if (item.HasProperty("original_listitem_url") &&
-           URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
+  if (!URIUtils::IsBlurayPath(item.GetDynPath()) && item.HasProperty("original_listitem_url") &&
+      URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
   {
     CFileItem item2(item);
     item2.SetPath(item.GetProperty("original_listitem_url").asString());


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Two part fix:
1) Ensure setting table entry is preserved when the fileId is updated for bluray:// paths (v22 only). Also fixes file name issue when settings table saved after watching through menu.
2) Adjust where state (which is just playlist) is restored for blurays in videoplayer (ensures selected when streams are selected). Some refactoring of CDVDInputStreamBluray to fix audio/subs not restored after directly resuming from playlist when first played through menu. 

It seems that resuming through menu (ie. watching through bluray menu and then choosing play from beginning from context menu and resuming via the BDJ menu) audio/sub restoration is broken - but then it is in Omega as well.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #26943.

Bug present in Omega and Piers. If a bluray is part watched with non-default audio/subtitle language then this is not restored upon resume.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally and by bug reporter.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
