### PR TITLE
Add dvcc metadata to InputStream interface

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -492,6 +492,95 @@ private:
 //------------------------------------------------------------------------------
 
 //==============================================================================
+/// @defgroup cpp_kodi_addon_inputstream_Defs_Interface_InputstreamDvccMetadata class InputstreamDvccMetadata
+/// @ingroup cpp_kodi_addon_inputstream_Defs_Interface
+/// @brief **Dolby Vision Configuration Constraint (DVCC) metadata**\n
+/// Describes the metadata used for Dolby Vision stream configuration.
+///
+/// Used on @ref kodi::addon::InputstreamInfo::SetDvccMetadata and @ref kodi::addon::InputstreamInfo::GetDvccMetadata.
+///
+/// ----------------------------------------------------------------------------
+///
+/// @copydetails cpp_kodi_addon_inputstream_Defs_Interface_InputstreamDvccMetadata_Help
+///
+///@{
+class ATTR_DLL_LOCAL InputstreamDvccMetadata
+  : public CStructHdl<InputstreamDvccMetadata, INPUTSTREAM_DVCC_METADATA>
+{
+  /*! \cond PRIVATE */
+  friend class CInstanceInputStream;
+  friend class InputstreamInfo;
+  /*! \endcond */
+
+public:
+  InputstreamDvccMetadata() = default;
+
+  InputstreamDvccMetadata(const InputstreamDvccMetadata& stream) : CStructHdl(stream) {}
+
+  InputstreamDvccMetadata& operator=(const InputstreamDvccMetadata&) = default;
+
+  /// @defgroup cpp_kodi_addon_inputstream_Defs_Interface_InputstreamDvccMetadata_Help Value Help
+  /// @ingroup cpp_kodi_addon_inputstream_Defs_Interface_InputstreamDvccMetadata
+  ///
+  /// <b>The following table contains values that can be set with @ref cpp_kodi_addon_inputstream_Defs_Interface_InputstreamDvccMetadata :</b>
+  /// | Name | Type | Set call | Get call
+  /// |------|------|----------|----------
+  /// | **DVCC version major** | `uint8_t` | SetDvVersionMajor | GetDvVersionMajor
+  /// | **DVCC version minor** | `uint8_t` | SetDvVersionMinor | GetDvVersionMinor
+  /// | **Dolby Vision profile** | `uint8_t` | SetDvProfile | GetDvProfile
+  /// | **Dolby Vision level** | `uint8_t` | SetDvLevel | GetDvLevel
+  /// | **RPU present flag** | `bool` | SetRpuPresentFlag | GetRpuPresentFlag
+  /// | **Enhancement Layer present flag** | `bool` | SetElPresentFlag | GetElPresentFlag
+  /// | **Base Layer present flag** | `bool` | SetBlPresentFlag | GetBlPresentFlag
+  /// | **BL signal compatibility ID** | `uint8_t` | SetBlSignalCompatibilityId | GetBlSignalCompatibilityId
+  /// | **Compression method** | `uint8_t` | SetMdCompression | GetMdCompression
+
+  bool operator==(const kodi::addon::InputstreamDvccMetadata& right) const
+  {
+    if (memcmp(m_cStructure, right.m_cStructure, sizeof(INPUTSTREAM_DVCC_METADATA)) == 0)
+      return true;
+    return false;
+  }
+
+  void SetDvVersionMajor(uint8_t value) { m_cStructure->m_dvVersionMajor = value; }
+  uint8_t GetDvVersionMajor() const { return m_cStructure->m_dvVersionMajor; }
+
+  void SetDvVersionMinor(uint8_t value) { m_cStructure->m_dvVersionMinor = value; }
+  uint8_t GetDvVersionMinor() const { return m_cStructure->m_dvVersionMinor; }
+
+  void SetDvProfile(uint8_t value) { m_cStructure->m_dvProfile = value; }
+  uint8_t GetDvProfile() const { return m_cStructure->m_dvProfile; }
+
+  void SetDvLevel(uint8_t value) { m_cStructure->m_dvLevel = value; }
+  uint8_t GetDvLevel() const { return m_cStructure->m_dvLevel; }
+
+  void SetRpuPresentFlag(bool value) { m_cStructure->m_rpuPresentFlag = value; }
+  bool GetRpuPresentFlag() const { return m_cStructure->m_rpuPresentFlag; }
+
+  void SetElPresentFlag(bool value) { m_cStructure->m_elPresentFlag = value; }
+  bool GetElPresentFlag() const { return m_cStructure->m_elPresentFlag; }
+
+  void SetBlPresentFlag(bool value) { m_cStructure->m_blPresentFlag = value; }
+  bool GetBlPresentFlag() const { return m_cStructure->m_blPresentFlag; }
+
+  void SetBlSignalCompatibilityId(uint8_t value)
+  {
+    m_cStructure->m_dvBlSignalCompatibilityId = value;
+  }
+  uint8_t GetBlSignalCompatibilityId() const { return m_cStructure->m_dvBlSignalCompatibilityId; }
+
+  void SetMdCompression(uint8_t value) { m_cStructure->m_dvMdCompression = value; }
+  uint8_t GetMdCompression() const { return m_cStructure->m_dvMdCompression; }
+
+private:
+  InputstreamDvccMetadata(const INPUTSTREAM_DVCC_METADATA* stream) : CStructHdl(stream) {}
+
+  InputstreamDvccMetadata(INPUTSTREAM_DVCC_METADATA* stream) : CStructHdl(stream) {}
+};
+///@}
+//------------------------------------------------------------------------------
+
+//==============================================================================
 /// @defgroup cpp_kodi_addon_inputstream_Defs_Interface_InputstreamInfo class InputstreamInfo
 /// @ingroup cpp_kodi_addon_inputstream_Defs_Interface
 /// @brief **Inputstream add-on stream info**\n
@@ -554,6 +643,7 @@ public:
   /// | **Color transfer characteristic** |  | no | @ref InputstreamInfo::SetColorTransferCharacteristic "SetColorTransferCharacteristic" | @ref InputstreamInfo::GetColorTransferCharacteristic "GetColorTransferCharacteristic"
   /// | **Mastering metadata** |  | no | @ref InputstreamInfo::SetMasteringMetadata "SetMasteringMetadata" | @ref InputstreamInfo::GetMasteringMetadata "GetMasteringMetadata"
   /// | **Content light metadata** |  | no | @ref InputstreamInfo::SetContentLightMetadata "SetContentLightMetadata" | @ref InputstreamInfo::GetContentLightMetadata "GetContentLightMetadata"
+  /// | **DVCC metadata** |  | no | @ref InputstreamInfo::SetDVCCMetadata "SetDVCCMetadata" | @ref InputstreamInfo::GetDVCCMetadata "GetDVCCMetadata"
   ///
 
   /// @addtogroup cpp_kodi_addon_inputstream_Defs_Interface_InputstreamInfo
@@ -902,6 +992,23 @@ public:
   /// @brief Clear content light static Metadata.
   void ClearContentLightMetadata() { m_cStructure->m_contentLightMetadata = nullptr; }
 
+  /// @brief Set Dolby Vision Configuration Constraint (DVCC) metadata.
+  ///
+  /// @param[in] dvccMetadata The settable metadata with @ref InputstreamDvccMetadata
+  void SetDvccMetadata(const kodi::addon::InputstreamDvccMetadata& dvccMetadata)
+  {
+    m_dvccMetadata = dvccMetadata;
+    m_cStructure->m_dvccMetadata = m_dvccMetadata;
+  }
+
+  /// @brief Get DVCC metadata previously set with @ref SetDvccMetadata.
+  ///
+  /// @return Reference to the DVCC metadata wrapper.
+  const kodi::addon::InputstreamDvccMetadata& GetDvccMetadata() const { return m_dvccMetadata; }
+
+  /// @brief Clear DVCC metadata.
+  void ClearDvccMetadata() { m_cStructure->m_dvccMetadata = nullptr; }
+
   ///@}
 
 private:
@@ -932,6 +1039,7 @@ private:
   StreamCryptoSession m_cryptoSession;
   InputstreamMasteringMetadata m_masteringMetadata;
   InputstreamContentlightMetadata m_contentLightMetadata;
+  InputstreamDvccMetadata m_dvccMetadata;
 };
 ///@}
 //------------------------------------------------------------------------------

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream.h
@@ -497,6 +497,40 @@ extern "C"
   ///@}
   //------------------------------------------------------------------------------
 
+  //! @brief Dolby Vision configuration metadata (dvcc)
+  typedef struct INPUTSTREAM_DVCC_METADATA
+  {
+    //! @brief dvcc version major
+    uint8_t m_dvVersionMajor;
+
+    //! @brief dvcc version minor
+    uint8_t m_dvVersionMinor;
+
+    //! @brief Dolby Vision profile identifier
+    uint8_t m_dvProfile;
+
+    //! @brief Dolby Vision level identifier
+    uint8_t m_dvLevel;
+
+    //! @brief RPU (Reference Processing Unit) present flag
+    bool m_rpuPresentFlag;
+
+    //! @brief Enhancement Layer present flag
+    bool m_elPresentFlag;
+
+    //! @brief Base Layer present flag
+    bool m_blPresentFlag;
+
+    //! @brief BL (Base Layer) signal compatibility ID
+    uint8_t m_dvBlSignalCompatibilityId;
+
+    //! @brief The compression method in use
+    uint8_t m_dvMdCompression;
+
+  } INPUTSTREAM_DVCC_METADATA;
+  ///@}
+  //------------------------------------------------------------------------------
+
   /*!
    * @brief stream properties
    */
@@ -590,6 +624,9 @@ extern "C"
 
     //! @brief content light static Metadata
     struct INPUTSTREAM_CONTENTLIGHT_METADATA* m_contentLightMetadata;
+
+    //! @brief Dolby Vision config metadata (dvcc atom)
+    struct INPUTSTREAM_DVCC_METADATA* m_dvccMetadata;
   };
 
   struct INPUTSTREAM_TIMES

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -108,8 +108,8 @@
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "c-api/addon-instance/imagedecoder.h" \
                                                       "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "3.3.0"
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "3.3.0"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "3.4.0"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "3.4.0"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "c-api/addon-instance/inputstream.h" \
                                                       "c-api/addon-instance/inputstream/demux_packet.h" \

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -495,6 +495,7 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
     streamVideo->masteringMetaData = source->masteringMetaData;
     streamVideo->contentLightMetaData = source->contentLightMetaData;
     streamVideo->hdr_type = source->hdr_type;
+    streamVideo->dovi = source->dovi;
 
     streamVideo->m_parser_split = true;
     streamVideo->changes++;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -497,6 +497,22 @@ KODI_HANDLE CInputStreamAddon::cb_get_stream_transfer(KODI_HANDLE handle,
     }
     //@}
 
+    // Dolby Vision DVCC metadata mapping
+    if (stream->m_dvccMetadata)
+    {
+      videoStream->dovi.dv_version_major = stream->m_dvccMetadata->m_dvVersionMajor;
+      videoStream->dovi.dv_version_minor = stream->m_dvccMetadata->m_dvVersionMinor;
+      videoStream->dovi.dv_profile = stream->m_dvccMetadata->m_dvProfile;
+      videoStream->dovi.dv_level = stream->m_dvccMetadata->m_dvLevel;
+      videoStream->dovi.rpu_present_flag = stream->m_dvccMetadata->m_rpuPresentFlag;
+      videoStream->dovi.el_present_flag = stream->m_dvccMetadata->m_elPresentFlag;
+      videoStream->dovi.bl_present_flag = stream->m_dvccMetadata->m_blPresentFlag;
+      videoStream->dovi.dv_bl_signal_compatibility_id =
+          stream->m_dvccMetadata->m_dvBlSignalCompatibilityId;
+      videoStream->dovi.dv_md_compression = stream->m_dvccMetadata->m_dvMdCompression;
+    }
+    //@}
+
     /*
     // Way to include part on new API version
     if (Addon()->GetTypeVersionDll(ADDON_TYPE::ADDON_INSTANCE_INPUTSTREAM) >= AddonVersion("3.0.0")) // Set the version to your new


### PR DESCRIPTION
## Description
We need to be able to pass the dvcc metadata from inputstream.adaptive into kodi to set the necessary dv_profile used in CMediaPipelineWebOS

Requires https://github.com/xbmc/inputstream.adaptive/pull/1920 for functionality in IA to be merged however as an interface only it is safe to merge on its own.

## Motivation and context
Necessary pre-cursor for correct DV Widevine (L1) playback on webOS

## How has this been tested?
1. Playback of 4k UHD Dolby Vision content on Disney+ with the Disney+ addon and IA with Widevine (L1) support (currently nearing end of development)

2. Playback of 1080p (no DV) on Disney+ to confirm no breakage for non-DV case.

Logs from IA reading that data from a D+ movie:
```
2025-08-20 13:14:57.270 T:5683    debug <inputstream.adaptive>: PopulateDvccMetadata: PopulateDvccMetadata: ver 1.0, profile 5, level 6, rpu=1, el=0, bl=1, bl_compat_id=0
```

Logs from kodi with this data passed into the media pipeline in kodi:
```
2025-08-20 14:12:20.753 T:3791    debug <general>: DVCC: profile 5 level 6 rpu=1 el=0 bl=1 bl_compat_id=0
```

These come directly from AP4_DvccAtom which has the following fields:

```
AP4_UI08 m_DvVersionMajor;
AP4_UI08 m_DvVersionMinor;
AP4_UI08 m_DvProfile;
AP4_UI08 m_DvLevel;
AP4_UI08 m_RpuPresentFlag;
AP4_UI08 m_ElPresentFlag;
AP4_UI08 m_BlPresentFlag;
AP4_UI08 m_DvBlSignalCompatibilityID;
```

## What is the effect on users?
The ability to select the correct profile for DV.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
