### PR TITLE
webOS: passthrough encrypted data to secure decoder

### DIFF
--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.h
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.h
@@ -74,9 +74,10 @@ public:
   /**
    * @brief Check if a codec is supported by the pipeline.
    * @param codec AVCodecID to check.
+   * @param includeSecure If true, include secure codecs in the check.
    * @return True if supported, false otherwise.
    */
-  static bool Supports(AVCodecID codec);
+  static bool Supports(AVCodecID codec, bool includeSecure = false);
 
   /**
    * @brief Flush all pending video messages.


### PR DESCRIPTION
## Description
This is the last of a set of changes to implement Widevine decoding on webOS. This PR forwards encrypted packets received from IA directly to the secure decoder in webOS. They are not decrypted and therefore the secure path is maintained. This allows for 4K UHD playback on webOS including Dolby Vision.

This PR should be safe to merge on its own but the functionality will not be present until the other PRs are merged:

https://github.com/xbmc/xbmc/pull/27136 -> Adds Dolby Vision metadata to Inputstream interface
https://github.com/xbmc/inputstream.adaptive/pull/1900 -> Adds L1 support to webOS
https://github.com/xbmc/xbmc/pull/27078 -> Fix OpenSSL symbols being exported (merged)
https://github.com/xbmc/inputstream.adaptive/pull/1893 -> Adds webOS Widevine library support (merged)
https://github.com/emilsvennesson/script.module.inputstreamhelper/pull/592 -> Adds webOS to helper (merged)

Note due to an issue with AAC support, we have limited AAC to cryptosessions only. AAC will otherwise be transcoded as it did before when dealing with unencrypted packets so users are not affected.

## Motivation and context
Playback of UHD content on streaming services.

## How has this been tested?
Tested on **Disney+** on a webOS 24 TV:

- 4K UHD DV
- 4k UHD HDR10
- 1080p

AAC, DD+ and Dolby Atmos are supported.

**Prime:**
4K UHD DV stream tested
(DV has purple tint, unrelated to this PR, another PR will be released for that)

**ITV X:**
1080p stream tested

Testing on webOS 5 - 23 has been extremely limited.

## What is the effect on users?
Allows webOS to playback 4k UHD content using supported addons.

Some addons will need updates to recognize L1 support after merging otherwise they will still be limited to L3 (upto 1080p) depending on provider limitation. For example, https://github.com/Sandmann79/xbmc/pull/788 is waiting to be reviewed by the code maintainer.

Note to end users: webOS 5 - 23?? (need to clarify exact versions): In order to use widevine, /dev/tee0 must be created if it does not exist. This is because /dev/tee0 is not exposed in most dev environments that kodi runs as at the moment. This is a separate issue. This is not a problem with webOS 24.

webOS 4 is still being worked on, that supports in being worked on for IA.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
