### PR TITLE
Fixes from previous refactor ISO 639-1-2/ISO 3166-1 PR

### DIFF
--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -434,6 +434,9 @@ bool CLangCodeExpander::LookupInISO639Tables(const std::string& code, std::strin
   StringUtils::Trim(sCode);
   uint32_t longCode = StringToLongCode(sCode);
 
+  if (longCode == NO_INT_LANG_CODE)
+    return false;
+
   if (sCode.length() == 2)
   {
     auto ret = CIso639_1::LookupByCode(longCode);

--- a/xbmc/utils/i18n/Iso639.h
+++ b/xbmc/utils/i18n/Iso639.h
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <limits>
 #include <ranges>
 #include <string>
 #include <string_view>
@@ -30,16 +31,20 @@ std::string LongCodeToString(uint32_t code);
 
 namespace
 {
+// \brief The language code has no 4 bytes integer representation (StringToLongCode)
+constexpr uint32_t NO_INT_LANG_CODE{std::numeric_limits<uint32_t>::max()};
+
 /*!
  * \brief Convert a language code from 2-3 letters string to a 4 bytes integer
  * \param[in] The string representation of the code
- * \return integer representation of the code
+ * \return integer representation of the code, otherwise NO_INT_LANG_CODE if fails
  */
 constexpr uint32_t StringToLongCode(std::string_view a)
 {
   const size_t len = a.length();
 
-  assert(len <= 4);
+  if (len == 0 || len > 4)
+    return NO_INT_LANG_CODE;
 
   return static_cast<uint32_t>(len >= 4 ? a[len - 4] : 0) << 24 |
          static_cast<uint32_t>(len >= 3 ? a[len - 3] : 0) << 16 |

--- a/xbmc/utils/i18n/Iso639_1.cpp
+++ b/xbmc/utils/i18n/Iso639_1.cpp
@@ -65,9 +65,16 @@ bool CIso639_1::ListLanguages(std::map<std::string, std::string>& langMap)
                          [](const LCENTRY& e)
                          { return std::make_pair(LongCodeToString(e.code), std::string{e.name}); });
 
-  std::ranges::transform(
-      TableISO639_1_DeprByName, std::inserter(langMap, langMap.end()), [](const LCENTRY& e)
-      { return std::make_pair(LongCodeToString(e.code), std::string{e.name} + " (Deprecated)"); });
+  std::ranges::transform(TableISO639_1_DeprByName, std::inserter(langMap, langMap.end()),
+                         [](const LCENTRY& e)
+                         {
+                           const std::string langCode = LongCodeToString(e.code);
+                           std::string desc{e.name};
+                           // Show the language code in the description to distinguish from the regular one
+                           desc += " \"" + langCode + "\"";
+
+                           return std::make_pair(langCode, desc);
+                         });
 
   return true;
 }

--- a/xbmc/utils/i18n/Iso639_1.cpp
+++ b/xbmc/utils/i18n/Iso639_1.cpp
@@ -24,6 +24,9 @@ std::optional<std::string> CIso639_1::LookupByCode(std::string_view code)
 
 std::optional<std::string> CIso639_1::LookupByCode(uint32_t longCode)
 {
+  if (longCode == NO_INT_LANG_CODE)
+    return std::nullopt;
+
   {
     auto it = std::ranges::lower_bound(TableISO639_1ByCode, longCode, {}, &LCENTRY::code);
     if (it != TableISO639_1ByCode.end() && longCode == it->code)

--- a/xbmc/utils/i18n/Iso639_2.cpp
+++ b/xbmc/utils/i18n/Iso639_2.cpp
@@ -64,6 +64,9 @@ std::optional<std::string> CIso639_2::LookupByCode(std::string_view tCode)
 
 std::optional<std::string> CIso639_2::LookupByCode(uint32_t longTcode)
 {
+  if (longTcode == NO_INT_LANG_CODE)
+    return std::nullopt;
+
   auto it = std::ranges::lower_bound(TableISO639_2ByCode, longTcode, {}, &LCENTRY::code);
   if (it != TableISO639_2ByCode.end() && longTcode == it->code)
     return std::string{it->name};
@@ -107,6 +110,9 @@ bool CIso639_2::ListLanguages(std::map<std::string, std::string>& langMap)
 
 std::optional<uint32_t> CIso639_2::BCodeToTCode(uint32_t bCode)
 {
+  if (bCode == NO_INT_LANG_CODE)
+    return std::nullopt;
+
   auto it =
       std::ranges::lower_bound(ISO639_2_TB_MappingsByB, bCode, {}, &ISO639_2_TB::bibliographic);
   if (it != ISO639_2_TB_MappingsByB.end() && bCode == it->bibliographic)
@@ -118,6 +124,9 @@ std::optional<uint32_t> CIso639_2::BCodeToTCode(uint32_t bCode)
 std::optional<std::string> CIso639_2::TCodeToBCode(std::string_view tCode)
 {
   const uint32_t longCode = StringToLongCode(tCode);
+
+  if (longCode == NO_INT_LANG_CODE)
+    return std::nullopt;
 
   auto it =
       std::ranges::lower_bound(ISO639_2_TB_Mappings, longCode, {}, &ISO639_2_TB::terminological);

--- a/xbmc/utils/i18n/test/TestIso639_1.cpp
+++ b/xbmc/utils/i18n/test/TestIso639_1.cpp
@@ -40,6 +40,11 @@ TEST(TestI18nIso639_1, LookupByCode1)
   longCode = StringToLongCode("zz");
   result = CIso639_1::LookupByCode(longCode);
   EXPECT_FALSE(result.has_value());
+
+  // invalid case, must not match to any value
+  longCode = StringToLongCode("pt-br");
+  result = CIso639_1::LookupByCode(longCode);
+  EXPECT_FALSE(result.has_value());
 }
 
 TEST(TestI18nIso639_1, LookupByCode2)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
fix regression from PR #27314

1) Fix crashes when you pass language code with region such as "pt-br" or others, due to assert check
https://github.com/xbmc/xbmc/blob/c5799f0e143f2aa8e744c902d0fff04f9f92bee0/xbmc/utils/i18n/Iso639.h#L42

2) Removed "deprecated" text from language list, IMO this is not a thing that should be shown in GUI, users have no idea of the meaning, better show the language code to distinguish from the regular version
BEFORE:
<img width="1018" height="300" alt="501877133-a327a4c3-44e2-454d-9ae7-a47a54d19ed4" src="https://github.com/user-attachments/assets/b0f840a9-d47c-49e3-981d-8e6db9f19f62" />
AFTER:
<img width="1044" height="268" alt="immagine" src="https://github.com/user-attachments/assets/706d02f8-ca56-43a1-b713-0a2bf0fa5d62" />
If you prefer other type of text style let me know

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
see comments from https://github.com/xbmc/xbmc/pull/27314#issuecomment-3407696326
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
