### PR TITLE
Fix fork branch fetch to use origin namespace

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,9 +40,10 @@ jobs:
           HEAD_REF=$(echo "$PR_DATA" | jq -r '.head.ref')
 
           if [ "$FORK_OWNER" != "${{ github.repository_owner }}" ]; then
-            echo "Adding fork remote: https://github.com/$FORK_OWNER/$FORK_REPO.git"
-            git remote add fork "https://github.com/$FORK_OWNER/$FORK_REPO.git"
-            git fetch fork "$HEAD_REF"
+            echo "Fetching fork branch from: https://github.com/$FORK_OWNER/$FORK_REPO.git"
+            # Fetch the fork branch directly into origin's namespace so the action can find it
+            git fetch "https://github.com/$FORK_OWNER/$FORK_REPO.git" "$HEAD_REF:refs/remotes/origin/$HEAD_REF"
+            echo "Successfully fetched $HEAD_REF from fork"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Even with PR #27329 merged, fork PRs still fail with:
```
fatal: couldn't find remote ref [branch]
```

The previous fix added the fork as a separate git remote, but the claude-code-action internally runs `git fetch origin [branch]` and doesn't know about other remotes.

## Solution

Fetch the fork branch directly into origin's refs namespace as `refs/remotes/origin/[branch]`. This makes the branch available when the action tries to fetch it from origin.

**Before:** `git remote add fork ... && git fetch fork [branch]` → action can't see it
**After:** `git fetch [fork-url] [branch]:refs/remotes/origin/[branch]` → action can find it

🤖 Generated with [Claude Code](https://claude.com/claude-code)