### PR TITLE
[Windows] changed LogF and LogFC to use __FUNCTION__

### DIFF
--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -131,11 +131,17 @@ public:
                                        fmt::make_format_args(args...));
   }
 
+#ifdef TARGET_WINDOWS
+#define LogF(level, format, ...) Log((level), ("{}: " format), __FUNCTION__, ##__VA_ARGS__)
+#define LogFC(level, component, format, ...) \
+  Log((level), (component), ("{}: " format), __FUNCTION__, ##__VA_ARGS__)
+#else
 #define LogF(level, format, ...) \
   Log((level), ("{}: " format), std::source_location::current().function_name(), ##__VA_ARGS__)
 #define LogFC(level, component, format, ...) \
   Log((level), (component), ("{}: " format), std::source_location::current().function_name(), \
       ##__VA_ARGS__)
+#endif
 
 private:
   static CLog& GetInstance();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
[Windows] changed `LogF` and `LogFC` to use `__FUNCTION__`

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Commented in https://github.com/xbmc/xbmc/pull/27238#issuecomment-3289765982

From https://github.com/xbmc/xbmc/pull/26767 was changed to use `std::source_location::current().function_name()` in all platforms and this is a great improvement, especially in Android and Linux because allows log name spaces and class names (very useful to locate the exact code that generates the log). 

On Windows, however, this is already provided by `__FUNCTION__` and `std:source_location` has the drawback that it generates too much detail with return values ​​(calling convention) and in function parameters (the entire template of defined/custom types):

**Before**
`2025-09-16 16:07:11.591 T:27428 warning <general>: void __cdecl ADDON::CAddonMgr::FindAddons(class std::map<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >,class std::shared_ptr<class ADDON::CAddonInfo>,struct std::less<void>,class std::allocator<struct std::pair<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const ,class std::shared_ptr<class ADDON::CAddonInfo> > > > &,const class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > &) const: Addon 'game.controller.default' already present with higher version 1.0.45 at 'V:\kodi-build\Debug\addons\game.controller.default\' - other version 1.0.40 at 'C:\Users\User\AppData\Roaming\Kodi\addons\game.controller.default\' will be ignored`

**After**
`2025-09-16 15:36:46.844 T:15304 warning <general>: ADDON::CAddonMgr::FindAddons: Addon 'game.controller.default' already present with higher version 1.0.45 at 'V:\kodi-build\Debug\addons\game.controller.default\' - other version 1.0.40 at 'C:\Users\User\AppData\Roaming\Kodi\addons\game.controller.default\' will be ignored`

There are no changes on other platforms, and the excessive info, calling convention, and extreme verbosity in types seems to be limited to Windows, so this resolves the issue for now.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows x64

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
More understandable logs, especially for regular users.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
