### PR TITLE
Improve Smart Playlist Handling of NULL-able  Fields + Treat 0 as Not Rated

### DIFF
--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -1136,9 +1136,12 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
     query = db.PrepareSQL(negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND streamdetails.iStreamType = %i GROUP BY streamdetails.idFile HAVING COUNT(streamdetails.iStreamType) " + parameter + ")",CStreamDetail::SUBTITLE);
   else if (m_field == FieldHdrType)
     query = negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND strHdrType " + parameter + ")";
-  if (m_field == FieldPlaycount && strType != "songs" && strType != "albums" && strType != "tvshows")
-  { // playcount IS stored as NULL OR number IN video db
-    const std::string field = GetField(FieldPlaycount, strType);
+  if ((m_field == FieldPlaycount && strType != "songs" && strType != "albums" &&
+       strType != "tvshows") ||
+      m_field == FieldUserRating)
+  {
+    // playcount and userrating are stored as NULL or > 0 number IN video db
+    const std::string field = GetField(m_field, strType);
 
     if ((m_operator == OPERATOR_EQUALS && param == "0") ||
         (m_operator == OPERATOR_DOES_NOT_EQUAL && param != "0") ||

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -1137,12 +1137,17 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
     query = negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND strHdrType " + parameter + ")";
   if (m_field == FieldPlaycount && strType != "songs" && strType != "albums" && strType != "tvshows")
   { // playcount IS stored as NULL OR number IN video db
+    const std::string field = GetField(FieldPlaycount, strType);
+
     if ((m_operator == OPERATOR_EQUALS && param == "0") ||
         (m_operator == OPERATOR_DOES_NOT_EQUAL && param != "0") ||
         (m_operator == OPERATOR_LESS_THAN))
     {
-      std::string field = GetField(FieldPlaycount, strType);
       query = field + " IS NULL OR " + field + parameter;
+    }
+    else
+    {
+      query = field + " IS NOT NULL AND " + field + parameter;
     }
   }
   if (query.empty())

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -934,6 +934,19 @@ std::string CSmartPlaylistRule::FormatYearQuery(const std::string& field,
   return query;
 }
 
+namespace
+{
+std::string FormatNullableDate(const std::string& field,
+                               CDatabaseQueryRule::SearchOperator oper,
+                               const std::string& parameter)
+{
+  if (oper == OPERATOR_LESS_THAN || oper == OPERATOR_BEFORE || oper == OPERATOR_NOT_IN_THE_LAST)
+    return field + " IS NULL OR " + field + parameter;
+  else
+    return field + " IS NOT NULL AND " + field + parameter;
+}
+} // namespace
+
 std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, const std::string &oper, const std::string &param,
                                                  const CDatabase &db, const std::string &strType) const
 {
@@ -951,10 +964,8 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
       query = negate + " EXISTS (SELECT 1 FROM song_artist, artist WHERE song_artist.idSong = " + GetField(FieldId, strType) + " AND song_artist.idArtist = artist.idArtist AND artist.strArtist" + parameter + ")";
     else if (m_field == FieldAlbumArtist)
       query = negate + " EXISTS (SELECT 1 FROM album_artist, artist WHERE album_artist.idAlbum = " + table + ".idAlbum AND album_artist.idArtist = artist.idArtist AND artist.strArtist" + parameter + ")";
-    else if (m_field == FieldLastPlayed &&
-             (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE ||
-              m_operator == OPERATOR_NOT_IN_THE_LAST))
-      query = GetField(m_field, strType) + " is NULL or " + GetField(m_field, strType) + parameter;
+    else if (m_field == FieldLastPlayed)
+      query = FormatNullableDate(GetField(m_field, strType), m_operator, parameter);
     else if (m_field == FieldSource)
       query = negate + " EXISTS (SELECT 1 FROM album_source, source WHERE album_source.idAlbum = " + table + ".idAlbum AND album_source.idSource = source.idSource AND source.strName" + parameter + ")";
     else if (m_field == FieldYear || m_field == FieldOrigYear)
@@ -980,10 +991,8 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
       query = negate + " EXISTS (SELECT 1 FROM album_artist, artist WHERE album_artist.idAlbum = " + GetField(FieldId, strType) + " AND album_artist.idArtist = artist.idArtist AND artist.strArtist" + parameter + ")";
     else if (m_field == FieldPath)
       query = negate + " EXISTS (SELECT 1 FROM song JOIN path on song.idpath = path.idpath WHERE song.idAlbum = " + GetField(FieldId, strType) + " AND path.strPath" + parameter + ")";
-    else if (m_field == FieldLastPlayed &&
-             (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE ||
-              m_operator == OPERATOR_NOT_IN_THE_LAST))
-      query = GetField(m_field, strType) + " is NULL or " + GetField(m_field, strType) + parameter;
+    else if (m_field == FieldLastPlayed)
+      query = FormatNullableDate(GetField(m_field, strType), m_operator, parameter);
     else if (m_field == FieldSource)
       query = negate + " EXISTS (SELECT 1 FROM album_source, source WHERE album_source.idAlbum = " + GetField(FieldId, strType) + " AND album_source.idSource = source.idSource AND source.strName" + parameter + ")";
     else if (m_field == FieldDiscTitle)
@@ -1043,10 +1052,8 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
       query = negate + FormatLinkQuery("studio", "studio", MediaTypeMovie, GetField(FieldId, strType), parameter);
     else if (m_field == FieldCountry)
       query = negate + FormatLinkQuery("country", "country", MediaTypeMovie, GetField(FieldId, strType), parameter);
-    else if ((m_field == FieldLastPlayed || m_field == FieldDateAdded) &&
-             (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE ||
-              m_operator == OPERATOR_NOT_IN_THE_LAST))
-      query = GetField(m_field, strType) + " IS NULL OR " + GetField(m_field, strType) + parameter;
+    else if (m_field == FieldLastPlayed || m_field == FieldDateAdded)
+      query = FormatNullableDate(GetField(m_field, strType), m_operator, parameter);
     else if (m_field == FieldTag)
       query = negate + FormatLinkQuery("tag", "tag", MediaTypeMovie, GetField(FieldId, strType), parameter);
   }
@@ -1062,10 +1069,8 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
       query = negate + FormatLinkQuery("studio", "studio", MediaTypeMusicVideo, GetField(FieldId, strType), parameter);
     else if (m_field == FieldDirector)
       query = negate + FormatLinkQuery("director", "actor", MediaTypeMusicVideo, GetField(FieldId, strType), parameter);
-    else if ((m_field == FieldLastPlayed || m_field == FieldDateAdded) &&
-             (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE ||
-              m_operator == OPERATOR_NOT_IN_THE_LAST))
-      query = GetField(m_field, strType) + " IS NULL OR " + GetField(m_field, strType) + parameter;
+    else if (m_field == FieldLastPlayed || m_field == FieldDateAdded)
+      query = FormatNullableDate(GetField(m_field, strType), m_operator, parameter);
     else if (m_field == FieldTag)
       query = negate + FormatLinkQuery("tag", "tag", MediaTypeMusicVideo, GetField(FieldId, strType), parameter);
   }
@@ -1083,10 +1088,8 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
       query = negate + FormatLinkQuery("studio", "studio", MediaTypeTvShow, GetField(FieldId, strType), parameter);
     else if (m_field == FieldMPAA)
       query = negate + " (" + GetField(m_field, strType) + parameter + ")";
-    else if ((m_field == FieldLastPlayed || m_field == FieldDateAdded) &&
-             (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE ||
-              m_operator == OPERATOR_NOT_IN_THE_LAST))
-      query = GetField(m_field, strType) + " IS NULL OR " + GetField(m_field, strType) + parameter;
+    else if (m_field == FieldLastPlayed || m_field == FieldDateAdded)
+      query = FormatNullableDate(GetField(m_field, strType), m_operator, parameter);
     else if (m_field == FieldPlaycount)
       query = "CASE WHEN COALESCE(" + GetField(FieldNumberOfEpisodes, strType) + " - " + GetField(FieldNumberOfWatchedEpisodes, strType) + ", 0) > 0 THEN 0 ELSE 1 END " + parameter;
     else if (m_field == FieldTag)
@@ -1106,10 +1109,8 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
       query = negate + FormatLinkQuery("actor", "actor", MediaTypeEpisode, GetField(FieldId, strType), parameter);
     else if (m_field == FieldWriter)
       query = negate + FormatLinkQuery("writer", "actor", MediaTypeEpisode, GetField(FieldId, strType), parameter);
-    else if ((m_field == FieldLastPlayed || m_field == FieldDateAdded) &&
-             (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE ||
-              m_operator == OPERATOR_NOT_IN_THE_LAST))
-      query = GetField(m_field, strType) + " IS NULL OR " + GetField(m_field, strType) + parameter;
+    else if (m_field == FieldLastPlayed || m_field == FieldDateAdded)
+      query = FormatNullableDate(GetField(m_field, strType), m_operator, parameter);
     else if (m_field == FieldStudio)
       query = negate + FormatLinkQuery("studio", "studio", MediaTypeTvShow, (table + ".idShow").c_str(), parameter);
     else if (m_field == FieldMPAA)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Modified the SQL generation of the userrating, playcount, dateadded and lastplayed smart playlist rules to take better care of NULL db values so that rules like "smartplaylist is not XXX" provide the complement of the results instead of excluding results with NULL values.

Also treat the user rating 0 in the GUI as "not rated" (0 or NULL value in the database).

Handling of NULL dateadded should not be needed but the generic code handles it and it doesn't hurt.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #21530 and similar issues for other fields.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Scenarios similar to the bug report for all fields mentioned in the main description.
For example,
1/ user rating
- create smartplaylist A with rule "userrating is 0"
- create smartplaylist B with rule "smartplaylist is not A"

before PR, the smartplaylist A returned no results, and B returned no results either.
after PR, A returns the not-rated movies/episodes/etc and B returns the rated with any value >= 1

2/ last played
- create smartplaylist A with rule "last played after 2025-01-01"
- create smartplaylist B with rule "smartplaylist is not A"
before PR, A returns the movies/episodes/etc played in 2025 or later, B returns the items played before 2025, but only if they were played at least once.
after PR, A returns the same as before, B returns all items not played in 2025 or later (ie never played or played before 2025)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Improved smart playlist rules, with 0 user rating represented unrated and "smartplaylist is not" rules providing the expected results.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
