### PR TITLE
Fix random SonarQube findings introduced since September 20 2025

### DIFF
--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -26,7 +26,7 @@ public:
 
   bool operator==(const CURL& url) const { return url.Get() == Get(); }
   // explicit equals operator for std::string comparison
-  friend bool operator==(const CURL& url, const std::string& str) { return url.Get() == str; }
+  friend bool operator==(const CURL& url, const std::string_view str) { return url.Get() == str; }
 
   void Reset();
   void Parse(std::string strURL);

--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -148,7 +148,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     if (isDir)
       URIUtils::AddSlashAtEnd(path);
 
-    auto& item = fileItems.emplace_back(std::make_shared<CFileItem>(name));
+    const auto& item = fileItems.emplace_back(std::make_shared<CFileItem>(name));
     item->SetPath(path);
     item->SetDateTime(GetDirEntryTime(st));
     item->SetFolder(isDir);
@@ -190,7 +190,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       path = URIUtils::AddFileToFolder(path, dirent->name);
       URIUtils::AddSlashAtEnd(path);
 
-      auto& item = fileItems.emplace_back(std::make_shared<CFileItem>(dirent->name));
+      const auto& item = fileItems.emplace_back(std::make_shared<CFileItem>(dirent->name));
       item->SetPath(path);
       item->SetFolder(true);
     }

--- a/xbmc/weather/WeatherJob.cpp
+++ b/xbmc/weather/WeatherJob.cpp
@@ -123,7 +123,7 @@ void FormatTemperature(std::string& text, double temp)
 class CWeatherPropertyWriter
 {
 public:
-  CWeatherPropertyWriter(CGUIWindow& window,
+  CWeatherPropertyWriter(const CGUIWindow& window,
                          CWeatherTokenLocalizer& localizer,
                          CWeatherManager::WeatherInfoV2& info)
     : m_propReader(window, localizer),


### PR DESCRIPTION
## Description
Fixing some of the SonarQube findings introduced since XXX:

Like always, no functional changes intended.

Findings addressed:
* "std::string_view" should be used to pass a read-only string to a function cpp:S6009
* Pointer and reference parameters should be "const" if the corresponding object is not modified cpp:S995
* Pointer and reference local variables should be "const" if the corresponding object is not modified cpp:S5350

## Motivation and context
Improving code quality and maintainability.

## How has this been tested?
Builds and runs.

## What is the effect on users?
Hopefully none.

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
