### PR TITLE
[guiinfo] Add spaces when translating list separator parameters.

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -10484,21 +10484,21 @@ namespace
 std::string TranslateListSeparator(const std::string& param)
 {
   if (StringUtils::EqualsNoCase(param, "comma"))
-    return ",";
+    return ", ";
   else if (StringUtils::EqualsNoCase(param, "pipe"))
-    return "|";
+    return " | ";
   else if (StringUtils::EqualsNoCase(param, "slash"))
-    return "/";
+    return " / ";
   else if (StringUtils::EqualsNoCase(param, "cr"))
     return "\n";
   else if (StringUtils::EqualsNoCase(param, "dash"))
-    return "-";
+    return " - ";
   else if (StringUtils::EqualsNoCase(param, "colon"))
-    return ":";
+    return " : ";
   else if (StringUtils::EqualsNoCase(param, "semicolon"))
-    return ";";
+    return "; ";
   else if (StringUtils::EqualsNoCase(param, "fullstop"))
-    return ".";
+    return ". ";
   else
   {
     CLog::Log(LOGERROR, "unhandled separator param {}", param);


### PR DESCRIPTION
## Description
Add spaces when translating list separators (introduced in https://github.com/xbmc/xbmc/pull/26362/commits/6c6b8180a49afb02738a6f970c68776ee82ef843) 

## Motivation and context
Requested internally by @Hitcher and also here https://github.com/xbmc/xbmc/pull/26362#issuecomment-3172442360

## How has this been tested?
Temporarily modified some Estuary xml files and checked visually that it works as designed.

## What is the effect on users?
Improved user experience in skins using the new list separators.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
