### PR TITLE
[Android] [webOS] Add Dolby Vision setting to set zero L5 metadata

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24358,7 +24358,19 @@ msgctxt "#39208"
 msgid "Starfish is the hardware video decoder for LG's webOS. Disable it for troubleshooting or testing."
 msgstr ""
 
-#empty strings from id 39209 to 39999
+#. Title of Dolby Vision level 5 metadata zero override setting
+#: system/settings/settings.xml
+msgctxt "#39209"
+msgid "Dolby Vision: Override level 5 metadata to zero"
+msgstr ""
+
+#. Help text for setting "Dolby Vision: Override level 5 metadata to zero" of label #39209
+#: system/settings/settings.xml
+msgctxt "#39210"
+msgid "If enabled, Dolby Vision files will have level 5 (active area) metadata overridden to zero offsets. Enable if your display has issues with incorrectly cropped image in Dolby Vision playback."
+msgstr ""
+
+#empty strings from id 39211 to 39999
 
 # 40000 to 40800 are reserved for Video Versions feature
 

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -241,6 +241,25 @@
             <hidevalue>false</hidevalue>
           </control>
         </setting>
+        <setting id="videoplayer.dovizerolevel5" type="boolean" label="39209" help="39210">
+          <requirement><!-- Android and webOS use CBitstreamConverter -->
+            <or>
+              <condition>HAS_MEDIACODEC</condition>
+              <condition>HAVE_WEBOS</condition>
+            </or>
+          </requirement>
+          <dependencies>
+            <dependency type="visible">
+              <or>
+                <condition on="property" name="supportsdolbyvision" />
+                <condition>HAVE_WEBOS</condition>
+              </or>
+            </dependency>
+          </dependencies>
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
       </group>
       <group id="4" label="14232">
         <setting id="videoplayer.stereoscopicplaybackmode" type="integer" label="36520" help="36537">

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -500,10 +500,12 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
       bool convertDovi{false};
       bool removeDovi{false};
       bool removeHdr10Plus{false};
+      bool doviZeroLevel5{false};
 
       if (settings)
       {
         convertDovi = settings->GetBool(CSettings::SETTING_VIDEOPLAYER_CONVERTDOVI);
+        doviZeroLevel5 = settings->GetBool(CSettings::SETTING_VIDEOPLAYER_DOVIZEROLEVEL5);
 
         const std::shared_ptr<CSettingList> allowedHdrFormatsSetting(
             std::dynamic_pointer_cast<CSettingList>(
@@ -600,6 +602,7 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
         {
           m_bitstream->SetRemoveDovi(removeDovi);
           m_bitstream->SetRemoveHdr10Plus(removeHdr10Plus);
+          m_bitstream->SetDoviZeroLevel5(doviZeroLevel5);
 
           // Only set for profile 7, container hint allows to skip parsing unnecessarily
           if (m_hints.dovi.dv_profile == 7)

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
@@ -846,6 +846,7 @@ void CMediaPipelineWebOS::SetupBitstreamConverter(CDVDStreamInfo& hint)
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   const bool convertDovi =
       hint.dovi.el_present_flag || settings->GetBool(CSettings::SETTING_VIDEOPLAYER_CONVERTDOVI);
+  const bool doviZeroLevel5 = settings->GetBool(CSettings::SETTING_VIDEOPLAYER_DOVIZEROLEVEL5);
 
   const std::shared_ptr allowedHdrFormatsSetting(std::dynamic_pointer_cast<CSettingList>(
       settings->GetSetting(CSettings::SETTING_VIDEOPLAYER_ALLOWEDHDRFORMATS)));
@@ -864,6 +865,7 @@ void CMediaPipelineWebOS::SetupBitstreamConverter(CDVDStreamInfo& hint)
         if (hint.codec == AV_CODEC_ID_HEVC)
         {
           m_bitstream->SetRemoveDovi(removeDovi);
+          m_bitstream->SetDoviZeroLevel5(doviZeroLevel5);
 
           // webOS doesn't support HDR10+ and it can cause issues
           m_bitstream->SetRemoveHdr10Plus(true);

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -137,6 +137,7 @@ public:
   static constexpr auto SETTING_VIDEOPLAYER_SUPPORTMVC = "videoplayer.supportmvc";
   static constexpr auto SETTING_VIDEOPLAYER_CONVERTDOVI = "videoplayer.convertdovi";
   static constexpr auto SETTING_VIDEOPLAYER_ALLOWEDHDRFORMATS = "videoplayer.allowedhdrformats";
+  static constexpr auto SETTING_VIDEOPLAYER_DOVIZEROLEVEL5 = "videoplayer.dovizerolevel5";
   static constexpr auto SETTING_VIDEOPLAYER_QUEUETIMESIZE = "videoplayer.queuetimesize";
   static constexpr auto SETTING_VIDEOPLAYER_QUEUEDATASIZE = "videoplayer.queuedatasize";
   static constexpr auto SETTING_MYVIDEOS_SELECTACTION = "myvideos.selectaction";

--- a/xbmc/utils/BitstreamConverter.cpp
+++ b/xbmc/utils/BitstreamConverter.cpp
@@ -22,9 +22,6 @@
 extern "C"
 {
 #include <libavutil/intreadwrite.h>
-#ifdef HAVE_LIBDOVI
-#include <libdovi/rpu_parser.h>
-#endif
 }
 
 enum {
@@ -263,32 +260,6 @@ static bool has_sei_recovery_point(const uint8_t *p, const uint8_t *end)
 
   return false;
 }
-
-#ifdef HAVE_LIBDOVI
-// The returned data must be freed with `dovi_data_free`
-// May be NULL if no conversion was done
-static const DoviData* convert_dovi_rpu_nal(uint8_t* buf, uint32_t nal_size)
-{
-  DoviRpuOpaque* rpu = dovi_parse_unspec62_nalu(buf, nal_size);
-  const DoviRpuDataHeader* header = dovi_rpu_get_header(rpu);
-  const DoviData* rpu_data = NULL;
-
-  if (header && header->guessed_profile == 7)
-  {
-    int ret = dovi_convert_rpu_with_mode(rpu, 2);
-    if (ret < 0)
-      goto done;
-
-    rpu_data = dovi_write_unspec62_nalu(rpu);
-  }
-
-done:
-  dovi_rpu_free_header(header);
-  dovi_rpu_free(rpu);
-
-  return rpu_data;
-}
-#endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////
@@ -1005,13 +976,13 @@ bool CBitstreamConverter::BitstreamConvert(uint8_t* pData, int iSize, uint8_t **
         }
       }
 
-      if (write_buf && m_convert_dovi)
+      if (write_buf)
       {
         if (unit_type == HEVC_NAL_UNSPEC62)
         {
 #ifdef HAVE_LIBDOVI
           // Convert the RPU itself
-          rpu_data = convert_dovi_rpu_nal(buf, nal_size);
+          rpu_data = processDoviRpu(buf, nal_size);
           if (rpu_data)
           {
             buf_to_write = rpu_data->data;
@@ -1019,7 +990,7 @@ bool CBitstreamConverter::BitstreamConvert(uint8_t* pData, int iSize, uint8_t **
           }
 #endif
         }
-        else if (unit_type == HEVC_NAL_UNSPEC63)
+        else if (m_convert_dovi && unit_type == HEVC_NAL_UNSPEC63)
         {
           // Ignore the enhancement layer, may or may not help
           write_buf = false;
@@ -1334,3 +1305,43 @@ bool CBitstreamConverter::mpeg2_sequence_header(const uint8_t *data, const uint3
   return changed;
 }
 
+#ifdef HAVE_LIBDOVI
+// Processes Dolby Vision RPU
+//   - Converts to profile 8.1 if `m_convert_dovi` is enabled
+//
+// The returned data must be freed with `dovi_data_free`
+// May be NULL if no processing was done or if parsing errored
+const DoviData* CBitstreamConverter::processDoviRpu(uint8_t* buf, uint32_t nalSize)
+{
+  // early exit if no processing option is enabled
+  if (!m_convert_dovi)
+    return NULL;
+
+  DoviRpuOpaque* rpu = dovi_parse_unspec62_nalu(buf, nalSize);
+  const DoviRpuDataHeader* header = dovi_rpu_get_header(rpu);
+  const DoviData* rpuData = NULL;
+
+  int ret = 0;
+  bool processed = false;
+
+  if (!header)
+  {
+    dovi_rpu_free(rpu);
+    return rpuData;
+  }
+
+  if (header->guessed_profile == 7)
+  {
+    ret = dovi_convert_rpu_with_mode(rpu, 2);
+    processed = true;
+  }
+
+  if (ret == 0 && processed)
+    rpuData = dovi_write_unspec62_nalu(rpu);
+
+  dovi_rpu_free_header(header);
+  dovi_rpu_free(rpu);
+
+  return rpuData;
+}
+#endif

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -17,6 +17,10 @@ extern "C" {
 #include <libavformat/avformat.h>
 #include <libavfilter/avfilter.h>
 #include <libavcodec/avcodec.h>
+
+#ifdef HAVE_LIBDOVI
+#include <libdovi/rpu_parser.h>
+#endif
 }
 
 typedef struct
@@ -122,6 +126,10 @@ protected:
                                     const uint8_t* in,
                                     uint32_t in_size,
                                     uint8_t nal_type);
+
+#ifdef HAVE_LIBDOVI
+  const DoviData* processDoviRpu(uint8_t* buf, uint32_t nalSize);
+#endif
 
   typedef struct omx_bitstream_ctx {
       uint8_t  length_size;

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -157,4 +157,5 @@ protected:
   bool m_convert_dovi;
   bool m_removeDovi;
   bool m_removeHdr10Plus;
+  bool m_setDoviZeroLevel5;
 };

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -106,6 +106,7 @@ public:
   void SetConvertDovi(bool value) { m_convert_dovi = value; }
   void SetRemoveDovi(bool value) { m_removeDovi = value; }
   void SetRemoveHdr10Plus(bool value) { m_removeHdr10Plus = value; }
+  void SetDoviZeroLevel5(bool value) { m_setDoviZeroLevel5 = value; }
 
   static bool       mpeg2_sequence_header(const uint8_t *data, const uint32_t size, mpeg2_sequence *sequence);
 


### PR DESCRIPTION
## Description
Provide a control over Dolby Vision level 5 metadata on Android and webOS.
When enabled, the Dolby Vision L5 metadata is overridden (or added if absent) to 0 offsets, meaning the active area is the whole image.
As example for a letterboxed video, you may have offsets at the top/bottom like 280 pixels.
Those would be overridden to 0 when the setting is enabled.

## Motivation and context
Some setups may have issues when playing back incorrectly authored Dolby Vision media, most often user generated or modified videos.
This setting allows control to use or discard original source level 5 metadata (active area info)

These supported devices and OS implement level 5 metadata usage:
- Android TVs running Kodi
- LG webOS

On a properly authored file, playback is normal.
On a misauthored video, the image may be cropped incorrectly.

For any other HDMI connected devices, most of the time L5 is removed or ignored by the Dolby Vision processing.
So the option would have no effect, regardless if it's enabled or not.

Reference issues:
- https://github.com/xbmc/xbmc/issues/24420
- https://github.com/xbmc/xbmc/issues/24764
- https://github.com/xbmc/xbmc/issues/27033

Unrelated motivation is upstreaming this for CoreELEC.

## How has this been tested?
Tested on webOS.

## What is the effect on users?
None by default.

## Screenshots:
<img width="640" height="480" alt="screen" src="https://github.com/user-attachments/assets/8b38617b-944f-44fb-9d00-cbdeaee31151" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
