### PR TITLE
[Utils] Remove redundant mutable keyword.

### DIFF
--- a/xbmc/utils/ProgressJob.cpp
+++ b/xbmc/utils/ProgressJob.cpp
@@ -18,21 +18,17 @@
 #include <math.h>
 
 CProgressJob::CProgressJob()
-  : m_progress(NULL),
-    m_progressDialog(NULL)
 { }
 
-CProgressJob::CProgressJob(CGUIDialogProgressBarHandle* progressBar)
-  : m_progress(progressBar),
-    m_progressDialog(NULL)
+CProgressJob::CProgressJob(CGUIDialogProgressBarHandle* progressBar) : m_progress(progressBar)
 { }
 
 CProgressJob::~CProgressJob()
 {
   MarkFinished();
 
-  m_progress = NULL;
-  m_progressDialog = NULL;
+  m_progress = nullptr;
+  m_progressDialog = nullptr;
 }
 
 bool CProgressJob::ShouldCancel(unsigned int progress, unsigned int total) const
@@ -47,14 +43,14 @@ bool CProgressJob::ShouldCancel(unsigned int progress, unsigned int total) const
 
 bool CProgressJob::DoModal()
 {
-  m_progress = NULL;
+  m_progress = nullptr;
 
   // get a progress dialog if we don't already have one
-  if (m_progressDialog == NULL)
+  if (m_progressDialog == nullptr)
   {
     m_progressDialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
 
-    if (m_progressDialog == NULL)
+    if (m_progressDialog == nullptr)
       return false;
   }
 
@@ -83,8 +79,7 @@ void CProgressJob::SetProgressIndicators(CGUIDialogProgressBarHandle* progressBa
 
 void CProgressJob::ShowProgressDialog() const
 {
-  if (!IsModal() || m_progressDialog == NULL ||
-      m_progressDialog->IsDialogRunning())
+  if (!IsModal() || m_progressDialog == nullptr || m_progressDialog->IsDialogRunning())
     return;
 
   // show the progress dialog as a modal dialog with a progress bar
@@ -97,9 +92,9 @@ void CProgressJob::SetTitle(const std::string &title)
   if (!m_updateInformation)
     return;
 
-  if (m_progress != NULL)
+  if (m_progress != nullptr)
     m_progress->SetTitle(title);
-  else if (m_progressDialog != NULL)
+  else if (m_progressDialog != nullptr)
   {
     m_progressDialog->SetHeading(CVariant{title});
 
@@ -114,9 +109,9 @@ void CProgressJob::SetText(const std::string &text)
   if (!m_updateInformation)
     return;
 
-  if (m_progress != NULL)
+  if (m_progress != nullptr)
     m_progress->SetText(text);
-  else if (m_progressDialog != NULL)
+  else if (m_progressDialog != nullptr)
   {
     m_progressDialog->SetText(CVariant{text});
 
@@ -131,9 +126,9 @@ void CProgressJob::SetProgress(float percentage) const
   if (!m_updateProgress)
     return;
 
-  if (m_progress != NULL)
+  if (m_progress != nullptr)
     m_progress->SetPercentage(percentage);
-  else if (m_progressDialog != NULL)
+  else if (m_progressDialog != nullptr)
   {
     ShowProgressDialog();
 
@@ -153,15 +148,15 @@ void CProgressJob::SetProgress(int currentStep, int totalSteps) const
   if (!m_updateProgress)
     return;
 
-  if (m_progress != NULL)
+  if (m_progress != nullptr)
     m_progress->SetProgress(currentStep, totalSteps);
-  else if (m_progressDialog != NULL)
+  else if (m_progressDialog != nullptr)
     SetProgress((static_cast<float>(currentStep) * 100.0f) / totalSteps);
 }
 
 void CProgressJob::MarkFinished()
 {
-  if (m_progress != NULL)
+  if (m_progress != nullptr)
   {
     if (m_updateProgress)
     {
@@ -171,13 +166,13 @@ void CProgressJob::MarkFinished()
       m_progress = nullptr;
     }
   }
-  else if (m_progressDialog != NULL && m_autoClose)
+  else if (m_progressDialog != nullptr && m_autoClose)
     m_progressDialog->Close();
 }
 
 bool CProgressJob::IsCancelled() const
 {
-  if (m_progressDialog != NULL)
+  if (m_progressDialog != nullptr)
     return m_progressDialog->IsCanceled();
 
   return false;

--- a/xbmc/utils/ProgressJob.h
+++ b/xbmc/utils/ProgressJob.h
@@ -154,10 +154,10 @@ protected:
   bool IsCancelled() const;
 
 private:
-  bool m_modal = false;
-  bool m_autoClose = true;
-  bool m_updateProgress = true;
-  bool m_updateInformation = true;
-  mutable CGUIDialogProgressBarHandle* m_progress;
-  mutable CGUIDialogProgress* m_progressDialog;
+  bool m_modal{false};
+  bool m_autoClose{true};
+  bool m_updateProgress{true};
+  bool m_updateInformation{true};
+  CGUIDialogProgressBarHandle* m_progress{nullptr};
+  CGUIDialogProgress* m_progressDialog{nullptr};
 };


### PR DESCRIPTION
## Description
Discovered some redundant mutable keywords. These pointer members have setter methods which are non-const.

## Motivation and context
Clean-up

## How has this been tested?
Building
Running
Existing Tests

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
