### PR TITLE
[Android] New dialog to explain the record audio permission

### DIFF
--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -42,7 +42,6 @@ import java.util.zip.ZipFile;
 
 public class Splash extends Activity
 {
-
   private static final int Uninitialized = 0;
   private static final int InError = 1;
   private static final int Checking = 2;
@@ -57,6 +56,7 @@ public class Splash extends Activity
   private static final int CheckingPermissionsInfo = 11;
   private static final int CheckExternalStorage = 12;
   private static final int RecordAudioPermission = 13;
+  private static final int RecordAudioInfo = 14;
   private static final int StartingXBMC = 99;
 
   private static final String TAG = "@APP_NAME@";
@@ -102,18 +102,13 @@ public class Splash extends Activity
           showErrorDialog(mSplash, getString(R.string.error_title), mErrorMsg);
           break;
         case CheckingPermissionsInfo:
-          AlertDialog dialog = new AlertDialog.Builder(mSplash).create();
-          dialog.setCancelable(false);
-          dialog.setTitle(getString(R.string.info_title));
-          dialog.setMessage(getString(R.string.notice_dialog, "@APP_NAME@"));
-          dialog.setButton(DialogInterface.BUTTON_NEUTRAL, getString(R.string.continue_button),
-                  (dialog1, which) -> mStateMachine.sendEmptyMessage(RecordAudioPermission));
-          dialog.show();
+          mSplash.mTextView.setText(getString(R.string.asking_permissions));
+          showInfoDialog(getString(R.string.notice_dialog, "@APP_NAME@"), CheckingPermissions);
+          break;
+        case RecordAudioInfo:
+          showInfoDialog(getString(R.string.record_audio_dialog, "@APP_NAME@"), RecordAudioPermission);
           break;
         case RecordAudioPermission:
-          mSplash.mTextView.setText(getString(R.string.asking_permissions));
-          mSplash.mProgress.setVisibility(View.INVISIBLE);
-
           requestPermissions(new String[]{Manifest.permission.RECORD_AUDIO},
                   RECORDAUDIO_RESULT_CODE);
           break;
@@ -367,7 +362,7 @@ public class Splash extends Activity
       switch (mState)
       {
         case Caching:
-          mSplash.mTextView.setText(getString(R.string.first_run, "@APP_NAME@"));
+          mSplash.mTextView.setText(getString(R.string.first_run));
           mSplash.mProgress.setVisibility(View.VISIBLE);
           mSplash.mProgress.setProgress(value);
           break;
@@ -408,6 +403,23 @@ public class Splash extends Activity
     // Make links actually clickable
     ((TextView) myAlertDialog.findViewById(android.R.id.message))
             .setMovementMethod(LinkMovementMethod.getInstance());
+  }
+
+  /**
+   * Displays an info dialog with a specified message and a button to continue.
+   *
+   * @param message The message to be displayed in the dialog.
+   * @param state   The next state to be sent to the state machine.
+   */
+  private void showInfoDialog(final String message, int state)
+  {
+    AlertDialog dialog = new AlertDialog.Builder(this).create();
+    dialog.setCancelable(false);
+    dialog.setTitle(getString(R.string.info_title));
+    dialog.setMessage(message);
+    dialog.setButton(DialogInterface.BUTTON_NEUTRAL, getString(R.string.continue_button),
+            (dialog1, which) -> mStateMachine.sendEmptyMessage(state));
+    dialog.show();
   }
 
   private void SetupEnvironment()
@@ -532,12 +544,12 @@ public class Splash extends Activity
         {
           mPermissionOK = true;
         }
-        mStateMachine.sendEmptyMessage(CheckingPermissionsDone);
+        mStateMachine.sendEmptyMessage(RecordAudioInfo);
         break;
       }
       case RECORDAUDIO_RESULT_CODE:
       {
-        mStateMachine.sendEmptyMessage(CheckingPermissions);
+        mStateMachine.sendEmptyMessage(CheckingPermissionsDone);
       }
     }
   }
@@ -552,7 +564,7 @@ public class Splash extends Activity
       {
         mPermissionOK = true;
       }
-      mStateMachine.sendEmptyMessage(CheckingPermissionsDone);
+      mStateMachine.sendEmptyMessage(RecordAudioInfo);
     }
   }
 
@@ -660,6 +672,7 @@ public class Splash extends Activity
 
     setContentView(R.layout.activity_splash);
     mProgress = findViewById(R.id.progressBar1);
+    mProgress.setVisibility(View.INVISIBLE);
     mTextView = findViewById(R.id.textView1);
 
     if (mState == InError || mState == CheckingPermissionsInfo)

--- a/tools/android/packaging/xbmc/strings.xml.in
+++ b/tools/android/packaging/xbmc/strings.xml.in
@@ -12,6 +12,7 @@
     <string name="info_title">Info</string>
     <string name="exit_button">Exit</string>
     <string name="notice_dialog">%1$s requires access to your device media and files to function. Please allow this via the following dialogue box or %1$s will exit.</string>
+    <string name="record_audio_dialog">%1$s asks for permission to record audio. This is only used for voice search. Please allow or deny this in the following dialogue box.</string>
     <string name="asking_permissions">Asking for permissions…</string>
     <string name="clearing_cache">Clearing cache…</string>
     <string name="waiting_external">Waiting for external storage…</string>


### PR DESCRIPTION
## Description
Add a dialog box to explain why the audio recording permission is requested when starting the app for the first time.

This permission is only needed if you want to use voice search in kodi.

I've added a text proposal, any suggestions are welcome.

## Motivation and context
Seen in a [comment](https://github.com/xbmc/xbmc/pull/27044#issuecomment-3153922032) and seems like a good idea.

## How has this been tested?
Runtime-tested on Android TV 11

## Screenshots (if appropriate):
<img width="1920" height="1080" alt="screen" src="https://github.com/user-attachments/assets/94f8c837-c40e-4922-9b01-0a51d7f52423" />

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
