### PR TITLE
[utils/log.*] Use a dedicated logger for every pre-defined logging component

### DIFF
--- a/xbmc/utils/Map.h
+++ b/xbmc/utils/Map.h
@@ -84,6 +84,9 @@ public:
   constexpr auto cbegin() const { return m_map.cbegin(); }
   constexpr auto cend() const { return m_map.cend(); }
 
+  constexpr auto begin() const { return m_map.begin(); }
+  constexpr auto end() const { return m_map.end(); }
+
 private:
   CMap() = delete;
 


### PR DESCRIPTION
Users can activate "component specific logging" and select the components to log from a list of predefined components in Kodi's settings. However, in the generated log file there is no information which component logged the respective line. 

This PR introduces a dedicated logger for every predefined logging component (currently we have only one logger named "general").

Example:

Before:
```log
2025-07-17 13:14:35.878 T:3136558   debug <general>: PVR::CPVRManager::CPVRManager(): PVR Manager instance created
```

Before:
```log
2025-07-17 13:14:35.878 T:3136558   debug <pvr>: PVR::CPVRManager::CPVRManager(): PVR Manager instance created
```

Runtime-tested for quite some time on Android and macOS, does what it should, no performance decrease detected.

@neo1973 maybe you can have a look?