### PR TITLE
Android: Request media storage permissions on Android 13+

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -12,6 +12,9 @@
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 
     <uses-feature
         android:name="android.hardware.bluetooth"

--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -121,7 +121,14 @@ public class Splash extends Activity
                   RECORDAUDIO_RESULT_CODE);
           break;
         case CheckingPermissions:
-          if (Build.VERSION.SDK_INT >= 33 || (Build.VERSION.SDK_INT >= 30 && !isAndroidTV()))
+          if (Build.VERSION.SDK_INT >= 33)
+          {
+            requestPermissions(new String[]{Manifest.permission.READ_MEDIA_AUDIO,
+                    Manifest.permission.READ_MEDIA_VIDEO,
+                    Manifest.permission.READ_MEDIA_IMAGES},
+                    PERMISSION_RESULT_CODE);
+          }
+          else if (Build.VERSION.SDK_INT >= 30 && !isAndroidTV())
           {
             try
             {
@@ -505,7 +512,17 @@ public class Splash extends Activity
   private boolean CheckPermissions()
   {
     boolean retVal = false;
-    if (Build.VERSION.SDK_INT >= 33 || (Build.VERSION.SDK_INT >= 30 && !isAndroidTV()))
+    if (Build.VERSION.SDK_INT >= 33)
+    {
+      int audioCheck = checkSelfPermission(Manifest.permission.READ_MEDIA_AUDIO);
+      int videoCheck = checkSelfPermission(Manifest.permission.READ_MEDIA_VIDEO);
+      int imageCheck = checkSelfPermission(Manifest.permission.READ_MEDIA_IMAGES);
+      if (audioCheck == PERMISSION_GRANTED &&
+          videoCheck == PERMISSION_GRANTED &&
+          imageCheck == PERMISSION_GRANTED)
+        retVal = true;
+    }
+    else if (Build.VERSION.SDK_INT >= 30 && !isAndroidTV())
     {
       if (Environment.isExternalStorageManager())
       {
@@ -530,10 +547,24 @@ public class Splash extends Activity
       case PERMISSION_RESULT_CODE:
       {
         // If request is cancelled, the result arrays are empty.
-        if (grantResults.length > 0
-                && grantResults[0] == PERMISSION_GRANTED)
+        if (grantResults.length > 0)
         {
-          mPermissionOK = true;
+          if (Build.VERSION.SDK_INT >= 33)
+          {
+            mPermissionOK = true;
+            for (int result : grantResults)
+            {
+              if (result != PERMISSION_GRANTED)
+              {
+                mPermissionOK = false;
+                break;
+              }
+            }
+          }
+          else if (grantResults[0] == PERMISSION_GRANTED)
+          {
+            mPermissionOK = true;
+          }
         }
         mStateMachine.sendEmptyMessage(CheckingPermissionsDone);
         break;


### PR DESCRIPTION
## Description

On my Pixel Tablet, starting Kodi gives this error since I updated Android over a year ago:

<img width="2560" height="1600" alt="Screenshot_20250804-131640" src="https://github.com/user-attachments/assets/640c3886-57cb-4654-8706-88c4539ae246" />

It happens immediately after microphone permissions. In the log I only see:

```
08-04 17:41:46.401 17785 17785 I Kodi    : XBMCProperties: Expected at /storage/emulated/0/xbmc_env.properties
08-04 17:41:46.404 17785 17785 D Kodi    : External storage = /storage/emulated/0; state = mounted
```

To fix this, I made the following changes:

* Declared the new granular media permissions in the Android manifest so Kodi can access audio, video, and image files on Android 13+ devices
* Reworked the splash screen’s permission flow to request `READ_MEDIA_*` permissions on Android 13+ instead of relying on the deprecated “manage all files” approach
* Updated the permission-checking logic to verify the grant state of these media permissions before Kodi proceeds

## Motivation and context

Tested RetroPlayer builds on my Pixel Tablet. Kodi hasn't opened for a long time.

## How has this been tested?

Tested on my Google Pixel Tablet with both Android 15 and Android 16.

Before: Error shown above

After: I give Kodi file permissions, and the app starts succesfully.

## What is the effect on users?

* Fixed Kodi exiting with "Permission denied!! Exiting..." error message on startup.

## Screenshots

New permissions flow:

<img width="2560" height="1600" alt="Screenshot_20250804-230520" src="https://github.com/user-attachments/assets/0dffb5d3-f17b-4cc6-8075-38d881cf9a7e" />

<img width="2560" height="1600" alt="Screenshot_20250804-230528" src="https://github.com/user-attachments/assets/12e0f2d4-8a57-48e9-83e6-ed9a2705bbff" />

<img width="2560" height="1600" alt="Screenshot_20250804-230536" src="https://github.com/user-attachments/assets/d0fe3cb8-f473-4083-996e-615ede06c167" />

<img width="2560" height="1600" alt="Screenshot_20250804-230544" src="https://github.com/user-attachments/assets/80ba307c-6530-4235-9f8c-6a9c8ffc5b6f" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

CC @joseluismarti 