### PR TITLE
[webOS] Packaging: Explicitly make gst-plugin-scanner executable

### DIFF
--- a/cmake/scripts/webos/Install.cmake
+++ b/cmake/scripts/webos/Install.cmake
@@ -30,7 +30,6 @@ set(APP_INSTALL_DIRS ${CMAKE_BINARY_DIR}/addons
                      ${CMAKE_BINARY_DIR}/userdata)
 set(APP_TOOLCHAIN_FILES ${TOOLCHAIN}/${HOST}/sysroot/lib/libatomic.so.1
                         ${TOOLCHAIN}/${HOST}/sysroot/lib/libcrypt.so.1
-                        ${TOOLCHAIN}/${HOST}/sysroot/usr/libexec/gstreamer-1.0/gst-plugin-scanner
                         ${CMAKE_BINARY_DIR}/libAcbAPI.so.1)
 set(BIN_ADDONS_DIR ${DEPENDS_PATH}/addons)
 
@@ -43,6 +42,8 @@ file(WRITE ${CMAKE_BINARY_DIR}/install.cmake "
   file(INSTALL ${DEPENDS_PATH}/lib/python${PYTHON_VERSION} DESTINATION ${APP_PACKAGE_DIR}/lib FOLLOW_SYMLINK_CHAIN
        PATTERN config-${PYTHON_VERSION}-arm-linux-gnueabi EXCLUDE)
   file(INSTALL ${APP_TOOLCHAIN_FILES} DESTINATION ${APP_PACKAGE_DIR}/lib FOLLOW_SYMLINK_CHAIN)
+  file(INSTALL \"${TOOLCHAIN}/${HOST}/sysroot/usr/libexec/gstreamer-1.0/gst-plugin-scanner\" DESTINATION \"${APP_PACKAGE_DIR}/lib\"
+       FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 
   file(STRINGS ${CMAKE_BINARY_DIR}/missing_libs.txt missing_libs)
   foreach(lib IN LISTS missing_libs)

--- a/xbmc/platform/linux/PlatformWebOS.cpp
+++ b/xbmc/platform/linux/PlatformWebOS.cpp
@@ -47,7 +47,7 @@ bool CPlatformWebOS::InitStageOne()
   const auto HOME = GetHomePath();
 
   setenv("APPID", CCompileInfo::GetPackage(), 0);
-  setenv("GST_PLUGIN_SCANNER", (HOME + "/lib/gst-plugin-scanner").c_str(), 1);
+  setenv("GST_PLUGIN_SCANNER_1_0", (HOME + "/lib/gst-plugin-scanner").c_str(), 1);
   setenv("XDG_RUNTIME_DIR", "/tmp/xdg", 1);
   setenv("XKB_CONFIG_ROOT", "/usr/share/X11/xkb", 1);
   setenv("WAYLAND_DISPLAY", "wayland-0", 1);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Followup of #27377 `gst-plugin-scanner` needs to be packaged as executable
Use `GST_PLUGIN_SCANNER_1_0` instead of `GST_PLUGIN_SCANNER` because the former takes priority:
https://github.com/GStreamer/gstreamer/blob/da0fc45f15a58e76cd0985daf483e1378166cb34/subprojects/gstreamer/gst/gstpluginloader-win32.c#L470-L473

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. --> 
Fix for https://github.com/xbmc/xbmc/issues/27419

When this happened on my device, I traced down the issue to the jailed environment not being able to call `gst-plugin-scanner`. I verified the fix by applying it manually by copying over the binary to the `lib` dir and executing it. `gst-plugin-scanner` creates a cache somewhere and does not run after the initial call, so it was working for me. That's why I missed that the executable flags were missing.

It also seems that it is required to set `GST_PLUGIN_SCANNER_1_0` opposing to the hint that gstreamer itself gives:

`
(kodi-webos:5593): GStreamer-WARNING **: 22:32:15.926: External plugin loader failed. This most likely means that the plugin loader helper binary was not found or could not be run. You might need to set the GST_PLUGIN_SCANNER environment variable if your setup is unusual. This should normally not be required though.
`

 `GST_PLUGIN_SCANNER_1_0` takes precedence over `GST_PLUGIN_SCANNER` and as a conclusion means that the former must already be defined

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
