### PR TITLE
webOS: add missing parameter to Supports check for secure audio

### DIFF
--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
@@ -269,7 +269,7 @@ bool CMediaPipelineWebOS::OpenAudioStream(CDVDStreamInfo& audioHint)
       m_processInfo.SetAudioChannels(CAEUtil::GetAEChannelLayout(audioHint.channellayout));
       m_processInfo.SetAudioSampleRate(audioHint.samplerate);
       m_processInfo.SetAudioBitsPerSample(audioHint.bitspersample);
-      if (Supports(audioHint.codec, audioHint.cryptoSession != nullptr))
+      if (Supports(audioHint.codec, audioHint.profile, audioHint.cryptoSession != nullptr))
         m_processInfo.SetAudioDecoderName("starfish-" +
                                           std::string(ms_codecMap.at(audioHint.codec).name));
       else if (m_audioEncoder)
@@ -694,7 +694,7 @@ bool CMediaPipelineWebOS::Load(CDVDStreamInfo videoHint, CDVDStreamInfo audioHin
       m_processInfo.SetAudioChannels(CAEUtil::GuessChLayout(audioHint.channels));
     m_processInfo.SetAudioSampleRate(audioHint.samplerate);
     m_processInfo.SetAudioBitsPerSample(audioHint.bitspersample);
-    if (Supports(audioHint.codec, audioHint.cryptoSession != nullptr))
+    if (Supports(audioHint.codec, audioHint.profile, audioHint.cryptoSession != nullptr))
       m_processInfo.SetAudioDecoderName(std::string("starfish-") +
                                         std::string(ms_codecMap.at(audioHint.codec).name));
     else if (m_audioEncoder)
@@ -736,7 +736,7 @@ std::string CMediaPipelineWebOS::SetupAudio(CDVDStreamInfo& audioHint, CVariant&
   m_encoderBuffers = nullptr;
 
   std::string codecName = "AC3";
-  if (!Supports(audioHint.codec, audioHint.cryptoSession != nullptr))
+  if (!Supports(audioHint.codec, audioHint.profile, audioHint.cryptoSession != nullptr))
   {
     m_audioCodec = std::make_unique<CDVDAudioCodecFFmpeg>(m_processInfo);
     CDVDCodecOptions options;


### PR DESCRIPTION
## Description
kodi currently crashes with secure AAC audio on webOS

[This PR ](https://github.com/xbmc/xbmc/pull/27218) added codec profile as a parameter, but there was an additional 3 usages of the Support function where this was not updated.

This caused the boolean result for audioHint.cryptoSession to be mistakenly used as the second parameter, causing Supports to return the incorrect result. Instead of passing this audio stream to the media pipeline untouched it passes the audio to ffmpeg to transcode, which does not support encrypted audio, making kodi crash.

## Motivation and context
Prevents kodi crashing.

## How has this been tested?
Playback of encrypted widevine stream on webOS 25 TV using:

- ITV-X addon that has AAC audio.
- Disney+ addon that has DD 5.1+ audio

## What is the effect on users?
Allows playback without a crash with AAC audio on widevine on webOS.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [] All new and existing tests passed
