### PR TITLE
[windows] PlatformDefs.h update typedef for ssize_t

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
@@ -95,7 +95,8 @@
 
 #ifdef _WIN32 // windows
 #if !defined(_SSIZE_T_DEFINED) && !defined(HAVE_SSIZE_T)
-typedef intptr_t ssize_t;
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
 #define _SSIZE_T_DEFINED
 #endif // !_SSIZE_T_DEFINED
 #ifndef SSIZE_MAX

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/filesystem.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/filesystem.h
@@ -15,7 +15,8 @@
 
 #ifdef _WIN32 // windows
 #ifndef _SSIZE_T_DEFINED
-typedef intptr_t ssize_t;
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
 #define _SSIZE_T_DEFINED
 #endif // !_SSIZE_T_DEFINED
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -37,8 +37,8 @@
 // because cmake uses this area in this form to perform its addon dependency
 // check.
 // clang-format off
-#define ADDON_GLOBAL_VERSION_MAIN                     "2.0.2"
-#define ADDON_GLOBAL_VERSION_MAIN_MIN                 "2.0.0"
+#define ADDON_GLOBAL_VERSION_MAIN                     "2.0.3"
+#define ADDON_GLOBAL_VERSION_MAIN_MIN                 "2.0.3"
 #define ADDON_GLOBAL_VERSION_MAIN_XML_ID              "kodi.binary.global.main"
 #define ADDON_GLOBAL_VERSION_MAIN_DEPENDS             "AddonBase.h" \
                                                       "addon-instance/" \
@@ -62,8 +62,8 @@
 #define ADDON_GLOBAL_VERSION_AUDIOENGINE_DEPENDS      "AudioEngine.h" \
                                                       "c-api/audio_engine.h"
 
-#define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.1.10"
-#define ADDON_GLOBAL_VERSION_FILESYSTEM_MIN           "1.1.7"
+#define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.1.11"
+#define ADDON_GLOBAL_VERSION_FILESYSTEM_MIN           "1.1.11"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_XML_ID        "kodi.binary.global.filesystem"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_DEPENDS       "Filesystem.h" \
                                                       "c-api/filesystem.h" \

--- a/xbmc/platform/win32/PlatformDefs.h
+++ b/xbmc/platform/win32/PlatformDefs.h
@@ -20,7 +20,8 @@ typedef __int64       __off64_t;
 typedef long          __off_t;
 
 #if !defined(_SSIZE_T_DEFINED) && !defined(HAVE_SSIZE_T)
-typedef intptr_t      ssize_t;
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
 #define _SSIZE_T_DEFINED
 #endif // !_SSIZE_T_DEFINED
 #ifndef SSIZE_MAX


### PR DESCRIPTION
## Description
windows basetsd.h sets a different definition. use the default windows now provides

https://learn.microsoft.com/en-us/windows/win32/winprog/windows-data-types

```
SSIZE_T	
A signed version of [SIZE_T](https://learn.microsoft.com/en-us/windows/win32/winprog/windows-data-types#size_t).

This type is declared in BaseTsd.h as follows:

typedef LONG_PTR SSIZE_T;
```

## Motivation and context
libudfread has made a change in its public headers for new (unreleased) version. https://code.videolan.org/videolan/libudfread/-/commit/92016f87a84780cb76f123897160e00434a4fc89

As we include this in kodi, it currently fails to build on some platforms (win32)

```
C:\xbmc\project\BuildDependencies\win32\include\udfread\udfread.h(34,17): error C2371: 'ssize_
t': redefinition; different basic types [C:\xbmc\build\libkodi.vcxproj]
  (compiling source file '../xbmc/filesystem/UDFDirectory.cpp')
      C:\xbmc\xbmc\platform\win32\PlatformDefs.h(23,23):
      see declaration of 'ssize_t'
```

The initial commit that brings our definition of ssize_t dates way back to prior to MS providing a definition of ssize_t as best i can tell.

Instead of defining our own, use what appears to have become the "standard" definition with modern MSC.

I assume we need to make the dev-kit match the internal PlatformsDef.h, else goblins may appear. @notspiff maybe you can give some insight regarding the addon ramifications of such a change?

If we change the dev-kit, i assume this will force rebuild requirements for most (all?) addons due to the addon_base.h change?

## How has this been tested?
Can build/run win32 build with newest libudfread

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
