### PR TITLE
[filesystem] Refactored CNFSDirectory::GetDirectory

### DIFF
--- a/xbmc/FileItemList.h
+++ b/xbmc/FileItemList.h
@@ -46,6 +46,8 @@ public:
   void Add(CFileItemPtr item);
   void Add(CFileItem&& item);
   void AddFront(const CFileItemPtr& pItem, int itemPosition);
+  void AddItems(const std::vector<CFileItemPtr>& items);
+  void AddItems(std::vector<CFileItemPtr>&& items);
   void Remove(const CFileItem* pItem);
   void Remove(int iItem);
   CFileItemPtr Get(int iItem) const;
@@ -196,6 +198,9 @@ private:
    \sa Stack
    */
   void StackFolders();
+
+  void AddFastLookupItem(const CFileItemPtr& item);
+  void AddFastLookupItems(const std::vector<CFileItemPtr>& items);
 
   std::vector<std::shared_ptr<CFileItem>> m_items;
   std::map<std::string, std::shared_ptr<CFileItem>, std::less<>> m_map;

--- a/xbmc/filesystem/NFSDirectory.h
+++ b/xbmc/filesystem/NFSDirectory.h
@@ -26,9 +26,11 @@ namespace XFILE
       bool Exists(const CURL& url) override;
       bool Remove(const CURL& url) override;
     private:
-      bool GetServerList(CFileItemList &items);
-      bool GetDirectoryFromExportList(const std::string& strPath, CFileItemList &items);
-      bool ResolveSymlink( const std::string &dirName, struct nfsdirent *dirent, CURL &resolvedUrl);
+      std::vector<CFileItemPtr> GetServerList();
+      std::vector<CFileItemPtr> GetDirectoryFromExportList(const CURL& inputURL);
+      bool ResolveSymlink(const std::string& dirName,
+                          struct nfsdirent* dirent,
+                          std::string& resolvedPath);
   };
 }
 


### PR DESCRIPTION
## Description
Refactoring: Only do work that needs to be done.
Avoid calculating values which may be discarded.

Update local vector before adding list items to FileItemList.
This avoids multiple requests to taking the FileItemList lock.

A performance improvement has been measured by a TV show library scan.

| Master | This Branch | Difference |
| ------ | ----------- | ---------- |
| 33 min | 30 min      | 3 min ~ 9% |

Performance test details:

- Using locally stored .nfo files to avoid Scrapers accessing the internet.
- NFS test was on the same machine (ie. `nfs://localhost/library/tv_shows`) to reduce actual network traffic interference.
- Use std::make_shared to reduce allocations.

`CFileItemList::AddItems`: Avoid copying when move is available
`CFileItemList::AddFastLookupItem`: Factor out common code
`NFSDirectory::GetServerList`: Return vector<CFileItemPtr>
`NFSDirectory::GetServerExportList`: Return vector<CFileItemPtr>

After looking at the implementation of `CFileItemList::AddItems` and
optimizing a little more I got some updated timings from an NFS scan.

| Master | This Branch | Difference  |
| ------ | ----------- | ----------- |
| 32 min | 28 min      | 4 min ~ 10% |

## Motivation and context

## How has this been tested?
Manual library scan over NFS.

## What is the effect on users?
Improved NFS performance

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
