### PR TITLE
[PVR][profiles] Fixes for problems with PVR stop/start on profile switch

### DIFF
--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -195,7 +195,7 @@ bool CGUIPassword::SetMasterLockMode(bool bDetails)
 {
   const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  CProfile* profile = profileManager->GetProfile(0);
+  CProfile* profile{profileManager->GetProfile(MASTER_PROFILE_ID)};
   if (profile)
   {
     CProfile::CLock locks = profile->GetLocks();
@@ -226,7 +226,7 @@ bool CGUIPassword::IsProfileLockUnlocked(int iProfile, bool& bCanceled, bool pro
   if (iProfile == -1)
     iProfileToCheck = profileManager->GetCurrentProfileIndex();
 
-  if (iProfileToCheck == 0)
+  if (iProfileToCheck == MASTER_PROFILE_ID)
     return IsMasterLockUnlocked(prompt,bCanceled);
   else
   {

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -1716,7 +1716,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
   case TMSG_LOADPROFILE:
     {
       const int profile = pMsg->param1;
-      if (profile >= 0)
+      if (profile > INVALID_PROFILE_ID)
         CServiceBroker::GetSettingsComponent()->GetProfileManager()->LoadProfile(static_cast<unsigned int>(profile));
     }
 

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -261,7 +261,7 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     {
       const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
       int iProfileId = profileManager->GetAutoLoginProfileId();
-      if ((iProfileId < 0) || !profileManager->GetProfileName(iProfileId, value))
+      if ((iProfileId < MASTER_PROFILE_ID) || !profileManager->GetProfileName(iProfileId, value))
         value = g_localizeStrings.Get(37014); // Last used profile
       return true;
     }

--- a/xbmc/interfaces/builtins/ProfileBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ProfileBuiltins.cpp
@@ -34,8 +34,9 @@ static int LoadProfile(const std::vector<std::string>& params)
   int index = profileManager->GetProfileIndex(params[0]);
   bool prompt = (params.size() == 2 && StringUtils::EqualsNoCase(params[1], "prompt"));
   bool bCanceled;
-  if (index >= 0 && (profileManager->GetMasterProfile().getLockMode() == LockMode::EVERYONE ||
-                     g_passwordManager.IsProfileLockUnlocked(index, bCanceled, prompt)))
+  if (index > INVALID_PROFILE_ID &&
+      (profileManager->GetMasterProfile().getLockMode() == LockMode::EVERYONE ||
+       g_passwordManager.IsProfileLockUnlocked(index, bCanceled, prompt)))
   {
     CServiceBroker::GetAppMessenger()->PostMsg(TMSG_LOADPROFILE, index);
   }

--- a/xbmc/interfaces/json-rpc/ProfilesOperations.cpp
+++ b/xbmc/interfaces/json-rpc/ProfilesOperations.cpp
@@ -91,7 +91,7 @@ JSONRPC_STATUS CProfilesOperations::LoadProfile(const std::string &method, ITran
   std::string profilename = parameterObject["profile"].asString();
   int index = profileManager->GetProfileIndex(profilename);
 
-  if (index < 0)
+  if (index <= INVALID_PROFILE_ID)
     return InvalidParams;
 
   // get the profile

--- a/xbmc/profiles/Profile.h
+++ b/xbmc/profiles/Profile.h
@@ -15,6 +15,9 @@
 
 class TiXmlNode;
 
+constexpr int INVALID_PROFILE_ID = -1;
+constexpr int MASTER_PROFILE_ID = 0; // id of the master profile
+
 class CProfile
 {
 public:
@@ -38,7 +41,9 @@ public:
     bool games;
   };
 
-  CProfile(const std::string &directory = "", const std::string &name = "", const int id = -1);
+  CProfile(const std::string& directory = "",
+           const std::string& name = "",
+           const int id = INVALID_PROFILE_ID);
   ~CProfile(void);
 
   void Load(const TiXmlNode *node, int nextIdProfile);

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -194,26 +194,27 @@ bool CProfileManager::Load()
 
   if (m_profiles.empty())
   { // add the master user
-    CProfile profile("special://masterprofile/", "Master user", 0);
+    CProfile profile("special://masterprofile/", "Master user", MASTER_PROFILE_ID);
     AddProfile(profile);
   }
 
   // check the validity of the previous profile index
   if (m_lastUsedProfile >= m_profiles.size())
-    m_lastUsedProfile = 0;
+    m_lastUsedProfile = MASTER_PROFILE_ID;
 
   SetCurrentProfileId(m_lastUsedProfile);
 
   // check the validity of the auto login profile index
-  if (m_autoLoginProfile < -1 || m_autoLoginProfile >= (int)m_profiles.size())
-    m_autoLoginProfile = -1;
-  else if (m_autoLoginProfile >= 0)
+  if (m_autoLoginProfile < INVALID_PROFILE_ID ||
+      m_autoLoginProfile >= static_cast<int>(m_profiles.size()))
+    m_autoLoginProfile = INVALID_PROFILE_ID;
+  else if (m_autoLoginProfile > INVALID_PROFILE_ID)
     SetCurrentProfileId(m_autoLoginProfile);
 
   // the login screen runs as the master profile, so if we're using this, we need to ensure
   // we switch to the master profile
   if (m_usingLoginScreen)
-    SetCurrentProfileId(0);
+    SetCurrentProfileId(MASTER_PROFILE_ID);
 
   return ret;
 }
@@ -248,9 +249,9 @@ void CProfileManager::Clear()
   m_usingLoginScreen = false;
   m_profileLoadedForLogin = false;
   m_previousProfileLoadedForLogin = false;
-  m_lastUsedProfile = 0;
-  m_nextProfileId = 0;
-  SetCurrentProfileId(0);
+  m_lastUsedProfile = MASTER_PROFILE_ID;
+  m_nextProfileId = MASTER_PROFILE_ID;
+  SetCurrentProfileId(MASTER_PROFILE_ID);
   m_profiles.clear();
 }
 
@@ -268,7 +269,7 @@ void CProfileManager::PrepareLoadProfile(unsigned int profileIndex)
   // stop PVR related services
   pvrManager.Stop();
 
-  if (profileIndex != 0 || !IsMasterProfile())
+  if (profileIndex != MASTER_PROFILE_ID || !IsMasterProfile())
     networkManager.NetworkMessage(CNetworkBase::SERVICES_DOWN, 1);
 }
 
@@ -285,7 +286,7 @@ bool CProfileManager::LoadProfile(unsigned int index)
 
   PrepareLoadProfile(index);
 
-  if (index == 0 && IsMasterProfile())
+  if (index == MASTER_PROFILE_ID && IsMasterProfile())
   {
     CGUIWindow* pWindow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow(WINDOW_HOME);
     if (pWindow)
@@ -336,7 +337,7 @@ bool CProfileManager::LoadProfile(unsigned int index)
     infoMgr.GetInfoProviders().GetLibraryInfoProvider().ResetLibraryBools();
   }
 
-  if (m_currentProfile != 0)
+  if (m_currentProfile != MASTER_PROFILE_ID)
   {
     CXBMCTinyXML doc;
     if (doc.LoadFile(URIUtils::AddFileToFolder(GetUserDataFolder(), "guisettings.xml")))
@@ -414,7 +415,8 @@ void CProfileManager::FinalizeLoadProfile()
   favouritesManager.ReInit(GetProfileUserDataFolder());
 
   // Start these operations only when a profile is loaded, not on the login screen
-  if (!m_profileLoadedForLogin || (m_profileLoadedForLogin && m_lastUsedProfile == 0))
+  if (!m_profileLoadedForLogin ||
+      (m_profileLoadedForLogin && m_lastUsedProfile == MASTER_PROFILE_ID))
   {
     pvrManager.Init();
     serviceAddons.Start();
@@ -485,8 +487,8 @@ bool CProfileManager::DeleteProfile(unsigned int index)
     return false;
 
   // fall back to master profile if necessary
-  if ((int)index == m_autoLoginProfile)
-    m_autoLoginProfile = 0;
+  if (static_cast<int>(index) == m_autoLoginProfile)
+    m_autoLoginProfile = MASTER_PROFILE_ID;
 
   // delete profile
   std::string strDirectory = profile->getDirectory();
@@ -495,7 +497,7 @@ bool CProfileManager::DeleteProfile(unsigned int index)
   // fall back to master profile if necessary
   if (index == m_currentProfile)
   {
-    LoadProfile(0);
+    LoadProfile(MASTER_PROFILE_ID);
     m_settings->Save();
   }
 
@@ -535,7 +537,7 @@ const CProfile& CProfileManager::GetMasterProfile() const
 {
   std::unique_lock lock(m_critical);
   if (!m_profiles.empty())
-    return m_profiles[0];
+    return m_profiles[MASTER_PROFILE_ID];
 
   CLog::Log(LOGERROR, "{}: master profile doesn't exist", __FUNCTION__);
   return EmptyProfile;
@@ -578,7 +580,7 @@ int CProfileManager::GetProfileIndex(const std::string &name) const
       return i;
   }
 
-  return -1;
+  return INVALID_PROFILE_ID;
 }
 
 void CProfileManager::AddProfile(const CProfile &profile)
@@ -610,12 +612,12 @@ void CProfileManager::LoadMasterProfileForLogin()
   std::unique_lock lock(m_critical);
   // save the previous user
   m_lastUsedProfile = m_currentProfile;
-  if (m_currentProfile != 0)
+  if (m_currentProfile != MASTER_PROFILE_ID)
   {
     // determines that the (master) profile has only been loaded for login
     m_profileLoadedForLogin = true;
 
-    LoadProfile(0);
+    LoadProfile(MASTER_PROFILE_ID);
 
     // remember that the (master) profile has only been loaded for login
     m_previousProfileLoadedForLogin = true;
@@ -640,7 +642,7 @@ std::string CProfileManager::GetUserDataFolder() const
 
 std::string CProfileManager::GetProfileUserDataFolder() const
 {
-  if (m_currentProfile == 0)
+  if (m_currentProfile == MASTER_PROFILE_ID)
     return GetUserDataFolder();
 
   return URIUtils::AddFileToFolder(GetUserDataFolder(), GetCurrentProfile().getDirectory());
@@ -695,7 +697,7 @@ std::string CProfileManager::GetSavestatesFolder() const
 
 std::string CProfileManager::GetSettingsFile() const
 {
-  if (m_currentProfile == 0)
+  if (m_currentProfile == MASTER_PROFILE_ID)
     return "special://masterprofile/guisettings.xml";
 
   return "special://profile/guisettings.xml";

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -274,6 +274,15 @@ void CProfileManager::PrepareLoadProfile(unsigned int profileIndex)
 
 bool CProfileManager::LoadProfile(unsigned int index)
 {
+  std::unique_lock lock(m_critical);
+
+  // check if the index is valid or not
+  if (index >= m_profiles.size())
+  {
+    CLog::LogF(LOGERROR, "Profile not loaded. Invalid profile id {}", index);
+    return false;
+  }
+
   PrepareLoadProfile(index);
 
   if (index == 0 && IsMasterProfile())
@@ -287,15 +296,6 @@ bool CProfileManager::LoadProfile(unsigned int index)
 
     return true;
   }
-
-  std::unique_lock lock(m_critical);
-  // check if the index is valid or not
-  if (index >= m_profiles.size())
-    return false;
-
-  // check if the profile is already active
-  if (m_currentProfile == index)
-    return true;
 
   // save any settings of the currently used skin but only if the (master)
   // profile hasn't just been loaded as a temporary profile for login

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -411,15 +411,12 @@ void CProfileManager::FinalizeLoadProfile()
   // Restart context menu manager
   contextMenuManager.Init();
 
-  // Restart PVR services if we are not just loading the master profile for the login screen
-  if (m_previousProfileLoadedForLogin || m_currentProfile != 0 || m_lastUsedProfile == 0)
-    pvrManager.Init();
-
   favouritesManager.ReInit(GetProfileUserDataFolder());
 
   // Start these operations only when a profile is loaded, not on the login screen
   if (!m_profileLoadedForLogin || (m_profileLoadedForLogin && m_lastUsedProfile == 0))
   {
+    pvrManager.Init();
     serviceAddons.Start();
     g_application.UpdateLibraries();
   }

--- a/xbmc/profiles/ProfileManager.h
+++ b/xbmc/profiles/ProfileManager.h
@@ -85,7 +85,7 @@ public:
 
   /*! \brief Retrieve index of a particular profile by name
     \param name name of the profile index to retrieve
-    \return index of this profile, -1 if invalid.
+    \return index of this profile, INVALID_PROFILE_ID if invalid.
     */
   int GetProfileIndex(const std::string &name) const;
 
@@ -116,14 +116,14 @@ public:
   /*! \brief Are we the master user?
     \return true if the current profile is the master user, false otherwise
     */
-  bool IsMasterProfile() const { return m_currentProfile == 0; }
+  bool IsMasterProfile() const { return m_currentProfile == MASTER_PROFILE_ID; }
 
   /*! \brief Update the date of the current profile
     */
   void UpdateCurrentProfileDate();
 
   /*! \brief Load the master user for the purposes of logging in
-    Loads the master user.  Identical to LoadProfile(0) but doesn't
+    Loads the master user.  Identical to LoadProfile(MASTER_PROFILE_ID) but doesn't
     update the last logged in details
     */
   void LoadMasterProfileForLogin();
@@ -147,16 +147,16 @@ public:
   int GetCurrentProfileId() const { return GetCurrentProfile().getId(); }
 
   /*! \brief Retrieve the autologin profile id
-    Retrieves the autologin profile id. When set to -1, then the last
+    Retrieves the autologin profile id. When set to INVALID_PROFILE_ID, then the last
     used profile will be loaded
     \return the id to the autologin profile
     */
   int GetAutoLoginProfileId() const { return m_autoLoginProfile; }
 
-  /*! \brief Retrieve the autologin profile id
-    Retrieves the autologin profile id. When set to -1, then the last
+  /*! \brief Set the autologin profile id
+    sets the autologin profile id. When set to INVALID_PROFILE_ID, then the last
     used profile will be loaded
-    \return the id to the autologin profile
+    \param profileId the id for the autologin profile
     */
   void SetAutoLoginProfileId(const int profileId)
   {
@@ -208,12 +208,12 @@ private:
   bool m_usingLoginScreen = false;
   bool m_profileLoadedForLogin = false;
   bool m_previousProfileLoadedForLogin = false;
-  int m_autoLoginProfile = -1;
-  unsigned int m_lastUsedProfile = 0;
-  unsigned int m_currentProfile =
-      0; // do not modify directly, use SetCurrentProfileId() function instead
-  int m_nextProfileId =
-      0; // for tracking the next available id to give to a new profile to ensure id's are not re-used
+  int m_autoLoginProfile{INVALID_PROFILE_ID};
+  unsigned int m_lastUsedProfile{MASTER_PROFILE_ID};
+  unsigned int m_currentProfile{
+      MASTER_PROFILE_ID}; // do not modify directly, use SetCurrentProfileId() function instead
+  int m_nextProfileId{
+      MASTER_PROFILE_ID}; // for tracking the next available id to give to a new profile to ensure id's are not re-used
   mutable CCriticalSection m_critical;
 
   // Event properties

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -60,7 +60,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
     return false;
 
   dialog->m_needsSaving = false;
-  dialog->m_isDefault = iProfile == 0;
+  dialog->m_isDefault = (iProfile == MASTER_PROFILE_ID);
   dialog->m_showDetails = !firstLogin;
 
   const CProfile *profile = profileManager->GetProfile(iProfile);

--- a/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
+++ b/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
@@ -64,7 +64,7 @@ void CGUIWindowSettingsProfile::OnPopupMenu(int iItem)
   // popup the context menu
   CContextButtons choices;
   choices.Add(1, 20092); // Load profile
-  if (iItem > 0)
+  if (iItem > MASTER_PROFILE_ID)
     choices.Add(2, 117); // Delete
 
   int choice = CGUIDialogContextMenu::ShowAndGetChoice(choices);

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -355,12 +355,14 @@ void CPVRManager::Init() const
 {
   m_addons->DestroyClients();
 
-  // initial check for enabled addons
-  // if at least one pvr addon is enabled, PVRManager start up
-  CServiceBroker::GetJobManager()->Submit([this] {
-    Clients()->Start();
-    return true;
-  });
+  // Initialize PVR client addons and start PVR manager thread.
+  CServiceBroker::GetJobManager()->Submit(
+      [this]
+      {
+        m_addons->Start();
+        return true;
+      },
+      CJob::PRIORITY_DEDICATED);
 }
 
 void CPVRManager::Start()

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1005,8 +1005,11 @@ void CPVRManager::ConnectionStateChange(const CPVRClient* client,
                                         PVR_CONNECTION_STATE state,
                                         const std::string& message) const
 {
-  CServiceBroker::GetJobManager()->Submit([this, client, connectString, state, message] {
-    Clients()->ConnectionStateChange(client, connectString, state, message);
-    return true;
-  });
+  CServiceBroker::GetJobManager()->Submit(
+      [this, client, connectString, state, message]
+      {
+        m_addons->ConnectionStateChange(client, connectString, state, message);
+        return true;
+      },
+      CJob::PRIORITY_DEDICATED);
 }

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -353,6 +353,8 @@ void CPVRManager::ResetProperties()
 
 void CPVRManager::Init() const
 {
+  m_addons->DestroyClients();
+
   // initial check for enabled addons
   // if at least one pvr addon is enabled, PVRManager start up
   CServiceBroker::GetJobManager()->Submit([this] {

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -72,10 +72,7 @@ CPVRClients::~CPVRClients()
   CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
   CServiceBroker::GetAddonMgr().UnregisterAddonMgrCallback(AddonType::PVRDLL);
 
-  for (const auto& [_, client] : m_clientMap)
-  {
-    client->Destroy();
-  }
+  DestroyClients();
 }
 
 void CPVRClients::Start()
@@ -101,6 +98,18 @@ void CPVRClients::Continue()
   {
     client->Continue();
   }
+}
+
+void CPVRClients::DestroyClients()
+{
+  std::unique_lock lock(m_critSection);
+  for (const auto& [_, client] : m_clientMap)
+  {
+    CLog::LogF(LOGINFO, "Destroying PVR client: addonId={}, instanceId={}, clientId={}",
+               client->ID(), client->InstanceId(), client->GetID());
+    client->Destroy();
+  }
+  m_clientMap.clear();
 }
 
 CPVRClients::UpdateClientAction CPVRClients::GetUpdateClientAction(

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -105,8 +105,8 @@ void CPVRClients::DestroyClients()
   std::unique_lock lock(m_critSection);
   for (const auto& [_, client] : m_clientMap)
   {
-    CLog::LogF(LOGINFO, "Destroying PVR client: addonId={}, instanceId={}, clientId={}",
-               client->ID(), client->InstanceId(), client->GetID());
+    CLog::Log(LOGINFO, "Destroying PVR client: addonId={}, instanceId={}, clientId={}",
+              client->ID(), client->InstanceId(), client->GetID());
     client->Destroy();
   }
   m_clientMap.clear();
@@ -194,22 +194,22 @@ void CPVRClients::UpdateClients(const std::string& changedAddonId /* = "" */)
             else
               client = std::make_shared<CPVRClient>(addon, instanceId, clientId);
 
-            CLog::LogF(LOGINFO, "Creating PVR client: addonId={}, instanceId={}, clientId={}",
-                       addon->ID(), instanceId, clientId);
+            CLog::Log(LOGINFO, "Creating PVR client: addonId={}, instanceId={}, clientId={}",
+                      addon->ID(), instanceId, clientId);
             clientsToCreate.emplace_back(client);
             break;
           }
           case RECREATE:
           {
-            CLog::LogF(LOGINFO, "Recreating PVR client: addonId={}, instanceId={}, clientId={}",
-                       addon->ID(), instanceId, clientId);
+            CLog::Log(LOGINFO, "Recreating PVR client: addonId={}, instanceId={}, clientId={}",
+                      addon->ID(), instanceId, clientId);
             clientsToReCreate.emplace_back(clientId, addon->Name());
             break;
           }
           case DESTROY:
           {
-            CLog::LogF(LOGINFO, "Destroying PVR client: addonId={}, instanceId={}, clientId={}",
-                       addon->ID(), instanceId, clientId);
+            CLog::Log(LOGINFO, "Destroying PVR client: addonId={}, instanceId={}, clientId={}",
+                      addon->ID(), instanceId, clientId);
             clientsToDestroy.emplace_back(clientId);
             break;
           }

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -66,6 +66,11 @@ public:
   void Continue();
 
   /*!
+   * @brief Destroy all clients.
+   */
+  void DestroyClients();
+
+  /*!
    * @brief Update all clients, sync with Addon Manager state (start, restart, shutdown clients).
    * @param changedAddonId The id of the changed addon, empty string denotes 'any addon'.
    */

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -93,7 +93,7 @@ bool CGUIWindowLoginScreen::OnMessage(CGUIMessage& message)
 
           if (bOkay)
           {
-            if (iItem >= 0)
+            if (iItem > INVALID_PROFILE_ID)
               CServiceBroker::GetAppMessenger()->PostMsg(TMSG_LOADPROFILE, iItem);
           }
           else


### PR DESCRIPTION
## Description
I was working with @emveepee who encountered a couple of problems with PVR re-init when switching profiles:
* PVR not loading at all after profile switch (only spinning circles on Estuary PVR home screen)
* PVR taking very long to load after profile switch (spinning circles for a long time on Estuary PVR home screen)
* Some PVR data of old profile shown in PVR of new profile

In addition to the fixes, the PR contains a commit to eliminate magic numbers in `CProfileManager`. This "happened" unplanned, while reading the code to understand what it does.

## Motivation and context
Fix bugs reported so that PVR is re-inited properly for all known use cases.

## How has this been tested?
Runtime-tested by me and emveepee with various test scenarios.

## What is the effect on users?
PVR properly working after switching profile.

## Screenshots (if appropriate):
All this happens only in certain scenarios, not always, so a bit hard to explain in detail.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
