### PR TITLE
[tools/depends][native] pkg-config 'force' argument is no longer necessary

### DIFF
--- a/tools/depends/native/pkg-config/Makefile
+++ b/tools/depends/native/pkg-config/Makefile
@@ -33,7 +33,6 @@ $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); patch -p1 -i ../001-fix-gcc15-build.patch
 	cd $(PLATFORM); $(CONFIGURE)
-	cd $(PLATFORM); sed -ie "s|LN = ln|LN = ln -f|" Makefile
 
 $(LIBDYLIB): $(PLATFORM)
 	$(MAKE) -C $(PLATFORM)


### PR DESCRIPTION
## Description
Fixes the following compilation error:

```
ln -f -f pkg-config x86_64-unknown-linux-gnu-pkg-config
error: the argument '--force' cannot be used multiple times
```

This fix was added to the source, related commit:
https://gitlab.freedesktop.org/pkg-config/pkg-config/-/commit/d377ee6b740373895cb67cdc14a98c0d71650e05

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
