### PR TITLE
NFSDirectory: not use `limits.h` for NFS MAX_PATH

### DIFF
--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -19,8 +19,6 @@
 #include <sys\stat.h>
 #endif
 
-#include <limits.h>
-
 #include <nfsc/libnfs-raw-nfs.h>
 #include <nfsc/libnfs.h>
 
@@ -39,6 +37,7 @@ using namespace XFILE;
 
 namespace
 {
+constexpr int NFS_MAX_PATH = 4096;
 
 KODI::TIME::FileTime GetDirEntryTime(struct nfsdirent* dirent)
 {
@@ -130,8 +129,8 @@ bool CNFSDirectory::ResolveSymlink(const std::string& dirName,
 
   std::string fullpath = dirName + dirent->name;
 
-  char resolvedLink[MAX_PATH];
-  ret = nfs_readlink(gNfsConnection.GetNfsContext(), fullpath.c_str(), resolvedLink, MAX_PATH);
+  char resolvedLink[NFS_MAX_PATH];
+  ret = nfs_readlink(gNfsConnection.GetNfsContext(), fullpath.c_str(), resolvedLink, NFS_MAX_PATH);
 
   if(ret == 0)
   {


### PR DESCRIPTION
## Description
NFSDirectory: not use `limits.h` for NFS MAX_PATH

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently is included `limits.h` only for `MAX_PATH` but this is not very good because NFS max path is always 4096 but on Windows MAX_PATH is defined as 260 (and is not defined in `limits.h`). 

So on Windows, this is artificially limiting the maximum length of NFS paths. Current Windows versions support more than 260 char for paths but anyway is not relevant here because is not in use any Windows API. 

NFS max path limit only depends on NFS server itself and API used (libnfs), then is safe assume in all platforms 4096 because libnfs not has any limit here.

In Linux nothing changes because MAX_PATH is defined anyway as 4096. Other platforms may define MAX_PATH as 1024 but this for native platform file system (not NFS) anyway.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Windows x64 resolving NFS symlink to a folder of ~1300 chars length. 

- Before, this case failed because the 260 buffer wasn't sufficient to resolve the symbolic link. 
- Now, the path displays correctly in the Kodi file manager.



## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Removes artificial NFS MAX_PATH limit on platforms where MAX_PATH is defined < 4096.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
