### PR TITLE
[cmake] windows arch use CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE

### DIFF
--- a/cmake/scripts/windows/ArchSetup.cmake
+++ b/cmake/scripts/windows/ArchSetup.cmake
@@ -9,9 +9,7 @@ endif()
 
 # -------- Host Settings ---------
 
-set(_gentoolset ${CMAKE_GENERATOR_TOOLSET})
-string(REPLACE "host=" "" HOSTTOOLSET "${_gentoolset}")
-unset(_gentoolset)
+set(HOSTTOOLSET ${CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE})
 
 # -------- Architecture settings ---------
 

--- a/cmake/scripts/windowsstore/ArchSetup.cmake
+++ b/cmake/scripts/windowsstore/ArchSetup.cmake
@@ -11,9 +11,7 @@ endif()
 
 # -------- Host Settings ---------
 
-set(_gentoolset ${CMAKE_GENERATOR_TOOLSET})
-string(REPLACE "host=" "" HOSTTOOLSET ${_gentoolset})
-unset(_gentoolset)
+set(HOSTTOOLSET ${CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE})
 
 # -------- Architecture settings ---------
 


### PR DESCRIPTION
## Description
Use CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE for host toolset

## Motivation and context
Fix an issue where CMAKE_GENERATOR_TOOLSET can be empty if command line ``-T`` argument is not passed. Seemed to only occur with windows store generation

```
C:\repos\xbmc\build>cmake -G "Visual Studio 17 2022" -A x64 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0.22621.0 ..
<...>
-- System type: WindowsStore
CMake Error at cmake/scripts/windowsstore/ArchSetup.cmake:15 (string):
  string sub-command REPLACE requires at least four arguments.
Call Stack (most recent call first):
  cmake/scripts/common/ArchSetup.cmake:78 (include)
  CMakeLists.txt:84 (include)

```

As a side note, theres no need to supply ``-T host=x64`` as per docs, but theres no harm, so not bothering to change. If anyone is building on an arm windows install, feel free to drop it to use the arm64 native host toolset

## How has this been tested?
Windows x64/uwp

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
