### PR TITLE
[Shader Preset API v1.1.0] Add plumbing for shader pass aliases

### DIFF
--- a/xbmc/addons/ShaderPreset.cpp
+++ b/xbmc/addons/ShaderPreset.cpp
@@ -37,7 +37,7 @@ bool CShaderPreset::ReadShaderPreset(video_shader& shader)
   return m_struct.toAddon->VideoShaderRead(&m_struct, m_file, &shader);
 }
 
-void CShaderPreset::WriteShaderPreset(const video_shader& shader)
+bool CShaderPreset::WriteShaderPreset(const video_shader& shader)
 {
   return m_struct.toAddon->VideoShaderWrite(&m_struct, m_file, &shader);
 }

--- a/xbmc/addons/ShaderPreset.cpp
+++ b/xbmc/addons/ShaderPreset.cpp
@@ -215,6 +215,8 @@ void CShaderPresetAddon::TranslateShaderPass(const video_shader_pass& pass,
   shaderFbo.sRgbFramebuffer = fbo.srgb_fbo;
 
   shaderPass.mipmap = pass.mipmap;
+
+  shaderPass.alias = pass.alias ? pass.alias : "";
 }
 
 void CShaderPresetAddon::TranslateShaderLut(const video_shader_lut& lut,

--- a/xbmc/addons/ShaderPreset.h
+++ b/xbmc/addons/ShaderPreset.h
@@ -42,8 +42,10 @@ public:
    * etc) to disk
    *
    * \param shader Shader passes handle
+   *
+   * \return True if successful, otherwise false
    */
-  void WriteShaderPreset(const video_shader& shader);
+  bool WriteShaderPreset(const video_shader& shader);
 
   /*!
    * \brief Resolve all shader parameters belonging to the shader preset

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/ShaderPreset.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/ShaderPreset.h
@@ -159,7 +159,9 @@ public:
   /// @param file Preset file to read from
   /// @param shader Shader passes handle
   ///
-  virtual void ShaderPresetWrite(preset_file file, const video_shader& shader) {}
+  /// @return True if successful, otherwise false
+  ///
+  virtual bool ShaderPresetWrite(preset_file file, const video_shader& shader) { return false; }
   //----------------------------------------------------------------------------
 
   //============================================================================
@@ -232,13 +234,15 @@ private:
     return false;
   }
 
-  inline static void ADDON_video_shader_write_file(const AddonInstance_ShaderPreset* addonInstance,
+  inline static bool ADDON_video_shader_write_file(const AddonInstance_ShaderPreset* addonInstance,
                                                    preset_file file,
                                                    const video_shader* shader)
   {
     if (shader != nullptr)
-      static_cast<CInstanceShaderPreset*>(addonInstance->toAddon->addonInstance)
+      return static_cast<CInstanceShaderPreset*>(addonInstance->toAddon->addonInstance)
           ->ShaderPresetWrite(file, *shader);
+
+    return false;
   }
 
   inline static bool ADDON_video_shader_resolve_parameters(

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/shaderpreset.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/shaderpreset.h
@@ -180,6 +180,11 @@ extern "C"
      * \brief Mipmapping
      */
     bool mipmap;
+
+    /*!
+     * \brief Aliased pass name
+     */
+    char* alias;
   } video_shader_pass;
 
   typedef struct video_shader_lut

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/shaderpreset.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/shaderpreset.h
@@ -275,7 +275,7 @@ extern "C"
     bool(__cdecl* VideoShaderRead)(const struct AddonInstance_ShaderPreset*,
                                    preset_file,
                                    struct video_shader*);
-    void(__cdecl* VideoShaderWrite)(const struct AddonInstance_ShaderPreset*,
+    bool(__cdecl* VideoShaderWrite)(const struct AddonInstance_ShaderPreset*,
                                     preset_file,
                                     const struct video_shader*);
     bool(__cdecl* VideoShaderResolveParameters)(const struct AddonInstance_ShaderPreset*,

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -163,8 +163,8 @@
 #define ADDON_INSTANCE_VERSION_SCREENSAVER_DEPENDS    "c-api/addon-instance/screensaver.h" \
                                                       "addon-instance/Screensaver.h"
 
-#define ADDON_INSTANCE_VERSION_SHADERPRESET           "1.0.0"
-#define ADDON_INSTANCE_VERSION_SHADERPRESET_MIN       "1.0.0"
+#define ADDON_INSTANCE_VERSION_SHADERPRESET           "1.1.0"
+#define ADDON_INSTANCE_VERSION_SHADERPRESET_MIN       "1.1.0"
 #define ADDON_INSTANCE_VERSION_SHADERPRESET_XML_ID    "kodi.binary.instance.shaderpreset"
 #define ADDON_INSTANCE_VERSION_SHADERPRESET_DEPENDS   "addon-instance/ShaderPreset.h"
 

--- a/xbmc/cores/RetroPlayer/shaders/ShaderTypes.h
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderTypes.h
@@ -86,6 +86,7 @@ struct ShaderPass
   unsigned int frameCountMod{0};
   FboScale fbo;
   bool mipmap{false};
+  std::string alias;
 
   std::vector<ShaderLut> luts;
   std::vector<ShaderParameter> parameters;


### PR DESCRIPTION
## Description

Shader pass aliases have been in RetroArch for a long time (introduced in https://github.com/libretro/RetroArch/pull/706), but were apparently never implemented in Kodi, causing some shaders like the holy grail of CRT shaders, _CRT-Royale_, to fail.

This PR adds the `alias` parameter to the shader preset API, and in https://github.com/kodi-game/game.shader.presets/pull/25 we populate the parameter from the local shader.

Required by https://github.com/kodi-game/game.shader.presets/pull/25

EDIT: Also added a small change to include a missing bool return type on a function that in theory could fail.

## Motivation and context

In the future, RetroPlayer support for aliases will be implemented. This PR is just to get the API change and add-on support in place.

## How has this been tested?

Testing in progress.

## What is the effect on users?

* Progress toward fixing shader presets that use pass aliases

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
