### PR TITLE
[python] Fix random segfaults on Android / webOS on startup / script execution / finalization

### DIFF
--- a/xbmc/interfaces/python/PythonInvoker.h
+++ b/xbmc/interfaces/python/PythonInvoker.h
@@ -61,6 +61,7 @@ private:
   FILE* PyFile_AsFileWithMode(PyObject* py_file, const char* mode);
 
   PyThreadState* m_threadState;
+  PyThreadState* m_mainThreadState{nullptr};
   bool m_stop = false;
   CEvent m_stoppedEvent;
 

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -21,6 +21,8 @@
 class CPythonInvoker;
 class CVariant;
 
+typedef struct _ts PyThreadState;
+
 typedef struct
 {
   int id;
@@ -100,13 +102,15 @@ public:
   void OnScriptFinalized(ILanguageInvoker* invoker) override;
   ILanguageInvoker* CreateInvoker() override;
 
+  PyThreadState* GetMainThreadState() const { return m_mainThreadState; }
+
   bool WaitForEvent(CEvent& hEvent, unsigned int milliseconds);
 
 private:
   static bool m_bInitialized; // whether global python runtime was already initialized
 
   CCriticalSection m_critSection;
-  void* m_mainThreadState{nullptr};
+  PyThreadState* m_mainThreadState{nullptr};
   int m_iDllScriptCounter{0}; // to keep track of the total scripts running that need the dll
 
   //Vector with list of threads used for running scripts


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR fixes an issue where Kodi crashes on startup. This primarily affects webOS and Android but in #27025 also LibreElec was mentioned.

The fix involves storing the main interpreter and using that instead of trying to retrieve the main threadstate by calling `PyInterpreterState_ThreadHead(PyInterpreterState_Main())`. I can't say for certain why the current call segfaults and I can only speculate: In general all python functions must be called while holding the GIL except if they explicitly state, that it is not required. The [docs](https://docs.python.org/3/c-api/init.html#c.PyInterpreterState_Main) don't explicitly state that these are safe to use without holding the GIL, so maybe that is the issue. Also there is very little information on these functions and these are marked as 
> These functions are only intended to be used by advanced debugging tools.

Regarding the technical implementation of the fix it is a bit messy currently. I wanted to get this PRed so others can actually test the fix first if it does indeed work correctly. Given the nature of randomness it might have been me just getting lucky, although I doubt it after trying 100 times. Before that fix roughly 1/10th of the time Kodi would segfault on startup.

When `Py_Initialize` is called after that function call we own the GIL so calling `PyEval_SaveThread` releases it and returns it. `XBPython` is extended with a function `GetMainThreadState` which can then be used from the invokers to retrieve the main thread state.

The other commit fixes a current misuse of the API from different threads. Using a python thread state object is only safe from the thread it was created from. If a thread state object is used from a different thread then a new thread state must be created first and then later disposed (see [here](https://docs.python.org/3/c-api/init.html#supporting-subinterpreters-in-non-python-threads)). This currently happens when the invoker tries to acquire the main thread state and when an invoker is stopped. These trigger an assertion too in an assertion enabled build (`--with-assertions` at configure time)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #27025

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS 9 by starting Kodi 100 times and experienced no segfault anymore on startup

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
