### PR TITLE
Fix waylandpp compilation on GCC 14.2.0

### DIFF
--- a/tools/depends/target/waylandpp/001-fix-gcc14-build.patch
+++ b/tools/depends/target/waylandpp/001-fix-gcc14-build.patch
@@ -1,0 +1,11 @@
+--- a/include/wayland-server.hpp
++++ b/include/wayland-server.hpp
+@@ -27,6 +27,7 @@
+ #define WAYLAND_SERVER_HPP
+
+ #include <atomic>
++#include <cstdint>
+ #include <functional>
+ #include <list>
+ #include <memory>
+

--- a/tools/depends/target/waylandpp/Makefile
+++ b/tools/depends/target/waylandpp/Makefile
@@ -1,6 +1,6 @@
 -include ../../Makefile.include
 include WAYLANDPP-VERSION ../../download-files.include
-DEPS =Makefile ../../download-files.include WAYLANDPP-VERSION
+DEPS =Makefile ../../download-files.include WAYLANDPP-VERSION 001-fix-gcc14-build.patch
 
 LIBDYLIB=$(PLATFORM)/build/libwayland-client++.so
 
@@ -36,6 +36,7 @@ ifeq ($(PREFIX),)
 endif
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); patch -p1 -i ../001-fix-gcc14-build.patch
 	mkdir -p $(BUILDDIR)
 	cd $(BUILDDIR); $(CMAKE) $(CMAKE_OPTIONS) ..
 


### PR DESCRIPTION
## Description
waylandpp will not compile on GCC 14.2.0 due to missing include:

```
[ 26%] Building CXX object CMakeFiles/wayland-server++.dir/wayland-server-protocol.cpp.o
/home/cscd98/Developer/kodi-webos/tools/depends/target/waylandpp/arm-webos-linux-gnueabi-release/build/wayland-server-protocol.hpp:186:25: error: ‘uint32_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
  186 |   static constexpr std::uint32_t global_since_version = 1;
```

PR has also been sent upstream: https://github.com/NilsBrause/waylandpp/pull/92

## Motivation and context
This PR removed one include that is not included in upstream:
https://github.com/xbmc/xbmc/pull/27090

## How has this been tested?
Compile tools/depends/target/waylandpp with and without patch

## What is the effect on users?
No affect on users but allows developers to compile waylandpp

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
