### PR TITLE
Fix random SonarQube findings introduced since September 1 2025

### DIFF
--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -160,8 +160,7 @@ int CNfoFile::Load(const CURL& nfoPath)
 {
   Close();
   XFILE::CFile file;
-  std::vector<uint8_t> buf;
-  if (file.LoadFile(nfoPath, buf) > 0)
+  if (std::vector<uint8_t> buf; file.LoadFile(nfoPath, buf) > 0)
   {
     m_doc.assign(reinterpret_cast<char*>(buf.data()), buf.size());
     m_headPos = 0;

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -266,8 +266,7 @@ CDateTimeSpan GetCurrentTimezoneBias()
   std::unique_lock lock(critSection);
 
   // This method gets called very often and is expensive, so refresh info only every 5 mins.
-  static XbmcThreads::EndTime<> biasRefreshTimeout(0s);
-  if (biasRefreshTimeout.IsTimePast())
+  if (static XbmcThreads::EndTime<> biasRefreshTimeout(0s); biasRefreshTimeout.IsTimePast())
   {
     KODI::TIME::SystemTime now;
     KODI::TIME::GetLocalTime(&now);

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -515,7 +515,7 @@ class ATTR_DLL_LOCAL InputstreamDvccMetadata
 public:
   InputstreamDvccMetadata() = default;
 
-  InputstreamDvccMetadata(const InputstreamDvccMetadata& stream) : CStructHdl(stream) {}
+  InputstreamDvccMetadata(const InputstreamDvccMetadata& stream) = default;
 
   InputstreamDvccMetadata& operator=(const InputstreamDvccMetadata&) = default;
 
@@ -573,9 +573,9 @@ public:
   uint8_t GetMdCompression() const { return m_cStructure->m_dvMdCompression; }
 
 private:
-  InputstreamDvccMetadata(const INPUTSTREAM_DVCC_METADATA* stream) : CStructHdl(stream) {}
+  explicit InputstreamDvccMetadata(const INPUTSTREAM_DVCC_METADATA* stream) : CStructHdl(stream) {}
 
-  InputstreamDvccMetadata(INPUTSTREAM_DVCC_METADATA* stream) : CStructHdl(stream) {}
+  explicit InputstreamDvccMetadata(INPUTSTREAM_DVCC_METADATA* stream) : CStructHdl(stream) {}
 };
 ///@}
 //------------------------------------------------------------------------------

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -1996,8 +1996,8 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   using enum CApplicationPlay::GatherPlaybackDetailsResult;
 
   CApplicationPlay appPlay{*stackHelper};
-  const auto result{appPlay.GatherPlaybackDetails(item, player, bRestart)};
-  if (result == RESULT_ERROR)
+  if (const auto result{appPlay.GatherPlaybackDetails(item, player, bRestart)};
+      result == RESULT_ERROR)
     return false;
   else if (result == RESULT_NO_PLAYLIST_SELECTED)
     return true; // Special case; not to be treated as error.

--- a/xbmc/application/ApplicationPlay.cpp
+++ b/xbmc/application/ApplicationPlay.cpp
@@ -309,10 +309,10 @@ void CApplicationPlay::DetermineFullScreen()
 }
 
 CApplicationPlay::GatherPlaybackDetailsResult CApplicationPlay::GatherPlaybackDetails(
-    const CFileItem& item, const std::string& player, bool restart)
+    const CFileItem& item, std::string player, bool restart)
 {
   m_item = item;
-  m_player = player;
+  m_player = std::move(player);
 
   if (m_item.IsStack())
   {

--- a/xbmc/application/ApplicationPlay.h
+++ b/xbmc/application/ApplicationPlay.h
@@ -42,7 +42,7 @@ public:
    * \return the result
    */
   GatherPlaybackDetailsResult GatherPlaybackDetails(const CFileItem& item,
-                                                    const std::string& player,
+                                                    std::string player,
                                                     bool restart);
 
   /*!

--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -242,10 +242,9 @@ void CApplicationPlayerCallback::OnPlayerCloseFile(const CFileItem& file,
   if (isStack)
     UpdateStackAndItem(file, fileItem, bookmark, stackHelper);
 
-  const std::shared_ptr<CAdvancedSettings> advancedSettings{
-      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()};
-
-  if (WithinPercentOfEnd(bookmark, advancedSettings->m_videoIgnorePercentAtEnd))
+  if (const std::shared_ptr<CAdvancedSettings> advancedSettings{
+          CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()};
+      WithinPercentOfEnd(bookmark, advancedSettings->m_videoIgnorePercentAtEnd))
     bookmark.timeInSeconds = -1.0; // Finished (bookmark cleared)
   else if (bookmark.timeInSeconds < advancedSettings->m_videoIgnoreSecondsAtStart)
     bookmark.timeInSeconds = 0.0; // Not played enough to bookmark (bookmark cleared)

--- a/xbmc/cores/RetroPlayer/playback/GameLoop.cpp
+++ b/xbmc/cores/RetroPlayer/playback/GameLoop.cpp
@@ -27,7 +27,7 @@ constexpr auto PAUSE_SLEEP = 5s;
 CGameLoop::CGameLoop(IGameLoopCallback* callback, double fps)
   : CThread("GameLoop"),
     m_callback(callback),
-    m_fps(fps ? fps : DEFAULT_FPS)
+    m_fps(fps != 0.0 ? fps : DEFAULT_FPS)
 {
 }
 

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.cpp
@@ -24,9 +24,7 @@ using namespace RETRO;
 
 const double MAX_DELAY = 0.3; // seconds
 
-CRetroPlayerAudio::CRetroPlayerAudio(CRPProcessInfo& processInfo)
-  : m_processInfo(processInfo),
-    m_pAudioStream(nullptr)
+CRetroPlayerAudio::CRetroPlayerAudio(CRPProcessInfo& processInfo) : m_processInfo(processInfo)
 {
   CLog::Log(LOGDEBUG, "RetroPlayer[AUDIO]: Initializing audio");
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoPPFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoPPFFmpeg.h
@@ -30,7 +30,7 @@ public:
   void SetType(const std::string& mType, bool deinterlace) override;
   void Process(VideoPicture* picture) override;
 
-protected:
+private:
   std::string m_sType;
   CProcessInfo &m_processInfo;
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
@@ -258,9 +258,8 @@ CDVDInputStream::UpdateState CDVDInputStream::UpdatePlaylistDetails(
     case DVDSTREAM_TYPE_DVD:
     {
       // Only update streamdetails if not already set (ie. from NFO)
-      if (item.GetProperty("update_stream_details").asBoolean(false))
-        if (item.HasVideoInfoTag())
-          item.GetVideoInfoTag()->m_streamDetails = it3->details;
+      if (item.GetProperty("update_stream_details").asBoolean(false) && item.HasVideoInfoTag())
+        item.GetVideoInfoTag()->m_streamDetails = it3->details;
 
       break;
     }

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -580,7 +580,7 @@ static bool GetRecentlyUpdatedAddons(VECADDONS& addons)
     return false;
 
   auto limit = CDateTime::GetCurrentDateTime() - CDateTimeSpan(14, 0, 0, 0);
-  auto isOld = [limit](const AddonPtr& addon){ return addon->LastUpdated() < limit; };
+  auto isOld = [&limit](const AddonPtr& addon) { return addon->LastUpdated() < limit; };
   addons.erase(std::remove_if(addons.begin(), addons.end(), isOld), addons.end());
   return true;
 }

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -584,8 +584,7 @@ int CFile::Stat(const CURL& file, struct __stat64* buffer)
 
 bool CFile::FileExists(const std::string& path)
 {
-  struct __stat64 s;
-  if (XFILE::CFile::Stat(path, &s) == 0)
+  if (struct __stat64 s; XFILE::CFile::Stat(path, &s) == 0)
     return !S_ISDIR(s.st_mode);
   return false;
 }

--- a/xbmc/filesystem/bluray/M2TSParser.cpp
+++ b/xbmc/filesystem/bluray/M2TSParser.cpp
@@ -502,7 +502,7 @@ bool ParsePAT(const std::span<std::byte>& PAT,
     {
       unsigned int pmPID{GetWord(PAT, offset + i + 2) & PID_MASK};
       pmtPIDs.insert(pmPID);
-      pidSection.try_emplace(pmPID, SectionAssembler{}); // Prepare assembler
+      pidSection.try_emplace(pmPID); // Prepare assembler
       CLog::LogFC(LOGDEBUG, LOGBLURAY, "Found pmPID {} for program {}",
                   fmt::format("{:04x}", pmPID), programNumber);
     }
@@ -566,7 +566,7 @@ void ProcessPMTEntry(std::vector<std::byte>& section,
     streams[elementaryPID]->streamType = streamType;
     streams[elementaryPID]->descriptors = std::move(descriptors);
 
-    pesSection.try_emplace(elementaryPID, PESAssembler{}); // Prepare assembler
+    pesSection.try_emplace(elementaryPID); // Prepare assembler
 
     CLog::LogFC(LOGDEBUG, LOGBLURAY,
                 "Found stream at offset 0x{} - type: {} (0x{}), pid: 0x{}, lang {}",

--- a/xbmc/games/controllers/Controller.cpp
+++ b/xbmc/games/controllers/Controller.cpp
@@ -59,7 +59,7 @@ const ControllerPtr CController::EmptyPtr;
 
 CController::CController(const ADDON::AddonInfoPtr& addonInfo)
   : CAddon(addonInfo, ADDON::AddonType::GAME_CONTROLLER),
-    m_layout(new CControllerLayout)
+    m_layout(std::make_unique<CControllerLayout>())
 {
 }
 

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -44,7 +44,7 @@ constexpr auto POST_MAPPING_WAIT_TIME_MS = 5000ms;
 
 CGUIConfigurationWizard::CGUIConfigurationWizard()
   : CThread("GUIConfigurationWizard"),
-    m_actionMap(new KEYMAP::CKeyboardActionMap)
+    m_actionMap(std::make_unique<KEYMAP::CKeyboardActionMap>())
 {
   InitializeState();
 }

--- a/xbmc/games/controllers/windows/GUIFeatureList.cpp
+++ b/xbmc/games/controllers/windows/GUIFeatureList.cpp
@@ -31,14 +31,13 @@ using namespace GAME;
 CGUIFeatureList::CGUIFeatureList(CGUIWindow* window, GameClientPtr gameClient)
   : m_window(window),
     m_gameClient(std::move(gameClient)),
-    m_wizard(new CGUIConfigurationWizard)
+    m_wizard(std::make_unique<CGUIConfigurationWizard>())
 {
 }
 
 CGUIFeatureList::~CGUIFeatureList(void)
 {
   Deinitialize();
-  delete m_wizard;
 }
 
 bool CGUIFeatureList::Initialize(void)
@@ -264,8 +263,8 @@ std::vector<CGUIButtonControl*> CGUIFeatureList::GetButtons(
   {
     BUTTON_TYPE buttonType = CGUIFeatureTranslator::GetButtonType(feature.Type());
 
-    CGUIButtonControl* pButton = CGUIFeatureFactory::CreateButton(buttonType, *m_guiButtonTemplate,
-                                                                  m_wizard, feature, buttonIndex);
+    CGUIButtonControl* pButton = CGUIFeatureFactory::CreateButton(
+        buttonType, *m_guiButtonTemplate, m_wizard.get(), feature, buttonIndex);
 
     // If successful, add button to result
     if (pButton != nullptr)
@@ -288,6 +287,6 @@ CGUIButtonControl* CGUIFeatureList::GetSelectKeyButton(
       m_wizard->RegisterKey(feature);
   }
 
-  return CGUIFeatureFactory::CreateButton(BUTTON_TYPE::SELECT_KEY, *m_guiButtonTemplate, m_wizard,
-                                          CPhysicalFeature(), buttonIndex);
+  return CGUIFeatureFactory::CreateButton(BUTTON_TYPE::SELECT_KEY, *m_guiButtonTemplate,
+                                          m_wizard.get(), CPhysicalFeature(), buttonIndex);
 }

--- a/xbmc/games/controllers/windows/GUIFeatureList.h
+++ b/xbmc/games/controllers/windows/GUIFeatureList.h
@@ -14,6 +14,8 @@
 #include "games/controllers/input/PhysicalFeature.h"
 #include "input/joysticks/JoystickTypes.h"
 
+#include <memory>
+
 class CGUIButtonControl;
 class CGUIControlGroupList;
 class CGUIImage;
@@ -74,7 +76,7 @@ private:
   // Game window stuff
   GameClientPtr m_gameClient;
   ControllerPtr m_controller;
-  IConfigurationWizard* m_wizard;
+  std::unique_ptr<IConfigurationWizard> m_wizard;
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/dialogs/osd/DialogGameOSD.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameOSD.cpp
@@ -21,7 +21,7 @@ using namespace GAME;
 
 CDialogGameOSD::CDialogGameOSD()
   : CGUIDialog(WINDOW_DIALOG_GAME_OSD, "GameOSD.xml"),
-    m_helpDialog(new CDialogGameOSDHelp(*this))
+    m_helpDialog(std::make_unique<CDialogGameOSDHelp>(*this))
 {
   // Initialize CGUIWindow
   m_loadType = KEEP_IN_MEMORY;

--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -53,7 +53,7 @@ constexpr auto CONSTANT_NODES = make_set<std::string_view>({
     "textoffsety", "textwidth",  "timeperimage",  "top",        "width",
 });
 
-static constexpr std::string_view EXPRESSION_ATTRIBUTE = "condition";
+constexpr std::string_view EXPRESSION_ATTRIBUTE = "condition";
 
 constexpr auto EXPRESSION_NODES = make_set<std::string_view>({
     "enable",

--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -584,7 +584,7 @@ void CGUITextLayout::WrapText(const vecText &text, float maxWidth)
     std::vector<character_t> tmp;
     tmp.reserve(line.m_text.size());
     auto widthOf = [&](const std::vector<character_t>::const_iterator start,
-                       const std::vector<character_t>::const_iterator end) -> float
+                       const std::vector<character_t>::const_iterator end)
     {
       if (start == end)
         return 0.0f;
@@ -613,10 +613,10 @@ void CGUITextLayout::WrapText(const vecText &text, float maxWidth)
                                   std::bind_front(&CGUITextLayout::CanWrapAtLetter, this));
       const bool hasSpace = (wordEnd != line.m_text.end());
       const float wordWidth = widthOf(current, wordEnd);
-      const float spaceWidth = hasSpace ? widthOf(wordEnd, wordEnd + 1) : 0.0f;
 
       // Try to include word + trailing space
-      if (currentWidth + wordWidth + spaceWidth <= maxWidth)
+      if (const float spaceWidth = hasSpace ? widthOf(wordEnd, wordEnd + 1) : 0.0f;
+          currentWidth + wordWidth + spaceWidth <= maxWidth)
       {
         currentWidth += wordWidth + spaceWidth;
         lastNonSpaceInLine = wordEnd; // exclude trailing space

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -21,14 +21,14 @@
 class CPythonInvoker;
 class CVariant;
 
-typedef struct _ts PyThreadState;
+using PyThreadState = struct _ts;
 
-typedef struct
+struct PyElem
 {
   int id;
   bool bDone;
   CPythonInvoker* pyThread;
-} PyElem;
+};
 
 class LibraryLoader;
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -68,8 +68,7 @@ CPeripheralCecAdapter::CPeripheralCecAdapter(CPeripherals& manager,
                                              const PeripheralScanResult& scanResult,
                                              CPeripheralBus* bus)
   : CPeripheralHID(manager, scanResult, bus),
-    CThread("CECAdapter"),
-    m_cecAdapter(NULL)
+    CThread("CECAdapter")
 {
   ResetMembers();
   m_features.push_back(FEATURE_CEC);
@@ -90,7 +89,7 @@ CPeripheralCecAdapter::~CPeripheralCecAdapter(void)
   if (m_cecAdapter)
   {
     CECDestroy(m_cecAdapter);
-    m_cecAdapter = NULL;
+    m_cecAdapter = nullptr;
   }
 }
 
@@ -98,7 +97,7 @@ void CPeripheralCecAdapter::ResetMembers(void)
 {
   if (m_cecAdapter)
     CECDestroy(m_cecAdapter);
-  m_cecAdapter = NULL;
+  m_cecAdapter = nullptr;
   m_bStarted = false;
   m_bHasButton = false;
   m_bIsReady = false;
@@ -120,7 +119,7 @@ void CPeripheralCecAdapter::ResetMembers(void)
   m_bActiveSourceBeforeStandby = false;
   m_bOnPlayReceived = false;
   m_bPlaybackPaused = false;
-  m_queryThread = NULL;
+  m_queryThread = nullptr;
   m_bPowerOnScreensaver = false;
   m_bUseTVMenuLanguage = false;
   m_bSendInactiveSource = false;
@@ -270,7 +269,7 @@ bool CPeripheralCecAdapter::InitialiseFeature(const PeripheralFeature feature)
       m_bError = true;
       if (m_cecAdapter)
         CECDestroy(m_cecAdapter);
-      m_cecAdapter = NULL;
+      m_cecAdapter = nullptr;
 
       m_features.clear();
       return false;
@@ -1224,7 +1223,7 @@ void CPeripheralCecAdapter::CecSourceActivated(void* cbParam,
         bShowingSlideshow
             ? CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(
                   WINDOW_SLIDESHOW)
-            : NULL;
+            : nullptr;
 
     const auto& components = CServiceBroker::GetAppComponents();
     const auto appPlayer = components.GetComponent<CApplicationPlayer>();

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -165,7 +165,7 @@ private:
                                  const uint8_t activated);
   static void CecKeyPress(void* cbParam, const CEC::cec_keypress* key);
 
-  CEC::ICECAdapter* m_cecAdapter;
+  CEC::ICECAdapter* m_cecAdapter{nullptr};
   bool m_bStarted;
   bool m_bHasButton;
   bool m_bIsReady;

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -40,7 +40,7 @@ CPeripheralJoystick::CPeripheralJoystick(CPeripherals& manager,
                                          const PeripheralScanResult& scanResult,
                                          CPeripheralBus* bus)
   : CPeripheral(manager, scanResult, bus),
-    m_rumbleGenerator(new CRumbleGenerator)
+    m_rumbleGenerator(std::make_unique<CRumbleGenerator>())
 {
   m_features.push_back(FEATURE_JOYSTICK);
   // FEATURE_RUMBLE conditionally added via SetMotorCount()

--- a/xbmc/platform/posix/XTimeUtils.cpp
+++ b/xbmc/platform/posix/XTimeUtils.cpp
@@ -27,7 +27,8 @@ namespace
 int64_t days_from_civil(int64_t y, unsigned m, unsigned d)
 {
   // y: full year (e.g., 2025), m: 1..12, d: 1..31
-  y -= (m <= 2);
+  if (m <= 2)
+    y -= 1;
   const int64_t era{(y >= 0 ? y : y - 399) / 400};
   const unsigned yoe{static_cast<unsigned>(y - era * 400)}; // [0, 399]
   const unsigned doy{(153u * (m + (m > 2 ? -3u : 9u)) + 2u) / 5u + d - 1u}; // [0, 365]
@@ -53,11 +54,10 @@ time_t SystemTimeToTimeT(const KODI::TIME::SystemTime& systemTime)
                         static_cast<int64_t>(systemTime.second)};
 
   // Validate range for time_t
-  if (seconds < static_cast<int64_t>(std::numeric_limits<time_t>::min()) ||
-      seconds > static_cast<int64_t>(std::numeric_limits<time_t>::max()))
+  if (seconds < std::numeric_limits<time_t>::min() || seconds > std::numeric_limits<time_t>::max())
     return static_cast<time_t>(-1); // error
 
-  return static_cast<time_t>(seconds);
+  return seconds;
 }
 } // unnamed namespace
 

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -877,7 +877,7 @@ void CPVRManager::TriggerRecordingsSizeInProgressUpdate()
 
 void CPVRManager::TriggerRecordingsUpdate(int clientId)
 {
-  m_pendingUpdates->Append("pvr-update-recordings-" + std::to_string(clientId),
+  m_pendingUpdates->Append(StringUtils::Format("pvr-update-recordings-{}", clientId),
                            [this, clientId]()
                            {
                              if (!IsKnownClient(clientId))
@@ -897,7 +897,7 @@ void CPVRManager::TriggerRecordingsUpdate()
 
 void CPVRManager::TriggerTimersUpdate(int clientId)
 {
-  m_pendingUpdates->Append("pvr-update-timers-" + std::to_string(clientId),
+  m_pendingUpdates->Append(StringUtils::Format("pvr-update-timers-{}", clientId),
                            [this, clientId]()
                            {
                              if (!IsKnownClient(clientId))
@@ -916,7 +916,7 @@ void CPVRManager::TriggerTimersUpdate()
 
 void CPVRManager::TriggerProvidersUpdate(int clientId)
 {
-  m_pendingUpdates->Append("pvr-update-channel-providers-" + std::to_string(clientId),
+  m_pendingUpdates->Append(StringUtils::Format("pvr-update-channel-providers-{}", clientId),
                            [this, clientId]()
                            {
                              if (!IsKnownClient(clientId))
@@ -936,7 +936,7 @@ void CPVRManager::TriggerProvidersUpdate()
 
 void CPVRManager::TriggerChannelsUpdate(int clientId)
 {
-  m_pendingUpdates->Append("pvr-update-channels-" + std::to_string(clientId),
+  m_pendingUpdates->Append(StringUtils::Format("pvr-update-channels-{}", clientId),
                            [this, clientId]()
                            {
                              if (!IsKnownClient(clientId))
@@ -956,7 +956,7 @@ void CPVRManager::TriggerChannelsUpdate()
 
 void CPVRManager::TriggerChannelGroupsUpdate(int clientId)
 {
-  m_pendingUpdates->Append("pvr-update-channelgroups-" + std::to_string(clientId),
+  m_pendingUpdates->Append(StringUtils::Format("pvr-update-channelgroups-{}", clientId),
                            [this, clientId]()
                            {
                              if (!IsKnownClient(clientId))
@@ -989,13 +989,14 @@ void CPVRManager::TriggerSearchMissingChannelIcons()
 
 void CPVRManager::TriggerSearchMissingChannelIcons(const std::shared_ptr<CPVRChannelGroup>& group)
 {
-  m_pendingUpdates->Append("pvr-search-missing-channel-icons-" + std::to_string(group->GroupID()),
-                           [group]()
-                           {
-                             CPVRGUIChannelIconUpdater updater({group}, false);
-                             updater.SearchAndUpdateMissingChannelIcons();
-                             return true;
-                           });
+  m_pendingUpdates->Append(
+      StringUtils::Format("pvr-search-missing-channel-icons-{}", group->GroupID()),
+      [group]()
+      {
+        CPVRGUIChannelIconUpdater updater({group}, false);
+        updater.SearchAndUpdateMissingChannelIcons();
+        return true;
+      });
 }
 
 void CPVRManager::TriggerCleanupCachedImages()

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1191,7 +1191,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     {
       const char* XML_SORTMETHOD = "sortmethod";
       const char* XML_SORTORDER = "sortorder";
-      int sortMethod = static_cast<int>(SortByNone);
+      auto sortMethod = static_cast<int>(SortByNone);
       static constexpr CSet validSortMethods{SortByLabel, SortByDate,          SortBySize,
                                              SortByFile,  SortByEpisodeNumber, SortByProvider};
       XMLUtils::GetInt(pSortDecription, XML_SORTMETHOD, sortMethod, static_cast<int>(SortByNone),

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -166,12 +166,8 @@ bool CLangCodeExpander::ConvertToISO6392B(const std::string& strCharCode,
       if (tCode)
       {
         // Map T to B code for the few languages that have differences
-        auto bCode = CIso639_2::TCodeToBCode(*tCode);
-        if (bCode)
-          strISO6392B = *bCode;
-        else
-          strISO6392B = *tCode;
-
+        const auto bCode{CIso639_2::TCodeToBCode(*tCode)};
+        strISO6392B = bCode.value_or(*tCode);
         return true;
       }
     }
@@ -448,7 +444,7 @@ bool CLangCodeExpander::LookupInISO639Tables(const std::string& code, std::strin
 
     // Map B to T for the few codes that have differences
     auto tCode = CIso639_2::BCodeToTCode(longCode);
-    if (tCode)
+    if (tCode.has_value())
       longCode = *tCode;
 
     // Lookup the T code

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1187,8 +1187,7 @@ bool URIUtils::IsSmb(const std::string& strFile)
   if (IsSpecial(strFile))
     return IsSmb(CSpecialProtocol::TranslatePath(strFile));
 
-  CURL url(strFile);
-  if (url.HasParentInHostname())
+  if (const CURL url{strFile}; url.HasParentInHostname())
     return IsSmb(url.GetHostName());
 
   return IsProtocol(strFile, "smb");
@@ -1207,8 +1206,7 @@ bool URIUtils::IsFTP(const std::string& strFile)
   if (IsSpecial(strFile))
     return IsFTP(CSpecialProtocol::TranslatePath(strFile));
 
-  CURL url(strFile);
-  if (url.HasParentInHostname())
+  if (const CURL url{strFile}; url.HasParentInHostname())
     return IsFTP(url.GetHostName());
 
   return IsProtocol(strFile, "ftp") ||
@@ -1301,8 +1299,7 @@ bool URIUtils::IsDAV(const std::string& strFile)
   if (IsSpecial(strFile))
     return IsDAV(CSpecialProtocol::TranslatePath(strFile));
 
-  CURL url(strFile);
-  if (url.HasParentInHostname())
+  if (const CURL url{strFile}; url.HasParentInHostname())
     return IsDAV(url.GetHostName());
 
   return IsProtocol(strFile, "dav") ||
@@ -1437,8 +1434,7 @@ bool URIUtils::IsNfs(const std::string& strFile)
   if (IsSpecial(strFile))
     return IsNfs(CSpecialProtocol::TranslatePath(strFile));
 
-  CURL url(strFile);
-  if (url.HasParentInHostname())
+  if (const CURL url{strFile}; url.HasParentInHostname())
     return IsNfs(url.GetHostName());
 
   return IsProtocol(strFile, "nfs");

--- a/xbmc/utils/i18n/Iso639.cpp
+++ b/xbmc/utils/i18n/Iso639.cpp
@@ -28,7 +28,7 @@ std::string LongCodeToString(uint32_t code)
     code >>= 8;
   }
   // Reverse the string for the final result
-  std::reverse(ret.begin(), ret.end());
+  std::ranges::reverse(ret);
   return ret;
 }
 } // namespace KODI::UTILS::I18N

--- a/xbmc/utils/i18n/Iso639_2.cpp
+++ b/xbmc/utils/i18n/Iso639_2.cpp
@@ -50,7 +50,7 @@ private:
   }
 };
 // Ensure initialization of the table when the program starts before any class function can run.
-static CIso639_2_Initializer g_initializer;
+CIso639_2_Initializer g_initializer;
 } // namespace
 } // namespace KODI::UTILS::I18N
 

--- a/xbmc/utils/test/TestLangCodeExpander.cpp
+++ b/xbmc/utils/test/TestLangCodeExpander.cpp
@@ -22,7 +22,8 @@ public:
 
 TEST(TestLangCodeExpander, ConvertISO6391ToISO6392B)
 {
-  std::string refstr, varstr;
+  std::string refstr;
+  std::string varstr;
 
   refstr = "eng";
   EXPECT_TRUE(g_LangCodeExpander.ConvertISO6391ToISO6392B("en", varstr));
@@ -47,7 +48,8 @@ TEST(TestLangCodeExpander, ConvertISO6391ToISO6392B)
 
 TEST(TestLangCodeExpander, ConvertToISO6392B)
 {
-  std::string refstr, varstr;
+  std::string refstr;
+  std::string varstr;
 
   refstr = "eng";
   EXPECT_TRUE(g_LangCodeExpander.ConvertToISO6392B("en", varstr));
@@ -92,7 +94,8 @@ TEST(TestLangCodeExpander, ConvertToISO6392B)
 
 TEST(TestLangCodeExpander, ConvertToISO6391)
 {
-  std::string refstr, varstr;
+  std::string refstr;
+  std::string varstr;
 
   refstr = "en";
   EXPECT_TRUE(g_LangCodeExpander.ConvertToISO6391("en", varstr));
@@ -131,7 +134,8 @@ TEST(TestLangCodeExpander, ConvertToISO6391)
 #ifdef TARGET_WINDOWS
 TEST(TestLangCodeExpander, ConvertWindowsLanguageCodeToISO6392B)
 {
-  std::string refstr, varstr;
+  std::string refstr;
+  std::string varstr;
 
   refstr = "slo";
   EXPECT_TRUE(g_LangCodeExpander.ConvertWindowsLanguageCodeToISO6392B("slk", varstr));
@@ -149,7 +153,8 @@ TEST(TestLangCodeExpander, ConvertWindowsLanguageCodeToISO6392B)
 
 TEST(TestLangCodeExpander, ConvertToISO6392T)
 {
-  std::string refstr, varstr;
+  std::string refstr;
+  std::string varstr;
 
   refstr = "deu";
   EXPECT_TRUE(g_LangCodeExpander.ConvertToISO6392T("de", varstr));

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3553,13 +3553,11 @@ int CVideoDatabase::AddSeason(int showID,
                               const std::string& plot /* = "" */)
 {
   int seasonId = GetSeasonId(showID, season);
-  if (seasonId < 0)
-  {
-    if (ExecuteQuery(PrepareSQL("INSERT INTO seasons (idShow, season, name, plot) "
-                                "VALUES (%i, %i, '%s', '%s')",
-                                showID, season, name.c_str(), plot.c_str())))
-      seasonId = static_cast<int>(m_pDS->lastinsertid());
-  }
+  if (seasonId < 0 && ExecuteQuery(PrepareSQL("INSERT INTO seasons (idShow, season, name, plot) "
+                                              "VALUES (%i, %i, '%s', '%s')",
+                                              showID, season, name.c_str(), plot.c_str())))
+    seasonId = static_cast<int>(m_pDS->lastinsertid());
+
   return seasonId;
 }
 

--- a/xbmc/weather/WeatherJob.cpp
+++ b/xbmc/weather/WeatherJob.cpp
@@ -246,7 +246,7 @@ void CWeatherJob::SetFromPropertiesV2()
   if (gui == nullptr)
     return;
 
-  CGUIWindow* window{gui->GetWindowManager().GetWindow(WINDOW_WEATHER)};
+  const CGUIWindow* window{gui->GetWindowManager().GetWindow(WINDOW_WEATHER)};
   if (window == nullptr)
     return;
 


### PR DESCRIPTION
## Description
Fixing some of the SonarQube findings introduced since Sep 1st, 2025:

Like always, no functional changes intended.

Findings addressed:
* "auto" should be used to avoid repetition of types cpp:S5827
* "bool" expressions should not be used as operands to built-in operators other than =, &&, ||, !, ==, !=, unary &, and the conditional operator cpp:S872
* "empty()" should be used to test for emptiness cpp:S1155
* "explicit" should be used on single-parameter constructors and conversion operators cpp:S1709
* "if" and "switch" initializer should be used to reduce scope of variables cpp:S6004
* "make_unique" and "make_shared" should be used to construct "unique_ptr" and "shared_ptr" cpp:S5950
* "nullptr" should be used to denote the null pointer cpp:S4962
* "static" should not be used in unnamed namespaces cpp:S3609
* "std::format" should be used instead of string concatenation and "std::to_string" cpp:S6185
* "std::optional" member function "value_or" should be used cpp:S6023
* "std::string_view" and "std::span" parameters should be directly constructed from sequences cpp:S6231
* "std::string_view" should be used to pass a read-only string to a function cpp:S6009
* "switch" statements should cover all cases cpp:S3562
* "using" should be preferred for type aliasing cpp:S5416
* Assignments should not be made from within conditions cpp:S1121
* C-style array should not be used cpp:S5945
* Capture by reference in lambdas used locally cpp:S5495
* Control characters should not be used in literals cpp:S2479
* Function parameters should not be of type "std::unique_ptr<T> const &" cpp:S4998
* Header files should not contain unnamed namespaces cpp:S1000
* Implicit casts should not lower precision cpp:S5276
* Literal suffix "L" for long integers shall be upper case cpp:S818
* Member data should be initialized in-class or in a constructor initialization list cpp:S3230
* Member variables should not be "protected" cpp:S3656
* Memory should not be managed manually cpp:S5025
* Mergeable "if" statements should be combined cpp:S1066
* Multiple variables should not be declared on the same line cpp:S1659
* Named methods should be used to avoid confusion between testing an optional or an expected and testing the wrapped value cpp:S7172
* Objects should not be created solely to be passed as arguments to functions that perform delegated object creation cpp:S6011
* Pointer and reference local variables should be "const" if the corresponding object is not modified cpp:S5350
* Redundant casts should not be used cpp:S1905
* Redundant lambda return types should be omitted cpp:S3574
* STL algorithms and range-based for loops should be preferred to traditional for loops cpp:S5566
* STL constrained algorithms with range parameter should be used when iterating over the entire range cpp:S6197
* Special member function should not be defined unless a non standard behavior is required cpp:S3490

## Motivation and context
Improving code quality and maintainability.

## How has this been tested?
Builds and runs.

## What is the effect on users?
Hopefully none.

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
