### PR TITLE
[wayland] Have CColorManager cleanup automatically in its destructor

### DIFF
--- a/xbmc/windowing/wayland/ColorManager.cpp
+++ b/xbmc/windowing/wayland/ColorManager.cpp
@@ -272,6 +272,11 @@ CColorManager::CColorManager(CConnection& connection)
   };
 }
 
+CColorManager::~CColorManager()
+{
+  UnsetSurface();
+}
+
 void CColorManager::SetSurface(const wayland::surface_t& surface)
 {
   UnsetSurface();
@@ -461,6 +466,8 @@ using namespace KODI::WINDOWING::WAYLAND;
 CColorManager::CColorManager(CConnection& /*connection*/)
 {
 }
+
+CColorManager::~CColorManager() = default;
 
 void CColorManager::SetSurface(const wayland::surface_t& /*surface*/)
 {

--- a/xbmc/windowing/wayland/ColorManager.h
+++ b/xbmc/windowing/wayland/ColorManager.h
@@ -23,6 +23,7 @@ class CColorManager
 {
 public:
   CColorManager(CConnection& connection);
+  ~CColorManager();
 
   void SetSurface(const wayland::surface_t& surface);
   void UnsetSurface();

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -388,8 +388,6 @@ IShellSurface* CWinSystemWayland::CreateShellSurface(const std::string& name)
 
 bool CWinSystemWayland::DestroyWindow()
 {
-  m_colorManager->UnsetSurface();
-
   // Make sure no more events get processed when we kill the instances
   CWinEventsWayland::SetDisplay(nullptr);
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

See title. Fixes nullptr access when `CWinSystemWayland` couldn't be initialized and the remains are cleaned up.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #27164.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Launched Kodi on GBM --> doesn't crash anymore. Still runs fine on Wayland and no problems when stopping Kodi.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

See above.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
