### PR TITLE
[docs] Remove "-T host=x64" from Windows README

### DIFF
--- a/docs/README.Windows.md
+++ b/docs/README.Windows.md
@@ -209,12 +209,12 @@ cd kodi-build
 
 Configure build for 64bit (**recommended**):
 ```
-cmake -G "Visual Studio 17 2022" -A x64 -T host=x64 %userprofile%\kodi
+cmake -G "Visual Studio 17 2022" -A x64 %userprofile%\kodi
 ```
 
 Or configure build for 32bit:
 ```
-cmake -G "Visual Studio 17 2022" -A Win32 -T host=x64 %userprofile%\kodi
+cmake -G "Visual Studio 17 2022" -A Win32 %userprofile%\kodi
 ```
 
 Or configure build for ARM 64bit:
@@ -224,12 +224,12 @@ cmake -G "Visual Studio 17 2022" -A arm64 %userprofile%\kodi
 
 Or configure build for UWP 64bit:
 ```
-cmake -G "Visual Studio 17 2022" -A x64 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0 -T host=x64 %userprofile%\kodi
+cmake -G "Visual Studio 17 2022" -A x64 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0 %userprofile%\kodi
 ```
 
 Or configure build for UWP 32bit:
 ```
-cmake -G "Visual Studio 17 2022" -A Win32 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0 -T host=x64 %userprofile%\kodi
+cmake -G "Visual Studio 17 2022" -A Win32 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0 %userprofile%\kodi
 ```
 
 Build Kodi:


### PR DESCRIPTION
## Description

As title says. `-T host=x64` is not needed when building on Windows.

## Motivation and context

This change benefits Windows ARM64 users

## How has this been tested?

### CMake

```
CLANGARM64 ~/Documents/kodi-master/build (retroplayer-22alpha3) $ cmake -G 'Visual Studio 17 2022' -A x64 ..

-- Selecting Windows SDK version 10.0.26100.0 to target Windows 10.0.26200.
-- The CXX compiler identification is MSVC 19.44.35219.0
-- The C compiler identification is MSVC 19.44.35219.0
-- The ASM compiler identification is MSVC
-- Found assembler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.44.35207/bin/Hostarm64/x64/cl.exe
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.44.35207/bin/Hostarm64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.44.35207/bin/Hostarm64/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Mirror download location: http://mirrors.kodi.tv
-- Source directory: ~/Documents/kodi-master
-- Build directory: ~/Documents/kodi-master/build
-- Generator: Multi-configuration (Visual Studio 17 2022)
-- CMake Version: 4.0.3
-- System type: Windows
-- Core system type: windows
-- Platform: windows
-- CPU: ARM64, ARCH: x64
-- Cross-Compiling: FALSE
-- Execute build artefacts on host:
-- Depends based build:
-- statx() not found
-- Could NOT find CCache (missing: CCACHE_PROGRAM)
-- Could NOT find ClangFormat (missing: CLANG_FORMAT_EXECUTABLE) (Required is at least version "9.0")
-- Found FlatC Compiler: ~/Documents/kodi-master/project/BuildDependencies/tools/bin/flatc.exe (found version "23.3.3")
-- Found JsonSchemaBuilder: ~/Documents/kodi-master/project/BuildDependencies/tools/bin/JsonSchemaBuilder.exe
-- External TexturePacker for WIN32 will be executed during build: ~/Documents/kodi-master/project/BuildDependencies/tools/tools/TexturePacker/TexturePacker.exe
-- Found DX Effects Compiler Tool (FXC): C:/Program Files (x86)/Windows Kits/10/bin/10.0.26100.0/x86/fxc.exe
-- Found Msys: ~/Documents/kodi-master/project/BuildDependencies/msys64
-- Building crossguid: (version "ca1bf4b810e2d188d04cb6286f957008ee1b7681")
-- Found Threads: TRUE
-- Building effects11: (version "11.29")
-- Found Libtorrent: ~/Documents/kodi-master/project/BuildDependencies/x64/lib/torrent-rasterbar.lib (found version "62eae38e4beb80f8290dd230eb008830f5324b11")
-- #---- CONFIGURATION ----#
-- Platforms: windows
-- App package: org.xbmc.kodi
-- -- PATH config --
-- Prefix: C:/Program Files/kodi
-- Libdir: C:/Program Files/kodi/lib
-- Bindir: C:/Program Files/kodi/bin
-- Includedir: C:/Program Files/kodi/include
-- Datarootdir: C:/Program Files/kodi/share
-- Datadir: C:/Program Files/kodi/share
-- CCACHE enabled: No
-- CLANGFORMAT enabled: No
-- CLANGTIDY enabled: No
-- CPPCHECK enabled: No
-- INCLUDEWHATYOUUSE enabled: No
-- ALSA enabled: No
-- AVAHI enabled: No
-- BLUETOOTH enabled: No
-- BLURAY enabled: Yes
-- CAP enabled: No
-- CEC enabled: Yes
-- DBUS enabled: No
-- ISO9660PP enabled: No
-- LCMS2 enabled: No
-- LIRCCLIENT enabled: No
-- MDNS enabled: Yes
-- MICROHTTPD enabled: Yes
-- NFS enabled: Yes
-- PIPEWIRE enabled: No
-- PLIST enabled: Yes
-- PULSEAUDIO enabled: No
-- PYTHON enabled: Yes
-- SMBCLIENT enabled: Yes
-- SNDIO enabled: No
-- UDEV enabled: No
-- UDFREAD enabled: Yes
-- XSLT enabled: Yes
-- LIBAACS enabled: Yes
-- LIBBDPLUS enabled: Yes
-- MARIADBCLIENT enabled: Yes
-- LIBUSB enabled: No
-- LIBTORRENT enabled: Yes
-- Configuring done (17.1s)
-- Generating done (2.2s)
-- Build files have been written to: ~/Documents/kodi-master/build
```

### Building

Build succeeds.

### Runtime

In progress.

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
