### PR TITLE
[cosmetic] Fix a couple doxygen texts of recent PRs

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6393,7 +6393,7 @@ constexpr std::array<InfoMap, 3> container_str = {{
 ///   \table_row3{   <b>`ListItem.AudioChannels(format)`</b>,
 ///                  \anchor ListItem_AudioChannels
 ///                  _string_,
-///     @param[in] format (optional) format of the infolabel. Possible values for the format:
+///     @param format (optional) format of the infolabel. Possible values for the format:
 ///       - <b>(blank)</b> no format value: count of channels
 ///       - <b>defaultlayout</b> return a default channel layout in the format x.y.z for the
 ///         channel count (x=listener level speakers\, y=lfe channels\, z=overhead channels).

--- a/xbmc/utils/i18n/Iso639_1.h
+++ b/xbmc/utils/i18n/Iso639_1.h
@@ -30,7 +30,7 @@ public:
 
   /*!
    * \brief Retrieve the name of the language for the provided ISO 639-1 code.
-   * \param[in] code alpha-2 ISO 639-1 code, coded as a 32 bit unsigned integer
+   * \param[in] longCode alpha-2 ISO 639-1 code, coded as a 32 bit unsigned integer
    * \return English name of the language, nullopt if no language by that code exists.
    */
   static std::optional<std::string> LookupByCode(uint32_t longCode);

--- a/xbmc/utils/i18n/Iso639_2.h
+++ b/xbmc/utils/i18n/Iso639_2.h
@@ -23,14 +23,14 @@ public:
 
   /*!
    * \brief Retrieve the name of the language for the provided ISO 639-2 code.
-   * \param[in] code alpha-3 ISO 639-2/T code
+   * \param[in] tCode alpha-3 ISO 639-2/T code
    * \return English name of the language, nullopt if no language by that code exists.
    */
   static std::optional<std::string> LookupByCode(std::string_view tCode);
 
   /*!
    * \brief Retrieve the name of the language for the provided ISO 639-2 code.
-   * \param[in] code alpha-3 ISO 639-2/T code, coded as a 32 bit unsigned integer
+   * \param[in] longCode alpha-3 ISO 639-2/T code, coded as a 32 bit unsigned integer
    * \return English name of the language, nullopt if no language by that code exists.
    */
   static std::optional<std::string> LookupByCode(uint32_t longTcode);

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -165,10 +165,10 @@ public:
   };
   /*!
    * \brief Set the original language, with optional preprocessing.
-   * \param language[in] ISO 639-2/B language code or text to be preprocessed.
+   * \param[in] language ISO 639-2/B language code or text to be preprocessed.
    * The preprocessing can convert from ISO 639-1, ISO 639-2/B and ISO 639-2/T codes or a full
    * english name string to ISO-639-2/B.
-   * \param proc[in] processing type
+   * \param[in] proc processing type
    * \return success of the preprocessing
    */
   bool SetOriginalLanguage(std::string language, LanguageProcessing proc);
@@ -331,8 +331,8 @@ public:
   bool HasVideoVersions() const { return m_hasVideoVersions; }
 
   /*!
-   * @brief Set whether this video has video versions.
-   * @param hasVersion The versions flag.
+   * \brief Set whether this video has video versions.
+   * \param[in] hasVersions The versions flag.
    */
   void SetHasVideoVersions(bool hasVersions);
 
@@ -444,7 +444,7 @@ public:
 protected:
   /*!
    * \brief Add the seasons information to an XML node
-   * \param element  the root XML element to append to
+   * \param[in] node the XML node to append to
    * \return true for success, false otherwise.
    */
   bool SaveTvShowSeasons(TiXmlNode* node) const;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Fix Doxygen problem introduced in #26835
For some reason, the parameter direction was not understood in the context of infolabels, even though it works fine for regular functions.

Fixed/improved a couple more warnings related to some of my recent PRs.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Thanks @Hitcher for pointing out the issue with ListItem.AudioChannels

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Built doxygen documentation locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
