### PR TITLE
depends: Fix rebuilding Python modules

### DIFF
--- a/tools/depends/native/pythonmodule-setuptools/Makefile
+++ b/tools/depends/native/pythonmodule-setuptools/Makefile
@@ -8,7 +8,7 @@ export PIP_CACHE_DIR=$(TARBALLS_LOCATION)/pip-cache
 all: .installed-$(PLATFORM)
 
 .installed-$(PLATFORM):
-	PYTHONPATH="$(NATIVEPREFIX)/lib/python${NATIVE_PYTHON_VERSION}/site-packages" $(NATIVEPREFIX)/bin/python3 -m pip install setuptools==$(VERSION)
+	PYTHONPATH="$(NATIVEPREFIX)/lib/python${NATIVE_PYTHON_VERSION}/site-packages" $(NATIVEPREFIX)/bin/python3 -m pip install --ignore-installed setuptools==$(VERSION)
 	cd $(NATIVEPREFIX)/lib/python${NATIVE_PYTHON_VERSION}/site-packages; patch -p1 -i $(abs_top_srcdir)/native/pythonmodule-setuptools/01-distutils-flag.patch
 	touch $@
 


### PR DESCRIPTION
## Description

When rebuilding, `patch` attempts to apply the patch a second time, interrupting the build:

```
~/Documents/kodi-android/tools/depends/native/pythonmodule-setuptools$ time make
[notice] A new release of pip is available: 25.1.1 -> 25.2
[notice] To update, run: pip3 install --upgrade pip
patching file setuptools/_distutils/sysconfig.py
Reversed (or previously applied) patch detected!  Assume -R? [n] 
```

This fixes the problem by always overwriting Python modules, giving `patch` a fresh state to succeed.

`--ignore-installed` causes packages to always be installed, even if already present, which gives us the fresh state.

## Motivation and context

Testing Android PRs on top of latest master.

## How has this been tested?

Building for latest Android.

Before: Interrupts build with above error.

After: Depends build successfully.

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
