### PR TITLE
Add fork remote configuration for Claude workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure git for fork PR
+        if: github.event.issue.pull_request
+        run: |
+          # Fetch PR details to get fork information
+          PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
+          FORK_OWNER=$(echo "$PR_DATA" | jq -r '.head.repo.owner.login')
+          FORK_REPO=$(echo "$PR_DATA" | jq -r '.head.repo.name')
+          HEAD_REF=$(echo "$PR_DATA" | jq -r '.head.ref')
+
+          if [ "$FORK_OWNER" != "${{ github.repository_owner }}" ]; then
+            echo "Adding fork remote: https://github.com/$FORK_OWNER/$FORK_REPO.git"
+            git remote add fork "https://github.com/$FORK_OWNER/$FORK_REPO.git"
+            git fetch fork "$HEAD_REF"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Problem

Even after PR #27328, the Claude workflow still fails on fork PRs with:
```
This is an open PR, checking out PR branch...
fatal: couldn't find remote ref [branch]
```

The issue is that the claude-code-action internally tries to checkout the PR branch, but only has the base repository configured as "origin". Fork branches don't exist in the base repo.

## Solution

Added a pre-flight step that:
1. Detects if the comment is on a fork PR
2. Fetches PR metadata to get fork repository info
3. Adds the fork as a git remote
4. Fetches the PR branch from the fork

This makes the fork branch available when the action tries to check it out internally.

## Testing

After merge, test by commenting `@claude` on fork PR #27220

🤖 Generated with [Claude Code](https://claude.com/claude-code)