### PR TITLE
Update XBMCProperties.java.in due a bug defining "xbmc.data" property in TVs that can't read default "xbmc_env.properties" file

### DIFF
--- a/tools/android/packaging/xbmc/src/XBMCProperties.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCProperties.java.in
@@ -53,7 +53,7 @@ public class XBMCProperties
     }
     
     //Fallback to define "xbmc.data" pointing to Kodi Installation Path in case of "xbmc.data" is not already defined
-    if(System.getProperty("xbmc.data")==null||System.getProperty("xbmc.data").isBlank()) {
+    if (System.getProperty("xbmc.data") == null || System.getProperty("xbmc.data").trim().isEmpty())
       Properties sysProp = new Properties(System.getProperties());
       System.setProperty("xbmc.data", mContext.getFilesDir()+"");
       System.setProperty("xbmc.proploaded", "yes");

--- a/tools/android/packaging/xbmc/src/XBMCProperties.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCProperties.java.in
@@ -51,6 +51,14 @@ public class XBMCProperties
         Log.e(TAG, "XBMCProperties: Error loading " + propfn + " (" + e.getMessage() + ")");
       }
     }
+    
+    //Fallback to define "xbmc.data" pointing to Kodi Installation Path in case of "xbmc.data" is not already defined
+    if(System.getProperty("xbmc.data")==null||System.getProperty("xbmc.data").isBlank()) {
+      Properties sysProp = new Properties(System.getProperties());
+      System.setProperty("xbmc.data", mContext.getFilesDir()+"");
+      System.setProperty("xbmc.proploaded", "yes");
+      Log.i(TAG,"XBMCProperties: Defined 'xbmc.data' by default to '"+System.getProperty("xbmc.data")+"'");
+    }
   }
 
   public static String getStringProperty(String key, String devValue)


### PR DESCRIPTION
Added a Fallback to define "xbmc.data" pointing to Kodi Installation Path in case of "xbmc.data" is not already defined

## Description
Kodi installations on external flash memory of some Android TVs stores the database, metadata, and all Kodi stuff on internal flash memory instead of the external one. It forces device to run out of space quickly on internal storage and make TV to start malfunction in an intermittent way. For example no TV or turner or HDMI inputs.

## Motivation and context
[https://forum.kodi.tv/showthread.php?tid=382945](url)

## How has this been tested?
[https://forum.kodi.tv/showthread.php?tid=382945](url)

## What is the effect on users?
When Android TV runs out of storage on internal flash memory, TV or turner or HDMI inputs are unavailable.

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
