### PR TITLE
[FileItemList] Undo accidental revert on bad merge.

### DIFF
--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -125,8 +125,8 @@ void CFileItemList::ClearItems()
 
 void CFileItemList::AddFastLookupItem(const CFileItemPtr& item)
 {
-  m_map.try_emplace(
-      m_ignoreURLOptions ? CURL(item->GetPath()).GetWithoutOptions() : item->GetPath(), item);
+  m_map.try_emplace(m_ignoreURLOptions ? item->GetURL().GetWithoutOptions() : item->GetPath(),
+                    item);
 }
 
 void CFileItemList::AddFastLookupItems(const std::vector<CFileItemPtr>& items)


### PR DESCRIPTION


## Description
Credit to @CrystalP. It was [discovered](https://github.com/xbmc/xbmc/pull/27092#discussion_r2289809915) that a branch had been committed with an error.

#26873 introduced an optimization to allow CURL objects to be obtained, cheaper than parsing a new CURL object, from a FileItem. Callers were updated to take advantage of this cheaper functionality.
#27092 refactored one of the callers using this method as an effeciency boost.

There must have been a bad merge in #27092 as the improvement had been accidentally removed.

This branch is to restore that optimization.

## Motivation and context

## How has this been tested?
Tests were added in #26873 

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
