### PR TITLE
[Estuary] Hide short date in Weather widgets

### DIFF
--- a/addons/skin.estuary/xml/Includes_Home.xml
+++ b/addons/skin.estuary/xml/Includes_Home.xml
@@ -656,7 +656,7 @@
 						</control>
 						<control type="multiimage">
 							<left>60</left>
-							<top>108</top>
+							<top>94</top>
 							<width>130</width>
 							<height>130</height>
 							<imagepath>$INFO[ListItem.Icon]</imagepath>
@@ -670,14 +670,6 @@
 							<top>45</top>
 							<align>center</align>
 							<label>$INFO[ListItem.Label]</label>
-							<width>230</width>
-						</control>
-						<control type="label">
-							<left>15</left>
-							<top>78</top>
-							<align>center</align>
-							<font>font12</font>
-							<label>$INFO[ListItem.Property(ShortDate)]</label>
 							<width>230</width>
 						</control>
 						<control type="label">
@@ -720,7 +712,7 @@
 						</control>
 						<control type="multiimage">
 							<left>60</left>
-							<top>108</top>
+							<top>94</top>
 							<width>130</width>
 							<height>130</height>
 							<imagepath>$INFO[ListItem.Icon]</imagepath>
@@ -734,14 +726,6 @@
 							<top>45</top>
 							<align>center</align>
 							<label>$INFO[ListItem.Label]</label>
-							<width>230</width>
-						</control>
-						<control type="label">
-							<left>15</left>
-							<top>78</top>
-							<align>center</align>
-							<font>font12</font>
-							<label>$INFO[ListItem.Property(ShortDate)]</label>
 							<width>230</width>
 						</control>
 						<control type="label">


### PR DESCRIPTION
## Description

As title says, this hides the short date in weather widgets on the Home screen and in the Weather window.

## Motivation and context

There's a LOT of text on the screen, and all the mostly duplicate text can go, with no real loss in meaning.

## How has this been tested?

Tested on macOS ARM with OpenMeteo weather add-on.

## What is the effect on users?

* Improved layout of Weather information

## Screenshots (if appropriate):

Before:

<img width="1302" height="760" alt="Screenshot 2025-10-15 at 10 44 42 PM" src="https://github.com/user-attachments/assets/3c20fe0f-cb31-4a90-a57e-5ee926073666" />

After:

<img width="1305" height="758" alt="Screenshot 2025-10-15 at 10 42 25 PM" src="https://github.com/user-attachments/assets/964bf00d-a19e-484b-a2dc-95d5dbc55231" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
