### PR TITLE
[VideoInfoTag] Add nfo file versioning

### DIFF
--- a/xbmc/CMakeLists.txt
+++ b/xbmc/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCES AutoSwitch.cpp
             LangInfo.cpp
             MediaSource.cpp
             NfoFile.cpp
+            NfoUtils.cpp
             PasswordManager.cpp
             PlayListPlayer.cpp
             PartyModeManager.cpp
@@ -61,6 +62,7 @@ set(HEADERS AutoSwitch.h
             LockMode.h
             MediaSource.h
             NfoFile.h
+            NfoUtils.h
             PartyModeManager.h
             PasswordManager.h
             PlayListPlayer.h

--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -39,9 +39,11 @@ const TiXmlElement* CNfoFile::GetRootElement() const
 {
   if (!m_xmlParsed)
   {
-    if (m_headPos < m_doc.size())
-      m_xmlDoc.Parse(m_doc.substr(m_headPos), TIXML_ENCODING_UNKNOWN);
+    // Try only once - read errors are not transient
     m_xmlParsed = true;
+
+    if (m_headPos < m_doc.size())
+      IngestXml(m_xmlDoc, m_doc.substr(m_headPos));
   }
   return m_xmlDoc.RootElement();
 }

--- a/xbmc/NfoFile.h
+++ b/xbmc/NfoFile.h
@@ -13,6 +13,7 @@
 //////////////////////////////////////////////////////////////////////
 
 #include "InfoScanner.h"
+#include "NfoUtils.h"
 #include "URL.h"
 #include "addons/Scraper.h"
 #include "utils/XBMCTinyXML.h"
@@ -39,15 +40,17 @@ public:
     if (document)
     {
       CXBMCTinyXML doc;
-      doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+      if (!IngestXml(doc, document))
+        return false;
+
       return details.Load(doc.RootElement(), true, prioritise);
     }
 
-    const TiXmlElement* root = GetRootElement();
-    if (!root)
-      return false;
+    // version upgrade applied when the document was cached
+    if (const TiXmlElement* root = GetRootElement(); root != nullptr)
+      return details.Load(root, true, prioritise);
 
-    return details.Load(root, true, prioritise);
+    return false;
   }
 
   void Close();
@@ -73,6 +76,26 @@ private:
 
   // Returns the root element of m_doc (from m_headPos)
   const TiXmlElement* GetRootElement() const;
+
+  /*!
+   * \brief Read the Xml text into the provided CXBMCTinyXML instance.
+   * \param[in,out] doc CXBMCTinyXML instance
+   * \param[in] docText XML text
+   * \return true and a populated \p doc for success, false and empty \p doc for failure.
+   */
+  static bool IngestXml(CXBMCTinyXML& doc, const std::string& xmlText)
+  {
+    // defined inline to satisfy linker for private static function used by public template caller
+    if (doc.Parse(xmlText, TIXML_ENCODING_UNKNOWN))
+    {
+      if (TiXmlElement* root = doc.RootElement(); root != nullptr)
+        if (CNfoUtils::Upgrade(root))
+          return true;
+    }
+
+    doc.Clear();
+    return false;
+  }
 
   std::string m_doc;
   size_t m_headPos = 0;

--- a/xbmc/NfoUtils.cpp
+++ b/xbmc/NfoUtils.cpp
@@ -146,6 +146,51 @@ bool ConvertRating(TiXmlElement* root)
   return true;
 }
 
+// Convert <set>Set Name</set> to <set><name>Set Name</name></set>
+// New tags (if any) are preserved and prevent the generation of a new style tag from a legacy tag.
+bool ConvertMovieSet(TiXmlElement* root)
+{
+  bool hasNewStyle{false};
+  std::string legacyName;
+  std::string dummy;
+
+  TiXmlNode* node = root->FirstChildElement("set");
+  while (node != nullptr)
+  {
+    // Found <set><name>xxx</name></set>?
+    if (XMLUtils::GetString(node, "name", dummy) && !dummy.empty())
+    {
+      hasNewStyle = true;
+      // Keep and skip to next tag
+      node = node->NextSibling("set");
+      continue;
+    }
+
+    // No new style tag idenfied yet? Look for legacy <set>xxx</set> tag
+    if (!hasNewStyle)
+    {
+      const TiXmlNode* child = node->FirstChild();
+      if (child != nullptr && child->Type() == TiXmlNode::TINYXML_TEXT)
+      {
+        const std::string name = child->ValueStr();
+        if (!name.empty() && legacyName.empty())
+          legacyName = name;
+      }
+    }
+    node = XMLUtils::RemoveAndReturnNextSibling(node, "set");
+  }
+
+  // No new style tag and a legacy tag found? Create a new style tag from the legacy info.
+  if (!hasNewStyle && !legacyName.empty())
+  {
+    TiXmlElement set("set");
+    XMLUtils::SetString(&set, "name", legacyName);
+    root->InsertEndChild(set);
+  }
+
+  return true;
+}
+
 bool UpgradeMovie(TiXmlElement* root, int currentVersion)
 {
   if (currentVersion < 1)
@@ -154,6 +199,9 @@ bool UpgradeMovie(TiXmlElement* root, int currentVersion)
       return false;
 
     if (!ConvertRating(root))
+      return false;
+
+    if (!ConvertMovieSet(root))
       return false;
   }
   return true;

--- a/xbmc/NfoUtils.cpp
+++ b/xbmc/NfoUtils.cpp
@@ -21,10 +21,10 @@ namespace
 constexpr int VERSION_LEGACY = 0; // nfo has no version attribute and predates version support
 
 // Current nfo versions
-constexpr int VERSION_MOVIE = 0;
-constexpr int VERSION_TVSHOW = 0;
-constexpr int VERSION_EPISODEDETAILS = 0;
-constexpr int VERSION_MUSICVIDEOS = 0;
+constexpr int VERSION_MOVIE = 1;
+constexpr int VERSION_TVSHOW = 1;
+constexpr int VERSION_EPISODEDETAILS = 1;
+constexpr int VERSION_MUSICVIDEOS = 1;
 
 struct nfoDetails
 {
@@ -66,23 +66,73 @@ constexpr int CurrentNfoVersion(std::string_view tag)
   return VERSION_LEGACY;
 }
 
+// When there are no uniqueid tags, convert <id>xxx</id> tags to <uniqueid>xxx</uniqueid>
+// All <id> tags are removed regardless.
+bool ConvertIdToUniqueId(TiXmlElement* root)
+{
+  const bool hasUniqueId = (nullptr != root->FirstChildElement("uniqueid"));
+
+  TiXmlNode* id = root->FirstChildElement("id");
+
+  // The original code read only the first <id> value. Convert the first, remove the rest
+  if (!hasUniqueId && id != nullptr)
+  {
+    if (const TiXmlNode* idChild = id->FirstChild(); idChild != nullptr)
+    {
+      if (std::string value = idChild->ValueStr(); !value.empty())
+      {
+        if (nullptr == XMLUtils::SetString(root, "uniqueid", value))
+        {
+          CLog::LogF(LOGERROR, "unable to add uniqueid tag, value {}", value);
+          return false;
+        }
+      }
+    }
+  }
+
+  for (TiXmlNode* node = id; node != nullptr;)
+    node = XMLUtils::RemoveAndReturnNextSibling(node, "id");
+
+  return true;
+}
+
 bool UpgradeMovie(TiXmlElement* root, int currentVersion)
 {
+  if (currentVersion < 1)
+  {
+    if (!ConvertIdToUniqueId(root))
+      return false;
+  }
   return true;
 }
 
 bool UpgradeTvShow(TiXmlElement* root, int currentVersion)
 {
+  if (currentVersion < 1)
+  {
+    if (!ConvertIdToUniqueId(root))
+      return false;
+  }
   return true;
 }
 
 bool UpgradeEpisodeDetails(TiXmlElement* root, int currentVersion)
 {
+  if (currentVersion < 1)
+  {
+    if (!ConvertIdToUniqueId(root))
+      return false;
+  }
   return true;
 }
 
 bool UpgradeMusicVideos(TiXmlElement* root, int currentVersion)
 {
+  if (currentVersion < 1)
+  {
+    if (!ConvertIdToUniqueId(root))
+      return false;
+  }
   return true;
 }
 } // namespace

--- a/xbmc/NfoUtils.cpp
+++ b/xbmc/NfoUtils.cpp
@@ -11,6 +11,9 @@
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
+#include <algorithm>
+#include <array>
+#include <optional>
 #include <string>
 
 namespace
@@ -23,16 +26,42 @@ constexpr int VERSION_TVSHOW = 0;
 constexpr int VERSION_EPISODEDETAILS = 0;
 constexpr int VERSION_MUSICVIDEOS = 0;
 
+struct nfoDetails
+{
+  std::string_view m_tagName;
+  int m_version;
+  bool (*m_upgradeFn)(TiXmlElement*, int); //! @todo C++23 convert to std::function
+};
+
+bool UpgradeMovie(TiXmlElement* root, int currentVersion);
+bool UpgradeTvShow(TiXmlElement* root, int currentVersion);
+bool UpgradeEpisodeDetails(TiXmlElement* root, int currentVersion);
+bool UpgradeMusicVideos(TiXmlElement* root, int currentVersion);
+
+using namespace std::literals::string_view_literals;
+
+// clang-format off
+constexpr std::array<struct nfoDetails, 4> nfos{{
+    {"movie"sv,                   VERSION_MOVIE,                   UpgradeMovie},
+    {"tvshow"sv,                  VERSION_TVSHOW,                  UpgradeTvShow},
+    {"episodedetails"sv,          VERSION_EPISODEDETAILS,          UpgradeEpisodeDetails},
+    {"musicvideos"sv,             VERSION_MUSICVIDEOS,             UpgradeMusicVideos},
+}};
+// clang-format on
+
+constexpr std::optional<nfoDetails> FindNfoParameters(std::string_view tag)
+{
+  if (const auto it{std::ranges::find(nfos, tag, &nfoDetails::m_tagName)}; it != nfos.end())
+    return *it;
+  else
+    return std::nullopt;
+}
+
 constexpr int CurrentNfoVersion(std::string_view tag)
 {
-  if (tag == "movie")
-    return VERSION_MOVIE;
-  if (tag == "tvshow")
-    return VERSION_TVSHOW;
-  if (tag == "episodedetails")
-    return VERSION_EPISODEDETAILS;
-  if (tag == "musicvideos")
-    return VERSION_EPISODEDETAILS;
+  const auto& param{FindNfoParameters(tag)};
+  if (param)
+    return param->m_version;
 
   return VERSION_LEGACY;
 }
@@ -68,28 +97,22 @@ void CNfoUtils::SetVersion(TiXmlElement& elem, std::string_view tag)
 
 bool CNfoUtils::Upgrade(TiXmlElement* root)
 {
-  const std::string type = root->ValueStr();
+  const std::string type{root->ValueStr()};
   int version;
   if (root->QueryIntAttribute("version", &version) != TIXML_SUCCESS)
     version = VERSION_LEGACY;
 
   const int targetVersion = CurrentNfoVersion(type);
 
-  //! @todo refactor in a generic manner once more than one tag type has to be handled
   if (targetVersion > VERSION_LEGACY && version < targetVersion)
   {
     CLog::LogF(LOGDEBUG, "upgrading {} from version {} to {}", type, version, targetVersion);
 
     root->SetAttribute("version", targetVersion);
 
-    if (type == "movie")
-      return UpgradeMovie(root, version);
-    if (type == "tvshow")
-      return UpgradeTvShow(root, version);
-    if (type == "episodedetails")
-      return UpgradeEpisodeDetails(root, version);
-    if (type == "musicvideos")
-      return UpgradeMusicVideos(root, version);
+    const auto& param{FindNfoParameters(type)};
+    if (param)
+      return param->m_upgradeFn(root, version);
   }
 
   return true;

--- a/xbmc/NfoUtils.cpp
+++ b/xbmc/NfoUtils.cpp
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "NfoUtils.h"
+
+#include "utils/XMLUtils.h"
+#include "utils/log.h"
+
+#include <string>
+
+namespace
+{
+constexpr int VERSION_LEGACY = 0; // nfo has no version attribute and predates version support
+
+constexpr int CurrentNfoVersion(std::string_view tag)
+{
+  return VERSION_LEGACY;
+}
+} // namespace
+
+void CNfoUtils::SetVersion(TiXmlElement& elem, std::string_view tag)
+{
+  const int version{CurrentNfoVersion(tag)};
+
+  if (version > VERSION_LEGACY)
+    elem.SetAttribute("version", version);
+}
+
+bool CNfoUtils::Upgrade(TiXmlElement* root)
+{
+  const std::string type = root->ValueStr();
+  int version;
+  if (root->QueryIntAttribute("version", &version) != TIXML_SUCCESS)
+    version = VERSION_LEGACY;
+
+  const int targetVersion = CurrentNfoVersion(type);
+
+  //! @todo refactor in a generic manner once more than one tag type has to be handled
+  if (targetVersion > VERSION_LEGACY && version < targetVersion)
+  {
+    CLog::LogF(LOGDEBUG, "upgrading {} from version {} to {}", type, version, targetVersion);
+
+    root->SetAttribute("version", targetVersion);
+
+    // Upgrade code goes here
+  }
+
+  return true;
+}

--- a/xbmc/NfoUtils.cpp
+++ b/xbmc/NfoUtils.cpp
@@ -17,9 +17,44 @@ namespace
 {
 constexpr int VERSION_LEGACY = 0; // nfo has no version attribute and predates version support
 
+// Current nfo versions
+constexpr int VERSION_MOVIE = 0;
+constexpr int VERSION_TVSHOW = 0;
+constexpr int VERSION_EPISODEDETAILS = 0;
+constexpr int VERSION_MUSICVIDEOS = 0;
+
 constexpr int CurrentNfoVersion(std::string_view tag)
 {
+  if (tag == "movie")
+    return VERSION_MOVIE;
+  if (tag == "tvshow")
+    return VERSION_TVSHOW;
+  if (tag == "episodedetails")
+    return VERSION_EPISODEDETAILS;
+  if (tag == "musicvideos")
+    return VERSION_EPISODEDETAILS;
+
   return VERSION_LEGACY;
+}
+
+bool UpgradeMovie(TiXmlElement* root, int currentVersion)
+{
+  return true;
+}
+
+bool UpgradeTvShow(TiXmlElement* root, int currentVersion)
+{
+  return true;
+}
+
+bool UpgradeEpisodeDetails(TiXmlElement* root, int currentVersion)
+{
+  return true;
+}
+
+bool UpgradeMusicVideos(TiXmlElement* root, int currentVersion)
+{
+  return true;
 }
 } // namespace
 
@@ -47,7 +82,14 @@ bool CNfoUtils::Upgrade(TiXmlElement* root)
 
     root->SetAttribute("version", targetVersion);
 
-    // Upgrade code goes here
+    if (type == "movie")
+      return UpgradeMovie(root, version);
+    if (type == "tvshow")
+      return UpgradeTvShow(root, version);
+    if (type == "episodedetails")
+      return UpgradeEpisodeDetails(root, version);
+    if (type == "musicvideos")
+      return UpgradeMusicVideos(root, version);
   }
 
   return true;

--- a/xbmc/NfoUtils.cpp
+++ b/xbmc/NfoUtils.cpp
@@ -8,6 +8,7 @@
 
 #include "NfoUtils.h"
 
+#include "utils/StringUtils.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
@@ -96,11 +97,63 @@ bool ConvertIdToUniqueId(TiXmlElement* root)
   return true;
 }
 
+// When there are no "ratings" tags, convert <rating max="zzz">xxx</rating><votes>yyy</votes> tags to
+// <ratings><rating max="zzz"><value>xxx</value><votes>yyy</votes></rating></ratings>
+// All <rating> and <votes> tags are removed regardless.
+bool ConvertRating(TiXmlElement* root)
+{
+  const bool hasRatings = (nullptr != root->FirstChildElement("ratings"));
+
+  TiXmlElement* ratingElement = root->FirstChildElement("rating");
+
+  // Convert only when <rating> exists and has a value
+  if (!hasRatings && ratingElement != nullptr)
+  {
+    if (TiXmlNode* rating = ratingElement->FirstChild(); rating != nullptr)
+    {
+      // Extract the information
+      const std::string ratingValue = rating->Value();
+
+      std::optional<int> votes;
+      std::string value;
+      if (XMLUtils::GetString(root, "votes", value))
+        votes = StringUtils::ReturnDigits(value);
+
+      std::string maxValue;
+      ratingElement->QueryStringAttribute("max", &maxValue);
+
+      // Create new node
+      TiXmlElement newRating("rating");
+      if (!maxValue.empty())
+        newRating.SetAttribute("max", maxValue);
+      XMLUtils::SetString(&newRating, "value", ratingValue);
+      if (votes.has_value())
+        XMLUtils::SetInt(&newRating, "votes", votes.value());
+
+      TiXmlElement newRatings("ratings");
+      newRatings.InsertEndChild(newRating);
+
+      root->InsertEndChild(newRatings);
+    }
+  }
+
+  for (TiXmlNode* node = ratingElement; node != nullptr;)
+    node = XMLUtils::RemoveAndReturnNextSibling(node, "rating");
+
+  for (TiXmlNode* node = root->FirstChildElement("votes"); node != nullptr;)
+    node = XMLUtils::RemoveAndReturnNextSibling(node, "votes");
+
+  return true;
+}
+
 bool UpgradeMovie(TiXmlElement* root, int currentVersion)
 {
   if (currentVersion < 1)
   {
     if (!ConvertIdToUniqueId(root))
+      return false;
+
+    if (!ConvertRating(root))
       return false;
   }
   return true;
@@ -112,6 +165,9 @@ bool UpgradeTvShow(TiXmlElement* root, int currentVersion)
   {
     if (!ConvertIdToUniqueId(root))
       return false;
+
+    if (!ConvertRating(root))
+      return false;
   }
   return true;
 }
@@ -122,6 +178,9 @@ bool UpgradeEpisodeDetails(TiXmlElement* root, int currentVersion)
   {
     if (!ConvertIdToUniqueId(root))
       return false;
+
+    if (!ConvertRating(root))
+      return false;
   }
   return true;
 }
@@ -131,6 +190,9 @@ bool UpgradeMusicVideos(TiXmlElement* root, int currentVersion)
   if (currentVersion < 1)
   {
     if (!ConvertIdToUniqueId(root))
+      return false;
+
+    if (!ConvertRating(root))
       return false;
   }
   return true;

--- a/xbmc/NfoUtils.h
+++ b/xbmc/NfoUtils.h
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/XBMCTinyXML.h"
+
+#include <string_view>
+
+class CNfoUtils
+{
+public:
+  CNfoUtils() = delete;
+
+  /*!
+   * \brief Bring the XML representation of a NFO file up to date.
+   * \param[in] root Root of the XML document
+   * \return true for success (successful upgrade, already up to date, not versioned, ...)
+   *         and false for any error.
+   */
+  static bool Upgrade(TiXmlElement* root);
+
+  /*!
+   * \brief Add a <version> attribute to the element \p elem. The element value is the current
+   *        version of the provided NFO type \p tag.
+   * \param[in] elem Element to add to.
+   * \param[in] tag NFO type (ex. movie, tvshow)
+   */
+  static void SetVersion(TiXmlElement& elem, std::string_view tag);
+};

--- a/xbmc/test/CMakeLists.txt
+++ b/xbmc/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES TestAutoSwitch.cpp
             TestFileItem.cpp
             TestLangInfo.cpp
             TestMediaSource.cpp
+            TestNfoUtils.cpp
             TestPasswordManager.cpp
             TestURL.cpp
             TestUtil.cpp

--- a/xbmc/test/TestNfoUtils.cpp
+++ b/xbmc/test/TestNfoUtils.cpp
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "NfoUtils.h"
+#include "test/TestUtils.h"
+#include "utils/XBMCTinyXML.h"
+#include "video/VideoInfoTag.h"
+
+#include <map>
+#include <string>
+
+#include <gtest/gtest.h>
+
+TEST(TestNfoUtils, UpgradeUniqueId)
+{
+  const std::string document =
+      R"(<tvshow>
+         <id>64043</id>
+         <id>65048</id>
+         </tvshow>)";
+
+  const std::string expectedXml = R"(<tvshow version="1">
+    <uniqueid>64043</uniqueid>
+</tvshow>
+)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  EXPECT_TRUE(CNfoUtils::Upgrade(doc.RootElement()));
+
+  //! @todo compare in TinyXml representation. Less sensitive to formatting (indentation, carriage returns...)
+  TiXmlPrinter printer;
+  doc.Accept(&printer);
+  std::string result = printer.Str();
+
+  EXPECT_EQ(result, expectedXml);
+}
+
+TEST(TestNfoUtils, UpgradeUniqueId2)
+{
+  const std::string document =
+      R"(<tvshow>
+         <id>12345</id>
+         <uniqueid type="imdb">64043</uniqueid>
+         <id>23456</id>
+         </tvshow>)";
+
+  const std::string expectedXml = R"(<tvshow version="1">
+    <uniqueid type="imdb">64043</uniqueid>
+</tvshow>
+)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  EXPECT_TRUE(CNfoUtils::Upgrade(doc.RootElement()));
+
+  //! @todo compare in TinyXml representation. Less sensitive to formatting (indentation, carriage returns...)
+  TiXmlPrinter printer;
+  doc.Accept(&printer);
+  std::string result = printer.Str();
+
+  EXPECT_EQ(result, expectedXml);
+}
+
+TEST(TestNfoUtils, UpgradeUniqueId3)
+{
+  const std::string document =
+      R"(<tvshow>
+         <id></id>
+         <id>65048</id>
+         </tvshow>)";
+
+  const std::string expectedXml = "<tvshow version=\"1\" />\n";
+
+  CXBMCTinyXML doc;
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  EXPECT_TRUE(CNfoUtils::Upgrade(doc.RootElement()));
+
+  //! @todo compare in TinyXml representation. Less sensitive to formatting (indentation, carriage returns...)
+  TiXmlPrinter printer;
+  doc.Accept(&printer);
+  std::string result = printer.Str();
+
+  EXPECT_EQ(result, expectedXml);
+}

--- a/xbmc/test/TestNfoUtils.cpp
+++ b/xbmc/test/TestNfoUtils.cpp
@@ -230,3 +230,71 @@ TEST(TestNfoUtils, UpgradeRating2)
 
   EXPECT_EQ(result, expectedXml);
 }
+
+TEST(TestNfoUtils, UpgradeSet)
+{
+  // legacy-only tags
+  std::string document =
+      R"(<movie>
+           <set></set>
+           <set>set name</set>
+           <set>other set</set>
+         </movie>)";
+
+  std::string expectedXml = R"(<movie version="1">
+    <set>
+        <name>set name</name>
+    </set>
+</movie>
+)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  EXPECT_TRUE(CNfoUtils::Upgrade(doc.RootElement()));
+
+  //! @todo compare in TinyXml representation. Less sensitive to formatting (indentation, carriage returns...)
+  std::string result;
+  {
+    TiXmlPrinter printer;
+    doc.Accept(&printer);
+    result = printer.Str();
+  }
+  EXPECT_EQ(result, expectedXml);
+}
+
+TEST(TestNfoUtils, UpgradeSet2)
+{
+  // With both old and new style tags
+  std::string document =
+      R"(<movie>
+           <set>name</set>
+           <set><name>Set 1</name></set>
+           <set><name>Set 2</name></set>
+           <set>other set</set>
+         </movie>)";
+
+  std::string expectedXml = R"(<movie version="1">
+    <set>
+        <name>Set 1</name>
+    </set>
+    <set>
+        <name>Set 2</name>
+    </set>
+</movie>
+)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  EXPECT_TRUE(CNfoUtils::Upgrade(doc.RootElement()));
+
+  //! @todo compare in TinyXml representation. Less sensitive to formatting (indentation, carriage returns...)
+  std::string result;
+  {
+    TiXmlPrinter printer;
+    doc.Accept(&printer);
+    result = printer.Str();
+  }
+  EXPECT_EQ(result, expectedXml);
+}

--- a/xbmc/test/TestNfoUtils.cpp
+++ b/xbmc/test/TestNfoUtils.cpp
@@ -91,3 +91,142 @@ TEST(TestNfoUtils, UpgradeUniqueId3)
 
   EXPECT_EQ(result, expectedXml);
 }
+
+TEST(TestNfoUtils, UpgradeRating)
+{
+  // with all possible attributes
+  std::string document =
+      R"(<tvshow>
+           <rating max="12.34">1.23</rating>
+           <votes>234</votes>
+         </tvshow>)";
+
+  std::string expectedXml = R"(<tvshow version="1">
+    <ratings>
+        <rating max="12.34">
+            <value>1.23</value>
+            <votes>234</votes>
+        </rating>
+    </ratings>
+</tvshow>
+)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  EXPECT_TRUE(CNfoUtils::Upgrade(doc.RootElement()));
+
+  //! @todo compare in TinyXml representation. Less sensitive to formatting (indentation, carriage returns...)
+  std::string result;
+  {
+    TiXmlPrinter printer;
+    doc.Accept(&printer);
+    result = printer.Str();
+  }
+  EXPECT_EQ(result, expectedXml);
+
+  // with minimum attributes
+  document =
+      R"(<tvshow>
+           <rating>1.23</rating>
+         </tvshow>)";
+
+  expectedXml = R"(<tvshow version="1">
+    <ratings>
+        <rating>
+            <value>1.23</value>
+        </rating>
+    </ratings>
+</tvshow>
+)";
+
+  doc.Clear();
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  EXPECT_TRUE(CNfoUtils::Upgrade(doc.RootElement()));
+
+  //! @todo compare in TinyXml representation. Less sensitive to formatting (indentation, carriage returns...)
+  {
+    TiXmlPrinter printer;
+    doc.Accept(&printer);
+    result = printer.Str();
+  }
+  EXPECT_EQ(result, expectedXml);
+
+  // erroneous rating tag
+  document =
+      R"(<tvshow>
+           <rating></rating>
+         </tvshow>)";
+
+  expectedXml = "<tvshow version=\"1\" />\n";
+
+  doc.Clear();
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  EXPECT_TRUE(CNfoUtils::Upgrade(doc.RootElement()));
+
+  //! @todo compare in TinyXml representation. Less sensitive to formatting (indentation, carriage returns...)
+  {
+    TiXmlPrinter printer;
+    doc.Accept(&printer);
+    result = printer.Str();
+  }
+  EXPECT_EQ(result, expectedXml);
+
+  // missing rating tag with votes tag
+  document =
+      R"(<tvshow>
+           <votes>234</votes>
+         </tvshow>)";
+
+  expectedXml = "<tvshow version=\"1\" />\n";
+
+  doc.Clear();
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  EXPECT_TRUE(CNfoUtils::Upgrade(doc.RootElement()));
+
+  //! @todo compare in TinyXml representation. Less sensitive to formatting (indentation, carriage returns...)
+  {
+    TiXmlPrinter printer;
+    doc.Accept(&printer);
+    result = printer.Str();
+  }
+  EXPECT_EQ(result, expectedXml);
+}
+
+TEST(TestNfoUtils, UpgradeRating2)
+{
+  // Presence of <ratings> node cancels conversion of existing <rating> or <votes> nodes.
+  const std::string document =
+      R"(<tvshow>
+           <ratings><rating max="12.34"><value>1.23</value><votes>234</votes></rating></ratings>
+           <rating max="12.34">1.23</rating>
+           <rating max="23.45">2.34</rating>
+           <votes>234</votes>
+           <votes>345</votes>
+         </tvshow>)";
+
+  const std::string expectedXml = R"(<tvshow version="1">
+    <ratings>
+        <rating max="12.34">
+            <value>1.23</value>
+            <votes>234</votes>
+        </rating>
+    </ratings>
+</tvshow>
+)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  EXPECT_TRUE(CNfoUtils::Upgrade(doc.RootElement()));
+
+  //! @todo compare in TinyXml representation. Less sensitive to formatting (indentation, carriage returns...)
+  TiXmlPrinter printer;
+  doc.Accept(&printer);
+  std::string result = printer.Str();
+
+  EXPECT_EQ(result, expectedXml);
+}

--- a/xbmc/utils/XMLUtils.cpp
+++ b/xbmc/utils/XMLUtils.cpp
@@ -821,3 +821,40 @@ bool XMLUtils::RemoveNode(tinyxml2::XMLNode* node)
 
   return true;
 }
+
+TiXmlNode* XMLUtils::RemoveAndReturnNextSibling(TiXmlNode* node, const char* tag)
+{
+  if (node == nullptr)
+    return nullptr;
+
+  TiXmlNode* parent = node->Parent();
+  // TinyXml doesn't allow removal of the root of the document and does nothing.
+  // Skip unnecessary work and avoid infinite loop if caller relies on nullptr output to stop looping.
+  if (parent->Type() == TiXmlNode::TINYXML_DOCUMENT)
+    return nullptr;
+
+  TiXmlNode* next = node->NextSiblingElement(tag);
+
+  if (!parent->RemoveChild(node))
+    return nullptr;
+
+  return next;
+}
+
+tinyxml2::XMLNode* XMLUtils::RemoveAndReturnNextSibling(tinyxml2::XMLNode* node, const char* tag)
+{
+  if (node == nullptr)
+    return nullptr;
+
+  tinyxml2::XMLNode* parent = node->Parent();
+  // TinyXml doesn't allow removal of the root of the document and does nothing.
+  // Skip unnecessary work and avoid infinite loop if caller relies on nullptr output to stop looping.
+  if (parent->ToDocument() != nullptr)
+    return nullptr;
+
+  tinyxml2::XMLNode* next = node->NextSiblingElement(tag);
+
+  parent->DeleteChild(node);
+
+  return next;
+}

--- a/xbmc/utils/XMLUtils.h
+++ b/xbmc/utils/XMLUtils.h
@@ -175,6 +175,10 @@ public:
   static bool RemoveNode(TiXmlNode* node);
   static bool RemoveNode(tinyxml2::XMLNode* node);
 
+  static TiXmlNode* RemoveAndReturnNextSibling(TiXmlNode* node, const char* tag = nullptr);
+  static tinyxml2::XMLNode* RemoveAndReturnNextSibling(tinyxml2::XMLNode* node,
+                                                       const char* tag = nullptr);
+
   static const int path_version = 1;
 };
 

--- a/xbmc/utils/test/TestXMLUtils.cpp
+++ b/xbmc/utils/test/TestXMLUtils.cpp
@@ -821,3 +821,47 @@ TEST(TestXMLUtils, RemoveNodeFreestanding)
     EXPECT_FALSE(XMLUtils::RemoveNode(clone));
   }
 }
+
+TEST(TestXMLUtils, RemoveAndReturnNextSibling)
+{
+  {
+    CXBMCTinyXML a;
+
+    a.Parse(std::string(
+        "<root><node>some string</node><other>string</other><node>other string</node></root>"));
+    TiXmlNode* node = a.RootElement()->FirstChildElement("node");
+    node = XMLUtils::RemoveAndReturnNextSibling(node, "node");
+
+    EXPECT_TRUE(node != nullptr);
+    EXPECT_EQ(node->FirstChild()->ValueStr(), "other string");
+
+    node = XMLUtils::RemoveAndReturnNextSibling(node, "node");
+
+    EXPECT_TRUE(node == nullptr);
+
+    a.Parse(std::string("<root>some string</root>"));
+    node = XMLUtils::RemoveAndReturnNextSibling(a.RootElement(), "node");
+
+    EXPECT_TRUE(node == nullptr);
+  }
+  {
+    CXBMCTinyXML2 a;
+    a.Parse(std::string(
+        "<root><node>some string</node><other>string</other><node>other string</node></root>"));
+    tinyxml2::XMLNode* root = a.RootElement();
+    tinyxml2::XMLNode* node = root->FirstChildElement("node");
+    node = XMLUtils::RemoveAndReturnNextSibling(node, "node");
+
+    EXPECT_TRUE(node != nullptr);
+    EXPECT_STREQ(node->FirstChild()->Value(), "other string");
+
+    node = XMLUtils::RemoveAndReturnNextSibling(node, "node");
+
+    EXPECT_TRUE(node == nullptr);
+
+    a.Parse(std::string("<root>some string</root>"));
+    node = XMLUtils::RemoveAndReturnNextSibling(a.RootElement(), "node");
+
+    EXPECT_TRUE(node == nullptr);
+  }
+}

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -122,22 +122,10 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const std::string &tag, bool savePathI
     XMLUtils::SetString(movie, "showtitle", m_strShowTitle);
   if (!m_strSortTitle.empty())
     XMLUtils::SetString(movie, "sorttitle", m_strSortTitle);
-  if (!m_ratings.empty())
-  {
-    TiXmlElement ratings("ratings");
-    for (const auto& [name, value] : m_ratings)
-    {
-      TiXmlElement rating("rating");
-      rating.SetAttribute("name", name.c_str());
-      XMLUtils::SetFloat(&rating, "value", value.rating);
-      XMLUtils::SetInt(&rating, "votes", value.votes);
-      rating.SetAttribute("max", 10);
-      if (name == m_strDefaultRating)
-        rating.SetAttribute("default", "true");
-      ratings.InsertEndChild(rating);
-    }
-    movie->InsertEndChild(ratings);
-  }
+
+  if (!SaveRatings(movie))
+    return false;
+
   XMLUtils::SetInt(movie, "userrating", m_iUserRating);
 
   if (m_EpBookmark.timeInSeconds > 0)
@@ -370,6 +358,31 @@ bool CVideoInfoTag::SaveUniqueId(TiXmlNode* node) const
   return true;
 }
 
+bool CVideoInfoTag::SaveRatings(TiXmlNode* node) const
+{
+  if (!m_ratings.empty())
+  {
+    TiXmlElement ratings("ratings");
+    for (const auto& [name, value] : m_ratings)
+    {
+      TiXmlElement rating("rating");
+      rating.SetAttribute("name", name.c_str());
+      if (nullptr == XMLUtils::SetFloat(&rating, "value", value.rating))
+        return false;
+      if (nullptr == XMLUtils::SetInt(&rating, "votes", value.votes))
+        return false;
+      rating.SetAttribute("max", 10);
+      if (name == m_strDefaultRating)
+        rating.SetAttribute("default", "true");
+      if (nullptr == ratings.InsertEndChild(rating))
+        return false;
+    }
+    if (nullptr == node->InsertEndChild(ratings))
+      return false;
+  }
+  return true;
+}
+
 bool CVideoInfoTag::Load(const TiXmlElement *element, bool append, bool prioritise)
 {
   if (!element)
@@ -468,8 +481,6 @@ void CVideoInfoTag::Merge(CVideoInfoTag& other)
     m_ratings = other.m_ratings;
     m_strDefaultRating = other.m_strDefaultRating;
   }
-  if (other.m_iIdRating != -1)
-    m_iIdRating = other.m_iIdRating;
   if (other.m_iUserRating)
     m_iUserRating = other.m_iUserRating;
 
@@ -1147,7 +1158,6 @@ std::string CVideoInfoTag::GetCast(const std::string& separator,
 void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
 {
   std::string value;
-  float fValue;
 
   if (StringUtils::ToLower(XMLUtils::GetAttribute(movie, "override")) == "true")
     SetOverride(true);
@@ -1188,19 +1198,6 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
           (child->QueryBoolAttribute("default", &isDefault) == TIXML_SUCCESS) && isDefault)
         m_strDefaultRating = name;
     }
-  }
-  else if (XMLUtils::GetFloat(movie, "rating", fValue))
-  {
-    CRating r(fValue, 0);
-    if (XMLUtils::GetString(movie, "votes", value))
-      r.votes = StringUtils::ReturnDigits(value);
-    int max_value = 10;
-    const TiXmlElement* rElement = movie->FirstChildElement("rating");
-    if (rElement && (rElement->QueryIntAttribute("max", &max_value) == TIXML_SUCCESS) && max_value >= 1)
-      r.rating = r.rating / static_cast<float>(max_value) *
-                 10.0f; // Normalise the Movie Rating to between 1 and 10
-    SetRating(r, "default");
-    m_strDefaultRating = "default";
   }
   XMLUtils::GetInt(movie, "userrating", m_iUserRating);
 

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1433,17 +1433,11 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
     node = node->NextSiblingElement("actor");
   }
 
-  // Pre-Jarvis NFO file:
-  // <set>A set</set>
-  if (XMLUtils::GetString(movie, "set", value))
-    SetSet(value);
-  // Jarvis+:
-  // <set><name>A set</name><overview>A set with a number of movies...</overview></set>
   node = movie->FirstChildElement("set");
   if (node)
   {
     // No name, no set
-    if (XMLUtils::GetString(node, "name", value))
+    if (XMLUtils::GetString(node, "name", value) && !value.empty())
     {
       SetSet(value);
       if (XMLUtils::GetString(node, "overview", value))

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -8,6 +8,7 @@
 
 #include "VideoInfoTag.h"
 
+#include "NfoUtils.h"
 #include "ServiceBroker.h"
 #include "imagefiles/ImageFileURL.h"
 #include "resources/LocalizeStrings.h"
@@ -108,6 +109,8 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const std::string &tag, bool savePathI
 
   // we start with a <tag> tag
   TiXmlElement movieElement(tag.c_str());
+  CNfoUtils::SetVersion(movieElement, tag);
+
   TiXmlNode *movie = node->InsertEndChild(movieElement);
 
   if (!movie) return false;

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -215,17 +215,9 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const std::string &tag, bool savePathI
       XMLUtils::SetString(movie, "episodeguide", m_strEpisodeGuide);
   }
 
-  XMLUtils::SetString(movie, "id", GetUniqueID());
-  for (const auto& [type, value] : m_uniqueIDs)
-  {
-    TiXmlElement uniqueID("uniqueid");
-    uniqueID.SetAttribute("type", type);
-    if (type == m_strDefaultUniqueID)
-      uniqueID.SetAttribute("default", "true");
-    uniqueID.InsertEndChild(TiXmlText(value));
+  if (!SaveUniqueId(movie))
+    return false;
 
-    movie->InsertEndChild(uniqueID);
-  }
   XMLUtils::SetStringArray(movie, "genre", m_genre);
   XMLUtils::SetStringArray(movie, "country", m_country);
   if (m_set.HasTitle())
@@ -357,6 +349,23 @@ bool CVideoInfoTag::SaveTvShowSeasons(TiXmlNode* root) const
       if (nullptr == root->InsertEndChild(season))
         return false;
     }
+  }
+  return true;
+}
+
+bool CVideoInfoTag::SaveUniqueId(TiXmlNode* node) const
+{
+  for (const auto& [type, value] : m_uniqueIDs)
+  {
+    TiXmlElement uniqueID("uniqueid");
+    uniqueID.SetAttribute("type", type);
+    if (type == m_strDefaultUniqueID)
+      uniqueID.SetAttribute("default", "true");
+    if (nullptr == uniqueID.InsertEndChild(TiXmlText(value)))
+      return false;
+
+    if (nullptr == node->InsertEndChild(uniqueID))
+      return false;
   }
   return true;
 }
@@ -1254,28 +1263,20 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
   if (XMLUtils::GetString(movie, "path", value))
     SetPath(value);
 
-  const TiXmlElement* uniqueid = movie->FirstChildElement("uniqueid");
-  if (uniqueid == nullptr)
+  for (const TiXmlElement* uniqueid = movie->FirstChildElement("uniqueid"); uniqueid != nullptr;
+       uniqueid = uniqueid->NextSiblingElement("uniqueid"))
   {
-    if (XMLUtils::GetString(movie, "id", value))
-      SetUniqueID(value);
-  }
-  else
-  {
-    for (; uniqueid != nullptr; uniqueid = uniqueid->NextSiblingElement("uniqueid"))
+    if (uniqueid->FirstChild())
     {
-      if (uniqueid->FirstChild())
+      if (uniqueid->QueryStringAttribute("type", &value) == TIXML_SUCCESS)
+        SetUniqueID(uniqueid->FirstChild()->ValueStr(), value);
+      else
+        SetUniqueID(uniqueid->FirstChild()->ValueStr());
+      bool isDefault;
+      if (m_strDefaultUniqueID == "unknown" &&
+          (uniqueid->QueryBoolAttribute("default", &isDefault) == TIXML_SUCCESS) && isDefault)
       {
-        if (uniqueid->QueryStringAttribute("type", &value) == TIXML_SUCCESS)
-          SetUniqueID(uniqueid->FirstChild()->ValueStr(), value);
-        else
-          SetUniqueID(uniqueid->FirstChild()->ValueStr());
-        bool isDefault;
-        if (m_strDefaultUniqueID == "unknown" &&
-            (uniqueid->QueryBoolAttribute("default", &isDefault) == TIXML_SUCCESS) && isDefault)
-        {
-          m_strDefaultUniqueID = value;
-        }
+        m_strDefaultUniqueID = value;
       }
     }
   }

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -443,6 +443,13 @@ protected:
    */
   bool SaveTvShowSeasons(TiXmlNode* node) const;
 
+  /*!
+   * \brief Add the uniqueid information to an XML node
+   * \param element  the root XML element to append to
+   * \return true for success, false otherwise.
+   */
+  bool SaveUniqueId(TiXmlNode* node) const;
+
 private:
   /* \brief Parse our native XML format for video info.
    See Load for a description of the available tag types.

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -49,6 +49,11 @@ public:
   CRating(float r, int v): rating(r), votes(v) {}
   float rating = 0.0f;
   int votes = 0;
+  bool operator==(const CRating& other) const
+  {
+    // floating point equality OK for unit tests but may require tweaking for general comparison.
+    return rating == other.rating && votes == other.votes;
+  }
 };
 using RatingMap = std::map<std::string, CRating, std::less<>>;
 
@@ -449,6 +454,13 @@ protected:
    * \return true for success, false otherwise.
    */
   bool SaveUniqueId(TiXmlNode* node) const;
+
+  /*!
+   * \brief Add the ratings information to an XML node
+   * \param element  the root XML element to append to
+   * \return true for success, false otherwise.
+   */
+  bool SaveRatings(TiXmlNode* node) const;
 
 private:
   /* \brief Parse our native XML format for video info.

--- a/xbmc/video/test/TestVideoInfoTag.cpp
+++ b/xbmc/video/test/TestVideoInfoTag.cpp
@@ -22,6 +22,7 @@ class CVideoInfoTagTest : public CVideoInfoTag
 public:
   bool CallSaveTvShowSeasons(TiXmlNode* node) { return SaveTvShowSeasons(node); }
   bool CallSaveUniqueId(TiXmlNode* node) { return SaveUniqueId(node); }
+  bool CallSaveRatings(TiXmlNode* node) { return SaveRatings(node); }
 };
 
 TEST(TestVideoInfoTag, ReadTVShowSeasons)
@@ -229,6 +230,85 @@ TEST(TestVideoInfoTag, SaveUniqueId)
 
   CXBMCTinyXML xmlDoc;
   details.CallSaveUniqueId(&xmlDoc);
+
+  //! @todo compare in TinyXml representation. Less sensitive to formatting (indentation, carriage returns...)
+  TiXmlPrinter printer;
+  xmlDoc.Accept(&printer);
+  std::string result = printer.Str();
+
+  EXPECT_EQ(result, expectedXml);
+}
+
+TEST(TestVideoInfoTag, LoadRatings)
+{
+  const std::string document =
+      R"(<tvshow version="1">
+         <ratings>
+           <rating name="foo" max="10" default="true">
+             <value>8.64</value>
+             <votes>123</votes>
+           </rating>
+           <rating name="bar" max="20">
+             <value>8.64</value>
+             <votes>234</votes>
+           </rating>
+         </ratings>
+       </tvshow>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  CVideoInfoTag details;
+  EXPECT_TRUE(details.Load(doc.RootElement(), true, false));
+
+  EXPECT_EQ(details.GetDefaultRating(), "foo");
+
+  EXPECT_EQ(details.GetRating("foo"), CRating(8.64f, 123));
+  EXPECT_EQ(details.GetRating("bar"), CRating(4.32f, 234));
+}
+
+TEST(TestVideoInfoTag, LoadRatingsLegacy)
+{
+  const std::string document =
+      R"(<tvshow version="1">
+           <ratings>
+             <rating max="20">
+               <value>12</value>
+               <votes>234</votes>
+             </rating>
+           </ratings>
+         </tvshow>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  CVideoInfoTag details;
+  EXPECT_TRUE(details.Load(doc.RootElement(), true, false));
+
+  EXPECT_EQ(details.GetDefaultRating(), "default");
+  EXPECT_EQ(details.GetRating("default"), CRating(6.0f, 234));
+}
+
+TEST(TestVideoInfoTag, SaveRatings)
+{
+  CVideoInfoTagTest details;
+  details.SetRating(1.23f, 1234, "foo", false);
+  details.SetRating(2.34f, 2345, "bar", true);
+
+  const std::string expectedXml = R"(<ratings>
+    <rating name="bar" max="10" default="true">
+        <value>2.340000</value>
+        <votes>2345</votes>
+    </rating>
+    <rating name="foo" max="10">
+        <value>1.230000</value>
+        <votes>1234</votes>
+    </rating>
+</ratings>
+)";
+
+  CXBMCTinyXML xmlDoc;
+  details.CallSaveRatings(&xmlDoc);
 
   //! @todo compare in TinyXml representation. Less sensitive to formatting (indentation, carriage returns...)
   TiXmlPrinter printer;

--- a/xbmc/video/test/TestVideoInfoTag.cpp
+++ b/xbmc/video/test/TestVideoInfoTag.cpp
@@ -16,6 +16,14 @@
 
 #include <gtest/gtest.h>
 
+// Trick to make protected methods accessible for unit testing and maintain encapsulation
+class CVideoInfoTagTest : public CVideoInfoTag
+{
+public:
+  bool CallSaveTvShowSeasons(TiXmlNode* node) { return SaveTvShowSeasons(node); }
+  bool CallSaveUniqueId(TiXmlNode* node) { return SaveUniqueId(node); }
+};
+
 TEST(TestVideoInfoTag, ReadTVShowSeasons)
 {
   const std::string document =
@@ -42,13 +50,6 @@ TEST(TestVideoInfoTag, ReadTVShowSeasons)
   EXPECT_EQ(details.m_seasons, reference);
 }
 
-// Trick to make protected methods accessible for testing
-class CVideoInfoTagTest : public CVideoInfoTag
-{
-public:
-  bool ForwardSaveTvShowSeasons(TiXmlNode* node) { return SaveTvShowSeasons(node); }
-};
-
 TEST(TestVideoInfoTag, SaveTVShowSeasons)
 {
   const std::map<int, CVideoInfoTag::SeasonAttributes> reference = {
@@ -64,7 +65,7 @@ TEST(TestVideoInfoTag, SaveTVShowSeasons)
   details.SetSeasons(reference);
 
   CXBMCTinyXML xmlDoc;
-  details.ForwardSaveTvShowSeasons(&xmlDoc);
+  details.CallSaveTvShowSeasons(&xmlDoc);
 
   EXPECT_EQ(referenceXml, XMLUtils::NodeStringSerialization(xmlDoc.RootElement(),
                                                             XMLUtils::SerializationFormat::PRETTY));
@@ -169,3 +170,70 @@ TEST_P(OriginalLanguageTester, SetOriginalLanguage)
 INSTANTIATE_TEST_SUITE_P(TestVideoInfoTag,
                          OriginalLanguageTester,
                          testing::ValuesIn(OriginalLanguageTests));
+
+TEST(TestVideoInfoTag, LoadUniqueId)
+{
+  const std::string document = R"(<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+  <tvshow version="1">
+    <uniqueid type="imdb">tt4577466</uniqueid>
+    <uniqueid type="tmdb" default="true">64043</uniqueid>
+    <uniqueid type="tvdb">299350</uniqueid>
+  </tvshow>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  CVideoInfoTag details;
+  EXPECT_TRUE(details.Load(doc.RootElement(), true, false));
+
+  std::map<std::string, std::string, std::less<>> reference = {
+      {"imdb", "tt4577466"}, {"tmdb", "64043"}, {"tvdb", "299350"}};
+
+  EXPECT_EQ(details.GetDefaultUniqueID(), "tmdb");
+  EXPECT_EQ(details.GetUniqueIDs(), reference);
+}
+
+TEST(TestVideoInfoTag, LoadUniqueIdLegacy)
+{
+  const std::string document = R"(<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+  <tvshow version="1">
+    <uniqueid>64043</uniqueid>
+  </tvshow>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  CVideoInfoTag details;
+  EXPECT_TRUE(details.Load(doc.RootElement(), true, false));
+
+  std::map<std::string, std::string, std::less<>> reference = {{"unknown", "64043"}};
+
+  EXPECT_EQ(details.GetDefaultUniqueID(), "unknown");
+  EXPECT_EQ(details.GetUniqueIDs(), reference);
+}
+
+TEST(TestVideoInfoTag, SaveUniqueId)
+{
+  CVideoInfoTagTest details;
+  details.SetUniqueID("123456", "", false);
+  details.SetUniqueID("tt4577466", "imdb", false);
+  details.SetUniqueID("64043", "tmdb", true);
+  details.SetUniqueID("299350", "tvdb", false);
+
+  const std::string expectedXml =
+      R"(<uniqueid type="imdb">tt4577466</uniqueid>
+<uniqueid type="tmdb" default="true">64043</uniqueid>
+<uniqueid type="tvdb">299350</uniqueid>
+<uniqueid type="unknown">123456</uniqueid>
+)";
+
+  CXBMCTinyXML xmlDoc;
+  details.CallSaveUniqueId(&xmlDoc);
+
+  //! @todo compare in TinyXml representation. Less sensitive to formatting (indentation, carriage returns...)
+  TiXmlPrinter printer;
+  xmlDoc.Accept(&printer);
+  std::string result = printer.Str();
+
+  EXPECT_EQ(result, expectedXml);
+}

--- a/xbmc/video/test/TestVideoInfoTag.cpp
+++ b/xbmc/video/test/TestVideoInfoTag.cpp
@@ -317,3 +317,51 @@ TEST(TestVideoInfoTag, SaveRatings)
 
   EXPECT_EQ(result, expectedXml);
 }
+
+TEST(TestVideoInfoTag, LoadSet)
+{
+  // Legacy nfo converted to current version don't have overview, no need to test separately
+
+  std::string document = R"(<movie version="1"> <set> <name>Set 1</name> </set> </movie>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  CVideoInfoTagTest details;
+  EXPECT_TRUE(details.Load(doc.RootElement(), true, false));
+  EXPECT_EQ(details.m_set.GetTitle(), "Set 1");
+  EXPECT_FALSE(details.m_set.GetUpdateSetOverview());
+
+  document = R"(<movie version="1"> <set> <name></name> </set> </movie>)";
+
+  doc.Clear();
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+  details.Reset();
+
+  EXPECT_TRUE(details.Load(doc.RootElement(), true, false));
+  EXPECT_EQ(details.m_set.GetTitle(), "");
+  EXPECT_FALSE(details.m_set.GetUpdateSetOverview());
+
+  document = R"(<movie version="1"> <set> <overview>overview</overview> </set> </movie>)";
+
+  doc.Clear();
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+  details.Reset();
+
+  EXPECT_TRUE(details.Load(doc.RootElement(), true, false));
+  EXPECT_EQ(details.m_set.GetTitle(), "");
+  EXPECT_EQ(details.m_set.GetOverview(), "");
+  EXPECT_FALSE(details.m_set.GetUpdateSetOverview());
+
+  document =
+      R"(<movie version="1"> <set> <name>Set 1</name> <overview>Overview</overview> </set> </movie>)";
+
+  doc.Clear();
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+  details.Reset();
+
+  EXPECT_TRUE(details.Load(doc.RootElement(), true, false));
+  EXPECT_EQ(details.m_set.GetTitle(), "Set 1");
+  EXPECT_EQ(details.m_set.GetOverview(), "Overview");
+  EXPECT_TRUE(details.m_set.GetUpdateSetOverview());
+}


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Add a mechanism to manage versions of .nfo files, similar to the database upgrade mechanism.

A version number attribute was added in the top level tag of the nfo, ex:
```
<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
<tvshow version="1">
...
</tvshow>
```

The different types of nfo (movies, tv shows, episodes, etc) have independent version numbers. A nfo missing the version attribute is treated as version 0 (ie all existing nfo up until now).

* nfo import
When a nfo file is read, its version number is compared with the current version number for the nfo type and an upgrade function is ran on the in-memory XML to transform it into the latest revision (multiple upgrades are chained as needed, ex. version 0 to 1 to 2 etc until current version).

* nfo export
Exporting the library creates single or multiple nfo with the version attribute set to the current version of the respective nfo and the content is in the latest format.

To demonstrate the usage, three format changes for deprecated top level tags `<id>`, `<rating>` and `<set>` are included in dedicated commits.

Some note/question
* Limit: unlike database upgrades, nfo files are read and processed in isolation and as needed only. For an equivalent, all nfo of all paths would have to be read and combined in memory when any nfo is accessed.

* I remembered about XSLT technology late in the dev of the PR. I never used it before, don't know if it is flexible enough for Kodi's nfo, and the libxslt dependency was maybe on its way out since XML scrapers are deprecated? Thoughts appreciated.

* Naming: created a class named CNfoUtils, but could be changed to a more specific CNfoVersioning for example.

* some unit tests in TestVideoInfoTag and TestNfoUtils need to compare xml documents. Ideally the in-memory representations would be compared (but is there a library for that? seems like a significant dev effort), rather than the text generated by the XML, more brittle.

* there is no need right now in this PR, but adding some lineage information to VideoInfoTag would probably be good (field indicating source nfo or db for example + original version of nfo)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Retire code supporting deprecated tags, allow the evolution/refactoring of the tags in an nfo without breaking backwards compatibility or requiring nfo read/write to support all formats at once.

Example of future change enabled by this: tvshows.nfo has season information (art, season name, and soon to be added season plot) in unrelated tags. While working, it's not "clean" and also complicates the code, Something like this could be done:

Version n
```
<tvshow version="n">
  <namedseason number=1>Season 1</namedseason>
  <seasonplot number="1">Plot 1</seasonplot>
  <thumb spoof="" cache="" season="1" type="season" aspect="poster" preview=.........</thumb>
</tvshow>
```

Version n+1
```
<tvshow version="n+1">
    <seasondetails>
        <season>1</season>
        <name>Season 1</name>
        <plot>Plot 1</plot>
        <thumb spoof="" cache="" aspect="poster" preview=.........</thumb>
    </seasondetails>
</tvshow>
```
laying some ground work for an eventual split of seasons into dedicated season.nfo files.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added lots of unit tests.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Library manager apps / nfo creators should generate the new format to use the direct import path in Kodi.
They likely already do and only need to declare a version number in the generated nfo.

## Screenshots (if appropriate):

"legacy" nfo (version 0):
```
<movie>
  <id>12356</id>
  <rating max="10">5.2</rating>
  <votes>234</votes>
  <set>Set Name</set>
</movie>
```

same after import/export cycle (version 1) - only recommended/supported tags:
```
<movie version="1">
  <uniqueid>12356</uniqueid>
  <ratings>
    <rating max="10">
      <value>5.2</value>
      <votes>234</votes>
    </rating>
  </ratings>
  <set>
    <name>Set Name</name>
  </set>
</movie>
```
and VideoInfoTag::ParseNative and Save don't have the code for the deprecated tags anymore.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
