### PR TITLE
[Video][Android] Adaptive Frame Sync (AFS) – scaffold & design (no behavior change)

### DIFF
--- a/xbmc/cores/VideoPlayer/AdaptiveFrameSync.h.
+++ b/xbmc/cores/VideoPlayer/AdaptiveFrameSync.h.
@@ -1,0 +1,26 @@
+#pragma once
+#include <string>
+
+namespace KODI {
+namespace VIDEO {
+
+enum class AFSPolicy { TRUE_MATCH, EXACT_MULTIPLE, NEAR_MULTIPLE, SMOOTH_SYNC, DISABLED };
+
+struct AFSProbe {
+  bool displayHasNative24 = false;
+  bool displayHas120 = false;
+  bool passthroughPossible = false;
+  double contentFps = 0.0;
+  std::string device; // manufacturer/model (best-effort)
+};
+
+class AdaptiveFrameSync {
+public:
+  static bool IsEnabled();                 // temporary: off by default
+  static AFSProbe ProbeCapabilities();     // stub
+  static AFSPolicy SelectPolicy(const AFSProbe& p);
+  static void LogDecision(const AFSProbe& p, AFSPolicy policy);
+};
+
+} // namespace VIDEO
+} // namespace KODI

--- a/xbmc/cores/VideoPlayer/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES AudioSinkAE.cpp
             PTSTracker.cpp
             Edl.cpp
             VideoPlayer.cpp
+            AdaptiveFrameSync.cpp
             VideoPlayerAudio.cpp
             VideoPlayerAudioID3.cpp
             VideoPlayerRadioRDS.cpp
@@ -30,6 +31,7 @@ set(HEADERS AudioSinkAE.h
             IVideoPlayer.h
             PTSTracker.h
             VideoPlayer.h
+            AdaptiveFrameSync.h
             VideoPlayerAudio.h
             VideoPlayerAudioID3.h
             VideoPlayerRadioRDS.h

--- a/xbmc/cores/VideoPlayer/xbmc/cores/VideoPlayer/AdaptiveFrameSync.cpp
+++ b/xbmc/cores/VideoPlayer/xbmc/cores/VideoPlayer/AdaptiveFrameSync.cpp
@@ -1,0 +1,55 @@
+#include "AdaptiveFrameSync.h"
+#include "utils/log.h"
+
+#ifdef TARGET_ANDROID
+#include <android/api-level.h>
+#endif
+
+using namespace KODI::VIDEO;
+
+bool AdaptiveFrameSync::IsEnabled()
+{
+  // Draft: hardcode false for now. We'll hook to a real setting later.
+  return false;
+}
+
+AFSProbe AdaptiveFrameSync::ProbeCapabilities()
+{
+  AFSProbe p;
+#ifdef TARGET_ANDROID
+  // TODO: query DisplayManager/SurfaceFlinger via JNI for real modes
+  // Stub values to prove the pipeline and logs work
+  p.displayHasNative24 = false;
+  p.displayHas120 = true;
+  p.device = "Android-Stub";
+#else
+  p.device = "Non-Android";
+#endif
+  p.passthroughPossible = true; // optimistic default
+  return p;
+}
+
+AFSPolicy AdaptiveFrameSync::SelectPolicy(const AFSProbe& p)
+{
+  if (!IsEnabled()) return AFSPolicy::DISABLED;
+  if (p.displayHasNative24) return AFSPolicy::TRUE_MATCH;
+  if (p.displayHas120)      return AFSPolicy::EXACT_MULTIPLE;
+  return AFSPolicy::NEAR_MULTIPLE;
+}
+
+void AdaptiveFrameSync::LogDecision(const AFSProbe& p, AFSPolicy policy)
+{
+  const char* name = "DISABLED";
+  switch (policy)
+  {
+    case AFSPolicy::TRUE_MATCH:     name = "TRUE_MATCH"; break;
+    case AFSPolicy::EXACT_MULTIPLE: name = "EXACT_MULTIPLE"; break;
+    case AFSPolicy::NEAR_MULTIPLE:  name = "NEAR_MULTIPLE"; break;
+    case AFSPolicy::SMOOTH_SYNC:    name = "SMOOTH_SYNC"; break;
+    case AFSPolicy::DISABLED:       name = "DISABLED"; break;
+  }
+
+  CLog::Log(LOGINFO,
+            "AFS: device='{}' native24={} 120hz={} passthrough={} -> policy={}",
+            p.device, p.displayHasNative24, p.displayHas120, p.passthroughPossible, name);
+}


### PR DESCRIPTION
## Description
This PR introduces scaffolding for Adaptive Frame Sync (AFS), a proposed improvement to Kodi’s refresh/sync behavior on Android.

## Problem
On many Android TVs/boxes, Kodi can’t reliably switch to the content’s native refresh rate (23.976/24p), which causes visible judder. The current fallback, “Sync playback to display,” fixes judder but disables audio passthrough, forcing users to choose between smooth video or bitstream audio.

## Proposal: Adaptive Frame Sync (AFS)
Add a small policy engine that probes display/audio capabilities at playback start and automatically picks the best strategy.

**Policy ladder**
- **A) TRUE_MATCH** — Request native 23.976/24 Hz when exposed by the OS (keep passthrough).
- **B) EXACT_MULTIPLE** — Use 120/48 Hz with frame doubling/tripling, VSYNC-locked (keep passthrough).
- **C) NEAR_MULTIPLE** — If stuck at 60 Hz, use a cadence planner phase-locked to VSYNC for predictable repeats (keep passthrough).
- **D) SMOOTH_SYNC** — Last resort: enable current “Sync playback to display” (disables passthrough) only if A–C aren’t possible.

**Vendor profiles**
Ship JSON hints for known devices (e.g., certain Hisense Android TVs or Amlogic variants) to steer defaults without hardcoding per-device hacks in core.

## This PR (scaffold only)
- Adds `xbmc/cores/VideoPlayer/AdaptiveFrameSync.h` and `.cpp` with stubs for:
  - `ProbeCapabilities()`
  - `SelectPolicy(...)`
  - `LogDecision(...)`
- Updates `CMakeLists.txt` to build new code.
- No runtime behavior changes; `IsEnabled()` returns `false`.
- Goal: agree on placement/architecture before wiring real probes and switching.

## Planned follow-ups (separate PRs after feedback)
- Android capability probe (DisplayManager/SurfaceFlinger via JNI; AudioTrack passthrough check).
- GUI setting: “Adaptive Frame Sync (Auto/Off)” under Player → Videos.
- Implement A/B/C strategies (true match, exact multiple, near multiple) without touching audio where possible.
- Optional: integrate D-tier by cleanly invoking the existing “Sync playback to display” path with clearer UX.

## Testing plan
- **Clips:** 23.976/24/25/29.97/50/59.94 (H.264/HEVC/AV1; SDR/HDR).
- **Devices:** Hisense Android TV, Nvidia Shield, Fire TV 4K, Amlogic S905X3/X4.
- **Acceptance:** AFS chooses the expected tier; passthrough preserved for A/B/C; D only when necessary; no drift on 30+ minutes of 23.976 @ 60 Hz with cadence planner.


