### PR TITLE
[filesystem] Switch to long for CURLPROXY_* enums

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -47,7 +47,7 @@ using namespace std::chrono_literals;
 
 namespace
 {
-constexpr auto proxyType2CUrlProxyType{make_map<XFILE::CCurlFile::ProxyType, int>({
+constexpr auto proxyType2CUrlProxyType{make_map<XFILE::CCurlFile::ProxyType, long>({
     {CCurlFile::ProxyType::HTTP, CURLPROXY_HTTP},
     {CCurlFile::ProxyType::SOCKS4, CURLPROXY_SOCKS4},
     {CCurlFile::ProxyType::SOCKS4A, CURLPROXY_SOCKS4A},


### PR DESCRIPTION
## Description / Motivation and context

curl 8.16.0 bumped the enums to long, see: https://github.com/curl/curl/pull/18054

This fixes the build with curl 8.16+ for the following failure:

	/builds/alpine/aports/community/kodi/src/xbmc-21.2-Omega/xbmc/filesystem/CurlFile.cpp:48:5: error: cannot initialize an array element of type 'curl_proxytype' with an rvalue of type 'long'
	   48 |     CURLPROXY_HTTP,   CURLPROXY_SOCKS4,          CURLPROXY_SOCKS4A,
	      |     ^~~~~~~~~~~~~~
	/usr/include/curl/curl.h:791:35: note: expanded from macro 'CURLPROXY_HTTP'
	  791 | #define CURLPROXY_HTTP            0L /* added in 7.10, new in 7.19.4 default is
	      |                                   ^~
	...

## How has this been tested?
Built on Alpine Linux with musl libc on x86_64.

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
