### PR TITLE
RetroPlayer: Fix sorting of public member functions and a log c/p error

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -270,6 +270,11 @@ void CRPRenderManager::AddFrame(const uint8_t* data,
   }
 }
 
+void CRPRenderManager::Flush()
+{
+  m_bFlush = true;
+}
+
 bool CRPRenderManager::Create(unsigned int width, unsigned int height)
 {
   //! @todo
@@ -355,11 +360,6 @@ void CRPRenderManager::CheckFlush()
 
     m_bFlush = false;
   }
-}
-
-void CRPRenderManager::Flush()
-{
-  m_bFlush = true;
 }
 
 void CRPRenderManager::RenderWindow(bool bClear, const RESOLUTION_INFO& coordsRes)

--- a/xbmc/games/addons/streams/GameClientStreamHwFramebuffer.cpp
+++ b/xbmc/games/addons/streams/GameClientStreamHwFramebuffer.cpp
@@ -30,7 +30,7 @@ bool CGameClientStreamHwFramebuffer::OpenStream(RETRO::IRetroPlayerStream* strea
       dynamic_cast<RETRO::CRetroPlayerRendering*>(stream);
   if (renderingStream == nullptr)
   {
-    CLog::Log(LOGERROR, "GAME: RetroPlayer stream is not an audio stream");
+    CLog::Log(LOGERROR, "GAME: RetroPlayer stream is not a rendering stream");
     return false;
   }
 


### PR DESCRIPTION
## Description

Fixes sort order of public member functions in the .cpp file as compared to the header file.

EDIT: Forgot to include a c/p fix from https://github.com/xbmc/xbmc/pull/27007.

## Motivation and context

Split out from https://github.com/xbmc/xbmc/pull/27007. I plan to close that one.

## How has this been tested?

Used my brain AI to reason through correctness and the resulting success.

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
