### PR TITLE
Dynamic plane selection with GBM

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -63,6 +63,8 @@ CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
     AVDRMLayerDescriptor* layer = &desc->layers[0];
     uint32_t format = layer->format;
     uint64_t modifier = desc->objects[0].format_modifier;
+    uint64_t width = buf->GetWidth();
+    uint64_t height = buf->GetHeight();
 
     buf->ReleaseDescriptor();
 
@@ -70,14 +72,7 @@ CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
     if (!gui)
       return nullptr;
 
-    if (!gui->SupportsFormat(CDRMUtils::FourCCWithAlpha(gui->GetFormat())))
-      return nullptr;
-
-    auto plane = drm->GetVideoPlane();
-    if (!plane)
-      return nullptr;
-
-    if (!plane->SupportsFormatAndModifier(format, modifier))
+    if (!drm->FindVideoAndGuiPlane(format, modifier, width, height))
       return nullptr;
 
     return new CRendererDRMPRIME();
@@ -89,8 +84,7 @@ CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
 void CRendererDRMPRIME::Register()
 {
   CWinSystemGbm* winSystem = dynamic_cast<CWinSystemGbm*>(CServiceBroker::GetWinSystem());
-  if (winSystem && winSystem->GetDrm()->GetVideoPlane() &&
-      std::dynamic_pointer_cast<CDRMAtomic>(winSystem->GetDrm()))
+  if (winSystem && std::dynamic_pointer_cast<CDRMAtomic>(winSystem->GetDrm()))
   {
     CServiceBroker::GetSettingsComponent()
         ->GetSettings()

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -167,12 +167,12 @@ void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
   auto plane = m_DRM->GetVideoPlane();
 
   std::optional<uint64_t> colorEncoding =
-      plane->GetPropertyValue("COLOR_ENCODING", GetColorEncoding(picture));
+      plane->GetPropertyEnumValue("COLOR_ENCODING", GetColorEncoding(picture));
   if (colorEncoding)
     m_DRM->AddProperty(plane, "COLOR_ENCODING", colorEncoding.value());
 
   std::optional<uint64_t> colorRange =
-      plane->GetPropertyValue("COLOR_RANGE", GetColorRange(picture));
+      plane->GetPropertyEnumValue("COLOR_RANGE", GetColorRange(picture));
   if (colorRange)
     m_DRM->AddProperty(plane, "COLOR_RANGE", colorRange.value());
 }

--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -271,7 +271,7 @@ bool CEGLContextUtils::InitializeDisplay(EGLint renderingApi)
   return true;
 }
 
-bool CEGLContextUtils::ChooseConfig(EGLint renderableType, EGLint visualId, bool hdr)
+bool CEGLContextUtils::ChooseConfig(EGLint renderableType, EGLint visualId, bool hdr, int alpha)
 {
   EGLint numMatched{0};
 
@@ -286,7 +286,7 @@ bool CEGLContextUtils::ChooseConfig(EGLint renderableType, EGLint visualId, bool
   attribs.Add({{EGL_RED_SIZE, 8},
                {EGL_GREEN_SIZE, 8},
                {EGL_BLUE_SIZE, 8},
-               {EGL_ALPHA_SIZE, 8},
+               {EGL_ALPHA_SIZE, alpha},
                {EGL_DEPTH_SIZE, 16},
                {EGL_STENCIL_SIZE, 0},
                {EGL_SAMPLE_BUFFERS, 0},

--- a/xbmc/utils/EGLUtils.h
+++ b/xbmc/utils/EGLUtils.h
@@ -196,7 +196,7 @@ public:
   bool CreateSurface(EGLNativeWindowType nativeWindow, EGLint HDRcolorSpace = EGL_NONE);
   bool CreatePlatformSurface(void* nativeWindow, EGLNativeWindowType nativeWindowLegacy);
   bool InitializeDisplay(EGLint renderingApi);
-  bool ChooseConfig(EGLint renderableType, EGLint visualId = 0, bool hdr = false);
+  bool ChooseConfig(EGLint renderableType, EGLint visualId = 0, bool hdr = false, int alpha = 8);
   bool CreateContext(CEGLAttributesVec contextAttribs);
   bool BindContext();
   void Destroy();

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -22,6 +22,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
+#include "utils/DRMHelpers.h"
 #include "utils/DisplayInfo.h"
 #include "utils/Map.h"
 #include "utils/StringUtils.h"
@@ -95,6 +96,15 @@ CWinSystemGbm::CWinSystemGbm()
 }
 
 CWinSystemGbm::~CWinSystemGbm() = default;
+
+const std::string CWinSystemGbm::GetName()
+{
+  auto gui_plane = m_DRM->GetGuiPlane();
+  if (gui_plane == nullptr)
+    return "gbm";
+  return "gbm (" + DRMHELPERS::FourCCToString(m_DRM->GetGuiPlane()->GetFormat()) + " " +
+         DRMHELPERS::ModifierToString(m_DRM->GetGuiPlane()->GetModifier()) + ")";
+}
 
 bool CWinSystemGbm::InitWindowSystem()
 {

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -361,7 +361,7 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
   {
     if (connector->SupportsProperty("Colorspace"))
     {
-      std::optional<uint64_t> colorspace = connector->GetPropertyValue("Colorspace", "Default");
+      std::optional<uint64_t> colorspace = connector->GetPropertyEnumValue("Colorspace", "Default");
       if (colorspace)
       {
         CLog::LogF(LOGDEBUG, "setting connector colorspace to Default");
@@ -389,7 +389,7 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
       m_info->SupportsColorimetry(colorimetry))
   {
     std::optional<uint64_t> colorspace =
-        connector->GetPropertyValue("Colorspace", ColorimetryMap.at(colorimetry));
+        connector->GetPropertyEnumValue("Colorspace", ColorimetryMap.at(colorimetry));
     if (colorspace)
     {
       CLog::LogF(LOGDEBUG, "setting connector colorspace to {}", ColorimetryMap.at(colorimetry));

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -39,7 +39,7 @@ public:
   CWinSystemGbm();
   ~CWinSystemGbm() override;
 
-  const std::string GetName() override { return "gbm"; }
+  const std::string GetName() override;
 
   bool InitWindowSystem() override;
   bool DestroyWindowSystem() override;

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -33,24 +33,16 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint 
     return false;
   }
 
-  auto plane = m_DRM->GetGuiPlane();
-  uint32_t visualId = plane != nullptr ? plane->GetFormat() : DRM_FORMAT_XRGB2101010;
-
-  // prefer alpha visual id, fallback to non-alpha visual id
-  if (!m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithAlpha(visualId)) &&
-      !m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithoutAlpha(visualId)))
+  auto guiformats = m_DRM->GetGuiFormats();
+  if (!std::ranges::any_of(guiformats,
+                           [&](struct guiformat format)
+                           {
+                             return format.active &&
+                                    m_eglContext.ChooseConfig(renderableType, format.drm, false,
+                                                              format.alpha);
+                           }))
   {
-    // fallback to 8bit format if no EGL config was found for 10bit
-    if (plane)
-      plane->SetFormat(DRM_FORMAT_XRGB8888);
-
-    visualId = plane != nullptr ? plane->GetFormat() : DRM_FORMAT_XRGB8888;
-
-    if (!m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithAlpha(visualId)) &&
-        !m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithoutAlpha(visualId)))
-    {
-      return false;
-    }
+    return false;
   }
 
   if (!CreateContext())
@@ -99,15 +91,20 @@ bool CWinSystemGbmEGLContext::CreateNewWindow(const std::string& name,
   }
 
   uint32_t format = m_eglContext.GetConfigAttrib(EGL_NATIVE_VISUAL_ID);
+  std::vector<uint64_t> fallbackModifiers = {DRM_FORMAT_MOD_LINEAR};
+  std::vector<uint64_t>* modifiers = &fallbackModifiers;
 
-  std::vector<uint64_t> modifiers;
+  for (auto& fmt : m_DRM->GetGuiFormats())
+  {
+    if (fmt.drm == format && fmt.active)
+    {
+      modifiers = &fmt.modifiers;
+      break;
+    }
+  }
 
-  auto plane = m_DRM->GetGuiPlane();
-  if (plane)
-    modifiers = plane->GetModifiersForFormat(format);
-
-  if (!m_GBM->GetDevice().CreateSurface(res.iWidth, res.iHeight, format, modifiers.data(),
-                                        modifiers.size()))
+  if (!m_GBM->GetDevice().CreateSurface(res.iWidth, res.iHeight, format, modifiers->data(),
+                                        modifiers->size()))
   {
     CLog::Log(LOGERROR, "CWinSystemGbmEGLContext::{} - failed to initialize GBM", __FUNCTION__);
     return false;
@@ -129,11 +126,26 @@ bool CWinSystemGbmEGLContext::CreateNewWindow(const std::string& name,
     return false;
   }
 
+  if (!m_eglContext.TrySwapBuffers())
+  {
+    return false;
+  }
+
+  struct gbm_bo* bo = m_GBM->GetDevice().GetSurface().LockFrontBuffer().Get();
+
+#if defined(HAS_GBM_MODIFIERS)
+  uint64_t modifier = gbm_bo_get_modifier(bo);
+#else
+  uint64_t modifier = DRM_FORMAT_MOD_LINEAR;
+#endif
+  if (!m_DRM->FindGuiPlane(gbm_bo_get_format(bo), modifier))
+  {
+    return false;
+  }
   m_bFullScreen = fullScreen;
   m_nWidth = res.iWidth;
   m_nHeight = res.iHeight;
   m_fRefreshRate = res.fRefreshRate;
-
   CLog::Log(LOGDEBUG, "CWinSystemGbmEGLContext::{} - initialized GBM", __FUNCTION__);
   return true;
 }

--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
@@ -133,11 +133,6 @@ void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, boo
 
   if (rendered)
   {
-    if (videoLayer)
-      m_gui_plane->SetFormat(CDRMUtils::FourCCWithAlpha(m_gui_plane->GetFormat()));
-    else
-      m_gui_plane->SetFormat(CDRMUtils::FourCCWithoutAlpha(m_gui_plane->GetFormat()));
-
     drm_fb = CDRMUtils::DrmFbGetFromBo(bo);
     if (!drm_fb)
     {

--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
@@ -25,27 +25,58 @@ using namespace KODI::WINDOWING::GBM;
 
 void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool videoLayer)
 {
-  uint32_t blob_id;
+  // Declared at function scope so the blob outlives drmModeAtomicCommit.
+  // DRM requires the blob to remain alive for the duration of the commit;
+  // destroying it before the commit returns leaves the atomic request
+  // referencing an invalid id and the kernel rejects with EINVAL.
+  CDRMPropertyBlob modeBlob;
+
+  if (m_old_crtc != nullptr)
+  {
+    if (m_old_crtc->GetId() != m_crtc->GetId())
+    {
+      AddProperty(m_old_crtc, "ACTIVE", 0);
+      AddProperty(m_old_crtc, "MODE_ID", 0);
+      flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
+    }
+
+    for (const auto& plane : m_planes)
+    {
+      if (m_gui_plane != nullptr && m_gui_plane->GetId() == plane->GetId())
+        continue;
+      if (m_video_plane != nullptr && m_video_plane->GetId() == plane->GetId())
+        continue;
+
+      uint64_t planeid = plane->GetPropertyValue("CRTC_ID").value_or(0);
+      if (planeid == m_crtc->GetId() || planeid == m_old_crtc->GetId())
+      {
+        AddProperty(plane.get(), "CRTC_ID", 0);
+        AddProperty(plane.get(), "FB_ID", 0);
+      }
+
+      // below disables the planes which are not in our crtcs, in other words
+      // crts attached to other connectors (ie: 2nd monitor), amdgpu requires at least
+      // one primary plane to enable crtcs, if we disable rest of the planes in amdgpu
+      // atomic commit will fail
+      if (!(HasQuirk(QUIRK_NEEDSPRIMARY)))
+      {
+        AddProperty(plane.get(), "CRTC_ID", 0);
+        AddProperty(plane.get(), "FB_ID", 0);
+      }
+    }
+    m_old_crtc = nullptr;
+  }
 
   if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
   {
     if (!AddProperty(m_connector, "CRTC_ID", m_crtc->GetCrtcId()))
       return;
 
-    if (drmModeCreatePropertyBlob(m_fd, m_mode, sizeof(*m_mode), &blob_id) != 0)
+    modeBlob = CDRMPropertyBlob(m_fd, m_mode, sizeof(*m_mode));
+    if (!modeBlob.IsValid())
       return;
 
-    if (m_active && m_orig_crtc && m_orig_crtc->GetCrtcId() != m_crtc->GetCrtcId())
-    {
-      // if using a different CRTC than the original, disable original to avoid EINVAL
-      if (!AddProperty(m_orig_crtc, "MODE_ID", 0))
-        return;
-
-      if (!AddProperty(m_orig_crtc, "ACTIVE", 0))
-        return;
-    }
-
-    if (!AddProperty(m_crtc, "MODE_ID", blob_id))
+    if (!AddProperty(m_crtc, "MODE_ID", modeBlob.Get()))
       return;
 
     if (!AddProperty(m_crtc, "ACTIVE", m_active ? 1 : 0))
@@ -71,9 +102,12 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
       AddProperty(m_gui_plane, "IN_FENCE_FD", m_inFenceFd);
     }
   }
-  else if (videoLayer && !CServiceBroker::GetGUI()->GetWindowManager().HasVisibleControls())
+  else if (videoLayer && !CServiceBroker::GetGUI()->GetWindowManager().HasVisibleControls() &&
+           !HasQuirk(QUIRK_NEEDSPRIMARY))
   {
     // disable gui plane when video layer is active and gui has no visible controls
+    //except when crtc requires at least one plane with primary type. in amdgpu such precondition
+    // is satisfied by selecting gui plane as primary, so disabling it will result commit failure
     AddProperty(m_gui_plane, "FB_ID", 0);
     AddProperty(m_gui_plane, "CRTC_ID", 0);
   }
@@ -113,13 +147,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
   {
     close(m_inFenceFd);
     m_inFenceFd = -1;
-  }
-
-  if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
-  {
-    if (drmModeDestroyPropertyBlob(m_fd, blob_id) != 0)
-      CLog::Log(LOGERROR, "CDRMAtomic::{} - failed to destroy property blob: {}", __FUNCTION__,
-                strerror(errno));
   }
 
   m_atomicRequestQueue.emplace_back(std::make_unique<CDRMAtomicRequest>());
@@ -172,12 +199,6 @@ bool CDRMAtomic::InitDrm()
 
   if (!CDRMUtils::InitDrm())
     return false;
-
-  for (auto& plane : m_planes)
-  {
-    AddProperty(plane.get(), "FB_ID", 0);
-    AddProperty(plane.get(), "CRTC_ID", 0);
-  }
 
   CLog::Log(LOGDEBUG, "CDRMAtomic::{} - initialized atomic DRM", __FUNCTION__);
 

--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
@@ -118,10 +118,10 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
   auto ret = drmModeAtomicCommit(m_fd, m_req->Get(), flags | DRM_MODE_ATOMIC_TEST_ONLY, nullptr);
   if (ret < 0)
   {
-    CLog::Log(LOGERROR,
-              "CDRMAtomic::{} - test commit failed: ({}) - falling back to last successful atomic "
-              "request",
-              __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR,
+               "test commit failed: ({}) - falling back to last successful atomic "
+               "request",
+               strerror(errno));
 
     auto oldRequest = m_atomicRequestQueue.front().get();
     CDRMAtomicRequest::LogAtomicDiff(m_req, oldRequest);
@@ -135,7 +135,7 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
   ret = drmModeAtomicCommit(m_fd, m_req->Get(), flags, nullptr);
   if (ret < 0)
   {
-    CLog::Log(LOGERROR, "CDRMAtomic::{} - atomic commit failed: {}", __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR, "atomic commit failed: {}", strerror(errno));
     m_atomicRequestQueue.pop_back();
   }
   else if (m_atomicRequestQueue.size() > 1)
@@ -163,7 +163,7 @@ void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, boo
     drm_fb = CDRMUtils::DrmFbGetFromBo(bo);
     if (!drm_fb)
     {
-      CLog::Log(LOGERROR, "CDRMAtomic::{} - Failed to get a new FBO", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Failed to get a new FBO");
       return;
     }
 
@@ -175,7 +175,7 @@ void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, boo
   {
     flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
     m_need_modeset = false;
-    CLog::Log(LOGDEBUG, "CDRMAtomic::{} - Execute modeset at next commit", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "Execute modeset at next commit");
   }
 
   DrmAtomicCommit(!drm_fb ? 0 : drm_fb->fb_id, flags, rendered, videoLayer);
@@ -189,8 +189,7 @@ bool CDRMAtomic::InitDrm()
   auto ret = drmSetClientCap(m_fd, DRM_CLIENT_CAP_ATOMIC, 1);
   if (ret)
   {
-    CLog::Log(LOGERROR, "CDRMAtomic::{} - no atomic modesetting support: {}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "no atomic modesetting support: {}", strerror(errno));
     return false;
   }
 
@@ -200,7 +199,7 @@ bool CDRMAtomic::InitDrm()
   if (!CDRMUtils::InitDrm())
     return false;
 
-  CLog::Log(LOGDEBUG, "CDRMAtomic::{} - initialized atomic DRM", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "initialized atomic DRM");
 
   return true;
 }
@@ -274,14 +273,14 @@ void CDRMAtomic::CDRMAtomicRequest::LogAtomicDiff(CDRMAtomicRequest* current,
     }
   }
 
-  CLog::Log(LOGDEBUG, "CDRMAtomicRequest::{} - DRM Atomic Request Diff:", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "DRM Atomic Request Diff:");
 
   LogAtomicRequest(LOGERROR, atomicDiff);
 }
 
 void CDRMAtomic::CDRMAtomicRequest::LogAtomicRequest()
 {
-  CLog::Log(LOGDEBUG, "CDRMAtomicRequest::{} - DRM Atomic Request:", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "DRM Atomic Request:");
   LogAtomicRequest(LOGDEBUG, m_atomicRequestItems);
 }
 
@@ -299,7 +298,7 @@ void CDRMAtomic::CDRMAtomicRequest::LogAtomicRequest(
                      "\tValue: " + std::to_string(property.second));
   }
 
-  CLog::Log(logLevel, "{}", message);
+  CLog::LogF(logLevel, "{}", message);
 }
 
 void CDRMAtomic::CDRMAtomicRequest::DrmModeAtomicReqDeleter::operator()(drmModeAtomicReqPtr p) const

--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
@@ -138,9 +138,17 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
     CLog::LogF(LOGERROR, "atomic commit failed: {}", strerror(errno));
     m_atomicRequestQueue.pop_back();
   }
-  else if (m_atomicRequestQueue.size() > 1)
+  else
   {
-    m_atomicRequestQueue.pop_front();
+    // Sync the property cache with values the kernel accepted.
+    // This must happen after a successful commit so that
+    // GetPropertyValue() returns current state (e.g. CRTC_ID=0
+    // after Disable()). Without this, stale cached values cause
+    // incorrect plane cleanup on subsequent video playback.
+    m_req->CacheProperties();
+
+    if (m_atomicRequestQueue.size() > 1)
+      m_atomicRequestQueue.pop_front();
   }
 
   if (m_inFenceFd != -1)
@@ -247,6 +255,17 @@ bool CDRMAtomic::CDRMAtomicRequest::AddProperty(CDRMObject* object,
 
   m_atomicRequestItems[object][propertyId] = value;
   return true;
+}
+
+void CDRMAtomic::CDRMAtomicRequest::CacheProperties()
+{
+  for (const auto& [object, properties] : m_atomicRequestItems)
+  {
+    for (const auto& [propertyId, value] : properties)
+    {
+      object->CachePropertyValue(propertyId, value);
+    }
+  }
 }
 
 void CDRMAtomic::CDRMAtomicRequest::LogAtomicDiff(CDRMAtomicRequest* current,

--- a/xbmc/windowing/gbm/drm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "DRMUtils.h"
+#include "utils/log.h"
 
 #include <cstdint>
 #include <deque>

--- a/xbmc/windowing/gbm/drm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
@@ -52,6 +52,7 @@ private:
     drmModeAtomicReqPtr Get() const { return m_atomicRequest.get(); }
 
     bool AddProperty(CDRMObject* object, const char* name, uint64_t value);
+    void CacheProperties();
     void LogAtomicRequest();
 
     static void LogAtomicDiff(CDRMAtomicRequest* current, CDRMAtomicRequest* old);

--- a/xbmc/windowing/gbm/drm/DRMConnector.cpp
+++ b/xbmc/windowing/gbm/drm/DRMConnector.cpp
@@ -101,19 +101,15 @@ std::string CDRMConnector::GetName()
 
 std::vector<uint8_t> CDRMConnector::GetEDID() const
 {
-  auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
-                               [](auto& prop) { return prop->name == std::string_view("EDID"); });
 
-  if (property == m_propsInfo.end())
+  uint64_t blob_id = GetPropertyValue("EDID").value_or(0);
+
+  if (blob_id == 0)
   {
     CLog::LogF(LOGDEBUG, "failed to find EDID property for connector: {}",
                m_connector->connector_id);
     return {};
   }
-
-  uint64_t blob_id = m_props->prop_values[std::distance(m_propsInfo.begin(), property)];
-  if (blob_id == 0)
-    return {};
 
   drmModePropertyBlobPtr blob = drmModeGetPropertyBlob(m_fd, blob_id);
   if (!blob)

--- a/xbmc/windowing/gbm/drm/DRMConnector.cpp
+++ b/xbmc/windowing/gbm/drm/DRMConnector.cpp
@@ -66,7 +66,7 @@ bool CDRMConnector::CheckConnector()
   unsigned retryCnt = 7;
   while (!IsConnected() && retryCnt > 0)
   {
-    CLog::Log(LOGDEBUG, "CDRMConnector::{} - connector is disconnected", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "connector is disconnected");
     retryCnt--;
     KODI::TIME::Sleep(1s);
 

--- a/xbmc/windowing/gbm/drm/DRMCrtc.cpp
+++ b/xbmc/windowing/gbm/drm/DRMCrtc.cpp
@@ -15,7 +15,10 @@
 
 using namespace KODI::WINDOWING::GBM;
 
-CDRMCrtc::CDRMCrtc(int fd, uint32_t crtc) : CDRMObject(fd), m_crtc(drmModeGetCrtc(m_fd, crtc))
+CDRMCrtc::CDRMCrtc(int fd, uint32_t crtc, int offset)
+  : CDRMObject(fd),
+    m_crtc(drmModeGetCrtc(m_fd, crtc)),
+    m_offset(offset)
 {
   if (!m_crtc)
     throw std::runtime_error("drmModeGetCrtc failed: " + std::string{strerror(errno)});

--- a/xbmc/windowing/gbm/drm/DRMCrtc.h
+++ b/xbmc/windowing/gbm/drm/DRMCrtc.h
@@ -20,7 +20,7 @@ namespace GBM
 class CDRMCrtc : public CDRMObject
 {
 public:
-  explicit CDRMCrtc(int fd, uint32_t crtc);
+  CDRMCrtc(int fd, uint32_t crtc, int offset);
   CDRMCrtc(const CDRMCrtc&) = delete;
   CDRMCrtc& operator=(const CDRMCrtc&) = delete;
   ~CDRMCrtc() = default;
@@ -29,6 +29,7 @@ public:
   uint32_t GetBufferId() const { return m_crtc->buffer_id; }
   uint32_t GetX() const { return m_crtc->x; }
   uint32_t GetY() const { return m_crtc->y; }
+  uint32_t GetOffset() const { return m_offset; }
   drmModeModeInfoPtr GetMode() const { return &m_crtc->mode; }
   bool GetModeValid() const { return m_crtc->mode_valid != 0; }
 
@@ -39,6 +40,7 @@ private:
   };
 
   std::unique_ptr<drmModeCrtc, DrmModeCrtcDeleter> m_crtc;
+  int m_offset{0};
 };
 
 } // namespace GBM

--- a/xbmc/windowing/gbm/drm/DRMEncoder.cpp
+++ b/xbmc/windowing/gbm/drm/DRMEncoder.cpp
@@ -21,3 +21,24 @@ CDRMEncoder::CDRMEncoder(int fd, uint32_t encoder)
   if (!m_encoder)
     throw std::runtime_error("drmModeGetEncoder failed: " + std::string{strerror(errno)});
 }
+
+std::vector<CDRMCrtc*> CDRMEncoder::GetPossibleCrtcs(
+    const std::vector<std::unique_ptr<CDRMCrtc>>& crtcs, CDRMCrtc* preferred) const
+{
+  std::vector<CDRMCrtc*> possible;
+
+  for (auto& crtc : crtcs)
+  {
+    // Check bitmask
+    if (!(m_encoder->possible_crtcs & (1 << crtc->GetOffset())))
+      continue;
+
+    // Use raw pointer for the result
+    if (preferred && preferred->GetId() == crtc->GetId())
+      possible.insert(possible.begin(), crtc.get()); // Put preferred at front
+    else
+      possible.push_back(crtc.get());
+  }
+
+  return possible;
+}

--- a/xbmc/windowing/gbm/drm/DRMEncoder.h
+++ b/xbmc/windowing/gbm/drm/DRMEncoder.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "DRMCrtc.h"
 #include "DRMObject.h"
 
 namespace KODI
@@ -27,7 +28,8 @@ public:
 
   uint32_t GetEncoderId() const { return m_encoder->encoder_id; }
   uint32_t GetCrtcId() const { return m_encoder->crtc_id; }
-  uint32_t GetPossibleCrtcs() const { return m_encoder->possible_crtcs; }
+  std::vector<CDRMCrtc*> GetPossibleCrtcs(const std::vector<std::unique_ptr<CDRMCrtc>>& crtcs,
+                                          CDRMCrtc* preferred = nullptr) const;
 
 private:
   struct DrmModeEncoderDeleter

--- a/xbmc/windowing/gbm/drm/DRMLegacy.cpp
+++ b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
@@ -36,16 +36,15 @@ bool CDRMLegacy::SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo)
 
   if (ret < 0)
   {
-    CLog::Log(LOGERROR, "CDRMLegacy::{} - failed to set crtc mode: {}x{}{} @ {} Hz", __FUNCTION__,
-              m_mode->hdisplay, m_mode->vdisplay,
-              m_mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "", m_mode->vrefresh);
+    CLog::LogF(LOGERROR, "failed to set crtc mode: {}x{}{} @ {} Hz", m_mode->hdisplay,
+               m_mode->vdisplay, m_mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "",
+               m_mode->vrefresh);
 
     return false;
   }
 
-  CLog::Log(LOGDEBUG, "CDRMLegacy::{} - set crtc mode: {}x{}{} @ {} Hz", __FUNCTION__,
-            m_mode->hdisplay, m_mode->vdisplay, m_mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "",
-            m_mode->vrefresh);
+  CLog::LogF(LOGDEBUG, "set crtc mode: {}x{}{} @ {} Hz", m_mode->hdisplay, m_mode->vdisplay,
+             m_mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "", m_mode->vrefresh);
 
   return true;
 }
@@ -100,7 +99,7 @@ bool CDRMLegacy::QueueFlip(struct gbm_bo* bo)
 
   if (ret)
   {
-    CLog::Log(LOGDEBUG, "CDRMLegacy::{} - failed to queue DRM page flip", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "failed to queue DRM page flip");
     return false;
   }
 
@@ -124,7 +123,7 @@ bool CDRMLegacy::InitDrm()
   if (!CDRMUtils::InitDrm())
     return false;
 
-  CLog::Log(LOGDEBUG, "CDRMLegacy::{} - initialized legacy DRM", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "initialized legacy DRM");
   return true;
 }
 
@@ -132,7 +131,7 @@ bool CDRMLegacy::SetActive(bool active)
 {
   if (!m_connector->SetProperty("DPMS", active ? DRM_MODE_DPMS_ON : DRM_MODE_DPMS_OFF))
   {
-    CLog::Log(LOGDEBUG, "CDRMLegacy::{} - failed to set DPMS property", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "failed to set DPMS property");
     return false;
   }
 

--- a/xbmc/windowing/gbm/drm/DRMObject.cpp
+++ b/xbmc/windowing/gbm/drm/DRMObject.cpp
@@ -105,6 +105,17 @@ std::optional<uint64_t> CDRMObject::GetPropertyEnumValue(std::string_view name,
   return {};
 }
 
+std::optional<uint64_t> CDRMObject::GetPropertyValue(const std::string& name) const
+{
+  auto property =
+      std::ranges::find_if(m_propsInfo, [&name](const auto& prop) { return prop->name == name; });
+
+  if (property == m_propsInfo.end())
+    return {};
+
+  return m_props->prop_values[std::ranges::distance(m_propsInfo.begin(), property)];
+}
+
 bool CDRMObject::SetProperty(const std::string& name, uint64_t value)
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),

--- a/xbmc/windowing/gbm/drm/DRMObject.cpp
+++ b/xbmc/windowing/gbm/drm/DRMObject.cpp
@@ -80,8 +80,8 @@ bool CDRMObject::GetProperties(uint32_t id, uint32_t type)
   return true;
 }
 
-std::optional<uint64_t> CDRMObject::GetPropertyValue(std::string_view name,
-                                                     std::string_view valueName) const
+std::optional<uint64_t> CDRMObject::GetPropertyEnumValue(std::string_view name,
+                                                         std::string_view valueName) const
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
                                [&name](const auto& prop) { return prop->name == name; });

--- a/xbmc/windowing/gbm/drm/DRMObject.cpp
+++ b/xbmc/windowing/gbm/drm/DRMObject.cpp
@@ -116,6 +116,19 @@ std::optional<uint64_t> CDRMObject::GetPropertyValue(const std::string& name) co
   return m_props->prop_values[std::ranges::distance(m_propsInfo.begin(), property)];
 }
 
+bool CDRMObject::CachePropertyValue(uint32_t propertyId, uint64_t value)
+{
+  for (size_t i = 0; i < m_propsInfo.size(); i++)
+  {
+    if (m_propsInfo[i]->prop_id == propertyId)
+    {
+      m_props->prop_values[i] = value;
+      return true;
+    }
+  }
+  return false;
+}
+
 bool CDRMObject::SetProperty(const std::string& name, uint64_t value)
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
@@ -123,9 +136,9 @@ bool CDRMObject::SetProperty(const std::string& name, uint64_t value)
 
   if (property != m_propsInfo.end())
   {
-    int ret = drmModeObjectSetProperty(m_fd, m_id, m_type, property->get()->prop_id, value);
-    if (ret == 0)
-      return true;
+    if (drmModeObjectSetProperty(m_fd, m_id, m_type, property->get()->prop_id, value))
+      return false;
+    return CachePropertyValue(property->get()->prop_id, value);
   }
 
   return false;

--- a/xbmc/windowing/gbm/drm/DRMObject.cpp
+++ b/xbmc/windowing/gbm/drm/DRMObject.cpp
@@ -129,6 +129,26 @@ bool CDRMObject::CachePropertyValue(uint32_t propertyId, uint64_t value)
   return false;
 }
 
+std::optional<std::pair<uint64_t, uint64_t>> CDRMObject::GetRangePropertyLimits(
+    const std::string& name) const
+{
+  auto property =
+      std::ranges::find_if(m_propsInfo, [&name](const auto& prop) { return prop->name == name; });
+
+  if (property == m_propsInfo.end())
+    return {};
+
+  auto prop = property->get();
+
+  if (!static_cast<bool>(drm_property_type_is(prop, DRM_MODE_PROP_RANGE)))
+    return {};
+
+  if (prop->count_values != 2)
+    return {};
+
+  return std::make_pair(prop->values[0], prop->values[1]);
+}
+
 bool CDRMObject::SetProperty(const std::string& name, uint64_t value)
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),

--- a/xbmc/windowing/gbm/drm/DRMObject.cpp
+++ b/xbmc/windowing/gbm/drm/DRMObject.cpp
@@ -53,7 +53,7 @@ std::string CDRMObject::GetPropertyName(uint32_t propertyId) const
   return "invalid property";
 }
 
-uint32_t CDRMObject::GetPropertyId(const std::string& name) const
+uint32_t CDRMObject::GetPropertyId(std::string_view name) const
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
                                [&name](const auto& prop) { return prop->name == name; });
@@ -105,7 +105,7 @@ std::optional<uint64_t> CDRMObject::GetPropertyEnumValue(std::string_view name,
   return {};
 }
 
-std::optional<uint64_t> CDRMObject::GetPropertyValue(const std::string& name) const
+std::optional<uint64_t> CDRMObject::GetPropertyValue(std::string_view name) const
 {
   auto property =
       std::ranges::find_if(m_propsInfo, [&name](const auto& prop) { return prop->name == name; });
@@ -130,7 +130,7 @@ bool CDRMObject::CachePropertyValue(uint32_t propertyId, uint64_t value)
 }
 
 std::optional<std::pair<uint64_t, uint64_t>> CDRMObject::GetRangePropertyLimits(
-    const std::string& name) const
+    std::string_view name) const
 {
   auto property =
       std::ranges::find_if(m_propsInfo, [&name](const auto& prop) { return prop->name == name; });
@@ -149,7 +149,7 @@ std::optional<std::pair<uint64_t, uint64_t>> CDRMObject::GetRangePropertyLimits(
   return std::make_pair(prop->values[0], prop->values[1]);
 }
 
-bool CDRMObject::SetProperty(const std::string& name, uint64_t value)
+bool CDRMObject::SetProperty(std::string_view name, uint64_t value)
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
                                [&name](const auto& prop) { return prop->name == name; });
@@ -164,7 +164,7 @@ bool CDRMObject::SetProperty(const std::string& name, uint64_t value)
   return false;
 }
 
-std::optional<bool> CDRMObject::IsPropertyImmutable(const std::string& name) const
+std::optional<bool> CDRMObject::IsPropertyImmutable(std::string_view name) const
 {
   auto property =
       std::ranges::find_if(m_propsInfo, [&name](const auto& prop) { return prop->name == name; });
@@ -175,7 +175,7 @@ std::optional<bool> CDRMObject::IsPropertyImmutable(const std::string& name) con
   return static_cast<bool>(drm_property_type_is(property->get(), DRM_MODE_PROP_IMMUTABLE));
 }
 
-bool CDRMObject::SupportsProperty(const std::string& name)
+bool CDRMObject::SupportsProperty(std::string_view name)
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
                                [&name](const auto& prop) { return prop->name == name; });

--- a/xbmc/windowing/gbm/drm/DRMObject.cpp
+++ b/xbmc/windowing/gbm/drm/DRMObject.cpp
@@ -144,6 +144,17 @@ bool CDRMObject::SetProperty(const std::string& name, uint64_t value)
   return false;
 }
 
+std::optional<bool> CDRMObject::IsPropertyImmutable(const std::string& name) const
+{
+  auto property =
+      std::ranges::find_if(m_propsInfo, [&name](const auto& prop) { return prop->name == name; });
+
+  if (property == m_propsInfo.end())
+    return {};
+
+  return static_cast<bool>(drm_property_type_is(property->get(), DRM_MODE_PROP_IMMUTABLE));
+}
+
 bool CDRMObject::SupportsProperty(const std::string& name)
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),

--- a/xbmc/windowing/gbm/drm/DRMObject.h
+++ b/xbmc/windowing/gbm/drm/DRMObject.h
@@ -41,6 +41,7 @@ public:
 
   bool SetProperty(const std::string& name, uint64_t value);
   bool SupportsProperty(const std::string& name);
+  std::optional<uint64_t> GetPropertyValue(const std::string& name) const;
 
 protected:
   explicit CDRMObject(int fd);

--- a/xbmc/windowing/gbm/drm/DRMObject.h
+++ b/xbmc/windowing/gbm/drm/DRMObject.h
@@ -36,7 +36,8 @@ public:
 
   uint32_t GetId() const { return m_id; }
   uint32_t GetPropertyId(const std::string& name) const;
-  std::optional<uint64_t> GetPropertyValue(std::string_view name, std::string_view valueName) const;
+  std::optional<uint64_t> GetPropertyEnumValue(std::string_view name,
+                                               std::string_view valueName) const;
 
   bool SetProperty(const std::string& name, uint64_t value);
   bool SupportsProperty(const std::string& name);

--- a/xbmc/windowing/gbm/drm/DRMObject.h
+++ b/xbmc/windowing/gbm/drm/DRMObject.h
@@ -42,6 +42,7 @@ public:
   bool SetProperty(const std::string& name, uint64_t value);
   bool SupportsProperty(const std::string& name);
   std::optional<uint64_t> GetPropertyValue(const std::string& name) const;
+  bool CachePropertyValue(uint32_t propertyId, uint64_t value);
 
 protected:
   explicit CDRMObject(int fd);

--- a/xbmc/windowing/gbm/drm/DRMObject.h
+++ b/xbmc/windowing/gbm/drm/DRMObject.h
@@ -43,6 +43,7 @@ public:
   bool SupportsProperty(const std::string& name);
   std::optional<uint64_t> GetPropertyValue(const std::string& name) const;
   bool CachePropertyValue(uint32_t propertyId, uint64_t value);
+  std::optional<bool> IsPropertyImmutable(const std::string& name) const;
 
 protected:
   explicit CDRMObject(int fd);

--- a/xbmc/windowing/gbm/drm/DRMObject.h
+++ b/xbmc/windowing/gbm/drm/DRMObject.h
@@ -8,11 +8,16 @@
 
 #pragma once
 
+#include "utils/log.h"
+
+#include <cerrno>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <optional>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <xf86drmMode.h>
@@ -71,6 +76,73 @@ protected:
 private:
   uint32_t m_id{0};
   uint32_t m_type{0};
+};
+
+/*!
+ * \brief RAII wrapper around a DRM property blob.
+ *
+ * Owns both the drm fd and the blob id, and destroys the blob on
+ * scope exit. Move-only.
+ *
+ * Lifetime note: an atomic commit that references the blob id must
+ * complete BEFORE this object is destroyed; DRM requires the blob to
+ * be alive for the duration of the commit. Declare at a scope (local
+ * or member) that ends AFTER drmModeAtomicCommit returns.
+ */
+class CDRMPropertyBlob
+{
+public:
+  CDRMPropertyBlob() = default;
+
+  CDRMPropertyBlob(int fd, const void* data, std::size_t size) : m_fd(fd)
+  {
+    if (drmModeCreatePropertyBlob(fd, data, size, &m_id) != 0)
+      m_id = 0;
+  }
+
+  ~CDRMPropertyBlob() { Reset(); }
+
+  CDRMPropertyBlob(const CDRMPropertyBlob&) = delete;
+  CDRMPropertyBlob& operator=(const CDRMPropertyBlob&) = delete;
+
+  CDRMPropertyBlob(CDRMPropertyBlob&& other) noexcept
+    : m_fd(other.m_fd),
+      m_id(std::exchange(other.m_id, 0))
+  {
+  }
+
+  CDRMPropertyBlob& operator=(CDRMPropertyBlob&& other) noexcept
+  {
+    if (this != &other)
+    {
+      Reset();
+      m_fd = other.m_fd;
+      m_id = std::exchange(other.m_id, 0);
+    }
+    return *this;
+  }
+
+  /*! \brief Blob id to pass to AddProperty / atomic commit. */
+  std::uint32_t Get() const { return m_id; }
+
+  /*! \brief True if the blob was successfully created and not yet released. */
+  bool IsValid() const { return m_id != 0; }
+
+  /*!
+   * \brief Destroy the owned blob (if any) and return to the null state.
+   *
+   * Safe to call on a default-constructed or already-released instance.
+   */
+  void Reset()
+  {
+    if (m_id != 0 && drmModeDestroyPropertyBlob(m_fd, m_id) != 0)
+      CLog::LogF(LOGERROR, "failed to destroy property blob: {}", std::strerror(errno));
+    m_id = 0;
+  }
+
+private:
+  int m_fd{-1};
+  std::uint32_t m_id{0};
 };
 
 } // namespace GBM

--- a/xbmc/windowing/gbm/drm/DRMObject.h
+++ b/xbmc/windowing/gbm/drm/DRMObject.h
@@ -44,6 +44,8 @@ public:
   std::optional<uint64_t> GetPropertyValue(const std::string& name) const;
   bool CachePropertyValue(uint32_t propertyId, uint64_t value);
   std::optional<bool> IsPropertyImmutable(const std::string& name) const;
+  std::optional<std::pair<uint64_t, uint64_t>> GetRangePropertyLimits(
+      const std::string& name) const;
 
 protected:
   explicit CDRMObject(int fd);

--- a/xbmc/windowing/gbm/drm/DRMObject.h
+++ b/xbmc/windowing/gbm/drm/DRMObject.h
@@ -40,17 +40,16 @@ public:
   std::string GetPropertyName(uint32_t propertyId) const;
 
   uint32_t GetId() const { return m_id; }
-  uint32_t GetPropertyId(const std::string& name) const;
+  uint32_t GetPropertyId(std::string_view name) const;
   std::optional<uint64_t> GetPropertyEnumValue(std::string_view name,
                                                std::string_view valueName) const;
 
-  bool SetProperty(const std::string& name, uint64_t value);
-  bool SupportsProperty(const std::string& name);
-  std::optional<uint64_t> GetPropertyValue(const std::string& name) const;
+  bool SetProperty(std::string_view name, uint64_t value);
+  bool SupportsProperty(std::string_view name);
+  std::optional<uint64_t> GetPropertyValue(std::string_view name) const;
   bool CachePropertyValue(uint32_t propertyId, uint64_t value);
-  std::optional<bool> IsPropertyImmutable(const std::string& name) const;
-  std::optional<std::pair<uint64_t, uint64_t>> GetRangePropertyLimits(
-      const std::string& name) const;
+  std::optional<bool> IsPropertyImmutable(std::string_view name) const;
+  std::optional<std::pair<uint64_t, uint64_t>> GetRangePropertyLimits(std::string_view name) const;
 
 protected:
   explicit CDRMObject(int fd);

--- a/xbmc/windowing/gbm/drm/DRMPlane.cpp
+++ b/xbmc/windowing/gbm/drm/DRMPlane.cpp
@@ -82,12 +82,7 @@ bool CDRMPlane::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
 
 void CDRMPlane::FindModifiers()
 {
-  auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(), [](auto& prop)
-                               { return StringUtils::EqualsNoCase(prop->name, "IN_FORMATS"); });
-
-  uint64_t blob_id = 0;
-  if (property != m_propsInfo.end())
-    blob_id = m_props->prop_values[std::distance(m_propsInfo.begin(), property)];
+  uint64_t blob_id = GetPropertyValue("IN_FORMATS").value_or(0);
 
   if (blob_id == 0)
     return;

--- a/xbmc/windowing/gbm/drm/DRMPlane.cpp
+++ b/xbmc/windowing/gbm/drm/DRMPlane.cpp
@@ -49,8 +49,7 @@ bool CDRMPlane::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
   {
     if (!SupportsFormat(format))
     {
-      CLog::Log(LOGDEBUG, "CDRMPlane::{} - format not supported: {}", __FUNCTION__,
-                DRMHELPERS::FourCCToString(format));
+      CLog::LogF(LOGDEBUG, "format not supported: {}", DRMHELPERS::FourCCToString(format));
       return false;
     }
   }
@@ -59,23 +58,21 @@ bool CDRMPlane::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
     auto formatModifiers = &m_modifiers_map[format];
     if (formatModifiers->empty())
     {
-      CLog::Log(LOGDEBUG, "CDRMPlane::{} - format not supported: {}", __FUNCTION__,
-                DRMHELPERS::FourCCToString(format));
+      CLog::LogF(LOGDEBUG, "format not supported: {}", DRMHELPERS::FourCCToString(format));
       return false;
     }
 
     auto formatModifier = std::ranges::find(*formatModifiers, modifier);
     if (formatModifier == formatModifiers->end())
     {
-      CLog::Log(LOGDEBUG, "CDRMPlane::{} - modifier ({}) not supported for format ({})",
-                __FUNCTION__, DRMHELPERS::ModifierToString(modifier),
-                DRMHELPERS::FourCCToString(format));
+      CLog::LogF(LOGDEBUG, "modifier ({}) not supported for format ({})",
+                 DRMHELPERS::ModifierToString(modifier), DRMHELPERS::FourCCToString(format));
       return false;
     }
   }
 
-  CLog::Log(LOGDEBUG, "CDRMPlane::{} - found plane format ({}) and modifier ({})", __FUNCTION__,
-            DRMHELPERS::FourCCToString(format), DRMHELPERS::ModifierToString(modifier));
+  CLog::LogF(LOGDEBUG, "found plane format ({}) and modifier ({})",
+             DRMHELPERS::FourCCToString(format), DRMHELPERS::ModifierToString(modifier));
 
   return true;
 }
@@ -173,11 +170,11 @@ bool CDRMPlane::MoveOnTopOf(CDRMPlane* other)
   const auto [other_zpos_min, other_zpos_max] =
       other->GetRangePropertyLimits("zpos").value_or(std::pair<uint64_t, uint64_t>(0, 0));
 
-  CLog::LogF(LOGDEBUG, "CDRMPlane::{} - zpos_available: {}", __FUNCTION__, zpos_available);
-  CLog::LogF(LOGDEBUG, "CDRMPlane::{} - plane {} zpos: {}[{}-{}], immutable: {}", __FUNCTION__,
-             GetId(), zpos, zpos_min, zpos_max, zpos_immutable);
-  CLog::LogF(LOGDEBUG, "CDRMPlane::{} - plane {} zpos: {}[{}-{}], immutable: {}", __FUNCTION__,
-             other->GetId(), other_zpos, other_zpos_min, other_zpos_max, other_zpos_immutable);
+  CLog::LogF(LOGDEBUG, "zpos_available: {}", zpos_available);
+  CLog::LogF(LOGDEBUG, "plane {} zpos: {}[{}-{}], immutable: {}", GetId(), zpos, zpos_min, zpos_max,
+             zpos_immutable);
+  CLog::LogF(LOGDEBUG, "plane {} zpos: {}[{}-{}], immutable: {}", other->GetId(), other_zpos,
+             other_zpos_min, other_zpos_max, other_zpos_immutable);
 
   if (zpos > other_zpos)
     return true;
@@ -188,9 +185,8 @@ bool CDRMPlane::MoveOnTopOf(CDRMPlane* other)
   if (!other_zpos_immutable && zpos_immutable && zpos > other_zpos_min)
   {
     other->SetProperty("zpos", other_zpos_min);
-    CLog::LogF(LOGDEBUG,
-               "CDRMPlane::{} - moving down plane {}, zpos [{}->{}] under plane {} zpos {}",
-               __FUNCTION__, other->GetId(), other_zpos, other_zpos_min, GetId(), zpos);
+    CLog::LogF(LOGDEBUG, "moving down plane {}, zpos [{}->{}] under plane {} zpos {}",
+               other->GetId(), other_zpos, other_zpos_min, GetId(), zpos);
     return true;
   }
 
@@ -198,9 +194,8 @@ bool CDRMPlane::MoveOnTopOf(CDRMPlane* other)
   {
     if (SetProperty("zpos", zpos_max))
     {
-      CLog::LogF(LOGDEBUG,
-                 "CDRMPlane::{} - moving up plane {}, zpos [{}->{}] on top of plane {} zpos {}",
-                 __FUNCTION__, GetId(), zpos, zpos_max, other->GetId(), other_zpos);
+      CLog::LogF(LOGDEBUG, "moving up plane {}, zpos [{}->{}] on top of plane {} zpos {}", GetId(),
+                 zpos, zpos_max, other->GetId(), other_zpos);
       return true;
     }
     return false;
@@ -211,10 +206,9 @@ bool CDRMPlane::MoveOnTopOf(CDRMPlane* other)
     bool success = SetProperty("zpos", zpos_max) && other->SetProperty("zpos", other_zpos_min);
     if (success)
     {
-      CLog::LogF(
-          LOGDEBUG,
-          "CDRMPlane::{} - moving up plane {} zpos [{}->{}] and moving down plane {} zpos [{}->{}]",
-          __FUNCTION__, GetId(), zpos, zpos_max, other->GetId(), other_zpos, other_zpos_min);
+      CLog::LogF(LOGDEBUG,
+                 "moving up plane {} zpos [{}->{}] and moving down plane {} zpos [{}->{}]", GetId(),
+                 zpos, zpos_max, other->GetId(), other_zpos, other_zpos_min);
     }
     return success;
   }

--- a/xbmc/windowing/gbm/drm/DRMPlane.cpp
+++ b/xbmc/windowing/gbm/drm/DRMPlane.cpp
@@ -154,3 +154,70 @@ bool CDRMPlane::Check(
 
   return true;
 }
+
+bool CDRMPlane::MoveOnTopOf(CDRMPlane* other)
+{
+  if (other == nullptr)
+    return false;
+
+  const bool zpos_available = SupportsProperty("zpos") && other->SupportsProperty("zpos");
+
+  const uint64_t zpos = GetPropertyValue("zpos").value_or(0);
+  const uint64_t other_zpos = other->GetPropertyValue("zpos").value_or(0);
+
+  const bool zpos_immutable = IsPropertyImmutable("zpos").value_or(true);
+  const bool other_zpos_immutable = other->IsPropertyImmutable("zpos").value_or(true);
+
+  const auto [zpos_min, zpos_max] =
+      GetRangePropertyLimits("zpos").value_or(std::pair<uint64_t, uint64_t>(0, 0));
+  const auto [other_zpos_min, other_zpos_max] =
+      other->GetRangePropertyLimits("zpos").value_or(std::pair<uint64_t, uint64_t>(0, 0));
+
+  CLog::LogF(LOGDEBUG, "CDRMPlane::{} - zpos_available: {}", __FUNCTION__, zpos_available);
+  CLog::LogF(LOGDEBUG, "CDRMPlane::{} - plane {} zpos: {}[{}-{}], immutable: {}", __FUNCTION__,
+             GetId(), zpos, zpos_min, zpos_max, zpos_immutable);
+  CLog::LogF(LOGDEBUG, "CDRMPlane::{} - plane {} zpos: {}[{}-{}], immutable: {}", __FUNCTION__,
+             other->GetId(), other_zpos, other_zpos_min, other_zpos_max, other_zpos_immutable);
+
+  if (zpos > other_zpos)
+    return true;
+
+  if (!zpos_available && GetId() > other->GetId())
+    return true;
+
+  if (!other_zpos_immutable && zpos_immutable && zpos > other_zpos_min)
+  {
+    other->SetProperty("zpos", other_zpos_min);
+    CLog::LogF(LOGDEBUG,
+               "CDRMPlane::{} - moving down plane {}, zpos [{}->{}] under plane {} zpos {}",
+               __FUNCTION__, other->GetId(), other_zpos, other_zpos_min, GetId(), zpos);
+    return true;
+  }
+
+  if (other_zpos_immutable && !zpos_immutable && zpos_max > other_zpos)
+  {
+    if (SetProperty("zpos", zpos_max))
+    {
+      CLog::LogF(LOGDEBUG,
+                 "CDRMPlane::{} - moving up plane {}, zpos [{}->{}] on top of plane {} zpos {}",
+                 __FUNCTION__, GetId(), zpos, zpos_max, other->GetId(), other_zpos);
+      return true;
+    }
+    return false;
+  }
+
+  if (!other_zpos_immutable && !zpos_immutable && zpos_max > other_zpos_min)
+  {
+    bool success = SetProperty("zpos", zpos_max) && other->SetProperty("zpos", other_zpos_min);
+    if (success)
+    {
+      CLog::LogF(
+          LOGDEBUG,
+          "CDRMPlane::{} - moving up plane {} zpos [{}->{}] and moving down plane {} zpos [{}->{}]",
+          __FUNCTION__, GetId(), zpos, zpos_max, other->GetId(), other_zpos, other_zpos_min);
+    }
+    return success;
+  }
+
+  return false;
+}

--- a/xbmc/windowing/gbm/drm/DRMPlane.h
+++ b/xbmc/windowing/gbm/drm/DRMPlane.h
@@ -36,6 +36,8 @@ public:
 
   void SetFormat(const uint32_t newFormat) { m_format = newFormat; }
   uint32_t GetFormat() const { return m_format; }
+  void SetModifier(const uint64_t newModifier) { m_modifier = newModifier; }
+  uint64_t GetModifier() const { return m_modifier; }
   std::vector<uint64_t>& GetModifiersForFormat(uint32_t format) { return m_modifiers_map[format]; }
 
   bool SupportsFormat(uint32_t format);
@@ -51,6 +53,7 @@ private:
 
   std::map<uint32_t, std::vector<uint64_t>> m_modifiers_map;
   uint32_t m_format{DRM_FORMAT_XRGB8888};
+  uint64_t m_modifier{DRM_FORMAT_MOD_INVALID};
 };
 
 } // namespace GBM

--- a/xbmc/windowing/gbm/drm/DRMPlane.h
+++ b/xbmc/windowing/gbm/drm/DRMPlane.h
@@ -54,6 +54,7 @@ public:
   bool SupportsFormatAndModifier(uint32_t format, uint64_t modifier);
   bool Check(
       uint64_t w, uint64_t h, uint32_t format, uint64_t modifier, CDRMCrtc* crtc, PlaneType type);
+  bool MoveOnTopOf(CDRMPlane* other);
 
 private:
   struct DrmModePlaneDeleter

--- a/xbmc/windowing/gbm/drm/DRMPlane.h
+++ b/xbmc/windowing/gbm/drm/DRMPlane.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "DRMCrtc.h"
 #include "DRMObject.h"
 
 #include <map>
@@ -20,6 +21,15 @@ namespace WINDOWING
 {
 namespace GBM
 {
+
+enum PlaneType
+{
+  PLANE_TYPE_OVERLAY,
+  PLANE_TYPE_PRIMARY,
+  PLANE_TYPE_CURSOR,
+  PLANE_TYPE_UNKNOWN,
+  PLANE_TYPE_ANY,
+};
 
 class CDRMPlane : public CDRMObject
 {
@@ -42,6 +52,8 @@ public:
 
   bool SupportsFormat(uint32_t format);
   bool SupportsFormatAndModifier(uint32_t format, uint64_t modifier);
+  bool Check(
+      uint64_t w, uint64_t h, uint32_t format, uint64_t modifier, CDRMCrtc* crtc, PlaneType type);
 
 private:
   struct DrmModePlaneDeleter

--- a/xbmc/windowing/gbm/drm/DRMPlane.h
+++ b/xbmc/windowing/gbm/drm/DRMPlane.h
@@ -40,7 +40,6 @@ public:
   ~CDRMPlane() = default;
 
   uint32_t GetPlaneId() const { return m_plane->plane_id; }
-  uint32_t GetPossibleCrtcs() const { return m_plane->possible_crtcs; }
 
   void FindModifiers();
 
@@ -65,7 +64,7 @@ private:
   std::unique_ptr<drmModePlane, DrmModePlaneDeleter> m_plane;
 
   std::map<uint32_t, std::vector<uint64_t>> m_modifiers_map;
-  uint32_t m_format{DRM_FORMAT_XRGB8888};
+  uint32_t m_format{DRM_FORMAT_INVALID};
   uint64_t m_modifier{DRM_FORMAT_MOD_INVALID};
 };
 

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -163,20 +163,18 @@ bool CDRMUtils::FindPreferredMode()
 
 bool CDRMUtils::FindPlanes()
 {
-  for (size_t i = 0; i < m_crtcs.size(); i++)
+  for (auto& crtc : m_encoder->GetPossibleCrtcs(m_crtcs))
   {
-    if (!(m_encoder->GetPossibleCrtcs() & (1 << i)))
-      continue;
-
-    auto videoPlane = std::ranges::find_if(m_planes,
-                                           [&i](auto& plane)
-                                           {
-                                             if (plane->GetPossibleCrtcs() & (1 << i))
-                                             {
-                                               return plane->SupportsFormat(DRM_FORMAT_NV12);
-                                             }
-                                             return false;
-                                           });
+    auto videoPlane =
+        std::ranges::find_if(m_planes,
+                             [&crtc](auto& plane)
+                             {
+                               if (plane->GetPossibleCrtcs() & (1 << crtc->GetOffset()))
+                               {
+                                 return plane->SupportsFormat(DRM_FORMAT_NV12);
+                               }
+                               return false;
+                             });
 
     uint32_t videoPlaneId{0};
 
@@ -185,9 +183,9 @@ bool CDRMUtils::FindPlanes()
 
     auto guiPlane = std::ranges::find_if(
         m_planes,
-        [&i, &videoPlaneId](auto& plane)
+        [&crtc, &videoPlaneId](auto& plane)
         {
-          if (plane->GetPossibleCrtcs() & (1 << i))
+          if (plane->GetPossibleCrtcs() & (1 << crtc->GetOffset()))
           {
             return (plane->GetPlaneId() != videoPlaneId &&
                     (videoPlaneId == 0 || plane->SupportsFormat(DRM_FORMAT_ARGB8888)) &&
@@ -199,7 +197,7 @@ bool CDRMUtils::FindPlanes()
 
     if (videoPlane != m_planes.end() && guiPlane != m_planes.end())
     {
-      m_crtc = m_crtcs[i].get();
+      m_crtc = crtc;
       m_video_plane = videoPlane->get();
       m_gui_plane = guiPlane->get();
       break;
@@ -207,9 +205,9 @@ bool CDRMUtils::FindPlanes()
 
     if (guiPlane != m_planes.end())
     {
-      if (!m_crtc && m_encoder->GetCrtcId() == m_crtcs[i]->GetCrtcId())
+      if (!m_crtc && m_encoder->GetCrtcId() == crtc->GetCrtcId())
       {
-        m_crtc = m_crtcs[i].get();
+        m_crtc = crtc;
         m_gui_plane = guiPlane->get();
         m_video_plane = nullptr;
       }
@@ -543,23 +541,19 @@ bool CDRMUtils::FindEncoder()
 
 bool CDRMUtils::FindCrtc()
 {
-  for (size_t i = 0; i < m_crtcs.size(); i++)
+  for (auto& crtc : m_encoder->GetPossibleCrtcs(m_crtcs))
   {
-    if (m_encoder->GetPossibleCrtcs() & (1 << i))
+    if (crtc->GetCrtcId() != m_encoder->GetCrtcId())
+      continue;
+    m_orig_crtc = crtc;
+    if (m_orig_crtc->GetModeValid())
     {
-      if (m_crtcs[i]->GetCrtcId() == m_encoder->GetCrtcId())
-      {
-        m_orig_crtc = m_crtcs[i].get();
-        if (m_orig_crtc->GetModeValid())
-        {
-          m_mode = m_orig_crtc->GetMode();
-          CLog::LogF(LOGDEBUG, "Original crtc mode: {}x{}{} @ {} Hz", m_mode->hdisplay,
-                     m_mode->vdisplay, m_mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "",
-                     m_mode->vrefresh);
-        }
-        return true;
-      }
+      m_mode = m_orig_crtc->GetMode();
+      CLog::LogF(LOGDEBUG, "Original crtc mode: {}x{}{} @ {} Hz", m_mode->hdisplay,
+                 m_mode->vdisplay, m_mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "",
+                 m_mode->vrefresh);
     }
+    return true;
   }
 
   return false;

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -413,7 +413,7 @@ bool CDRMUtils::InitDrm()
 
   m_crtcs.clear();
   for (int i = 0; i < resources->count_crtcs; i++)
-    m_crtcs.emplace_back(std::make_unique<CDRMCrtc>(m_fd, resources->crtcs[i]));
+    m_crtcs.emplace_back(std::make_unique<CDRMCrtc>(m_fd, resources->crtcs[i], i));
 
   drmModeFreeResources(resources);
 

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -162,8 +162,8 @@ bool CDRMUtils::FindGuiPlane(uint32_t format, uint64_t modifier)
 
   if (gui_format == m_gui_formats.end())
   {
-    CLog::LogF(LOGERROR, "CDRMUtils::{} - Requested format {} for gui plane is not supported",
-               __FUNCTION__, DRMHELPERS::FourCCToString(format));
+    CLog::LogF(LOGERROR, "Requested format {} for gui plane is not supported",
+               DRMHELPERS::FourCCToString(format));
     return false;
   }
 
@@ -195,20 +195,15 @@ bool CDRMUtils::FindGuiPlane(uint32_t format, uint64_t modifier)
       m_old_crtc = m_crtc;
       m_crtc = crtc;
       m_gui_plane = plane.get();
-      CLog::LogF(
-          LOGINFO,
-          "CDRMUtils::{} - Using gui plane [{}x{}] id:{}, format:{}, modifier:{}, crtc id:{}",
-          __FUNCTION__, res.iWidth, res.iHeight, m_gui_plane->GetId(),
-          DRMHELPERS::FourCCToString(format), DRMHELPERS::ModifierToString(modifier),
-          m_crtc->GetId());
+      CLog::LogF(LOGINFO, "Using gui plane [{}x{}] id:{}, format:{}, modifier:{}, crtc id:{}",
+                 res.iWidth, res.iHeight, m_gui_plane->GetId(), DRMHELPERS::FourCCToString(format),
+                 DRMHELPERS::ModifierToString(modifier), m_crtc->GetId());
       return true;
     }
   }
 
-  CLog::LogF(LOGERROR,
-             "CDRMUtils::{} - Requested format {} and modifier {} for gui plane is not supported",
-             __FUNCTION__, DRMHELPERS::FourCCToString(format),
-             DRMHELPERS::ModifierToString(modifier));
+  CLog::LogF(LOGERROR, "Requested format {} and modifier {} for gui plane is not supported",
+             DRMHELPERS::FourCCToString(format), DRMHELPERS::ModifierToString(modifier));
 
   return false;
 }
@@ -228,9 +223,9 @@ bool CDRMUtils::FindVideoAndGuiPlane(uint32_t format,
     if (!gui_format.alpha)
     {
       CLog::LogF(LOGWARNING,
-                 "CDRMUtils::{} - GUI plane format {} can not do alpha blending, "
+                 "GUI plane format {} can not do alpha blending, "
                  "video will be rendered through EGL import over the gui plane",
-                 __FUNCTION__, DRMHELPERS::FourCCToString(m_gui_plane->GetFormat()));
+                 DRMHELPERS::FourCCToString(m_gui_plane->GetFormat()));
       m_video_plane = nullptr;
       return false;
     }
@@ -272,9 +267,9 @@ bool CDRMUtils::FindVideoAndGuiPlane(uint32_t format,
         m_video_plane = video_plane.get();
 
         CLog::LogF(LOGINFO,
-                   "CDRMUtils::{} - Using gui plane [{}x{}] id:{}, video plane [{}x{}] id:{} on "
+                   "Using gui plane [{}x{}] id:{}, video plane [{}x{}] id:{} on "
                    "crtc id:{} for video format:{}, video modifier:{}",
-                   __FUNCTION__, res.iWidth, res.iHeight, m_gui_plane->GetId(), width, height,
+                   res.iWidth, res.iHeight, m_gui_plane->GetId(), width, height,
                    m_video_plane->GetId(), m_crtc->GetId(), DRMHELPERS::FourCCToString(format),
                    DRMHELPERS::ModifierToString(modifier));
         return true;
@@ -283,10 +278,10 @@ bool CDRMUtils::FindVideoAndGuiPlane(uint32_t format,
   }
 
   CLog::LogF(LOGWARNING,
-             "CDRMUtils::{} - Rendering will be done through EGL. "
+             "Rendering will be done through EGL. "
              "Can not find a Video Plane [{}x{}] format:{}, modifier:{} "
              "together with a Gui Plane [{}x{}] format:{}, modifier:{}.",
-             __FUNCTION__, res.iWidth, res.iHeight, DRMHELPERS::FourCCToString(format),
+             res.iWidth, res.iHeight, DRMHELPERS::FourCCToString(format),
              DRMHELPERS::ModifierToString(modifier), width, height,
              DRMHELPERS::FourCCToString(m_gui_plane->GetFormat()),
              DRMHELPERS::ModifierToString(m_gui_plane->GetModifier()));
@@ -532,7 +527,7 @@ bool CDRMUtils::InitDrm()
       return false;
     }
 
-    CLog::Log(LOGINFO, "CDRMUtils: Successfully authorized drm magic");
+    CLog::LogF(LOGINFO, "Successfully authorized drm magic");
   }
 
   const PlaneType gui_type = HasQuirk(QUIRK_NEEDSPRIMARY) ? PLANE_TYPE_PRIMARY : PLANE_TYPE_ANY;
@@ -601,7 +596,7 @@ bool CDRMUtils::FindConnector()
     return false;
   }
 
-  CLog::Log(LOGINFO, "CDRMUtils: Using connector: {}", connector->get()->GetName());
+  CLog::LogF(LOGINFO, "Using connector: {}", connector->get()->GetName());
 
   m_connector = connector->get();
   return true;
@@ -619,7 +614,7 @@ bool CDRMUtils::FindEncoder()
     return false;
   }
 
-  CLog::Log(LOGINFO, "CDRMUtils: Using encoder: {}", encoder->get()->GetEncoderId());
+  CLog::LogF(LOGINFO, "Using encoder: {}", encoder->get()->GetEncoderId());
 
   m_encoder = encoder->get();
   return true;

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -64,17 +64,12 @@ drm_fb* CDRMUtils::DrmFbGetFromBo(struct gbm_bo* bo)
   {
     struct drm_fb* fb = static_cast<drm_fb*>(gbm_bo_get_user_data(bo));
     if (fb)
-    {
-      if (m_gui_plane->GetFormat() == fb->format)
-        return fb;
-      else
-        DrmFbDestroyCallback(bo, gbm_bo_get_user_data(bo));
-    }
+      return fb;
   }
 
   struct drm_fb* fb = new drm_fb;
   fb->bo = bo;
-  fb->format = m_gui_plane->GetFormat();
+  fb->format = gbm_bo_get_format(bo);
 
   uint32_t width, height, handles[4] = {0}, strides[4] = {0}, offsets[4] = {0};
 
@@ -161,77 +156,141 @@ bool CDRMUtils::FindPreferredMode()
   return true;
 }
 
-bool CDRMUtils::FindPlanes()
+bool CDRMUtils::FindGuiPlane(uint32_t format, uint64_t modifier)
 {
-  for (auto& crtc : m_encoder->GetPossibleCrtcs(m_crtcs))
+  const auto gui_format = std::ranges::find(m_gui_formats, format, &guiformat::drm);
+
+  if (gui_format == m_gui_formats.end())
   {
-    auto videoPlane =
-        std::ranges::find_if(m_planes,
-                             [&crtc](auto& plane)
-                             {
-                               if (plane->GetPossibleCrtcs() & (1 << crtc->GetOffset()))
-                               {
-                                 return plane->SupportsFormat(DRM_FORMAT_NV12);
-                               }
-                               return false;
-                             });
+    CLog::LogF(LOGERROR, "CDRMUtils::{} - Requested format {} for gui plane is not supported",
+               __FUNCTION__, DRMHELPERS::FourCCToString(format));
+    return false;
+  }
 
-    uint32_t videoPlaneId{0};
+  const PlaneType gui_type = HasQuirk(QUIRK_NEEDSPRIMARY) ? PLANE_TYPE_PRIMARY : PLANE_TYPE_ANY;
+  const RESOLUTION_INFO res = GetCurrentMode();
 
-    if (videoPlane != m_planes.end())
-      videoPlaneId = videoPlane->get()->GetPlaneId();
+  if (m_crtc && m_gui_plane &&
+      m_gui_plane->Check(res.iWidth, res.iHeight, format, modifier, m_crtc, gui_type))
+  {
+    CLog::LogF(LOGINFO,
+               "Using existing gui plane [{}x{}] id:{}, format:{}, modifier:{}, crtc id:{}",
+               res.iWidth, res.iHeight, m_gui_plane->GetId(), DRMHELPERS::FourCCToString(format),
+               DRMHELPERS::ModifierToString(modifier), m_crtc->GetId());
+    return true;
+  }
 
-    auto guiPlane = std::ranges::find_if(
-        m_planes,
-        [&crtc, &videoPlaneId](auto& plane)
-        {
-          if (plane->GetPossibleCrtcs() & (1 << crtc->GetOffset()))
-          {
-            return (plane->GetPlaneId() != videoPlaneId &&
-                    (videoPlaneId == 0 || plane->SupportsFormat(DRM_FORMAT_ARGB8888)) &&
-                    (plane->SupportsFormat(DRM_FORMAT_XRGB2101010) ||
-                     plane->SupportsFormat(DRM_FORMAT_XRGB8888)));
-          }
-          return false;
-        });
-
-    if (videoPlane != m_planes.end() && guiPlane != m_planes.end())
+  for (auto& crtc : m_encoder->GetPossibleCrtcs(m_crtcs, m_crtc))
+  {
+    for (auto& plane : m_planes)
     {
+      if (m_video_plane && m_video_plane->GetId() == plane.get()->GetId())
+        continue;
+
+      if (!plane->Check(res.iWidth, res.iHeight, format, modifier, crtc, gui_type))
+        continue;
+
+      plane->SetFormat(format);
+      plane->SetModifier(modifier);
+      m_old_crtc = m_crtc;
       m_crtc = crtc;
-      m_video_plane = videoPlane->get();
-      m_gui_plane = guiPlane->get();
-      break;
+      m_gui_plane = plane.get();
+      CLog::LogF(
+          LOGINFO,
+          "CDRMUtils::{} - Using gui plane [{}x{}] id:{}, format:{}, modifier:{}, crtc id:{}",
+          __FUNCTION__, res.iWidth, res.iHeight, m_gui_plane->GetId(),
+          DRMHELPERS::FourCCToString(format), DRMHELPERS::ModifierToString(modifier),
+          m_crtc->GetId());
+      return true;
     }
+  }
 
-    if (guiPlane != m_planes.end())
+  CLog::LogF(LOGERROR,
+             "CDRMUtils::{} - Requested format {} and modifier {} for gui plane is not supported",
+             __FUNCTION__, DRMHELPERS::FourCCToString(format),
+             DRMHELPERS::ModifierToString(modifier));
+
+  return false;
+}
+
+bool CDRMUtils::FindVideoAndGuiPlane(uint32_t format,
+                                     uint64_t modifier,
+                                     uint64_t width,
+                                     uint64_t height)
+{
+  if (m_gui_plane == nullptr)
+    return false;
+
+  for (auto& gui_format : m_gui_formats)
+  {
+    if (gui_format.drm != m_gui_plane->GetFormat())
+      continue;
+    if (!gui_format.alpha)
     {
-      if (!m_crtc && m_encoder->GetCrtcId() == crtc->GetCrtcId())
+      CLog::LogF(LOGWARNING,
+                 "CDRMUtils::{} - GUI plane format {} can not do alpha blending, "
+                 "video will be rendered through EGL import over the gui plane",
+                 __FUNCTION__, DRMHELPERS::FourCCToString(m_gui_plane->GetFormat()));
+      m_video_plane = nullptr;
+      return false;
+    }
+    break;
+  }
+
+  const PlaneType gui_type = HasQuirk(QUIRK_NEEDSPRIMARY) ? PLANE_TYPE_PRIMARY : PLANE_TYPE_ANY;
+  const RESOLUTION_INFO res = GetCurrentMode();
+
+  // check if current config already satisfies
+  if (m_video_plane != nullptr &&
+      m_video_plane->Check(width, height, format, modifier, m_crtc, PLANE_TYPE_ANY))
+    return true;
+
+  for (auto& crtc : m_encoder->GetPossibleCrtcs(m_crtcs, m_crtc))
+  {
+    for (auto& gui_plane : m_planes)
+    {
+      if (!gui_plane->Check(res.iWidth, res.iHeight, m_gui_plane->GetFormat(),
+                            m_gui_plane->GetModifier(), crtc, gui_type))
+        continue;
+
+      for (auto& video_plane : m_planes)
       {
+        if (video_plane->GetId() == gui_plane->GetId() ||
+            !video_plane->Check(width, height, format, modifier, crtc, PLANE_TYPE_ANY) ||
+            !gui_plane->MoveOnTopOf(video_plane.get()))
+          continue;
+
+        gui_plane->SetFormat(m_gui_plane->GetFormat());
+        gui_plane->SetModifier(m_gui_plane->GetModifier());
+        video_plane->SetFormat(format);
+        video_plane->SetModifier(modifier);
+
+        m_old_crtc = m_crtc;
         m_crtc = crtc;
-        m_gui_plane = guiPlane->get();
-        m_video_plane = nullptr;
+
+        m_gui_plane = gui_plane.get();
+        m_video_plane = video_plane.get();
+
+        CLog::LogF(LOGINFO,
+                   "CDRMUtils::{} - Using gui plane [{}x{}] id:{}, video plane [{}x{}] id:{} on "
+                   "crtc id:{} for video format:{}, video modifier:{}",
+                   __FUNCTION__, res.iWidth, res.iHeight, m_gui_plane->GetId(), width, height,
+                   m_video_plane->GetId(), m_crtc->GetId(), DRMHELPERS::FourCCToString(format),
+                   DRMHELPERS::ModifierToString(modifier));
+        return true;
       }
     }
   }
 
-  CLog::Log(LOGINFO, "CDRMUtils: using crtc: {}", m_crtc->GetCrtcId());
-
-  // video plane may not be available
-  if (m_video_plane)
-    CLog::LogF(LOGDEBUG, "Using video plane {}", m_video_plane->GetPlaneId());
-
-  if (m_gui_plane->SupportsFormat(DRM_FORMAT_XRGB2101010))
-  {
-    m_gui_plane->SetFormat(DRM_FORMAT_XRGB2101010);
-    CLog::LogF(LOGDEBUG, "Using 10bit gui plane {}", m_gui_plane->GetPlaneId());
-  }
-  else
-  {
-    m_gui_plane->SetFormat(DRM_FORMAT_XRGB8888);
-    CLog::LogF(LOGDEBUG, "Using gui plane {}", m_gui_plane->GetPlaneId());
-  }
-
-  return true;
+  CLog::LogF(LOGWARNING,
+             "CDRMUtils::{} - Rendering will be done through EGL. "
+             "Can not find a Video Plane [{}x{}] format:{}, modifier:{} "
+             "together with a Gui Plane [{}x{}] format:{}, modifier:{}.",
+             __FUNCTION__, res.iWidth, res.iHeight, DRMHELPERS::FourCCToString(format),
+             DRMHELPERS::ModifierToString(modifier), width, height,
+             DRMHELPERS::FourCCToString(m_gui_plane->GetFormat()),
+             DRMHELPERS::ModifierToString(m_gui_plane->GetModifier()));
+  return false;
 }
 
 void CDRMUtils::PrintDrmDeviceInfo(drmDevicePtr device)
@@ -342,6 +401,14 @@ bool CDRMUtils::OpenDrm(bool needConnector)
 
     CLog::LogF(LOGDEBUG, "Opened device: {}", device->nodes[DRM_NODE_PRIMARY]);
 
+    drmVersionPtr version = drmGetVersion(m_fd);
+    if (version)
+    {
+      if (strcmp(version->name, "amdgpu") == 0)
+        m_drm_quirks |= QUIRK_NEEDSPRIMARY;
+      drmFreeVersion(version);
+    }
+
     PrintDrmDeviceInfo(device);
 
     const char* renderPath = drmGetRenderDeviceNameFromFd(m_fd);
@@ -440,9 +507,6 @@ bool CDRMUtils::InitDrm()
   if (!FindCrtc())
     return false;
 
-  if (!FindPlanes())
-    return false;
-
   if (!FindPreferredMode())
     return false;
 
@@ -471,6 +535,28 @@ bool CDRMUtils::InitDrm()
     CLog::Log(LOGINFO, "CDRMUtils: Successfully authorized drm magic");
   }
 
+  const PlaneType gui_type = HasQuirk(QUIRK_NEEDSPRIMARY) ? PLANE_TYPE_PRIMARY : PLANE_TYPE_ANY;
+  const RESOLUTION_INFO res = GetCurrentMode();
+
+  for (auto& plane : m_planes)
+  {
+    for (auto& format : m_gui_formats)
+    {
+      if (!plane->Check(res.iWidth, res.iHeight, format.drm, DRM_FORMAT_MOD_INVALID, nullptr,
+                        gui_type))
+        continue;
+
+      if (!format.active)
+        format.active = true;
+
+      for (uint64_t modifier : plane->GetModifiersForFormat(format.drm))
+      {
+        auto it = std::ranges::find(format.modifiers, modifier);
+        if (it == format.modifiers.end())
+          format.modifiers.push_back(modifier);
+      }
+    }
+  }
   return true;
 }
 
@@ -546,12 +632,13 @@ bool CDRMUtils::FindCrtc()
     if (crtc->GetCrtcId() != m_encoder->GetCrtcId())
       continue;
     m_orig_crtc = crtc;
+    m_crtc = m_orig_crtc;
     if (m_orig_crtc->GetModeValid())
     {
       m_mode = m_orig_crtc->GetMode();
-      CLog::LogF(LOGDEBUG, "Original crtc mode: {}x{}{} @ {} Hz", m_mode->hdisplay,
-                 m_mode->vdisplay, m_mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "",
-                 m_mode->vrefresh);
+      CLog::LogF(LOGDEBUG, "Original crtc id: {}, mode: {}x{}{} @ {} Hz", m_crtc->GetCrtcId(),
+                 m_mode->hdisplay, m_mode->vdisplay,
+                 m_mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "", m_mode->vrefresh);
     }
     return true;
   }
@@ -688,14 +775,4 @@ std::vector<std::string> CDRMUtils::GetConnectedConnectorNames()
   }
 
   return connectorNames;
-}
-
-uint32_t CDRMUtils::FourCCWithAlpha(uint32_t fourcc)
-{
-  return (fourcc & 0xFFFFFF00) | static_cast<uint32_t>('A');
-}
-
-uint32_t CDRMUtils::FourCCWithoutAlpha(uint32_t fourcc)
-{
-  return (fourcc & 0xFFFFFF00) | static_cast<uint32_t>('X');
 }

--- a/xbmc/windowing/gbm/drm/OffScreenModeSetting.cpp
+++ b/xbmc/windowing/gbm/drm/OffScreenModeSetting.cpp
@@ -24,7 +24,7 @@ bool COffScreenModeSetting::InitDrm()
   if (!CDRMUtils::OpenDrm(false))
     return false;
 
-  CLog::Log(LOGDEBUG, "COffScreenModeSetting::{} - initialized offscreen DRM", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "initialized offscreen DRM");
   return true;
 }
 


### PR DESCRIPTION
## Description
When DRM planes are different according to the format and modifier combination, Kodi should select the video plane to render dynamically acording to the requested DRM format and Modifier combination.

This is the reworked version of: https://github.com/xbmc/xbmc/pull/24431

I have tested it with rockchip vop2 driver both in rk3588 and rk3528. Would be better to test with a bigger variety of drm drivers.

@chewitt 

## Motivation and context
Solves https://github.com/xbmc/xbmc/issues/24422

## Screenshots

### New setting to enable/disable usage of modifiers in GUI plane
![20251107_013447](https://github.com/user-attachments/assets/1aab72bb-f843-47a0-a182-e7c4f67b7a5f)

### System info now also reports format and modifier used in gui rendering
#### AFBC compressed gui with ARGB8888 format
![20251107_014141](https://github.com/user-attachments/assets/cbccd7b4-f02f-4b52-8610-d1be6052b5a0)
#### Uncompressed (LINEAR) gui with ARGB8888 format
![20251107_014612](https://github.com/user-attachments/assets/ae74755f-8ddf-49d1-a731-4990cb840ffb)
#### Uncompressed (LINEAR) gui with XRGB8888 format, (egl only)
![20251107_014840](https://github.com/user-attachments/assets/f7cb89d3-a8ff-4d1e-8b1b-d0a529d7e3a3)
#### Uncompressed but Tiled (intel drm) gui with ARGB8888 format
![20251107_064451](https://github.com/user-attachments/assets/b8c98a03-a3b1-4a23-bb03-e30a8067cafd)



## How has this been tested?
Tested with rk3588 based rock5b board with rockchip [linux vendor kernel 5.10](https://github.com/radxa/kernel/)
FFmpeg uses [linux mpp driver](https://github.com/rockchip-linux/mpp) from with [ ffmpeg-rockchip](https://github.com/nyanmisaka/ffmpeg-rockchip) that support DRM Prime with AFBC support

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
