### PR TITLE
Random SonarQube findings which were introduced since July 18 2025

### DIFF
--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -59,8 +59,15 @@ CInfoScanner::InfoType CNfoFile::Create(const std::string& strPath,
     if (m_type == AddonType::SCRAPER_MOVIES)
     {
       m_headPos = m_doc.find("<movies>");
-      while (index-- > 0 && (m_headPos = m_doc.find("<movie", m_headPos + 1)) != std::string::npos)
-        ;
+      if (m_headPos != std::string::npos)
+      {
+        while (index-- > 0)
+        {
+          m_headPos = m_doc.find("<movie", m_headPos + 1);
+          if (m_headPos == std::string::npos)
+            break;
+        }
+      }
     }
     bNfo = m_headPos != std::string::npos ? GetDetails(details) : false;
     overrideNfo = details.GetOverride();
@@ -70,7 +77,7 @@ CInfoScanner::InfoType CNfoFile::Create(const std::string& strPath,
 
   // search ..
   int res = -1;
-  for (auto& scraper : vecScrapers)
+  for (const auto& scraper : vecScrapers)
     if ((res = Scrape(scraper, m_scurl, m_doc)) == 0 || res == 2)
       break;
 

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
@@ -115,6 +115,18 @@ void CDialogGameVideoFilter::InitScalingMethods()
   }
 }
 
+namespace
+{
+TiXmlNode* GetFirstChildOfNode(TiXmlNode& node, const char* childName)
+{
+  TiXmlNode* ret{node.FirstChild(childName)};
+  if (ret)
+    return ret->FirstChild();
+
+  return ret;
+}
+} // unnamed namespace
+
 void CDialogGameVideoFilter::InitVideoFilters()
 {
 
@@ -168,17 +180,17 @@ void CDialogGameVideoFilter::InitVideoFilters()
     if (child->FirstChild() == nullptr)
       continue;
 
-    TiXmlNode* pathNode;
-    if ((pathNode = child->FirstChild("path")) && (pathNode = pathNode->FirstChild()))
+    const TiXmlNode* pathNode{GetFirstChildOfNode(*child, "path")};
+    if (pathNode)
       videoFilter.path =
           URIUtils::AddFileToFolder(URIUtils::GetBasePath(xmlPath), pathNode->Value());
 
-    TiXmlNode* nameNode;
-    if ((nameNode = child->FirstChild("name")) && (nameNode = nameNode->FirstChild()))
+    const TiXmlNode* nameNode{GetFirstChildOfNode(*child, "name")};
+    if (nameNode)
       videoFilter.name = nameNode->Value();
 
-    TiXmlNode* folderNode;
-    if ((folderNode = child->FirstChild("folder")) && (folderNode = folderNode->FirstChild()))
+    const TiXmlNode* folderNode{GetFirstChildOfNode(*child, "folder")};
+    if (folderNode)
       videoFilter.folder = folderNode->Value();
 
     videoFilters.emplace_back(videoFilter);

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -474,17 +474,15 @@ bool CTagLoaderTagLib::ParseTag(ID3v2::Tag* id3v2,
       }
     else if (it->first == "CHAP")
     {
-      using namespace std::ranges::views;
-
       constexpr auto toChapterFrame = [](auto* f) { return dynamic_cast<ID3v2::ChapterFrame*>(f); };
 
       // Produce a view of ChapterFrame pointers.
       auto chapterFrames = it->second // original FrameList
-                           | transform(toChapterFrame) // cast
-                           | filter([](auto* p) { return p; }); // keep non‑null
+                           | std::ranges::views::transform(toChapterFrame) // cast
+                           | std::ranges::views::filter([](auto* p) { return p; }); // keep non‑null
 
-      std::size_t chapNumber = 0;
-      for (auto* chapFrame : chapterFrames)
+      auto chapNumber{0};
+      for (const auto* chapFrame : chapterFrames)
       {
         ChapterDetails& chapter = chapters[chapNumber];
 
@@ -497,7 +495,7 @@ bool CTagLoaderTagLib::ParseTag(ID3v2::Tag* id3v2,
         std::chrono::milliseconds endTimeMs(chapFrame->endTime());
 
         // Make sure the very last chapter runs to EOF
-        if (chapNumber == static_cast<std::size_t>(std::ranges::distance(chapterFrames) - 1))
+        if (chapNumber == std::ranges::distance(chapterFrames) - 1)
           endTimeMs = totalLenMs;
 
         chapter.startTimeMs = startTimeMs;

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -709,7 +709,7 @@ TEST_F(TestURIUtils, GetDiscFile)
 
 TEST_F(TestURIUtils, GetDiscUnderlyingFile)
 {
-  CURL url = CURL("bluray://smb%3a%2f%2fsomepath%2fpath%2f/file.ext");
+  CURL url{"bluray://smb%3a%2f%2fsomepath%2fpath%2f/file.ext"};
   EXPECT_EQ("smb://somepath/path/file.ext", URIUtils::GetDiscUnderlyingFile(url));
 
   url = CURL("bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/file.ext");

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -506,7 +506,7 @@ struct EpisodeInformation
   unsigned int duration{0};
 };
 
-using EpisodeFileMap = std::multimap<std::string, EpisodeInformation>;
+using EpisodeFileMap = std::multimap<std::string, EpisodeInformation, std::less<>>;
 using EpisodeFileMapEntry = std::pair<std::string, EpisodeInformation>;
 
 class CVideoDatabase : public CDatabase
@@ -669,8 +669,8 @@ public:
   void GetEpisodesByFileId(int idFile, std::vector<CVideoInfoTag>& episodes);
   bool GetEpisodeMap(int idShow,
                      EpisodeFileMap& fileMap,
-                     std::unique_ptr<dbiplus::Dataset>& pDS,
-                     int idFile = -1 /* = -1 */);
+                     const std::unique_ptr<dbiplus::Dataset>& pDS,
+                     int idFile = -1 /* = -1 */) const;
 
   int SetDetailsForItem(CVideoInfoTag& details, const KODI::ART::Artwork& artwork);
   int SetDetailsForItem(int id,
@@ -1109,7 +1109,7 @@ public:
   void UpdateFileDateAdded(CVideoInfoTag& details);
 
   void ExportToXML(const std::string &path, bool singleFile = true, bool images=false, bool actorThumbs=false, bool overwrite=false);
-  void ExportArt(const CFileItem& item, const KODI::ART::Artwork& artwork, bool overwrite);
+  void ExportArt(const CFileItem& item, const KODI::ART::Artwork& artwork, bool overwrite) const;
   void ExportActorThumbs(const std::string& path,
                          const std::string& singlePath,
                          const CVideoInfoTag& tag,

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1033,10 +1033,9 @@ CVideoInfoScanner::~CVideoInfoScanner()
                                                                                     : nullptr,
                      pDlgProgress))
       {
-        if (UpdateSetInTag(*pItem->GetVideoInfoTag()))
-          if (!AddSet(pItem->GetVideoInfoTag()->m_set))
-            return InfoRet::INFO_ERROR;
-        const int dbId = AddVideo(pItem, info2, bDirNames, useLocal);
+        if (UpdateSetInTag(*pItem->GetVideoInfoTag()) && !AddSet(pItem->GetVideoInfoTag()->m_set))
+          return InfoRet::INFO_ERROR;
+        const int dbId{static_cast<int>(AddVideo(pItem, info2, bDirNames, useLocal))};
         if (dbId < 0)
           return InfoRet::INFO_ERROR;
         if (!m_ignoreVideoVersions && ProcessVideoVersion(VideoDbContentType::MOVIES, dbId))
@@ -1058,10 +1057,9 @@ CVideoInfoScanner::~CVideoInfoScanner()
                                                                                   : nullptr,
                    pDlgProgress))
     {
-      if (UpdateSetInTag(*pItem->GetVideoInfoTag()))
-        if (!AddSet(pItem->GetVideoInfoTag()->m_set))
-          return InfoRet::INFO_ERROR;
-      const int dbId = AddVideo(pItem, info2, bDirNames, useLocal);
+      if (UpdateSetInTag(*pItem->GetVideoInfoTag()) && !AddSet(pItem->GetVideoInfoTag()->m_set))
+        return InfoRet::INFO_ERROR;
+      const int dbId{static_cast<int>(AddVideo(pItem, info2, bDirNames, useLocal))};
       if (dbId < 0)
         return InfoRet::INFO_ERROR;
       if (!m_ignoreVideoVersions && ProcessVideoVersion(VideoDbContentType::MOVIES, dbId))
@@ -1203,7 +1201,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
                         useLocal && !item->IsPlugin(), useRemoteArt);
         for (const auto& [season, art] : seasonArt)
         {
-          const int seasonID{m_database.AddSeason(showID, season)};
+          const int seasonID{m_database.AddSeason(static_cast<int>(showID), season)};
           m_database.SetArtForItem(seasonID, MediaTypeSeason, art);
         }
       }
@@ -1910,7 +1908,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       if (idMovie != -1)
       {
         lResult = m_database.AddMovieVersion(*pItem, idMovie, art);
-        movieDetails.m_iDbId = lResult;
+        movieDetails.m_iDbId = static_cast<int>(lResult);
         movieDetails.m_type = MediaTypeMovie;
       }
     }
@@ -2698,9 +2696,10 @@ CVideoInfoScanner::~CVideoInfoScanner()
     }
   }
 
-  void CVideoInfoScanner::FetchActorThumbs(std::vector<SActorInfo>& actors,
-                                           const std::string& strPath,
-                                           UseRemoteArtWithLocalScraper useRemoteArt /* = yes */)
+  void CVideoInfoScanner::FetchActorThumbs(
+      std::vector<SActorInfo>& actors,
+      const std::string& strPath,
+      UseRemoteArtWithLocalScraper useRemoteArt /* = YES */) const
   {
     CFileItemList items;
     // don't try to fetch anything local with plugin source

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -257,7 +257,7 @@ namespace KODI::VIDEO
     void FetchActorThumbs(
         std::vector<SActorInfo>& actors,
         const std::string& strPath,
-        UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES);
+        UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES) const;
 
     static int GetPathHash(const CFileItemList &items, std::string &hash);
 

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -170,7 +170,7 @@ public:
   void SetNamedSeasons(std::map<int, std::string> namedSeasons);
   void SetUserrating(int userrating);
 
-  void SetOverride(bool override) { m_override = override; }
+  void SetOverride(bool setOverride) { m_override = setOverride; }
   bool GetOverride() const { return m_override; }
 
   /*!

--- a/xbmc/video/tags/VideoTagLoaderNFO.cpp
+++ b/xbmc/video/tags/VideoTagLoaderNFO.cpp
@@ -201,7 +201,7 @@ std::string CVideoTagLoaderNFO::FindNFO(const CFileItem& item,
     const std::string strPath{item.IsFolder() ? item.GetPath()
                                               : URIUtils::GetDirectory(item.GetPath())};
     CFileItemList items;
-    if (CDirectory::GetDirectory(strPath, items, ".nfo", DIR_FLAG_DEFAULTS) && items.Size() > 0)
+    if (CDirectory::GetDirectory(strPath, items, ".nfo", DIR_FLAG_DEFAULTS) && !items.IsEmpty())
     {
       const CVideoInfoTag* tag{item.GetVideoInfoTag()};
       auto nfoItems{items | std::views::filter(


### PR DESCRIPTION
## Description
Fixing SonarQube findings introduced between July 18 and August 3. Like always, no functional changes intended.

* "std::move" should only be used where moving can happen cpp:S5415
* "auto" should be used to avoid repetition of types cpp:S5827
* The right-hand operands of && and || should not contain side effects cpp:S912
* Pointer and reference local variables should be "const" if the corresponding object is not modified cpp:S5350
* Implicit casts should not lower precision cpp:S5276
* Unused function parameters should be removed cpp:S1172
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* Pointer and reference parameters should be "const" if the corresponding object is not modified cpp:S995
* Variables should not be shadowed cpp:S1117
* Context-sensitive keywords should not be used as identifiers cpp:S1669
* "empty()" should be used to test for emptiness cpp:S1155
* Mergeable "if" statements should be combined cpp:S1066
* The right-hand operands of && and || should not contain side effects cpp:S912
* Transparent function objects should be used with associative "std::string" containers cpp:S6045

## Motivation and context
Improving code quality and maintainability.

## How has this been tested?
Builds and runs.

## What is the effect on users?
Hopefully none.

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
