### PR TITLE
[RetroPlayer] Add a frame-ended callback for FBO plumbing (needed for GL support)

### DIFF
--- a/xbmc/cores/RetroPlayer/buffers/IRenderBufferPool.h
+++ b/xbmc/cores/RetroPlayer/buffers/IRenderBufferPool.h
@@ -70,6 +70,15 @@ public:
    * \brief Call in GetBuffer() before returning buffer to caller
    */
   virtual std::shared_ptr<IRenderBufferPool> GetPtr() { return shared_from_this(); }
+
+  /*!
+   * \brief Release resources tied to the rendering context
+   *
+   * This function is called when the render context is being destroyed.
+   * Implementations should free any context-specific resources so that the
+   * pool can be safely recreated.
+   */
+  virtual void DestroyContext() {}
 };
 } // namespace RETRO
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/playback/GameLoop.cpp
+++ b/xbmc/cores/RetroPlayer/playback/GameLoop.cpp
@@ -123,6 +123,9 @@ void CGameLoop::Process(void)
         m_sleepEvent.Wait(sleepTimeUs);
     }
   }
+
+  // Notify the callback that the loop has finished processing
+  m_callback->EndEvent();
 }
 
 std::chrono::microseconds CGameLoop::FrameTimeUs() const

--- a/xbmc/cores/RetroPlayer/playback/GameLoop.h
+++ b/xbmc/cores/RetroPlayer/playback/GameLoop.h
@@ -41,6 +41,14 @@ public:
    * \brief The prior frame is being shown
    */
   virtual void RewindEvent() = 0;
+
+  /*!
+   * \brief Called when the game loop has ended
+   *
+   * This gives implementers a chance to release resources or execute final
+   * actions once the thread finishes processing frames.
+   */
+  virtual void EndEvent() = 0;
 };
 
 /*!

--- a/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
+++ b/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
@@ -323,6 +323,11 @@ void CReversiblePlayback::RewindEvent()
   m_gameClient->RunFrame();
 }
 
+void CReversiblePlayback::EndEvent()
+{
+  m_renderManager.DestroyContext();
+}
+
 void CReversiblePlayback::AddFrame()
 {
   std::unique_lock lock(m_mutex);

--- a/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.h
+++ b/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.h
@@ -65,6 +65,7 @@ public:
   // implementation of IGameLoopCallback
   void FrameEvent() override;
   void RewindEvent() override;
+  void EndEvent() override;
 
   // implementation of Observer
   void Notify(const Observable& obs, const ObservableMessage msg) override;

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -275,6 +275,12 @@ void CRPRenderManager::Flush()
   m_bFlush = true;
 }
 
+void CRPRenderManager::DestroyContext()
+{
+  for (IRenderBufferPool* bufferPool : m_processInfo.GetBufferManager().GetBufferPools())
+    bufferPool->DestroyContext();
+}
+
 bool CRPRenderManager::Create(unsigned int width, unsigned int height)
 {
   //! @todo

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -101,6 +101,7 @@ public:
                 float displayAspectRatio,
                 unsigned int orientationDegCW);
   void Flush();
+  void DestroyContext();
 
   // Hardware rendering functions
   //! @todo These are only examples pulled from the history of the OpenGL


### PR DESCRIPTION
## Description

FBOs for OpenGL support will likely need to know when the frame has finished being played. Let's plumb in the function now to lower technical debt of the GL work.

Taken from the most recent GL branch: https://github.com/garbear/xbmc/commits/retro-gl-v3/

CC @lrusak - Is this wanted? Should we remove the check for `HasVisibleRenderer()`?

## Motivation and context

Adds a stubbed callback to lower the technical debt of the current GL work.

## How has this been tested?

Tested on macOS ARM M2 in parallels. Games play as before.

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
