### PR TITLE
[addons] Use a dedicated logger for every binary addon instance

### DIFF
--- a/xbmc/addons/interfaces/AddonBase.cpp
+++ b/xbmc/addons/interfaces/AddonBase.cpp
@@ -181,7 +181,7 @@ void Interface_Base::addon_log_msg(const KODI_ADDON_BACKEND_HDL hdl,
       break;
   }
 
-  CLog::Log(logLevel, "AddOnLog: {}: {}", addon->ID(), strMessage);
+  CLog::Log(addon->ID(), logLevel, "{}", strMessage);
 }
 
 char* Interface_Base::get_type_version(const KODI_ADDON_BACKEND_HDL hdl, int type)

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -312,10 +312,21 @@ void CLog::FormatAndLogInternal(spdlog::level::level_enum level,
     return;
 
   auto message = fmt::vformat(format, args);
-
-  // fixup newline alignment, number of spaces should equal prefix length
   FormatLineBreaks(message);
   GetLoggerById(component)->log(level, message);
+}
+
+void CLog::FormatAndLogInternal(const std::string& loggerName,
+                                spdlog::level::level_enum level,
+                                fmt::string_view format,
+                                fmt::format_args args)
+{
+  if (level < m_defaultLogger->level())
+    return;
+
+  auto message = fmt::vformat(format, args);
+  FormatLineBreaks(message);
+  GetLogger(loggerName)->log(level, message);
 }
 
 Logger CLog::CreateLogger(const std::string& loggerName)
@@ -343,5 +354,6 @@ void CLog::SetComponentLogLevel(const std::vector<CVariant>& components)
 
 void CLog::FormatLineBreaks(std::string& message) const
 {
+  // fixup newline alignment, number of spaces should equal prefix length
   StringUtils::Replace(message, "\n", "\n                                                   ");
 }

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -121,6 +121,16 @@ public:
     GetInstance().FormatAndLogInternal(level, component, format, fmt::make_format_args(args...));
   }
 
+  template<typename... Args>
+  static void Log(const std::string& loggerName,
+                  int level,
+                  fmt::format_string<Args...> format,
+                  Args&&... args)
+  {
+    GetInstance().FormatAndLogInternal(loggerName, MapLogLevel(level), format,
+                                       fmt::make_format_args(args...));
+  }
+
 #define LogF(level, format, ...) \
   Log((level), ("{}: " format), std::source_location::current().function_name(), ##__VA_ARGS__)
 #define LogFC(level, component, format, ...) \
@@ -134,6 +144,11 @@ private:
 
   void FormatAndLogInternal(spdlog::level::level_enum level,
                             uint32_t component,
+                            fmt::string_view format,
+                            fmt::format_args args);
+
+  void FormatAndLogInternal(const std::string& loggerName,
+                            spdlog::level::level_enum level,
                             fmt::string_view format,
                             fmt::format_args args);
 


### PR DESCRIPTION
This improves logging for binary addons by introducing a dedicated logger per addon instance. I think this change makes behavior more aligned with the rest of the logging system, to use dedicated loggers, not to "extend" the general logger with special log syntax.

Before:
```
2025-07-18 23:57:34.842 T:6120328   debug <general>: AddOnLog: pvr.hts: CreateInstance: Creating PVR-Client instance
```
After:
```
2025-07-18 23:50:50.246 T:6099713   debug <pvr.hts>: CreateInstance: Creating PVR-Client instance
```

Runtime-tested for quite some time now, on macOS and Android, no problems found.

@neo1973 could you have a look, please? 