### PR TITLE
[weather] Implement queueing for weather update requests.

### DIFF
--- a/xbmc/weather/WeatherManager.h
+++ b/xbmc/weather/WeatherManager.h
@@ -13,6 +13,7 @@
 #include "utils/InfoLoader.h"
 
 #include <array>
+#include <deque>
 #include <map>
 #include <memory>
 #include <string>
@@ -96,7 +97,7 @@ public:
 
   /*!
    \brief Sets the location to the specified index and refreshes the weather data.
-   No concurrent updates. First request wins, subsequent requests ignored until completion.
+   No concurrent updates. Queues request if another request was initiated already.
    \param location the location index (can be any value except INVALID_LOCATION)
    */
   void SetLocation(int location);
@@ -152,5 +153,5 @@ private:
 
   static constexpr int INVALID_LOCATION{0};
   int m_location{1}; // Current active location
-  int m_newLocation{INVALID_LOCATION}; // Pending location update, or INVALID_LOCATION if none
+  std::deque<int> m_pendingLocationUpdates;
 };


### PR DESCRIPTION
## Description
This PR implements queuing of requests to change current weather location. Currently , when a user rapidly clicks to change weather location, those clicks will be ignored until the location change triggered by the first click is done. Now, subsequent clicks will be remembered and once the previous location change was done, next change will be triggered. So, no clicks get "lost" anymore.    

## Motivation and context
Wanted to fix that requests to change weather location can get lost.

## How has this been tested?
By hammering at my keyboard like crazy to trigger as many weather location changes as a could in a very short time.

## What is the effect on users?
None for normal users, the crazy ones now also should be satisfied by applications behavior. :-)

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
