### PR TITLE
[favourites][Estuary] Favourites window: Improve handling when no favourites are defined

### DIFF
--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -156,9 +156,10 @@ msgctxt "#31024"
 msgid "Choose rating to display for media items"
 msgstr ""
 
-#: /xml/DialogFavourites.xml
+#: /xml/Home.xml
+#: /xml/MyFavourites.xml
 msgctxt "#31025"
-msgid "No favourites found. You can add any item from media views to this list by using the context menu."
+msgid "No favourites found. You can add items from media and other views by using the context menu."
 msgstr ""
 
 #: /xml/DialogSeekBar.xml

--- a/addons/skin.estuary/xml/MyFavourites.xml
+++ b/addons/skin.estuary/xml/MyFavourites.xml
@@ -7,6 +7,7 @@
 	<controls>
 		<include>DefaultBackground</include>
 		<control type="group">
+			<visible>Integer.IsGreater(Container.NumItems,0)</visible>
 			<animation effect="fade" start="100" end="0" time="200" tween="sine" condition="$EXP[infodialog_active]">Conditional</animation>
 			<include>View_50_List</include>
 			<include>View_52_IconWall</include>
@@ -36,6 +37,22 @@
 					<include>MediaMenuNowPlaying</include>
 				</control>
 			</control>
+		</control>
+		<control type="group">
+			<visible>Integer.IsEqual(Container.NumItems,0)</visible>
+			<control type="textbox">
+				<left>500</left>
+				<top>90</top>
+				<width>900</width>
+				<bottom>0</bottom>
+				<aligny>center</aligny>
+				<align>center</align>
+				<label>$LOCALIZE[31025]</label>
+			</control>
+			<include content="TopBar">
+				<param name="breadcrumbs_label" value="$LOCALIZE[1036]" />
+				<param name="sublabel" value="" />
+			</include>
 		</control>
 	</controls>
 </window>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Having no favourites set leads to the Favourites window having a non-functioning ".." entry.  The PR improves this by fixing window core implementation to go to home window when the ".." entry is selected (like done in other windows) and to improve Estuary favourites window implementation to not show the listing at all if no favourites are available.
 
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #25218 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By looking at the screen after applying the patch, with and without favourites defined.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Improved user experience in both Estuary and other skins.

## Screenshots (if appropriate):
**Before:**
<img width="1710" height="1107" alt="Screenshot 2025-09-18 at 11 57 24" src="https://github.com/user-attachments/assets/23ba5269-11ed-4c5b-89c6-20d24635635b" />

**After:**
<img width="1710" height="1107" alt="Screenshot 2025-09-18 at 18 10 37" src="https://github.com/user-attachments/assets/f6144f3f-a462-43c9-8097-4bf5bb4bf594" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
