### PR TITLE
Add InfoTagVideo::setAvailableFanart method for Kodi Python API

### DIFF
--- a/addons/xbmc.python/addon.xml
+++ b/addons/xbmc.python/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.python" version="3.0.1" provider-name="Team Kodi">
+<addon id="xbmc.python" version="3.0.2" provider-name="Team Kodi">
   <backwards-compatibility abi="3.0.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>

--- a/xbmc/interfaces/legacy/Dictionary.h
+++ b/xbmc/interfaces/legacy/Dictionary.h
@@ -28,7 +28,10 @@ namespace XBMCAddon
    * native api handles these calls by converting the string to the
    * appropriate types.
    */
-  template<class T> class Dictionary : public std::map<String,T> {};
+  template<class T>
+  class Dictionary : public std::map<String, T, std::less<>>
+  {
+  };
 
   typedef Dictionary<StringOrInt> Properties;
 }

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -759,6 +759,12 @@ namespace XBMCAddon
       addAvailableArtworkRaw(infoTag, url, art_type, preview, referrer, cache, post, isgz, season);
     }
 
+    void InfoTagVideo::setAvailableFanart(const std::vector<Properties>& images)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setAvailableFanartRaw(infoTag, images);
+    }
+
     void InfoTagVideo::setDbIdRaw(CVideoInfoTag* infoTag, int dbId)
     {
       infoTag->m_iDbId = dbId;
@@ -1096,6 +1102,31 @@ namespace XBMCAddon
     {
       infoTag->m_strPictureURL.AddParsedUrl(url, art_type, preview, referrer, cache, post, isgz,
                                             season);
+    }
+
+    void InfoTagVideo::setAvailableFanartRaw(CVideoInfoTag* infoTag,
+                                             const std::vector<Properties>& images)
+    {
+      infoTag->m_fanart.Clear();
+      for (const auto& dictionary : images)
+      {
+        auto getValue = [&](std::string_view str) -> const std::string&
+        {
+          const auto iter = dictionary.find(str);
+          if (iter != dictionary.end())
+            return iter->second;
+          else
+            return StringUtils::Empty;
+        };
+
+        if (const std::string& image = getValue("image"); !image.empty())
+        {
+          const std::string& preview = getValue("preview");
+          const std::string& colors = getValue("colors");
+          infoTag->m_fanart.AddFanart(image, preview, colors);
+        }
+      }
+      infoTag->m_fanart.Pack();
     }
   }
 }

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "AddonClass.h"
+#include "Dictionary.h"
 #include "Tuple.h"
 #include "utils/StreamDetails.h"
 #include "video/VideoInfoTag.h"
@@ -2742,6 +2743,38 @@ namespace XBMCAddon
 #endif
       /// @}
 
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ setAvailableFanart(images) }
+      /// Set available images (needed for video scrapers)
+      ///
+      /// @param images            list of dictionaries (see below for relevant keys)
+      ///
+      /// - Keys:
+      /// | Label         | Description                                     |
+      /// |--------------:|:------------------------------------------------|
+      /// | image         | string (http://www.someurl.com/someimage.png)
+      /// | preview       | [opt] string (http://www.someurl.com/somepreviewimage.png)
+      /// | colors        | [opt] string (either comma separated Kodi hex values ("FFFFFFFF,DDDDDDDD") or TVDB RGB Int Triplets ("|68,69,59|69,70,58|78,78,68|"))
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v22 New function added.
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ...
+      /// fanart = [{"image": path_to_image_1, "preview": path_to_preview_1}, {"image": path_to_image_2, "preview": path_to_preview_2}]
+      /// info_tag.setAvailableFanart(fanart)
+      /// ...
+      /// ~~~~~~~~~~~~~
+      ///
+      setAvailableFanart(...);
+#else
+      void setAvailableFanart(const std::vector<Properties>& images);
+#endif
+
 #ifndef SWIG
       static void setDbIdRaw(CVideoInfoTag* infoTag, int dbId);
       static void setUniqueIDRaw(CVideoInfoTag* infoTag,
@@ -2826,6 +2859,8 @@ namespace XBMCAddon
                                          bool post = false,
                                          bool isgz = false,
                                          int season = -1);
+      static void setAvailableFanartRaw(CVideoInfoTag* infoTag,
+                                        const std::vector<Properties>& images);
 #endif
     };
   }

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -848,6 +848,7 @@ namespace XBMCAddon
       ///
       ///-----------------------------------------------------------------------
       /// @python_v18 New function added.
+      /// @python_v22 Deprecated. Use **InfoTagVideo.setAvailableFanart()** instead.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}

--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -913,7 +913,7 @@ namespace PythonBindings
    // constants
    PyModule_AddStringConstant(module, "__author__", "Team Kodi <http://kodi.tv>");
    PyModule_AddStringConstant(module, "__date__", CCompileInfo::GetBuildDate().c_str());
-   PyModule_AddStringConstant(module, "__version__", "3.0.1");
+   PyModule_AddStringConstant(module, "__version__", "3.0.2");
    PyModule_AddStringConstant(module, "__credits__", "Team Kodi");
    PyModule_AddStringConstant(module, "__platform__", "ALL");
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

When moving management of media properties from `ListItem` to the respective `InfoTag` the `ListItem.setAvailableFanart()` method seems to have been forgotten, and available fanart is still set via `ListItem`, while `addAvailableArtwork()` is done via `InfoTagVideo`.
This PR moves fanart management from `ListItem` to `InfoTagVideo`.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR restores the consistency of Python API for media properties management.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It was tested using a modified version of my TVmaze TV shows scraper.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
