### PR TITLE
[Windows] Automates the reinstallation of MSYS2 when necessary

### DIFF
--- a/tools/buildsteps/windows/download-msys2.bat
+++ b/tools/buildsteps/windows/download-msys2.bat
@@ -36,6 +36,19 @@ set msyspackages=diffutils gcc make patch perl tar yasm
 set gaspreprocurl=https://github.com/FFmpeg/gas-preprocessor/archive/master.tar.gz
 set usemirror=yes
 set opt=mintty
+set hash_file=%instdir%\%msys2%\installed_hash.txt
+
+:: get current SHA256 hash of this script file (download-msys2.bat)
+for /f "delims=" %%a in ('PowerShell "Get-FileHash %~nx0 | Select-Object -ExpandProperty Hash"') do set hash=%%a
+
+:: remove MSYS2 install if the installed hash is unknown (installed_hash.txt not found)
+if not exist %hash_file% if exist "%instdir%\%msys2%" rmdir "%instdir%\%msys2%" /S /Q
+
+:: remove MSYS2 install if the installed hash is different from the current hash
+if exist %hash_file% (
+  set /p installed_hash=<%hash_file%
+  if not !installed_hash!==%hash% rmdir "%instdir%\%msys2%" /S /Q
+)
 
 :: if KODI_MIRROR is not set externally to this script, set it to the default mirror URL
 if "%KODI_MIRROR%"=="" set KODI_MIRROR=https://mirrors.kodi.tv
@@ -454,6 +467,8 @@ IF ERRORLEVEL == 1 (
     ECHO Something goes wrong...
     exit /B 1
   )
+
+echo %hash%>%hash_file%
 
 echo.-------------------------------------------------------------------------------
 echo.install msys2 system done


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Automates the reinstallation of MSYS2 when necessary.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently MSYS2 only is installed when no exist any install in local system. Then when is updated MSYS2 version or changed installed packages is need manual remove of current install to download and install again.

This has happened in FFmpeg 8.0 PR --> https://github.com/xbmc/xbmc/pull/27149 and this is the reason initially has failed on Windows (even added required nasm package). 

This PR automates the reinstall logic: is installed when not exist (same as before) but also when MSYS2 version changes or packages changes or any other thing in the installation script changes... is used sha256 hash of self script. 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Nothing to users but automates Jenkins maintenance.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
