### PR TITLE
Fix automated review to checkout fork repository

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 
       - name: Run Claude Code Review


### PR DESCRIPTION
## Problem

The automated review workflow (`claude-code-review.yml`) uses `pull_request_target` but wasn't specifying the fork repository in the checkout step. This causes it to fail for fork PRs because it tries to checkout a SHA/branch that doesn't exist in the base repository.

## Solution

Checkout the fork repository directly by specifying:
- `repository: ${{ github.event.pull_request.head.repo.full_name }}`
- `ref: ${{ github.event.pull_request.head.ref }}`

## How It Works

With `pull_request_target`, the PR event contains fork information:

```yaml
repository: garbear/xbmc        # Fork repository (from head.repo.full_name)
ref: game-captions              # Branch name (from head.ref)
```

This works for both fork and non-fork PRs:
- **Fork PR**: Checks out `garbear/xbmc @ game-captions`
- **Non-fork PR**: Checks out `xbmc/xbmc @ branch-name`

## Completes Fork Support

This completes fork PR support for both workflows:
- ✅ `claude.yml` - `@claude` mentions (fixed in #27335)
- ✅ `claude-code-review.yml` - Automated reviews on PR open/sync (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)