### PR TITLE
[Addons] Bump game.controller.snes version for typo fix

### DIFF
--- a/addons/game.controller.snes/addon.xml
+++ b/addons/game.controller.snes/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="game.controller.snes"
         name="SNES Controller"
-        version="1.0.43"
+        version="1.0.44"
         provider-name="Team Kodi">
     <extension point="kodi.game.controller" library="resources/layout.xml"/>
     <extension point="xbmc.addon.metadata">
@@ -49,7 +49,7 @@
         <description lang="cs_CZ">SNES (taky známé jako Super NES nebo Super Nintendo) je 16 bitová konzole vydaná v roce 1990. Návrh ovladače posloužil jako inspirace pro PlayStation, Dreamcast, Xbox a Wii Classic.</description>
         <description lang="da_DK">SNES (også kendt som Super NES eller Super Nintendo) er en 16-bit konsol udgivet i 1990. Controllerdesignet fungerede som inspiration til PlayStation-, Dreamcast-, Xbox- og Wii Classic-controllere.</description>
         <description lang="de_DE">SNES (auch bekannt als Super NES oder Super Nintendo) ist eine 1990 veröffentlichte 16-bit Konsole. Das Controller-Design diente als Inspiration für die Controller von Playstation, Dreamcast, Xbox und Wii Classic.</description>
-        <description lang="en_GB">The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers.</description>
+        <description lang="en_GB">The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers.</description>
         <description lang="es_ES">La SNES (también conocida como Super NES o Super Nintendo) es una consola de 16-bit lanzada en 1990. El diseño de su mando sirvió de inspiracion para la PlayStation, Dreamcast, Xbox y los Mandos Clásicos de Wii.</description>
         <description lang="es_MX">La SNES (también conocida como Super NES o Super Nintendo) es una consola de 16-bit lanzada en 1990. El diseño del control sirvió como inspiración para los controles de PlayStation, Dreamcast, Xbox, y de la Wii Classic.</description>
         <description lang="fa_IR">اس‌نس (SNES که به نام‌های سوپر NES و سوپر نینتندو هم شناخته می‌شود) کنسولی ۱۶بیتی است که در ۱۳۶۷ ارائه شد. طرّاحی دسته‌اش، الهامی برای دسته‌های پلی‌استیشن، دریم‌کست، اکس‌باکس و وی بود.</description>

--- a/addons/game.controller.snes/resources/language/resource.language.af_za/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.af_za/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2024-01-15 01:17+0000\n"
 "Last-Translator: Heiko Berner <berner.h@gmail.com>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "SNES beheerder"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "Die SNES (ook bekend as Super NES of Super Nintendo) is 'n 16-bis konsole vrygestel in 1990. Die beheerder ontwerp het gedien as inspirasie vir die PlayStation, Dreamcast, Xbox en Wii Classic beheerders."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.am_et/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.am_et/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.ar_sa/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.ar_sa/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2023-02-17 22:58+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.ast_es/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.ast_es/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-02-27 10:00+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.az_az/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.az_az/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.be_by/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.be_by/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-02-16 12:00+0000\n"
 "Last-Translator: Antikruk <zmicerturok@gmail.com>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "Кантролер SNES"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "SNES (таксама вядомая як Super NES або Super Nintendo) - 16-бітавая гульнявая кансоль, выпушчаная ў 1990. Па ўзоры яе кантролераў ствараліся кантролеры для PlayStation, Dreamcast, Xbox і Wii Classic."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.bg_bg/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.bg_bg/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.bs_ba/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.bs_ba/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-12-15 12:13+0000\n"
 "Last-Translator: SecularSteve <fairfull.playing@gmail.com>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "Super Nintendo Džojstik"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "Super Nintendo (također poznat kao Super NES ili SNES) je 16-bitna konzola objavljena 1990-te godine. Dizajn džojstika poslužio je kao inspiracija za PlayStation, Dreamcast, Xbox i Wii Classic džojstike."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.ca_es/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.ca_es/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-08-18 16:16+0000\n"
 "Last-Translator: Xean <xeanhort007@gmail.com>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "Comandament SNES"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "La SNES (també coneguda com Super NES o Super Nintendo) és una consola de 16 bits llançada el 1990. El disseny del comandament va servir d'inspiració per als comandaments de PlayStation, Dreamcast, Xbox i Wii Classic."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.cs_cz/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.cs_cz/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-03-29 14:22+0000\n"
 "Last-Translator: Kryštof Černý <cleverline1mc@gmail.com>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "Ovladač SNES"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "SNES (taky známé jako Super NES nebo Super Nintendo) je 16 bitová konzole vydaná v roce 1990. Návrh ovladače posloužil jako inspirace pro PlayStation, Dreamcast, Xbox a Wii Classic."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.cy_gb/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.cy_gb/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.da_dk/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.da_dk/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-07-31 01:17+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "SNES controller"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "SNES (også kendt som Super NES eller Super Nintendo) er en 16-bit konsol udgivet i 1990. Controllerdesignet fungerede som inspiration til PlayStation-, Dreamcast-, Xbox- og Wii Classic-controllere."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.de_de/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.de_de/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "SNES-Controller"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "SNES (auch bekannt als Super NES oder Super Nintendo) ist eine 1990 veröffentlichte 16-bit Konsole. Das Controller-Design diente als Inspiration für die Controller von Playstation, Dreamcast, Xbox und Wii Classic."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.el_gr/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.el_gr/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.en_au/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.en_au/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.en_gb/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.en_gb/strings.po
@@ -21,7 +21,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.en_nz/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.en_nz/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.en_us/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.en_us/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.eo/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.eo/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.es_ar/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.es_ar/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.es_es/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.es_es/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2023-01-16 22:15+0000\n"
 "Last-Translator: José Antonio Alvarado <jalvarado0.eses@gmail.com>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "Mando SNES"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "La SNES (también conocida como Super NES o Super Nintendo) es una consola de 16-bit lanzada en 1990. El diseño de su mando sirvió de inspiracion para la PlayStation, Dreamcast, Xbox y los Mandos Clásicos de Wii."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.es_mx/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.es_mx/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-09-27 02:31+0000\n"
 "Last-Translator: Edson Armando <edsonarmando78@outlook.com>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "Control de SNES"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "La SNES (también conocida como Super NES o Super Nintendo) es una consola de 16-bit lanzada en 1990. El diseño del control sirvió como inspiración para los controles de PlayStation, Dreamcast, Xbox, y de la Wii Classic."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.et_ee/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.et_ee/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2025-03-09 08:31+0000\n"
 "Last-Translator: rimasx <riks_12@hot.ee>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.eu_es/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.eu_es/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.fa_af/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.fa_af/strings.po
@@ -21,7 +21,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.fa_ir/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.fa_ir/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-07-31 01:17+0000\n"
 "Last-Translator: Danial Behzadi <dani.behzi@ubuntu.com>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "دستهٔ SNES"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "اس‌نس (SNES که به نام‌های سوپر NES و سوپر نینتندو هم شناخته می‌شود) کنسولی ۱۶بیتی است که در ۱۳۶۷ ارائه شد. طرّاحی دسته‌اش، الهامی برای دسته‌های پلی‌استیشن، دریم‌کست، اکس‌باکس و وی بود."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.fi_fi/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.fi_fi/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-07-08 17:12+0000\n"
 "Last-Translator: Oskari Lavinto <olavinto@protonmail.com>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "SNES-ohjain"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "SNES (tunnetaan myös nimillä Super NES ja Super Nintendo) on 16-bittinen konsoli, joka julkaistiin vuonna 1990. Sen ohjaimen suunnittelu toimi inspiraationa PlayStation-, Dreamcast-, Xbox- ja Wii Classic -ohjaimille."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.fil/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.fil/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-06-15 13:14+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.fo_fo/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.fo_fo/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.fr_ca/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.fr_ca/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-12-15 12:13+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.fr_fr/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.fr_fr/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2023-04-02 10:39+0000\n"
 "Last-Translator: skypichat <skypichat@hotmail.fr>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "Manette Super Nintendo"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "La SNES (connue aussi sous le nom de Super NES ou Super Nintendo) est une console 16 bit sortie en 1990. Le dessin de la manette a servi d'inspiration pour les manettes de la PlayStation, la Dreamcast, la Xbox et la Wii Classic."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.gl_es/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.gl_es/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.he_il/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.he_il/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "בקר SNES"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "SNES (ידוע גם בשם סופר NES או סופר נינטנדו) היא מערכת משחקים ב־16 סיביות שיצאה לאור ב־1990. עיצוב הבקר שימש השראה לבקרים של PlayStation,‏ Dreamcast,‏ Xbox ו־Wii Classic."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.hi_in/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.hi_in/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.hr_hr/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.hr_hr/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2023-01-16 22:15+0000\n"
 "Last-Translator: gogogogi <trebelnik2@gmail.com>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "SNES upravljački uređaj"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "SNES (poznat kao i Super NES ili Super Nintendo) je 16-bitna konzola iz 1990. Dizajn upravljačkog uređaja poslužio je kao inspiracija za PlayStation, Dreamcast, Xbox i Wii Classic upravljačke uređaje."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.hu_hu/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.hu_hu/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-09-06 22:35+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "SNES kontroller"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "A SNES (más néven Super NES vagy Super Nintendo) egy 1990-ben kiadott 16 bites konzol. A vezérlő kialakítása inspirációt jelentett a PlayStation, a Dreamcast, az Xbox és a Wii Classic vezérlőkhöz."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.hy_am/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.hy_am/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.id_id/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.id_id/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-11-23 14:46+0000\n"
 "Last-Translator: Nao3Line Prez <n.yazawa6932@gmail.com>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "Kontrol SNES"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "SNES (juga dikenal sebagai Super NES atau Super Nintendo) adalah konsol 16-bit yang dirilis pada tahun 1990. Desain pengontrol berfungsi sebagai inspirasi untuk pengontrol PlayStation, Dreamcast, Xbox, dan Wii Classic."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.is_is/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.is_is/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-02-27 10:00+0000\n"
 "Last-Translator: Sveinn í Felli <sv1@fellsnet.is>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "SNES-stýring"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "SNES-stýringin (einnig þekkt sem Super NES eða Super Nintendo) er 16-bita leikjastýring frá 1990. Hönnun stýringarinnar var innblástur fyrir leikjastýringar PlayStation, Dreamcast, Xbox og Wii Classic."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.it_it/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.it_it/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-11-18 08:28+0000\n"
 "Last-Translator: Massimo Pissarello <mapi68@gmail.com>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "Controller SNES"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "Il SNES (noto anche come Super NES o Super Nintendo) è una console a 16 bit rilasciata nel 1990. Il design del controller è servito da ispirazione per i controller PlayStation, Dreamcast, Xbox e Wii Classic."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.ja_jp/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.ja_jp/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2023-02-07 08:18+0000\n"
 "Last-Translator: Kohji Matsubayashi <shaolin405mi16@gmail.com>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.kn_in/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.kn_in/strings.po
@@ -21,7 +21,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.ko_kr/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.ko_kr/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-08-26 10:37+0000\n"
 "Last-Translator: Minho Park <parkmino@gmail.com>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "SNES 컨트롤러"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "SNES(Super NES 또는 슈퍼 닌텐도라고도 함)는 1990년에 출시된 16비트 콘솔입니다. 컨트롤러 디자인은 PlayStation, Dreamcast, Xbox 및 Wii 클래식 컨트롤러에 영감을 주었습니다."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.lt_lt/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.lt_lt/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "SNES valdiklis"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "SNES (taip pat žinomas kaip Super NES arba Super Nintendo) yra 16 bitų konsolė, išleista 1990 m. Valdiklio dizainas įkvėpė PlayStation, Dreamcast, Xbox ir Wii Classic valdiklius."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.lv_lv/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.lv_lv/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2023-02-19 03:26+0000\n"
 "Last-Translator: Coool (github.com/Coool) <coool@mail.lv>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "SNES kontrolieris"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "SNES (pazīstams arī kā Super NES vai Super Nintendo) ir 16 bitu konsole, kas izlaista 1990. gadā. Kontroliera dizains kalpoja par iedvesmu PlayStation, Dreamcast, Xbox un Wii Classic kontrolieriem."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.mi/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.mi/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.mk_mk/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.mk_mk/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.ml_in/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.ml_in/strings.po
@@ -21,7 +21,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.mn_mn/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.mn_mn/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.ms_my/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.ms_my/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.mt_mt/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.mt_mt/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.my_mm/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.my_mm/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.nb_no/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.nb_no/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-11-26 00:39+0000\n"
 "Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "SNES-kontroller"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.nl_nl/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.nl_nl/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-12-15 12:13+0000\n"
 "Last-Translator: Deleted User <noreply+158@weblate.org>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "SNES controller"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "De SNES (ook bekend als de Super NES of Super Nintendo) is een 16-bit console uit 1990. Het controller ontwerp heeft gediend als inspiratie voor de PlayStations, Dreamcast, Xbox en Wii controllers."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.oc_fr/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.oc_fr/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-09 11:35+0000\n"
 "Last-Translator: Mejans <farga@mejans.fr>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.os_os/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.os_os/strings.po
@@ -21,7 +21,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.pl_pl/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.pl_pl/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-11-10 20:25+0000\n"
 "Last-Translator: bkiziuk <kiziuk@gmail.com>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "Kontroler SNES"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "SNES (znana również jako Super NES lub Super Nintendo) to 16-bitowa konsola wydana w 1990 roku. Wzór kontrolera był inspiracją dla kontrolerów PlayStation, Dreamcast, Xbox i Wii Classic."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.pt_br/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.pt_br/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-09-06 22:35+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "Controlador SNES"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "O SNES (também conhecido como Super NES ou Super Nintendo) é um console de 16 bits lançado em 1990. O design do controlador serviu de inspiração para os controles PlayStation, Dreamcast, Xbox e Wii Classic."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.pt_pt/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.pt_pt/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.ro_ro/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.ro_ro/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-04-03 13:41+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.ru_ru/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.ru_ru/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-20 04:28+0000\n"
 "Last-Translator: Dmitry Petrov <dimakrm361@gmail.com>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "SNES контроллер"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "SNES (также известная как Super NES или Super Nintendo) - 16-битная консоль, выпущенная в 1990 году. Дизайн контроллера послужил источником вдохновения для контроллеров PlayStation, Dreamcast, Xbox и Wii Classic."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.si_lk/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.si_lk/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.sk_sk/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.sk_sk/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-06-15 13:14+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "SNES controller"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "SNES (tiež známy ako Super NES alebo Super Nintendo) je 16-bitová konzola vydaná v roku 1990. Dizajn ovládača slúžil ako inšpirácia pre ovládače PlayStation, Dreamcast, Xbox a Wii Classic."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.sl_si/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.sl_si/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.sq_al/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.sq_al/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-02-27 10:00+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.sr_rs/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.sr_rs/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.sr_rs@latin/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.sr_rs@latin/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.sv_se/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.sv_se/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2025-04-06 00:27+0000\n"
 "Last-Translator: Daniel Nylander <daniel@danielnylander.se>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "SNES-handkontroller"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "SNES (även känd som Super NES eller Super Nintendo) är en 16-bitars konsol som släpptes 1990. Handkontrollens design fungerade som inspiration för handkontrollerna till PlayStation, Dreamcast, Xbox och Wii Classic."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.szl/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.szl/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.ta_in/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.ta_in/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.te_in/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.te_in/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.tg_tj/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.tg_tj/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.th_th/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.th_th/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.tr_tr/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.tr_tr/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2023-07-07 22:42+0000\n"
 "Last-Translator: queeup <queeup@zoho.com>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "SNES oyun kumandası"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "SNES (Super NES veya Super Nintendo olarak da bilinir), 1990 yılında yayımlanan 16 bit bir konsoldur. Konsol denetimcisi, PlayStation, Dreamcast, Xbox ve Wii Classic oyun kumandaları için bir esin kaynağı olarak kabul edilmektedir."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.uk_ua/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.uk_ua/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2025-07-19 15:29+0000\n"
 "Last-Translator: Pavlo Marianov <acid@jack.kyiv.ua>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "Контролер SNES"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "SNES (також відома як Super NES або Super Nintendo) — це 16-бітна ігрова консоль, що вийшла в 1990 році. Дизайн контролера став джерелом натхнення для геймпадів PlayStation, Dreamcast, Xbox та Wii Classic."
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.uz_uz/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.uz_uz/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.vi_vn/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.vi_vn/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2023-07-07 22:42+0000\n"
 "Last-Translator: Nguyễn Trung Hậu <trunghau1712@gmail.com>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr ""
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.zh_cn/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.zh_cn/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KODI Main\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/xbmc/issues/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-09-12 18:33+0000\n"
 "Last-Translator: taxigps <taxigps@sina.com>\n"
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "SNES 控制器"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "SNES（又名超级 NES 或超级任天堂）是1990年发布的16位游戏主机。其手柄设计为 PlayStation、Dreamcast、Xbox 和 Wii 经典手柄提供了灵感。"
 
 msgctxt "Addon Disclaimer"

--- a/addons/game.controller.snes/resources/language/resource.language.zh_tw/strings.po
+++ b/addons/game.controller.snes/resources/language/resource.language.zh_tw/strings.po
@@ -22,7 +22,7 @@ msgid "SNES controller"
 msgstr "SNES控制器"
 
 msgctxt "Addon Description"
-msgid "The SNES (akso known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
+msgid "The SNES (also known as Super NES or Super Nintendo) is a 16-bit console released in 1990. The controller design served as inspiration for the PlayStation, Dreamcast, Xbox and Wii Classic controllers."
 msgstr "SNES(又名超任)是在1990發表的16位元遊戲主機。該機型的控制器設計思路啟發了後繼的PS、DC、Xbox及Wii等主機。"
 
 msgctxt "Addon Disclaimer"


### PR DESCRIPTION
## Description

Copilot found a typo in the SNES controller description, so I put out a new version that fixes it.

## Motivation and context

Noticed by Copilot in https://github.com/xbmc/xbmc/pull/27094.

## How has this been tested?

Before:

<img width="1347" height="757" alt="Screenshot 2025-08-14 at 4 31 59 PM" src="https://github.com/user-attachments/assets/f5dbf5a6-fe02-47b9-b054-a8ba1bcae0ae" />

After:

<img width="1347" height="755" alt="Screenshot 2025-08-14 at 4 35 38 PM" src="https://github.com/user-attachments/assets/a0acfdda-4814-4bee-90ef-3c34afea7cd7" />

## What is the effect on users?

* Fixed typo in SNES controller description

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
