### PR TITLE
[ffmpeg] Use AV_PROFILE_* defines instead of the deprecated FF_PROFILE_*

### DIFF
--- a/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
+++ b/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
@@ -19,6 +19,11 @@
 
 #include <mutex>
 
+extern "C"
+{
+#include <libavcodec/defs.h>
+}
+
 using namespace std::chrono_literals;
 
 CAudioSinkAE::CAudioSinkAE(CDVDClock *clock) : m_pClock(clock)
@@ -353,10 +358,10 @@ CAEStreamInfo::DataType CAudioSinkAE::GetPassthroughStreamType(AVCodecID codecId
       break;
 
     case AV_CODEC_ID_DTS:
-      if (profile == FF_PROFILE_DTS_HD_HRA)
+      if (profile == AV_PROFILE_DTS_HD_HRA)
         format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD;
-      else if (profile == FF_PROFILE_DTS_HD_MA || profile == FF_PROFILE_DTS_HD_MA_X ||
-               profile == FF_PROFILE_DTS_HD_MA_X_IMAX)
+      else if (profile == AV_PROFILE_DTS_HD_MA || profile == AV_PROFILE_DTS_HD_MA_X ||
+               profile == AV_PROFILE_DTS_HD_MA_X_IMAX)
         format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD_MA;
       else
         format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD_CORE;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -16,6 +16,11 @@
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
 #include "utils/log.h"
 
+extern "C"
+{
+#include <libavcodec/defs.h>
+}
+
 namespace
 {
 AVPixelFormat ConvertToPixelFormat(const VIDEOCODEC_FORMAT videoFormat)
@@ -125,33 +130,33 @@ bool CAddonVideoCodec::CopyToInitData(VIDEOCODEC_INITDATA &initData, CDVDStreamI
     initData.codec = VIDEOCODEC_H264;
     switch (hints.profile)
     {
-    case 0:
-    case FF_PROFILE_UNKNOWN:
-      initData.codecProfile = STREAMCODEC_PROFILE::CodecProfileUnknown;
-      break;
-    case FF_PROFILE_H264_BASELINE:
-      initData.codecProfile = STREAMCODEC_PROFILE::H264CodecProfileBaseline;
-      break;
-    case FF_PROFILE_H264_MAIN:
-      initData.codecProfile = STREAMCODEC_PROFILE::H264CodecProfileMain;
-      break;
-    case FF_PROFILE_H264_EXTENDED:
-      initData.codecProfile = STREAMCODEC_PROFILE::H264CodecProfileExtended;
-      break;
-    case FF_PROFILE_H264_HIGH:
-      initData.codecProfile = STREAMCODEC_PROFILE::H264CodecProfileHigh;
-      break;
-    case FF_PROFILE_H264_HIGH_10:
-      initData.codecProfile = STREAMCODEC_PROFILE::H264CodecProfileHigh10;
-      break;
-    case FF_PROFILE_H264_HIGH_422:
-      initData.codecProfile = STREAMCODEC_PROFILE::H264CodecProfileHigh422;
-      break;
-    case FF_PROFILE_H264_HIGH_444_PREDICTIVE:
-      initData.codecProfile = STREAMCODEC_PROFILE::H264CodecProfileHigh444Predictive;
-      break;
-    default:
-      return false;
+      case 0:
+      case AV_PROFILE_UNKNOWN:
+        initData.codecProfile = STREAMCODEC_PROFILE::CodecProfileUnknown;
+        break;
+      case AV_PROFILE_H264_BASELINE:
+        initData.codecProfile = STREAMCODEC_PROFILE::H264CodecProfileBaseline;
+        break;
+      case AV_PROFILE_H264_MAIN:
+        initData.codecProfile = STREAMCODEC_PROFILE::H264CodecProfileMain;
+        break;
+      case AV_PROFILE_H264_EXTENDED:
+        initData.codecProfile = STREAMCODEC_PROFILE::H264CodecProfileExtended;
+        break;
+      case AV_PROFILE_H264_HIGH:
+        initData.codecProfile = STREAMCODEC_PROFILE::H264CodecProfileHigh;
+        break;
+      case AV_PROFILE_H264_HIGH_10:
+        initData.codecProfile = STREAMCODEC_PROFILE::H264CodecProfileHigh10;
+        break;
+      case AV_PROFILE_H264_HIGH_422:
+        initData.codecProfile = STREAMCODEC_PROFILE::H264CodecProfileHigh422;
+        break;
+      case AV_PROFILE_H264_HIGH_444_PREDICTIVE:
+        initData.codecProfile = STREAMCODEC_PROFILE::H264CodecProfileHigh444Predictive;
+        break;
+      default:
+        return false;
     }
     break;
   case AV_CODEC_ID_VP8:
@@ -161,43 +166,43 @@ bool CAddonVideoCodec::CopyToInitData(VIDEOCODEC_INITDATA &initData, CDVDStreamI
     initData.codec = VIDEOCODEC_VP9;
     switch (hints.profile)
     {
-    case FF_PROFILE_UNKNOWN:
-      initData.codecProfile = STREAMCODEC_PROFILE::CodecProfileUnknown;
-      break;
-    case FF_PROFILE_VP9_0:
-      initData.codecProfile = STREAMCODEC_PROFILE::VP9CodecProfile0;
-      break;
-    case FF_PROFILE_VP9_1:
-      initData.codecProfile = STREAMCODEC_PROFILE::VP9CodecProfile1;
-      break;
-    case FF_PROFILE_VP9_2:
-      initData.codecProfile = STREAMCODEC_PROFILE::VP9CodecProfile2;
-      break;
-    case FF_PROFILE_VP9_3:
-      initData.codecProfile = STREAMCODEC_PROFILE::VP9CodecProfile3;
-      break;
-    default:
-      return false;
+      case AV_PROFILE_UNKNOWN:
+        initData.codecProfile = STREAMCODEC_PROFILE::CodecProfileUnknown;
+        break;
+      case AV_PROFILE_VP9_0:
+        initData.codecProfile = STREAMCODEC_PROFILE::VP9CodecProfile0;
+        break;
+      case AV_PROFILE_VP9_1:
+        initData.codecProfile = STREAMCODEC_PROFILE::VP9CodecProfile1;
+        break;
+      case AV_PROFILE_VP9_2:
+        initData.codecProfile = STREAMCODEC_PROFILE::VP9CodecProfile2;
+        break;
+      case AV_PROFILE_VP9_3:
+        initData.codecProfile = STREAMCODEC_PROFILE::VP9CodecProfile3;
+        break;
+      default:
+        return false;
     }
     break;
   case AV_CODEC_ID_AV1:
     initData.codec = VIDEOCODEC_AV1;
     switch (hints.profile)
     {
-    case FF_PROFILE_UNKNOWN:
-      initData.codecProfile = STREAMCODEC_PROFILE::CodecProfileUnknown;
-      break;
-    case FF_PROFILE_AV1_MAIN:
-      initData.codecProfile = STREAMCODEC_PROFILE::AV1CodecProfileMain;
-      break;
-    case FF_PROFILE_AV1_HIGH:
-      initData.codecProfile = STREAMCODEC_PROFILE::AV1CodecProfileHigh;
-      break;
-    case FF_PROFILE_AV1_PROFESSIONAL:
-      initData.codecProfile = STREAMCODEC_PROFILE::AV1CodecProfileProfessional;
-      break;
-    default:
-      return false;
+      case AV_PROFILE_UNKNOWN:
+        initData.codecProfile = STREAMCODEC_PROFILE::CodecProfileUnknown;
+        break;
+      case AV_PROFILE_AV1_MAIN:
+        initData.codecProfile = STREAMCODEC_PROFILE::AV1CodecProfileMain;
+        break;
+      case AV_PROFILE_AV1_HIGH:
+        initData.codecProfile = STREAMCODEC_PROFILE::AV1CodecProfileHigh;
+        break;
+      case AV_PROFILE_AV1_PROFESSIONAL:
+        initData.codecProfile = STREAMCODEC_PROFILE::AV1CodecProfileProfessional;
+        break;
+      default:
+        return false;
     }
     break;
   default:

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -28,6 +28,7 @@
 #include <mutex>
 
 extern "C" {
+#include <libavcodec/defs.h>
 #include <libavfilter/avfilter.h>
 #include <libavfilter/buffersink.h>
 #include <libavfilter/buffersrc.h>
@@ -257,8 +258,8 @@ enum AVPixelFormat CDVDVideoCodecFFmpeg::GetFormat(struct AVCodecContext * avctx
   // 2nd condition:
   // fix an ffmpeg issue here, it calls us with an invalid profile
   // then a 2nd call with a valid one
-  if(ctx->m_decoderState != STATE_HW_SINGLE ||
-     (avctx->codec_id == AV_CODEC_ID_VC1 && avctx->profile == FF_PROFILE_UNKNOWN))
+  if (ctx->m_decoderState != STATE_HW_SINGLE ||
+      (avctx->codec_id == AV_CODEC_ID_VC1 && avctx->profile == AV_PROFILE_UNKNOWN))
   {
     AVPixelFormat defaultFmt = avcodec_default_get_format(avctx, fmt);
     pixFmtName = av_get_pix_fmt_name(defaultFmt);
@@ -1037,11 +1038,11 @@ bool CDVDVideoCodecFFmpeg::GetPictureCommon(VideoPicture* pVideoPicture)
   else if (m_pCodecContext->pix_fmt == AV_PIX_FMT_YUV420P10)
     pVideoPicture->colorBits = 10;
   else if (m_pCodecContext->codec_id == AV_CODEC_ID_HEVC &&
-           m_pCodecContext->profile == FF_PROFILE_HEVC_MAIN_10)
+           m_pCodecContext->profile == AV_PROFILE_HEVC_MAIN_10)
     pVideoPicture->colorBits = 10;
   else if (m_pCodecContext->codec_id == AV_CODEC_ID_H264 &&
-           (m_pCodecContext->profile == FF_PROFILE_H264_HIGH_10||
-            m_pCodecContext->profile == FF_PROFILE_H264_HIGH_10_INTRA))
+           (m_pCodecContext->profile == AV_PROFILE_H264_HIGH_10 ||
+            m_pCodecContext->profile == AV_PROFILE_H264_HIGH_10_INTRA))
     pVideoPicture->colorBits = 10;
   else if ((m_pCodecContext->codec_id == AV_CODEC_ID_VP9 ||
             m_pCodecContext->codec_id == AV_CODEC_ID_AV1) &&

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -39,6 +39,11 @@
 #include <initguid.h>
 #include <sdkddkver.h>
 
+extern "C"
+{
+#include <libavcodec/defs.h>
+}
+
 using namespace DXVA;
 using namespace Microsoft::WRL;
 using namespace std::chrono_literals;
@@ -67,20 +72,20 @@ DEFINE_GUID(DXVA_NoEncrypt, 0x1b81beD0, 0xa0c7, 0x11d3, 0xb9, 0x84, 0x00, 0xc0, 
 
 namespace
 {
-constexpr int PROFILES_MPEG2_SIMPLE[] = {FF_PROFILE_MPEG2_SIMPLE, FF_PROFILE_UNKNOWN};
-constexpr int PROFILES_MPEG2_MAIN[] = {FF_PROFILE_MPEG2_SIMPLE, FF_PROFILE_MPEG2_MAIN,
-                                       FF_PROFILE_UNKNOWN};
-constexpr int PROFILES_H264_HIGH[] = {FF_PROFILE_H264_BASELINE,
-                                      FF_PROFILE_H264_CONSTRAINED_BASELINE, FF_PROFILE_H264_MAIN,
-                                      FF_PROFILE_H264_HIGH, FF_PROFILE_UNKNOWN};
-constexpr int PROFILES_HEVC_MAIN[] = {FF_PROFILE_HEVC_MAIN, FF_PROFILE_UNKNOWN};
-constexpr int PROFILES_HEVC_MAIN10[] = {FF_PROFILE_HEVC_MAIN, FF_PROFILE_HEVC_MAIN_10,
-                                        FF_PROFILE_UNKNOWN};
-constexpr int PROFILES_VP9_0[] = {FF_PROFILE_VP9_0, FF_PROFILE_UNKNOWN};
-constexpr int PROFILES_VP9_10_2[] = {FF_PROFILE_VP9_2, FF_PROFILE_UNKNOWN};
-constexpr int PROFILES_AV1_MAIN[] = {FF_PROFILE_AV1_MAIN, FF_PROFILE_UNKNOWN};
-constexpr int PROFILES_AV1_HIGH[] = {FF_PROFILE_AV1_HIGH, FF_PROFILE_UNKNOWN};
-constexpr int PROFILES_AV1_PROFESSIONAL[] = {FF_PROFILE_AV1_PROFESSIONAL, FF_PROFILE_UNKNOWN};
+constexpr int PROFILES_MPEG2_SIMPLE[] = {AV_PROFILE_MPEG2_SIMPLE, AV_PROFILE_UNKNOWN};
+constexpr int PROFILES_MPEG2_MAIN[] = {AV_PROFILE_MPEG2_SIMPLE, AV_PROFILE_MPEG2_MAIN,
+                                       AV_PROFILE_UNKNOWN};
+constexpr int PROFILES_H264_HIGH[] = {AV_PROFILE_H264_BASELINE,
+                                      AV_PROFILE_H264_CONSTRAINED_BASELINE, AV_PROFILE_H264_MAIN,
+                                      AV_PROFILE_H264_HIGH, AV_PROFILE_UNKNOWN};
+constexpr int PROFILES_HEVC_MAIN[] = {AV_PROFILE_HEVC_MAIN, AV_PROFILE_UNKNOWN};
+constexpr int PROFILES_HEVC_MAIN10[] = {AV_PROFILE_HEVC_MAIN, AV_PROFILE_HEVC_MAIN_10,
+                                        AV_PROFILE_UNKNOWN};
+constexpr int PROFILES_VP9_0[] = {AV_PROFILE_VP9_0, AV_PROFILE_UNKNOWN};
+constexpr int PROFILES_VP9_10_2[] = {AV_PROFILE_VP9_2, AV_PROFILE_UNKNOWN};
+constexpr int PROFILES_AV1_MAIN[] = {AV_PROFILE_AV1_MAIN, AV_PROFILE_UNKNOWN};
+constexpr int PROFILES_AV1_HIGH[] = {AV_PROFILE_AV1_HIGH, AV_PROFILE_UNKNOWN};
+constexpr int PROFILES_AV1_PROFESSIONAL[] = {AV_PROFILE_AV1_PROFESSIONAL, AV_PROFILE_UNKNOWN};
 } // namespace
 
 typedef struct
@@ -462,10 +467,10 @@ bool CContext::GetFormatAndConfig(AVCodecContext* avctx, D3D11_VIDEO_DECODER_DES
       supported = false;
       if (mode.profiles == nullptr)
         supported = true;
-      else if (avctx->profile == FF_PROFILE_UNKNOWN)
+      else if (avctx->profile == AV_PROFILE_UNKNOWN)
         supported = true;
       else
-        for (const int* pProfile = &mode.profiles[0]; *pProfile != FF_PROFILE_UNKNOWN; ++pProfile)
+        for (const int* pProfile = &mode.profiles[0]; *pProfile != AV_PROFILE_UNKNOWN; ++pProfile)
         {
           if (*pProfile == avctx->profile)
           {
@@ -484,9 +489,9 @@ bool CContext::GetFormatAndConfig(AVCodecContext* avctx, D3D11_VIDEO_DECODER_DES
     {
       bool bHighBits =
           (avctx->codec_id == AV_CODEC_ID_HEVC && (avctx->sw_pix_fmt == AV_PIX_FMT_YUV420P10 ||
-                                                   avctx->profile == FF_PROFILE_HEVC_MAIN_10)) ||
+                                                   avctx->profile == AV_PROFILE_HEVC_MAIN_10)) ||
           (avctx->codec_id == AV_CODEC_ID_VP9 &&
-           (avctx->sw_pix_fmt == AV_PIX_FMT_YUV420P10 || avctx->profile == FF_PROFILE_VP9_2)) ||
+           (avctx->sw_pix_fmt == AV_PIX_FMT_YUV420P10 || avctx->profile == AV_PROFILE_VP9_2)) ||
           (avctx->codec_id == AV_CODEC_ID_AV1 && avctx->sw_pix_fmt == AV_PIX_FMT_YUV420P10);
 
       if (bHighBits && render_targets_dxgi[j] < DXGI_FORMAT_P010)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
@@ -23,7 +23,7 @@ std::string CDemuxStreamAudio::GetStreamType()
       break;
     case AV_CODEC_ID_EAC3:
     {
-      if (profile == FF_PROFILE_EAC3_DDP_ATMOS)
+      if (profile == AV_PROFILE_EAC3_DDP_ATMOS)
         strInfo = "DD+ ATMOS";
       else
         strInfo = "DD+";
@@ -33,25 +33,25 @@ std::string CDemuxStreamAudio::GetStreamType()
     {
       switch (profile)
       {
-        case FF_PROFILE_DTS_96_24:
+        case AV_PROFILE_DTS_96_24:
           strInfo = "DTS 96/24";
           break;
-        case FF_PROFILE_DTS_ES:
+        case AV_PROFILE_DTS_ES:
           strInfo = "DTS ES";
           break;
-        case FF_PROFILE_DTS_EXPRESS:
+        case AV_PROFILE_DTS_EXPRESS:
           strInfo = "DTS EXPRESS";
           break;
-        case FF_PROFILE_DTS_HD_MA:
+        case AV_PROFILE_DTS_HD_MA:
           strInfo = "DTS-HD MA";
           break;
-        case FF_PROFILE_DTS_HD_HRA:
+        case AV_PROFILE_DTS_HD_HRA:
           strInfo = "DTS-HD HRA";
           break;
-        case FF_PROFILE_DTS_HD_MA_X:
+        case AV_PROFILE_DTS_HD_MA_X:
           strInfo = "DTS-HD MA X";
           break;
-        case FF_PROFILE_DTS_HD_MA_X_IMAX:
+        case AV_PROFILE_DTS_HD_MA_X_IMAX:
           strInfo = "DTS-HD MA X (IMAX)";
           break;
         default:
@@ -67,7 +67,7 @@ std::string CDemuxStreamAudio::GetStreamType()
       strInfo = "MP3";
       break;
     case AV_CODEC_ID_TRUEHD:
-      if (profile == FF_PROFILE_TRUEHD_ATMOS)
+      if (profile == AV_PROFILE_TRUEHD_ATMOS)
         strInfo = "TrueHD ATMOS";
       else
         strInfo = "TrueHD";
@@ -76,21 +76,21 @@ std::string CDemuxStreamAudio::GetStreamType()
     {
       switch (profile)
       {
-        case FF_PROFILE_AAC_LOW:
-        case FF_PROFILE_MPEG2_AAC_LOW:
+        case AV_PROFILE_AAC_LOW:
+        case AV_PROFILE_MPEG2_AAC_LOW:
           strInfo = "AAC-LC";
           break;
-        case FF_PROFILE_AAC_HE:
-        case FF_PROFILE_MPEG2_AAC_HE:
+        case AV_PROFILE_AAC_HE:
+        case AV_PROFILE_MPEG2_AAC_HE:
           strInfo = "HE-AAC";
           break;
-        case FF_PROFILE_AAC_HE_V2:
+        case AV_PROFILE_AAC_HE_V2:
           strInfo = "HE-AACv2";
           break;
-        case FF_PROFILE_AAC_SSR:
+        case AV_PROFILE_AAC_SSR:
           strInfo = "AAC-SSR";
           break;
-        case FF_PROFILE_AAC_LTP:
+        case AV_PROFILE_AAC_LTP:
           strInfo = "AAC-LTP";
           break;
         default:

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -33,6 +33,7 @@ class IAddonProvider;
 extern "C"
 {
 #include <libavcodec/avcodec.h>
+#include <libavcodec/defs.h>
 #include <libavutil/dovi_meta.h>
 #include <libavutil/mastering_display_metadata.h>
 }
@@ -78,8 +79,8 @@ public:
     dvdNavId = 0;
     demuxerId = -1;
     codec_fourcc = 0;
-    profile = FF_PROFILE_UNKNOWN;
-    level = FF_LEVEL_UNKNOWN;
+    profile = AV_PROFILE_UNKNOWN;
+    level = AV_LEVEL_UNKNOWN;
     type = STREAM_NONE;
     source = STREAM_SOURCE_NONE;
     iDuration = 0;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -20,6 +20,11 @@
 #include <type_traits>
 #include <utility>
 
+extern "C"
+{
+#include <libavcodec/defs.h>
+}
+
 class CDemuxStreamClientInternal
 {
 public:
@@ -207,7 +212,7 @@ bool CDVDDemuxClient::ParsePacket(DemuxPacket* pkt)
   if (len >= 0)
   {
     if (stream->m_context->profile != st->profile &&
-        stream->m_context->profile != FF_PROFILE_UNKNOWN)
+        stream->m_context->profile != AV_PROFILE_UNKNOWN)
     {
       CLog::Log(LOGDEBUG, "CDVDDemuxClient::ParsePacket - ({}) profile changed from {} to {}", st->uniqueId, st->profile, stream->m_context->profile);
       st->profile = stream->m_context->profile;
@@ -215,8 +220,7 @@ bool CDVDDemuxClient::ParsePacket(DemuxPacket* pkt)
       st->disabled = false;
     }
 
-    if (stream->m_context->level != st->level &&
-        stream->m_context->level != FF_LEVEL_UNKNOWN)
+    if (stream->m_context->level != st->level && stream->m_context->level != AV_LEVEL_UNKNOWN)
     {
       CLog::Log(LOGDEBUG, "CDVDDemuxClient::ParsePacket - ({}) level changed from {} to {}", st->uniqueId, st->level, stream->m_context->level);
       st->level = stream->m_context->level;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -26,6 +26,11 @@
 
 #include <memory>
 
+extern "C"
+{
+#include <libavcodec/defs.h>
+}
+
 CInputStreamProvider::CInputStreamProvider(const ADDON::AddonInfoPtr& addonInfo,
                                            KODI_HANDLE parentInstance)
   : m_addonInfo(addonInfo), m_parentInstance(parentInstance)
@@ -707,35 +712,35 @@ int CInputStreamAddon::ConvertVideoCodecProfile(STREAMCODEC_PROFILE profile)
   switch (profile)
   {
   case H264CodecProfileBaseline:
-    return FF_PROFILE_H264_BASELINE;
+    return AV_PROFILE_H264_BASELINE;
   case H264CodecProfileMain:
-    return FF_PROFILE_H264_MAIN;
+    return AV_PROFILE_H264_MAIN;
   case H264CodecProfileExtended:
-    return FF_PROFILE_H264_EXTENDED;
+    return AV_PROFILE_H264_EXTENDED;
   case H264CodecProfileHigh:
-    return FF_PROFILE_H264_HIGH;
+    return AV_PROFILE_H264_HIGH;
   case H264CodecProfileHigh10:
-    return FF_PROFILE_H264_HIGH_10;
+    return AV_PROFILE_H264_HIGH_10;
   case H264CodecProfileHigh422:
-    return FF_PROFILE_H264_HIGH_422;
+    return AV_PROFILE_H264_HIGH_422;
   case H264CodecProfileHigh444Predictive:
-    return FF_PROFILE_H264_HIGH_444_PREDICTIVE;
+    return AV_PROFILE_H264_HIGH_444_PREDICTIVE;
   case VP9CodecProfile0:
-    return FF_PROFILE_VP9_0;
+    return AV_PROFILE_VP9_0;
   case VP9CodecProfile1:
-    return FF_PROFILE_VP9_1;
+    return AV_PROFILE_VP9_1;
   case VP9CodecProfile2:
-    return FF_PROFILE_VP9_2;
+    return AV_PROFILE_VP9_2;
   case VP9CodecProfile3:
-    return FF_PROFILE_VP9_3;
+    return AV_PROFILE_VP9_3;
   case AV1CodecProfileMain:
-    return FF_PROFILE_AV1_MAIN;
+    return AV_PROFILE_AV1_MAIN;
   case AV1CodecProfileHigh:
-    return FF_PROFILE_AV1_HIGH;
+    return AV_PROFILE_AV1_HIGH;
   case AV1CodecProfileProfessional:
-    return FF_PROFILE_AV1_PROFESSIONAL;
+    return AV_PROFILE_AV1_PROFESSIONAL;
   default:
-    return FF_PROFILE_UNKNOWN;
+    return AV_PROFILE_UNKNOWN;
   }
 }
 
@@ -744,45 +749,45 @@ int CInputStreamAddon::ConvertAudioCodecProfile(STREAMCODEC_PROFILE profile)
   switch (profile)
   {
     case AACCodecProfileMAIN:
-      return FF_PROFILE_AAC_MAIN;
+      return AV_PROFILE_AAC_MAIN;
     case AACCodecProfileLOW:
-      return FF_PROFILE_AAC_LOW;
+      return AV_PROFILE_AAC_LOW;
     case AACCodecProfileSSR:
-      return FF_PROFILE_AAC_SSR;
+      return AV_PROFILE_AAC_SSR;
     case AACCodecProfileLTP:
-      return FF_PROFILE_AAC_LTP;
+      return AV_PROFILE_AAC_LTP;
     case AACCodecProfileHE:
-      return FF_PROFILE_AAC_HE;
+      return AV_PROFILE_AAC_HE;
     case AACCodecProfileHEV2:
-      return FF_PROFILE_AAC_HE_V2;
+      return AV_PROFILE_AAC_HE_V2;
     case AACCodecProfileLD:
-      return FF_PROFILE_AAC_LD;
+      return AV_PROFILE_AAC_LD;
     case AACCodecProfileELD:
-      return FF_PROFILE_AAC_ELD;
+      return AV_PROFILE_AAC_ELD;
     case MPEG2AACCodecProfileLOW:
-      return FF_PROFILE_MPEG2_AAC_LOW;
+      return AV_PROFILE_MPEG2_AAC_LOW;
     case MPEG2AACCodecProfileHE:
-      return FF_PROFILE_MPEG2_AAC_HE;
+      return AV_PROFILE_MPEG2_AAC_HE;
     case DTSCodecProfile:
-      return FF_PROFILE_DTS;
+      return AV_PROFILE_DTS;
     case DTSCodecProfileES:
-      return FF_PROFILE_DTS_ES;
+      return AV_PROFILE_DTS_ES;
     case DTSCodecProfile9624:
-      return FF_PROFILE_DTS_96_24;
+      return AV_PROFILE_DTS_96_24;
     case DTSCodecProfileHDHRA:
-      return FF_PROFILE_DTS_HD_HRA;
+      return AV_PROFILE_DTS_HD_HRA;
     case DTSCodecProfileHDMA:
-      return FF_PROFILE_DTS_HD_MA;
+      return AV_PROFILE_DTS_HD_MA;
     case DTSCodecProfileHDExpress:
-      return FF_PROFILE_DTS_EXPRESS;
+      return AV_PROFILE_DTS_EXPRESS;
     case DTSCodecProfileHDMAX:
-      return FF_PROFILE_DTS_HD_MA_X;
+      return AV_PROFILE_DTS_HD_MA_X;
     case DTSCodecProfileHDMAIMAX:
-      return FF_PROFILE_DTS_HD_MA_X_IMAX;
+      return AV_PROFILE_DTS_HD_MA_X_IMAX;
     case DDPlusCodecProfileAtmos:
-      return FF_PROFILE_EAC3_DDP_ATMOS;
+      return AV_PROFILE_EAC3_DDP_ATMOS;
     default:
-      return FF_PROFILE_UNKNOWN;
+      return AV_PROFILE_UNKNOWN;
   }
 }
 

--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -22,6 +22,11 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
+extern "C"
+{
+#include <libavcodec/defs.h>
+}
+
 VideoPlayerCodec::VideoPlayerCodec() : m_processInfo(CProcessInfo::CreateInstance())
 {
   m_CodecName = "VideoPlayer";
@@ -492,10 +497,10 @@ CAEStreamInfo::DataType VideoPlayerCodec::GetPassthroughStreamType(AVCodecID cod
       break;
 
     case AV_CODEC_ID_DTS:
-      if (profile == FF_PROFILE_DTS_HD_HRA)
+      if (profile == AV_PROFILE_DTS_HD_HRA)
         format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD;
-      else if (profile == FF_PROFILE_DTS_HD_MA || profile == FF_PROFILE_DTS_HD_MA_X ||
-               profile == FF_PROFILE_DTS_HD_MA_X_IMAX)
+      else if (profile == AV_PROFILE_DTS_HD_MA || profile == AV_PROFILE_DTS_HD_MA_X ||
+               profile == AV_PROFILE_DTS_HD_MA_X_IMAX)
         format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD_MA;
       else
         format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD_CORE;

--- a/xbmc/utils/StreamUtils.cpp
+++ b/xbmc/utils/StreamUtils.cpp
@@ -11,7 +11,7 @@
 extern "C"
 {
 #include <libavcodec/avcodec.h>
-#include <libavformat/avformat.h>
+#include <libavcodec/defs.h>
 }
 
 int StreamUtils::GetCodecPriority(const std::string &codec)
@@ -43,13 +43,13 @@ std::string StreamUtils::GetCodecName(int codecId, int profile)
 
   if (codecId == AV_CODEC_ID_DTS)
   {
-    if (profile == FF_PROFILE_DTS_HD_MA)
+    if (profile == AV_PROFILE_DTS_HD_MA)
       codecName = "dtshd_ma";
-    else if (profile == FF_PROFILE_DTS_HD_MA_X)
+    else if (profile == AV_PROFILE_DTS_HD_MA_X)
       codecName = "dtshd_ma_x";
-    else if (profile == FF_PROFILE_DTS_HD_MA_X_IMAX)
+    else if (profile == AV_PROFILE_DTS_HD_MA_X_IMAX)
       codecName = "dtshd_ma_x_imax";
-    else if (profile == FF_PROFILE_DTS_HD_HRA)
+    else if (profile == AV_PROFILE_DTS_HD_HRA)
       codecName = "dtshd_hra";
     else
       codecName = "dca";
@@ -61,21 +61,21 @@ std::string StreamUtils::GetCodecName(int codecId, int profile)
   {
     switch (profile)
     {
-      case FF_PROFILE_AAC_LOW:
-      case FF_PROFILE_MPEG2_AAC_LOW:
+      case AV_PROFILE_AAC_LOW:
+      case AV_PROFILE_MPEG2_AAC_LOW:
         codecName = "aac_lc";
         break;
-      case FF_PROFILE_AAC_HE:
-      case FF_PROFILE_MPEG2_AAC_HE:
+      case AV_PROFILE_AAC_HE:
+      case AV_PROFILE_MPEG2_AAC_HE:
         codecName = "he_aac";
         break;
-      case FF_PROFILE_AAC_HE_V2:
+      case AV_PROFILE_AAC_HE_V2:
         codecName = "he_aac_v2";
         break;
-      case FF_PROFILE_AAC_SSR:
+      case AV_PROFILE_AAC_SSR:
         codecName = "aac_ssr";
         break;
-      case FF_PROFILE_AAC_LTP:
+      case AV_PROFILE_AAC_LTP:
         codecName = "aac_ltp";
         break;
       default:


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Use the AV_PROFILE_* constants instead of the deprecated FF_PROFILE_*, as indicated in avcodec.h
The constants have the same value so no behaviour change expected.

ffmpeg headers inclusion is already inconsistent, fixing that is not the purpose of the PR.
avcodec.h includes defs.h where the new constants are defined > build doesn't break.
I could add a defs.h inclusion to the Kodi files using the new constants if it is thought to be an improvement.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Code modernization.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Builds/runs.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
