### PR TITLE
[Video][Bluray] More robust update of playcount/lastplayed/dateadded fields when saving bluray:// file or creating bluray:// versions.

### DIFF
--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -156,7 +156,11 @@ bool CGUIDialogSimpleMenu::ShowPlaylistSelection(CFileItem& item)
           {
             // Revert file to base file (BDMV/ISO)
             database.BeginTransaction();
-            if (database.SetFileForMedia(base, it.mediaType, it.idMedia, it.idFile) > 0)
+            if (database.SetFileForMedia(base, it.mediaType, it.idMedia,
+                                         CVideoDatabase::FileRecord{
+                                             .m_idFile = it.idFile,
+                                             .m_dateAdded = item.GetVideoInfoTag()->m_dateAdded}) >
+                0)
               database.CommitTransaction();
             else
               database.RollbackTransaction();

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -219,7 +219,11 @@ void CSaveFileState::DoWork(CFileItem& item,
           // tag->m_iFileId contains the idFile originally played and may be different to the idFile
           // in the movie table entry if it's a non-default video version
           const int newFileId{videodatabase.SetFileForMedia(
-              item.GetDynPath(), item.GetVideoContentType(), tag->m_iDbId, tag->m_iFileId)};
+              item.GetDynPath(), item.GetVideoContentType(), tag->m_iDbId,
+              CVideoDatabase::FileRecord{.m_idFile = tag->m_iFileId,
+                                         .m_playCount = tag->GetPlayCount(),
+                                         .m_lastPlayed = tag->m_lastPlayed,
+                                         .m_dateAdded = tag->m_dateAdded})};
           if (newFileId > 0)
           {
             videodatabase.CommitTransaction();

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -712,10 +712,23 @@ public:
                            const KODI::ART::Artwork& artwork,
                            int idShow,
                            int idEpisode = -1);
+
+  /*!
+   * @brief The FileInfo structure represents a DB record of the files table.
+   */
+  struct FileRecord
+  {
+    int m_idFile{-1};
+    int m_playCount{-1};
+    CDateTime m_lastPlayed{};
+    CDateTime m_dateAdded{};
+  };
+
   int SetFileForMedia(const std::string& fileAndPath,
                       VideoDbContentType type,
                       int mediaId,
-                      int oldIdFile);
+                      FileRecord oldFile);
+
   int SetDetailsForMusicVideo(CVideoInfoTag& details,
                               const KODI::ART::Artwork& artwork,
                               int idMVideo = -1);
@@ -1062,6 +1075,17 @@ public:
   void CleanDatabase(CGUIDialogProgressBarHandle* handle = nullptr,
                      const std::set<int>& paths = std::set<int>(),
                      bool showProgress = true);
+
+  enum class FileExistsAction
+  {
+    ACTION_NONE,
+    ACTION_UPDATE
+  };
+
+  int AddOrUpdateFile(const std::string& fileAndPath,
+                      const std::string& parentPath,
+                      const FileRecord& fileInfo,
+                      FileExistsAction existsAction);
 
   /*! \brief Add a file to the database, if necessary
    If the file is already in the database, we simply return its id.
@@ -1474,9 +1498,12 @@ protected:
                              int max,
                              const T& offsets) const;
 
-  int SetFileForEpisode(const std::string& fileAndPath, int idEpisode, int oldIdFile);
-  int SetFileForMovie(const std::string& fileAndPath, int idMovie, int oldIdFile);
-  int SetFileForUnknown(const std::string& fileAndPath, int oldIdFile);
+  int SetFileForEpisode(const std::string& fileAndPath,
+                        int idEpisode,
+                        int oldIdFile,
+                        int newIdFile);
+  int SetFileForMovie(const std::string& fileAndPath, int idMovie, int oldIdFile, int newIdFile);
+  int SetFileForUnknown(const std::string& fileAndPath, int oldIdFile, int newIdFile);
 
 private:
   void CreateTables() override;
@@ -1568,11 +1595,4 @@ private:
   static void AnnounceUpdate(const std::string& content, int id);
 
   static CDateTime GetDateAdded(const std::string& filename, CDateTime dateAdded = CDateTime());
-
-  /*! \brief Create a new file to replace an old one (ie. for bluray playlists), preserving the date the original file was added.
-   \param fileAndPath the full path of the new file to add
-   \param oldIdFile file id of the file to replace
-   \return the new fileId, -1 on error
-   */
-  int AddFilePreserveDateAdded(const std::string& fileAndPath, int oldIdFile);
 };

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -346,8 +346,11 @@ bool CGUIDialogVideoManagerVersions::ChoosePlaylist(const std::shared_ptr<CFileI
     m_database.BeginTransaction();
     if (replaceExistingFile == ReplaceExistingFile::YES)
     {
-      videoDbSuccess = m_database.SetFileForMedia(item->GetDynPath(), item->GetVideoContentType(),
-                                                  idMovie, item->GetVideoInfoTag()->m_iFileId);
+      videoDbSuccess =
+          m_database.SetFileForMedia(
+              item->GetDynPath(), item->GetVideoContentType(), item->GetVideoInfoTag()->m_iDbId,
+              CVideoDatabase::FileRecord{.m_idFile = item->GetVideoInfoTag()->m_iFileId,
+                                         .m_dateAdded = item->GetVideoInfoTag()->m_dateAdded}) > 0;
       if (videoDbSuccess)
       {
         m_database.SetStreamDetailsForFile(item->GetVideoInfoTag()->m_streamDetails,
@@ -368,7 +371,8 @@ bool CGUIDialogVideoManagerVersions::ChoosePlaylist(const std::shared_ptr<CFileI
       if (idVideoVersion < 0)
         return false;
 
-      const int idFile{m_database.AddFile(item->GetDynPath())};
+      const int idFile{
+          m_database.AddFile(item->GetDynPath(), "", item->GetVideoInfoTag()->m_dateAdded)};
       if (idFile > 0)
       {
         videoDbSuccess = true;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Preserve all 3 fields when replacing a base bluray file (ISO/BDMV) with a bluray:// file path.
The bluray:// file can get created in a number of different places (ie. updating playcount etc..) but `SetFileForMedia()` is the last one called and deletes the old file, so the update is done here.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previous patch didn't always work - if idFile was created before `SetFileForMedia()` and didn't cover all 3 fields.
Advice from @CrystalP about code.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
