### PR TITLE
[Video] Fix kodi21 bluray resume audio/subtitle switching bug.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -340,6 +340,7 @@ bool CDVDInputStreamBluray::Open()
   else if (resumable && m_item.GetStartOffset() == STARTOFFSET_RESUME && m_item.IsResumable())
   {
     m_navmode = false;
+    m_isResuming = true;
     m_titleInfo = GetTitleFromState(m_item.GetVideoInfoTag()->GetResumePoint().playerState);
   }
   else
@@ -561,6 +562,11 @@ void CDVDInputStreamBluray::ProcessEvent() {
     pid = -1;
     if (m_titleInfo && m_clip && static_cast<uint32_t>(m_clip->audio_stream_count) > (m_event.param - 1))
       pid = m_clip->audio_streams[m_event.param - 1].pid;
+    if (m_isResuming)
+    {
+        bd_select_stream(m_bd, BLURAY_AUDIO_STREAM, pid, 1); 
+        CLog::Log(LOGDEBUG, "CDVDInputStreamBluray::BD_EVENT_AUDIO_STREAM - selected audio stream (pid: {}) in resume mode", pid);
+    }
     CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - BD_EVENT_AUDIO_STREAM {} {}", m_event.param, pid);
     m_player->OnDiscNavResult(static_cast<void*>(&pid), BD_EVENT_AUDIO_STREAM);
     break;
@@ -575,6 +581,11 @@ void CDVDInputStreamBluray::ProcessEvent() {
     pid = -1;
     if (m_titleInfo && m_clip && static_cast<uint32_t>(m_clip->pg_stream_count) > (m_event.param - 1))
       pid = m_clip->pg_streams[m_event.param - 1].pid;
+    if (m_isResuming)
+    {
+        bd_select_stream(m_bd, BLURAY_PG_TEXTST_STREAM, pid, 1); 
+        CLog::Log(LOGDEBUG, "CDVDInputStreamBluray::BD_EVENT_PG_TEXTST_STREAM - selected subtitle stream (pid: {}) in resume mode", pid);
+    }
     CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - BD_EVENT_PG_TEXTST_STREAM {}, {}", m_event.param,
               pid);
     m_player->OnDiscNavResult(static_cast<void*>(&pid), BD_EVENT_PG_TEXTST_STREAM);

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -156,6 +156,7 @@ protected:
   bool m_isInMainMenu = false;
   bool m_hasOverlay = false;
   bool m_navmode = false;
+  bool m_isResuming = false;
   int m_dispTimeBeforeRead = 0;
 
   typedef std::shared_ptr<CDVDOverlayImage> SOverlay;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3816,7 +3816,17 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
     m_pCCDemuxer = std::make_unique<CDVDDemuxCC>(hint.codec);
     m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_VIDEOMUX);
   }
-
+  
+  if (m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_BLURAY))
+  {
+    CDVDInputStreamBluray* blurayStream = dynamic_cast<CDVDInputStreamBluray*>(m_pInputStream.get());
+    if (blurayStream && blurayStream->IsResuming())
+    {
+      SetAudioStream(1);
+      CLog::Log(LOGDEBUG, "CVideoPlayer::OpenVideoStream - use 1 audiotrackIndex as default");
+    }
+  }
+  
   return true;
 }
 


### PR DESCRIPTION
…resuming playback of Blu-ray discs

## Description
DVDInputStreamBluray.cpp
DVDInputStreamBluray.h
VideoPlayer.cpp

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Tested in CoreELEC

## What is the effect on users?
fix kodi21 bluray resume bug

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
