### PR TITLE
EGLUtils: Ensure we have at least 8 alpha bits

### DIFF
--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -286,7 +286,7 @@ bool CEGLContextUtils::ChooseConfig(EGLint renderableType, EGLint visualId, bool
   attribs.Add({{EGL_RED_SIZE, 8},
                {EGL_GREEN_SIZE, 8},
                {EGL_BLUE_SIZE, 8},
-               {EGL_ALPHA_SIZE, 2},
+               {EGL_ALPHA_SIZE, 8},
                {EGL_DEPTH_SIZE, 16},
                {EGL_STENCIL_SIZE, 0},
                {EGL_SAMPLE_BUFFERS, 0},


### PR DESCRIPTION

## Description
Previously R10G10B10A2 will be preferred over R8G8B8A8 if supported by MESA
But 2 bits of alpha looks very bad in kodi when transparency effects are used.

Ensure we have at leats 8 bits of alpha.

## Motivation and context
This fixes issues like [this](https://forums.raspberrypi.com/viewtopic.php?p=2335291#p2335291) and [this](https://github.com/LibreELEC/LibreELEC.tv/issues/8461).

Also this now matches the X11 code path [here](https://github.com/xbmc/xbmc/blob/3b4f1c0c85de90fdf5012fe11e750bbf2b610d5a/xbmc/windowing/X11/WinSystemX11GLESContext.cpp#L251)



<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
In LibreELEC on Pi5. Prior to PR kmsprint reports `FB 681 1920x1080 XR30` and after it `FB 683 1920x1080 XR24`
(i.e. framebuffer originally R10G10B10A2 and subsequently R8G8B8A8).

Fade effects are much nicer.

<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
Better quality GUI with transparency effects
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
