### PR TITLE
Add Season Plot

### DIFF
--- a/addons/skin.estuary/xml/DialogVideoInfo.xml
+++ b/addons/skin.estuary/xml/DialogVideoInfo.xml
@@ -114,9 +114,9 @@
 						<textoffsety>20</textoffsety>
 						<aligny>bottom</aligny>
 						<label></label>
-						<onclick condition="!String.IsEmpty(ListItem.Plot)">SetProperty(TextViewer_Header,$LOCALIZE[207],home)</onclick>
-						<onclick condition="!String.IsEmpty(ListItem.Plot)">SetProperty(TextViewer_Text,$ESCINFO[ListItem.Plot],home)</onclick>
-						<onclick condition="!String.IsEmpty(ListItem.Plot)">ActivateWindow(1102)</onclick>
+						<onclick>SetProperty(TextViewer_Header,$LOCALIZE[207],home)</onclick>
+						<onclick>SetProperty(TextViewer_Text,$ESCVAR[VideoInfoPlotVar],home)</onclick>
+						<onclick>ActivateWindow(1102)</onclick>
 						<onup>50</onup>
 						<onleft>4000</onleft>
 						<onright>4000</onright>
@@ -139,9 +139,9 @@
 						<textoffsety>20</textoffsety>
 						<aligny>bottom</aligny>
 						<label></label>
-						<onclick condition="!String.IsEmpty(ListItem.Plot)">SetProperty(TextViewer_Header,$LOCALIZE[207],home)</onclick>
-						<onclick condition="!String.IsEmpty(ListItem.Plot)">SetProperty(TextViewer_Text,$ESCINFO[ListItem.Plot],home)</onclick>
-						<onclick condition="!String.IsEmpty(ListItem.Plot)">ActivateWindow(1102)</onclick>
+						<onclick>SetProperty(TextViewer_Header,$LOCALIZE[207],home)</onclick>
+						<onclick>SetProperty(TextViewer_Text,$ESCVAR[VideoInfoPlotVar],home)</onclick>
+						<onclick>ActivateWindow(1102)</onclick>
 						<onup>50</onup>
 						<onleft>4000</onleft>
 						<onright>4000</onright>
@@ -154,7 +154,7 @@
 						<top>25</top>
 						<width>670</width>
 						<height>363</height>
-						<label fallback="19055">$INFO[ListItem.Plot]</label>
+						<label fallback="19055">$VAR[VideoInfoPlotVar]</label>
 						<autoscroll delay="10000" time="5000" repeat="10000">Skin.HasSetting(AutoScroll)</autoscroll>
 						<visible>Integer.IsGreater(Container(4000).NumItems,0)</visible>
 					</control>
@@ -163,7 +163,7 @@
 						<top>25</top>
 						<width>1165</width>
 						<height>363</height>
-						<label fallback="19055">$INFO[ListItem.Plot]</label>
+						<label fallback="19055">$VAR[VideoInfoPlotVar]</label>
 						<autoscroll delay="10000" time="5000" repeat="10000">Skin.HasSetting(AutoScroll)</autoscroll>
 						<visible>!Integer.IsGreater(Container(4000).NumItems,0)</visible>
 					</control>

--- a/addons/skin.estuary/xml/MyVideoNav.xml
+++ b/addons/skin.estuary/xml/MyVideoNav.xml
@@ -49,8 +49,8 @@
 						<top>240</top>
 						<width>525</width>
 						<bottom>100</bottom>
-						<visible>![ListItem.IsCollection + String.IsEmpty(ListItem.Plot)]</visible>
-						<label>$INFO[ListItem.Tagline,[I],[/I][CR][CR]]$INFO[ListItem.Plot][CR][CR]</label>
+						<visible>![ListItem.IsCollection + String.IsEmpty(ListItem.Plot) + String.IsEqual(ListItem.DBType,season) + String.IsEmpty(Container.ShowPlot)]</visible>
+						<label>$INFO[ListItem.Tagline,[I],[/I][CR][CR]]$VAR[VideoInfoPlotVar][CR][CR]</label>
 						<autoscroll delay="10000" time="3000" repeat="10000">Skin.HasSetting(autoscroll)</autoscroll>
 					</control>
 					<control type="textbox">
@@ -63,7 +63,7 @@
 						<font>font27</font>
 						<textcolor>80FFFFFF</textcolor>
 						<label>$LOCALIZE[19055]</label>
-						<visible>String.IsEmpty(Listitem.Plot) + String.IsEmpty(Listitem.Tagline) + !ListItem.IsCollection + !ListItem.IsParentFolder</visible>
+						<visible>String.IsEmpty(Listitem.Plot) + String.IsEqual(ListItem.DBType,season) + String.IsEmpty(Container.ShowPlot) + String.IsEmpty(Listitem.Tagline) + !ListItem.IsCollection + !ListItem.IsParentFolder</visible>
 					</control>
 					<control type="group">
 						<left>20</left>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -107,7 +107,8 @@
 	</variable>
 	<variable name="PlotTextBoxVar">
 		<value condition="!String.IsEmpty(ListItem.PlotOutline)">$INFO[ListItem.PlotOutline]</value>
-		<value>$INFO[ListItem.Plot]</value>
+		<value condition="!String.IsEmpty(ListItem.Plot)">$INFO[ListItem.Plot]</value>
+		<value condition="String.IsEqual(ListItem.DBType,season)">$INFO[Container.ShowPlot]</value>
 	</variable>
 	<variable name="ShiftLeftTextBoxVar">
 		<value condition="Window.IsActive(pictures)">$INFO[ListItem.Property(description),,[CR]]$INFO[ListItem.PictureDatetime,[COLOR button_focus]$LOCALIZE[552]:  [/COLOR],[CR]]$INFO[ListItem.PictureResolution,[COLOR button_focus]$LOCALIZE[169]:  [/COLOR],[CR]]$INFO[ListItem.PictureCamMake,[COLOR button_focus]$LOCALIZE[31041]:  [/COLOR],[CR]]$INFO[ListItem.PictureCamModel,[COLOR button_focus]$LOCALIZE[21823]:  [/COLOR],[CR]]</value>
@@ -122,7 +123,8 @@
 		<value condition="String.IsEqual(listitem.dbtype,artist)">$INFO[ListItem.Property(artist_description)]</value>
 		<value condition="String.IsEqual(listitem.dbtype,album)">$INFO[ListItem.Property(album_description)]</value>
 		<value condition="!String.IsEmpty(ListItem.PlotOutline)">$INFO[ListItem.PlotOutline]</value>
-		<value>$INFO[ListItem.Plot]</value>
+		<value condition="!String.IsEmpty(ListItem.Plot)">$INFO[ListItem.Plot]</value>
+		<value condition="String.IsEqual(ListItem.DBType,season)">$INFO[Container.ShowPlot]</value>
 	</variable>
 	<variable name="SelectLabel">
 		<value condition="Control.IsVisible(50)">[COLOR=button_focus]$INFO[Container(50).NumItems][/COLOR] $LOCALIZE[31036] - [COLOR=button_focus]$INFO[Container(50).CurrentPage]/$INFO[Container(50).NumPages][/COLOR]</value>
@@ -151,6 +153,7 @@
 		<value condition="String.IsEqual(listitem.dbtype,artist)">$INFO[ListItem.Property(artist_description)]</value>
 		<value condition="!String.IsEmpty(ListItem.PlotOutline)">$INFO[ListItem.PlotOutline]</value>
 		<value condition="!String.IsEmpty(ListItem.Plot)">$INFO[ListItem.Plot]</value>
+		<value condition="String.IsEqual(ListItem.DBType,season)">$INFO[Container.ShowPlot]</value>
 		<value condition="String.IsEqual(ListItem.DBType,song) + !Window.IsActive(musicplaylist)">$VAR[MusicTrackInfo,[COLOR button_focus]$LOCALIZE[554]: [/COLOR],[CR]]$INFO[ListItem.Artist,[COLOR button_focus]$LOCALIZE[557]: [/COLOR],[CR]]$INFO[listitem.Album,[COLOR button_focus]$LOCALIZE[558]: [/COLOR],[CR]]$VAR[InfoDiscVar,[COLOR button_focus]$LOCALIZE[427]: [/COLOR],[CR]]$INFO[ListItem.Year,[COLOR button_focus]$LOCALIZE[345]: [/COLOR],[CR]]$INFO[ListItem.Genre,[COLOR button_focus]$LOCALIZE[515]: [/COLOR],[CR]]$INFO[ListItem.Duration,[COLOR button_focus]$LOCALIZE[180]: [/COLOR],[CR]]$INFO[ListItem.Playcount,[COLOR button_focus]$LOCALIZE[567]: [/COLOR],[CR]]$INFO[ListItem.LastPlayed,[COLOR button_focus]$LOCALIZE[568]: [/COLOR],]</value>
 		<value condition="String.IsEqual(ListItem.DBType,song) + Window.IsActive(musicplaylist)">[COLOR button_focus][B]$LOCALIZE[31037]: [/COLOR]$INFO[Container.CurrentItem,,/]$INFO[Container.NumItems][/B][CR]$VAR[MusicTrackInfo,[COLOR button_focus]$LOCALIZE[554]: [/COLOR],[CR]]$INFO[ListItem.Artist,[COLOR button_focus]$LOCALIZE[557]: [/COLOR],[CR]]$INFO[listitem.Album,[COLOR button_focus]$LOCALIZE[558]: [/COLOR],[CR]]$VAR[InfoDiscVar,[COLOR button_focus]$LOCALIZE[427]: [/COLOR],[CR]]$INFO[ListItem.Year,[COLOR button_focus]$LOCALIZE[345]: [/COLOR],[CR]]$INFO[ListItem.Genre,[COLOR button_focus]$LOCALIZE[515]: [/COLOR],[CR]]$INFO[ListItem.Duration,[COLOR button_focus]$LOCALIZE[180]: [/COLOR],[CR]]$INFO[ListItem.Playcount,[COLOR button_focus]$LOCALIZE[567]: [/COLOR]]</value>
 		<value condition="Container.Content(favourites)">$INFO[ListItem.Property(favourite.action),[COLOR button_focus]$LOCALIZE[15217]: [/COLOR],[CR]]$INFO[ListItem.Property(favourite.provider),[COLOR button_focus]$LOCALIZE[15225]: [/COLOR],[CR]]</value>
@@ -388,6 +391,10 @@
 		<value condition="!String.IsEmpty(ListItem.TVShowTitle)">$INFO[ListItem.TVShowTitle]$INFO[ListItem.Year, ([COLOR grey],[/COLOR])]</value>
 		<value condition="!String.IsEmpty(ListItem.Title)">$INFO[ListItem.Title]$INFO[ListItem.Year, ([COLOR grey],[/COLOR])]</value>
 		<value>$INFO[ListItem.Label]$INFO[ListItem.Year, ([COLOR grey],[/COLOR])]</value>
+	</variable>
+	<variable name="VideoInfoPlotVar">
+		<value condition="!String.IsEmpty(ListItem.Plot)">$INFO[ListItem.Plot]</value>
+		<value condition="String.IsEqual(ListItem.DBType,season)">$INFO[Container.ShowPlot]</value>
 	</variable>
 	<variable name="VideoInfoPlayButtonLabelVar">
 		<value condition="String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,season) | String.IsEqual(ListItem.DBType,set)">$LOCALIZE[1024]</value>

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -685,16 +685,18 @@ namespace XBMCAddon
       setResumePointRaw(infoTag, time, totalTime);
     }
 
-    void InfoTagVideo::addSeason(int number, std::string name /* = "" */)
+    void InfoTagVideo::addSeason(int number,
+                                 std::string name /* = "" */,
+                                 std::string plot /* = "" */)
     {
       XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
-      addSeasonRaw(infoTag, number, std::move(name));
+      addSeasonRaw(infoTag, number, std::move(name), std::move(plot));
     }
 
-    void InfoTagVideo::addSeasons(const std::vector<Tuple<int, std::string>>& namedSeasons)
+    void InfoTagVideo::addSeasons(const std::vector<Tuple<int, std::string, std::string>>& seasons)
     {
       XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
-      addSeasonsRaw(infoTag, namedSeasons);
+      addSeasonsRaw(infoTag, seasons);
     }
 
     void InfoTagVideo::addVideoStream(const VideoStreamDetail* stream)
@@ -1034,16 +1036,20 @@ namespace XBMCAddon
       infoTag->SetResumePoint(resumePoint);
     }
 
-    void InfoTagVideo::addSeasonRaw(CVideoInfoTag* infoTag, int number, std::string name /* = "" */)
+    void InfoTagVideo::addSeasonRaw(CVideoInfoTag* infoTag,
+                                    int number,
+                                    std::string name /* = "" */,
+                                    std::string plot /* = "" */)
     {
       infoTag->m_seasons[number].m_name = std::move(name);
+      infoTag->m_seasons[number].m_plot = std::move(plot);
     }
 
-    void InfoTagVideo::addSeasonsRaw(CVideoInfoTag* infoTag,
-                                     const std::vector<Tuple<int, std::string>>& namedSeasons)
+    void InfoTagVideo::addSeasonsRaw(
+        CVideoInfoTag* infoTag, const std::vector<Tuple<int, std::string, std::string>>& seasons)
     {
-      for (const auto& season : namedSeasons)
-        addSeasonRaw(infoTag, season.first(), season.second());
+      for (const auto& season : seasons)
+        addSeasonRaw(infoTag, season.first(), season.second(), season.third());
     }
 
     void InfoTagVideo::addStreamRaw(CVideoInfoTag* infoTag, CStreamDetail* stream)

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -1036,7 +1036,7 @@ namespace XBMCAddon
 
     void InfoTagVideo::addSeasonRaw(CVideoInfoTag* infoTag, int number, std::string name /* = "" */)
     {
-      infoTag->m_namedSeasons[number] = std::move(name);
+      infoTag->m_seasons[number].m_name = std::move(name);
     }
 
     void InfoTagVideo::addSeasonsRaw(CVideoInfoTag* infoTag,

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -2573,45 +2573,48 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_InfoTagVideo
-      /// @brief \python_func{ addSeason(number, [name]) }
-      /// Add a season with name. It needs at least the season number.
+      /// @brief \python_func{ addSeason(number, [name], [plot]) }
+      /// Add a season with name and a plot. It needs at least the season number.
       ///
       /// @param number     int - the number of the season.
       /// @param name       string - the name of the season. Default "".
+      /// @param plot       string - the plot of the season. Default "".
       ///
       ///
       ///-----------------------------------------------------------------------
       ///
       /// @python_v20 New function added.
+      /// @python_v22 Added plot parameter
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
       /// ...
-      /// # addSeason(number, name))
-      /// infotagvideo.addSeason(1, "Murder House")
+      /// # addSeason(number, name, plot))
+      /// infotagvideo.addSeason(1, "Murder House", "The first installment revolves around...")
       /// ...
       /// ~~~~~~~~~~~~~
       ///
       addSeason(...);
 #else
-      void addSeason(int number, std::string name = "");
+      void addSeason(int number, std::string name = "", std::string plot = "");
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_InfoTagVideo
-      /// @brief \python_func{ addSeasons(namedseasons) }
-      /// Add named seasons to the TV show.
+      /// @brief \python_func{ addSeasons(seasons) }
+      /// Add seasons to the TV show.
       ///
-      /// @param namedseasons       list - `[ (season, name) ]`.
+      /// @param seasons       list - `[ (season, name, plot) ]`.
       ///
       ///
       ///-----------------------------------------------------------------------
       /// @python_v20 New function added.
+      /// @python_v22 Added third element to the tuple for the season plot
       ///
       addSeasons(...);
 #else
-      void addSeasons(const std::vector<Tuple<int, std::string>>& namedseasons);
+      void addSeasons(const std::vector<Tuple<int, std::string, std::string>>& seasons);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -2768,9 +2771,12 @@ namespace XBMCAddon
       static void setCastRaw(CVideoInfoTag* infoTag, std::vector<SActorInfo> cast);
       static void setResumePointRaw(CVideoInfoTag* infoTag, double time, double totalTime = 0.0);
 
-      static void addSeasonRaw(CVideoInfoTag* infoTag, int number, std::string name = "");
+      static void addSeasonRaw(CVideoInfoTag* infoTag,
+                               int number,
+                               std::string name = "",
+                               std::string plot = "");
       static void addSeasonsRaw(CVideoInfoTag* infoTag,
-                                const std::vector<Tuple<int, std::string>>& namedSeasons);
+                                const std::vector<Tuple<int, std::string, std::string>>& seasons);
 
       static void addStreamRaw(CVideoInfoTag* infoTag, CStreamDetail* stream);
       static void finalizeStreamsRaw(CVideoInfoTag* infoTag);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -373,6 +373,7 @@ enum VIDEODB_SEASON_IDS // this enum MUST match the offset struct further down!!
   VIDEODB_ID_SEASON_EPISODES_WATCHED = 13,
   VIDEODB_ID_SEASON_PREMIERED = 14,
   VIDEODB_ID_SEASON_EPISODES_INPROGRESS = 15,
+  VIDEODB_ID_SEASON_PLOT = 16,
   VIDEODB_ID_SEASON_MAX
 };
 
@@ -1256,11 +1257,13 @@ public:
   bool GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription &sorting) override;
 
   /*! \brief Will check if the season exists and if that is not the case add it to the database.
-  \param showID The id of the show in question.
-  \param season The season number we want to add.
+  \param[in] showID The id of the show in question.
+  \param[in] season The season number we want to add.
+  \param[in] name Name of the season
+  \param[in] plot Plot of the season
   \return The dbId of the season.
   */
-  int AddSeason(int showID, int season, const std::string& name = "");
+  int AddSeason(int showID, int season, const std::string& name = "", const std::string& plot = "");
   int AddSet(const std::string& strSet,
              const std::string& strOverview = "",
              const std::string& strOriginalSet = "",

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1217,8 +1217,20 @@ public:
   bool RemoveArtForItem(int mediaId,
                         const MediaType& mediaType,
                         const std::set<std::string, std::less<>>& artTypes);
+  /*!
+   * \brief Retrieve season information of a TV show.
+   * \param[in] showId ID of the show
+   * \param[out] seasons Map of the season information. Key = ID of the season, values = season number
+   * \return true for success, false otherwise
+   */
   bool GetTvShowSeasons(int showId, std::map<int, int> &seasons);
-  bool GetTvShowNamedSeasons(int showId, std::map<int, std::string> &seasons);
+  /*!
+   * \brief Retrieve season information of a TV show.
+   * \param[in] showId ID of the show
+   * \param[out] seasons Map of the season information. Key = season number, values = SeasonAttributes structure
+   * \return true for success, false otherwise
+   */
+  bool GetTvShowSeasons(int showId, std::map<int, CVideoInfoTag::SeasonAttributes>& seasons);
 
   /*!
    * \brief Get the custom named season.

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -167,7 +167,12 @@ public:
   void SetShowLink(std::vector<std::string> showLink);
   void SetUniqueID(std::string_view uniqueid, const std::string& type = "", bool def = false);
   void RemoveUniqueID(const std::string& type);
-  void SetNamedSeasons(std::map<int, std::string> namedSeasons);
+  struct SeasonAttributes
+  {
+    std::string m_name;
+    std::string m_plot;
+  };
+  void SetSeasons(std::map<int, SeasonAttributes> seasons);
   void SetUserrating(int userrating);
 
   void SetOverride(bool setOverride) { m_override = setOverride; }
@@ -389,7 +394,7 @@ public:
   std::string m_strAlbum;
   CDateTime m_lastPlayed;
   std::vector<std::string> m_showLink;
-  std::map<int, std::string> m_namedSeasons;
+  std::map<int, SeasonAttributes> m_seasons;
   int m_iTop250;
   int m_year;
   int m_iSeason;

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -171,6 +171,8 @@ public:
   {
     std::string m_name;
     std::string m_plot;
+    bool operator==(const SeasonAttributes& other) const = default;
+    bool IsEmpty() const { return m_name.empty() && m_plot.empty(); }
   };
   void SetSeasons(std::map<int, SeasonAttributes> seasons);
   void SetUserrating(int userrating);
@@ -422,6 +424,14 @@ public:
 
   // TODO: cannot be private, because of 'struct SDbTableOffsets'
   unsigned int m_duration; ///< duration in seconds
+
+protected:
+  /*!
+   * \brief Add the seasons information to an XML node
+   * \param element  the root XML element to append to
+   * \return true for success, false otherwise.
+   */
+  bool SaveTvShowSeasons(TiXmlNode* node) const;
 
 private:
   /* \brief Parse our native XML format for video info.

--- a/xbmc/video/test/CMakeLists.txt
+++ b/xbmc/video/test/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES TestStacks.cpp
             TestVideoDbUrl.cpp
             TestVideoFileItemClassify.cpp
             TestVideoInfoScanner.cpp
+            TestVideoInfoTag.cpp
             TestVideoUtils.cpp)
 
 core_add_test_library(video_test)

--- a/xbmc/video/test/TestVideoInfoTag.cpp
+++ b/xbmc/video/test/TestVideoInfoTag.cpp
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (C) 2005-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "test/TestUtils.h"
+#include "utils/XBMCTinyXML.h"
+#include "video/VideoInfoTag.h"
+
+#include <map>
+#include <string>
+
+#include <gtest/gtest.h>
+
+TEST(TestVideoInfoTag, ReadTVShowSeasons)
+{
+  const std::string document =
+      R"(<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+         <tvshow>
+         <namedseason number="1">season 1</namedseason>
+         <namedseason number="2"></namedseason>
+         <namedseason number="3"></namedseason>
+         <namedseason number="4">season 4</namedseason>
+         <seasonplot number="3">plot 3</seasonplot>
+         <seasonplot number="4">plot 4</seasonplot>
+         <seasonplot number="5"></seasonplot>
+         </tvshow>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  CVideoInfoTag details;
+  EXPECT_TRUE(details.Load(doc.RootElement(), true, false));
+
+  const std::map<int, CVideoInfoTag::SeasonAttributes> reference = {
+      {1, {"season 1", ""}}, {3, {"", "plot 3"}}, {4, {"season 4", "plot 4"}}};
+
+  EXPECT_EQ(details.m_seasons, reference);
+}
+
+// Trick to make protected methods accessible for testing
+class CVideoInfoTagTest : public CVideoInfoTag
+{
+public:
+  bool ForwardSaveTvShowSeasons(TiXmlNode* node) { return SaveTvShowSeasons(node); }
+};
+
+TEST(TestVideoInfoTag, SaveTVShowSeasons)
+{
+  const std::map<int, CVideoInfoTag::SeasonAttributes> reference = {
+      {1, {"season 1", "plot 1"}}, {2, {"", "plot 2"}}, {3, {"season 3", ""}}, {4, {"", ""}}};
+
+  const std::string referenceXml = R"(<namedseason number="1">season 1</namedseason>
+<seasonplot number="1">plot 1</seasonplot>
+<seasonplot number="2">plot 2</seasonplot>
+<namedseason number="3">season 3</namedseason>
+)";
+
+  CVideoInfoTagTest details;
+  details.SetSeasons(reference);
+
+  CXBMCTinyXML xmlDoc;
+  details.ForwardSaveTvShowSeasons(&xmlDoc);
+
+  TiXmlPrinter printer;
+  xmlDoc.Accept(&printer);
+  std::string result = printer.Str();
+
+  EXPECT_EQ(result, referenceXml);
+}

--- a/xbmc/video/windows/VideoFileItemListModifier.cpp
+++ b/xbmc/video/windows/VideoFileItemListModifier.cpp
@@ -102,12 +102,13 @@ void CVideoFileItemListModifier::AddQueuingFolder(CFileItemList& items)
       {
         for (int i = 1; i < items.Size(); i++)
         {
-          if (items[i]->GetVideoInfoTag() &&
+          if (items[i]->HasVideoInfoTag() &&
               items[i]->GetVideoInfoTag()->m_type == MediaTypeSeason &&
               items[i]->GetVideoInfoTag()->m_iSeason > 0)
           {
             *pItem->GetVideoInfoTag() = *items[i]->GetVideoInfoTag();
             pItem->GetVideoInfoTag()->m_iSeason = -1;
+            pItem->GetVideoInfoTag()->m_strPlot = "";
             break;
           }
         }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Add storage for a season plot in the seasons table, videodb version bump, add the plumbing to make it visible in the GUI, to import from Python scraper and import/export in tvshow.nfo and single library export file.
Added matching unit test for import/export of tvshow.nfo.

New tag in tvshow.nfo:
```
<tvshow>
...
<seasonplot number="1">Season plot</seasonplot>
...
</tvshow>
```

The season plot is provided in the existing infolabel ListItem.Plot and is blank for a season without plot.

Left to do (help needed)
- Scrapers updates . They can push the season plot back via an additional parameter of InfoTag.AddSeason or AddSeasons.
- ~~Estuary change : how to implement fallback to container.showplot for missing season plot (left panel in the list of seasons). I didn't find the location to modify in the skin code.~~

Questions:
- Does a Python API version need to be bumped somehow? Similar past changes didn't seem to do anything special.

note: display of seasons in the info dialog in Videos nodes is broken, fixing to properly display season plot and fallback to show plot is beyond the scope of this PR.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Metadata sites offer season plot for many shows, it would be nice to see it when navigating the library.
Use the tv show plot as fallback as it's likely that not all seasons have plots.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

negative testing: import of old nfo with namedseason tag, online scraper
new behaviour: import of manually created nfo with new tags, export to single file and separate files
navigated in the library to check appearance of season plot and fallback to tv show plot.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Ability to see season plot once media managers generate appropriate nfo or metadata scrapers return the data.

## Screenshots (if appropriate):

season with season plot:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/f5ef9203-973c-47ea-8786-95938b777c9c" />

season with no season plot:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/2f2acb91-3723-400b-826e-b3d10cc76e60" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
