### PR TITLE
[wayland] Fix CColorManager if the compositor doesn't support the protocol

### DIFF
--- a/xbmc/windowing/wayland/ColorManager.cpp
+++ b/xbmc/windowing/wayland/ColorManager.cpp
@@ -250,6 +250,12 @@ CColorManager::CColorManager(CConnection& connection)
   registry.RequestSingleton(m_colorManager, 1, 1, false);
   registry.Bind();
 
+  if (!m_colorManager)
+  {
+    CLog::Log(LOGINFO, "Color management protocol not supported");
+    return;
+  }
+
   m_colorManager.on_supported_intent() = [&](wayland::color_manager_v1_render_intent intent)
   {
     CLog::Log(LOGDEBUG, "Supported render intent: {}", intent);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Fix crash on Wayland if the compositor doesn't support the color management protocol. I thought it's allowed to setup the callbacks if the protocol isn't supported and they are just never called, but that isn't the case.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes the problem reported in https://github.com/xbmc/xbmc/issues/27164#issuecomment-3231974051.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Run Kodi with the Cage compositor, doesn't crash anymore. Run with KWin and HDR works.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Don't crash if the Wayland compositor doesn't support the color management protocol.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
