### PR TITLE
[log/fmt] add a custom formatter for enum class StreamType to prevent logging o…

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -15,6 +15,8 @@
 #include <string>
 #include <vector>
 
+#include <fmt/format.h>
+
 #ifndef __GNUC__
 #pragma warning(push)
 #pragma warning(disable : 4244)
@@ -50,6 +52,43 @@ enum class StreamType
   TELETEXT, // Teletext data stream
   RADIO_RDS, // Radio RDS data stream
   AUDIO_ID3 // Audio ID3 data stream
+};
+
+template<>
+struct fmt::formatter<StreamType> : fmt::formatter<std::string_view>
+{
+  template<typename FormatContext>
+  constexpr auto format(const StreamType& type, FormatContext& ctx) const
+  {
+    return fmt::formatter<std::string_view>::format(enumToStreamType(type), ctx);
+  }
+
+private:
+  static constexpr std::string_view enumToStreamType(StreamType type)
+  {
+    using namespace std::literals::string_view_literals;
+    switch (type)
+    {
+      using enum StreamType;
+      case NONE:
+        return "none"sv;
+      case AUDIO:
+        return "audio"sv;
+      case VIDEO:
+        return "video"sv;
+      case DATA:
+        return "data"sv;
+      case SUBTITLE:
+        return "subtitle"sv;
+      case TELETEXT:
+        return "teletext"sv;
+      case RADIO_RDS:
+        return "radio rds"sv;
+      case AUDIO_ID3:
+        return "audio id3"sv;
+    }
+    throw std::invalid_argument("no streamtype string found");
+  }
 };
 
 enum StreamSource


### PR DESCRIPTION
…f almost meaningless ints

credits @ksooo - thank you!

## Description
a custom fomatter is desirable in order to get clear text logged instead of integers when logging an enum class type
like `StreamType` - introduced in https://github.com/xbmc/xbmc/pull/27040

doesn't even build with `libfmt9` when this formatter doesnt exist

## How has this been tested?
it builds on deb12 / libfmt9

## What is the effect on users?
more meaningful logs and less build errors

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
