### PR TITLE
[depends][xkbcommon] Allow out-of-bounds keycodes without error

### DIFF
--- a/tools/depends/target/libxkbcommon/0001-No-error-on-out-of-bounds-keycode.patch
+++ b/tools/depends/target/libxkbcommon/0001-No-error-on-out-of-bounds-keycode.patch
@@ -1,0 +1,11 @@
+--- a/src/xkbcomp/keycodes.c
++++ b/src/xkbcomp/keycodes.c
+@@ -206,7 +206,7 @@ AddKeyName(KeyNamesInfo *info, xkb_keycode_t kc, xkb_atom_t name,
+         log_err(info->ctx, XKB_LOG_MESSAGE_NO_ID,
+                 "Keycode too big: must be < %#"PRIx32", got %#"PRIx32"; "
+                 "Key ignored\n", XKB_KEYCODE_MAX_IMPL, kc);
+-        return false;
++        return true;
+     }
+ 
+     const xkb_atom_t old_name =

--- a/tools/depends/target/libxkbcommon/Makefile
+++ b/tools/depends/target/libxkbcommon/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include LIBXKBCOMMON-VERSION ../../download-files.include
-DEPS =../../Makefile.include LIBXKBCOMMON-VERSION Makefile ../../download-files.include
+DEPS =../../Makefile.include LIBXKBCOMMON-VERSION Makefile 0001-No-error-on-out-of-bounds-keycode.patch ../../download-files.include
 
 # configuration settings
 MESON_BUILD_TYPE=release
@@ -31,6 +31,7 @@ all: .installed-$(PLATFORM)
 $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); patch -p1 -i ../0001-No-error-on-out-of-bounds-keycode.patch
 	cd $(PLATFORM); $(CONFIGURE) . build
 
 $(LIBDYLIB): $(PLATFORM)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
After #27088 we noticed that keyboard input was broken on webOS. This is due to a behaviour change in `libxkbcommon` which hard fails on a keymap with a keycode > `0x2ff`. On webOS such a key exists in the keymap making `xkb_keymap_new_from_string` fail:

```
2025-08-19 14:41:09.075 T:6803    error <general>: [xkb] Keycode too big: must be < 0xfff, got 0x5030; Key ignored
2025-08-19 14:41:09.075 T:6803    error <general>: [xkb] Failed to compile xkb_keycodes
2025-08-19 14:41:09.075 T:6803    error <general>: [xkb] [XKB-822] Failed to compile keymap
```

Add a small patch to `libxkbcommon` to no longer hard fail in such a case and just ignore the key as the log xkb output suggests.

Behaviour change introduced in https://github.com/xkbcommon/libxkbcommon/pull/626
Tracked upstream in https://github.com/xkbcommon/libxkbcommon/issues/849

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
