### PR TITLE
[VideoPlayer] Propagate disable stream to demuxer when OpenStream fails

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3827,6 +3827,12 @@ bool CVideoPlayer::OpenStream(CCurrentStream& current, int64_t demuxerId, int iS
       CLog::Log(LOGWARNING, "{} - Unsupported stream {}. Stream disabled.", __FUNCTION__,
                 stream->uniqueId);
       stream->disabled = true;
+
+      CCurrentStream failedStream = current;
+      failedStream.id = iStream;
+      failedStream.demuxerId = demuxerId;
+      failedStream.source = source;
+      SetEnableStream(failedStream, false);
     }
   }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Propagate disable stream to demuxer when internal VP OpenStream fails

The simplest use case to reproduce the problem is avoid providing extradata in a video stream (see How has this been tested section)

What happens:
when VP open a stream and fails internally, it attempts to open another stream, but without informing the demuxer that the previously requested stream must be “closed"/disabled. So the demuxer dont know what stream should be used for the playback, so when playback starts, ISAdaptive provides the video data also for all the forgotten opened streams never closed by VP.

Since the demuxer ISAdaptive, has no way to know what happen in Kodi core internals, Kodi core must inform the demuxer that the requested stream that was trying to open must be closed, so this add the missing demuxer callback

PS:
it is worth clarifying that there may be an alternative way to avoid touch VP, but to me sound more a workaround, so that each demuxer binary addon, should check every time if VP try to open multiple times streams of same type (video/audio/subtitle), then force close the previous one, but i think that this not an appropriate solution, since forces add-ons to have a superfluous internal double-check for streams requested by VP, where a callback solve the problem in clean way.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #27120 (the second final problem, so this will close the issue)
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
the "easiest" way to test this is:
1) build ISAdaptive addon, by deleting following line:
https://github.com/xbmc/inputstream.adaptive/blob/cac7e809c5c476dc01191f2c41bc4c7290d47236/src/codechandler/AVCCodecHandler.cpp#L33
2) install the modified ISAdaptive addon
3) open ISAdaptive settings and set "Stream selection type" setting to: Manual OSD
4) play a video stream that have multiple resolutions in AVC/H264 codec
5) look at log, tons of these, each one for each video stream
```
2025-10-03 18:43:21.805 T:5328    debug <inputstream.adaptive>: GetStream(1008)
2025-10-03 18:43:21.805 T:5328    error <general>: CVideoPlayerVideo::OpenStream: Codec id 27 require extradata.
2025-10-03 18:43:21.805 T:5328  warning <general>: CVideoPlayer::OpenStream - Unsupported stream 1008. Stream disabled.
```
with this PR, for each failed stream you can see the "disable" callback, example:
`2025-10-03 19:36:54.727 T:33700   debug <inputstream.adaptive>: EnableStream(1008: false)`

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Users don't see anything, but this can have a terrible impact on bandwidth usage and memory usage
since for all failed opened streams, video packages will be downloaded, processed, and sent to VP for nothing

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
