### PR TITLE
[FileItemList] Factor out manual index iteration while removing items into a common function.

### DIFF
--- a/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
@@ -312,30 +312,25 @@ bool CGUIWindowAddonBrowser::GetDirectory(const std::string& strDirectory, CFile
         CServiceBroker::GetSettingsComponent()->GetSettings();
     if (settings->GetBool(CSettings::SETTING_GENERAL_ADDONFOREIGNFILTER))
     {
-      int i = 0;
-      while (i < items.Size())
-      {
-        auto prop = items[i]->GetProperty("Addon.Language");
-        if (!prop.isNull() && IsForeign(prop.asString()))
-          items.Remove(i);
-        else
-          ++i;
-      }
+      items.erase_if(
+          [](const CFileItemPtr& item)
+          {
+            auto prop = item->GetProperty("Addon.Language");
+            return !prop.isNull() && IsForeign(prop.asString());
+          });
     }
     if (settings->GetBool(CSettings::SETTING_GENERAL_ADDONBROKENFILTER))
     {
-      for (int i = items.Size() - 1; i >= 0; i--)
-      {
-        if (items[i]->GetAddonInfo() &&
-            items[i]->GetAddonInfo()->LifecycleState() == AddonLifecycleState::BROKEN)
-        {
-          //check if it's installed
-          AddonPtr addon;
-          if (!CServiceBroker::GetAddonMgr().GetAddon(items[i]->GetProperty("Addon.ID").asString(),
-                                                      addon, OnlyEnabled::CHOICE_YES))
-            items.Remove(i);
-        }
-      }
+      items.erase_if(
+          [](const CFileItemPtr& item)
+          {
+            AddonPtr addon;
+            //check if it's installed
+            return item->GetAddonInfo() &&
+                   item->GetAddonInfo()->LifecycleState() == AddonLifecycleState::BROKEN &&
+                   !CServiceBroker::GetAddonMgr().GetAddon(item->GetProperty("Addon.ID").asString(),
+                                                           addon, OnlyEnabled::CHOICE_YES);
+          });
     }
   }
 

--- a/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
@@ -128,13 +128,13 @@ bool CSavestateDatabase::GetSavestatesNav(CFileItemList& items,
 
   if (!gameClient.empty())
   {
-    for (int i = items.Size() - 1; i >= 0; i--)
-    {
-      std::unique_ptr<ISavestate> save = AllocateSavestate();
-      GetSavestate(items[i]->GetPath(), *save);
-      if (save->GameClientID() != gameClient)
-        items.Remove(i);
-    }
+    items.erase_if(
+        [this, &gameClient](const CFileItemPtr& item)
+        {
+          std::unique_ptr<ISavestate> save = AllocateSavestate();
+          GetSavestate(item->GetPath(), *save);
+          return save->GameClientID() != gameClient;
+        });
   }
 
   for (int i = 0; i < items.Size(); i++)

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -410,12 +410,7 @@ void CGUIDialogFileBrowser::Update(const std::string &strDirectory)
   // some evil stuff don't work with the '/' mask, e.g. shoutcast directory - make sure no files are in there
   if (m_browsingForFolders)
   {
-    for (int i=0;i<m_vecItems->Size();++i)
-      if (!(*m_vecItems)[i]->IsFolder())
-      {
-        m_vecItems->Remove(i);
-        i--;
-      }
+    m_vecItems->erase_if([](const CFileItemPtr& item) { return !item->IsFolder(); });
   }
 
   // No need to set thumbs

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -258,28 +258,15 @@ bool CDirectory::GetDirectory(const CURL& url,
     if (!pDirectory->AllowAll())
     {
       pDirectory->SetMask(hints.mask);
-      for (int i = 0; i < items.Size(); ++i)
-      {
-        CFileItemPtr item = items[i];
-        if (!item->IsFolder() && !pDirectory->IsAllowed(item->GetURL()))
-        {
-          items.Remove(i);
-          i--; // don't confuse loop
-        }
-      }
+      items.erase_if([&pDirectory](const CFileItemPtr& item)
+                     { return !item->IsFolder() && !pDirectory->IsAllowed(item->GetURL()); });
     }
     // filter hidden files
     //! @todo we shouldn't be checking the gui setting here, callers should use getHidden instead
     if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_SHOWHIDDEN) && !(hints.flags & DIR_FLAG_GET_HIDDEN))
     {
-      for (int i = 0; i < items.Size(); ++i)
-      {
-        if (items[i]->GetProperty("file:hidden").asBoolean())
-        {
-          items.Remove(i);
-          i--; // don't confuse loop
-        }
-      }
+      items.erase_if([](const CFileItemPtr& item)
+                     { return item->GetProperty("file:hidden").asBoolean(); });
     }
 
     //  Should any of the files we read be treated as a directory?

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -599,11 +599,8 @@ int PlayOrQueueMedia(const std::vector<std::string>& params,
           playlistId = PLAYLIST::Id::TYPE_MUSIC;
         else
         {
-          for (int i = items.Size() - 1; i >= 0; i--) //remove music entries
-          {
-            if (!VIDEO::IsVideo(*items[i]))
-              items.Remove(i);
-          }
+          //remove music entries
+          items.erase_if([](const CFileItemPtr& item) { return !VIDEO::IsVideo(*item); });
         }
       }
 

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -917,12 +917,12 @@ NPT_Result CUPnPServer::BuildResponse(PLT_ActionReference& action,
   // this isn't pretty but needed to properly hide the addons node from clients
   if (StringUtils::StartsWith(items.GetPath(), "library"))
   {
-    for (int i = 0; i < items.Size(); i++)
-    {
-      if (StringUtils::StartsWith(items[i]->GetPath(), "addons") ||
-          StringUtils::EndsWith(items[i]->GetPath(), "/addons.xml/"))
-        items.Remove(i);
-    }
+    items.erase_if(
+        [](const CFileItemPtr& item)
+        {
+          return StringUtils::StartsWith(item->GetPath(), "addons") ||
+                 StringUtils::EndsWith(item->GetPath(), "/addons.xml/");
+        });
   }
 
   // won't return more than UPNP_MAX_RETURNED_ITEMS items at a time to keep things smooth

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -191,9 +191,8 @@ void CGUIWindowPictures::OnPrepareFileItems(CFileItemList& items)
 {
   CGUIMediaWindow::OnPrepareFileItems(items);
 
-  for (int i=0;i<items.Size();++i )
-    if (StringUtils::EqualsNoCase(items[i]->GetLabel(), "folder.jpg"))
-      items.Remove(i);
+  items.erase_if([](const CFileItemPtr& item)
+                 { return StringUtils::EqualsNoCase(item->GetLabel(), "folder.jpg"); });
 
   if (items.GetFolderCount() == items.Size() || !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_PICTURES_USETAGS))
     return;

--- a/xbmc/pictures/PictureFolderImageFileLoader.cpp
+++ b/xbmc/pictures/PictureFolderImageFileLoader.cpp
@@ -37,16 +37,10 @@ std::unique_ptr<CTexture> CPictureFolderImageFileLoader::Load(
                            CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(),
                            DIR_FLAG_NO_FILE_DIRS);
 
-  for (int i = 0; i < imagesInFolder.Size();)
-  {
-    if (!imagesInFolder[i]->IsPicture() || imagesInFolder[i]->IsZIP() ||
-        imagesInFolder[i]->IsRAR() || PLAYLIST::IsPlayList(*imagesInFolder[i]))
-    {
-      imagesInFolder.Remove(i);
-    }
-    else
-      i++;
-  }
+  imagesInFolder.erase_if(
+      [](const CFileItemPtr& item) {
+        return !item->IsPicture() || item->IsZIP() || item->IsRAR() || PLAYLIST::IsPlayList(*item);
+      });
   if (imagesInFolder.IsEmpty())
   {
     return {};

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -165,16 +165,11 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
       // create the folder thumb by choosing 4 random thumbs within the folder and putting
       // them into one thumb.
       // count the number of images
-      for (int i=0; i < items.Size();)
-      {
-        if (!items[i]->IsPicture() || items[i]->IsZIP() || items[i]->IsRAR() ||
-            PLAYLIST::IsPlayList(*items[i]))
-        {
-          items.Remove(i);
-        }
-        else
-          i++;
-      }
+      items.erase_if(
+          [](const CFileItemPtr& item) {
+            return !item->IsPicture() || item->IsZIP() || item->IsRAR() ||
+                   PLAYLIST::IsPlayList(*item);
+          });
 
       if (items.IsEmpty())
       {

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -2048,19 +2048,9 @@ bool CGUIDialogVideoInfo::LinkMovieToTvShow(const std::shared_ptr<CFileItem>& it
     if (!database.GetLinksToTvShow(dbId, ids))
       return false;
 
-    for (int i = 0; i < list.Size(); )
-    {
-      size_t j;
-      for (j = 0; j < ids.size(); ++j)
-      {
-        if (list[i]->GetVideoInfoTag()->m_iDbId == ids[j])
-          break;
-      }
-      if (j == ids.size())
-        i++;
-      else
-        list.Remove(i);
-    }
+    list.erase_if(
+        [&ids](const CFileItemPtr& item)
+        { return std::ranges::find(ids, item->GetVideoInfoTag()->m_iDbId) != ids.end(); });
   }
 
   int iSelectedLabel = 0;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -804,16 +804,8 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
   if (iWindow == WINDOW_PICTURES)
     regexps = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_pictureExcludeFromListingRegExps;
 
-  if (!regexps.empty())
-  {
-    for (int i=0; i < items.Size();)
-    {
-      if (CUtil::ExcludeFileOrFolder(items[i]->GetPath(), regexps))
-        items.Remove(i);
-      else
-        i++;
-    }
-  }
+  items.erase_if([&regexps](const CFileItemPtr& item)
+                 { return CUtil::ExcludeFileOrFolder(item->GetPath(), regexps); });
 
   // clear the filter
   SetProperty("filter", "");


### PR DESCRIPTION

## Description
Factored out common code for filtering of items from a `CFileItemList` and guarded against the issues described below.
Changed the existing use cases of filtering to use this method where it was easy to do so.

## Motivation and context
`FileItemList` has a mutex which implies that these object can be shared across threads. When iterating over the items of the list the state of the iteration may be invalidated by another thread. The lock must be held while the iteration is in progress.

```
int index = 0;
while (index < items.Size())
{
    foo( items[index] ); // index may now be invalid
    ++index;
}
```

Moreover, when removing from a container with indicies like this then care must be taken to ensure that the index is not corrupted by the act of removal.

```
int index = 0;
while (index < items.Size())
{
    if (TestCondition(items[index]))
        items.Remove(index);
    ++index; // index is not as expected if the removal happened.
}
```

Most usages get this 2nd logic correct but it is still error-prone. It is a bad interface to enforce on the users of `CFileItemList`.

## How has this been tested?
Building
Existing test suite

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
