### PR TITLE
[cmake] FindBrotli cleanup and fix pkgconfig search

### DIFF
--- a/cmake/scripts/common/ModuleHelpers.cmake
+++ b/cmake/scripts/common/ModuleHelpers.cmake
@@ -512,7 +512,7 @@ macro(BUILD_DEP_TARGET)
 
   # Set both <UPPER>_FOUND and <lower>_FOUND as we have some legacy macros/functions that
   # rely on <UPPER>_FOUND, but cmake has new policies that are heading towards <lower>_FOUND
-  set(${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME}_FOUND ON CACHE BOOL "${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME}_FOUND" FORCE)
+  set(${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME}_FOUND 1)
 
   string(TOUPPER "${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME}" _search_upper)
   set(${_search_upper}_FOUND ON CACHE BOOL "${_search_upper}_FOUND" FORCE)


### PR DESCRIPTION
## Description
Fix pkgconfig search for Brotli libs
Cleanup logging related code that is deemed not relevant

## Motivation and context
@notspiff noticed internal exiv2 failing to build with system brotli. Brotli cmake packages use Brotli, but pkgconfig requires explicit brotlicommon/brotlidec for search

## How has this been tested?
Maybe @notspiff can test

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
