### PR TITLE
Fix add-on sources missing when mediasources.xml is absent

### DIFF
--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -46,7 +46,7 @@ public:
   void Initialize();
   void Stop();
 
-  bool LoadSources();
+  void LoadSources();
   bool SaveSources();
 
   void GetLocalDrives(std::vector<CMediaSource>& localDrives, bool includeQ = true);


### PR DESCRIPTION
## Description

When testing from a new install on my Google Pixel Tablet, the "Game add-ons" item was missing in the root My Games window. It only showed the "Add games..." item.

The root cause was that add-on items were only loaded after `mediasources.xml` was loaded, and if the file didn't exist (or was bad), then add-on sources were never loaded.

This should also be an issue for all other media types.

## Motivation and context

Noticed when testing an Alpha 1 build on multiple fresh devices.

## How has this been tested?

Tested on my Macbook M2.

## What is the effect on users?

* Fixed missing add-on items in root windows of fresh installs

## Screenshots (if appropriate):

Before, on a fresh install:

<img width="1347" height="762" alt="Screenshot 2025-08-05 at 1 17 23 AM" src="https://github.com/user-attachments/assets/ccd092f9-3775-49b2-b8fd-c678d67d49df" />

After, or with mediasources.xml present:

<img width="1346" height="760" alt="Screenshot 2025-08-05 at 1 18 36 AM" src="https://github.com/user-attachments/assets/50f67986-c43c-47c7-95e2-2732290e66dc" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
