### PR TITLE
[dbwrappers] Add missing include <cstdint>

### DIFF
--- a/xbmc/dbwrappers/qry_dat.h
+++ b/xbmc/dbwrappers/qry_dat.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <ostream>
 #include <string>
 #include <string_view>


### PR DESCRIPTION
## Description / Motivation and context

Build fails with Kodi 22.0a1 on Alpine Linux edge (musl, gcc 15.2.0) because it is missing the cstdint header for int64_t.

	In file included from /builds/alpine/aports/community/kodi/src/xbmc-22.0a1-Piers/xbmc/utils/DatabaseUtils.cpp:11:
	In file included from /builds/alpine/aports/community/kodi/src/xbmc-22.0a1-Piers/xbmc/dbwrappers/dataset.h:15:
	/builds/alpine/aports/community/kodi/src/xbmc-22.0a1-Piers/xbmc/dbwrappers/qry_dat.h:62:5: error: unknown type name 'int64_t'
	   62 |     int64_t int64_value;
	      |     ^
	/builds/alpine/aports/community/kodi/src/xbmc-22.0a1-Piers/xbmc/dbwrappers/qry_dat.h:79:30: error: unknown type name 'int64_t'
	   79 |   explicit field_value(const int64_t i);
	      |                              ^
	/builds/alpine/aports/community/kodi/src/xbmc-22.0a1-Piers/xbmc/dbwrappers/qry_dat.h:97:3: error: unknown type name 'int64_t'
	   97 |   int64_t get_asInt64() const;
	      |   ^
	/builds/alpine/aports/community/kodi/src/xbmc-22.0a1-Piers/xbmc/dbwrappers/qry_dat.h:149:32: error: unknown type name 'int64_t'
	  149 |   field_value& operator=(const int64_t i)
	      |                                ^
	/builds/alpine/aports/community/kodi/src/xbmc-22.0a1-Piers/xbmc/dbwrappers/qry_dat.h:234:26: error: unknown type name 'int64_t'
	  234 |   void set_asInt64(const int64_t i);
	      |                          ^
	5 errors generated.

## How has this been tested?
Not yet

## What is the effect on users?
None

## Screenshots (if appropriate):
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
