### PR TITLE
[VideoPlayer] Fix Fancy PGS Subs

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
@@ -271,7 +271,7 @@ std::shared_ptr<CDVDOverlay> CDVDOverlayCodecFFmpeg::GetOverlay()
     overlay->y = rect.y;
     overlay->width = rect.w;
     overlay->height = rect.h;
-    overlay->bForced = rect.flags != 0;
+    overlay->bForced = (rect.flags & AV_SUBTITLE_FLAG_FORCED);
     overlay->source_width = m_width;
     overlay->source_height = m_height;
 

--- a/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
@@ -85,7 +85,11 @@ void CDVDOverlayContainer::CleanUp(double pts)
       while (!bNewer && ++it2 != m_overlays.end())
       {
         const std::shared_ptr<CDVDOverlay>& pOverlay2 = *it2;
-        if (pOverlay2->bForced && pOverlay2->iPTSStartTime <= pts) bNewer = true;
+        // There can be multiple overlays queued at same start point.
+        // Skip them to find a new start point.
+        if (pOverlay2->bForced && pOverlay2->iPTSStartTime <= pts &&
+            pOverlay->iPTSStartTime != pOverlay2->iPTSStartTime)
+          bNewer = true;
       }
 
       if (bNewer)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Some fancy PGS subs have multiple rects per picture as well as the forced flag > results in multiple overlays with forced flag + same start time.

The clean up of overlays CDVDOverlayContainer::CleanUp() assumed a single overlay per start time and thought that the next overlays at the same start time are replacement of the first ones, which should be deleted.
The change skips forced overlays that share a start time.

The issue doesn't come up for non-forced overlays because the forced flag has special code to handle the display of menus.

If this has side effects, the alternative is to create overlays of type DVDOVERLAY_TYPE_GROUP as parent of the multiple rects.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix issue reported in forums https://forum.kodi.tv/showthread.php / #27095 (sample included)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With the sample. Other samples of simple PGS were not affected.
Unsure how menus should be tested, but logically the change should not affect them.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

correct display of PGS fan subs.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
