### PR TITLE
[Android] Update the logic that checks the app is already running

### DIFF
--- a/tools/android/packaging/xbmc/src/Main.java.in
+++ b/tools/android/packaging/xbmc/src/Main.java.in
@@ -51,6 +51,7 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
   }
   private ArrayList<DelayedIntent> mDelayedIntents = new ArrayList<>();
   private boolean mPaused = true;
+  private static boolean mActivityRunning = false;
 
   // Launchers that support the Recommended Content API
   private final Set<String> mRecommendedLaunchers = new HashSet<String>() {{
@@ -213,6 +214,7 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
   public void onStart()
   {
     super.onStart();
+    mActivityRunning = true;
 
     Choreographer.getInstance().removeFrameCallback(this);
     Choreographer.getInstance().postFrameCallback(this);
@@ -301,6 +303,11 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
 
     getApplicationContext().getContentResolver().unregisterContentObserver(mSettingsContentObserver);
     super.onDestroy();
+    mActivityRunning = false;
+  }
+
+  public static boolean isActivityRunning() {
+    return mActivityRunning;
   }
 
   @Override

--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -7,8 +7,6 @@ import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 
 import android.Manifest;
 import android.app.Activity;
-import android.app.ActivityManager;
-import android.app.ActivityManager.RunningTaskInfo;
 import android.app.AlertDialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -37,7 +35,6 @@ import java.io.InputStream;
 import java.io.IOException;
 import java.lang.System;
 import java.util.Enumeration;
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.zip.ZipEntry;
@@ -620,19 +617,11 @@ public class Splash extends Activity
     // Be sure properties are initialized for native
     XBMCProperties.initialize(getApplicationContext());
 
-    // Check if @APP_NAME@ is not already running
-    ActivityManager activityManager = (ActivityManager) getBaseContext()
-            .getSystemService(Context.ACTIVITY_SERVICE);
-    List<RunningTaskInfo> tasks = activityManager
-            .getRunningTasks(Integer.MAX_VALUE);
-    for (RunningTaskInfo task : tasks)
-      if (task.topActivity != null && task.topActivity.toString().equalsIgnoreCase(
-              "ComponentInfo{@APP_PACKAGE@/@APP_PACKAGE@.Main}"))
-      {
-        // @APP_NAME@ already running; just activate it
-        startXBMC();
-        return;
-      }
+    if (Main.isActivityRunning()) {
+      Log.d(TAG, "@APP_NAME@ already running; just activate it");
+      startXBMC();
+      return;
+    }
 
     mStateMachine.sendEmptyMessage(Checking);
 


### PR DESCRIPTION
## Description
Currently, the `getRunningTasks` method is used to obtain a list of the tasks that are currently running and thus check if the app is already running.

This method has been deprecated in API level 21. For backwards compatibility, it will still return at least the caller's own tasks. According to docs, such uses are not supported, and will likely break in the future.

I propose a simpler way to check whether the Main activity is already running by using a static variable that maintains the status of the activity.

## Motivation and context
Replace deprecated code

## How has this been tested?
Runtime-tested on Android TV 11

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
