### PR TITLE
webOS: report current video and maximum resolution to Inputstream addons

### DIFF
--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
@@ -1381,6 +1381,15 @@ void CMediaPipelineWebOS::ProcessAudio()
   }
 }
 
+void CMediaPipelineWebOS::GetVideoResolution(unsigned int& width, unsigned int& height) const
+{
+  if (m_videoHint.codec)
+  {
+    width = m_videoHint.width;
+    height = m_videoHint.height;
+  }
+}
+
 void CMediaPipelineWebOS::PlayerCallback(int32_t type, const int64_t numValue, const char* strValue)
 {
   const std::string logStr = strValue != nullptr ? strValue : "";

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.h
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.h
@@ -241,6 +241,13 @@ public:
    */
   std::string GetVideoInfo();
 
+  /**
+   * @brief Get the resolution of the video stream
+   * @param width Stream width (output parameter)
+   * @param height Stream height (output parameter)
+   */
+  void GetVideoResolution(unsigned int& width, unsigned int& height) const;
+
 protected:
   /**
    * @brief Video processing thread loop.

--- a/xbmc/cores/VideoPlayer/VideoPlayerWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerWebOS.cpp
@@ -73,3 +73,13 @@ void CVideoPlayerWebOS::CreatePlayers()
   m_VideoPlayerAudioID3 = std::make_unique<CVideoPlayerAudioID3>(*m_processInfo);
   m_players_created = true;
 }
+
+void CVideoPlayerWebOS::GetVideoResolution(unsigned int& width, unsigned int& height)
+{
+  if (m_mediaPipelineWebOS)
+  {
+    m_mediaPipelineWebOS->GetVideoResolution(width, height);
+  }
+  else
+    CVideoPlayer::GetVideoResolution(width, height);
+}

--- a/xbmc/cores/VideoPlayer/VideoPlayerWebOS.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerWebOS.h
@@ -19,6 +19,7 @@ class CVideoPlayerWebOS final : public CVideoPlayer
 public:
   explicit CVideoPlayerWebOS(IPlayerCallback& callback);
   ~CVideoPlayerWebOS() override;
+  void GetVideoResolution(unsigned int& width, unsigned int& height) override;
 
 protected:
   void CreatePlayers() override;

--- a/xbmc/windowing/wayland/WinSystemWaylandWebOS.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandWebOS.cpp
@@ -19,6 +19,7 @@
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/ApplicationMessenger.h"
+#include "settings/DisplaySettings.h"
 #include "utils/JSONVariantParser.h"
 #include "utils/log.h"
 
@@ -27,6 +28,16 @@
 namespace
 {
 constexpr const char* LUNA_REGISTER_APP = "luna://com.webos.service.applicationmanager/registerApp";
+
+constexpr unsigned int WIDTH_1080P = 1920;
+constexpr unsigned int HEIGHT_1080P = 1080;
+constexpr unsigned int SCREEN_WIDTH_4K = 3840;
+constexpr unsigned int SCREEN_HEIGHT_4K = 2160;
+
+constexpr unsigned int WIDTH_720P = 1280;
+constexpr unsigned int HEIGHT_720P = 720;
+constexpr unsigned int SCREEN_WIDTH_1080P = 1080;
+constexpr unsigned int SCREEN_HEIGHT_1080P = 1920;
 } // namespace
 
 namespace KODI::WINDOWING::WAYLAND
@@ -190,6 +201,23 @@ bool CWinSystemWaylandWebOS::OnAppLifecycleEvent(LSHandle* sh, LSMessage* reply)
     shellSurface->SetFullScreen(nullptr, 60.0f);
 
   return true;
+}
+
+void CWinSystemWaylandWebOS::UpdateResolutions()
+{
+  CWinSystemWayland::UpdateResolutions();
+
+  RESOLUTION_INFO& res = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
+  if (res.iWidth == WIDTH_1080P && res.iHeight == HEIGHT_1080P)
+  {
+    res.iScreenHeight = SCREEN_HEIGHT_4K;
+    res.iScreenWidth = SCREEN_WIDTH_4K;
+  }
+  else if (res.iWidth == WIDTH_720P && res.iHeight == HEIGHT_720P)
+  {
+    res.iScreenHeight = SCREEN_HEIGHT_1080P;
+    res.iScreenWidth = SCREEN_WIDTH_1080P;
+  }
 }
 
 } // namespace KODI::WINDOWING::WAYLAND

--- a/xbmc/windowing/wayland/WinSystemWaylandWebOS.h
+++ b/xbmc/windowing/wayland/WinSystemWaylandWebOS.h
@@ -48,6 +48,7 @@ public:
   bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override;
   bool HasCursor() override;
   void OnConfigure(std::uint32_t serial, CSizeInt size, IShellSurface::StateBitset state) override;
+  void UpdateResolutions() override;
 
 protected:
   std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() override;


### PR DESCRIPTION
## Description
As reported by @CastagnaIT in https://github.com/xbmc/inputstream.adaptive/pull/1900

We are not reporting the correct video resolution to Inputstream interface
We are also not reporting the correct maximum screen resolution either.

Both are currently incorrectly reported as 1920x1080 for a 4K TV.

## Motivation and context
Code is made use of here:

https://github.com/xbmc/xbmc/blob/master/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp#L799:

1. With a 4K stream it now returns the correct video resolution of 4K (fix from @sundermann)

2. This now correctly sets the maximum screen resolution to 4K instead of 1920x1080. Their is no currently easily API to determine screen width/height so we rely on hard coded 4K which works with the vast majority of users.

## How has this been tested?
Tested on D+ addon:

- 4K UHD DV stream
- 1080P stream

## What is the effect on users?
Streams will now go straight to 4K UHD stream (subject to bandwidth) instead of a transition from 720p->4K after 30 seconds. Should avoid any possible upscaling.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
