### PR TITLE
[Encoder] Remove usage of resampler

### DIFF
--- a/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.h
+++ b/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.h
@@ -10,10 +10,6 @@
 
 #include "cores/AudioEngine/Interfaces/AEEncoder.h"
 
-extern "C" {
-#include <libswresample/swresample.h>
-}
-
 /* ffmpeg re-defines this, so undef it to squash the warning */
 #undef restrict
 
@@ -40,14 +36,12 @@ private:
   AVCodecID m_CodecID;
   unsigned int m_BitRate = 0;
   AEAudioFormat m_CurrentFormat;
-  AVCodecContext *m_CodecCtx;
-  SwrContext *m_SwrCtx;
+  AVCodecContext* m_CodecCtx;
   CAEChannelInfo m_Layout;
   int m_BufferSize = 0;
   int m_OutputSize = 0;
   double m_OutputRatio = 0.0;
   double m_SampleRateMul = 0.0;
-  unsigned int  m_NeededFrames = 0;
-  bool m_NeedConversion = false;
+  unsigned int m_NeededFrames = 0;
 };
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Another small clean up I came across while working on the webos video player. The resampler is set up but never actually used. I guess at some point it must have been planned that the encoder automatically sets up resampling if needed but in its current form the resampler does nothing.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Saves some bytes I guess

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
