### PR TITLE
[video] TV shows: Migrate 'Scan for new content' context menu item to 'new' context menu system.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7160,6 +7160,9 @@ msgctxt "#13348"
 msgid "Search IMDb..."
 msgstr ""
 
+#. Label for context menu item entries for scanning new items to the video library, e.g. new episodes of a TV show.
+#: xbmc/video/ContextMenus.h
+#: xbmc/video/windows/GUIWindowVideoNav.cpp
 msgctxt "#13349"
 msgid "Scan for new content"
 msgstr ""

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -94,6 +94,7 @@ void CContextMenuManager::Init()
       std::make_shared<CONTEXTMENU::CVideoMarkWatched>(),
       std::make_shared<CONTEXTMENU::CVideoMarkUnWatched>(),
       std::make_shared<CONTEXTMENU::CVideoRemoveResumePoint>(),
+      std::make_shared<CONTEXTMENU::CTVShowScanForNewContent>(),
       std::make_shared<CONTEXTMENU::CEjectDisk>(),
       std::make_shared<CONTEXTMENU::CEjectDrive>(),
       std::make_shared<CONTEXTMENU::CFavouritesTargetBrowse>(),

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -24,6 +24,7 @@
 #include "utils/URIUtils.h"
 #include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
+#include "video/VideoLibraryQueue.h"
 #include "video/VideoManagerTypes.h"
 #include "video/VideoUtils.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
@@ -445,4 +446,20 @@ bool CVideoPlayAndQueue::Execute(const std::shared_ptr<CFileItem>& item) const
 
   return true; //! @todo implement
 }
+
+bool CTVShowScanForNewContent::IsVisible(const CFileItem& item) const
+{
+  return !item.IsParentFolder() && item.HasVideoInfoTag() &&
+         item.GetVideoInfoTag()->m_type == MediaTypeTvShow;
 }
+
+bool CTVShowScanForNewContent::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  const std::string strPath{VIDEO::IsVideoDb(*item) ? item->GetVideoInfoTag()->m_strPath
+                                                    : item->GetPath()};
+  CVideoLibraryQueue::GetInstance().ScanLibrary(strPath, true /* scanAll */,
+                                                true /* showProgress */);
+  return true;
+}
+
+} // namespace CONTEXTMENU

--- a/xbmc/video/ContextMenus.h
+++ b/xbmc/video/ContextMenus.h
@@ -141,4 +141,11 @@ struct CVideoPlayAndQueue : IContextMenuItem
   bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 };
 
-}
+struct CTVShowScanForNewContent : CStaticContextMenuAction
+{
+  CTVShowScanForNewContent() : CStaticContextMenuAction(13349) {} // Scan for new content
+  bool IsVisible(const CFileItem& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
+};
+
+} // namespace CONTEXTMENU

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -838,7 +838,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
         {
           buttons.Add(CONTEXT_BUTTON_EDIT, 16106);
         }
-        if (node == NodeType::TITLE_TVSHOWS)
+        if (node == NodeType::TITLE_TVSHOWS || node == NodeType::INPROGRESS_TVSHOWS)
         {
           buttons.Add(CONTEXT_BUTTON_SCAN, 13349);
         }

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -838,11 +838,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
         {
           buttons.Add(CONTEXT_BUTTON_EDIT, 16106);
         }
-        if (node == NodeType::TITLE_TVSHOWS || node == NodeType::INPROGRESS_TVSHOWS)
-        {
-          buttons.Add(CONTEXT_BUTTON_SCAN, 13349);
-        }
-        else if (node == NodeType::ACTOR)
+        if (node == NodeType::ACTOR)
         {
           // Add 'Choose art' for all not 'all items' folders
           if (item->IsFolder() && !CVideoDatabaseDirectory::IsAllItem(item->GetPath()))


### PR DESCRIPTION
## Description
Migrates 'Scan for new content' context menu item for TV shows to 'new' context menu system, making it available outside the video window, for example in Estuary Home screen widgets.

## Motivation and context
Missed that functionality in Estuary Home screen widgets.

## How has this been tested?
Runtime-tested on macOS and Android, latest Kodi master.

## What is the effect on users?
Context menu items being available in Estuary Home screen widgets for more convenience.

## Screenshots (if appropriate):
<img width="3473" height="2180" alt="Screenshot 2025-08-19 at 16 56 39" src="https://github.com/user-attachments/assets/9172ba46-e661-4085-a009-d3f26fb9fa19" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
