### PR TITLE
[Android] Catch NameNotFoundException when returns the application's Resources

### DIFF
--- a/xbmc/platform/android/filesystem/AndroidAppFile.cpp
+++ b/xbmc/platform/android/filesystem/AndroidAppFile.cpp
@@ -107,6 +107,8 @@ unsigned int CFileAndroidApp::ReadIcon(unsigned char** lpBuf, unsigned int* widt
   if (m_icon)
   {
     CJNIResources res = CJNIContext::GetPackageManager().getResourcesForApplication(m_packageName);
+    if (env->ExceptionCheck())
+      env->ExceptionClear();
     if (res)
     {
       for (int i=0; densities[i] != -1 && !bmp; ++i)


### PR DESCRIPTION
## Description
Catch the `PackageManager.NameNotFoundException` thrown if the resources for the given Android application cannot be loaded.

## Motivation and context
Detected while trying to identify the cause of the crash [reported in the forum](https://forum.kodi.tv/showthread.php?tid=382837) that occurs when selecting “Add-ons” in the side menu.

## How has this been tested?
My device does not have this problem with Android apps installed, so I cannot verify that it fixes the bug.

In any case, this improvement is necessary. 

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
