### PR TITLE
Apply clang-format to BitstreamConverter

### DIFF
--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -12,7 +12,8 @@
 
 #include <stdint.h>
 
-extern "C" {
+extern "C"
+{
 #include <libavutil/avutil.h>
 #include <libavformat/avformat.h>
 #include <libavfilter/avfilter.h>
@@ -25,20 +26,20 @@ extern "C" {
 
 typedef struct
 {
-  const uint8_t *data;
-  const uint8_t *end;
+  const uint8_t* data;
+  const uint8_t* end;
   int head;
   uint64_t cache;
 } nal_bitstream;
 
 typedef struct mpeg2_sequence
 {
-  uint32_t  width;
-  uint32_t  height;
-  uint32_t  fps_rate;
-  uint32_t  fps_scale;
-  float     ratio;
-  uint32_t  ratio_info;
+  uint32_t width;
+  uint32_t height;
+  uint32_t fps_rate;
+  uint32_t fps_scale;
+  float ratio;
+  uint32_t ratio_info;
 } mpeg2_sequence;
 
 typedef struct
@@ -83,7 +84,7 @@ public:
 
   static bool Open() { return true; }
   static void Close();
-  static bool CanStartDecode(const uint8_t *buf, int buf_size);
+  static bool CanStartDecode(const uint8_t* buf, int buf_size);
 };
 
 class CBitstreamConverter
@@ -92,34 +93,36 @@ public:
   CBitstreamConverter();
   ~CBitstreamConverter();
 
-  bool              Open(enum AVCodecID codec, uint8_t *in_extradata, int in_extrasize, bool to_annexb);
-  void              Close(void);
-  bool NeedConvert(void) const { return m_convert_bitstream; }
-  bool              Convert(uint8_t *pData, int iSize);
-  uint8_t*          GetConvertBuffer(void) const;
-  int               GetConvertSize() const;
+  bool Open(enum AVCodecID codec, uint8_t* in_extradata, int in_extrasize, bool to_annexb);
+  void Close();
+  bool NeedConvert() const { return m_convert_bitstream; }
+  bool Convert(uint8_t* pData, int iSize);
+  uint8_t* GetConvertBuffer() const;
+  int GetConvertSize() const;
   uint8_t* GetExtraData();
   const uint8_t* GetExtraData() const;
-  int               GetExtraSize() const;
-  void              ResetStartDecode(void);
-  bool              CanStartDecode() const;
+  int GetExtraSize() const;
+  void ResetStartDecode();
+  bool CanStartDecode() const;
   void SetConvertDovi(bool value) { m_convert_dovi = value; }
   void SetRemoveDovi(bool value) { m_removeDovi = value; }
   void SetRemoveHdr10Plus(bool value) { m_removeHdr10Plus = value; }
   void SetDoviZeroLevel5(bool value) { m_setDoviZeroLevel5 = value; }
 
-  static bool       mpeg2_sequence_header(const uint8_t *data, const uint32_t size, mpeg2_sequence *sequence);
+  static bool mpeg2_sequence_header(const uint8_t* data,
+                                    const uint32_t size,
+                                    mpeg2_sequence* sequence);
 
 protected:
-  static int  avc_parse_nal_units(AVIOContext *pb, const uint8_t *buf_in, int size);
-  static int  avc_parse_nal_units_buf(const uint8_t *buf_in, uint8_t **buf, int *size);
-  int         isom_write_avcc(AVIOContext *pb, const uint8_t *data, int len);
+  static int avc_parse_nal_units(AVIOContext* pb, const uint8_t* buf_in, int size);
+  static int avc_parse_nal_units_buf(const uint8_t* buf_in, uint8_t** buf, int* size);
+  int isom_write_avcc(AVIOContext* pb, const uint8_t* data, int len);
   // bitstream to bytestream (Annex B) conversion support.
-  bool              IsIDR(uint8_t unit_type);
-  bool              IsSlice(uint8_t unit_type);
-  bool              BitstreamConvertInitAVC(void *in_extradata, int in_extrasize);
-  bool              BitstreamConvertInitHEVC(void *in_extradata, int in_extrasize);
-  bool              BitstreamConvert(uint8_t* pData, int iSize, uint8_t **poutbuf, int *poutbuf_size);
+  bool IsIDR(uint8_t unit_type);
+  bool IsSlice(uint8_t unit_type);
+  bool BitstreamConvertInitAVC(void* in_extradata, int in_extrasize);
+  bool BitstreamConvertInitHEVC(void* in_extradata, int in_extrasize);
+  bool BitstreamConvert(uint8_t* pData, int iSize, uint8_t** poutbuf, int* poutbuf_size);
   static void BitstreamAllocAndCopy(uint8_t** poutbuf,
                                     int* poutbuf_size,
                                     const uint8_t* sps_pps,
@@ -140,21 +143,21 @@ protected:
       uint32_t size;
   } omx_bitstream_ctx;
 
-  uint8_t          *m_convertBuffer;
-  int               m_convertSize;
-  uint8_t          *m_inputBuffer;
-  int               m_inputSize;
+  uint8_t* m_convertBuffer;
+  int m_convertSize;
+  uint8_t* m_inputBuffer;
+  int m_inputSize;
 
-  uint32_t          m_sps_pps_size;
+  uint32_t m_sps_pps_size;
   omx_bitstream_ctx m_sps_pps_context;
-  bool              m_convert_bitstream;
-  bool              m_to_annexb;
+  bool m_convert_bitstream;
+  bool m_to_annexb;
 
   FFmpegExtraData m_extraData;
-  bool              m_convert_3byteTo4byteNALSize;
-  bool              m_convert_bytestream;
-  AVCodecID         m_codec;
-  bool              m_start_decode;
+  bool m_convert_3byteTo4byteNALSize;
+  bool m_convert_bytestream;
+  AVCodecID m_codec;
+  bool m_start_decode;
   bool m_convert_dovi;
   bool m_removeDovi;
   bool m_removeHdr10Plus;


### PR DESCRIPTION
## Description
BitstreamConverter.cpp/h is not currently formatted according to current coding style.

## Motivation and context
I'm making some changes in a future PR.

## How has this been tested?
Simple recompile

## What is the effect on users?
None
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [x] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
