### PR TITLE
webOS: remove extradata from aac, set profile as per spec

### DIFF
--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
@@ -820,7 +820,7 @@ std::string CMediaPipelineWebOS::SetupAudio(CDVDStreamInfo& audioHint, CVariant&
   else if (audioHint.codec == AV_CODEC_ID_AAC || audioHint.codec == AV_CODEC_ID_AAC_LATM)
   {
     optInfo["aacInfo"]["channels"] = audioHint.channels;
-    optInfo["aacInfo"]["profile"] = audioHint.profile;
+    optInfo["aacInfo"]["profile"] = audioHint.profile + 1;
     optInfo["aacInfo"]["format"] = audioHint.extradata ? "raw" : "adts";
 
     const uint8_t* data = audioHint.extradata.GetData();
@@ -833,14 +833,6 @@ std::string CMediaPipelineWebOS::SetupAudio(CDVDStreamInfo& audioHint, CVariant&
       unsigned int parsedRate = ParseAACSampleRate(data, size);
       if (parsedRate > 0)
         audioHint.samplerate = parsedRate;
-
-      CVariant codecData;
-      codecData.reserve(size);
-      for (size_t i = 0; i < size; ++i)
-        codecData.append(static_cast<int>(data[i]));
-
-      optInfo["aacInfo"]["codecData"] = codecData;
-      optInfo["aacInfo"]["codecSize"] = static_cast<int>(size);
     }
 
     optInfo["aacInfo"]["frequency"] = audioHint.samplerate / 1000.0;


### PR DESCRIPTION
## Description
Fixes for incorrect AAC profile being selected by webOS, which breaks playback on some older webOS versions

## Motivation and context
It was reported that a AAC LC test file was not being played back correctly on webOS 5 (however same file works fine on mine which is webOS 10).

It appears that extradata is not actually required for playback of any of the test files, and that webOS actually recreates the extradata from the other config we give it, so it is not required (and may cause issues). What it actually uses the extradata for however is anyone's guess.

Cause of the issue might be that AAC profiles start from 1 (Source: https://wiki.multimedia.cx/index.php/MPEG-4_Audio),  however ffmpeg profiles start from 0 e.g.:
```
#define AV_PROFILE_AAC_MAIN         0
#define AV_PROFILE_AAC_LOW          1
#define AV_PROFILE_AAC_SSR          2
#define AV_PROFILE_AAC_LTP          3
#define AV_PROFILE_AAC_HE           4
```

At present when passing the ffmpeg profile for a AAC LC test file it is not picking the right profile on their end.

Test file - ffmpeg -i:
```
Stream #0:1[0x2](und): Audio: aac (LC) (mp4a / 0x6134706D), 32000 Hz, 5.1, fltp, 266 kb/s (default)
```

**webOS: AAC Codec data** = 0xA, 0xB0 -> AudioSpecificConfig for AAC Main profile, this is wrong.

Passing profile + 1 however becomes:

**webOS: AAC Codec data** = 0x12, 0xB0 -> AAC‑LC, this is now correct

Also confirmed with HE-AAC and HE-AAC v2:

**HE-AAC v1 test file** -> 0x2B, 0xB0, HE‑AAC v1 (AAC‑LC core + SBR), this is now correct with profile + 1
**HE-AAC v2 test file** -> 0xEB, 0x10, HE‑AAC v2 (AAC‑LC + SBR + Parametric Stereo), this is now correct with profile + 1

So the correct thing to do is set profile + 1 to match the spec.

## How has this been tested?
**HE-AAC v1** (ChID-BLITS-EBU.HE-AAC)
**HE-AAC v2** (LFE-SBRstereo.HE-AACv2)
**AAC LC 5.1** (ChID-BLITS-EBU.HE-AAC) convert to AAC LC 5.1 by ffmpeg
**AAC LC 2.0** (ITV-X playback)

Note: The frequency is still wrong in the AAC codec data, e.g. in the test file it is 32 Khz, but we are clearly passing it the correct values:
```
AAC format=raw, channels=6, frequency=32000, AOT=2 freqIdx[5], frequency[32000]
AAC Codec data = 0x12, 0xB0, 0x0 , 0x0 , 0x0, 0x0
```

32000 Khz → 5 frequency Index
However, channels is incorrect, but it plays back in 5.1 with my surround sound just fine.

## What is the effect on users?
Playback correctly for some webOS versions

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
