### PR TITLE
[PVR] Recordings window: Disable 'group recordings' when displaying ' Recently added recordings'

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -69,6 +69,14 @@ void CGUIWindowPVRRecordingsBase::OnWindowLoaded()
   CONTROL_SELECT(CONTROL_BTNGROUPITEMS);
 }
 
+void CGUIWindowPVRRecordingsBase::OnInitWindow()
+{
+  const CURL url{m_vecItems->GetPath()};
+  const std::string viewMode{url.GetOption("view")};
+  m_forceUngrouped = (viewMode == "flat");
+  CGUIWindowPVRBase::OnInitWindow();
+}
+
 void CGUIWindowPVRRecordingsBase::OnDeinitWindow(int nextWindowID)
 {
   if (UTILS::HasClientAndProvider(m_vecItems->GetPath()))
@@ -228,8 +236,11 @@ void CGUIWindowPVRRecordingsBase::UpdateButtons()
   SET_CONTROL_LABEL(CONTROL_BTNSHOWMODE, g_localizeStrings.Get(iStringId));
 
   const bool bGroupRecordings{
-      m_settings->GetBoolValue(CSettings::SETTING_PVRRECORD_GROUPRECORDINGS)};
+      !m_forceUngrouped && m_settings->GetBoolValue(CSettings::SETTING_PVRRECORD_GROUPRECORDINGS)};
+
   SET_CONTROL_SELECTED(GetID(), CONTROL_BTNGROUPITEMS, bGroupRecordings);
+
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTNGROUPITEMS, !m_forceUngrouped);
 
   auto* btnShowDeleted{static_cast<CGUIRadioButtonControl*>(GetControl(CONTROL_BTNSHOWDELETED))};
   if (btnShowDeleted)

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.h
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.h
@@ -29,6 +29,7 @@ public:
   ~CGUIWindowPVRRecordingsBase() override;
 
   void OnWindowLoaded() override;
+  void OnInitWindow() override;
   void OnDeinitWindow(int nextWindowID) override;
   bool OnMessage(CGUIMessage& message) override;
   bool OnAction(const CAction& action) override;
@@ -48,6 +49,7 @@ private:
   bool OnContextButtonDeleteAll(CONTEXT_BUTTON button) const;
 
   bool m_bShowDeletedRecordings{false};
+  bool m_forceUngrouped{false};
   CVideoThumbLoader m_thumbLoader;
   CVideoDatabase m_database;
   std::unique_ptr<CPVRSettings> m_settings;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Recordings window: Disable 'group recordings' when displaying ' Recently added recordings'. 
Reason: Achieve consistency with other "Recently added" media listings of Kodi.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/xbmc/xbmc/issues/27155#issuecomment-3217260423

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Runtime-tested on macOS and Android, latest Kodi master

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
They cannot try to change grouping which would not work, so (hopefully) less confusion.

## Screenshots (if appropriate):
<img width="1680" height="1050" alt="Screenshot 2025-08-25 at 22 42 35" src="https://github.com/user-attachments/assets/19be44db-3e81-4b80-957e-87f499bc63b5" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
