### PR TITLE
[Subtitles][Settings] Change default subtitle setting to "forced_only"

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -564,7 +564,7 @@
       <group id="2" label="287">
         <setting id="locale.subtitlelanguage" type="string" label="286" help="36120">
           <level>0</level>
-          <default>original</default>
+          <default>forced_only</default>
           <constraints>
             <options>subtitlestreamlanguages</options>
           </constraints>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Change default subtitle setting to "forced_only"

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently default setting is "original".  This causes in 99% of cases enable subtitle track that matches with first audio language, same result as user selects the preferred language or the same language as the audio and this is like "I want subtitles enabled all the time with same language as audio".

This causes user confusion and complaints like:
- https://github.com/xbmc/xbmc/issues/27225
- https://github.com/xbmc/xbmc/issues/27222
- https://forum.kodi.tv/showthread.php?tid=382228

I think "forced only" is a better default setting for several reasons:

- It works similarly to version 21.x. So users who install v22 Alpha with a clean install won't notice the difference.
- This is probably the setting most users want and use. Watch content with the user's native audio and forced only subtitles (when exist in stream).
- Users with more specific preferences e.g watching movies with the original audio and full subtitles, still need to change the settings and are more aware of it, so they won't interpret it as a "bug."


## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows x64

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Better default setting for subtitles.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
