### PR TITLE
Shaders: Use new OpenGLES shader manifest

### DIFF
--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
@@ -125,10 +125,12 @@ void CDialogGameVideoFilter::InitVideoFilters()
 
   //! @todo Have the add-on give us the xml as a string (or parse it)
   std::string xmlFilename;
-#ifdef TARGET_WINDOWS
-  xmlFilename = "ShaderPresetsHLSLP.xml";
-#else
+#if defined(HAS_GLES)
+  xmlFilename = "ShaderPresetsGLSLP_GLES.xml";
+#elif defined(HAS_GL)
   xmlFilename = "ShaderPresetsGLSLP.xml";
+#else
+  xmlFilename = "ShaderPresetsHLSLP.xml";
 #endif
 
   const std::string homeAddonPath = CSpecialProtocol::TranslatePath(


### PR DESCRIPTION
## Description

This change adds the GLES shader manifest from https://github.com/kodi-game/game.shader.presets/pull/22. It contains mostly versions of the shaders chosen for GL, but curated for embedded devices running GLES.

Note that adding #ifdefs to the code is not great. I intend to pass the shader manifest from the add-on. But this is out of scope of this PR.

Requires https://github.com/kodi-game/game.shader.presets/pull/22.

## Motivation and context

Credit to @KOPRajs for posting this patch in https://github.com/xbmc/xbmc/pull/26961.

## How has this been tested?

Included in test builds: https://github.com/garbear/xbmc/releases/tag/retroplayer-22alpha1-20250803

Tested on NVidia Shield with latest FW. Tested on Google Pixel Tablet with Android 15 and 16.

## What is the effect on users?

* Added optimized shaders for OpenGLES

## Screenshots

On my Google Pixel Tablet with Android 16:

<img width="2560" height="1600" alt="Screenshot_20250805-000222" src="https://github.com/user-attachments/assets/8e22ad0c-23a4-496a-83fb-1ac20fda984d" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
