### PR TITLE
Add explicit github_token to fix OIDC errors on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,6 +38,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Problem

The automated review workflow (`claude-code-review.yml`) fails with OIDC token errors on fork PRs:

```
App token exchange failed: 401 Unauthorized - Invalid OIDC token
Failed to setup GitHub token: Error: Invalid OIDC token
```

This happens specifically with `pull_request_target` on fork PRs.

## Solution

Add explicit `github_token: ${{ secrets.GITHUB_TOKEN }}` to the action to bypass OIDC authentication and use the standard GitHub Actions token instead.

```yaml
- uses: anthropics/claude-code-action@v1
  with:
    claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
    github_token: ${{ secrets.GITHUB_TOKEN }}  # ← Added
```

## Why This Works

- `pull_request_target` runs in the **base repository context**
- `GITHUB_TOKEN` has the necessary permissions in this context
- Providing explicit `github_token` bypasses OIDC authentication
- This matches the error message's suggestion

## Completes Fork Support

This completes the automated review fork support started in #27336:
- ✅ Checkout fork repository correctly
- ✅ Use proper authentication method for fork PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)