### PR TITLE
Actor cache

### DIFF
--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1354,6 +1354,13 @@ public:
   int AddVideoVersionType(const std::string& typeVideoVersion,
                           VideoAssetTypeOwner owner,
                           VideoAssetType assetType);
+
+  void AddCast(int mediaId, const char* mediaType, const std::vector<SActorInfo>& cast);
+  void AddCast(int mediaId,
+               const char* mediaType,
+               const std::vector<SActorInfo>& cast,
+               std::unordered_map<std::string, int>& actorCache);
+
   /*!
    * \brief Create a new video asset from the provided item and type and attach it to an owner
    * A file record is created for items with a path new to the database.
@@ -1477,8 +1484,6 @@ protected:
   void UpdateLinksToItem(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);
   void AddActorLinksToItem(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);
   void UpdateActorLinksToItem(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);
-
-  void AddCast(int mediaId, const char *mediaType, const std::vector<SActorInfo> &cast);
 
   CVideoInfoTag GetDetailsForMovie(dbiplus::Dataset& pDS, int getDetails = VideoDbDetailsNone);
   CVideoInfoTag GetDetailsForMovie(const dbiplus::sql_record* const record, int getDetails = VideoDbDetailsNone);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1991,6 +1991,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         int idShow = showInfo ? showInfo->m_iDbId : -1;
         int idEpisode = m_database.AddNewEpisode(idShow, movieDetails);
         lResult = m_database.SetDetailsForEpisode(movieDetails, art, idShow, idEpisode);
+        m_database.AddCast(lResult, "episode", movieDetails.m_cast, m_actorCache);
         movieDetails.m_iDbId = lResult;
         movieDetails.m_type = MediaTypeEpisode;
         movieDetails.m_strShowTitle = showInfo ? showInfo->m_strTitle : "";

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2832,10 +2832,10 @@ CVideoInfoScanner::~CVideoInfoScanner()
         if (!thumbUrl.m_url.empty())
         {
           const std::string thumb{CScraperUrl::GetThumbUrl(thumbUrl)};
-          const bool useThisRemoteArt{useRemoteArt != UseRemoteArtWithLocalScraper::NO ||
-                                      !URIUtils::IsRemote(thumb)};
+          const bool useThisArt{useRemoteArt != UseRemoteArtWithLocalScraper::NO ||
+                                !URIUtils::IsRemote(thumb)};
 
-          if (useThisRemoteArt)
+          if (useThisArt)
           {
             if (actor.thumb.empty())
               actor.thumb = thumb;

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -47,6 +47,12 @@ namespace KODI::VIDEO
     bool m_allExtAudio; /* treat all audio files in video directory as external tracks */
   } SScanSettings;
 
+  struct TVShowContext
+  {
+    std::unordered_map<std::string, int> actorCache{};
+    std::map<std::string, std::string> actorImageCache{};
+  };
+
   class CVideoInfoScanner : public CInfoScanner
   {
 
@@ -255,9 +261,14 @@ namespace KODI::VIDEO
      \param strPath - path on filesystem to look for local thumbs
      \param useRemoteArt - use remote art (ie. http://) even if derived from local .nfo file. Defaults to yes.
      */
+    std::map<std::string, std::string> BuildActorThumbLookup(std::string_view strPath) const;
     void FetchActorThumbs(
         std::vector<SActorInfo>& actors,
-        const std::string& strPath,
+        std::string_view strPath,
+        UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES) const;
+    void FetchActorThumbs(
+        std::vector<SActorInfo>& actors,
+        const std::map<std::string, std::string>& actorImageLookup,
         UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES) const;
 
     static int GetPathHash(const CFileItemList &items, std::string &hash);
@@ -330,6 +341,6 @@ namespace KODI::VIDEO
     std::set<int> m_pathsToClean;
     std::shared_ptr<CAdvancedSettings> m_advancedSettings;
     CVideoDatabase::ScraperCache m_scraperCache;
-    std::unordered_map<std::string, int> m_actorCache{};
+    TVShowContext m_tvshowContext;
   };
   } // namespace KODI::VIDEO

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -330,5 +330,6 @@ namespace KODI::VIDEO
     std::set<int> m_pathsToClean;
     std::shared_ptr<CAdvancedSettings> m_advancedSettings;
     CVideoDatabase::ScraperCache m_scraperCache;
+    std::unordered_map<std::string, int> m_actorCache{};
   };
   } // namespace KODI::VIDEO


### PR DESCRIPTION
## Description
During a Library scan a TV show may repeat work for each season and/or episode. This branch introduces a context object which can be used to store scan context per TV show and enable repeated work to be cached or computed ahead of time before the TV show scan has begun.

An actors id cache has been added to this context, this works best when a TV show has reoccurring actors. Storing the actor ID in this cache will prevents the scanning of each episode performing a lookup in the database for each actor.

Similar for the actor thumb. Once a thumb has been loaded the duplicate work for other episodes (in which the same actor stars) can be avoided.

Each iteration of the Library Scan loop resets the context which will clear these two caches. This is on the assumption that the cast of the next TV show will have no overlap with the previous TV show. It is also a effecient way of managing the size of the cache.

## Motivation and context
Avoiding duplicated work will reduce the duration of library scans.

## How has this been tested?
Manually scanning TV show library.
Comparing profiler instrumentation counts from before and after

## What is the effect on users?
Faster TV show library scans

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
