### PR TITLE
[Python] Call Py_Initialize from main thread

### DIFF
--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -34,11 +34,44 @@
 
 #include <algorithm>
 
-bool XBPython::m_bInitialized = false;
-
 XBPython::XBPython()
 {
   CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
+
+  CLog::Log(LOGDEBUG, "initializing python engine.");
+  // Darwin packs .pyo files, we need PYTHONOPTIMIZE on in order to load them.
+  // linux built with unified builds only packages the pyo files so need it
+#if defined(TARGET_DARWIN) || defined(TARGET_LINUX)
+  setenv("PYTHONOPTIMIZE", "1", 1);
+#endif
+  // Info about interesting python envvars available
+  // at http://docs.python.org/using/cmdline.html#environment-variables
+
+#if !defined(TARGET_WINDOWS) && !defined(TARGET_ANDROID)
+  // check if we are running as real xbmc.app or just binary
+  if (!CUtil::GetFrameworksPath(true).empty())
+  {
+    // using external python, its build looking for xxx/lib/python3.8
+    // so point it to frameworks which is where python3.8 is located
+    setenv("PYTHONHOME", CSpecialProtocol::TranslatePath("special://frameworks").c_str(), 1);
+    setenv("PYTHONPATH", CSpecialProtocol::TranslatePath("special://frameworks").c_str(), 1);
+    CLog::Log(LOGDEBUG, "PYTHONHOME -> {}",
+              CSpecialProtocol::TranslatePath("special://frameworks"));
+    CLog::Log(LOGDEBUG, "PYTHONPATH -> {}",
+              CSpecialProtocol::TranslatePath("special://frameworks"));
+  }
+#endif
+
+  // *::GlobalInitializeModules() functions call PyImport_ExtendInittab(). PyImport_ExtendInittab() should
+  // be called before Py_Initialize() as required by the Python documentation.
+  CAddonPythonInvoker::GlobalInitializeModules();
+
+#ifdef HAS_WEB_INTERFACE
+  CHTTPPythonWsgiInvoker::GlobalInitializeModules();
+#endif
+
+  Py_Initialize();
+  m_mainThreadState = PyEval_SaveThread();
 }
 
 XBPython::~XBPython()
@@ -60,8 +93,6 @@ XBPython::~XBPython()
 }
 
 #define LOCK_AND_COPY(type, dest, src) \
-  if (!m_bInitialized) \
-    return; \
   std::unique_lock lock(src); \
   src.hadSomethingRemoved = false; \
   type dest; \
@@ -442,26 +473,23 @@ void XBPython::Uninitialize()
 
 void XBPython::Process()
 {
-  if (m_bInitialized)
+  PyList tmpvec;
+  std::unique_lock lock(m_vecPyList);
+  for (PyList::iterator it = m_vecPyList.begin(); it != m_vecPyList.end();)
   {
-    PyList tmpvec;
-    std::unique_lock lock(m_vecPyList);
-    for (PyList::iterator it = m_vecPyList.begin(); it != m_vecPyList.end();)
+    if (it->bDone)
     {
-      if (it->bDone)
-      {
-        tmpvec.push_back(*it);
-        it = m_vecPyList.erase(it);
-        m_vecPyList.hadSomethingRemoved = true;
-      }
-      else
-        ++it;
+      tmpvec.push_back(*it);
+      it = m_vecPyList.erase(it);
+      m_vecPyList.hadSomethingRemoved = true;
     }
-    lock.unlock();
-
-    //delete scripts which are done
-    tmpvec.clear();
+    else
+      ++it;
   }
+  lock.unlock();
+
+  //delete scripts which are done
+  tmpvec.clear();
 }
 
 bool XBPython::OnScriptInitialized(ILanguageInvoker* invoker)
@@ -470,57 +498,16 @@ bool XBPython::OnScriptInitialized(ILanguageInvoker* invoker)
     return false;
 
   XBMC_TRACE;
-  CLog::Log(LOGDEBUG, "initializing python engine.");
+  CLog::Log(LOGDEBUG, "initializing python script");
   std::unique_lock lock(m_critSection);
   m_iDllScriptCounter++;
-  if (!m_bInitialized)
-  {
-    // Darwin packs .pyo files, we need PYTHONOPTIMIZE on in order to load them.
-    // linux built with unified builds only packages the pyo files so need it
-#if defined(TARGET_DARWIN) || defined(TARGET_LINUX)
-    setenv("PYTHONOPTIMIZE", "1", 1);
-#endif
-    // Info about interesting python envvars available
-    // at http://docs.python.org/using/cmdline.html#environment-variables
 
-#if !defined(TARGET_WINDOWS) && !defined(TARGET_ANDROID)
-    // check if we are running as real xbmc.app or just binary
-    if (!CUtil::GetFrameworksPath(true).empty())
-    {
-      // using external python, it's build looking for xxx/lib/python3.8
-      // so point it to frameworks which is where python3.8 is located
-      setenv("PYTHONHOME", CSpecialProtocol::TranslatePath("special://frameworks").c_str(), 1);
-      setenv("PYTHONPATH", CSpecialProtocol::TranslatePath("special://frameworks").c_str(), 1);
-      CLog::Log(LOGDEBUG, "PYTHONHOME -> {}",
-                CSpecialProtocol::TranslatePath("special://frameworks"));
-      CLog::Log(LOGDEBUG, "PYTHONPATH -> {}",
-                CSpecialProtocol::TranslatePath("special://frameworks"));
-    }
-#endif
-
-    // *::GlobalInitializeModules() functions call PyImport_ExtendInittab(). PyImport_ExtendInittab() should
-    // be called before Py_Initialize() as required by the Python documentation.
-    CAddonPythonInvoker::GlobalInitializeModules();
-
-#ifdef HAS_WEB_INTERFACE
-    CHTTPPythonWsgiInvoker::GlobalInitializeModules();
-#endif
-
-    Py_Initialize();
-    m_mainThreadState = PyEval_SaveThread();
-
-    m_bInitialized = true;
-  }
-
-  return m_bInitialized;
+  return true;
 }
 
 void XBPython::OnScriptStarted(ILanguageInvoker* invoker)
 {
   if (invoker == NULL)
-    return;
-
-  if (!m_bInitialized)
     return;
 
   PyElem inf;

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -107,8 +107,6 @@ public:
   bool WaitForEvent(CEvent& hEvent, unsigned int milliseconds);
 
 private:
-  static bool m_bInitialized; // whether global python runtime was already initialized
-
   CCriticalSection m_critSection;
   PyThreadState* m_mainThreadState{nullptr};
   int m_iDllScriptCounter{0}; // to keep track of the total scripts running that need the dll


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fix calling `Py_Initialize` and `Py_Finalize` from different threads. Issue arose in python 3.14. `m_bInitialized` is not necessary anymore as `Py_Initialize` cannot fail (it is always an fatal error as per docs) and we initialize in the constructor. `XBPython` is a singleton class.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix segfault on shutdown

Checking the docs on [`Py_Finalize`](https://docs.python.org/3/c-api/init.html#c.Py_FinalizeEx) reveals since 3.12:

> Since this is the reverse of [Py_Initialize()](https://docs.python.org/3/c-api/init.html#c.Py_Initialize), it should be called in the same thread with the same interpreter active. That means the main thread and the main interpreter. This should never be called while [Py_RunMain()](https://docs.python.org/3/c-api/init.html#c.Py_RunMain) is running.

Currently `Py_Initialize` is called whenever the first script runs from that script's thread. Then the finalization happens from the main thread. This is not allowed as per the python documentation.

Stacktrace:

```
* thread #5, name = 'XBMCMainThread', stop reason = signal SIGABRT
  * frame #0: 0x00000001984a6388 libsystem_kernel.dylib`__pthread_kill + 8
    frame #1: 0x00000001984df88c libsystem_pthread.dylib`pthread_kill + 296
    frame #2: 0x00000001983e8a3c libsystem_c.dylib`abort + 124
    frame #3: 0x000000010709d328 Kodi`fatal_error_exit(status=<unavailable>) at pylifecycle.c:3155:9 [opt]
    frame #4: 0x000000010709d104 Kodi`fatal_error(fd=<unavailable>, header=<unavailable>, prefix=<unavailable>, msg=<unavailable>, status=-1) at pylifecycle.c:0 [opt]
    frame #5: 0x000000010709ba08 Kodi`_Py_FatalErrorFunc(func=<unavailable>, msg=<unavailable>) at pylifecycle.c:3387:5 [opt]
    frame #6: 0x000000010701a780 Kodi`_Py_CheckRecursiveCall(tstate=<unavailable>, where=<unavailable>) at ceval.c:491:9 [opt]
    frame #7: 0x0000000106ef7d68 Kodi`method_vectorcall_NOARGS [inlined] _Py_EnterRecursiveCallTstate(tstate=0x000000010a621580, where=<unavailable>) at pycore_ceval.h:216:41 [opt]
    frame #8: 0x0000000106ef7d4c Kodi`method_vectorcall_NOARGS [inlined] method_enter_call(tstate=0x000000010a621580, func=0x0000607000ce9ae0) at descrobject.c:300:9 [opt]
    frame #9: 0x0000000106ef7d4c Kodi`method_vectorcall_NOARGS(func=0x0000607000ce9ae0, args=0x000000016f4d1dd8, nargsf=<unavailable>, kwnames=<unavailable>) at descrobject.c:444:37 [opt]
    frame #10: 0x0000000106ee8dbc Kodi`_PyObject_VectorcallTstate(tstate=0x000000010a621580, callable=<unavailable>, args=0x000000016f4d1dd8, nargsf=1, kwnames=0x0000000000000000) at pycore_call.h:169:11 [opt]
    frame #11: 0x0000000106eea9e4 Kodi`PyObject_VectorcallMethod(name=<unavailable>, args=<unavailable>, nargsf=<unavailable>, kwnames=0x0000000000000000) at call.c:856:24 [opt]
    frame #12: 0x0000000106f0b838 Kodi`_PyFile_Flush [inlined] PyObject_CallMethodNoArgs(self=0x000061100054e750, name=<unavailable>) at abstract.h:65:12 [opt]
    frame #13: 0x0000000106f0b818 Kodi`_PyFile_Flush(file=<unavailable>) at fileobject.c:542:21 [opt]
    frame #14: 0x000000010709f38c Kodi`flush_std_files at pylifecycle.c:1820:13 [opt]
    frame #15: 0x000000010709d0fc Kodi`fatal_error(fd=2, header=<unavailable>, prefix=<unavailable>, msg=<unavailable>, status=-1) at pylifecycle.c:3364:9 [opt]
    frame #16: 0x000000010709ba08 Kodi`_Py_FatalErrorFunc(func=<unavailable>, msg=<unavailable>) at pylifecycle.c:3387:5 [opt]
    frame #17: 0x000000010701a780 Kodi`_Py_CheckRecursiveCall(tstate=<unavailable>, where=<unavailable>) at ceval.c:491:9 [opt]
    frame #18: 0x0000000106ef7d68 Kodi`method_vectorcall_NOARGS [inlined] _Py_EnterRecursiveCallTstate(tstate=0x000000010a621580, where=<unavailable>) at pycore_ceval.h:216:41 [opt]
    frame #19: 0x0000000106ef7d4c Kodi`method_vectorcall_NOARGS [inlined] method_enter_call(tstate=0x000000010a621580, func=0x0000607000ce9ae0) at descrobject.c:300:9 [opt]
    frame #20: 0x0000000106ef7d4c Kodi`method_vectorcall_NOARGS(func=0x0000607000ce9ae0, args=0x000000016f4d2018, nargsf=<unavailable>, kwnames=<unavailable>) at descrobject.c:444:37 [opt]
    frame #21: 0x0000000106ee8dbc Kodi`_PyObject_VectorcallTstate(tstate=0x000000010a621580, callable=<unavailable>, args=0x000000016f4d2018, nargsf=1, kwnames=0x0000000000000000) at pycore_call.h:169:11 [opt]
    frame #22: 0x0000000106eea9e4 Kodi`PyObject_VectorcallMethod(name=<unavailable>, args=<unavailable>, nargsf=<unavailable>, kwnames=0x0000000000000000) at call.c:856:24 [opt]
    frame #23: 0x0000000106f0b838 Kodi`_PyFile_Flush [inlined] PyObject_CallMethodNoArgs(self=0x000061100054e750, name=<unavailable>) at abstract.h:65:12 [opt]
    frame #24: 0x0000000106f0b818 Kodi`_PyFile_Flush(file=<unavailable>) at fileobject.c:542:21 [opt]
    frame #25: 0x000000010709f38c Kodi`flush_std_files at pylifecycle.c:1820:13 [opt]
    frame #26: 0x000000010709b20c Kodi`_Py_Finalize(runtime=<unavailable>) at pylifecycle.c:2109:9 [opt]
    frame #27: 0x0000000100cb33b4 Kodi`XBPython::~XBPython(this=0x00006170000a3380) at XBPython.cpp:58:5
    frame #28: 0x0000000100cb350c Kodi`XBPython::~XBPython(this=0x00006170000a3380) at XBPython.cpp:45:1
    frame #29: 0x0000000100cb3598 Kodi`XBPython::~XBPython(this=0x00006170000a3380) at XBPython.cpp:45:1
    frame #30: 0x0000000102f9d73c Kodi`std::__1::default_delete<XBPython>::operator()[abi:ne190102](this=0x000061100006e588, __ptr=0x00006170000a3380) const at unique_ptr.h:81:5
    frame #31: 0x0000000102f8c1f0 Kodi`std::__1::unique_ptr<XBPython, std::__1::default_delete<XBPython>>::reset[abi:ne190102](this=0x000061100006e588, __p=0x0000000000000000) at unique_ptr.h:293:7
    frame #32: 0x0000000102f86df0 Kodi`CServiceManager::DeinitStageOne(this=0x000061100006e540) at ServiceManager.cpp:281:14
    frame #33: 0x0000000102802d10 Kodi`CApplication::Cleanup(this=0x0000618000000080) at Application.cpp:2024:25
    frame #34: 0x0000000102802400 Kodi`CApplication::Run(this=0x0000618000000080) at Application.cpp:1928:3
    frame #35: 0x00000001020af890 Kodi`XBMC_Run(renderGUI=true) at xbmc.cpp:63:26
    frame #36: 0x0000000100b664d8 Kodi`__46-[XBMCDelegate applicationDidFinishLaunching:]_block_invoke(.block_descriptor=0x0000000109da8020) at XBMCApplication.mm:158:5
    frame #37: 0x0000000199b92ba8 Foundation`__NSThread__start__ + 732
    frame #38: 0x0000000111c8e4a8 libclang_rt.asan_osx_dynamic.dylib`asan_thread_start(void*) + 80
    frame #39: 0x00000001984dfc0c libsystem_pthread.dylib`_pthread_start + 136
```

Python debug error

```
Fatal Python error: _Py_CheckRecursiveCall: Unrecoverable stack overflow (used 14560 kB) while calling a Python object
Python runtime state: finalizing (tstate=0x000000010a621580)
```

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
macOS

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
