### PR TITLE
Random SonarQube findings which were introduced lately

### DIFF
--- a/xbmc/AutoSwitch.cpp
+++ b/xbmc/AutoSwitch.cpp
@@ -141,7 +141,7 @@ bool CAutoSwitch::ByThumbPercent(bool bHideParentDirItems, int iPercent, const C
 /// \param iPercent Percent of non-default thumbs to autoswitch on
 bool CAutoSwitch::ByFileCount(const CFileItemList& vecItems)
 {
-  if (vecItems.Size() == 0)
+  if (vecItems.IsEmpty())
     return false;
   return static_cast<float>(vecItems.GetFileCount()) / vecItems.Size() > 0.25f;
 }

--- a/xbmc/CueDocument.cpp
+++ b/xbmc/CueDocument.cpp
@@ -229,7 +229,7 @@ void CCueDocument::UpdateMediaFile(const std::string& oldMediaFile, const std::s
 
 void CCueDocument::GetMediaFiles(std::vector<std::string>& mediaFiles)
 {
-  std::set<std::string> uniqueFiles;
+  std::set<std::string, std::less<>> uniqueFiles;
   std::ranges::transform(m_tracks, std::inserter(uniqueFiles, uniqueFiles.end()),
                          [](const auto& track) { return track.strFile; });
 

--- a/xbmc/MediaSource.cpp
+++ b/xbmc/MediaSource.cpp
@@ -24,7 +24,7 @@ bool CMediaSource::IsWritable() const
   return CUtil::SupportsWriteFileOperations(strPath);
 }
 
-void CMediaSource::FromNameAndPaths(const std::string& name, const std::vector<std::string>& paths)
+void CMediaSource::FromNameAndPaths(std::string_view name, const std::vector<std::string>& paths)
 {
   vecPaths = paths;
   if (paths.empty())
@@ -61,6 +61,7 @@ void CMediaSource::FromNameAndPaths(const std::string& name, const std::vector<s
     m_iDriveType = SourceType::LOCAL;
   else
     m_iDriveType = SourceType::UNKNOWN;
+
   // check - convert to url and back again to make sure strPath is accurate
   // in terms of what we expect
   strPath = CURL(strPath).Get();

--- a/xbmc/MediaSource.h
+++ b/xbmc/MediaSource.h
@@ -12,6 +12,7 @@
 #include "utils/LockInfo.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 /*!
@@ -24,7 +25,7 @@ class CMediaSource final
 public:
   bool operator==(const CMediaSource &right) const;
 
-  void FromNameAndPaths(const std::string& name, const std::vector<std::string>& paths);
+  void FromNameAndPaths(std::string_view name, const std::vector<std::string>& paths);
   bool IsWritable() const;
 
   KODI::UTILS::CLockInfo& GetLockInfo() { return m_lockInfo; }

--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -210,19 +210,21 @@ private:
     using namespace std::literals::string_view_literals;
     switch (type)
     {
-      case ADDON::ContentType::MOVIES:
+      using enum ADDON::ContentType;
+
+      case MOVIES:
         return "movies"sv;
-      case ADDON::ContentType::TVSHOWS:
+      case TVSHOWS:
         return "TV shows"sv;
-      case ADDON::ContentType::MUSICVIDEOS:
+      case MUSICVIDEOS:
         return "music videos"sv;
-      case ADDON::ContentType::ALBUMS:
+      case ALBUMS:
         return "albums"sv;
-      case ADDON::ContentType::ARTISTS:
+      case ARTISTS:
         return "artists"sv;
-      case ADDON::ContentType::NONE:
+      case NONE:
         return "none"sv;
-    };
+    }
     throw std::invalid_argument("no content string found");
   }
 };

--- a/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
@@ -75,14 +75,14 @@ bool CGUIWindowAddonBrowser::OnMessage(CGUIMessage& message)
     {
       CServiceBroker::GetRepositoryUpdater().Events().Subscribe(
           this,
-          [](const ADDON::CRepositoryUpdater::RepositoryUpdated& event)
+          [](const ADDON::CRepositoryUpdater::RepositoryUpdated& /*event*/)
           {
             CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE);
             CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
           });
       CServiceBroker::GetAddonMgr().Events().Subscribe(
           this,
-          [](const ADDON::AddonEvent& event)
+          [](const ADDON::AddonEvent& /*event*/)
           {
             CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE);
             CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
@@ -208,7 +208,7 @@ ShaderParameterMap CShaderPreset::GetShaderParameters(
   std::smatch matches;
 
   std::vector<std::string> validParams;
-  std::string::const_iterator searchStart(sourceStr.cbegin());
+  auto searchStart(sourceStr.cbegin());
   while (regex_search(searchStart, sourceStr.cend(), matches, pragmaParamRegex))
   {
     validParams.push_back(matches[1].str());

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.h
@@ -77,7 +77,7 @@ protected:
 
   // Set of paths of presets that are known to not load correctly
   // Should not contain "" (empty path) because this signifies that a preset is not loaded
-  std::set<std::string> m_failedPaths;
+  std::set<std::string, std::less<>> m_failedPaths;
 
   // All video shader passes of the currently loaded preset
   std::vector<ShaderPass> m_passes;

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPresetFactory.h
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPresetFactory.h
@@ -31,7 +31,7 @@ public:
   /*!
    * \brief Create the factory and register all shader preset add-ons
    */
-  CShaderPresetFactory(ADDON::CAddonMgr& addons);
+  explicit CShaderPresetFactory(ADDON::CAddonMgr& addons);
   ~CShaderPresetFactory();
 
   /*!
@@ -47,7 +47,7 @@ public:
    *
    * \param load The loader that was passed to RegisterLoader()
    */
-  void UnregisterLoader(IShaderPresetLoader* loader);
+  void UnregisterLoader(const IShaderPresetLoader* loader);
 
   /*!
    * \brief Check if any shader preset add-ons have been loaded
@@ -75,7 +75,7 @@ public:
    *
    * \return True if a loader can load the preset, false otherwise
    */
-  bool CanLoadPreset(const std::string& presetPath);
+  bool CanLoadPreset(const std::string& presetPath) const;
 
 private:
   void UpdateAddons();
@@ -83,8 +83,8 @@ private:
   // Construction parameters
   ADDON::CAddonMgr& m_addons;
 
-  std::map<std::string, IShaderPresetLoader*> m_loaders;
-  std::map<std::string, std::unique_ptr<ADDON::CShaderPresetAddon>> m_shaderAddons;
-  std::map<std::string, std::unique_ptr<ADDON::CShaderPresetAddon>> m_failedAddons;
+  std::map<std::string, IShaderPresetLoader*, std::less<>> m_loaders;
+  std::map<std::string, std::unique_ptr<ADDON::CShaderPresetAddon>, std::less<>> m_shaderAddons;
+  std::map<std::string, std::unique_ptr<ADDON::CShaderPresetAddon>, std::less<>> m_failedAddons;
 };
 } // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/ShaderTypes.h
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderTypes.h
@@ -17,7 +17,7 @@
 
 namespace KODI::SHADER
 {
-using ShaderParameterMap = std::map<std::string, float>;
+using ShaderParameterMap = std::map<std::string, float, std::less<>>;
 
 enum class FilterType
 {
@@ -98,11 +98,10 @@ struct float2
   template<typename T>
   float2(T x_, T y_) : x(static_cast<float>(x_)), y(static_cast<float>(y_))
   {
-    static_assert(std::is_arithmetic<T>::value, "Not an arithmetic type");
+    static_assert(std::is_arithmetic_v<T>, "Not an arithmetic type");
   }
 
-  bool operator==(const float2& rhs) const { return x == rhs.x && y == rhs.y; }
-  bool operator!=(const float2& rhs) const { return !(*this == rhs); }
+  bool operator==(const float2& rhs) const = default;
 
   template<typename T>
   T Max()

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
@@ -360,10 +360,10 @@ void CShaderGL::SetShaderParameters(CGLTexture& sourceTexture)
   glUniformMatrix4fv(m_MVPMatrixLoc, 1, GL_FALSE, reinterpret_cast<const GLfloat*>(&m_MVP));
 
   // Set #pragma parameters
-  for (const auto& param : m_shaderParameters)
+  for (const auto& [paramName, paramValue] : m_shaderParameters)
   {
-    GLint paramLoc = glGetUniformLocation(m_shaderProgram, param.first.c_str());
-    glUniform1f(paramLoc, param.second);
+    GLint paramLoc = glGetUniformLocation(m_shaderProgram, paramName.c_str());
+    glUniform1f(paramLoc, paramValue);
   }
 
   // Set source texture

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.cpp
@@ -183,7 +183,7 @@ bool CShaderPresetGL::CreateShaderTextures()
         return false;
       }
 
-      ShaderPass& nextPass = m_passes[shaderIdx + 1];
+      const ShaderPass& nextPass = m_passes[shaderIdx + 1];
 
       if (nextPass.mipmap)
         textureGL->SetMipmapping();

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
@@ -346,10 +346,10 @@ void CShaderGLES::SetShaderParameters(CGLESTexture& sourceTexture)
   glUniformMatrix4fv(m_MVPMatrixLoc, 1, GL_FALSE, reinterpret_cast<const GLfloat*>(&m_MVP));
 
   // Set #pragma parameters
-  for (const auto& param : m_shaderParameters)
+  for (const auto& [paramName, paramValue] : m_shaderParameters)
   {
-    GLint paramLoc = glGetUniformLocation(m_shaderProgram, param.first.c_str());
-    glUniform1f(paramLoc, param.second);
+    GLint paramLoc = glGetUniformLocation(m_shaderProgram, paramName.c_str());
+    glUniform1f(paramLoc, paramValue);
   }
 
   // Set source texture

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.cpp
@@ -183,7 +183,7 @@ bool CShaderPresetGLES::CreateShaderTextures()
         return false;
       }
 
-      ShaderPass& nextPass = m_passes[shaderIdx + 1];
+      const ShaderPass& nextPass = m_passes[shaderIdx + 1];
 
       if (nextPass.mipmap)
         textureGL->SetMipmapping();

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.cpp
@@ -252,8 +252,8 @@ void CShaderDX::SetShaderParameters(const CD3DTexture& sourceTexture)
   //! @todo(optimization) Add frame_count to separate cbuffer
   m_effect.SetConstantBuffer("input", m_pInputBuffer);
 
-  for (const auto& paramIt : m_shaderParameters)
-    m_effect.SetFloatArray(paramIt.first.c_str(), &paramIt.second, 1);
+  for (const auto& [paramName, paramValue] : m_shaderParameters)
+    m_effect.SetFloatArray(paramName.c_str(), &paramValue, 1);
 
   for (const std::shared_ptr<IShaderLut>& lut : m_luts)
   {

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -976,8 +976,8 @@ void CStrAccum::VXPrintf(MYSQL* conn,
     }
     /* Find out what flags are present */
     flag_leftjustify = flag_plussign = flag_blanksign = flag_alternateform = flag_altform2 =
-        flag_zeropad = 0;
-    done = 0;
+        flag_zeropad = false;
+    done = false;
     do
     {
       switch (c)
@@ -1181,7 +1181,7 @@ void CStrAccum::VXPrintf(MYSQL* conn,
           prefix = 0;
         }
         if (longvalue == 0)
-          flag_alternateform = 0;
+          flag_alternateform = false;
         if (flag_zeropad && precision < width - (prefix != 0))
         {
           precision = width - (prefix != 0);
@@ -1330,7 +1330,7 @@ void CStrAccum::VXPrintf(MYSQL* conn,
         }
         else
         {
-          flag_rtz = 0;
+          flag_rtz = false;
         }
         if (xtype == etEXP)
         {
@@ -1341,7 +1341,7 @@ void CStrAccum::VXPrintf(MYSQL* conn,
           e2 = exp;
         }
         nsd = 0;
-        flag_dp = (precision > 0 ? 1 : 0) | flag_alternateform | flag_altform2;
+        flag_dp = (precision > 0 ? 1 : 0) || flag_alternateform || flag_altform2;
         /* The sign in front of the number */
         if (prefix)
         {

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -271,10 +271,11 @@ void CGUIDialogSmartPlaylistEditor::OnCancel()
 void CGUIDialogSmartPlaylistEditor::OnMatch()
 {
   // toggle between AND and OR setting
-  if (m_playlist.m_ruleCombination.GetType() == CDatabaseQueryRuleCombination::Type::COMBINATION_OR)
-    m_playlist.m_ruleCombination.SetType(CDatabaseQueryRuleCombination::Type::COMBINATION_AND);
+  using enum CDatabaseQueryRuleCombination::Type;
+  if (m_playlist.m_ruleCombination.GetType() == COMBINATION_OR)
+    m_playlist.m_ruleCombination.SetType(COMBINATION_AND);
   else
-    m_playlist.m_ruleCombination.SetType(CDatabaseQueryRuleCombination::Type::COMBINATION_OR);
+    m_playlist.m_ruleCombination.SetType(COMBINATION_OR);
   UpdateButtons();
 }
 

--- a/xbmc/favourites/GUIWindowFavourites.cpp
+++ b/xbmc/favourites/GUIWindowFavourites.cpp
@@ -31,7 +31,7 @@ CGUIWindowFavourites::CGUIWindowFavourites()
   m_loadType = KEEP_IN_MEMORY;
   CServiceBroker::GetFavouritesService().Events().Subscribe(
       this,
-      [this](const CFavouritesService::FavouritesUpdated& event)
+      [this](const CFavouritesService::FavouritesUpdated& /*event*/)
       {
         CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), 0, 0);
         CServiceBroker::GetAppMessenger()->SendGUIMessage(m);

--- a/xbmc/filesystem/BlurayDiscCache.cpp
+++ b/xbmc/filesystem/BlurayDiscCache.cpp
@@ -22,8 +22,7 @@ CacheMap::iterator CBlurayDiscCache::SetDisc(const std::string& path)
   std::string storedPath{CURL(path).GetWithoutOptions()};
   URIUtils::RemoveSlashAtEnd(storedPath);
 
-  Disc disc;
-  const auto [it, _]{m_cache.try_emplace(storedPath, disc)};
+  const auto [it, _]{m_cache.try_emplace(storedPath)};
   return it;
 }
 

--- a/xbmc/games/controllers/input/ControllerActivity.cpp
+++ b/xbmc/games/controllers/input/ControllerActivity.cpp
@@ -32,8 +32,8 @@ float CControllerActivity::GetActivation() const
   if (!m_mousePointers.empty() && m_activeMouseButtons.empty())
   {
     const bool anyPointerActive =
-        std::any_of(m_mousePointers.begin(), m_mousePointers.end(), [](const auto& it)
-                    { return it.second.active && !it.second.timer.IsTimePast(); });
+        std::ranges::any_of(m_mousePointers, [](const auto& it)
+                            { return it.second.active && !it.second.timer.IsTimePast(); });
     if (!anyPointerActive)
       return 0.0f;
   }
@@ -99,8 +99,8 @@ void CControllerActivity::OnKeyRelease(const KEYBOARD::KeyName& key)
 }
 
 void CControllerActivity::OnMouseMotion(const MOUSE::PointerName& relpointer,
-                                        int differenceX,
-                                        int differenceY)
+                                        int /*differenceX*/,
+                                        int /*differenceY*/)
 {
   auto& pointer = m_mousePointers[relpointer];
   pointer.active = true;

--- a/xbmc/games/controllers/windows/GUIControllerWindow.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerWindow.cpp
@@ -248,7 +248,8 @@ void CGUIControllerWindow::OnInitWindow(void)
 
   // subscribe to events
   CServiceBroker::GetRepositoryUpdater().Events().Subscribe(
-      this, [this](const ADDON::CRepositoryUpdater::RepositoryUpdated& event) { UpdateButtons(); });
+      this,
+      [this](const ADDON::CRepositoryUpdater::RepositoryUpdated& /*event*/) { UpdateButtons(); });
   CServiceBroker::GetAddonMgr().Events().Subscribe(
       this,
       [this](const ADDON::AddonEvent& event)

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
@@ -169,20 +169,17 @@ void CDialogGameVideoFilter::InitVideoFilters()
       continue;
 
     TiXmlNode* pathNode;
-    if ((pathNode = child->FirstChild("path")))
-      if ((pathNode = pathNode->FirstChild()))
-        videoFilter.path =
-            URIUtils::AddFileToFolder(URIUtils::GetBasePath(xmlPath), pathNode->Value());
+    if ((pathNode = child->FirstChild("path")) && (pathNode = pathNode->FirstChild()))
+      videoFilter.path =
+          URIUtils::AddFileToFolder(URIUtils::GetBasePath(xmlPath), pathNode->Value());
 
     TiXmlNode* nameNode;
-    if ((nameNode = child->FirstChild("name")))
-      if ((nameNode = nameNode->FirstChild()))
-        videoFilter.name = nameNode->Value();
+    if ((nameNode = child->FirstChild("name")) && (nameNode = nameNode->FirstChild()))
+      videoFilter.name = nameNode->Value();
 
     TiXmlNode* folderNode;
-    if ((folderNode = child->FirstChild("folder")))
-      if ((folderNode = folderNode->FirstChild()))
-        videoFilter.folder = folderNode->Value();
+    if ((folderNode = child->FirstChild("folder")) && (folderNode = folderNode->FirstChild()))
+      videoFilter.folder = folderNode->Value();
 
     videoFilters.emplace_back(videoFilter);
   }

--- a/xbmc/guilib/guiinfo/VisualisationGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VisualisationGUIInfo.cpp
@@ -41,7 +41,7 @@ bool CVisualisationGUIInfo::GetLabel(std::string& value, const CFileItem *item, 
       CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
       if (msg.GetPointer())
       {
-        auto* viz{static_cast<CGUIVisualisationControl*>(msg.GetPointer())};
+        const auto* viz{static_cast<const CGUIVisualisationControl*>(msg.GetPointer())};
         value = viz->GetActivePresetName();
         URIUtils::RemoveExtension(value);
         return true;
@@ -85,7 +85,7 @@ bool CVisualisationGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int 
       CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
       if (msg.GetPointer())
       {
-        auto* viz{static_cast<CGUIVisualisationControl*>(msg.GetPointer())};
+        const auto* viz{static_cast<const CGUIVisualisationControl*>(msg.GetPointer())};
         value = viz->IsLocked();
         return true;
       }
@@ -102,7 +102,7 @@ bool CVisualisationGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int 
       CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
       if (msg.GetPointer())
       {
-        auto* viz{static_cast<CGUIVisualisationControl*>(msg.GetPointer())};
+        const auto* viz{static_cast<const CGUIVisualisationControl*>(msg.GetPointer())};
         value = viz->HasPresets();
         return true;
       }

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -437,7 +437,7 @@ static int PlayDVD(const std::vector<std::string>& params)
 /*! \brief Play currently inserted Bluray, allowing the user to choose the playlist.
  *  \param params Not used here (but needed for builtin interface).
  */
-static int PlayPlaylist(const std::vector<std::string>& params)
+static int PlayPlaylist(const std::vector<std::string>& /*params*/)
 {
 #ifdef HAS_OPTICAL_DRIVE
   MEDIA_DETECT::PlayDiscOptions options(

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -13214,7 +13214,7 @@ std::vector<CScraperUrl::SUrlEntry> CMusicDatabase::GetAvailableArtForItem(
 
 int CMusicDatabase::GetOrderFilter(const std::string& type,
                                    const SortDescription& sorting,
-                                   Filter& filter)
+                                   Filter& filter) const
 {
   // Populate filter with ORDER BY clause and any extra scalar query fields needed for sort
   int iFieldsAdded = 0;

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -634,7 +634,7 @@ public:
   int GetDiscsCount(const std::string& baseDir, const Filter& filter = Filter());
   int GetSongsCount(const Filter& filter = Filter());
   bool GetFilter(CDbUrl& musicUrl, Filter& filter, SortDescription& sorting) override;
-  int GetOrderFilter(const std::string& type, const SortDescription& sorting, Filter& filter);
+  int GetOrderFilter(const std::string& type, const SortDescription& sorting, Filter& filter) const;
 
   /////////////////////////////////////////////////
   // Party Mode

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -251,8 +251,8 @@ PeripheralBusPtr CPeripherals::GetBusWithDevice(const std::string& strLocation) 
 {
   std::unique_lock lock(m_critSectionBusses);
 
-  const auto& bus = std::ranges::find_if(m_busses, [&strLocation](const PeripheralBusPtr& bus)
-                                         { return bus->HasPeripheral(strLocation); });
+  const auto& bus = std::ranges::find_if(m_busses, [&strLocation](const PeripheralBusPtr& b)
+                                         { return b->HasPeripheral(strLocation); });
   if (bus != m_busses.cend())
     return *bus;
 

--- a/xbmc/playlists/PlayListURL.cpp
+++ b/xbmc/playlists/PlayListURL.cpp
@@ -55,10 +55,7 @@ bool CPlayListURL::Load(const std::string& strFileName)
       {
         StringUtils::RemoveCRLF(strLine);
         if (StringUtils::StartsWith(strLine, "URL="))
-        {
-          auto newItem{std::make_shared<CFileItem>(strLine.substr(4), false)};
-          Add(std::move(newItem));
-        }
+          Add(std::make_shared<CFileItem>(strLine.substr(4), false));
       }
     }
   }

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -272,8 +272,8 @@ bool CSmartPlaylistRule::Validate(const std::string &input, void *data)
   // Split the input into multiple values and validate every value separately
   const std::vector<std::string> values{StringUtils::Split(input, RULE_VALUE_SEPARATOR)};
 
-  return (std::all_of(values.begin(), values.end(),
-                      [data, validator](const auto& s) { return validator(s, data); }));
+  return (
+      std::ranges::all_of(values, [data, validator](const auto& s) { return validator(s, data); }));
 }
 
 bool CSmartPlaylistRule::ValidateRating(const std::string &input, void *data)
@@ -318,7 +318,7 @@ bool CSmartPlaylistRule::ValidateDate(const std::string& input, void* data)
   if (!data)
     return false;
 
-  CSmartPlaylistRule* rule = static_cast<CSmartPlaylistRule*>(data);
+  const auto* rule = static_cast<CSmartPlaylistRule*>(data);
 
   //! @todo implement a validation for relative dates
   if (rule->m_operator == OPERATOR_IN_THE_LAST || rule->m_operator == OPERATOR_NOT_IN_THE_LAST)

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -374,7 +374,7 @@ void CProfileManager::FinalizeLoadProfile()
 {
   CContextMenuManager &contextMenuManager = CServiceBroker::GetContextMenuManager();
   ADDON::CServiceAddonManager &serviceAddons = CServiceBroker::GetServiceAddons();
-  PVR::CPVRManager &pvrManager = CServiceBroker::GetPVRManager();
+  const PVR::CPVRManager& pvrManager = CServiceBroker::GetPVRManager();
   CNetworkBase &networkManager = CServiceBroker::GetNetwork();
   ADDON::CAddonMgr &addonManager = CServiceBroker::GetAddonMgr();
   CWeatherManager &weatherManager = CServiceBroker::GetWeatherManager();

--- a/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
@@ -298,7 +298,7 @@ std::string CGUIDialogLockSettings::GetLockModeLabel()
       m_locks.mode == LockMode::EVERYONE ? 1223 : 12336 + static_cast<int>(m_locks.mode));
 }
 
-void CGUIDialogLockSettings::SetDetailSettingsEnabled(bool enabled)
+void CGUIDialogLockSettings::SetDetailSettingsEnabled(bool enabled) const
 {
   if (!m_details)
     return;

--- a/xbmc/profiles/dialogs/GUIDialogLockSettings.h
+++ b/xbmc/profiles/dialogs/GUIDialogLockSettings.h
@@ -37,7 +37,7 @@ protected:
 
 private:
   std::string GetLockModeLabel();
-  void SetDetailSettingsEnabled(bool enabled);
+  void SetDetailSettingsEnabled(bool enabled) const;
   void SetSettingLockCodeLabel();
 
   bool m_changed = false;

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -491,7 +491,7 @@ bool CPVRChannelGroups::LoadFromDatabase(const std::vector<std::shared_ptr<CPVRC
             // Update group client priorities
             std::vector<std::shared_ptr<CPVRChannelGroup>> groups;
             {
-              std::unique_lock lock(m_critSection);
+              std::unique_lock l(m_critSection);
               groups = m_groups;
             }
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
@@ -195,7 +195,7 @@ bool CGUIDialogPVRRecordingSettings::Save()
 
 void CGUIDialogPVRRecordingSettings::LifetimesFiller(const SettingConstPtr& setting,
                                                      std::vector<IntegerSettingOption>& list,
-                                                     int& current)
+                                                     int& current) const
 {
   list.clear();
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.h
@@ -47,7 +47,7 @@ protected:
 private:
   void LifetimesFiller(const std::shared_ptr<const CSetting>& setting,
                        std::vector<IntegerSettingOption>& list,
-                       int& current);
+                       int& current) const;
 
   std::shared_ptr<CPVRRecording> m_recording;
   std::string m_strTitle;

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -898,7 +898,7 @@ void CGUIDialogPVRTimerSettings::AddCondition(const std::shared_ptr<CSetting>& s
                                               const std::string& identifier,
                                               const SettingConditionCheck& condition,
                                               SettingDependencyType depType,
-                                              const std::string& settingId)
+                                              const std::string& settingId) const
 {
   GetSettingsManager()->AddDynamicCondition(identifier, condition);
   CSettingDependency dep(depType, GetSettingsManager());
@@ -1051,7 +1051,7 @@ void CGUIDialogPVRTimerSettings::InitializeChannelsList()
 
 void CGUIDialogPVRTimerSettings::TypesFiller(const SettingConstPtr& setting,
                                              std::vector<IntegerSettingOption>& list,
-                                             int& current)
+                                             int& current) const
 {
   list.clear();
   current = 0;
@@ -1139,7 +1139,7 @@ void CGUIDialogPVRTimerSettings::ChannelsFiller(const SettingConstPtr& setting,
 
 void CGUIDialogPVRTimerSettings::DaysFiller(const SettingConstPtr& setting,
                                             std::vector<IntegerSettingOption>& list,
-                                            int& current)
+                                            int& current) const
 {
   list.clear();
   current = 0;
@@ -1181,7 +1181,7 @@ void CGUIDialogPVRTimerSettings::DaysFiller(const SettingConstPtr& setting,
 
 void CGUIDialogPVRTimerSettings::DupEpisodesFiller(const SettingConstPtr& setting,
                                                    std::vector<IntegerSettingOption>& list,
-                                                   int& current)
+                                                   int& current) const
 {
   list.clear();
 
@@ -1194,7 +1194,7 @@ void CGUIDialogPVRTimerSettings::DupEpisodesFiller(const SettingConstPtr& settin
 
 void CGUIDialogPVRTimerSettings::WeekdaysFiller(const SettingConstPtr& setting,
                                                 std::vector<IntegerSettingOption>& list,
-                                                int& current)
+                                                int& current) const
 {
   list.clear();
   list.emplace_back(g_localizeStrings.Get(831), PVR_WEEKDAY_MONDAY); // "Mondays"
@@ -1210,7 +1210,7 @@ void CGUIDialogPVRTimerSettings::WeekdaysFiller(const SettingConstPtr& setting,
 
 void CGUIDialogPVRTimerSettings::PrioritiesFiller(const SettingConstPtr& setting,
                                                   std::vector<IntegerSettingOption>& list,
-                                                  int& current)
+                                                  int& current) const
 {
   list.clear();
 
@@ -1238,7 +1238,7 @@ void CGUIDialogPVRTimerSettings::PrioritiesFiller(const SettingConstPtr& setting
 
 void CGUIDialogPVRTimerSettings::LifetimesFiller(const SettingConstPtr& setting,
                                                  std::vector<IntegerSettingOption>& list,
-                                                 int& current)
+                                                 int& current) const
 {
   list.clear();
 
@@ -1267,7 +1267,7 @@ void CGUIDialogPVRTimerSettings::LifetimesFiller(const SettingConstPtr& setting,
 
 void CGUIDialogPVRTimerSettings::MaxRecordingsFiller(const SettingConstPtr& setting,
                                                      std::vector<IntegerSettingOption>& list,
-                                                     int& current)
+                                                     int& current) const
 {
   list.clear();
 
@@ -1295,7 +1295,7 @@ void CGUIDialogPVRTimerSettings::MaxRecordingsFiller(const SettingConstPtr& sett
 
 void CGUIDialogPVRTimerSettings::RecordingGroupFiller(const SettingConstPtr& setting,
                                                       std::vector<IntegerSettingOption>& list,
-                                                      int& current)
+                                                      int& current) const
 {
   list.clear();
 
@@ -1308,7 +1308,7 @@ void CGUIDialogPVRTimerSettings::RecordingGroupFiller(const SettingConstPtr& set
 
 void CGUIDialogPVRTimerSettings::MarginTimeFiller(const SettingConstPtr& setting,
                                                   std::vector<IntegerSettingOption>& list,
-                                                  int& current)
+                                                  int& current) const
 {
   list.clear();
 
@@ -1344,7 +1344,7 @@ void CGUIDialogPVRTimerSettings::MarginTimeFiller(const SettingConstPtr& setting
 void CGUIDialogPVRTimerSettings::CustomIntSettingDefinitionsFiller(
     const std::shared_ptr<const CSetting>& setting,
     std::vector<IntegerSettingOption>& list,
-    int& current)
+    int& current) const
 {
   list.clear();
 
@@ -1356,7 +1356,7 @@ void CGUIDialogPVRTimerSettings::CustomIntSettingDefinitionsFiller(
 void CGUIDialogPVRTimerSettings::CustomStringSettingDefinitionsFiller(
     const std::shared_ptr<const CSetting>& setting,
     std::vector<StringSettingOption>& list,
-    std::string& current)
+    std::string& current) const
 {
   list.clear();
 
@@ -1371,7 +1371,7 @@ std::string CGUIDialogPVRTimerSettings::WeekdaysValueFormatter(const SettingCons
 }
 
 void CGUIDialogPVRTimerSettings::AddTypeDependentEnableCondition(
-    const std::shared_ptr<CSetting>& setting, const std::string& identifier)
+    const std::shared_ptr<CSetting>& setting, const std::string& identifier) const
 {
   // Enable setting depending on read-only attribute of the selected timer type
   std::string id(identifier);
@@ -1385,7 +1385,7 @@ void CGUIDialogPVRTimerSettings::AddTypeDependentEnableCondition(
 
 bool CGUIDialogPVRTimerSettings::TypeReadOnlyCondition(const std::string& condition,
                                                        const std::string& value,
-                                                       const SettingConstPtr& setting)
+                                                       const SettingConstPtr& setting) const
 {
   if (!setting)
     return false;
@@ -1445,7 +1445,7 @@ bool CGUIDialogPVRTimerSettings::TypeReadOnlyCondition(const std::string& condit
 }
 
 void CGUIDialogPVRTimerSettings::AddTypeDependentVisibilityCondition(
-    const std::shared_ptr<CSetting>& setting, const std::string& identifier)
+    const std::shared_ptr<CSetting>& setting, const std::string& identifier) const
 {
   // Show or hide setting depending on attributes of the selected timer type
   std::string id(identifier);
@@ -1459,7 +1459,7 @@ void CGUIDialogPVRTimerSettings::AddTypeDependentVisibilityCondition(
 
 bool CGUIDialogPVRTimerSettings::TypeSupportsCondition(const std::string& condition,
                                                        const std::string& value,
-                                                       const SettingConstPtr& setting)
+                                                       const SettingConstPtr& setting) const
 {
   if (!setting)
     return false;
@@ -1527,7 +1527,7 @@ bool CGUIDialogPVRTimerSettings::TypeSupportsCondition(const std::string& condit
 }
 
 void CGUIDialogPVRTimerSettings::AddStartAnytimeDependentVisibilityCondition(
-    const std::shared_ptr<CSetting>& setting, const std::string& identifier)
+    const std::shared_ptr<CSetting>& setting, const std::string& identifier) const
 {
   // Show or hide setting depending on value of setting "any time"
   std::string id(identifier);
@@ -1541,7 +1541,7 @@ void CGUIDialogPVRTimerSettings::AddStartAnytimeDependentVisibilityCondition(
 
 bool CGUIDialogPVRTimerSettings::StartAnytimeSetCondition(const std::string& condition,
                                                           const std::string& value,
-                                                          const SettingConstPtr& setting)
+                                                          const SettingConstPtr& setting) const
 {
   if (!setting)
     return false;
@@ -1569,7 +1569,7 @@ bool CGUIDialogPVRTimerSettings::StartAnytimeSetCondition(const std::string& con
 }
 
 void CGUIDialogPVRTimerSettings::AddEndAnytimeDependentVisibilityCondition(
-    const std::shared_ptr<CSetting>& setting, const std::string& identifier)
+    const std::shared_ptr<CSetting>& setting, const std::string& identifier) const
 {
   // Show or hide setting depending on value of setting "any time"
   std::string id(identifier);
@@ -1583,7 +1583,7 @@ void CGUIDialogPVRTimerSettings::AddEndAnytimeDependentVisibilityCondition(
 
 bool CGUIDialogPVRTimerSettings::EndAnytimeSetCondition(const std::string& condition,
                                                         const std::string& value,
-                                                        const SettingConstPtr& setting)
+                                                        const SettingConstPtr& setting) const
 {
   if (!setting)
     return false;

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
@@ -90,40 +90,40 @@ private:
 
   void TypesFiller(const std::shared_ptr<const CSetting>& setting,
                    std::vector<IntegerSettingOption>& list,
-                   int& current);
+                   int& current) const;
   void ChannelsFiller(const std::shared_ptr<const CSetting>& setting,
                       std::vector<IntegerSettingOption>& list,
                       int& current);
   void DaysFiller(const std::shared_ptr<const CSetting>& setting,
                   std::vector<IntegerSettingOption>& list,
-                  int& current);
+                  int& current) const;
   void DupEpisodesFiller(const std::shared_ptr<const CSetting>& setting,
                          std::vector<IntegerSettingOption>& list,
-                         int& current);
+                         int& current) const;
   void WeekdaysFiller(const std::shared_ptr<const CSetting>& setting,
                       std::vector<IntegerSettingOption>& list,
-                      int& current);
+                      int& current) const;
   void PrioritiesFiller(const std::shared_ptr<const CSetting>& setting,
                         std::vector<IntegerSettingOption>& list,
-                        int& current);
+                        int& current) const;
   void LifetimesFiller(const std::shared_ptr<const CSetting>& setting,
                        std::vector<IntegerSettingOption>& list,
-                       int& current);
+                       int& current) const;
   void MaxRecordingsFiller(const std::shared_ptr<const CSetting>& setting,
                            std::vector<IntegerSettingOption>& list,
-                           int& current);
+                           int& current) const;
   void RecordingGroupFiller(const std::shared_ptr<const CSetting>& setting,
                             std::vector<IntegerSettingOption>& list,
-                            int& current);
+                            int& current) const;
   void MarginTimeFiller(const std::shared_ptr<const CSetting>& setting,
                         std::vector<IntegerSettingOption>& list,
-                        int& current);
+                        int& current) const;
   void CustomIntSettingDefinitionsFiller(const std::shared_ptr<const CSetting>& setting,
                                          std::vector<IntegerSettingOption>& list,
-                                         int& current);
+                                         int& current) const;
   void CustomStringSettingDefinitionsFiller(const std::shared_ptr<const CSetting>& setting,
                                             std::vector<StringSettingOption>& list,
-                                            std::string& current);
+                                            std::string& current) const;
 
   static std::string WeekdaysValueFormatter(const std::shared_ptr<const CSetting>& setting);
 
@@ -131,30 +131,30 @@ private:
                     const std::string& identifier,
                     const SettingConditionCheck& condition,
                     SettingDependencyType depType,
-                    const std::string& settingId);
+                    const std::string& settingId) const;
 
   void AddTypeDependentEnableCondition(const std::shared_ptr<CSetting>& setting,
-                                       const std::string& identifier);
+                                       const std::string& identifier) const;
   bool TypeReadOnlyCondition(const std::string& condition,
                              const std::string& value,
-                             const std::shared_ptr<const CSetting>& setting);
+                             const std::shared_ptr<const CSetting>& setting) const;
 
   void AddTypeDependentVisibilityCondition(const std::shared_ptr<CSetting>& setting,
-                                           const std::string& identifier);
+                                           const std::string& identifier) const;
   bool TypeSupportsCondition(const std::string& condition,
                              const std::string& value,
-                             const std::shared_ptr<const CSetting>& setting);
+                             const std::shared_ptr<const CSetting>& setting) const;
 
   void AddStartAnytimeDependentVisibilityCondition(const std::shared_ptr<CSetting>& setting,
-                                                   const std::string& identifier);
+                                                   const std::string& identifier) const;
   bool StartAnytimeSetCondition(const std::string& condition,
                                 const std::string& value,
-                                const std::shared_ptr<const CSetting>& setting);
+                                const std::shared_ptr<const CSetting>& setting) const;
   void AddEndAnytimeDependentVisibilityCondition(const std::shared_ptr<CSetting>& setting,
-                                                 const std::string& identifier);
+                                                 const std::string& identifier) const;
   bool EndAnytimeSetCondition(const std::string& condition,
                               const std::string& value,
-                              const std::shared_ptr<const CSetting>& setting);
+                              const std::shared_ptr<const CSetting>& setting) const;
 
   using TypeEntriesMap = std::map<int, std::shared_ptr<CPVRTimerType>>;
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -965,7 +965,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     GetCustomRegexps(pPictureExcludes, m_pictureExcludeFromListingRegExps);
 
   // picture extensions
-  TiXmlElement* pExts = pRootElement->FirstChildElement("pictureextensions");
+  const TiXmlElement* pExts = pRootElement->FirstChildElement("pictureextensions");
   if (pExts)
     GetCustomExtensions(pExts, m_pictureExtensions);
 
@@ -1025,19 +1025,19 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   XMLUtils::GetString(pRootElement, "tvmultipartmatching", m_tvshowMultiPartEnumRegExp);
 
   // path substitutions
-  TiXmlElement* pPathSubstitution = pRootElement->FirstChildElement("pathsubstitution");
+  const TiXmlElement* pPathSubstitution = pRootElement->FirstChildElement("pathsubstitution");
   if (pPathSubstitution)
   {
     m_pathSubstitutions.clear();
     CLog::Log(LOGDEBUG,"Configuring path substitutions");
-    TiXmlNode* pSubstitute = pPathSubstitution->FirstChildElement("substitute");
+    const TiXmlNode* pSubstitute = pPathSubstitution->FirstChildElement("substitute");
     while (pSubstitute)
     {
       std::string strFrom, strTo;
-      TiXmlNode* pFrom = pSubstitute->FirstChild("from");
+      const TiXmlNode* pFrom = pSubstitute->FirstChild("from");
       if (pFrom && !pFrom->NoChildren())
         strFrom = CSpecialProtocol::TranslatePath(pFrom->FirstChild()->Value()).c_str();
-      TiXmlNode* pTo = pSubstitute->FirstChild("to");
+      const TiXmlNode* pTo = pSubstitute->FirstChild("to");
       if (pTo && !pTo->NoChildren())
         strTo = pTo->FirstChild()->Value();
 
@@ -1075,17 +1075,17 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   XMLUtils::GetBoolean(pRootElement, "detectasudf", m_detectAsUdf);
 
   // music thumbs
-  TiXmlElement* pThumbs = pRootElement->FirstChildElement("musicthumbs");
+  const TiXmlElement* pThumbs = pRootElement->FirstChildElement("musicthumbs");
   if (pThumbs)
     GetCustomExtensions(pThumbs,m_musicThumbs);
 
   // show art for shoutcast v2 streams (set to false for devices with limited storage)
   XMLUtils::GetBoolean(pRootElement, "shoutcastart", m_bShoutcastArt);
   // music filename->tag filters
-  TiXmlElement* filters = pRootElement->FirstChildElement("musicfilenamefilters");
+  const TiXmlElement* filters = pRootElement->FirstChildElement("musicfilenamefilters");
   if (filters)
   {
-    TiXmlNode* filter = filters->FirstChild("filter");
+    const TiXmlNode* filter = filters->FirstChild("filter");
     while (filter)
     {
       if (filter->FirstChild())
@@ -1094,10 +1094,10 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     }
   }
 
-  TiXmlElement* pHostEntries = pRootElement->FirstChildElement("hosts");
+  const TiXmlElement* pHostEntries = pRootElement->FirstChildElement("hosts");
   if (pHostEntries)
   {
-    TiXmlElement* element = pHostEntries->FirstChildElement("entry");
+    const TiXmlElement* element = pHostEntries->FirstChildElement("entry");
     while(element)
     {
       if(!element->NoChildren())
@@ -1116,7 +1116,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 
   XMLUtils::GetBoolean(pRootElement, "alwaysontop", m_alwaysOnTop);
 
-  TiXmlElement *pPVR = pRootElement->FirstChildElement("pvr");
+  const TiXmlElement* pPVR = pRootElement->FirstChildElement("pvr");
   if (pPVR)
   {
     XMLUtils::GetInt(pPVR, "timecorrection", m_iPVRTimeCorrection, 0, 1440);

--- a/xbmc/utils/JSONVariantWriter.cpp
+++ b/xbmc/utils/JSONVariantWriter.cpp
@@ -76,7 +76,7 @@ bool CJSONVariantWriter::Write(const CVariant &value, std::string& output, bool 
       output = json.dump(1, '\t');
     }
   }
-  catch (nlohmann::json::exception& e)
+  catch (nlohmann::json::exception&)
   {
     return false;
   }

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -357,7 +357,7 @@ std::string ByEpisodeNumber(SortAttribute attributes, const SortItem &values)
 
 std::string BySeason(SortAttribute attributes, const SortItem &values)
 {
-  int season = static_cast<int>(values.at(FieldSeason).asInteger());
+  auto season = static_cast<int>(values.at(FieldSeason).asInteger());
 
   if (season == 0)
     season = std::numeric_limits<int>::max();

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3154,11 +3154,13 @@ int CVideoDatabase::SetFileForMedia(const std::string& fileAndPath,
 
   switch (type)
   {
-    case VideoDbContentType::MOVIES:
+    using enum VideoDbContentType;
+
+    case MOVIES:
       return SetFileForMovie(fileAndPath, mediaId, oldIdFile);
-    case VideoDbContentType::EPISODES:
+    case EPISODES:
       return SetFileForEpisode(fileAndPath, mediaId, oldIdFile);
-    case VideoDbContentType::UNKNOWN:
+    case UNKNOWN:
       return SetFileForUnknown(fileAndPath, oldIdFile); // Used for removable blurays
     default:
       CLog::LogF(LOGDEBUG, "unsupported media type {}", type);
@@ -4889,12 +4891,12 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMovie(const dbiplus::sql_record* cons
   return details;
 }
 
-CSetInfoTag CVideoDatabase::GetDetailsForSet(dbiplus::Dataset& pDS)
+CSetInfoTag CVideoDatabase::GetDetailsForSet(dbiplus::Dataset& pDS) const
 {
   return GetDetailsForSet(pDS.get_sql_record());
 }
 
-CSetInfoTag CVideoDatabase::GetDetailsForSet(const dbiplus::sql_record* const record)
+CSetInfoTag CVideoDatabase::GetDetailsForSet(const dbiplus::sql_record* const record) const
 {
   CSetInfoTag details;
 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -205,19 +205,21 @@ private:
     using namespace std::literals::string_view_literals;
     switch (type)
     {
-      case VideoDbContentType::UNKNOWN:
+      using enum VideoDbContentType;
+
+      case UNKNOWN:
         return "unknown"sv;
-      case VideoDbContentType::MOVIES:
+      case MOVIES:
         return "movies"sv;
-      case VideoDbContentType::TVSHOWS:
+      case TVSHOWS:
         return "TV shows"sv;
-      case VideoDbContentType::MUSICVIDEOS:
+      case MUSICVIDEOS:
         return "music videos"sv;
-      case VideoDbContentType::EPISODES:
+      case EPISODES:
         return "episodes"sv;
-      case VideoDbContentType::MOVIE_SETS:
+      case MOVIE_SETS:
         return "movie sets"sv;
-      case VideoDbContentType::MUSICALBUMS:
+      case MUSICALBUMS:
         return "music albums"sv;
     };
     throw std::invalid_argument("no videodb content string found");
@@ -1367,8 +1369,8 @@ protected:
 
   CVideoInfoTag GetDetailsForMovie(dbiplus::Dataset& pDS, int getDetails = VideoDbDetailsNone);
   CVideoInfoTag GetDetailsForMovie(const dbiplus::sql_record* const record, int getDetails = VideoDbDetailsNone);
-  CSetInfoTag GetDetailsForSet(dbiplus::Dataset& pDS);
-  CSetInfoTag GetDetailsForSet(const dbiplus::sql_record* const record);
+  CSetInfoTag GetDetailsForSet(dbiplus::Dataset& pDS) const;
+  CSetInfoTag GetDetailsForSet(const dbiplus::sql_record* const record) const;
   CVideoInfoTag GetDetailsForTvShow(dbiplus::Dataset& pDS,
                                     int getDetails = VideoDbDetailsNone,
                                     CFileItem* item = nullptr);

--- a/xbmc/video/tags/SetTagLoaderNFO.h
+++ b/xbmc/video/tags/SetTagLoaderNFO.h
@@ -27,6 +27,6 @@ public:
   //! \brief tag Tag to load info into
   CInfoScanner::InfoType Load(CSetInfoTag& tag, bool prioritise) override;
 
-protected:
+private:
   std::string m_path; //!< Path to nfo file
 };


### PR DESCRIPTION
## Description
Most probably my last PR before I'm going to take a break from the project, just to empty my personal PR pipeline.

Fixes several recently introduced code smells detected by SonarQube, which were easy to fix, without much effort.

Introduced between July 9 and July 17:
* Unused function parameters should be removed cpp:S1172
* Concise syntax should be used for concatenatable namespaces cpp:S5812
* Pointer and reference local variables should be "const" if the corresponding object is not modified cpp:S5350
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* Variables should not be shadowed cpp:S1117
* "std::move" should only be used where moving can happen cpp:S5415

Introduced earlier:
* Empty statements should be removed cpp:S1116
* "using enum" should be used in scopes with high concentration of "enum" constants cpp:S6177
* "empty()" should be used to test for emptiness cpp:S1155
* Transparent function objects should be used with associative "std::string" containers cpp:S6045
* "std::string_view" should be used to pass a read-only string to a function cpp:S6009
* "auto" should be used to store a result of functions that conventionally return an iterator or a range cpp:S6234
* "try_emplace" should be used with "std::map" and "std::unordered_map" cpp:S6030
* Pointer and reference parameters should be "const" if the corresponding object is not modified cpp:S995
* STL algorithms and range-based for loops should be preferred to traditional for loops cpp:S5566
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* "auto" should be used to avoid repetition of types cpp:S5827
* "explicit" should be used on single-parameter constructors and conversion operators cpp:S1709
* The "_t" and "_v" version of type traits should be used instead of "::type" and "::value" cpp:S6020
* Comparision operators ("<=>", "==") should be defaulted unless non-default behavior is required cpp:S6230
* Redundant comparison operators should not be defined cpp:S6186
* Structured binding should be used cpp:S6005
* Pointer and reference local variables should be "const" if the corresponding object is not modified cpp:S5350
* Integer literals should not be cast to bool cpp:S5820
* "bool" expressions should not be used as operands to built-in operators other than =, &&, ||, !, ==, !=, unary &, and the conditional operator cpp:S872
* Unused function parameters should be removed cpp:S1172
* Objects should not be created solely to be passed as arguments to functions that perform delegated object creation cpp:S6011
* Mergeable "if" statements should be combined cpp:S1066
* Unused local variables should be removed cpp:S1481
* Member variables should not be "protected" cpp:S3656

## Motivation and context
Improve code quality. 
Modernize code base.
Fix non-functional issues (e.g. performance by reducing number of string copies).

## How has this been tested?
Compiles.
Runtime-tested on macOS and Android for couple of days.
Existing test are green.

## What is the effect on users?
None, maybe slightly improved performance (startup, while using, shutdown)

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
