### PR TITLE
[cmake][darwin] blank a number of xcode environment variables

### DIFF
--- a/cmake/scripts/darwin_embedded/ArchSetup.cmake
+++ b/cmake/scripts/darwin_embedded/ArchSetup.cmake
@@ -51,6 +51,20 @@ set(CMAKE_XCODE_ATTRIBUTE_INLINES_ARE_PRIVATE_EXTERN OFF)
 set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN OFF)
 set(CMAKE_XCODE_ATTRIBUTE_COPY_PHASE_STRIP OFF)
 
+# Tahoe seems to be setting environment variables at the xcode project level that
+# causes issues on shell based build objects that we use. Forcefully blank the most
+# problematic variables
+set(CMAKE_XCODE_ATTRIBUTE_DRIVERKIT_DEPLOYMENT_TARGET "")
+set(CMAKE_XCODE_ATTRIBUTE_WATCHOS_DEPLOYMENT_TARGET "")
+set(CMAKE_XCODE_ATTRIBUTE_XROS_DEPLOYMENT_TARGET "")
+set(CMAKE_XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET "")
+
+if(CORE_PLATFORM_NAME_LC STREQUAL tvos)
+  set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "")
+else()
+  set(CMAKE_XCODE_ATTRIBUTE_TVOS_DEPLOYMENT_TARGET "")
+endif()
+
 include(cmake/scripts/darwin/Macros.cmake)
 enable_arc()
 

--- a/cmake/scripts/osx/ArchSetup.cmake
+++ b/cmake/scripts/osx/ArchSetup.cmake
@@ -24,6 +24,15 @@ else()
   endif()
 endif()
 
+# Tahoe seems to be setting environment variables at the xcode project level that
+# causes issues on shell based build objects that we use. Forcefully blank the most
+# problematic variables
+set(CMAKE_XCODE_ATTRIBUTE_DRIVERKIT_DEPLOYMENT_TARGET "")
+set(CMAKE_XCODE_ATTRIBUTE_WATCHOS_DEPLOYMENT_TARGET "")
+set(CMAKE_XCODE_ATTRIBUTE_XROS_DEPLOYMENT_TARGET "")
+set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "")
+set(CMAKE_XCODE_ATTRIBUTE_TVOS_DEPLOYMENT_TARGET "")
+
 # xbmchelper (old apple IR remotes) only make sense for x86
 # last macs featuring the IR receiver are those of mid 2012
 # which are still able to run Mojave (10.14). Drop all together


### PR DESCRIPTION
## Description
Tahoe seems to be setting ``*_DEPLOYMENT_TARGET`` variables for targets that arent required for a project. Force unset the unnecessary variables to stop issues with targets that shell out their process, which would inadvertently then think it was building an incorrect target

example error
```
/macos/clang:1:1: conflicting deployment targets, both '12.0' and '25.1' are present in environment
```

example env
```
    <...>
    DRIVERKIT_DEPLOYMENT_TARGET = 25.1
    <...>
    IPHONEOS_DEPLOYMENT_TARGET = 12.0
    <...>
    XROS_DEPLOYMENT_TARGET = 26.1
    <...>
```

## Motivation and context
Fix some specific build failures occuring for macos with combinations of Tahoe and xcode.

## How has this been tested?
@ksooo 

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
