### PR TITLE
[CURL] Fix recently added tests on win32.

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -75,17 +75,22 @@ void CURL::Parse(std::string strURL1)
   size_t iPos = strURL.find("://");
   if (iPos == std::string::npos)
   {
-    /* Consider files with the extensions {.zip .apk .rar} as special if they exist
-     * on the filesystem and convert the archive paths into archive protocols.
-     * Example:
-     *   [input]  /foo/bar.zip/alice.rar/bob.avi
-     *   [result] zip://rar:///foo/bar.zip/alice.rar/bob.avi
-     */
+    // Consider files with the extensions {.zip .apk .rar} as special if they exist
+    // on the filesystem and convert the archive paths into archive protocols.
+    // Example:
+    //   [input]  /foo/bar.zip/alice.rar/bob.avi
+    //   [result] zip://rar:///foo/bar.zip/alice.rar/bob.avi
+    //
+    // clang-format off
     static constexpr const std::string_view protocolReplacements[][2] = {
         {".zip/", "zip://"},
         {".apk/", "apk://"},
         {".rar/", "rar://"},
+        {".zip\\", "zip://"},
+        {".apk\\", "apk://"},
+        {".rar\\", "rar://"},
     };
+    // clang-format on
 
     for (const auto& [ext, proto] : protocolReplacements)
     {
@@ -97,7 +102,7 @@ void CURL::Parse(std::string strURL1)
 
         if (XFILE::CFile::FileExists(archiveName))
         {
-          *this = CURL(std::string(proto) + Encode(archiveName) + strURL.substr(extPos));
+          *this = CURL(std::string(proto) + Encode(archiveName) + '/' + strURL.substr(extPos + 1));
           return;
         }
       }

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -1093,140 +1093,158 @@ struct CURLArchiveConstructionTestData
   std::string protocol;
   std::string filename;
   std::string hostname;
+  bool encodeFilename{false};
 };
 
-TEST_F(TestURIUtils, DISABLED_CURLConstructionOfArchiveFile)
+std::ostream& operator<<(std::ostream& os, const CURLArchiveConstructionTestData& data)
 {
-  const std::vector<CURLArchiveConstructionTestData> test_data{
-      // Zip file tests
-      {
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/does_not_exist.zip/kodi-dev.png"),
-          "",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/does_not_exist.zip/kodi-dev.png"),
-          "",
-      },
-      {
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/zipfile.zip/kodi-dev.png"),
-          "zip",
-          "kodi-dev.png",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/zipfile.zip"),
-      },
-      {
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_zip.zip/does_not_exist.png"),
-          "zip",
-          "does_not_exist.png",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_zip.zip"),
-      },
-      {
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_zip.zip/zipfile.zip"),
-          "zip",
-          "zipfile.zip",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_zip.zip"),
-      },
-      {
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_zip.zip/rarfile.rar"),
-          "zip",
-          "rarfile.rar",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_zip.zip"),
-      },
-      {
-          XBMC_REF_FILE_PATH(
-              "xbmc/utils/test/resources/archives_in_zip.zip/zipfile.zip/does_not_exist.png"),
-          "zip",
-          "zipfile.zip/does_not_exist.png",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_zip.zip"),
-      },
-      {
-          XBMC_REF_FILE_PATH(
-              "xbmc/utils/test/resources/archives_in_zip.zip/zipfile.zip/kodi-dev.png"),
-          "zip",
-          "zipfile.zip/kodi-dev.png",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_zip.zip"),
-      },
-      {
-          XBMC_REF_FILE_PATH(
-              "xbmc/utils/test/resources/archives_in_zip.zip/rarfile.rar/does_not_exist.png"),
-          "zip",
-          "rarfile.rar/does_not_exist.png",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_zip.zip"),
-      },
-      {
-          XBMC_REF_FILE_PATH(
-              "xbmc/utils/test/resources/archives_in_zip.zip/rarfile.rar/kodi-dev.png"),
-          "zip",
-          "rarfile.rar/kodi-dev.png",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_zip.zip"),
-      },
-      // Rar file tests
-      {
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/does_not_exist.rar/kodi-dev.png"),
-          "",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/does_not_exist.rar/kodi-dev.png"),
-          "",
-      },
-      {
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/rarfile.rar/kodi-dev.png"),
-          "rar",
-          "kodi-dev.png",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/rarfile.rar"),
-      },
-      {
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_rar.rar/does_not_exist.png"),
-          "rar",
-          "does_not_exist.png",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_rar.rar"),
-      },
-      {
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_rar.rar/zipfile.zip"),
-          "rar",
-          "zipfile.zip",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_rar.rar"),
-      },
-      {
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_rar.rar/rarfile.rar"),
-          "rar",
-          "rarfile.rar",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_rar.rar"),
-      },
-      {
-          XBMC_REF_FILE_PATH(
-              "xbmc/utils/test/resources/archives_in_rar.rar/zipfile.zip/does_not_exist.png"),
-          "rar",
-          "zipfile.zip/does_not_exist.png",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_rar.rar"),
-      },
-      {
-          XBMC_REF_FILE_PATH(
-              "xbmc/utils/test/resources/archives_in_rar.rar/zipfile.zip/kodi-dev.png"),
-          "rar",
-          "zipfile.zip/kodi-dev.png",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_rar.rar"),
-      },
-      {
-          XBMC_REF_FILE_PATH(
-              "xbmc/utils/test/resources/archives_in_rar.rar/rarfile.rar/does_not_exist.png"),
-          "rar",
-          "rarfile.rar/does_not_exist.png",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_rar.rar"),
-      },
-      {
-          XBMC_REF_FILE_PATH(
-              "xbmc/utils/test/resources/archives_in_rar.rar/rarfile.rar/kodi-dev.png"),
-          "rar",
-          "rarfile.rar/kodi-dev.png",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_rar.rar"),
-      },
-  };
+  return os << "CURLArchiveConstructionTestData { " << data.input << " }" << std::endl;
+}
 
-  for (const auto& param : test_data)
+const auto ArchiveFileParsingTests = std::array{
+    // Zip file tests
+    CURLArchiveConstructionTestData{
+        "xbmc/utils/test/resources/does_not_exist.zip/kodi-dev.png",
+        "",
+        "xbmc/utils/test/resources/does_not_exist.zip/kodi-dev.png",
+        "",
+        true,
+    },
+    CURLArchiveConstructionTestData{
+        "xbmc/utils/test/resources/zipfile.zip/kodi-dev.png",
+        "zip",
+        "kodi-dev.png",
+        "xbmc/utils/test/resources/zipfile.zip",
+    },
+    CURLArchiveConstructionTestData{
+        "xbmc/utils/test/resources/archives_in_zip.zip/does_not_exist.png",
+        "zip",
+        "does_not_exist.png",
+        "xbmc/utils/test/resources/archives_in_zip.zip",
+    },
+    CURLArchiveConstructionTestData{
+        "xbmc/utils/test/resources/archives_in_zip.zip/zipfile.zip",
+        "zip",
+        "zipfile.zip",
+        "xbmc/utils/test/resources/archives_in_zip.zip",
+    },
+    CURLArchiveConstructionTestData{
+        "xbmc/utils/test/resources/archives_in_zip.zip/rarfile.rar",
+        "zip",
+        "rarfile.rar",
+        "xbmc/utils/test/resources/archives_in_zip.zip",
+    },
+    CURLArchiveConstructionTestData{
+        "xbmc/utils/test/resources/archives_in_zip.zip/zipfile.zip/does_not_exist.png",
+        "zip",
+        "zipfile.zip/does_not_exist.png",
+        "xbmc/utils/test/resources/archives_in_zip.zip",
+    },
+    CURLArchiveConstructionTestData{
+        "xbmc/utils/test/resources/archives_in_zip.zip/zipfile.zip/kodi-dev.png",
+        "zip",
+        "zipfile.zip/kodi-dev.png",
+        "xbmc/utils/test/resources/archives_in_zip.zip",
+    },
+    CURLArchiveConstructionTestData{
+        "xbmc/utils/test/resources/archives_in_zip.zip/rarfile.rar/does_not_exist.png",
+        "zip",
+        "rarfile.rar/does_not_exist.png",
+        "xbmc/utils/test/resources/archives_in_zip.zip",
+    },
+    CURLArchiveConstructionTestData{
+        "xbmc/utils/test/resources/archives_in_zip.zip/rarfile.rar/kodi-dev.png",
+        "zip",
+        "rarfile.rar/kodi-dev.png",
+        "xbmc/utils/test/resources/archives_in_zip.zip",
+    },
+    // Rar file tests
+    CURLArchiveConstructionTestData{
+        "xbmc/utils/test/resources/does_not_exist.rar/kodi-dev.png",
+        "",
+        "xbmc/utils/test/resources/does_not_exist.rar/kodi-dev.png",
+        "",
+        true,
+    },
+    CURLArchiveConstructionTestData{
+        "xbmc/utils/test/resources/rarfile.rar/kodi-dev.png",
+        "rar",
+        "kodi-dev.png",
+        "xbmc/utils/test/resources/rarfile.rar",
+    },
+    CURLArchiveConstructionTestData{
+        "xbmc/utils/test/resources/archives_in_rar.rar/does_not_exist.png",
+        "rar",
+        "does_not_exist.png",
+        "xbmc/utils/test/resources/archives_in_rar.rar",
+    },
+    CURLArchiveConstructionTestData{
+        "xbmc/utils/test/resources/archives_in_rar.rar/zipfile.zip",
+        "rar",
+        "zipfile.zip",
+        "xbmc/utils/test/resources/archives_in_rar.rar",
+    },
+    CURLArchiveConstructionTestData{
+        "xbmc/utils/test/resources/archives_in_rar.rar/rarfile.rar",
+        "rar",
+        "rarfile.rar",
+        "xbmc/utils/test/resources/archives_in_rar.rar",
+    },
+    /* These tests are causing SEH exceptions on Win64
+		 */
+    CURLArchiveConstructionTestData{
+        "xbmc/utils/test/resources/archives_in_rar.rar/zipfile.zip/does_not_exist.png",
+        "rar",
+        "zipfile.zip/does_not_exist.png",
+        "xbmc/utils/test/resources/archives_in_rar.rar",
+    },
+    CURLArchiveConstructionTestData{
+        "xbmc/utils/test/resources/archives_in_rar.rar/zipfile.zip/kodi-dev.png",
+        "rar",
+        "zipfile.zip/kodi-dev.png",
+        "xbmc/utils/test/resources/archives_in_rar.rar",
+    },
+    CURLArchiveConstructionTestData{
+        "xbmc/utils/test/resources/archives_in_rar.rar/rarfile.rar/does_not_exist.png",
+        "rar",
+        "rarfile.rar/does_not_exist.png",
+        "xbmc/utils/test/resources/archives_in_rar.rar",
+    },
+    CURLArchiveConstructionTestData{
+        "xbmc/utils/test/resources/archives_in_rar.rar/rarfile.rar/kodi-dev.png",
+        "rar",
+        "rarfile.rar/kodi-dev.png",
+        "xbmc/utils/test/resources/archives_in_rar.rar",
+    },
+};
+
+class ArchiveFileParsingTester : public testing::Test,
+                                 public testing::WithParamInterface<CURLArchiveConstructionTestData>
+{
+};
+
+TEST_P(ArchiveFileParsingTester, TestArchiveFileParsingNativeSlashes)
+{
+  const auto& param = GetParam();
+  const std::string path = XBMC_REF_FILE_PATH(param.input);
+  const CURL url(path);
+
+  EXPECT_EQ(param.protocol, url.GetProtocol());
+  if (param.encodeFilename)
   {
-    const CURL url(param.input);
-
-    EXPECT_EQ(param.protocol, url.GetProtocol());
-    EXPECT_EQ(param.filename, url.GetFileName());
+    EXPECT_EQ(XBMC_REF_FILE_PATH(param.filename), url.GetFileName());
     EXPECT_EQ(param.hostname, CURL::Decode(url.GetHostName()));
   }
+  else
+  {
+    EXPECT_EQ(param.filename, url.GetFileName());
+    EXPECT_EQ(XBMC_REF_FILE_PATH(param.hostname), CURL::Decode(url.GetHostName()));
+  }
 }
+
+INSTANTIATE_TEST_SUITE_P(TestURIUtils,
+                         ArchiveFileParsingTester,
+                         testing::ValuesIn(ArchiveFileParsingTests));
 
 struct GetFileOrFolderNameTest
 {


### PR DESCRIPTION
#26871 
The URL parsing was refactored for archive paths. Tests were added and found to be failing on Win32.

@CrystalP  had the great insight that this was related to the unix vs windows slashes used in the parsing. Extra strings used to parse archive files to the parser have been added to account for windows slashes when parsing.

Redundant test has been removed from #26871. The removed test was superceeded by committed archive file tests on the same branch.

## Description
Fix tests. Should also enable archive file browsing on windows.

## Motivation and context
Windows slashes added to the archive URL parsing.

## How has this been tested?
Unit tests from #26871 

## What is the effect on users?
Tests should now pass on windows. 
Archive files should be browseable on windows.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [X] **None of the above** (please explain below)
Fixing test.

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
