### PR TITLE
Fix Claude workflows: add write permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,9 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
+      actions: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary

Fixes the CI failures in the Claude Code workflows that were introduced in PR #27322.

## Changes

- Changed `pull-requests` from `read` to `write` (required for `gh pr comment`)
- Changed `issues` from `read` to `write` (required for posting comments)  
- Added `actions: read` to `claude-code-review.yml` for consistency with `claude.yml`

## Problem

The workflows were failing with "Could not fetch an OIDC token" errors because they didn't have the proper permissions according to the [setup guide](https://github.com/anthropics/claude-code-action/blob/main/docs/setup.md), which requires:
- Issues: Read & Write
- Pull requests: Read & Write

## Test

This should resolve the failures seen in:
- https://github.com/xbmc/xbmc/actions/runs/18407241992
- https://github.com/xbmc/xbmc/actions/runs/18411608441/job/52465142879

🤖 Generated with [Claude Code](https://claude.com/claude-code)