### PR TITLE
[Video][Library] Local artwork rarely not found when importing a bluray:// movie.

### DIFF
--- a/xbmc/utils/ArtUtils.cpp
+++ b/xbmc/utils/ArtUtils.cpp
@@ -233,8 +233,8 @@ std::string GetLocalArtBaseFilename(const CFileItem& item,
   if (item.IsMultiPath())
     strFile = CMultiPathDirectory::GetFirstPath(item.GetPath());
 
-  if (URIUtils::IsBlurayPath(file))
-    file = strFile = URIUtils::GetDiscFile(file);
+  if (URIUtils::IsBlurayPath(item.GetDynPath()))
+    file = strFile = URIUtils::GetDiscFile(item.GetDynPath());
 
   if (URIUtils::IsOpticalMediaFile(file))
   {
@@ -242,9 +242,6 @@ std::string GetLocalArtBaseFilename(const CFileItem& item,
     useFolder = true; // ByRef so changes behaviour in GetLocalArt()
     strFile = URIUtils::GetBasePath(file);
   }
-
-  if (URIUtils::IsBlurayPath(file))
-    strFile = URIUtils::GetDiscFile(file);
 
   if (!URIUtils::GetFileName(file).empty() && item.HasVideoInfoTag() &&
       additionalIdentifiers != AdditionalIdentifiers::NONE)

--- a/xbmc/utils/test/TestArtUtils.cpp
+++ b/xbmc/utils/test/TestArtUtils.cpp
@@ -70,6 +70,7 @@ AdvancedSettingsResetBase::AdvancedSettingsResetBase()
 struct ArtFilenameTest
 {
   std::string path;
+  std::string dynPath;
   std::string result;
   bool isFolder = false;
   bool result_folder = false;
@@ -86,32 +87,36 @@ class GetLocalArtBaseFilenameTest : public testing::WithParamInterface<ArtFilena
 };
 
 const auto local_art_filename_tests = std::array{
-    ArtFilenameTest{"/home/user/foo.avi", "/home/user/foo.avi"},
-    ArtFilenameTest{"stack:///home/user/foo-cd1.avi , /home/user/foo-cd2.avi",
+    ArtFilenameTest{"/home/user/foo.avi", "", "/home/user/foo.avi"},
+    ArtFilenameTest{"stack:///home/user/foo-cd1.avi , /home/user/foo-cd2.avi", "",
                     "/home/user/foo.avi"},
-    ArtFilenameTest{"zip://%2fhome%2fuser%2fbar.zip/foo.avi", "/home/user/foo.avi"},
-    ArtFilenameTest{"multipath://%2fhome%2fuser%2fbar%2f/%2fhome%2fuser%2ffoo%2f",
+    ArtFilenameTest{"zip://%2fhome%2fuser%2fbar.zip/foo.avi", "", "/home/user/foo.avi"},
+    ArtFilenameTest{"multipath://%2fhome%2fuser%2fbar%2f/%2fhome%2fuser%2ffoo%2f", "",
                     "/home/user/bar/", true, true},
-    ArtFilenameTest{"/home/user/foo/foo.iso", "/home/user/foo/foo.iso"},
-    ArtFilenameTest{"/home/user/VIDEO_TS/VIDEO_TS.IFO", "/home/user/", false, true},
-    ArtFilenameTest{"/home/user/BDMV/index.bdmv", "/home/user/", false, true},
-    ArtFilenameTest{"/home/user/foo.avi", "/home/user/", false, true, true},
+    ArtFilenameTest{"/home/user/foo/foo.iso", "", "/home/user/foo/foo.iso"},
+    ArtFilenameTest{"/home/user/VIDEO_TS/VIDEO_TS.IFO", "", "/home/user/", false, true},
+    ArtFilenameTest{"/home/user/BDMV/index.bdmv", "", "/home/user/", false, true},
+    ArtFilenameTest{"/home/user/foo.avi", "", "/home/user/", false, true, true},
     ArtFilenameTest{
+        "smb://somepath/movie.iso",
         "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/00800.mpls",
         "smb://somepath/movie.iso"},
-    ArtFilenameTest{"bluray://smb%3a%2f%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", "smb://somepath/",
-                    false, true},
-    ArtFilenameTest{"bluray://smb%3a%2f%2fsomepath%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls",
+    ArtFilenameTest{
+        "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/00800.mpls",
+        "", "smb://somepath/movie.iso"},
+    ArtFilenameTest{"bluray://smb%3a%2f%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", "",
+                    "smb://somepath/", false, true},
+    ArtFilenameTest{"bluray://smb%3a%2f%2fsomepath%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls", "",
                     "smb://somepath/disc 1/", false, true},
-    ArtFilenameTest{"/home/user/foo.avi", "/home/user/foo-S03E04.avi", false, false, false,
+    ArtFilenameTest{"/home/user/foo.avi", "", "/home/user/foo-S03E04.avi", false, false, false,
                     ART::AdditionalIdentifiers::SEASON_AND_EPISODE, -1, 3, 4},
     ArtFilenameTest{"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252ftvshow.iso%2f/BDMV/"
                     "PLAYLIST/00800.mpls",
-                    "smb://somepath/tvshow-S03E04.iso", false, false, false,
+                    "", "smb://somepath/tvshow-S03E04.iso", false, false, false,
                     ART::AdditionalIdentifiers::SEASON_AND_EPISODE, -1, 3, 4},
     ArtFilenameTest{"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/"
                     "PLAYLIST/00800.mpls",
-                    "smb://somepath/movie-00800.iso", false, false, false,
+                    "", "smb://somepath/movie-00800.iso", false, false, false,
                     ART::AdditionalIdentifiers::PLAYLIST, 800},
 };
 
@@ -331,6 +336,7 @@ INSTANTIATE_TEST_SUITE_P(TestArtUtils, TestLocalArt, testing::ValuesIn(local_art
 TEST_P(GetLocalArtBaseFilenameTest, GetLocalArtBaseFilename)
 {
   CFileItem item(GetParam().path, GetParam().isFolder);
+  item.SetDynPath(GetParam().dynPath);
   CVideoInfoTag* tag{item.GetVideoInfoTag()};
   tag->m_iSeason = GetParam().season;
   tag->m_iEpisode = GetParam().episode;

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2186,13 +2186,19 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
         std::string path;
         if (content == ContentType::TVSHOWS)
+        {
           path = ART::GetLocalArtBaseFilename(*pItem, useFolder,
                                               pItem->GetProperty(MULTIPLE_EPISODES).asBoolean(false)
                                                   ? ART::AdditionalIdentifiers::SEASON_AND_EPISODE
                                                   : ART::AdditionalIdentifiers::NONE);
-        else if (content == ContentType::MOVIE_VERSIONS || pItem->GetVideoInfoTag()->m_iTrack > -1)
+        }
+        else if (content == ContentType::MOVIE_VERSIONS ||
+                 (pItem->HasVideoVersions() && pItem->GetVideoInfoTag()->m_iTrack > -1))
+        {
+          // Add playlist identifier only when there are multiple versions of the movie on the same disc
           path =
               ART::GetLocalArtBaseFilename(*pItem, useFolder, ART::AdditionalIdentifiers::PLAYLIST);
+        }
         else
           path = ART::GetLocalArtBaseFilename(*pItem, useFolder);
         AddLocalItemArtwork(art, artTypes, path, addAll, exactName);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

If a bluray has a playlist selected the art/nfo filename includes the playlist number only if there are multiple versions, but the import routine always looked for a playlist number in the filename even if there were no (ie. a single) versions.

Additionaly there was an error and code duplication in GetArtLocalBaseFilename() which has been corrected and a test case added.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To reproduce:
1) Watch a bluray iso, selecting a playlist
2) Export to separate files (creating nfo etc..)
3) New library
4) Either change the poster image or set the noremoteartwithlocalscraper advanced setting to true.
5) Add source, local scraper

The wrong or no poster image appears in the library.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
