### PR TITLE
[Depends] Allow BASE_URL overrides for dependencies

### DIFF
--- a/tools/depends/target/crossguid/Makefile
+++ b/tools/depends/target/crossguid/Makefile
@@ -17,7 +17,7 @@ else
     CXXFLAGS += -std=c++17
     PLATFORM = native
     TARBALLS_LOCATION = $(ROOT_DIR)
-    BASE_URL := http://mirrors.kodi.tv/build-deps/sources
+    BASE_URL ?= http://mirrors.kodi.tv/build-deps/sources
     RETRIEVE_TOOL := curl
     RETRIEVE_TOOL_FLAGS := -LsS --create-dirs --retry 10 --retry-connrefused -o
     ARCHIVE_TOOL := tar

--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -32,7 +32,7 @@ else
   RETRIEVE_TOOL = curl
   RETRIEVE_TOOL_FLAGS = -LsS --create-dirs --retry 10 --retry-connrefused -o
   ARCHIVE_TOOL_FLAGS = --strip-components=1 -xf
-  BASE_URL := http://mirrors.kodi.tv/build-deps/sources
+  BASE_URL ?= http://mirrors.kodi.tv/build-deps/sources
 endif
 
 include ../../download-files.include

--- a/tools/depends/target/flatbuffers/Makefile
+++ b/tools/depends/target/flatbuffers/Makefile
@@ -7,7 +7,7 @@ ifeq ($(PLATFORM),)
 	ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 	PLATFORM = native
 	TARBALLS_LOCATION = $(ROOT_DIR)
-	BASE_URL := http://mirrors.kodi.tv/build-deps/sources
+	BASE_URL ?= http://mirrors.kodi.tv/build-deps/sources
 	RETRIEVE_TOOL := curl
 	RETRIEVE_TOOL_FLAGS := -LsS --create-dirs --retry 10 --retry-connrefused -o
 	ARCHIVE_TOOL := tar

--- a/tools/depends/target/fmt/Makefile
+++ b/tools/depends/target/fmt/Makefile
@@ -13,7 +13,7 @@ else
   ifeq ($(PLATFORM),)
     PLATFORM = native
     TARBALLS_LOCATION = $(ROOT_DIR)
-    BASE_URL := http://mirrors.kodi.tv/build-deps/sources
+    BASE_URL ?= http://mirrors.kodi.tv/build-deps/sources
     RETRIEVE_TOOL := curl
     RETRIEVE_TOOL_FLAGS := -LsS --create-dirs --retry 10 --retry-connrefused -o
     ARCHIVE_TOOL := tar

--- a/tools/depends/target/spdlog/Makefile
+++ b/tools/depends/target/spdlog/Makefile
@@ -18,7 +18,7 @@ else
   ifeq ($(PLATFORM),)
     PLATFORM = native
     TARBALLS_LOCATION = $(ROOT_DIR)
-    BASE_URL := http://mirrors.kodi.tv/build-deps/sources
+    BASE_URL ?= http://mirrors.kodi.tv/build-deps/sources
     RETRIEVE_TOOL := curl
     RETRIEVE_TOOL_FLAGS := -LsS --create-dirs --retry 10 --retry-connrefused -o
     ARCHIVE_TOOL := tar

--- a/tools/depends/target/wayland-protocols/Makefile
+++ b/tools/depends/target/wayland-protocols/Makefile
@@ -13,7 +13,7 @@ ifeq ($(PLATFORM),)
 	ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 	PLATFORM = native
 	TARBALLS_LOCATION = $(ROOT_DIR)
-	BASE_URL := http://mirrors.kodi.tv/build-deps/sources
+	BASE_URL ?= http://mirrors.kodi.tv/build-deps/sources
 	RETRIEVE_TOOL := curl
 	RETRIEVE_TOOL_FLAGS := -LsS --create-dirs --retry 10 --retry-connrefused -o
 	ARCHIVE_TOOL := tar

--- a/tools/depends/target/waylandpp/Makefile
+++ b/tools/depends/target/waylandpp/Makefile
@@ -9,7 +9,7 @@ ifeq ($(PLATFORM),)
 	ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 	PLATFORM = native
 	TARBALLS_LOCATION = $(ROOT_DIR)
-	BASE_URL := http://mirrors.kodi.tv/build-deps/sources
+	BASE_URL ?= http://mirrors.kodi.tv/build-deps/sources
 	RETRIEVE_TOOL := curl
 	RETRIEVE_TOOL_FLAGS := -LsS --create-dirs --retry 10 --retry-connrefused -o
 	ARCHIVE_TOOL := tar


### PR DESCRIPTION
## Description
Found while working on https://github.com/xbmc/xbmc/pull/27090, all of these depends also suffer from the same issue (hardcoded BASE_URL)
