### PR TITLE
[URLUtils] Reduce dependency on `fmt` library

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -32,6 +32,7 @@
 #endif
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <charconv>
 #include <ranges>
@@ -49,6 +50,31 @@ namespace
 {
 
 constexpr std::string_view DecodeURLSpecialChars{"+%"};
+
+// Lookup table for URL encoding. This is more efficient than using fmt::format
+// for such a simple operation and this function has been identified as a hot path
+// during library scans; especially encoding the contents of nfo files into URL
+// parameters.
+constexpr std::array<const char*, 256> hex_chars{
+    // clang-format off
+    "%00", "%01", "%02", "%03", "%04", "%05", "%06", "%07", "%08", "%09", "%0a", "%0b", "%0c", "%0d", "%0e", "%0f",
+    "%10", "%11", "%12", "%13", "%14", "%15", "%16", "%17", "%18", "%19", "%1a", "%1b", "%1c", "%1d", "%1e", "%1f",
+    "%20", "%21", "%22", "%23", "%24", "%25", "%26", "%27", "%28", "%29", "%2a", "%2b", "%2c", "%2d", "%2e", "%2f",
+    "%30", "%31", "%32", "%33", "%34", "%35", "%36", "%37", "%38", "%39", "%3a", "%3b", "%3c", "%3d", "%3e", "%3f",
+    "%40", "%41", "%42", "%43", "%44", "%45", "%46", "%47", "%48", "%49", "%4a", "%4b", "%4c", "%4d", "%4e", "%4f",
+    "%50", "%51", "%52", "%53", "%54", "%55", "%56", "%57", "%58", "%59", "%5a", "%5b", "%5c", "%5d", "%5e", "%5f",
+    "%60", "%61", "%62", "%63", "%64", "%65", "%66", "%67", "%68", "%69", "%6a", "%6b", "%6c", "%6d", "%6e", "%6f",
+    "%70", "%71", "%72", "%73", "%74", "%75", "%76", "%77", "%78", "%79", "%7a", "%7b", "%7c", "%7d", "%7e", "%7f",
+    "%80", "%81", "%82", "%83", "%84", "%85", "%86", "%87", "%88", "%89", "%8a", "%8b", "%8c", "%8d", "%8e", "%8f",
+    "%90", "%91", "%92", "%93", "%94", "%95", "%96", "%97", "%98", "%99", "%9a", "%9b", "%9c", "%9d", "%9e", "%9f",
+    "%a0", "%a1", "%a2", "%a3", "%a4", "%a5", "%a6", "%a7", "%a8", "%a9", "%aa", "%ab", "%ac", "%ad", "%ae", "%af",
+    "%b0", "%b1", "%b2", "%b3", "%b4", "%b5", "%b6", "%b7", "%b8", "%b9", "%ba", "%bb", "%bc", "%bd", "%be", "%bf",
+    "%c0", "%c1", "%c2", "%c3", "%c4", "%c5", "%c6", "%c7", "%c8", "%c9", "%ca", "%cb", "%cc", "%cd", "%ce", "%cf",
+    "%d0", "%d1", "%d2", "%d3", "%d4", "%d5", "%d6", "%d7", "%d8", "%d9", "%da", "%db", "%dc", "%dd", "%de", "%df",
+    "%e0", "%e1", "%e2", "%e3", "%e4", "%e5", "%e6", "%e7", "%e8", "%e9", "%ea", "%eb", "%ec", "%ed", "%ee", "%ef",
+    "%f0", "%f1", "%f2", "%f3", "%f4", "%f5", "%f6", "%f7", "%f8", "%f9", "%fa", "%fb", "%fc", "%fd", "%fe", "%ff",
+    // clang-format on
+};
 
 std::optional<char> DecodeOctlet(std::string_view& encoded)
 {
@@ -95,15 +121,17 @@ std::string URIUtils::URLDecode(std::string_view encoded)
 
 std::string URIUtils::URLEncode(std::string_view decoded, std::string_view URLSpec)
 {
-  std::ostringstream oss;
+  std::string result;
+  result.reserve(decoded.size() * 2);
+
   for (const auto& ch : decoded)
   {
     if (StringUtils::isasciialphanum(ch) || URLSpec.find(ch) != std::string::npos)
-      oss << ch;
+      result += ch;
     else
-      fmt::format_to(std::ostreambuf_iterator(oss), "%{:02x}", static_cast<unsigned char>(ch));
+      result.append(hex_chars[static_cast<unsigned char>(ch)], 3);
   }
-  return std::move(oss).str();
+  return result;
 }
 
 void URIUtils::RegisterAdvancedSettings(const CAdvancedSettings& advancedSettings)


### PR DESCRIPTION

## Description
URLEncode uses the formatting library `fmt` to format characters into hex digits as described in the URL encoding spec. This contains runtime overhead as the format pattern string needs to be interpreted. For such a simple operation of converting a char into hex digits we can implement this manually and reduce the overhead of using the `fmt` library. 

## Motivation and context
This function made an appearance on a profile of Kodi.

## How has this been tested?
Unit tests. There are loads of existing tests for URLEncode

## What is the effect on users?
I have seen this function called repeatidly during a library scan (surprising). Something related to generating a URI for a plugin. There should be a nominal improvement in speed for library scans.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
