### PR TITLE
[VideoDatabase] Prevents inserting new empty unique ID's and prevents existing ones from being used to match different versions of the same movie

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4647,12 +4647,13 @@ void CVideoDatabase::GetSameVideoItems(const CFileItem& item, CFileItemList& ite
     // note 2: for type 'tmdb' the same value may be used for a movie and a tv episode, only
     // distinguished by media_type.
     // @todo make the (value,type) pairs truly unique
-    m_pDS->query(PrepareSQL("SELECT DISTINCT media_id "
-                            "FROM uniqueid "
-                            "WHERE (media_type, value, type) IN "
-                            "  (SELECT media_type, value, type "
-                            "  FROM uniqueid WHERE media_id = %i AND media_type = '%s') ",
-                            dbId, mediaType.c_str()));
+    m_pDS->query(
+        PrepareSQL("SELECT DISTINCT media_id "
+                   "FROM uniqueid "
+                   "WHERE (media_type, value, type) IN "
+                   "  (SELECT media_type, value, type "
+                   "  FROM uniqueid WHERE media_id = %i AND media_type = '%s' AND value != '') ",
+                   dbId, mediaType.c_str()));
 
     while (!m_pDS->eof())
     {


### PR DESCRIPTION
## Description
~Prevents inserting new empty unique ID's~ and prevents existing ones from being used to match different versions of the same movie

Fix https://github.com/xbmc/xbmc/issues/27122

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/xbmc/xbmc/issues/27122

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested that existing movies with empty IDs no longer appears as suggest from Manage Versions / Add Version dialog.

Before, selecting any movie with an empty ID was obtained a list of all other movies with empty ID's as suggestion for "Add Version".

Tested also that movies with same unique ID continues matching as suggestion for "Add Version" from "Manage Versions".

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Mitigates false positives of popup message "Found a different version of the movie xxx. Would you like to convert it into an additional version of the original?" during scanning movies. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
