### PR TITLE
URIUtils: Include resource:// protocol in IsHD check

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -916,7 +916,8 @@ bool URIUtils::IsHD(const std::string& strFileName)
   if (HasParentInHostname(url))
     return IsHD(url.GetHostName());
 
-  return url.GetProtocol().empty() || url.IsProtocol("file") || url.IsProtocol("win-lib");
+  return url.GetProtocol().empty() || url.IsProtocol("file") || url.IsProtocol("win-lib") ||
+         url.IsProtocol("resource");
 }
 
 bool URIUtils::IsDVD(const std::string& strFile)


### PR DESCRIPTION
## Description

As title says. `resource://` files are on the local filesystem.

Solves small icons from `resource://` add-ons being rendered with the Large Texture Manager.

## Motivation and context

Split out from https://github.com/xbmc/xbmc/pull/26881.

## How has this been tested?

Tested on macOS ARM with latest development work (player avatars in the Player Manager).

## What is the effect on users?

* None

## Screenshots

Showing a skin image and a `resource://` image with NN filtering. The skin image gets NN, the `resource://` image using the Large Texture Manager doesn't.

<img width="1136" alt="Screenshot 2025-06-18 at 5 27 54 PM" src="https://github.com/user-attachments/assets/6500626e-128b-43fa-9ab3-cd47c7530efc" />

With the fix:

<img width="1138" alt="Screenshot 2025-06-18 at 5 28 56 PM" src="https://github.com/user-attachments/assets/fcb39a05-c579-491a-bb82-90d008340160" />

Both images get the NN filter.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
