### PR TITLE
[xbmc] Add missing include <cstdint>

### DIFF
--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -15,6 +15,7 @@
 
 #include "utils/Artwork.h"
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 /*!
 \file GUIMessage.h
 \brief

--- a/xbmc/video/VideoUtils.h
+++ b/xbmc/video/VideoUtils.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <tuple>


### PR DESCRIPTION
## Description

Starting with gcc 15 it failed on musl libc with:

	/home/buildozer/git/aports/community/kodi/src/xbmc-21.2-Omega/xbmc/guilib/GUIMessage.h:378:15: error: unknown type name 'int64_t'
	  378 |               int64_t param1,
	      |               ^
	...


## Motivation and context

Needed for int64_t

## How has this been tested?

Builds for Alpine Linux edge (gcc 15, musl)

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
