### PR TITLE
Setting to control watched/unwatched status of upgraded copies of watched movies/episodes / fix movies

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -8803,7 +8803,10 @@ msgctxt "#14250"
 msgid "Audio Decoder"
 msgstr ""
 
-#empty string with id 14251
+#: system/settings/settings.xml
+msgctxt "#14251"
+msgid "Preserve play count / last played on media upgrade"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14252"
@@ -19936,7 +19939,11 @@ msgctxt "#36158"
 msgid "Enable DXVA2 hardware decoding of video files."
 msgstr ""
 
-#empty string with id 36159
+#. Description of setting with label #14251 "Preserve play count / last played on media upgrade"
+#: system/settings/settings.xml
+msgctxt "#36159"
+msgid "Disabled: additional copies of movies and episodes are initially unwatched.[CR]Enabled: the play count and last played date of the original media are copied to additional copies scanned into the library."
+msgstr ""
 
 #. Description of setting with label #13429 "Allow hardware acceleration (VDADecoder)"
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1150,6 +1150,11 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
+        <setting id="videolibrary.preserveplaycount" type="boolean" label="14251" help="36159">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
       </group>
       <group id="2" label="744">
         <setting id="myvideos.stackvideos" type="boolean" label="20435" help="36182">

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -787,7 +787,8 @@ JSONRPC_STATUS CVideoLibrary::SetEpisodeDetails(const std::string &method, ITran
   std::set<std::string, std::less<>> updatedDetails;
   UpdateVideoTag(parameterObject, infos, artwork, removedArtwork, updatedDetails);
 
-  if (videodatabase.SetDetailsForEpisode(infos, artwork, tvshowid, id) <= 0)
+  if (videodatabase.SetDetailsForEpisode(infos, artwork, tvshowid, id, MediaUpgradeAction::NONE) <=
+      0)
     return InternalError;
 
   if (!videodatabase.RemoveArtForItem(infos.m_iDbId, MediaTypeEpisode, removedArtwork))

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -99,6 +99,7 @@ public:
   static constexpr auto SETTING_VIDEOLIBRARY_IGNOREVIDEOVERSIONS =
       "videolibrary.ignorevideoversions";
   static constexpr auto SETTING_VIDEOLIBRARY_IGNOREVIDEOEXTRAS = "videolibrary.ignorevideoextras";
+  static constexpr auto SETTING_VIDEOLIBRARY_PRESERVEPLAYCOUNT = "videolibrary.preserveplaycount";
   static constexpr auto SETTING_LOCALE_AUDIOLANGUAGE = "locale.audiolanguage";
   static constexpr auto SETTING_VIDEOPLAYER_PREFERDEFAULTFLAG = "videoplayer.preferdefaultflag";
   static constexpr auto SETTING_VIDEOPLAYER_AUTOPLAYNEXTITEM = "videoplayer.autoplaynextitem";

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2794,7 +2794,7 @@ int CVideoDatabase::SetDetailsForMovie(CVideoInfoTag& details,
 
     SetArtForItem(idMovie, MediaTypeMovie, artwork);
 
-    if (upgradeAction == MediaUpgradeAction::PRESERVE_PLAYCOUNT && !details.HasUniqueID() &&
+    if (upgradeAction == MediaUpgradeAction::PRESERVE_PLAYCOUNT && details.HasUniqueID() &&
         details.HasYear())
     { // query DB for any movies matching online id and year
       std::string strSQL = PrepareSQL("SELECT files.playCount, files.lastPlayed "

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2707,7 +2707,7 @@ int CVideoDatabase::SetDetailsForItem(int id,
     return -1;
 
   if (mediaType == MediaTypeMovie)
-    return SetDetailsForMovie(details, artwork, id);
+    return SetDetailsForMovie(details, artwork, id, MediaUpgradeAction::NONE);
   else if (mediaType == MediaTypeVideoCollection)
     return SetDetailsForMovieSet(details, artwork, id);
   else if (mediaType == MediaTypeTvShow)
@@ -2721,7 +2721,7 @@ int CVideoDatabase::SetDetailsForItem(int id,
   else if (mediaType == MediaTypeSeason)
     return SetDetailsForSeason(details, artwork, details.m_iIdShow, id);
   else if (mediaType == MediaTypeEpisode)
-    return SetDetailsForEpisode(details, artwork, details.m_iIdShow, id);
+    return SetDetailsForEpisode(details, artwork, details.m_iIdShow, id, MediaUpgradeAction::NONE);
   else if (mediaType == MediaTypeMusicVideo)
     return SetDetailsForMusicVideo(details, artwork, id);
 
@@ -2730,7 +2730,8 @@ int CVideoDatabase::SetDetailsForItem(int id,
 
 int CVideoDatabase::SetDetailsForMovie(CVideoInfoTag& details,
                                        const KODI::ART::Artwork& artwork,
-                                       int idMovie /* = -1 */)
+                                       int idMovie,
+                                       MediaUpgradeAction upgradeAction)
 {
   const auto filePath = details.GetPath();
 
@@ -2793,7 +2794,8 @@ int CVideoDatabase::SetDetailsForMovie(CVideoInfoTag& details,
 
     SetArtForItem(idMovie, MediaTypeMovie, artwork);
 
-    if (!details.HasUniqueID() && details.HasYear())
+    if (upgradeAction == MediaUpgradeAction::PRESERVE_PLAYCOUNT && !details.HasUniqueID() &&
+        details.HasYear())
     { // query DB for any movies matching online id and year
       std::string strSQL = PrepareSQL("SELECT files.playCount, files.lastPlayed "
                                       "FROM movie "
@@ -3355,7 +3357,8 @@ bool CVideoDatabase::DeleteFile(int idFile)
 int CVideoDatabase::SetDetailsForEpisode(CVideoInfoTag& details,
                                          const KODI::ART::Artwork& artwork,
                                          int idShow,
-                                         int idEpisode /* = -1 */)
+                                         int idEpisode,
+                                         MediaUpgradeAction upgradeAction)
 {
   const auto filePath = details.GetPath();
 
@@ -3402,7 +3405,8 @@ int CVideoDatabase::SetDetailsForEpisode(CVideoInfoTag& details,
 
     SetArtForItem(idEpisode, MediaTypeEpisode, artwork);
 
-    if (details.m_iEpisode != -1 && details.m_iSeason != -1)
+    if (upgradeAction == MediaUpgradeAction::PRESERVE_PLAYCOUNT && details.m_iEpisode != -1 &&
+        details.m_iSeason != -1)
     { // query DB for any episodes matching idShow, Season and Episode
       std::string strSQL = PrepareSQL("SELECT files.playCount, files.lastPlayed "
                                       "FROM episode INNER JOIN files ON files.idFile=episode.idFile "

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -490,6 +490,12 @@ enum class DeleteMovieHashAction
   HASH_PRESERVE
 };
 
+enum class MediaUpgradeAction
+{
+  NONE,
+  PRESERVE_PLAYCOUNT
+};
+
 #define COMPARE_PERCENTAGE     0.90f // 90%
 #define COMPARE_PERCENTAGE_MIN 0.50f // 50%
 
@@ -665,7 +671,8 @@ public:
 
   int SetDetailsForMovie(CVideoInfoTag& details,
                          const KODI::ART::Artwork& artwork,
-                         int idMovie = -1);
+                         int idMovie,
+                         MediaUpgradeAction upgradeAction);
   int SetDetailsForMovieSet(const CVideoInfoTag& details,
                             const KODI::ART::Artwork& artwork,
                             int idSet = -1);
@@ -696,7 +703,8 @@ public:
   int SetDetailsForEpisode(CVideoInfoTag& details,
                            const KODI::ART::Artwork& artwork,
                            int idShow,
-                           int idEpisode = -1);
+                           int idEpisode,
+                           MediaUpgradeAction upgradeAction);
   int SetFileForMedia(const std::string& fileAndPath,
                       VideoDbContentType type,
                       int mediaId,

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -198,6 +198,7 @@ CVideoInfoScanner::CVideoInfoScanner()
 
   m_ignoreVideoVersions = settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_IGNOREVIDEOVERSIONS);
   m_ignoreVideoExtras = settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_IGNOREVIDEOEXTRAS);
+  m_preservePlayCount = settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_PRESERVEPLAYCOUNT);
 }
 
 CVideoInfoScanner::~CVideoInfoScanner()
@@ -1799,7 +1800,9 @@ CVideoInfoScanner::~CVideoInfoScanner()
             StringUtils::Format(g_localizeStrings.Get(29995), movieDetails.m_strTitle, discNum);
       }
 
-      lResult = m_database.SetDetailsForMovie(movieDetails, art);
+      lResult = m_database.SetDetailsForMovie(
+          movieDetails, art, -1,
+          m_preservePlayCount ? MediaUpgradeAction::PRESERVE_PLAYCOUNT : MediaUpgradeAction::NONE);
       movieDetails.m_iDbId = lResult;
       movieDetails.m_type = MediaTypeMovie;
 
@@ -1843,9 +1846,12 @@ CVideoInfoScanner::~CVideoInfoScanner()
       {
         // we add episode then set details, as otherwise set details will delete the
         // episode then add, which breaks multi-episode files.
-        int idShow = showInfo ? showInfo->m_iDbId : -1;
-        int idEpisode = m_database.AddNewEpisode(idShow, movieDetails);
-        lResult = m_database.SetDetailsForEpisode(movieDetails, art, idShow, idEpisode);
+        const int idShow = showInfo ? showInfo->m_iDbId : -1;
+        const int idEpisode = m_database.AddNewEpisode(idShow, movieDetails);
+        lResult = m_database.SetDetailsForEpisode(movieDetails, art, idShow, idEpisode,
+                                                  m_preservePlayCount
+                                                      ? MediaUpgradeAction::PRESERVE_PLAYCOUNT
+                                                      : MediaUpgradeAction::NONE);
         movieDetails.m_iDbId = lResult;
         movieDetails.m_type = MediaTypeEpisode;
         movieDetails.m_strShowTitle = showInfo ? showInfo->m_strTitle : "";

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -311,5 +311,6 @@ namespace KODI::VIDEO
     std::set<int> m_pathsToClean;
     std::shared_ptr<CAdvancedSettings> m_advancedSettings;
     CVideoDatabase::ScraperCache m_scraperCache;
+    bool m_preservePlayCount{true};
   };
   } // namespace KODI::VIDEO


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The upgrades of movies are added unwatched to the library but upgrades of episodes are added watched if the library contains a watched earlier copy.

Preserving play count / last played date was added by #2457 but broken unintentionally for movies since #10000.

Solved with a setting to switch the playcount / last played copy on or off, and a fix of the inverted logic that broke the feature for movies.
The setting is defaulted to off since I don't remember complaints after the feature was broken and it works better when taking versions into account. I also find it more convenient that way to easily locate upgraded episodes to be watched.

If nobody cares about the feature then the code could be removed instead of made more complex with a setting.

Used the opportunity to finetune a bit the logic:
- If there are multiple existing episodes/movies, use the most recently added
- Copy the last played date even if the play count is zero/NULL (ie never played to the end)
- The json-rpc path should not have been modified originally since that would override the parameters provided by the json client.

note: the existing logic of SetDetailsForMovie that matches movies on year + unique id without the metadata provider name (ex. imdb) is questionable but outside of the scope of this PR.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Issues found while reviewing the code that stores play count / last played date for other PR.

A proper system to track upgrades and filter upgrades in the GUI would be better but also a lot more work.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Setting on and off, "Update library" from library views and "Scan for new content" from Videos, on both movies and episodes, with and without existing identical movies/episodes.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Setting to control if the watched information of a movie or episode is copied to additional copies added to the library. Remain unwatched by default (same as current behavior for movies).

## Screenshots (if appropriate):
new setting in Media/Videos, Advanced level:

<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/52d2de3d-9c81-4af6-8112-e85ace051e29" />

suggestions for the setting name / description are welcome.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
