### PR TITLE
[Video][Library][WIP][Alpha 3] Hash and look for changes in the Movie Sets Information Folder as part of library scanning.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1975,7 +1975,11 @@ msgctxt "#407"
 msgid "Hardware keyboard layouts"
 msgstr ""
 
-#empty strings from id 408 to 408
+#. Shown during library scan
+#: xbmc/video/VideoInfoScanner.cpp
+msgctxt "#408"
+msgid "Updating sets"
+msgstr ""
 
 msgctxt "#409"
 msgid "Defaults"

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 #include <climits>
+#include <ranges>
 #include <regex>
 #include <string>
 #include <vector>
@@ -223,6 +224,8 @@ void CAdvancedSettings::Initialize()
                                         m_allExcludeFromScanRegExps.begin(),
                                         m_allExcludeFromScanRegExps.end());
 
+  m_setExcludeFromScanRegExps.clear();
+  std::ranges::copy(m_allExcludeFromScanRegExps, std::back_inserter(m_setExcludeFromScanRegExps));
 
   m_tvshowExcludeFromScanRegExps.clear();
   m_tvshowExcludeFromScanRegExps.emplace_back("[!-._ \\\\/]sample[-._ \\\\/]");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -214,6 +214,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::vector<std::string> m_videoExcludeFromListingRegExps;
     std::vector<std::string> m_allExcludeFromScanRegExps;
     std::vector<std::string> m_moviesExcludeFromScanRegExps;
+    std::vector<std::string> m_setExcludeFromScanRegExps;
     std::vector<std::string> m_tvshowExcludeFromScanRegExps;
     std::vector<std::string> m_audioExcludeFromListingRegExps;
     std::vector<std::string> m_audioExcludeFromScanRegExps;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2593,6 +2593,28 @@ bool CVideoDatabase::GetSetInfo(int idSet, CVideoInfoTag& details, CFileItem* it
   return false;
 }
 
+bool CVideoDatabase::GetSetInfoTag(const std::string& title, CSetInfoTag& tag) const
+{
+  if (!m_pDB || !m_pDS)
+    return false;
+
+  try
+  {
+    m_pDS->query(PrepareSQL("SELECT * FROM sets WHERE strOriginalSet='%s' LIMIT 1", title.c_str()));
+    if (!m_pDS->eof())
+    {
+      tag = GetDetailsForSet(*m_pDS);
+      return true;
+    }
+    return false;
+  }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "({}) failed", title);
+  }
+  return false;
+}
+
 bool CVideoDatabase::GetFileInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details, int idFile /* = -1 */)
 {
   try

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -642,6 +642,7 @@ public:
   bool GetEpisodeInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details, int idEpisode = -1, int getDetails = VideoDbDetailsAll);
   bool GetMusicVideoInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details, int idMVideo = -1, int getDetails = VideoDbDetailsAll);
   bool GetSetInfo(int idSet, CVideoInfoTag& details, CFileItem* item = nullptr);
+  bool GetSetInfoTag(const std::string& title, CSetInfoTag& tag) const;
   bool GetFileInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details, int idFile = -1);
 
   int GetPathId(const std::string& strPath);

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -303,6 +303,8 @@ namespace KODI::VIDEO
     std::pair<InfoType, std::unique_ptr<IVideoInfoTagLoader>> ReadInfoTag(
         CFileItem& item, const ADDON::ScraperPtr& scraper, bool lookInFolder, bool resetTag);
 
+    void UpdateSets();
+
     bool m_bStop;
     bool m_scanAll;
     bool m_ignoreVideoVersions{false};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

This PR introduces a function that scans the Movie Set Information Folder (if present) for set.nfo files and updates sets as needed. It hashes the folders and stores them in the path table.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Following on from #27018 which fixed a regression that slowed down library scanning in #26295 this restores functionality that scans any set.nfo files in the MSIF for updates.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed