### PR TITLE
fix splash message

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -598,9 +598,12 @@ bool CApplication::Initialize()
   int iDots = 1;
   while (!event.Wait(1000ms))
   {
-    CServiceBroker::GetRenderSystem()->ShowSplash(
-        std::string(iDots, ' ') + (databaseManager.IsConnecting() ? connecting : updating) +
-        std::string(iDots, '.'));
+    if (databaseManager.IsConnecting() || databaseManager.IsUpgrading())
+    {
+      CServiceBroker::GetRenderSystem()->ShowSplash(
+          std::string(iDots, ' ') + (databaseManager.IsUpgrading() ? updating : connecting) +
+          std::string(iDots, '.'));
+    }
 
     if (iDots == 3)
       iDots = 1;


### PR DESCRIPTION
## Description
follow up fix after https://github.com/xbmc/xbmc/pull/26661
the message on the splash should only be shown if dbManager is either connecting or upgrading databases.

## How has this been tested?
built with LibreElec 13 on RPi

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
