### PR TITLE
Move CAlbum::ReleaseType to it's own class, rename to AudioType and update codebase accordingly

### DIFF
--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -23,14 +23,6 @@
 
 using namespace MUSIC_INFO;
 
-struct ReleaseTypeInfo
-{
-  ReleaseType type;
-  std::string name;
-};
-
-ReleaseTypeInfo releaseTypes[] = {{ReleaseType::Album, "album"}, {ReleaseType::Single, "single"}};
-
 CAlbum::CAlbum(const CFileItem& item)
 {
   Reset();
@@ -396,7 +388,7 @@ std::string CAlbum::GetAlbumArtistSort() const
   return artistString;
 }
 
-std::vector<int> CAlbum::GetArtistIDArray() const
+const std::vector<int> CAlbum::GetArtistIDArray() const
 {
   // Get album artist IDs for json rpc
   std::vector<int> artistids;
@@ -407,12 +399,12 @@ std::vector<int> CAlbum::GetArtistIDArray() const
 
 std::string CAlbum::GetReleaseType() const
 {
-  return ReleaseTypeToString(releaseType);
+  return AudioType::ToString(releaseType);
 }
 
 void CAlbum::SetReleaseType(const std::string& strReleaseType)
 {
-  releaseType = ReleaseTypeFromString(strReleaseType);
+  releaseType = AudioType::FromString(strReleaseType);
 }
 
 void CAlbum::SetDateAdded(const std::string& strDateAdded)
@@ -433,28 +425,6 @@ void CAlbum::SetDateNew(const std::string& strDateNew)
 void CAlbum::SetLastPlayed(const std::string& strLastPlayed)
 {
   lastPlayed.SetFromDBDateTime(strLastPlayed);
-}
-
-std::string CAlbum::ReleaseTypeToString(ReleaseType releaseType)
-{
-  for (const ReleaseTypeInfo& releaseTypeInfo : releaseTypes)
-  {
-    if (releaseTypeInfo.type == releaseType)
-      return releaseTypeInfo.name;
-  }
-
-  return "album";
-}
-
-ReleaseType CAlbum::ReleaseTypeFromString(const std::string& strReleaseType)
-{
-  for (const ReleaseTypeInfo& releaseTypeInfo : releaseTypes)
-  {
-    if (releaseTypeInfo.name == strReleaseType)
-      return releaseTypeInfo.type;
-  }
-
-  return ReleaseType::Album;
 }
 
 bool CAlbum::operator<(const CAlbum &a) const
@@ -597,8 +567,7 @@ bool CAlbum::Load(const TiXmlElement *album, bool append, bool prioritise)
   if (XMLUtils::GetString(album, "releasetype", strReleaseType))
     SetReleaseType(strReleaseType);
   else
-    releaseType = ReleaseType::Album;
-
+    releaseType = AudioType::Type::Album;
   return true;
 }
 

--- a/xbmc/music/Album.h
+++ b/xbmc/music/Album.h
@@ -14,6 +14,7 @@
 */
 
 #include "Artist.h"
+#include "AudioType.h"
 #include "Song.h"
 #include "XBDateTime.h"
 #include "utils/Artwork.h"
@@ -73,7 +74,7 @@ public:
     lastPlayed.Reset();
     iTotalDiscs = -1;
     songs.clear();
-    releaseType = ReleaseType::Album;
+    releaseType = AudioType::Type::Album;
     strLastScraped.clear();
     bScrapedMBID = false;
     bArtistSongMerge = false;
@@ -106,7 +107,8 @@ public:
   /*! \brief Get album artist IDs (for json rpc) from the vector of artistcredits objects
   \return album artist IDs as a vector of integers
   */
-  std::vector<int> GetArtistIDArray() const;
+
+  const std::vector<int> GetArtistIDArray() const;
 
   std::string GetReleaseType() const;
   void SetReleaseType(const std::string& strReleaseType);
@@ -114,9 +116,6 @@ public:
   void SetDateUpdated(const std::string& strDateUpdated);
   void SetDateNew(const std::string& strDateNew);
   void SetLastPlayed(const std::string& strLastPlayed);
-
-  static std::string ReleaseTypeToString(ReleaseType releaseType);
-  static ReleaseType ReleaseTypeFromString(const std::string& strReleaseType);
 
   /*! \brief Set album artist credits using the arrays of tag values.
    If strArtistSort (as from ALBUMARTISTSORT tag) is already set then individual
@@ -176,7 +175,7 @@ public:
   CDateTime lastPlayed;
   int iTotalDiscs = -1;
   std::vector<CSong> songs; ///< Local songs
-  ReleaseType releaseType = ReleaseType::Album;
+  AudioType::Type releaseType = AudioType::Type::Album;
   std::string strLastScraped;
   bool bScrapedMBID = false;
   bool bArtistSongMerge = false;

--- a/xbmc/music/AudioType.h
+++ b/xbmc/music/AudioType.h
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+class AudioType
+{
+public:
+  enum class Type : uint8_t
+  {
+    Album = 0,
+    Single,
+    AudioBook
+  };
+
+  static Type FromString(const std::string_view str)
+  {
+    for (const auto& info : releaseTypes)
+      if (str == info.name)
+        return info.type;
+    return Type::Album; // default fallback
+  }
+
+  static std::string ToString(Type type)
+  {
+    for (const auto& info : releaseTypes)
+      if (info.type == type)
+        return info.name;
+    return "album"; // default fallback
+  }
+
+private:
+  struct ReleaseTypeInfo
+  {
+    Type type;
+    const char* name;
+  };
+
+  static constexpr ReleaseTypeInfo releaseTypes[] = {
+      {Type::Album, "album"}, {Type::Single, "single"}, {Type::AudioBook, "audiobook"}};
+};

--- a/xbmc/music/CMakeLists.txt
+++ b/xbmc/music/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES Album.cpp
 
 set(HEADERS Album.h
             Artist.h
+            AudioType.h
             ContextMenus.h
             GUIViewStateMusic.h
             MusicDatabase.h

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -1425,7 +1425,7 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum,
                              const std::string& strType,
                              const std::string& strReleaseStatus,
                              bool bCompilation,
-                             ReleaseType releaseType)
+                             AudioType::Type releaseType)
 {
   std::string strSQL;
   try
@@ -1462,7 +1462,7 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum,
                      strAlbum.c_str(), strArtist.c_str(), strGenre.c_str(), //
                      strReleaseDate.c_str(), strOrigReleaseDate.c_str(), bBoxedSet, //
                      strRecordLabel.c_str(), strType.c_str(), strReleaseStatus.c_str(), //
-                     bCompilation, CAlbum::ReleaseTypeToString(releaseType).c_str());
+                     bCompilation, AudioType::ToString(releaseType).c_str());
 
       if (strMusicBrainzAlbumID.empty())
         strSQL += PrepareSQL(", NULL");
@@ -1516,7 +1516,7 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum,
                      "WHERE idAlbum=%i",
                      strGenre.c_str(), strReleaseDate.c_str(), strOrigReleaseDate.c_str(), //
                      bBoxedSet, strRecordLabel.c_str(), strType.c_str(), strReleaseStatus.c_str(),
-                     bCompilation, CAlbum::ReleaseTypeToString(releaseType).c_str(), //
+                     bCompilation, AudioType::ToString(releaseType).c_str(), //
                      idAlbum);
       m_pDS->exec(strSQL);
       DeleteAlbumArtistsByAlbum(idAlbum);
@@ -1554,7 +1554,7 @@ int CMusicDatabase::UpdateAlbum(int idAlbum,
                                 const std::string& strOrigReleaseDate,
                                 bool bBoxedSet,
                                 bool bCompilation,
-                                ReleaseType releaseType,
+                                AudioType::Type releaseType,
                                 bool bScrapedMBID)
 {
   if (idAlbum < 0)
@@ -1584,7 +1584,7 @@ int CMusicDatabase::UpdateAlbum(int idAlbum,
                       strType.c_str(), static_cast<double>(fRating), iUserrating, iVotes, //
                       strReleaseDate.c_str(), strOrigReleaseDate.c_str(), //
                       bBoxedSet, bCompilation, //
-                      CAlbum::ReleaseTypeToString(releaseType).c_str(), strReleaseStatus.c_str(), //
+                      AudioType::ToString(releaseType).c_str(), strReleaseStatus.c_str(), //
                       CDateTime::GetUTCDateTime().GetAsDBDateTime().c_str(), bScrapedMBID);
   if (strMusicBrainzAlbumID.empty())
     strSQL += PrepareSQL(", strMusicBrainzAlbumID = NULL");
@@ -3212,7 +3212,7 @@ void CMusicDatabase::GetFileItemFromDataset(const dbiplus::sql_record* const rec
   // get the album artist string from songview (not the album_artist and artist tables)
   item->GetMusicInfoTag()->SetAlbumArtist(record->at(song_strAlbumArtists).get_asString());
   item->GetMusicInfoTag()->SetAlbumReleaseType(
-      CAlbum::ReleaseTypeFromString(record->at(song_strAlbumReleaseType).get_asString()));
+      AudioType::FromString(record->at(song_strAlbumReleaseType).get_asString()));
   item->GetMusicInfoTag()->SetBPM(record->at(song_iBPM).get_asInt());
   item->GetMusicInfoTag()->SetBitRate(record->at(song_iBitRate).get_asInt());
   item->GetMusicInfoTag()->SetSampleRate(record->at(song_iSampleRate).get_asInt());
@@ -3747,7 +3747,7 @@ bool CMusicDatabase::GetRecentlyPlayedAlbums(std::vector<CAlbum>& albums)
                    "JOIN albumview ON albumview.idAlbum = playedalbums.idAlbum "
                    "JOIN albumartistview ON albumview.idAlbum = albumartistview.idAlbum "
                    "ORDER BY albumview.lastplayed DESC, albumartistview.iorder ",
-                   CAlbum::ReleaseTypeToString(ReleaseType::Album).c_str(), RECENTLY_PLAYED_LIMIT);
+                   AudioType::ToString(AudioType::Type::Album).c_str(), RECENTLY_PLAYED_LIMIT);
 
     auto queryStart = std::chrono::steady_clock::now();
     CLog::LogF(LOGDEBUG, "query: {}", strSQL);
@@ -8557,11 +8557,12 @@ void CMusicDatabase::UpdateTables(int version)
 
     // set strReleaseType based on album name
     m_pDS->exec(PrepareSQL(
-        "UPDATE album SET strReleaseType = '%s' WHERE strAlbum IS NOT NULL AND strAlbum <> ''",
-        CAlbum::ReleaseTypeToString(ReleaseType::Album).c_str()));
+      "UPDATE album SET strReleaseType = '%s' WHERE strAlbum IS NOT NULL AND strAlbum <> ''",
+        AudioType::ToString(AudioType::Type::Album).c_str()));
     m_pDS->exec(
-        PrepareSQL("UPDATE album SET strReleaseType = '%s' WHERE strAlbum IS NULL OR strAlbum = ''",
-                   CAlbum::ReleaseTypeToString(ReleaseType::Single).c_str()));
+        PrepareSQL(
+        "UPDATE album SET strReleaseType = '%s' WHERE strAlbum IS NULL OR strAlbum = ''",
+         AudioType::ToString(AudioType::Type::Single).c_str()));
   }
   if (version < 51)
   {
@@ -11135,7 +11136,7 @@ int CMusicDatabase::GetSinglesCount()
 {
   CDatabase::Filter filter(
       PrepareSQL("songview.idAlbum IN (SELECT idAlbum FROM album WHERE strReleaseType = '%s')",
-                 CAlbum::ReleaseTypeToString(ReleaseType::Single).c_str()));
+                 AudioType::ToString(AudioType::Type::Single).c_str()));
   return GetSongsCount(filter);
 }
 
@@ -11875,7 +11876,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
       // Find albums to export
       std::vector<int> albumIds;
       std::string strSQL = PrepareSQL("SELECT idAlbum FROM album WHERE strReleaseType = '%s' ",
-                                      CAlbum::ReleaseTypeToString(ReleaseType::Album).c_str());
+                                      AudioType::ToString(AudioType::Type::Album).c_str());
       if (!settings.IsUnscraped())
         strSQL += "AND lastScraped IS NOT NULL";
       CLog::LogF(LOGDEBUG, "{}", strSQL);
@@ -12765,7 +12766,7 @@ void CMusicDatabase::SetPropertiesFromAlbum(CFileItem& item, const CAlbum& album
 
   item.SetProperty("album_isboxset", album.bBoxedSet);
   item.SetProperty("album_totaldiscs", album.iTotalDiscs);
-  item.SetProperty("album_releasetype", CAlbum::ReleaseTypeToString(album.releaseType));
+  item.SetProperty("album_releasetype", AudioType::ToString(album.releaseType));
   item.SetProperty("album_duration",
                    StringUtils::SecondsToTimeString(album.iAlbumDuration, TIME_FORMAT_GUESS));
 }
@@ -13623,7 +13624,7 @@ bool CMusicDatabase::GetFilter(CDbUrl& musicUrl, Filter& filter, SortDescription
       option = options.find("show_singles");
       if (option == options.end() || !option->second.asBoolean())
         filter.AppendWhere(PrepareSQL("albumview.strReleaseType = '%s'",
-                                      CAlbum::ReleaseTypeToString(ReleaseType::Album).c_str()));
+                                      AudioType::ToString(AudioType::Type::Album).c_str()));
     }
   }
   else if (type == "discs")
@@ -13726,7 +13727,7 @@ bool CMusicDatabase::GetFilter(CDbUrl& musicUrl, Filter& filter, SortDescription
       filter.AppendWhere(PrepareSQL(
           "songview.idAlbum %sIN (SELECT idAlbum FROM album WHERE strReleaseType = '%s')",
           option->second.asBoolean() ? "" : "NOT ",
-          CAlbum::ReleaseTypeToString(ReleaseType::Single).c_str()));
+          AudioType::ToString(AudioType::Type::Single).c_str()));
 
     // When have idAlbum skip year, compilation, boxset criteria as already applied via album
     if (idAlbum < 0)

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -15,6 +15,7 @@
 
 #include "addons/Scraper.h"
 #include "dbwrappers/Database.h"
+#include "music/AudioType.h"
 #include "settings/LibExportSettings.h"
 #include "utils/Artwork.h"
 #include "utils/SortUtils.h"
@@ -300,7 +301,7 @@ public:
                const std::string& strType,
                const std::string& strReleaseStatus,
                bool bCompilation,
-               ReleaseType releaseType);
+               AudioType::Type releaseType);
 
   /*! \brief retrieve an album, optionally with all songs.
    \param idAlbum the database id of the album.
@@ -331,7 +332,7 @@ public:
                   const std::string& strOrigReleaseDate,
                   bool bBoxedSet,
                   bool bCompilation,
-                  ReleaseType releaseType,
+                  AudioType::Type releaseType,
                   bool bScrapedMBID);
   bool ClearAlbumLastScrapedTime(int idAlbum);
   bool HasAlbumBeenScraped(int idAlbum) const;

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -38,6 +38,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "imagefiles/ImageFileURL.h"
 #include "interfaces/AnnouncementManager.h"
+#include "music/AudioType.h"
 #include "music/MusicFileItemClassify.h"
 #include "music/MusicLibraryQueue.h"
 #include "music/MusicThumbLoader.h"
@@ -992,8 +993,7 @@ int CMusicInfoScanner::RetrieveMusicInfo(const std::string& strDirectory, CFileI
 
     // mark albums without a title as singles
     if (album.strAlbum.empty())
-      album.releaseType = ReleaseType::Single;
-
+      album.releaseType = AudioType::Type::Single;
     album.strPath = strDirectory;
     m_musicDatabase.AddAlbum(album, m_idSourcePath);
     m_albumsAdded.insert(album.idAlbum);

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -270,7 +270,7 @@ const ReplayGain& CMusicInfoTag::GetReplayGain() const
   return m_replayGain;
 }
 
-ReleaseType CMusicInfoTag::GetAlbumReleaseType() const
+AudioType::Type CMusicInfoTag::GetAlbumReleaseType() const
 {
   return m_albumReleaseType;
 }
@@ -761,7 +761,7 @@ void CMusicInfoTag::SetReplayGain(const ReplayGain& aGain)
   m_replayGain = aGain;
 }
 
-void CMusicInfoTag::SetAlbumReleaseType(ReleaseType releaseType)
+void CMusicInfoTag::SetAlbumReleaseType(AudioType::Type releaseType)
 {
   m_albumReleaseType = releaseType;
 }
@@ -977,9 +977,9 @@ void CMusicInfoTag::Serialize(CVariant& value) const
   value["compilationartist"] = m_bCompilation;
   value["compilation"] = m_bCompilation;
   if (m_type.compare(MediaTypeAlbum) == 0)
-    value["releasetype"] = CAlbum::ReleaseTypeToString(m_albumReleaseType);
+    value["releasetype"] = AudioType::ToString(m_albumReleaseType);
   else if (m_type.compare(MediaTypeSong) == 0)
-    value["albumreleasetype"] = CAlbum::ReleaseTypeToString(m_albumReleaseType);
+    value["albumreleasetype"] = AudioType::ToString(m_albumReleaseType);
   value["isboxset"] = m_bBoxset;
   value["totaldiscs"] = m_iDiscTotal;
   value["disctitle"] = m_strDiscSubtitle;
@@ -1196,7 +1196,7 @@ void CMusicInfoTag::Archive(CArchive& ar)
 
     int albumReleaseType;
     ar >> albumReleaseType;
-    m_albumReleaseType = static_cast<ReleaseType>(albumReleaseType);
+    m_albumReleaseType = static_cast<AudioType::Type>(albumReleaseType);
     ar >> m_iBPM;
     ar >> m_samplerate;
     ar >> m_bitrate;
@@ -1245,7 +1245,7 @@ void CMusicInfoTag::Clear()
   m_iAlbumId = -1;
   m_coverArt.Clear();
   m_replayGain = ReplayGain();
-  m_albumReleaseType = ReleaseType::Album;
+  m_albumReleaseType = AudioType::Type::Album;
   m_listeners = 0;
   m_Rating = 0;
   m_Userrating = 0;

--- a/xbmc/music/tags/MusicInfoTag.h
+++ b/xbmc/music/tags/MusicInfoTag.h
@@ -11,6 +11,7 @@
 #include "ReplayGain.h"
 #include "XBDateTime.h"
 #include "music/Album.h"
+#include "music/AudioType.h"
 #include "music/Song.h"
 #include "utils/IArchivable.h"
 #include "utils/ISerializable.h"
@@ -89,8 +90,8 @@ public:
   const std::string& GetSongVideoURL() const;
   const EmbeddedArtInfo &GetCoverArtInfo() const;
   const ReplayGain& GetReplayGain() const;
-  ReleaseType GetAlbumReleaseType() const;
   const std::vector<ChapterDetails>& GetChapterMarks() const;
+  AudioType::Type GetAlbumReleaseType() const;
 
   void SetURL(std::string_view strURL);
   void SetTitle(const std::string& strTitle);
@@ -149,7 +150,7 @@ public:
   void SetBoxset(bool boxset);
   void SetCoverArtInfo(size_t size, const std::string &mimeType);
   void SetReplayGain(const ReplayGain& aGain);
-  void SetAlbumReleaseType(ReleaseType releaseType);
+  void SetAlbumReleaseType(AudioType::Type releaseType);
   void SetType(MediaType_view mediaType);
   void SetDiscSubtitle(std::string_view strDiscSubtitle);
   void SetTotalDiscs(int iDiscTotal);
@@ -254,7 +255,7 @@ private:
   int m_iDiscTotal;
   bool m_bBoxset;
   int m_iBPM;
-  ReleaseType m_albumReleaseType;
+  AudioType::Type m_albumReleaseType;
   std::string m_strReleaseStatus;
   int m_samplerate;
   int m_channels;


### PR DESCRIPTION
## Description
Move CAlbum::ReleaseType and its associated releaseInfo out of CAlbum and into a new class in preparation for some later improvements.  Modernise the code a little at the same time.

## Motivation and context
Wanting to modernise the music library and do more stuff with audiobooks will require a new audiobook type at some point.  Having a type of `CAlbum::Audiobook` doesn't really sit well in my head, so I've spun it out into a separate class `AudioType`.  I feel this will be better when I get to adding audiobooks as a type.  `AudioType::Type::Audiobook` is somewhat better I think than `CAlbum::Audiobook`.  There might well be further expansion in the future too.  It would be trivial after this PR to add a new `Podcast` type for instance.

It also means going forwards that it'll be easier to set the audiobook type directly from the tags and hopefully move away from using "m4b" as the audiobook definition. That's far too narrow these days for what I have in mind.

It will be easier to separate things out in the GUI based on the AudioType.  The library currently only does this for albums and singles as they are the only current types, but we can be better!

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It builds and runs.  No functional issues were noticed when viewing or playing items from an existing library.  New items were scanned in correctly.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
None.  Internal code change only.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
