### PR TITLE
CDRMAtomic: don't create egl fence unless atomic drm init was succesful

### DIFF
--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -11,6 +11,7 @@
 #include "OptionalsReg.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
+#include "drm/DRMAtomic.h"
 #include "utils/log.h"
 
 using namespace KODI::WINDOWING::GBM;
@@ -61,7 +62,15 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint 
   if (CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_ANDROID_native_fence_sync") &&
       CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_KHR_fence_sync"))
   {
-    m_eglFence = std::make_unique<KODI::UTILS::EGL::CEGLFence>(m_eglContext.GetEGLDisplay());
+    if (std::dynamic_pointer_cast<CDRMAtomic>(m_DRM))
+    {
+      m_eglFence = std::make_unique<KODI::UTILS::EGL::CEGLFence>(m_eglContext.GetEGLDisplay());
+    }
+    else
+    {
+      CLog::Log(LOGWARNING, "[GBM] EGL_KHR_fence_sync and EGL_ANDROID_native_fence_sync supported"
+                            ", but atomic DRM not initialized");
+    }
   }
   else
   {

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -11,7 +11,6 @@
 #include "OptionalsReg.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
-#include "drm/DRMAtomic.h"
 #include "utils/log.h"
 
 using namespace KODI::WINDOWING::GBM;
@@ -62,14 +61,14 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint 
   if (CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_ANDROID_native_fence_sync") &&
       CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_KHR_fence_sync"))
   {
-    if (std::dynamic_pointer_cast<CDRMAtomic>(m_DRM))
+    if (m_DRM->SupportsFencing())
     {
       m_eglFence = std::make_unique<KODI::UTILS::EGL::CEGLFence>(m_eglContext.GetEGLDisplay());
     }
     else
     {
       CLog::Log(LOGWARNING, "[GBM] EGL_KHR_fence_sync and EGL_ANDROID_native_fence_sync supported"
-                            ", but atomic DRM not initialized");
+                            ", but DRM backend doesn't support fencing");
     }
   }
   else

--- a/xbmc/windowing/gbm/drm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
@@ -32,6 +32,7 @@ public:
   bool SetActive(bool active) override;
   bool InitDrm() override;
   void DestroyDrm() override;
+  bool SupportsFencing() override { return true; }
   bool AddProperty(CDRMObject* object, const char* name, uint64_t value);
 
 private:

--- a/xbmc/windowing/gbm/drm/DRMUtils.h
+++ b/xbmc/windowing/gbm/drm/DRMUtils.h
@@ -45,6 +45,7 @@ public:
   virtual bool SetActive(bool active) { return false; }
   virtual bool InitDrm();
   virtual void DestroyDrm();
+  virtual bool SupportsFencing() { return false; }
 
   int GetFileDescriptor() const { return m_fd; }
   int GetRenderNodeFileDescriptor() const { return m_renderFd; }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR is relevant for systems which support the `EGL_KHR_fence_sync` and `EGL_ANDROID_native_fence_sync` extensions, but where Atomic DRM fails to initialize. In that case, the system usually correctly falls back to the Legacy DRM backend.

The current code without this PR initializes `m_eglFence` based only on the presence of the EGL extensions, without considering the active DRM backend. This creates a mismatch in synchronization strategies:

1. The `PresentRender` function executes its EGL fence-based synchronization logic (e.g., `WaitSyncGPU`, `SetInFenceFd`).
2. This logic is designed to work with the Atomic DRM backend, which consumes these fences via properties like `IN_FENCE_FD`.
3. The active `CDRMLegacy` backend does not support atomic properties and ignores these fences. It relies on its own blocking synchronization via `drmModePageFlip` events.

This mismatch can lead to incorrect synchronization, with the GPU waiting on fences that are never consumed by the display controller.

This change ensures that `m_eglFence` is only initialized if the `CDRMAtomic` backend is successfully loaded. When Legacy DRM is active, `m_eglFence` will be null, correctly disabling the EGL fencing path and falling back to `CDRMLegacy` backend's own blocking synchronization to function as the sole mechanism.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This solves #27116 in the case where DRM Legacy intializes (original behavior as outlined, i.e. before the work-around which makes CDRMAtomic initialize).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Applied patch to 21.2-Omega (no backporting needed). Developed against master branch where issue is still present (I tested this while creating #27116).

Tested:
- start Kodi at boot via systemd in GBM mode (using https://github.com/graysky2/kodi-standalone-service)
- verified CDRMLegacy was initialized (`CDRMLegacy::InitDrm - initialized legacy DRM`)
- observed the new Warning message indicating the occurence of this specific case (`[GBM] EGL_KHR_fence_sync and EGL_ANDROID_native_fence_sync supported, but atomic DRM not initialized`)
- used Kodi for some time, started some streams, without observing tearing nor black screens.
- clean exit at the end via the menu

I did observe some low fps in the UI shortly after stopping the second or third stream, but responsiveness recovered. Not sure how my system (Intel i3-9100 - GeForce GTX 1650 SUPER) would've acted otherwise with CDRMLegacy, as this never worked that long. CPU usage stays around 10%. Logfile shows a couple of these lines (4 occurences in 2min):
```
warning <general>: OutputPicture - timeout waiting for buffer
```

Kodi debug logfile: 
[kodi-PR-drmlegacy-eglfence-fix.log](https://github.com/user-attachments/files/21822892/kodi-PR-drmlegacy-eglfence-fix.log)


## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Many issues are reported linked to the EGLFence synchronization code. This fix resolves at least issue #27116, but maybe also others reported against #23921. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
