### PR TITLE
[profiles] Profiles window: Prompt before reloading the active profile

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6743,7 +6743,13 @@ msgctxt "#13201"
 msgid "Delete profile '{0:s}'?"
 msgstr ""
 
-#empty strings from id 13202 to 13203
+#. Label for reload profile confirmation dialog
+#: xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+msgctxt "#13202"
+msgid "Reload profile '{0:s}'?"
+msgstr ""
+
+#empty string with id 13203
 
 #. used by several skins
 msgctxt "#13204"

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -24,7 +24,6 @@
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPowerHandling.h"
 #include "dialogs/GUIDialogKaiToast.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "events/EventLog.h"
 #include "events/EventLogManager.h"
 #include "favourites/FavouritesService.h" //! @todo Remove me
@@ -469,22 +468,11 @@ bool CProfileManager::DeleteProfile(unsigned int index)
 {
   std::unique_lock lock(m_critical);
   const CProfile *profile = GetProfile(index);
-  if (profile == NULL)
+  if (!profile)
+  {
+    CLog::LogF(LOGERROR, "Profile not deleted. Invalid profile id {}", index);
     return false;
-
-  CGUIDialogYesNo* dlgYesNo = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogYesNo>(WINDOW_DIALOG_YES_NO);
-  if (dlgYesNo == NULL)
-    return false;
-
-  const std::string& str = g_localizeStrings.Get(13201);
-  dlgYesNo->SetHeading(CVariant{13200});
-  dlgYesNo->SetLine(0, CVariant{StringUtils::Format(str, profile->getName())});
-  dlgYesNo->SetLine(1, CVariant{""});
-  dlgYesNo->SetLine(2, CVariant{""});
-  dlgYesNo->Open();
-
-  if (!dlgYesNo->IsConfirmed())
-    return false;
+  }
 
   // fall back to master profile if necessary
   if (static_cast<int>(index) == m_autoLoginProfile)

--- a/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
+++ b/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
@@ -20,10 +20,12 @@
 #include "guilib/LocalizeStrings.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "profiles/Profile.h"
 #include "profiles/ProfileManager.h"
 #include "profiles/dialogs/GUIDialogProfileSettings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "windows/GUIWindowFileManager.h"
@@ -58,7 +60,7 @@ void CGUIWindowSettingsProfile::OnPopupMenu(int iItem)
 {
   const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  if (iItem == (int)profileManager->GetNumberOfProfiles())
+  if (iItem == static_cast<int>(profileManager->GetNumberOfProfiles()))
     return;
 
   // popup the context menu
@@ -70,6 +72,16 @@ void CGUIWindowSettingsProfile::OnPopupMenu(int iItem)
   int choice = CGUIDialogContextMenu::ShowAndGetChoice(choices);
   if (choice == 1)
   {
+    // Reload of active profile?
+    if (iItem == static_cast<int>(profileManager->GetCurrentProfileIndex()))
+    {
+      const std::string msg{StringUtils::Format(g_localizeStrings.Get(13202),
+                                                profileManager->GetProfile(iItem)->getName())};
+      using namespace KODI::MESSAGING::HELPERS;
+      if (ShowYesNoDialogText(CVariant{13200} /* Profiles */, CVariant{msg} /* Reload profile?*/) !=
+          DialogResponse::CHOICE_YES)
+        return;
+    }
     CServiceBroker::GetAppMessenger()->PostMsg(TMSG_LOADPROFILE, iItem);
     return;
   }

--- a/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
+++ b/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
@@ -88,6 +88,13 @@ void CGUIWindowSettingsProfile::OnPopupMenu(int iItem)
 
   if (choice == 2)
   {
+    const std::string msg{StringUtils::Format(g_localizeStrings.Get(13201),
+                                              profileManager->GetProfile(iItem)->getName())};
+    using namespace KODI::MESSAGING::HELPERS;
+    if (ShowYesNoDialogText(CVariant{13200} /* Profiles */, CVariant{msg} /* Delete profile?*/) !=
+        DialogResponse::CHOICE_YES)
+      return;
+
     if (profileManager->DeleteProfile(iItem))
       iItem--;
   }


### PR DESCRIPTION
## Description
A small usability improvement. Show a confirmation dialog before the currently active profile gets reloaded from Profiles window.

Second commit is just a small refactoring to move existing GUI code to prompt for deletion of a profile where it belongs. ;-)

## Motivation and context
Make users aware that they are about to reload the currently active profile, which actually technically works but might not be intended.

## How has this been tested?
Compile, run, check whether the dialog appears and the two exit options behave as expected.

## What is the effect on users?
To get the chance to cancel the reload of the active profile in case this was unintentionally.

@emveepee fyi

## Screenshots (if appropriate):
<img width="1680" height="1050" alt="Screenshot 2025-08-03 at 11 26 16" src="https://github.com/user-attachments/assets/69c83c2a-f74f-4ddd-b4fc-0fa3e5232dff" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
