### PR TITLE
[PVR] Add missing default values to advancedsettings.xml for pvrrecordings 

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -22,6 +22,7 @@
 #include "settings/lib/SettingsManager.h"
 #include "utils/FileUtils.h"
 #include "utils/LangCodeExpander.h"
+#include "utils/Set.h"
 #include "utils/StringUtils.h"
 #include "utils/SystemInfo.h"
 #include "utils/URIUtils.h"
@@ -1190,16 +1191,19 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     {
       const char* XML_SORTMETHOD = "sortmethod";
       const char* XML_SORTORDER = "sortorder";
-      int sortMethod;
-      // ignore SortByTime for duration defaults
-      if (XMLUtils::GetInt(pSortDecription, XML_SORTMETHOD, sortMethod, SortByLabel, SortByFile))
+      int sortMethod = static_cast<int>(SortByNone);
+      static constexpr CSet validSortMethods{SortByLabel, SortByDate,          SortBySize,
+                                             SortByFile,  SortByEpisodeNumber, SortByProvider};
+      XMLUtils::GetInt(pSortDecription, XML_SORTMETHOD, sortMethod, static_cast<int>(SortByNone),
+                       static_cast<int>(SortByUserPreference));
+      if (validSortMethods.contains(static_cast<SortBy>(sortMethod)))
       {
         int sortOrder;
         if (XMLUtils::GetInt(pSortDecription, XML_SORTORDER, sortOrder, SortOrderAscending,
                              SortOrderDescending))
         {
-          m_PVRDefaultSortOrder.sortBy = (SortBy)sortMethod;
-          m_PVRDefaultSortOrder.sortOrder = (SortOrder)sortOrder;
+          m_PVRDefaultSortOrder.sortBy = static_cast<SortBy>(sortMethod);
+          m_PVRDefaultSortOrder.sortOrder = static_cast<SortOrder>(sortOrder);
         }
       }
     }


### PR DESCRIPTION
## Description
This PR adds SortByEpisodeNumber and SortByProvider to the supported values in the addvancedsettings.xml  sortmethod override for pvrrecordings.
<!--- Describe your change in detail here. -->

Current logic used the range of 1-4  as allowed values for sorthmethod.  The new  logic check of set of all the sortmethods for pvr recordings, adding 23 and 58

Removed incorrect logic of setting value 4 (SortByFile)  when the advancedsettings value was higher than for 4

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
User are unable to set Episode Number or Provider sort default values in advancedsettings.xml

<!--- If it fixes an open issue, please link to the issue here. -->

Discussed on the forum here https://forum.kodi.tv/showthread.php?tid=382847

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
Tested setting values all values.  If <pvrrecordings /> was not found the -1 value is not contained in the set .
<!--- Include details of your testing environment, and the tests you ran to -->
Cannot test sort by provider but the GUI did change
<!--- see how your change affects other areas of the code, etc. -->
The new default values were visible in the Estuary GUI.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
Users can set the default sort for any recording group and not relay on a parent default, freeing up flexibility on the root directory sort
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly

The wiki for the setting https://kodi.wiki/view/Advancedsettings.xml#pvrrecordings  needs to change to

```
<sortmethod>2</sortmethod>  <!-- 1=Name 2=Date 3=Size 4=File  23=Episode 58=Provider-->
```

- [ X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X ] All new and existing tests passed
