### PR TITLE
[cores/Retroplayer/shaders] Misc SonarQube findings, episode 2

### DIFF
--- a/xbmc/cores/RetroPlayer/shaders/IShader.h
+++ b/xbmc/cores/RetroPlayer/shaders/IShader.h
@@ -16,9 +16,7 @@
 #include <string>
 #include <vector>
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 class IShaderLut;
 class IShaderTexture;
@@ -94,5 +92,4 @@ public:
    */
   virtual void UpdateMVP() = 0;
 };
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/IShaderLut.h
+++ b/xbmc/cores/RetroPlayer/shaders/IShaderLut.h
@@ -17,9 +17,7 @@
 
 class CTexture;
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 /*!
  * \brief A lookup table to apply color transforms in a shader
@@ -64,5 +62,4 @@ protected:
   std::string m_id;
   std::string m_path;
 };
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/IShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/shaders/IShaderPreset.h
@@ -14,9 +14,7 @@
 #include <string>
 #include <vector>
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 class IShaderTexture;
 
@@ -88,5 +86,4 @@ public:
    */
   virtual std::vector<ShaderPass>& GetPasses() = 0;
 };
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/IShaderPresetLoader.h
+++ b/xbmc/cores/RetroPlayer/shaders/IShaderPresetLoader.h
@@ -10,9 +10,7 @@
 
 #include <string>
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 class IShaderPreset;
 
@@ -34,5 +32,4 @@ public:
    */
   virtual bool LoadPreset(const std::string& presetPath, IShaderPreset& shaderPreset) = 0;
 };
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/IShaderSampler.h
+++ b/xbmc/cores/RetroPlayer/shaders/IShaderSampler.h
@@ -8,14 +8,11 @@
 
 #pragma once
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 class IShaderSampler
 {
 public:
   virtual ~IShaderSampler() = default;
 };
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/IShaderTexture.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/IShaderTexture.cpp
@@ -8,7 +8,6 @@
 
 #include "IShaderTexture.h"
 
-using namespace KODI;
-using namespace SHADER;
+using namespace KODI::SHADER;
 
 IShaderTexture::~IShaderTexture() = default;

--- a/xbmc/cores/RetroPlayer/shaders/IShaderTexture.h
+++ b/xbmc/cores/RetroPlayer/shaders/IShaderTexture.h
@@ -8,9 +8,7 @@
 
 #pragma once
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 /*!
  * \brief Interface for a shader texture
@@ -37,5 +35,4 @@ public:
    */
   virtual float GetHeight() const = 0;
 };
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
@@ -19,8 +19,7 @@
 
 #include <regex>
 
-using namespace KODI;
-using namespace SHADER;
+using namespace KODI::SHADER;
 
 CShaderPreset::CShaderPreset(RETRO::CRenderContext& context,
                              unsigned videoWidth,
@@ -178,15 +177,13 @@ void CShaderPreset::UpdateMVPs()
 void CShaderPreset::PrepareParameters(const RETRO::ViewportCoordinates& dest,
                                       IShaderTexture& source)
 {
-  m_dest = dest;
-
   const auto numPasses = static_cast<unsigned int>(m_pShaders.size());
 
   // Prepare parameters for all shader passes
   for (unsigned int shaderIdx = 0; shaderIdx < numPasses; ++shaderIdx)
   {
     std::unique_ptr<IShader>& videoShader = m_pShaders[shaderIdx];
-    videoShader->PrepareParameters(m_dest, source, m_pShaderTextures, m_pShaders,
+    videoShader->PrepareParameters(dest, source, m_pShaderTextures, m_pShaders,
                                    static_cast<uint64_t>(m_frameCount));
   }
 }

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.h
@@ -97,9 +97,6 @@ protected:
   // Size of the actual source video data (ie. 160x144 for the Game Boy)
   float2 m_videoSize;
 
-  // Array of vertices that comprise the full viewport
-  RETRO::ViewportCoordinates m_dest{};
-
   // Number of frames that have passed
   float m_frameCount = 0.0f;
 

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPresetFactory.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPresetFactory.cpp
@@ -20,8 +20,7 @@
 #include <algorithm>
 #include <string>
 
-using namespace KODI;
-using namespace SHADER;
+using namespace KODI::SHADER;
 
 CShaderPresetFactory::CShaderPresetFactory(ADDON::CAddonMgr& addons) : m_addons(addons)
 {

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPresetFactory.h
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPresetFactory.h
@@ -21,9 +21,7 @@ class CBinaryAddonManager;
 class CShaderPresetAddon;
 } // namespace ADDON
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 class IShaderPresetLoader;
 
@@ -89,5 +87,4 @@ private:
   std::map<std::string, std::unique_ptr<ADDON::CShaderPresetAddon>> m_shaderAddons;
   std::map<std::string, std::unique_ptr<ADDON::CShaderPresetAddon>> m_failedAddons;
 };
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/ShaderTypes.h
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderTypes.h
@@ -15,9 +15,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 using ShaderParameterMap = std::map<std::string, float>;
 
@@ -120,5 +118,4 @@ struct float2
   float x;
   float y;
 };
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/ShaderUtils.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderUtils.cpp
@@ -8,8 +8,7 @@
 
 #include "ShaderUtils.h"
 
-using namespace KODI;
-using namespace SHADER;
+using namespace KODI::SHADER;
 
 std::string CShaderUtils::StripParameterPragmas(std::string source)
 {

--- a/xbmc/cores/RetroPlayer/shaders/ShaderUtils.h
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderUtils.h
@@ -10,9 +10,7 @@
 
 #include "ShaderTypes.h"
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 class CShaderUtils
 {
@@ -27,5 +25,4 @@ public:
    */
   static float2 GetOptimalTextureSize(float2 videoSize);
 };
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
@@ -18,8 +18,7 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
-using namespace KODI;
-using namespace SHADER;
+using namespace KODI::SHADER;
 
 CShaderGL::CShaderGL() = default;
 
@@ -298,7 +297,7 @@ void CShaderGL::UpdateUniformInputs(
   }
   else // First pass
   {
-    CShaderTextureGL& shaderTextureGL = static_cast<CShaderTextureGL&>(sourceTexture);
+    auto& shaderTextureGL = static_cast<CShaderTextureGL&>(sourceTexture);
     m_uniformFrameInputs = GetFrameInputData(shaderTextureGL.GetTexture().GetTextureID());
   }
 
@@ -307,7 +306,7 @@ void CShaderGL::UpdateUniformInputs(
 
   for (unsigned int i = 0; i < m_passIdx + 1; ++i)
   {
-    CShaderGL& shader = static_cast<CShaderGL&>(*pShaders[i]);
+    const auto& shader = static_cast<const CShaderGL&>(*pShaders[i]);
     UniformFrameInputs frameInput = shader.GetFrameUniformInputs();
     m_passesUniformFrameInputs.emplace_back(frameInput);
   }

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
@@ -16,9 +16,7 @@
 #include <array>
 #include <stdint.h>
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 class CShaderGL : public IShader
 {
@@ -130,5 +128,4 @@ private:
   std::array<GLuint, 3> m_shaderVertexVBO{GL_NONE};
   GLuint m_shaderIndexVBO = GL_NONE;
 };
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderLutGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderLutGL.cpp
@@ -18,8 +18,7 @@
 
 #include <utility>
 
-using namespace KODI;
-using namespace SHADER;
+using namespace KODI::SHADER;
 
 CShaderLutGL::CShaderLutGL(std::string id, std::string path)
   : IShaderLut(std::move(id), std::move(path))

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderLutGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderLutGL.h
@@ -16,9 +16,7 @@
 
 #include "system_gl.h"
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 class CTextureBase;
 struct ShaderLut;
@@ -39,5 +37,4 @@ private:
   std::unique_ptr<CTexture> m_texture;
 };
 
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.cpp
@@ -18,8 +18,7 @@
 
 #include <regex>
 
-using namespace KODI;
-using namespace SHADER;
+using namespace KODI::SHADER;
 
 CShaderPresetGL::CShaderPresetGL(RETRO::CRenderContext& context,
                                  unsigned int videoWidth,

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGL.cpp
@@ -13,8 +13,7 @@
 
 #include <cassert>
 
-using namespace KODI;
-using namespace SHADER;
+using namespace KODI::SHADER;
 
 CShaderTextureGL::CShaderTextureGL(std::shared_ptr<CGLTexture> texture, bool sRgbFramebuffer)
   : m_texture(std::move(texture)), m_sRgbFramebuffer(sRgbFramebuffer)

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderUtilsGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderUtilsGL.cpp
@@ -11,8 +11,7 @@
 #include "ServiceBroker.h"
 #include "rendering/gl/RenderSystemGL.h"
 
-using namespace KODI;
-using namespace SHADER;
+using namespace KODI::SHADER;
 
 GLint CShaderUtilsGL::TranslateWrapType(WrapType wrapType)
 {

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
@@ -16,19 +16,12 @@
 #include <array>
 #include <stdint.h>
 
-namespace KODI
-{
-namespace RETRO
-{
-class CRenderContext;
-}
-
-namespace SHADER
+namespace KODI::SHADER
 {
 class CShaderGLES : public IShader
 {
 public:
-  CShaderGLES(RETRO::CRenderContext& context);
+  CShaderGLES();
   ~CShaderGLES() override;
 
   // Implementation of IShader
@@ -73,7 +66,7 @@ private:
                            uint64_t frameCount);
   UniformInputs GetInputData(uint64_t frameCount = 0);
   UniformFrameInputs GetFrameInputData(GLuint texture);
-  UniformFrameInputs GetFrameUniformInputs() { return m_uniformFrameInputs; }
+  UniformFrameInputs GetFrameUniformInputs() const { return m_uniformFrameInputs; }
   void GetUniformLocs();
   void SetShaderParameters(CGLESTexture& sourceTexture);
 
@@ -115,10 +108,10 @@ private:
   unsigned int m_frameCountMod{0};
 
   GLuint m_shaderProgram{0};
-  GLubyte m_indices[4];
-  float m_VertexCoords[4][3];
-  float m_colors[4][3];
-  float m_TexCoords[4][2];
+  std::array<GLubyte, 4> m_indices;
+  std::array<std::array<float, 3>, 4> m_VertexCoords;
+  std::array<std::array<float, 3>, 4> m_colors;
+  std::array<std::array<float, 2>, 4> m_TexCoords;
 
   UniformInputs m_uniformInputs;
   UniformFrameInputs m_uniformFrameInputs;
@@ -131,8 +124,7 @@ private:
   GLint m_InputSizeLoc{-1};
   GLint m_MVPMatrixLoc{-1};
 
-  GLuint m_shaderVertexVBO[3]{GL_NONE};
+  std::array<GLuint, 3> m_shaderVertexVBO{GL_NONE};
   GLuint m_shaderIndexVBO = GL_NONE;
 };
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderLutGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderLutGLES.cpp
@@ -18,8 +18,7 @@
 
 #include <utility>
 
-using namespace KODI;
-using namespace SHADER;
+using namespace KODI::SHADER;
 
 CShaderLutGLES::CShaderLutGLES(std::string id, std::string path)
   : IShaderLut(std::move(id), std::move(path))

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderLutGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderLutGLES.h
@@ -16,9 +16,7 @@
 
 #include "system_gl.h"
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 class CTextureBase;
 struct ShaderLut;
@@ -39,5 +37,4 @@ private:
   std::unique_ptr<CTexture> m_texture;
 };
 
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderTextureGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderTextureGLES.cpp
@@ -13,8 +13,7 @@
 
 #include <cassert>
 
-using namespace KODI;
-using namespace SHADER;
+using namespace KODI::SHADER;
 
 CShaderTextureGLES::CShaderTextureGLES(std::shared_ptr<CGLESTexture> texture, bool sRgbFramebuffer)
   : m_texture(std::move(texture)), m_sRgbFramebuffer(sRgbFramebuffer)
@@ -52,11 +51,8 @@ bool CShaderTextureGLES::BindFBO()
   if (renderTargetID == 0)
     return false;
 
-  if (FBO == 0)
-  {
-    if (!CreateFBO())
-      return false;
-  }
+  if (FBO == 0 && !CreateFBO())
+    return false;
 
   glBindFramebuffer(GL_FRAMEBUFFER, FBO);
   glBindTexture(GL_TEXTURE_2D, renderTargetID);
@@ -64,7 +60,7 @@ bool CShaderTextureGLES::BindFBO()
 
   if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
   {
-    CLog::Log(LOGERROR, "{}: Framebuffer is not complete!", __func__);
+    CLog::LogF(LOGERROR, "Framebuffer is not complete!");
     UnbindFBO();
     return false;
   }
@@ -72,7 +68,7 @@ bool CShaderTextureGLES::BindFBO()
   return true;
 }
 
-void CShaderTextureGLES::UnbindFBO()
+void CShaderTextureGLES::UnbindFBO() const
 {
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderTextureGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderTextureGLES.h
@@ -16,9 +16,7 @@
 
 class CGLESTexture;
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 
 class CShaderTextureGLES : public IShaderTexture
@@ -39,12 +37,11 @@ public:
   // Frame buffer interface
   bool CreateFBO();
   bool BindFBO();
-  void UnbindFBO();
+  void UnbindFBO() const;
 
 private:
   std::shared_ptr<CGLESTexture> m_texture;
   bool m_sRgbFramebuffer{false};
   GLuint FBO{0};
 };
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderUtilsGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderUtilsGLES.cpp
@@ -11,8 +11,7 @@
 #include "ServiceBroker.h"
 #include "rendering/gles/RenderSystemGLES.h"
 
-using namespace KODI;
-using namespace SHADER;
+using namespace KODI::SHADER;
 
 GLint CShaderUtilsGLES::TranslateWrapType(WrapType wrapType)
 {
@@ -77,7 +76,8 @@ std::string CShaderUtilsGLES::GetGLSLVersion(std::string& source)
   // Set GLSL version according to GL version
   else
   {
-    unsigned int major, minor;
+    unsigned int major{0};
+    unsigned int minor{0};
     CServiceBroker::GetRenderSystem()->GetRenderVersion(major, minor);
     version = major * 100 + minor * 10;
 

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderUtilsGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderUtilsGLES.h
@@ -12,9 +12,7 @@
 
 #include "system_gl.h"
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 
 class CShaderUtilsGLES
@@ -24,5 +22,4 @@ public:
   static std::string GetGLSLVersion(std::string& source);
 };
 
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.cpp
@@ -13,8 +13,7 @@
 #include "rendering/dx/DeviceResources.h"
 #include "utils/log.h"
 
-using namespace KODI;
-using namespace SHADER;
+using namespace KODI::SHADER;
 
 bool CRPWinShader::CreateVertexBuffer(unsigned int count, unsigned int size)
 {

--- a/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.h
@@ -19,9 +19,7 @@
 #include <d3d11.h>
 #include <wrl/client.h>
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 
 class CRPWinShader
@@ -77,5 +75,4 @@ private:
   KODI::RETRO::ViewportCoordinates m_destPoints{};
 };
 
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.cpp
@@ -21,12 +21,9 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
-using namespace KODI;
-using namespace SHADER;
+using namespace KODI::SHADER;
 
-CShaderDX::CShaderDX(RETRO::CRenderContext& context) : m_context(context)
-{
-}
+CShaderDX::CShaderDX() = default;
 
 CShaderDX::~CShaderDX()
 {
@@ -88,18 +85,11 @@ void CShaderDX::Render(IShaderTexture& source, IShaderTexture& target)
   const CD3DTexture& sourceTexture = sourceDX.GetTexture();
 
   //! @todo Handle ref textures better
-  CShaderTextureDX* targetDX = dynamic_cast<CShaderTextureDX*>(&target);
-  CShaderTextureDXRef* targetDXRef = dynamic_cast<CShaderTextureDXRef*>(&target);
+  auto* targetDX = dynamic_cast<CShaderTextureDX*>(&target);
+  auto* targetDXRef = dynamic_cast<CShaderTextureDXRef*>(&target);
 
   CD3DTexture& targetTexture =
       targetDX != nullptr ? targetDX->GetTexture() : targetDXRef->GetTexture();
-
-  //! @todo Doesn't work. Another PSSetSamplers gets called by FX11 right before rendering
-  // overriding this.
-  /*
-  CRenderSystemDX *renderingDX = static_cast<CRenderSystemDX*>(m_context.Rendering());
-  renderingDX->Get3D11Context()->PSSetSamplers(2, 1, &m_pSampler);
-  */
 
   //! @todo Check for nullptr
   SetShaderParameters(sourceTexture);
@@ -267,7 +257,7 @@ void CShaderDX::SetShaderParameters(const CD3DTexture& sourceTexture)
 
   for (const std::shared_ptr<IShaderLut>& lut : m_luts)
   {
-    CDXTexture* texture = dynamic_cast<CDXTexture*>(lut->GetTexture());
+    auto* texture = dynamic_cast<CDXTexture*>(lut->GetTexture());
     if (texture != nullptr)
       m_effect.SetTexture(lut->GetID().c_str(), texture->GetShaderResource());
   }

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.h
@@ -18,14 +18,7 @@
 
 #include <DirectXMath.h>
 
-namespace KODI
-{
-namespace RETRO
-{
-class CRenderContext;
-}
-
-namespace SHADER
+namespace KODI::SHADER
 {
 class IShaderLut;
 class IShaderSampler;
@@ -33,7 +26,7 @@ class IShaderSampler;
 class CShaderDX : protected CRPWinShader, public IShader
 {
 public:
-  CShaderDX(RETRO::CRenderContext& context);
+  CShaderDX();
   ~CShaderDX() override;
 
   // Implementation of IShader
@@ -97,9 +90,6 @@ private:
   cbInput GetInputData(uint64_t frameCount = 0) const;
   void SetShaderParameters(const CD3DTexture& sourceTexture);
 
-  // Construction parameters
-  RETRO::CRenderContext& m_context;
-
   // Currently loaded shader's source code
   std::string m_shaderSource;
 
@@ -144,5 +134,4 @@ private:
   //ID3D11SamplerState* m_pSampler{nullptr};
 };
 
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderLutDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderLutDX.cpp
@@ -17,8 +17,7 @@
 
 #include <utility>
 
-using namespace KODI;
-using namespace SHADER;
+using namespace KODI::SHADER;
 
 CShaderLutDX::CShaderLutDX(std::string id, std::string path)
   : IShaderLut(std::move(id), std::move(path))
@@ -43,7 +42,7 @@ bool CShaderLutDX::Create(const ShaderLut& lut)
 std::unique_ptr<CTexture> CShaderLutDX::CreateLUTexture(const ShaderLut& lut)
 {
   std::unique_ptr<CTexture> texture = CTexture::LoadFromFile(lut.path);
-  CDXTexture* textureDX = static_cast<CDXTexture*>(texture.get());
+  auto* textureDX = static_cast<CDXTexture*>(texture.get());
 
   if (textureDX == nullptr)
   {

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderLutDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderLutDX.h
@@ -16,9 +16,7 @@
 
 #include <d3d11.h>
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 class CTextureBase;
 struct ShaderLut;
@@ -42,5 +40,4 @@ private:
   std::unique_ptr<CTexture> m_texture;
 };
 
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.cpp
@@ -18,8 +18,7 @@
 
 #include <regex>
 
-using namespace KODI;
-using namespace SHADER;
+using namespace KODI::SHADER;
 
 CShaderPresetDX::CShaderPresetDX(RETRO::CRenderContext& context,
                                  unsigned videoWidth,
@@ -50,7 +49,7 @@ bool CShaderPresetDX::CreateShaders()
     }
 
     // Create the shader
-    auto videoShader = std::make_unique<CShaderDX>(m_context);
+    auto videoShader = std::make_unique<CShaderDX>();
 
     const std::string& shaderSource = pass.vertexSource; // Also contains fragment source
     const std::string& shaderPath = pass.sourcePath;
@@ -84,7 +83,7 @@ bool CShaderPresetDX::CreateLayouts()
 {
   for (std::unique_ptr<IShader>& videoShader : m_pShaders)
   {
-    CShaderDX* videoShaderDX = static_cast<CShaderDX*>(videoShader.get());
+    auto* videoShaderDX = static_cast<CShaderDX*>(videoShader.get());
     videoShaderDX->CreateVertexBuffer(4, sizeof(CUSTOMVERTEX));
 
     // Create input layout
@@ -109,7 +108,7 @@ bool CShaderPresetDX::CreateBuffers()
 {
   for (std::unique_ptr<IShader>& videoShader : m_pShaders)
   {
-    CShaderDX* videoShaderDX = static_cast<CShaderDX*>(videoShader.get());
+    auto* videoShaderDX = static_cast<CShaderDX*>(videoShader.get());
     videoShaderDX->CreateInputBuffer();
   }
 
@@ -139,11 +138,12 @@ bool CShaderPresetDX::CreateShaderTextures()
         break;
       case ScaleType::VIEWPORT:
         scaledSize.x =
-            pass.fbo.scaleX.scale ? pass.fbo.scaleX.scale * m_outputSize.x : m_outputSize.x;
+            pass.fbo.scaleX.scale != 0.0f ? pass.fbo.scaleX.scale * m_outputSize.x : m_outputSize.x;
         break;
       case ScaleType::INPUT:
       default:
-        scaledSize.x = pass.fbo.scaleX.scale ? pass.fbo.scaleX.scale * prevSize.x : prevSize.x;
+        scaledSize.x =
+            pass.fbo.scaleX.scale != 0.0f ? pass.fbo.scaleX.scale * prevSize.x : prevSize.x;
         break;
     }
     switch (pass.fbo.scaleY.scaleType)
@@ -153,11 +153,12 @@ bool CShaderPresetDX::CreateShaderTextures()
         break;
       case ScaleType::VIEWPORT:
         scaledSize.y =
-            pass.fbo.scaleY.scale ? pass.fbo.scaleY.scale * m_outputSize.y : m_outputSize.y;
+            pass.fbo.scaleY.scale != 0.0f ? pass.fbo.scaleY.scale * m_outputSize.y : m_outputSize.y;
         break;
       case ScaleType::INPUT:
       default:
-        scaledSize.y = pass.fbo.scaleY.scale ? pass.fbo.scaleY.scale * prevSize.y : prevSize.y;
+        scaledSize.y =
+            pass.fbo.scaleY.scale != 0.0f ? pass.fbo.scaleY.scale * prevSize.y : prevSize.y;
         break;
     }
 

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderSamplerDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderSamplerDX.cpp
@@ -8,8 +8,7 @@
 
 #include "ShaderSamplerDX.h"
 
-using namespace KODI;
-using namespace SHADER;
+using namespace KODI::SHADER;
 
 CShaderSamplerDX::CShaderSamplerDX(ID3D11SamplerState* sampler) : m_sampler(sampler)
 {

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderSamplerDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderSamplerDX.h
@@ -12,9 +12,7 @@
 
 #include <d3d11.h>
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 
 class CShaderSamplerDX : public IShaderSampler
@@ -27,5 +25,4 @@ private:
   ID3D11SamplerState* const m_sampler;
 };
 
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderTextureDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderTextureDX.cpp
@@ -13,8 +13,7 @@
 #include <cassert>
 #include <utility>
 
-using namespace KODI;
-using namespace SHADER;
+using namespace KODI::SHADER;
 
 CShaderTextureDX::CShaderTextureDX(std::shared_ptr<CD3DTexture> texture)
   : m_texture(std::move(texture))

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderTextureDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderTextureDX.h
@@ -16,9 +16,7 @@
 
 class CD3DTexture;
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 
 /*!
@@ -44,5 +42,4 @@ private:
   const std::shared_ptr<CD3DTexture> m_texture;
 };
 
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderTextureDXRef.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderTextureDXRef.cpp
@@ -10,8 +10,7 @@
 
 #include "guilib/D3DResource.h"
 
-using namespace KODI;
-using namespace SHADER;
+using namespace KODI::SHADER;
 
 CShaderTextureDXRef::CShaderTextureDXRef(CD3DTexture& texture) : m_texture(texture)
 {

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderTextureDXRef.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderTextureDXRef.h
@@ -16,9 +16,7 @@
 
 class CD3DTexture;
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 
 /*!
@@ -46,5 +44,4 @@ private:
   CD3DTexture& m_texture;
 };
 
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderTypesDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderTypesDX.h
@@ -10,9 +10,7 @@
 
 #include <minwindef.h>
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 struct CUSTOMVERTEX
 {
@@ -23,5 +21,4 @@ struct CUSTOMVERTEX
   FLOAT tu;
   FLOAT tv;
 };
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderUtilsDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderUtilsDX.cpp
@@ -8,8 +8,7 @@
 
 #include "ShaderUtilsDX.h"
 
-using namespace KODI;
-using namespace SHADER;
+using namespace KODI::SHADER;
 
 D3D11_TEXTURE_ADDRESS_MODE CShaderUtilsDX::TranslateWrapType(WrapType wrapType)
 {

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderUtilsDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderUtilsDX.h
@@ -13,9 +13,7 @@
 #include <DirectXMath.h>
 #include <d3d11.h>
 
-namespace KODI
-{
-namespace SHADER
+namespace KODI::SHADER
 {
 class CShaderUtilsDX
 {
@@ -23,5 +21,4 @@ public:
   static D3D11_TEXTURE_ADDRESS_MODE TranslateWrapType(WrapType wrapType);
   static DirectX::XMFLOAT2 ToDXVector(const float2& vec);
 };
-} // namespace SHADER
-} // namespace KODI
+} // namespace KODI::SHADER


### PR DESCRIPTION
Follow-up o #26976, as discussed. Brings GLES and DX in sync with the changes already done for GL. Additionally, condensed namespaces are introduced across all cores/Retroplayer/shaders files. And I removed `CShaderPreset::m_dest` member variable as requested.

@garbear @KOPRajs please review.