### PR TITLE
[win] make-mingwlibs add some defensive exits on failure paths

### DIFF
--- a/tools/buildsteps/windows/buildhelpers.sh
+++ b/tools/buildsteps/windows/buildhelpers.sh
@@ -29,7 +29,10 @@ if which tput >/dev/null 2>&1; then
 fi
 
 if [[ ! -d /build/src ]]; then
-  mkdir -p /build/src
+  if ! mkdir -p /build/src; then
+    echo "Unable to create src directory"
+    exit 1
+  fi
 fi
 
 do_wget() {

--- a/tools/buildsteps/windows/make-mingwlibs.sh
+++ b/tools/buildsteps/windows/make-mingwlibs.sh
@@ -130,6 +130,7 @@ run_builds() {
           echo "-------------------------------------------------------------------------------"
           echo " $TRIPLET build environment not configured, please run download-msys2.bat"
           echo "-------------------------------------------------------------------------------"
+          exit 1
         else
           source $profile_path
           buildProcess


### PR DESCRIPTION
## Description
return error codes on some failure paths, otherwise the scripts can be seen as still succeeding to the caller (eg cmake externalproject_add)

## Motivation and context
cmake internal ffmpeg build for windows was seen as succeeding, even when some fatal errors occured. 

## How has this been tested?
locally by forcing failures such as commented in https://github.com/xbmc/xbmc/pull/27351#issuecomment-3404021042

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
