### PR TITLE
[VideoVersions] Fix/improve the generation/import of versions.

### DIFF
--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -222,6 +222,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::vector<CRegExp> m_videoStackRegExps;
     std::vector<CRegExp> m_folderStackRegExps;
     std::vector<std::string> m_trailerMatchRegExps;
+    std::string m_titleTrailingPartNumberRegExp;
+    std::string m_trailingPartNumberRegExp;
     SETTINGS_TVSHOWLIST m_tvshowEnumRegExps;
     std::string m_tvshowMultiPartEnumRegExp;
     using StringMapping = std::vector<std::pair<std::string, std::string>>;

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -20,7 +20,6 @@
 #include "filesystem/MultiPathDirectory.h"
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/StackDirectory.h"
-#include "guilib/LocalizeStrings.h"
 #include "network/DNSNameCache.h"
 #include "network/Network.h"
 #include "pvr/channels/PVRChannelsPath.h"
@@ -674,14 +673,21 @@ int URIUtils::GetBlurayPlaylistFromPath(const std::string& path)
   return playlist;
 }
 
+bool URIUtils::CompareDiscPaths(const std::string& path1, const std::string& path2)
+{
+  std::string base1{GetDiscBase(path1)};
+  std::string base2{GetDiscBase(path2)};
+  return PathEquals(base1, base2, true, true);
+}
+
+std::string URIUtils::GetTitleTrailingPartNumberRegex()
+{
+  return m_advancedSettings->m_titleTrailingPartNumberRegExp;
+}
+
 std::string URIUtils::GetTrailingPartNumberRegex()
 {
-  // Build regex inserting local specific spelling of disc (xxx)
-  // \/?:cd|dvd|xxx|dis[ck][ _.-]*([0-9]+)$
-  std::string localeDiscStr{StringUtils::Format("{} ", g_localizeStrings.Get(427))};
-  if (!localeDiscStr.empty())
-    localeDiscStr += "|";
-  return {R"([\\\/](?:cd|dvd|)" + localeDiscStr + R"(dis[ck])[ _.-]*(\d{1,3})$)"};
+  return m_advancedSettings->m_trailingPartNumberRegExp;
 }
 
 std::string URLEncodePath(const std::string& strPath)

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -161,7 +161,19 @@ public:
    */
   static int GetBlurayPlaylistFromPath(const std::string& path);
 
+  /*! \brief Resolve two paths to their disc base (if needed) and compare for equality.
+   \param path1 first path to resolve and compare
+   \param path2 second path to resolve and compare
+   \return the playlist number
+   */
+  static bool CompareDiscPaths(const std::string& path1, const std::string& path2);
+
   /*! \brief Get the regex for matching trailing part numbers.
+   \return the regex
+   */
+  static std::string GetTitleTrailingPartNumberRegex();
+
+  /*! \brief Get the regex for matching trailing part numbers including leading path separator.
    \return the regex
    */
   static std::string GetTrailingPartNumberRegex();

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -927,6 +927,21 @@ TEST_F(TestURIUtils, GetBlurayPlaylistFromPath)
             800);
 }
 
+TEST_F(TestURIUtils, RemovePartNumberFromTitle)
+{
+  const std::string r{URIUtils::GetTitleTrailingPartNumberRegex()};
+  CRegExp regex{true, CRegExp::autoUtf8, r.c_str()};
+
+  std::string title{"Movie (Disc 1)"};
+  EXPECT_EQ(regex.RegFind(title), 5);
+
+  title = "Movie-(Disk 100)";
+  EXPECT_EQ(regex.RegFind(title), 5);
+
+  title = "Movie";
+  EXPECT_EQ(regex.RegFind(title), -1);
+}
+
 struct TestIsHostOnLANData
 {
   const static bool DONT_TEST_LOCAL_NETWORK = false;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4660,8 +4660,6 @@ void CVideoDatabase::GetSameVideoItems(const CFileItem& item,
     // distinguished by media_type.
     // @todo make the (value,type) pairs truly unique
     std::unordered_set<int> itemIds;
-    itemIds.reserve(
-        10); // Arbitrary starting size - unlikely to be more than 10 versions of a movie
     std::string sql;
     if (matchingMask & UniqueId)
     {

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -12462,7 +12462,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
         }
         if (lastTitle == currentTitle && item.HasVideoVersions())
         {
-          item.SetProperty("idMovie", lastMovieId);
+          item.GetVideoInfoTag()->m_iDbId = lastMovieId;
           scanner.AddVideo(&item, nullptr, useFolders, true, nullptr, true,
                            ContentType::MOVIE_VERSIONS);
         }

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1383,6 +1383,7 @@ public:
 
   enum MatchingMask : uint8_t
   {
+    None = 0x00,
     UniqueId = 0x01,
     Path = 0x02,
     Title = 0x04

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -514,12 +514,6 @@ enum class DeleteMovieHashAction
 #define COMPARE_PERCENTAGE     0.90f // 90%
 #define COMPARE_PERCENTAGE_MIN 0.50f // 50%
 
-enum class AllowNonFileNameMatch : bool
-{
-  NO_MATCH,
-  YES_MATCH
-};
-
 struct EpisodeInformation
 {
   int index{0};
@@ -1384,11 +1378,19 @@ public:
   VideoAssetInfo GetVideoVersionInfo(const std::string& filenameAndPath);
   bool UpdateAssetsOwner(const std::string& mediaType, int dbIdSource, int dbIdTarget);
 
-  int GetMovieId(const std::string& strFilenameAndPath,
-                 AllowNonFileNameMatch allowNonFileNameMatch = AllowNonFileNameMatch::NO_MATCH);
+  int GetMovieId(const std::string& strFilenameAndPath);
   std::string GetMovieTitle(int idMovie);
-  int GetMovieIdByTitle(const std::string& title);
-  void GetSameVideoItems(const CFileItem& item, CFileItemList& items);
+
+  enum MatchingMask : uint8_t
+  {
+    UniqueId = 0x01,
+    Path = 0x02,
+    Title = 0x04
+  };
+
+  void GetSameVideoItems(const CFileItem& item,
+                         CFileItemList& items,
+                         int matchingMask = UniqueId | Title);
   int GetFileIdByMovie(int idMovie);
   int GetFileIdByFile(const std::string& fullpath);
   std::string GetFileBasePathById(int idFile);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -751,8 +751,6 @@ public:
   bool SetStreamDetailsForFile(const CStreamDetails& details,
                                const std::string& strFileNameAndPath);
 
-  int AddMovieVersion(CFileItem& item, int idMovie, const KODI::ART::Artwork& art);
-
   /*!
    * \brief Clear any existing stream details and add the new provided details to a file.
    * \param[in] details New stream details

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1393,7 +1393,6 @@ public:
                          CFileItemList& items,
                          int matchingMask = UniqueId | Title);
   int GetFileIdByMovie(int idMovie);
-  int GetFileIdByFile(const std::string& fullpath);
   std::string GetFileBasePathById(int idFile);
 
   /*!

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1302,6 +1302,7 @@ public:
 
   std::string GetVideoItemTitle(VideoDbContentType itemType, int dbId);
   std::string GetVideoVersionById(int id);
+  int GetVideoVersionByTitle(const std::string& title) const;
   void GetVideoVersions(VideoDbContentType itemType,
                         int dbId,
                         CFileItemList& items,
@@ -1343,6 +1344,7 @@ public:
 
   void SetDefaultVideoVersion(VideoDbContentType itemType, int dbId, int idFile);
   void SetVideoVersion(int idFile, int idVideoVersion);
+  int AddOrValidateVideoVersionType(const std::string& typeVideoVersion);
   int AddVideoVersionType(const std::string& typeVideoVersion,
                           VideoAssetTypeOwner owner,
                           VideoAssetType assetType);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -985,7 +985,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         // See if movie already in library
         CFileItemList items;
         using enum CVideoDatabase::MatchingMask;
-        m_database.GetSameVideoItems(item, items, UniqueId | (bDirNames ? Path : 0));
+        m_database.GetSameVideoItems(item, items, UniqueId | (bDirNames ? Path : None));
         if (!items.IsEmpty())
         {
           // Movie already exists

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1044,7 +1044,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
           // Look for default version
           if (tag->IsDefaultVideoVersion())
-            defaultVersionFileId = tag->m_iFileId; // Updated in AddPlaylistMovieVersion()
+            defaultVersionFileId = tag->m_iFileId; // Updated in AddVideoAsset()
         }
       } while (result == InfoType::FULL);
 
@@ -1977,9 +1977,13 @@ CVideoInfoScanner::~CVideoInfoScanner()
             tag->m_iDbId}; // Set in AddVideo() for movies and RetrieveInfoForMovie() for versions
         if (idMovie != -1)
         {
-          lResult = m_database.AddMovieVersion(*pItem, idMovie, art);
-          movieDetails.m_iDbId = idMovie;
-          movieDetails.m_type = MediaTypeMovie;
+          pItem->SetArt(art); // May have been filtered above
+          CVideoInfoTag* vtag{pItem->GetVideoInfoTag()};
+          lResult =
+              m_database.AddVideoAsset(VideoDbContentType::MOVIES, idMovie,
+                                       tag->GetAssetInfo().GetId(), VideoAssetType::VERSION, *pItem)
+                  ? vtag->m_iFileId
+                  : -1;
         }
       }
     }

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
@@ -137,5 +137,7 @@ private:
   bool ChoosePlaylist(const std::shared_ptr<CFileItem>& item,
                       ReplaceExistingFile replaceExistingFile);
 
+  void RemovePartNumberFromTitle();
+
   std::shared_ptr<CFileItem> m_defaultVideoVersion;
 };

--- a/xbmc/video/tags/VideoTagLoaderNFO.cpp
+++ b/xbmc/video/tags/VideoTagLoaderNFO.cpp
@@ -97,11 +97,23 @@ CInfoScanner::InfoType CVideoTagLoaderNFO::Load(CVideoInfoTag& tag,
   }
 
   if (result != NONE)
-    CLog::Log(LOGDEBUG, "VideoInfoScanner: Found matching {} NFO file: {}", InfoTypeToStr(result),
-              CURL::GetRedacted(m_path));
+  {
+    const std::string type{InfoTypeToStr(result)};
+    if (m_item.HasProperty("nfo_index"))
+      CLog::Log(LOGDEBUG, "VideoInfoScanner: Found additional version ({}) in {} NFO file: {}",
+                m_item.GetProperty("nfo_index").asInteger32(), type, CURL::GetRedacted(m_path));
+    else
+      CLog::Log(LOGDEBUG, "VideoInfoScanner: Found matching {} NFO file: {}", type,
+                CURL::GetRedacted(m_path));
+  }
   else
-    CLog::Log(LOGDEBUG, "VideoInfoScanner: No NFO file found. Using title search for '{}'",
-              CURL::GetRedacted(m_item.GetPath()));
+  {
+    if (m_item.HasProperty("nfo_index"))
+      CLog::Log(LOGDEBUG, "VideoInfoScanner: No additional versions found in NFO file.");
+    else
+      CLog::Log(LOGDEBUG, "VideoInfoScanner: No NFO file found. Using title search for '{}'",
+                CURL::GetRedacted(m_item.GetPath()));
+  }
 
   return result;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Thanks to @ksooo and @CrystalP for comments on movie versions in previous commits.

**Commit 1**

As suggested by @CrystalP, remove the use of a FileItem property.

**Commit 2**

Thanks to @ksooo for pointing out `existingMovieId` was unused.
This was a result of the second fix of #27129.
The side effect of this was versions spread accross nfos were not properly added if they had a different filename/directory derived title to the one in the nfo. New movie entries were created rather than video version entries.
This commit fixes that.

**Commit 3**

While investigating above I was looking at how Disc n is appended to titles for bluray/dvds.
This makes sense when there are multiple discs containing the same movie.
For example - A lot of UHD packages also contain a bluray disc of the movie (often with additional extras etc..) - and these would often be placed in subdirectories `Disc n` under the main movie directory eg. `Aliens (1986)`
To avoid duplicate entries in the library #24076 appended `(Disc n)` to the title and created a set (if the movie wasn't in one already).

However, when converting to versions the `(Disc n)` is not needed any more so this commit removes it.

**Commit 4**

As suggested by @CrystalP use AddVideoAsset() to add a version.

**Commit 5**

When importing movie versions from nfos the art assigned to the movie is that of the first version added, however it may not be the default version - so when the default version is set at the end, make sure the art is updated as well.

**Commit 6**

`AddNewMovie()` assumed all versions were the default (40400). Now, if an asset (version) id is specified in the VideoInfoTag() that is used.

When user defined video version ids (eg. a specific type of edit) then that video version needs adding to the videoversiontype table (if it doesn't already exist) in AddNewMovie() before the version itself is created.

**Commit 7**

Bluray versions, when created as additional versions on a disc, have no art but probably should have the same art as the base version (at least to start with).

**Commit 8**

Remove definition for a function that doesn't exist

**Commit 9**

Improved logging for finding versions (or not) in a multi-movie nfo.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Issues identified above.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally and on slack.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
