### PR TITLE
[VideoPlayer] Close PGS/VobSub subtitles when audio language dont match

### DIFF
--- a/xbmc/utils/StreamUtils.cpp
+++ b/xbmc/utils/StreamUtils.cpp
@@ -150,3 +150,9 @@ std::string StreamUtils::GetLayout(unsigned int channels)
 
   return layout;
 }
+
+bool StreamUtils::IsCodecSupportForcedOverlay(int codecId)
+{
+  return codecId == AV_CODEC_ID_DVD_SUBTITLE || codecId == AV_CODEC_ID_HDMV_PGS_SUBTITLE ||
+         codecId == AV_CODEC_ID_DVB_SUBTITLE;
+}

--- a/xbmc/utils/StreamUtils.h
+++ b/xbmc/utils/StreamUtils.h
@@ -54,4 +54,11 @@ public:
    * \return the layout
    */
   static std::string GetLayout(unsigned int channels);
+
+  /*!
+   * \brief Determines if a codec support forced overlays (on image type subtitles).
+   * \param codecId The ffmpeg codec id
+   * \return True when support forced overlay, otherwise false
+   */
+  static bool IsCodecSupportForcedOverlay(int codecId);
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Stream selection always try to select the "best" track based on settings also when subtitles are disabled, and internally the stream is kept opened

This means that even though subtitles are disabled, they are still parsed.
Parsing PGS/VobSub subtitles that support “forced” mode on individual images will override the subtitle settings,
with the result that "forced" images are always displayed on screen, even if subtitles settings are set to disabled.

This can also lead to the display of an unwanted language,
the behaviour is:
`-> kodi select "best" language -> open the stream -> if dont match the settings, it set the subs visibility to false, but still kept the stream opened`

so it is necessary to close the stream at least when it does not match the audio language,
in order to avoid parsing (and show on screen) unwanted languages

this is based on closed PR #26087 after further verification i think this is currently the best approach
except that i added an additional check for the subtitle type so as not to affect other subtitle types with this behavior

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #26050
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
user test stream:
[Bud_VOBSUB_Forced.zip](https://github.com/user-attachments/files/23499113/Bud_VOBSUB_Forced.zip)

1) set kodi audio and subtitles language settings to english
2) play the video
3) BEFORE: kodi show unwanted language (forced overlays)
AFTER: kodi internally close the stream because dont match audio language (forced overlays are not parsed/shown)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
avoid show unwanted language
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
