### PR TITLE
[windows] download-msys2 call vswhere to setup env

### DIFF
--- a/tools/buildsteps/windows/arm-uwp/download-msys2.bat
+++ b/tools/buildsteps/windows/arm-uwp/download-msys2.bat
@@ -1,5 +1,11 @@
 @ECHO OFF
 
 PUSHD %~dp0\..
+CALL vswhere.bat arm store
+IF ERRORLEVEL 1 (
+  ECHO ERROR! download-msys2.bat: Something went wrong when calling vswhere.bat
+  POPD
+  EXIT /B 1
+)
 CALL download-msys2.bat %*
 POPD

--- a/tools/buildsteps/windows/arm64/download-msys2.bat
+++ b/tools/buildsteps/windows/arm64/download-msys2.bat
@@ -1,5 +1,11 @@
 @ECHO OFF
 
 PUSHD %~dp0\..
+CALL vswhere.bat arm64
+IF ERRORLEVEL 1 (
+  ECHO ERROR! download-msys2.bat: Something went wrong when calling vswhere.bat
+  POPD
+  EXIT /B 1
+)
 CALL download-msys2.bat %*
 POPD

--- a/tools/buildsteps/windows/win32-uwp/download-msys2.bat
+++ b/tools/buildsteps/windows/win32-uwp/download-msys2.bat
@@ -1,5 +1,11 @@
 @ECHO OFF
 
 PUSHD %~dp0\..
+CALL vswhere.bat x86 store
+IF ERRORLEVEL 1 (
+  ECHO ERROR! download-msys2.bat: Something went wrong when calling vswhere.bat
+  POPD
+  EXIT /B 1
+)
 CALL download-msys2.bat %*
 POPD

--- a/tools/buildsteps/windows/win32/download-msys2.bat
+++ b/tools/buildsteps/windows/win32/download-msys2.bat
@@ -1,5 +1,11 @@
 @ECHO OFF
 
 PUSHD %~dp0\..
+CALL vswhere.bat x86
+IF ERRORLEVEL 1 (
+  ECHO ERROR! download-msys2.bat: Something went wrong when calling vswhere.bat
+  POPD
+  EXIT /B 1
+)
 CALL download-msys2.bat %*
 POPD

--- a/tools/buildsteps/windows/x64-uwp/download-msys2.bat
+++ b/tools/buildsteps/windows/x64-uwp/download-msys2.bat
@@ -1,5 +1,11 @@
 @ECHO OFF
 
 PUSHD %~dp0\..
+CALL vswhere.bat x64 store
+IF ERRORLEVEL 1 (
+  ECHO ERROR! download-msys2.bat: Something went wrong when calling vswhere.bat
+  POPD
+  EXIT /B 1
+)
 CALL download-msys2.bat %*
 POPD

--- a/tools/buildsteps/windows/x64/download-msys2.bat
+++ b/tools/buildsteps/windows/x64/download-msys2.bat
@@ -1,5 +1,11 @@
 @ECHO OFF
 
 PUSHD %~dp0\..
+CALL vswhere.bat x64
+IF ERRORLEVEL 1 (
+  ECHO ERROR! download-msys2.bat: Something went wrong when calling vswhere.bat
+  POPD
+  EXIT /B 1
+)
 CALL download-msys2.bat %*
 POPD


### PR DESCRIPTION
## Description
Add vswhere calls to download-msys2.bat to make sure the env gets created

## Motivation and context
Since #27237 theres no requirement to call make-mingwlibs prior to cmake generation. the make-mingwlibs/make-addons scripts are the first scripts to setup the env using vswhere. This just adds the call to a "required" script, to make sure env is setup.

Theres no issue in current code, however when looking to use meson and building dav1d, if the env isnt setup properly, tools like armasm64 may not be in the env, causing issues

## How has this been tested?
Build with/without the patch and using tools that arent in every VS env (eg armasm64)

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
