### PR TITLE
[PVR] CPVRPlaybackState: Add proper error handling for Get*StreamProperties PVR add-on API calls.

### DIFF
--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -156,7 +156,10 @@ bool ResolveChannel(CFileItem& item,
   if (source == PVR_SOURCE::DEFAULT)
     client->StreamClosed();
 
-  client->GetChannelStreamProperties(item.GetPVRChannelInfoTag(), source, props);
+  const PVR_ERROR ret{
+      client->GetChannelStreamProperties(item.GetPVRChannelInfoTag(), source, props)};
+  if (ret != PVR_ERROR_NO_ERROR && ret != PVR_ERROR_NOT_IMPLEMENTED)
+    return false;
 
   if (props.LivePlaybackAsEPG())
   {
@@ -172,7 +175,10 @@ bool ResolveEPG(CFileItem& item,
                 const std::shared_ptr<const CPVRClient>& client)
 {
   client->StreamClosed();
-  client->GetEpgTagStreamProperties(item.GetEPGInfoTag(), props);
+
+  const PVR_ERROR ret{client->GetEpgTagStreamProperties(item.GetEPGInfoTag(), props)};
+  if (ret != PVR_ERROR_NO_ERROR && ret != PVR_ERROR_NOT_IMPLEMENTED)
+    return false;
 
   if (props.EPGPlaybackAsLive())
   {
@@ -195,7 +201,10 @@ bool ResolveRecording(const CFileItem& item,
                       CPVRStreamProperties& props,
                       const std::shared_ptr<const CPVRClient>& client)
 {
-  client->GetRecordingStreamProperties(item.GetPVRRecordingInfoTag(), props);
+  const PVR_ERROR ret{client->GetRecordingStreamProperties(item.GetPVRRecordingInfoTag(), props)};
+  if (ret != PVR_ERROR_NO_ERROR && ret != PVR_ERROR_NOT_IMPLEMENTED)
+    return false;
+
   return true;
 }
 } // unnamed namespace


### PR DESCRIPTION
## Description
Adds error handling for `Get*StreamProperties` PVR add-on API calls.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix missing error handling for `Get*StreamProperties` PVR add-on API calls reported by @emveepee 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checked pvr.plutotv is still able to play streams.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
In case the API call fails, no playback start, error message.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
