### PR TITLE
[i18n] Fix LangCodeExpander Bugs

### DIFF
--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -156,6 +156,12 @@ bool CLangCodeExpander::ConvertToISO6392B(const std::string& strCharCode,
       strISO6392B = charCode;
       return true;
     }
+
+    if (const auto bCode{CIso639_2::TCodeToBCode(charCode)}; bCode.has_value())
+    {
+      strISO6392B = bCode.value();
+      return true;
+    }
   }
   else if (strCharCode.size() > 3)
   {

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -179,9 +179,12 @@ bool CLangCodeExpander::ConvertToISO6392B(const std::string& strCharCode,
     }
 
     // Try search on language addons
-    strISO6392B = g_langInfo.ConvertEnglishNameToAddonLocale(strCharCode);
-    if (!strISO6392B.empty())
+    if (const std::string addonLang = g_langInfo.ConvertEnglishNameToAddonLocale(strCharCode);
+        !addonLang.empty())
+    {
+      strISO6392B = addonLang;
       return true;
+    }
   }
   return false;
 }
@@ -385,10 +388,12 @@ bool CLangCodeExpander::ReverseLookup(const std::string& desc, std::string& code
   }
 
   // Find on language addons
-  code = g_langInfo.ConvertEnglishNameToAddonLocale(descTmp);
-  if (!code.empty())
+  if (const std::string addonLang = g_langInfo.ConvertEnglishNameToAddonLocale(descTmp);
+      !addonLang.empty())
+  {
+    code = addonLang;
     return true;
-
+  }
   return false;
 }
 

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -385,22 +385,16 @@ bool CLangCodeExpander::ReverseLookup(const std::string& desc, std::string& code
     }
   }
 
-  std::string_view name = descTmp;
+  if (const auto ret = CIso639_1::LookupByName(descTmp); ret.has_value())
   {
-    auto ret = CIso639_1::LookupByName(name);
-    if (ret)
-    {
-      code = *ret;
-      return true;
-    }
+    code = *ret;
+    return true;
   }
+
+  if (const auto ret = CIso639_2::LookupByName(descTmp); ret.has_value())
   {
-    auto ret = CIso639_2::LookupByName(name);
-    if (ret)
-    {
-      code = *ret;
-      return true;
-    }
+    code = *ret;
+    return true;
   }
 
   // Find on language addons

--- a/xbmc/utils/test/TestLangCodeExpander.cpp
+++ b/xbmc/utils/test/TestLangCodeExpander.cpp
@@ -88,6 +88,9 @@ TEST(TestLangCodeExpander, ConvertToISO6392B)
   EXPECT_FALSE(g_LangCodeExpander.ConvertToISO6392B("aaa", varstr));
   EXPECT_EQ(refstr, varstr);
 
+  EXPECT_FALSE(g_LangCodeExpander.ConvertToISO6392B("en-US", varstr));
+  EXPECT_EQ(refstr, varstr);
+
   // Full english name, case insensitive
   refstr = "eng";
   EXPECT_TRUE(g_LangCodeExpander.ConvertToISO6392B("English", varstr, true));
@@ -96,11 +99,6 @@ TEST(TestLangCodeExpander, ConvertToISO6392B)
   refstr = "eng";
   EXPECT_TRUE(g_LangCodeExpander.ConvertToISO6392B("english", varstr, true));
   EXPECT_EQ(refstr, varstr);
-
-  // Existing bug
-  //refstr = "ger";
-  //EXPECT_TRUE(g_LangCodeExpander.ConvertToISO6392B("deu", varstr));
-  //EXPECT_EQ(refstr, varstr);
 }
 
 TEST(TestLangCodeExpander, ConvertToISO6391)

--- a/xbmc/utils/test/TestLangCodeExpander.cpp
+++ b/xbmc/utils/test/TestLangCodeExpander.cpp
@@ -70,10 +70,11 @@ TEST(TestLangCodeExpander, ConvertToISO6392B)
   EXPECT_EQ(refstr, varstr);
 
   // win_id != iso639_2b
-  refstr = "fra";
+  refstr = "fre";
   EXPECT_TRUE(g_LangCodeExpander.ConvertToISO6392B("fra", varstr, true));
   EXPECT_EQ(refstr, varstr);
 
+  //! \todo analyze, v.suspicious. What old situation required matching languages with regions?
   // Region code
   refstr = "bol";
   EXPECT_TRUE(g_LangCodeExpander.ConvertToISO6392B("bol", varstr));
@@ -175,13 +176,7 @@ TEST(TestLangCodeExpander, ConvertToISO6392T)
   EXPECT_TRUE(g_LangCodeExpander.ConvertToISO6392T("deu", varstr, true));
   EXPECT_EQ(refstr, varstr);
 
-  // Should return deu instead of failing. Side effect of failure in Convert but maybe happens for historical reasons and something
-  // relies on that.
-  // For some reason, the function allows the language code to match with the region 'deu',
-  // but since it's not a valid ISO639-2/B code, it cannot be translated to its ISO-639-2/T code
-  refstr = "invalid";
-  varstr = "invalid";
-  EXPECT_FALSE(g_LangCodeExpander.ConvertToISO6392T("deu", varstr));
+  EXPECT_TRUE(g_LangCodeExpander.ConvertToISO6392T("deu", varstr));
   EXPECT_EQ(refstr, varstr);
 }
 

--- a/xbmc/utils/test/TestLangCodeExpander.cpp
+++ b/xbmc/utils/test/TestLangCodeExpander.cpp
@@ -51,11 +51,22 @@ TEST(TestLangCodeExpander, ConvertToISO6392B)
   std::string refstr;
   std::string varstr;
 
+  // ISO 639-2 with identical B and T forms
   refstr = "eng";
   EXPECT_TRUE(g_LangCodeExpander.ConvertToISO6392B("en", varstr));
   EXPECT_EQ(refstr, varstr);
 
   EXPECT_TRUE(g_LangCodeExpander.ConvertToISO6392B("eng", varstr));
+  EXPECT_EQ(refstr, varstr);
+
+  // ISO 639-2/B
+  refstr = "fre";
+  EXPECT_TRUE(g_LangCodeExpander.ConvertToISO6392B("fre", varstr));
+  EXPECT_EQ(refstr, varstr);
+
+  // ISO 639-2/T
+  refstr = "cze";
+  EXPECT_TRUE(g_LangCodeExpander.ConvertToISO6392B("ces", varstr));
   EXPECT_EQ(refstr, varstr);
 
   // win_id != iso639_2b
@@ -68,7 +79,7 @@ TEST(TestLangCodeExpander, ConvertToISO6392B)
   EXPECT_TRUE(g_LangCodeExpander.ConvertToISO6392B("bol", varstr));
   EXPECT_EQ(refstr, varstr);
 
-  // non existent
+  // non-existent or non-convertible
   refstr = "invalid";
   varstr = "invalid";
   EXPECT_FALSE(g_LangCodeExpander.ConvertToISO6392B("ac", varstr));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Fix issues in LangCodeExpander and ReverseLookup:
- ConvertToISO6392B didn't accept 639-2/T inputs as its documentation suggested
- ConvertToISO6392B used to return the win_id instead of a 6392B code
- ConvertToISO6392B and ReverseLookup modified the return string after failure, unlike all the other functions of the class
- Moved the match of countries to last position in ConvertToISO6392B as it was before #27229. This remains weird logic and fragile. Still, that fixes fra > fre (fra is both a ISO 639-2/T language code and a ISO 3166-1 region)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Issues found while adding other features

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Modified the unit tests that reflected the legacy wrong results.
All unit tests pass.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Improved language handling for a few cases

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
