### PR TITLE
Fix fork PR support by checking out fork repository directly

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,17 +30,37 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Fetch PR ref for fork support
+      - name: Setup git wrapper for fork PR support
         if: github.event.issue.pull_request
         run: |
-          # GitHub exposes all PRs (even from forks) as refs/pull/NUMBER/head
-          # Fetch this ref and create a local branch that the action can use
+          # Get PR info
           PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
           HEAD_REF=$(echo "$PR_DATA" | jq -r '.head.ref')
+          PR_NUMBER=${{ github.event.issue.number }}
 
-          echo "Fetching PR #${{ github.event.issue.number }} as refs/pull/${{ github.event.issue.number }}/head"
-          git fetch origin +refs/pull/${{ github.event.issue.number }}/head:refs/remotes/origin/$HEAD_REF
-          echo "Successfully fetched PR ref as origin/$HEAD_REF"
+          # Pre-fetch the PR using GitHub's PR refs
+          echo "Pre-fetching PR #$PR_NUMBER"
+          git fetch origin +refs/pull/$PR_NUMBER/head:refs/remotes/origin/$HEAD_REF
+
+          # Create a git wrapper to intercept fetch commands
+          mkdir -p /tmp/git-wrapper
+          cat > /tmp/git-wrapper/git << 'EOF'
+#!/bin/bash
+# Wrapper to intercept git fetch for fork PRs
+if [[ "$1" == "fetch" && "$2" == "origin" ]]; then
+  BRANCH_NAME="${3#refs/remotes/origin/}"
+  echo "[git wrapper] Intercepting fetch for branch: $BRANCH_NAME"
+  # The branch already exists from our pre-fetch, just exit successfully
+  exit 0
+fi
+# Pass through all other git commands
+exec /usr/bin/git "$@"
+EOF
+          chmod +x /tmp/git-wrapper/git
+
+          # Add wrapper to PATH
+          echo "/tmp/git-wrapper" >> $GITHUB_PATH
+          echo "Git wrapper installed for fork PR support"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,44 +25,24 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
+      - name: Get PR info for fork support
+        if: github.event.issue.pull_request
+        id: pr-info
+        run: |
+          PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
+          echo "pr_head_owner=$(echo "$PR_DATA" | jq -r '.head.repo.owner.login')" >> $GITHUB_OUTPUT
+          echo "pr_head_repo=$(echo "$PR_DATA" | jq -r '.head.repo.name')" >> $GITHUB_OUTPUT
+          echo "pr_head_ref=$(echo "$PR_DATA" | jq -r '.head.ref')" >> $GITHUB_OUTPUT
+          echo "is_fork=$(echo "$PR_DATA" | jq -r '.head.repo.fork')" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.issue.pull_request && steps.pr-info.outputs.is_fork == 'true' && format('{0}/{1}', steps.pr-info.outputs.pr_head_owner, steps.pr-info.outputs.pr_head_repo) || github.repository }}
+          ref: ${{ github.event.issue.pull_request && steps.pr-info.outputs.pr_head_ref || github.ref }}
           fetch-depth: 0
-
-      - name: Setup git wrapper for fork PR support
-        if: github.event.issue.pull_request
-        run: |
-          # Get PR info
-          PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
-          HEAD_REF=$(echo "$PR_DATA" | jq -r '.head.ref')
-          PR_NUMBER=${{ github.event.issue.number }}
-
-          # Pre-fetch the PR using GitHub's PR refs
-          echo "Pre-fetching PR #$PR_NUMBER"
-          git fetch origin +refs/pull/$PR_NUMBER/head:refs/remotes/origin/$HEAD_REF
-
-          # Create a git wrapper to intercept fetch commands
-          mkdir -p /tmp/git-wrapper
-          cat > /tmp/git-wrapper/git << 'EOF'
-#!/bin/bash
-# Wrapper to intercept git fetch for fork PRs
-if [[ "$1" == "fetch" && "$2" == "origin" ]]; then
-  BRANCH_NAME="${3#refs/remotes/origin/}"
-  echo "[git wrapper] Intercepting fetch for branch: $BRANCH_NAME"
-  # The branch already exists from our pre-fetch, just exit successfully
-  exit 0
-fi
-# Pass through all other git commands
-exec /usr/bin/git "$@"
-EOF
-          chmod +x /tmp/git-wrapper/git
-
-          # Add wrapper to PATH
-          echo "/tmp/git-wrapper" >> $GITHUB_PATH
-          echo "Git wrapper installed for fork PR support"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
## Problem

Fork PRs fail because the claude-code-action tries to fetch fork branches from the base repository where they don't exist.

## Solution

**Checkout the fork repository directly** instead of trying to fetch fork branches from the base repo.

## How It Works

```yaml
# Get PR info
PR_DATA=$(gh api repos/xbmc/xbmc/pulls/27089)
pr_head_owner=$(echo "$PR_DATA" | jq -r '.head.repo.owner.login')  # e.g., "garbear"
pr_head_repo=$(echo "$PR_DATA" | jq -r '.head.repo.name')          # e.g., "xbmc"
pr_head_ref=$(echo "$PR_DATA" | jq -r '.head.ref')                 # e.g., "game-captions"

# Checkout fork repository directly
repository: garbear/xbmc
ref: game-captions
```

The `actions/checkout` action can checkout **any public repository**, not just the base repo. This allows us to check out fork repos directly where the branches actually exist.

## Why This Works

- ✅ Fork branches exist in fork repositories  
- ✅ `actions/checkout` supports any public repo  
- ✅ No complex git operations needed  
- ✅ Works for both fork and non-fork PRs  
- ✅ Clean, simple solution  

## References

This matches how other repos handle fork PRs:
- https://github.com/CryptoGnome/aster_lick_hunter_node/commit/a8f5e6116f6ada8dda8fc1361399422ec0e670e2

🤖 Generated with [Claude Code](https://claude.com/claude-code)