### PR TITLE
Always set hdr to DV if codec four cc matches for Inputstream

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -450,13 +450,12 @@ KODI_HANDLE CInputStreamAddon::cb_get_stream_transfer(KODI_HANDLE handle,
         static_cast<AVColorTransferCharacteristic>(stream->m_colorTransferCharacteristic);
 
     // Determine the HDR type
-    if (videoStream->colorTransferCharacteristic == AVCOL_TRC_SMPTE2084)
+    if (stream->m_codecFourCC == MKTAG('d', 'v', 'h', '1') ||
+        stream->m_codecFourCC == MKTAG('d', 'v', 'h', 'e'))
+      videoStream->hdr_type = StreamHdrType::HDR_TYPE_DOLBYVISION;
+    else if (videoStream->colorTransferCharacteristic == AVCOL_TRC_SMPTE2084)
     {
-      if (stream->m_codecFourCC == MKTAG('d', 'v', 'h', '1') ||
-          stream->m_codecFourCC == MKTAG('d', 'v', 'h', 'e'))
-        videoStream->hdr_type = StreamHdrType::HDR_TYPE_DOLBYVISION;
-      else
-        videoStream->hdr_type = StreamHdrType::HDR_TYPE_HDR10;
+      videoStream->hdr_type = StreamHdrType::HDR_TYPE_HDR10;
     }
     else if (videoStream->colorTransferCharacteristic == AVCOL_TRC_ARIB_STD_B67)
       videoStream->hdr_type = StreamHdrType::HDR_TYPE_HLG;


### PR DESCRIPTION
## Description
DV is not always AVCOL_TRC_SMPTE2084?

Fix courtesy of @Uukrull 

## Motivation and context
DV on Prime on webOS has a purple tint.

## How has this been tested?
Playback on 4K UHD DV stream from Prime on webOS TV running webOS 24.

Before fix: DV has purple tint
After fix: no more purple tint

## What is the effect on users?
Fixes purple tint, getting correct colours.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
