### PR TITLE
[cores][dllLoader] Use snprintf instead of strncpy/strncat for safer …

### DIFF
--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -999,8 +999,8 @@ extern "C"
         strncpy(entry->d_name, "..\0", 3);
       else
       {
-        strncpy(entry->d_name, dirData->items[dirData->curr_index - 2]->GetLabel().c_str(), sizeof(entry->d_name));
-        entry->d_name[sizeof(entry->d_name)-1] = '\0'; // null-terminate any truncated paths
+        snprintf(entry->d_name, sizeof(entry->d_name), "%s",
+                 dirData->items[dirData->curr_index - 2]->GetLabel().c_str());
       }
       dirData->last_entry = entry;
       dirData->curr_index++;
@@ -1881,19 +1881,14 @@ extern "C"
 
           if (free_position != NULL)
           {
-            // free position, copy value
             size = strlen(var) + strlen(value) + 2;
-            *free_position = (char*)malloc(size); // for '=' and 0 termination
-            if ((*free_position))
+            *free_position = static_cast<char*>(malloc(size));
+            if (*free_position)
             {
-              strncpy(*free_position, var, size);
-              (*free_position)[size - 1] = '\0';
-              strncat(*free_position, "=", size - strlen(*free_position));
-              strncat(*free_position, value, size - strlen(*free_position));
+              snprintf(*free_position, size, "%s=%s", var, value);
               added = true;
             }
           }
-
         }
 
         free(value);


### PR DESCRIPTION
…and cleaner string formatting

## Description
Replace manual string copying and concatenation with snprintf in two locations.  I have to say, this is wayyyy out of my comfort zone and if I've pinged you for a review and shouldn't have then I apologise.  But with such old code, I'm erring much on the side of caution. I'm not even sure what to label it as.

## Motivation and context
When changing the CMAKE flags to *_INIT in a previous PR (https://github.com/xbmc/xbmc/pull/27030) the quality gate was triggered on webos and so although the build did actually complete, it failed the quality gates and was thus marked as a failure.

Investigation seems to show some 14 ~ 15 year old code was at fault. IDK what changed in the compiler flags to make things a little stricter, but apparently that's what happened.

<img width="1452" height="349" alt="webos-clang-warnings" src="https://github.com/user-attachments/assets/a527ed32-1050-4d57-9d9f-012bb233b233" />


## How has this been tested?
Built webos with these changes on top of the cmake changes with no warnings.

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
