### PR TITLE
[AudioEngine] PipeWire: account for partially filled buffer delay

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -624,6 +624,10 @@ void CAESinkPipewire::GetDelay(AEDelayStatus& status)
   if (state != PW_STREAM_STATE_STREAMING)
     return;
 
+  pw_buffer* buffer = m_stream->PeekBuffer();
+  if (buffer)
+    time.queued += buffer->size;
+
   const std::chrono::duration<double, std::ratio<1>> delay =
       PWTimeToAEDelay(time, m_format.m_sampleRate);
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
@@ -88,6 +88,11 @@ void CPipewireStream::SetActive(bool active)
   m_running = active;
 }
 
+pw_buffer* CPipewireStream::PeekBuffer()
+{
+  return m_buffer;
+}
+
 pw_buffer* CPipewireStream::GetBuffer()
 {
   if (!m_buffer)

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
@@ -41,6 +41,7 @@ public:
   void SetActive(bool active);
 
   pw_buffer* GetBuffer();
+  pw_buffer* PeekBuffer();
   void QueueBuffer();
 
   void Flush(bool drain);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Since #27053 some audio data may remain stored in a partially filled unqueued buffer.  The audio engine considers it as written to the sink, so it should be separately accounted for in GetDelay().

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Reading the code: if there is a partially filled unqueued buffer when AddPackets() exits, CActiveAESink::OutputSamples gets a delay value that does not account for the samples waiting in the buffer.

This adds extra jitter to the delay fed into the audio engine. In practice the effect seems to be hard to observe, the A/V sync is probably slightly off and audio engine is caching more audio than needed.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested on desktop setup.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Not much effect in practice. Theoretically better A/V sync.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
