### PR TITLE
[CURL] Domain name gets encoded but does not get decoded.

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -319,6 +319,7 @@ void CURL::Parse(std::string strURL1)
     SetHostName(m_strHostName);
   }
 
+  m_strDomain = Decode(m_strDomain);
   m_strUserName = Decode(m_strUserName);
   m_strPassword = Decode(m_strPassword);
 }

--- a/xbmc/test/TestURL.cpp
+++ b/xbmc/test/TestURL.cpp
@@ -77,3 +77,21 @@ TEST(TestURLGetWithoutOptions, PreserveSlashesBetweenProtocolAndPath)
   CURL input{url};
   EXPECT_EQ(input.GetWithoutOptions(), url);
 }
+
+TEST(TestURL, TestWithoutFilenameEncodingDecoding)
+{
+  std::string decoded_with_path{
+      "smb://dom^inName;u$ername:pa$$word@example.com/stream/example/index.m3u8"};
+
+  CURL input{decoded_with_path};
+  EXPECT_EQ("smb://dom%5einName;u%24ername:pa%24%24word@example.com/", input.GetWithoutFilename());
+  EXPECT_EQ("dom^inName", input.GetDomain());
+  EXPECT_EQ("u$ername", input.GetUserName());
+  EXPECT_EQ("pa$$word", input.GetPassWord());
+
+  CURL decoded(input.GetWithoutFilename());
+  EXPECT_EQ("smb://dom%5einName;u%24ername:pa%24%24word@example.com/", decoded.Get());
+  EXPECT_EQ("dom^inName", decoded.GetDomain());
+  EXPECT_EQ("u$ername", decoded.GetUserName());
+  EXPECT_EQ("pa$$word", decoded.GetPassWord());
+}


### PR DESCRIPTION
## Description
It is arguable that domain should not get encoded in the first place. The test which has been written is a false test because the domain contains invalid characters given the Microsoft spec.

The "proper" solution here would be to _not_ encode the domain name. I think this will be difficult to reason about as there may be obscure corner cases (non standard implementations) existing which depend on this behavour now.

I will be happy to go the other way and remove the domain name encoding instead but this does contain some risk. Thoughts?

## Motivation and context

## How has this been tested?
Added unit test

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
