### PR TITLE
Revert "[ffmpeg][darwin_embedded] Enable yadif_videotoolbox"

### DIFF
--- a/tools/depends/target/ffmpeg/CMakeLists.txt
+++ b/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -92,6 +92,7 @@ elseif(CORE_SYSTEM_NAME STREQUAL android)
   endif()
 elseif(CORE_SYSTEM_NAME STREQUAL darwin_embedded)
   list(APPEND ffmpeg_conf --enable-videotoolbox
+                          --disable-filter=yadif_videotoolbox
                           --target-os=darwin
               )
 elseif(CORE_SYSTEM_NAME STREQUAL osx)


### PR DESCRIPTION
## Description
This reverts commit 5db93aea5e2cf7f744212d6caa699a89616a95b9.

## Motivation and context
It was actually wrong to enable this filter. Currently it uses the metal and metallib compilers with hardcoded defaults in ffmpeg using the macosx SDK.

https://github.com/FFmpeg/FFmpeg/blob/0ae8df5f2ceea82337a2456ef16f930faf160189/configure#L4237-L4238

For now just revert the commit. Ideally we would just set METALCC and METALLIB to be ``xcrun -sdk <actualsdk> <binary>``, but i dont have time to go down that rabbit hole right now.

## How has this been tested?
part of #27447 

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
