### PR TITLE
[Video][Bluray] Couple of small bluray related fixes.

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2527,6 +2527,7 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
 
       // Reset any resume state as new playlist chosen
       options = {};
+      item.ClearProperty("force_playlist_selection");
     }
   }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3174,11 +3174,33 @@ int CVideoDatabase::SetFileForMedia(const std::string& fileAndPath,
   }
 }
 
+int CVideoDatabase::AddFilePreserveDateAdded(const std::string& fileAndPath, int oldIdFile)
+{
+  try
+  {
+    // Preserve date added
+    m_pDS->query(PrepareSQL("SELECT dateAdded FROM files WHERE idFile=%i", oldIdFile));
+    if (m_pDS->eof())
+      return -1;
+
+    CDateTime dateAdded;
+    dateAdded.SetFromDBDateTime(m_pDS->fv("dateAdded").get_asString());
+
+    return AddFile(fileAndPath, "", dateAdded);
+  }
+  catch (const std::exception& e)
+  {
+    CLog::LogF(LOGERROR, "failed - oldIdFile {}, fileAndPath {} - error {}", oldIdFile, fileAndPath,
+               e.what());
+  }
+  return -1;
+}
+
 int CVideoDatabase::SetFileForEpisode(const std::string& fileAndPath, int idEpisode, int oldIdFile)
 {
   assert(m_pDB->in_transaction());
 
-  const int idFile = AddFile(fileAndPath);
+  const int idFile{AddFilePreserveDateAdded(fileAndPath, oldIdFile)};
   if (idFile < 0)
     return -1;
 
@@ -3200,7 +3222,7 @@ int CVideoDatabase::SetFileForMovie(const std::string& fileAndPath, int idMovie,
 {
   assert(m_pDB->in_transaction());
 
-  const int idFile{AddFile(fileAndPath)};
+  const int idFile{AddFilePreserveDateAdded(fileAndPath, oldIdFile)};
   if (idFile < 0)
     return -1;
 
@@ -3241,7 +3263,7 @@ int CVideoDatabase::SetFileForUnknown(const std::string& fileAndPath, int oldIdF
 {
   assert(m_pDB->in_transaction());
 
-  const int idFile{AddFile(fileAndPath)};
+  const int idFile{AddFilePreserveDateAdded(fileAndPath, oldIdFile)};
   if (idFile < 0)
     return -1;
 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1515,4 +1515,11 @@ private:
   static void AnnounceUpdate(const std::string& content, int id);
 
   static CDateTime GetDateAdded(const std::string& filename, CDateTime dateAdded = CDateTime());
+
+  /*! \brief Create a new file to replace an old one (ie. for bluray playlists), preserving the date the original file was added.
+   \param fileAndPath the full path of the new file to add
+   \param oldIdFile file id of the file to replace
+   \return the new fileId, -1 on error
+   */
+  int AddFilePreserveDateAdded(const std::string& fileAndPath, int oldIdFile);
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

1) Preserve date added when generating a new fileId for bluray playlist.
2) Clear force playlist selection flag once playlist selected (reported by @CrystalP)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Date added not preserved so when viewing bluray once played in library view sorted by date added, it ended up in wrong place.

If you used context menu to change playlist and then went to play the bluray again during same kodi instance you would be asked to select playlist again.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
