### PR TITLE
RetroPlayer: Better game loop

### DIFF
--- a/xbmc/cores/RetroPlayer/playback/GameLoop.cpp
+++ b/xbmc/cores/RetroPlayer/playback/GameLoop.cpp
@@ -25,35 +25,46 @@ CGameLoop::CGameLoop(IGameLoopCallback* callback, double fps)
 
 CGameLoop::~CGameLoop()
 {
+  // Ensure the game loop is stopped when the object is destroyed
   Stop();
 }
 
 void CGameLoop::Start()
 {
+  // Start the thread by invoking the base class's Create method
   Create();
 }
 
 void CGameLoop::Stop()
 {
+  // Request to stop the thread
   StopThread(false);
+
+  // Wake up the thread if it's waiting on the sleep event
   m_sleepEvent.Set();
+
+  // Wait until the thread is fully stopped
   StopThread(true);
 }
 
 void CGameLoop::SetSpeed(double speedFactor)
 {
+  // Set the new speed factor
   m_speedFactor = speedFactor;
 
+  // Wake up the thread to apply the new speed immediately
   m_sleepEvent.Set();
 }
 
 void CGameLoop::PauseAsync()
 {
+  // Pause the game loop asynchronously by setting speed to 0
   SetSpeed(0.0);
 }
 
 void CGameLoop::Process(void)
 {
+  // Main game loop that runs until the thread is requested to stop
   while (!m_bStop)
   {
     if (m_speedFactor == 0.0)

--- a/xbmc/cores/RetroPlayer/playback/GameLoop.cpp
+++ b/xbmc/cores/RetroPlayer/playback/GameLoop.cpp
@@ -15,11 +15,17 @@ using namespace KODI;
 using namespace RETRO;
 using namespace std::chrono_literals;
 
-#define DEFAULT_FPS 60 // In case fps is 0 (shouldn't happen)
-#define FOREVER_MS (7 * 24 * 60 * 60 * 1000) // 1 week is large enough
+namespace
+{
+// Default FPS value in case fps is 0 (which shouldn't happen)
+constexpr double DEFAULT_FPS = 60.0;
+
+// Duration to sleep while the game loop is paused
+constexpr auto PAUSE_SLEEP = 5s;
+} // namespace
 
 CGameLoop::CGameLoop(IGameLoopCallback* callback, double fps)
-  : CThread("GameLoop"), m_callback(callback), m_fps(fps ? fps : DEFAULT_FPS), m_speedFactor(0.0)
+  : CThread("GameLoop"), m_callback(callback), m_fps(fps ? fps : DEFAULT_FPS)
 {
 }
 
@@ -50,7 +56,7 @@ void CGameLoop::Stop()
 void CGameLoop::SetSpeed(double speedFactor)
 {
   // Set the new speed factor
-  m_speedFactor = speedFactor;
+  m_speedFactor.store(speedFactor);
 
   // Wake up the thread to apply the new speed immediately
   m_sleepEvent.Set();
@@ -67,75 +73,67 @@ void CGameLoop::Process(void)
   // Main game loop that runs until the thread is requested to stop
   while (!m_bStop)
   {
-    if (m_speedFactor == 0.0)
+    // If the speed factor has changed, reset the last frame time and update
+    // the loop speed factor
+    const double speed = m_speedFactor.load();
+    if (m_loopSpeedFactor != speed)
     {
-      m_lastFrameMs = 0.0;
-      m_sleepEvent.Wait(5000ms);
+      // Reset last frame time
+      m_lastFrameUs = std::chrono::microseconds::zero();
+
+      // Update loop speed factor
+      m_loopSpeedFactor = speed;
+    }
+
+    // If the game is paused, wait before checking again
+    if (m_loopSpeedFactor == 0.0)
+    {
+      // Wait for a long duration if paused
+      m_sleepEvent.Wait(PAUSE_SLEEP);
     }
     else
     {
-      if (m_speedFactor > 0.0)
+      // If it's the first frame or after a reset, set the last frame time to
+      // the current time
+      if (m_lastFrameUs == std::chrono::microseconds::zero())
+        m_lastFrameUs = NowUs();
+
+      // Trigger the appropriate callback depending on the direction of time
+      // (forward or rewind)
+      if (m_loopSpeedFactor > 0.0)
         m_callback->FrameEvent();
-      else if (m_speedFactor < 0.0)
+      else if (m_loopSpeedFactor < 0.0)
         m_callback->RewindEvent();
 
-      if (m_lastFrameMs > 0.0)
-      {
-        m_lastFrameMs += FrameTimeMs();
-        m_adjustTime = m_lastFrameMs - NowMs();
-      }
-      else
-      {
-        m_lastFrameMs = NowMs();
-        m_adjustTime = 0.0;
-      }
+      // Calculate the time for the next frame by adding the frame duration to
+      // the last frame time
+      const std::chrono::microseconds nextFrameUs = m_lastFrameUs + FrameTimeUs();
 
-      // Calculate sleep time
-      double sleepTimeMs = SleepTimeMs();
+      // Update the last frame time to ensure accurate timing for the next loop
+      // iteration
+      m_lastFrameUs = nextFrameUs;
 
-      // Sleep at least 1 ms to avoid sleeping forever
-      while (sleepTimeMs > 1.0)
-      {
-        m_sleepEvent.Wait(std::chrono::milliseconds(static_cast<unsigned int>(sleepTimeMs)));
+      // Calculate how much time to sleep before the next frame should be processed
+      const std::chrono::microseconds sleepTimeUs = (nextFrameUs - NowUs());
 
-        if (m_bStop)
-          break;
-
-        // Speed may have changed, update sleep time
-        sleepTimeMs = SleepTimeMs();
-      }
+      // Only sleep if there is time left before the next frame
+      if (sleepTimeUs > std::chrono::microseconds::zero())
+        m_sleepEvent.Wait(sleepTimeUs);
     }
   }
 }
 
-double CGameLoop::FrameTimeMs() const
+std::chrono::microseconds CGameLoop::FrameTimeUs() const
 {
-  if (m_speedFactor != 0.0)
-    return 1000.0 / m_fps / std::abs(m_speedFactor);
-  else
-    return 1000.0 / m_fps / 1.0;
+  // Calculate the duration of one frame in microseconds based on the FPS and
+  // speed factor
+  const double factor = m_loopSpeedFactor != 0.0 ? std::abs(m_loopSpeedFactor) : 1.0;
+  return std::chrono::duration_cast<std::chrono::microseconds>(1s / m_fps / factor);
 }
 
-double CGameLoop::SleepTimeMs() const
+std::chrono::microseconds CGameLoop::NowUs() const
 {
-  // Calculate next frame time
-  const double nextFrameMs = m_lastFrameMs + FrameTimeMs();
-
-  // Calculate sleep time
-  double sleepTimeMs = (nextFrameMs - NowMs()) + m_adjustTime;
-
-  // Reset adjust time
-  m_adjustTime = 0.0;
-
-  // Positive or zero
-  sleepTimeMs = (sleepTimeMs >= 0.0 ? sleepTimeMs : 0.0);
-
-  return sleepTimeMs;
-}
-
-double CGameLoop::NowMs() const
-{
-  return std::chrono::duration<double, std::milli>(
-             std::chrono::steady_clock::now().time_since_epoch())
-      .count();
+  // Get the current time in microseconds since the steady clock epoch
+  return std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::steady_clock::now().time_since_epoch());
 }

--- a/xbmc/cores/RetroPlayer/playback/GameLoop.h
+++ b/xbmc/cores/RetroPlayer/playback/GameLoop.h
@@ -17,6 +17,15 @@ namespace KODI
 {
 namespace RETRO
 {
+/*!
+ * \brief Interface for the game loop callback
+ *
+ * The IGameLoopCallback interface provides the necessary methods for handling
+ * frame events within the game loop.
+ *
+ * Implementers must define how the next frame (FrameEvent) and previous frame
+ * (RewindEvent) are processed.
+ */
 class IGameLoopCallback
 {
 public:
@@ -33,6 +42,17 @@ public:
   virtual void RewindEvent() = 0;
 };
 
+/*!
+ * \brief The game loop class
+ *
+ * CGameLoop is responsible for managing the timing and execution of frame
+ * updates in a game or emulator.
+ *
+ * Inside the Process method, the loop checks for changes in the speed factor,
+ * updates frame timing, and uses precise sleep intervals to maintain a
+ * consistent frame rate while invoking the appropriate callbacks for frame
+ * events.
+ */
 class CGameLoop : protected CThread
 {
 public:

--- a/xbmc/cores/RetroPlayer/playback/GameLoop.h
+++ b/xbmc/cores/RetroPlayer/playback/GameLoop.h
@@ -12,6 +12,7 @@
 #include "threads/Thread.h"
 
 #include <atomic>
+#include <chrono>
 
 namespace KODI
 {
@@ -65,7 +66,7 @@ public:
 
   double FPS() const { return m_fps; }
 
-  double GetSpeed() const { return m_speedFactor; }
+  double GetSpeed() const { return m_speedFactor.load(); }
   void SetSpeed(double speedFactor);
   void PauseAsync();
 
@@ -74,15 +75,14 @@ protected:
   void Process() override;
 
 private:
-  double FrameTimeMs() const;
-  double SleepTimeMs() const;
-  double NowMs() const;
+  std::chrono::microseconds FrameTimeUs() const;
+  std::chrono::microseconds NowUs() const;
 
   IGameLoopCallback* const m_callback;
   const double m_fps;
-  std::atomic<double> m_speedFactor;
-  double m_lastFrameMs = 0.0;
-  mutable double m_adjustTime = 0.0;
+  std::atomic<double> m_speedFactor{0.0};
+  double m_loopSpeedFactor{0.0};
+  std::chrono::microseconds m_lastFrameUs{std::chrono::microseconds::zero()};
   CEvent m_sleepEvent;
 };
 } // namespace RETRO


### PR DESCRIPTION
## Description

Switches game-loop timing from `double`-millisecond math to `chrono::microseconds` + atomics.

Entire logic is from https://github.com/xbmc/xbmc/pull/25460. Comments, stylization and atomic improvements by myself, as I approach being an AI.

Benefits:

* Previously, jitter was introduced by millisecond-level rounding errors used to accumulate every frame.
* With the new loop, we do one `Wait()` call without a spin loop, which probably cuts OS wake-up variance from ~1-3ms to < 0.2ms.
* Thread safety enforced throughout, preventing mid-sleep hiccups, keeping frame cadence even during fast-forward/rewind.

CC @KOPRajs @GTechAlpha 

## Motivation and context

Fixes long-standing timing drift, rewind stalls, and rare crashes seen in high-speed cores (e.g. PCSX ReARMed). Cleans up code for easier future tweaks.

## How has this been tested?

Integrated in my test builds since https://github.com/xbmc/xbmc/pull/25460 was open in July 2024.

## What is the effect on users?

* Fixed minor stutters during gameplay

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
