### PR TITLE
[CURL] Forward CURL object through interfaces.

### DIFF
--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -64,10 +64,8 @@ CPluginDirectory::~CPluginDirectory(void)
 {
 }
 
-bool CPluginDirectory::StartScript(const std::string& strPath, bool resume)
+bool CPluginDirectory::StartScript(const CURL& url, bool resume)
 {
-  CURL url(strPath);
-
   ADDON::AddonPtr addon;
   // try the plugin type first, and if not found, try an unknown type
   if (!CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), addon, AddonType::PLUGIN,
@@ -81,17 +79,22 @@ bool CPluginDirectory::StartScript(const std::string& strPath, bool resume)
     return false;
   }
 
+  const std::string& path = url.Get();
+
   // clear out our status variables
   m_fileResult = std::make_unique<CFileItem>();
   m_listItems->Clear();
-  m_listItems->SetPath(strPath);
+  m_listItems->SetPath(path);
   m_listItems->SetLabel(addon->Name());
   m_cancelled = false;
   m_success = false;
   m_totalItems = 0;
 
+  if (path.empty())
+    return false;
+
   // run the script
-  return RunScript(this, addon, strPath, resume);
+  return RunScript(this, addon, url, resume);
 }
 
 bool CPluginDirectory::GetResolvedPluginResult(CFileItem& resultItem)
@@ -140,7 +143,7 @@ bool CPluginDirectory::GetPluginResult(const std::string& strPath, CFileItem &re
   CURL url(strPath);
   CPluginDirectory newDir;
 
-  bool success = newDir.StartScript(strPath, resume);
+  bool success = newDir.StartScript(url, resume);
 
   if (success)
   { // update the play path and metadata, saving the old one as needed
@@ -468,8 +471,7 @@ void CPluginDirectory::AddSortMethod(int handle,
 
 bool CPluginDirectory::GetDirectory(const CURL& url, CFileItemList& items)
 {
-  const std::string pathToUrl(url.Get());
-  bool success = StartScript(pathToUrl, false);
+  bool success = StartScript(url, false);
 
   // append the items to the list
   items.Assign(*m_listItems, true); // true to keep the current items
@@ -477,10 +479,9 @@ bool CPluginDirectory::GetDirectory(const CURL& url, CFileItemList& items)
   return success;
 }
 
-bool CPluginDirectory::RunScriptWithParams(const std::string& strPath, bool resume)
+bool CPluginDirectory::RunScriptWithParams(const CURL& url, bool resume)
 {
-  CURL url(strPath);
-  if (url.GetHostName().empty()) // called with no script - should never happen
+  if (url.Get().empty() || url.GetHostName().empty()) // called with no script - should never happen
     return false;
 
   AddonPtr addon;
@@ -493,7 +494,7 @@ bool CPluginDirectory::RunScriptWithParams(const std::string& strPath, bool resu
     return false;
   }
 
-  return ExecuteScript(addon, strPath, resume) >= 0;
+  return ExecuteScript(addon, url, resume) >= 0;
 }
 
 void CPluginDirectory::SetResolvedUrl(int handle, bool success, const CFileItem *resultItem)

--- a/xbmc/filesystem/PluginDirectory.h
+++ b/xbmc/filesystem/PluginDirectory.h
@@ -34,7 +34,7 @@ public:
   bool Exists(const CURL& url) override { return true; }
   float GetProgress() const override;
   void CancelDirectory() override;
-  static bool RunScriptWithParams(const std::string& strPath, bool resume);
+  static bool RunScriptWithParams(const CURL& url, bool resume);
 
   /*! \brief Get a reproducible CFileItem by trying to recursively resolve the plugin paths
   up to a maximum allowed limit. If no plugin paths exist it will be ignored.
@@ -80,7 +80,7 @@ protected:
   bool IsCancelled() const override { return m_cancelled; }
 
 private:
-  bool StartScript(const std::string& strPath, bool resume);
+  bool StartScript(const CURL& url, bool resume);
 
   std::unique_ptr<CFileItemList> m_listItems;
   std::unique_ptr<CFileItem> m_fileResult;

--- a/xbmc/interfaces/builtins/AddonBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AddonBuiltins.cpp
@@ -95,7 +95,7 @@ static int RunPlugin(const std::vector<std::string>& params)
     if (!item.IsFolder())
     {
       item.SetPath(params[0]);
-      XFILE::CPluginDirectory::RunScriptWithParams(item.GetPath(), false);
+      XFILE::CPluginDirectory::RunScriptWithParams(item.GetURL(), false);
     }
   }
   else

--- a/xbmc/interfaces/generic/RunningScriptsHandler.h
+++ b/xbmc/interfaces/generic/RunningScriptsHandler.h
@@ -29,14 +29,10 @@ protected:
   using CScriptRunner::ExecuteScript;
   using CScriptRunner::GetAddon;
   using CScriptRunner::SetDone;
-  using CScriptRunner::StartScript;
 
-  bool RunScript(TScript* script,
-                 const ADDON::AddonPtr& addon,
-                 const std::string& path,
-                 bool resume)
+  bool RunScript(TScript* script, const ADDON::AddonPtr& addon, const CURL& url, bool resume)
   {
-    if (script == nullptr || addon == nullptr || path.empty())
+    if (script == nullptr || addon == nullptr)
       return false;
 
     // reuse an existing script handle or get a new one if necessary
@@ -47,7 +43,7 @@ protected:
       ReuseScriptHandle(handle, script);
 
     // run the script
-    auto result = CScriptRunner::RunScript(addon, path, handle, resume);
+    auto result = CScriptRunner::RunScript(addon, url, handle, resume);
 
     // remove the script handle if necessary
     RemoveScriptHandle(handle);

--- a/xbmc/interfaces/generic/ScriptRunner.cpp
+++ b/xbmc/interfaces/generic/ScriptRunner.cpp
@@ -33,17 +33,12 @@ ADDON::AddonPtr CScriptRunner::GetAddon() const
 CScriptRunner::CScriptRunner() : m_scriptDone(true)
 { }
 
-bool CScriptRunner::StartScript(const ADDON::AddonPtr& addon, const std::string& path)
-{
-  return RunScriptInternal(addon, path, 0, false);
-}
-
 bool CScriptRunner::RunScript(const ADDON::AddonPtr& addon,
-                              const std::string& path,
+                              const CURL& url,
                               int handle,
                               bool resume)
 {
-  return RunScriptInternal(addon, path, handle, resume, true);
+  return RunScriptInternal(addon, url, handle, resume, true);
 }
 
 void CScriptRunner::SetDone()
@@ -51,20 +46,15 @@ void CScriptRunner::SetDone()
   m_scriptDone.Set();
 }
 
-int CScriptRunner::ExecuteScript(const ADDON::AddonPtr& addon, const std::string& path, bool resume)
+int CScriptRunner::ExecuteScript(const ADDON::AddonPtr& addon, const CURL& path, bool resume)
 {
   return ExecuteScript(addon, path, -1, resume);
 }
 
-int CScriptRunner::ExecuteScript(const ADDON::AddonPtr& addon,
-                                 const std::string& path,
-                                 int handle,
-                                 bool resume)
+int CScriptRunner::ExecuteScript(const ADDON::AddonPtr& addon, CURL url, int handle, bool resume)
 {
-  if (addon == nullptr || path.empty())
+  if (addon == nullptr)
     return false;
-
-  CURL url(path);
 
   // get options and remove them from the URL because we can then use the url
   // to generate the base path which is passed to the add-on script
@@ -92,13 +82,10 @@ int CScriptRunner::ExecuteScript(const ADDON::AddonPtr& addon,
   return scriptId;
 }
 
-bool CScriptRunner::RunScriptInternal(const ADDON::AddonPtr& addon,
-                                      const std::string& path,
-                                      int handle,
-                                      bool resume,
-                                      bool wait /* = true */)
+bool CScriptRunner::RunScriptInternal(
+    const ADDON::AddonPtr& addon, const CURL& url, int handle, bool resume, bool wait /* = true */)
 {
-  if (addon == nullptr || path.empty())
+  if (addon == nullptr)
     return false;
 
   // reset our wait event
@@ -107,7 +94,7 @@ bool CScriptRunner::RunScriptInternal(const ADDON::AddonPtr& addon,
   // store the add-on
   m_addon = addon;
 
-  int scriptId = ExecuteScript(addon, path, handle, resume);
+  int scriptId = ExecuteScript(addon, url, handle, resume);
   if (scriptId < 0)
     return false;
 

--- a/xbmc/interfaces/generic/ScriptRunner.h
+++ b/xbmc/interfaces/generic/ScriptRunner.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "URL.h"
 #include "addons/IAddon.h"
 #include "threads/Event.h"
 
@@ -24,23 +25,16 @@ protected:
 
   ADDON::AddonPtr GetAddon() const;
 
-  bool StartScript(const ADDON::AddonPtr& addon, const std::string& path);
-  bool RunScript(const ADDON::AddonPtr& addon, const std::string& path, int handle, bool resume);
+  bool RunScript(const ADDON::AddonPtr& addon, const CURL& url, int handle, bool resume);
 
   void SetDone();
 
-  static int ExecuteScript(const ADDON::AddonPtr& addon, const std::string& path, bool resume);
-  static int ExecuteScript(const ADDON::AddonPtr& addon,
-                           const std::string& path,
-                           int handle,
-                           bool resume);
+  static int ExecuteScript(const ADDON::AddonPtr& addon, const CURL& url, bool resume);
+  static int ExecuteScript(const ADDON::AddonPtr& addon, CURL url, int handle, bool resume);
 
 private:
-  bool RunScriptInternal(const ADDON::AddonPtr& addon,
-                         const std::string& path,
-                         int handle,
-                         bool resume,
-                         bool wait = true);
+  bool RunScriptInternal(
+      const ADDON::AddonPtr& addon, const CURL& url, int handle, bool resume, bool wait = true);
   bool WaitOnScriptResult(int scriptId, const std::string& path, const std::string& name);
 
   ADDON::AddonPtr m_addon;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1131,7 +1131,7 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
   else if (pItem->IsPlugin() && !pItem->GetProperty("isplayable").asBoolean())
   {
     bool resume = pItem->GetStartOffset() == STARTOFFSET_RESUME;
-    return XFILE::CPluginDirectory::RunScriptWithParams(pItem->GetPath(), resume);
+    return XFILE::CPluginDirectory::RunScriptWithParams(pItem->GetURL(), resume);
   }
 #if defined(TARGET_ANDROID)
   else if (pItem->IsAndroidApp())


### PR DESCRIPTION
## Description
2 CURL objects are created for each call to `PluginDirectory::GetDirectory`. This is unecessary as the CURL object is passed into this method.
Pass this object down through the call tree to save creation of these objects much lower in the call stack.

## Motivation and context
Profiling/Optimization

## How has this been tested?
Library scan with items needed to be fetch through a plugin

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
