### PR TITLE
[CDateTime][PVR] Fix Daylight Saving Time Switch Issues

### DIFF
--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -196,8 +196,12 @@ public:
   void SetValid(bool yesNo);
   bool IsValid() const;
 
-  static void ResetTimezoneBias(void);
-  static CDateTimeSpan GetTimezoneBias(void);
+  /*! \brief Get system timezone bias for this datetime value.
+   \note This calculates the bias for this specific datetime, which may differ
+         from the timezone bias for 'now' if DST rules have changed.
+   \return The bias as time span.
+   */
+  CDateTimeSpan GetTimezoneBias() const;
 
 private:
   bool ToFileTime(const KODI::TIME::SystemTime& time, KODI::TIME::FileTime& fileTime) const;

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -12,6 +12,7 @@
 #include "utils/TimeFormat.h"
 #include "utils/XTimeUtils.h"
 
+#include <optional>
 #include <string>
 
 #include "PlatformDefs.h"
@@ -203,6 +204,11 @@ public:
    */
   CDateTimeSpan GetTimezoneBias() const;
 
+  /*! \brief Set timezone bias for this datetime value (for testing purposes).
+   \param bias The bias to set.
+   */
+  void SetTimeZoneBias(const CDateTimeSpan& bias) { m_timeZoneBias = bias; }
+
 private:
   bool ToFileTime(const KODI::TIME::SystemTime& time, KODI::TIME::FileTime& fileTime) const;
   bool ToFileTime(const time_t& time, KODI::TIME::FileTime& fileTime) const;
@@ -221,4 +227,5 @@ private:
   };
 
   State m_state;
+  mutable std::optional<CDateTimeSpan> m_timeZoneBias;
 };

--- a/xbmc/platform/posix/XTimeUtils.cpp
+++ b/xbmc/platform/posix/XTimeUtils.cpp
@@ -210,7 +210,12 @@ int LocalFileTimeToFileTime(const FileTime* localFileTime, FileTime* fileTime)
   l.u.LowPart = localFileTime->lowDateTime;
   l.u.HighPart = localFileTime->highDateTime;
 
-  l.QuadPart += (unsigned long long) timezone * 10000000;
+  time_t ft;
+  struct tm tm_ft;
+  FileTimeToTimeT(localFileTime, &ft);
+  localtime_r(&ft, &tm_ft);
+
+  l.QuadPart -= static_cast<unsigned long long>(tm_ft.tm_gmtoff) * 10000000;
 
   fileTime->lowDateTime = l.u.LowPart;
   fileTime->highDateTime = l.u.HighPart;

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
@@ -128,20 +128,23 @@ void CGUIEPGGridContainerModel::Initialize(const CFileItemList& items,
 
   ////////////////////////////////////////////////////////////////////////
   // Create ruler items
-  CDateTime ruler;
-  ruler.SetFromUTCDateTime(m_gridStart);
-  CDateTime rulerEnd;
-  rulerEnd.SetFromUTCDateTime(m_gridEnd);
-  auto rulerItem{std::make_shared<CFileItem>(ruler.GetAsLocalizedDate(true))};
-  rulerItem->SetProperty("DateLabel", true);
-  m_rulerItems.emplace_back(rulerItem);
 
+  // 1) ruler date item
+  CDateTime rulerDateLocal;
+  rulerDateLocal.SetFromUTCDateTime(m_gridStart);
+  auto rulerDateItem{std::make_shared<CFileItem>(rulerDateLocal.GetAsLocalizedDate(true))};
+  rulerDateItem->SetProperty("DateLabel", true);
+  m_rulerItems.emplace_back(std::move(rulerDateItem));
+
+  // 2) ruler time items
   const CDateTimeSpan unit(0, 0, blocksPerRulerItem * m_minutesPerBlock, 0);
-  for (; ruler < rulerEnd; ruler += unit)
+  CDateTime rulerLocal;
+  for (CDateTime rulerUTC = m_gridStart; rulerUTC < m_gridEnd; rulerUTC += unit)
   {
-    rulerItem = std::make_shared<CFileItem>(ruler.GetAsLocalizedTime("", false));
-    rulerItem->SetLabel2(ruler.GetAsLocalizedDate(true));
-    m_rulerItems.emplace_back(rulerItem);
+    rulerLocal.SetFromUTCDateTime(rulerUTC);
+    auto rulerItem{std::make_shared<CFileItem>(rulerLocal.GetAsLocalizedTime("", false))};
+    rulerItem->SetLabel2(rulerLocal.GetAsLocalizedDate(true));
+    m_rulerItems.emplace_back(std::move(rulerItem));
   }
 
   m_firstActiveChannel = iFirstChannel;

--- a/xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
@@ -204,8 +204,6 @@ bool CPVRGUIActionsDatabase::ResetDatabase(bool bResetEPGOnly) const
     bResetClients = selector.IsResetClientsSelected();
   }
 
-  CDateTime::ResetTimezoneBias();
-
   CLog::LogFC(LOGDEBUG, LOGPVR, "PVR clearing {} database", bResetEPGOnly ? "EPG" : "PVR and EPG");
 
   pDlgProgress->SetHeading(CVariant{313}); // "Cleaning database"

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -411,20 +411,6 @@ public:
   void SetFirstDayFromLocalTime(const CDateTime& firstDay);
 
   /*!
-   * @brief Helper function to convert a given CDateTime containing data as UTC to local time.
-   * @param utc A CDateTime instance carrying data as UTC.
-   * @return A CDateTime instance carrying data as local time.
-   */
-  static CDateTime ConvertUTCToLocalTime(const CDateTime& utc);
-
-  /*!
-   * @brief Helper function to convert a given CDateTime containing data as local time to UTC.
-   * @param local A CDateTime instance carrying data as local time.
-   * @return A CDateTime instance carrying data as UTC.
-   */
-  static CDateTime ConvertLocalTimeToUTC(const CDateTime& local);
-
-  /*!
    * @brief Get the duration of this timer in seconds, excluding padding times.
    * @return The duration.
    */

--- a/xbmc/pvr/timers/PVRTimerRuleMatcher.cpp
+++ b/xbmc/pvr/timers/PVRTimerRuleMatcher.cpp
@@ -21,9 +21,9 @@ using namespace PVR;
 
 CPVRTimerRuleMatcher::CPVRTimerRuleMatcher(const std::shared_ptr<CPVRTimerInfoTag>& timerRule,
                                            const CDateTime& start)
-  : m_timerRule(timerRule),
-    m_start(CPVRTimerInfoTag::ConvertUTCToLocalTime(start))
+  : m_timerRule(timerRule)
 {
+  m_start.SetFromUTCDateTime(start);
 }
 
 CPVRTimerRuleMatcher::~CPVRTimerRuleMatcher() = default;
@@ -75,9 +75,9 @@ CDateTime CPVRTimerRuleMatcher::GetNextTimerStart() const
 
 bool CPVRTimerRuleMatcher::Matches(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
-  return epgTag && CPVRTimerInfoTag::ConvertUTCToLocalTime(epgTag->EndAsUTC()) > m_start &&
-         MatchSeriesLink(epgTag) && MatchChannel(epgTag) && MatchStart(epgTag) &&
-         MatchEnd(epgTag) && MatchDayOfWeek(epgTag) && MatchSearchText(epgTag);
+  return epgTag && epgTag->EndAsLocalTime() > m_start && MatchSeriesLink(epgTag) &&
+         MatchChannel(epgTag) && MatchStart(epgTag) && MatchEnd(epgTag) && MatchDayOfWeek(epgTag) &&
+         MatchSearchText(epgTag);
 }
 
 bool CPVRTimerRuleMatcher::MatchSeriesLink(
@@ -110,7 +110,7 @@ bool CPVRTimerRuleMatcher::MatchStart(const std::shared_ptr<const CPVREpgInfoTag
   if (m_timerRule->GetTimerType()->SupportsFirstDay())
   {
     // only year, month and day do matter here...
-    const CDateTime startEpgLocal = CPVRTimerInfoTag::ConvertUTCToLocalTime(epgTag->StartAsUTC());
+    const CDateTime startEpgLocal(epgTag->StartAsLocalTime());
     const CDateTime startEpg(startEpgLocal.GetYear(), startEpgLocal.GetMonth(),
                              startEpgLocal.GetDay(), 0, 0, 0);
     const CDateTime firstDayLocal = m_timerRule->FirstDayAsLocalTime();
@@ -126,7 +126,7 @@ bool CPVRTimerRuleMatcher::MatchStart(const std::shared_ptr<const CPVREpgInfoTag
   if (m_timerRule->GetTimerType()->SupportsStartTime())
   {
     // only hours and minutes do matter here...
-    const CDateTime startEpgLocal = CPVRTimerInfoTag::ConvertUTCToLocalTime(epgTag->StartAsUTC());
+    const CDateTime startEpgLocal(epgTag->StartAsLocalTime());
     const CDateTime startEpg(2000, 1, 1, startEpgLocal.GetHour(), startEpgLocal.GetMinute(), 0);
     const CDateTime startTimerLocal = m_timerRule->StartAsLocalTime();
     const CDateTime startTimer(2000, 1, 1, startTimerLocal.GetHour(), startTimerLocal.GetMinute(),
@@ -145,7 +145,7 @@ bool CPVRTimerRuleMatcher::MatchEnd(const std::shared_ptr<const CPVREpgInfoTag>&
   if (m_timerRule->GetTimerType()->SupportsEndTime())
   {
     // only hours and minutes do matter here...
-    const CDateTime endEpgLocal = CPVRTimerInfoTag::ConvertUTCToLocalTime(epgTag->EndAsUTC());
+    const CDateTime endEpgLocal(epgTag->EndAsLocalTime());
     const CDateTime endEpg(2000, 1, 1, endEpgLocal.GetHour(), endEpgLocal.GetMinute(), 0);
     const CDateTime endTimerLocal = m_timerRule->EndAsLocalTime();
     const CDateTime endTimer(2000, 1, 1, endTimerLocal.GetHour(), endTimerLocal.GetMinute(), 0);
@@ -160,7 +160,7 @@ bool CPVRTimerRuleMatcher::MatchDayOfWeek(const std::shared_ptr<const CPVREpgInf
   if (m_timerRule->GetTimerType()->SupportsWeekdays() &&
       m_timerRule->WeekDays() != PVR_WEEKDAY_ALLDAYS)
   {
-    const CDateTime startEpgLocal{CPVRTimerInfoTag::ConvertUTCToLocalTime(epgTag->StartAsUTC())};
+    const CDateTime startEpgLocal{epgTag->StartAsLocalTime()};
     int startWeekday{startEpgLocal.GetDayOfWeek()};
     if (startWeekday == 0)
       startWeekday = 7;

--- a/xbmc/test/TestDateTime.cpp
+++ b/xbmc/test/TestDateTime.cpp
@@ -659,8 +659,7 @@ TEST_F(TestDateTime, GetAsTm)
   }
 }
 
-// Disabled pending std::chrono and std::date changes.
-TEST_F(TestDateTime, DISABLED_GetAsTimeStamp)
+TEST_F(TestDateTime, GetAsTimeStamp)
 {
   CDateTime dateTime;
   dateTime.SetDateTime(1991, 05, 14, 12, 34, 56);

--- a/xbmc/test/TestDateTime.cpp
+++ b/xbmc/test/TestDateTime.cpp
@@ -350,20 +350,28 @@ TEST_F(TestDateTime, GetAsStrings)
   EXPECT_EQ(dateTime.GetAsW3CDate(), "1991-05-14");
 }
 
-// disabled because we have no way to validate these values
-// GetTimezoneBias() always returns a positive value so
-// there is no way to detect the direction of the offset
-TEST_F(TestDateTime, DISABLED_GetAsStringsWithBias)
+TEST_F(TestDateTime, GetAsStringsWithBias)
 {
   CDateTime dateTime;
   dateTime.SetDateTime(1991, 05, 14, 12, 34, 56);
 
-  CDateTime dateTimeWithBias(dateTime);
-  dateTimeWithBias += dateTime.GetTimezoneBias();
-
+  // Positive bias
+  dateTime.SetTimeZoneBias(CDateTimeSpan{0, 8, 0, 0});
   EXPECT_EQ(dateTime.GetAsRFC1123DateTime(), "Tue, 14 May 1991 20:34:56 GMT");
   EXPECT_EQ(dateTime.GetAsW3CDateTime(false), "1991-05-14T12:34:56+08:00");
   EXPECT_EQ(dateTime.GetAsW3CDateTime(true), "1991-05-14T20:34:56Z");
+
+  // No bias
+  dateTime.SetTimeZoneBias(CDateTimeSpan{0, 0, 0, 0});
+  EXPECT_EQ(dateTime.GetAsRFC1123DateTime(), "Tue, 14 May 1991 12:34:56 GMT");
+  EXPECT_EQ(dateTime.GetAsW3CDateTime(false), "1991-05-14T12:34:56+00:00");
+  EXPECT_EQ(dateTime.GetAsW3CDateTime(true), "1991-05-14T12:34:56Z");
+
+  // Negative bias
+  dateTime.SetTimeZoneBias(CDateTimeSpan{0, -8, 0, 0});
+  EXPECT_EQ(dateTime.GetAsRFC1123DateTime(), "Tue, 14 May 1991 04:34:56 GMT");
+  EXPECT_EQ(dateTime.GetAsW3CDateTime(false), "1991-05-14T12:34:56-08:00");
+  EXPECT_EQ(dateTime.GetAsW3CDateTime(true), "1991-05-14T04:34:56Z");
 }
 
 TEST_F(TestDateTime, GetAsLocalized)

--- a/xbmc/test/TestDateTime.cpp
+++ b/xbmc/test/TestDateTime.cpp
@@ -238,10 +238,9 @@ TEST_F(TestDateTime, SetFromW3CDate)
 
 TEST_F(TestDateTime, SetFromW3CDateTime)
 {
-  CDateTimeSpan bias = CDateTime::GetTimezoneBias();
   CDateTime dateTime;
   dateTime.SetFromDBDateTime("1994-11-05 13:15:30");
-  dateTime += bias;
+  dateTime += dateTime.GetTimezoneBias();
   std::string dateTimeStr = dateTime.GetAsDBDate() + "T" + dateTime.GetAsDBTime() + "Z";
 
   CDateTime dateTime1;
@@ -265,10 +264,9 @@ TEST_F(TestDateTime, SetFromW3CDateTime)
 
 TEST_F(TestDateTime, SetFromUTCDateTime)
 {
-  CDateTimeSpan bias = CDateTime::GetTimezoneBias();
-
   CDateTime dateTime1;
   dateTime1.SetFromDBDateTime("1991-05-14 12:34:56");
+  const CDateTimeSpan bias{dateTime1.GetTimezoneBias()};
   dateTime1 += bias;
 
   CDateTime dateTime2;
@@ -357,13 +355,11 @@ TEST_F(TestDateTime, GetAsStrings)
 // there is no way to detect the direction of the offset
 TEST_F(TestDateTime, DISABLED_GetAsStringsWithBias)
 {
-  CDateTimeSpan bias = CDateTime::GetTimezoneBias();
-
   CDateTime dateTime;
   dateTime.SetDateTime(1991, 05, 14, 12, 34, 56);
 
   CDateTime dateTimeWithBias(dateTime);
-  dateTimeWithBias += bias;
+  dateTimeWithBias += dateTime.GetTimezoneBias();
 
   EXPECT_EQ(dateTime.GetAsRFC1123DateTime(), "Tue, 14 May 1991 20:34:56 GMT");
   EXPECT_EQ(dateTime.GetAsW3CDateTime(false), "1991-05-14T12:34:56+08:00");
@@ -666,28 +662,24 @@ TEST_F(TestDateTime, GetAsTm)
 // Disabled pending std::chrono and std::date changes.
 TEST_F(TestDateTime, DISABLED_GetAsTimeStamp)
 {
-  CDateTimeSpan bias = CDateTime::GetTimezoneBias();
-
   CDateTime dateTime;
   dateTime.SetDateTime(1991, 05, 14, 12, 34, 56);
 
   KODI::TIME::FileTime fileTime;
   dateTime.GetAsTimeStamp(fileTime);
-  dateTime += bias;
+  dateTime += dateTime.GetTimezoneBias();
 
   EXPECT_TRUE(dateTime == fileTime);
 }
 
 TEST_F(TestDateTime, GetAsUTCDateTime)
 {
-  CDateTimeSpan bias = CDateTime::GetTimezoneBias();
-
   CDateTime dateTime1;
   dateTime1.SetDateTime(1991, 05, 14, 12, 34, 56);
 
   CDateTime dateTime2;
   dateTime2 = dateTime1.GetAsUTCDateTime();
-  dateTime2 -= bias;
+  dateTime2 -= dateTime1.GetTimezoneBias();
 
   EXPECT_EQ(dateTime2.GetYear(), 1991);
   EXPECT_EQ(dateTime2.GetMonth(), 5);

--- a/xbmc/utils/XTimeUtils.h
+++ b/xbmc/utils/XTimeUtils.h
@@ -9,8 +9,10 @@
 #pragma once
 
 #include <chrono>
+#include <cstdint>
 #include <string>
 #include <thread>
+#include <tuple>
 
 #if !defined(TARGET_WINDOWS)
 #include "PlatformDefs.h"
@@ -39,22 +41,6 @@ struct SystemTime
   unsigned short milliseconds;
 };
 
-struct TimeZoneInformation
-{
-  long bias;
-  std::string standardName;
-  SystemTime standardDate;
-  long standardBias;
-  std::string daylightName;
-  SystemTime daylightDate;
-  long daylightBias;
-};
-
-constexpr int KODI_TIME_ZONE_ID_INVALID{-1};
-constexpr int KODI_TIME_ZONE_ID_UNKNOWN{0};
-constexpr int KODI_TIME_ZONE_ID_STANDARD{1};
-constexpr int KODI_TIME_ZONE_ID_DAYLIGHT{2};
-
 struct FileTime
 {
   unsigned int lowDateTime;
@@ -62,7 +48,12 @@ struct FileTime
 };
 
 void GetLocalTime(SystemTime* systemTime);
-uint32_t GetTimeZoneInformation(TimeZoneInformation* timeZoneInformation);
+
+/*! \brief Return bias in minutes for the system time zone and the given time value.
+ \param time The time value.
+ \return a tuple with a sucess flag and the the bias in minutes.
+*/
+std::tuple<bool, int64_t> GetTimezoneBias(const SystemTime& time);
 
 template<typename Rep, typename Period>
 void Sleep(std::chrono::duration<Rep, Period> duration)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR fixes along standing issue with PVR Guide showing wrong time for all EPG entries starting/ending after daylight saving time (DST) switch until Kodi gets restarted. There is even an add-on which can be used to automate the workaround. But this ofc is a workaround at best, as after the restart the EPG entries starting/ending after DST switch will have the correct times, but all entries starting/ending before DST switch are now wrong. :-/  Lastly, not only the Guide window is effected and not only EPG entries, also recordings and timers may have wrong time values.

This PR addresses the root cause for all these issues, namely `CDateTime` class not handling time zone bias (where DST offset is part of) correctly. The bias was only calculated once on Kodi start for current time zone and current time and never changed, also not upon a DST switch ocuuring while Kodi is running. And the bias is also dependent on the actual time value, and can be different from the bias calculated for "now" upon Kodi startup. It must be calculated for every time value separately. 

Also included in this PR is a fix for the Guide window time ruler to visualize the extra/missing time on DST switch correctly and removal of code in PVR timers which was present already to partly workaround the bugs in `CDateTime`. 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I wanted to fix a long standing bug, because I was sick of having to restart Kodi manually after a DST switch.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, be checking all use cases that came to mind and automated `CDateTime` tests are all green (after adjusting them to an `CDateTime` interface change).

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Proper time values for PVR items after DST switch with restarting Kodi. I'm not aware of other Kodi components suffering from the problems but they all should be fixed now.

## Screenshots (if appropriate):
<img width="1710" height="1107" alt="Screenshot 2025-10-26 at 19 27 32" src="https://github.com/user-attachments/assets/72eb50c9-4b28-480f-b895-940a73b28ae0" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
