### PR TITLE
[Windows][CURL] Fix URL parsing of zip and apk for Windows

### DIFF
--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -1095,7 +1095,7 @@ struct CURLArchiveConstructionTestData
   std::string hostname;
 };
 
-TEST_F(TestURIUtils, DISABLED_CURLConstructionOfArchiveFile)
+TEST_F(TestURIUtils, CURLConstructionOfArchiveFile)
 {
   const std::vector<CURLArchiveConstructionTestData> test_data{
       // Zip file tests
@@ -1142,79 +1142,6 @@ TEST_F(TestURIUtils, DISABLED_CURLConstructionOfArchiveFile)
           "zip",
           "zipfile.zip/kodi-dev.png",
           XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_zip.zip"),
-      },
-      {
-          XBMC_REF_FILE_PATH(
-              "xbmc/utils/test/resources/archives_in_zip.zip/rarfile.rar/does_not_exist.png"),
-          "zip",
-          "rarfile.rar/does_not_exist.png",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_zip.zip"),
-      },
-      {
-          XBMC_REF_FILE_PATH(
-              "xbmc/utils/test/resources/archives_in_zip.zip/rarfile.rar/kodi-dev.png"),
-          "zip",
-          "rarfile.rar/kodi-dev.png",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_zip.zip"),
-      },
-      // Rar file tests
-      {
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/does_not_exist.rar/kodi-dev.png"),
-          "",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/does_not_exist.rar/kodi-dev.png"),
-          "",
-      },
-      {
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/rarfile.rar/kodi-dev.png"),
-          "rar",
-          "kodi-dev.png",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/rarfile.rar"),
-      },
-      {
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_rar.rar/does_not_exist.png"),
-          "rar",
-          "does_not_exist.png",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_rar.rar"),
-      },
-      {
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_rar.rar/zipfile.zip"),
-          "rar",
-          "zipfile.zip",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_rar.rar"),
-      },
-      {
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_rar.rar/rarfile.rar"),
-          "rar",
-          "rarfile.rar",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_rar.rar"),
-      },
-      {
-          XBMC_REF_FILE_PATH(
-              "xbmc/utils/test/resources/archives_in_rar.rar/zipfile.zip/does_not_exist.png"),
-          "rar",
-          "zipfile.zip/does_not_exist.png",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_rar.rar"),
-      },
-      {
-          XBMC_REF_FILE_PATH(
-              "xbmc/utils/test/resources/archives_in_rar.rar/zipfile.zip/kodi-dev.png"),
-          "rar",
-          "zipfile.zip/kodi-dev.png",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_rar.rar"),
-      },
-      {
-          XBMC_REF_FILE_PATH(
-              "xbmc/utils/test/resources/archives_in_rar.rar/rarfile.rar/does_not_exist.png"),
-          "rar",
-          "rarfile.rar/does_not_exist.png",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_rar.rar"),
-      },
-      {
-          XBMC_REF_FILE_PATH(
-              "xbmc/utils/test/resources/archives_in_rar.rar/rarfile.rar/kodi-dev.png"),
-          "rar",
-          "rarfile.rar/kodi-dev.png",
-          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_rar.rar"),
       },
   };
 

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -1098,7 +1098,6 @@ struct CURLArchiveConstructionTestData
 TEST_F(TestURIUtils, CURLConstructionOfArchiveFile)
 {
   const std::vector<CURLArchiveConstructionTestData> test_data{
-      // Zip file tests
       {
           XBMC_REF_FILE_PATH("xbmc/utils/test/resources/does_not_exist.zip/kodi-dev.png"),
           "",
@@ -1141,6 +1140,20 @@ TEST_F(TestURIUtils, CURLConstructionOfArchiveFile)
               "xbmc/utils/test/resources/archives_in_zip.zip/zipfile.zip/kodi-dev.png"),
           "zip",
           "zipfile.zip/kodi-dev.png",
+          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_zip.zip"),
+      },
+      {
+          XBMC_REF_FILE_PATH(
+              "xbmc/utils/test/resources/archives_in_zip.zip/directory/does_not_exist.png"),
+          "zip",
+          "directory/does_not_exist.png",
+          XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_zip.zip"),
+      },
+      {
+          XBMC_REF_FILE_PATH(
+              "xbmc/utils/test/resources/archives_in_zip.zip/directory/kodi-dev.png"),
+          "zip",
+          "directory/kodi-dev.png",
           XBMC_REF_FILE_PATH("xbmc/utils/test/resources/archives_in_zip.zip"),
       },
   };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Fixed parsing of urls involving .zip or .apk archives in Windows paths: allow for both / and \ path separators.

Removed .rar handling not provided by core.

This is slightly different from the patch proposed by @thexai in #27479 because even though the result is the same today, it seems to me that the URL encoded .zip path should be treated as opaque data and it shouldn't be searched in the recursive Parse call.

Re-enabled the unit tests and added a couple with regular subdirectories in the .zip

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Address failing unit tests in Windows, rolling back recent CURL changes showed that although some code was broken before #26871 it was made worse. Fixed both issues.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Archive url unit tests pass, the additional tests pass.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

maybe fixed a recent regression, it's unclear where Kodi uses CURL::Parse in the same way as the unit tests.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
