### PR TITLE
[GUIDialogSubtitleSettings] Fix browse local files playlist regression

### DIFF
--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -145,34 +145,34 @@ bool CPlayListM3U::Load(const std::string& strFileName)
              !StringUtils::StartsWith(strLine, ArtistMarker) &&
              !StringUtils::StartsWith(strLine, AlbumMarker))
     {
-      std::string strFileName = strLine;
+      std::string filePath = strLine;
 
-      if (!strFileName.empty() && strFileName[0] == '#')
+      if (!filePath.empty() && filePath[0] == '#')
         continue; // assume a comment or something else we don't support
 
       // Skip self - do not load playlist recursively
       // We compare case-less in case user has input incorrect case of the current playlist
-      if (StringUtils::EqualsNoCase(URIUtils::GetFileName(strFileName), m_strPlayListName))
+      if (StringUtils::EqualsNoCase(URIUtils::GetFileName(filePath), m_strPlayListName))
         continue;
 
-      if (!strFileName.empty())
+      if (!filePath.empty())
       {
         if (!utf8)
-          g_charsetConverter.unknownToUTF8(strFileName);
+          g_charsetConverter.unknownToUTF8(filePath);
 
         // If no info was read from from the extended tag information, use the file name
         if (strInfo.empty())
         {
-          strInfo = URIUtils::GetFileName(strFileName);
+          strInfo = URIUtils::GetFileName(filePath);
         }
 
         // should substitution occur before or after charset conversion??
-        strFileName = URIUtils::SubstitutePath(strFileName);
+        filePath = URIUtils::SubstitutePath(filePath);
 
         // Get the full path file name and add it to the the play list
-        CUtil::GetQualifiedFilename(m_strBasePath, strFileName);
+        CUtil::GetQualifiedFilename(m_strBasePath, filePath);
         CFileItemPtr newItem(new CFileItem(strInfo));
-        newItem->SetPath(strFileName);
+        newItem->SetPath(filePath);
         if (iStartOffset != 0 || iEndOffset != 0)
         {
           newItem->SetStartOffset(iStartOffset);

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -187,7 +187,11 @@ bool CPlayListM3U::Load(const std::string& strFileName)
         }
         if (VIDEO::IsVideo(*newItem) &&
             !newItem->HasVideoInfoTag()) // File is a video and needs a VideoInfoTag
+        {
           newItem->GetVideoInfoTag()->Reset(); // Force VideoInfoTag creation
+          newItem->GetVideoInfoTag()->SetPath(m_strBasePath);
+          newItem->GetVideoInfoTag()->SetFileNameAndPath(strFileName);
+        }
         if (lDuration && MUSIC::IsAudio(*newItem))
           newItem->GetMusicInfoTag()->SetDuration(lDuration);
         for (auto &prop : properties)

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1383,6 +1383,19 @@ bool URIUtils::IsNetworkFilesystem(const std::string& strPath)
   return false;
 }
 
+bool URIUtils::IsSharingFileService(const std::string& strPath)
+{
+  if (IsSmb(strPath) || IsNfs(strPath) || IsUPnP(strPath) || IsFTP(strPath))
+    return true;
+
+  //! @todo sftp/ssh special case has to be handled by vfs addon
+  CURL url(strPath);
+  if (url.IsProtocol("sftp") || url.IsProtocol("ssh"))
+    return true;
+
+  return false;
+}
+
 bool URIUtils::IsUPnP(const std::string& strFile)
 {
   return IsProtocol(strFile, "upnp");

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -237,6 +237,7 @@ public:
   static bool IsInternetStream(const CURL& url, bool bStrictCheck = false);
   static bool IsStreamedFilesystem(const std::string& strPath);
   static bool IsNetworkFilesystem(const std::string& strPath);
+  static bool IsSharingFileService(const std::string& strPath);
   static bool IsInAPK(const std::string& strFile);
   static bool IsInZIP(const std::string& strFile);
   static bool IsISO9660(const std::string& strFile);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
When PR #24303 has been merged has broken "Browse for subtitles" menu on OSD settings
for cases of playlists like STRM, so if you try to "browse" to load external subtiltes, kodi try to browse wrongly the website url instead to browse e.g. the HDD folder

the problem is that has been replaced all conditions with dynPath
but with Playlists there are different uses of GetPath/GetDynPath:
- playlist with mutiple media urls:
GetPath contains the media url
GetDynPath is empty
- playlist with single media url:
GetPath contains the strm file path
GetDynPath contains the media url

then there is no always a way to get the original playlist file path (e.g. strm)

the fix consists in to set the file path to each `VideoInfoTag` of `FileItem` while parsing the playlist
so that we can have a safe way to retrieve the playlist file path in safe way

this is an alternative proposal solution from my old PR #25480

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #24779

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
i have attached some STRM samples with different use cases
[_Samples.zip](https://github.com/user-attachments/files/23688514/_Samples.zip)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
are able to browse and load subtiltles files by using OSD while in playback with playlists

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
