### PR TITLE
[DateTime] Initialize DateTime with constant value.

### DIFF
--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -614,7 +614,7 @@ void CDateTime::Archive(CArchive& ar)
 
 void CDateTime::Reset()
 {
-  SetDateTime(1601, 1, 1, 0, 0, 0);
+  m_time = {0, 0}; // Windows epoch 1601-01-01
   SetValid(false);
 }
 

--- a/xbmc/test/TestDateTime.cpp
+++ b/xbmc/test/TestDateTime.cpp
@@ -697,19 +697,14 @@ TEST_F(TestDateTime, GetAsUTCDateTime)
   EXPECT_EQ(dateTime2.GetSecond(), 56);
 }
 
-// disabled on osx and freebsd as their mktime functions
-// don't work for dates before 1900
-#if defined(TARGET_DARWIN_OSX) || defined(TARGET_FREEBSD)
-TEST_F(TestDateTime, DISABLED_Reset)
-#else
 TEST_F(TestDateTime, Reset)
-#endif
 {
   CDateTime dateTime;
   dateTime.SetDateTime(1991, 05, 14, 12, 34, 56);
 
   dateTime.Reset();
 
+  EXPECT_FALSE(dateTime.IsValid());
   EXPECT_EQ(dateTime.GetYear(), 1601);
   EXPECT_EQ(dateTime.GetMonth(), 1);
   EXPECT_EQ(dateTime.GetDay(), 1);


### PR DESCRIPTION
[DateTime] Cache commonly created DateTime value.

## Description
A CDateTime object is created every time a CFileItem object is created.
The datetime object defaults to holding an invalid time which is calculated using syscalls. As this "invalid" value is constant we only need to calculate it once and future calls can reuse the same value.

Creation of a CDateTime object was taking 46% of the time when building a CFileItem object on a Linux system.

## Motivation and context
Performance improvement when creating CFileItem objects

## How has this been tested?

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
