### PR TITLE
[webOS][VideoPlayer] Set subtitle from old player

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerWebOS.cpp
@@ -39,7 +39,9 @@ void CVideoPlayerWebOS::CreatePlayers()
   if (canStarfish && CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
                          CSettings::SETTING_VIDEOPLAYER_USESTARFISHDECODER))
   {
-    bool hasAudio = m_SelectionStreams.CountType(StreamType::AUDIO);
+    const bool hasAudio = m_SelectionStreams.CountType(StreamType::AUDIO);
+    const bool subtitlesEnabled = m_VideoPlayerVideo->IsSubtitleEnabled();
+    const double subtitleDelay = m_VideoPlayerVideo->GetSubtitleDelay();
 
     m_mediaPipelineWebOS = std::make_unique<CMediaPipelineWebOS>(
         *m_processInfo, m_renderManager, m_clock, m_messenger, m_overlayContainer, hasAudio);
@@ -48,10 +50,8 @@ void CVideoPlayerWebOS::CreatePlayers()
     m_VideoPlayerAudio =
         std::make_unique<CVideoPlayerAudioWebOS>(*m_mediaPipelineWebOS, *m_processInfo);
 
-    const CVideoSettings settings = m_processInfo->GetVideoSettings();
-    m_VideoPlayerVideo->EnableSubtitle(settings.m_SubtitleOn);
-    m_VideoPlayerVideo->SetSubtitleDelay(
-        static_cast<int>(-settings.m_SubtitleDelay * DVD_TIME_BASE));
+    m_VideoPlayerVideo->EnableSubtitle(subtitlesEnabled);
+    m_VideoPlayerVideo->SetSubtitleDelay(subtitleDelay);
   }
   else if (m_mediaPipelineWebOS || (!m_VideoPlayerVideo && !m_VideoPlayerAudio))
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Set subtitle delay and enabled from the previously created video players. `CreatePlayers` is called twice. The webOS pipeline is only created after the 2nd call because we need to make sure the webOS player can actually play the stream. At that point the subtitles settings have already been set so we have to explicitly reset them for the webOS pipeline too.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix a bug reported on the forums where subtitles were not correctly enabled.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
