### PR TITLE
[cmake] add meson cross generation macros and add cmake binary to meson.cross

### DIFF
--- a/cmake/scripts/common/ModuleHelpers.cmake
+++ b/cmake/scripts/common/ModuleHelpers.cmake
@@ -709,3 +709,161 @@ endmacro()
 define_property(TARGET PROPERTY LIB_BUILD
                        BRIEF_DOCS "This target will be compiling the library"
                        FULL_DOCS "This target will be compiling the library")
+
+
+# Functions to generate meson cross files for a platform
+
+macro(generate_mesoncrossfile)
+
+  create_mesonbinaries()
+  file(WRITE ${DEPENDS_PATH}/share/cross-file.meson "${meson_binaries_string}\n")
+
+  create_mesonhostmachine()
+  file(APPEND ${DEPENDS_PATH}/share/cross-file.meson "${meson_host_machine_string}\n")
+
+  create_mesonproperties()
+  file(APPEND ${DEPENDS_PATH}/share/cross-file.meson "${meson_properties_string}\n")
+
+  create_mesonbuiltin()
+  file(APPEND ${DEPENDS_PATH}/share/cross-file.meson "${meson_builtin_string}\n")
+
+endmacro()
+
+# Creates the [binaries] block of a meson cross file
+# sets meson_binaries_string to PARENT_SCOPE
+function(create_mesonbinaries)
+
+  set(binariespairs "c" "CMAKE_C_COMPILER"
+                    "cpp" "CMAKE_CXX_COMPILER"
+                    "ar" "CMAKE_AR"
+                    "cmake" "CMAKE_COMMAND")
+
+  if(NOT "${CMAKE_STRIP}" STREQUAL "")
+    list(APPEND binariespairs "strip" "CMAKE_STRIP")
+  endif()
+
+  if(PKG_CONFIG_EXECUTABLE)
+    list(APPEND binariespairs "pkg-config" "PKG_CONFIG_EXECUTABLE")
+  endif()
+
+  # Get/set loop limit (Size - 1) from size of binariespairs list
+  list(LENGTH binariespairs options_length)
+  math(EXPR options_length "${options_length} - 1")
+
+  foreach(option_arg RANGE 0 ${options_length} 2)
+    math(EXPR cmake_arg "${option_arg} + 1")
+    # meson option name
+    list(GET binariespairs ${option_arg} meson_label_name)
+    # cmake source variable name
+    list(GET binariespairs ${cmake_arg} cmake_binary_name)
+
+    set(input "${${cmake_binary_name}}")
+    string(STRIP "${input}" input)
+
+    string(PREPEND input "${meson_label_name} = '")
+    string(APPEND input "'")
+    string(APPEND output_string "${input}\n")
+  endforeach()
+
+  # Easiest to just prepend header at the end of the full string creation
+  string(PREPEND output_string "[binaries]\n")
+  set(meson_binaries_string ${output_string} PARENT_SCOPE)
+endfunction()
+
+# Creates the [host_machine] block of a meson cross file
+# sets meson_host_machine_string to PARENT_SCOPE
+function(create_mesonhostmachine)
+
+  # Non-exhaustive list to map cmake CPU to meson cpu names
+  # https://mesonbuild.com/Reference-tables.html#cpu-families
+  string(TOUPPER ${CMAKE_C_COMPILER_ARCHITECTURE_ID} UPPER_C_ARCH)
+  if("${UPPER_C_ARCH}" MATCHES "ARM64" OR "${UPPER_C_ARCH}" MATCHES "AARCH64")
+    set(meson_cpu_family aarch64)
+  elseif("${UPPER_C_ARCH}" MATCHES "ARMV.")
+    set(meson_cpu_family arm)
+  elseif("${UPPER_C_ARCH}" STREQUAL "x64" OR "${UPPER_C_ARCH}" STREQUAL "X86_64")
+    set(meson_cpu_family x86_64)
+  elseif("${UPPER_C_ARCH}" STREQUAL "X86" OR "${UPPER_C_ARCH}" MATCHES "I.86")
+    set(meson_cpu_family x86)
+  endif()
+
+  # Non-exhaustive list to map cmake to meson os names
+  # https://mesonbuild.com/Reference-tables.html#operating-system-names
+  if(CMAKE_SYSTEM_NAME MATCHES "Android")
+    set(meson_sys_name android)
+  elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+    set(meson_sys_name darwin)
+  elseif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+    set(meson_sys_name freebsd)
+  elseif(CMAKE_SYSTEM_NAME MATCHES "Linux")
+    set(meson_sys_name linux)
+  elseif(CMAKE_SYSTEM_NAME MATCHES "NetBSD")
+    set(meson_sys_name netbsd)
+  elseif(CMAKE_SYSTEM_NAME MATCHES Windows)
+    set(meson_sys_name windows)
+  endif()
+
+  string(APPEND output_string "system = '${meson_sys_name}'\n")
+  string(APPEND output_string "cpu_family = '${meson_cpu_family}'\n")
+
+  # cpu is apparently unnecessary from a functional stand point, however the field
+  # is still required. We have no easy way to populate, so for now just use an empty value
+  string(APPEND output_string "cpu = ''\n")
+  string(APPEND output_string "endian = 'little'\n")
+
+  # Easiest to just prepend header at the end of the full string creation
+  string(PREPEND output_string "[host_machine]\n")
+  set(meson_host_machine_string ${output_string} PARENT_SCOPE)
+endfunction()
+
+# Creates the [properties] block of a meson cross file
+# sets meson_properties_string to PARENT_SCOPE
+function(create_mesonproperties)
+
+  string(APPEND output_string "pkg_config_libdir = '${DEPENDS_PATH}/lib/pkgconfig'\n")
+
+  # Easiest to just prepend header at the end of the full string creation
+  string(PREPEND output_string "[properties]\n")
+  set(meson_properties_string ${output_string} PARENT_SCOPE)
+endfunction()
+
+# Creates the [Built-in Options] block of a meson cross file
+# sets meson_builtin_string to PARENT_SCOPE
+function(create_mesonbuiltin)
+
+  set(builtinpairs "c_args" "CMAKE_C_FLAGS"
+                   "c_link_args" "CMAKE_EXE_LINKER_FLAGS"
+                   "cpp_args" "CMAKE_CXX_FLAGS"
+                   "cpp_link_args" "CMAKE_EXE_LINKER_FLAGS")
+
+  # Get/set loop limit (Size - 1) from size of builtinpairs list
+  list(LENGTH builtinpairs options_length)
+  math(EXPR options_length "${options_length} - 1")
+
+  foreach(option_arg RANGE 0 ${options_length} 2)
+    math(EXPR cmake_flag_arg "${option_arg} + 1")
+    # meson option name
+    list(GET builtinpairs ${option_arg} meson_label_name)
+    # cmake source variable name
+    list(GET builtinpairs ${cmake_flag_arg} cmake_flag_name)
+
+    set(input "${${cmake_flag_name}}")
+    string(STRIP "${input}" input)
+
+    # builtinpairs cmake source variables are specifically single strings, and not lists
+    string(REPLACE " " "', '" tmp_string "${input}")
+    string(PREPEND tmp_string "${meson_label_name} = ['")
+    string(APPEND tmp_string "']")
+    string(APPEND output_string "${tmp_string}\n")
+  endforeach()
+
+  string(APPEND output_string "default_library = 'static'\n")
+  string(APPEND output_string "prefix = '${DEPENDS_PATH}'\n")
+  string(APPEND output_string "libdir = 'lib'\n")
+  string(APPEND output_string "bindir = 'bin'\n")
+  string(APPEND output_string "includedir = 'include'\n")
+
+  # Easiest to just prepend header at the end of the full string creation
+  string(PREPEND output_string "[built-in options]\n")
+  set(meson_builtin_string ${output_string} PARENT_SCOPE)
+endfunction()

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -818,6 +818,7 @@ c = $MESON_CC
 cpp = $MESON_CXX
 ar = '$AR'
 strip = '$STRIP'
+cmake = '$prefix/$tool_dir/bin/cmake'
 pkgconfig = '$prefix/$tool_dir/bin/pkg-config'
 pkg-config = '$prefix/$tool_dir/bin/pkg-config'
 


### PR DESCRIPTION
## Description
add cmake to [binaries] for tools/depends, and add generation macros for a meson target cross file.

## Motivation and context
pull out some standalone commits from #27369

macros/functions in ModuleHelpers are currently unused, but will be a requirement to enable using meson build systems on windows platforms. We have to use cross files to be able to build non host platforms (ie UWP, or ARM64/x86 on an x86_64 host)

## How has this been tested?
macos/windows - meson.cross files generated, and match expected output

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
