### PR TITLE
[VideoThumbLoader] Refactor

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2739,41 +2739,6 @@ std::string CVideoDatabase::GetValueString(const CVideoInfoTag& details,
 }
 
 //********************************************************************************************************************************
-int CVideoDatabase::SetDetailsForItem(CVideoInfoTag& details, const KODI::ART::Artwork& artwork)
-{
-  return SetDetailsForItem(details.m_iDbId, details.m_type, details, artwork);
-}
-
-int CVideoDatabase::SetDetailsForItem(int id,
-                                      MediaType_view mediaType,
-                                      CVideoInfoTag& details,
-                                      const KODI::ART::Artwork& artwork)
-{
-  if (mediaType == MediaTypeNone)
-    return -1;
-
-  if (mediaType == MediaTypeMovie)
-    return SetDetailsForMovie(details, artwork, id);
-  else if (mediaType == MediaTypeVideoCollection)
-    return SetDetailsForMovieSet(details, artwork, id);
-  else if (mediaType == MediaTypeTvShow)
-  {
-    KODI::ART::SeasonsArtwork seasonArtwork;
-    if (!UpdateDetailsForTvShow(id, details, artwork, seasonArtwork))
-      return -1;
-
-    return id;
-  }
-  else if (mediaType == MediaTypeSeason)
-    return SetDetailsForSeason(details, artwork, details.m_iIdShow, id);
-  else if (mediaType == MediaTypeEpisode)
-    return SetDetailsForEpisode(details, artwork, details.m_iIdShow, id);
-  else if (mediaType == MediaTypeMusicVideo)
-    return SetDetailsForMusicVideo(details, artwork, id);
-
-  return -1;
-}
-
 int CVideoDatabase::SetDetailsForMovie(CVideoInfoTag& details,
                                        const KODI::ART::Artwork& artwork,
                                        int idMovie /* = -1 */)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -688,12 +688,6 @@ public:
                      dbiplus::Dataset& pDS,
                      int idFile = -1 /* = -1 */) const;
 
-  int SetDetailsForItem(CVideoInfoTag& details, const KODI::ART::Artwork& artwork);
-  int SetDetailsForItem(int id,
-                        MediaType_view mediaType,
-                        CVideoInfoTag& details,
-                        const KODI::ART::Artwork& artwork);
-
   int SetDetailsForMovie(CVideoInfoTag& details,
                          const KODI::ART::Artwork& artwork,
                          int idMovie = -1);

--- a/xbmc/video/VideoThumbLoader.h
+++ b/xbmc/video/VideoThumbLoader.h
@@ -84,4 +84,7 @@ protected:
   void DetectAndAddMissingItemData(CFileItem &item);
 
   const KODI::ART::Artwork& GetArtFromCache(const std::string& mediaType, const int id);
+
+private:
+  int SetDetailsForItem(CVideoInfoTag& details, const KODI::ART::Artwork& artwork);
 };


### PR DESCRIPTION
- Merge the two implementation of `SetDetailsForItem` into a single function
- Move `SetDetailsForItem` from `CVideoDatabase` to `CVideoThumbLoader`

## Description
When the thumb loader has completed its scan of a file it sometimes want to commit its updated details to the video database. In addition to the thumbs data, the methods which it chooses to use is updating much more details about the file.

## Motivation and context
- `SetDetailsForItem` is called from a single place in the codebase: `CVideoThumbLoader::LoadItemLookup`. I have moved this function closer to the caller.
- The `CVideoDatabase` methods it calls seems overkill for the data it is trying trying to update. These calls need investigating to check if a more lightweight call could be used to update only the required data in the database.
- This method was mildly hindering work on another branch: #27313

## How has this been tested?
Building

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
