### PR TITLE
Fix busy dialog crash

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2837,13 +2837,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
       const auto appPlayer = GetComponent<CApplicationPlayer>();
       if (!m_itemCurrentFile->IsLiveTV() ||
           (!appPlayer->IsPlayingVideo() && !appPlayer->IsPlayingAudio()))
-      {
-        CGUIDialogBusy* dialog =
-            CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(
-                WINDOW_DIALOG_BUSY);
-        if (dialog && !dialog->IsDialogRunning())
-          dialog->WaitOnEvent(m_playerEvent);
-      }
+        CGUIDialogBusy::WaitOnEvent(m_playerEvent);
 
       return true;
     }

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -76,30 +76,30 @@ bool CGUIDialogBusy::WaitOnEvent(CEvent &event, unsigned int displaytime /* = 10
   bool cancelled = false;
   if (!event.Wait(std::chrono::milliseconds(displaytime)))
   {
-    // throw up the progress
-    CGUIDialogBusy* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);
+    CGUIDialogBusy* dialog = static_cast<CGUIDialogBusy*>(
+        CServiceBroker::GetGUI()->GetWindowManager().GetWindow(WINDOW_DIALOG_BUSY));
     if (dialog)
     {
-      if (dialog->IsDialogRunning())
+      if (++dialog->m_waiters == 1)
       {
-        CLog::Log(LOGFATAL, "Logic error due to two concurrent busydialogs, this is a known issue. "
-                            "The application will exit.");
-        throw std::logic_error("busy dialog already running");
+        dialog->Open();
       }
-
-      dialog->Open();
 
       while (!event.Wait(1ms))
       {
         dialog->ProcessRenderLoop(false);
-        if (allowCancel && dialog->IsCanceled())
+        if (allowCancel && dialog->m_cancelled)
         {
           cancelled = true;
           break;
         }
       }
 
-      dialog->Close(true);
+      if (--dialog->m_waiters == 0)
+      {
+        dialog->Close(true); // Force close.
+        dialog->ProcessRenderLoop(false); // Force repaint.
+      }
     }
   }
   return !cancelled;
@@ -109,19 +109,18 @@ CGUIDialogBusy::CGUIDialogBusy(void)
   : CGUIDialog(WINDOW_DIALOG_BUSY, "DialogBusy.xml", DialogModalityType::MODAL)
 {
   m_loadType = LOAD_ON_GUI_INIT;
-  m_bCanceled = false;
+  m_cancelled = false;
 }
 
 CGUIDialogBusy::~CGUIDialogBusy(void) = default;
 
 void CGUIDialogBusy::Open_Internal(bool bProcessRenderLoop, const std::string& param /* = "" */)
 {
-  m_bCanceled = false;
   m_bLastVisible = true;
+  m_cancelled = false;
 
   CGUIDialog::Open_Internal(false, param);
 }
-
 
 void CGUIDialogBusy::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
@@ -142,6 +141,6 @@ void CGUIDialogBusy::Render()
 
 bool CGUIDialogBusy::OnBack(int actionID)
 {
-  m_bCanceled = true;
+  m_cancelled = true;
   return true;
 }

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -80,14 +80,16 @@ bool CGUIDialogBusy::WaitOnEvent(CEvent &event, unsigned int displaytime /* = 10
         CServiceBroker::GetGUI()->GetWindowManager().GetWindow(WINDOW_DIALOG_BUSY));
     if (dialog)
     {
-      if (++dialog->m_waiters == 1)
+      const uint32_t level = ++dialog->m_waiters;
+      if (level == 1)
       {
         dialog->Open();
       }
 
       while (!event.Wait(1ms))
       {
-        dialog->ProcessRenderLoop(false);
+        if (level == dialog->m_waiters)
+          dialog->ProcessRenderLoop(false);
         if (allowCancel && dialog->m_cancelled)
         {
           cancelled = true;

--- a/xbmc/dialogs/GUIDialogBusy.h
+++ b/xbmc/dialogs/GUIDialogBusy.h
@@ -10,22 +10,16 @@
 
 #include "guilib/GUIDialog.h"
 
+#include <cstdint>
+
 class IRunnable;
 class CEvent;
 
-class CGUIDialogBusy: public CGUIDialog
+class CGUIDialogBusy : private CGUIDialog
 {
-public:
-  CGUIDialogBusy(void);
-  ~CGUIDialogBusy(void) override;
-  bool OnBack(int actionID) override;
-  void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
-  void Render() override;
-  /*! \brief set the current progress of the busy operation
-   \param progress a percentage of progress
-   */
-  bool IsCanceled() { return m_bCanceled; }
+  friend class CGUIWindowManager;
 
+public:
   /*! \brief Wait for a runnable to execute off-thread.
    Creates a thread to run the given runnable, and while waiting
    it displays the busy dialog.
@@ -44,8 +38,17 @@ public:
    \return true if the event completed, false if cancelled.
    */
   static bool WaitOnEvent(CEvent &event, unsigned int displaytime = 100, bool allowCancel = true);
-protected:
+
+private:
+  CGUIDialogBusy();
+  ~CGUIDialogBusy() override;
+
   void Open_Internal(bool bProcessRenderLoop, const std::string& param = "") override;
-  bool m_bCanceled;
-  bool m_bLastVisible = false;
+  bool OnBack(int actionID) override;
+  void DoProcess(unsigned int currentTime, CDirtyRegionList& dirtyregions) override;
+  void Render() override;
+
+  bool m_bLastVisible{false};
+  bool m_cancelled{false};
+  uint32_t m_waiters{0};
 };

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -251,8 +251,6 @@ bool CGUIWindowMusicPlayList::OnAction(const CAction& action)
 
 bool CGUIWindowMusicPlayList::OnBack(int actionID)
 {
-  CancelUpdateItems();
-
   if (actionID == ACTION_NAV_BACK)
     return CGUIWindow::OnBack(actionID); // base class goes up a folder, but none to go up
   return CGUIWindowMusicBase::OnBack(actionID);

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -228,8 +228,6 @@ bool CGUIMediaWindow::OnAction(const CAction &action)
 
 bool CGUIMediaWindow::OnBack(int actionID)
 {
-  CancelUpdateItems();
-
   CURL filterUrl(m_strFilterPath);
   if (actionID == ACTION_NAV_BACK &&
       !m_vecItems->IsVirtualDirectoryRoot() &&
@@ -247,25 +245,23 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
   switch ( message.GetMessage() )
   {
   case GUI_MSG_WINDOW_DEINIT:
+  {
+    m_iLastControl = GetFocusedControlID();
+    CGUIWindow::OnMessage(message);
+
+    // get rid of any active filtering
+    if (m_canFilterAdvanced)
     {
-      CancelUpdateItems();
-
-      m_iLastControl = GetFocusedControlID();
-      CGUIWindow::OnMessage(message);
-
-      // get rid of any active filtering
-      if (m_canFilterAdvanced)
-      {
-        m_canFilterAdvanced = false;
-        m_filter.Reset();
-      }
-      m_strFilterPath.clear();
-
-      // Call ClearFileItems() after our window has finished doing any WindowClose
-      // animations
-      ClearFileItems();
-      return true;
+      m_canFilterAdvanced = false;
+      m_filter.Reset();
     }
+    m_strFilterPath.clear();
+
+    // Call ClearFileItems() after our window has finished doing any WindowClose
+    // animations
+    ClearFileItems();
+    return true;
+  }
     break;
 
   case GUI_MSG_CLICKED:
@@ -2212,7 +2208,7 @@ bool CGUIMediaWindow::GetDirectoryItems(CURL &url, CFileItemList &items, bool us
     bool ret = true;
     CGetDirectoryItems getItems(m_rootDir, url, items, useDir);
 
-    if (!WaitGetDirectoryItems(getItems))
+    if (!CGUIDialogBusy::Wait(&getItems, 100, true))
     {
       // cancelled
       ret = false;
@@ -2224,77 +2220,17 @@ bool CGUIMediaWindow::GetDirectoryItems(CURL &url, CFileItemList &items, bool us
       {
         ret = false;
       }
-      else if (!WaitGetDirectoryItems(getItems) || !getItems.m_result)
+      else if (!CGUIDialogBusy::Wait(&getItems, 100, true) || !getItems.m_result)
       {
         ret = false;
       }
     }
 
-    m_updateJobActive = false;
     m_rootDir.ReleaseDirImpl();
     return ret;
   }
   else
   {
     return m_rootDir.GetDirectory(url, items, useDir, false);
-  }
-}
-
-bool CGUIMediaWindow::WaitGetDirectoryItems(CGetDirectoryItems &items)
-{
-  bool ret = true;
-  CGUIDialogBusy* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);
-  if (dialog && !dialog->IsDialogRunning())
-  {
-    if (!CGUIDialogBusy::Wait(&items, 100, true))
-    {
-      // cancelled
-      ret = false;
-    }
-  }
-  else
-  {
-    m_updateJobActive = true;
-    m_updateAborted = false;
-    m_updateEvent.Reset();
-    CServiceBroker::GetJobManager()->Submit(
-        [&]() {
-          items.Run();
-          m_updateEvent.Set();
-        },
-        nullptr, CJob::PRIORITY_NORMAL);
-
-    // Loop until either the job ended or update canceled via CGUIMediaWindow::CancelUpdateItems.
-    while (!m_updateAborted && !m_updateEvent.Wait(1ms))
-    {
-      if (!ProcessRenderLoop(false))
-        break;
-    }
-
-    if (m_updateAborted)
-    {
-      CLog::LogF(LOGDEBUG, "Get directory items job was canceled.");
-      ret = false;
-    }
-    else if (!items.m_result)
-    {
-      CLog::LogF(LOGDEBUG, "Get directory items job was unsuccessful.");
-      ret = false;
-    }
-  }
-  return ret;
-}
-
-void CGUIMediaWindow::CancelUpdateItems()
-{
-  if (m_updateJobActive)
-  {
-    m_rootDir.CancelDirectory();
-    m_updateAborted = true;
-    if (!m_updateEvent.Wait(5000ms))
-    {
-      CLog::Log(LOGERROR, "CGUIMediaWindow::CancelUpdateItems - error cancel update");
-    }
-    m_updateJobActive = false;
   }
 }

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -162,9 +162,7 @@ protected:
   virtual void OnDeleteItem(int iItem);
   void OnRenameItem(int iItem);
   bool WaitForNetwork() const;
-  bool GetDirectoryItems(CURL &url, CFileItemList &items, bool useDir);
-  bool WaitGetDirectoryItems(CGetDirectoryItems &items);
-  void CancelUpdateItems();
+  bool GetDirectoryItems(CURL& url, CFileItemList& items, bool useDir);
 
   /*! \brief Translate the folder to start in from the given quick path
    \param url the folder the user wants
@@ -203,9 +201,6 @@ protected:
   protected:
     std::atomic_bool &m_update;
   };
-  CEvent m_updateEvent;
-  std::atomic_bool m_updateAborted = {false};
-  std::atomic_bool m_updateJobActive = {false};
 
   // save control state on window exit
   int m_iLastControl;


### PR DESCRIPTION
## Description

Split out from https://github.com/xbmc/xbmc/pull/21563 and addressed "stacking" of render loop issue.

I cherry-picked the commit from @ksooo , and added a basic patch to make CGUIDialogBusy::WaitOnEvent() fully re-entrant without duplicating render loops.

There might still be race conditions (e.g. many busy dialogs opened/closed all at once simultaneously), but under sane busy dialog use, this fix should be good to cover most situations that previously caused a crash.

## Motivation and context

Fixes https://github.com/xbmc/xbmc/issues/16756.

## How has this been tested?

Included in latest RetroPlayer test builds (upcoming).

## What is the effect on users?

* Fixed crash when two busy dialogs are opened

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
