### PR TITLE
GL/GLES: fix (compressed) textures

### DIFF
--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -247,14 +247,15 @@ void CGLTexture::LoadToGPU()
 
   TextureFormat glFormat = GetFormatGL(m_textureFormat);
 
-  if (glFormat.format == GL_FALSE)
+  if (glFormat.internalFormat == GL_FALSE)
   {
     CLog::LogF(LOGDEBUG, "Failed to load texture. Unsupported format {}", m_textureFormat);
     m_loadedToGPU = true;
     return;
   }
 
-  if ((m_textureFormat & KD_TEX_FMT_SDR) || (m_textureFormat & KD_TEX_FMT_HDR))
+  const int formatType = m_textureFormat & KD_TEX_FMT_TYPE_MASK;
+  if (formatType == KD_TEX_FMT_SDR || formatType == KD_TEX_FMT_HDR)
   {
     glTexImage2D(GL_TEXTURE_2D, 0, glFormat.internalFormat, m_textureWidth, m_textureHeight, 0,
                  glFormat.format, glFormat.type, m_pixels);

--- a/xbmc/guilib/TextureGLES.cpp
+++ b/xbmc/guilib/TextureGLES.cpp
@@ -406,6 +406,7 @@ void CGLESTexture::SwapBlueRedSwizzle(GLint& component)
 TextureFormat CGLESTexture::GetFormatGLES20(KD_TEX_FMT textureFormat)
 {
   TextureFormat glFormat;
+  const int formatType = m_textureFormat & KD_TEX_FMT_TYPE_MASK;
 
   // GLES 2.0 does not support swizzling. But for some Kodi formats+swizzles,
   // we can map GLES formats (Luminance, Luminance-Alpha, BGRA). The swizzle
@@ -438,8 +439,8 @@ TextureFormat CGLESTexture::GetFormatGLES20(KD_TEX_FMT textureFormat)
       glFormat.format = glFormat.internalFormat = GL_RGBA;
     }
   }
-  else if (textureFormat & KD_TEX_FMT_SDR || textureFormat & KD_TEX_FMT_HDR ||
-           textureFormat & KD_TEX_FMT_ETC1)
+  else if (formatType == KD_TEX_FMT_SDR || formatType == KD_TEX_FMT_HDR ||
+           formatType == KD_TEX_FMT_ETC1)
   {
     const auto it = TextureMappingGLES20.find(textureFormat);
     if (it != TextureMappingGLES20.cend())
@@ -459,8 +460,10 @@ TextureFormat CGLESTexture::GetFormatGLES20(KD_TEX_FMT textureFormat)
 TextureFormat CGLESTexture::GetFormatGLES30(KD_TEX_FMT textureFormat)
 {
   TextureFormat glFormat;
+  const int formatType = m_textureFormat & KD_TEX_FMT_TYPE_MASK;
 
-  if (textureFormat & KD_TEX_FMT_SDR || textureFormat & KD_TEX_FMT_HDR)
+  if (formatType == KD_TEX_FMT_SDR || formatType == KD_TEX_FMT_HDR ||
+      formatType == KD_TEX_FMT_ETC1 || formatType == KD_TEX_FMT_ETC2)
   {
 #if defined(GL_ES_VERSION_3_0)
     const auto it = TextureMappingGLES30.find(textureFormat);

--- a/xbmc/guilib/TextureGLES.cpp
+++ b/xbmc/guilib/TextureGLES.cpp
@@ -313,7 +313,8 @@ void CGLESTexture::LoadToGPU()
     return;
   }
 
-  if ((m_textureFormat & KD_TEX_FMT_SDR) || (m_textureFormat & KD_TEX_FMT_HDR))
+  const int formatType = m_textureFormat & KD_TEX_FMT_TYPE_MASK;
+  if (formatType == KD_TEX_FMT_SDR || formatType == KD_TEX_FMT_HDR)
   {
     glTexImage2D(GL_TEXTURE_2D, 0, glesFormat.internalFormat, m_textureWidth, m_textureHeight, 0,
                  glesFormat.format, glesFormat.type, m_pixels);
@@ -406,7 +407,7 @@ void CGLESTexture::SwapBlueRedSwizzle(GLint& component)
 TextureFormat CGLESTexture::GetFormatGLES20(KD_TEX_FMT textureFormat)
 {
   TextureFormat glFormat;
-  const int formatType = m_textureFormat & KD_TEX_FMT_TYPE_MASK;
+  const int formatType = textureFormat & KD_TEX_FMT_TYPE_MASK;
 
   // GLES 2.0 does not support swizzling. But for some Kodi formats+swizzles,
   // we can map GLES formats (Luminance, Luminance-Alpha, BGRA). The swizzle
@@ -460,7 +461,7 @@ TextureFormat CGLESTexture::GetFormatGLES20(KD_TEX_FMT textureFormat)
 TextureFormat CGLESTexture::GetFormatGLES30(KD_TEX_FMT textureFormat)
 {
   TextureFormat glFormat;
-  const int formatType = m_textureFormat & KD_TEX_FMT_TYPE_MASK;
+  const int formatType = textureFormat & KD_TEX_FMT_TYPE_MASK;
 
   if (formatType == KD_TEX_FMT_SDR || formatType == KD_TEX_FMT_HDR ||
       formatType == KD_TEX_FMT_ETC1 || formatType == KD_TEX_FMT_ETC2)


### PR DESCRIPTION
## Description
This PR fixes support for compressed textures on GL/GLES. 

## Motivation and context
Required for having compressed textures some day. I just wanted to split a few things off the texturepacker PR.

## How has this been tested?
The UI still looks fine running GL and GLES. 

## What is the effect on users?
Basically none.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
