### PR TITLE
[VideoPlayerVideo] Removed extradata requirement to AV1

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -119,8 +119,7 @@ bool CVideoPlayerVideo::OpenStream(CDVDStreamInfo hint)
         hint.codec == AV_CODEC_ID_HEVC ||
         hint.codec == AV_CODEC_ID_MPEG4 ||
         hint.codec == AV_CODEC_ID_WMV3 ||
-        hint.codec == AV_CODEC_ID_VC1 ||
-        hint.codec == AV_CODEC_ID_AV1)
+        hint.codec == AV_CODEC_ID_VC1)
     {
       CLog::LogF(LOGERROR, "Codec id {} require extradata.", hint.codec);
       return false;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
AV1 use OBU's in data structure and its extradata use same OBU's

but seem there are different use cases:
- webm container: does not seem to have strict rules for providing AV1 OBUS extradata on initialization segment/packet, this lead that kodi core refuse the video stream and try to open all other available streams (without close the previous one, bug?)
- MP4 container: is expected to have always extradata on initialization segment/packet, so no problem

by removing this extradata restriction ffmpeg can extract the extradata from the first video stream packet, and play the stream without problems

I was unable to find comprehensive docs for the webm container related to AV1, so i also relied ask to AI

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #27120, only 1 (of 2) problems of the issue

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. install inputstream adaptive
2. on inputstream adaptive settings set, "stream selection type" to "Manual OSD"
3. play STRM:
```
#KODIPROP:mimetype=application/dash+xml
#KODIPROP:inputstream=inputstream.adaptive
https://storage.googleapis.com/bitmovin-demos/av1/stream_chrome.mpd

```

this avoid kodi to open/refuse all streams, as following log snippet example
```
2025-09-18 15:30:33.938 T:8796    debug <inputstream.adaptive>: OpenStream(1001)
2025-09-18 15:30:33.939 T:12420   debug <general>: CurlFile::XFILE::CCurlFile::Open - <https://storage.googleapis.com/bitmovin-demos/av1/AV1_480-Thu_Aug_16_17%3A16%3A29_CEST_2018/video/480/init.hdr>
2025-09-18 15:30:33.994 T:12420   debug <inputstream.adaptive>: [AS-0] Download finished: https://storage.googleapis.com/bitmovin-demos/av1/AV1_480-Thu_Aug_16_17%3A16%3A29_CEST_2018/video/480/init.hdr (downloaded 122 byte, speed 2232.00 byte/s)
2025-09-18 15:30:33.994 T:8796    debug <inputstream.adaptive>: GetStream(1001)
2025-09-18 15:30:33.995 T:8796    debug <general>: CDVDDemuxClient::RequestStream(): added/updated stream 1001 with codec_id 225
2025-09-18 15:30:33.995 T:8796    error <general>: CVideoPlayerVideo::OpenStream: Codec id 225 require extradata.
2025-09-18 15:30:33.995 T:8796  warning <general>: CVideoPlayer::OpenStream - Unsupported stream 1001. Stream disabled.
2025-09-18 15:30:33.995 T:8796     info <general>: Opening stream: 1004 source: 256
2025-09-18 15:30:33.995 T:8796    debug <inputstream.adaptive>: OpenStream(1004)
2025-09-18 15:30:33.996 T:17992   debug <general>: CurlFile::XFILE::CCurlFile::Open - <https://storage.googleapis.com/bitmovin-demos/av1/AV1_1280_8-Thu_Aug_16_18%3A09%3A15_CEST_2018/video/1280_2/init.hdr>
2025-09-18 15:30:34.030 T:17992   debug <inputstream.adaptive>: [AS-3] Download finished: https://storage.googleapis.com/bitmovin-demos/av1/AV1_1280_8-Thu_Aug_16_18%3A09%3A15_CEST_2018/video/1280_2/init.hdr (downloaded 123 byte, speed 3686.00 byte/s)
2025-09-18 15:30:34.030 T:8796    debug <inputstream.adaptive>: GetStream(1004)
2025-09-18 15:30:34.030 T:8796    debug <general>: CDVDDemuxClient::RequestStream(): added/updated stream 1004 with codec_id 225
2025-09-18 15:30:34.030 T:8796    error <general>: CVideoPlayerVideo::OpenStream: Codec id 225 require extradata.
2025-09-18 15:30:34.030 T:8796  warning <general>: CVideoPlayer::OpenStream - Unsupported stream 1004. Stream disabled.
2025-09-18 15:30:34.030 T:8796     info <general>: Opening stream: 1002 source: 256
2025-09-18 15:30:34.030 T:8796    debug <inputstream.adaptive>: OpenStream(1002)
2025-09-18 15:30:34.031 T:11360   debug <general>: CurlFile::XFILE::CCurlFile::Open - <https://storage.googleapis.com/bitmovin-demos/av1/AV1_640-Thu_Aug_16_17%3A17%3A24_CEST_2018/video/640/init.hdr>
2025-09-18 15:30:34.210 T:11360   debug <inputstream.adaptive>: [AS-1] Download finished: https://storage.googleapis.com/bitmovin-demos/av1/AV1_640-Thu_Aug_16_17%3A17%3A24_CEST_2018/video/640/init.hdr (downloaded 123 byte, speed 690.00 byte/s)
2025-09-18 15:30:34.210 T:8796    debug <inputstream.adaptive>: GetStream(1002)
2025-09-18 15:30:34.210 T:8796    debug <general>: CDVDDemuxClient::RequestStream(): added/updated stream 1002 with codec_id 225
2025-09-18 15:30:34.210 T:8796    error <general>: CVideoPlayerVideo::OpenStream: Codec id 225 require extradata.
2025-09-18 15:30:34.210 T:8796  warning <general>: CVideoPlayer::OpenStream - Unsupported stream 1002. Stream disabled.
2025-09-18 15:30:34.210 T:8796     info <general>: Opening stream: 1003 source: 256
2025-09-18 15:30:34.210 T:8796    debug <inputstream.adaptive>: OpenStream(1003)
...
```


## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
be able to play the webm stream

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
