### PR TITLE
[PVR] CPVRGUIActionsTimers::EditTimer: Fix new timer created with wrong client index

### DIFF
--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
@@ -657,8 +657,7 @@ bool CPVRGUIActionsTimers::EditTimer(const CFileItem& item) const
   }
 
   // clone the timer.
-  const auto newTimer{std::make_shared<CPVRTimerInfoTag>()};
-  newTimer->UpdateEntry(timer);
+  const std::shared_ptr<CPVRTimerInfoTag> newTimer{CPVRTimerInfoTag::CreateFromTimer(timer)};
 
   if (ShowTimerSettings(newTimer) &&
       (!timer->GetTimerType()->IsReadOnly() || timer->GetTimerType()->SupportsEnableDisable()))

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -764,6 +764,15 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateTimerTag(
   return CreateFromDate(channel, start, iDuration, false);
 }
 
+std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateFromTimer(
+    const std::shared_ptr<CPVRTimerInfoTag>& tag)
+{
+  auto newTimer{std::make_shared<CPVRTimerInfoTag>()};
+  newTimer->UpdateEntry(tag);
+  newTimer->m_iClientIndex = PVR_TIMER_NO_CLIENT_INDEX;
+  return newTimer;
+}
+
 std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateFromDate(
     const std::shared_ptr<CPVRChannel>& channel,
     const CDateTime& start,

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -93,6 +93,14 @@ public:
                                                          bool bCreateRule = false);
 
   /*!
+   * @brief create a timer from the given timer.
+   * @param tag the timer
+   * @return the timer or null if timer could not be created
+   */
+  static std::shared_ptr<CPVRTimerInfoTag> CreateFromTimer(
+      const std::shared_ptr<CPVRTimerInfoTag>& tag);
+
+  /*!
    * @brief create a reminder timer for the given start date.
    * @param start the start date
    * @param iDuration the duration the reminder is valid


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fixes an issue reported by @emveepee internally, where a newly created timer instance did not have `m_iClientIndex` initialized  to `PVR_TIMER_NO_CLIENT_INDEX`, which causes problems for pvr.nextpvr (maybe other add-ons are effected as well) when adding new timers.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix editing timers work.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Runtime-tested by @emveepee 

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Editing timers works.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
