### PR TITLE
[addons] Fix misc SonarQube findings.

### DIFF
--- a/xbmc/addons/addoninfo/AddonExtensions.cpp
+++ b/xbmc/addons/addoninfo/AddonExtensions.cpp
@@ -17,17 +17,17 @@ bool SExtValue::asBoolean() const
   return StringUtils::EqualsNoCase(str, "true");
 }
 
-const SExtValue CAddonExtensions::GetValue(const std::string& id) const
+SExtValue CAddonExtensions::GetValue(std::string_view id) const
 {
-  for (const auto& values : m_values)
+  for (const auto& [_, values] : m_values)
   {
-    for (const auto& value : values.second)
+    for (const auto& [valueId, valueValue] : values)
     {
-      if (value.first == id)
-        return value.second;
+      if (valueId == id)
+        return valueValue;
     }
   }
-  return SExtValue("");
+  return {};
 }
 
 const EXT_VALUES& CAddonExtensions::GetValues() const
@@ -35,27 +35,27 @@ const EXT_VALUES& CAddonExtensions::GetValues() const
   return m_values;
 }
 
-const CAddonExtensions* CAddonExtensions::GetElement(const std::string& id) const
+const CAddonExtensions* CAddonExtensions::GetElement(std::string_view id) const
 {
-  for (const auto& child : m_children)
+  for (const auto& [childId, childExts] : m_children)
   {
-    if (child.first == id)
-      return &child.second;
+    if (childId == id)
+      return &childExts;
   }
 
   return nullptr;
 }
 
-const EXT_ELEMENTS CAddonExtensions::GetElements(const std::string& id) const
+EXT_ELEMENTS CAddonExtensions::GetElements(std::string_view id /*= ""*/) const
 {
   if (id.empty())
     return m_children;
 
   EXT_ELEMENTS children;
-  for (const auto& child : m_children)
+  for (const auto& [childId, childExts] : m_children)
   {
-    if (child.first == id)
-      children.emplace_back(child.first, child.second);
+    if (childId == id)
+      children.emplace_back(childId, childExts);
   }
   return children;
 }

--- a/xbmc/addons/addoninfo/AddonExtensions.h
+++ b/xbmc/addons/addoninfo/AddonExtensions.h
@@ -10,6 +10,7 @@
 
 #include <stdlib.h>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace ADDON
@@ -20,34 +21,38 @@ class CAddonDatabaseSerializer;
 
 struct SExtValue
 {
-  explicit SExtValue(const std::string& strValue) : str(strValue) { }
+  SExtValue() = default;
+  explicit SExtValue(const std::string& strValue) : str(strValue) {}
+
   const std::string& asString() const { return str; }
   bool asBoolean() const;
   int asInteger() const { return std::atoi(str.c_str()); }
   float asFloat() const { return static_cast<float>(std::atof(str.c_str())); }
   bool empty() const { return str.empty(); }
+
   const std::string str;
 };
 
 class CExtValues;
 class CAddonExtensions;
-typedef std::vector<std::pair<std::string, CAddonExtensions>> EXT_ELEMENTS;
-typedef std::vector<std::pair<std::string, SExtValue>> EXT_VALUE;
-typedef std::vector<std::pair<std::string, CExtValues>> EXT_VALUES;
+
+using EXT_ELEMENTS = std::vector<std::pair<std::string, CAddonExtensions>>;
+using EXT_VALUE = std::vector<std::pair<std::string, SExtValue>>;
+using EXT_VALUES = std::vector<std::pair<std::string, CExtValues>>;
 
 class CExtValues : public EXT_VALUE
 {
 public:
-  CExtValues(const EXT_VALUE& values) : EXT_VALUE(values) { }
+  explicit CExtValues(const EXT_VALUE& values) : EXT_VALUE(values) {}
 
-  const SExtValue GetValue(const std::string& id) const
+  SExtValue GetValue(std::string_view id) const
   {
-    for (const auto& value : *this)
+    for (const auto& [valueId, valueValue] : *this)
     {
-      if (value.first == id)
-        return value.second;
+      if (valueId == id)
+        return valueValue;
     }
-    return SExtValue("");
+    return {};
   }
 };
 
@@ -57,10 +62,10 @@ public:
   CAddonExtensions() = default;
   ~CAddonExtensions() = default;
 
-  const SExtValue GetValue(const std::string& id) const;
+  SExtValue GetValue(std::string_view id) const;
   const EXT_VALUES& GetValues() const;
-  const CAddonExtensions* GetElement(const std::string& id) const;
-  const EXT_ELEMENTS GetElements(const std::string& id = "") const;
+  const CAddonExtensions* GetElement(std::string_view id) const;
+  EXT_ELEMENTS GetElements(std::string_view id = "") const;
 
   void Insert(const std::string& id, const std::string& value);
 

--- a/xbmc/addons/addoninfo/AddonInfo.h
+++ b/xbmc/addons/addoninfo/AddonInfo.h
@@ -11,11 +11,12 @@
 #include "XBDateTime.h"
 #include "addons/AddonVersion.h"
 #include "utils/Artwork.h"
+#include "utils/Locale.h"
 
 #include <map>
 #include <memory>
 #include <string>
-#include <unordered_map>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -27,8 +28,9 @@ enum class AddonType;
 class CAddonBuilder;
 class CAddonInfo;
 class CAddonType;
-typedef std::shared_ptr<CAddonInfo> AddonInfoPtr;
-typedef std::vector<AddonInfoPtr> AddonInfos;
+
+using AddonInfoPtr = std::shared_ptr<CAddonInfo>;
+using AddonInfos = std::vector<AddonInfoPtr>;
 
 using AddonInstanceId = uint32_t;
 
@@ -109,8 +111,10 @@ enum class AddonLifecycleState
 struct DependencyInfo
 {
   std::string id;
-  CAddonVersion versionMin, version;
+  CAddonVersion versionMin;
+  CAddonVersion version;
   bool optional;
+
   DependencyInfo(std::string id,
                  const CAddonVersion& versionMin,
                  const CAddonVersion& version,
@@ -122,16 +126,7 @@ struct DependencyInfo
   {
   }
 
-  bool operator==(const DependencyInfo& rhs) const
-  {
-    return id == rhs.id && versionMin == rhs.versionMin && version == rhs.version &&
-           optional == rhs.optional;
-  }
-
-  bool operator!=(const DependencyInfo& rhs) const
-  {
-    return !(rhs == *this);
-  }
+  bool operator==(const DependencyInfo& rhs) const = default;
 };
 
 using InfoMap = std::map<std::string, std::string, std::less<>>;
@@ -146,9 +141,12 @@ public:
 
   void SetMainType(AddonType type) { m_mainType = type; }
   void SetBinary(bool isBinary) { m_isBinary = isBinary; }
-  void SetLibName(const std::string& libname) { m_libname = libname; }
-  void SetPath(const std::string& path) { m_path = path; }
-  void AddExtraInfo(const std::string& idName, const std::string& value) { m_extrainfo[idName] = value; }
+  void SetLibName(std::string_view libname) { m_libname = libname; }
+  void SetPath(std::string_view path) { m_path = path; }
+  void AddExtraInfo(const std::string& idName, std::string_view value)
+  {
+    m_extrainfo[idName] = value;
+  }
   void SetLastUsed(const CDateTime& dateTime) { m_lastUsed = dateTime; }
 
   const std::string& ID() const { return m_id; }
@@ -256,7 +254,7 @@ public:
   static std::string TranslateType(AddonType type, bool pretty = false);
   static std::string TranslateIconType(AddonType type);
   static AddonType TranslateType(const std::string& string);
-  static AddonType TranslateSubContent(const std::string& content);
+  static AddonType TranslateSubContent(std::string_view content);
   static AddonInstanceSupport InstanceSupportType(AddonType type);
   //@}
 
@@ -273,8 +271,8 @@ private:
   bool m_isBinary = false;
   std::string m_name;
   std::string m_license;
-  std::unordered_map<std::string, std::string> m_summary;
-  std::unordered_map<std::string, std::string> m_description;
+  CLocale::LocalizedStringsMap m_summary;
+  CLocale::LocalizedStringsMap m_description;
   std::string m_author;
   std::string m_source;
   std::string m_website;
@@ -282,14 +280,14 @@ private:
   std::string m_email;
   std::string m_path;
   std::string m_profilePath;
-  std::unordered_map<std::string, std::string> m_changelog;
+  CLocale::LocalizedStringsMap m_changelog;
   std::string m_icon;
   KODI::ART::Artwork m_art;
   std::vector<std::string> m_screenshots;
-  std::unordered_map<std::string, std::string> m_disclaimer;
+  CLocale::LocalizedStringsMap m_disclaimer;
   std::vector<DependencyInfo> m_dependencies;
   AddonLifecycleState m_lifecycleState = AddonLifecycleState::NORMAL;
-  std::unordered_map<std::string, std::string> m_lifecycleStateDescription;
+  CLocale::LocalizedStringsMap m_lifecycleStateDescription;
   CDateTime m_installDate;
   CDateTime m_lastUpdated;
   CDateTime m_lastUsed;
@@ -303,7 +301,7 @@ private:
   bool m_supportsAddonSettings{false};
   bool m_supportsInstanceSettings{false};
 
-  const std::string& GetTranslatedText(const std::unordered_map<std::string, std::string>& locales) const;
+  const std::string& GetTranslatedText(const CLocale::LocalizedStringsMap& locales) const;
 };
 
 } /* namespace ADDON */

--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -58,19 +58,17 @@ void CAddonInfoBuilderFromDB::SetLicense(std::string license)
 
 void CAddonInfoBuilderFromDB::SetSummary(std::string summary)
 {
-  m_addonInfo->m_summary.insert(std::pair<std::string, std::string>("unk", std::move(summary)));
+  m_addonInfo->m_summary.try_emplace("unk", std::move(summary));
 }
 
 void CAddonInfoBuilderFromDB::SetDescription(std::string description)
 {
-  m_addonInfo->m_description.insert(
-      std::pair<std::string, std::string>("unk", std::move(description)));
+  m_addonInfo->m_description.try_emplace("unk", std::move(description));
 }
 
 void CAddonInfoBuilderFromDB::SetDisclaimer(std::string disclaimer)
 {
-  m_addonInfo->m_disclaimer.insert(
-      std::pair<std::string, std::string>("unk", std::move(disclaimer)));
+  m_addonInfo->m_disclaimer.try_emplace("unk", std::move(disclaimer));
 }
 
 void CAddonInfoBuilderFromDB::SetAuthor(std::string author)
@@ -120,7 +118,7 @@ void CAddonInfoBuilderFromDB::SetScreenshots(std::vector<std::string> screenshot
 
 void CAddonInfoBuilderFromDB::SetChangelog(std::string changelog)
 {
-  m_addonInfo->m_changelog.insert(std::pair<std::string, std::string>("unk", std::move(changelog)));
+  m_addonInfo->m_changelog.try_emplace("unk", std::move(changelog));
 }
 
 void CAddonInfoBuilderFromDB::SetLifecycleState(AddonLifecycleState state, std::string description)
@@ -195,11 +193,11 @@ AddonInfoPtr CAddonInfoBuilder::Generate(const std::string& id, AddonType type)
   // any character to go through.
   if (id.empty() || id.find_first_not_of(VALID_ADDON_IDENTIFIER_CHARACTERS) != std::string::npos)
   {
-    CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: identifier '{}' is invalid", __FUNCTION__, id);
+    CLog::LogF(LOGERROR, "Identifier '{}' is invalid", id);
     return nullptr;
   }
 
-  AddonInfoPtr addon = std::make_shared<CAddonInfo>();
+  auto addon = std::make_shared<CAddonInfo>();
   addon->m_id = id;
   addon->m_mainType = type;
   return addon;
@@ -212,21 +210,21 @@ AddonInfoPtr CAddonInfoBuilder::Generate(const std::string& addonPath, bool plat
   CXBMCTinyXML2 xmlDoc;
   if (!xmlDoc.LoadFile(URIUtils::AddFileToFolder(addonRealPath, "addon.xml")))
   {
-    CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: Unable to load '{}', Line {}\n{}", __FUNCTION__,
-              URIUtils::AddFileToFolder(addonRealPath, "addon.xml"), xmlDoc.ErrorLineNum(),
-              xmlDoc.ErrorStr());
+    CLog::LogF(LOGERROR, "Unable to load '{}', Line: {}, Error: {}",
+               URIUtils::AddFileToFolder(addonRealPath, "addon.xml"), xmlDoc.ErrorLineNum(),
+               xmlDoc.ErrorStr());
     return nullptr;
   }
 
-  AddonInfoPtr addon = std::make_shared<CAddonInfo>();
+  auto addon = std::make_shared<CAddonInfo>();
   if (!ParseXML(addon, xmlDoc.RootElement(), addonRealPath))
     return nullptr;
 
   if (!platformCheck || PlatformSupportsAddon(addon))
     return addon;
 
-  CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: No platform for add-on {} (supported platforms: {})",
-            __FUNCTION__, addon->ID(), StringUtils::Join(addon->m_platforms, ", "));
+  CLog::LogF(LOGERROR, "No platform for add-on {} (supported platforms: {})", addon->ID(),
+             StringUtils::Join(addon->m_platforms, ", "));
 
   return nullptr;
 }
@@ -235,7 +233,7 @@ AddonInfoPtr CAddonInfoBuilder::Generate(const tinyxml2::XMLElement* baseElement
                                          const RepositoryDirInfo& repo,
                                          bool platformCheck /*= true*/)
 {
-  AddonInfoPtr addon = std::make_shared<CAddonInfo>();
+  auto addon = std::make_shared<CAddonInfo>();
   if (!ParseXML(addon, baseElement, repo.datadir, repo))
     return nullptr;
 
@@ -245,8 +243,11 @@ AddonInfoPtr CAddonInfoBuilder::Generate(const tinyxml2::XMLElement* baseElement
   return nullptr;
 }
 
-void CAddonInfoBuilder::SetInstallData(const AddonInfoPtr& addon, const CDateTime& installDate, const CDateTime& lastUpdated,
-                                       const CDateTime& lastUsed, const std::string& origin)
+void CAddonInfoBuilder::SetInstallData(const AddonInfoPtr& addon,
+                                       const CDateTime& installDate,
+                                       const CDateTime& lastUpdated,
+                                       const CDateTime& lastUsed,
+                                       std::string_view origin)
 {
   if (!addon)
     return;
@@ -279,7 +280,7 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon,
 
   if (!StringUtils::EqualsNoCase(element->Value(), "addon"))
   {
-    CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: file from '{}' doesn't contain <addon>", __FUNCTION__, addonPath);
+    CLog::LogF(LOGERROR, "File from '{}' doesn't contain <addon>", addonPath);
     return false;
   }
 
@@ -305,11 +306,10 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon,
 
   if (addon->m_id.empty() || addon->m_version.empty())
   {
-    CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: file '{}' doesn't contain required values on <addon ... > id='{}', version='{}'",
-              __FUNCTION__,
-              addonPath,
-              addon->m_id.empty() ? "missing" : addon->m_id,
-              addon->m_version.empty() ? "missing" : addon->m_version.asString());
+    CLog::LogF(LOGERROR,
+               "File '{}' doesn't contain required values on <addon ... > id='{}', version='{}'",
+               addonPath, addon->m_id.empty() ? "missing" : addon->m_id,
+               addon->m_version.empty() ? "missing" : addon->m_version.asString());
     return false;
   }
 
@@ -318,7 +318,7 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon,
   // any character to go through.
   if (addon->m_id.find_first_not_of(VALID_ADDON_IDENTIFIER_CHARACTERS) != std::string::npos)
   {
-    CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: identifier {} is invalid", __FUNCTION__, addon->m_id);
+    CLog::LogF(LOGERROR, "Identifier {} is invalid", addon->m_id);
     return false;
   }
 
@@ -418,7 +418,7 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon,
       /*
        * Parse addon.xml "<assets>...</assets>"
        */
-      const auto* element = child->FirstChildElement("assets");
+      element = child->FirstChildElement("assets");
       if (element)
       {
         for (const auto* elementsAssets = element->FirstChildElement(); elementsAssets != nullptr;
@@ -465,9 +465,7 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon,
       {
         using namespace std::literals;
         auto platforms = StringUtils::Split(element->GetText(), {{" "sv, "\t"sv, "\n"sv, "\r"sv}});
-        platforms.erase(std::remove_if(platforms.begin(), platforms.end(),
-                        [](const std::string& platform) { return platform.empty(); }),
-                        platforms.cend());
+        std::erase_if(platforms, [](std::string_view platform) { return platform.empty(); });
         addon->m_platforms = platforms;
       }
 
@@ -502,8 +500,8 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon,
       if (element && element->GetText() != nullptr)
       {
         addon->m_lifecycleState = AddonLifecycleState::BROKEN;
-        addon->m_lifecycleStateDescription.emplace(KODI_ADDON_DEFAULT_LANGUAGE_CODE,
-                                                   element->GetText());
+        addon->m_lifecycleStateDescription.try_emplace(KODI_ADDON_DEFAULT_LANGUAGE_CODE,
+                                                       element->GetText());
       }
 
       /* Parse addon.xml "<lifecyclestate">...</lifecyclestate>" */
@@ -565,7 +563,8 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon,
       AddonType type = CAddonInfo::TranslateType(point);
       if (type == AddonType::UNKNOWN || type >= AddonType::MAX_TYPES)
       {
-        CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: file '{}' doesn't contain a valid add-on type name ({})", __FUNCTION__, addon->m_path, point);
+        CLog::LogF(LOGERROR, "File '{}' doesn't contain a valid add-on type name ({})",
+                   addon->m_path, point);
         return false;
       }
 
@@ -603,8 +602,10 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon,
       // Prevent log file entry if data is from repository, there normal on
       // addons for other OS's
       if (!isRepoXMLContent)
-        CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: addon.xml from '{}' for binary type '{}' doesn't contain library and addon becomes ignored",
-                      __FUNCTION__, addon->ID(), CAddonInfo::TranslateType(addon->m_mainType));
+        CLog::LogF(LOGERROR,
+                   "addon.xml from '{}' for binary type '{}' doesn't contain library and addon "
+                   "becomes ignored",
+                   addon->ID(), CAddonInfo::TranslateType(addon->m_mainType));
       return false;
     }
   }
@@ -648,20 +649,19 @@ bool CAddonInfoBuilder::ParseXMLTypes(CAddonType& addonType,
         if (std::regex_match(library, libRegex))
         {
           info->SetBinary(true);
-          CLog::Log(LOGDEBUG, "CAddonInfoBuilder::{}: Binary addon found: {}", __func__,
-                    info->ID());
+          CLog::LogF(LOGDEBUG, "Binary addon found: {}", info->ID());
         }
       }
       catch (const std::regex_error& e)
       {
-        CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: Regex error caught: {}", __func__,
-                  e.what());
+        CLog::LogF(LOGERROR, "Regex error caught: {}", e.what());
       }
     }
 
     if (!ParseXMLExtension(addonType, child))
     {
-      CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: addon.xml file doesn't contain a valid add-on extensions ({})", __FUNCTION__, info->ID());
+      CLog::LogF(LOGERROR, "addon.xml file doesn't contain a valid add-on extensions ({})",
+                 info->ID());
       return false;
     }
     if (!addonType.GetValue("provides").empty())
@@ -687,7 +687,7 @@ bool CAddonInfoBuilder::ParseXMLExtension(CAddonExtensions& addonExt,
       if (!value.empty())
       {
         name = "@" + name;
-        extension.emplace_back(std::make_pair(name, SExtValue(value)));
+        extension.emplace_back(name, SExtValue(value));
       }
     }
     attribute = attribute->Next();
@@ -702,31 +702,31 @@ bool CAddonInfoBuilder::ParseXMLExtension(CAddonExtensions& addonExt,
     if (!id.empty())
     {
       EXT_VALUE childExtension;
-      const auto* attribute = childElement->FirstAttribute();
-      while (attribute)
+      const auto* childAttribute = childElement->FirstAttribute();
+      while (childAttribute)
       {
-        std::string name = attribute->Name();
+        std::string name = childAttribute->Name();
         if (name != "point")
         {
-          const std::string value = StringUtils::CreateFromCString(attribute->Value());
+          const std::string value = StringUtils::CreateFromCString(childAttribute->Value());
           if (!value.empty())
           {
             name = id + "@" + name;
-            childExtension.emplace_back(std::make_pair(name, SExtValue(value)));
+            childExtension.emplace_back(name, SExtValue(value));
           }
         }
-        attribute = attribute->Next();
+        childAttribute = childAttribute->Next();
       }
 
       const std::string childElementText = StringUtils::CreateFromCString(childElement->GetText());
 
       if (!childElementText.empty())
       {
-        childExtension.emplace_back(std::make_pair(id, SExtValue(childElementText)));
+        childExtension.emplace_back(id, SExtValue(childElementText));
       }
 
       if (!childExtension.empty())
-        addonExt.m_values.emplace_back(std::make_pair(id, std::move(childExtension)));
+        addonExt.m_values.emplace_back(id, std::move(childExtension));
 
       if (childElementText.empty())
       {
@@ -735,7 +735,7 @@ bool CAddonInfoBuilder::ParseXMLExtension(CAddonExtensions& addonExt,
         {
           CAddonExtensions subElement;
           if (ParseXMLExtension(subElement, childElement))
-            addonExt.m_children.emplace_back(std::make_pair(id, std::move(subElement)));
+            addonExt.m_children.emplace_back(id, std::move(subElement));
         }
       }
     }
@@ -747,7 +747,7 @@ bool CAddonInfoBuilder::ParseXMLExtension(CAddonExtensions& addonExt,
 
 bool CAddonInfoBuilder::GetTextList(const tinyxml2::XMLElement* element,
                                     const std::string& tag,
-                                    std::unordered_map<std::string, std::string>& translatedValues)
+                                    CLocale::LocalizedStringsMap& translatedValues)
 {
   if (!element)
     return false;
@@ -762,13 +762,12 @@ bool CAddonInfoBuilder::GetTextList(const tinyxml2::XMLElement* element,
     if (lang != nullptr)
     {
       if (strcmp(lang, "no") == 0)
-        translatedValues.insert(std::make_pair("nb_NO", text != nullptr ? text : ""));
+        translatedValues.try_emplace("nb_NO", text != nullptr ? text : "");
       else
-        translatedValues.insert(std::make_pair(lang, text != nullptr ? text : ""));
+        translatedValues.try_emplace(lang, text != nullptr ? text : "");
     }
     else
-      translatedValues.insert(
-          std::make_pair(KODI_ADDON_DEFAULT_LANGUAGE_CODE, text != nullptr ? text : ""));
+      translatedValues.try_emplace(KODI_ADDON_DEFAULT_LANGUAGE_CODE, text != nullptr ? text : "");
   }
 
   return !translatedValues.empty();
@@ -878,8 +877,8 @@ bool CAddonInfoBuilder::PlatformSupportsAddon(const AddonInfoPtr& addon)
 #endif
   };
 
-  return std::find_first_of(addon->m_platforms.begin(), addon->m_platforms.end(),
-      supportedPlatforms.begin(), supportedPlatforms.end()) != addon->m_platforms.end();
+  return std::ranges::find_first_of(addon->m_platforms, supportedPlatforms) !=
+         addon->m_platforms.end();
 }
 
 }

--- a/xbmc/addons/addoninfo/AddonInfoBuilder.h
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.h
@@ -10,11 +10,11 @@
 
 #include "addons/IAddon.h"
 #include "utils/Artwork.h"
+#include "utils/Locale.h"
 
 #include <map>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 class CDateTime;
@@ -51,8 +51,11 @@ public:
     * @brief Parts used from CAddonDatabase
     */
   //@{
-  static void SetInstallData(const AddonInfoPtr& addon, const CDateTime& installDate,
-                             const CDateTime& lastUpdated, const CDateTime& lastUsed, const std::string& origin);
+  static void SetInstallData(const AddonInfoPtr& addon,
+                             const CDateTime& installDate,
+                             const CDateTime& lastUpdated,
+                             const CDateTime& lastUsed,
+                             std::string_view origin);
   //@}
 
 private:
@@ -69,7 +72,7 @@ private:
   static bool ParseXMLExtension(CAddonExtensions& addonExt, const tinyxml2::XMLElement* element);
   static bool GetTextList(const tinyxml2::XMLElement* element,
                           const std::string& tag,
-                          std::unordered_map<std::string, std::string>& translatedValues);
+                          CLocale::LocalizedStringsMap& translatedValues);
   static const char* GetPlatformLibraryName(const tinyxml2::XMLElement* element);
   static bool PlatformSupportsAddon(const AddonInfoPtr& addon);
 };
@@ -108,7 +111,7 @@ public:
   void SetPackageSize(uint64_t size);
   void SetExtensions(CAddonType addonType);
 
-  const AddonInfoPtr& get() { return m_addonInfo; }
+  const AddonInfoPtr& get() const { return m_addonInfo; }
 
 private:
   AddonInfoPtr m_addonInfo;

--- a/xbmc/addons/addoninfo/AddonType.cpp
+++ b/xbmc/addons/addoninfo/AddonType.cpp
@@ -46,9 +46,9 @@ void CAddonType::SetProvides(const std::string& content)
 
     for (const auto& provide : StringUtils::Split(content, ' '))
     {
-      AddonType content = CAddonInfo::TranslateSubContent(provide);
-      if (content != AddonType::UNKNOWN)
-        m_providedSubContent.insert(content);
+      AddonType subContent = CAddonInfo::TranslateSubContent(provide);
+      if (subContent != AddonType::UNKNOWN)
+        m_providedSubContent.insert(subContent);
     }
   }
 }

--- a/xbmc/addons/addoninfo/AddonType.h
+++ b/xbmc/addons/addoninfo/AddonType.h
@@ -76,7 +76,7 @@ class CAddonDatabaseSerializer;
 class CAddonType : public CAddonExtensions
 {
 public:
-  CAddonType(AddonType type = AddonType::UNKNOWN) : m_type(type) {}
+  explicit CAddonType(AddonType type = AddonType::UNKNOWN) : m_type(type) {}
 
   AddonType Type() const { return m_type; }
   std::string LibPath() const;

--- a/xbmc/addons/binary-addons/AddonDll.h
+++ b/xbmc/addons/binary-addons/AddonDll.h
@@ -21,7 +21,6 @@ namespace ADDON
 {
 
 class CBinaryAddonBase;
-using BinaryAddonBasePtr = std::shared_ptr<CBinaryAddonBase>;
 
 /*!
  * Addon instance handler, used as identify for std::map to find related
@@ -51,7 +50,7 @@ public:
 class CAddonDll : public CAddon
 {
 public:
-  CAddonDll(const AddonInfoPtr& addonInfo, BinaryAddonBasePtr addonBase);
+  CAddonDll(const AddonInfoPtr& addonInfo, std::shared_ptr<CBinaryAddonBase> addonBase);
   CAddonDll(const AddonInfoPtr& addonInfo, AddonType addonType);
   ~CAddonDll() override;
 
@@ -98,7 +97,7 @@ public:
    *
    * @param[in] instance The for addon used data structure for active instance
    */
-  void DestroyInstance(KODI_ADDON_INSTANCE_STRUCT* instance);
+  void DestroyInstance(const KODI_ADDON_INSTANCE_STRUCT* instance);
 
   bool IsInUse() const override;
   void RegisterInformer(CAddonDllInformer* informer);
@@ -114,9 +113,10 @@ public:
 protected:
   static std::string GetDllPath(const std::string& strFileName);
 
-  std::string m_parentLib;
-
 private:
+  CAddonDll(const CAddonDll&) = delete;
+  CAddonDll& operator=(const CAddonDll&) = delete;
+
   /*!
    * @brief Main addon creation call function
    *
@@ -142,14 +142,11 @@ private:
 
   bool CheckAPIVersion(int type);
 
-  BinaryAddonBasePtr m_binaryAddonBase = nullptr;
-  DllAddon* m_pDll = nullptr;
-  bool m_initialized = false;
   bool LoadDll();
-  std::map<ADDON_INSTANCE_HANDLER, KODI_ADDON_INSTANCE_STRUCT*> m_usedInstances;
-  CAddonDllInformer* m_informer = nullptr;
 
   virtual ADDON_STATUS TransferSettings(AddonInstanceId instanceId);
+
+  std::string m_parentLib;
 
   /*!
    * This structure, which is fixed to the addon headers, makes use of the at
@@ -158,6 +155,12 @@ private:
    * /xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
    */
   AddonGlobalInterface m_interface = {};
+
+  std::shared_ptr<CBinaryAddonBase> m_binaryAddonBase;
+  std::unique_ptr<DllAddon> m_pDll;
+  bool m_initialized{false};
+  std::map<ADDON_INSTANCE_HANDLER, KODI_ADDON_INSTANCE_STRUCT*> m_usedInstances;
+  CAddonDllInformer* m_informer = nullptr;
 };
 
 } /* namespace ADDON */

--- a/xbmc/addons/binary-addons/AddonInstanceHandler.h
+++ b/xbmc/addons/binary-addons/AddonInstanceHandler.h
@@ -22,13 +22,11 @@ namespace ADDON
 {
 
 class CAddonDll;
-using AddonDllPtr = std::shared_ptr<CAddonDll>;
 
 class CAddonInfo;
 using AddonInfoPtr = std::shared_ptr<CAddonInfo>;
 
 class CBinaryAddonBase;
-using BinaryAddonBasePtr = std::shared_ptr<CBinaryAddonBase>;
 
 class IAddonInstanceHandler
 {
@@ -67,7 +65,7 @@ public:
 
   ADDON_TYPE UsedType() const { return m_type; }
   AddonInstanceId InstanceId() const { return m_instanceId; }
-  const std::string& UniqueWorkID() { return m_uniqueWorkID; }
+  const std::string& UniqueWorkID() const { return m_uniqueWorkID; }
 
   std::string ID() const;
   AddonInstanceId InstanceID() const;
@@ -80,7 +78,7 @@ public:
 
   ADDON_STATUS CreateInstance();
   void DestroyInstance();
-  const AddonDllPtr& Addon() const { return m_addon; }
+  const std::shared_ptr<CAddonDll>& Addon() const { return m_addon; }
   AddonInfoPtr GetAddonInfo() const { return m_addonInfo; }
 
   virtual void OnPreInstall() {}
@@ -89,11 +87,13 @@ public:
   virtual void OnPostUnInstall() {}
 
 protected:
-  KODI_ADDON_INSTANCE_INFO m_info{};
   KODI_ADDON_INSTANCE_STRUCT m_ifc{};
 
 private:
-  std::shared_ptr<CSetting> GetSetting(const std::string& setting);
+  IAddonInstanceHandler(const IAddonInstanceHandler&) = delete;
+  IAddonInstanceHandler& operator=(const IAddonInstanceHandler&) = delete;
+
+  std::shared_ptr<CSetting> GetSetting(const std::string& setting) const;
 
   static char* get_instance_user_path(const KODI_ADDON_INSTANCE_BACKEND_HDL hdl);
   static bool is_instance_setting_using_default(const KODI_ADDON_INSTANCE_BACKEND_HDL hdl,
@@ -123,13 +123,17 @@ private:
                                           const char* id,
                                           const char* value);
 
+  KODI_ADDON_INSTANCE_INFO m_info;
+  KODI_ADDON_INSTANCE_FUNC_CB m_callbacks;
+  KODI_ADDON_INSTANCE_FUNC m_functions;
+
   const ADDON_TYPE m_type;
   const AddonInstanceId m_instanceId;
   std::string m_uniqueWorkID;
   KODI_HANDLE m_parentInstance;
   AddonInfoPtr m_addonInfo;
-  BinaryAddonBasePtr m_addonBase;
-  AddonDllPtr m_addon;
+  std::shared_ptr<CBinaryAddonBase> m_addonBase;
+  std::shared_ptr<CAddonDll> m_addon;
   static CCriticalSection m_cdSec;
 };
 

--- a/xbmc/addons/binary-addons/BinaryAddonBase.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonBase.cpp
@@ -22,12 +22,11 @@ const std::string& CBinaryAddonBase::ID() const
   return m_addonInfo->ID();
 }
 
-AddonDllPtr CBinaryAddonBase::GetAddon(IAddonInstanceHandler* handler)
+std::shared_ptr<CAddonDll> CBinaryAddonBase::GetAddon(IAddonInstanceHandler* handler)
 {
   if (handler == nullptr)
   {
-    CLog::Log(LOGERROR, "CBinaryAddonBase::{}: for Id '{}' called with empty instance handler",
-              __FUNCTION__, ID());
+    CLog::LogF(LOGERROR, "No instance handler given for addon-on '{}'", ID());
     return nullptr;
   }
 
@@ -47,8 +46,7 @@ void CBinaryAddonBase::ReleaseAddon(IAddonInstanceHandler* handler)
 {
   if (handler == nullptr)
   {
-    CLog::Log(LOGERROR, "CBinaryAddonBase::{}: for Id '{}' called with empty instance handler",
-              __FUNCTION__, ID());
+    CLog::LogF(LOGERROR, "No instance handler given for addon-on '{}'", ID());
     return;
   }
 
@@ -73,34 +71,34 @@ size_t CBinaryAddonBase::UsedInstanceCount() const
   return m_activeAddonHandlers.size();
 }
 
-AddonDllPtr CBinaryAddonBase::GetActiveAddon()
+std::shared_ptr<CAddonDll> CBinaryAddonBase::GetActiveAddon()
 {
   std::unique_lock lock(m_critSection);
   return m_activeAddon;
 }
 
-void CBinaryAddonBase::OnPreInstall()
+void CBinaryAddonBase::OnPreInstall() const
 {
   const std::unordered_set<IAddonInstanceHandler*> activeAddonHandlers = m_activeAddonHandlers;
   for (const auto& instance : activeAddonHandlers)
     instance->OnPreInstall();
 }
 
-void CBinaryAddonBase::OnPostInstall(bool update, bool modal)
+void CBinaryAddonBase::OnPostInstall(bool update, bool modal) const
 {
   const std::unordered_set<IAddonInstanceHandler*> activeAddonHandlers = m_activeAddonHandlers;
   for (const auto& instance : activeAddonHandlers)
     instance->OnPostInstall(update, modal);
 }
 
-void CBinaryAddonBase::OnPreUnInstall()
+void CBinaryAddonBase::OnPreUnInstall() const
 {
   const std::unordered_set<IAddonInstanceHandler*> activeAddonHandlers = m_activeAddonHandlers;
   for (const auto& instance : activeAddonHandlers)
     instance->OnPreUnInstall();
 }
 
-void CBinaryAddonBase::OnPostUnInstall()
+void CBinaryAddonBase::OnPostUnInstall() const
 {
   const std::unordered_set<IAddonInstanceHandler*> activeAddonHandlers = m_activeAddonHandlers;
   for (const auto& instance : activeAddonHandlers)

--- a/xbmc/addons/binary-addons/BinaryAddonBase.h
+++ b/xbmc/addons/binary-addons/BinaryAddonBase.h
@@ -23,7 +23,6 @@ namespace ADDON
   using AddonInfoPtr = std::shared_ptr<CAddonInfo>;
 
   class CAddonDll;
-  typedef std::shared_ptr<CAddonDll> AddonDllPtr;
 
   class CBinaryAddonBase : public std::enable_shared_from_this<CBinaryAddonBase>
   {
@@ -32,22 +31,22 @@ namespace ADDON
 
     const std::string& ID() const;
 
-    AddonDllPtr GetAddon(IAddonInstanceHandler* handler);
+    std::shared_ptr<CAddonDll> GetAddon(IAddonInstanceHandler* handler);
     void ReleaseAddon(IAddonInstanceHandler* handler);
     size_t UsedInstanceCount() const;
 
-    AddonDllPtr GetActiveAddon();
+    std::shared_ptr<CAddonDll> GetActiveAddon();
 
-    void OnPreInstall();
-    void OnPostInstall(bool update, bool modal);
-    void OnPreUnInstall();
-    void OnPostUnInstall();
+    void OnPreInstall() const;
+    void OnPostInstall(bool update, bool modal) const;
+    void OnPreUnInstall() const;
+    void OnPostUnInstall() const;
 
   private:
     AddonInfoPtr m_addonInfo;
 
     mutable CCriticalSection m_critSection;
-    AddonDllPtr m_activeAddon;
+    std::shared_ptr<CAddonDll> m_activeAddon;
     std::unordered_set<IAddonInstanceHandler*> m_activeAddonHandlers;
   };
 

--- a/xbmc/addons/binary-addons/BinaryAddonManager.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.cpp
@@ -17,13 +17,14 @@
 
 using namespace ADDON;
 
-BinaryAddonBasePtr CBinaryAddonManager::GetAddonBase(const AddonInfoPtr& addonInfo,
-                                                     IAddonInstanceHandler* handler,
-                                                     AddonDllPtr& addon)
+std::shared_ptr<CBinaryAddonBase> CBinaryAddonManager::GetAddonBase(
+    const AddonInfoPtr& addonInfo,
+    IAddonInstanceHandler* handler,
+    std::shared_ptr<CAddonDll>& addon)
 {
   std::unique_lock lock(m_critSection);
 
-  BinaryAddonBasePtr addonBase;
+  std::shared_ptr<CBinaryAddonBase> addonBase;
 
   const auto& addonInstances = m_runningAddons.find(addonInfo->ID());
   if (addonInstances != m_runningAddons.end())
@@ -43,14 +44,13 @@ BinaryAddonBasePtr CBinaryAddonManager::GetAddonBase(const AddonInfoPtr& addonIn
   }
   if (!addon)
   {
-    CLog::Log(LOGFATAL, "CBinaryAddonManager::{}: Tried to get add-on '{}' who not available!",
-              __func__, addonInfo->ID());
+    CLog::LogF(LOGFATAL, "Unable to get add-on '{}'!", addonInfo->ID());
   }
 
   return addonBase;
 }
 
-void CBinaryAddonManager::ReleaseAddonBase(const BinaryAddonBasePtr& addonBase,
+void CBinaryAddonManager::ReleaseAddonBase(const std::shared_ptr<CBinaryAddonBase>& addonBase,
                                            IAddonInstanceHandler* handler)
 {
   const auto& addon = m_runningAddons.find(addonBase->ID());
@@ -65,7 +65,8 @@ void CBinaryAddonManager::ReleaseAddonBase(const BinaryAddonBasePtr& addonBase,
   m_runningAddons.erase(addon);
 }
 
-BinaryAddonBasePtr CBinaryAddonManager::GetRunningAddonBase(const std::string& addonId) const
+std::shared_ptr<CBinaryAddonBase> CBinaryAddonManager::GetRunningAddonBase(
+    const std::string& addonId) const
 {
   std::unique_lock lock(m_critSection);
 
@@ -80,7 +81,7 @@ AddonPtr CBinaryAddonManager::GetRunningAddon(const std::string& addonId) const
 {
   std::unique_lock lock(m_critSection);
 
-  const BinaryAddonBasePtr base = GetRunningAddonBase(addonId);
+  const std::shared_ptr<CBinaryAddonBase> base = GetRunningAddonBase(addonId);
   if (base)
     return base->GetActiveAddon();
 

--- a/xbmc/addons/binary-addons/BinaryAddonManager.h
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.h
@@ -25,10 +25,7 @@ namespace ADDON
   using AddonInfoPtr = std::shared_ptr<CAddonInfo>;
 
   class CAddonDll;
-  typedef std::shared_ptr<CAddonDll> AddonDllPtr;
-
   class CBinaryAddonBase;
-  typedef std::shared_ptr<CBinaryAddonBase> BinaryAddonBasePtr;
 
   class CBinaryAddonManager
   {
@@ -51,9 +48,9 @@ namespace ADDON
      * @ref IAddonInstanceHandler, use nowhere else allowed!
      *
      */
-    BinaryAddonBasePtr GetAddonBase(const AddonInfoPtr& addonInfo,
-                                    IAddonInstanceHandler* handler,
-                                    AddonDllPtr& addon);
+    std::shared_ptr<CBinaryAddonBase> GetAddonBase(const AddonInfoPtr& addonInfo,
+                                                   IAddonInstanceHandler* handler,
+                                                   std::shared_ptr<CAddonDll>& addon);
 
     /*!
      * @brief Release a running addon instance handle base.
@@ -65,7 +62,8 @@ namespace ADDON
      * @param[in] handler related instance handle class
      *
      */
-    void ReleaseAddonBase(const BinaryAddonBasePtr& addonBase, IAddonInstanceHandler* handler);
+    void ReleaseAddonBase(const std::shared_ptr<CBinaryAddonBase>& addonBase,
+                          IAddonInstanceHandler* handler);
 
     /*!
      * @brief Get running addon base class for a given addon id.
@@ -74,7 +72,7 @@ namespace ADDON
      * @return running addon base class if found, nullptr otherwise.
      *
      */
-    BinaryAddonBasePtr GetRunningAddonBase(const std::string& addonId) const;
+    std::shared_ptr<CBinaryAddonBase> GetRunningAddonBase(const std::string& addonId) const;
 
     /*!
      * @brief Used from other addon manager to get active addon over a from him
@@ -89,7 +87,7 @@ namespace ADDON
   private:
     mutable CCriticalSection m_critSection;
 
-    std::map<std::string, BinaryAddonBasePtr> m_runningAddons;
+    std::map<std::string, std::shared_ptr<CBinaryAddonBase>, std::less<>> m_runningAddons;
   };
 
 } /* namespace ADDON */

--- a/xbmc/addons/binary-addons/DllAddon.h
+++ b/xbmc/addons/binary-addons/DllAddon.h
@@ -21,12 +21,11 @@ public:
 
 class DllAddon : public DllDynamic, public DllAddonInterface
 {
-public:
   DECLARE_DLL_WRAPPER_TEMPLATE(DllAddon)
   DEFINE_METHOD1(ADDON_STATUS, Create, (void* p1))
   DEFINE_METHOD1(const char*, GetAddonTypeVersion, (int p1))
   DEFINE_METHOD1(const char*, GetAddonTypeMinVersion, (int p1))
-  bool GetAddonTypeMinVersion_available() { return m_GetAddonTypeMinVersion != nullptr; }
+  bool GetAddonTypeMinVersion_available() const { return m_GetAddonTypeMinVersion != nullptr; }
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD_RENAME(ADDON_Create, Create)
     RESOLVE_METHOD_RENAME(ADDON_GetTypeVersion, GetAddonTypeVersion)

--- a/xbmc/addons/gui/GUIDialogAddonInfo.h
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.h
@@ -92,10 +92,11 @@ private:
   void OnInstall();
   void OnUninstall();
   void OnEnableDisable();
-  void OnSettings();
+  void OnSettings() const;
   void OnSelect();
   void OnToggleAutoUpdates();
-  int AskForVersion(std::vector<std::pair<ADDON::CAddonVersion, std::string>>& versions);
+  int AskForVersion(
+      const std::vector<std::pair<ADDON::CAddonVersion, std::string>>& versions) const;
 
   /*!
    * @brief Returns true if current addon can be opened (i.e is a plugin)
@@ -125,7 +126,7 @@ private:
    * @param[in] line2 the action that could not be completed.
    * @return true if prompted, false otherwise.
    */
-  bool PromptIfDependency(int heading, int line2);
+  bool PromptIfDependency(int heading, int line2) const;
 
   /*!
    * @brief Show a dialog with the addon's dependencies.
@@ -139,7 +140,7 @@ private:
   /*!
    * @brief Show a dialog with the addon's supported extensions and mimetypes.
    */
-  void ShowSupportList();
+  void ShowSupportList() const;
 
   /*!
    * @brief Used to build up the dependency list shown by @ref ShowDependencyList()

--- a/xbmc/addons/gui/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonSettings.cpp
@@ -36,14 +36,14 @@
 #include "utils/log.h"
 #include "view/ViewStateSettings.h"
 
-#define CONTROL_BTN_LEVELS 20
-
 using namespace ADDON;
 using namespace KODI;
 using namespace MESSAGING;
 
 namespace
 {
+constexpr int CONTROL_BTN_LEVELS = 20;
+
 // Fallback icon shown when no add-on icon is available
 constexpr const char* DEFAULT_ADDON_ICON = "DefaultAddon.png";
 } // namespace
@@ -75,10 +75,10 @@ bool CGUIDialogAddonSettings::OnMessage(CGUIMessage& message)
 
       if (instanceId != m_instanceId)
       {
-        CLog::Log(LOGERROR,
-                  "CGUIDialogAddonSettings::{}: Set value \"{}\" from add-on \"{}\" called with "
-                  "invalid instance id (given: {}, needed: {})",
-                  __func__, m_addon->ID(), settingId, instanceId, m_instanceId);
+        CLog::LogF(
+            LOGERROR,
+            R"(Set value "{}" from add-on "{}" called with invalid instance id (given: {}, needed: {}))",
+            m_addon->ID(), settingId, instanceId, m_instanceId);
         break;
       }
 
@@ -229,7 +229,7 @@ bool CGUIDialogAddonSettings::ShowForMultipleInstances(const ADDON::AddonPtr& ad
   while (true)
   {
     std::vector<ADDON::AddonInstanceId> ids = addon->GetKnownInstanceIds();
-    std::sort(ids.begin(), ids.end(), [](const auto& a, const auto& b) { return a < b; });
+    std::ranges::sort(ids, [](const auto& a, const auto& b) { return a < b; });
 
     dialog->Reset();
     dialog->SetHeading(10012); // Add-on configurations and settings
@@ -265,37 +265,37 @@ bool CGUIDialogAddonSettings::ShowForMultipleInstances(const ADDON::AddonPtr& ad
     const ADDON::AddonInstanceId addInstanceId = highestId + 1;
     const ADDON::AddonInstanceId removeInstanceId = highestId + 2;
 
-    CFileItemPtr item =
-        std::make_shared<CFileItem>(g_localizeStrings.Get(10014)); // Add add-on configuration
+    auto item{
+        std::make_shared<CFileItem>(g_localizeStrings.Get(10014))}; // Add add-on configuration
     item->SetProperty("id", addInstanceId);
-    itemsGeneral.Add(item);
+    itemsGeneral.Add(std::move(item));
 
     if (ids.size() > 1) // Forbid removal of last instance
     {
       item =
           std::make_shared<CFileItem>(g_localizeStrings.Get(10015)); // Remove add-on configuration
       item->SetProperty("id", removeInstanceId);
-      itemsGeneral.Add(item);
+      itemsGeneral.Add(std::move(item));
     }
 
     if (addon->HasSettings(ADDON_SETTINGS_ID))
     {
       item = std::make_shared<CFileItem>(g_localizeStrings.Get(10013)); // Edit Add-on settings
       item->SetProperty("id", ADDON_SETTINGS_ID);
-      itemsGeneral.Add(item);
+      itemsGeneral.Add(std::move(item));
     }
 
-    for (auto& it : itemsGeneral)
+    for (const auto& it : itemsGeneral)
       dialog->Add(*it);
 
-    for (auto& it : itemsInstances)
+    for (const auto& it : itemsInstances)
       dialog->Add(*it);
 
     // Select last selected item, first instance config item or first item
     if (lastSelected >= 0)
       dialog->SetSelected(lastSelected);
     else
-      dialog->SetSelected(itemsInstances.Size() > 0 ? itemsGeneral.Size() : 0);
+      dialog->SetSelected(itemsInstances.IsEmpty() ? 0 : itemsGeneral.Size());
 
     dialog->Open();
 
@@ -332,11 +332,11 @@ bool CGUIDialogAddonSettings::ShowForMultipleInstances(const ADDON::AddonPtr& ad
       dialog->SetHeading(10010); // Select add-on configuration to remove
       dialog->SetUseDetails(false);
 
-      for (auto& it : itemsInstances)
+      for (const auto& it : itemsInstances)
       {
-        CFileItem item(*it);
-        item.SetLabel((*it).GetProperty("name").asString());
-        dialog->Add(item);
+        CFileItem instanceItem(*it);
+        instanceItem.SetLabel((*it).GetProperty("name").asString());
+        dialog->Add(instanceItem);
       }
 
       dialog->SetSelected(0);

--- a/xbmc/addons/gui/GUIWindowAddonBrowser.h
+++ b/xbmc/addons/gui/GUIWindowAddonBrowser.h
@@ -106,6 +106,6 @@ protected:
 
 private:
   void SetProperties();
-  void UpdateStatus(const CFileItemPtr& item);
+  void UpdateStatus(const CFileItemPtr& item) const;
   CProgramThumbLoader m_thumbLoader;
 };

--- a/xbmc/addons/gui/skin/SkinTimer.cpp
+++ b/xbmc/addons/gui/skin/SkinTimer.cpp
@@ -100,7 +100,7 @@ bool CSkinTimer::ResetsOnStart() const
   return m_resetOnStart;
 }
 
-void CSkinTimer::OnStart()
+void CSkinTimer::OnStart() const
 {
   if (m_startActions.HasAnyActions())
   {
@@ -108,7 +108,7 @@ void CSkinTimer::OnStart()
   }
 }
 
-void CSkinTimer::OnStop()
+void CSkinTimer::OnStop() const
 {
   if (m_stopActions.HasAnyActions())
   {

--- a/xbmc/addons/gui/skin/SkinTimer.h
+++ b/xbmc/addons/gui/skin/SkinTimer.h
@@ -106,10 +106,10 @@ public:
 
 private:
   /*! \brief Called when this timer is started */
-  void OnStart();
+  void OnStart() const;
 
   /*! \brief Called when this timer is stopped */
-  void OnStop();
+  void OnStop() const;
 
   /*! The name of the skin timer */
   std::string m_name;

--- a/xbmc/addons/gui/skin/SkinTimerManager.cpp
+++ b/xbmc/addons/gui/skin/SkinTimerManager.cpp
@@ -50,7 +50,7 @@ void CSkinTimerManager::LoadTimers(const std::string& path)
 
 void CSkinTimerManager::LoadTimerInternal(const tinyxml2::XMLNode* node)
 {
-  if ((!node->FirstChildElement("name") || !node->FirstChildElement("name")->FirstChild()))
+  if (!node->FirstChildElement("name") || !node->FirstChildElement("name")->FirstChild())
   {
     CLog::LogF(LOGERROR, "Missing required field 'name' for valid skin timer. Ignoring timer.");
     return;
@@ -126,8 +126,8 @@ void CSkinTimerManager::LoadTimerInternal(const tinyxml2::XMLNode* node)
     onStopElement = onStopElement->NextSiblingElement("onstop");
   }
 
-  m_timers[timerName] = std::make_unique<CSkinTimer>(CSkinTimer(
-      timerName, startInfo, resetInfo, stopInfo, startActions, stopActions, resetOnStart));
+  m_timers[timerName] = std::make_unique<CSkinTimer>(timerName, startInfo, resetInfo, stopInfo,
+                                                     startActions, stopActions, resetOnStart);
 }
 
 bool CSkinTimerManager::TimerIsRunning(const std::string& timer) const
@@ -215,7 +215,7 @@ void CSkinTimerManager::Stop()
   m_timers.clear();
 }
 
-void CSkinTimerManager::Process()
+void CSkinTimerManager::Process() const
 {
   for (const auto& [key, val] : m_timers)
   {

--- a/xbmc/addons/gui/skin/SkinTimerManager.h
+++ b/xbmc/addons/gui/skin/SkinTimerManager.h
@@ -33,7 +33,7 @@ public:
   /*! \brief Skin timer manager constructor
    *  \param infoMgr reference to the infomanager
    */
-  CSkinTimerManager(CGUIInfoManager& infoMgr);
+  explicit CSkinTimerManager(CGUIInfoManager& infoMgr);
   CSkinTimerManager() = delete;
 
   /*! \brief Default skin timer manager destructor */
@@ -89,7 +89,7 @@ public:
   // CThread methods
 
   /*! \brief Run the main manager processing loop */
-  void Process();
+  void Process() const;
 
 private:
   /*! \brief Loads a specific timer
@@ -99,6 +99,6 @@ private:
   void LoadTimerInternal(const tinyxml2::XMLNode* node);
 
   /*! Container for the skin timers */
-  std::map<std::string, std::unique_ptr<CSkinTimer>> m_timers;
+  std::map<std::string, std::unique_ptr<CSkinTimer>, std::less<>> m_timers;
   CGUIInfoManager& m_infoMgr;
 };

--- a/xbmc/addons/interfaces/AddonBase.h
+++ b/xbmc/addons/interfaces/AddonBase.h
@@ -11,12 +11,14 @@
 #include "addons/IAddon.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon_base.h"
 
+#include <functional>
+
 extern "C"
 {
 namespace ADDON
 {
 
-typedef void* (*ADDON_GET_INTERFACE_FN)(const std::string& name, const std::string& version);
+using AddonGetInterface = std::function<void*(const std::string& name, const std::string& version)>;
 
 class CAddonDll;
 
@@ -34,13 +36,13 @@ struct Interface_Base
                             AddonGlobalInterface& addonInterface,
                             KODI_ADDON_INSTANCE_STRUCT* firstKodiInstance);
   static void DeInitInterface(AddonGlobalInterface& addonInterface);
-  static void RegisterInterface(ADDON_GET_INTERFACE_FN fn);
-  static bool UpdateSettingInActiveDialog(CAddonDll* addon,
+  static void RegisterInterface(const AddonGetInterface& fn);
+  static bool UpdateSettingInActiveDialog(const CAddonDll* addon,
                                           AddonInstanceId instanceId,
                                           const char* id,
                                           const std::string& value);
 
-  static std::vector<ADDON_GET_INTERFACE_FN> s_registeredInterfaces;
+  static std::vector<AddonGetInterface> s_registeredInterfaces;
 
   /*!
    * @brief callback functions from add-on to kodi

--- a/xbmc/addons/interfaces/AudioEngine.cpp
+++ b/xbmc/addons/interfaces/AudioEngine.cpp
@@ -304,9 +304,8 @@ AEStreamHandle* Interface_AudioEngine::audioengine_make_stream(void* kodiBase,
 {
   if (!kodiBase || !streamFormat)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamFormat='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamFormat));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamFormat='{}')", kodiBase,
+               static_cast<void*>(streamFormat));
     return nullptr;
   }
 
@@ -315,11 +314,11 @@ AEStreamHandle* Interface_AudioEngine::audioengine_make_stream(void* kodiBase,
     return nullptr;
 
   CAEChannelInfo layout;
-  for (unsigned int ch = 0; ch < AUDIOENGINE_CH_MAX; ++ch)
+  for (AudioEngineChannel ch : streamFormat->m_channels)
   {
-    if (streamFormat->m_channels[ch] == AUDIOENGINE_CH_NULL)
+    if (ch == AUDIOENGINE_CH_NULL)
       break;
-    layout += TranslateAEChannelToKodi(streamFormat->m_channels[ch]);
+    layout += TranslateAEChannelToKodi(ch);
   }
 
   AEAudioFormat format;
@@ -343,9 +342,8 @@ void Interface_AudioEngine::audioengine_free_stream(void* kodiBase, AEStreamHand
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return;
   }
 
@@ -358,9 +356,8 @@ bool Interface_AudioEngine::get_current_sink_format(void* kodiBase, AUDIO_ENGINE
 {
   if (!kodiBase || !format)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', format='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(format));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', format='{}')", kodiBase,
+               static_cast<void*>(format));
     return false;
   }
 
@@ -371,8 +368,7 @@ bool Interface_AudioEngine::get_current_sink_format(void* kodiBase, AUDIO_ENGINE
   AEAudioFormat sinkFormat;
   if (!engine->GetCurrentSinkFormat(sinkFormat))
   {
-    CLog::Log(LOGERROR, "Interface_AudioEngine::{} - failed to get current sink format from AE!",
-              __FUNCTION__);
+    CLog::LogF(LOGERROR, "Failed to get current sink format from AE!");
     return false;
   }
 
@@ -393,9 +389,8 @@ unsigned int Interface_AudioEngine::aestream_get_space(void* kodiBase, AEStreamH
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return 0;
   }
 
@@ -413,9 +408,8 @@ unsigned int Interface_AudioEngine::aestream_add_data(void* kodiBase,
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return 0;
   }
 
@@ -433,9 +427,8 @@ double Interface_AudioEngine::aestream_get_delay(void* kodiBase, AEStreamHandle*
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return -1.0;
   }
 
@@ -449,9 +442,8 @@ bool Interface_AudioEngine::aestream_is_buffering(void* kodiBase, AEStreamHandle
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return false;
   }
 
@@ -465,9 +457,8 @@ double Interface_AudioEngine::aestream_get_cache_time(void* kodiBase, AEStreamHa
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return -1.0;
   }
 
@@ -481,9 +472,8 @@ double Interface_AudioEngine::aestream_get_cache_total(void* kodiBase, AEStreamH
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return -1.0;
   }
 
@@ -497,9 +487,8 @@ void Interface_AudioEngine::aestream_pause(void* kodiBase, AEStreamHandle* strea
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return;
   }
 
@@ -513,9 +502,8 @@ void Interface_AudioEngine::aestream_resume(void* kodiBase, AEStreamHandle* stre
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return;
   }
 
@@ -526,9 +514,8 @@ void Interface_AudioEngine::aestream_drain(void* kodiBase, AEStreamHandle* strea
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return;
   }
 
@@ -542,9 +529,8 @@ bool Interface_AudioEngine::aestream_is_draining(void* kodiBase, AEStreamHandle*
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return false;
   }
 
@@ -558,9 +544,8 @@ bool Interface_AudioEngine::aestream_is_drained(void* kodiBase, AEStreamHandle* 
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return false;
   }
 
@@ -574,9 +559,8 @@ void Interface_AudioEngine::aestream_flush(void* kodiBase, AEStreamHandle* strea
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return;
   }
 
@@ -590,9 +574,8 @@ float Interface_AudioEngine::aestream_get_volume(void* kodiBase, AEStreamHandle*
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return -1.0f;
   }
 
@@ -608,9 +591,8 @@ void Interface_AudioEngine::aestream_set_volume(void* kodiBase,
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return;
   }
 
@@ -625,9 +607,8 @@ float Interface_AudioEngine::aestream_get_amplification(void* kodiBase,
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return -1.0f;
   }
 
@@ -643,9 +624,8 @@ void Interface_AudioEngine::aestream_set_amplification(void* kodiBase,
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return;
   }
 
@@ -660,9 +640,8 @@ unsigned int Interface_AudioEngine::aestream_get_frame_size(void* kodiBase,
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return 0;
   }
 
@@ -677,9 +656,8 @@ unsigned int Interface_AudioEngine::aestream_get_channel_count(void* kodiBase,
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return 0;
   }
 
@@ -694,9 +672,8 @@ unsigned int Interface_AudioEngine::aestream_get_sample_rate(void* kodiBase,
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return 0;
   }
 
@@ -711,9 +688,8 @@ AudioEngineDataFormat Interface_AudioEngine::aestream_get_data_format(void* kodi
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return AUDIOENGINE_FMT_INVALID;
   }
 
@@ -728,9 +704,8 @@ double Interface_AudioEngine::aestream_get_resample_ratio(void* kodiBase,
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return -1.0;
   }
 
@@ -746,9 +721,8 @@ void Interface_AudioEngine::aestream_set_resample_ratio(void* kodiBase,
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR, "Invalid stream data (kodiBase='{}', streamHandle='{}')", kodiBase,
+               streamHandle);
     return;
   }
 

--- a/xbmc/addons/interfaces/General.cpp
+++ b/xbmc/addons/interfaces/General.cpp
@@ -68,27 +68,25 @@ void Interface_General::DeInit(AddonGlobalInterface* addonInterface)
 
 char* Interface_General::unknown_to_utf8(void* kodiBase, const char* source, bool* ret, bool failOnBadChar)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon || !source || !ret)
   {
-    CLog::Log(LOGERROR, "Interface_General::{} - invalid data (addon='{}', source='{}', ret='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(source), static_cast<void*>(ret));
+    CLog::LogF(LOGERROR, "Invalid data (addon='{}', source='{}', ret='{}')", kodiBase,
+               static_cast<const void*>(source), static_cast<void*>(ret));
     return nullptr;
   }
 
   std::string string;
-  *ret = g_charsetConverter.unknownToUTF8(source, string, failOnBadChar);
-  char* buffer = strdup(string.c_str());
-  return buffer;
+  *ret = CCharsetConverter::unknownToUTF8(source, string, failOnBadChar);
+  return strdup(string.c_str());
 }
 
 char* Interface_General::get_language(void* kodiBase, int format, bool region)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_General::{} - invalid data (addon='{}')", __FUNCTION__,
-              kodiBase);
+    CLog::LogF(LOGERROR, "Invalid data (addon='{}')", kodiBase);
     return nullptr;
   }
 
@@ -132,8 +130,7 @@ char* Interface_General::get_language(void* kodiBase, int format, bool region)
     }
   }
 
-  char* buffer = strdup(string.c_str());
-  return buffer;
+  return strdup(string.c_str());
 }
 
 bool Interface_General::queue_notification(void* kodiBase, int type, const char* header,
@@ -141,11 +138,11 @@ bool Interface_General::queue_notification(void* kodiBase, int type, const char*
                                            unsigned int displayTime, bool withSound,
                                            unsigned int messageTime)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  if (addon == nullptr || message == nullptr)
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  if (!addon || !message)
   {
-    CLog::Log(LOGERROR, "Interface_General::{} - invalid data (addon='{}', message='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(message));
+    CLog::LogF(LOGERROR, "Invalid data (addon='{}', message='{}')", kodiBase,
+               static_cast<const void*>(message));
     return false;
   }
 
@@ -165,30 +162,27 @@ bool Interface_General::queue_notification(void* kodiBase, int type, const char*
     case QueueMsg::QUEUE_WARNING:
       usedType = CGUIDialogKaiToast::Warning;
       withSound = true;
-      CLog::Log(LOGDEBUG, "Interface_General::{} - {} - Warning Message: '{}'", __FUNCTION__,
-                addon->Name(), message);
+      CLog::LogF(LOGDEBUG, "{} - Warning Message: '{}'", addon->Name(), message);
       break;
     case QueueMsg::QUEUE_ERROR:
       usedType = CGUIDialogKaiToast::Error;
       withSound = true;
-      CLog::Log(LOGDEBUG, "Interface_General::{} - {} - Error Message : '{}'", __FUNCTION__,
-                addon->Name(), message);
+      CLog::LogF(LOGDEBUG, "{} - Error Message : '{}'", addon->Name(), message);
       break;
     case QueueMsg::QUEUE_INFO:
     default:
       usedType = CGUIDialogKaiToast::Info;
       withSound = false;
-      CLog::Log(LOGDEBUG, "Interface_General::{} - {} - Info Message : '{}'", __FUNCTION__,
-                addon->Name(), message);
+      CLog::LogF(LOGDEBUG, "{} - Info Message : '{}'", addon->Name(), message);
       break;
     }
 
     if (imageFile && strlen(imageFile) > 0)
     {
-      CLog::Log(LOGERROR,
-                "Interface_General::{} - To use given image file '{}' must be type value set to "
-                "'QUEUE_OWN_STYLE'",
-                __FUNCTION__, imageFile);
+      CLog::LogF(LOGERROR,
+                 "To use given image file '{}' must be type value set to "
+                 "'QUEUE_OWN_STYLE'",
+                 imageFile);
     }
 
     CGUIDialogKaiToast::QueueNotification(usedType, usedHeader, message, 3000, withSound);
@@ -202,11 +196,11 @@ bool Interface_General::queue_notification(void* kodiBase, int type, const char*
 
 void Interface_General::get_md5(void* kodiBase, const char* text, char* md5)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  if (addon == nullptr || text == nullptr)
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  if (!addon || !text)
   {
-    CLog::Log(LOGERROR, "Interface_General::{} - invalid data (addon='{}', text='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(text));
+    CLog::LogF(LOGERROR, "Invalid data (addon='{}', text='{}')", kodiBase,
+               static_cast<const void*>(text));
     return;
   }
 
@@ -216,11 +210,11 @@ void Interface_General::get_md5(void* kodiBase, const char* text, char* md5)
 
 char* Interface_General::get_region(void* kodiBase, const char* id)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  if (addon == nullptr || id == nullptr)
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  if (!addon || !id)
   {
-    CLog::Log(LOGERROR, "Interface_General::{} - invalid data (addon='{}', id='{}')", __FUNCTION__,
-              kodiBase, static_cast<const void*>(id));
+    CLog::LogF(LOGERROR, "Invalid data (addon='{}', id='{}')", kodiBase,
+               static_cast<const void*>(id));
     return nullptr;
   }
 
@@ -265,22 +259,20 @@ char* Interface_General::get_region(void* kodiBase, const char* id)
                                  g_langInfo.GetMeridiemSymbol(MeridiemSymbol::PM));
   else
   {
-    CLog::Log(LOGERROR, "Interface_General::{} -  add-on '{}' requests invalid id '{}'",
-              __FUNCTION__, addon->Name(), id);
+    CLog::LogF(LOGERROR, "Add-on '{}' requests invalid id '{}'", addon->Name(), id);
     return nullptr;
   }
 
-  char* buffer = strdup(result.c_str());
-  return buffer;
+  return strdup(result.c_str());
 }
 
 void Interface_General::get_free_mem(void* kodiBase, long* free, long* total, bool as_bytes)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  if (addon == nullptr || free == nullptr || total == nullptr)
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  if (!addon || !free || !total)
   {
-    CLog::Log(LOGERROR, "Interface_General::{} - invalid data (addon='{}', free='{}', total='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(free), static_cast<void*>(total));
+    CLog::LogF(LOGERROR, "Invalid data (addon='{}', free='{}', total='{}')", kodiBase,
+               static_cast<void*>(free), static_cast<void*>(total));
     return;
   }
 
@@ -297,11 +289,10 @@ void Interface_General::get_free_mem(void* kodiBase, long* free, long* total, bo
 
 int Interface_General::get_global_idle_time(void* kodiBase)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  if (addon == nullptr)
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_General::{} - invalid data (addon='{}')", __FUNCTION__,
-              kodiBase);
+    CLog::LogF(LOGERROR, "Invalid data (addon='{}')", kodiBase);
     return -1;
   }
 
@@ -315,14 +306,12 @@ bool Interface_General::is_addon_avilable(void* kodiBase,
                                           char** version,
                                           bool* enabled)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  if (addon == nullptr || id == nullptr || version == nullptr || enabled == nullptr)
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  if (!addon || !id || !version || !enabled)
   {
-    CLog::Log(
-        LOGERROR,
-        "Interface_General::{} - invalid data (addon='{}', id='{}', version='{}', enabled='{}')",
-        __FUNCTION__, kodiBase, static_cast<const void*>(id), static_cast<void*>(version),
-        static_cast<void*>(enabled));
+    CLog::LogF(LOGERROR, "Invalid data (addon='{}', id='{}', version='{}', enabled='{}')", kodiBase,
+               static_cast<const void*>(id), static_cast<void*>(version),
+               static_cast<void*>(enabled));
     return false;
   }
 
@@ -337,16 +326,15 @@ bool Interface_General::is_addon_avilable(void* kodiBase,
 
 void Interface_General::kodi_version(void* kodiBase, char** compile_name, int* major, int* minor, char** revision, char** tag, char** tagversion)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  if (addon == nullptr || compile_name == nullptr || major == nullptr || minor == nullptr ||
-     revision == nullptr || tag == nullptr || tagversion == nullptr)
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  if (!addon || !compile_name || !major || !minor || !revision || !tag || !tagversion)
   {
-    CLog::Log(LOGERROR,
-              "Interface_General::{} - invalid data (addon='{}', compile_name='{}', major='{}', "
-              "minor='{}', revision='{}', tag='{}', tagversion='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(compile_name), static_cast<void*>(major),
-              static_cast<void*>(minor), static_cast<void*>(revision), static_cast<void*>(tag),
-              static_cast<void*>(tagversion));
+    CLog::LogF(LOGERROR,
+               "Invalid data (addon='{}', compile_name='{}', major='{}', "
+               "minor='{}', revision='{}', tag='{}', tagversion='{}')",
+               kodiBase, static_cast<void*>(compile_name), static_cast<void*>(major),
+               static_cast<void*>(minor), static_cast<void*>(revision), static_cast<void*>(tag),
+               static_cast<void*>(tagversion));
     return;
   }
 
@@ -354,7 +342,7 @@ void Interface_General::kodi_version(void* kodiBase, char** compile_name, int* m
   *major = CCompileInfo::GetMajor();
   *minor = CCompileInfo::GetMinor();
   *revision = strdup(CCompileInfo::GetSCMID());
-  std::string tagStr = CCompileInfo::GetSuffix();
+  const std::string tagStr{CCompileInfo::GetSuffix()};
   if (StringUtils::StartsWithNoCase(tagStr, "alpha"))
   {
     *tag = strdup("alpha");
@@ -378,11 +366,10 @@ void Interface_General::kodi_version(void* kodiBase, char** compile_name, int* m
 
 char* Interface_General::get_current_skin_id(void* kodiBase)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  if (addon == nullptr)
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_General::{} - invalid data (addon='{}')", __FUNCTION__,
-              kodiBase);
+    CLog::LogF(LOGERROR, "Invalid data (addon='{}')", kodiBase);
     return nullptr;
   }
 
@@ -391,17 +378,16 @@ char* Interface_General::get_current_skin_id(void* kodiBase)
 
 bool Interface_General::get_keyboard_layout(void* kodiBase, char** layout_name, int modifier_key, AddonKeyboardKeyTable* c_layout)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  if (addon == nullptr || c_layout == nullptr || layout_name == nullptr)
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  if (!addon || !c_layout || !layout_name)
   {
-    CLog::Log(LOGERROR,
-              "Interface_General::{} - invalid data (addon='{}', c_layout='{}', layout_name='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(c_layout),
-              static_cast<void*>(layout_name));
+    CLog::LogF(LOGERROR, "Invalid data (addon='{}', c_layout='{}', layout_name='{}')", kodiBase,
+               static_cast<void*>(c_layout), static_cast<void*>(layout_name));
     return false;
   }
 
-  std::string activeLayout = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_LOCALE_ACTIVEKEYBOARDLAYOUT);
+  const std::string activeLayout{CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
+      CSettings::SETTING_LOCALE_ACTIVEKEYBOARDLAYOUT)};
 
   KEYBOARD::CKeyboardLayout layout;
   if (!CServiceBroker::GetKeyboardLayoutManager()->GetLayout(activeLayout, layout))
@@ -419,7 +405,7 @@ bool Interface_General::get_keyboard_layout(void* kodiBase, char** layout_name, 
   {
     for (unsigned int column = 0; column < STD_KB_BUTTONS_PER_ROW; column++)
     {
-      std::string label = layout.GetCharAt(row, column, modifiers);
+      const std::string label{layout.GetCharAt(row, column, modifiers)};
       c_layout->keys[row][column] = strdup(label.c_str());
     }
   }
@@ -429,22 +415,24 @@ bool Interface_General::get_keyboard_layout(void* kodiBase, char** layout_name, 
 
 bool Interface_General::change_keyboard_layout(void* kodiBase, char** layout_name)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  if (addon == nullptr || layout_name == nullptr)
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  if (!addon || !layout_name)
   {
-    CLog::Log(LOGERROR, "Interface_General::{} - invalid data (addon='{}', layout_name='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(layout_name));
+    CLog::LogF(LOGERROR, "Invalid data (addon='{}', layout_name='{}')", kodiBase,
+               static_cast<void*>(layout_name));
     return false;
   }
 
   std::vector<KEYBOARD::CKeyboardLayout> layouts;
   unsigned int currentLayout = 0;
 
-  const KEYBOARD::KeyboardLayouts& keyboardLayouts =
-      CServiceBroker::GetKeyboardLayoutManager()->GetLayouts();
-  const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-  std::vector<CVariant> layoutNames = settings->GetList(CSettings::SETTING_LOCALE_KEYBOARDLAYOUTS);
-  std::string activeLayout = settings->GetString(CSettings::SETTING_LOCALE_ACTIVEKEYBOARDLAYOUT);
+  const KEYBOARD::KeyboardLayouts& keyboardLayouts{
+      CServiceBroker::GetKeyboardLayoutManager()->GetLayouts()};
+  const std::shared_ptr<CSettings> settings{CServiceBroker::GetSettingsComponent()->GetSettings()};
+  const std::vector<CVariant> layoutNames{
+      settings->GetList(CSettings::SETTING_LOCALE_KEYBOARDLAYOUTS)};
+  const std::string activeLayout{
+      settings->GetString(CSettings::SETTING_LOCALE_ACTIVEKEYBOARDLAYOUT)};
 
   for (const auto& layoutName : layoutNames)
   {
@@ -453,7 +441,7 @@ bool Interface_General::change_keyboard_layout(void* kodiBase, char** layout_nam
     {
       layouts.emplace_back(keyboardLayout->second);
       if (layoutName.asString() == activeLayout)
-        currentLayout = layouts.size() - 1;
+        currentLayout = static_cast<unsigned int>(layouts.size() - 1);
     }
   }
 

--- a/xbmc/addons/interfaces/Network.cpp
+++ b/xbmc/addons/interfaces/Network.cpp
@@ -46,11 +46,11 @@ void Interface_Network::DeInit(AddonGlobalInterface* addonInterface)
 
 bool Interface_Network::wake_on_lan(void* kodiBase, const char* mac)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  if (addon == nullptr || mac == nullptr)
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  if (!addon || !mac)
   {
-    CLog::Log(LOGERROR, "Interface_Network::{} - invalid data (addon='{}', mac='{}')", __FUNCTION__,
-              kodiBase, static_cast<const void*>(mac));
+    CLog::LogF(LOGERROR, "Invalid data (addon='{}', mac='{}')", kodiBase,
+               static_cast<const void*>(mac));
     return false;
   }
 
@@ -59,11 +59,10 @@ bool Interface_Network::wake_on_lan(void* kodiBase, const char* mac)
 
 char* Interface_Network::get_ip_address(void* kodiBase)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  if (addon == nullptr)
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_Network::{} - invalid data (addon='{}')", __FUNCTION__,
-              kodiBase);
+    CLog::LogF(LOGERROR, "Invalid data (addon='{}')", kodiBase);
     return nullptr;
   }
 
@@ -74,19 +73,18 @@ char* Interface_Network::get_ip_address(void* kodiBase)
   else
     titleIP = "127.0.0.1";
 
-  char* buffer = nullptr;
-  if (!titleIP.empty())
-    buffer = strdup(titleIP.c_str());
-  return buffer;
+  if (titleIP.empty())
+    return nullptr;
+
+  return strdup(titleIP.c_str());
 }
 
 char* Interface_Network::get_hostname(void* kodiBase)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  if (addon == nullptr)
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_Network::{} - invalid data (addon='{}')", __FUNCTION__,
-              kodiBase);
+    CLog::LogF(LOGERROR, "Invalid data (addon='{}')", kodiBase);
     return nullptr;
   }
 
@@ -94,36 +92,35 @@ char* Interface_Network::get_hostname(void* kodiBase)
   if (!CServiceBroker::GetNetwork().GetHostName(hostname))
     return nullptr;
 
-  char* buffer = nullptr;
-  if (!hostname.empty())
-    buffer = strdup(hostname.c_str());
-  return buffer;
+  if (hostname.empty())
+    return nullptr;
+
+  return strdup(hostname.c_str());
 }
 
 char* Interface_Network::get_user_agent(void* kodiBase)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  if (addon == nullptr)
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_Network::{} - invalid data (addon='{}')", __FUNCTION__,
-              kodiBase);
+    CLog::LogF(LOGERROR, "Invalid data (addon='{}')", kodiBase);
     return nullptr;
   }
 
-  std::string string = CSysInfo::GetUserAgent();
-  char* buffer = nullptr;
-  if (!string.empty())
-    buffer = strdup(string.c_str());
-  return buffer;
+  const std::string string{CSysInfo::GetUserAgent()};
+  if (string.empty())
+    return nullptr;
+
+  return strdup(string.c_str());
 }
 
 bool Interface_Network::is_local_host(void* kodiBase, const char* hostname)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  if (addon == nullptr || hostname == nullptr)
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  if (!addon || !hostname)
   {
-    CLog::Log(LOGERROR, "Interface_Network::{} - invalid data (addon='{}', hostname='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(hostname));
+    CLog::LogF(LOGERROR, "Invalid data (addon='{}', hostname='{}')", kodiBase,
+               static_cast<const void*>(hostname));
     return false;
   }
 
@@ -132,11 +129,11 @@ bool Interface_Network::is_local_host(void* kodiBase, const char* hostname)
 
 bool Interface_Network::is_host_on_lan(void* kodiBase, const char* hostname, bool offLineCheck)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  if (addon == nullptr || hostname == nullptr)
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  if (!addon || !hostname)
   {
-    CLog::Log(LOGERROR, "Interface_Network::{} - invalid data (addon='{}', hostname='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(hostname));
+    CLog::LogF(LOGERROR, "Invalid data (addon='{}', hostname='{}')", kodiBase,
+               static_cast<const void*>(hostname));
     return false;
   }
 
@@ -147,37 +144,37 @@ bool Interface_Network::is_host_on_lan(void* kodiBase, const char* hostname, boo
 
 char* Interface_Network::dns_lookup(void* kodiBase, const char* url, bool* ret)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  if (addon == nullptr || url == nullptr || ret == nullptr)
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  if (!addon || !url || !ret)
   {
-    CLog::Log(LOGERROR, "Interface_Network::{} - invalid data (addon='{}', url='{}', ret='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(url), static_cast<void*>(ret));
+    CLog::LogF(LOGERROR, "Invalid data (addon='{}', url='{}', ret='{}')", kodiBase,
+               static_cast<const void*>(url), static_cast<void*>(ret));
     return nullptr;
   }
 
   std::string string;
   *ret = CServiceBroker::GetDNSNameCache()->Lookup(url, string);
-  char* buffer = nullptr;
-  if (!string.empty())
-    buffer = strdup(string.c_str());
-  return buffer;
+  if (string.empty())
+    return nullptr;
+
+  return strdup(string.c_str());
 }
 
 char* Interface_Network::url_encode(void* kodiBase, const char* url)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  if (addon == nullptr || url == nullptr)
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  if (!addon || !url)
   {
-    CLog::Log(LOGERROR, "Interface_Network::{} - invalid data (addon='{}', url='{}')", __FUNCTION__,
-              kodiBase, static_cast<const void*>(url));
+    CLog::LogF(LOGERROR, "Invalid data (addon='{}', url='{}')", kodiBase,
+               static_cast<const void*>(url));
     return nullptr;
   }
 
-  std::string string = CURL::Encode(url);
-  char* buffer = nullptr;
-  if (!string.empty())
-    buffer = strdup(string.c_str());
-  return buffer;
+  const std::string string{CURL::Encode(url)};
+  if (string.empty())
+    return nullptr;
+
+  return strdup(string.c_str());
 }
 
 } /* namespace ADDON */

--- a/xbmc/addons/interfaces/gui/General.cpp
+++ b/xbmc/addons/interfaces/gui/General.cpp
@@ -149,10 +149,10 @@ void Interface_GUIGeneral::unlock()
 //@{
 int Interface_GUIGeneral::get_screen_height(KODI_HANDLE kodiBase)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "kodi::gui::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return -1;
   }
 
@@ -161,10 +161,10 @@ int Interface_GUIGeneral::get_screen_height(KODI_HANDLE kodiBase)
 
 int Interface_GUIGeneral::get_screen_width(KODI_HANDLE kodiBase)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "kodi::gui::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return -1;
   }
 
@@ -173,24 +173,24 @@ int Interface_GUIGeneral::get_screen_width(KODI_HANDLE kodiBase)
 
 int Interface_GUIGeneral::get_video_resolution(KODI_HANDLE kodiBase)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "kodi::gui::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return -1;
   }
 
-  return (int)CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution();
+  return static_cast<int>(CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution());
 }
 //@}
 
 //@{
 int Interface_GUIGeneral::get_current_window_dialog_id(KODI_HANDLE kodiBase)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "kodi::gui::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return -1;
   }
 
@@ -200,10 +200,10 @@ int Interface_GUIGeneral::get_current_window_dialog_id(KODI_HANDLE kodiBase)
 
 int Interface_GUIGeneral::get_current_window_id(KODI_HANDLE kodiBase)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "kodi::gui::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return -1;
   }
 
@@ -218,10 +218,10 @@ ADDON_HARDWARE_CONTEXT Interface_GUIGeneral::get_hw_context(KODI_HANDLE kodiBase
 
 AdjustRefreshRateStatus Interface_GUIGeneral::get_adjust_refresh_rate_status(KODI_HANDLE kodiBase)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "kodi::gui::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return ADJUST_REFRESHRATE_STATUS_OFF;
   }
 
@@ -230,20 +230,15 @@ AdjustRefreshRateStatus Interface_GUIGeneral::get_adjust_refresh_rate_status(KOD
   {
     case AdjustRefreshRate::ADJUST_REFRESHRATE_OFF:
       return ADJUST_REFRESHRATE_STATUS_OFF;
-      break;
     case AdjustRefreshRate::ADJUST_REFRESHRATE_ON_START:
       return ADJUST_REFRESHRATE_STATUS_ON_START;
-      break;
     case AdjustRefreshRate::ADJUST_REFRESHRATE_ON_STARTSTOP:
       return ADJUST_REFRESHRATE_STATUS_ON_STARTSTOP;
-      break;
     case AdjustRefreshRate::ADJUST_REFRESHRATE_ALWAYS:
       return ADJUST_REFRESHRATE_STATUS_ALWAYS;
-      break;
     default:
-      CLog::Log(LOGERROR, "kodi::gui::{} - Unhandled Adjust refresh rate setting", __func__);
+      CLog::LogF(LOGERROR, "Unhandled Adjust refresh rate setting");
       return ADJUST_REFRESHRATE_STATUS_OFF;
-      break;
   }
 }
 

--- a/xbmc/addons/interfaces/gui/ListItem.cpp
+++ b/xbmc/addons/interfaces/gui/ListItem.cpp
@@ -49,14 +49,14 @@ KODI_GUI_LISTITEM_HANDLE Interface_GUIListItem::create(KODI_HANDLE kodiBase,
                                                        const char* label2,
                                                        const char* path)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "ADDON::Interface_GUIListItem::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return nullptr;
   }
 
-  CFileItemPtr* item = new CFileItemPtr(new CFileItem());
+  auto* item{new std::shared_ptr<CFileItem>(new CFileItem())};
   if (label)
     item->get()->SetLabel(label);
   if (label2)
@@ -69,41 +69,39 @@ KODI_GUI_LISTITEM_HANDLE Interface_GUIListItem::create(KODI_HANDLE kodiBase,
 
 void Interface_GUIListItem::destroy(KODI_HANDLE kodiBase, KODI_GUI_LISTITEM_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "ADDON::Interface_GUIListItem::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return;
   }
 
-  CFileItemPtr* item = static_cast<CFileItemPtr*>(handle);
+  const auto* item = static_cast<const std::shared_ptr<CFileItem>*>(handle);
   if (item)
     delete item;
 }
 
 char* Interface_GUIListItem::get_label(KODI_HANDLE kodiBase, KODI_GUI_LISTITEM_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CFileItemPtr* item = static_cast<CFileItemPtr*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* item = static_cast<const std::shared_ptr<CFileItem>*>(handle);
   if (!addon || !item)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIListItem::{} - invalid handler data (kodiBase='{}', handle='{}') on "
-              "addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') on "
+               "addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return nullptr;
   }
 
-  if (item->get() == nullptr)
+  if (!item->get())
   {
-    CLog::Log(LOGERROR, "Interface_GUIListItem::{} - empty list item called on addon '{}'",
-              __func__, addon->ID());
+    CLog::LogF(LOGERROR, "Empty list item called on addon '{}'", addon->ID());
     return nullptr;
   }
 
-  char* ret;
   Interface_GUIGeneral::lock();
-  ret = strdup(item->get()->GetLabel().c_str());
+  char* ret = strdup(item->get()->GetLabel().c_str());
   Interface_GUIGeneral::unlock();
   return ret;
 }
@@ -112,22 +110,20 @@ void Interface_GUIListItem::set_label(KODI_HANDLE kodiBase,
                                       KODI_GUI_LISTITEM_HANDLE handle,
                                       const char* label)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CFileItemPtr* item = static_cast<CFileItemPtr*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* item = static_cast<const std::shared_ptr<CFileItem>*>(handle);
   if (!addon || !item || !label)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIListItem::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "label='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(label),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "label='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(label), addon ? addon->ID() : "unknown");
     return;
   }
 
-  if (item->get() == nullptr)
+  if (!item->get())
   {
-    CLog::Log(LOGERROR, "Interface_GUIListItem::{} - empty list item called on addon '{}'",
-              __func__, addon->ID());
+    CLog::LogF(LOGERROR, "Empty list item called on addon '{}'", addon->ID());
     return;
   }
 
@@ -138,27 +134,25 @@ void Interface_GUIListItem::set_label(KODI_HANDLE kodiBase,
 
 char* Interface_GUIListItem::get_label2(KODI_HANDLE kodiBase, KODI_GUI_LISTITEM_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CFileItemPtr* item = static_cast<CFileItemPtr*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* item = static_cast<const std::shared_ptr<CFileItem>*>(handle);
   if (!addon || !item)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIListItem::{} - invalid handler data (kodiBase='{}', handle='{}') on "
-              "addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') on "
+               "addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return nullptr;
   }
 
-  if (item->get() == nullptr)
+  if (!item->get())
   {
-    CLog::Log(LOGERROR, "Interface_GUIListItem::{} - empty list item called on addon '{}'",
-              __func__, addon->ID());
+    CLog::LogF(LOGERROR, "Empty list item called on addon '{}'", addon->ID());
     return nullptr;
   }
 
-  char* ret;
   Interface_GUIGeneral::lock();
-  ret = strdup(item->get()->GetLabel2().c_str());
+  char* ret = strdup(item->get()->GetLabel2().c_str());
   Interface_GUIGeneral::unlock();
   return ret;
 }
@@ -167,22 +161,20 @@ void Interface_GUIListItem::set_label2(KODI_HANDLE kodiBase,
                                        KODI_GUI_LISTITEM_HANDLE handle,
                                        const char* label)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CFileItemPtr* item = static_cast<CFileItemPtr*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* item = static_cast<const std::shared_ptr<CFileItem>*>(handle);
   if (!addon || !item || !label)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIListItem::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "label='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(label),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "label='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(label), addon ? addon->ID() : "unknown");
     return;
   }
 
-  if (item->get() == nullptr)
+  if (!item->get())
   {
-    CLog::Log(LOGERROR, "Interface_GUIListItem::{} - empty list item called on addon '{}'",
-              __func__, addon->ID());
+    CLog::LogF(LOGERROR, "Empty list item called on addon '{}'", addon->ID());
     return;
   }
 
@@ -195,28 +187,25 @@ char* Interface_GUIListItem::get_art(KODI_HANDLE kodiBase,
                                      KODI_GUI_LISTITEM_HANDLE handle,
                                      const char* type)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CFileItemPtr* item = static_cast<CFileItemPtr*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* item = static_cast<const std::shared_ptr<CFileItem>*>(handle);
   if (!addon || !item || !type)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIListItem::{} - invalid handler data (kodiBase='{}', type='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(type),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', type='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(type), addon ? addon->ID() : "unknown");
     return nullptr;
   }
 
-  if (item->get() == nullptr)
+  if (!item->get())
   {
-    CLog::Log(LOGERROR, "Interface_GUIListItem::{} - empty list item called on addon '{}'",
-              __func__, addon->ID());
+    CLog::LogF(LOGERROR, "Empty list item called on addon '{}'", addon->ID());
     return nullptr;
   }
 
-  char* ret;
   Interface_GUIGeneral::lock();
-  ret = strdup(item->get()->GetArt(type).c_str());
+  char* ret = strdup(item->get()->GetArt(type).c_str());
   Interface_GUIGeneral::unlock();
   return ret;
 }
@@ -226,22 +215,21 @@ void Interface_GUIListItem::set_art(KODI_HANDLE kodiBase,
                                     const char* type,
                                     const char* label)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CFileItemPtr* item = static_cast<CFileItemPtr*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* item = static_cast<const std::shared_ptr<CFileItem>*>(handle);
   if (!addon || !item || !type || !label)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIListItem::{} - invalid handler data (kodiBase='{}', handle='{}', type= "
-              "'{}', label='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(type),
-              static_cast<const void*>(label), addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', type= "
+               "'{}', label='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(type), static_cast<const void*>(label),
+               addon ? addon->ID() : "unknown");
     return;
   }
 
-  if (item->get() == nullptr)
+  if (!item->get())
   {
-    CLog::Log(LOGERROR, "Interface_GUIListItem::{} - empty list item called on addon '{}'",
-              __func__, addon->ID());
+    CLog::LogF(LOGERROR, "Empty list item called on addon '{}'", addon->ID());
     return;
   }
 
@@ -252,27 +240,25 @@ void Interface_GUIListItem::set_art(KODI_HANDLE kodiBase,
 
 char* Interface_GUIListItem::get_path(KODI_HANDLE kodiBase, KODI_GUI_LISTITEM_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CFileItemPtr* item = static_cast<CFileItemPtr*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* item = static_cast<const std::shared_ptr<CFileItem>*>(handle);
   if (!addon || !item)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIListItem::{} - invalid handler data (kodiBase='{}', handle='{}') on "
-              "addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') on "
+               "addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return nullptr;
   }
 
-  if (item->get() == nullptr)
+  if (!item->get())
   {
-    CLog::Log(LOGERROR, "Interface_GUIListItem::{} - empty list item called on addon '{}'",
-              __func__, addon->ID());
+    CLog::LogF(LOGERROR, "Empty list item called on addon '{}'", addon->ID());
     return nullptr;
   }
 
-  char* ret;
   Interface_GUIGeneral::lock();
-  ret = strdup(item->get()->GetPath().c_str());
+  char* ret = strdup(item->get()->GetPath().c_str());
   Interface_GUIGeneral::unlock();
   return ret;
 }
@@ -282,22 +268,20 @@ void Interface_GUIListItem::set_path(KODI_HANDLE kodiBase,
                                      KODI_GUI_LISTITEM_HANDLE handle,
                                      const char* path)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CFileItemPtr* item = static_cast<CFileItemPtr*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* item = static_cast<const std::shared_ptr<CFileItem>*>(handle);
   if (!addon || !item || !path)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIListItem::{} - invalid handler data (kodiBase='{}', path='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(path),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', path='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(path), addon ? addon->ID() : "unknown");
     return;
   }
 
-  if (item->get() == nullptr)
+  if (!item->get())
   {
-    CLog::Log(LOGERROR, "Interface_GUIListItem::{} - empty list item called on addon '{}'",
-              __func__, addon->ID());
+    CLog::LogF(LOGERROR, "Empty list item called on addon '{}'", addon->ID());
     return;
   }
 
@@ -311,22 +295,21 @@ void Interface_GUIListItem::set_property(KODI_HANDLE kodiBase,
                                          const char* key,
                                          const char* value)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CFileItemPtr* item = static_cast<CFileItemPtr*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* item = static_cast<const std::shared_ptr<CFileItem>*>(handle);
   if (!addon || !item || !key || !value)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIListItem::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "key='{}', value='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(key),
-              static_cast<const void*>(value), addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "key='{}', value='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(key), static_cast<const void*>(value),
+               addon ? addon->ID() : "unknown");
     return;
   }
 
-  if (item->get() == nullptr)
+  if (!item->get())
   {
-    CLog::Log(LOGERROR, "Interface_GUIListItem::{} - empty list item called on addon '{}'",
-              __func__, addon->ID());
+    CLog::LogF(LOGERROR, "Empty list item called on addon '{}'", addon->ID());
     return;
   }
 
@@ -342,22 +325,20 @@ char* Interface_GUIListItem::get_property(KODI_HANDLE kodiBase,
                                           KODI_GUI_LISTITEM_HANDLE handle,
                                           const char* key)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CFileItemPtr* item = static_cast<CFileItemPtr*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* item = static_cast<const std::shared_ptr<CFileItem>*>(handle);
   if (!addon || !item || !key)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIListItem::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "key='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(key),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "key='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(key), addon ? addon->ID() : "unknown");
     return nullptr;
   }
 
-  if (item->get() == nullptr)
+  if (!item->get())
   {
-    CLog::Log(LOGERROR, "Interface_GUIListItem::{} - empty list item called on addon '{}'",
-              __func__, addon->ID());
+    CLog::LogF(LOGERROR, "Empty list item called on addon '{}'", addon->ID());
     return nullptr;
   }
 
@@ -375,21 +356,20 @@ void Interface_GUIListItem::select(KODI_HANDLE kodiBase,
                                    KODI_GUI_LISTITEM_HANDLE handle,
                                    bool select)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CFileItemPtr* item = static_cast<CFileItemPtr*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* item = static_cast<const std::shared_ptr<CFileItem>*>(handle);
   if (!addon || !item)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIListItem::{} - invalid handler data (kodiBase='{}', handle='{}') on "
-              "addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') on "
+               "addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
-  if (item->get() == nullptr)
+  if (!item->get())
   {
-    CLog::Log(LOGERROR, "Interface_GUIListItem::{} - empty list item called on addon '{}'",
-              __func__, addon->ID());
+    CLog::LogF(LOGERROR, "Empty list item called on addon '{}'", addon->ID());
     return;
   }
 
@@ -400,26 +380,25 @@ void Interface_GUIListItem::select(KODI_HANDLE kodiBase,
 
 bool Interface_GUIListItem::is_selected(KODI_HANDLE kodiBase, KODI_GUI_LISTITEM_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CFileItemPtr* item = static_cast<CFileItemPtr*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* item = static_cast<const std::shared_ptr<CFileItem>*>(handle);
   if (!addon || !item)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIListItem::{} - invalid handler data (kodiBase='{}', handle='{}') on "
-              "addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') on "
+               "addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return false;
   }
 
-  if (item->get() == nullptr)
+  if (!item->get())
   {
-    CLog::Log(LOGERROR, "Interface_GUIListItem::{} - empty list item called on addon '{}'",
-              __func__, addon->ID());
+    CLog::LogF(LOGERROR, "Empty list item called on addon '{}'", addon->ID());
     return false;
   }
 
   Interface_GUIGeneral::lock();
-  bool ret = item->get()->IsSelected();
+  const bool ret = item->get()->IsSelected();
   Interface_GUIGeneral::unlock();
 
   return ret;

--- a/xbmc/addons/interfaces/gui/Window.cpp
+++ b/xbmc/addons/interfaces/gui/Window.cpp
@@ -33,6 +33,8 @@
 #include "utils/Variant.h"
 #include "utils/log.h"
 
+#include <source_location>
+
 namespace ADDON
 {
 
@@ -115,23 +117,23 @@ KODI_GUI_WINDOW_HANDLE Interface_GUIWindow::create(KODI_HANDLE kodiBase,
                                                    bool as_dialog,
                                                    bool is_media)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  auto* addon = static_cast<CAddonDll*>(kodiBase);
   if (!addon || !xml_filename || !default_skin)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (xml_filename='{}', "
-              "default_skin='{}') on addon '{}'",
-              __func__, static_cast<const void*>(xml_filename),
-              static_cast<const void*>(default_skin), addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (xml_filename='{}', "
+               "default_skin='{}') on addon '{}'",
+               static_cast<const void*>(xml_filename), static_cast<const void*>(default_skin),
+               addon ? addon->ID() : "unknown");
     return nullptr;
   }
 
   if (as_dialog && is_media)
   {
-    CLog::Log(LOGWARNING,
-              "Interface_GUIWindow::{}: {}/{} - addon tries to create dialog as media window who "
-              "not allowed, contact Developer '{}' of this addon",
-              __func__, CAddonInfo::TranslateType(addon->Type()), addon->Name(), addon->Author());
+    CLog::LogF(LOGWARNING,
+               "{}/{} - addon tries to create a dialog as media window which is "
+               "not allowed. Contact the developer '{}' of this addon.",
+               CAddonInfo::TranslateType(addon->Type()), addon->Name(), addon->Author());
   }
 
   RESOLUTION_INFO res;
@@ -140,12 +142,12 @@ KODI_GUI_WINDOW_HANDLE Interface_GUIWindow::create(KODI_HANDLE kodiBase,
   if (!CFileUtils::Exists(strSkinPath))
   {
     std::string str("none");
-    ADDON::AddonInfoPtr addonInfo =
-        std::make_shared<ADDON::CAddonInfo>(str, ADDON::AddonType::SKIN);
+    const ADDON::AddonInfoPtr addonInfo{
+        std::make_shared<ADDON::CAddonInfo>(str, ADDON::AddonType::SKIN)};
 
     // Check for the matching folder for the skin in the fallback skins folder
-    std::string fallbackPath = URIUtils::AddFileToFolder(addon->Path(), "resources", "skins");
-    std::string basePath = URIUtils::AddFileToFolder(fallbackPath, g_SkinInfo->ID());
+    const std::string fallbackPath{URIUtils::AddFileToFolder(addon->Path(), "resources", "skins")};
+    const std::string basePath{URIUtils::AddFileToFolder(fallbackPath, g_SkinInfo->ID())};
 
     strSkinPath = g_SkinInfo->GetSkinPath(xml_filename, &res, basePath);
 
@@ -153,8 +155,8 @@ KODI_GUI_WINDOW_HANDLE Interface_GUIWindow::create(KODI_HANDLE kodiBase,
     if (CFileUtils::Exists(basePath))
     {
       addonInfo->SetPath(basePath);
-      const std::shared_ptr<ADDON::CSkinInfo> skinInfo =
-          std::make_shared<ADDON::CSkinInfo>(addonInfo, res);
+      const std::shared_ptr<ADDON::CSkinInfo> skinInfo{
+          std::make_shared<ADDON::CSkinInfo>(addonInfo, res)};
       skinInfo->Start();
       strSkinPath = skinInfo->GetSkinPath(xml_filename, &res);
     }
@@ -170,56 +172,49 @@ KODI_GUI_WINDOW_HANDLE Interface_GUIWindow::create(KODI_HANDLE kodiBase,
       strSkinPath = skinInfo->GetSkinPath(xml_filename, &res);
       if (!CFileUtils::Exists(strSkinPath))
       {
-        CLog::Log(LOGERROR,
-                  "Interface_GUIWindow::{}: {}/{} - XML File '{}' for Window is missing, contact "
-                  "Developer '{}' of this addon",
-                  __func__, CAddonInfo::TranslateType(addon->Type()), addon->Name(), strSkinPath,
-                  addon->Author());
+        CLog::LogF(LOGERROR,
+                   "{}/{} - XML File '{}' for Window is missing. Contact the "
+                   "developer '{}' of this addon.",
+                   CAddonInfo::TranslateType(addon->Type()), addon->Name(), strSkinPath,
+                   addon->Author());
         return nullptr;
       }
     }
   }
 
-  int id = GetNextAvailableWindowId();
+  const int id{GetNextAvailableWindowId()};
   if (id < 0)
     return nullptr;
 
-  CGUIWindow* window;
-  if (!as_dialog)
-    window = new CGUIAddonWindow(id, strSkinPath, addon, is_media);
-  else
-    window = new CGUIAddonWindowDialog(id, strSkinPath, addon);
+  auto window{as_dialog ? std::make_unique<CGUIAddonWindowDialog>(id, strSkinPath, addon)
+                        : std::make_unique<CGUIAddonWindow>(id, strSkinPath, addon, is_media)};
 
   Interface_GUIGeneral::lock();
-  CServiceBroker::GetGUI()->GetWindowManager().Add(window);
+  CServiceBroker::GetGUI()->GetWindowManager().Add(window.get());
   Interface_GUIGeneral::unlock();
 
   if (!CServiceBroker::GetGUI()->GetWindowManager().GetWindow(id))
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - Requested window id '{}' does not exist for addon '{}'",
-              __func__, id, addon->ID());
-    delete window;
+    CLog::LogF(LOGERROR, "Requested window id '{}' does not exist for addon '{}'", id, addon->ID());
     return nullptr;
   }
   window->SetCoordsRes(res);
-  return window;
+  return window.release();
 }
 
 void Interface_GUIWindow::destroy(KODI_HANDLE kodiBase, KODI_GUI_WINDOW_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (handle='{}') on addon '{}'",
-              __func__, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR, "Invalid handler data (handle='{}') on addon '{}'", handle,
+               addon ? addon->ID() : "unknown");
     return;
   }
 
   Interface_GUIGeneral::lock();
-  CGUIWindow* pWindow =
+  const CGUIWindow* pWindow =
       CServiceBroker::GetGUI()->GetWindowManager().GetWindow(pAddonWindow->GetID());
   if (pWindow)
   {
@@ -254,14 +249,14 @@ void Interface_GUIWindow::set_callbacks(
     void (*CBGetContextButtons)(KODI_GUI_CLIENT_HANDLE, int, gui_context_menu_pair*, unsigned int*),
     bool (*CBOnContextButton)(KODI_GUI_CLIENT_HANDLE, int, unsigned int))
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow || !clienthandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (handle='{}', clienthandle='{}') "
-              "on addon '{}'",
-              __func__, handle, clienthandle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (handle='{}', clienthandle='{}') "
+               "on addon '{}'",
+               handle, clienthandle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -278,13 +273,12 @@ void Interface_GUIWindow::set_callbacks(
 
 bool Interface_GUIWindow::show(KODI_HANDLE kodiBase, KODI_GUI_WINDOW_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (handle='{}') on addon '{}'",
-              __func__, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR, "Invalid handler data (handle='{}') on addon '{}'", handle,
+               addon ? addon->ID() : "unknown");
     return false;
   }
 
@@ -304,13 +298,12 @@ bool Interface_GUIWindow::show(KODI_HANDLE kodiBase, KODI_GUI_WINDOW_HANDLE hand
 
 bool Interface_GUIWindow::close(KODI_HANDLE kodiBase, KODI_GUI_WINDOW_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (handle='{}') on addon '{}'",
-              __func__, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR, "Invalid handler data (handle='{}') on addon '{}'", handle,
+               addon ? addon->ID() : "unknown");
     return false;
   }
 
@@ -332,13 +325,12 @@ bool Interface_GUIWindow::close(KODI_HANDLE kodiBase, KODI_GUI_WINDOW_HANDLE han
 
 bool Interface_GUIWindow::do_modal(KODI_HANDLE kodiBase, KODI_GUI_WINDOW_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (handle='{}') on addon '{}'",
-              __func__, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR, "Invalid handler data (handle='{}') on addon '{}'", handle,
+               addon ? addon->ID() : "unknown");
     return false;
   }
 
@@ -368,21 +360,20 @@ bool Interface_GUIWindow::set_focus_id(KODI_HANDLE kodiBase,
                                        KODI_GUI_WINDOW_HANDLE handle,
                                        int control_id)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}') on "
-              "addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') on "
+               "addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return false;
   }
 
   if (!pAddonWindow->GetControl(control_id))
   {
-    CLog::Log(LOGERROR, "Interface_GUIWindow - {}: {} - Control does not exist in window", __func__,
-              addon->Name());
+    CLog::LogF(LOGERROR, "{} - Control does not exist in window", addon->Name());
     return false;
   }
 
@@ -396,14 +387,14 @@ bool Interface_GUIWindow::set_focus_id(KODI_HANDLE kodiBase,
 
 int Interface_GUIWindow::get_focus_id(KODI_HANDLE kodiBase, KODI_GUI_WINDOW_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* pAddonWindow = static_cast<const CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}') on "
-              "addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') on "
+               "addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return -1;
   }
 
@@ -412,8 +403,7 @@ int Interface_GUIWindow::get_focus_id(KODI_HANDLE kodiBase, KODI_GUI_WINDOW_HAND
   Interface_GUIGeneral::unlock();
 
   if (control_id == -1)
-    CLog::Log(LOGERROR, "Interface_GUIWindow - {}: {} - No control in this window has focus",
-              __func__, addon->Name());
+    CLog::LogF(LOGERROR, "{} - No control in this window has focus", addon->Name());
 
   return control_id;
 }
@@ -423,15 +413,14 @@ void Interface_GUIWindow::set_control_label(KODI_HANDLE kodiBase,
                                             int control_id,
                                             const char* label)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow || !label)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "label='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(label),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "label='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(label), addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -447,14 +436,14 @@ void Interface_GUIWindow::set_control_visible(KODI_HANDLE kodiBase,
                                               int control_id,
                                               bool visible)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}') on "
-              "addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') on "
+               "addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -469,14 +458,14 @@ void Interface_GUIWindow::set_control_selected(KODI_HANDLE kodiBase,
                                                int control_id,
                                                bool selected)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}') on "
-              "addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') on "
+               "addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -497,15 +486,15 @@ void Interface_GUIWindow::set_property(KODI_HANDLE kodiBase,
                                        const char* key,
                                        const char* value)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow || !key || !value)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "key='{}', value='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(key),
-              static_cast<const void*>(value), addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "key='{}', value='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(key), static_cast<const void*>(value),
+               addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -522,15 +511,14 @@ void Interface_GUIWindow::set_property_int(KODI_HANDLE kodiBase,
                                            const char* key,
                                            int value)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow || !key)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "key='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(key),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "key='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(key), addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -547,15 +535,14 @@ void Interface_GUIWindow::set_property_bool(KODI_HANDLE kodiBase,
                                             const char* key,
                                             bool value)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow || !key)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "key='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(key),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "key='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(key), addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -572,15 +559,14 @@ void Interface_GUIWindow::set_property_double(KODI_HANDLE kodiBase,
                                               const char* key,
                                               double value)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow || !key)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "key='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(key),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "key='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(key), addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -596,15 +582,14 @@ char* Interface_GUIWindow::get_property(KODI_HANDLE kodiBase,
                                         KODI_GUI_WINDOW_HANDLE handle,
                                         const char* key)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* pAddonWindow = static_cast<const CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow || !key)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "key='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(key),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "key='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(key), addon ? addon->ID() : "unknown");
     return nullptr;
   }
 
@@ -612,7 +597,7 @@ char* Interface_GUIWindow::get_property(KODI_HANDLE kodiBase,
   StringUtils::ToLower(lowerKey);
 
   Interface_GUIGeneral::lock();
-  std::string value = pAddonWindow->GetProperty(lowerKey).asString();
+  const std::string value = pAddonWindow->GetProperty(lowerKey).asString();
   Interface_GUIGeneral::unlock();
 
   return strdup(value.c_str());
@@ -622,15 +607,14 @@ int Interface_GUIWindow::get_property_int(KODI_HANDLE kodiBase,
                                           KODI_GUI_WINDOW_HANDLE handle,
                                           const char* key)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* pAddonWindow = static_cast<const CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow || !key)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "key='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(key),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "key='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(key), addon ? addon->ID() : "unknown");
     return -1;
   }
 
@@ -638,7 +622,7 @@ int Interface_GUIWindow::get_property_int(KODI_HANDLE kodiBase,
   StringUtils::ToLower(lowerKey);
 
   Interface_GUIGeneral::lock();
-  int value = static_cast<int>(pAddonWindow->GetProperty(lowerKey).asInteger());
+  const int value = static_cast<int>(pAddonWindow->GetProperty(lowerKey).asInteger());
   Interface_GUIGeneral::unlock();
 
   return value;
@@ -648,15 +632,14 @@ bool Interface_GUIWindow::get_property_bool(KODI_HANDLE kodiBase,
                                             KODI_GUI_WINDOW_HANDLE handle,
                                             const char* key)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* pAddonWindow = static_cast<const CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow || !key)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "key='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(key),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "key='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(key), addon ? addon->ID() : "unknown");
     return false;
   }
 
@@ -664,7 +647,7 @@ bool Interface_GUIWindow::get_property_bool(KODI_HANDLE kodiBase,
   StringUtils::ToLower(lowerKey);
 
   Interface_GUIGeneral::lock();
-  bool value = pAddonWindow->GetProperty(lowerKey).asBoolean();
+  const bool value = pAddonWindow->GetProperty(lowerKey).asBoolean();
   Interface_GUIGeneral::unlock();
 
   return value;
@@ -674,15 +657,14 @@ double Interface_GUIWindow::get_property_double(KODI_HANDLE kodiBase,
                                                 KODI_GUI_WINDOW_HANDLE handle,
                                                 const char* key)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* pAddonWindow = static_cast<const CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow || !key)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "key='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(key),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "key='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(key), addon ? addon->ID() : "unknown");
     return 0.0;
   }
 
@@ -690,7 +672,7 @@ double Interface_GUIWindow::get_property_double(KODI_HANDLE kodiBase,
   StringUtils::ToLower(lowerKey);
 
   Interface_GUIGeneral::lock();
-  double value = pAddonWindow->GetProperty(lowerKey).asDouble();
+  const double value = pAddonWindow->GetProperty(lowerKey).asDouble();
   Interface_GUIGeneral::unlock();
 
   return value;
@@ -698,14 +680,14 @@ double Interface_GUIWindow::get_property_double(KODI_HANDLE kodiBase,
 
 void Interface_GUIWindow::clear_properties(KODI_HANDLE kodiBase, KODI_GUI_WINDOW_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}') on "
-              "addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') on "
+               "addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -718,15 +700,14 @@ void Interface_GUIWindow::clear_property(KODI_HANDLE kodiBase,
                                          KODI_GUI_WINDOW_HANDLE handle,
                                          const char* key)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow || !key)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "key='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(key),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "key='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(key), addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -745,14 +726,14 @@ void Interface_GUIWindow::clear_property(KODI_HANDLE kodiBase,
 //@{
 void Interface_GUIWindow::clear_item_list(KODI_HANDLE kodiBase, KODI_GUI_WINDOW_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}') on "
-              "addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') on "
+               "addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -766,22 +747,21 @@ void Interface_GUIWindow::add_list_item(KODI_HANDLE kodiBase,
                                         KODI_GUI_LISTITEM_HANDLE item,
                                         int list_position)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow || !item)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "item='{}') on addon '{}'",
-              __func__, kodiBase, handle, item, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "item='{}') on addon '{}'",
+               kodiBase, handle, item, addon ? addon->ID() : "unknown");
     return;
   }
 
-  CFileItemPtr* pItem(static_cast<CFileItemPtr*>(item));
-  if (pItem->get() == nullptr)
+  auto* pItem = static_cast<std::shared_ptr<CFileItem>*>(item);
+  if (!pItem->get())
   {
-    CLog::Log(LOGERROR, "Interface_GUIWindow::{} - empty list item called on addon '{}'", __func__,
-              addon->ID());
+    CLog::LogF(LOGERROR, "Empty list item called on addon '{}'", addon->ID());
     return;
   }
 
@@ -794,14 +774,14 @@ void Interface_GUIWindow::remove_list_item_from_position(KODI_HANDLE kodiBase,
                                                          KODI_GUI_WINDOW_HANDLE handle,
                                                          int list_position)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}') on "
-              "addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') on "
+               "addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -814,22 +794,21 @@ void Interface_GUIWindow::remove_list_item(KODI_HANDLE kodiBase,
                                            KODI_GUI_WINDOW_HANDLE handle,
                                            KODI_GUI_LISTITEM_HANDLE item)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow || !item)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "item='{}') on addon '{}'",
-              __func__, kodiBase, handle, item, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "item='{}') on addon '{}'",
+               kodiBase, handle, item, addon ? addon->ID() : "unknown");
     return;
   }
 
-  CFileItemPtr* pItem(static_cast<CFileItemPtr*>(item));
-  if (pItem->get() == nullptr)
+  auto* pItem = static_cast<std::shared_ptr<CFileItem>*>(item);
+  if (!pItem->get())
   {
-    CLog::Log(LOGERROR, "Interface_GUIWindow::{} - empty list item called on addon '{}'", __func__,
-              addon->ID());
+    CLog::LogF(LOGERROR, "Empty list item called on addon '{}'", addon->ID());
     return;
   }
 
@@ -842,23 +821,22 @@ KODI_GUI_LISTITEM_HANDLE Interface_GUIWindow::get_list_item(KODI_HANDLE kodiBase
                                                             KODI_GUI_WINDOW_HANDLE handle,
                                                             int list_position)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}') on "
-              "addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') on "
+               "addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return nullptr;
   }
 
   Interface_GUIGeneral::lock();
   CFileItemPtr* pItem(pAddonWindow->GetListItem(list_position));
-  if (pItem == nullptr || pItem->get() == nullptr)
+  if (!pItem || !pItem->get())
   {
-    CLog::Log(LOGERROR, "ADDON::Interface_GUIWindow - {}: {} - Index out of range", __func__,
-              addon->Name());
+    CLog::LogF(LOGERROR, "{} - Index out of range", addon->Name());
 
     if (pItem)
     {
@@ -875,14 +853,14 @@ void Interface_GUIWindow::set_current_list_position(KODI_HANDLE kodiBase,
                                                     KODI_GUI_WINDOW_HANDLE handle,
                                                     int list_position)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}') on "
-              "addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') on "
+               "addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -894,19 +872,19 @@ void Interface_GUIWindow::set_current_list_position(KODI_HANDLE kodiBase,
 int Interface_GUIWindow::get_current_list_position(KODI_HANDLE kodiBase,
                                                    KODI_GUI_WINDOW_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}') on "
-              "addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') on "
+               "addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return -1;
   }
 
   Interface_GUIGeneral::lock();
-  int listPos = pAddonWindow->GetCurrentListPosition();
+  const int listPos = pAddonWindow->GetCurrentListPosition();
   Interface_GUIGeneral::unlock();
 
   return listPos;
@@ -914,19 +892,19 @@ int Interface_GUIWindow::get_current_list_position(KODI_HANDLE kodiBase,
 
 int Interface_GUIWindow::get_list_size(KODI_HANDLE kodiBase, KODI_GUI_WINDOW_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}') on "
-              "addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') on "
+               "addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return -1;
   }
 
   Interface_GUIGeneral::lock();
-  int listSize = pAddonWindow->GetListSize();
+  const int listSize = pAddonWindow->GetListSize();
   Interface_GUIGeneral::unlock();
 
   return listSize;
@@ -937,15 +915,15 @@ void Interface_GUIWindow::set_container_property(KODI_HANDLE kodiBase,
                                                  const char* key,
                                                  const char* value)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow || !key || !value)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "key='{}', value='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(key),
-              static_cast<const void*>(value), addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "key='{}', value='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(key), static_cast<const void*>(value),
+               addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -958,15 +936,14 @@ void Interface_GUIWindow::set_container_content(KODI_HANDLE kodiBase,
                                                 KODI_GUI_WINDOW_HANDLE handle,
                                                 const char* value)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow || !value)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "value='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(value),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "value='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(value), addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -978,19 +955,19 @@ void Interface_GUIWindow::set_container_content(KODI_HANDLE kodiBase,
 int Interface_GUIWindow::get_current_container_id(KODI_HANDLE kodiBase,
                                                   KODI_GUI_WINDOW_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}') on "
-              "addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') on "
+               "addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return -1;
   }
 
   Interface_GUIGeneral::lock();
-  int id = pAddonWindow->GetCurrentContainerControlId();
+  const int id = pAddonWindow->GetCurrentContainerControlId();
   Interface_GUIGeneral::unlock();
 
   return id;
@@ -1003,14 +980,14 @@ int Interface_GUIWindow::get_current_container_id(KODI_HANDLE kodiBase,
 //@{
 void Interface_GUIWindow::mark_dirty_region(KODI_HANDLE kodiBase, KODI_GUI_WINDOW_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}') on "
-              "addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') on "
+               "addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -1028,60 +1005,64 @@ KODI_GUI_CONTROL_HANDLE Interface_GUIWindow::get_control_button(KODI_HANDLE kodi
                                                                 KODI_GUI_WINDOW_HANDLE handle,
                                                                 int control_id)
 {
-  return GetControl(kodiBase, handle, control_id, __func__, CGUIControl::GUICONTROL_BUTTON,
-                    "button");
+  return GetControl(kodiBase, handle, control_id, std::source_location::current().function_name(),
+                    CGUIControl::GUICONTROL_BUTTON, "button");
 }
 
 KODI_GUI_CONTROL_HANDLE Interface_GUIWindow::get_control_edit(KODI_HANDLE kodiBase,
                                                               KODI_GUI_WINDOW_HANDLE handle,
                                                               int control_id)
 {
-  return GetControl(kodiBase, handle, control_id, __func__, CGUIControl::GUICONTROL_EDIT, "edit");
+  return GetControl(kodiBase, handle, control_id, std::source_location::current().function_name(),
+                    CGUIControl::GUICONTROL_EDIT, "edit");
 }
 
 KODI_GUI_CONTROL_HANDLE Interface_GUIWindow::get_control_fade_label(KODI_HANDLE kodiBase,
                                                                     KODI_GUI_WINDOW_HANDLE handle,
                                                                     int control_id)
 {
-  return GetControl(kodiBase, handle, control_id, __func__, CGUIControl::GUICONTROL_FADELABEL,
-                    "fade label");
+  return GetControl(kodiBase, handle, control_id, std::source_location::current().function_name(),
+                    CGUIControl::GUICONTROL_FADELABEL, "fade label");
 }
 
 KODI_GUI_CONTROL_HANDLE Interface_GUIWindow::get_control_image(KODI_HANDLE kodiBase,
                                                                KODI_GUI_WINDOW_HANDLE handle,
                                                                int control_id)
 {
-  return GetControl(kodiBase, handle, control_id, __func__, CGUIControl::GUICONTROL_IMAGE, "image");
+  return GetControl(kodiBase, handle, control_id, std::source_location::current().function_name(),
+                    CGUIControl::GUICONTROL_IMAGE, "image");
 }
 
 KODI_GUI_CONTROL_HANDLE Interface_GUIWindow::get_control_label(KODI_HANDLE kodiBase,
                                                                KODI_GUI_WINDOW_HANDLE handle,
                                                                int control_id)
 {
-  return GetControl(kodiBase, handle, control_id, __func__, CGUIControl::GUICONTROL_LABEL, "label");
+  return GetControl(kodiBase, handle, control_id, std::source_location::current().function_name(),
+                    CGUIControl::GUICONTROL_LABEL, "label");
 }
 KODI_GUI_CONTROL_HANDLE Interface_GUIWindow::get_control_progress(KODI_HANDLE kodiBase,
                                                                   KODI_GUI_WINDOW_HANDLE handle,
                                                                   int control_id)
 {
-  return GetControl(kodiBase, handle, control_id, __func__, CGUIControl::GUICONTROL_PROGRESS,
-                    "progress");
+  return GetControl(kodiBase, handle, control_id, std::source_location::current().function_name(),
+                    CGUIControl::GUICONTROL_PROGRESS, "progress");
 }
 
 KODI_GUI_CONTROL_HANDLE Interface_GUIWindow::get_control_radio_button(KODI_HANDLE kodiBase,
                                                                       KODI_GUI_WINDOW_HANDLE handle,
                                                                       int control_id)
 {
-  return GetControl(kodiBase, handle, control_id, __func__, CGUIControl::GUICONTROL_RADIO,
-                    "radio button");
+  return GetControl(kodiBase, handle, control_id, std::source_location::current().function_name(),
+                    CGUIControl::GUICONTROL_RADIO, "radio button");
 }
 
 KODI_GUI_CONTROL_HANDLE Interface_GUIWindow::get_control_render_addon(KODI_HANDLE kodiBase,
                                                                       KODI_GUI_WINDOW_HANDLE handle,
                                                                       int control_id)
 {
-  CGUIControl* pGUIControl = static_cast<CGUIControl*>(GetControl(
-      kodiBase, handle, control_id, __func__, CGUIControl::GUICONTROL_RENDERADDON, "renderaddon"));
+  CGUIControl* pGUIControl = static_cast<CGUIControl*>(
+      GetControl(kodiBase, handle, control_id, std::source_location::current().function_name(),
+                 CGUIControl::GUICONTROL_RENDERADDON, "renderaddon"));
   if (!pGUIControl)
     return nullptr;
 
@@ -1093,31 +1074,32 @@ KODI_GUI_CONTROL_HANDLE Interface_GUIWindow::get_control_render_addon(KODI_HANDL
 KODI_GUI_CONTROL_HANDLE Interface_GUIWindow::get_control_settings_slider(
     KODI_HANDLE kodiBase, KODI_GUI_WINDOW_HANDLE handle, int control_id)
 {
-  return GetControl(kodiBase, handle, control_id, __func__, CGUIControl::GUICONTROL_SETTINGS_SLIDER,
-                    "settings slider");
+  return GetControl(kodiBase, handle, control_id, std::source_location::current().function_name(),
+                    CGUIControl::GUICONTROL_SETTINGS_SLIDER, "settings slider");
 }
 
 KODI_GUI_CONTROL_HANDLE Interface_GUIWindow::get_control_slider(KODI_HANDLE kodiBase,
                                                                 KODI_GUI_WINDOW_HANDLE handle,
                                                                 int control_id)
 {
-  return GetControl(kodiBase, handle, control_id, __func__, CGUIControl::GUICONTROL_SLIDER,
-                    "slider");
+  return GetControl(kodiBase, handle, control_id, std::source_location::current().function_name(),
+                    CGUIControl::GUICONTROL_SLIDER, "slider");
 }
 
 KODI_GUI_CONTROL_HANDLE Interface_GUIWindow::get_control_spin(KODI_HANDLE kodiBase,
                                                               KODI_GUI_WINDOW_HANDLE handle,
                                                               int control_id)
 {
-  return GetControl(kodiBase, handle, control_id, __func__, CGUIControl::GUICONTROL_SPINEX, "spin");
+  return GetControl(kodiBase, handle, control_id, std::source_location::current().function_name(),
+                    CGUIControl::GUICONTROL_SPINEX, "spin");
 }
 
 KODI_GUI_CONTROL_HANDLE Interface_GUIWindow::get_control_text_box(KODI_HANDLE kodiBase,
                                                                   KODI_GUI_WINDOW_HANDLE handle,
                                                                   int control_id)
 {
-  return GetControl(kodiBase, handle, control_id, __func__, CGUIControl::GUICONTROL_TEXTBOX,
-                    "textbox");
+  return GetControl(kodiBase, handle, control_id, std::source_location::current().function_name(),
+                    CGUIControl::GUICONTROL_TEXTBOX, "textbox");
 }
 //@}
 
@@ -1128,14 +1110,14 @@ KODI_GUI_CONTROL_HANDLE Interface_GUIWindow::GetControl(KODI_HANDLE kodiBase,
                                                         CGUIControl::GUICONTROLTYPES type,
                                                         const std::string& typeName)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonWindow* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - invalid handler data (kodiBase='{}', handle='{}') on "
-              "addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') on "
+               "addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return nullptr;
   }
 
@@ -1150,17 +1132,14 @@ int Interface_GUIWindow::GetNextAvailableWindowId()
   if (CServiceBroker::GetGUI()->GetWindowManager().GetWindow(WINDOW_ADDON_END))
   {
     Interface_GUIGeneral::unlock();
-    CLog::Log(LOGERROR,
-              "Interface_GUIWindow::{} - Maximum number of windows for binary addons reached",
-              __func__);
+    CLog::LogF(LOGERROR, "Maximum number of windows for binary addons reached");
     return -1;
   }
 
   // window id's WINDOW_ADDON_START - WINDOW_ADDON_END are reserved for addons
   // get first window id that is not in use
   int id = WINDOW_ADDON_START;
-  while (id < WINDOW_ADDON_END &&
-         CServiceBroker::GetGUI()->GetWindowManager().GetWindow(id) != nullptr)
+  while (id < WINDOW_ADDON_END && CServiceBroker::GetGUI()->GetWindowManager().GetWindow(id))
     id++;
 
   Interface_GUIGeneral::unlock();
@@ -1168,11 +1147,7 @@ int Interface_GUIWindow::GetNextAvailableWindowId()
 }
 
 CGUIAddonWindow::CGUIAddonWindow(int id, const std::string& strXML, CAddonDll* addon, bool isMedia)
-  : CGUIMediaWindow(id, strXML.c_str()),
-    m_windowId(id),
-    m_actionEvent(true),
-    m_addon(addon),
-    m_isMedia(isMedia)
+  : CGUIMediaWindow(id, strXML.c_str()), m_windowId(id), m_addon(addon), m_isMedia(isMedia)
 {
   m_loadType = LOAD_ON_GUI_INIT;
 }
@@ -1183,31 +1158,26 @@ CGUIControl* CGUIAddonWindow::GetAddonControl(int controlId,
 {
   // Load window resources, if not already done, to have related xml content
   // present and to let control find it
-  if (!m_windowLoaded)
+  if (!m_windowLoaded && !Initialize())
   {
-    if (!Initialize())
-    {
-      CLog::Log(LOGERROR,
-                "CGUIAddonGUI_Window::{}: {} - Window initialize failed by control id '{}' request "
-                "for '{}'",
-                __func__, m_addon->Name(), controlId, typeName);
-      return nullptr;
-    }
+    CLog::LogF(LOGERROR,
+               "{} - Window initialize failed by control id '{}' request "
+               "for '{}'",
+               m_addon->Name(), controlId, typeName);
+    return nullptr;
   }
 
   CGUIControl* pGUIControl = GetControl(controlId);
   if (!pGUIControl)
   {
-    CLog::Log(LOGERROR,
-              "CGUIAddonGUI_Window::{}: {} - Requested GUI control Id '{}' for '{}' not present!",
-              __func__, m_addon->Name(), controlId, typeName);
+    CLog::LogF(LOGERROR, "{} - Requested GUI control Id '{}' for '{}' not present!",
+               m_addon->Name(), controlId, typeName);
     return nullptr;
   }
   else if (pGUIControl->GetControlType() != type)
   {
-    CLog::Log(LOGERROR,
-              "CGUIAddonGUI_Window::{}: {} - Requested GUI control Id '{}' not the type '{}'!",
-              __func__, m_addon->Name(), controlId, typeName);
+    CLog::LogF(LOGERROR, "{} - Requested GUI control Id '{}' has not type '{}'!", m_addon->Name(),
+               controlId, typeName);
     return nullptr;
   }
 
@@ -1232,7 +1202,6 @@ bool CGUIAddonWindow::OnMessage(CGUIMessage& message)
     {
       return CGUIMediaWindow::OnMessage(message);
     }
-    break;
 
     case GUI_MSG_WINDOW_INIT:
     {
@@ -1240,9 +1209,9 @@ bool CGUIAddonWindow::OnMessage(CGUIMessage& message)
 
       if (CBOnInit)
         CBOnInit(m_clientHandle);
+
       return true;
     }
-    break;
 
     case GUI_MSG_FOCUSED:
     {
@@ -1253,11 +1222,11 @@ bool CGUIAddonWindow::OnMessage(CGUIMessage& message)
         return true;
       }
       // check if our focused control is one of our category buttons
-      int iControl = message.GetControlId();
+      const int iControl = message.GetControlId();
       if (CBOnFocus)
         CBOnFocus(m_clientHandle, iControl);
+      break;
     }
-    break;
 
     case GUI_MSG_NOTIFY_ALL:
     {
@@ -1271,9 +1240,9 @@ bool CGUIAddonWindow::OnMessage(CGUIMessage& message)
     case GUI_MSG_CLICKED:
     {
       int iControl = message.GetSenderId();
-      if (iControl && iControl != this->GetID())
+      if (iControl && iControl != GetID())
       {
-        CGUIControl* controlClicked = this->GetControl(iControl);
+        CGUIControl* controlClicked = GetControl(iControl);
 
         // The old python way used to check list AND SELECITEM method or if its a button, checkmark.
         // Its done this way for now to allow other controls without a python version like togglebutton to still raise a onAction event
@@ -1300,8 +1269,10 @@ bool CGUIAddonWindow::OnMessage(CGUIMessage& message)
           }
         }
       }
+      break;
     }
-    break;
+    default:
+      break;
   }
 
   return CGUIMediaWindow::OnMessage(message);
@@ -1359,7 +1330,7 @@ void CGUIAddonWindow::RemoveItem(CFileItemPtr* fileItem)
   UpdateButtons();
 }
 
-int CGUIAddonWindow::GetCurrentListPosition()
+int CGUIAddonWindow::GetCurrentListPosition() const
 {
   return m_viewControl.GetSelectedItem();
 }
@@ -1369,7 +1340,7 @@ void CGUIAddonWindow::SetCurrentListPosition(int item)
   m_viewControl.SetSelectedItem(item);
 }
 
-int CGUIAddonWindow::GetListSize()
+int CGUIAddonWindow::GetListSize() const
 {
   return m_vecItems->Size();
 }
@@ -1378,7 +1349,7 @@ CFileItemPtr* CGUIAddonWindow::GetListItem(int position)
 {
   if (position < 0 || position >= m_vecItems->Size())
     return nullptr;
-  return new CFileItemPtr(m_vecItems->Get(position));
+  return new std::shared_ptr<CFileItem>(m_vecItems->Get(position));
 }
 
 void CGUIAddonWindow::ClearList()
@@ -1412,7 +1383,8 @@ void CGUIAddonWindow::GetContextButtons(int itemNumber, CContextButtons& buttons
   {
     CBGetContextButtons(m_clientHandle, itemNumber, c_buttons, &size);
     for (unsigned int i = 0; i < size; ++i)
-      buttons.push_back(std::pair<unsigned int, std::string>(c_buttons[i].id, c_buttons[i].name));
+      buttons.emplace_back(
+          std::pair<unsigned int, std::string>(c_buttons[i].id, c_buttons[i].name));
   }
 }
 
@@ -1448,7 +1420,7 @@ void CGUIAddonWindowDialog::Show(bool show /* = true */, bool modal /* = true*/)
 {
   if (modal)
   {
-    unsigned int count = CServiceBroker::GetWinSystem()->GetGfxContext().exit();
+    const unsigned int count{CServiceBroker::GetWinSystem()->GetGfxContext().exit()};
     CServiceBroker::GetAppMessenger()->SendMsg(TMSG_GUI_ADDON_DIALOG, 0, show ? 1 : 0,
                                                static_cast<void*>(this));
     CServiceBroker::GetWinSystem()->GetGfxContext().restore(count);

--- a/xbmc/addons/interfaces/gui/Window.h
+++ b/xbmc/addons/interfaces/gui/Window.h
@@ -219,8 +219,8 @@ extern "C"
     void RemoveItem(CFileItemPtr* fileItem);
     void ClearList();
     CFileItemPtr* GetListItem(int position);
-    int GetListSize();
-    int GetCurrentListPosition();
+    int GetListSize() const;
+    int GetCurrentListPosition() const;
     void SetCurrentListPosition(int item);
     void SetContainerProperty(const std::string& key, const std::string& value);
     void SetContainerContent(const std::string& value);
@@ -248,16 +248,16 @@ extern "C"
                               int itemNumber,
                               unsigned int button) = nullptr;
 
-    const int m_windowId;
-    int m_oldWindowId = 0;
+    const int m_windowId{0};
+    int m_oldWindowId{0};
 
   private:
     void WaitForActionEvent(unsigned int timeout);
 
-    CEvent m_actionEvent;
-    ADDON::CAddonDll* m_addon;
+    CEvent m_actionEvent{true};
+    ADDON::CAddonDll* m_addon{nullptr};
     std::string m_mediaDir;
-    bool m_isMedia;
+    bool m_isMedia{false};
   };
 
   class CGUIAddonWindowDialog : public CGUIAddonWindow

--- a/xbmc/addons/interfaces/gui/controls/Button.cpp
+++ b/xbmc/addons/interfaces/gui/controls/Button.cpp
@@ -41,14 +41,14 @@ void Interface_GUIControlButton::set_visible(KODI_HANDLE kodiBase,
                                              KODI_GUI_CONTROL_HANDLE handle,
                                              bool visible)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIButtonControl* control = static_cast<CGUIButtonControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIButtonControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlButton::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -59,14 +59,14 @@ void Interface_GUIControlButton::set_enabled(KODI_HANDLE kodiBase,
                                              KODI_GUI_CONTROL_HANDLE handle,
                                              bool enabled)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIButtonControl* control = static_cast<CGUIButtonControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIButtonControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlButton::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -77,15 +77,14 @@ void Interface_GUIControlButton::set_label(KODI_HANDLE kodiBase,
                                            KODI_GUI_CONTROL_HANDLE handle,
                                            const char* label)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIButtonControl* control = static_cast<CGUIButtonControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIButtonControl*>(handle);
   if (!addon || !control || !label)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlButton::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "label='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(label),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "label='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(label), addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -94,14 +93,14 @@ void Interface_GUIControlButton::set_label(KODI_HANDLE kodiBase,
 
 char* Interface_GUIControlButton::get_label(KODI_HANDLE kodiBase, KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIButtonControl* control = static_cast<CGUIButtonControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const CGUIButtonControl* control = static_cast<const CGUIButtonControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlButton::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return nullptr;
   }
 
@@ -112,15 +111,14 @@ void Interface_GUIControlButton::set_label2(KODI_HANDLE kodiBase,
                                             KODI_GUI_CONTROL_HANDLE handle,
                                             const char* label)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIButtonControl* control = static_cast<CGUIButtonControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIButtonControl*>(handle);
   if (!addon || !control || !label)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlButton::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "label='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(label),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "label='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(label), addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -129,14 +127,14 @@ void Interface_GUIControlButton::set_label2(KODI_HANDLE kodiBase,
 
 char* Interface_GUIControlButton::get_label2(KODI_HANDLE kodiBase, KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIButtonControl* control = static_cast<CGUIButtonControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUIButtonControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlButton::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return nullptr;
   }
 

--- a/xbmc/addons/interfaces/gui/controls/Edit.cpp
+++ b/xbmc/addons/interfaces/gui/controls/Edit.cpp
@@ -41,14 +41,14 @@ void Interface_GUIControlEdit::set_visible(KODI_HANDLE kodiBase,
                                            KODI_GUI_CONTROL_HANDLE handle,
                                            bool visible)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIEditControl* control = static_cast<CGUIEditControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIEditControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlEdit::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -59,14 +59,14 @@ void Interface_GUIControlEdit::set_enabled(KODI_HANDLE kodiBase,
                                            KODI_GUI_CONTROL_HANDLE handle,
                                            bool enable)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIEditControl* control = static_cast<CGUIEditControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIEditControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlEdit::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -78,15 +78,15 @@ void Interface_GUIControlEdit::set_input_type(KODI_HANDLE kodiBase,
                                               int type,
                                               const char* heading)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIEditControl* control = static_cast<CGUIEditControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIEditControl*>(handle);
   if (!addon || !control || !heading)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlEdit::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "heading='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(heading),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "heading='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(heading),
+               addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -135,15 +135,14 @@ void Interface_GUIControlEdit::set_label(KODI_HANDLE kodiBase,
                                          KODI_GUI_CONTROL_HANDLE handle,
                                          const char* label)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIEditControl* control = static_cast<CGUIEditControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIEditControl*>(handle);
   if (!addon || !control || !label)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlEdit::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "label='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(label),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "label='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(label), addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -152,14 +151,14 @@ void Interface_GUIControlEdit::set_label(KODI_HANDLE kodiBase,
 
 char* Interface_GUIControlEdit::get_label(KODI_HANDLE kodiBase, KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIEditControl* control = static_cast<CGUIEditControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIEditControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlEdit::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return nullptr;
   }
 
@@ -170,15 +169,14 @@ void Interface_GUIControlEdit::set_text(KODI_HANDLE kodiBase,
                                         KODI_GUI_CONTROL_HANDLE handle,
                                         const char* text)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIEditControl* control = static_cast<CGUIEditControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIEditControl*>(handle);
   if (!addon || !control || !text)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlEdit::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "text='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(text),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "text='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(text), addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -187,14 +185,14 @@ void Interface_GUIControlEdit::set_text(KODI_HANDLE kodiBase,
 
 char* Interface_GUIControlEdit::get_text(KODI_HANDLE kodiBase, KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIEditControl* control = static_cast<CGUIEditControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIEditControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlEdit::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return nullptr;
   }
 
@@ -205,14 +203,14 @@ void Interface_GUIControlEdit::set_cursor_position(KODI_HANDLE kodiBase,
                                                    KODI_GUI_CONTROL_HANDLE handle,
                                                    unsigned int position)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIEditControl* control = static_cast<CGUIEditControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIEditControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlEdit::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -222,14 +220,14 @@ void Interface_GUIControlEdit::set_cursor_position(KODI_HANDLE kodiBase,
 unsigned int Interface_GUIControlEdit::get_cursor_position(KODI_HANDLE kodiBase,
                                                            KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIEditControl* control = static_cast<CGUIEditControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIEditControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlEdit::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return 0;
   }
 

--- a/xbmc/addons/interfaces/gui/controls/FadeLabel.cpp
+++ b/xbmc/addons/interfaces/gui/controls/FadeLabel.cpp
@@ -38,14 +38,14 @@ void Interface_GUIControlFadeLabel::set_visible(KODI_HANDLE kodiBase,
                                                 KODI_GUI_CONTROL_HANDLE handle,
                                                 bool visible)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIFadeLabelControl* control = static_cast<CGUIFadeLabelControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIFadeLabelControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlFadeLabel::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -56,15 +56,14 @@ void Interface_GUIControlFadeLabel::add_label(KODI_HANDLE kodiBase,
                                               KODI_GUI_CONTROL_HANDLE handle,
                                               const char* label)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIFadeLabelControl* control = static_cast<CGUIFadeLabelControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIFadeLabelControl*>(handle);
   if (!addon || !control || !label)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlFadeLabel::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}', label='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(label),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}', label='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(label), addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -75,35 +74,34 @@ void Interface_GUIControlFadeLabel::add_label(KODI_HANDLE kodiBase,
 
 char* Interface_GUIControlFadeLabel::get_label(KODI_HANDLE kodiBase, KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIFadeLabelControl* control = static_cast<CGUIFadeLabelControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIFadeLabelControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlFadeLabel::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return nullptr;
   }
 
   CGUIMessage msg(GUI_MSG_ITEM_SELECTED, control->GetParentID(), control->GetID());
   control->OnMessage(msg);
-  std::string text = msg.GetLabel();
-  return strdup(text.c_str());
+  return strdup(msg.GetLabel().c_str());
 }
 
 void Interface_GUIControlFadeLabel::set_scrolling(KODI_HANDLE kodiBase,
                                                   KODI_GUI_CONTROL_HANDLE handle,
                                                   bool scroll)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIFadeLabelControl* control = static_cast<CGUIFadeLabelControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIFadeLabelControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlFadeLabel::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -112,14 +110,14 @@ void Interface_GUIControlFadeLabel::set_scrolling(KODI_HANDLE kodiBase,
 
 void Interface_GUIControlFadeLabel::reset(KODI_HANDLE kodiBase, KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIFadeLabelControl* control = static_cast<CGUIFadeLabelControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIFadeLabelControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlFadeLabel::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 

--- a/xbmc/addons/interfaces/gui/controls/Image.cpp
+++ b/xbmc/addons/interfaces/gui/controls/Image.cpp
@@ -37,14 +37,14 @@ void Interface_GUIControlImage::set_visible(KODI_HANDLE kodiBase,
                                             KODI_GUI_CONTROL_HANDLE handle,
                                             bool visible)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIImage* control = static_cast<CGUIImage*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIImage*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlImage::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -56,15 +56,15 @@ void Interface_GUIControlImage::set_filename(KODI_HANDLE kodiBase,
                                              const char* filename,
                                              bool use_cache)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIImage* control = static_cast<CGUIImage*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIImage*>(handle);
   if (!addon || !control || !filename)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlImage::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "filename='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(filename),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "filename='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(filename),
+               addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -75,14 +75,14 @@ void Interface_GUIControlImage::set_color_diffuse(KODI_HANDLE kodiBase,
                                                   KODI_GUI_CONTROL_HANDLE handle,
                                                   uint32_t colorDiffuse)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIImage* control = static_cast<CGUIImage*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIImage*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlImage::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 

--- a/xbmc/addons/interfaces/gui/controls/Label.cpp
+++ b/xbmc/addons/interfaces/gui/controls/Label.cpp
@@ -38,14 +38,14 @@ void Interface_GUIControlLabel::set_visible(KODI_HANDLE kodiBase,
                                             KODI_GUI_CONTROL_HANDLE handle,
                                             bool visible)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUILabelControl* control = static_cast<CGUILabelControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUILabelControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlLabel::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -56,15 +56,14 @@ void Interface_GUIControlLabel::set_label(KODI_HANDLE kodiBase,
                                           KODI_GUI_CONTROL_HANDLE handle,
                                           const char* label)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUILabelControl* control = static_cast<CGUILabelControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUILabelControl*>(handle);
   if (!addon || !control || !label)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlLabel::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "label='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(label),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "label='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(label), addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -75,14 +74,14 @@ void Interface_GUIControlLabel::set_label(KODI_HANDLE kodiBase,
 
 char* Interface_GUIControlLabel::get_label(KODI_HANDLE kodiBase, KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUILabelControl* control = static_cast<CGUILabelControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUILabelControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlLabel::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return nullptr;
   }
 

--- a/xbmc/addons/interfaces/gui/controls/Progress.cpp
+++ b/xbmc/addons/interfaces/gui/controls/Progress.cpp
@@ -36,14 +36,14 @@ void Interface_GUIControlProgress::set_visible(KODI_HANDLE kodiBase,
                                                KODI_GUI_CONTROL_HANDLE handle,
                                                bool visible)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIProgressControl* control = static_cast<CGUIProgressControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIProgressControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlProgress::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -54,14 +54,14 @@ void Interface_GUIControlProgress::set_percentage(KODI_HANDLE kodiBase,
                                                   KODI_GUI_CONTROL_HANDLE handle,
                                                   float percent)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIProgressControl* control = static_cast<CGUIProgressControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIProgressControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlProgress::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -71,14 +71,14 @@ void Interface_GUIControlProgress::set_percentage(KODI_HANDLE kodiBase,
 float Interface_GUIControlProgress::get_percentage(KODI_HANDLE kodiBase,
                                                    KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIProgressControl* control = static_cast<CGUIProgressControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUIProgressControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlProgress::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return 0.0f;
   }
 

--- a/xbmc/addons/interfaces/gui/controls/RadioButton.cpp
+++ b/xbmc/addons/interfaces/gui/controls/RadioButton.cpp
@@ -40,14 +40,14 @@ void Interface_GUIControlRadioButton::set_visible(KODI_HANDLE kodiBase,
                                                   KODI_GUI_CONTROL_HANDLE handle,
                                                   bool visible)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIRadioButtonControl* control = static_cast<CGUIRadioButtonControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIRadioButtonControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlRadioButton::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -58,14 +58,14 @@ void Interface_GUIControlRadioButton::set_enabled(KODI_HANDLE kodiBase,
                                                   KODI_GUI_CONTROL_HANDLE handle,
                                                   bool enabled)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIRadioButtonControl* control = static_cast<CGUIRadioButtonControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIRadioButtonControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlRadioButton::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -76,15 +76,14 @@ void Interface_GUIControlRadioButton::set_label(KODI_HANDLE kodiBase,
                                                 KODI_GUI_CONTROL_HANDLE handle,
                                                 const char* label)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIRadioButtonControl* control = static_cast<CGUIRadioButtonControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIRadioButtonControl*>(handle);
   if (!addon || !control || !label)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlRadioButton::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}', label='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(label),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}', label='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(label), addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -94,14 +93,14 @@ void Interface_GUIControlRadioButton::set_label(KODI_HANDLE kodiBase,
 char* Interface_GUIControlRadioButton::get_label(KODI_HANDLE kodiBase,
                                                  KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIRadioButtonControl* control = static_cast<CGUIRadioButtonControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUIRadioButtonControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlRadioButton::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return nullptr;
   }
 
@@ -112,14 +111,14 @@ void Interface_GUIControlRadioButton::set_selected(KODI_HANDLE kodiBase,
                                                    KODI_GUI_CONTROL_HANDLE handle,
                                                    bool selected)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIRadioButtonControl* control = static_cast<CGUIRadioButtonControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIRadioButtonControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlRadioButton::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -129,14 +128,14 @@ void Interface_GUIControlRadioButton::set_selected(KODI_HANDLE kodiBase,
 bool Interface_GUIControlRadioButton::is_selected(KODI_HANDLE kodiBase,
                                                   KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIRadioButtonControl* control = static_cast<CGUIRadioButtonControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUIRadioButtonControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlRadioButton::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return false;
   }
 

--- a/xbmc/addons/interfaces/gui/controls/Rendering.cpp
+++ b/xbmc/addons/interfaces/gui/controls/Rendering.cpp
@@ -40,14 +40,14 @@ void Interface_GUIControlAddonRendering::set_callbacks(
     void (*stopCB)(KODI_GUI_CLIENT_HANDLE),
     bool (*dirtyCB)(KODI_GUI_CLIENT_HANDLE))
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonRenderingControl* control = static_cast<CGUIAddonRenderingControl*>(handle);
+  auto* addon = static_cast<CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIAddonRenderingControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlAddonRendering::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -66,19 +66,19 @@ void Interface_GUIControlAddonRendering::set_callbacks(
 void Interface_GUIControlAddonRendering::destroy(KODI_HANDLE kodiBase,
                                                  KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUIAddonRenderingControl* control = static_cast<CGUIAddonRenderingControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUIAddonRenderingControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlAddonRendering::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
   Interface_GUIGeneral::lock();
-  static_cast<CGUIAddonRenderingControl*>(handle)->Delete();
+  control->Delete();
   Interface_GUIGeneral::unlock();
 }
 
@@ -89,13 +89,10 @@ CGUIAddonRenderingControl::CGUIAddonRenderingControl(CGUIRenderingControl* contr
 
 bool CGUIAddonRenderingControl::Create(int x, int y, int w, int h, void* device)
 {
-  if (CBCreate)
+  if (CBCreate && CBCreate(m_clientHandle, x, y, w, h, device))
   {
-    if (CBCreate(m_clientHandle, x, y, w, h, device))
-    {
-      ++m_refCount;
-      return true;
-    }
+    ++m_refCount;
+    return true;
   }
   return false;
 }

--- a/xbmc/addons/interfaces/gui/controls/Rendering.h
+++ b/xbmc/addons/interfaces/gui/controls/Rendering.h
@@ -73,17 +73,17 @@ extern "C"
     bool IsDirty() override;
     virtual void Delete();
 
-  protected:
+  private:
     bool (*CBCreate)(KODI_GUI_CLIENT_HANDLE cbhdl, int x, int y, int w, int h, void* device) =
         nullptr;
     void (*CBRender)(KODI_GUI_CLIENT_HANDLE cbhdl) = nullptr;
     void (*CBStop)(KODI_GUI_CLIENT_HANDLE cbhdl) = nullptr;
     bool (*CBDirty)(KODI_GUI_CLIENT_HANDLE cbhdl) = nullptr;
 
-    KODI_GUI_CLIENT_HANDLE m_clientHandle = nullptr;
-    CAddonDll* m_addon = nullptr;
-    CGUIRenderingControl* m_control;
-    int m_refCount = 1;
+    KODI_GUI_CLIENT_HANDLE m_clientHandle{nullptr};
+    CAddonDll* m_addon{nullptr};
+    CGUIRenderingControl* m_control{nullptr};
+    int m_refCount{1};
   };
 
   } /* namespace ADDON */

--- a/xbmc/addons/interfaces/gui/controls/SettingsSlider.cpp
+++ b/xbmc/addons/interfaces/gui/controls/SettingsSlider.cpp
@@ -54,14 +54,14 @@ void Interface_GUIControlSettingsSlider::set_visible(KODI_HANDLE kodiBase,
                                                      KODI_GUI_CONTROL_HANDLE handle,
                                                      bool visible)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISettingsSliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSettingsSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -72,14 +72,14 @@ void Interface_GUIControlSettingsSlider::set_enabled(KODI_HANDLE kodiBase,
                                                      KODI_GUI_CONTROL_HANDLE handle,
                                                      bool enabled)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISettingsSliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSettingsSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -90,15 +90,14 @@ void Interface_GUIControlSettingsSlider::set_text(KODI_HANDLE kodiBase,
                                                   KODI_GUI_CONTROL_HANDLE handle,
                                                   const char* text)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUISettingsSliderControl*>(handle);
   if (!addon || !control || !text)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSettingsSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}', text='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(text),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}', text='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(text), addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -109,14 +108,14 @@ void Interface_GUIControlSettingsSlider::set_text(KODI_HANDLE kodiBase,
 
 void Interface_GUIControlSettingsSlider::reset(KODI_HANDLE kodiBase, KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUISettingsSliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSettingsSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -129,14 +128,14 @@ void Interface_GUIControlSettingsSlider::set_int_range(KODI_HANDLE kodiBase,
                                                        int start,
                                                        int end)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISettingsSliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSettingsSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -148,14 +147,14 @@ void Interface_GUIControlSettingsSlider::set_int_value(KODI_HANDLE kodiBase,
                                                        KODI_GUI_CONTROL_HANDLE handle,
                                                        int value)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISettingsSliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSettingsSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -166,14 +165,14 @@ void Interface_GUIControlSettingsSlider::set_int_value(KODI_HANDLE kodiBase,
 int Interface_GUIControlSettingsSlider::get_int_value(KODI_HANDLE kodiBase,
                                                       KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUISettingsSliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSettingsSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return -1;
   }
 
@@ -184,14 +183,14 @@ void Interface_GUIControlSettingsSlider::set_int_interval(KODI_HANDLE kodiBase,
                                                           KODI_GUI_CONTROL_HANDLE handle,
                                                           int interval)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISettingsSliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSettingsSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -202,14 +201,14 @@ void Interface_GUIControlSettingsSlider::set_percentage(KODI_HANDLE kodiBase,
                                                         KODI_GUI_CONTROL_HANDLE handle,
                                                         float percent)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISettingsSliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSettingsSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -220,14 +219,14 @@ void Interface_GUIControlSettingsSlider::set_percentage(KODI_HANDLE kodiBase,
 float Interface_GUIControlSettingsSlider::get_percentage(KODI_HANDLE kodiBase,
                                                          KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUISettingsSliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSettingsSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return 0.0f;
   }
 
@@ -239,14 +238,14 @@ void Interface_GUIControlSettingsSlider::set_float_range(KODI_HANDLE kodiBase,
                                                          float start,
                                                          float end)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISettingsSliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSettingsSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -258,14 +257,14 @@ void Interface_GUIControlSettingsSlider::set_float_value(KODI_HANDLE kodiBase,
                                                          KODI_GUI_CONTROL_HANDLE handle,
                                                          float value)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISettingsSliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSettingsSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -276,14 +275,14 @@ void Interface_GUIControlSettingsSlider::set_float_value(KODI_HANDLE kodiBase,
 float Interface_GUIControlSettingsSlider::get_float_value(KODI_HANDLE kodiBase,
                                                           KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUISettingsSliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSettingsSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return 0.0f;
   }
 
@@ -294,14 +293,14 @@ void Interface_GUIControlSettingsSlider::set_float_interval(KODI_HANDLE kodiBase
                                                             KODI_GUI_CONTROL_HANDLE handle,
                                                             float interval)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISettingsSliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSettingsSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 

--- a/xbmc/addons/interfaces/gui/controls/Slider.cpp
+++ b/xbmc/addons/interfaces/gui/controls/Slider.cpp
@@ -53,14 +53,14 @@ void Interface_GUIControlSlider::set_visible(KODI_HANDLE kodiBase,
                                              KODI_GUI_CONTROL_HANDLE handle,
                                              bool visible)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -71,14 +71,14 @@ void Interface_GUIControlSlider::set_enabled(KODI_HANDLE kodiBase,
                                              KODI_GUI_CONTROL_HANDLE handle,
                                              bool enabled)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -87,14 +87,14 @@ void Interface_GUIControlSlider::set_enabled(KODI_HANDLE kodiBase,
 
 void Interface_GUIControlSlider::reset(KODI_HANDLE kodiBase, KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUISliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -105,14 +105,14 @@ void Interface_GUIControlSlider::reset(KODI_HANDLE kodiBase, KODI_GUI_CONTROL_HA
 char* Interface_GUIControlSlider::get_description(KODI_HANDLE kodiBase,
                                                   KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUISliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return nullptr;
   }
 
@@ -124,14 +124,14 @@ void Interface_GUIControlSlider::set_int_range(KODI_HANDLE kodiBase,
                                                int start,
                                                int end)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -143,14 +143,14 @@ void Interface_GUIControlSlider::set_int_value(KODI_HANDLE kodiBase,
                                                KODI_GUI_CONTROL_HANDLE handle,
                                                int value)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -160,14 +160,14 @@ void Interface_GUIControlSlider::set_int_value(KODI_HANDLE kodiBase,
 
 int Interface_GUIControlSlider::get_int_value(KODI_HANDLE kodiBase, KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUISliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return -1;
   }
 
@@ -178,14 +178,14 @@ void Interface_GUIControlSlider::set_int_interval(KODI_HANDLE kodiBase,
                                                   KODI_GUI_CONTROL_HANDLE handle,
                                                   int interval)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -196,14 +196,14 @@ void Interface_GUIControlSlider::set_percentage(KODI_HANDLE kodiBase,
                                                 KODI_GUI_CONTROL_HANDLE handle,
                                                 float percent)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -214,14 +214,14 @@ void Interface_GUIControlSlider::set_percentage(KODI_HANDLE kodiBase,
 float Interface_GUIControlSlider::get_percentage(KODI_HANDLE kodiBase,
                                                  KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUISliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return 0.0f;
   }
 
@@ -233,14 +233,14 @@ void Interface_GUIControlSlider::set_float_range(KODI_HANDLE kodiBase,
                                                  float start,
                                                  float end)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -252,14 +252,14 @@ void Interface_GUIControlSlider::set_float_value(KODI_HANDLE kodiBase,
                                                  KODI_GUI_CONTROL_HANDLE handle,
                                                  float value)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -270,14 +270,14 @@ void Interface_GUIControlSlider::set_float_value(KODI_HANDLE kodiBase,
 float Interface_GUIControlSlider::get_float_value(KODI_HANDLE kodiBase,
                                                   KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUISliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return 0.0f;
   }
 
@@ -288,14 +288,14 @@ void Interface_GUIControlSlider::set_float_interval(KODI_HANDLE kodiBase,
                                                     KODI_GUI_CONTROL_HANDLE handle,
                                                     float interval)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISliderControl*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSlider::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 

--- a/xbmc/addons/interfaces/gui/controls/Spin.cpp
+++ b/xbmc/addons/interfaces/gui/controls/Spin.cpp
@@ -54,14 +54,14 @@ void Interface_GUIControlSpin::set_visible(KODI_HANDLE kodiBase,
                                            KODI_GUI_CONTROL_HANDLE handle,
                                            bool visible)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISpinControlEx*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSpin::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -72,14 +72,14 @@ void Interface_GUIControlSpin::set_enabled(KODI_HANDLE kodiBase,
                                            KODI_GUI_CONTROL_HANDLE handle,
                                            bool enabled)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISpinControlEx*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSpin::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -90,15 +90,14 @@ void Interface_GUIControlSpin::set_text(KODI_HANDLE kodiBase,
                                         KODI_GUI_CONTROL_HANDLE handle,
                                         const char* text)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUISpinControlEx*>(handle);
   if (!addon || !control || !text)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSpin::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "text='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(text),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "text='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(text), addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -109,14 +108,14 @@ void Interface_GUIControlSpin::set_text(KODI_HANDLE kodiBase,
 
 void Interface_GUIControlSpin::reset(KODI_HANDLE kodiBase, KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUISpinControlEx*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSpin::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -128,14 +127,14 @@ void Interface_GUIControlSpin::set_type(KODI_HANDLE kodiBase,
                                         KODI_GUI_CONTROL_HANDLE handle,
                                         int type)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISpinControlEx*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSpin::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -147,15 +146,15 @@ void Interface_GUIControlSpin::add_string_label(KODI_HANDLE kodiBase,
                                                 const char* label,
                                                 const char* value)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISpinControlEx*>(handle);
   if (!addon || !control || !label || !value)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSpin::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "label='{}', value='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(label),
-              static_cast<const void*>(value), addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "label='{}', value='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(label), static_cast<const void*>(value),
+               addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -166,15 +165,14 @@ void Interface_GUIControlSpin::set_string_value(KODI_HANDLE kodiBase,
                                                 KODI_GUI_CONTROL_HANDLE handle,
                                                 const char* value)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISpinControlEx*>(handle);
   if (!addon || !control || !value)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSpin::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "value='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(value),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "value='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(value), addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -184,14 +182,14 @@ void Interface_GUIControlSpin::set_string_value(KODI_HANDLE kodiBase,
 char* Interface_GUIControlSpin::get_string_value(KODI_HANDLE kodiBase,
                                                  KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUISpinControlEx*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSpin::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return nullptr;
   }
 
@@ -203,15 +201,14 @@ void Interface_GUIControlSpin::add_int_label(KODI_HANDLE kodiBase,
                                              const char* label,
                                              int value)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISpinControlEx*>(handle);
   if (!addon || !control || !label)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSpin::{} - invalid handler data (kodiBase='{}', handle='{}', "
-              "label='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(label),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}', "
+               "label='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(label), addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -223,14 +220,14 @@ void Interface_GUIControlSpin::set_int_range(KODI_HANDLE kodiBase,
                                              int start,
                                              int end)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISpinControlEx*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSpin::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -241,14 +238,14 @@ void Interface_GUIControlSpin::set_int_value(KODI_HANDLE kodiBase,
                                              KODI_GUI_CONTROL_HANDLE handle,
                                              int value)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISpinControlEx*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSpin::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -257,14 +254,14 @@ void Interface_GUIControlSpin::set_int_value(KODI_HANDLE kodiBase,
 
 int Interface_GUIControlSpin::get_int_value(KODI_HANDLE kodiBase, KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUISpinControlEx*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSpin::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return -1;
   }
 
@@ -276,14 +273,14 @@ void Interface_GUIControlSpin::set_float_range(KODI_HANDLE kodiBase,
                                                float start,
                                                float end)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISpinControlEx*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSpin::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -294,14 +291,14 @@ void Interface_GUIControlSpin::set_float_value(KODI_HANDLE kodiBase,
                                                KODI_GUI_CONTROL_HANDLE handle,
                                                float value)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISpinControlEx*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSpin::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -311,14 +308,14 @@ void Interface_GUIControlSpin::set_float_value(KODI_HANDLE kodiBase,
 float Interface_GUIControlSpin::get_float_value(KODI_HANDLE kodiBase,
                                                 KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUISpinControlEx*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSpin::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return 0.0f;
   }
 
@@ -329,14 +326,14 @@ void Interface_GUIControlSpin::set_float_interval(KODI_HANDLE kodiBase,
                                                   KODI_GUI_CONTROL_HANDLE handle,
                                                   float interval)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUISpinControlEx*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlSpin::{} - invalid handler data (kodiBase='{}', handle='{}') "
-              "on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', handle='{}') "
+               "on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 

--- a/xbmc/addons/interfaces/gui/controls/TextBox.cpp
+++ b/xbmc/addons/interfaces/gui/controls/TextBox.cpp
@@ -41,14 +41,14 @@ void Interface_GUIControlTextBox::set_visible(KODI_HANDLE kodiBase,
                                               KODI_GUI_CONTROL_HANDLE handle,
                                               bool visible)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUITextBox* control = static_cast<CGUITextBox*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUITextBox*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlTextBox::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -57,14 +57,14 @@ void Interface_GUIControlTextBox::set_visible(KODI_HANDLE kodiBase,
 
 void Interface_GUIControlTextBox::reset(KODI_HANDLE kodiBase, KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUITextBox* control = static_cast<CGUITextBox*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUITextBox*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlTextBox::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -76,15 +76,14 @@ void Interface_GUIControlTextBox::set_text(KODI_HANDLE kodiBase,
                                            KODI_GUI_CONTROL_HANDLE handle,
                                            const char* text)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUITextBox* control = static_cast<CGUITextBox*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUITextBox*>(handle);
   if (!addon || !control || !text)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlTextBox::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}', text='{}') on addon '{}'",
-              __func__, kodiBase, handle, static_cast<const void*>(text),
-              addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}', text='{}') on addon '{}'",
+               kodiBase, handle, static_cast<const void*>(text), addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -95,14 +94,14 @@ void Interface_GUIControlTextBox::set_text(KODI_HANDLE kodiBase,
 
 char* Interface_GUIControlTextBox::get_text(KODI_HANDLE kodiBase, KODI_GUI_CONTROL_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUITextBox* control = static_cast<CGUITextBox*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  const auto* control = static_cast<const CGUITextBox*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlTextBox::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return nullptr;
   }
 
@@ -113,14 +112,14 @@ void Interface_GUIControlTextBox::scroll(KODI_HANDLE kodiBase,
                                          KODI_GUI_CONTROL_HANDLE handle,
                                          unsigned int position)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUITextBox* control = static_cast<CGUITextBox*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUITextBox*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlTextBox::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 
@@ -130,14 +129,14 @@ void Interface_GUIControlTextBox::scroll(KODI_HANDLE kodiBase,
 void Interface_GUIControlTextBox::set_auto_scrolling(
     KODI_HANDLE kodiBase, KODI_GUI_CONTROL_HANDLE handle, int delay, int time, int repeat)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  CGUITextBox* control = static_cast<CGUITextBox*>(handle);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
+  auto* control = static_cast<CGUITextBox*>(handle);
   if (!addon || !control)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIControlTextBox::{} - invalid handler data (kodiBase='{}', "
-              "handle='{}') on addon '{}'",
-              __func__, kodiBase, handle, addon ? addon->ID() : "unknown");
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (kodiBase='{}', "
+               "handle='{}') on addon '{}'",
+               kodiBase, handle, addon ? addon->ID() : "unknown");
     return;
   }
 

--- a/xbmc/addons/interfaces/gui/dialogs/ContextMenu.cpp
+++ b/xbmc/addons/interfaces/gui/dialogs/ContextMenu.cpp
@@ -37,23 +37,19 @@ int Interface_GUIDialogContextMenu::open(KODI_HANDLE kodiBase,
                                          const char* entries[],
                                          unsigned int size)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogContextMenu::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return -1;
   }
 
-  CGUIDialogContextMenu* dialog =
-      CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogContextMenu>(
-          WINDOW_DIALOG_CONTEXT_MENU);
-  if (!heading || !entries || !dialog)
+  if (!heading || !entries)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogContextMenu::{} - invalid handler data (heading='{}', "
-              "entries='{}', dialog='{}') on addon '{}'",
-              __func__, static_cast<const void*>(heading), static_cast<const void*>(entries),
-              kodiBase, addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (heading='{}', "
+               "entries='{}') on addon '{}'",
+               static_cast<const void*>(heading), static_cast<const void*>(entries), addon->ID());
     return -1;
   }
 
@@ -61,7 +57,7 @@ int Interface_GUIDialogContextMenu::open(KODI_HANDLE kodiBase,
   for (unsigned int i = 0; i < size; ++i)
     choices.Add(i, entries[i]);
 
-  return dialog->Show(choices);
+  return CGUIDialogContextMenu::Show(choices);
 }
 
 } /* namespace ADDON */

--- a/xbmc/addons/interfaces/gui/dialogs/ExtendedProgressBar.cpp
+++ b/xbmc/addons/interfaces/gui/dialogs/ExtendedProgressBar.cpp
@@ -45,11 +45,10 @@ void Interface_GUIDialogExtendedProgress::DeInit(AddonGlobalInterface* addonInte
 KODI_GUI_HANDLE Interface_GUIDialogExtendedProgress::new_dialog(KODI_HANDLE kodiBase,
                                                                 const char* title)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::{} - invalid kodi base data",
-              __func__);
+    CLog::LogF(LOGERROR, "Invalid kodi base data");
     return nullptr;
   }
 
@@ -59,10 +58,10 @@ KODI_GUI_HANDLE Interface_GUIDialogExtendedProgress::new_dialog(KODI_HANDLE kodi
           WINDOW_DIALOG_EXT_PROGRESS);
   if (!title || !dialog)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogExtendedProgress::{} - invalid handler data (title='{}', "
-              "dialog='{}') on addon '{}'",
-              __func__, static_cast<const void*>(title), static_cast<void*>(dialog), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (title='{}', "
+               "dialog='{}') on addon '{}'",
+               static_cast<const void*>(title), static_cast<void*>(dialog), addon->ID());
     return nullptr;
   }
 
@@ -73,20 +72,19 @@ KODI_GUI_HANDLE Interface_GUIDialogExtendedProgress::new_dialog(KODI_HANDLE kodi
 void Interface_GUIDialogExtendedProgress::delete_dialog(KODI_HANDLE kodiBase,
                                                         KODI_GUI_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::{} - invalid kodi base data",
-              __func__);
+    CLog::LogF(LOGERROR, "Invalid kodi base data");
     return;
   }
 
   if (!handle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogExtendedProgress::{} - invalid handler data (handle='{}') on "
-              "addon '{}'",
-              __func__, handle, addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (handle='{}') on "
+               "addon '{}'",
+               handle, addon->ID());
     return;
   }
 
@@ -95,20 +93,19 @@ void Interface_GUIDialogExtendedProgress::delete_dialog(KODI_HANDLE kodiBase,
 
 char* Interface_GUIDialogExtendedProgress::get_title(KODI_HANDLE kodiBase, KODI_GUI_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::{} - invalid kodi base data",
-              __func__);
+    CLog::LogF(LOGERROR, "Invalid kodi base data");
     return nullptr;
   }
 
   if (!handle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogExtendedProgress::{} - invalid handler data (handle='{}') on "
-              "addon '{}'",
-              __func__, handle, addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (handle='{}') on "
+               "addon '{}'",
+               handle, addon->ID());
     return nullptr;
   }
 
@@ -119,20 +116,19 @@ void Interface_GUIDialogExtendedProgress::set_title(KODI_HANDLE kodiBase,
                                                     KODI_GUI_HANDLE handle,
                                                     const char* title)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::{} - invalid kodi base data",
-              __func__);
+    CLog::LogF(LOGERROR, "Invalid kodi base data");
     return;
   }
 
   if (!handle || !title)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogExtendedProgress::{} - invalid handler data (handle='{}', "
-              "title='{}') on addon '{}'",
-              __func__, handle, static_cast<const void*>(title), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (handle='{}', "
+               "title='{}') on addon '{}'",
+               handle, static_cast<const void*>(title), addon->ID());
     return;
   }
 
@@ -141,20 +137,19 @@ void Interface_GUIDialogExtendedProgress::set_title(KODI_HANDLE kodiBase,
 
 char* Interface_GUIDialogExtendedProgress::get_text(KODI_HANDLE kodiBase, KODI_GUI_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::{} - invalid kodi base data",
-              __func__);
+    CLog::LogF(LOGERROR, "Invalid kodi base data");
     return nullptr;
   }
 
   if (!handle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogExtendedProgress::{} - invalid add-on data (handle='{}') on "
-              "addon '{}'",
-              __func__, handle, addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid add-on data (handle='{}') on "
+               "addon '{}'",
+               handle, addon->ID());
     return nullptr;
   }
 
@@ -165,20 +160,19 @@ void Interface_GUIDialogExtendedProgress::set_text(KODI_HANDLE kodiBase,
                                                    KODI_GUI_HANDLE handle,
                                                    const char* text)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::{} - invalid kodi base data",
-              __func__);
+    CLog::LogF(LOGERROR, "Invalid kodi base data");
     return;
   }
 
   if (!handle || !text)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogExtendedProgress::{} - invalid handler data (handle='{}', "
-              "text='{}') on addon '{}'",
-              __func__, handle, static_cast<const void*>(text), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (handle='{}', "
+               "text='{}') on addon '{}'",
+               handle, static_cast<const void*>(text), addon->ID());
     return;
   }
 
@@ -187,20 +181,19 @@ void Interface_GUIDialogExtendedProgress::set_text(KODI_HANDLE kodiBase,
 
 bool Interface_GUIDialogExtendedProgress::is_finished(KODI_HANDLE kodiBase, KODI_GUI_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::{} - invalid kodi base data",
-              __func__);
+    CLog::LogF(LOGERROR, "Invalid kodi base data");
     return false;
   }
 
   if (!handle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogExtendedProgress::{} - invalid add-on data (handle='{}') on "
-              "addon '{}'",
-              __func__, handle, addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid add-on data (handle='{}') on "
+               "addon '{}'",
+               handle, addon->ID());
     return false;
   }
 
@@ -210,20 +203,19 @@ bool Interface_GUIDialogExtendedProgress::is_finished(KODI_HANDLE kodiBase, KODI
 void Interface_GUIDialogExtendedProgress::mark_finished(KODI_HANDLE kodiBase,
                                                         KODI_GUI_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::{} - invalid kodi base data",
-              __func__);
+    CLog::LogF(LOGERROR, "Invalid kodi base data");
     return;
   }
 
   if (!handle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogExtendedProgress::{} - invalid add-on data (handle='{}') on "
-              "addon '{}'",
-              __func__, handle, addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid add-on data (handle='{}') on "
+               "addon '{}'",
+               handle, addon->ID());
     return;
   }
 
@@ -233,20 +225,19 @@ void Interface_GUIDialogExtendedProgress::mark_finished(KODI_HANDLE kodiBase,
 float Interface_GUIDialogExtendedProgress::get_percentage(KODI_HANDLE kodiBase,
                                                           KODI_GUI_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::{} - invalid kodi base data",
-              __func__);
+    CLog::LogF(LOGERROR, "Invalid kodi base data");
     return 0.0f;
   }
 
   if (!handle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogExtendedProgress::{} - invalid add-on data (handle='{}') on "
-              "addon '{}'",
-              __func__, handle, addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid add-on data (handle='{}') on "
+               "addon '{}'",
+               handle, addon->ID());
     return 0.0f;
   }
 
@@ -257,20 +248,19 @@ void Interface_GUIDialogExtendedProgress::set_percentage(KODI_HANDLE kodiBase,
                                                          KODI_GUI_HANDLE handle,
                                                          float percentage)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::{} - invalid kodi base data",
-              __func__);
+    CLog::LogF(LOGERROR, "Invalid kodi base data");
     return;
   }
 
   if (!handle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogExtendedProgress::{} - invalid add-on data (handle='{}') on "
-              "addon '{}'",
-              __func__, handle, addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid add-on data (handle='{}') on "
+               "addon '{}'",
+               handle, addon->ID());
     return;
   }
 
@@ -282,20 +272,19 @@ void Interface_GUIDialogExtendedProgress::set_progress(KODI_HANDLE kodiBase,
                                                        int currentItem,
                                                        int itemCount)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::{} - invalid kodi base data",
-              __func__);
+    CLog::LogF(LOGERROR, "Invalid kodi base data");
     return;
   }
 
   if (!handle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogExtendedProgress::{} - invalid add-on data (handle='{}') on "
-              "addon '{}'",
-              __func__, handle, addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid add-on data (handle='{}') on "
+               "addon '{}'",
+               handle, addon->ID());
     return;
   }
 

--- a/xbmc/addons/interfaces/gui/dialogs/FileBrowser.cpp
+++ b/xbmc/addons/interfaces/gui/dialogs/FileBrowser.cpp
@@ -51,20 +51,20 @@ bool Interface_GUIDialogFileBrowser::show_and_get_directory(KODI_HANDLE kodiBase
                                                             char** path_out,
                                                             bool write_only)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!shares || !heading || !path_in || !path_out)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogFileBrowser::{} - invalid handler data (shares='{}', "
-              "heading='{}', path_in='{}', path_out='{}') on addon '{}'",
-              __func__, static_cast<const void*>(shares), static_cast<const void*>(heading),
-              static_cast<const void*>(path_in), static_cast<void*>(path_out), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (shares='{}', "
+               "heading='{}', path_in='{}', path_out='{}') on addon '{}'",
+               static_cast<const void*>(shares), static_cast<const void*>(heading),
+               static_cast<const void*>(path_in), static_cast<void*>(path_out), addon->ID());
     return false;
   }
 
@@ -72,7 +72,8 @@ bool Interface_GUIDialogFileBrowser::show_and_get_directory(KODI_HANDLE kodiBase
 
   std::vector<CMediaSource> vecShares;
   GetVECShares(vecShares, shares, strPath);
-  bool bRet = CGUIDialogFileBrowser::ShowAndGetDirectory(vecShares, heading, strPath, write_only);
+  const bool bRet{
+      CGUIDialogFileBrowser::ShowAndGetDirectory(vecShares, heading, strPath, write_only)};
   if (bRet)
     *path_out = strdup(strPath.c_str());
   return bRet;
@@ -87,21 +88,21 @@ bool Interface_GUIDialogFileBrowser::show_and_get_file(KODI_HANDLE kodiBase,
                                                        bool use_thumbs,
                                                        bool use_file_directories)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!shares || !mask || !heading || !path_in || !path_out)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogFileBrowser::{} - invalid handler data (shares='{}', mask='{}', "
-              "heading='{}', path_in='{}', path_out='{}') on addon '{}'",
-              __func__, static_cast<const void*>(shares), static_cast<const void*>(mask),
-              static_cast<const void*>(heading), static_cast<const void*>(path_in),
-              static_cast<void*>(path_out), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (shares='{}', mask='{}', "
+               "heading='{}', path_in='{}', path_out='{}') on addon '{}'",
+               static_cast<const void*>(shares), static_cast<const void*>(mask),
+               static_cast<const void*>(heading), static_cast<const void*>(path_in),
+               static_cast<void*>(path_out), addon->ID());
     return false;
   }
 
@@ -109,8 +110,8 @@ bool Interface_GUIDialogFileBrowser::show_and_get_file(KODI_HANDLE kodiBase,
 
   std::vector<CMediaSource> vecShares;
   GetVECShares(vecShares, shares, strPath);
-  bool bRet = CGUIDialogFileBrowser::ShowAndGetFile(vecShares, mask, heading, strPath, use_thumbs,
-                                                    use_file_directories);
+  const bool bRet{CGUIDialogFileBrowser::ShowAndGetFile(vecShares, mask, heading, strPath,
+                                                        use_thumbs, use_file_directories)};
   if (bRet)
     *path_out = strdup(strPath.c_str());
   return bRet;
@@ -126,27 +127,27 @@ bool Interface_GUIDialogFileBrowser::show_and_get_file_from_dir(KODI_HANDLE kodi
                                                                 bool use_file_directories,
                                                                 bool single_list)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!directory || !mask || !heading || !path_in || !path_out)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogFileBrowser::{} - invalid handler data (directory='{}', "
-              "mask='{}', heading='{}', path_in='{}', path_out='{}') on addon '{}'",
-              __func__, static_cast<const void*>(directory), static_cast<const void*>(mask),
-              static_cast<const void*>(heading), static_cast<const void*>(path_in),
-              static_cast<void*>(path_out), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (directory='{}', "
+               "mask='{}', heading='{}', path_in='{}', path_out='{}') on addon '{}'",
+               static_cast<const void*>(directory), static_cast<const void*>(mask),
+               static_cast<const void*>(heading), static_cast<const void*>(path_in),
+               static_cast<void*>(path_out), addon->ID());
     return false;
   }
 
   std::string strPath = path_in;
-  bool bRet = CGUIDialogFileBrowser::ShowAndGetFile(directory, mask, heading, strPath, use_thumbs,
-                                                    use_file_directories, single_list);
+  const bool bRet{CGUIDialogFileBrowser::ShowAndGetFile(
+      directory, mask, heading, strPath, use_thumbs, use_file_directories, single_list)};
   if (bRet)
     *path_out = strdup(strPath.c_str());
   return bRet;
@@ -161,21 +162,21 @@ bool Interface_GUIDialogFileBrowser::show_and_get_file_list(KODI_HANDLE kodiBase
                                                             bool use_thumbs,
                                                             bool use_file_directories)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!shares || !mask || !heading || !file_list || !entries)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogFileBrowser::{} - invalid handler data (shares='{}', mask='{}', "
-              "heading='{}', file_list='{}', entries='{}') on addon '{}'",
-              __func__, static_cast<const void*>(shares), static_cast<const void*>(mask),
-              static_cast<const void*>(heading), static_cast<void*>(file_list),
-              static_cast<void*>(entries), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (shares='{}', mask='{}', "
+               "heading='{}', file_list='{}', entries='{}') on addon '{}'",
+               static_cast<const void*>(shares), static_cast<const void*>(mask),
+               static_cast<const void*>(heading), static_cast<void*>(file_list),
+               static_cast<void*>(entries), addon->ID());
     return false;
   }
 
@@ -183,11 +184,11 @@ bool Interface_GUIDialogFileBrowser::show_and_get_file_list(KODI_HANDLE kodiBase
   GetVECShares(vecShares, shares, "");
 
   std::vector<std::string> pathsInt;
-  bool bRet = CGUIDialogFileBrowser::ShowAndGetFileList(vecShares, mask, heading, pathsInt,
-                                                        use_thumbs, use_file_directories);
+  const bool bRet{CGUIDialogFileBrowser::ShowAndGetFileList(vecShares, mask, heading, pathsInt,
+                                                            use_thumbs, use_file_directories)};
   if (bRet)
   {
-    *entries = pathsInt.size();
+    *entries = static_cast<unsigned int>(pathsInt.size());
     *file_list = static_cast<char**>(malloc(*entries * sizeof(char*)));
     for (unsigned int i = 0; i < *entries; ++i)
       (*file_list)[i] = strdup(pathsInt[i].c_str());
@@ -204,21 +205,20 @@ bool Interface_GUIDialogFileBrowser::show_and_get_source(KODI_HANDLE kodiBase,
                                                          const char* additionalShare,
                                                          const char* strType)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!strType || !additionalShare || !path_in || !path_out)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogFileBrowser::{} - invalid handler data (additionalShare='{}', "
-              "strType='{}', path_in='{}', path_out='{}') on addon '{}'",
-              __func__, static_cast<const void*>(additionalShare),
-              static_cast<const void*>(strType), static_cast<const void*>(path_in),
-              static_cast<void*>(path_out), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (additionalShare='{}', "
+               "strType='{}', path_in='{}', path_out='{}') on addon '{}'",
+               static_cast<const void*>(additionalShare), static_cast<const void*>(strType),
+               static_cast<const void*>(path_in), static_cast<void*>(path_out), addon->ID());
     return false;
   }
 
@@ -227,8 +227,8 @@ bool Interface_GUIDialogFileBrowser::show_and_get_source(KODI_HANDLE kodiBase,
   std::vector<CMediaSource> vecShares;
   if (additionalShare)
     GetVECShares(vecShares, additionalShare, strPath);
-  bool bRet =
-      CGUIDialogFileBrowser::ShowAndGetSource(strPath, allowNetworkShares, &vecShares, strType);
+  const bool bRet{
+      CGUIDialogFileBrowser::ShowAndGetSource(strPath, allowNetworkShares, &vecShares, strType)};
   if (bRet)
     *path_out = strdup(strPath.c_str());
   return bRet;
@@ -240,20 +240,19 @@ bool Interface_GUIDialogFileBrowser::show_and_get_image(KODI_HANDLE kodiBase,
                                                         const char* path_in,
                                                         char** path_out)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!shares || !heading)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogFileBrowser::{} - invalid handler data (shares='{}', "
-              "heading='{}') on addon '{}'",
-              __func__, static_cast<const void*>(shares), static_cast<const void*>(heading),
-              addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (shares='{}', "
+               "heading='{}') on addon '{}'",
+               static_cast<const void*>(shares), static_cast<const void*>(heading), addon->ID());
     return false;
   }
 
@@ -261,7 +260,7 @@ bool Interface_GUIDialogFileBrowser::show_and_get_image(KODI_HANDLE kodiBase,
 
   std::vector<CMediaSource> vecShares;
   GetVECShares(vecShares, shares, strPath);
-  bool bRet = CGUIDialogFileBrowser::ShowAndGetImage(vecShares, heading, strPath);
+  const bool bRet{CGUIDialogFileBrowser::ShowAndGetImage(vecShares, heading, strPath)};
   if (bRet)
     *path_out = strdup(strPath.c_str());
   return bRet;
@@ -273,20 +272,20 @@ bool Interface_GUIDialogFileBrowser::show_and_get_image_list(KODI_HANDLE kodiBas
                                                              char*** file_list,
                                                              unsigned int* entries)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!shares || !heading || !file_list || !entries)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogFileBrowser::{} - invalid handler data (shares='{}', "
-              "heading='{}', file_list='{}', entries='{}') on addon '{}'",
-              __func__, static_cast<const void*>(shares), static_cast<const void*>(heading),
-              static_cast<void*>(file_list), static_cast<void*>(entries), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (shares='{}', "
+               "heading='{}', file_list='{}', entries='{}') on addon '{}'",
+               static_cast<const void*>(shares), static_cast<const void*>(heading),
+               static_cast<void*>(file_list), static_cast<void*>(entries), addon->ID());
     return false;
   }
 
@@ -294,10 +293,10 @@ bool Interface_GUIDialogFileBrowser::show_and_get_image_list(KODI_HANDLE kodiBas
   GetVECShares(vecShares, shares, "");
 
   std::vector<std::string> pathsInt;
-  bool bRet = CGUIDialogFileBrowser::ShowAndGetImageList(vecShares, heading, pathsInt);
+  const bool bRet{CGUIDialogFileBrowser::ShowAndGetImageList(vecShares, heading, pathsInt)};
   if (bRet)
   {
-    *entries = pathsInt.size();
+    *entries = static_cast<unsigned int>(pathsInt.size());
     *file_list = static_cast<char**>(malloc(*entries * sizeof(char*)));
     for (unsigned int i = 0; i < *entries; ++i)
       (*file_list)[i] = strdup(pathsInt[i].c_str());
@@ -311,10 +310,10 @@ void Interface_GUIDialogFileBrowser::clear_file_list(KODI_HANDLE kodiBase,
                                                      char*** file_list,
                                                      unsigned int entries)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return;
   }
 
@@ -328,15 +327,15 @@ void Interface_GUIDialogFileBrowser::clear_file_list(KODI_HANDLE kodiBase,
   else
   {
 
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogFileBrowser::{} - invalid handler data (file_list='{}') on "
-              "addon '{}'",
-              __func__, static_cast<void*>(file_list), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (file_list='{}') on "
+               "addon '{}'",
+               static_cast<void*>(file_list), addon->ID());
   }
 }
 
 void Interface_GUIDialogFileBrowser::GetVECShares(std::vector<CMediaSource>& vecShares,
-                                                  const std::string& strShares,
+                                                  std::string_view strShares,
                                                   const std::string& strPath)
 {
   std::size_t found;
@@ -352,36 +351,41 @@ void Interface_GUIDialogFileBrowser::GetVECShares(std::vector<CMediaSource>& vec
   found = strShares.find("programs");
   if (found != std::string::npos)
   {
-    std::vector<CMediaSource>* sources = CMediaSourceSettings::GetInstance().GetSources("programs");
+    const std::vector<CMediaSource>* sources{
+        CMediaSourceSettings::GetInstance().GetSources("programs")};
     if (sources != nullptr)
       vecShares.insert(vecShares.end(), sources->begin(), sources->end());
   }
   found = strShares.find("files");
   if (found != std::string::npos)
   {
-    std::vector<CMediaSource>* sources = CMediaSourceSettings::GetInstance().GetSources("files");
-    if (sources != nullptr)
+    const std::vector<CMediaSource>* sources{
+        CMediaSourceSettings::GetInstance().GetSources("files")};
+    if (sources)
       vecShares.insert(vecShares.end(), sources->begin(), sources->end());
   }
   found = strShares.find("music");
   if (found != std::string::npos)
   {
-    std::vector<CMediaSource>* sources = CMediaSourceSettings::GetInstance().GetSources("music");
-    if (sources != nullptr)
+    const std::vector<CMediaSource>* sources{
+        CMediaSourceSettings::GetInstance().GetSources("music")};
+    if (sources)
       vecShares.insert(vecShares.end(), sources->begin(), sources->end());
   }
   found = strShares.find("video");
   if (found != std::string::npos)
   {
-    std::vector<CMediaSource>* sources = CMediaSourceSettings::GetInstance().GetSources("video");
-    if (sources != nullptr)
+    const std::vector<CMediaSource>* sources{
+        CMediaSourceSettings::GetInstance().GetSources("video")};
+    if (sources)
       vecShares.insert(vecShares.end(), sources->begin(), sources->end());
   }
   found = strShares.find("pictures");
   if (found != std::string::npos)
   {
-    std::vector<CMediaSource>* sources = CMediaSourceSettings::GetInstance().GetSources("pictures");
-    if (sources != nullptr)
+    const std::vector<CMediaSource>* sources{
+        CMediaSourceSettings::GetInstance().GetSources("pictures")};
+    if (sources)
       vecShares.insert(vecShares.end(), sources->begin(), sources->end());
   }
 
@@ -394,9 +398,9 @@ void Interface_GUIDialogFileBrowser::GetVECShares(std::vector<CMediaSource>& vec
       basePath = tempPath;
     share.strPath = basePath;
     // don't include the user details in the share name
-    CURL url(share.strPath);
+    const CURL url{share.strPath};
     share.strName = url.GetWithoutUserDetails();
-    vecShares.push_back(share);
+    vecShares.emplace_back(std::move(share));
   }
 }
 

--- a/xbmc/addons/interfaces/gui/dialogs/FileBrowser.h
+++ b/xbmc/addons/interfaces/gui/dialogs/FileBrowser.h
@@ -11,6 +11,7 @@
 #include "addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/filebrowser.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 class CMediaSource;
@@ -106,7 +107,7 @@ extern "C"
 
   private:
     static void GetVECShares(std::vector<CMediaSource>& vecShares,
-                             const std::string& strShares,
+                             std::string_view strShares,
                              const std::string& strPath);
   };
 

--- a/xbmc/addons/interfaces/gui/dialogs/Keyboard.cpp
+++ b/xbmc/addons/interfaces/gui/dialogs/Keyboard.cpp
@@ -54,26 +54,26 @@ bool Interface_GUIDialogKeyboard::show_and_get_input_with_head(KODI_HANDLE kodiB
                                                                bool hidden_input,
                                                                unsigned int auto_close_ms)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!text_in || !text_out || !heading)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogKeyboard::{} - invalid handler data (text_in='{}', "
-              "text_out='{}', heading='{}') on addon '{}'",
-              __func__, static_cast<const void*>(text_in), static_cast<void*>(text_out),
-              static_cast<const void*>(heading), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (text_in='{}', "
+               "text_out='{}', heading='{}') on addon '{}'",
+               static_cast<const void*>(text_in), static_cast<void*>(text_out),
+               static_cast<const void*>(heading), addon->ID());
     return false;
   }
 
   std::string str = text_in;
-  bool bRet = CGUIKeyboardFactory::ShowAndGetInput(str, CVariant{heading}, allow_empty_result,
-                                                   hidden_input, auto_close_ms);
+  const bool bRet{CGUIKeyboardFactory::ShowAndGetInput(str, CVariant{heading}, allow_empty_result,
+                                                       hidden_input, auto_close_ms)};
   if (bRet)
     *text_out = strdup(str.c_str());
   return bRet;
@@ -85,25 +85,24 @@ bool Interface_GUIDialogKeyboard::show_and_get_input(KODI_HANDLE kodiBase,
                                                      bool allow_empty_result,
                                                      unsigned int auto_close_ms)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!text_in || !text_out)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogKeyboard::{} - invalid handler data (text_in='{}', "
-              "text_out='{}') on addon '{}'",
-              __func__, static_cast<const void*>(text_in), static_cast<void*>(text_out),
-              addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (text_in='{}', "
+               "text_out='{}') on addon '{}'",
+               static_cast<const void*>(text_in), static_cast<void*>(text_out), addon->ID());
     return false;
   }
 
   std::string str = text_in;
-  bool bRet = CGUIKeyboardFactory::ShowAndGetInput(str, allow_empty_result, auto_close_ms);
+  const bool bRet{CGUIKeyboardFactory::ShowAndGetInput(str, allow_empty_result, auto_close_ms)};
   if (bRet)
     *text_out = strdup(str.c_str());
   return bRet;
@@ -116,26 +115,26 @@ bool Interface_GUIDialogKeyboard::show_and_get_new_password_with_head(KODI_HANDL
                                                                       bool allow_empty_result,
                                                                       unsigned int auto_close_ms)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!password_in || !password_out || !heading)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogKeyboard::{} - invalid handler data (password_in='{}', "
-              "password_out='{}', heading='{}') on addon '{}'",
-              __func__, static_cast<const void*>(password_in), static_cast<void*>(password_out),
-              static_cast<const void*>(heading), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (password_in='{}', "
+               "password_out='{}', heading='{}') on addon '{}'",
+               static_cast<const void*>(password_in), static_cast<void*>(password_out),
+               static_cast<const void*>(heading), addon->ID());
     return false;
   }
 
   std::string str = password_in;
-  bool bRet =
-      CGUIKeyboardFactory::ShowAndGetNewPassword(str, heading, allow_empty_result, auto_close_ms);
+  const bool bRet{
+      CGUIKeyboardFactory::ShowAndGetNewPassword(str, heading, allow_empty_result, auto_close_ms)};
   if (bRet)
     *password_out = strdup(str.c_str());
   return bRet;
@@ -146,25 +145,25 @@ bool Interface_GUIDialogKeyboard::show_and_get_new_password(KODI_HANDLE kodiBase
                                                             char** password_out,
                                                             unsigned int auto_close_ms)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!password_in || !password_out)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogKeyboard::{} - invalid handler data (password_in='{}', "
-              "password_out='{}') on addon '{}'",
-              __func__, static_cast<const void*>(password_in), static_cast<void*>(password_out),
-              addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (password_in='{}', "
+               "password_out='{}') on addon '{}'",
+               static_cast<const void*>(password_in), static_cast<void*>(password_out),
+               addon->ID());
     return false;
   }
 
   std::string str = password_in;
-  bool bRet = CGUIKeyboardFactory::ShowAndGetNewPassword(str, auto_close_ms);
+  const bool bRet{CGUIKeyboardFactory::ShowAndGetNewPassword(str, auto_close_ms)};
   if (bRet)
     *password_out = strdup(str.c_str());
   return bRet;
@@ -176,26 +175,25 @@ bool Interface_GUIDialogKeyboard::show_and_verify_new_password_with_head(KODI_HA
                                                                          bool allowEmpty,
                                                                          unsigned int auto_close_ms)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!password_out || !heading)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogKeyboard::{} - invalid handler data (password_out='{}', "
-              "heading='{}') on addon '{}'",
-              __func__, static_cast<void*>(password_out), static_cast<const void*>(heading),
-              addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (password_out='{}', "
+               "heading='{}') on addon '{}'",
+               static_cast<void*>(password_out), static_cast<const void*>(heading), addon->ID());
     return false;
   }
 
   std::string str;
-  bool bRet =
-      CGUIKeyboardFactory::ShowAndVerifyNewPassword(str, heading, allowEmpty, auto_close_ms);
+  const bool bRet{
+      CGUIKeyboardFactory::ShowAndVerifyNewPassword(str, heading, allowEmpty, auto_close_ms)};
   if (bRet)
     *password_out = strdup(str.c_str());
   return bRet;
@@ -205,24 +203,24 @@ bool Interface_GUIDialogKeyboard::show_and_verify_new_password(KODI_HANDLE kodiB
                                                                char** password_out,
                                                                unsigned int auto_close_ms)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!password_out)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogKeyboard::{} - invalid handler data (password_out='{}') on "
-              "addon '{}'",
-              __func__, static_cast<void*>(password_out), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (password_out='{}') on "
+               "addon '{}'",
+               static_cast<void*>(password_out), addon->ID());
     return false;
   }
 
   std::string str;
-  bool bRet = CGUIKeyboardFactory::ShowAndVerifyNewPassword(str, auto_close_ms);
+  const bool bRet{CGUIKeyboardFactory::ShowAndVerifyNewPassword(str, auto_close_ms)};
   if (bRet)
     *password_out = strdup(str.c_str());
   return bRet;
@@ -235,25 +233,25 @@ int Interface_GUIDialogKeyboard::show_and_verify_password(KODI_HANDLE kodiBase,
                                                           int retries,
                                                           unsigned int auto_close_ms)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!password_in || !password_out || !heading)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogKeyboard::{} - invalid handler data (password_in='{}', "
-              "password_out='{}', heading='{}') on addon '{}'",
-              __func__, static_cast<const void*>(password_in), static_cast<void*>(password_out),
-              static_cast<const void*>(heading), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (password_in='{}', "
+               "password_out='{}', heading='{}') on addon '{}'",
+               static_cast<const void*>(password_in), static_cast<void*>(password_out),
+               static_cast<const void*>(heading), addon->ID());
     return false;
   }
 
   std::string str = password_in;
-  int iRet = CGUIKeyboardFactory::ShowAndVerifyPassword(str, heading, retries, auto_close_ms);
+  const int iRet{CGUIKeyboardFactory::ShowAndVerifyPassword(str, heading, retries, auto_close_ms)};
   if (iRet)
     *password_out = strdup(str.c_str());
   return iRet;
@@ -265,26 +263,25 @@ bool Interface_GUIDialogKeyboard::show_and_get_filter(KODI_HANDLE kodiBase,
                                                       bool searching,
                                                       unsigned int auto_close_ms)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!text_in || !text_out)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogKeyboard::{} - invalid handler data (text_in='{}', "
-              "text_out='{}') on addon '{}'",
-              __func__, static_cast<const void*>(text_in), static_cast<void*>(text_out),
-              addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (text_in='{}', "
+               "text_out='{}') on addon '{}'",
+               static_cast<const void*>(text_in), static_cast<void*>(text_out), addon->ID());
     return false;
   }
 
 
   std::string str = text_in;
-  bool bRet = CGUIKeyboardFactory::ShowAndGetFilter(str, searching, auto_close_ms);
+  const bool bRet{CGUIKeyboardFactory::ShowAndGetFilter(str, searching, auto_close_ms)};
   if (bRet)
     *text_out = strdup(str.c_str());
   return bRet;
@@ -294,10 +291,10 @@ bool Interface_GUIDialogKeyboard::send_text_to_active_keyboard(KODI_HANDLE kodiB
                                                                const char* text,
                                                                bool close_keyboard)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
@@ -306,10 +303,10 @@ bool Interface_GUIDialogKeyboard::send_text_to_active_keyboard(KODI_HANDLE kodiB
 
 bool Interface_GUIDialogKeyboard::is_keyboard_activated(KODI_HANDLE kodiBase)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 

--- a/xbmc/addons/interfaces/gui/dialogs/Numeric.cpp
+++ b/xbmc/addons/interfaces/gui/dialogs/Numeric.cpp
@@ -42,15 +42,15 @@ void Interface_GUIDialogNumeric::DeInit(AddonGlobalInterface* addonInterface)
 
 bool Interface_GUIDialogNumeric::show_and_verify_new_password(KODI_HANDLE kodiBase, char** password)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   std::string str;
-  bool bRet = CGUIDialogNumeric::ShowAndVerifyNewPassword(str);
+  const bool bRet{CGUIDialogNumeric::ShowAndVerifyNewPassword(str)};
   if (bRet)
     *password = strdup(str.c_str());
   return bRet;
@@ -61,20 +61,19 @@ int Interface_GUIDialogNumeric::show_and_verify_password(KODI_HANDLE kodiBase,
                                                          const char* heading,
                                                          int retries)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return -1;
   }
 
   if (!password || !heading)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogNumeric::{} - invalid handler data (password='{}', heading='{}') "
-              "on addon '{}'",
-              __func__, static_cast<const void*>(password), static_cast<const void*>(heading),
-              addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (password='{}', heading='{}') "
+               "on addon '{}'",
+               static_cast<const void*>(password), static_cast<const void*>(heading), addon->ID());
     return -1;
   }
 
@@ -88,20 +87,20 @@ bool Interface_GUIDialogNumeric::show_and_verify_input(KODI_HANDLE kodiBase,
                                                        const char* heading,
                                                        bool verify_input)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!verify_in || !verify_out || !heading)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogNumeric::{} - invalid handler data (verify_in='{}', "
-              "verify_out='{}', heading='{}') on addon '{}'",
-              __func__, static_cast<const void*>(verify_in), static_cast<void*>(verify_out),
-              static_cast<const void*>(heading), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (verify_in='{}', "
+               "verify_out='{}', heading='{}') on addon '{}'",
+               static_cast<const void*>(verify_in), static_cast<void*>(verify_out),
+               static_cast<const void*>(heading), addon->ID());
     return false;
   }
 
@@ -119,19 +118,19 @@ bool Interface_GUIDialogNumeric::show_and_get_time(KODI_HANDLE kodiBase,
                                                    tm* time,
                                                    const char* heading)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!time || !heading)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogNumeric::{} - invalid handler data (time='{}', heading='{}') on "
-              "addon '{}'",
-              __func__, static_cast<void*>(time), static_cast<const void*>(heading), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (time='{}', heading='{}') on "
+               "addon '{}'",
+               static_cast<void*>(time), static_cast<const void*>(heading), addon->ID());
     return false;
   }
 
@@ -151,19 +150,19 @@ bool Interface_GUIDialogNumeric::show_and_get_date(KODI_HANDLE kodiBase,
                                                    tm* date,
                                                    const char* heading)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!date || !heading)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogNumeric::{} - invalid handler data (date='{}', heading='{}') on "
-              "addon '{}'",
-              __func__, static_cast<void*>(date), static_cast<const void*>(heading), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (date='{}', heading='{}') on "
+               "addon '{}'",
+               static_cast<void*>(date), static_cast<const void*>(heading), addon->ID());
     return false;
   }
 
@@ -184,25 +183,25 @@ bool Interface_GUIDialogNumeric::show_and_get_ip_address(KODI_HANDLE kodiBase,
                                                          char** ip_address_out,
                                                          const char* heading)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!ip_address_in || !ip_address_out || !heading)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogNumeric::{} - invalid handler data (ip_address_in='{}', "
-              "ip_address_out='{}', heading='{}') on addon '{}'",
-              __func__, static_cast<const void*>(ip_address_in), static_cast<void*>(ip_address_out),
-              static_cast<const void*>(heading), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (ip_address_in='{}', "
+               "ip_address_out='{}', heading='{}') on addon '{}'",
+               static_cast<const void*>(ip_address_in), static_cast<void*>(ip_address_out),
+               static_cast<const void*>(heading), addon->ID());
     return false;
   }
 
   std::string strIP = ip_address_in;
-  bool bRet = CGUIDialogNumeric::ShowAndGetIPAddress(strIP, heading);
+  const bool bRet{CGUIDialogNumeric::ShowAndGetIPAddress(strIP, heading)};
   if (bRet)
     *ip_address_out = strdup(strIP.c_str());
   return bRet;
@@ -214,25 +213,25 @@ bool Interface_GUIDialogNumeric::show_and_get_number(KODI_HANDLE kodiBase,
                                                      const char* heading,
                                                      unsigned int auto_close_ms)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!number_in || !number_out || !heading)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogNumeric::{} - invalid handler data (number_in='{}', "
-              "number_out='{}', heading='{}') on addon '{}'",
-              __func__, static_cast<const void*>(number_in), static_cast<void*>(number_out),
-              static_cast<const void*>(heading), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (number_in='{}', "
+               "number_out='{}', heading='{}') on addon '{}'",
+               static_cast<const void*>(number_in), static_cast<void*>(number_out),
+               static_cast<const void*>(heading), addon->ID());
     return false;
   }
 
   std::string str = number_in;
-  bool bRet = CGUIDialogNumeric::ShowAndGetNumber(str, heading, auto_close_ms);
+  const bool bRet{CGUIDialogNumeric::ShowAndGetNumber(str, heading, auto_close_ms)};
   if (bRet)
     *number_out = strdup(str.c_str());
   return bRet;
@@ -243,25 +242,25 @@ bool Interface_GUIDialogNumeric::show_and_get_seconds(KODI_HANDLE kodiBase,
                                                       char** time_out,
                                                       const char* heading)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!time_in || !time_out || !heading)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogNumeric::{} - invalid handler data (time_in='{}', time_out='{}', "
-              "heading='{}') on addon '{}'",
-              __func__, static_cast<const void*>(time_in), static_cast<void*>(time_out),
-              static_cast<const void*>(heading), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (time_in='{}', time_out='{}', "
+               "heading='{}') on addon '{}'",
+               static_cast<const void*>(time_in), static_cast<void*>(time_out),
+               static_cast<const void*>(heading), addon->ID());
     return false;
   }
 
   std::string str = time_in;
-  bool bRet = CGUIDialogNumeric::ShowAndGetSeconds(str, heading);
+  const bool bRet{CGUIDialogNumeric::ShowAndGetSeconds(str, heading)};
   if (bRet)
     *time_out = strdup(str.c_str());
   return bRet;

--- a/xbmc/addons/interfaces/gui/dialogs/OK.cpp
+++ b/xbmc/addons/interfaces/gui/dialogs/OK.cpp
@@ -38,12 +38,11 @@ void Interface_GUIDialogOK::show_and_get_input_single_text(KODI_HANDLE kodiBase,
                                                            const char* heading,
                                                            const char* text)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon || !heading || !text)
   {
-    CLog::Log(
-        LOGERROR, "Interface_GUIDialogOK:{} - invalid data (addon='{}', heading='{}', text='{}')",
-        __func__, kodiBase, static_cast<const void*>(heading), static_cast<const void*>(text));
+    CLog::LogF(LOGERROR, "Invalid data (addon='{}', heading='{}', text='{}')", kodiBase,
+               static_cast<const void*>(heading), static_cast<const void*>(text));
     return;
   }
 
@@ -56,15 +55,14 @@ void Interface_GUIDialogOK::show_and_get_input_line_text(KODI_HANDLE kodiBase,
                                                          const char* line1,
                                                          const char* line2)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon || !heading || !line0 || !line1 || !line2)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogOK::{} - invalid data (addon='{}', heading='{}', line0='{}', "
-              "line1='{}', line2='{}')",
-              __func__, kodiBase, static_cast<const void*>(heading),
-              static_cast<const void*>(line0), static_cast<const void*>(line1),
-              static_cast<const void*>(line2));
+    CLog::LogF(LOGERROR,
+               "Invalid data (addon='{}', heading='{}', line0='{}', "
+               "line1='{}', line2='{}')",
+               kodiBase, static_cast<const void*>(heading), static_cast<const void*>(line0),
+               static_cast<const void*>(line1), static_cast<const void*>(line2));
     return;
   }
   HELPERS::ShowOKDialogLines(CVariant{heading}, CVariant{line0}, CVariant{line1}, CVariant{line2});

--- a/xbmc/addons/interfaces/gui/dialogs/Progress.cpp
+++ b/xbmc/addons/interfaces/gui/dialogs/Progress.cpp
@@ -47,10 +47,10 @@ void Interface_GUIDialogProgress::DeInit(AddonGlobalInterface* addonInterface)
 
 KODI_GUI_HANDLE Interface_GUIDialogProgress::new_dialog(KODI_HANDLE kodiBase)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return nullptr;
   }
 
@@ -59,9 +59,8 @@ KODI_GUI_HANDLE Interface_GUIDialogProgress::new_dialog(KODI_HANDLE kodiBase)
           WINDOW_DIALOG_PROGRESS);
   if (!dialog)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogProgress::{} - invalid handler data (dialog='{}') on addon '{}'",
-              __func__, static_cast<void*>(dialog), addon->ID());
+    CLog::LogF(LOGERROR, "Invalid handler data (dialog='{}') on addon '{}'",
+               static_cast<void*>(dialog), addon->ID());
     return nullptr;
   }
 
@@ -70,18 +69,16 @@ KODI_GUI_HANDLE Interface_GUIDialogProgress::new_dialog(KODI_HANDLE kodiBase)
 
 void Interface_GUIDialogProgress::delete_dialog(KODI_HANDLE kodiBase, KODI_GUI_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return;
   }
 
   if (!handle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogProgress::{} - invalid handler data (handle='{}') on addon '{}'",
-              __func__, handle, addon->ID());
+    CLog::LogF(LOGERROR, "Invalid handler data (handle='{}') on addon '{}'", handle, addon->ID());
     return;
   }
 
@@ -90,18 +87,16 @@ void Interface_GUIDialogProgress::delete_dialog(KODI_HANDLE kodiBase, KODI_GUI_H
 
 void Interface_GUIDialogProgress::open(KODI_HANDLE kodiBase, KODI_GUI_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return;
   }
 
   if (!handle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogProgress::{} - invalid handler data (handle='{}') on addon '{}'",
-              __func__, handle, addon->ID());
+    CLog::LogF(LOGERROR, "Invalid handler data (handle='{}') on addon '{}'", handle, addon->ID());
     return;
   }
 
@@ -112,19 +107,19 @@ void Interface_GUIDialogProgress::set_heading(KODI_HANDLE kodiBase,
                                               KODI_GUI_HANDLE handle,
                                               const char* heading)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return;
   }
 
   if (!handle || !heading)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogProgress::{} - invalid handler data (handle='{}', heading='{}') "
-              "on addon '{}'",
-              __func__, handle, static_cast<const void*>(heading), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (handle='{}', heading='{}') "
+               "on addon '{}'",
+               handle, static_cast<const void*>(heading), addon->ID());
     return;
   }
 
@@ -136,19 +131,19 @@ void Interface_GUIDialogProgress::set_line(KODI_HANDLE kodiBase,
                                            unsigned int line,
                                            const char* text)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return;
   }
 
   if (!handle || !text)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogProgress::{} - invalid handler data (handle='{}', text='{}') on "
-              "addon '{}'",
-              __func__, handle, static_cast<const void*>(text), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (handle='{}', text='{}') on "
+               "addon '{}'",
+               handle, static_cast<const void*>(text), addon->ID());
     return;
   }
 
@@ -159,18 +154,16 @@ void Interface_GUIDialogProgress::set_can_cancel(KODI_HANDLE kodiBase,
                                                  KODI_GUI_HANDLE handle,
                                                  bool canCancel)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return;
   }
 
   if (!handle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogProgress::{} - invalid handler data (handle='{}') on addon '{}'",
-              __func__, handle, addon->ID());
+    CLog::LogF(LOGERROR, "Invalid handler data (handle='{}') on addon '{}'", handle, addon->ID());
     return;
   }
 
@@ -179,18 +172,16 @@ void Interface_GUIDialogProgress::set_can_cancel(KODI_HANDLE kodiBase,
 
 bool Interface_GUIDialogProgress::is_canceled(KODI_HANDLE kodiBase, KODI_GUI_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!handle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogProgress::{} - invalid handler data (handle='{}') on addon '{}'",
-              __func__, handle, addon->ID());
+    CLog::LogF(LOGERROR, "Invalid handler data (handle='{}') on addon '{}'", handle, addon->ID());
     return false;
   }
 
@@ -201,18 +192,16 @@ void Interface_GUIDialogProgress::set_percentage(KODI_HANDLE kodiBase,
                                                  KODI_GUI_HANDLE handle,
                                                  int percentage)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return;
   }
 
   if (!handle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogProgress::{} - invalid handler data (handle='{}') on addon '{}'",
-              __func__, handle, addon->ID());
+    CLog::LogF(LOGERROR, "Invalid handler data (handle='{}') on addon '{}'", handle, addon->ID());
     return;
   }
 
@@ -221,18 +210,16 @@ void Interface_GUIDialogProgress::set_percentage(KODI_HANDLE kodiBase,
 
 int Interface_GUIDialogProgress::get_percentage(KODI_HANDLE kodiBase, KODI_GUI_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return 0;
   }
 
   if (!handle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogProgress::{} - invalid handler data (handle='{}') on addon '{}'",
-              __func__, handle, addon->ID());
+    CLog::LogF(LOGERROR, "Invalid handler data (handle='{}') on addon '{}'", handle, addon->ID());
     return 0;
   }
 
@@ -243,18 +230,16 @@ void Interface_GUIDialogProgress::show_progress_bar(KODI_HANDLE kodiBase,
                                                     KODI_GUI_HANDLE handle,
                                                     bool onOff)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return;
   }
 
   if (!handle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogProgress::{} - invalid handler data (handle='{}') on addon '{}'",
-              __func__, handle, addon->ID());
+    CLog::LogF(LOGERROR, "Invalid handler data (handle='{}') on addon '{}'", handle, addon->ID());
     return;
   }
 
@@ -265,18 +250,16 @@ void Interface_GUIDialogProgress::set_progress_max(KODI_HANDLE kodiBase,
                                                    KODI_GUI_HANDLE handle,
                                                    int max)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return;
   }
 
   if (!handle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogProgress::{} - invalid handler data (handle='{}') on addon '{}'",
-              __func__, handle, addon->ID());
+    CLog::LogF(LOGERROR, "Invalid handler data (handle='{}') on addon '{}'", handle, addon->ID());
     return;
   }
 
@@ -287,18 +270,16 @@ void Interface_GUIDialogProgress::set_progress_advance(KODI_HANDLE kodiBase,
                                                        KODI_GUI_HANDLE handle,
                                                        int nSteps)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return;
   }
 
   if (!handle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogProgress::{} - invalid handler data (handle='{}') on addon '{}'",
-              __func__, handle, addon->ID());
+    CLog::LogF(LOGERROR, "Invalid handler data (handle='{}') on addon '{}'", handle, addon->ID());
     return;
   }
 
@@ -307,18 +288,16 @@ void Interface_GUIDialogProgress::set_progress_advance(KODI_HANDLE kodiBase,
 
 bool Interface_GUIDialogProgress::abort(KODI_HANDLE kodiBase, KODI_GUI_HANDLE handle)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!handle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogProgress::{} - invalid handler data (handle='{}') on addon '{}'",
-              __func__, handle, addon->ID());
+    CLog::LogF(LOGERROR, "Invalid handler data (handle='{}') on addon '{}'", handle, addon->ID());
     return false;
   }
 

--- a/xbmc/addons/interfaces/gui/dialogs/Select.cpp
+++ b/xbmc/addons/interfaces/gui/dialogs/Select.cpp
@@ -40,10 +40,10 @@ int Interface_GUIDialogSelect::open(KODI_HANDLE kodiBase,
                                     int selected,
                                     unsigned int autoclose)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogSelect::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return -1;
   }
 
@@ -52,11 +52,11 @@ int Interface_GUIDialogSelect::open(KODI_HANDLE kodiBase,
           WINDOW_DIALOG_SELECT);
   if (!heading || !entries || !dialog)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogSelect::{} - invalid handler data (heading='{}', entries='{}', "
-              "dialog='{}') on addon '{}'",
-              __func__, static_cast<const void*>(heading), static_cast<const void*>(entries),
-              static_cast<void*>(dialog), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (heading='{}', entries='{}', "
+               "dialog='{}') on addon '{}'",
+               static_cast<const void*>(heading), static_cast<const void*>(entries),
+               static_cast<void*>(dialog), addon->ID());
     return -1;
   }
 
@@ -84,10 +84,10 @@ bool Interface_GUIDialogSelect::open_multi_select(KODI_HANDLE kodiBase,
                                                   unsigned int size,
                                                   unsigned int autoclose)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogMultiSelect::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
@@ -96,12 +96,12 @@ bool Interface_GUIDialogSelect::open_multi_select(KODI_HANDLE kodiBase,
           WINDOW_DIALOG_SELECT);
   if (!heading || !entryIDs || !entryNames || !entriesSelected || !dialog)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogMultiSelect::{} - invalid handler data (heading='{}', "
-              "entryIDs='{}', entryNames='{}', entriesSelected='{}', dialog='{}') on addon '{}'",
-              __func__, static_cast<const void*>(heading), static_cast<const void*>(entryIDs),
-              static_cast<const void*>(entryNames), static_cast<void*>(entriesSelected),
-              static_cast<void*>(dialog), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (heading='{}', "
+               "entryIDs='{}', entryNames='{}', entriesSelected='{}', dialog='{}') on addon '{}'",
+               static_cast<const void*>(heading), static_cast<const void*>(entryIDs),
+               static_cast<const void*>(entryNames), static_cast<void*>(entriesSelected),
+               static_cast<void*>(dialog), addon->ID());
     return false;
   }
 
@@ -115,7 +115,7 @@ bool Interface_GUIDialogSelect::open_multi_select(KODI_HANDLE kodiBase,
   {
     dialog->Add(entryNames[i]);
     if (entriesSelected[i])
-      selectedIndexes.push_back(i);
+      selectedIndexes.emplace_back(i);
   }
 
   dialog->SetSelected(selectedIndexes);
@@ -130,10 +130,10 @@ bool Interface_GUIDialogSelect::open_multi_select(KODI_HANDLE kodiBase,
 
     selectedIndexes = dialog->GetSelectedItems();
 
-    for (unsigned int i = 0; i < selectedIndexes.size(); ++i)
+    for (int selectedIndex : selectedIndexes)
     {
-      if (selectedIndexes[i])
-        entriesSelected[selectedIndexes[i]] = true;
+      if (selectedIndex)
+        entriesSelected[selectedIndex] = true;
     }
   }
 

--- a/xbmc/addons/interfaces/gui/dialogs/TextViewer.cpp
+++ b/xbmc/addons/interfaces/gui/dialogs/TextViewer.cpp
@@ -36,10 +36,10 @@ void Interface_GUIDialogTextViewer::open(KODI_HANDLE kodiBase,
                                          const char* heading,
                                          const char* text)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogTextViewer::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return;
   }
 
@@ -48,11 +48,11 @@ void Interface_GUIDialogTextViewer::open(KODI_HANDLE kodiBase,
           WINDOW_DIALOG_TEXT_VIEWER);
   if (!heading || !text || !dialog)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogTextViewer::{} - invalid handler data (heading='{}', text='{}', "
-              "dialog='{}') on addon '{}'",
-              __func__, static_cast<const void*>(heading), static_cast<const void*>(text),
-              static_cast<void*>(dialog), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (heading='{}', text='{}', "
+               "dialog='{}') on addon '{}'",
+               static_cast<const void*>(heading), static_cast<const void*>(text),
+               static_cast<void*>(dialog), addon->ID());
     return;
   }
 

--- a/xbmc/addons/interfaces/gui/dialogs/YesNo.cpp
+++ b/xbmc/addons/interfaces/gui/dialogs/YesNo.cpp
@@ -44,25 +44,25 @@ bool Interface_GUIDialogYesNo::show_and_get_input_single_text(KODI_HANDLE kodiBa
                                                               const char* noLabel,
                                                               const char* yesLabel)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogYesNo::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!heading || !text || !canceled || !noLabel || !yesLabel)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogYesNo::{} - invalid handler data (heading='{}', text='{}', "
-              "canceled='{}', noLabel='{}', yesLabel='{}') on addon '{}'",
-              __func__, static_cast<const void*>(heading), static_cast<const void*>(text),
-              static_cast<void*>(canceled), static_cast<const void*>(noLabel),
-              static_cast<const void*>(yesLabel), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (heading='{}', text='{}', "
+               "canceled='{}', noLabel='{}', yesLabel='{}') on addon '{}'",
+               static_cast<const void*>(heading), static_cast<const void*>(text),
+               static_cast<void*>(canceled), static_cast<const void*>(noLabel),
+               static_cast<const void*>(yesLabel), addon->ID());
     return false;
   }
 
-  DialogResponse result = HELPERS::ShowYesNoDialogText(heading, text, noLabel, yesLabel);
+  const DialogResponse result{HELPERS::ShowYesNoDialogText(heading, text, noLabel, yesLabel)};
   *canceled = (result == DialogResponse::CHOICE_CANCELLED);
   return (result == DialogResponse::CHOICE_YES);
 }
@@ -75,22 +75,22 @@ bool Interface_GUIDialogYesNo::show_and_get_input_line_text(KODI_HANDLE kodiBase
                                                             const char* noLabel,
                                                             const char* yesLabel)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogYesNo::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!heading || !line0 || !line1 || !line2 || !noLabel || !yesLabel)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogYesNo::{} - invalid handler data (heading='{}', line0='{}', "
-              "line1='{}', line2='{}', "
-              "noLabel='{}', yesLabel='{}') on addon '{}'",
-              __func__, static_cast<const void*>(heading), static_cast<const void*>(line0),
-              static_cast<const void*>(line1), static_cast<const void*>(line2),
-              static_cast<const void*>(noLabel), static_cast<const void*>(yesLabel), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (heading='{}', line0='{}', "
+               "line1='{}', line2='{}', "
+               "noLabel='{}', yesLabel='{}') on addon '{}'",
+               static_cast<const void*>(heading), static_cast<const void*>(line0),
+               static_cast<const void*>(line1), static_cast<const void*>(line2),
+               static_cast<const void*>(noLabel), static_cast<const void*>(yesLabel), addon->ID());
     return false;
   }
 
@@ -107,28 +107,28 @@ bool Interface_GUIDialogYesNo::show_and_get_input_line_button_text(KODI_HANDLE k
                                                                    const char* noLabel,
                                                                    const char* yesLabel)
 {
-  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  const auto* addon = static_cast<const CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_GUIDialogYesNo::{} - invalid data", __func__);
+    CLog::LogF(LOGERROR, "Invalid data");
     return false;
   }
 
   if (!heading || !line0 || !line1 || !line2 || !canceled || !noLabel || !yesLabel)
   {
-    CLog::Log(LOGERROR,
-              "Interface_GUIDialogYesNo::{} - invalid handler data (heading='{}', line0='{}', "
-              "line1='{}', line2='{}', "
-              "canceled='{}', noLabel='{}', yesLabel='{}') on addon '{}'",
-              __func__, static_cast<const void*>(heading), static_cast<const void*>(line0),
-              static_cast<const void*>(line1), static_cast<const void*>(line2),
-              static_cast<const void*>(canceled), static_cast<const void*>(noLabel),
-              static_cast<const void*>(yesLabel), addon->ID());
+    CLog::LogF(LOGERROR,
+               "Invalid handler data (heading='{}', line0='{}', "
+               "line1='{}', line2='{}', "
+               "canceled='{}', noLabel='{}', yesLabel='{}') on addon '{}'",
+               static_cast<const void*>(heading), static_cast<const void*>(line0),
+               static_cast<const void*>(line1), static_cast<const void*>(line2),
+               static_cast<const void*>(canceled), static_cast<const void*>(noLabel),
+               static_cast<const void*>(yesLabel), addon->ID());
     return false;
   }
 
-  DialogResponse result =
-      HELPERS::ShowYesNoDialogLines(heading, line0, line1, line2, noLabel, yesLabel);
+  const DialogResponse result{
+      HELPERS::ShowYesNoDialogLines(heading, line0, line1, line2, noLabel, yesLabel)};
   *canceled = (result == DialogResponse::CHOICE_CANCELLED);
   return (result == DialogResponse::CHOICE_YES);
 }

--- a/xbmc/addons/settings/AddonSettings.h
+++ b/xbmc/addons/settings/AddonSettings.h
@@ -85,7 +85,7 @@ protected:
   bool InitializeDefinitions() override { return false; }
 
 private:
-  bool AddInstanceSettings();
+  bool AddInstanceSettings() const;
   bool InitializeDefinitions(const CXBMCTinyXML& doc);
 
   bool ParseSettingVersion(const CXBMCTinyXML& doc, uint32_t& version) const;
@@ -93,11 +93,12 @@ private:
   std::shared_ptr<CSettingGroup> ParseOldSettingElement(
       const TiXmlElement* categoryElement,
       const std::shared_ptr<CSettingCategory>& category,
-      std::set<std::string>& settingIds);
+      std::set<std::string, std::less<>>& settingIds);
 
-  std::shared_ptr<CSettingCategory> ParseOldCategoryElement(uint32_t& categoryId,
-                                                            const TiXmlElement* categoryElement,
-                                                            std::set<std::string>& settingIds);
+  std::shared_ptr<CSettingCategory> ParseOldCategoryElement(
+      uint32_t& categoryId,
+      const TiXmlElement* categoryElement,
+      std::set<std::string, std::less<>>& settingIds);
 
   bool InitializeFromOldSettingDefinitions(const CXBMCTinyXML& doc);
   std::shared_ptr<CSetting> InitializeFromOldSettingAction(const std::string& settingId,
@@ -165,7 +166,7 @@ private:
       std::string source);
 
   bool LoadOldSettingValues(const CXBMCTinyXML& doc,
-                            std::map<std::string, std::string>& settings) const;
+                            std::map<std::string, std::string, std::less<>>& settings) const;
 
   struct ConditionExpression
   {

--- a/xbmc/addons/settings/SettingUrlEncodedString.h
+++ b/xbmc/addons/settings/SettingUrlEncodedString.h
@@ -17,7 +17,8 @@ namespace ADDON
   class CSettingUrlEncodedString : public CSettingString
   {
   public:
-    CSettingUrlEncodedString(const std::string& id, CSettingsManager* settingsManager = nullptr);
+    explicit CSettingUrlEncodedString(const std::string& id,
+                                      CSettingsManager* settingsManager = nullptr);
     CSettingUrlEncodedString(const std::string& id,
                              int label,
                              const std::string& value,

--- a/xbmc/utils/Locale.cpp
+++ b/xbmc/utils/Locale.cpp
@@ -175,22 +175,22 @@ std::string CLocale::FindBestMatch(const std::set<std::string>& locales) const
   return bestMatch;
 }
 
-std::string CLocale::FindBestMatch(const std::unordered_map<std::string, std::string>& locales) const
+std::string CLocale::FindBestMatch(const LocalizedStringsMap& locales) const
 {
   std::string bestMatch = "";
   int bestMatchRank = -1;
 
-  for (auto const& locale : locales)
+  for (auto const& [locale, _] : locales)
   {
     // check if there is an exact match
-    if (Equals(locale.first))
-      return locale.first;
+    if (Equals(locale))
+      return locale;
 
-    int matchRank = GetMatchRank(locale.first);
+    int matchRank = GetMatchRank(locale);
     if (matchRank > bestMatchRank)
     {
       bestMatchRank = matchRank;
-      bestMatch = locale.first;
+      bestMatch = locale;
     }
   }
 

--- a/xbmc/utils/Locale.h
+++ b/xbmc/utils/Locale.h
@@ -131,6 +131,18 @@ public:
   */
   std::string FindBestMatch(const std::set<std::string>& locales) const;
 
+  struct StringHash
+  {
+    using is_transparent = void; // Enables heterogeneous operations.
+    std::size_t operator()(std::string_view sv) const
+    {
+      std::hash<std::string_view> hasher;
+      return hasher(sv);
+    }
+  };
+  using LocalizedStringsMap =
+      std::unordered_map<std::string, std::string, StringHash, std::equal_to<>>;
+
   /*!
   \brief Tries to find the locale in the given list that matches this locale
          best.
@@ -142,7 +154,7 @@ public:
   \remark Used from \ref CAddonInfo::GetTranslatedText to prevent copy from map
           to set.
   */
-  std::string FindBestMatch(const std::unordered_map<std::string, std::string>& locales) const;
+  std::string FindBestMatch(const LocalizedStringsMap& locales) const;
 
 private:
   static bool CheckValidity(const std::string& language, const std::string& territory, const std::string& codeset, const std::string& modifier);


### PR DESCRIPTION
## Description
Fixing a lot (but not all) of SonarQube findings in xbmc/addons. Many monkey work in here to get rid of `__FUNCTION__` and friends usage...

Like always, no functional changes intended.

Findings addressed:

addons/addoninfo
* Return type of functions shouldn't be const qualified value cpp:S5951
* "using" should be preferred for type aliasing cpp:S5416
* "explicit" should be used on single-parameter constructors and conversion operators cpp:S1709 
* "std::string_view" should be used to pass a read-only string to a function cpp:S6009
* Structured binding should be used cpp:S6005
* Multiple variables should not be declared on the same line cpp:S1659
* Redundant comparison operators should not be defined cpp:S6186
* Comparision operators ("<=>", "==") should be defaulted unless non-default behavior is required cpp:S6230
* Transparent function objects should be used with associative "std::string" containers cpp:S6045
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* STL algorithms and range-based for loops should be preferred to traditional for loops cpp:S5566
* "using enum" should be used in scopes with high concentration of "enum" constants cpp:S6177
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* "try_emplace" should be used with "std::map" and "std::unordered_map" cpp:S6030
* "std::source_location" should be used instead of "__FILE__", "__LINE__", and "__func__" macros cpp:S6190
* "auto" should be used to avoid repetition of types cpp:S5827
* Variables should not be shadowed cpp:S1117
* Elements in a container should be erased with "std::erase" or "std::erase_if" cpp:S6165
* Objects should not be created solely to be passed as arguments to functions that perform delegated object creation cpp:S6011

addons/binary-addons
* Memory should not be managed manually cpp:S5025
* Pointer and reference parameters should be "const" if the corresponding object is not modified cpp:S995
* Pointer and reference local variables should be "const" if the corresponding object is not modified cpp:S5350
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* "auto" should be used to avoid repetition of types cpp:S5827
* "make_unique" and "make_shared" should be used to construct "unique_ptr" and "shared_ptr" cpp:S5950
* Member variables should not be "protected" cpp:S3656
* Classes should have regular copy and move semantic cpp:S3624
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* "auto" should be used to avoid repetition of types cpp:S5827
* "std::source_location" should be used instead of "__FILE__", "__LINE__", and "__func__" macros cpp:S6190
* "using" should be preferred for type aliasing cpp:S5416
* Transparent function objects should be used with associative "std::string" containers cpp:S6045
* Access specifiers should not be redundant cpp:S3539

addons/gui
* Macros should not be used to define constants cpp:S5028
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* Pointer and reference parameters should be "const" if the corresponding object is not modified cpp:S995
* Structured binding should be used cpp:S6005
* Mergeable "if" statements should be combined cpp:S1066
* Variables should not be shadowed cpp:S1117
* STL algorithms and range-based for loops should be preferred to traditional for loops cpp:S5566
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* "auto" should be used to avoid repetition of types cpp:S5827
* Pointer and reference local variables should be "const" if the corresponding object is not modified cpp:S5350
* "std::source_location" should be used instead of "__FILE__", "__LINE__", and "__func__" macros cpp:S6190
* Raw string literals should be used cpp:S3628
* "empty()" should be used to test for emptiness cpp:S1155
* Transparent function objects should be used with associative "std::string" containers cpp:S6045
* "try_emplace" should be used with "std::map" and "std::unordered_map" cpp:S6030
* "make_unique" and "make_shared" should be used to construct "unique_ptr" and "shared_ptr" cpp:S5950
* Redundant pairs of parentheses should be removed cpp:S1110
* Objects should not be created solely to be passed as arguments to functions that perform delegated object creation cpp:S6011

addons/gui/skin
* "explicit" should be used on single-parameter constructors and conversion operators cpp:S1709
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* Transparent function objects should be used with associative "std::string" containers cpp:S6045

addons/interfaces
* Pointer and reference parameters should be "const" if the corresponding object is not modified cpp:S995
* Pointer and reference local variables should be "const" if the corresponding object is not modified cpp:S5350
* "auto" should be used to avoid repetition of types cpp:S5827
* Unused function parameters should be removed cpp:S1172
* Implicit casts should not lower precision cpp:S5276
* Function pointers should not be used as function parameters cpp:S5205
* STL algorithms and range-based for loops should be preferred to traditional for loops cpp:S5566
* Redundant casts should not be used cpp:S1905
* 'extern "C"' should not be used with namespaces cpp:S3732
* Empty statements should be removed cpp:S1116
* "empty()" should be used to test for emptiness cpp:S1155
* "static" members should be accessed statically cpp:S2209

addons/interfaces/gui
* "auto" should be used to avoid repetition of types cpp:S5827
* Pointer and reference local variables should be "const" if the corresponding object is not modified cpp:S5350
* "std::source_location" should be used instead of "__FILE__", "__LINE__", and "__func__" macros cpp:S6190
* Member data should be initialized in-class or in a constructor initialization list cpp:S3230
* Mergeable "if" statements should be combined cpp:S1066
* "switch" statements should cover all cases cpp:S3562
* Member functions that don't mutate their objects should be declared "const" cpp:S5817

addons/interfaces/gui/(controls|dialogs)
* "auto" should be used to avoid repetition of types cpp:S5827
* Pointer and reference local variables should be "const" if the corresponding object is not modified cpp:S5350
* "std::source_location" should be used instead of "__FILE__", "__LINE__", and "__func__" macros cpp:S6190
* Mergeable "if" statements should be combined cpp:S1066
* Member variables should not be "protected" cpp:S3656
* "static" members should be accessed statically cpp:S2209
* Implicit casts should not lower precision cpp:S5276
* "std::string_view" should be used to pass a read-only string to a function cpp:S6009
* STL algorithms and range-based for loops should be preferred to traditional for loops cpp:S5566

addons/settings
* Unused function parameters should be removed cpp:S1172
* "auto" should be used to avoid repetition of types cpp:S5827
* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* "std::source_location" should be used instead of "__FILE__", "__LINE__", and "__func__" macros cpp:S6190
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* Transparent function objects should be used with associative "std::string" containers cpp:S6045
* "try_emplace" should be used with "std::map" and "std::unordered_map" cpp:S6030
* Structured binding should be used cpp:S6005
* Raw string literals should be used cpp:S3628
* Variables should not be shadowed cpp:S1117
* Multiple variables should not be declared on the same line cpp:S1659
* Implicit casts should not lower precision cpp:S5276
* "explicit" should be used on single-parameter constructors and conversion operators cpp:S1709



## Motivation and context
Improving code quality and maintainability.

## How has this been tested?
Builds and runs.

## What is the effect on users?
Hopefully none.

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed