### PR TITLE
[OverlayCodecWebVTT] Handle D_WEBVTT/SUBTITLES format

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.h
@@ -34,4 +34,5 @@ private:
   bool m_isISOFormat{false};
   bool m_allowFlush{true};
   std::vector<int> m_previousSubIds;
+  bool m_isDataPacket{false};
 };

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1753,9 +1753,14 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
           CDemuxStreamSubtitleFFmpeg* st = new CDemuxStreamSubtitleFFmpeg(pStream);
           stream = st;
 
+          if (pStream->codecpar->codec_id == AV_CODEC_ID_WEBVTT)
+          {
+            stream->flags = static_cast<StreamFlags>(static_cast<int>(stream->flags) |
+                                                     FLAG_WEBVTT_DATA_PACKETS);
+          }
+
           if (av_dict_get(pStream->metadata, "title", NULL, 0))
             st->m_description = av_dict_get(pStream->metadata, "title", NULL, 0)->value;
-
           break;
         }
       }
@@ -1825,7 +1830,8 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
 
     stream->source = STREAM_SOURCE_DEMUX;
     stream->pPrivate = pStream;
-    stream->flags = (StreamFlags)pStream->disposition;
+    stream->flags =
+        static_cast<StreamFlags>(static_cast<int>(stream->flags) | pStream->disposition);
 
     AVDictionaryEntry* langTag = av_dict_get(pStream->metadata, "language", NULL, 0);
     if (!langTag)

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
@@ -258,6 +258,24 @@ bool CWebVTTHandler::CheckSignature(const std::string& data)
   return false;
 }
 
+void CWebVTTHandler::InitDecoderCue(double startTime, double endTime)
+{
+  // Prepare for a new subtitle data
+  m_subtitleData = subtitleData();
+
+  m_subtitleData.startTime = startTime + m_offset;
+  m_subtitleData.stopTime = endTime + m_offset;
+
+  // Load default settings by parsing an empty string
+  std::string settings;
+  GetCueSettings(settings);
+
+  // From the next lines we should have the text area
+  // so set the section to CUE_TEXT to prepare decoder
+  // to read the text area with DecodeLine method
+  m_currentSection = WebvttSection::CUE_TEXT;
+}
+
 void CWebVTTHandler::DecodeLine(std::string line, std::vector<subtitleData>* subList)
 {
   // Keep lines values history, needed to identify the cue ID

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
@@ -166,6 +166,16 @@ public:
   bool CheckSignature(const std::string& data);
 
   /*!
+   * \brief To be used when packages dont have the CUE timing string.
+   *        Initialize the decoder with following CUE timing,
+   *        after this call the decoder is prepared to read the
+   *        CUE text area by using DecodeLine method.
+   * \param startTime The start time
+   * \param endTime The end time
+   */
+  void InitDecoderCue(double startTime, double endTime);
+
+  /*!
   * \brief Decode a line of the WebVTT text data
   * \param line The line to decode
   * \param subList The list to be filled with decoded subtitles

--- a/xbmc/cores/VideoPlayer/Interface/StreamInfo.h
+++ b/xbmc/cores/VideoPlayer/Interface/StreamInfo.h
@@ -28,7 +28,8 @@ enum StreamFlags
   FLAG_FORCED = 0x0040,
   FLAG_HEARING_IMPAIRED = 0x0080,
   FLAG_VISUAL_IMPAIRED = 0x0100,
-  FLAG_STILL_IMAGES = 0x100000
+  FLAG_STILL_IMAGES = 0x100000,
+  FLAG_WEBVTT_DATA_PACKETS = 0x200000, // WebVTT packages are derived from a data format
 };
 
 enum class StreamHdrType


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Currently ffmpeg has incomplete support to webvtt
it support D_WEBVTT/SUBTITLES (of WebM specs)
but dont support S_TEXT/WEBVTT (of Matroska specs) thats seem to be more common format

anyway currently the D_WEBVTT/SUBTITLES case was not handled correctly
there are two ways to achieve this
1) implement libass to `CDVDOverlayCodecFFmpeg` and let `avcodec_decode_subtitle2` to convert packages to ass format (to me its not clear if in a future they can also think to change output format), then pass the resulting data to libass
2) use the our `COverlayCodecWebVTT` decoder

since the first option result a bit complex todo due to libass requirement
i preferred reusing our `COverlayCodecWebVTT` decoder adapting it to needs

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
i was testing an issue related to webvtt and i found a sample stream that was not working

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
[8BIT-001_D_WEBVTT.zip](https://github.com/user-attachments/files/23362747/8BIT-001_D_WEBVTT.zip)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
