### PR TITLE
[URIUtils] Modernize GetFileOrFolderName

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -302,20 +302,24 @@ std::string URIUtils::GetFileName(const std::string& strFileNameAndPath)
   return strFileNameAndPath.substr(i + 1);
 }
 
-std::string URIUtils::GetFileOrFolderName(const std::string& path)
+std::string URIUtils::GetFileOrFolderName(std::string_view path)
 {
   if (path.empty())
     return {};
 
-  std::string temp = path;
+  constexpr char separators[] = "/\\";
 
-  char ch = path[path.size() - 1];
-  if (ch == '/' || ch == '\\')
+  auto idx = path.find_last_of(separators);
+  if (idx == path.size() - 1)
   {
-    temp = path.substr(0, path.size() - 1);
+    path.remove_suffix(1);
+    idx = path.find_last_of(separators);
   }
 
-  return temp.substr(temp.find_last_of("/\\") + 1);
+  if (idx == std::string_view::npos)
+    return std::string{path};
+  else
+    return std::string{path.substr(idx + 1)};
 }
 
 void URIUtils::Split(const std::string& strFileNameAndPath,

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -44,7 +44,7 @@ public:
 
   static std::string GetFileName(const CURL& url);
   static std::string GetFileName(const std::string& strFileNameAndPath);
-  static std::string GetFileOrFolderName(const std::string& path);
+  static std::string GetFileOrFolderName(std::string_view path);
 
   static std::string GetExtension(const CURL& url);
   static std::string GetExtension(const std::string& strFileName);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Building on the fix of  URIUtils::GetFileOrFolderName in #27455, modernize with string_view to avoid a string copy when invoked for a directory.

Added matching unit tests in TestURIUtils.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

modernize the code.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added new unit tests covering all relevant cases I could think of.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [ ] All new and existing tests passed
