### PR TITLE
[cmake] FindFFMPEG handle version/rebuild requirements better

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -53,7 +53,7 @@ macro(buildFFMPEG)
 
     # Todo: buildmode?
     set(PROMPTLEVEL noprompt)
-    set(BUILDMODE clean)
+    set(BUILDMODE noclean)
 
     set(build32 no)
     set(build64 no)

--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -213,7 +213,7 @@ macro(buildFFMPEG)
   endif()
 
   foreach(_ffmpeg_pkg IN ITEMS ${FFMPEG_PKGS})
-    string(REGEX REPLACE ">=.*" "" _libname ${_ffmpeg_pkg})
+    string(REGEX REPLACE "[>]?=.*" "" _libname ${_ffmpeg_pkg})
 
     if(NOT TARGET ffmpeg::${_libname})
       add_library(ffmpeg::${_libname} ${target_scope} IMPORTED)
@@ -237,15 +237,29 @@ if(WITH_FFMPEG)
   message(STATUS "Warning: FFmpeg version checking disabled")
   set(REQUIRED_FFMPEG_VERSION undef)
 else()
-  # required ffmpeg library versions
-  set(REQUIRED_FFMPEG_VERSION 7.0.0)
-  set(_avcodec_ver ">=61.3.100")
-  set(_avfilter_ver ">=10.1.100")
-  set(_avformat_ver ">=61.1.100")
-  set(_avutil_ver ">=59.8.100")
-  set(_postproc_ver ">=58.1.100")
-  set(_swresample_ver ">=5.1.100")
-  set(_swscale_ver ">=8.1.100")
+  # We track multiple versions due to API changes. For dependsbuild or windows, we always
+  # have latest version to properly track rebuiling.
+  if(KODI_DEPENDSBUILD OR (WIN32 OR WINDOWS_STORE))
+    # required ffmpeg library versions - tools/depends/target/ffmpeg versions
+    set(REQUIRED_FFMPEG_VERSION 8.0.0)
+    set(_avutil_ver "=60.8.100")
+    set(_avcodec_ver "=62.11.100")
+    set(_avformat_ver "=62.3.100")
+    set(_avfilter_ver "=11.4.100")
+    set(_swscale_ver "=9.1.100")
+    set(_swresample_ver "=6.1.100")
+    set(_postproc_ver "=59.1.100")
+  else()
+    # required ffmpeg library versions - minimum supported API compat versions
+    set(REQUIRED_FFMPEG_VERSION 7.0.0)
+    set(_avutil_ver ">=59.8.100")
+    set(_avcodec_ver ">=61.3.100")
+    set(_avformat_ver ">=61.1.100")
+    set(_avfilter_ver ">=10.1.100")
+    set(_swscale_ver ">=8.1.100")
+    set(_swresample_ver ">=5.1.100")
+    set(_postproc_ver ">=58.1.100")
+  endif()
 endif()
 
 # Allows building with external ffmpeg not found in system paths,
@@ -288,7 +302,7 @@ else()
   endmacro()
 
   foreach(_ffmpeg_pkg IN ITEMS ${FFMPEG_PKGS})
-    string(REGEX REPLACE ">=.*" "" _libname ${_ffmpeg_pkg})
+    string(REGEX REPLACE "[>]?=.*" "" _libname ${_ffmpeg_pkg})
     ffmpeg_find_lib(${_libname})
   endforeach()
 
@@ -360,7 +374,7 @@ else()
 
           foreach(ldflag IN LISTS FFMPEG_${libname}_LDFLAGS)
             foreach(pkgname IN ITEMS ${FFMPEG_PKGS})
-              string(REGEX REPLACE ">=.*" "" _shortlibname ${pkgname})
+              string(REGEX REPLACE "[>]?=.*" "" _shortlibname ${pkgname})
               string(TOUPPER ${_shortlibname} _shortlibname_UPPER)
               string(REPLACE "lib" "" shortname ${_shortlibname})
   
@@ -381,7 +395,7 @@ else()
     endmacro()
 
     foreach(_ffmpeg_pkg IN ITEMS ${FFMPEG_PKGS})
-      string(REGEX REPLACE ">=.*" "" _libname ${_ffmpeg_pkg})
+      string(REGEX REPLACE "[>]?=.*" "" _libname ${_ffmpeg_pkg})
       ffmpeg_create_target(${_libname})
     endforeach()
   else()
@@ -410,7 +424,7 @@ if(FFMPEG_FOUND)
   endif()
 
   foreach(_ffmpeg_pkg IN ITEMS ${FFMPEG_PKGS})
-    string(REGEX REPLACE ">=.*" "" _libname ${_ffmpeg_pkg})
+    string(REGEX REPLACE "[>]?=.*" "" _libname ${_ffmpeg_pkg})
     if(TARGET ffmpeg::${_libname})
       target_link_libraries(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} INTERFACE ffmpeg::${_libname})
 


### PR DESCRIPTION
## Description
Always enable internal build target for windows. Msys script handles rebuild expectations
Set BUILDMODE to noclean for windows. This matches "old" behaviour on CI
Add versions for tools/depends platforms and windows for FFMPEG. FFMPEG doesnt not always have API breaks between majors, so we may want to allow older versions to be used, but internal builds we want to test against our specified versions.
Utilise pkg config searches for unix platforms and use version find spec modifiers to allow better version tracking

## Motivation and context
CI rebuild issues

## How has this been tested?
Jenkins

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
