### PR TITLE
[video] Moved call to `URIUtils::GetParentPath` to better location.

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1617,12 +1617,14 @@ int CVideoDatabase::AddNewMovie(CVideoInfoTag& details)
   return -1;
 }
 
-bool CVideoDatabase::AddPathToTvShow(int idShow, const std::string &path, const std::string &parentPath, const CDateTime& dateAdded /* = CDateTime() */)
+bool CVideoDatabase::AddPathToTvShow(int idShow,
+                                     const std::string& path,
+                                     const CDateTime& dateAdded)
 {
   // Check if this path is already added
   int idPath = GetPathId(path);
   if (idPath < 0)
-    idPath = AddPath(path, parentPath, GetDateAdded(path, dateAdded));
+    idPath = AddPath(path, URIUtils::GetParentPath(path), GetDateAdded(path, dateAdded));
 
   return ExecuteQuery(PrepareSQL("REPLACE INTO tvshowlinkpath(idShow, idPath) VALUES (%i,%i)", idShow, idPath));
 }
@@ -3097,12 +3099,11 @@ int CVideoDatabase::GetMatchingTvShow(const CVideoInfoTag& details) const
   return id;
 }
 
-int CVideoDatabase::SetDetailsForTvShow(
-    const std::vector<std::pair<std::string, std::string>>& paths,
-    CVideoInfoTag& details,
-    const KODI::ART::Artwork& artwork,
-    const KODI::ART::SeasonsArtwork& seasonArt,
-    int idTvShow /*= -1 */)
+int CVideoDatabase::SetDetailsForTvShow(const std::vector<std::string>& paths,
+                                        CVideoInfoTag& details,
+                                        const KODI::ART::Artwork& artwork,
+                                        const KODI::ART::SeasonsArtwork& seasonArt,
+                                        int idTvShow /*= -1 */)
 {
 
   /*
@@ -3116,7 +3117,7 @@ int CVideoDatabase::SetDetailsForTvShow(
 
   if (idTvShow < 0)
   {
-    for (const auto& [path, _] : paths)
+    for (const auto& path : paths)
     {
       idTvShow = GetTvShowId(path);
       if (idTvShow > -1)
@@ -3133,8 +3134,8 @@ int CVideoDatabase::SetDetailsForTvShow(
   }
 
   // add any paths to the tvshow
-  for (const auto& [path, parentpath] : paths)
-    AddPathToTvShow(idTvShow, path, parentpath, details.m_dateAdded);
+  for (const auto& path : paths)
+    AddPathToTvShow(idTvShow, path, details.m_dateAdded);
 
   UpdateDetailsForTvShow(idTvShow, details, artwork, seasonArt);
 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -695,7 +695,7 @@ public:
    \param idTvShow the database id of the tvshow if known (defaults to -1)
    \return the id of the tvshow.
    */
-  int SetDetailsForTvShow(const std::vector<std::pair<std::string, std::string>>& paths,
+  int SetDetailsForTvShow(const std::vector<std::string>& paths,
                           CVideoInfoTag& details,
                           const KODI::ART::Artwork& artwork,
                           const KODI::ART::SeasonsArtwork& seasonArt,
@@ -1411,11 +1411,10 @@ protected:
   /*! \brief Adds a path to the tvshow link table.
    \param idShow the id of the show.
    \param path the path to add.
-   \param parentPath the parent path of the path to add.
    \param dateAdded date/time when the path was added
    \return true if successfully added, false otherwise.
    */
-  bool AddPathToTvShow(int idShow, const std::string &path, const std::string &parentPath, const CDateTime& dateAdded = CDateTime());
+  bool AddPathToTvShow(int idShow, const std::string& path, const CDateTime& dateAdded);
 
   /*! \brief Check whether a show is already in the library.
    Matches on unique identifier or matching title and premiered date.

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1980,9 +1980,6 @@ CVideoInfoScanner::~CVideoInfoScanner()
         std::vector<std::string> multipath;
         if (!URIUtils::IsMultiPath(path) || !CMultiPathDirectory::GetPaths(path, multipath))
           multipath.push_back(path);
-        std::vector<std::pair<std::string, std::string> > paths;
-        for (std::vector<std::string>::const_iterator i = multipath.begin(); i != multipath.end(); ++i)
-          paths.emplace_back(*i, URIUtils::GetParentPath(*i));
 
         KODI::ART::SeasonsArtwork seasonArt;
 
@@ -1990,7 +1987,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
           GetSeasonThumbs(movieDetails, seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason),
                           useLocal && !pItem->IsPlugin(), useRemoteArt);
 
-        lResult = m_database.SetDetailsForTvShow(paths, movieDetails, art, seasonArt);
+        lResult = m_database.SetDetailsForTvShow(multipath, movieDetails, art, seasonArt);
         movieDetails.m_iDbId = lResult;
         movieDetails.m_type = MediaTypeTvShow;
       }


### PR DESCRIPTION

## Description
A data structure of pair<path, ParentPath(path)> was being created and passed through a few layers of functions.

As the ParentPath is calculated then this can be calculated at the point it is needed which simplifies the data structure.

## Motivation and context
Clean up code

## How has this been tested?

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
