### PR TITLE
[Video][Bluray] Improvement to episode recognition logic.

### DIFF
--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -232,6 +232,9 @@ private:
   void GetPlaylistsFromGroup(unsigned int episodeIndex,
                              const std::vector<CandidatePlaylistInformation>& group);
   void UseGroupMethod(unsigned int episodeIndex, const std::vector<CVideoInfoTag>& episodesOnDisc);
+  void UseTotalMethod(unsigned int episodeIndex,
+                      const std::vector<CVideoInfoTag>& episodesOnDisc,
+                      const PlaylistMap& playlists);
   static int CalculateMultiple(std::chrono::milliseconds duration,
                                std::chrono::milliseconds averageShortest,
                                double multiplePercent);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Add logic to determine the episode when the total number of viable playlists matches the number of episodes on disc, and the duration of each is close to the expected duration. Used when other, more precise, options have failed.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Episodes are not correctly identified in the simple menu on the bluray Twisted Metal S1D1.

Before:
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/816a1950-3975-4851-93db-848e87df44bf" />

After:
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/43744e86-f31b-4b7c-809c-cd381fbd5bfe" />

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
