### PR TITLE
Add ability to retrieve the music and video database names currently in use

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -10264,10 +10264,32 @@ constexpr std::array<InfoMap, 63> slideshow = {{
 ///     @skinning_v19 **[New Boolean Condition]** \link Library_HasNode `Library.HasNode(path)`\endlink
 ///     <p>
 ///   }
+///   \table_row3{   <b>`Library.MusicDBName`</b>,
+///                  \anchor Library_MusicDBName
+///                  _string_,
+///     @return The name of the music database currently in use.
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link Library_MusicDBName `Library.MusicDBName`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`Library.VideoDBName`</b>,
+///                  \anchor Library_VideoDBName
+///                  _string_,
+///     @return The name of the video database currently in use.
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link Library_VideoDBName `Library.VideoDBName`\endlink
+///     <p>
+///   }
 /// \table_end
 /// @todo Make this annotate an array of infobools/labels to make it easier to track
 ///
 /// -----------------------------------------------------------------------------
+// clang-format off
+constexpr std::array<InfoMap, 2> library_labels = {{
+    {"musicdbname",     LIBRARY_MUSICDB_NAME},
+    {"videodbname",     LIBRARY_VIDEODB_NAME}, // labels from here
+}};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \section modules_rm_infolabels_booleans Additional revision history for Infolabels and Boolean Conditions
@@ -10803,6 +10825,10 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         StringUtils::ToLower(node);
         return AddMultiInfo(CGUIInfo(LIBRARY_HAS_NODE, prop.param(), 0));
       }
+      else if (prop.Name() == "musicdbname")
+        return LIBRARY_MUSICDB_NAME;
+      else if (prop.Name() == "videodbname")
+        return LIBRARY_VIDEODB_NAME;
     }
     else if (cat.Name() == "musicplayer")
     {

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -874,3 +874,13 @@ bool CDatabase::BuildSQL(const std::string& strBaseDir,
 
   return BuildSQL(strQuery, filter, strSQL);
 }
+
+std::string CDatabase::GetDatabaseName(const DatabaseSettings& settings)
+{
+  DatabaseSettings dbSettings = settings;
+  std::string dbName = dbSettings.name;
+  if (dbName.empty())
+    dbName = GetBaseDBName();
+  dbName += std::to_string(GetSchemaVersion());
+  return dbName;
+}

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -112,6 +112,7 @@ public:
   void DropAnalytics();
 
   std::string PrepareSQL(std::string_view sqlFormat, ...) const;
+  std::string GetDatabaseName(const DatabaseSettings& db);
 
   /*!
    * @brief Get a single value from a table.

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -503,6 +503,8 @@ constexpr uint32_t LIBRARY_IS_SCANNING_MUSIC         = 730;
 constexpr uint32_t LIBRARY_HAS_ROLE                  = 735;
 constexpr uint32_t LIBRARY_HAS_BOXSETS               = 736;
 constexpr uint32_t LIBRARY_HAS_NODE                  = 737;
+constexpr uint32_t LIBRARY_MUSICDB_NAME              = 738;
+constexpr uint32_t LIBRARY_VIDEODB_NAME              = 739;
 
 constexpr uint32_t SYSTEM_PLATFORM_LINUX             = 741;
 constexpr uint32_t SYSTEM_PLATFORM_WINDOWS           = 742;

--- a/xbmc/guilib/guiinfo/LibraryGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/LibraryGUIInfo.cpp
@@ -92,6 +92,22 @@ bool CLibraryGUIInfo::InitCurrentItem(CFileItem *item)
 
 bool CLibraryGUIInfo::GetLabel(std::string& value, const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback) const
 {
+  switch (info.GetInfo())
+  {
+    case LIBRARY_MUSICDB_NAME:
+    {
+      CMusicDatabase db;
+      value = db.GetDatabaseName();
+      return true;
+    }
+    case LIBRARY_VIDEODB_NAME:
+    {
+      CVideoDatabase db;
+      value = db.GetDatabaseName();
+      return true;
+    }
+  }
+
   return false;
 }
 

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -1426,3 +1426,10 @@ bool CAudioLibrary::CheckForAdditionalProperties(const CVariant &properties, con
 
   return !foundProperties.empty();
 }
+
+JSONRPC_STATUS CAudioLibrary::GetDatabaseName(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
+{
+  CMusicDatabase audiodatabase;
+  result = audiodatabase.GetDatabaseName();
+  return OK;
+}

--- a/xbmc/interfaces/json-rpc/AudioLibrary.h
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.h
@@ -53,6 +53,8 @@ namespace JSONRPC
     static JSONRPC_STATUS Export(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
     static JSONRPC_STATUS Clean(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
 
+    static JSONRPC_STATUS GetDatabaseName(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
+
     static bool FillFileItem(
         const std::string& strFilename,
         std::shared_ptr<CFileItem>& item,

--- a/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
+++ b/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
@@ -100,6 +100,7 @@ JsonRpcMethodMap CJSONServiceDescription::m_methodMaps[] = {
   { "Files.Download",                               CFileOperations::Download },
 
 // Music Library
+  { "AudioLibrary.GetDatabaseName",                 CAudioLibrary::GetDatabaseName },
   { "AudioLibrary.GetProperties",                   CAudioLibrary::GetProperties },
   { "AudioLibrary.GetArtists",                      CAudioLibrary::GetArtists },
   { "AudioLibrary.GetArtistDetails",                CAudioLibrary::GetArtistDetails },
@@ -126,6 +127,7 @@ JsonRpcMethodMap CJSONServiceDescription::m_methodMaps[] = {
   { "AudioLibrary.Clean",                           CAudioLibrary::Clean },
 
 // Video Library
+  { "VideoLibrary.GetDatabaseName",                 CVideoLibrary::GetDatabaseName },
   { "VideoLibrary.GetGenres",                       CVideoLibrary::GetGenres },
   { "VideoLibrary.GetTags",                         CVideoLibrary::GetTags },
   { "VideoLibrary.GetAvailableArtTypes",            CVideoLibrary::GetAvailableArtTypes },

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -1407,3 +1407,10 @@ void CVideoLibrary::UpdateVideoTag(const CVariant& parameterObject,
     updatedDetails.insert("dateadded");
   }
 }
+
+JSONRPC_STATUS CVideoLibrary::GetDatabaseName(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
+{
+  CVideoDatabase videodatabase;
+  result = videodatabase.GetDatabaseName();
+  return OK;
+}

--- a/xbmc/interfaces/json-rpc/VideoLibrary.h
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.h
@@ -73,6 +73,8 @@ namespace JSONRPC
     static JSONRPC_STATUS Export(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
     static JSONRPC_STATUS Clean(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
 
+    static JSONRPC_STATUS GetDatabaseName(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
+
     static bool FillFileItem(
         const std::string& strFilename,
         std::shared_ptr<CFileItem>& item,

--- a/xbmc/interfaces/json-rpc/schema/methods.json
+++ b/xbmc/interfaces/json-rpc/schema/methods.json
@@ -1601,6 +1601,14 @@
     ],
     "returns": "string"
   },
+  "AudioLibrary.GetDatabaseName": {
+    "type": "method",
+    "description": "Get current music database name",
+    "transport": "Response",
+    "permission": "ReadData",
+    "params": [],
+    "returns": "string"
+  },
   "AudioLibrary.GetProperties": {
     "type": "method",
     "description": "Retrieves the values of the music library properties",
@@ -3168,6 +3176,14 @@
         "description": "Whether or not to show the progress bar or any other GUI dialog"
       }
     ],
+    "returns": "string"
+  },
+  "VideoLibrary.GetDatabaseName": {
+    "type": "method",
+    "description": "Get current video database name",
+    "transport": "Response",
+    "permission": "ReadData",
+    "params": [],
     "returns": "string"
   },
   "VideoLibrary.GetMovies": {

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -122,6 +122,12 @@ CMusicDatabase::~CMusicDatabase()
   EmptyCache();
 }
 
+std::string CMusicDatabase::GetDatabaseName()
+{
+  return CDatabase::GetDatabaseName(
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_databaseMusic);
+}
+
 bool CMusicDatabase::Open()
 {
   return CDatabase::Open(

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -91,6 +91,8 @@ public:
   CMusicDatabase();
   ~CMusicDatabase() override;
 
+  std::string GetDatabaseName();
+
   bool Open() override;
   bool CommitTransaction() override;
   void EmptyCache();

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -86,6 +86,12 @@ CVideoDatabase::CVideoDatabase() = default;
 CVideoDatabase::~CVideoDatabase() = default;
 
 //********************************************************************************************************************************
+std::string CVideoDatabase::GetDatabaseName()
+{
+  return CDatabase::GetDatabaseName(
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_databaseVideo);
+}
+
 bool CVideoDatabase::Open()
 {
   return CDatabase::Open(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_databaseVideo);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -551,6 +551,8 @@ public:
   CVideoDatabase();
   ~CVideoDatabase() override;
 
+  std::string GetDatabaseName();
+
   bool Open() override;
   bool CommitTransaction() override;
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Add GetDatabaseName() functions to MusicLibrary, VideoLibrary and dbwrapper/CDatabase.
Add AudioLibrary.GetDatabaseName and VideoLibrary.GetDatabaseName json-rpc methods.
Add Library.MusicDBName and Library.VideoDBName infolabel tags.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I have a mix of test/dev/normal Kodi boxes, usually configured to use shared databases. In trying to bisect a problem, I've ran into the database schema changing and thus the database name. I noticed various addons and tools assume the databases in use are the newest ones but that's not always true. Some don't even account for custom database names and assume the default MyMusic/MyVideos prefix. This patch set adds the ability for scripts/addons via infolabel tags, and external tools via json-rpc to query a running Kodi instance for the actual database names being used, allowing those tools to access the correct databases.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested the infolabel tags by modifying skin.estuary `$INFO[Library.MusicDBName]`, `$INFO[Library.VideoDBName` and tagoverview `xbmc.getInfoLabel('Library.VideoDBName')`. I tested the json-rpc methods `AudioLibrary.GetDatabaseName` and `VideoLibrary.GetDatabaseName` using curl POST. The correct database names were returned in all tests.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
This is mainly helpful for people who do testing/development, run different Kodi versions, or use external apps accessing the databases and need to know which exact database name a specific Kodi instance is using.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
