### PR TITLE
URIUtils: Ensure hex numbers are unsigned when doing URL encoding

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -102,7 +102,7 @@ std::string URIUtils::URLEncode(std::string_view decoded, std::string_view URLSp
     if (StringUtils::isasciialphanum(ch) || URLSpec.find(ch) != std::string::npos)
       oss << ch;
     else
-      fmt::format_to(std::ostreambuf_iterator(oss), "%{:02x}", ch);
+      fmt::format_to(std::ostreambuf_iterator(oss), "%{:02x}", static_cast<unsigned char>(ch));
   }
   return std::move(oss).str();
 }

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -690,6 +690,7 @@ constexpr URLEncodings EncodingTestData[] = {
     {"{", "%7b"},
     {"|", "%7c"},
     {"}", "%7d"},
+    {"\u03A9", "%ce%a9"}, // Greek Capital Letter Omega
 
     // Encoding needed (Non alpha)
     {"\x1", "%01"},


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Hopefully this fixes the issue reported in https://github.com/xbmc/xbmc/pull/27134#issuecomment-3314699903. Weirdly, I was originally able to reproduce this, then changed something, changed it back and the error was gone... Maybe the problem comes from `char` being neither signed or unsigned... Anyway, I think this is the right fix.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See above.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added unit test.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
