### PR TITLE
[smb] Rewrite GetDirectory to use smbc_readdirplus2() where possible for orders of magnitude performance improvements.

### DIFF
--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -38,12 +38,6 @@
 
 #include <libsmbclient.h>
 
-struct CachedDirEntry
-{
-  unsigned int type;
-  std::string name;
-};
-
 using namespace XFILE;
 
 CSMBDirectory::CSMBDirectory(void)
@@ -103,144 +97,108 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   URIUtils::AddSlashAtEnd(strRoot);
   URIUtils::AddSlashAtEnd(strAuth);
 
-  std::string strFile;
-
-  // need to keep the samba lock for as short as possible.
-  // so we first cache all directory entries and then go over them again asking for stat
-  // "stat" is locked each time. that way the lock is freed between stat requests
-  std::vector<CachedDirEntry> vecEntries;
-  struct smbc_dirent* dirEnt;
-
   lock.lock();
   if (!smb.IsSmbValid())
     return false;
-  while ((dirEnt = smbc_readdir(fd)))
-  {
-    CachedDirEntry aDir;
-    aDir.type = dirEnt->smbc_type;
-    aDir.name = dirEnt->name;
-    vecEntries.push_back(aDir);
-  }
-  smbc_closedir(fd);
-  lock.unlock();
 
-  for (size_t i=0; i<vecEntries.size(); i++)
+  const libsmb_file_info* fi;
+  struct stat st;
+  bool atLeastOneEntry = false;
+  while ((fi = smbc_readdirplus2(fd, &st)))
   {
-    const CachedDirEntry& aDir = vecEntries[i];
-
+    atLeastOneEntry = true;
     // We use UTF-8 internally, as does SMB
-    strFile = aDir.name;
+    std::string name = fi->name;
 
-    if (!strFile.empty() && strFile != "." && strFile != ".."
-      && strFile != "lost+found"
-      && aDir.type != SMBC_PRINTER_SHARE && aDir.type != SMBC_IPC_SHARE)
+    if (name == "." || name == ".." || name == "lost+found")
+      continue;
+
+    int64_t size = 0;
+    const bool isDir = S_ISDIR(st.st_mode);
+    int64_t timeDate = 0;
+    bool hidden = StringUtils::StartsWith(name, ".");
+
+    // only stat files that can give proper responses
+    if (S_ISREG(st.st_mode) || isDir)
     {
-     int64_t iSize = 0;
-      bool bIsDir = true;
-      int64_t lTimeDate = 0;
-      bool hidden = false;
+      // This is also present in stuct stat using S_IXOTH but given the potential for confusion
+      // let's be explicit.
+      hidden = hidden || fi->attrs & SMBC_DOS_MODE_HIDDEN;
 
-      if(StringUtils::EndsWith(strFile, "$") && aDir.type == SMBC_FILE_SHARE )
+      timeDate = st.st_mtime;
+      if (timeDate == 0) // if modification date is missing, use create date
+        timeDate = st.st_ctime;
+      size = st.st_size;
+    }
+
+    KODI::TIME::FileTime fileTime, localTime;
+    KODI::TIME::TimeTToFileTime(timeDate, &fileTime);
+    KODI::TIME::FileTimeToLocalFileTime(&fileTime, &localTime);
+
+    const auto item = std::make_shared<CFileItem>(name);
+    item->SetDateTime(localTime);
+    if (hidden)
+      item->SetProperty("file:hidden", true);
+    if (isDir)
+    {
+      std::string path(strRoot);
+
+      path = URIUtils::AddFileToFolder(path, name);
+      URIUtils::AddSlashAtEnd(path);
+      item->SetPath(path);
+      item->SetFolder(true);
+    }
+    else
+    {
+      item->SetPath(strRoot + name);
+      item->SetFolder(false);
+      item->SetSize(size);
+    }
+    items.Add(item);
+  }
+
+  // No results from smbc_readdirplus2() suggests server or share browsing.
+  // Use smbclient's legacy API for this.
+  if (!atLeastOneEntry)
+  {
+    if (smbc_lseekdir(fd, 0) < 0)
+    {
+      CLog::LogF(LOGERROR, "Unable to seek directory : '{}'\nunix_err:'{:x}' error: '{}'",
+                 CURL::GetRedacted(strAuth), errno, strerror(errno));
+      return false;
+    }
+
+    struct smbc_dirent* dirent;
+    while ((dirent = smbc_readdir(fd)))
+    {
+      if (dirent->smbc_type != SMBC_FILE_SHARE && dirent->smbc_type != SMBC_SERVER)
         continue;
 
-      if (StringUtils::StartsWith(strFile, "."))
-        hidden = true;
-
-      // only stat files that can give proper responses
-      if ( aDir.type == SMBC_FILE ||
-           aDir.type == SMBC_DIR )
+      const auto item = std::make_shared<CFileItem>(dirent->name);
+      std::string path(strRoot);
+      // needed for network / workgroup browsing
+      // skip if root if we are given a server
+      if (dirent->smbc_type == SMBC_SERVER)
       {
-        // set this here to if the stat should fail
-        bIsDir = (aDir.type == SMBC_DIR);
-
-        struct stat info = {};
-        if ((m_flags & DIR_FLAG_NO_FILE_INFO)==0 && CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_sambastatfiles)
-        {
-          // make sure we use the authenticated path which contains any default username
-          const std::string strFullName = strAuth + smb.URLEncode(strFile);
-
-          lock.lock();
-          if (!smb.IsSmbValid())
-          {
-            items.ClearItems();
-            return false;
-          }
-
-          if( smbc_stat(strFullName.c_str(), &info) == 0 )
-          {
-
-            char value[20];
-            // We poll for extended attributes which symbolizes bits but split up into a string. Where 0x02 is hidden and 0x12 is hidden directory.
-            // According to the libsmbclient.h it returns 0 on success and -1 on error.
-            // But before Samba 4.17.5 it seems to return the length of the returned value
-            // (which is 4), see https://bugzilla.samba.org/show_bug.cgi?id=14808.
-            // Checking for >= 0 should work both for the old erroneous and the correct behaviour.
-            if (smbc_getxattr(strFullName.c_str(), "system.dos_attr.mode", value, sizeof(value)) >= 0)
-            {
-              long longvalue = strtol(value, NULL, 16);
-              if (longvalue & SMBC_DOS_MODE_HIDDEN)
-                hidden = true;
-            }
-            else
-              CLog::Log(
-                  LOGERROR,
-                  "Getting extended attributes for the share: '{}'\nunix_err:'{:x}' error: '{}'",
-                  CURL::GetRedacted(strFullName), errno, strerror(errno));
-
-            bIsDir = S_ISDIR(info.st_mode);
-            lTimeDate = info.st_mtime;
-            if(lTimeDate == 0) // if modification date is missing, use create date
-              lTimeDate = info.st_ctime;
-            iSize = info.st_size;
-          }
-          else
-            CLog::Log(LOGERROR, "{} - Failed to stat file {}", __FUNCTION__,
-                      CURL::GetRedacted(strFullName));
-
-          lock.unlock();
-        }
+        /* create url with same options, user, pass.. but no filename or host*/
+        CURL rooturl(strRoot);
+        rooturl.SetFileName("");
+        rooturl.SetHostName("");
+        path = smb.URLEncode(rooturl);
       }
-
-      KODI::TIME::FileTime fileTime, localTime;
-      KODI::TIME::TimeTToFileTime(lTimeDate, &fileTime);
-      KODI::TIME::FileTimeToLocalFileTime(&fileTime, &localTime);
-
-      if (bIsDir)
-      {
-        CFileItemPtr pItem(new CFileItem(strFile));
-        std::string path(strRoot);
-
-        // needed for network / workgroup browsing
-        // skip if root if we are given a server
-        if (aDir.type == SMBC_SERVER)
-        {
-          /* create url with same options, user, pass.. but no filename or host*/
-          CURL rooturl(strRoot);
-          rooturl.SetFileName("");
-          rooturl.SetHostName("");
-          path = smb.URLEncode(rooturl);
-        }
-        path = URIUtils::AddFileToFolder(path,aDir.name);
-        URIUtils::AddSlashAtEnd(path);
-        pItem->SetPath(path);
-        pItem->SetFolder(true);
-        pItem->SetDateTime(localTime);
-        if (hidden)
-          pItem->SetProperty("file:hidden", true);
-        items.Add(pItem);
-      }
-      else
-      {
-        CFileItemPtr pItem(new CFileItem(strFile));
-        pItem->SetPath(strRoot + aDir.name);
-        pItem->SetFolder(false);
-        pItem->SetSize(iSize);
-        pItem->SetDateTime(localTime);
-        if (hidden)
-          pItem->SetProperty("file:hidden", true);
-        items.Add(pItem);
-      }
+      path = URIUtils::AddFileToFolder(path, dirent->name);
+      URIUtils::AddSlashAtEnd(path);
+      item->SetPath(path);
+      item->SetFolder(true);
+      items.Add(item);
     }
+  }
+
+  if (smbc_closedir(fd) < 0)
+  {
+    CLog::LogF(LOGERROR, "Unable to close directory : '{}'\nunix_err:'{:x}' error: '{}'",
+               CURL::GetRedacted(strAuth), errno, strerror(errno));
+    return true; // we already got our listing
   }
 
   return true;


### PR DESCRIPTION
## Description
This obsoletes the need for stat/getxattr when using SMB for Kodi's use case.

In the case of a directory (within a share) with 464 subdirectories this results in
* stat(): 464 -> 0
* getxattr(): 464 -> 0
* wallclock time: 433152 us -> 5205 us (~99% less)

... while retaining mtime/ctime/size/hidden info.

In general we get
* reduction in network traffic
* simpler locking logic
* reduction in memory use (removal of cache)

The slower/less reliable/higher latency the link and the less processing power the stronger the effect.

This API does not allow share browsing (dir appears empty) so a fallback is added for that use case.

## Motivation and context
Faster listings. See above.

## How has this been tested?
* Browsed some large SMB shares, saw difference, measured difference.
* Browsed a "server", observed listing of shares on the server
* Did **NOT** try workgroups browsing (don't have them; IIRC they're part of SMB1 only(?) so should not be used)

## What is the effect on users?
Faster directory listings over SMB. ~83x in my test.

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
