### PR TITLE
Format codeowners code with clang-format

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
@@ -208,12 +208,14 @@ public:
   CStructHdl() : m_cStructure(new C_STRUCT()), m_owner(true) {}
 
   CStructHdl(const CStructHdl& cppClass)
-    : m_cStructure(new C_STRUCT(*cppClass.m_cStructure)), m_owner(true)
+    : m_cStructure(new C_STRUCT(*cppClass.m_cStructure)),
+      m_owner(true)
   {
   }
 
   explicit CStructHdl(const C_STRUCT* cStructure)
-    : m_cStructure(new C_STRUCT(*cStructure)), m_owner(true)
+    : m_cStructure(new C_STRUCT(*cStructure)),
+      m_owner(true)
   {
   }
 
@@ -293,13 +295,15 @@ public:
   }
 
   DynamicCStructHdl(const DynamicCStructHdl& cppClass)
-    : m_cStructure(new C_STRUCT(*cppClass.m_cStructure)), m_owner(true)
+    : m_cStructure(new C_STRUCT(*cppClass.m_cStructure)),
+      m_owner(true)
   {
     CPP_CLASS::AllocResources(cppClass.m_cStructure, m_cStructure);
   }
 
   explicit DynamicCStructHdl(const C_STRUCT* cStructure)
-    : m_cStructure(new C_STRUCT(*cStructure)), m_owner(true)
+    : m_cStructure(new C_STRUCT(*cStructure)),
+      m_owner(true)
   {
     CPP_CLASS::AllocResources(cStructure, m_cStructure);
   }

--- a/xbmc/addons/kodi-dev-kit/include/kodi/Filesystem.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/Filesystem.h
@@ -562,7 +562,11 @@ public:
             bool folder = false,
             int64_t size = -1,
             time_t dateTime = 0)
-    : m_label(label), m_path(path), m_folder(folder), m_size(size), m_dateTime(dateTime)
+    : m_label(label),
+      m_path(path),
+      m_folder(folder),
+      m_size(size),
+      m_dateTime(dateTime)
   {
   }
   //----------------------------------------------------------------------------

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/peripheral/PeripheralUtils.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/peripheral/PeripheralUtils.h
@@ -251,7 +251,8 @@ public:
   ///                 as default
   /// @param[in] strName [optional] Name of related peripheral
   Peripheral(PERIPHERAL_TYPE type = PERIPHERAL_TYPE_UNKNOWN, const std::string& strName = "")
-    : m_type(type), m_strName(strName)
+    : m_type(type),
+      m_strName(strName)
   {
   }
 
@@ -838,7 +839,8 @@ protected:
    * @brief Construct a driver primitive of the specified type
    */
   DriverPrimitive(JOYSTICK_DRIVER_PRIMITIVE_TYPE type, unsigned int driverIndex)
-    : m_type(type), m_driverIndex(driverIndex)
+    : m_type(type),
+      m_driverIndex(driverIndex)
   {
   }
 
@@ -902,7 +904,8 @@ public:
   ///
   /// @param[in] keycode Keycode to use
   DriverPrimitive(std::string keycode)
-    : m_type(JOYSTICK_DRIVER_PRIMITIVE_TYPE_KEY), m_keycode(std::move(keycode))
+    : m_type(JOYSTICK_DRIVER_PRIMITIVE_TYPE_KEY),
+      m_keycode(std::move(keycode))
   {
   }
 
@@ -921,7 +924,8 @@ public:
   ///
   /// @param[in] direction With @ref JOYSTICK_DRIVER_RELPOINTER_DIRECTION defined direction
   DriverPrimitive(JOYSTICK_DRIVER_RELPOINTER_DIRECTION direction)
-    : m_type(JOYSTICK_DRIVER_PRIMITIVE_TYPE_RELPOINTER_DIRECTION), m_relPointerDirection(direction)
+    : m_type(JOYSTICK_DRIVER_PRIMITIVE_TYPE_RELPOINTER_DIRECTION),
+      m_relPointerDirection(direction)
   {
   }
 
@@ -1178,7 +1182,9 @@ public:
   ///                 as default
   JoystickFeature(const std::string& name = "",
                   JOYSTICK_FEATURE_TYPE type = JOYSTICK_FEATURE_TYPE_UNKNOWN)
-    : m_name(name), m_type(type), m_primitives{}
+    : m_name(name),
+      m_type(type),
+      m_primitives{}
   {
   }
 
@@ -1272,7 +1278,8 @@ public:
   ///@}
 
   explicit JoystickFeature(const JOYSTICK_FEATURE& feature)
-    : m_name(feature.name ? feature.name : ""), m_type(feature.type)
+    : m_name(feature.name ? feature.name : ""),
+      m_type(feature.type)
   {
     for (unsigned int i = 0; i < JOYSTICK_PRIMITIVE_MAX; i++)
       m_primitives[i] = DriverPrimitive(feature.primitives[i]);

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/ChannelGroups.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/ChannelGroups.h
@@ -115,7 +115,8 @@ public:
   /*! \cond PRIVATE */
   PVRChannelGroupsResultSet() = delete;
   PVRChannelGroupsResultSet(const AddonInstance_PVR* instance, PVR_HANDLE handle)
-    : m_instance(instance), m_handle(handle)
+    : m_instance(instance),
+      m_handle(handle)
   {
   }
   /*! \endcond */
@@ -261,7 +262,8 @@ public:
   /*! \cond PRIVATE */
   PVRChannelGroupMembersResultSet() = delete;
   PVRChannelGroupMembersResultSet(const AddonInstance_PVR* instance, PVR_HANDLE handle)
-    : m_instance(instance), m_handle(handle)
+    : m_instance(instance),
+      m_handle(handle)
   {
   }
   /*! \endcond */

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Channels.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Channels.h
@@ -228,7 +228,8 @@ public:
   /*! \cond PRIVATE */
   PVRChannelsResultSet() = delete;
   PVRChannelsResultSet(const AddonInstance_PVR* instance, PVR_HANDLE handle)
-    : m_instance(instance), m_handle(handle)
+    : m_instance(instance),
+      m_handle(handle)
   {
   }
   /*! \endcond */

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/EPG.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/EPG.h
@@ -562,7 +562,8 @@ public:
   /*! \cond PRIVATE */
   PVREPGTagsResultSet() = delete;
   PVREPGTagsResultSet(const AddonInstance_PVR* instance, PVR_HANDLE handle)
-    : m_instance(instance), m_handle(handle)
+    : m_instance(instance),
+      m_handle(handle)
   {
   }
   /*! \endcond */

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Providers.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Providers.h
@@ -191,7 +191,8 @@ public:
   /*! \cond PRIVATE */
   PVRProvidersResultSet() = delete;
   PVRProvidersResultSet(const AddonInstance_PVR* instance, PVR_HANDLE handle)
-    : m_instance(instance), m_handle(handle)
+    : m_instance(instance),
+      m_handle(handle)
   {
   }
   /*! \endcond */

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Recordings.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Recordings.h
@@ -656,7 +656,8 @@ public:
   /*! \cond PRIVATE */
   PVRRecordingsResultSet() = delete;
   PVRRecordingsResultSet(const AddonInstance_PVR* instance, PVR_HANDLE handle)
-    : m_instance(instance), m_handle(handle)
+    : m_instance(instance),
+      m_handle(handle)
   {
   }
   /*! \endcond */

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Timers.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Timers.h
@@ -546,7 +546,8 @@ public:
   /*! \cond PRIVATE */
   PVRTimersResultSet() = delete;
   PVRTimersResultSet(const AddonInstance_PVR* instance, PVR_HANDLE handle)
-    : m_instance(instance), m_handle(handle)
+    : m_instance(instance),
+      m_handle(handle)
   {
   }
   /*! \endcond */

--- a/xbmc/addons/kodi-dev-kit/include/kodi/tools/StringUtils.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/tools/StringUtils.h
@@ -3026,15 +3026,9 @@ private:
     return 0;
   }
 
-  inline static char ToLowerAscii(char c)
-  {
-    return 'A' <= c && c <= 'Z' ? c - 'A' + 'a' : c;
-  }
+  inline static char ToLowerAscii(char c) { return 'A' <= c && c <= 'Z' ? c - 'A' + 'a' : c; }
 
-  inline static char ToUpperAscii(char c)
-  {
-    return 'a' <= c && c <= 'z' ? c - 'a' + 'A' : c;
-  }
+  inline static char ToUpperAscii(char c) { return 'a' <= c && c <= 'z' ? c - 'a' + 'A' : c; }
 
   inline static wchar_t tolowerUnicode(const wchar_t& c)
   {

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -58,7 +58,8 @@ using namespace GAME;
 using namespace RETRO;
 
 CRetroPlayer::CRetroPlayer(IPlayerCallback& callback)
-  : IPlayer(callback), m_gameServices(CServiceBroker::GetGameServices())
+  : IPlayer(callback),
+    m_gameServices(CServiceBroker::GetGameServices())
 {
   ResetPlayback();
   CServiceBroker::GetWinSystem()->RegisterRenderLoop(this);

--- a/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.cpp
@@ -23,7 +23,9 @@ constexpr auto AUTOSAVE_DURATION_SECS = 10s; // Auto-save every 10 seconds
 
 CRetroPlayerAutoSave::CRetroPlayerAutoSave(IAutoSaveCallback& callback,
                                            GAME::CGameSettings& settings)
-  : CThread("CRetroPlayerAutoSave"), m_callback(callback), m_settings(settings)
+  : CThread("CRetroPlayerAutoSave"),
+    m_callback(callback),
+    m_settings(settings)
 {
   CLog::Log(LOGDEBUG, "RetroPlayer[SAVE]: Initializing autosave");
 

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.cpp
@@ -19,7 +19,9 @@ using namespace KODI;
 using namespace RETRO;
 
 CRenderBufferDMA::CRenderBufferDMA(CRenderContext& context, int fourcc)
-  : m_context(context), m_fourcc(fourcc), m_bo(CBufferObject::GetBufferObject(false))
+  : m_context(context),
+    m_fourcc(fourcc),
+    m_bo(CBufferObject::GetBufferObject(false))
 {
   auto winSystemEGL =
       dynamic_cast<KODI::WINDOWING::LINUX::CWinSystemEGL*>(CServiceBroker::GetWinSystem());

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferOpenGL.cpp
@@ -17,7 +17,10 @@ CRenderBufferOpenGL::CRenderBufferOpenGL(GLuint pixeltype,
                                          GLuint internalformat,
                                          GLuint pixelformat,
                                          GLuint bpp)
-  : m_pixeltype(pixeltype), m_internalformat(internalformat), m_pixelformat(pixelformat), m_bpp(bpp)
+  : m_pixeltype(pixeltype),
+    m_internalformat(internalformat),
+    m_pixelformat(pixelformat),
+    m_bpp(bpp)
 {
 }
 

--- a/xbmc/cores/RetroPlayer/cheevos/Cheevos.cpp
+++ b/xbmc/cores/RetroPlayer/cheevos/Cheevos.cpp
@@ -89,7 +89,9 @@ constexpr auto extensionToConsole = make_map<std::string_view, RConsoleID>({
 CCheevos::CCheevos(GAME::CGameClient* gameClient,
                    const std::string& userName,
                    const std::string& loginToken)
-  : m_gameClient(gameClient), m_userName(userName), m_loginToken(loginToken)
+  : m_gameClient(gameClient),
+    m_userName(userName),
+    m_loginToken(loginToken)
 {
 }
 

--- a/xbmc/cores/RetroPlayer/guibridge/GUIGameSettings.cpp
+++ b/xbmc/cores/RetroPlayer/guibridge/GUIGameSettings.cpp
@@ -18,7 +18,8 @@ using namespace KODI;
 using namespace RETRO;
 
 CGUIGameSettings::CGUIGameSettings(CRPProcessInfo& processInfo)
-  : m_processInfo(processInfo), m_guiSettings(processInfo.GetRenderContext().GetGameSettings())
+  : m_processInfo(processInfo),
+    m_guiSettings(processInfo.GetRenderContext().GetGameSettings())
 {
   // Reset game settings
   m_guiSettings = m_processInfo.GetRenderContext().GetDefaultGameSettings();

--- a/xbmc/cores/RetroPlayer/guibridge/GUIRenderHandle.cpp
+++ b/xbmc/cores/RetroPlayer/guibridge/GUIRenderHandle.cpp
@@ -16,7 +16,8 @@ using namespace RETRO;
 // --- CGUIRenderHandle --------------------------------------------------------
 
 CGUIRenderHandle::CGUIRenderHandle(CGUIGameRenderManager& renderManager, RENDER_HANDLE type)
-  : m_renderManager(renderManager), m_type(type)
+  : m_renderManager(renderManager),
+    m_type(type)
 {
 }
 
@@ -49,7 +50,8 @@ void CGUIRenderHandle::ClearBackground()
 
 CGUIRenderControlHandle::CGUIRenderControlHandle(CGUIGameRenderManager& renderManager,
                                                  CGUIGameControl& control)
-  : CGUIRenderHandle(renderManager, RENDER_HANDLE::CONTROL), m_control(control)
+  : CGUIRenderHandle(renderManager, RENDER_HANDLE::CONTROL),
+    m_control(control)
 {
 }
 
@@ -57,6 +59,7 @@ CGUIRenderControlHandle::CGUIRenderControlHandle(CGUIGameRenderManager& renderMa
 
 CGUIRenderFullScreenHandle::CGUIRenderFullScreenHandle(CGUIGameRenderManager& renderManager,
                                                        CGameWindowFullScreen& window)
-  : CGUIRenderHandle(renderManager, RENDER_HANDLE::WINDOW), m_window(window)
+  : CGUIRenderHandle(renderManager, RENDER_HANDLE::WINDOW),
+    m_window(window)
 {
 }

--- a/xbmc/cores/RetroPlayer/guibridge/GUIRenderTarget.cpp
+++ b/xbmc/cores/RetroPlayer/guibridge/GUIRenderTarget.cpp
@@ -24,7 +24,8 @@ CGUIRenderTarget::CGUIRenderTarget(IRenderManager* renderManager) : m_renderMana
 // --- CGUIRenderControl -------------------------------------------------------
 
 CGUIRenderControl::CGUIRenderControl(IRenderManager* renderManager, CGUIGameControl& gameControl)
-  : CGUIRenderTarget(renderManager), m_gameControl(gameControl)
+  : CGUIRenderTarget(renderManager),
+    m_gameControl(gameControl)
 {
 }
 
@@ -45,7 +46,8 @@ void CGUIRenderControl::RenderEx()
 
 CGUIRenderFullScreen::CGUIRenderFullScreen(IRenderManager* renderManager,
                                            CGameWindowFullScreen& window)
-  : CGUIRenderTarget(renderManager), m_window(window)
+  : CGUIRenderTarget(renderManager),
+    m_window(window)
 {
 }
 

--- a/xbmc/cores/RetroPlayer/playback/GameLoop.cpp
+++ b/xbmc/cores/RetroPlayer/playback/GameLoop.cpp
@@ -25,7 +25,9 @@ constexpr auto PAUSE_SLEEP = 5s;
 } // namespace
 
 CGameLoop::CGameLoop(IGameLoopCallback* callback, double fps)
-  : CThread("GameLoop"), m_callback(callback), m_fps(fps ? fps : DEFAULT_FPS)
+  : CThread("GameLoop"),
+    m_callback(callback),
+    m_fps(fps ? fps : DEFAULT_FPS)
 {
 }
 

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
@@ -24,7 +24,9 @@ using namespace RETRO;
 CRPBaseRenderer::CRPBaseRenderer(const CRenderSettings& renderSettings,
                                  CRenderContext& context,
                                  std::shared_ptr<IRenderBufferPool> bufferPool)
-  : m_context(context), m_bufferPool(std::move(bufferPool)), m_renderSettings(renderSettings)
+  : m_context(context),
+    m_bufferPool(std::move(bufferPool)),
+    m_renderSettings(renderSettings)
 {
   m_bufferPool->RegisterRenderer(this);
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
@@ -51,7 +51,9 @@ RenderBufferPoolVector CWinRendererFactory::CreateBufferPools(CRenderContext& co
 // --- CWinRenderBuffer --------------------------------------------------------
 
 CWinRenderBuffer::CWinRenderBuffer(AVPixelFormat pixFormat, DXGI_FORMAT dxFormat)
-  : m_pixFormat(pixFormat), m_targetDxFormat(dxFormat), m_targetPixFormat(GetPixFormat())
+  : m_pixFormat(pixFormat),
+    m_targetDxFormat(dxFormat),
+    m_targetPixFormat(GetPixFormat())
 {
 }
 

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
@@ -24,7 +24,8 @@ using namespace KODI::SHADER;
 CShaderPreset::CShaderPreset(RETRO::CRenderContext& context,
                              unsigned videoWidth,
                              unsigned videoHeight)
-  : m_context(context), m_videoSize(videoWidth, videoHeight)
+  : m_context(context),
+    m_videoSize(videoWidth, videoHeight)
 {
 }
 

--- a/xbmc/cores/RetroPlayer/shaders/ShaderTypes.h
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderTypes.h
@@ -97,7 +97,8 @@ struct float2
   float2() : x(0.0f), y(0.0f) {}
 
   template<typename T>
-  float2(T x_, T y_) : x(static_cast<float>(x_)), y(static_cast<float>(y_))
+  float2(T x_, T y_) : x(static_cast<float>(x_)),
+                       y(static_cast<float>(y_))
   {
     static_assert(std::is_arithmetic_v<T>, "Not an arithmetic type");
   }

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGL.cpp
@@ -16,7 +16,8 @@
 using namespace KODI::SHADER;
 
 CShaderTextureGL::CShaderTextureGL(std::shared_ptr<CGLTexture> texture, bool sRgbFramebuffer)
-  : m_texture(std::move(texture)), m_sRgbFramebuffer(sRgbFramebuffer)
+  : m_texture(std::move(texture)),
+    m_sRgbFramebuffer(sRgbFramebuffer)
 {
   assert(m_texture.get() != nullptr);
 }

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderTextureGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderTextureGLES.cpp
@@ -16,7 +16,8 @@
 using namespace KODI::SHADER;
 
 CShaderTextureGLES::CShaderTextureGLES(std::shared_ptr<CGLESTexture> texture, bool sRgbFramebuffer)
-  : m_texture(std::move(texture)), m_sRgbFramebuffer(sRgbFramebuffer)
+  : m_texture(std::move(texture)),
+    m_sRgbFramebuffer(sRgbFramebuffer)
 {
   assert(m_texture.get() != nullptr);
 }

--- a/xbmc/cores/RetroPlayer/streams/RPStreamManager.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RPStreamManager.cpp
@@ -18,7 +18,8 @@ using namespace KODI;
 using namespace RETRO;
 
 CRPStreamManager::CRPStreamManager(CRPRenderManager& renderManager, CRPProcessInfo& processInfo)
-  : m_renderManager(renderManager), m_processInfo(processInfo)
+  : m_renderManager(renderManager),
+    m_processInfo(processInfo)
 {
 }
 

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.cpp
@@ -25,7 +25,8 @@ using namespace RETRO;
 const double MAX_DELAY = 0.3; // seconds
 
 CRetroPlayerAudio::CRetroPlayerAudio(CRPProcessInfo& processInfo)
-  : m_processInfo(processInfo), m_pAudioStream(nullptr)
+  : m_processInfo(processInfo),
+    m_pAudioStream(nullptr)
 {
   CLog::Log(LOGDEBUG, "RetroPlayer[AUDIO]: Initializing audio");
 }

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.h
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.h
@@ -24,7 +24,9 @@ class CRPProcessInfo;
 struct AudioStreamProperties : public StreamProperties
 {
   AudioStreamProperties(PCMFormat format, double sampleRate, AudioChannelMap channelMap)
-    : format(format), sampleRate(sampleRate), channelMap(channelMap)
+    : format(format),
+      sampleRate(sampleRate),
+      channelMap(channelMap)
   {
   }
 

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerRendering.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerRendering.cpp
@@ -18,7 +18,8 @@ using namespace RETRO;
 
 CRetroPlayerRendering::CRetroPlayerRendering(CRPRenderManager& renderManager,
                                              CRPProcessInfo& processInfo)
-  : m_renderManager(renderManager), m_processInfo(processInfo)
+  : m_renderManager(renderManager),
+    m_processInfo(processInfo)
 {
   CLog::Log(LOGDEBUG, "RetroPlayer[RENDERING]: Initializing rendering");
 }

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerVideo.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerVideo.cpp
@@ -17,7 +17,8 @@ using namespace KODI;
 using namespace RETRO;
 
 CRetroPlayerVideo::CRetroPlayerVideo(CRPRenderManager& renderManager, CRPProcessInfo& processInfo)
-  : m_renderManager(renderManager), m_processInfo(processInfo)
+  : m_renderManager(renderManager),
+    m_processInfo(processInfo)
 {
   CLog::Log(LOGDEBUG, "RetroPlayer[VIDEO]: Initializing video");
 

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerVideo.h
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerVideo.h
@@ -56,7 +56,11 @@ struct VideoStreamBuffer : public StreamBuffer
 
   VideoStreamBuffer(
       AVPixelFormat pixfmt, uint8_t* data, size_t size, DataAccess access, DataAlignment alignment)
-    : pixfmt(pixfmt), data(data), size(size), access(access), alignment(alignment)
+    : pixfmt(pixfmt),
+      data(data),
+      size(size),
+      access(access),
+      alignment(alignment)
   {
   }
 

--- a/xbmc/games/addons/GameClientInGameSaves.cpp
+++ b/xbmc/games/addons/GameClientInGameSaves.cpp
@@ -28,7 +28,8 @@ using namespace GAME;
 
 CGameClientInGameSaves::CGameClientInGameSaves(CGameClient* addon,
                                                const AddonInstance_Game* dllStruct)
-  : m_gameClient(addon), m_dllStruct(dllStruct)
+  : m_gameClient(addon),
+    m_dllStruct(dllStruct)
 {
   assert(m_gameClient != nullptr);
   assert(m_dllStruct != nullptr);

--- a/xbmc/games/addons/GameClientProperties.cpp
+++ b/xbmc/games/addons/GameClientProperties.cpp
@@ -40,7 +40,8 @@ using namespace GAME;
 using namespace XFILE;
 
 CGameClientProperties::CGameClientProperties(const CGameClient& parent, AddonProps_Game& props)
-  : m_parent(parent), m_properties(props)
+  : m_parent(parent),
+    m_properties(props)
 {
 }
 

--- a/xbmc/games/addons/GameClientSubsystem.cpp
+++ b/xbmc/games/addons/GameClientSubsystem.cpp
@@ -23,7 +23,9 @@ using namespace GAME;
 CGameClientSubsystem::CGameClientSubsystem(CGameClient& gameClient,
                                            AddonInstance_Game& addonStruct,
                                            CCriticalSection& clientAccess)
-  : m_gameClient(gameClient), m_struct(addonStruct), m_clientAccess(clientAccess)
+  : m_gameClient(gameClient),
+    m_struct(addonStruct),
+    m_clientAccess(clientAccess)
 {
 }
 

--- a/xbmc/games/addons/cheevos/GameClientCheevos.cpp
+++ b/xbmc/games/addons/cheevos/GameClientCheevos.cpp
@@ -16,7 +16,8 @@ using namespace KODI;
 using namespace GAME;
 
 CGameClientCheevos::CGameClientCheevos(CGameClient& gameClient, AddonInstance_Game& addonStruct)
-  : m_gameClient(gameClient), m_struct(addonStruct)
+  : m_gameClient(gameClient),
+    m_struct(addonStruct)
 {
 }
 

--- a/xbmc/games/addons/input/GameClientController.cpp
+++ b/xbmc/games/addons/input/GameClientController.cpp
@@ -33,7 +33,9 @@ using namespace KODI;
 using namespace GAME;
 
 CGameClientController::CGameClientController(CGameClientInput& input, ControllerPtr controller)
-  : m_input(input), m_controller(std::move(controller)), m_controllerId(m_controller->ID())
+  : m_input(input),
+    m_controller(std::move(controller)),
+    m_controllerId(m_controller->ID())
 {
   // Generate arrays of features
   for (const CPhysicalFeature& feature : m_controller->Features())

--- a/xbmc/games/addons/input/GameClientPort.cpp
+++ b/xbmc/games/addons/input/GameClientPort.cpp
@@ -38,7 +38,8 @@ CGameClientPort::CGameClientPort(const game_input_port& port)
 }
 
 CGameClientPort::CGameClientPort(const ControllerVector& controllers)
-  : m_type(PORT_TYPE::CONTROLLER), m_portId(DEFAULT_PORT_ID)
+  : m_type(PORT_TYPE::CONTROLLER),
+    m_portId(DEFAULT_PORT_ID)
 {
   for (const auto& controller : controllers)
     m_acceptedDevices.emplace_back(new CGameClientDevice(controller));

--- a/xbmc/games/addons/input/GameClientTopology.cpp
+++ b/xbmc/games/addons/input/GameClientTopology.cpp
@@ -39,7 +39,9 @@ bool ContainsOnlySeparator(const std::string& address,
 } // namespace
 
 CGameClientTopology::CGameClientTopology(GameClientPortVec ports, int playerLimit)
-  : m_ports(std::move(ports)), m_playerLimit(playerLimit), m_controllers(GetControllerTree(m_ports))
+  : m_ports(std::move(ports)),
+    m_playerLimit(playerLimit),
+    m_controllers(GetControllerTree(m_ports))
 {
 }
 

--- a/xbmc/games/agents/input/AgentInput.cpp
+++ b/xbmc/games/agents/input/AgentInput.cpp
@@ -26,7 +26,8 @@ using namespace KODI;
 using namespace GAME;
 
 CAgentInput::CAgentInput(PERIPHERALS::CPeripherals& peripheralManager, CInputManager& inputManager)
-  : m_peripheralManager(peripheralManager), m_inputManager(inputManager)
+  : m_peripheralManager(peripheralManager),
+    m_inputManager(inputManager)
 {
   // Register callbacks
   m_peripheralManager.RegisterObserver(this);

--- a/xbmc/games/agents/input/AgentKeyboard.cpp
+++ b/xbmc/games/agents/input/AgentKeyboard.cpp
@@ -18,7 +18,8 @@ using namespace KODI;
 using namespace GAME;
 
 CAgentKeyboard::CAgentKeyboard(PERIPHERALS::PeripheralPtr peripheral)
-  : m_peripheral(std::move(peripheral)), m_keyboardActivity(std::make_unique<CControllerActivity>())
+  : m_peripheral(std::move(peripheral)),
+    m_keyboardActivity(std::make_unique<CControllerActivity>())
 {
 }
 

--- a/xbmc/games/agents/input/AgentMouse.cpp
+++ b/xbmc/games/agents/input/AgentMouse.cpp
@@ -18,7 +18,8 @@ using namespace KODI;
 using namespace GAME;
 
 CAgentMouse::CAgentMouse(PERIPHERALS::PeripheralPtr peripheral)
-  : m_peripheral(std::move(peripheral)), m_mouseActivity(std::make_unique<CControllerActivity>())
+  : m_peripheral(std::move(peripheral)),
+    m_mouseActivity(std::make_unique<CControllerActivity>())
 {
 }
 

--- a/xbmc/games/controllers/Controller.cpp
+++ b/xbmc/games/controllers/Controller.cpp
@@ -28,7 +28,8 @@ using namespace GAME;
 struct FeatureTypeEqual
 {
   FeatureTypeEqual(FEATURE_TYPE type, JOYSTICK::INPUT_TYPE inputType)
-    : type(type), inputType(inputType)
+    : type(type),
+      inputType(inputType)
   {
   }
 
@@ -57,7 +58,8 @@ struct FeatureTypeEqual
 const ControllerPtr CController::EmptyPtr;
 
 CController::CController(const ADDON::AddonInfoPtr& addonInfo)
-  : CAddon(addonInfo, ADDON::AddonType::GAME_CONTROLLER), m_layout(new CControllerLayout)
+  : CAddon(addonInfo, ADDON::AddonType::GAME_CONTROLLER),
+    m_layout(new CControllerLayout)
 {
 }
 

--- a/xbmc/games/controllers/guicontrols/GUIFeatureButton.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIFeatureButton.cpp
@@ -24,7 +24,9 @@ CGUIFeatureButton::CGUIFeatureButton(const CGUIButtonControl& buttonTemplate,
                                      IConfigurationWizard* wizard,
                                      const CPhysicalFeature& feature,
                                      unsigned int index)
-  : CGUIButtonControl(buttonTemplate), m_feature(feature), m_wizard(wizard)
+  : CGUIButtonControl(buttonTemplate),
+    m_feature(feature),
+    m_wizard(wizard)
 {
   // Initialize CGUIButtonControl
   SetLabel(m_feature.Label());

--- a/xbmc/games/controllers/guicontrols/GUIGameControllerList.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIGameControllerList.cpp
@@ -47,7 +47,8 @@ CGUIGameControllerList::CGUIGameControllerList(int parentID,
 }
 
 CGUIGameControllerList::CGUIGameControllerList(const CGUIGameControllerList& other)
-  : CGUIListContainer(other), m_alignment(other.m_alignment)
+  : CGUIListContainer(other),
+    m_alignment(other.m_alignment)
 {
   // Initialize CGUIControl
   ControlType = GUICONTROL_GAMECONTROLLERLIST;

--- a/xbmc/games/controllers/input/DefaultButtonMap.cpp
+++ b/xbmc/games/controllers/input/DefaultButtonMap.cpp
@@ -20,7 +20,8 @@ using namespace KODI;
 using namespace GAME;
 
 CDefaultButtonMap::CDefaultButtonMap(PERIPHERALS::CPeripheral* device, std::string strControllerId)
-  : m_device(device), m_strControllerId(std::move(strControllerId))
+  : m_device(device),
+    m_strControllerId(std::move(strControllerId))
 {
 }
 

--- a/xbmc/games/controllers/input/PhysicalTopology.cpp
+++ b/xbmc/games/controllers/input/PhysicalTopology.cpp
@@ -21,7 +21,8 @@ using namespace KODI;
 using namespace GAME;
 
 CPhysicalTopology::CPhysicalTopology(bool bProvidesInput, std::vector<CPhysicalPort> ports)
-  : m_bProvidesInput(bProvidesInput), m_ports(std::move(ports))
+  : m_bProvidesInput(bProvidesInput),
+    m_ports(std::move(ports))
 {
 }
 

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -43,7 +43,8 @@ constexpr auto POST_MAPPING_WAIT_TIME_MS = 5000ms;
 } // namespace
 
 CGUIConfigurationWizard::CGUIConfigurationWizard()
-  : CThread("GUIConfigurationWizard"), m_actionMap(new KEYMAP::CKeyboardActionMap)
+  : CThread("GUIConfigurationWizard"),
+    m_actionMap(new KEYMAP::CKeyboardActionMap)
 {
   InitializeState();
 }

--- a/xbmc/games/controllers/windows/GUIFeatureList.cpp
+++ b/xbmc/games/controllers/windows/GUIFeatureList.cpp
@@ -29,7 +29,9 @@ using namespace KODI;
 using namespace GAME;
 
 CGUIFeatureList::CGUIFeatureList(CGUIWindow* window, GameClientPtr gameClient)
-  : m_window(window), m_gameClient(std::move(gameClient)), m_wizard(new CGUIConfigurationWizard)
+  : m_window(window),
+    m_gameClient(std::move(gameClient)),
+    m_wizard(new CGUIConfigurationWizard)
 {
 }
 

--- a/xbmc/games/dialogs/osd/DialogGameOSD.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameOSD.cpp
@@ -20,7 +20,8 @@ using namespace KODI;
 using namespace GAME;
 
 CDialogGameOSD::CDialogGameOSD()
-  : CGUIDialog(WINDOW_DIALOG_GAME_OSD, "GameOSD.xml"), m_helpDialog(new CDialogGameOSDHelp(*this))
+  : CGUIDialog(WINDOW_DIALOG_GAME_OSD, "GameOSD.xml"),
+    m_helpDialog(new CDialogGameOSDHelp(*this))
 {
   // Initialize CGUIWindow
   m_loadType = KEEP_IN_MEMORY;

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
@@ -50,7 +50,8 @@ CFileItemPtr CreateNewSaveItem()
 } // namespace
 
 CDialogInGameSaves::CDialogInGameSaves()
-  : CDialogGameVideoSelect(WINDOW_DIALOG_IN_GAME_SAVES), m_newSaveItem(CreateNewSaveItem())
+  : CDialogGameVideoSelect(WINDOW_DIALOG_IN_GAME_SAVES),
+    m_newSaveItem(CreateNewSaveItem())
 {
 }
 

--- a/xbmc/games/ports/input/PhysicalPort.cpp
+++ b/xbmc/games/ports/input/PhysicalPort.cpp
@@ -22,7 +22,8 @@ using namespace KODI;
 using namespace GAME;
 
 CPhysicalPort::CPhysicalPort(std::string portId, std::vector<std::string> accepts)
-  : m_portId(std::move(portId)), m_accepts(std::move(accepts))
+  : m_portId(std::move(portId)),
+    m_accepts(std::move(accepts))
 {
 }
 

--- a/xbmc/input/joysticks/DeadzoneFilter.cpp
+++ b/xbmc/input/joysticks/DeadzoneFilter.cpp
@@ -29,7 +29,8 @@ const char* CDeadzoneFilter::SETTING_LEFT_STICK_DEADZONE = "left_stick_deadzone"
 const char* CDeadzoneFilter::SETTING_RIGHT_STICK_DEADZONE = "right_stick_deadzone";
 
 CDeadzoneFilter::CDeadzoneFilter(IButtonMap* buttonMap, PERIPHERALS::CPeripheral* peripheral)
-  : m_buttonMap(buttonMap), m_peripheral(peripheral)
+  : m_buttonMap(buttonMap),
+    m_peripheral(peripheral)
 {
   if (m_buttonMap->ControllerID() != GAME::DEFAULT_CONTROLLER_ID)
     CLog::Log(LOGERROR, "ERROR: Must use default controller profile instead of {}",

--- a/xbmc/input/joysticks/DriverPrimitive.cpp
+++ b/xbmc/input/joysticks/DriverPrimitive.cpp
@@ -19,12 +19,15 @@ using namespace JOYSTICK;
 CDriverPrimitive::CDriverPrimitive(void) = default;
 
 CDriverPrimitive::CDriverPrimitive(PRIMITIVE_TYPE type, unsigned int index)
-  : m_type(type), m_driverIndex(index)
+  : m_type(type),
+    m_driverIndex(index)
 {
 }
 
 CDriverPrimitive::CDriverPrimitive(unsigned int hatIndex, HAT_DIRECTION direction)
-  : m_type(PRIMITIVE_TYPE::HAT), m_driverIndex(hatIndex), m_hatDirection(direction)
+  : m_type(PRIMITIVE_TYPE::HAT),
+    m_driverIndex(hatIndex),
+    m_hatDirection(direction)
 {
 }
 
@@ -41,17 +44,20 @@ CDriverPrimitive::CDriverPrimitive(unsigned int axisIndex,
 }
 
 CDriverPrimitive::CDriverPrimitive(XBMCKey keycode)
-  : m_type(PRIMITIVE_TYPE::KEY), m_keycode(keycode)
+  : m_type(PRIMITIVE_TYPE::KEY),
+    m_keycode(keycode)
 {
 }
 
 CDriverPrimitive::CDriverPrimitive(MOUSE::BUTTON_ID index)
-  : m_type(PRIMITIVE_TYPE::MOUSE_BUTTON), m_driverIndex(static_cast<unsigned int>(index))
+  : m_type(PRIMITIVE_TYPE::MOUSE_BUTTON),
+    m_driverIndex(static_cast<unsigned int>(index))
 {
 }
 
 CDriverPrimitive::CDriverPrimitive(RELATIVE_POINTER_DIRECTION direction)
-  : m_type(PRIMITIVE_TYPE::RELATIVE_POINTER), m_pointerDirection(direction)
+  : m_type(PRIMITIVE_TYPE::RELATIVE_POINTER),
+    m_pointerDirection(direction)
 {
 }
 

--- a/xbmc/input/joysticks/RumbleGenerator.cpp
+++ b/xbmc/input/joysticks/RumbleGenerator.cpp
@@ -31,7 +31,8 @@ using namespace KODI;
 using namespace JOYSTICK;
 
 CRumbleGenerator::CRumbleGenerator()
-  : CThread("RumbleGenerator"), m_motors(GetMotors(ControllerID()))
+  : CThread("RumbleGenerator"),
+    m_motors(GetMotors(ControllerID()))
 {
 }
 

--- a/xbmc/input/joysticks/generic/DriverReceiving.cpp
+++ b/xbmc/input/joysticks/generic/DriverReceiving.cpp
@@ -16,7 +16,8 @@ using namespace KODI;
 using namespace JOYSTICK;
 
 CDriverReceiving::CDriverReceiving(IDriverReceiver* receiver, IButtonMap* buttonMap)
-  : m_receiver(receiver), m_buttonMap(buttonMap)
+  : m_receiver(receiver),
+    m_buttonMap(buttonMap)
 {
 }
 

--- a/xbmc/input/joysticks/generic/InputHandling.cpp
+++ b/xbmc/input/joysticks/generic/InputHandling.cpp
@@ -25,7 +25,8 @@ using namespace JOYSTICK;
 CGUIDialogNewJoystick* const CInputHandling::m_dialog = new CGUIDialogNewJoystick;
 
 CInputHandling::CInputHandling(IInputHandler* handler, IButtonMap* buttonMap)
-  : m_handler(handler), m_buttonMap(buttonMap)
+  : m_handler(handler),
+    m_buttonMap(buttonMap)
 {
 }
 

--- a/xbmc/input/joysticks/mapping/AxisDetector.cpp
+++ b/xbmc/input/joysticks/mapping/AxisDetector.cpp
@@ -25,7 +25,9 @@ constexpr unsigned int TRIGGER_DELAY_MS = 200;
 CAxisDetector::CAxisDetector(CButtonMapping* buttonMapping,
                              unsigned int axisIndex,
                              const AxisConfiguration& config)
-  : CPrimitiveDetector(buttonMapping), m_axisIndex(axisIndex), m_config(config)
+  : CPrimitiveDetector(buttonMapping),
+    m_axisIndex(axisIndex),
+    m_config(config)
 {
 }
 

--- a/xbmc/input/joysticks/mapping/ButtonDetector.cpp
+++ b/xbmc/input/joysticks/mapping/ButtonDetector.cpp
@@ -14,7 +14,8 @@ using namespace KODI;
 using namespace JOYSTICK;
 
 CButtonDetector::CButtonDetector(CButtonMapping* buttonMapping, unsigned int buttonIndex)
-  : CPrimitiveDetector(buttonMapping), m_buttonIndex(buttonIndex)
+  : CPrimitiveDetector(buttonMapping),
+    m_buttonIndex(buttonIndex)
 {
 }
 

--- a/xbmc/input/joysticks/mapping/ButtonMapping.cpp
+++ b/xbmc/input/joysticks/mapping/ButtonMapping.cpp
@@ -37,7 +37,9 @@ constexpr unsigned int MAPPING_COOLDOWN_MS = 50;
 CButtonMapping::CButtonMapping(IButtonMapper* buttonMapper,
                                IButtonMap* buttonMap,
                                KEYMAP::IKeymap* keymap)
-  : m_buttonMapper(buttonMapper), m_buttonMap(buttonMap), m_keymap(keymap)
+  : m_buttonMapper(buttonMapper),
+    m_buttonMap(buttonMap),
+    m_keymap(keymap)
 {
   assert(m_buttonMapper != nullptr);
   assert(m_buttonMap != nullptr);

--- a/xbmc/input/joysticks/mapping/HatDetector.cpp
+++ b/xbmc/input/joysticks/mapping/HatDetector.cpp
@@ -14,7 +14,8 @@ using namespace KODI;
 using namespace JOYSTICK;
 
 CHatDetector::CHatDetector(CButtonMapping* buttonMapping, unsigned int hatIndex)
-  : CPrimitiveDetector(buttonMapping), m_hatIndex(hatIndex)
+  : CPrimitiveDetector(buttonMapping),
+    m_hatIndex(hatIndex)
 {
 }
 

--- a/xbmc/input/joysticks/mapping/KeyDetector.cpp
+++ b/xbmc/input/joysticks/mapping/KeyDetector.cpp
@@ -14,7 +14,8 @@ using namespace KODI;
 using namespace JOYSTICK;
 
 CKeyDetector::CKeyDetector(CButtonMapping* buttonMapping, XBMCKey keycode)
-  : CPrimitiveDetector(buttonMapping), m_keycode(keycode)
+  : CPrimitiveDetector(buttonMapping),
+    m_keycode(keycode)
 {
 }
 

--- a/xbmc/input/joysticks/mapping/MouseButtonDetector.cpp
+++ b/xbmc/input/joysticks/mapping/MouseButtonDetector.cpp
@@ -15,7 +15,8 @@ using namespace JOYSTICK;
 
 CMouseButtonDetector::CMouseButtonDetector(CButtonMapping* buttonMapping,
                                            MOUSE::BUTTON_ID buttonIndex)
-  : CPrimitiveDetector(buttonMapping), m_buttonIndex(buttonIndex)
+  : CPrimitiveDetector(buttonMapping),
+    m_buttonIndex(buttonIndex)
 {
 }
 

--- a/xbmc/input/keyboard/generic/DefaultKeyboardHandling.cpp
+++ b/xbmc/input/keyboard/generic/DefaultKeyboardHandling.cpp
@@ -19,7 +19,8 @@ using namespace KEYBOARD;
 
 CDefaultKeyboardHandling::CDefaultKeyboardHandling(PERIPHERALS::CPeripheral* peripheral,
                                                    IKeyboardInputHandler* handler)
-  : m_peripheral(peripheral), m_inputHandler(handler)
+  : m_peripheral(peripheral),
+    m_inputHandler(handler)
 {
 }
 

--- a/xbmc/input/keyboard/generic/KeyboardInputHandling.cpp
+++ b/xbmc/input/keyboard/generic/KeyboardInputHandling.cpp
@@ -18,7 +18,8 @@ using namespace KEYBOARD;
 
 CKeyboardInputHandling::CKeyboardInputHandling(IKeyboardInputHandler* handler,
                                                JOYSTICK::IButtonMap* buttonMap)
-  : m_handler(handler), m_buttonMap(buttonMap)
+  : m_handler(handler),
+    m_buttonMap(buttonMap)
 {
 }
 

--- a/xbmc/input/keymaps/Keymap.cpp
+++ b/xbmc/input/keymaps/Keymap.cpp
@@ -14,7 +14,8 @@ using namespace KODI;
 using namespace KEYMAP;
 
 CKeymap::CKeymap(std::shared_ptr<const IWindowKeymap> keymap, const IKeymapEnvironment* environment)
-  : m_keymap(std::move(keymap)), m_environment(environment)
+  : m_keymap(std::move(keymap)),
+    m_environment(environment)
 {
 }
 

--- a/xbmc/input/keymaps/joysticks/KeymapHandler.cpp
+++ b/xbmc/input/keymaps/joysticks/KeymapHandler.cpp
@@ -29,7 +29,8 @@ using namespace JOYSTICK;
 using namespace KEYMAP;
 
 CKeymapHandler::CKeymapHandler(ACTION::IActionListener* actionHandler, const IKeymap* keymap)
-  : m_actionHandler(actionHandler), m_keymap(keymap)
+  : m_actionHandler(actionHandler),
+    m_keymap(keymap)
 {
   assert(m_actionHandler != nullptr);
   assert(m_keymap != nullptr);

--- a/xbmc/input/keymaps/joysticks/KeymapHandling.cpp
+++ b/xbmc/input/keymaps/joysticks/KeymapHandling.cpp
@@ -25,7 +25,9 @@ using namespace KEYMAP;
 CKeymapHandling::CKeymapHandling(JOYSTICK::IInputProvider* inputProvider,
                                  bool pPromiscuous,
                                  const IKeymapEnvironment* environment)
-  : m_inputProvider(inputProvider), m_pPromiscuous(pPromiscuous), m_environment(environment)
+  : m_inputProvider(inputProvider),
+    m_pPromiscuous(pPromiscuous),
+    m_environment(environment)
 {
   LoadKeymaps();
   CServiceBroker::GetInputManager().RegisterObserver(this);

--- a/xbmc/input/mouse/MouseEvent.h
+++ b/xbmc/input/mouse/MouseEvent.h
@@ -21,7 +21,10 @@ class CMouseEvent
 {
 public:
   CMouseEvent(int actionID, int state = 0, float offsetX = 0, float offsetY = 0)
-    : m_id(actionID), m_state(state), m_offsetX(offsetX), m_offsetY(offsetY)
+    : m_id(actionID),
+      m_state(state),
+      m_offsetX(offsetX),
+      m_offsetY(offsetY)
   {
   }
 

--- a/xbmc/input/mouse/generic/DefaultMouseHandling.cpp
+++ b/xbmc/input/mouse/generic/DefaultMouseHandling.cpp
@@ -17,7 +17,8 @@ using namespace MOUSE;
 
 CDefaultMouseHandling::CDefaultMouseHandling(PERIPHERALS::CPeripheral* peripheral,
                                              IMouseInputHandler* handler)
-  : m_peripheral(peripheral), m_inputHandler(handler)
+  : m_peripheral(peripheral),
+    m_inputHandler(handler)
 {
 }
 

--- a/xbmc/input/mouse/generic/MouseInputHandling.cpp
+++ b/xbmc/input/mouse/generic/MouseInputHandling.cpp
@@ -17,7 +17,8 @@ using namespace MOUSE;
 
 CMouseInputHandling::CMouseInputHandling(IMouseInputHandler* handler,
                                          JOYSTICK::IButtonMap* buttonMap)
-  : m_handler(handler), m_buttonMap(buttonMap)
+  : m_handler(handler),
+    m_buttonMap(buttonMap)
 {
 }
 

--- a/xbmc/peripherals/PeripheralTypes.h
+++ b/xbmc/peripherals/PeripheralTypes.h
@@ -327,7 +327,8 @@ class PeripheralScanResult
 {
 public:
   explicit PeripheralScanResult(const PeripheralBusType busType)
-    : m_busType(busType), m_mappedBusType(busType)
+    : m_busType(busType),
+      m_mappedBusType(busType)
   {
   }
 

--- a/xbmc/peripherals/addons/AddonButtonMap.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMap.cpp
@@ -27,7 +27,10 @@ CAddonButtonMap::CAddonButtonMap(CPeripheral* device,
                                  const std::weak_ptr<CPeripheralAddon>& addon,
                                  const std::string& strControllerId,
                                  CPeripherals& manager)
-  : m_device(device), m_addon(addon), m_strControllerId(strControllerId), m_manager(manager)
+  : m_device(device),
+    m_addon(addon),
+    m_strControllerId(strControllerId),
+    m_manager(manager)
 {
   auto peripheralAddon = m_addon.lock();
   assert(peripheralAddon != nullptr);

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -52,7 +52,8 @@ using namespace XFILE;
 #endif
 
 CPeripheralAddon::CPeripheralAddon(const ADDON::AddonInfoPtr& addonInfo, CPeripherals& manager)
-  : IAddonInstanceHandler(ADDON_INSTANCE_PERIPHERAL, addonInfo), m_manager(manager)
+  : IAddonInstanceHandler(ADDON_INSTANCE_PERIPHERAL, addonInfo),
+    m_manager(manager)
 {
   m_bProvidesJoysticks =
       addonInfo->Type(ADDON::AddonType::PERIPHERALDLL)->GetValue("@provides_joysticks").asBoolean();

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -67,7 +67,9 @@ using namespace std::chrono_literals;
 CPeripheralCecAdapter::CPeripheralCecAdapter(CPeripherals& manager,
                                              const PeripheralScanResult& scanResult,
                                              CPeripheralBus* bus)
-  : CPeripheralHID(manager, scanResult, bus), CThread("CECAdapter"), m_cecAdapter(NULL)
+  : CPeripheralHID(manager, scanResult, bus),
+    CThread("CECAdapter"),
+    m_cecAdapter(NULL)
 {
   ResetMembers();
   m_features.push_back(FEATURE_CEC);
@@ -1525,7 +1527,9 @@ bool CPeripheralCecAdapter::WriteLogicalAddresses(const cec_logical_addresses& a
 
 CPeripheralCecAdapterUpdateThread::CPeripheralCecAdapterUpdateThread(
     CPeripheralCecAdapter* adapter, libcec_configuration* configuration)
-  : CThread("CECAdapterUpdate"), m_adapter(adapter), m_configuration(*configuration)
+  : CThread("CECAdapterUpdate"),
+    m_adapter(adapter),
+    m_configuration(*configuration)
 {
   m_nextConfiguration.Clear();
   m_event.Reset();

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -39,7 +39,8 @@ using namespace PERIPHERALS;
 CPeripheralJoystick::CPeripheralJoystick(CPeripherals& manager,
                                          const PeripheralScanResult& scanResult,
                                          CPeripheralBus* bus)
-  : CPeripheral(manager, scanResult, bus), m_rumbleGenerator(new CRumbleGenerator)
+  : CPeripheral(manager, scanResult, bus),
+    m_rumbleGenerator(new CRumbleGenerator)
 {
   m_features.push_back(FEATURE_JOYSTICK);
   // FEATURE_RUMBLE conditionally added via SetMotorCount()

--- a/xbmc/peripherals/events/EventScanner.cpp
+++ b/xbmc/peripherals/events/EventScanner.cpp
@@ -24,7 +24,8 @@ using namespace PERIPHERALS;
 #define WATCHDOG_TIMEOUT_MS 80
 
 CEventScanner::CEventScanner(IEventScannerCallback& callback)
-  : CThread("PeripEventScan"), m_callback(callback)
+  : CThread("PeripEventScan"),
+    m_callback(callback)
 {
 }
 


### PR DESCRIPTION
## Description

As title says, this applies clang-format to my codeowners code.

Formatted with the command:

```bash
clang-format-18 -style=file -i \
  $(find \
    xbmc/addons/kodi-dev-kit \
    xbmc/cores/Retro* \
    xbmc/games \
    xbmc/guilib/GUIControlFactory.* \
    xbmc/input \
    xbmc/peripherals \
    xbmc/platform/android/peripherals \
    xbmc/ServiceBroker.* \
    xbmc/ServiceManager.* \
      -name '*.cpp' -o -name '*.h' \
  )
```

## Motivation and context

Working on https://github.com/xbmc/xbmc/pull/21183 and my format command leaves dirty files.

## How has this been tested?

Compiles successfully. Runtime tested on smart displays around the apartment.

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
