### PR TITLE
[tools/depends][native] pythonmodule-setuptools set makefile build argument

### DIFF
--- a/tools/depends/native/pythonmodule-setuptools/Makefile
+++ b/tools/depends/native/pythonmodule-setuptools/Makefile
@@ -5,11 +5,15 @@ DEPS= ../../Makefile.include Makefile PYTHONMODULE-SETUPTOOLS-VERSION \
 
 export PIP_CACHE_DIR=$(TARBALLS_LOCATION)/pip-cache
 
+artifact=$(NATIVEPREFIX)/lib/python${NATIVE_PYTHON_VERSION}/site-packages/setuptools/__init__.py
+
 all: .installed-$(PLATFORM)
 
-.installed-$(PLATFORM):
+$(artifact):
 	PYTHONPATH="$(NATIVEPREFIX)/lib/python${NATIVE_PYTHON_VERSION}/site-packages" $(NATIVEPREFIX)/bin/python3 -m pip install --ignore-installed setuptools==$(VERSION)
 	cd $(NATIVEPREFIX)/lib/python${NATIVE_PYTHON_VERSION}/site-packages; patch -p1 -i $(abs_top_srcdir)/native/pythonmodule-setuptools/01-distutils-flag.patch
+
+.installed-$(PLATFORM): $(artifact)
 	touch $@
 
 clean:


### PR DESCRIPTION
## Description
explicitly split the action of building the dependency and its .install-$(platform) file creation/existence

## Motivation and context
If you build pythonmodule-setuptools for a platform, then remove the native location. the next time you build pythonmodule-setuptools will fail to run, as the .install-$(platform) file will still exist, even though the actual artifacts no longer do.
It wasnt quite correct to consolidate the make rules as done in 0b6ef92f62059d0aaf6954d991c68e304d3c41a8.

0276932a5ec4b8203eb9e93b33489998266e94cf was an attempt to fix a sympton, but avoids the actual issue

## How has this been tested?
Build native depends. rm the host build folder, retry building, pythonmodule-setuptools is correctly run
make clean/make distclean still correctly function

## What is the effect on users?
Able to build native depends

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
