### PR TITLE
[filesystem][CurlFile] Allow explicit use of HTTP Basic authentication

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/filesystem.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/filesystem.h
@@ -126,7 +126,7 @@ extern "C"
     /// | <b>`accept-charset`</b>             | Set the "accept-charset" header
     /// | <b>`acceptencoding or encoding`</b> | Set the "accept-encoding" header
     /// | <b>`active-remote`</b>              | Set the "active-remote" header
-    /// | <b>`auth`</b>                       | Set the authentication method. Possible values: any, anysafe, digest, ntlm
+    /// | <b>`auth`</b>                       | Set the authentication method. Possible values: any, anysafe, digest, ntlm, basic
     /// | <b>`connection-timeout`</b>         | Set the connection timeout in seconds
     /// | <b>`cookie`</b>                     | Set the "cookie" header
     /// | <b>`customrequest`</b>              | Set a custom HTTP request like DELETE

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -62,7 +62,7 @@
 #define ADDON_GLOBAL_VERSION_AUDIOENGINE_DEPENDS      "AudioEngine.h" \
                                                       "c-api/audio_engine.h"
 
-#define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.1.9"
+#define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.1.10"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_MIN           "1.1.7"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_XML_ID        "kodi.binary.global.filesystem"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_DEPENDS       "Filesystem.h" \

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -591,6 +591,8 @@ void CCurlFile::SetCommonOptions(CReadState* state, bool failOnError /* = true *
       g_curlInterface.easy_setopt(h, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
     else if( m_httpauth == "ntlm" )
       g_curlInterface.easy_setopt(h, CURLOPT_HTTPAUTH, CURLAUTH_NTLM);
+    else if (m_httpauth == "basic")
+      g_curlInterface.easy_setopt(h, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
     else
       bAuthSet = false;
   }

--- a/xbmc/filesystem/IFileTypes.h
+++ b/xbmc/filesystem/IFileTypes.h
@@ -90,7 +90,7 @@ enum class CURLOptionType
  * accept-charset: Set the "accept-charset" header
  * acceptencoding or encoding: Set the "accept-encoding" header
  * active-remote: Set the "active-remote" header
- * auth: Set the authentication method. Possible values: any, anysafe, digest, ntlm
+ * auth: Set the authentication method. Possible values: any, anysafe, digest, ntlm, basic
  * connection-timeout: Set the connection timeout in seconds
  * cookie: Set the "cookie" header
  * customrequest: Set a custom HTTP request like DELETE


### PR DESCRIPTION
## Description
Currently libcurl issues an unauthenticated request to the backend first to identify the available authentication mechanisms if no specifiy authentication mechanism has been specified. By allowing users to explicitly specify HTTP Basic authentication as the desired mechanism this extra roundtrip can be omitted.

## Motivation and context
Fix #22035  

If no specific authentication mechanism is specified in WebDAV URLs libcurl issues an anonymous HTTP request first to identify available authentication mechanisms before executing the desired authenticated request.  
In case of WebDav this results in a lot of "double" requests for each file in a directory and probing for additional meta files such as covers and thumbnails.  
Currently there is no way to specify HTTP Basic authentication as the desired authentication mechanism and therefore there is no way to avoid these extra unauthenticated requests for these files.

## How has this been tested?
1.  Compiled branch on Fedora Linux 42
2. Started Kodi
3. Added WebDAV video source with "|auth=basic" parameter in the URL (https://<my.webdav.host>:443/|auth=basic)
4. Browsed through WebDAV video source
5. Checked that there are only authenticated requests in the WebDAV HTTP server logs

## What is the effect on users?
Enable improved browsing performance of WebDAV sources with explicit HTTP Basic authentication

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
