### PR TITLE
RetroPlayer: Fix crash when creating savestate in Debug mode

### DIFF
--- a/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
@@ -598,7 +598,7 @@ void CSavestateFlatBuffer::Finalize()
 
   savestateBuilder.add_nominal_height(m_nominalHeight);
 
-  savestateBuilder.add_display_aspect_ratio(m_nominalDisplayAspectRatio);
+  savestateBuilder.add_nominal_display_aspect_ratio(m_nominalDisplayAspectRatio);
 
   savestateBuilder.add_max_width(m_maxWidth);
 


### PR DESCRIPTION
## Description

This PR fixes a crash when creating a savestate due to a typo in https://github.com/xbmc/xbmc/pull/26923.

I'm pretty sure the assert is only triggered in debug builds. In release builds, the field would be safely ignored.

## Motivation and context

Testing Stella to help a user in https://github.com/kodi-game/game.libretro.stella/issues/9.

## How has this been tested?

Tested with Stella on macOS ARM with a Debug build.

Before: Crash 10s into gameplay (first autosave)

After: No crash

## What is the effect on users?

* None, effectively

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
