### PR TITLE
[Estuary] Weather widgets: Only show separator if two items are available

### DIFF
--- a/addons/skin.estuary/xml/Includes_Home.xml
+++ b/addons/skin.estuary/xml/Includes_Home.xml
@@ -914,7 +914,7 @@
 	<include name="WeatherHourlyItem">
 		<item>
 			<label>$INFO[Weather.Data(Hourly.$PARAM[item_index].Time)]</label>
-			<label2>$INFO[Weather.Data(Hourly.$PARAM[item_index].Temperature)] ∙ $INFO[Weather.Data(Hourly.$PARAM[item_index].Precipitation)]</label2>
+			<label2>$INFO[Weather.Data(Hourly.$PARAM[item_index].Temperature)]$INFO[Weather.Data(Hourly.$PARAM[item_index].Precipitation), ∙ ]</label2>
 			<property name="Temperature">$INFO[Weather.Data(Hourly.$PARAM[item_index].Temperature)]</property>
 			<property name="Outlook">$INFO[Weather.Data(Hourly.$PARAM[item_id].Outlook)]</property>
 			<property name="Cloudiness">$INFO[Weather.Data(Hourly.$PARAM[item_index].Cloudiness)]</property>
@@ -928,7 +928,7 @@
 	<include name="WeatherDailyItem">
 		<item>
 			<label>$INFO[Weather.Data(Daily.$PARAM[item_index].ShortDay)]</label>
-			<label2>[COLOR blue]$INFO[Weather.Data(Daily.$PARAM[item_index].LowTemperature)][/COLOR] ∙ [COLOR red]$INFO[Weather.Data(Daily.$PARAM[item_index].HighTemperature)][/COLOR]</label2>
+			<label2>[COLOR blue]$INFO[Weather.Data(Daily.$PARAM[item_index].LowTemperature)][/COLOR]$INFO[Weather.Data(Daily.$PARAM[item_index].HighTemperature), ∙ [COLOR red],[/COLOR]]</label2>
 			<property name="LongDay">$INFO[Weather.Data(Daily.$PARAM[item_index].LongDay)]</property>
 			<property name="TempDay">$INFO[Weather.Data(Daily.$PARAM[item_index].TempDay)]</property>
 			<property name="Cloudiness">$INFO[Weather.Data(Daily.$PARAM[item_index].Cloudiness)]</property>


### PR DESCRIPTION
## Description
I found a weather add-on which does not support precipitation, leading to a visual glitch in Estuary's Hourly weather forecast widget. Normally the widget display temperature and precipitation on one line, separated by a dot. When no precipitation value is available, the separator was not removed (see screen shot)  This PR fixes the glitch.

## Motivation and context
Fix the visual glitch.

## How has this been tested?
By looking at the screen after applying the patch. :-)

## What is the effect on users?
Improved user experience.

## Screenshots (if appropriate):
<img width="1710" height="1107" alt="Screenshot 2025-09-13 at 17 11 43" src="https://github.com/user-attachments/assets/62c30733-9e2e-40fb-81e4-80d4a871fbd0" />

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
