### PR TITLE
[dbwrappers] Avoid copies of strings in database queries.

### DIFF
--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -257,7 +257,7 @@ void CDatabase::Split(const std::string& strFileNameAndPath,
   strFileName = strFileNameAndPath.substr(i);
 }
 
-std::string CDatabase::PrepareSQL(const char* sqlFormat, ...) const
+std::string CDatabase::PrepareSQL(std::string_view sqlFormat, ...) const
 {
   std::string strResult = "";
 

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -257,15 +257,15 @@ void CDatabase::Split(const std::string& strFileNameAndPath,
   strFileName = strFileNameAndPath.substr(i);
 }
 
-std::string CDatabase::PrepareSQL(std::string strStmt, ...) const
+std::string CDatabase::PrepareSQL(const char* sqlFormat, ...) const
 {
   std::string strResult = "";
 
   if (nullptr != m_pDB)
   {
     va_list args;
-    va_start(args, strStmt);
-    strResult = m_pDB->vprepare(strStmt.c_str(), args);
+    va_start(args, sqlFormat);
+    strResult = m_pDB->vprepare(sqlFormat, args);
     va_end(args);
   }
 

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -111,7 +111,14 @@ public:
   void CopyDB(const std::string& latestDb);
   void DropAnalytics();
 
-  std::string PrepareSQL(std::string strStmt, ...) const;
+  std::string PrepareSQL(const char* sqlFormat, ...) const;
+
+  template<typename String, typename... Args>
+    requires std::same_as<std::decay_t<String>, std::string>
+  std::string PrepareSQL(String&& sqlFormat, Args&&... args) const
+  {
+    return PrepareSQL(sqlFormat.c_str(), std::forward<Args>(args)...);
+  }
 
   /*!
    * @brief Get a single value from a table.

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -111,14 +111,7 @@ public:
   void CopyDB(const std::string& latestDb);
   void DropAnalytics();
 
-  std::string PrepareSQL(const char* sqlFormat, ...) const;
-
-  template<typename String, typename... Args>
-    requires std::same_as<std::decay_t<String>, std::string>
-  std::string PrepareSQL(String&& sqlFormat, Args&&... args) const
-  {
-    return PrepareSQL(sqlFormat.c_str(), std::forward<Args>(args)...);
-  }
+  std::string PrepareSQL(std::string_view sqlFormat, ...) const;
 
   /*!
    * @brief Get a single value from a table.

--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -172,7 +172,7 @@ public:
    \param args - va_list of variables for substitution in format string placeholders.
    \return escaped and formatted string.
    */
-  virtual std::string vprepare(const char* format, va_list args) = 0;
+  virtual std::string vprepare(std::string_view format, va_list args) = 0;
 
   virtual bool in_transaction() { return false; }
 };

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -1865,8 +1865,8 @@ bool MysqlDataset::query(const std::string& query)
   if (!handle())
     throw DbErrors("No Database Connection");
 
-  if (query.find("SELECT") == std::string::npos && query.find("select") == std::string::npos)
-    throw DbErrors("MUST be select SQL!");
+  // Must be a SELECT SQL query
+  assert(query.find("SELECT") != std::string::npos || query.find("select") != std::string::npos);
 
   close();
 

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -649,9 +649,9 @@ bool MysqlDatabase::exists()
 
 // methods for formatting
 // ---------------------------------------------
-std::string MysqlDatabase::vprepare(const char* format, va_list args)
+std::string MysqlDatabase::vprepare(std::string_view format, va_list args)
 {
-  std::string strFormat = format;
+  std::string strFormat = std::string(format);
   std::string strResult = "";
   size_t pos;
 

--- a/xbmc/dbwrappers/mysqldataset.h
+++ b/xbmc/dbwrappers/mysqldataset.h
@@ -75,7 +75,7 @@ public:
   void rollback_transaction() override;
 
   /* virtual methods for formatting */
-  std::string vprepare(const char* format, va_list args) override;
+  std::string vprepare(std::string_view format, va_list args) override;
 
   bool in_transaction() override { return _in_transaction; }
   int query_with_reconnect(const char* query);

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -621,9 +621,9 @@ void SqliteDatabase::rollback_transaction()
 
 // methods for formatting
 // ---------------------------------------------
-std::string SqliteDatabase::vprepare(const char* format, va_list args)
+std::string SqliteDatabase::vprepare(std::string_view format, va_list args)
 {
-  std::string strFormat = format;
+  std::string strFormat = std::string(format);
   std::string strResult = "";
   char* p;
   size_t pos;

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -930,8 +930,8 @@ bool SqliteDataset::query(const std::string& query)
   if (!handle())
     throw DbErrors("No Database Connection");
 
-  if (query.find("SELECT") == std::string::npos && query.find("select") == std::string::npos)
-    throw DbErrors("MUST be select SQL!");
+  // Must be a SELECT SQL query
+  assert(query.find("SELECT") != std::string::npos || query.find("select") != std::string::npos);
 
   close();
 

--- a/xbmc/dbwrappers/sqlitedataset.h
+++ b/xbmc/dbwrappers/sqlitedataset.h
@@ -81,7 +81,7 @@ public:
   void rollback_transaction() override;
 
   /* virtual methods for formatting */
-  std::string vprepare(const char* format, va_list args) override;
+  std::string vprepare(std::string_view format, va_list args) override;
 
   bool in_transaction() override { return _in_transaction; }
 };


### PR DESCRIPTION
## Description
- query method should accept query by string_view to avoid any string copies.
- Check for sqlite query string containing SELECT should be in an assert so the check does not slow down release builds.

## Motivation and context

## How has this been tested?
Manually

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
