### PR TITLE
[builtins][SortUtils] Fix usage of Container.SetSortMethod(0) and Container.SortDirection

### DIFF
--- a/xbmc/interfaces/builtins/GUIContainerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIContainerBuiltins.cpp
@@ -23,7 +23,7 @@
   template<int Dir>
 static int ChangeSortMethod(const std::vector<std::string>& params)
 {
-  CGUIMessage message(GUI_MSG_CHANGE_SORT_METHOD, CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow(), 0, 0, Dir);
+  CGUIMessage message(GUI_MSG_CHANGE_SORT_METHOD, CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow(), 0, -1, Dir);
   CServiceBroker::GetGUI()->GetWindowManager().SendMessage(message);
 
   return 0;
@@ -64,7 +64,11 @@ static int Refresh(const std::vector<std::string>& params)
  */
 static int SetSortMethod(const std::vector<std::string>& params)
 {
-  CGUIMessage message(GUI_MSG_CHANGE_SORT_METHOD, CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow(), 0, atoi(params[0].c_str()));
+  CGUIMessage message(GUI_MSG_CHANGE_SORT_METHOD, CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow(), 0, -1);
+  if (!params.empty() && !params[0].empty())
+  {
+    message.SetParam1(atoi(params[0].c_str()));
+  }
   CServiceBroker::GetGUI()->GetWindowManager().SendMessage(message);
 
   return 0;

--- a/xbmc/interfaces/builtins/GUIContainerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIContainerBuiltins.cpp
@@ -181,9 +181,9 @@ CBuiltins::CommandMap CGUIContainerBuiltins::GetOperations() const
            {"container.previoussortmethod", {"Change to the previous sort method", 0, ChangeSortMethod<-1>}},
            {"container.previousviewmode",   {"Move to the previous view type (and refresh the listing)", 0, ChangeViewMode<-1>}},
            {"container.refresh",            {"Refresh current listing", 0, Refresh}},
-           {"container.setsortdirection",   {"Toggle the sort direction", 0, ToggleSortDirection}},
            {"container.setsortmethod",      {"Change to the specified sort method", 1, SetSortMethod}},
            {"container.setviewmode",        {"Move to the view with the given id", 1, SetViewMode}},
+           {"container.sortdirection",      {"Toggle the sort direction", 0, ToggleSortDirection}},
            {"container.update",             {"Update current listing. Send Container.Update(path,replace) to reset the path history", 1, Update}}
          };
 }

--- a/xbmc/interfaces/builtins/GUIContainerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIContainerBuiltins.cpp
@@ -23,7 +23,8 @@
   template<int Dir>
 static int ChangeSortMethod(const std::vector<std::string>& params)
 {
-  CGUIMessage message(GUI_MSG_CHANGE_SORT_METHOD, CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow(), 0, -1, Dir);
+  CGUIMessage message(GUI_MSG_CHANGE_SORT_METHOD,
+                      CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow(), 0, -1, Dir);
   CServiceBroker::GetGUI()->GetWindowManager().SendMessage(message);
 
   return 0;
@@ -64,7 +65,8 @@ static int Refresh(const std::vector<std::string>& params)
  */
 static int SetSortMethod(const std::vector<std::string>& params)
 {
-  CGUIMessage message(GUI_MSG_CHANGE_SORT_METHOD, CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow(), 0, -1);
+  CGUIMessage message(GUI_MSG_CHANGE_SORT_METHOD,
+                      CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow(), 0, -1);
   if (!params.empty() && !params[0].empty())
   {
     message.SetParam1(atoi(params[0].c_str()));
@@ -179,15 +181,18 @@ static int Update(const std::vector<std::string>& params)
 
 CBuiltins::CommandMap CGUIContainerBuiltins::GetOperations() const
 {
-  return {
-           {"container.nextsortmethod",     {"Change to the next sort method", 0, ChangeSortMethod<1>}},
-           {"container.nextviewmode",       {"Move to the next view type (and refresh the listing)", 0, ChangeViewMode<1>}},
-           {"container.previoussortmethod", {"Change to the previous sort method", 0, ChangeSortMethod<-1>}},
-           {"container.previousviewmode",   {"Move to the previous view type (and refresh the listing)", 0, ChangeViewMode<-1>}},
-           {"container.refresh",            {"Refresh current listing", 0, Refresh}},
-           {"container.setsortmethod",      {"Change to the specified sort method", 1, SetSortMethod}},
-           {"container.setviewmode",        {"Move to the view with the given id", 1, SetViewMode}},
-           {"container.sortdirection",      {"Toggle the sort direction", 0, ToggleSortDirection}},
-           {"container.update",             {"Update current listing. Send Container.Update(path,replace) to reset the path history", 1, Update}}
-         };
+  return {{"container.nextsortmethod", {"Change to the next sort method", 0, ChangeSortMethod<1>}},
+          {"container.nextviewmode",
+           {"Move to the next view type (and refresh the listing)", 0, ChangeViewMode<1>}},
+          {"container.previoussortmethod",
+           {"Change to the previous sort method", 0, ChangeSortMethod<-1>}},
+          {"container.previousviewmode",
+           {"Move to the previous view type (and refresh the listing)", 0, ChangeViewMode<-1>}},
+          {"container.refresh", {"Refresh current listing", 0, Refresh}},
+          {"container.setsortmethod", {"Change to the specified sort method", 1, SetSortMethod}},
+          {"container.setviewmode", {"Move to the view with the given id", 1, SetViewMode}},
+          {"container.sortdirection", {"Toggle the sort direction", 0, ToggleSortDirection}},
+          {"container.update",
+           {"Update current listing. Send Container.Update(path,replace) to reset the path history",
+            1, Update}}};
 }

--- a/xbmc/utils/SortUtils.h
+++ b/xbmc/utils/SortUtils.h
@@ -51,8 +51,9 @@ typedef enum {
 ///@{
 typedef enum
 {
-  /// __0__  :
-  SortByNone = 0,
+  SortByStartMarker = -1,
+  /// __0__  : Unsorted
+  SortByNone,
   /// __1__  : Sort by Name                       <em>(String: <b><c>Label</c></b>)</em>
   SortByLabel,
   /// __2__  : Sort by Date                       <em>(String: <b><c>Date</c></b>)</em>
@@ -173,6 +174,9 @@ typedef enum
   /// __59__ : Sort by user preference            <em>(String: <b><c>UserPreference</c></b>)</em>
   /// @skinning_v20 <b>SortByUserPreference</b> New sort method added.
   SortByUserPreference,
+  // SortByEndMarker must remain as the last item in the enum.
+  // All new sort methods to be added prior to this end marker.
+  SortByEndMarker,
 } SortBy;
 ///@}
 

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -339,7 +339,7 @@ void CGUIViewState::AddSortMethod(const SortDescription& sortDescription,
 void CGUIViewState::SetCurrentSortMethod(int method)
 {
   SortBy sortBy = (SortBy)method;
-  if (sortBy < SortByNone || sortBy > SortByLastUsed)
+  if (sortBy <= SortByStartMarker || sortBy >= SortByEndMarker)
     return; // invalid
 
   SetSortMethod(sortBy);

--- a/xbmc/view/ViewStateSettings.cpp
+++ b/xbmc/view/ViewStateSettings.cpp
@@ -103,7 +103,8 @@ bool CViewStateSettings::Load(const TiXmlNode *settings)
     else
     {
       int sortMethod;
-      if (XMLUtils::GetInt(pViewState, XML_SORTMETHOD, sortMethod, SortByStartMarker + 1, SortByEndMarker - 1))
+      if (XMLUtils::GetInt(pViewState, XML_SORTMETHOD, sortMethod, SortByStartMarker + 1,
+                           SortByEndMarker - 1))
         viewState->second->m_sortDescription.sortBy = (SortBy)sortMethod;
       if (XMLUtils::GetInt(pViewState, XML_SORTATTRIBUTES, sortMethod, SortAttributeNone, SortAttributeIgnoreFolders))
         viewState->second->m_sortDescription.sortAttributes = (SortAttribute)sortMethod;

--- a/xbmc/view/ViewStateSettings.cpp
+++ b/xbmc/view/ViewStateSettings.cpp
@@ -103,7 +103,7 @@ bool CViewStateSettings::Load(const TiXmlNode *settings)
     else
     {
       int sortMethod;
-      if (XMLUtils::GetInt(pViewState, XML_SORTMETHOD, sortMethod, SortByNone, SortByLastUsed))
+      if (XMLUtils::GetInt(pViewState, XML_SORTMETHOD, sortMethod, SortByStartMarker + 1, SortByEndMarker - 1))
         viewState->second->m_sortDescription.sortBy = (SortBy)sortMethod;
       if (XMLUtils::GetInt(pViewState, XML_SORTATTRIBUTES, sortMethod, SortAttributeNone, SortAttributeIgnoreFolders))
         viewState->second->m_sortDescription.sortAttributes = (SortAttribute)sortMethod;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -499,7 +499,7 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
     {
       if (m_guiState)
       {
-        if (message.GetParam1())
+        if (message.GetParam1() >= SortByNone)
           m_guiState->SetCurrentSortMethod(message.GetParam1());
         else if (message.GetParam2())
           m_guiState->SetNextSortMethod(message.GetParam2());


### PR DESCRIPTION
## Description
Container.SortDirection has been broken since Kodi 16 by this commit https://github.com/xbmc/xbmc/commit/ac870b64b16dfd0fc2bd0496c14529cf6d563f41
This PR reverts the name change to re-align with documentation.

Container.SetSortMethod(0) has seemingly never worked which prevent resetting to the default unsorted sort method `SortByNone`. This PR utilises a sentinel value of `-1` as an invalid sort method ID rather than `0` to allow the valid `SortByNone` method to be used.

Additionally as new sort methods have been added various parts of the codebase have not been updated to properly make use of them. New markers have been added to the `SortBy` enum to eliminate the need to keep updating this manually.

## Motivation and context
Fix documented existing functionality to allow skins/addons to make use of it. Intend to do so in `plugin.video.youtube`.

## How has this been tested?
WIP - don't currently have a build environment setup. To be runtime tested.

## What is the effect on users?
Probably nothing until the functionality is used by a skin or addon.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
