### PR TITLE
webOS: pass AAC extradata to API as an array of ints

### DIFF
--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.h
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.h
@@ -75,10 +75,9 @@ public:
    * @brief Check if a codec is supported by the pipeline.
    * @param codec AVCodecID to check.
    * @param profile profile to check.
-   * @param includeSecure If true, include secure codecs in the check.
    * @return True if supported, false otherwise.
    */
-  static bool Supports(AVCodecID codec, int profile, bool includeSecure = false);
+  static bool Supports(AVCodecID codec, int profile);
 
   /**
    * @brief Flush all pending video messages.


### PR DESCRIPTION
## Description
We were unable to pass AAC extradata to webOS before as it was not in a format we understood. This PR resolves this, meaning webOS can now playback additional AAC formats like HE AAC and AAC LC 5.1 for encrypted streams.

Note it is necessary to use the frequency from extradata if provided otherwise sound is corrupted. This is because webOS seems to not like frequency being different in extradata to what is held in the frequency param.

The previous work around for isSecure has been removed as its no longer required.

## Motivation and context
Online services use a variety of a AAC formats and this should increase compatibility with those.

## How has this been tested?
_**local playback of kodi samples:**_
**HE-AAC:** ChID-BLITS-EBU.HE-AAC.mp4
**HE-AAC v2:** LFE-SBRstereo.HE-AACv2.mp4
**AAC LC 2.0:** V209 MP4 - HEVC 1080p 24fps 8bit - AAC2.0.AAC LC.mp4
**AAC LC 5.1:** ChID-BLITS-EBU.HE-AAC.mp4 (sample converted from HE-AAC to AAC LC 5.1 by ffmpeg first)

_**Online playback:**_
ITV-X **AAC LC 2.0** (could not find anything in 5.1)

_**ISA samples:**_
AAC 2.0 - yes
AAC LC 2.0 - yes
HE-AAC 2.0 - Google Axiom - yes
HE-AAC v2 2.0 - Google Axiom -  yes

Example of processing once received:
```
<custompipeline.cpp:getAudioCaps(2899)>"} AAC Codec data = 0xA, 0x10
```

Corresponds to:
```AAC‑LC, 44.1 kHz, stereo```

## What is the effect on users?
Increases compatibility with online streaming services.
For local playback, reduces need to transcode.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
