### PR TITLE
[Logs] Update some Log calls that still using `__func__`

### DIFF
--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -545,7 +545,7 @@ void CAutorun::HandleAutorun()
   if (mediadetect.m_evAutorun.Wait(0ms))
   {
     if (!ExecuteAutorun(""))
-      CLog::Log(LOGDEBUG, "{}: Could not execute autorun", __func__);
+      CLog::LogF(LOGDEBUG, "Could not execute autorun");
     mediadetect.m_evAutorun.Reset();
   }
 #endif

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -631,9 +631,8 @@ bool CGUIPassword::IsMediaFileUnlocked(const std::string& type, const std::strin
 
   if (!sources)
   {
-    CLog::Log(LOGERROR,
-              "{}: CMediaSourceSettings::GetInstance().GetSources(\"{}\") returned nullptr.",
-              __func__, type);
+    CLog::LogF(LOGERROR, "CMediaSourceSettings::GetInstance().GetSources(\"{}\") returned nullptr.",
+               type);
     return true;
   }
 

--- a/xbmc/cdrip/CDDARipJob.cpp
+++ b/xbmc/cdrip/CDDARipJob.cpp
@@ -64,7 +64,7 @@ CCDDARipJob::~CCDDARipJob() = default;
 
 bool CCDDARipJob::DoWork()
 {
-  CLog::Log(LOGINFO, "CCDDARipJob::{} - Start ripping track {} to {}", __func__, m_input, m_output);
+  CLog::Log(LOGINFO, "CCDDARipJob: Start ripping track {} to {}", m_input, m_output);
 
   // if we are ripping to a samba share, rip it to hd first and then copy it to the share
   CFileItem file(m_output, false);
@@ -73,7 +73,7 @@ bool CCDDARipJob::DoWork()
 
   if (m_output.empty())
   {
-    CLog::Log(LOGERROR, "CCDDARipJob::{} - Error opening file", __func__);
+    CLog::LogF(LOGERROR, "Error opening file");
     return false;
   }
 
@@ -82,7 +82,7 @@ bool CCDDARipJob::DoWork()
   std::unique_ptr<CEncoder> encoder{};
   if (!reader.Open(m_input, READ_CACHED) || !(encoder = SetupEncoder(reader)))
   {
-    CLog::Log(LOGERROR, "CCDDARipJob::{} - Opening failed", __func__);
+    CLog::LogF(LOGERROR, "Opening failed");
     return false;
   }
 
@@ -122,8 +122,7 @@ bool CCDDARipJob::DoWork()
     // copy the ripped track to the share
     if (!CFile::Copy(m_output, file.GetPath()))
     {
-      CLog::Log(LOGERROR, "CCDDARipJob::{} - Error copying file from {} to {}", __func__, m_output,
-                file.GetPath());
+      CLog::LogF(LOGERROR, "Error copying file from {} to {}", m_output, file.GetPath());
       CFile::Delete(m_output);
       return false;
     }
@@ -133,19 +132,19 @@ bool CCDDARipJob::DoWork()
 
   if (cancelled)
   {
-    CLog::Log(LOGWARNING, "CCDDARipJob::{} - User Cancelled CDDA Rip", __func__);
+    CLog::LogF(LOGWARNING, "User Cancelled CDDA Rip");
     CFile::Delete(m_output);
   }
   else if (result == 1)
-    CLog::Log(LOGERROR, "CCDDARipJob::{} - Error ripping {}", __func__, m_input);
+    CLog::LogF(LOGERROR, "Error ripping {}", m_input);
   else if (result < 0)
-    CLog::Log(LOGERROR, "CCDDARipJob::{} - Error encoding {}", __func__, m_input);
+    CLog::LogF(LOGERROR, "Error encoding {}", m_input);
   else
   {
-    CLog::Log(LOGINFO, "CCDDARipJob::{} - Finished ripping {}", __func__, m_input);
+    CLog::Log(LOGINFO, "CCDDARipJob: Finished ripping {}", m_input);
     if (m_eject)
     {
-      CLog::Log(LOGINFO, "CCDDARipJob::{} - Ejecting CD", __func__);
+      CLog::Log(LOGINFO, "CCDDARipJob: Ejecting CD");
       CServiceBroker::GetMediaManager().EjectTray();
     }
   }

--- a/xbmc/cdrip/CDDARipper.cpp
+++ b/xbmc/cdrip/CDDARipper.cpp
@@ -63,8 +63,7 @@ bool CCDDARipper::RipTrack(CFileItem* pItem)
   // don't rip non cdda items
   if (!URIUtils::HasExtension(pItem->GetPath(), ".cdda"))
   {
-    CLog::Log(LOGDEBUG, "CCDDARipper::{} - File '{}' is not a cdda track", __func__,
-              pItem->GetPath());
+    CLog::LogF(LOGDEBUG, "File '{}' is not a cdda track", pItem->GetPath());
     return false;
   }
 
@@ -90,7 +89,7 @@ bool CCDDARipper::RipCD()
   MEDIA_DETECT::CCdInfo* pInfo = CServiceBroker::GetMediaManager().GetCdInfo();
   if (pInfo == nullptr || !pInfo->IsAudio(1))
   {
-    CLog::Log(LOGDEBUG, "CCDDARipper::{} - CD is not an audio cd", __func__);
+    CLog::LogF(LOGDEBUG, "CD is not an audio cd");
     return false;
   }
 
@@ -163,7 +162,7 @@ bool CCDDARipper::CreateAlbumDir(const MUSIC_INFO::CMusicInfoTag& infoTag,
   if (strDirectory.size() < 3)
   {
     // no rip path has been set, show error
-    CLog::Log(LOGERROR, "CCDDARipper::{} - Required path has not been set", __func__);
+    CLog::LogF(LOGERROR, "Required path has not been set");
     HELPERS::ShowOKDialogText(CVariant{257}, CVariant{608});
     return false;
   }
@@ -190,8 +189,7 @@ bool CCDDARipper::CreateAlbumDir(const MUSIC_INFO::CMusicInfoTag& infoTag,
   // Create directory if it doesn't exist
   if (!CUtil::CreateDirectoryEx(strDirectory))
   {
-    CLog::Log(LOGERROR, "CCDDARipper::{} - Unable to create directory '{}'", __func__,
-              strDirectory);
+    CLog::LogF(LOGERROR, "Unable to create directory '{}'", strDirectory);
     return false;
   }
 

--- a/xbmc/cdrip/Encoder.cpp
+++ b/xbmc/cdrip/Encoder.cpp
@@ -33,7 +33,7 @@ bool CEncoder::EncoderInit(const std::string& strFile, int iInChannels, int iInR
 
   if (!FileCreate(strFile))
   {
-    CLog::Log(LOGERROR, "CEncoder::{} - Cannot open file: {}", __func__, strFile);
+    CLog::LogF(LOGERROR, "Cannot open file: '{}'", strFile);
     return false;
   }
 
@@ -45,7 +45,7 @@ ssize_t CEncoder::EncoderEncode(uint8_t* pbtStream, size_t nNumBytesRead)
   const int iBytes = Encode(pbtStream, nNumBytesRead);
   if (iBytes < 0)
   {
-    CLog::Log(LOGERROR, "CEncoder::{} - Internal encoder error: {}", __func__, iBytes);
+    CLog::LogF(LOGERROR, "Internal encoder error: {}", iBytes);
     return 0;
   }
   return 1;

--- a/xbmc/cdrip/EncoderFFmpeg.cpp
+++ b/xbmc/cdrip/EncoderFFmpeg.cpp
@@ -210,15 +210,14 @@ bool CEncoderFFmpeg::Init()
     if (err != 0)
       throw FFMpegException("Failed to write the header (error '{}')", FFMpegErrorToString(err));
 
-    CLog::Log(LOGDEBUG, "CEncoderFFmpeg::{} - Successfully initialized with muxer {} and codec {}",
-              __func__,
-              m_formatCtx->oformat->long_name ? m_formatCtx->oformat->long_name
-                                              : m_formatCtx->oformat->name,
-              codec->long_name ? codec->long_name : codec->name);
+    CLog::LogF(LOGDEBUG, "Successfully initialized with muxer {} and codec {}",
+               m_formatCtx->oformat->long_name ? m_formatCtx->oformat->long_name
+                                               : m_formatCtx->oformat->name,
+               codec->long_name ? codec->long_name : codec->name);
   }
   catch (const FFMpegException& caught)
   {
-    CLog::Log(LOGERROR, "CEncoderFFmpeg::{} - {}", __func__, caught.what());
+    CLog::LogF(LOGERROR, "{}", caught.what());
 
     av_freep(&m_buffer);
     av_channel_layout_uninit(&m_bufferFrame->ch_layout);
@@ -251,7 +250,7 @@ int CEncoderFFmpeg::avio_write_callback(void* opaque, const uint8_t* buf, int bu
   CEncoderFFmpeg* enc = static_cast<CEncoderFFmpeg*>(opaque);
   if (enc->Write(buf, buf_size) != buf_size)
   {
-    CLog::Log(LOGERROR, "CEncoderFFmpeg::{} - Error writing FFmpeg buffer to file", __func__);
+    CLog::LogF(LOGERROR, "Error writing FFmpeg buffer to file");
     return -1;
   }
   return buf_size;
@@ -292,8 +291,7 @@ bool CEncoderFFmpeg::WriteFrame()
   AVPacket* pkt = av_packet_alloc();
   if (!pkt)
   {
-    CLog::Log(LOGERROR, "CEncoderFFmpeg::{} - av_packet_alloc failed: {}", __func__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "av_packet_alloc failed: {}", strerror(errno));
     return false;
   }
 
@@ -349,7 +347,7 @@ bool CEncoderFFmpeg::WriteFrame()
   }
   catch (const FFMpegException& caught)
   {
-    CLog::Log(LOGERROR, "CEncoderFFmpeg::{} - {}", __func__, caught.what());
+    CLog::LogF(LOGERROR, "{}", caught.what());
   }
 
   av_packet_free(&pkt);

--- a/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
+++ b/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
@@ -356,7 +356,7 @@ int CAEEncoderFFmpeg::Encode(uint8_t *in, int in_size, uint8_t *out, int out_siz
   }
   catch (const FFMpegException& caught)
   {
-    CLog::Log(LOGERROR, "CAEEncoderFFmpeg::{} - {}", __func__, caught.what());
+    CLog::LogF(LOGERROR, "{}", caught.what());
   }
 
   av_channel_layout_uninit(&frame->ch_layout);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -73,9 +73,7 @@ bool CDVDAudioCodecPassthrough::Open(CDVDStreamInfo &hints, CDVDCodecOptions &op
 
     case CAEStreamInfo::STREAM_TYPE_TRUEHD:
       m_codecName = "pt-truehd";
-
-      CLog::Log(LOGDEBUG, "CDVDAudioCodecPassthrough::{} - passthrough output device is {}",
-                __func__, m_deviceIsRAW ? "RAW" : "IEC");
+      CLog::LogF(LOGDEBUG, "passthrough output device is {}", m_deviceIsRAW ? "RAW" : "IEC");
       break;
 
     default:

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -965,7 +965,7 @@ void CDVDVideoCodecAndroidMediaCodec::Dispose()
   if (!m_opened)
     return;
 
-  CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::{}", __func__);
+  CLog::LogF(LOGDEBUG, "call");
 
   // invalidate any inflight outputbuffers
   FlushInternal();
@@ -1329,8 +1329,7 @@ void CDVDVideoCodecAndroidMediaCodec::SetCodecControl(int flags)
 {
   if (m_codecControlFlags != flags)
   {
-    CLog::Log(LOGDEBUG, LOGVIDEO, "CDVDVideoCodecAndroidMediaCodec::{} {:x}->{:x}", __func__,
-              m_codecControlFlags, flags);
+    CLog::LogFC(LOGDEBUG, LOGVIDEO, "{:x}->{:x}", m_codecControlFlags, flags);
     m_codecControlFlags = flags;
   }
 }
@@ -1351,14 +1350,13 @@ void CDVDVideoCodecAndroidMediaCodec::FlushInternal()
 
 void CDVDVideoCodecAndroidMediaCodec::SignalEndOfStream()
 {
-  CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::{}: state: {}", __func__, m_state);
+  CLog::LogF(LOGDEBUG, "state: {}", m_state);
   if (m_codec && (m_state == MEDIACODEC_STATE_RUNNING))
   {
     // Release all mediaodec output buffers to allow drain if we don't get inputbuffer early
     if (m_videoBufferPool)
     {
-      CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::{}: ReleaseMediaCodecBuffers",
-                __func__);
+      CLog::LogF(LOGDEBUG, "ReleaseMediaCodecBuffers");
       m_videoBufferPool->ReleaseMediaCodecBuffers();
     }
 
@@ -1369,8 +1367,7 @@ void CDVDVideoCodecAndroidMediaCodec::SignalEndOfStream()
       {
         xbmc_jnienv()->ExceptionDescribe();
         xbmc_jnienv()->ExceptionClear();
-        CLog::Log(LOGERROR,
-                  "CDVDVideoCodecAndroidMediaCodec::SignalEndOfStream: dequeueInputBuffer failed");
+        CLog::LogF(LOGERROR, "dequeueInputBuffer failed");
       }
     }
 
@@ -1384,19 +1381,16 @@ void CDVDVideoCodecAndroidMediaCodec::SignalEndOfStream()
       {
         xbmc_jnienv()->ExceptionDescribe();
         xbmc_jnienv()->ExceptionClear();
-        CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec::{}: queueInputBuffer failed",
-                  __func__);
+        CLog::LogF(LOGERROR, "queueInputBuffer failed");
       }
       else
       {
         m_indexInputBuffer = -1;
-        CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::{}: BUFFER_FLAG_END_OF_STREAM send",
-                  __func__);
+        CLog::LogF(LOGDEBUG, "BUFFER_FLAG_END_OF_STREAM send");
       }
     }
     else
-      CLog::Log(LOGWARNING, "CDVDVideoCodecAndroidMediaCodec::{}: invalid index: {}", __func__,
-                m_indexInputBuffer);
+      CLog::LogF(LOGWARNING, "invalid index: {}", m_indexInputBuffer);
   }
 }
 
@@ -1405,7 +1399,7 @@ void CDVDVideoCodecAndroidMediaCodec::InjectExtraData(CJNIMediaFormat& mediaform
   if (!m_hints.extradata)
     return;
 
-  CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::{}", __func__);
+  CLog::LogF(LOGDEBUG, "call");
   size_t size = m_hints.extradata.GetSize();
   void* src_ptr = m_hints.extradata.GetData();
   if (m_bitstream)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -85,10 +85,10 @@ bool CInputStreamAddon::Supports(const AddonInfoPtr& addonInfo, const CFileItem&
   CVariant oldAddonProp = fileitem.GetProperty("inputstreamaddon");
   if (!oldAddonProp.isNull())
   {
-    CLog::Log(LOGERROR,
-              "CInputStreamAddon::{} - 'inputstreamaddon' has been deprecated, "
-              "please use `#KODIPROP:inputstream={}` instead",
-              __func__, oldAddonProp.asString());
+    CLog::LogF(
+        LOGERROR,
+        "'inputstreamaddon' has been deprecated, please use `#KODIPROP:inputstream={}` instead",
+        oldAddonProp.asString());
   }
 
   // check if a specific inputstream addon is requested
@@ -174,10 +174,8 @@ bool CInputStreamAddon::Open()
 
     if (props.m_nCountInfoValues >= STREAM_MAX_PROPERTY_COUNT)
     {
-      CLog::Log(LOGERROR,
-                "CInputStreamAddon::{} - Hit max count of stream properties, "
-                "have {}, actual count: {}",
-                __func__, STREAM_MAX_PROPERTY_COUNT, propsMap.size());
+      CLog::LogF(LOGERROR, "Hit max count of stream properties, have {}, actual count: {}",
+                 STREAM_MAX_PROPERTY_COUNT, propsMap.size());
       break;
     }
   }

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -87,10 +87,10 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
         std::unique_ptr<CAudioDecoder> result = std::make_unique<CAudioDecoder>(addonInfo.second);
         if (!result->CreateDecoder() || !result->ContainsFiles(url))
         {
-          CLog::Log(LOGINFO,
-                    "CFileDirectoryFactory::{}: Addon '{}' support extension '{}' but creation "
-                    "failed (seems not supported), trying other addons and Kodi",
-                    __func__, addonInfo.second->ID(), strExtension);
+          CLog::LogF(LOGWARNING,
+                     "Addon '{}' support extension '{}' but creation failed (seems not supported), "
+                     "trying other addons and Kodi",
+                     addonInfo.second->ID(), strExtension);
           continue;
         }
         return result.release();

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -140,10 +140,7 @@ CGUIFont* GUIFontManager::LoadTTF(const std::string& strFontName,
   CWinSystemBase* const winSystem = CServiceBroker::GetWinSystem();
   if (!winSystem)
   {
-    CLog::Log(LOGFATAL,
-              "GUIFontManager::{}: Something tries to call function without an available GUI "
-              "window system",
-              __func__);
+    CLog::LogF(LOGFATAL, "Something tries to call function without an available GUI window system");
     return nullptr;
   }
 
@@ -207,13 +204,12 @@ CGUIFont* GUIFontManager::LoadTTF(const std::string& strFontName,
       // font could not be loaded - try Arial.ttf, which we distribute
       if (strFilename != "arial.ttf")
       {
-        CLog::Log(LOGERROR, "GUIFontManager::{}: Couldn't load font name: {}({}), trying arial.ttf",
-                  __func__, strFontName, strFilename);
+        CLog::LogF(LOGERROR, "Couldn't load font name: {}({}), trying arial.ttf", strFontName,
+                   strFilename);
         return LoadTTF(strFontName, "arial.ttf", textColor, shadowColor, iSize, iStyle, border,
                        lineSpacing, originalAspect);
       }
-      CLog::Log(LOGERROR, "GUIFontManager::{}: Couldn't load font name:{} file:{}", __func__,
-                strFontName, strPath);
+      CLog::LogF(LOGERROR, "Couldn't load font name:{} file:{}", strFontName, strPath);
 
       return nullptr;
     }
@@ -303,8 +299,7 @@ void GUIFontManager::ReloadTTFFonts(void)
       {
         delete pFontFile;
         // font could not be loaded
-        CLog::Log(LOGERROR, "GUIFontManager::{}: Couldn't re-load font file: '{}'", __func__,
-                  strPath);
+        CLog::LogF(LOGERROR, "Couldn't re-load font file: '{}'", strPath);
         return;
       }
 

--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -337,8 +337,7 @@ std::unique_ptr<CTexture> CGUIFontTTFGL::ReallocTexture(unsigned int& newHeight)
 
   if (!newTexture || !newTexture->GetPixels())
   {
-    CLog::Log(LOGERROR, "GUIFontTTFGL::{}: Error creating new cache texture for size {:f}",
-              __func__, m_height);
+    CLog::LogF(LOGERROR, "Error creating new cache texture for size {:f}", m_height);
     return nullptr;
   }
 
@@ -347,8 +346,8 @@ std::unique_ptr<CTexture> CGUIFontTTFGL::ReallocTexture(unsigned int& newHeight)
   m_textureWidth = newTexture->GetWidth();
   m_textureScaleX = 1.0f / m_textureWidth;
   if (m_textureHeight < newHeight)
-    CLog::Log(LOGWARNING, "GUIFontTTFGL::{}: allocated new texture with height of {}, requested {}",
-              __func__, m_textureHeight, newHeight);
+    CLog::LogF(LOGWARNING, "allocated new texture with height of {}, requested {}", m_textureHeight,
+               newHeight);
   m_staticCache.Flush();
   m_dynamicCache.Flush();
 

--- a/xbmc/guilib/GUIFontTTFGLES.cpp
+++ b/xbmc/guilib/GUIFontTTFGLES.cpp
@@ -332,8 +332,7 @@ std::unique_ptr<CTexture> CGUIFontTTFGLES::ReallocTexture(unsigned int& newHeigh
 
   if (!newTexture || !newTexture->GetPixels())
   {
-    CLog::Log(LOGERROR, "GUIFontTTFGLES::{}: Error creating new cache texture for size {:f}",
-              __func__, m_height);
+    CLog::LogF(LOGERROR, "Error creating new cache texture for size {:f}", m_height);
     return nullptr;
   }
 
@@ -342,9 +341,8 @@ std::unique_ptr<CTexture> CGUIFontTTFGLES::ReallocTexture(unsigned int& newHeigh
   m_textureWidth = newTexture->GetWidth();
   m_textureScaleX = 1.0f / m_textureWidth;
   if (m_textureHeight < newHeight)
-    CLog::Log(LOGWARNING,
-              "GUIFontTTFGLES::{}: allocated new texture with height of {}, requested {}", __func__,
-              m_textureHeight, newHeight);
+    CLog::LogF(LOGWARNING, "allocated new texture with height of {}, requested {}", m_textureHeight,
+               newHeight);
   m_staticCache.Flush();
   m_dynamicCache.Flush();
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Update some Log calls that still using `__func__`

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Remove the residual use of `__func__` definition in logs in favor of `LogF` and `LogFC`

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Build Windows x64

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
nothing

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
