### PR TITLE
[Estuary] Update visibility conditions for versions and extras

### DIFF
--- a/addons/skin.estuary/xml/DialogVideoInfo.xml
+++ b/addons/skin.estuary/xml/DialogVideoInfo.xml
@@ -704,13 +704,13 @@
 							<label>$LOCALIZE[40000]</label>
 							<icon>icons/infodialogs/versions.png</icon>
 							<onclick>SendClick(14)</onclick>
-							<visible>String.IsEqual(ListItem.DBType,movie)</visible>
+							<visible>ListItem.HasVideoVersions</visible>
 						</item>
 						<item>
 							<label>$LOCALIZE[40211]</label>
 							<icon>icons/infodialogs/extras.png</icon>
 							<onclick>SendClick(15)</onclick>
-							<visible>String.IsEqual(ListItem.DBType,movie)</visible>
+							<visible>ListItem.HasVideoExtras</visible>
 						</item>
 						<item>
 							<label>$LOCALIZE[20457]</label>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Changed the visibility conditions for the 'versions' and 'extras' items in DialogVideoInfo.xml to use ListItem.HasVideoVersions and ListItem.HasVideoExtras instead of checking for movie DBType. This allows these items to be shown based on actual availability rather than just item type.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As mentioned on the forum these buttons weren't hidden when they should be.
https://forum.kodi.tv/showthread.php?tid=337992&pid=3243966#pid3243966

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
