### PR TITLE
[webOS][VideoPlayer] Improve hardware acceleration detection

### DIFF
--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
@@ -271,8 +271,13 @@ std::string CMediaPipelineWebOS::GetVideoInfo()
   return m_videoInfo;
 }
 
-bool CMediaPipelineWebOS::Supports(const AVCodecID codec, const bool includeSecure)
+bool CMediaPipelineWebOS::Supports(const AVCodecID codec,
+                                   const int profile,
+                                   const bool includeSecure)
 {
+  if ((codec == AV_CODEC_ID_H264 || codec == AV_CODEC_ID_AVS || codec == AV_CODEC_ID_CAVS) &&
+      profile == AV_PROFILE_H264_HIGH_10)
+    return false;
   if (const auto it = ms_codecMap.find(codec); it != ms_codecMap.end())
     return includeSecure || !it->second.isSecure;
   return false;
@@ -339,7 +344,7 @@ bool CMediaPipelineWebOS::OpenAudioStream(CDVDStreamInfo& audioHint)
 
 bool CMediaPipelineWebOS::OpenVideoStream(CDVDStreamInfo hint)
 {
-  if (!Supports(hint.codec))
+  if (!Supports(hint.codec, hint.profile))
   {
     CLog::LogF(LOGERROR, "Unsupported codec: {}", hint.codec);
     return false;

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.h
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.h
@@ -74,10 +74,11 @@ public:
   /**
    * @brief Check if a codec is supported by the pipeline.
    * @param codec AVCodecID to check.
+   * @param profile profile to check.
    * @param includeSecure If true, include secure codecs in the check.
    * @return True if supported, false otherwise.
    */
-  static bool Supports(AVCodecID codec, bool includeSecure = false);
+  static bool Supports(AVCodecID codec, int profile, bool includeSecure = false);
 
   /**
    * @brief Flush all pending video messages.

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -635,6 +635,8 @@ void CSelectionStreams::Update(const std::shared_ptr<CDVDInputStream>& input,
       s.filename2 = filename2;
       s.name = stream->GetStreamName();
       s.codec    = demuxer->GetStreamCodecName(stream->demuxerId, stream->uniqueId);
+      s.codecId = stream->codec;
+      s.profile = stream->profile;
       s.channels = 0; // Default to 0. Overwrite if STREAM_AUDIO below.
       if (stream->type == StreamType::VIDEO)
       {

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -478,7 +478,7 @@ protected:
   int64_t GetTime();
   float GetPercentage();
 
-  void UpdateContent();
+  virtual void UpdateContent();
   void UpdateContentState();
 
   void UpdateFileItemStreamDetails(CFileItem& item);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -188,6 +188,8 @@ struct SelectionStream
   int64_t demuxerId = -1;
   std::string codec;
   std::string codecDesc;
+  AVCodecID codecId = AV_CODEC_ID_NONE;
+  int profile = AV_PROFILE_UNKNOWN;
   int channels = 0;
   int bitrate = 0;
   int width = 0;

--- a/xbmc/cores/VideoPlayer/VideoPlayerWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerWebOS.cpp
@@ -45,15 +45,17 @@ void CVideoPlayerWebOS::CreatePlayers()
     const bool subtitlesEnabled = m_VideoPlayerVideo->IsSubtitleEnabled();
     const double subtitleDelay = m_VideoPlayerVideo->GetSubtitleDelay();
 
-    m_mediaPipelineWebOS = std::make_unique<CMediaPipelineWebOS>(
-        *m_processInfo, m_renderManager, m_clock, m_messenger, m_overlayContainer, hasAudio);
-    m_VideoPlayerVideo =
-        std::make_unique<CVideoPlayerVideoWebOS>(*m_mediaPipelineWebOS, *m_processInfo);
-    m_VideoPlayerAudio =
-        std::make_unique<CVideoPlayerAudioWebOS>(*m_mediaPipelineWebOS, *m_processInfo);
-
-    m_VideoPlayerVideo->EnableSubtitle(subtitlesEnabled);
-    m_VideoPlayerVideo->SetSubtitleDelay(subtitleDelay);
+    if (!m_mediaPipelineWebOS)
+    {
+      m_mediaPipelineWebOS = std::make_unique<CMediaPipelineWebOS>(
+          *m_processInfo, m_renderManager, m_clock, m_messenger, m_overlayContainer, hasAudio);
+      m_VideoPlayerVideo =
+          std::make_unique<CVideoPlayerVideoWebOS>(*m_mediaPipelineWebOS, *m_processInfo);
+      m_VideoPlayerAudio =
+          std::make_unique<CVideoPlayerAudioWebOS>(*m_mediaPipelineWebOS, *m_processInfo);
+      m_VideoPlayerVideo->EnableSubtitle(subtitlesEnabled);
+      m_VideoPlayerVideo->SetSubtitleDelay(subtitleDelay);
+    }
   }
   else if (m_mediaPipelineWebOS || (!m_VideoPlayerVideo && !m_VideoPlayerAudio))
   {
@@ -84,4 +86,10 @@ void CVideoPlayerWebOS::GetVideoResolution(unsigned int& width, unsigned int& he
   }
   else
     CVideoPlayer::GetVideoResolution(width, height);
+}
+
+void CVideoPlayerWebOS::UpdateContent()
+{
+  CVideoPlayer::UpdateContent();
+  CreatePlayers();
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayerWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerWebOS.cpp
@@ -28,12 +28,14 @@ void CVideoPlayerWebOS::CreatePlayers()
       std::ranges::any_of(m_SelectionStreams.Get(StreamType::VIDEO),
                           [](const auto& stream)
                           {
+                            if (stream.codecId != AV_CODEC_ID_NONE)
+                              return CMediaPipelineWebOS::Supports(stream.codecId, stream.profile);
                             const AVCodec* codec =
                                 avcodec_find_decoder_by_name(stream.codec.data());
                             if (!codec)
                               return false;
 
-                            return CMediaPipelineWebOS::Supports(codec->id);
+                            return CMediaPipelineWebOS::Supports(codec->id, stream.profile);
                           });
 
   if (canStarfish && CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(

--- a/xbmc/cores/VideoPlayer/VideoPlayerWebOS.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerWebOS.h
@@ -22,6 +22,8 @@ public:
   void GetVideoResolution(unsigned int& width, unsigned int& height) override;
 
 protected:
+  void UpdateContent() override;
+
   void CreatePlayers() override;
 
 private:


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Pass codec id and profile and store it in `SelectionStream` so it can be used to evaluate if a stream is eligible for hardware acceleration on webOS.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #27132 
Fix playback of h264 high10 which cannot be decoded in hardware.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS 9

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
