### PR TITLE
[addons] CGUIDialogAddonInfo: Fix add-on status not updated when enab…

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1459,6 +1459,8 @@ msgstr ""
 #. Label of timers state in PVR timer/timer rule window
 #: system/peripherals.xml
 #: system/settings/settings.xml
+#: xbmc/addons/settings/AddonSettings.cpp
+#: xbmc/addons/gui/GUIDialogAddonInfo.cpp
 #: xbmc/addons/gui/GUIDialogAddonSettings.cpp
 #: xbmc/filesystem/AddonsDirectory.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -16021,6 +16023,7 @@ msgid "Enable"
 msgstr ""
 
 #. Defines the state of the add-on in the add-on manager window
+#: xbmc/addons/gui/GUIDialogAddonInfo.cpp
 #: xbmc/filesystem/AddonsDirectory.cpp
 msgctxt "#24023"
 msgid "Disabled"

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -610,7 +610,8 @@ void CGUIDialogAddonInfo::OnEnableDisable()
     if (PromptIfDependency(24075, 24091))
       return; //required. can't disable
 
-    CServiceBroker::GetAddonMgr().DisableAddon(m_localAddon->ID(), AddonDisabledReason::USER);
+    if (CServiceBroker::GetAddonMgr().DisableAddon(m_localAddon->ID(), AddonDisabledReason::USER))
+      m_item->SetProperty("Addon.Status", g_localizeStrings.Get(24023)); // Disabled
   }
   else
   {
@@ -618,7 +619,8 @@ void CGUIDialogAddonInfo::OnEnableDisable()
     if (!ADDON::GUI::CHelpers::DialogAddonLifecycleUseAsk(m_localAddon))
       return;
 
-    CServiceBroker::GetAddonMgr().EnableAddon(m_localAddon->ID());
+    if (CServiceBroker::GetAddonMgr().EnableAddon(m_localAddon->ID()))
+      m_item->SetProperty("Addon.Status", g_localizeStrings.Get(305)); // Enabled
   }
 
   UpdateControls(PerformButtonFocus::CHOICE_NO);


### PR DESCRIPTION
…ling/disabling the add-on.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
When enabling or disabling an add-on using the respective add-on info dialog button, the add-on status info displayed in the dialog is not updated. The PR fixes this bug. 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Provide correct add-on status in the info dialog at any time.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By looking at the screen after applying the patch. :-)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Correct add-on status in the info dialog at any time.

## Screenshots (if appropriate):
<img width="1710" height="1107" alt="Screenshot 2025-09-19 at 00 09 36" src="https://github.com/user-attachments/assets/5850e564-97f2-4c93-8946-4d20343b63d6" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
