### PR TITLE
[Video] Fix fail to update videoversion when updating library.

### DIFF
--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1300,18 +1300,18 @@ public:
                              DeleteMovieCascadeAction cascadeAction);
 
   /*!
-   * \brief Adds a version of an existing movie to the database
+   * \brief Adds or updates a version of an existing movie to the database
    * \param itemType type of the video being converted
    * \param dbIdSource id of the video being converted
    * \param idVideoVersion new versiontype of the default version of the video
    * \param assetType new asset type of the default version of the video
-   * \return dbId in the videoversion table, -1 if failure
+   * \return true if success, false otherwise
    */
-  int AddVideoVersion(VideoDbContentType itemType,
-                      int dbIdSource,
-                      int idFile,
-                      int idVideoVersion,
-                      VideoAssetType assetType);
+  bool AddOrUpdateVideoVersion(VideoDbContentType itemType,
+                               int dbIdSource,
+                               int idFile,
+                               int idVideoVersion,
+                               VideoAssetType assetType);
 
   void SetDefaultVideoVersion(VideoDbContentType itemType, int dbId, int idFile);
   void SetVideoVersion(int idFile, int idVideoVersion);

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -381,8 +381,8 @@ bool CGUIDialogVideoManagerVersions::ChoosePlaylist(const std::shared_ptr<CFileI
       {
         videoDbSuccess = true;
         m_database.SetStreamDetailsForFileId(item->GetVideoInfoTag()->m_streamDetails, idFile);
-        if (m_database.AddVideoVersion(item->GetVideoContentType(), idMovie, idFile, idVideoVersion,
-                                       VideoAssetType::VERSION) < 0)
+        if (!m_database.AddOrUpdateVideoVersion(item->GetVideoContentType(), idMovie, idFile,
+                                                idVideoVersion, VideoAssetType::VERSION))
           return false;
       }
     }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

First issue:
AddVideoVersion() has been altered along the same lines of AddFile() to provide UPSERT functionailty.
This prevents a sql error when rescanning a folder that contains a movie nfo that's been altered.

This then unmasked a second issue:

Pre-requisites:
1) Fix one is in place (so never actually happened in a build in the 'wild')
2) A movie has already been scanned into the database
3) Something triggers the directory to be scanned again
4) There is an nfo present

Then it was being added as a video version rather than as a movie.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix further bugs identified in #27082.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally and by three testers in the bug report.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
