### PR TITLE
Random SonarQube findings which were introduced since August 2 2025

### DIFF
--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -310,7 +310,7 @@ void CSkinInfo::LoadTimers()
   m_skinTimerManager->LoadTimers(timersPath);
 }
 
-void CSkinInfo::ProcessTimers()
+void CSkinInfo::ProcessTimers() const
 {
   m_skinTimerManager->Process();
 }

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -179,7 +179,7 @@ public:
 
   /*! \brief Starts evaluating timers
    */
-  void ProcessTimers();
+  void ProcessTimers() const;
 
   /*! \brief Called when unloading a skin, allows to cleanup specific
    * skin resources.

--- a/xbmc/addons/interfaces/gui/ListItem.cpp
+++ b/xbmc/addons/interfaces/gui/ListItem.cpp
@@ -56,7 +56,8 @@ KODI_GUI_LISTITEM_HANDLE Interface_GUIListItem::create(KODI_HANDLE kodiBase,
     return nullptr;
   }
 
-  auto* item{new std::shared_ptr<CFileItem>(new CFileItem())};
+  auto* fileItem{new CFileItem()};
+  auto* item{new std::shared_ptr<CFileItem>(fileItem)};
   if (label)
     item->get()->SetLabel(label);
   if (label2)

--- a/xbmc/addons/interfaces/gui/Window.cpp
+++ b/xbmc/addons/interfaces/gui/Window.cpp
@@ -873,7 +873,7 @@ int Interface_GUIWindow::get_current_list_position(KODI_HANDLE kodiBase,
                                                    KODI_GUI_WINDOW_HANDLE handle)
 {
   const auto* addon = static_cast<const CAddonDll*>(kodiBase);
-  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* pAddonWindow = static_cast<const CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow)
   {
     CLog::LogF(LOGERROR,
@@ -893,7 +893,7 @@ int Interface_GUIWindow::get_current_list_position(KODI_HANDLE kodiBase,
 int Interface_GUIWindow::get_list_size(KODI_HANDLE kodiBase, KODI_GUI_WINDOW_HANDLE handle)
 {
   const auto* addon = static_cast<const CAddonDll*>(kodiBase);
-  auto* pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
+  const auto* pAddonWindow = static_cast<const CGUIAddonWindow*>(handle);
   if (!addon || !pAddonWindow)
   {
     CLog::LogF(LOGERROR,
@@ -1060,7 +1060,7 @@ KODI_GUI_CONTROL_HANDLE Interface_GUIWindow::get_control_render_addon(KODI_HANDL
                                                                       KODI_GUI_WINDOW_HANDLE handle,
                                                                       int control_id)
 {
-  CGUIControl* pGUIControl = static_cast<CGUIControl*>(
+  auto* pGUIControl = static_cast<CGUIControl*>(
       GetControl(kodiBase, handle, control_id, std::source_location::current().function_name(),
                  CGUIControl::GUICONTROL_RENDERADDON, "renderaddon"));
   if (!pGUIControl)
@@ -1242,7 +1242,7 @@ bool CGUIAddonWindow::OnMessage(CGUIMessage& message)
       int iControl = message.GetSenderId();
       if (iControl && iControl != GetID())
       {
-        CGUIControl* controlClicked = GetControl(iControl);
+        const CGUIControl* controlClicked = GetControl(iControl);
 
         // The old python way used to check list AND SELECITEM method or if its a button, checkmark.
         // Its done this way for now to allow other controls without a python version like togglebutton to still raise a onAction event

--- a/xbmc/addons/interfaces/gui/controls/Edit.cpp
+++ b/xbmc/addons/interfaces/gui/controls/Edit.cpp
@@ -152,7 +152,7 @@ void Interface_GUIControlEdit::set_label(KODI_HANDLE kodiBase,
 char* Interface_GUIControlEdit::get_label(KODI_HANDLE kodiBase, KODI_GUI_CONTROL_HANDLE handle)
 {
   const auto* addon = static_cast<const CAddonDll*>(kodiBase);
-  auto* control = static_cast<CGUIEditControl*>(handle);
+  const auto* control = static_cast<const CGUIEditControl*>(handle);
   if (!addon || !control)
   {
     CLog::LogF(LOGERROR,
@@ -186,7 +186,7 @@ void Interface_GUIControlEdit::set_text(KODI_HANDLE kodiBase,
 char* Interface_GUIControlEdit::get_text(KODI_HANDLE kodiBase, KODI_GUI_CONTROL_HANDLE handle)
 {
   const auto* addon = static_cast<const CAddonDll*>(kodiBase);
-  auto* control = static_cast<CGUIEditControl*>(handle);
+  const auto* control = static_cast<const CGUIEditControl*>(handle);
   if (!addon || !control)
   {
     CLog::LogF(LOGERROR,
@@ -221,7 +221,7 @@ unsigned int Interface_GUIControlEdit::get_cursor_position(KODI_HANDLE kodiBase,
                                                            KODI_GUI_CONTROL_HANDLE handle)
 {
   const auto* addon = static_cast<const CAddonDll*>(kodiBase);
-  auto* control = static_cast<CGUIEditControl*>(handle);
+  const auto* control = static_cast<const CGUIEditControl*>(handle);
   if (!addon || !control)
   {
     CLog::LogF(LOGERROR,

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -537,9 +537,9 @@ void CSelectionStreams::Update(const std::shared_ptr<CDVDInputStream>& input,
     for(int i=0;i<count;i++)
     {
       const auto stream =
-          std::find_if(demuxStreams.begin(), demuxStreams.end(), [i](const auto& stream)
-                       { return stream->type == StreamType::AUDIO && stream->dvdNavId == i; });
-      CDemuxStreamAudio* aStream =
+          std::find_if(demuxStreams.begin(), demuxStreams.end(), [i](const auto& strm)
+                       { return strm->type == StreamType::AUDIO && strm->dvdNavId == i; });
+      const CDemuxStreamAudio* aStream =
           (stream != demuxStreams.end()) ? static_cast<CDemuxStreamAudio*>(*stream) : nullptr;
 
       SelectionStream s;

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -259,7 +259,7 @@ void CDatabase::Split(const std::string& strFileNameAndPath,
 
 std::string CDatabase::PrepareSQL(std::string_view sqlFormat, ...) const
 {
-  std::string strResult = "";
+  std::string strResult;
 
   if (nullptr != m_pDB)
   {

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -651,8 +651,8 @@ bool MysqlDatabase::exists()
 // ---------------------------------------------
 std::string MysqlDatabase::vprepare(std::string_view format, va_list args)
 {
-  std::string strFormat = std::string(format);
-  std::string strResult = "";
+  std::string strFormat{format};
+  std::string strResult;
   size_t pos;
 
   //  %q is the sqlite format string for %s.

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -623,8 +623,8 @@ void SqliteDatabase::rollback_transaction()
 // ---------------------------------------------
 std::string SqliteDatabase::vprepare(std::string_view format, va_list args)
 {
-  std::string strFormat = std::string(format);
-  std::string strResult = "";
+  std::string strFormat{format};
+  std::string strResult;
   char* p;
   size_t pos;
 

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -76,7 +76,7 @@ bool CGUIDialogBusy::WaitOnEvent(CEvent &event, unsigned int displaytime /* = 10
   bool cancelled = false;
   if (!event.Wait(std::chrono::milliseconds(displaytime)))
   {
-    CGUIDialogBusy* dialog = static_cast<CGUIDialogBusy*>(
+    auto* dialog = static_cast<CGUIDialogBusy*>(
         CServiceBroker::GetGUI()->GetWindowManager().GetWindow(WINDOW_DIALOG_BUSY));
     if (dialog)
     {
@@ -111,7 +111,6 @@ CGUIDialogBusy::CGUIDialogBusy(void)
   : CGUIDialog(WINDOW_DIALOG_BUSY, "DialogBusy.xml", DialogModalityType::MODAL)
 {
   m_loadType = LOAD_ON_GUI_INIT;
-  m_cancelled = false;
 }
 
 CGUIDialogBusy::~CGUIDialogBusy(void) = default;

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -18,6 +18,7 @@
 #include "settings/SettingsComponent.h"
 #include "threads/SystemClock.h"
 #include "utils/Base64.h"
+#include "utils/Map.h"
 #include "utils/XTimeUtils.h"
 
 #include <algorithm>
@@ -44,16 +45,20 @@ using namespace std::chrono_literals;
 
 #define FITS_INT(a) (((a) <= INT_MAX) && ((a) >= INT_MIN))
 
-static const auto proxyType2CUrlProxyType = std::unordered_map<XFILE::CCurlFile::ProxyType, int>{
+namespace
+{
+constexpr auto proxyType2CUrlProxyType{make_map<XFILE::CCurlFile::ProxyType, int>({
     {CCurlFile::ProxyType::HTTP, CURLPROXY_HTTP},
     {CCurlFile::ProxyType::SOCKS4, CURLPROXY_SOCKS4},
     {CCurlFile::ProxyType::SOCKS4A, CURLPROXY_SOCKS4A},
     {CCurlFile::ProxyType::SOCKS5, CURLPROXY_SOCKS5},
     {CCurlFile::ProxyType::SOCKS5_REMOTE, CURLPROXY_SOCKS5_HOSTNAME},
     {CCurlFile::ProxyType::HTTPS, CURLPROXY_HTTPS},
-};
+})};
 
-static std::vector<uint8_t> cachedCaCertsBlob; // cached CA certs file
+std::vector<uint8_t> cachedCaCertsBlob; // cached CA certs file
+
+} // unnamed namespace
 
 #define FILLBUFFER_OK         0
 #define FILLBUFFER_NO_DATA    1

--- a/xbmc/filesystem/DirectoryCache.cpp
+++ b/xbmc/filesystem/DirectoryCache.cpp
@@ -153,12 +153,11 @@ void CDirectoryCache::AddFile(const CURL& url)
   std::string path = URIUtils::GetDirectory(url.GetWithoutOptions());
   URIUtils::RemoveSlashAtEnd(path);
 
-  auto i = m_cache.find(path);
-  if (i != m_cache.end())
+  const auto i{m_cache.find(path)};
+  if (i != m_cache.cend())
   {
-    CDir& dir = i->second;
-    CFileItemPtr item(new CFileItem(url.Get(), false));
-    dir.m_Items->Add(item);
+    CDir& dir{i->second};
+    dir.m_Items->Add(std::make_shared<CFileItem>(url.Get(), false));
     dir.SetLastAccess(m_accessCounter);
   }
 }

--- a/xbmc/filesystem/NFSDirectory.h
+++ b/xbmc/filesystem/NFSDirectory.h
@@ -30,11 +30,9 @@ namespace XFILE
       bool Exists(const CURL& url) override;
       bool Remove(const CURL& url) override;
     private:
-      std::vector<std::shared_ptr<CFileItem>> GetServerList();
-      std::vector<std::shared_ptr<CFileItem>> GetDirectoryFromExportList(const CURL& inputURL);
-      bool ResolveSymlink(const std::string& dirName,
-                          struct nfsdirent* dirent,
-                          std::string& resolvedPath);
+      std::vector<std::shared_ptr<CFileItem>> GetServerList() const;
+      std::vector<std::shared_ptr<CFileItem>> GetDirectoryFromExportList(
+          const CURL& inputURL) const;
   };
 }
 

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -1367,7 +1367,7 @@ JSONRPC_STATUS CAudioLibrary::RefreshArtist(const std::string& method,
 
   // Checking if artistID is a valid one
   const CVariant artistIdVariant{parameterObject["artistid"]};
-  const int artistID = static_cast<int>(artistIdVariant.asInteger());
+  const auto artistID{static_cast<int>(artistIdVariant.asInteger())};
   if (!musicdatabase.GetArtistExists(artistID))
     return InvalidParams;
 

--- a/xbmc/jobs/IJobCallback.h
+++ b/xbmc/jobs/IJobCallback.h
@@ -59,7 +59,7 @@ public:
    \param job the job that has been aborted.
    \sa CJobManager and CJob
    */
-  virtual void OnJobAbort(unsigned int jobID, CJob* job) {}
+  virtual void OnJobAbort(unsigned int jobID, CJob* job) { /* intentionally empty */ }
 
   /*!
    \brief An optional callback function that a job may call while processing.
@@ -78,5 +78,6 @@ public:
                              unsigned int total,
                              const CJob* job)
   {
+    /* intentionally empty */
   }
 };

--- a/xbmc/jobs/JobManager.cpp
+++ b/xbmc/jobs/JobManager.cpp
@@ -72,7 +72,7 @@ private:
 struct CJobManager::JobFinder
 {
   explicit JobFinder(const CJob* job) : m_job(job) {}
-  bool operator()(const CWorkItem& workItem) { return workItem.GetJob() == m_job; }
+  bool operator()(const CWorkItem& workItem) const { return workItem.GetJob() == m_job; }
 
   const CJob* m_job{nullptr};
 };
@@ -253,7 +253,7 @@ int CJobManager::IsProcessing(const std::string& type) const
 
   return static_cast<int>(std::ranges::count_if(
       m_processing,
-      [this, type](const auto& wi)
+      [this, &type](const auto& wi)
       {
         return (!m_pauseJobs || wi.GetPriority() != CJob::PRIORITY::PRIORITY_LOW_PAUSABLE) &&
                (std::string(wi.GetJob()->GetType()) == type);

--- a/xbmc/jobs/JobQueue.cpp
+++ b/xbmc/jobs/JobQueue.cpp
@@ -23,7 +23,7 @@ void CJobQueue::CJobPointer::CancelJob()
 struct CJobQueue::JobFinder
 {
   explicit JobFinder(const CJob* job) : m_job(job) {}
-  bool operator()(const CJobPointer& jobPtr) { return jobPtr.GetJob() == m_job; }
+  bool operator()(const CJobPointer& jobPtr) const { return jobPtr.GetJob() == m_job; }
 
   const CJob* m_job{nullptr};
 };
@@ -91,7 +91,7 @@ bool CJobQueue::AddJob(CJob* job)
   return true;
 }
 
-void CJobQueue::OnJobNotify(CJob* job)
+void CJobQueue::OnJobNotify(const CJob* job)
 {
   std::unique_lock lock(m_section);
 

--- a/xbmc/jobs/JobQueue.h
+++ b/xbmc/jobs/JobQueue.h
@@ -39,9 +39,9 @@ public:
    \param priority priority of this queue.
    \sa CJob
    */
-  CJobQueue(bool lifo = false,
-            unsigned int jobsAtOnce = 1,
-            CJob::PRIORITY priority = CJob::PRIORITY_LOW);
+  explicit CJobQueue(bool lifo = false,
+                     unsigned int jobsAtOnce = 1,
+                     CJob::PRIORITY priority = CJob::PRIORITY_LOW);
 
   /*!
    \brief CJobQueue destructor
@@ -149,7 +149,7 @@ private:
     unsigned int m_id{0};
   };
 
-  void OnJobNotify(CJob* job);
+  void OnJobNotify(const CJob* job);
   void QueueNextJob();
 
   using Queue = std::deque<CJobPointer>;

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -765,7 +765,7 @@ bool CMusicDatabase::AddAlbum(CAlbum& album, int idSource)
     {
       if (!song->m_chapters.empty())
       {
-        ChapterDetails& chapter = song->m_chapters[index];
+        const ChapterDetails& chapter{song->m_chapters[index]};
         // no title or just numbers  (1, 02, 003 etc) - generate a better one
         if (StringUtils::IsNaturalNumber(chapter.name) || chapter.name.empty())
           song->strTitle = StringUtils::Format(
@@ -775,7 +775,8 @@ bool CMusicDatabase::AddAlbum(CAlbum& album, int idSource)
 
         song->iStartOffset = static_cast<int>(chapter.startTimeMs.count());
         song->iEndOffset = static_cast<int>(chapter.endTimeMs.count());
-        song->iDuration = CUtil::ConvertMilliSecsToSecsInt(song->iEndOffset - song->iStartOffset);
+        song->iDuration = static_cast<int>(
+            CUtil::ConvertMilliSecsToSecsInt(song->iEndOffset - song->iStartOffset));
         // disc number is in top 16 bits, track in bottom 16 bits (disc << 16 | track)
         song->iTrack = (1 << 16) + index + 1; // disc 1 + track number
         song->idSong = -1; // make sure this is a new song to add

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -34,6 +34,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <string_view>
 #include <vector>
 
 using enum CDatabaseQueryRule::FieldType;
@@ -948,7 +949,7 @@ std::string FormatNullableDate(const std::string& field,
 
 std::string FormatNullableNumber(const std::string& field,
                                  CDatabaseQueryRule::SearchOperator oper,
-                                 const std::string& param,
+                                 std::string_view param,
                                  const std::string& parameter)
 {
   if ((oper == OPERATOR_EQUALS && param == "0") ||

--- a/xbmc/profiles/Profile.h
+++ b/xbmc/profiles/Profile.h
@@ -41,9 +41,9 @@ public:
     bool games;
   };
 
-  CProfile(const std::string& directory = "",
-           const std::string& name = "",
-           const int id = INVALID_PROFILE_ID);
+  explicit CProfile(const std::string& directory = "",
+                    const std::string& name = "",
+                    const int id = INVALID_PROFILE_ID);
   ~CProfile(void);
 
   void Load(const TiXmlNode *node, int nextIdProfile);

--- a/xbmc/utils/ProgressJob.cpp
+++ b/xbmc/utils/ProgressJob.cpp
@@ -17,9 +17,6 @@
 
 #include <math.h>
 
-CProgressJob::CProgressJob()
-{ }
-
 CProgressJob::CProgressJob(CGUIDialogProgressBarHandle* progressBar) : m_progress(progressBar)
 { }
 

--- a/xbmc/utils/ProgressJob.h
+++ b/xbmc/utils/ProgressJob.h
@@ -50,7 +50,7 @@ public:
   bool HasProgressIndicator() const;
 
 protected:
-  CProgressJob();
+  CProgressJob() = default;
   explicit CProgressJob(CGUIDialogProgressBarHandle* progressBar);
 
   /*!

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1915,10 +1915,9 @@ bool StringUtils::Contains(std::string_view str,
 {
   if (isCaseInsensitive)
   {
-    auto itStr =
-        std::search(str.begin(), str.end(), keyword.begin(), keyword.end(),
-                    [](char ch1, char ch2) { return ToUpperAscii(ch1) == ToUpperAscii(ch2); });
-    return (itStr != str.end());
+    const auto itStr{std::ranges::search(str, keyword, [](char ch1, char ch2)
+                                         { return ToUpperAscii(ch1) == ToUpperAscii(ch2); })};
+    return (!itStr.empty());
   }
 
   return str.find(keyword) != std::string_view::npos;

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -669,7 +669,7 @@ public:
   void GetEpisodesByFileId(int idFile, std::vector<CVideoInfoTag>& episodes);
   bool GetEpisodeMap(int idShow,
                      EpisodeFileMap& fileMap,
-                     const std::unique_ptr<dbiplus::Dataset>& pDS,
+                     dbiplus::Dataset& pDS,
                      int idFile = -1 /* = -1 */) const;
 
   int SetDetailsForItem(CVideoInfoTag& details, const KODI::ART::Artwork& artwork);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1705,9 +1705,10 @@ CVideoInfoScanner::~CVideoInfoScanner()
           {
             const std::string result{reg2.GetMatch(2)};
             const int last{std::stoi(result)};
-            const std::string prefix{offset < remainder.length()
-                                         ? StringUtils::ToLower(remainder.substr(offset, 2))
-                                         : std::string{}};
+            const std::string prefix{
+                offset < remainder.length()
+                    ? StringUtils::ToLower(std::string_view(remainder).substr(offset, 2))
+                    : std::string{}};
             const int next{(prefix == "-e" || prefix == "-s") && !disableEpisodeRanges
                                ? currentEpisode + 1
                                : last};
@@ -2123,7 +2124,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
                                      bool bApplyToDir,
                                      bool useLocal,
                                      const std::string& actorArtPath,
-                                     UseRemoteArtWithLocalScraper useRemoteArt /* = yes */)
+                                     UseRemoteArtWithLocalScraper useRemoteArt /* = yes */) const
   {
     int artLevel = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
         CSettings::SETTING_VIDEOLIBRARY_ARTWORK_LEVEL);

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -126,12 +126,13 @@ namespace KODI::VIDEO
      \param actorArtPath the path to search for actor thumbs. Defaults to empty.
      \param useRemoteArt use remote art if also using local scraper. Defaults to yes.
      */
-    void GetArtwork(CFileItem* pItem,
-                    ADDON::ContentType content,
-                    bool bApplyToDir = false,
-                    bool useLocal = true,
-                    const std::string& actorArtPath = "",
-                    UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES);
+    void GetArtwork(
+        CFileItem* pItem,
+        ADDON::ContentType content,
+        bool bApplyToDir = false,
+        bool useLocal = true,
+        const std::string& actorArtPath = "",
+        UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES) const;
 
     /*! \brief Get season thumbs for a tvshow.
      All seasons (regardless of whether the user has episodes) are added to the art map.

--- a/xbmc/windowing/wayland/ColorManager.h
+++ b/xbmc/windowing/wayland/ColorManager.h
@@ -22,7 +22,7 @@ namespace KODI::WINDOWING::WAYLAND
 class CColorManager
 {
 public:
-  CColorManager(CConnection& connection);
+  explicit CColorManager(CConnection& connection);
   ~CColorManager();
 
   void SetSurface(const wayland::surface_t& surface);
@@ -32,8 +32,8 @@ public:
   bool IsHDRDisplay() const;
   CHDRCapabilities GetDisplayHDRCapabilities() const;
 
-private:
 #ifdef HAS_WAYLAND_COLOR_MANAGEMENT
+private:
   void SetDisplayMetadata(wayland::image_description_creator_params_v1_t& descriptionCreator,
                           const VideoPicture* videoPicture);
   void SetLightMetadata(wayland::image_description_creator_params_v1_t& descriptionCreator,


### PR DESCRIPTION
## Description
What subject says. PR fixes a couple of SonarQube findings flagged as "new" since Aug 2, for new and touched code:

* Member functions that don't mutate their objects should be declared "const" cpp:S5817
* Unnecessary expensive copy should be avoided when using auto as a placeholder type cpp:S6032
* A single statement should not have more than one resource allocation cpp:S5502
* "auto" should be used to avoid repetition of types cpp:S5827
* Pointer and reference local variables should be "const" if the corresponding object is not modified cpp:S5350
* Variables should not be shadowed cpp:S1117
* Non-const global variables should not be used cpp:S5421
* "explicit" should be used on single-parameter constructors and conversion operators cpp:S1709
* Special member function should not be defined unless a non standard behavior is required cpp:S3490
* Function parameters should not be of type "std::unique_ptr<T> const &" cpp:S4998
* Member data should be initialized in-class or in a constructor initialization list cpp:S3230
* "make_unique" and "make_shared" should be used to construct "unique_ptr" and "shared_ptr" cpp:S5950
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* Methods should not be empty cpp:S1186
* Capture by reference in lambdas used locally cpp:S5495
* Pointer and reference parameters should be "const" if the corresponding object is not modified cpp:S995
* Implicit casts should not lower precision cpp:S5276
* Access specifiers should not be redundant cpp:S3539
* Pass by reference to const should be used for large input parameters cpp:S1238
* "std::string_view" and "std::span" parameters should be directly constructed from sequences cpp:S6231
* "try_emplace" should be used with "std::map" and "std::unordered_map" cpp:S6030
* Assignments should not be made from within conditions cpp:S1121

## Motivation and context
Bring number of SQ findings in new/ changed code down.

## How has this been tested?
Compiles and actively used, no regressions found.

## What is the effect on users?
Hopefully it has no effect, despite of small performance increasements here and there.

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
