### PR TITLE
[Video] Improve episode range determination when scanning library and add further tests.

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -268,12 +268,12 @@ void CAdvancedSettings::Initialize()
   m_tvshowEnumRegExps.emplace_back(false, "[\\\\/]([^\\\\/]+)\\.special\\.[a-z0-9]+$", 0, true);
 
   // foo.103*, 103 foo
-  // XXX: This regex is greedy and will match years in show names.  It should always be last.
+  // This regex is greedy and will match years in show names.  It should always be last.
   m_tvshowEnumRegExps.emplace_back(
       false,
       "[\\\\/\\._ -]([0-9]+)([0-9][0-9](?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([\\._ -][^\\\\/]*)$");
 
-  m_tvshowMultiPartEnumRegExp = "^[-_ex]+([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)";
+  m_tvshowMultiPartEnumRegExp = "^([-_ex]+)([0-9]+)(.*)";
 
   m_remoteDelay = 3;
   m_bScanIRServer = true;

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -58,6 +58,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <ranges>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -73,29 +74,68 @@ using KODI::UTILITY::CDigest;
 
 namespace
 {
+
+/**
+ * \brief Maximum allowed number of episodes in a single episode range.
+ *
+ * The value 50 was chosen as a safety limit to prevent accidental processing of
+ * extremely large episode ranges, which could be caused by malformed filenames or
+ * incorrect regular expression matches. Note this is a per-file number and not the
+ * total number of episodes in a season.
+ */
+constexpr int MAX_EPISODE_RANGE = 50;
+
+// Character following season/episode range must be one of these for range to be valid.
+constexpr std::string_view allowed{"-_.esx "};
+
+/*! \brief Perform checks, then add episodes in a given range to the episode list
+ \param first first episode in the range to add.
+ \param last last episode in the range.
+ \param episode the first episode in the range (already added to the list).
+ \param episodeList the list (vector) of episodes to add to.
+ \param regex the regex used to match the episode range.
+ \param remainder the remainder of the filename after the episode range.
+*/
 void ProcessEpisodeRange(int first,
                          int last,
                          VIDEO::EPISODE& episode,
                          VIDEO::EPISODELIST& episodeList,
-                         const std::string& regex)
+                         const std::string& regex,
+                         const std::string& remainder)
 {
-  if (first <= last)
-  {
-    for (int e = first; e <= last; ++e)
-    {
-      episode.iEpisode = e;
-      CLog::LogF(LOGDEBUG, "VideoInfoScanner: Adding multipart episode {} [{}]", episode.iEpisode,
-                 regex);
-      episodeList.push_back(episode);
-    }
-  }
-  else if (!episodeList.empty())
+  if (first > last && !episodeList.empty())
   {
     // SxxEaa-SxxEbb or Eaa-Ebb is backwards - bb<aa
     CLog::LogF(LOGDEBUG,
                "VideoInfoScanner: Removing season {}, episode {} as range {}-{} is backwards",
                episode.iSeason, episode.iEpisode, episodeList.back().iEpisode, last);
     episodeList.pop_back();
+    return;
+  }
+  if ((last - first + 1) > MAX_EPISODE_RANGE && !episodeList.empty())
+  {
+    CLog::LogF(LOGDEBUG,
+               "VideoInfoScanner: Removing season {}, episode {} as range is too large {} (maximum "
+               "allowed {})",
+               episode.iSeason, episode.iEpisode, last - first + 1, MAX_EPISODE_RANGE);
+    episodeList.pop_back();
+    return;
+  }
+  if (!remainder.empty() && allowed.find(static_cast<char>(std::tolower(static_cast<unsigned char>(
+                                remainder.front())))) == std::string_view::npos)
+  {
+    CLog::LogF(LOGDEBUG,
+               "VideoInfoScanner:Last episode in range {} is not part of an episode string ({}) "
+               "- ignoring",
+               last, remainder);
+    return;
+  }
+  for (int e = first; e <= last; ++e)
+  {
+    episode.iEpisode = e;
+    CLog::LogF(LOGDEBUG, "VideoInfoScanner: Adding multipart episode {} [{}]", episode.iEpisode,
+               regex);
+    episodeList.push_back(episode);
   }
 }
 
@@ -1611,7 +1651,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
                   disableEpisodeRanges || !remainder.starts_with("-") ? last : currentEpisode + 1};
 
               ProcessEpisodeRange(next, last, episode, episodeList,
-                                  m_advancedSettings->m_tvshowMultiPartEnumRegExp);
+                                  m_advancedSettings->m_tvshowMultiPartEnumRegExp, remainder);
 
               currentEpisode = episode.iEpisode;
               remainder = reg.GetMatch(3);
@@ -1653,15 +1693,18 @@ CVideoInfoScanner::~CVideoInfoScanner()
           else if ((regexp2pos < regexppos && regexp2pos != -1) || // episode match
                    (regexp2pos >= 0 && regexppos == -1))
           {
-            const int last{std::stoi(reg2.GetMatch(1))};
-            const int next{remainder.starts_with("-") && !disableEpisodeRanges ? currentEpisode + 1
-                                                                               : last};
+            const std::string result{reg2.GetMatch(2)};
+            const int last{std::stoi(result)};
+            const std::string prefix{StringUtils::ToLower(remainder.substr(0, 2))};
+            const int next{(prefix == "-e" || prefix == "-s") && !disableEpisodeRanges
+                               ? currentEpisode + 1
+                               : last};
 
             ProcessEpisodeRange(next, last, episode, episodeList,
-                                m_advancedSettings->m_tvshowMultiPartEnumRegExp);
+                                m_advancedSettings->m_tvshowMultiPartEnumRegExp, reg2.GetMatch(3));
 
             currentEpisode = episode.iEpisode;
-            offset += regexp2pos + reg2.GetFindLen();
+            offset += regexp2pos + static_cast<int>(reg2.GetMatch(1).length() + result.length());
           }
         }
       }

--- a/xbmc/video/test/TestVideoInfoScanner.cpp
+++ b/xbmc/video/test/TestVideoInfoScanner.cpp
@@ -29,18 +29,28 @@ struct TestEntry
 static const TestEntry TestData[] = {
     //season+episode
     {"foo.S02E03.mkv", {{2, 3}}, {{2, 3}}},
+    {"foo.S2E3.mkv", {{2, 3}}, {{2, 3}}},
+    {"foo.S02.E03.mkv", {{2, 3}}, {{2, 3}}},
+    {"foo.S02_E03.mkv", {{2, 3}}, {{2, 3}}},
+    {"foo.S02xE03.mkv", {{2, 3}}, {{2, 3}}},
+    {"foo.2x03.mkv", {{2, 3}}, {{2, 3}}},
     {"foo.203.mkv", {{2, 3}}, {{2, 3}}},
+    {"24 S01E01 12:00AM - 1:00AM.mkv", {{1, 1}}, {{1, 1}}},
+    {"Miracle Workers S01E02 13 Days.mkv", {{1, 2}}, {{1, 2}}},
     //episode only
     {"foo.Ep03.mkv", {{1, 3}}, {{1, 3}}},
     {"foo.Ep_03.mkv", {{1, 3}}, {{1, 3}}},
     {"foo.Part.III.mkv", {{1, 3}}, {{1, 3}}},
     {"foo.Part.3.mkv", {{1, 3}}, {{1, 3}}},
+    {"foo.pt.III.mkv", {{1, 3}}, {{1, 3}}},
+    {"foo.pt_IV.mkv", {{1, 4}}, {{1, 4}}},
     {"foo.E03.mkv", {{1, 3}}, {{1, 3}}},
     {"foo.2009.E03.mkv", {{1, 3}}, {{1, 3}}},
-    // multi-episode
+    // multi-episode (not ranges)
     {"The Legend of Korra - S01E01-02 - Welcome to Republic City & A Leaf in the Wind.mkv",
      {{1, 1}, {1, 2}},
      {{1, 1}, {1, 2}}},
+    {"foo s01e01-episode1.title-s01e02-episode2.title.mkv", {{1, 1}, {1, 2}}, {{1, 1}, {1, 2}}},
     {"foo.S01E01E02.mkv", {{1, 1}, {1, 2}}, {{1, 1}, {1, 2}}},
     {"foo.S01E03E04E05.mkv", {{1, 3}, {1, 4}, {1, 5}}, {{1, 3}, {1, 4}, {1, 5}}},
     {"foo.S02E01-S02E02.mkv", {{2, 1}, {2, 2}}, {{2, 1}, {2, 2}}},
@@ -52,37 +62,43 @@ static const TestEntry TestData[] = {
     {"foo 2x01x02.mkv", {{2, 1}, {2, 2}}, {{2, 1}, {2, 2}}},
     {"foo ep01-02.mkv", {{1, 1}, {1, 2}}, {{1, 1}, {1, 2}}},
     {"foo.S02E01S02E03.mkv", {{2, 1}, {2, 3}}, {{2, 1}, {2, 3}}},
-    // spanning episodes
-    {"foo.E03-05.mkv", {{1, 3}, {1, 4}, {1, 5}}, {{1, 3}, {1, 5}}},
-    {"foo.ep03-05.mkv", {{1, 3}, {1, 4}, {1, 5}}, {{1, 3}, {1, 5}}},
+    // spanning episode ranges
     {"foo.ep03-ep05.mkv", {{1, 3}, {1, 4}, {1, 5}}, {{1, 3}, {1, 5}}},
-    {"foo.5x03-5x05.mkv", {{5, 3}, {5, 4}, {5, 5}}, {{5, 3}, {5, 5}}},
-    {"foo.S05E03-05.mkv", {{5, 3}, {5, 4}, {5, 5}}, {{5, 3}, {5, 5}}},
     {"foo.S05E03-E05.mkv", {{5, 3}, {5, 4}, {5, 5}}, {{5, 3}, {5, 5}}},
     {"foo.S05E03-S05E05.mkv", {{5, 3}, {5, 4}, {5, 5}}, {{5, 3}, {5, 5}}},
     {"foo.S05E01-E03-E05.mkv", {{5, 1}, {5, 2}, {5, 3}, {5, 4}, {5, 5}}, {{5, 1}, {5, 3}, {5, 5}}},
     {"foo.S05E01-S05E03-S05E05.mkv",
      {{5, 1}, {5, 2}, {5, 3}, {5, 4}, {5, 5}},
      {{5, 1}, {5, 3}, {5, 5}}},
+    {"foo.5x03-5x05.mkv", {{5, 3}, {5, 4}, {5, 5}}, {{5, 3}, {5, 5}}},
+    // not ranges
+    {"foo.E03-05.mkv", {{1, 3}, {1, 5}}, {{1, 3}, {1, 5}}},
+    {"foo.ep03-05.mkv", {{1, 3}, {1, 5}}, {{1, 3}, {1, 5}}},
+    {"foo.S05E03-05.mkv", {{5, 3}, {5, 5}}, {{5, 3}, {5, 5}}},
     // multi-season
     {"foo.S00E100S05E03E04E05.mkv",
      {{0, 100}, {5, 3}, {5, 4}, {5, 5}},
      {{0, 100}, {5, 3}, {5, 4}, {5, 5}}},
     {"foo.S01E01E02S02E01.mkv", {{1, 1}, {1, 2}, {2, 1}}, {{1, 1}, {1, 2}, {2, 1}}},
-    {"foo.S00E01-04S05E03-E06.mkv",
+    {"foo.S00E01-E04S05E03-E06.mkv",
      {{0, 1}, {0, 2}, {0, 3}, {0, 4}, {5, 3}, {5, 4}, {5, 5}, {5, 6}},
      {{0, 1}, {0, 4}, {5, 3}, {5, 6}}},
-    // expected (partial) failure
+    // expected (partial) range failures
+    {"foo.S01E01-E100.mkv", {}, {{1, 1}, {1, 100}}}, // episode range too large
     {"foo.S01E01-S02E03.mkv", {}, {{1, 1}, {2, 3}}}, // cannot determine number of episodes in S01
     {"foo.S01E03-S01E01.mkv", {}, {{1, 3}, {1, 1}}}, // range backwards
     {"foo.S01E03-E01.mkv", {}, {{1, 3}, {1, 1}}}, // range backwards
     {"foo S00E01E03-S01E01.mkv", {{0, 1}}, {{0, 1}, {0, 3}, {1, 1}}}, // invalid range
-    {"foo.S00E01-04S01E01-S02E03.mkv",
+    {"foo.S00E01-E04S01E01-S02E03.mkv",
      {{0, 1}, {0, 2}, {0, 3}, {0, 4}},
      {{0, 1}, {0, 4}, {1, 1}, {2, 3}}}, // second range invalid
     {"foo.S01E03-S02E02S03E01-E04.mkv",
      {{3, 1}, {3, 2}, {3, 3}, {3, 4}},
-     {{1, 3}, {2, 2}, {3, 1}, {3, 4}}}}; // first range invalid
+     {{1, 3}, {2, 2}, {3, 1}, {3, 4}}}, // first range invalid
+    {"foo.S02E03-1080p.mkv", {{2, 3}}, {{2, 3}}}, // resolution
+    {"foo.S02E03-special.mkv", {{2, 3}}, {{2, 3}}}, // comment (starting with s)
+    {"foo.S02E03-extended.mkv", {{2, 3}}, {{2, 3}}}, // comment (starting with e)
+};
 
 class TestVideoInfoScanner : public Test,
                              public WithParamInterface<TestEntry>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Deal with some corner cases by improving range determination, limiting how ranges can be defined and instituting some safety checks on ranges.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Episode files named like this:

<img width="360" height="123" alt="image" src="https://github.com/user-attachments/assets/ae368043-d47e-4acc-9d68-10b50fda1aad" />

Would be misinterpreted as a range of 5-1080 etc...

This lead to library scanning delays. 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally. Test added.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
