### PR TITLE
[macOS] Skip Xcode simulator mounts

### DIFF
--- a/xbmc/platform/darwin/osx/storage/OSXStorageProvider.cpp
+++ b/xbmc/platform/darwin/osx/storage/OSXStorageProvider.cpp
@@ -108,6 +108,12 @@ void COSXStorageProvider::GetRemovableDrives(std::vector<CMediaSource>& removabl
       mountpoint = buf[i].f_mntonname;
       devicepath = buf[i].f_mntfromname;
 
+      // Xcode simulators mount disk images under the user's
+      // CoreSimulator directory. These are not actual removable
+      // drives, so skip them.
+      if (mountpoint.find("CoreSimulator") != std::string::npos)
+        continue;
+
       DADiskRef disk = DADiskCreateFromBSDName(kCFAllocatorDefault, session, devicepath.c_str());
       if (disk)
       {


### PR DESCRIPTION
## Description

On my macbook, I have 36 Xcode simulators that Kodi thinks are removable drives:

<img width="1347" height="759" alt="Screenshot 2025-07-27 at 4 01 37 PM" src="https://github.com/user-attachments/assets/0736a47b-426f-4d9d-b293-416ec830e3a6" />

<img width="1346" height="758" alt="Screenshot 2025-07-27 at 4 08 37 PM" src="https://github.com/user-attachments/assets/80526505-9979-4b9b-9790-a9b17f11a6d6" />

With this change, the simulators are hidden, improving usability:

<img width="1343" height="759" alt="Screenshot 2025-07-27 at 4 02 39 PM" src="https://github.com/user-attachments/assets/667a0459-9c03-465a-bc8e-0bd2393e7eb0" />

## Motivation and context

Testing Stella to help a user in https://github.com/kodi-game/game.libretro.stella/issues/9.

## How has this been tested?

Tested on macOS ARM v15.5.

## What is the effect on users?

* Fixed Xcode Simulators being shown as removable drives.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
