### PR TITLE
[video] CAsyncGetItemsForPlaylist::GetItemsForPlaylist: Keep sort order…

### DIFF
--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -453,7 +453,8 @@ namespace
 void GetItemsForPlayList(const std::shared_ptr<CFileItem>& item, CFileItemList& queuedItems)
 {
   if (VIDEO::UTILS::IsItemPlayable(*item))
-    VIDEO::UTILS::GetItemsForPlayList(item, queuedItems);
+    VIDEO::UTILS::GetItemsForPlayList(item, queuedItems,
+                                      ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM);
   else if (MUSIC_UTILS::IsItemPlayable(*item))
     MUSIC_UTILS::GetItemsForPlayList(item, queuedItems);
 }

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
@@ -106,7 +106,8 @@ bool CPVRGUIActionsPlayback::PlayRecording(const CFileItem& item) const
       parentItem->SetStartOffset(STARTOFFSET_RESUME);
 
     auto queuedItems{std::make_unique<CFileItemList>()};
-    VIDEO::UTILS::GetItemsForPlayList(parentItem, *queuedItems);
+    VIDEO::UTILS::GetItemsForPlayList(parentItem, *queuedItems,
+                                      ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM);
 
     // figure out where to start playback
     int pos{0};

--- a/xbmc/video/guilib/VideoGUIUtils.h
+++ b/xbmc/video/guilib/VideoGUIUtils.h
@@ -47,9 +47,12 @@ void QueueItem(const std::shared_ptr<CFileItem>& item, QueuePosition pos);
   busy dialog if action takes certain amount of time to give the user visual feedback.
   \param item [in] the item to add to the playlist
   \param queuedItems [out] the items that can be put in a play list
+  \param mode [in] queue all successors and play them after item
   \return true on success, false otherwise
   */
-bool GetItemsForPlayList(const std::shared_ptr<CFileItem>& item, CFileItemList& queuedItems);
+bool GetItemsForPlayList(const std::shared_ptr<CFileItem>& item,
+                         CFileItemList& queuedItems,
+                         ContentUtils::PlayMode mode);
 
 /*!
  \brief Check whether the given item can be played by the app playlist player as one or more videos.

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1082,7 +1082,8 @@ bool CGUIWindowVideoBase::PlayItem(const std::shared_ptr<CFileItem>& pItem,
 
     // recursively add items to list
     CFileItemList queuedItems;
-    VIDEO::UTILS::GetItemsForPlayList(item, queuedItems);
+    VIDEO::UTILS::GetItemsForPlayList(item, queuedItems,
+                                      ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM);
 
     CServiceBroker::GetPlaylistPlayer().ClearPlaylist(PLAYLIST::Id::TYPE_VIDEO);
     CServiceBroker::GetPlaylistPlayer().Reset();


### PR DESCRIPTION
… if play mode is 'play from here'.

## Description
When selecting "Play from here" from context menu of a video, user expects the order of the current view respected. This is currently not (always) the case. This PR fixes this issue.
 
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix the bug that sort order of active view is not always respected when using "Play from here".

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Runtime-tested on macOS and Android, latest Kodi master.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Feature "Play from here" works as expected.

## Screenshots (if appropriate):
<img width="1710" height="1107" alt="Screenshot 2025-09-21 at 13 53 16" src="https://github.com/user-attachments/assets/e857dedc-c073-4880-8425-3674a1e50ea8" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
