### PR TITLE
Reduce Claude PR review verbosity

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,6 +24,7 @@ jobs:
       issues: write
       id-token: write
       actions: read
+      checks: write
 
     steps:
       - name: Checkout repository
@@ -58,11 +59,12 @@ jobs:
             IMPORTANT:
             - Only list problems you find - don't mention what's good
             - Be brief - one line per issue
-            - If everything looks fine, don't comment at all (check passes silently = code is good)
             - Report all issues (critical and minor), but keep it concise
 
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+            After your review:
+            1. If you found issues: Use `gh pr comment` to post them as a comment
+            2. If everything looks good: Use `gh pr review --approve` to explicitly approve the PR with message "Code review passed - no issues found."
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,7 +42,7 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Review this pull request for any issues. Be concise and to the point.
+            Review this pull request for issues. Be extremely concise.
 
             Check for:
             - Bugs, crashes, undefined behavior
@@ -51,13 +51,17 @@ jobs:
             - Security vulnerabilities
             - Performance issues
             - Logic errors
-            - Code style/guidelines violations (see docs/CODE_GUIDELINES.md)
+            - Code style violations (see docs/CODE_GUIDELINES.md)
 
-            IMPORTANT - Format your review concisely:
-            - Group issues by severity: **Critical**, **Must Fix**, **Medium**, **Low**, **Minor**
-            - For each issue: state the problem and solution only, nothing more
-            - Skip positive feedback and explanations of what's working well
-            - Report all issues you find (critical to minor), but keep each concise
+            Format (issues only):
+            **Severity** (Critical/Must Fix/Medium/Low/Minor)
+            - File:line - Problem. Fix: solution.
+
+            Rules:
+            - NO positive feedback, NO "looks good", NO observations
+            - NO explanations beyond problem + fix
+            - Each issue: one line, location, problem, solution
+            - Skip section headers if no issues in that severity
 
             Note: The PR branch is already checked out in the current working directory.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -56,10 +56,11 @@ jobs:
             - Logic errors
             - Code style/guidelines violations (see docs/CONTRIBUTING.md)
 
-            IMPORTANT:
-            - Only list problems you find - don't mention what's good
-            - Be brief - one line per issue
-            - Report all issues (critical and minor), but keep it concise
+            IMPORTANT - Format your review concisely:
+            - Group issues by severity: **Critical**, **Must Fix**, **Medium**, **Low**, **Minor**
+            - For each issue: state the problem and solution only, nothing more
+            - Skip positive feedback and explanations of what's working well
+            - Report all issues you find (critical to minor), but keep each concise
 
             After your review:
             1. If you found issues: Use `gh pr comment` to post them as a comment

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,7 +24,6 @@ jobs:
       issues: write
       id-token: write
       actions: read
-      checks: write
 
     steps:
       - name: Checkout repository
@@ -54,7 +53,7 @@ jobs:
             - Security vulnerabilities
             - Performance issues
             - Logic errors
-            - Code style/guidelines violations (see docs/CONTRIBUTING.md)
+            - Code style/guidelines violations (see https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)
 
             IMPORTANT - Format your review concisely:
             - Group issues by severity: **Critical**, **Must Fix**, **Medium**, **Low**, **Minor**
@@ -66,7 +65,7 @@ jobs:
 
             After your review:
             1. If you found issues: Use `gh pr comment` for top-level summary, and `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues
-            2. If everything looks good: Use `gh pr review --approve` to explicitly approve the PR with message "Code review passed - no issues found."
+            2. If everything looks good: Use `gh pr review --approve` with NO message (just the approval checkmark)
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request_target:
-    types: [opened, synchronize]
+    types: [opened, ready_for_review]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.cpp"
@@ -44,14 +44,22 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
+            Review this pull request for any issues. Be concise and to the point.
 
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+            Check for:
+            - Bugs, crashes, undefined behavior
+            - Memory leaks, resource management issues
+            - Thread safety problems
+            - Security vulnerabilities
+            - Performance issues
+            - Logic errors
+            - Code style/guidelines violations (see docs/CONTRIBUTING.md)
+
+            IMPORTANT:
+            - Only list problems you find - don't mention what's good
+            - Be brief - one line per issue
+            - If everything looks fine, don't comment at all (check passes silently = code is good)
+            - Report all issues (critical and minor), but keep it concise
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,13 +55,15 @@ jobs:
 
             Format (issues only):
             **Severity** (Critical/Must Fix/Medium/Low/Minor)
-            - File:line - Problem. Fix: solution.
+
+            **Issue title** (file:line)
+            Brief description of problem. Suggested fix with reasoning if needed (2-3 lines max).
 
             Rules:
-            - NO positive feedback, NO "looks good", NO observations
-            - NO explanations beyond problem + fix
-            - Each issue: one line, location, problem, solution
-            - Skip section headers if no issues in that severity
+            - NO positive feedback, NO "looks good", NO summary sections
+            - Keep each issue brief but clear
+            - Use inline comments for code-specific issues
+            - Skip severity sections if empty
 
             Note: The PR branch is already checked out in the current working directory.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,11 +19,9 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
-      issues: write
       id-token: write
-      actions: read
 
     steps:
       - name: Checkout repository
@@ -53,7 +51,7 @@ jobs:
             - Security vulnerabilities
             - Performance issues
             - Logic errors
-            - Code style/guidelines violations (see https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)
+            - Code style/guidelines violations (see docs/CODE_GUIDELINES.md)
 
             IMPORTANT - Format your review concisely:
             - Group issues by severity: **Critical**, **Must Fix**, **Medium**, **Low**, **Minor**
@@ -70,4 +68,4 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Description
Reduces the verbosity of Claude Code reviews in response to feedback that it was too verbose.

## Changes

1. **Updated trigger from `synchronize` to `ready_for_review`**
   - Reviews now only run when PR is opened or marked ready for review
   - No more reviews on every push
   - Can manually re-trigger by converting to draft and back to ready

2. **Refined prompt to be concise and issue-focused**
   - Only reports problems found (no positive feedback)
   - Brief, one-line-per-issue format
   - Silent if everything looks good
   - Still checks comprehensively (bugs, security, performance, style, etc.)

## Example: PR #27350

### After (new concise output):

(no comment - everything looks good)

<hr>

### Or if issues were found:

## Issues Found

- Missing null check in foo.cpp:123 before dereferencing pointer
- Potential race condition in bar.cpp:456 - mutex not held when accessing shared state
- Memory leak in baz.cpp:789 - allocated buffer not freed on error path
- Style: Inconsistent brace placement in qux.cpp:101 (see CLAUDE.md)

<hr>

## Motivation
Addresses feedback from @sundermann in #27346 that Claude reviews were too wordy.

## Types of change
- [x] **Improvement** (non-breaking change which improves existing functionality)

Fixes #27346