### PR TITLE
[Windows] Allow Running Multiple Instances Simultaneously

### DIFF
--- a/xbmc/platform/win32/WinMain.cpp
+++ b/xbmc/platform/win32/WinMain.cpp
@@ -15,8 +15,10 @@
 #include "platform/xbmc.h"
 #include "threads/Thread.h"
 #include "utils/CharsetConverter.h" // Required to initialize converters before usage
+#include "utils/URIUtils.h"
 
 #include "platform/win32/CharsetConverter.h"
+#include "platform/win32/WIN32Util.h"
 #include "platform/win32/threads/Win32Exception.h"
 
 #include <Objbase.h>
@@ -88,6 +90,56 @@ static std::shared_ptr<CAppParams> ParseCommandLine()
   return appParamParser.GetAppParams();
 }
 
+namespace
+{
+/*!
+ * \brief Detect another running instance using the same data directory, using a flag file exclusion
+ * mechanism.
+ * 
+ * Attempt to create the file. If it already exists, another instance using the same data
+ * directory is running. New in v22.
+ * 
+ * \param[in] usePlatformDirectories false for portable mode, true for non-portable mode
+ * \param[out] handle Windows handle for the flag file.  Close the handle on program exit, not earlier.
+ * \return true if the flag file already exists (ie another instance is running)
+ */
+bool CheckAndSetFileFlag(bool usePlatformDirectories, HANDLE& handle)
+{
+  const std::string file =
+      URIUtils::AddFileToFolder(CWIN32Util::GetProfilePath(usePlatformDirectories), ".running");
+
+  constexpr DWORD NO_DESIRED_ACCESS = 0;
+  constexpr DWORD NO_SHARING = 0;
+
+  using KODI::PLATFORM::WINDOWS::ToW;
+  handle = CreateFileW(ToW(file).c_str(), NO_DESIRED_ACCESS, NO_SHARING, nullptr, CREATE_NEW,
+                       FILE_FLAG_DELETE_ON_CLOSE, NULL);
+
+  if (handle == INVALID_HANDLE_VALUE && GetLastError() == ERROR_FILE_EXISTS)
+    return true;
+
+  return false;
+}
+
+/*!
+ * \brief Detect another running instance, using a global mutex.
+ * 
+ * Attempt to create the mutex. If it already exists, that means another instance created it and is
+ * running. This is the legacy pre-v22 exclusion mechanism.
+ * 
+ * \param[out] handle Windows handle for the mutex. Close the handle on program exit, not earlier.
+ * \return true if the mutex already exists (ie another instance is running)
+ */
+bool CheckAndSetMutex(HANDLE& handle)
+{
+  handle = CreateMutexW(nullptr, FALSE, L"Kodi Media Center");
+  if (handle != NULL && GetLastError() == ERROR_ALREADY_EXISTS)
+    return true;
+
+  return false;
+}
+} // namespace
+
 //-----------------------------------------------------------------------------
 // Name: WinMain()
 // Desc: The application's entry point
@@ -122,13 +174,32 @@ _Use_decl_annotations_ INT WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, INT)
   int rcWinsock{WSANOTINITIALISED};
   WSADATA wd{};
 
-  // check if Kodi is already running
-  using KODI::PLATFORM::WINDOWS::ToW;
-  std::string appName = CCompileInfo::GetAppName();
-  HANDLE appRunningMutex = CreateMutex(nullptr, FALSE, ToW(appName + " Media Center").c_str());
-  if (appRunningMutex != nullptr && GetLastError() == ERROR_ALREADY_EXISTS)
+  // Detection of running Kodi instances
+  // (avoid conflicts and data corruption caused by two instances using the same data dir)
+  //
+  // * Non-portable mode. Interference with another Kodi on version < 22 may happen
+  // so use the legacy mutex mechanism it understands and abort if it already exists.
+  // There may be an older Kodi already running, or one may be started after us.
+  //! @todo in a few releases: remove that restriction and assume all Kodi installs understand the
+  //! file based protocol.
+  //
+  // * portable mode: most likely safe to allow multiple instances even if some are < v22
+  // because the user has to make special efforts to run two different installs with the same
+  // portable data dir.
+  //
+  // * Regardless of mode, v22 and higher implements a new file-based signal. Create a specific file
+  // in the data directory when starting up. If the file already exists, another Kodi >= 22
+  // instance is already running with that data directory, abort execution.
+
+  HANDLE appRunningMutex{NULL};
+  HANDLE appRunningFile{NULL};
+
+  // File-based method then mutex in non-portable mode for correct interaction with Kodi < v22 versions
+  if (CheckAndSetFileFlag(params->HasPlatformDirectories(), appRunningFile) ||
+      (params->HasPlatformDirectories() && CheckAndSetMutex(appRunningMutex)))
   {
-    auto appNameW = ToW(appName);
+    using KODI::PLATFORM::WINDOWS::ToW;
+    const auto appNameW = ToW(CCompileInfo::GetAppName());
     HWND hwnd = FindWindow(appNameW.c_str(), appNameW.c_str());
     if (hwnd != nullptr)
     {
@@ -182,6 +253,8 @@ cleanup:
     CoUninitialize();
   if (appRunningMutex)
     CloseHandle(appRunningMutex);
+  if (appRunningFile)
+    CloseHandle(appRunningFile);
 
   return status;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Relaxed the constraints that block running multiple instances of Kodi at the same time on Windows, and still maintain some safety.

* v22 and future versions
A Kodi instance creates a ".running" flag file in the Kodi user data directory it uses to mark it as in use.
New instances attempting to use the same directory fail to create the file and abort.
The file is removed automatically by Windows when the "owning" instance exits (cleanly or not).

* interaction with v21 and older
Older versions don't support the new mechanism. The risk of trouble is low for portable install, as it takes effort of the user to manage to have v22 and v21 attempt to use the same portable directory > allowed without locking mechanism.
To protect against separate non-portable install (would attempt to use the same data directory under the Windows user directory), the mutex mechanism remains in v22 in non-portable mode. It could be removed in a few releases, when only few pre-v22 installs remain.

@KarellenX I don't know if that's covered somewhere on the wiki or needs to be if it's not.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Ability to run multiple instances at the same time, for example development/debug of one version while using a stable Kodi on a different screen.

The modified code is very old, so I can only guess that it wasn't allowed before because of the risk of conflicts and data corruption if multiple Kodi ran with the same data directory (ex. multiple versions installed and ran in non-portable mode).

As far as I can tell the other platforms don't have that single instance constraint.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

results as expected for tests covering all cases I could think of:
Start non-portable after a Kodi 21: blocked by mutex
Start portable after Kodi 21: allowed
Start non-portable after another non-portable Kodi 22 with the PR: blocked by file
Start non-portable after another portable Kodi 22 with the PR: allowed
Start portable after another portable Kodi 22 with the PR, in same dir: blocked by file
Start portable after another portable Kodi 22 with the PR in a different dir: allowed

Start v21 (portable or non-portable, makes no difference) after a non-portable Kodi 22 with the PR: blocked by mutex
Start v21 (portable or non-portable, makes no difference) after a portable Kodi 22 with the PR: allowed.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Allow running multiple instances of Kodi simultaneously safely.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
