### PR TITLE
URIUtils: Fix `GetFileOrFolderName` with empty input

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -304,6 +304,9 @@ std::string URIUtils::GetFileName(const std::string& strFileNameAndPath)
 
 std::string URIUtils::GetFileOrFolderName(const std::string& path)
 {
+  if (path.empty())
+    return {};
+
   std::string temp = path;
 
   char ch = path[path.size() - 1];


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Fix undefined behavior if the input to `GetFileOrFolderName` is an empty string.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#27085 added new test cases that result in the following assert:
```
[ RUN      ] TestURLParseDetails.ParseAllURLResults
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/bits/basic_string.h:1349: const_reference std::basic_string<char>::operator[](size_type) const [_CharT = char, _Traits = std::char_traits<char>, _Alloc = std::allocator<char>]: Assertion '__pos <= size()' failed.
```
Stack trace:
```
Program received signal SIGABRT, Aborted.
__pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at pthread_kill.c:44
44            return INTERNAL_SYSCALL_ERROR_P (ret) ? INTERNAL_SYSCALL_ERRNO (ret) : 0;
(gdb) bt
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at pthread_kill.c:44
#1  0x00007ffff4898a13 in __pthread_kill_internal (threadid=<optimized out>, signo=6) at pthread_kill.c:89
#2  0x00007ffff483e410 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#3  0x00007ffff482557a in __GI_abort () at abort.c:77
#4  0x00007ffff4c9a41f in std::__glibcxx_assert_fail (file=<optimized out>, line=<optimized out>, function=<optimized out>, condition=<optimized out>) at /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/assert_fail.cc:41
#5  0x000055555f1f86ac in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::operator[] (this=0x7bffeeac8020, __pos=18446744073709551615)
    at /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/bits/basic_string.h:1349
#6  0x00005555620ce051 in URIUtils::GetFileOrFolderName (path="") at xbmc/utils/URIUtils.cpp:309
#7  0x000055555f3a1e01 in (anonymous namespace)::run_parse_tests (filename="/home/mark/Coding/Repos/kodi-git/build_clang_debug_sanitizer/xbmc/utils/test/testdata/1.json", param=...) at xbmc/utils/test/TestUrlParsing.cpp:469
#8  0x000055555f394e53 in TestURLParseDetails_ParseAllURLResults_Test::TestBody (this=0x7c1fef600070) at xbmc/utils/test/TestUrlParsing.cpp:752
#9  0x00007ffff7f5d427 in testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void> (location=0x7ffff7f63abf "the test body", object=0x7c1fef600070, method=<optimized out>) at /usr/src/debug/gtest/googletest-1.17.0/googletest/src/gtest.cc:2664
#10 testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) [clone .constprop.0] (object=object@entry=0x7c1fef600070, method=<optimized out>, 
    location=location@entry=0x7ffff7f63abf "the test body") at /usr/src/debug/gtest/googletest-1.17.0/googletest/src/gtest.cc:2700
#11 0x00007ffff7f466d0 in testing::Test::Run (this=0x7c1fef600070) at /usr/src/debug/gtest/googletest-1.17.0/googletest/src/gtest.cc:2739
#12 testing::Test::Run (this=this@entry=0x7c1fef600070) at /usr/src/debug/gtest/googletest-1.17.0/googletest/src/gtest.cc:2729
#13 0x00007ffff7f468cf in testing::TestInfo::Run (this=0x7d1fef5ecac0) at /usr/src/debug/gtest/googletest-1.17.0/googletest/src/gtest.cc:2885
#14 0x00007ffff7f46ae4 in testing::TestSuite::Run (this=0x7d1fef5ecc40) at /usr/src/debug/gtest/googletest-1.17.0/googletest/src/gtest.cc:3063
#15 testing::TestSuite::Run (this=0x7d1fef5ecc40) at /usr/src/debug/gtest/googletest-1.17.0/googletest/src/gtest.cc:3017
#16 0x00007ffff7f54129 in testing::internal::UnitTestImpl::RunAllTests (this=this@entry=0x7d6fef5e0080) at /usr/src/debug/gtest/googletest-1.17.0/googletest/src/gtest.cc:6054
#17 0x00007ffff7f54949 in testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (location=0x7ffff7f66238 "auxiliary test code (environments or event listeners)", object=0x7d6fef5e0080, method=<optimized out>)
    at /usr/src/debug/gtest/googletest-1.17.0/googletest/src/gtest.cc:2653
#18 testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (location=0x7ffff7f66238 "auxiliary test code (environments or event listeners)", object=0x7d6fef5e0080, method=<optimized out>)
    at /usr/src/debug/gtest/googletest-1.17.0/googletest/src/gtest.cc:2700
#19 testing::UnitTest::Run (this=0x7ffff7f7c260 <testing::UnitTest::GetInstance()::instance>) at /usr/src/debug/gtest/googletest-1.17.0/googletest/src/gtest.cc:5594
#20 0x000055555f197d1d in RUN_ALL_TESTS () at /usr/include/gtest/gtest.h:2334
#21 0x000055555f197b94 in main (argc=1, argv=0x7fffffffe228) at xbmc/test/xbmc-test.cpp:29
```

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit test don't crash anymore

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
