### PR TITLE
[Android] Refactor CFileAndroidApp::ReadIcon function

### DIFF
--- a/xbmc/platform/android/filesystem/AndroidAppFile.cpp
+++ b/xbmc/platform/android/filesystem/AndroidAppFile.cpp
@@ -90,6 +90,31 @@ CJNIBitmap GetBitmapFromDrawable(CJNIDrawable& drawable)
   return bmp;
 }
 
+CJNIBitmap GetBitmap(CJNIDrawable& drawable)
+{
+  JNIEnv* env = xbmc_jnienv();
+  CJNIBitmap bmp;
+  jclass cBmpDrw = env->FindClass("android/graphics/drawable/BitmapDrawable");
+  jclass cAidDrw = CJNIBase::GetSDKVersion() >= 26
+                       ? env->FindClass("android/graphics/drawable/AdaptiveIconDrawable")
+                       : nullptr;
+
+  if (env->IsInstanceOf(drawable.get_raw(), cBmpDrw))
+  {
+    CJNIBitmapDrawable resbmp = drawable;
+    if (resbmp)
+      bmp = resbmp.getBitmap();
+  }
+  else if (cAidDrw && env->IsInstanceOf(drawable.get_raw(), cAidDrw))
+    bmp = GetBitmapFromDrawable(drawable);
+
+  env->DeleteLocalRef(cBmpDrw);
+  if (cAidDrw)
+    env->DeleteLocalRef(cAidDrw);
+
+  return bmp;
+}
+
 } // namespace
 
 unsigned int CFileAndroidApp::ReadIcon(unsigned char** lpBuf, unsigned int* width, unsigned int* height)
@@ -99,10 +124,6 @@ unsigned int CFileAndroidApp::ReadIcon(unsigned char** lpBuf, unsigned int* widt
   int densities[] = { CJNIDisplayMetrics::DENSITY_XXXHIGH, CJNIDisplayMetrics::DENSITY_XXHIGH, CJNIDisplayMetrics::DENSITY_XHIGH, -1 };
 
   CJNIBitmap bmp;
-  jclass cBmpDrw = env->FindClass("android/graphics/drawable/BitmapDrawable");
-  jclass cAidDrw = CJNIBase::GetSDKVersion() >= 26
-                       ? env->FindClass("android/graphics/drawable/AdaptiveIconDrawable")
-                       : nullptr;
 
   if (m_icon)
   {
@@ -113,22 +134,10 @@ unsigned int CFileAndroidApp::ReadIcon(unsigned char** lpBuf, unsigned int* widt
       {
         int density = densities[i];
         CJNIDrawable drw = res.getDrawableForDensity(m_icon, density, CJNIContext::getTheme());
-        if (xbmc_jnienv()->ExceptionCheck())
-          xbmc_jnienv()->ExceptionClear();
-        else if (!drw);
-        else
-        {
-          if (env->IsInstanceOf(drw.get_raw(), cBmpDrw))
-          {
-            CJNIBitmapDrawable resbmp = drw;
-            if (resbmp)
-              bmp = resbmp.getBitmap();
-          }
-          else if (cAidDrw && env->IsInstanceOf(drw.get_raw(), cAidDrw))
-          {
-            bmp = GetBitmapFromDrawable(drw);
-          }
-        }
+        if (env->ExceptionCheck())
+          env->ExceptionClear();
+        if (drw)
+          bmp = GetBitmap(drw);
       }
     }
   }
@@ -136,22 +145,10 @@ unsigned int CFileAndroidApp::ReadIcon(unsigned char** lpBuf, unsigned int* widt
   if (!bmp)
   {
     CJNIDrawable drw = CJNIContext::GetPackageManager().getApplicationIcon(m_packageName);
-    if (xbmc_jnienv()->ExceptionCheck())
-      xbmc_jnienv()->ExceptionClear();
-    else if (!drw);
-    else
-    {
-      if (env->IsInstanceOf(drw.get_raw(), cBmpDrw))
-      {
-        CJNIBitmapDrawable resbmp = drw;
-        if (resbmp)
-          bmp = resbmp.getBitmap();
-      }
-      else if (cAidDrw && env->IsInstanceOf(drw.get_raw(), cAidDrw))
-      {
-        bmp = GetBitmapFromDrawable(drw);
-      }
-    }
+    if (env->ExceptionCheck())
+      env->ExceptionClear();
+    if (drw)
+      bmp = GetBitmap(drw);
   }
   if (!bmp)
     return 0;


### PR DESCRIPTION
## Description
Remove duplicate code and simplify.

## How has this been tested?
Continue displaying the icons of Android apps installed on the device in the Add-ons menu.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
