### PR TITLE
[CURL][URIUtils] Fixed inconsistency when getting filename from a windows drive spec.

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -199,9 +199,17 @@ std::string URIUtils::GetFileName(const std::string& strFileNameAndPath)
     return GetFileName(url.GetFileName());
   }
 
-  /* find the last slash */
-  const size_t slash = strFileNameAndPath.find_last_of("/\\");
-  return strFileNameAndPath.substr(slash+1);
+  int i = strFileNameAndPath.size() - 1;
+  while (i >= 0)
+  {
+    const char ch = strFileNameAndPath[i];
+    // Only break on ':' if it's a drive separator for DOS (ie d:foo)
+    if (ch == '/' || ch == '\\' || (ch == ':' && i == 1))
+      break;
+    else
+      i--;
+  }
+  return strFileNameAndPath.substr(i + 1);
 }
 
 std::string URIUtils::GetFileOrFolderName(const std::string& path)
@@ -223,18 +231,16 @@ void URIUtils::Split(const std::string& strFileNameAndPath,
   //Splits a full filename in path and file.
   //ex. smb://computer/share/directory/filename.ext -> strPath:smb://computer/share/directory/ and strFileName:filename.ext
   //Trailing slash will be preserved
-  strFileName = "";
-  strPath = "";
   int i = strFileNameAndPath.size() - 1;
-  while (i > 0)
+  while (i >= 0)
   {
-    char ch = strFileNameAndPath[i];
+    const char ch = strFileNameAndPath[i];
     // Only break on ':' if it's a drive separator for DOS (ie d:foo)
-    if (ch == '/' || ch == '\\' || (ch == ':' && i == 1)) break;
-    else i--;
+    if (ch == '/' || ch == '\\' || (ch == ':' && i == 1))
+      break;
+    else
+      i--;
   }
-  if (i == 0)
-    i--;
 
   // take left including the directory separator
   strPath = strFileNameAndPath.substr(0, i+1);
@@ -244,15 +250,9 @@ void URIUtils::Split(const std::string& strFileNameAndPath,
   // if actual uri, ignore options
   if (IsURL(strFileNameAndPath))
   {
-    i = strFileName.size() - 1;
-    while (i > 0)
-    {
-      char ch = strFileName[i];
-      if (ch == '?' || ch == '|') break;
-      else i--;
-    }
-    if (i > 0)
-      strFileName.resize(i);
+    size_t extras = strFileName.find_last_of("?|");
+    if (extras != std::string::npos)
+      strFileName.resize(extras);
   }
 }
 


### PR DESCRIPTION


## Description
Added consistency checks between `URLUtils` and `CURL::Parse`. Fixed found issues found between the two implementations.

Split #26931 into seperate branches. This is the second of those branches.

## Motivation and context
Consistency between different implmentations.

## How has this been tested?
Added unit tests

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
