### PR TITLE
Fix languages lookup assert

### DIFF
--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -432,11 +432,10 @@ bool CLangCodeExpander::LookupInISO639Tables(const std::string& code, std::strin
   std::string sCode(code);
   StringUtils::ToLower(sCode);
   StringUtils::Trim(sCode);
-  uint32_t longCode = StringToLongCode(sCode);
 
   if (sCode.length() == 2)
   {
-    auto ret = CIso639_1::LookupByCode(longCode);
+    auto ret = CIso639_1::LookupByCode(StringToLongCode(sCode));
     if (ret)
     {
       desc = *ret;
@@ -445,6 +444,8 @@ bool CLangCodeExpander::LookupInISO639Tables(const std::string& code, std::strin
   }
   else if (sCode.length() == 3)
   {
+    uint32_t longCode = StringToLongCode(sCode);
+
     // Map B to T for the few codes that have differences
     auto tCode = CIso639_2::BCodeToTCode(longCode);
     if (tCode)

--- a/xbmc/utils/i18n/Iso639.h
+++ b/xbmc/utils/i18n/Iso639.h
@@ -31,8 +31,8 @@ std::string LongCodeToString(uint32_t code);
 namespace
 {
 /*!
- * \brief Convert a language code from 2-3 letters string to a 4 bytes integer
- * \param[in] The string representation of the code
+ * \brief Convert a language code from 2-3 letter string to a 4-byte integer
+ * \param[in] a The string representation of the code
  * \return integer representation of the code
  */
 constexpr uint32_t StringToLongCode(std::string_view a)

--- a/xbmc/utils/i18n/Iso639_1.cpp
+++ b/xbmc/utils/i18n/Iso639_1.cpp
@@ -62,9 +62,9 @@ bool CIso639_1::ListLanguages(std::map<std::string, std::string>& langMap)
                          [](const LCENTRY& e)
                          { return std::make_pair(LongCodeToString(e.code), std::string{e.name}); });
 
-  std::ranges::transform(
-      TableISO639_1_DeprByName, std::inserter(langMap, langMap.end()), [](const LCENTRY& e)
-      { return std::make_pair(LongCodeToString(e.code), std::string{e.name} + " (Deprecated)"); });
+  std::ranges::transform(TableISO639_1_DeprByName, std::inserter(langMap, langMap.end()),
+                         [](const LCENTRY& e)
+                         { return std::make_pair(LongCodeToString(e.code), std::string{e.name}); });
 
   return true;
 }

--- a/xbmc/utils/i18n/Iso639_2.cpp
+++ b/xbmc/utils/i18n/Iso639_2.cpp
@@ -99,7 +99,7 @@ bool CIso639_2::ListLanguages(std::map<std::string, std::string>& langMap)
     //! Is it worth the effort and memory though.
     auto it = std::ranges::lower_bound(TableISO639_2ByCode, tb.terminological, {}, &LCENTRY::code);
     if (it != TableISO639_2ByCode.end() && tb.terminological == it->code)
-      langMap[bCode] = std::string(it->name) + " (non-preferred)";
+      langMap[bCode] = std::string(it->name);
   }
 
   return true;

--- a/xbmc/utils/test/TestLangCodeExpander.cpp
+++ b/xbmc/utils/test/TestLangCodeExpander.cpp
@@ -10,6 +10,16 @@
 
 #include <gtest/gtest.h>
 
+// Trick to make protected methods accessible for testing
+class CLangCodeExpanderTest : public CLangCodeExpander
+{
+public:
+  static bool CallLookupInISO639Tables(const std::string& code, std::string& desc)
+  {
+    return LookupInISO639Tables(code, desc);
+  }
+};
+
 TEST(TestLangCodeExpander, ConvertISO6391ToISO6392B)
 {
   std::string refstr, varstr;
@@ -159,4 +169,23 @@ TEST(TestLangCodeExpander, ConvertToISO6392T)
   varstr = "invalid";
   EXPECT_FALSE(g_LangCodeExpander.ConvertToISO6392T("deu", varstr));
   EXPECT_EQ(refstr, varstr);
+}
+
+TEST(TestLangCodeExpander, LookupInISO639Tables)
+{
+  std::string refstr, varstr;
+
+  refstr = "English";
+  EXPECT_TRUE(CLangCodeExpanderTest::CallLookupInISO639Tables("en", varstr));
+  EXPECT_EQ(refstr, varstr);
+
+  EXPECT_TRUE(CLangCodeExpanderTest::CallLookupInISO639Tables("eng", varstr));
+  EXPECT_EQ(refstr, varstr);
+
+  // There are no ISO 639-1 codes reserved for private use - use currently unassigned zz to test expected failure
+  EXPECT_FALSE(CLangCodeExpanderTest::CallLookupInISO639Tables("zz", varstr));
+
+  // Not alpha-2 or alpha-3 code format
+  EXPECT_FALSE(CLangCodeExpanderTest::CallLookupInISO639Tables("a", varstr));
+  EXPECT_FALSE(CLangCodeExpanderTest::CallLookupInISO639Tables("fr-CA", varstr));
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

LangCodeExpander::Lookup could trigger the assert in StringToLongCode() with BCP 47 language tags due to not checking length correctly prior to the call as the code before #27229 used to. Matching unit test added.

The appearance change of deprecated ISO 639-1 language codes in the languages list sparked some debate and bike shedding. Since it wasn't the purpose of the previous PRs or this one, the appearance is reverted to that prior to the PRs (=identical looking languages lines in the list), to be modified in followup PRs.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

assert triggered by ISA

debate around the appearance of deprecated languages.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added unit tests.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Hopefully clearer language list.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
