### PR TITLE
[webOS] Bundle gst-plugin-scanner

### DIFF
--- a/cmake/scripts/webos/Install.cmake
+++ b/cmake/scripts/webos/Install.cmake
@@ -30,6 +30,7 @@ set(APP_INSTALL_DIRS ${CMAKE_BINARY_DIR}/addons
                      ${CMAKE_BINARY_DIR}/userdata)
 set(APP_TOOLCHAIN_FILES ${TOOLCHAIN}/${HOST}/sysroot/lib/libatomic.so.1
                         ${TOOLCHAIN}/${HOST}/sysroot/lib/libcrypt.so.1
+                        ${TOOLCHAIN}/${HOST}/sysroot/usr/libexec/gstreamer-1.0/gst-plugin-scanner
                         ${CMAKE_BINARY_DIR}/libAcbAPI.so.1)
 set(BIN_ADDONS_DIR ${DEPENDS_PATH}/addons)
 

--- a/xbmc/platform/linux/PlatformWebOS.cpp
+++ b/xbmc/platform/linux/PlatformWebOS.cpp
@@ -47,6 +47,7 @@ bool CPlatformWebOS::InitStageOne()
   const auto HOME = GetHomePath();
 
   setenv("APPID", CCompileInfo::GetPackage(), 0);
+  setenv("GST_PLUGIN_SCANNER", (HOME + "/lib/gst-plugin-scanner").c_str(), 1);
   setenv("XDG_RUNTIME_DIR", "/tmp/xdg", 1);
   setenv("XKB_CONFIG_ROOT", "/usr/share/X11/xkb", 1);
   setenv("WAYLAND_DISPLAY", "wayland-0", 1);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Bundle `gst-plugin-scanner` to prevent permission issues in certain jailer configs causing segfaults for certain files.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
```
(kodi-webos:8191): GStreamer-WARNING **: 21:34:28.521: External plugin loader failed. This most likely means that the plugin loader helper binary was not found or could not be run. You might need to set the GST_PLUGIN_SCANNER environment variable if your setup is unusual. This should normally not be required though.
```

strace shows:
```
[pid  8797] execve("/usr/libexec/gstreamer-1.0/gst-plugin-scanner", ["/usr/libexec/gstreamer-1.0/gst-p"..., "-l", "/media/developer/apps/usr/palm/a"...], 0xab9ded8 /* 98 vars */) = -1 ENOENT (No such file or directory)
```

Unfortutately, it seems that certain jailer configuration can be missing access to `/usr/libexec/gstreamer-1.0` making the call to `gst-plugin-scanner` fail and causing a segfault. To prevent this we can bundle our own `gst-plugin-scanner` from the toolchain and update the environment variable `GST_PLUGIN_SCANNER` to point to it.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS 10

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
