### PR TITLE
[webOS] Implement HDR GUI peak brightness

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3080,6 +3080,7 @@
           <or>
             <condition>HAS_DX</condition>
             <condition>HAS_MEDIACODEC</condition>
+            <condition>HAVE_WEBOS</condition>
           </or>
         </requirement>
         <dependencies>

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
@@ -707,6 +707,8 @@ bool CMediaPipelineWebOS::Load(CDVDStreamInfo videoHint, CDVDStreamInfo audioHin
   m_picture.iDisplayWidth = videoHint.width;
   m_picture.iDisplayHeight = videoHint.height;
   m_picture.stereoMode = videoHint.stereo_mode;
+  m_picture.hdrType = videoHint.hdrType;
+  m_picture.color_transfer = videoHint.colorTransferCharacteristic;
 
   const int sorient = m_processInfo.GetVideoSettings().m_Orientation;
   const int orientation =

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererStarfish.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererStarfish.cpp
@@ -22,7 +22,10 @@ CRendererStarfish::CRendererStarfish()
   CLog::LogF(LOGINFO, "Instanced");
 }
 
-CRendererStarfish::~CRendererStarfish() = default;
+CRendererStarfish::~CRendererStarfish()
+{
+  CServiceBroker::GetWinSystem()->GetGfxContext().SetTransferPQ(false);
+}
 
 CBaseRenderer* CRendererStarfish::Create(CVideoBuffer* buffer)
 {
@@ -54,6 +57,13 @@ bool CRendererStarfish::Configure(const VideoPicture& picture,
   CalculateFrameAspectRatio(picture.iDisplayWidth, picture.iDisplayHeight);
   SetViewMode(m_videoSettings.m_ViewMode);
   ManageRenderArea();
+
+  if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
+      picture.hdrType == StreamHdrType::HDR_TYPE_DOLBYVISION)
+  {
+    if (CServiceBroker::GetWinSystem()->IsHDRDisplay())
+      CServiceBroker::GetWinSystem()->GetGfxContext().SetTransferPQ(true);
+  }
 
   m_configured = true;
 

--- a/xbmc/platform/linux/CMakeLists.txt
+++ b/xbmc/platform/linux/CMakeLists.txt
@@ -17,9 +17,11 @@ set(HEADERS AppParamParserLinux.h
 
 if(TARGET_WEBOS)
   list(APPEND SOURCES AppParamParserWebOS.cpp
-                      PlatformWebOS.cpp)
+                      PlatformWebOS.cpp
+                      WebOSTVPlatformConfig.cpp)
   list(APPEND HEADERS AppParamParserWebOS.h
-                      PlatformWebOS.h)
+                      PlatformWebOS.h
+                      WebOSTVPlatformConfig.h)
 endif()
 
 if(TARGET ${APP_NAME_LC}::Alsa)

--- a/xbmc/platform/linux/PlatformWebOS.cpp
+++ b/xbmc/platform/linux/PlatformWebOS.cpp
@@ -14,6 +14,8 @@
 #include "powermanagement/LunaPowerManagement.h"
 #include "utils/log.h"
 
+#include "platform/linux/WebOSTVPlatformConfig.h"
+
 #include <filesystem>
 
 #include <sys/resource.h>
@@ -69,6 +71,7 @@ bool CPlatformWebOS::InitStageTwo()
   if (setrlimit(RLIMIT_CORE, &limit) != 0)
     CLog::Log(LOGERROR, "Failed to disable core dumps");
 
+  WebOSTVPlatformConfig::Load();
   return CPlatformLinux::InitStageTwo();
 }
 

--- a/xbmc/platform/linux/WebOSTVPlatformConfig.cpp
+++ b/xbmc/platform/linux/WebOSTVPlatformConfig.cpp
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "WebOSTVPlatformConfig.h"
+
+#include "utils/JSONVariantParser.h"
+#include "utils/JSONVariantWriter.h"
+#include "utils/Variant.h"
+#include "utils/log.h"
+
+#include <webos-helpers/libhelpers.h>
+
+namespace
+{
+constexpr const char* LUNA_GET_CONFIG = "luna://com.webos.service.config/getConfigs";
+
+constexpr const char* CONFIGS = "configs";
+constexpr const char* CONFIG_NAMES = "configNames";
+const auto QUERY_CONFIG = std::vector<std::string>{"tv.model.*", "tv.nyx.*"};
+
+constexpr const char* EDID_TYPE = "tv.model.edidType";
+constexpr const char* SUPPORT_HDR = "tv.model.supportHDR";
+
+constexpr const char* PLATFORM_CODE = "tv.nyx.platformCode";
+
+constexpr const char* DTS = "dts";
+
+CVariant ms_config;
+} // namespace
+
+void WebOSTVPlatformConfig::Load()
+{
+  HContext requestContext;
+  requestContext.pub = true;
+  requestContext.multiple = false;
+  requestContext.callback = [](LSHandle* sh, LSMessage* msg, void* ctx)
+  {
+    std::string message = HLunaServiceMessage(msg);
+    CLog::LogF(LOGDEBUG, "TV config: {}", message);
+    if (!CJSONVariantParser::Parse(message, ms_config))
+    {
+      CLog::LogF(LOGERROR, "Failed to parse config JSON from Luna service");
+      return false;
+    }
+    ms_config = CVariant(ms_config[CONFIGS]);
+    return false;
+  };
+
+  CVariant request;
+  request[CONFIG_NAMES] = QUERY_CONFIG;
+  std::string payload;
+  CJSONVariantWriter::Write(request, payload, true);
+  if (HLunaServiceCall(LUNA_GET_CONFIG, payload.c_str(), &requestContext))
+  {
+    CLog::LogF(LOGWARNING, "Luna get config request call failed");
+  }
+}
+
+int WebOSTVPlatformConfig::GetWebOSVersion()
+{
+  return ms_config[PLATFORM_CODE].asInteger();
+}
+
+bool WebOSTVPlatformConfig::SupportsDTS()
+{
+  return ms_config[EDID_TYPE].asString().find(DTS) != std::string::npos;
+}
+
+bool WebOSTVPlatformConfig::SupportsHDR()
+{
+  return ms_config[SUPPORT_HDR].asBoolean();
+}

--- a/xbmc/platform/linux/WebOSTVPlatformConfig.h
+++ b/xbmc/platform/linux/WebOSTVPlatformConfig.h
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+class CVariant;
+
+class WebOSTVPlatformConfig
+{
+public:
+  static void Load();
+  static int GetWebOSVersion();
+  static bool SupportsDTS();
+  static bool SupportsHDR();
+};

--- a/xbmc/windowing/wayland/WinSystemWaylandWebOS.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandWebOS.cpp
@@ -20,8 +20,12 @@
 #include "input/actions/ActionIDs.h"
 #include "messaging/ApplicationMessenger.h"
 #include "settings/DisplaySettings.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/JSONVariantParser.h"
 #include "utils/log.h"
+
+#include "platform/linux/WebOSTVPlatformConfig.h"
 
 #include <CompileInfo.h>
 
@@ -218,6 +222,19 @@ void CWinSystemWaylandWebOS::UpdateResolutions()
     res.iScreenHeight = SCREEN_HEIGHT_1080P;
     res.iScreenWidth = SCREEN_WIDTH_1080P;
   }
+}
+
+float CWinSystemWaylandWebOS::GetGuiSdrPeakLuminance() const
+{
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  const int guiSdrPeak = settings->GetInt(CSettings::SETTING_VIDEOSCREEN_GUISDRPEAKLUMINANCE);
+
+  return (0.7f * guiSdrPeak + 30.0f) / 100.0f;
+}
+
+bool CWinSystemWaylandWebOS::IsHDRDisplay()
+{
+  return WebOSTVPlatformConfig::SupportsHDR();
 }
 
 } // namespace KODI::WINDOWING::WAYLAND

--- a/xbmc/windowing/wayland/WinSystemWaylandWebOS.h
+++ b/xbmc/windowing/wayland/WinSystemWaylandWebOS.h
@@ -50,6 +50,9 @@ public:
   void OnConfigure(std::uint32_t serial, CSizeInt size, IShellSurface::StateBitset state) override;
   void UpdateResolutions() override;
 
+  float GetGuiSdrPeakLuminance() const override;
+  bool IsHDRDisplay() override;
+
 protected:
   std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() override;
   std::unique_ptr<CSeat> CreateSeat(std::uint32_t name, wayland::seat_t& seat) override;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Implement #24756 for webOS.

I don't think there are webOS TVs without HDR since webOS 4 but the static TV config contains the key `tv.model.supportHDR` which can be queried through the luna bus. This also opens up the possibility to consolidate config checks from the media pipeline and the windowing system into their own platform config class that queries the config on startup.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Subtitles and GUI elements were very bright when HDR / DolbyVision content was playing.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS 9

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
