### PR TITLE
[win] get_formed enable supplying alternate source url for individual package

### DIFF
--- a/project/BuildDependencies/scripts/get_formed.cmd
+++ b/project/BuildDependencies/scripts/get_formed.cmd
@@ -31,8 +31,13 @@ echo Downloading from mirror %KODI_MIRROR%
 CALL :setStageName Starting downloads of Host (%NATIVEPLATFORM%) formed packages...
 SET SCRIPT_PATH=%CD%
 CD %DL_PATH% || EXIT /B 10
-FOR /F "eol=; tokens=1" %%f IN (%SCRIPT_PATH%\0_package.native-%NATIVEPLATFORM%.list) DO (
-  CALL :processFile %%f %NATIVE_PATH%
+FOR /F "eol=; tokens=1,2" %%f IN (%SCRIPT_PATH%\0_package.native-%NATIVEPLATFORM%.list) DO (
+  IF "%%g" == "" (
+    set "BASE_URL=%KODI_MIRROR%/build-deps/win32"
+  ) ELSE (
+    set "BASE_URL=%%g"
+  )
+  CALL :processFile %%f %NATIVE_PATH% !BASE_URL!
   REM Apparently there's a quirk in cmd so this means if error level => 1
   IF ERRORLEVEL 1 (
     ECHO One or more packages failed to download
@@ -42,8 +47,13 @@ FOR /F "eol=; tokens=1" %%f IN (%SCRIPT_PATH%\0_package.native-%NATIVEPLATFORM%.
 
 CALL :setStageName Starting downloads of Target (%TARGETPLATFORM%) formed packages...
 CD %DL_PATH% || EXIT /B 10
-FOR /F "eol=; tokens=1" %%f IN (%SCRIPT_PATH%\0_package.target-%TARGETPLATFORM%.list) DO (
-  CALL :processFile %%f %APP_PATH%
+FOR /F "eol=; tokens=1,2" %%f IN (%SCRIPT_PATH%\0_package.target-%TARGETPLATFORM%.list) DO (
+  IF "%%g" == "" (
+    set "BASE_URL=%KODI_MIRROR%/build-deps/win32"
+  ) ELSE (
+    set "BASE_URL=%%g"
+  )
+  CALL :processFile %%f %APP_PATH% !BASE_URL!
   REM Apparently there's a quirk in cmd so this means if error level => 1
   IF ERRORLEVEL 1 (
     ECHO One or more packages failed to download
@@ -73,8 +83,8 @@ SET RetryDownload=YES
 IF EXIST %1 (
   ECHO Using downloaded %1
 ) ELSE (
-  CALL :setSubStageName Downloading %1...
-  SET DOWNLOAD_URL=%KODI_MIRROR%/build-deps/win32/%1
+  CALL :setSubStageName Downloading %1 from %3...
+  SET DOWNLOAD_URL=%3/%1
   curl --retry 5 --retry-all-errors --retry-connrefused --retry-delay 5 --location --remote-name "!DOWNLOAD_URL!" 2>&1
   REM Apparently there's a quirk in cmd so this means if error level => 1
   IF ERRORLEVEL 1 (


### PR DESCRIPTION
## Description
Enable adding the equivalent to BASE_URL used tools/depends VERSION files.

An example addition to 0-package.native-win32.list could be

meson-1.9.1-64.msi https://github.com/mesonbuild/meson/releases/download/1.9.1/

Where the package meson-1.9.1-64.msi would be downloaded from the supplied url, and all other packages would continue to use the default url as supplied by KODI_MIRROR var

Another potential use case is for testing artifacts from kodi-deps. You can extract the archive from the kodi-deps build, and then upload (eg to github) and then reference the location

## Motivation and context
Test additions to native build tools for windows without being on mirrors

## How has this been tested?
Used in #27369

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
