### PR TITLE
Add BitstreamConverter VVC support

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -2431,7 +2431,7 @@ TRANSPORT_STREAM_STATE CDVDDemuxFFmpeg::TransportStreamVideoState()
       if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
       {
         if (idx == m_pkt.pkt.stream_index && m_pkt.pkt.dts != AV_NOPTS_VALUE &&
-            st->codecpar->extradata)
+            (st->codecpar->extradata || (st->codecpar->codec_id == AV_CODEC_ID_VVC)))
         {
           if (!m_startTime)
           {
@@ -2453,7 +2453,7 @@ TRANSPORT_STREAM_STATE CDVDDemuxFFmpeg::TransportStreamVideoState()
       if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
       {
         if (static_cast<int>(i) == m_pkt.pkt.stream_index && m_pkt.pkt.dts != AV_NOPTS_VALUE &&
-            st->codecpar->extradata)
+            (st->codecpar->extradata || (st->codecpar->codec_id == AV_CODEC_ID_VVC)))
         {
           if (!m_startTime)
           {

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -122,6 +122,7 @@ protected:
   bool IsSlice(uint8_t unit_type);
   bool BitstreamConvertInitAVC(void* in_extradata, int in_extrasize);
   bool BitstreamConvertInitHEVC(void* in_extradata, int in_extrasize);
+  bool BitstreamConvertInitVVC(void* in_extradata, int in_extrasize);
   bool BitstreamConvert(uint8_t* pData, int iSize, uint8_t** poutbuf, int* poutbuf_size);
   static void BitstreamAllocAndCopy(uint8_t** poutbuf,
                                     int* poutbuf_size,


### PR DESCRIPTION
## Description
Add BitConverter VVC support.

## Motivation and context
Make VVC streams be able to be used for hardware decoder.

## How has this been tested?
Ugoos AM9, S905X5 with VVC decoder in hardware.
Tested all container samples TS, MKV and MP4.
Sure, the underlaying codec handling needs to implemented for other platforms.
Now there is only support for Amlogic which is not part of this project.
In general it's simple open the bitstream convert by default call:
```c
      m_bitstream = new CBitstreamConverter();
      m_bitstream->Open(m_hints.codec, m_hints.extradata.GetData(), m_hints.extradata.GetSize(), true);
      if (m_hints.extradata.GetSize() == 0)
        m_bitstream->ResetStartDecode();
```

`ResetStartDecode` is need for TS where the extra data is skipped.
The converter must search for next SPS unit and set `m_start_decode` to be able to seek.
It's same behavior like h264 TS stream handling.
Other container use the codec extra data, attached in front of first packet written to the hardware decoder.
But this is might hardware dependent.

The additional commit `[DVDDemuxFFMPEG] fix codec id check for mpegts` solves a bug in in ffmpeg demuxer introduced by https://github.com/xbmc/xbmc/commit/a49156bf13ff8a33146b4e79c8f2f52b47b28be3.
On most samples the video stream isn't at index 0 so all streams must be checked by media type.

`TransportStreamVideoState` must also check `extradata_size` because if empty VVC TS stream will block forever.
This isn't the case for h264, so maybe there is a difference how the extra codec data is handled in the stream.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):
![bd23971657f9613d39f2efa8e386b7b09e1a0ae3_2_690x388](https://github.com/user-attachments/assets/88d8d473-5541-4b31-a72c-22f09a7d00ac)
![c0218e037e9e16bae6c001d28aba3ec75cfb4581_2_690x388](https://github.com/user-attachments/assets/72aa90cf-15f3-4e31-994e-8cd48f75292a)
![e647a3e1a34c6359bafa8ce00f7abb3becd5ebe3_2_690x388](https://github.com/user-attachments/assets/48f0ff7c-1a1d-4966-89cb-2c5ce71ee667)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
