### PR TITLE
[addons] CGUIDialogAddonInfo::OnSelectVersion: Sort available add-ons…

### DIFF
--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -394,6 +394,19 @@ void CGUIDialogAddonInfo::OnSelectVersion()
     HELPERS::ShowOKDialogText(CVariant{21341}, CVariant{21342});
   else
   {
+    // Sort first by origin, then by version - descending.
+    std::ranges::sort(versions,
+                      [](const auto& a, const auto& b)
+                      {
+                        const auto& [versionA, originA] = a;
+                        const auto& [versionB, originB] = b;
+
+                        if (originA == originB)
+                          return versionA > versionB;
+
+                        return originA > originB;
+                      });
+
     int i = AskForVersion(versions);
     if (i != -1)
     {


### PR DESCRIPTION
… before opening the selection dialog.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Before opening the version selection dialog in the add-on info dialog, sort the available versions, first by origin, then by version number, descending. Before this PR, order was kinda random (at least not sorted by version number).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improve overview of available add-on versions

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By looking at the screen after applying the patch. :-)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Improved overview of available add-on versions

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
