### PR TITLE
[cmake] Find modules unset patches variable after use

### DIFF
--- a/cmake/modules/FindASS.cmake
+++ b/cmake/modules/FindASS.cmake
@@ -32,6 +32,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
                   "${CMAKE_SOURCE_DIR}/tools/depends/target/libass/04-win-nullcheck-shared_hdc.patch")
 
       generate_patchcommand("${patches}")
+      unset(patches)
 
       set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_DEBUG_POSTFIX d)
     endif()

--- a/cmake/modules/FindBrotli.cmake
+++ b/cmake/modules/FindBrotli.cmake
@@ -16,6 +16,7 @@ if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
                 "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/02-all-cmake-install-config.patch")
 
     generate_patchcommand("${patches}")
+    unset(patches)
 
     set(CMAKE_ARGS -DBUILD_SHARED_LIBS=OFF
                    -DBROTLI_DISABLE_TESTS=ON

--- a/cmake/modules/FindCEC.cmake
+++ b/cmake/modules/FindCEC.cmake
@@ -25,6 +25,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
                 "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/007-all-cmake-version.patch")
 
     generate_patchcommand("${patches}")
+    unset(patches)
 
     set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_SHARED_LIB TRUE)
 

--- a/cmake/modules/FindCrossGUID.cmake
+++ b/cmake/modules/FindCrossGUID.cmake
@@ -25,6 +25,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
                 "${CMAKE_SOURCE_DIR}/tools/depends/target/crossguid/003-add-cstdint-include.patch")
 
     generate_patchcommand("${patches}")
+    unset(patches)
 
     set(CMAKE_ARGS -DCROSSGUID_TESTS=OFF
                    -DDISABLE_WALL=ON)

--- a/cmake/modules/FindEffects11.cmake
+++ b/cmake/modules/FindEffects11.cmake
@@ -13,6 +13,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
     set(patches "${CMAKE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/01-win-debugpostfix.patch")
     generate_patchcommand("${patches}")
+    unset(patches)
 
     # Effects 11 cant be built using /permissive-
     # strip and manually set the rest of the build flags

--- a/cmake/modules/FindExiv2.cmake
+++ b/cmake/modules/FindExiv2.cmake
@@ -18,6 +18,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     set(patches "${CMAKE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/0001-WIN-lib-postfix.patch")
 
     generate_patchcommand("${patches}")
+    unset(patches)
 
     if(WIN32 OR WINDOWS_STORE)
       set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_DEBUG_POSTFIX d)

--- a/cmake/modules/FindFmt.cmake
+++ b/cmake/modules/FindFmt.cmake
@@ -25,6 +25,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     if(WIN32 OR WINDOWS_STORE)
       set(patches "${CMAKE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/001-windows-pdb-symbol-gen.patch")
       generate_patchcommand("${patches}")
+      unset(patches)
     endif()
 
     set(CMAKE_ARGS -DCMAKE_CXX_EXTENSIONS=${CMAKE_CXX_EXTENSIONS}

--- a/cmake/modules/FindNFS.cmake
+++ b/cmake/modules/FindNFS.cmake
@@ -23,6 +23,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
       set(patches "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE}/01-MSUWP-compat.patch")
       generate_patchcommand("${patches}")
+      unset(patches)
     endif()
 
     BUILD_DEP_TARGET()

--- a/cmake/modules/FindNGHttp2.cmake
+++ b/cmake/modules/FindNGHttp2.cmake
@@ -14,6 +14,7 @@ if(NOT TARGET LIBRARY::NGHttp2)
 
     set(patches "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/01-all-cmake-version.patch")
     generate_patchcommand("${patches}")
+    unset(patches)
 
     set(CMAKE_ARGS -DENABLE_DEBUG=OFF
                    -DENABLE_FAILMALLOC=OFF

--- a/cmake/modules/FindP8Platform.cmake
+++ b/cmake/modules/FindP8Platform.cmake
@@ -16,6 +16,7 @@ if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
                 "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/004-all-fix-cxx-standard.patch")
 
     generate_patchcommand("${patches}")
+    unset(patches)
 
     set(CMAKE_ARGS -DBUILD_SHARED_LIBS=OFF)
 

--- a/cmake/modules/FindPCRE2.cmake
+++ b/cmake/modules/FindPCRE2.cmake
@@ -18,6 +18,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     set(patches "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/001-all-enable_docs_pc.patch")
 
     generate_patchcommand("${patches}")
+    unset(patches)
 
     if(CORE_SYSTEM_NAME STREQUAL darwin_embedded OR WINDOWS_STORE)
       set(EXTRA_ARGS -DPCRE2_SUPPORT_JIT=OFF)

--- a/cmake/modules/FindSpdlog.cmake
+++ b/cmake/modules/FindSpdlog.cmake
@@ -20,7 +20,8 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     if(WIN32 OR WINDOWS_STORE)
       set(patches "${CMAKE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/001-windows-pdb-symbol-gen.patch")
       generate_patchcommand("${patches}")
-  
+      unset(patches)
+
       set(EXTRA_ARGS -DSPDLOG_WCHAR_SUPPORT=ON
                      -DSPDLOG_WCHAR_FILENAMES=ON)
   

--- a/cmake/modules/FindTagLib.cmake
+++ b/cmake/modules/FindTagLib.cmake
@@ -27,7 +27,8 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     if(WIN32 OR WINDOWS_STORE)
       set(patches "${CMAKE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/001-cmake-pdb-debug.patch")
       generate_patchcommand("${patches}")
-  
+      unset(patches)
+
       if(WINDOWS_STORE)
         set(EXTRA_ARGS -DPLATFORM_WINRT=ON)
       endif()

--- a/cmake/modules/FindXSLT.cmake
+++ b/cmake/modules/FindXSLT.cmake
@@ -24,6 +24,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
       set(patches "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/01-win-change_libxml.patch")
 
       generate_patchcommand("${patches}")
+      unset(patches)
 
       if(WINDOWS_STORE)
         # Required for UWP


### PR DESCRIPTION
## Description
Cleanup non unique variable

## Motivation and context
There is potential that the variable can be accidentally used in an unrelated module. a function moves the data in patches to another variable (``PATCH_COMMAND``) that ``BUILD_DEP_TARGET()`` uses. ``PATCH_COMMAND`` is unset correctly, but patches may still be available.

Im not aware of a way to get the argument name's actual name in the parent scope, so because generate_patchcommand is function, cleanup is a manual unset. It could potentially be done in ``CLEAR_BUILD_VARS()`` that is called in ``BUILD_DEP_TARGET()``, but there would be a potential of a ``find_package`` call for a dependency occuring after a ``generate_patchcommand()`` function, but before a ``BUILD_DEP_TARGET()`` that would do the cleaning.

For now i think i'll just stick to manually cleaning the patch list

## How has this been tested?
Check patches is not set in find modules not expected to have patches

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
