### PR TITLE
[AudioEngine] PipeWire: synchronize to Process() callback

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
@@ -40,12 +40,8 @@ public:
   pw_stream_state GetState();
   void SetActive(bool active);
 
-  pw_buffer* DequeueBuffer();
-  void QueueBuffer(pw_buffer* buffer);
-
-  bool IsDriving() const;
-
-  bool TriggerProcess() const;
+  pw_buffer* GetBuffer();
+  void QueueBuffer();
 
   void Flush(bool drain);
 
@@ -55,6 +51,8 @@ public:
 
   pw_time GetTime() const;
 
+  bool NeedsData() const;
+
 private:
   static void StateChanged(void* userdata,
                            enum pw_stream_state old,
@@ -62,6 +60,7 @@ private:
                            const char* error);
   static void Process(void* userdata);
   static void Drained(void* userdata);
+  void Stop();
 
   static pw_stream_events CreateStreamEvents();
 
@@ -70,6 +69,11 @@ private:
   const pw_stream_events m_streamEvents;
 
   spa_hook m_streamListener;
+
+  pw_buffer* m_buffer;
+
+  bool m_waiting;
+  bool m_running;
 
   struct PipewireStreamDeleter
   {

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.cpp
@@ -57,3 +57,8 @@ void CPipewireThreadLoop::Signal(bool accept)
 {
   pw_thread_loop_signal(m_mainloop.get(), accept);
 }
+
+void CPipewireThreadLoop::Accept()
+{
+  pw_thread_loop_accept(m_mainloop.get());
+}

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h
@@ -34,6 +34,7 @@ public:
 
   int Wait(std::chrono::nanoseconds timeout);
   void Signal(bool accept);
+  void Accept();
 
 private:
   struct PipewireThreadLoopDeleter


### PR DESCRIPTION
## Description

Pull data synchronously with the stream's Process() callback, instead of pushing buffers asynchronously. This simplifies the pw_stream API usage. 

The previous code uses the pw_stream API in a bit of an "expert" mode and not quite correctly, e.g. pw_time::delay cannot be used in determining when the sink is full and should block.

Instead, queue one buffer for each Process() cycle, with exactly the requested number of samples. Then we don't need extra buffers, so don't request them.

Adjust CPipewireStream to make this a bit easier. Have Process() block until a buffer is queued. This uses the loop.Signal(true) <-> loop.Accept() condition variable in pw_thread_loop.

Bump requested PW_KEY_NODE_LATENCY up: this is the request for the maximum total software buffer delay, so for media playback it doesn't need to be small.

## Motivation and context

Fixes audio stutter for sinks that report long output latency (eg. Bluetooth). This change also reduces the actual audio output latency, since we only queue the amount of audio needed.

Fixes #27034

## How has this been tested?

PCM audio is tested on desktop configuration, with various Pipewire versions & force-quantum/force-rate settings.

- [ ] **Passthrough audio is not tested** -- in theory it should be OK, but this needs to be tested on HW

I don't have passthrough-capable audio equipment, so help with testing this is appreciated.

<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?

Fixes audio output with Pipewire backend on some Bluetooth output devices.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
