### PR TITLE
fix: prevent Claude code reviewer from creating accidental GitHub issue links

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -64,6 +64,7 @@ jobs:
             - Keep each issue brief but clear
             - Use inline comments for code-specific issues
             - Skip severity sections if empty
+            - When listing items, use (1), (2), (3) format - NEVER use #1, #2, #3 to avoid GitHub treating them as issue links
 
             Note: The PR branch is already checked out in the current working directory.
 


### PR DESCRIPTION
## Summary
Claude code reviewer was numbering list items as #1, #2, #3 which GitHub automatically converts to issue links, cluttering PR discussions. Updated the review prompt to explicitly instruct Claude to use (1), (2), (3) format instead.

## Changes
- Added explicit numbering format rule to `.github/workflows/claude-code-review.yml`
- Prevents unintended GitHub issue references in PR review comments