### PR TITLE
[Video] Fix episode thumbs not found if using local art.

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -12163,7 +12163,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
 
             // Art name is derived in GetLocalArt() which in turn calls GetTBNFile()
             // Need to set season/episode in VideoInfoTag
-            fileItem.SetProperty("is_multi_episode", true);
+            fileItem.SetProperty(MULTIPLE_EPISODES, true);
             CVideoInfoTag* tag{fileItem.GetVideoInfoTag()};
             tag->m_iSeason = episode.m_iSeason;
             tag->m_iEpisode = episode.m_iEpisode;
@@ -12296,7 +12296,7 @@ void CVideoDatabase::ExportArt(const CFileItem& item,
   {
     const std::string savedThumb{
         ART::GetLocalArt(item, artType, false,
-                         item.GetProperty("is_multi_episode").asBoolean(false)
+                         item.GetProperty(MULTIPLE_EPISODES).asBoolean(false)
                              ? ART::AdditionalIdentifiers::SEASON_AND_EPISODE
                              : ART::AdditionalIdentifiers::NONE)};
     CServiceBroker::GetTextureCache()->Export(artPath, savedThumb, overwrite);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -529,6 +529,8 @@ struct EpisodeInformation
 using EpisodeFileMap = std::multimap<std::string, EpisodeInformation, std::less<>>;
 using EpisodeFileMapEntry = std::pair<std::string, EpisodeInformation>;
 
+static constexpr const char* MULTIPLE_EPISODES{"multiple_episodes"};
+
 class CVideoDatabase : public CDatabase
 {
   struct FileInformation


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Only look for episode specific -SxxEyy art if multi-episode media file.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When importing episode art looked for -SxxEyy on art filename even if not a multi-episode file.

Fix #27130.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

In bug report and on slack.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
