### PR TITLE
Fix crash when cancelling weather add-on installation

### DIFF
--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -970,7 +970,7 @@ bool CGUIControlButtonSetting::OnClick()
       if (m_pSetting->GetType() == SettingType::List)
         std::static_pointer_cast<CSettingList>(m_pSetting)->FromString(addonIDs);
       else
-        SetValid(setting->SetValue(addonIDs[0]));
+        SetValid(setting->SetValue(!addonIDs.empty() ? addonIDs[0] : ""));
     }
     else if (controlFormat == "path" || controlFormat == "file" || controlFormat == "image")
       SetValid(GetPath(std::static_pointer_cast<CSettingPath>(m_pSetting), m_localizer));


### PR DESCRIPTION
## Description

Fixes a crash. I went to install a weather add-on:

<img width="1342" height="758" alt="Screenshot 2025-09-04 at 7 26 33 PM" src="https://github.com/user-attachments/assets/2d0bf3ca-9641-435d-a48c-e5a326180dd1" />

I cancelled the installation, which caused Kodi to crash.

The root cause is that `addonIDs` will be empty if the installation is cancelled.

## Motivation and context

Testing edge cases for https://github.com/xbmc/xbmc/pull/27212.

## How has this been tested?

Before:

Crash

After:

<img width="1314" height="733" alt="Screenshot 2025-09-04 at 7 23 13 PM" src="https://github.com/user-attachments/assets/8209b855-4e94-469c-8493-4da7001f150d" />

## What is the effect on users?

* Fixed crash when cancelling weather add-on installation.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
