### PR TITLE
[PasswordManager] Factor out common credentials code.

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -32,7 +32,25 @@
 
 using namespace ADDON;
 
-CURL::~CURL() = default;
+CURL::CURL(std::string strURL)
+{
+  Parse(std::move(strURL));
+}
+
+bool CURL::operator==(const CURL& url) const
+{
+  return url == Get();
+}
+
+bool operator==(const CURL& url, const std::string& str)
+{
+  return url.Get() == str;
+}
+
+bool operator==(const std::string& str, const CURL& url)
+{
+  return url == str;
+}
 
 void CURL::Reset()
 {

--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -18,16 +18,16 @@
 #undef SetPort // WIN32INCLUDES this is defined as SetPortA in WinSpool.h which is being included _somewhere_
 #endif
 
-class CURL
+class CURL final
 {
 public:
-  explicit CURL(std::string strURL) { Parse(std::move(strURL)); }
-
   CURL() = default;
-  virtual ~CURL(void);
+  explicit CURL(std::string strURL);
 
+  bool operator==(const CURL& url) const;
   // explicit equals operator for std::string comparison
-  bool operator==(const std::string &url) const { return Get() == url; }
+  friend bool operator==(const CURL& url, const std::string& str);
+  friend bool operator==(const std::string& str, const CURL& url);
 
   void Reset();
   void Parse(std::string strURL);

--- a/xbmc/filesystem/NptXbmcFile.cpp
+++ b/xbmc/filesystem/NptXbmcFile.cpp
@@ -296,16 +296,14 @@ NPT_XbmcFile::Open(NPT_File::OpenMode mode)
         }
 
         bool result;
-        CURL url(URIUtils::SubstitutePath(name));
-
-        if (CPasswordManager::GetInstance().IsURLSupported(url) && url.GetUserName().empty())
-          CPasswordManager::GetInstance().AuthenticateURL(url);
+        CURL url = CURL(name);
+        CURL authUrl = URIUtils::AddCredentials(URIUtils::SubstitutePath(url));
 
         // compute mode
         if (mode & NPT_FILE_OPEN_MODE_WRITE)
-          result = file->OpenForWrite(url, (mode & NPT_FILE_OPEN_MODE_TRUNCATE) ? true : false);
+          result = file->OpenForWrite(authUrl, (mode & NPT_FILE_OPEN_MODE_TRUNCATE) ? true : false);
         else
-          result = file->Open(url);
+          result = file->Open(authUrl);
 
         if (!result) return NPT_ERROR_NO_SUCH_FILE;
     }

--- a/xbmc/test/TestURL.cpp
+++ b/xbmc/test/TestURL.cpp
@@ -14,6 +14,35 @@ using ::testing::Test;
 using ::testing::WithParamInterface;
 using ::testing::ValuesIn;
 
+class TestCURL : public testing::Test
+{
+};
+
+TEST_F(TestCURL, TestComparison)
+{
+  CURL url1;
+  CURL url2;
+  CURL url3("http://www.aol.com/index.html?t=9");
+  CURL url4(url3);
+
+  EXPECT_FALSE(url1 == url3);
+  EXPECT_FALSE(url2 == url3);
+
+  EXPECT_TRUE(url1 == url1);
+  EXPECT_TRUE(url2 == url2);
+  EXPECT_TRUE(url3 == url3);
+  EXPECT_TRUE(url4 == url4);
+
+  EXPECT_TRUE(url1 == url2);
+  EXPECT_TRUE(url3 == url4);
+
+  EXPECT_TRUE(url3 == "http://www.aol.com/index.html?t=9");
+  EXPECT_TRUE("http://www.aol.com/index.html?t=9" == url3);
+
+  EXPECT_FALSE(url3 == "http://www.microsoft.com/index.html?t=9");
+  EXPECT_FALSE("http://www.microsoft.com/index.html?t=9" == url3);
+}
+
 struct TestURLGetWithoutUserDetailsData
 {
   std::string input;

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -10,6 +10,7 @@
 
 #include "FileItem.h"
 #include "FileItemList.h"
+#include "PasswordManager.h"
 #include "ServiceBroker.h"
 #include "StringUtils.h"
 #include "URL.h"
@@ -1720,4 +1721,11 @@ bool URIUtils::UpdateUrlEncoding(std::string &strFilename)
 
   strFilename = newFilename;
   return true;
+}
+
+CURL URIUtils::AddCredentials(CURL url)
+{
+  if (CPasswordManager::GetInstance().IsURLSupported(url) && url.GetUserName().empty())
+    CPasswordManager::GetInstance().AuthenticateURL(url);
+  return url;
 }

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -332,6 +332,8 @@ public:
    */
   static bool UpdateUrlEncoding(std::string &strFilename);
 
+  static CURL AddCredentials(CURL url);
+
 private:
   static std::string resolvePath(const std::string &path);
 


### PR DESCRIPTION


## Description
Adding username and password to a URL is used in multiple places. Factor out this functionality into its own function.

## Motivation and context

## How has this been tested?
Manually

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
