### PR TITLE
[guiinfo][weather][Estuary] Introduce GUI info label 'Weather.Data' as generic interface to weather data.

### DIFF
--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -632,7 +632,7 @@
 								<right>60</right>
 								<align>right</align>
 								<font>font30_title</font>
-								<label>$INFO[Weather.Location]</label>
+								<label>$INFO[Weather.Data(Location)]</label>
 							</control>
 							<control type="label">
 								<left>840</left>
@@ -642,7 +642,7 @@
 								<right>60</right>
 								<align>right</align>
 								<font>font14</font>
-								<label>$INFO[Weather.Conditions]</label>
+								<label>$INFO[Weather.Data(Current.Condition)]</label>
 							</control>
 							<control type="label">
 								<left>840</left>
@@ -652,7 +652,8 @@
 								<right>60</right>
 								<align>right</align>
 								<font>font14</font>
-								<label>$INFO[Weather.Temperature]</label>
+								<label>$INFO[Weather.Data(Current.Temperature)]$INFO[System.TemperatureUnits]</label>
+								<visible>![String.IsEmpty(Weather.Data(Current.Temperature))]</visible>
 							</control>
 							<control type="grouplist">
 								<top>50</top>
@@ -662,27 +663,27 @@
 								<align>left</align>
 								<itemgap>-110</itemgap>
 								<include content="WeatherIconHome" condition="!String.IsEmpty(Weather.Plugin)">
-									<param name="label" value="Window(weather).Property(Current.Wind)" />
+									<param name="label" value="Weather.Data(Current.Wind)" />
 									<param name="texture" value="icons/weather/wind.png" />
 									<param name="header" value="404" />
 								</include>
 								<include content="WeatherIconHome" condition="!String.IsEmpty(Weather.Plugin)">
-									<param name="label" value="Window(weather).Property(Current.Humidity)" />
+									<param name="label" value="Weather.Data(Current.Humidity)" />
 									<param name="texture" value="icons/weather/humidity.png" />
 									<param name="header" value="406" />
 								</include>
 								<include content="WeatherIconHome" condition="!String.IsEmpty(Weather.Plugin)">
-									<param name="label" value="Window(weather).Property(Current.Precipitation)" />
+									<param name="label" value="Weather.Data(Current.Precipitation)" />
 									<param name="texture" value="icons/weather/rain.png" />
 									<param name="header" value="33021" />
 								</include>
 								<include content="WeatherIconHome" condition="!String.IsEmpty(Weather.Plugin)">
-									<param name="label" value="Window(weather).Property(Today.Sunrise)" />
+									<param name="label" value="Weather.Data(Today.Sunrise)" />
 									<param name="texture" value="icons/weather/sunrise.png" />
 									<param name="header" value="405" />
 								</include>
 								<include content="WeatherIconHome" condition="!String.IsEmpty(Weather.Plugin)">
-									<param name="label" value="Window(weather).Property(Today.Sunset)" />
+									<param name="label" value="Weather.Data(Today.Sunset)" />
 									<param name="texture" value="icons/weather/sunset.png" />
 									<param name="header" value="403" />
 								</include>
@@ -692,13 +693,13 @@
 							<param name="content_include" value="DailyItems" />
 							<param name="list_id" value="15200" />
 							<param name="widget_header" value="$LOCALIZE[31019]"/>
-							<param name="visible" value="!String.IsEmpty(Window(weather).Property(Daily.IsFetched))" />
+							<param name="visible" value="!String.IsEmpty(Weather.Data(Daily.IsFetched))" />
 						</include>
 						<include content="WeatherWidget" condition="!String.IsEmpty(Weather.Plugin)">
 							<param name="content_include" value="HourlyItems" />
 							<param name="list_id" value="15100" />
 							<param name="widget_header" value="$LOCALIZE[33036]"/>
-							<param name="visible" value="!String.IsEmpty(Window(weather).Property(Hourly.IsFetched))" />
+							<param name="visible" value="!String.IsEmpty(Weather.Data(Hourly.IsFetched))" />
 						</include>
 					</control>
 					<include content="ImageWidget" condition="String.IsEmpty(Weather.plugin)">

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -1131,8 +1131,8 @@
 						<height>50</height>
 						<width>auto</width>
 						<aligny>center</aligny>
-						<label>$INFO[Window(Weather).Property(Current.Temperature)]$INFO[System.TemperatureUnits]</label>
-						<visible>Skin.HasSetting(show_weatherinfo) + Weather.IsFetched + ![String.IsEqual(Weather.FanartCode,na)]</visible>
+						<label>$INFO[Weather.Data(Current.Temperature)]$INFO[System.TemperatureUnits]</label>
+						<visible>Skin.HasSetting(show_weatherinfo) + Weather.IsFetched + ![String.IsEmpty(Weather.Data(Current.Temperature))]</visible>
 					</control>
 					<control type="image">
 						<top>1</top>
@@ -1140,8 +1140,8 @@
 						<height>50</height>
 						<fadetime>300</fadetime>
 						<aspectratio aligny="center" align="left">keep</aspectratio>
-						<texture>$INFO[Weather.FanartCode,weather/small/,.png]</texture>
-						<visible>Skin.HasSetting(show_weatherinfo) + Weather.IsFetched + ![String.IsEqual(Weather.FanartCode,na)]</visible>
+						<texture>$INFO[Weather.Data(Current.FanartCode),weather/small/,.png]</texture>
+						<visible>Skin.HasSetting(show_weatherinfo) + Weather.IsFetched + ![String.IsEqual(Weather.Data(Current.FanartCode),na)]</visible>
 					</control>
 					<control type="image">
 						<top>8</top>

--- a/addons/skin.estuary/xml/Includes_Home.xml
+++ b/addons/skin.estuary/xml/Includes_Home.xml
@@ -755,7 +755,7 @@
 			<item>
 				<icon>resource://resource.images.weathericons.default/na.png</icon>
 				<onclick>noop</onclick>
-				<visible>String.IsEmpty(Window(weather).Property(Hourly.IsFetched))</visible>
+				<visible>String.IsEmpty(Weather.Data(Hourly.IsFetched))</visible>
 			</item>
 			<include content="WeatherHourlyItem">
 				<param name="item_index" value="1" />
@@ -905,52 +905,52 @@
 	</include>
 	<include name="WeatherHourlyItem">
 		<item>
-			<label>$INFO[Window(weather).Property(Hourly.$PARAM[item_index].Time)]</label>
-			<label2>$INFO[Window(weather).Property(Hourly.$PARAM[item_index].Temperature)] ∙ $INFO[Window(weather).Property(Hourly.$PARAM[item_index].Precipitation)]</label2>
-			<property name="Temperature">$INFO[Window(weather).Property(Hourly.$PARAM[item_index].Temperature)]</property>
-			<property name="Outlook">$INFO[Window(weather).Property(Hourly.$PARAM[item_id].Outlook)]</property>
-			<property name="Cloudiness">$INFO[Window(weather).Property(Hourly.$PARAM[item_index].Cloudiness)]</property>
-			<property name="ShortDate">$INFO[Window(weather).Property(Hourly.$PARAM[item_index].ShortDate)]</property>
-			<property name="FanartCode">$INFO[Window(weather).Property(Hourly.$PARAM[item_index].FanartCode)]</property>
-			<thumb>resource://resource.images.weathericons.default/$INFO[Window(weather).Property(Hourly.$PARAM[item_index].OutlookIcon)]</thumb>
+			<label>$INFO[Weather.Data(Hourly.$PARAM[item_index].Time)]</label>
+			<label2>$INFO[Weather.Data(Hourly.$PARAM[item_index].Temperature)] ∙ $INFO[Weather.Data(Hourly.$PARAM[item_index].Precipitation)]</label2>
+			<property name="Temperature">$INFO[Weather.Data(Hourly.$PARAM[item_index].Temperature)]</property>
+			<property name="Outlook">$INFO[Weather.Data(Hourly.$PARAM[item_id].Outlook)]</property>
+			<property name="Cloudiness">$INFO[Weather.Data(Hourly.$PARAM[item_index].Cloudiness)]</property>
+			<property name="ShortDate">$INFO[Weather.Data(Hourly.$PARAM[item_index].ShortDate)]</property>
+			<property name="FanartCode">$INFO[Weather.Data(Hourly.$PARAM[item_index].FanartCode)]</property>
+			<thumb>resource://resource.images.weathericons.default/$INFO[Weather.Data(Hourly.$PARAM[item_index].OutlookIcon)]</thumb>
 			<onclick>noop</onclick>
-			<visible>!String.IsEmpty(Window(weather).Property(Hourly.$PARAM[item_index].Outlook))</visible>
+			<visible>!String.IsEmpty(Weather.Data(Hourly.$PARAM[item_index].Outlook))</visible>
 		</item>
 	</include>
 	<include name="WeatherDailyItem">
 		<item>
-			<label>$INFO[Window(weather).Property(Daily.$PARAM[item_index].ShortDay)]</label>
-			<label2>[COLOR blue]$INFO[Window(weather).Property(Daily.$PARAM[item_index].LowTemperature)][/COLOR] ∙ [COLOR red]$INFO[Window(weather).Property(Daily.$PARAM[item_index].HighTemperature)][/COLOR]</label2>
-			<property name="LongDay">$INFO[Window(weather).Property(Daily.$PARAM[item_index].LongDay)]</property>
-			<property name="TempDay">$INFO[Window(weather).Property(Daily.$PARAM[item_index].TempDay)]</property>
-			<property name="Cloudiness">$INFO[Window(weather).Property(Daily.$PARAM[item_index].Cloudiness)]</property>
-			<property name="Outlook">$INFO[Window(weather).Property(Daily.$PARAM[item_index].Outlook)]</property>
-			<property name="ShortDate">$INFO[Window(weather).Property(Daily.$PARAM[item_index].ShortDate)]</property>
-			<property name="FanartCode">$INFO[Window(weather).Property(Daily.$PARAM[item_index].FanartCode)]</property>
-			<thumb>resource://resource.images.weathericons.default/$INFO[Window(weather).Property(Daily.$PARAM[item_index].OutlookIcon)]</thumb>
+			<label>$INFO[Weather.Data(Daily.$PARAM[item_index].ShortDay)]</label>
+			<label2>[COLOR blue]$INFO[Weather.Data(Daily.$PARAM[item_index].LowTemperature)][/COLOR] ∙ [COLOR red]$INFO[Weather.Data(Daily.$PARAM[item_index].HighTemperature)][/COLOR]</label2>
+			<property name="LongDay">$INFO[Weather.Data(Daily.$PARAM[item_index].LongDay)]</property>
+			<property name="TempDay">$INFO[Weather.Data(Daily.$PARAM[item_index].TempDay)]</property>
+			<property name="Cloudiness">$INFO[Weather.Data(Daily.$PARAM[item_index].Cloudiness)]</property>
+			<property name="Outlook">$INFO[Weather.Data(Daily.$PARAM[item_index].Outlook)]</property>
+			<property name="ShortDate">$INFO[Weather.Data(Daily.$PARAM[item_index].ShortDate)]</property>
+			<property name="FanartCode">$INFO[Weather.Data(Daily.$PARAM[item_index].FanartCode)]</property>
+			<thumb>resource://resource.images.weathericons.default/$INFO[Weather.Data(Daily.$PARAM[item_index].OutlookIcon)]</thumb>
 			<onclick>noop</onclick>
-			<visible>!String.IsEmpty(Window(weather).Property(Daily.IsFetched)) + !String.IsEmpty(Window(weather).Property(Daily.$PARAM[item_index].Outlook))</visible>
+			<visible>!String.IsEmpty(Weather.Data(Daily.IsFetched)) + !String.IsEmpty(Weather.Data(Daily.$PARAM[item_index].Outlook))</visible>
 		</item>
 	</include>
 	<include name="WeatherDayItem">
 		<item>
-			<label>$INFO[Window(weather).Property(Day$PARAM[item_index].Title)]</label>
-			<label2>[COLOR blue]$INFO[Window(weather).Property(Day$PARAM[item_index].LowTemp)]$INFO[System.TemperatureUnits][/COLOR] ∙ [COLOR red]$INFO[Window(weather).Property(Day$PARAM[item_index].HighTemp)]$INFO[System.TemperatureUnits][/COLOR]</label2>
+			<label>$INFO[Weather.Data(Day$PARAM[item_index].Title)]</label>
+			<label2>[COLOR blue]$INFO[Weather.Data(Day$PARAM[item_index].LowTemp)]$INFO[System.TemperatureUnits][/COLOR] ∙ [COLOR red]$INFO[Weather.Data(Day$PARAM[item_index].HighTemp)]$INFO[System.TemperatureUnits][/COLOR]</label2>
 			<property name="LongDay"></property>
 			<property name="TempDay"></property>
 			<property name="Cloudiness"></property>
 			<property name="Outlook"></property>
 			<property name="ShortDate"></property>
-			<property name="FanartCode">$INFO[Window(weather).Property(Day$PARAM[item_index].FanartCode)]</property>
-			<thumb>$INFO[Window(weather).Property(Day$PARAM[item_index].OutlookIcon)]</thumb>
+			<property name="FanartCode">$INFO[Weather.Data(Day$PARAM[item_index].FanartCode)]</property>
+			<thumb>$INFO[Weather.Data(Day$PARAM[item_index].OutlookIcon)]</thumb>
 			<onclick>noop</onclick>
-			<visible>String.IsEmpty(Window(weather).Property(Daily.IsFetched)) + !String.IsEmpty(Window(weather).Property(Day$PARAM[item_index].Outlook))</visible>
+			<visible>String.IsEmpty(Weather.Data(Daily.IsFetched)) + !String.IsEmpty(Weather.Data(Day$PARAM[item_index].Outlook))</visible>
 		</item>
 	</include>
 	<include name="WeatherMapItem">
 		<control type="group" id="700$PARAM[item_id]">
 			<height>1110</height>
-			<visible>Weather.IsFetched + !String.IsEmpty(Window(weather).Property(Map.$PARAM[item_id].Area)) + !String.IsEmpty(Window(weather).Property(Map.IsFetched))</visible>
+			<visible>Weather.IsFetched + !String.IsEmpty(Weather.Data(Map.$PARAM[item_id].Area)) + !String.IsEmpty(Weather.Data(Map.IsFetched))</visible>
 			<centerleft>50%</centerleft>
 			<width>1920</width>
 			<control type="button" id="700$PARAM[item_id]0">
@@ -975,7 +975,7 @@
 				<top>160</top>
 				<width>1680</width>
 				<height>800</height>
-				<texture>$INFO[Window(weather).Property(Map.$PARAM[item_id].Area)]</texture>
+				<texture>$INFO[Weather.Data(Map.$PARAM[item_id].Area)]</texture>
 				<aspectratio>scale</aspectratio>
 			</control>
 			<control type="image" id="700$PARAM[item_id]3">
@@ -983,7 +983,7 @@
 				<top>160</top>
 				<width>1680</width>
 				<height>800</height>
-				<texture>$INFO[Window(weather).Property(Map.$PARAM[item_id].Layer)]</texture>
+				<texture>$INFO[Weather.Data(Map.$PARAM[item_id].Layer)]</texture>
 				<aspectratio>scale</aspectratio>
 				<colordiffuse>B0FFFFFF</colordiffuse>
 			</control>
@@ -999,7 +999,7 @@
 				<top>880</top>
 				<width>350</width>
 				<height>55</height>
-				<texture>$INFO[Window(weather).Property(Map.$PARAM[item_id].Legend)]</texture>
+				<texture>$INFO[Weather.Data(Map.$PARAM[item_id].Legend)]</texture>
 			</control>
 		</control>
 		<control type="label" id="700$PARAM[item_id]9">
@@ -1011,8 +1011,8 @@
 			<aligny>center</aligny>
 			<animation effect="slide" end="0,-92" time="0" condition="true">Conditional</animation>
 			<font>font30_title</font>
-			<label>$INFO[Window(weather).Property(Map.$PARAM[item_id].Heading)]</label>
-			<visible>Weather.IsFetched + !String.IsEmpty(Window(weather).Property(Map.$PARAM[item_id].Area)) + !String.IsEmpty(Window(weather).Property(Map.IsFetched))</visible>
+			<label>$INFO[Weather.Data(Map.$PARAM[item_id].Heading)]</label>
+			<visible>Weather.IsFetched + !String.IsEmpty(Weather.Data(Map.$PARAM[item_id].Area)) + !String.IsEmpty(Weather.Data(Map.IsFetched))</visible>
 		</control>
 	</include>
 	<include name="WidgetListCommon">

--- a/addons/skin.estuary/xml/MyWeather.xml
+++ b/addons/skin.estuary/xml/MyWeather.xml
@@ -68,7 +68,7 @@
 			<scrolltime tween="cubic" easing="out">500</scrolltime>
 			<include>OpenClose_Right</include>
 			<itemgap>-160</itemgap>
-			<visible>!String.StartsWith(Weather.Temperature,$LOCALIZE[503])</visible>
+			<visible>!String.StartsWith(Weather.Data(Current.Temperature),$LOCALIZE[503])</visible>
 			<control type="group" id="567">
 				<description>Weather info</description>
 				<height>410</height>
@@ -116,13 +116,14 @@
 					<width>300</width>
 					<align>right</align>
 					<font>WeatherTemp</font>
-					<label>$INFO[Weather.Temperature]</label>
+					<label>$INFO[Weather.Data(Current.Temperature)]$INFO[System.TemperatureUnits]</label>
+					<visible>![String.IsEmpty(Weather.Data(Current.Temperature))]</visible>
 				</control>
 				<control type="label">
 					<right>400</right>
 					<top>164</top>
 					<align>right</align>
-					<label>[I]$LOCALIZE[402]: $INFO[Window(weather).Property(Current.FeelsLike)]$INFO[System.TemperatureUnits][/I][CR]$INFO[Weather.Conditions]</label>
+					<label>[I]$LOCALIZE[402]: $INFO[Weather.Data(Current.FeelsLike)]$INFO[System.TemperatureUnits][/I][CR]$INFO[Weather.Data(Current.Condition)]</label>
 					<font>font14</font>
 					<width>630</width>
 				</control>
@@ -133,27 +134,27 @@
 					<align>justify</align>
 					<orientation>horizontal</orientation>
 					<include content="WeatherIconMyWeather">
-						<param name="label" value="Window(weather).Property(Current.Wind)" />
+						<param name="label" value="Weather.Data(Current.Wind)" />
 						<param name="texture" value="icons/weather/wind.png" />
 						<param name="header" value="$LOCALIZE[404]" />
 					</include>
 					<include content="WeatherIconMyWeather">
-						<param name="label" value="Window(weather).Property(Current.Humidity)" />
+						<param name="label" value="Weather.Data(Current.Humidity)" />
 						<param name="texture" value="icons/weather/humidity.png" />
 						<param name="header" value="$LOCALIZE[406]" />
 					</include>
 					<include content="WeatherIconMyWeather">
-						<param name="label" value="Window(weather).Property(Current.Precipitation)" />
+						<param name="label" value="Weather.Data(Current.Precipitation)" />
 						<param name="texture" value="icons/weather/rain.png" />
 						<param name="header" value="$LOCALIZE[33021]" />
 					</include>
 					<include content="WeatherIconMyWeather">
-						<param name="label" value="Window(weather).Property(Today.Sunrise)" />
+						<param name="label" value="Weather.Data(Today.Sunrise)" />
 						<param name="texture" value="icons/weather/sunrise.png" />
 						<param name="header" value="$LOCALIZE[405]" />
 					</include>
 					<include content="WeatherIconMyWeather">
-						<param name="label" value="Window(weather).Property(Today.Sunset)" />
+						<param name="label" value="Weather.Data(Today.Sunset)" />
 						<param name="texture" value="icons/weather/sunset.png" />
 						<param name="header" value="$LOCALIZE[403]" />
 					</include>
@@ -163,14 +164,14 @@
 				<param name="content_include" value="DailyItems" />
 				<param name="list_id" value="15100" />
 				<param name="widget_header" value="$LOCALIZE[31019]"/>
-				<param name="visible" value="!String.IsEmpty(Window(weather).Property(Daily.IsFetched))" />
+				<param name="visible" value="!String.IsEmpty(Weather.Data(Daily.IsFetched))" />
 				<param name="width" value="258" />
 			</include>
 			<include content="WeatherWidget">
 				<param name="content_include" value="HourlyItems" />
 				<param name="list_id" value="15200" />
 				<param name="widget_header" value="$LOCALIZE[33036]"/>
-				<param name="visible" value="!String.IsEmpty(Window(weather).Property(Hourly.IsFetched))" />
+				<param name="visible" value="!String.IsEmpty(Weather.Data(Hourly.IsFetched))" />
 				<param name="width" value="258" />
 			</include>
 			<include content="WeatherMapItem">
@@ -200,12 +201,12 @@
 			</include>
 		</control>
 		<include content="TopBar">
-			<param name="breadcrumbs_label" value="$LOCALIZE[8]$INFO[Window(Weather).Property(Location), / ]" />
-			<param name="sublabel" value="$INFO[Window(weather).Property(WeatherProvider)]" />
+			<param name="breadcrumbs_label" value="$LOCALIZE[8]$INFO[Weather.Data(Location), / ]" />
+			<param name="sublabel" value="$INFO[Weather.Data(WeatherProvider)]" />
 		</include>
 		<include>BottomBar</include>
 		<control type="group">
-			<visible>String.StartsWith(Weather.Temperature,$LOCALIZE[503])</visible>
+			<visible>String.StartsWith(Weather.Data(Current.Temperature),$LOCALIZE[503])</visible>
 			<animation effect="fade" time="400">VisibleChange</animation>
 			<control type="image">
 				<texture>colors/black.png</texture>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -465,7 +465,7 @@
 	</variable>
 	<variable name="WeatherFanartVar">
 		<value condition="!String.IsEmpty(Container.ListItem.Property(FanartCode))">$INFO[Skin.String(WeatherFanart.path)]$INFO[Container.ListItem.Property(FanartCode)]$INFO[Skin.String(WeatherFanart.ext)]</value>
-		<value condition="!String.IsEmpty(Window(weather).Property(current.fanartcode)) + !String.IsEmpty(Skin.String(weatherfanart.path))">$INFO[Skin.String(weatherfanart.path)]$INFO[Window(Weather).Property(Current.FanartCode)]$INFO[Skin.String(weatherfanart.ext)]</value>
+		<value condition="!String.IsEmpty(Weather.Data(current.fanartcode)) + !String.IsEmpty(Skin.String(weatherfanart.path))">$INFO[Skin.String(weatherfanart.path)]$INFO[Weather.Data(Current.FanartCode)]$INFO[Skin.String(weatherfanart.ext)]</value>
 		<value condition="!String.IsEmpty(Skin.String(HomeFanart.path))">$INFO[Skin.String(HomeFanart.path)]weather$INFO[Skin.String(HomeFanart.ext)]</value>
 	</variable>
 	<variable name="ListWatchedIconVar">

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1171,18 +1171,23 @@ constexpr std::array<InfoMap, 13> player_process = {{
 ///     @return **True** if the weather data has been downloaded.
 ///     <p>
 ///   }
+///   \table_row3{   <b>`Weather.Data(property)`</b>,
+///                  \anchor Weather_Data
+///                  _string_,
+///     @return Weather data, as specified by the parameter.
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link Weather_Data `Weather.Data(property)`\endlink
+///   }
 ///   \table_row3{   <b>`Weather.Conditions`</b>,
 ///                  \anchor Weather_Conditions
 ///                  _string_,
 ///     @return The current weather conditions as textual description.
-///     @note This is looked up in a background process.
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`Weather.ConditionsIcon`</b>,
 ///                  \anchor Weather_ConditionsIcon
 ///                  _string_,
 ///     @return The current weather conditions as an icon.
-///     @note This is looked up in a background process.
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`Weather.Temperature`</b>,
@@ -1213,9 +1218,10 @@ constexpr std::array<InfoMap, 13> player_process = {{
 ///
 /// -----------------------------------------------------------------------------
 // clang-format off
-constexpr std::array<InfoMap, 7> weather = {{
+constexpr std::array<InfoMap, 8> weather = {{
     {"isfetched",       WEATHER_IS_FETCHED},
-    {"conditions",      WEATHER_CONDITIONS_TEXT}, // labels from here
+    {"data",            WEATHER_DATA}, // labels from here
+    {"conditions",      WEATHER_CONDITIONS_TEXT},
     {"temperature",     WEATHER_TEMPERATURE},
     {"location",        WEATHER_LOCATION},
     {"fanartcode",      WEATHER_FANART_CODE},
@@ -10635,10 +10641,18 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
     }
     else if (cat.Name() == "weather")
     {
-      for (const auto& i : weather)
+      if (prop.num_params() == 0)
       {
-        if (prop.Name() == i.str)
-          return i.val;
+        for (const auto& i : weather)
+        {
+          if (prop.Name() == i.str)
+            return i.val;
+        }
+      }
+      else if (prop.num_params() == 1)
+      {
+        if (prop.Name() == "data")
+          return AddMultiInfo(CGUIInfo(WEATHER_DATA, prop.param(), 0));
       }
     }
     else if (cat.Name() == "network")

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -97,6 +97,8 @@ constexpr uint32_t PLAYER_IS_REMOTE                  = 85;
 constexpr uint32_t PLAYER_IS_EXTERNAL                = 86;
 constexpr uint32_t PLAYER_IS_LIVE                    = 87;
 
+constexpr uint32_t WEATHER_DATA                      = 95;
+// unused id 96 to 99
 constexpr uint32_t WEATHER_CONDITIONS_TEXT           = 100;
 constexpr uint32_t WEATHER_TEMPERATURE               = 101;
 constexpr uint32_t WEATHER_LOCATION                  = 102;

--- a/xbmc/guilib/guiinfo/WeatherGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/WeatherGUIInfo.cpp
@@ -33,6 +33,9 @@ bool CWeatherGUIInfo::GetLabel(std::string& value, const CFileItem *item, int co
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // WEATHER_*
     ///////////////////////////////////////////////////////////////////////////////////////////////
+    case WEATHER_DATA:
+      value = CServiceBroker::GetWeatherManager().GetProperty(info.GetData3());
+      return true;
     case WEATHER_CONDITIONS_TEXT:
       value = CServiceBroker::GetWeatherManager().GetInfo(WEATHER_LABEL_CURRENT_COND);
       StringUtils::Trim(value);

--- a/xbmc/weather/CMakeLists.txt
+++ b/xbmc/weather/CMakeLists.txt
@@ -1,9 +1,11 @@
 set(SOURCES GUIWindowWeather.cpp
             WeatherJob.cpp
-            WeatherManager.cpp)
+            WeatherManager.cpp
+            WeatherTokenLocalizer.cpp)
 
 set(HEADERS GUIWindowWeather.h
             WeatherJob.h
-            WeatherManager.h)
+            WeatherManager.h
+            WeatherTokenLocalizer.h)
 
 core_add_library(weather)

--- a/xbmc/weather/WeatherJob.h
+++ b/xbmc/weather/WeatherJob.h
@@ -10,11 +10,7 @@
 
 #include "jobs/Job.h"
 #include "weather/WeatherManager.h"
-
-#include <algorithm>
-#include <map>
-#include <string>
-#include <string_view>
+#include "weather/WeatherTokenLocalizer.h"
 
 class CWeatherJob : public CJob
 {
@@ -26,25 +22,9 @@ public:
   const WeatherInfo& GetInfo() const;
 
 private:
-  void LocalizeOverview(std::string& str);
-  void LocalizeOverviewToken(std::string& str);
-  void LoadLocalizedToken();
-
   void SetFromProperties();
 
-  struct CaseInsensitiveCompare
-  {
-    using is_transparent = void; // Enables heterogeneous operations.
-
-    bool operator()(const std::string_view& lhs, const std::string_view& rhs) const
-    {
-      return std::ranges::lexicographical_compare(lhs, rhs, [](char l, char r)
-                                                  { return std::tolower(l) < std::tolower(r); });
-    }
-  };
-
-  std::map<std::string, int, CaseInsensitiveCompare> m_localizedTokens;
-
   WeatherInfo m_info;
+  CWeatherTokenLocalizer m_localizer;
   int m_location{-1};
 };

--- a/xbmc/weather/WeatherManager.cpp
+++ b/xbmc/weather/WeatherManager.cpp
@@ -47,6 +47,43 @@ CWeatherManager::~CWeatherManager()
   settings->GetSettingsManager()->UnregisterCallback(this);
 }
 
+std::string CWeatherManager::GetProperty(const std::string& property)
+{
+  const std::string prop{StringUtils::ToLower(property)};
+  if (prop == "conditions")
+  {
+    return GetInfo(WEATHER_LABEL_CURRENT_COND);
+  }
+  else if (prop == "temperature")
+  {
+    return StringUtils::Format("{}{}", GetInfo(WEATHER_LABEL_CURRENT_TEMP),
+                               g_langInfo.GetTemperatureUnitString());
+  }
+  else if (prop == "location")
+  {
+    return GetInfo(WEATHER_LABEL_LOCATION);
+  }
+  else if (prop == "fanartcode")
+  {
+    std::string value{URIUtils::GetFileName(GetInfo(WEATHER_IMAGE_CURRENT_ICON))};
+    URIUtils::RemoveExtension(value);
+    return value;
+  }
+  else if (prop == "conditionsicon")
+  {
+    return GetInfo(WEATHER_IMAGE_CURRENT_ICON);
+  }
+
+  CGUIComponent* gui{CServiceBroker::GetGUI()};
+  if (gui)
+  {
+    const CGUIWindow* window{gui->GetWindowManager().GetWindow(WINDOW_WEATHER)};
+    if (window)
+      return window->GetProperty(property).asString();
+  }
+  return {};
+}
+
 std::string CWeatherManager::BusyInfo(int info) const
 {
   if (info == WEATHER_IMAGE_CURRENT_ICON)

--- a/xbmc/weather/WeatherManager.h
+++ b/xbmc/weather/WeatherManager.h
@@ -61,6 +61,13 @@ public:
   ~CWeatherManager() override;
 
   /*!
+   \brief Retrieve the value for the given weather property
+   \param property the full name of the property (e.g. Current.Temperature, Hourly.1.Temperature)
+   \return the property value
+   */
+  std::string GetProperty(const std::string& property);
+
+  /*!
    \brief Retrieve the city name for the specified location from the settings
    \param iLocation the location index (can be in the range [1..MAXLOCATION])
    \return the city name (without the accompanying region area code)

--- a/xbmc/weather/WeatherTokenLocalizer.cpp
+++ b/xbmc/weather/WeatherTokenLocalizer.cpp
@@ -1,0 +1,113 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "WeatherTokenLocalizer.h"
+
+#include "LangInfo.h"
+#include "ServiceBroker.h"
+#include "guilib/LocalizeStrings.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "settings/lib/Setting.h"
+#include "utils/POUtils.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+#include "utils/log.h"
+
+#include <string>
+#include <vector>
+
+namespace
+{
+constexpr unsigned int LOCALIZED_TOKEN_FIRSTID = 370;
+constexpr unsigned int LOCALIZED_TOKEN_LASTID = 395;
+constexpr unsigned int LOCALIZED_TOKEN_FIRSTID2 = 1350;
+constexpr unsigned int LOCALIZED_TOKEN_LASTID2 = 1449;
+constexpr unsigned int LOCALIZED_TOKEN_FIRSTID3 = 11;
+constexpr unsigned int LOCALIZED_TOKEN_LASTID3 = 17;
+constexpr unsigned int LOCALIZED_TOKEN_FIRSTID4 = 71;
+constexpr unsigned int LOCALIZED_TOKEN_LASTID4 = 97;
+
+} // unnamed namespace
+
+std::string CWeatherTokenLocalizer::LocalizeOverviewToken(const std::string& token)
+{
+  if (m_localizedTokens.empty())
+    LoadLocalizedTokens();
+
+  std::string locStr;
+  if (!token.empty())
+  {
+    const auto it{m_localizedTokens.find(token)};
+    if (it != m_localizedTokens.cend())
+      locStr = g_localizeStrings.Get(it->second);
+  }
+
+  if (locStr.empty())
+    locStr = token; // if not found, use original string as fallback
+
+  return locStr;
+}
+
+std::string CWeatherTokenLocalizer::LocalizeOverview(const std::string& str)
+{
+  std::vector<std::string> words{StringUtils::Split(str, " ")};
+  for (std::string& word : words)
+    word = LocalizeOverviewToken(word);
+
+  return StringUtils::Join(words, " ");
+}
+
+void CWeatherTokenLocalizer::LoadLocalizedTokens()
+{
+  // We load the english strings in to get our tokens
+  std::string language{LANGUAGE_DEFAULT};
+  const std::shared_ptr<const CSettingString> languageSetting{
+      std::static_pointer_cast<const CSettingString>(
+          CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(
+              CSettings::SETTING_LOCALE_LANGUAGE))};
+  if (languageSetting)
+    language = languageSetting->GetDefault();
+
+  // Load the strings.po file
+  const std::string fileName{
+      URIUtils::AddFileToFolder(CLangInfo::GetLanguagePath(language), "strings.po")};
+  CPODocument poDoc;
+  if (!poDoc.LoadFile(fileName))
+  {
+    CLog::LogF(LOGERROR, "Unable to load po file '{}'", fileName);
+    return;
+  }
+
+  int counter{0};
+  while (poDoc.GetNextEntry())
+  {
+    if (poDoc.GetEntryType() != ID_FOUND)
+      continue;
+
+    const uint32_t id{poDoc.GetEntryID()};
+    poDoc.ParseEntry(ISSOURCELANG);
+
+    if (id > LOCALIZED_TOKEN_LASTID2)
+      break;
+
+    if ((LOCALIZED_TOKEN_FIRSTID <= id && id <= LOCALIZED_TOKEN_LASTID) ||
+        (LOCALIZED_TOKEN_FIRSTID2 <= id && id <= LOCALIZED_TOKEN_LASTID2) ||
+        (LOCALIZED_TOKEN_FIRSTID3 <= id && id <= LOCALIZED_TOKEN_LASTID3) ||
+        (LOCALIZED_TOKEN_FIRSTID4 <= id && id <= LOCALIZED_TOKEN_LASTID4))
+    {
+      if (!poDoc.GetMsgid().empty())
+      {
+        m_localizedTokens.try_emplace(poDoc.GetMsgid(), id);
+        counter++;
+      }
+    }
+  }
+
+  CLog::LogF(LOGDEBUG, "Loaded {} weather tokens", counter);
+}

--- a/xbmc/weather/WeatherTokenLocalizer.h
+++ b/xbmc/weather/WeatherTokenLocalizer.h
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <map>
+#include <string>
+
+class CWeatherTokenLocalizer
+{
+public:
+  CWeatherTokenLocalizer() = default;
+  virtual ~CWeatherTokenLocalizer() = default;
+
+  std::string LocalizeOverview(const std::string& str);
+  std::string LocalizeOverviewToken(const std::string& str);
+
+private:
+  void LoadLocalizedTokens();
+
+  struct CaseInsensitiveCompare
+  {
+    using is_transparent = void; // Enables heterogeneous operations.
+
+    bool operator()(const std::string_view& lhs, const std::string_view& rhs) const
+    {
+      return std::ranges::lexicographical_compare(lhs, rhs, [](char l, char r)
+                                                  { return std::tolower(l) < std::tolower(r); });
+    }
+  };
+  std::map<std::string, int, CaseInsensitiveCompare> m_localizedTokens;
+};


### PR DESCRIPTION
## Description
* Introduce GUI info label 'Weather.Data' as generic interface to weather data.
* Change Estuary to use the new label instead of direct weather window property access. 
* **No functional changes, old 'API' still works, no add-ons or skins will break!** 
* This PR is the first step towards future fixes and improvements.
* Some refactoring along the line (separate commit)

**Skinning engine changes:**
* Introduce new GUI info label `Weather.Data(property)` as generic interface for any weather data that is provided using a property name,
** replacing any occurrence of `Window(weather).Property`. Simply change every `Window(weather).Property(foo)` occurence to `Weather.Data(foo)`.
** replacing any  occurrence of `Weather.Location` with `Weather.Data(Location)`
** replacing any  occurrence of `Weather.Conditions` with `Weather.Data(Current.Condition)`
** replacing any  occurrence of `Weather.Temperature` with `Weather.Data(Current.Temperature)`
** replacing any  occurrence of `Weather.FanartCode` with `Weather.Data(Current.FanartCode)`
** replacing any  occurrence of `Weather.ConditionsIcon` with `Weather.Data(Current.OutlookIcon)`

Special handling is required for `Current.ConditionIcon`, `Current.OutlookIcon` and `Day{}.OutlookIcon`, where a simple replace of `Window(weather).Property(` with `Weather.Data(` is not sufficient as an old core hack to always prepend `resource://resource.images.weathericons.default/` to the window property value was removed for the new skin API to

a) make behavior consistent with the other OutlookIcon definitions (like Hourly.{}.OutlookIcon- see spec here: https://kodi.wiki/view/Weather_addons#Required_output) and

b) to make it possible for the skin to implement weather icon packs

The skin now must supply the correct prefix for the weather icon pack to be used.

Weather info bools (e.g. Weather.IsFetched) stay untouched and are not accessible via `Weather.Data`

Note: existing API is still available. The new API is available *in addition to the old API*. idea is to deprecate old API and to migrate skins over time.

I used current API documentation on the wiki https://kodi.wiki/view/Weather_addons and the current weather implementation (core and skin) as reference. 

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Current weather architecture is a but flawed and I want to fix that.

![kodi-weather-architecture drawio](https://github.com/user-attachments/assets/d14a4483-b4e9-4835-b9ff-6ee8b0c72ee3)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Runtime-tested couple of weeks on macOS and Android, latest Kodi master and latest weather.openmeteo add-on.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

None so far, but this will change with my next PRs.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki => Skinning engine change!
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
