### PR TITLE
Fix fork PR support by adding fork to origin remote

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,10 +40,10 @@ jobs:
           HEAD_REF=$(echo "$PR_DATA" | jq -r '.head.ref')
 
           if [ "$FORK_OWNER" != "${{ github.repository_owner }}" ]; then
-            echo "Fetching fork branch from: https://github.com/$FORK_OWNER/$FORK_REPO.git"
-            # Fetch the fork branch directly into origin's namespace so the action can find it
-            git fetch "https://github.com/$FORK_OWNER/$FORK_REPO.git" "$HEAD_REF:refs/remotes/origin/$HEAD_REF"
-            echo "Successfully fetched $HEAD_REF from fork"
+            echo "Configuring git to fetch from fork: https://github.com/$FORK_OWNER/$FORK_REPO.git"
+            # Add the fork URL to origin so the action can fetch from it
+            git remote set-url origin --add "https://github.com/$FORK_OWNER/$FORK_REPO.git"
+            echo "Successfully configured origin to include fork repository"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Previous attempts still failing because the claude-code-action does:
```bash
git fetch origin [branch]
```

This fails because the fork branch doesn't exist in origin (xbmc/xbmc).

## Solution

Use `git remote set-url origin --add [fork-url]` to add the fork as an additional fetch URL for origin. 

When git fetches from origin, it will now try:
1. https://github.com/xbmc/xbmc.git (base repo)
2. https://github.com/[fork-owner]/xbmc.git (fork repo)

The branch will be found in the fork and the fetch will succeed.

## Testing

After merge, test on fork PR #27089

🤖 Generated with [Claude Code](https://claude.com/claude-code)