### PR TITLE
Fix fork PR support using GitHub PR refs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,21 +30,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure git for fork PR
+      - name: Fetch PR ref for fork support
         if: github.event.issue.pull_request
         run: |
-          # Fetch PR details to get fork information
+          # GitHub exposes all PRs (even from forks) as refs/pull/NUMBER/head
+          # Fetch this ref and create a local branch that the action can use
           PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
-          FORK_OWNER=$(echo "$PR_DATA" | jq -r '.head.repo.owner.login')
-          FORK_REPO=$(echo "$PR_DATA" | jq -r '.head.repo.name')
           HEAD_REF=$(echo "$PR_DATA" | jq -r '.head.ref')
 
-          if [ "$FORK_OWNER" != "${{ github.repository_owner }}" ]; then
-            echo "Configuring git to fetch from fork: https://github.com/$FORK_OWNER/$FORK_REPO.git"
-            # Add the fork URL to origin so the action can fetch from it
-            git remote set-url origin --add "https://github.com/$FORK_OWNER/$FORK_REPO.git"
-            echo "Successfully configured origin to include fork repository"
-          fi
+          echo "Fetching PR #${{ github.event.issue.number }} as refs/pull/${{ github.event.issue.number }}/head"
+          git fetch origin +refs/pull/${{ github.event.issue.number }}/head:refs/remotes/origin/$HEAD_REF
+          echo "Successfully fetched PR ref as origin/$HEAD_REF"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Problem

Fork PRs fail with `fatal: couldn't find remote ref [branch]` because the claude-code-action tries to fetch the branch from origin, but fork branches don't exist there.

## Solution

Use GitHub's built-in PR refs system. GitHub exposes **all PRs** (even from forks) as:
```
refs/pull/NUMBER/head
```

This ref exists in the base repository and contains the fork's code.

## How It Works

```bash
git fetch origin +refs/pull/27089/head:refs/remotes/origin/game-captions
```

This fetches PR #27089's code (from any fork) and creates it as `origin/game-captions` where the action expects it.

## Why This Works

- ✅ No need to access fork repository  
- ✅ GitHub already makes fork PR code available  
- ✅ Standard `git fetch origin` works  
- ✅ Matches how `gh pr checkout` works internally  

## References

- https://github.com/anthropics/claude-code-action/issues/223
- https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)