### PR TITLE
[cores/VideoPlayer/DVDDemuxers] DVDDemux.h: Fix misc SonarQube findings.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
@@ -10,7 +10,7 @@
 
 #include "utils/StringUtils.h"
 
-std::string CDemuxStreamAudio::GetStreamType()
+std::string CDemuxStreamAudio::GetStreamType() const
 {
   std::string strInfo;
   switch (codec)
@@ -138,7 +138,7 @@ std::string CDemuxStreamAudio::GetStreamType()
   return strInfo;
 }
 
-int CDVDDemux::GetNrOfStreams(StreamType streamType)
+int CDVDDemux::GetNrOfStreams(StreamType streamType) const
 {
   int iCounter = 0;
 
@@ -151,9 +151,9 @@ int CDVDDemux::GetNrOfStreams(StreamType streamType)
   return iCounter;
 }
 
-int CDVDDemux::GetNrOfSubtitleStreams()
+int CDVDDemux::GetNrOfSubtitleStreams() const
 {
-  return GetNrOfStreams(STREAM_SUBTITLE);
+  return GetNrOfStreams(StreamType::SUBTITLE);
 }
 
 std::string CDemuxStream::GetStreamName()

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.cpp
@@ -68,7 +68,7 @@ bool CDVDDemuxBXA::Open(const std::shared_ptr<CDVDInputStream>& pInput)
   m_stream->iBitsPerSample  = m_header.bitsPerSample;
   m_stream->iBitRate        = m_header.sampleRate * m_header.channels * m_header.bitsPerSample;
   m_stream->iChannels       = m_header.channels;
-  m_stream->type            = STREAM_AUDIO;
+  m_stream->type = StreamType::AUDIO;
   m_stream->codec           = AV_CODEC_ID_PCM_S16LE;
 
   return true;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.h
@@ -34,6 +34,7 @@ typedef struct
 
 #define BXA_PACKET_TYPE_FMT_DEMUX 1
 
+class CDVDInputStream;
 class CDemuxStreamAudioBXA;
 
 class CDVDDemuxBXA : public CDVDDemux

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.cpp
@@ -50,7 +50,7 @@ bool CDVDDemuxCDDA::Open(const std::shared_ptr<CDVDInputStream>& pInput)
   m_stream->iBitsPerSample  = 16;
   m_stream->iBitRate        = 44100 * 2 * 16;
   m_stream->iChannels       = 2;
-  m_stream->type            = STREAM_AUDIO;
+  m_stream->type = StreamType::AUDIO;
   m_stream->codec           = AV_CODEC_ID_PCM_S16LE;
 
   return true;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.h
@@ -17,6 +17,7 @@
 #endif
 
 class CDemuxStreamAudioCDDA;
+class CDVDInputStream;
 
 class CDVDDemuxCDDA : public CDVDDemux
 {

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -230,7 +230,7 @@ bool CDVDDemuxClient::ParsePacket(DemuxPacket* pkt)
 
     switch (st->type)
     {
-      case STREAM_AUDIO:
+      case StreamType::AUDIO:
       {
         CDemuxStreamClientInternalTpl<CDemuxStreamAudio>* sta = static_cast<CDemuxStreamClientInternalTpl<CDemuxStreamAudio>*>(st);
         int streamChannels = stream->m_context->ch_layout.nb_channels;
@@ -254,7 +254,7 @@ bool CDVDDemuxClient::ParsePacket(DemuxPacket* pkt)
           st->changes = -1; // stop parsing
         break;
       }
-      case STREAM_VIDEO:
+      case StreamType::VIDEO:
       {
         CDemuxStreamClientInternalTpl<CDemuxStreamVideo>* stv = static_cast<CDemuxStreamClientInternalTpl<CDemuxStreamVideo>*>(st);
         if (stream->m_parser->width != stv->iWidth && stream->m_parser->width != 0)
@@ -344,7 +344,7 @@ DemuxPacket* CDVDDemuxClient::Read()
       RequestStreams();
       DemuxPacket *pPacket = CDVDDemuxUtils::AllocateDemuxPacket(0);
       pPacket->iStreamId = DMX_SPECIALID_STREAMCHANGE;
-      pPacket->demuxerId = m_demuxerId;
+      pPacket->demuxerId = GetDemuxerId();
       return pPacket;
     }
   }
@@ -353,7 +353,7 @@ DemuxPacket* CDVDDemuxClient::Read()
   {
     CDVDDemuxUtils::FreeDemuxPacket(m_packet.release());
     DemuxPacket *pPacket = CDVDDemuxUtils::AllocateDemuxPacket(0);
-    pPacket->demuxerId = m_demuxerId;
+    pPacket->demuxerId = GetDemuxerId();
     return pPacket;
   }
 
@@ -420,7 +420,7 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
   std::shared_ptr<CDemuxStream> currentStream(GetStreamInternal(stream->uniqueId));
   std::shared_ptr<CDemuxStream> toStream;
 
-  if (stream->type == STREAM_AUDIO)
+  if (stream->type == StreamType::AUDIO)
   {
     CDemuxStreamAudio *source = dynamic_cast<CDemuxStreamAudio*>(stream);
     if (!source)
@@ -456,7 +456,7 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
     map[stream->uniqueId] = streamAudio;
     toStream = streamAudio;
   }
-  else if (stream->type == STREAM_VIDEO)
+  else if (stream->type == StreamType::VIDEO)
   {
     CDemuxStreamVideo *source = dynamic_cast<CDemuxStreamVideo*>(stream);
 
@@ -501,7 +501,7 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
     map[stream->uniqueId] = streamVideo;
     toStream = streamVideo;
   }
-  else if (stream->type == STREAM_SUBTITLE)
+  else if (stream->type == StreamType::SUBTITLE)
   {
     CDemuxStreamSubtitle *source = dynamic_cast<CDemuxStreamSubtitle*>(stream);
 
@@ -531,7 +531,7 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
     map[stream->uniqueId] = streamSubtitle;
     toStream = streamSubtitle;
   }
-  else if (stream->type == STREAM_TELETEXT)
+  else if (stream->type == StreamType::TELETEXT)
   {
     CDemuxStreamTeletext *source = dynamic_cast<CDemuxStreamTeletext*>(stream);
 
@@ -554,7 +554,7 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
     map[stream->uniqueId] = streamTeletext;
     toStream = streamTeletext;
   }
-  else if (stream->type == STREAM_RADIO_RDS)
+  else if (stream->type == StreamType::RADIO_RDS)
   {
     CDemuxStreamRadioRDS *source = dynamic_cast<CDemuxStreamRadioRDS*>(stream);
 
@@ -577,7 +577,7 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
     map[stream->uniqueId] = streamRDS;
     toStream = streamRDS;
   }
-  else if (stream->type == STREAM_AUDIO_ID3)
+  else if (stream->type == StreamType::AUDIO_ID3)
   {
     CDemuxStreamAudioID3* source = dynamic_cast<CDemuxStreamAudioID3*>(stream);
 
@@ -651,7 +651,7 @@ bool CDVDDemuxClient::IsVideoReady()
 {
   for (const auto& stream : m_streams)
   {
-    if (stream.first == m_videoStreamPlaying && stream.second->type == STREAM_VIDEO &&
+    if (stream.first == m_videoStreamPlaying && stream.second->type == StreamType::VIDEO &&
         CodecHasExtraData(stream.second->codec) && !stream.second->extraData)
       return false;
   }
@@ -720,7 +720,7 @@ void CDVDDemuxClient::OpenStream(int id)
     bool bOpenStream = m_IDemux->OpenStream(id);
 
     CDemuxStream *stream(m_IDemux->GetStream(id));
-    if (stream && stream->type == STREAM_VIDEO)
+    if (stream && stream->type == StreamType::VIDEO)
       m_videoStreamPlaying = id;
 
     if (bOpenStream)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1032,7 +1032,7 @@ DemuxPacket* CDVDDemuxFFmpeg::ReadInternal(bool keep)
 
           pPacket = CDVDDemuxUtils::AllocateDemuxPacket(0);
           pPacket->iStreamId = DMX_SPECIALID_STREAMCHANGE;
-          pPacket->demuxerId = m_demuxerId;
+          pPacket->demuxerId = GetDemuxerId();
 
           return pPacket;
         }
@@ -1146,7 +1146,7 @@ DemuxPacket* CDVDDemuxFFmpeg::ReadInternal(bool keep)
       stream = AddStream(pPacket->iStreamId);
     }
     // we already check for a valid m_streams[pPacket->iStreamId] above
-    else if (stream->type == STREAM_AUDIO)
+    else if (stream->type == StreamType::AUDIO)
     {
       CDemuxStreamAudioFFmpeg* audiostream = dynamic_cast<CDemuxStreamAudioFFmpeg*>(stream);
       int codecparChannels =
@@ -1159,7 +1159,7 @@ DemuxPacket* CDVDDemuxFFmpeg::ReadInternal(bool keep)
         stream = AddStream(pPacket->iStreamId);
       }
     }
-    else if (stream->type == STREAM_VIDEO)
+    else if (stream->type == StreamType::VIDEO)
     {
       if (static_cast<CDemuxStreamVideo*>(stream)->iWidth != m_pFormatContext->streams[pPacket->iStreamId]->codecpar->width ||
           static_cast<CDemuxStreamVideo*>(stream)->iHeight != m_pFormatContext->streams[pPacket->iStreamId]->codecpar->height)
@@ -1179,7 +1179,7 @@ DemuxPacket* CDVDDemuxFFmpeg::ReadInternal(bool keep)
     }
 
     pPacket->iStreamId = stream->uniqueId;
-    pPacket->demuxerId = m_demuxerId;
+    pPacket->demuxerId = GetDemuxerId();
   }
   return pPacket;
 }
@@ -1728,7 +1728,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
       case AVMEDIA_TYPE_DATA:
       {
         stream = new CDemuxStream();
-        stream->type = STREAM_DATA;
+        stream->type = StreamType::DATA;
         break;
       }
       case AVMEDIA_TYPE_SUBTITLE:
@@ -1737,7 +1737,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         {
           CDemuxStreamTeletext* st = new CDemuxStreamTeletext();
           stream = st;
-          stream->type = STREAM_TELETEXT;
+          stream->type = StreamType::TELETEXT;
           break;
         }
         else
@@ -1789,7 +1789,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
           }
         }
         stream = new CDemuxStream();
-        stream->type = STREAM_NONE;
+        stream->type = StreamType::NONE;
         break;
       }
       default:
@@ -1802,7 +1802,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
           return nullptr;
         }
         stream = new CDemuxStream();
-        stream->type = STREAM_NONE;
+        stream->type = StreamType::NONE;
       }
     }
 
@@ -1858,7 +1858,8 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
       }
     }
 
-    if (stream->type != STREAM_NONE && pStream->codecpar->extradata && pStream->codecpar->extradata_size > 0)
+    if (stream->type != StreamType::NONE && pStream->codecpar->extradata &&
+        pStream->codecpar->extradata_size > 0)
     {
       stream->extraData =
           FFmpegExtraData(pStream->codecpar->extradata, pStream->codecpar->extradata_size);
@@ -1926,7 +1927,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
     }
 
     stream->uniqueId = pStream->index;
-    stream->demuxerId = m_demuxerId;
+    stream->demuxerId = GetDemuxerId();
 
     AddStream(stream->uniqueId, stream);
     return stream;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -20,6 +20,7 @@ extern "C" {
 }
 
 class CDVDDemuxFFmpeg;
+class CDVDInputStream;
 class CURL;
 
 enum class TRANSPORT_STREAM_STATE

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.cpp
@@ -225,7 +225,7 @@ bool CDVDDemuxVobsub::ParseId(SState& state, std::string& line)
   stream->codec = AV_CODEC_ID_DVD_SUBTITLE;
   stream->uniqueId = m_Streams.size();
   stream->source = m_source;
-  stream->demuxerId = m_demuxerId;
+  stream->demuxerId = GetDemuxerId();
 
   state.id = stream->uniqueId;
   m_Streams.push_back(stream.release());

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -131,7 +131,7 @@ std::unique_ptr<CTexture> CDVDFileInfo::ExtractThumbToTexture(const CFileItem& f
     if (pStream)
     {
       // ignore if it's a picture attachment (e.g. jpeg artwork)
-      if (pStream->type == STREAM_VIDEO && !(pStream->flags & AV_DISPOSITION_ATTACHED_PIC))
+      if (pStream->type == StreamType::VIDEO && !(pStream->flags & AV_DISPOSITION_ATTACHED_PIC))
       {
         nVideoStream = pStream->uniqueId;
         demuxerId = pStream->demuxerId;
@@ -358,7 +358,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
   const CURL pathToUrl(path);
   for (CDemuxStream* stream : pDemux->GetStreams())
   {
-    if (stream->type == STREAM_VIDEO && !(stream->flags & AV_DISPOSITION_ATTACHED_PIC))
+    if (stream->type == StreamType::VIDEO && !(stream->flags & AV_DISPOSITION_ATTACHED_PIC))
     {
       CStreamDetailVideo *p = new CStreamDetailVideo();
       CDemuxStreamVideo* vstream = static_cast<CDemuxStreamVideo*>(stream);
@@ -397,7 +397,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
       retVal = true;
     }
 
-    else if (stream->type == STREAM_AUDIO)
+    else if (stream->type == StreamType::AUDIO)
     {
       CStreamDetailAudio *p = new CStreamDetailAudio();
       p->m_iChannels = static_cast<CDemuxStreamAudio*>(stream)->iChannels;
@@ -407,7 +407,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
       retVal = true;
     }
 
-    else if (stream->type == STREAM_SUBTITLE)
+    else if (stream->type == StreamType::SUBTITLE)
     {
       CStreamDetailSubtitle *p = new CStreamDetailSubtitle();
       p->m_strLanguage = stream->language;

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
@@ -33,7 +33,7 @@ CDVDStreamInfo::~CDVDStreamInfo() = default;
 void CDVDStreamInfo::Clear()
 {
   codec = AV_CODEC_ID_NONE;
-  type = STREAM_NONE;
+  type = StreamType::NONE;
   uniqueId = -1;
   source = STREAM_SOURCE_NONE;
   codecOptions = 0;
@@ -271,7 +271,7 @@ void CDVDStreamInfo::Assign(const CDemuxStream& right, bool withextradata)
   cryptoSession = right.cryptoSession;
   externalInterfaces = right.externalInterfaces;
 
-  if (right.type == STREAM_AUDIO)
+  if (right.type == StreamType::AUDIO)
   {
     const CDemuxStreamAudio *stream = static_cast<const CDemuxStreamAudio*>(&right);
     channels      = stream->iChannels;
@@ -281,7 +281,7 @@ void CDVDStreamInfo::Assign(const CDemuxStream& right, bool withextradata)
     bitspersample = stream->iBitsPerSample;
     channellayout = stream->iChannelLayout;
   }
-  else if (right.type == STREAM_VIDEO)
+  else if (right.type == StreamType::VIDEO)
   {
     const CDemuxStreamVideo *stream = static_cast<const CDemuxStreamVideo*>(&right);
     fpsscale  = stream->iFpsScale;
@@ -306,7 +306,7 @@ void CDVDStreamInfo::Assign(const CDemuxStream& right, bool withextradata)
     stereo_mode = stream->stereo_mode;
     dovi = stream->dovi;
   }
-  else if (right.type == STREAM_SUBTITLE)
+  else if (right.type == StreamType::SUBTITLE)
   {
   }
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -176,7 +176,7 @@ public:
 //------------------------------------------------------------------------------
 struct SelectionStream
 {
-  StreamType type = STREAM_NONE;
+  StreamType type = StreamType::NONE;
   int type_index = 0;
   std::string filename;
   std::string filename2;  // for vobsub subtitles, 2 files are necessary (idx/sub)

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.cpp
@@ -43,7 +43,7 @@ CVideoPlayerAudioID3::~CVideoPlayerAudioID3()
 
 bool CVideoPlayerAudioID3::CheckStream(const CDVDStreamInfo& hints)
 {
-  return hints.type == STREAM_AUDIO_ID3;
+  return hints.type == StreamType::AUDIO_ID3;
 }
 
 void CVideoPlayerAudioID3::Flush()
@@ -65,7 +65,7 @@ bool CVideoPlayerAudioID3::OpenStream(CDVDStreamInfo hints)
   CloseStream(true);
   m_messageQueue.Init();
 
-  if (hints.type == STREAM_AUDIO_ID3)
+  if (hints.type == StreamType::AUDIO_ID3)
   {
     Flush();
     CLog::Log(LOGINFO, "Creating Audio ID3 tag processor data thread");

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -513,7 +513,7 @@ CDVDRadioRDSData::~CDVDRadioRDSData()
 
 bool CDVDRadioRDSData::CheckStream(const CDVDStreamInfo& hints)
 {
-  if (hints.type == STREAM_RADIO_RDS)
+  if (hints.type == StreamType::RADIO_RDS)
     return true;
 
   return false;
@@ -524,7 +524,7 @@ bool CDVDRadioRDSData::OpenStream(CDVDStreamInfo hints)
   CloseStream(true);
 
   m_messageQueue.Init();
-  if (hints.type == STREAM_RADIO_RDS)
+  if (hints.type == StreamType::RADIO_RDS)
   {
     Flush();
     CLog::Log(LOGINFO, "Creating UECP (RDS) data thread");

--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -124,7 +124,7 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
   int64_t demuxerId = -1;
   for (auto stream : m_pDemuxer->GetStreams())
   {
-    if (stream && stream->type == STREAM_AUDIO)
+    if (stream && stream->type == StreamType::AUDIO)
     {
       m_nAudioStream = stream->uniqueId;
       demuxerId = stream->demuxerId;


### PR DESCRIPTION
## Description
Fixing SonarQube findings in cores/VideoPlayer/DVDDemuxers] DVDDemux.h. Separate PR because many files being involved (enum -> enum class change). Like always, no functional changes intended.

Findings addressed:
* Member data should be initialized in-class or in a constructor initialization list cpp:S3230
* #include directives in a file should only be preceded by other preprocessor directives or comments cpp:S954
* "nullptr" should be used to denote the null pointer cpp:S4962
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* Member variables should not be "protected" cpp:S3656
* Scoped enumerations should be used cpp:S3642

## Motivation and context
Improving code quality and maintainability.

## How has this been tested?
Builds and runs.

## What is the effect on users?
Hopefully none.

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
