### PR TITLE
[i18n] Add BCP47 Language Tags Parsing

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2197,13 +2197,13 @@ ExternalStreamInfo CUtil::GetExternalStreamDetailsFromFilename(const std::string
 
       if (info.language.empty())
       {
-        std::string langCode;
         // try to recognize language
-        if (g_LangCodeExpander.ConvertToISO6392B(*it, langCode))
-        {
-          info.language = langCode;
+        std::string langCode = *it;
+        // _ is used in BCP47 tags as subtag separator instead of - since - is a token separator.
+        // Convert back to - separator to parse.
+        std::ranges::replace(langCode, '_', '-');
+        if (g_LangCodeExpander.ConvertToBcp47(langCode, info.language))
           continue;
-        }
       }
 
       name = (*it) + " " + name;

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -891,7 +891,7 @@ namespace XBMCAddon
     bool InfoTagVideo::setOriginalLanguageRaw(CVideoInfoTag* infoTag, const String& language)
     {
       if (!infoTag->SetOriginalLanguage(language,
-                                        CVideoInfoTag::LanguageProcessing::PROCESSING_NORMALIZE))
+                                        CVideoInfoTag::LanguageTagSource::SOURCE_EXTERNAL))
       {
         CLog::LogF(LOGWARNING, "the language {} is not recognized", language);
         return false;

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -2083,7 +2083,7 @@ namespace XBMCAddon
       /// \brief \python_func{ setOriginalLanguage(language) }
       /// Set the original language of the video item.
       ///
-      /// \param language      string - ISO-639-1, ISO-639/B, ISO 639-2/T or full english name
+      /// \param language      string - ISO-639-1, ISO-639/B, ISO 639-2/T, BCP-47 or full english name
       /// \return [boolean]    status code. true for success, false for failure (most likely an unrecognized language parameter value).
       ///
       ///

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -606,7 +606,7 @@ std::string CLangCodeExpander::ConvertToISO6392T(const std::string& lang)
   return lang;
 }
 
-bool CLangCodeExpander::ConvertToAudioBcp47(const std::string& text, std::string& bcp47Lang)
+bool CLangCodeExpander::ConvertToBcp47(const std::string& text, std::string& bcp47Lang)
 {
   std::string code{text};
   StringUtils::Trim(code);

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -633,11 +633,20 @@ bool CLangCodeExpander::ConvertToBcp47(const std::string& text, std::string& bcp
 
 std::string CLangCodeExpander::FindLanguageCodeWithSubtag(const std::string& str)
 {
-  CRegExp regLangCode;
-  if (regLangCode.RegComp("\\{(([A-Za-z]{2,3})-([A-Za-z]{2}|[0-9]{3}|[A-Za-z]{4}))\\}") &&
-      regLangCode.RegFind(str) >= 0)
-  {
-    return regLangCode.GetMatch(1);
-  }
+  std::size_t begin = str.find("{");
+
+  if (begin == std::string::npos)
+    return "";
+
+  std::size_t end = str.find("}", begin + 1);
+
+  if (end == std::string::npos)
+    return "";
+
+  const auto tag = CBcp47::ParseTag(str.substr(begin + 1, end - begin - 1));
+
+  if (tag.has_value())
+    return tag->Format();
+
   return "";
 }

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -72,27 +72,10 @@ bool CLangCodeExpander::Lookup(const std::string& code, std::string& desc)
   if (LookupInLangAddons(code, desc))
     return true;
 
-  // Language code with subtag is supported only with language addons
-  // or with user defined map, then if not found we fallback by obtaining
-  // the primary code description only and appending the remaining
-  int iSplit = code.find('-');
-  if (iSplit > 0)
+  if (auto tag = CBcp47::ParseTag(code); tag.has_value())
   {
-    std::string primaryTagDesc;
-    const bool hasPrimaryTagDesc = Lookup(code.substr(0, iSplit), primaryTagDesc);
-    std::string subtagCode = code.substr(iSplit + 1);
-    if (hasPrimaryTagDesc)
-    {
-      if (!primaryTagDesc.empty())
-        desc = primaryTagDesc;
-      else
-        desc = code.substr(0, iSplit);
-
-      if (!subtagCode.empty())
-        desc += " - " + subtagCode;
-
-      return true;
-    }
+    desc = tag.value().Format(Bcp47FormattingStyle::FORMAT_ENGLISH);
+    return true;
   }
 
   return false;

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -88,6 +88,14 @@ public:
   */
   static bool ConvertISO6391ToISO6392B(const std::string& strISO6391, std::string& strISO6392B, bool checkWin32Locales = false);
 
+  /*!
+   * \brief Converts a language given as 3-Char (ISO 639-2/B or /T) to a 2-Char (ISO 639-1) code.
+   * \param[in] iso6392 The language that should be converted. Case-insensitive.
+   * \param[out] iso6391 The 2-Char (ISO 639-1) language code of the given language.
+   * \return true if the conversion succeeded, false otherwise.
+   */
+  static bool ConvertISO6392ToISO6391(std::string iso6392, std::string& iso6391);
+
   /** \brief Converts a language given as 2-Char (ISO 639-1),
   *          3-Char (ISO 639-2/T or ISO 639-2/B),
   *          or full english name string to a 3-Char ISO 639-2/T code.
@@ -140,6 +148,16 @@ public:
   std::vector<std::string> GetLanguageNames(LANGFORMATS format = ISO_639_1,
                                             LANG_LIST list = LANG_LIST::DEFAULT);
 
+  /*
+   * \brief Converts a language given as 2-Char (ISO 639-1),
+   *        3-Char (ISO 639-2/T, ISO 639-2/B), BCP 47 language tag
+   *        or full English name string to a BCP 47 tag describing audio content.
+   * \param[in] text The language to convert
+   * \param[out] bcp47 The BCP47 language tag
+   * \return true if the conversion succeeded, false otherwise.
+   */
+  bool ConvertToAudioBcp47(const std::string& text, std::string& bcp47);
+
 protected:
   static bool LookupInISO639Tables(const std::string& code, std::string& desc);
 
@@ -169,6 +187,15 @@ protected:
   *   \return true if desc was found, false otherwise.
   */
   bool LookupUserCode(const std::string& desc, std::string &userCode);
+
+  /*!
+   * \brief Converts a language given as 3-Char (ISO 639-2/B or /T) to a 2-Char (ISO 639-1) code.
+   *        Function meant to be used internally for an already validated input
+   * \param[in] iso6392 The language that should be converted. Must be trimmed and lowercased.
+   * \param[out] iso6391 The 2-Char (ISO 639-1) language code of the given language.
+   * \return true if the conversion succeeded, false otherwise.
+   */
+  static bool ConvertISO6392ToISO6391Internal(const std::string& iso6392, std::string& iso6391);
 
   typedef std::map<std::string, std::string> STRINGLOOKUPTABLE;
   STRINGLOOKUPTABLE m_mapUser;

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -151,12 +151,12 @@ public:
   /*
    * \brief Converts a language given as 2-Char (ISO 639-1),
    *        3-Char (ISO 639-2/T, ISO 639-2/B), BCP 47 language tag
-   *        or full English name string to a BCP 47 tag describing audio content.
+   *        or full English name string to a BCP 47 tag.
    * \param[in] text The language to convert
    * \param[out] bcp47 The BCP47 language tag
    * \return true if the conversion succeeded, false otherwise.
    */
-  bool ConvertToAudioBcp47(const std::string& text, std::string& bcp47);
+  bool ConvertToBcp47(const std::string& text, std::string& bcp47);
 
 protected:
   static bool LookupInISO639Tables(const std::string& code, std::string& desc);

--- a/xbmc/utils/RegExp.cpp
+++ b/xbmc/utils/RegExp.cpp
@@ -513,6 +513,21 @@ std::string CRegExp::GetMatch(int iSub /* = 0 */) const
   return m_subject.substr(pos, len);
 }
 
+std::string CRegExp::GetMatch(const char* name) const
+{
+  if (!m_re)
+  {
+    CLog::LogF(LOGERROR, "PCRE: Called before compilation or compilation failed.");
+    return {};
+  }
+
+  int ret = pcre2_substring_number_from_name(m_re, reinterpret_cast<PCRE2_SPTR>(name));
+  if (ret >= 0)
+    return GetMatch(ret);
+
+  return {};
+}
+
 void CRegExp::DumpOvector(int iLog /* = LOGDEBUG */)
 {
   if (iLog < LOGDEBUG || iLog > LOGNONE)

--- a/xbmc/utils/RegExp.h
+++ b/xbmc/utils/RegExp.h
@@ -106,6 +106,7 @@ public:
   int GetSubLength(int iSub) const;
   int GetCaptureTotal() const;
   std::string GetMatch(int iSub = 0) const;
+  std::string GetMatch(const char* name) const;
   const std::string& GetPattern() const { return m_pattern; }
   void DumpOvector(int iLog);
   /**

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -346,6 +346,11 @@ public:
   {
     return isasciiuppercaseletter(chr) || isasciilowercaseletter(chr);
   }
+  [[nodiscard]] inline static bool IsAsciiLetters(
+      std::string_view str) noexcept // locale independent
+  {
+    return std::ranges::all_of(str, [](char c) { return StringUtils::isasciiletter(c); }, {});
+  }
   [[nodiscard]] inline static bool isasciialphanum(char chr) noexcept // locale independent
   {
     return isasciiletter(chr) || isasciidigit(chr);

--- a/xbmc/utils/i18n/Bcp47.cpp
+++ b/xbmc/utils/i18n/Bcp47.cpp
@@ -1,0 +1,301 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "utils/i18n/Bcp47.h"
+
+#include "utils/RegExp.h"
+#include "utils/StringUtils.h"
+#include "utils/i18n/Bcp47Parser.h"
+#include "utils/i18n/Iso3166_1.h"
+#include "utils/i18n/Iso639.h"
+#include "utils/i18n/Iso639_1.h"
+#include "utils/i18n/Iso639_2.h"
+#include "utils/i18n/TableLanguageCodes.h"
+#include "utils/log.h"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <string_view>
+
+using namespace KODI::UTILS::I18N;
+using namespace std::literals;
+
+bool CBcp47::operator==(const ParsedBcp47Tag& other) const
+{
+  return other.m_language == m_language && other.m_extLangs == m_extLangs &&
+         other.m_script == m_script && other.m_region == m_region &&
+         other.m_variants == m_variants && other.m_extensions == m_extensions &&
+         other.m_privateUse == m_privateUse && other.m_grandfathered == m_grandfathered;
+}
+
+std::optional<CBcp47> CBcp47::ParseTag(std::string str)
+{
+  auto p = CBcp47Parser::Parse(str);
+
+  if (!p.has_value())
+    return std::nullopt;
+
+  CBcp47 tag;
+  tag.m_language = std::move(p->m_language);
+  tag.m_extLangs = std::move(p->m_extLangs);
+  tag.m_script = std::move(p->m_script);
+  tag.m_region = std::move(p->m_region);
+  tag.m_variants = std::move(p->m_variants);
+  tag.m_extensions = std::move(p->m_extensions);
+  tag.m_privateUse = std::move(p->m_privateUse);
+  tag.m_grandfathered = std::move(p->m_grandfathered);
+
+  tag.m_isValid = tag.Validate();
+
+  return tag;
+}
+
+bool CBcp47::Validate()
+{
+  // Validity rules from RFC5646:
+  // 1) well-formed: always true as the object can only be created from well-formed text tags.
+  //    Exception: irregular grandfathered tags do not have to be well formed in order to be valid
+  if (!m_grandfathered.empty())
+    return true;
+
+  // 2) either the tag is in the list of grandfathered tags or the primary language, extended
+  //    language, script, region and variant subtags appear in the IANA registry
+  if (!IsValidLanguage() || !IsValidRegion())
+    return false;
+  //! @todo validate grandfathered tags
+  //! @todo validate extended language - count of extlang may not be enough
+  if (HasMultipleExtLang())
+    return false;
+  //! @todo validate script against ISO 15924 - also reserved Qaaa-Qabx
+  //! @todo validate variants
+
+  // 3) There are no duplicate variant subtags
+  if (HasDuplicateVariants())
+    return false;
+
+  // 4) There are no duplicate singleton (extension) subtags
+  if (HasDuplicateExtensions())
+    return false;
+
+  // Validity within extensions is not considered
+  // Validity under older rules (RFC 3066) is not handled
+
+  return true;
+}
+
+bool CBcp47::IsValidLanguage() const
+{
+  // Language subtag, mandatory, validate against ISO 639
+  // except if a private use subtag was used.
+
+  if (m_language.empty())
+  {
+    if (!m_privateUse.empty())
+      return true;
+
+    CLog::LogF(LOGDEBUG, "The language subtag is mandatory and cannot be blank.");
+    return false;
+  }
+
+  //! @todo separate future PR replace with checks against the IANA subtags registry
+  if (m_language.length() == 2 && StringUtils::IsAsciiLetters(m_language))
+  {
+    // ISO 639-1
+    auto ret = CIso639_1::LookupByCode(m_language);
+    if (!ret)
+    {
+      CLog::LogF(LOGDEBUG, "{} is not a valid ISO 639-1 code.", m_language);
+      return false;
+    }
+    return true;
+  }
+  else if (m_language.length() == 3 && StringUtils::IsAsciiLetters(m_language))
+  {
+    // qaa-qtz range reserved for private use by ISO 639-2 - always accept
+    if (m_language >= "qaa" && m_language <= "qtz")
+      return true;
+
+    // Try ISO 639-2/T or B
+    std::string bCode;
+    const auto tCode = CIso639_2::LookupByCode(m_language);
+    if (tCode.has_value())
+      bCode = CIso639_2::TCodeToBCode(m_language).value_or(m_language);
+    else if (CIso639_2::BCodeToTCode(StringToLongCode(m_language)).has_value())
+      bCode = m_language;
+
+    if (bCode.empty())
+    {
+      CLog::LogF(LOGDEBUG, "{} is not a valid ISO 639-2 code.", m_language);
+      return false;
+    }
+
+    // The alpha-3 of languages that have an alpha-2 is not valid.
+    if (std::ranges::binary_search(LanguageCodesByIso639_2b, bCode, {}, &ISO639::iso639_2b))
+    {
+      CLog::LogF(LOGDEBUG,
+                 "{} has an equivalent ISO 639-1 2-char code and is therefore not valid in a BCP47 "
+                 "language tag.",
+                 m_language);
+      return false;
+    }
+    return true;
+  }
+
+  CLog::LogF(LOGDEBUG, "{} is not a valid language subtag.", m_language);
+  return false;
+}
+
+bool CBcp47::HasMultipleExtLang() const
+{
+  // Multiple extlang subtags cannot be valid per RFC 5646 2.2.2.4.
+  return m_extLangs.size() > 1;
+}
+
+bool CBcp47::IsValidRegion() const
+{
+  // Region subtag is optional
+  if (m_region.empty())
+    return true;
+
+  // Values reserved for private use
+  if (m_region == "aa" || (m_region >= "qm" && m_region <= "qz") ||
+      (m_region >= "xa" && m_region <= "xz") || m_region == "zz")
+    return true;
+
+  //! @todo separate future PR replace with checks against the IANA subtags registry
+  if (m_region.length() == 2 && StringUtils::IsAsciiLetters(m_region))
+  {
+    // ISO 3166-1
+    if (CIso3166_1::ContainsAlpha2(m_region))
+      return true;
+
+    CLog::LogF(LOGDEBUG, "{} is not a valid ISO 3166-1 alpha-2 code.", m_region);
+    return false;
+  }
+  else if (!m_region.empty())
+  {
+    // Probably a UN M.49 numeric region code - not supported
+    CLog::LogF(LOGDEBUG, "{} is not a valid region.", m_region);
+    return false;
+  }
+
+  // Region subtag is optional
+  return true;
+}
+
+bool CBcp47::HasDuplicateVariants() const
+{
+  if (m_variants.empty() || m_variants.size() < 2)
+    return false;
+
+  // Make a copy of pointers to the strings to avoid unnecessary copies of the strings to efficiently
+  // find duplicates in a C++ idiomatic way.
+  std::vector<const std::string*> variants;
+  variants.reserve(m_variants.size());
+
+  auto reference = [](const std::string& s) { return &s; };
+  auto dereference = [](const std::string* ptr) { return *ptr; };
+
+  std::ranges::transform(m_variants, std::back_inserter(variants), reference);
+  std::ranges::sort(variants, {}, dereference);
+
+  return variants.end() != std::ranges::adjacent_find(variants, {}, dereference);
+}
+
+bool CBcp47::HasDuplicateExtensions() const
+{
+  if (m_extensions.empty() || m_extensions.size() < 2)
+    return false;
+
+  // Copy only the field of the extension relevant to the identification of duplicates
+  // char copy is cheap and efficient.
+  std::vector<char> extensions;
+  extensions.reserve(m_extensions.size());
+
+  std::ranges::transform(m_extensions, std::back_inserter(extensions), &Bcp47Extension::name);
+  std::ranges::sort(extensions);
+
+  return extensions.end() != std::ranges::adjacent_find(extensions);
+}
+
+std::string CBcp47::Format() const
+{
+  std::string tag;
+
+  if (!m_grandfathered.empty())
+    return m_grandfathered;
+
+  if (!m_language.empty())
+  {
+    tag = m_language;
+
+    if (!m_extLangs.empty())
+    {
+      tag.push_back('-');
+      tag.append(StringUtils::Join(m_extLangs, "-"));
+    }
+
+    if (!m_script.empty())
+    {
+      tag.push_back('-');
+      std::string s = m_script;
+      StringUtils::ToCapitalize(s);
+      tag.append(s);
+    }
+
+    if (!m_region.empty())
+    {
+      tag.push_back('-');
+      tag.append(StringUtils::ToUpper(m_region));
+    }
+
+    if (!m_variants.empty())
+    {
+      tag.push_back('-');
+      tag.append(StringUtils::Join(m_variants, "-"));
+    }
+
+    if (!m_extensions.empty())
+    {
+      for (const auto& ext : m_extensions)
+      {
+        tag.push_back('-');
+        tag.push_back(ext.name);
+        tag.push_back('-');
+        tag.append(StringUtils::Join(ext.segments, "-"));
+      }
+    }
+  }
+
+  if (!m_privateUse.empty())
+  {
+    if (!tag.empty())
+      tag.push_back('-');
+    tag.append("x-");
+    tag.append(StringUtils::Join(m_privateUse, "-"));
+  }
+  return tag;
+}
+
+void CBcp47::Canonicalize()
+{
+  // RFC 5646 - 4.5
+  //
+  // 1. Sort the extensions alphabetically
+  std::ranges::sort(m_extensions, {}, &Bcp47Extension::name);
+
+  //! @todo once registry support is available:
+  //! @todo grandfathered tags preferred replacements
+  //! @todo subtags replacement with preferred values
+  //! @todo extlang replacement for canonical form - recreate extlang for extlang form
+  //! @todo reordering of variants using prefixes
+  //! @todo replacement of deprecated with preferred
+  //! @todo suppress script - not part of official canonicalization, but tags should not use
+  //! a script unless it adds information
+}

--- a/xbmc/utils/i18n/Bcp47.h
+++ b/xbmc/utils/i18n/Bcp47.h
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/i18n/Bcp47Common.h"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace KODI::UTILS::I18N
+{
+struct ParsedBcp47Tag;
+
+class CBcp47
+{
+public:
+  bool operator==(const CBcp47&) const = default;
+  bool operator==(const ParsedBcp47Tag& other) const;
+
+  /*!
+   * \brief Parse a language tag into its subtags. The subtags are not altered or validated.
+   * \param[in] str Text to parse 
+   * \return Object initialized with the subtags of a well-formed tag.
+   *         std::nullopt is returned when the text parameter is not a well-formed language tag.
+   */
+  static std::optional<CBcp47> ParseTag(std::string str);
+
+  /*!
+   * \brief Return the validity of the tag per RFC5646 validity rules
+   * \return true for a valid tag, otherwise false.
+   */
+  bool IsValid() const { return m_isValid; }
+
+  /*!
+   * \brief Transform the tag into its canonical from per RFC 5646 rules.
+   */
+  void Canonicalize();
+
+  /*!
+   * \brief Format the tag as BCP-47 with the recommended casing.
+   * \return the formatted tag
+   */
+  std::string Format() const;
+
+  // Accessors
+  const std::string& GetLanguage() const { return m_language; }
+  const std::vector<std::string>& GetExtLangs() const { return m_extLangs; }
+  const std::string& GetScript() const { return m_script; }
+  const std::string& GetRegion() const { return m_region; }
+  const std::vector<std::string>& GetVariants() const { return m_variants; }
+  const std::vector<Bcp47Extension>& GetExtensions() const { return m_extensions; }
+  const std::vector<std::string>& GetPrivateUse() const { return m_privateUse; }
+  const std::string& GetGrandfathered() const { return m_grandfathered; }
+
+  /*!
+   * \brief Identify grandfathered tags.
+   * \return true for a grandfathered tag, false otherwise.
+   */
+  bool IsGrandfathered() const { return !m_grandfathered.empty(); }
+
+private:
+  CBcp47() = default;
+
+  bool Validate();
+  bool IsValidLanguage() const;
+  bool HasMultipleExtLang() const;
+  bool IsValidRegion() const;
+  bool HasDuplicateVariants() const;
+  bool HasDuplicateExtensions() const;
+
+  bool m_isValid{false};
+
+  std::string m_language;
+  std::vector<std::string> m_extLangs;
+  std::string m_script;
+  std::string m_region;
+  std::vector<std::string> m_variants;
+  std::vector<Bcp47Extension> m_extensions;
+  std::vector<std::string> m_privateUse;
+  std::string m_grandfathered;
+};
+} // namespace KODI::UTILS::I18N

--- a/xbmc/utils/i18n/Bcp47.h
+++ b/xbmc/utils/i18n/Bcp47.h
@@ -16,6 +16,7 @@
 
 namespace KODI::UTILS::I18N
 {
+class CBcp47Formatter;
 struct ParsedBcp47Tag;
 
 class CBcp47
@@ -44,10 +45,11 @@ public:
   void Canonicalize();
 
   /*!
-   * \brief Format the tag as BCP-47 with the recommended casing.
-   * \return the formatted tag
+   * \brief Format the tag to text according to the provided format
+   * \param[in] style Format of the output
+   * \return The formatted tag
    */
-  std::string Format() const;
+  std::string Format(Bcp47FormattingStyle style = Bcp47FormattingStyle::FORMAT_BCP47) const;
 
   // Accessors
   const std::string& GetLanguage() const { return m_language; }
@@ -63,10 +65,12 @@ public:
    * \brief Identify grandfathered tags.
    * \return true for a grandfathered tag, false otherwise.
    */
-  bool IsGrandfathered() const { return !m_grandfathered.empty(); }
+  bool IsGrandfathered() const { return m_type == Bcp47TagType::GRANDFATHERED; }
 
 private:
   CBcp47() = default;
+
+  friend class CBcp47Formatter;
 
   bool Validate();
   bool IsValidLanguage() const;
@@ -77,6 +81,7 @@ private:
 
   bool m_isValid{false};
 
+  Bcp47TagType m_type = Bcp47TagType::WELL_FORMED;
   std::string m_language;
   std::vector<std::string> m_extLangs;
   std::string m_script;

--- a/xbmc/utils/i18n/Bcp47.h
+++ b/xbmc/utils/i18n/Bcp47.h
@@ -52,6 +52,8 @@ public:
   std::string Format(Bcp47FormattingStyle style = Bcp47FormattingStyle::FORMAT_BCP47) const;
 
   // Accessors
+  //! @todo consider returning const references
+  Bcp47TagType GetType() const { return m_type; }
   const std::string& GetLanguage() const { return m_language; }
   const std::vector<std::string>& GetExtLangs() const { return m_extLangs; }
   const std::string& GetScript() const { return m_script; }
@@ -61,16 +63,8 @@ public:
   const std::vector<std::string>& GetPrivateUse() const { return m_privateUse; }
   const std::string& GetGrandfathered() const { return m_grandfathered; }
 
-  /*!
-   * \brief Identify grandfathered tags.
-   * \return true for a grandfathered tag, false otherwise.
-   */
-  bool IsGrandfathered() const { return m_type == Bcp47TagType::GRANDFATHERED; }
-
 private:
   CBcp47() = default;
-
-  friend class CBcp47Formatter;
 
   bool Validate();
   bool IsValidLanguage() const;

--- a/xbmc/utils/i18n/Bcp47Common.h
+++ b/xbmc/utils/i18n/Bcp47Common.h
@@ -19,4 +19,17 @@ struct Bcp47Extension
   std::vector<std::string> segments;
   bool operator==(const Bcp47Extension& other) const = default;
 };
+
+enum class Bcp47FormattingStyle
+{
+  FORMAT_BCP47, ///< BCP47 language tag with the recommended casing
+  FORMAT_ENGLISH, ///< Subtags converted to English and formatted to mimick locale names
+};
+
+enum class Bcp47TagType
+{
+  WELL_FORMED, ///< The tag conforms to the syntax specified by RFC5646 and is not a special case.
+  GRANDFATHERED, ///< The tag is a regular or irregular grandfathered tag.
+  PRIVATE_USE, ///< The tag consists solely of private-use subtags.
+};
 } // namespace KODI::UTILS::I18N

--- a/xbmc/utils/i18n/Bcp47Common.h
+++ b/xbmc/utils/i18n/Bcp47Common.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace KODI::UTILS::I18N
+{
+struct Bcp47Extension
+{
+  char name;
+  std::vector<std::string> segments;
+  bool operator==(const Bcp47Extension& other) const = default;
+};
+} // namespace KODI::UTILS::I18N

--- a/xbmc/utils/i18n/Bcp47Formatter.cpp
+++ b/xbmc/utils/i18n/Bcp47Formatter.cpp
@@ -1,0 +1,248 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "utils/i18n/Bcp47Formatter.h"
+
+#include "utils/StringUtils.h"
+#include "utils/i18n/Bcp47.h"
+#include "utils/i18n/Iso3166_1.h"
+#include "utils/i18n/Iso639.h"
+#include "utils/i18n/Iso639_1.h"
+#include "utils/i18n/Iso639_2.h"
+
+#include <string_view>
+
+using namespace KODI::UTILS::I18N;
+
+namespace
+{
+bool LookupInISO639Tables(const std::string& code, std::string& desc)
+{
+  if (code.empty())
+    return false;
+
+  std::string sCode(code);
+  StringUtils::ToLower(sCode);
+  StringUtils::Trim(sCode);
+
+  if (sCode.length() == 2)
+  {
+    const auto ret = CIso639_1::LookupByCode(StringToLongCode(sCode));
+    if (ret.has_value())
+    {
+      desc = ret.value();
+      return true;
+    }
+  }
+  else if (sCode.length() == 3)
+  {
+    uint32_t longCode = StringToLongCode(sCode);
+
+    // Map B to T for the few codes that have differences
+    const auto tCode = CIso639_2::BCodeToTCode(longCode);
+    if (tCode.has_value())
+      longCode = tCode.value();
+
+    // Lookup the T code
+    const auto ret = CIso639_2::LookupByCode(longCode);
+    if (ret.has_value())
+    {
+      desc = ret.value();
+      return true;
+    }
+  }
+  return false;
+}
+} // namespace
+
+std::string CBcp47Formatter::Format(const CBcp47& tag) const
+{
+  std::string str;
+
+  if (tag.m_type == Bcp47TagType::GRANDFATHERED)
+  {
+    FormatGrandfathered(tag, str);
+    return str;
+  }
+
+  // Language may be empty only for tags made up only of a private use subtag
+  if (tag.m_type == Bcp47TagType::PRIVATE_USE)
+  {
+    FormatPrivateUse(tag, str);
+    return str;
+  }
+
+  if (m_style == Bcp47FormattingStyle::FORMAT_ENGLISH)
+  {
+    // Format the tag in a style similar to locale names, ex. English (United States)
+    FormatLanguage(tag, str);
+    std::size_t languageSize = str.size();
+
+    if (languageSize > 0)
+      str.append(" (");
+
+    std::size_t othersBegin = str.size();
+    constexpr std::string_view sep = ", ";
+
+    if (FormatExtLangs(tag, str))
+      str.append(sep);
+    if (FormatScript(tag, str))
+      str.append(sep);
+    if (FormatRegion(tag, str))
+      str.append(sep);
+    if (FormatVariants(tag, str))
+      str.append(sep);
+    if (FormatExtensions(tag, str))
+      str.append(sep);
+    if (FormatPrivateUse(tag, str))
+      str.append(sep);
+
+    if (str.size() > othersBegin)
+    {
+      // remove final space
+      str.erase(str.size() - sep.length());
+      str.append(")");
+    }
+    else
+    {
+      // language was the only subtag - remove additional formatting text
+      str.erase(languageSize);
+    }
+  }
+  else
+  {
+    // Format the tag as a BCP 47 tag with the recommended casing
+
+    str.reserve(35); // size recommended by RFC5646
+
+    if (FormatLanguage(tag, str))
+      str.push_back('-');
+    if (FormatExtLangs(tag, str))
+      str.push_back('-');
+    if (FormatScript(tag, str))
+      str.push_back('-');
+    if (FormatRegion(tag, str))
+      str.push_back('-');
+    if (FormatVariants(tag, str))
+      str.push_back('-');
+    if (FormatExtensions(tag, str))
+      str.push_back('-');
+    if (FormatPrivateUse(tag, str))
+      str.push_back('-');
+
+    // remove final -
+    if (!str.empty())
+      str.pop_back();
+  }
+
+  return str;
+}
+
+bool CBcp47Formatter::FormatLanguage(const CBcp47& tag, std::string& str) const
+{
+  if (tag.m_language.empty())
+    return false;
+
+  if (m_style == Bcp47FormattingStyle::FORMAT_ENGLISH)
+  {
+    // Language from ISO 639-1 or ISO 639-2
+    if (std::string lang; LookupInISO639Tables(tag.m_language, lang))
+      str.append(lang);
+    else
+      str.append(tag.m_language); // was likely ISO 639-3 or 639-5
+    return true;
+  }
+
+  str.append(tag.m_language);
+  return true;
+}
+
+bool CBcp47Formatter::FormatExtLangs(const CBcp47& tag, std::string& str) const
+{
+  if (tag.m_extLangs.empty())
+    return false;
+
+  str.append(StringUtils::Join(tag.m_extLangs, "-"));
+  return true;
+}
+
+bool CBcp47Formatter::FormatScript(const CBcp47& tag, std::string& str) const
+{
+  if (tag.m_script.empty())
+    return false;
+
+  std::string s = tag.m_script;
+  StringUtils::ToCapitalize(s);
+  str.append(s);
+  return true;
+}
+
+bool CBcp47Formatter::FormatRegion(const CBcp47& tag, std::string& str) const
+{
+  if (tag.m_region.empty())
+    return false;
+
+  if (m_style == Bcp47FormattingStyle::FORMAT_ENGLISH)
+  {
+    // Region from ISO 3166-1. UN M.49 is not supported.
+    const auto reg = CIso3166_1::LookupByCode(tag.m_region);
+    str.append(reg.value_or(StringUtils::ToUpper(tag.m_region)));
+  }
+  else
+  {
+    str.append(StringUtils::ToUpper(tag.m_region));
+  }
+  return true;
+}
+
+bool CBcp47Formatter::FormatVariants(const CBcp47& tag, std::string& str) const
+{
+  if (tag.m_variants.empty())
+    return false;
+
+  str.append(StringUtils::Join(tag.m_variants, "-"));
+  return true;
+}
+
+bool CBcp47Formatter::FormatExtensions(const CBcp47& tag, std::string& str) const
+{
+  if (tag.m_extensions.empty())
+    return false;
+
+  for (const auto& ext : tag.m_extensions)
+  {
+    str.push_back(ext.name);
+    str.push_back('-');
+    str.append(StringUtils::Join(ext.segments, "-"));
+    str.push_back('-');
+  }
+  // remove final -
+  str.pop_back();
+
+  return true;
+}
+
+bool CBcp47Formatter::FormatPrivateUse(const CBcp47& tag, std::string& str) const
+{
+  if (tag.m_privateUse.empty())
+    return false;
+
+  str.append("x-");
+  str.append(StringUtils::Join(tag.m_privateUse, "-"));
+
+  return true;
+}
+
+bool CBcp47Formatter::FormatGrandfathered(const CBcp47& tag, std::string& str) const
+{
+  if (tag.m_grandfathered.empty())
+    return false;
+
+  str.append(tag.m_grandfathered);
+  return true;
+}

--- a/xbmc/utils/i18n/Bcp47Formatter.cpp
+++ b/xbmc/utils/i18n/Bcp47Formatter.cpp
@@ -64,14 +64,14 @@ std::string CBcp47Formatter::Format(const CBcp47& tag) const
 {
   std::string str;
 
-  if (tag.m_type == Bcp47TagType::GRANDFATHERED)
+  if (tag.GetType() == Bcp47TagType::GRANDFATHERED)
   {
     FormatGrandfathered(tag, str);
     return str;
   }
 
   // Language may be empty only for tags made up only of a private use subtag
-  if (tag.m_type == Bcp47TagType::PRIVATE_USE)
+  if (tag.GetType() == Bcp47TagType::PRIVATE_USE)
   {
     FormatPrivateUse(tag, str);
     return str;
@@ -145,38 +145,41 @@ std::string CBcp47Formatter::Format(const CBcp47& tag) const
 
 bool CBcp47Formatter::FormatLanguage(const CBcp47& tag, std::string& str) const
 {
-  if (tag.m_language.empty())
+  const std::string& language = tag.GetLanguage();
+  if (language.empty())
     return false;
 
   if (m_style == Bcp47FormattingStyle::FORMAT_ENGLISH)
   {
     // Language from ISO 639-1 or ISO 639-2
-    if (std::string lang; LookupInISO639Tables(tag.m_language, lang))
+    if (std::string lang; LookupInISO639Tables(language, lang))
       str.append(lang);
     else
-      str.append(tag.m_language); // was likely ISO 639-3 or 639-5
+      str.append(language); // was likely ISO 639-3 or 639-5
     return true;
   }
 
-  str.append(tag.m_language);
+  str.append(language);
   return true;
 }
 
 bool CBcp47Formatter::FormatExtLangs(const CBcp47& tag, std::string& str) const
 {
-  if (tag.m_extLangs.empty())
+  const std::vector<std::string>& extLangs = tag.GetExtLangs();
+  if (extLangs.empty())
     return false;
 
-  str.append(StringUtils::Join(tag.m_extLangs, "-"));
+  str.append(StringUtils::Join(extLangs, "-"));
   return true;
 }
 
 bool CBcp47Formatter::FormatScript(const CBcp47& tag, std::string& str) const
 {
-  if (tag.m_script.empty())
+  const std::string& script = tag.GetScript();
+  if (script.empty())
     return false;
 
-  std::string s = tag.m_script;
+  std::string s = script;
   StringUtils::ToCapitalize(s);
   str.append(s);
   return true;
@@ -184,37 +187,40 @@ bool CBcp47Formatter::FormatScript(const CBcp47& tag, std::string& str) const
 
 bool CBcp47Formatter::FormatRegion(const CBcp47& tag, std::string& str) const
 {
-  if (tag.m_region.empty())
+  const std::string& region = tag.GetRegion();
+  if (region.empty())
     return false;
 
   if (m_style == Bcp47FormattingStyle::FORMAT_ENGLISH)
   {
     // Region from ISO 3166-1. UN M.49 is not supported.
-    const auto reg = CIso3166_1::LookupByCode(tag.m_region);
-    str.append(reg.value_or(StringUtils::ToUpper(tag.m_region)));
+    const auto reg = CIso3166_1::LookupByCode(region);
+    str.append(reg.value_or(StringUtils::ToUpper(region)));
   }
   else
   {
-    str.append(StringUtils::ToUpper(tag.m_region));
+    str.append(StringUtils::ToUpper(region));
   }
   return true;
 }
 
 bool CBcp47Formatter::FormatVariants(const CBcp47& tag, std::string& str) const
 {
-  if (tag.m_variants.empty())
+  const std::vector<std::string>& variants = tag.GetVariants();
+  if (variants.empty())
     return false;
 
-  str.append(StringUtils::Join(tag.m_variants, "-"));
+  str.append(StringUtils::Join(variants, "-"));
   return true;
 }
 
 bool CBcp47Formatter::FormatExtensions(const CBcp47& tag, std::string& str) const
 {
-  if (tag.m_extensions.empty())
+  const std::vector<Bcp47Extension>& extensions = tag.GetExtensions();
+  if (extensions.empty())
     return false;
 
-  for (const auto& ext : tag.m_extensions)
+  for (const auto& ext : extensions)
   {
     str.push_back(ext.name);
     str.push_back('-');
@@ -229,20 +235,22 @@ bool CBcp47Formatter::FormatExtensions(const CBcp47& tag, std::string& str) cons
 
 bool CBcp47Formatter::FormatPrivateUse(const CBcp47& tag, std::string& str) const
 {
-  if (tag.m_privateUse.empty())
+  const std::vector<std::string>& privateUse = tag.GetPrivateUse();
+  if (privateUse.empty())
     return false;
 
   str.append("x-");
-  str.append(StringUtils::Join(tag.m_privateUse, "-"));
+  str.append(StringUtils::Join(privateUse, "-"));
 
   return true;
 }
 
 bool CBcp47Formatter::FormatGrandfathered(const CBcp47& tag, std::string& str) const
 {
-  if (tag.m_grandfathered.empty())
+  const std::string& grandfathered = tag.GetGrandfathered();
+  if (grandfathered.empty())
     return false;
 
-  str.append(tag.m_grandfathered);
+  str.append(grandfathered);
   return true;
 }

--- a/xbmc/utils/i18n/Bcp47Formatter.h
+++ b/xbmc/utils/i18n/Bcp47Formatter.h
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/i18n/Bcp47Common.h"
+
+#include <string>
+
+namespace KODI::UTILS::I18N
+{
+class CBcp47;
+
+class CBcp47Formatter
+{
+public:
+  /*!
+   * \brief Create a BCP47 formatter
+   * \param[in] style Format of the output
+   */
+  CBcp47Formatter(Bcp47FormattingStyle style) : m_style(style) {}
+
+  /*!
+   * \brief Format a tag to text according to the previously chosen format
+   * \param[in] tag The tag to format
+   * \return The formatted tag
+   */
+  std::string Format(const CBcp47& tag) const;
+
+  /*!
+   * \brief Format a tag to text according to the provided format
+   * \param[in] tag The tag to format
+   * \param[in] style Format of the output
+   * \return The formatted tag
+   */
+  static std::string Format(const CBcp47& tag, Bcp47FormattingStyle style)
+  {
+    CBcp47Formatter formatter(style);
+    return formatter.Format(tag);
+  }
+
+private:
+  bool FormatLanguage(const CBcp47& tag, std::string& str) const;
+  bool FormatExtLangs(const CBcp47& tag, std::string& str) const;
+  bool FormatScript(const CBcp47& tag, std::string& str) const;
+  bool FormatRegion(const CBcp47& tag, std::string& str) const;
+  bool FormatVariants(const CBcp47& tag, std::string& str) const;
+  bool FormatExtensions(const CBcp47& tag, std::string& str) const;
+  bool FormatPrivateUse(const CBcp47& tag, std::string& str) const;
+  bool FormatGrandfathered(const CBcp47& tag, std::string& str) const;
+
+  Bcp47FormattingStyle m_style{Bcp47FormattingStyle::FORMAT_BCP47};
+};
+} // namespace KODI::UTILS::I18N

--- a/xbmc/utils/i18n/Bcp47Parser.cpp
+++ b/xbmc/utils/i18n/Bcp47Parser.cpp
@@ -1,0 +1,229 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "utils/i18n/Bcp47Parser.h"
+
+#include "utils/RegExp.h"
+#include "utils/StringUtils.h"
+#include "utils/i18n/Bcp47.h"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <string_view>
+
+using namespace KODI::UTILS::I18N;
+using namespace std::literals;
+
+std::optional<ParsedBcp47Tag> CBcp47Parser::Parse(std::string str)
+{
+  StringUtils::Trim(str);
+  StringUtils::ToLower(str);
+
+  // Try fast parse of ISO 639 codes first
+  auto tag = TryParseIso639(str);
+
+  // Maybe an regular grandfathered tag
+  if (!tag.has_value())
+    tag = TryParseRegularGrandfathered(str);
+
+  // Full parse of the language tag
+  if (!tag.has_value())
+    tag = TryGenericParse(str);
+
+  // Maybe an irregular grandfathered tag
+  if (!tag.has_value())
+    tag = TryParseIrregularGrandfathered(str);
+
+  return tag;
+}
+
+std::optional<ParsedBcp47Tag> CBcp47Parser::TryParseIso639(const std::string& str)
+{
+  assert(std::ranges::none_of(str, [](char c) { return StringUtils::isasciiuppercaseletter(c); }));
+
+  if ((str.length() == 2 || str.length() == 3) && StringUtils::IsAsciiLetters(str))
+  {
+    ParsedBcp47Tag tag;
+    tag.m_language = str;
+    return tag;
+  }
+
+  return std::nullopt;
+}
+
+std::optional<ParsedBcp47Tag> CBcp47Parser::TryGenericParse(const std::string& str)
+{
+  assert(std::ranges::none_of(str, [](char c) { return StringUtils::isasciiuppercaseletter(c); }));
+
+  // BCP 47 language tags are composed of multiple subtags in the following order:
+  // primary language subtag 2 or 3 letters (ISO 639-1/-2/-3/-5)
+  //   OR 4 letters reserved for future use
+  //   OR 5 to 8 letters registered subtag
+  // [optional] up to 3 extended languages subtags of 3 letters each, - separated, may follow a 2 or 3 letters language subtag
+  // [optional] script subtag: 4 letters (ISO 15924)
+  // [optional] region subtag: 2 letters (ISO3166) or 3 digits (UN M.49)
+  // [optional] variant subtags 5 to 8 letters each or 4 characters starting with a digit
+  // [optional] extension/private use subtags 1 letter except x then (- and 2 to 8 letters) at least once
+  // [optional] private-use subtag letter x then (- and 1 to 8 letters) at least once
+
+  // clang-format off
+  const char bcp47Regexp[] =
+      "^(?:(?:(?:(?:(?<langiso639>[a-z]{2,3})(?<extlangs>(?:-[a-z]{3}){0,3}))|(?<langother>[a-z]{4,8}))"
+      "(?:-(?<script>[a-z]{4}))?"
+      "(?:-(?<region>[a-z]{2}|[0-9]{3}))?"
+      "(?<variants>(?:-(?:(?:[a-z]{5,8})|(?:[0-9][a-z0-9]{3})))*)"
+      "(?<extensions>(?:-(?:[a-wy-z0-9](?:-[a-z0-9]{2,8})+))*)"
+      "(?:-[x](?<privateuse>(?:-[a-z0-9]{1,8})+))?)"
+      "|(?:x(?<globalprivateuse>(?:-[a-z0-9]{1,8})+)))$";
+  // clang-format on
+
+  static CRegExp regLangCode;
+  static bool initialized = regLangCode.RegComp(bcp47Regexp);
+
+  if (!initialized || regLangCode.RegFind(str) < 0)
+    return {};
+
+  ParsedBcp47Tag tag{};
+
+  tag.m_language = regLangCode.GetMatch("langiso639");
+  if (tag.m_language.empty())
+    tag.m_language = regLangCode.GetMatch("langother");
+
+  std::string extLangsRaw = regLangCode.GetMatch("extlangs");
+  if (!extLangsRaw.empty())
+    // Skip the initial - of the match
+    tag.m_extLangs = StringUtils::Split(extLangsRaw.substr(1, std::string::npos), '-');
+
+  tag.m_script = regLangCode.GetMatch("script");
+  tag.m_region = regLangCode.GetMatch("region");
+  std::string variantsRaw = regLangCode.GetMatch("variants");
+
+  if (!variantsRaw.empty())
+    // Skip the initial - of the match
+    tag.m_variants = StringUtils::Split(variantsRaw.substr(1, std::string::npos), '-');
+
+  std::string extensionsRaw = regLangCode.GetMatch("extensions");
+  if (!extensionsRaw.empty())
+  {
+    // The string starts with -a-xxxx..., with a the extension name and xxxx the extension text,
+    // at least 2 characters.
+    assert(extensionsRaw.length() >= std::size("-a-xx"));
+
+    char key = extensionsRaw[1];
+    std::vector<std::string> extSegments;
+
+    // Skip the initial -a-
+    auto extensions = StringUtils::Split(extensionsRaw.substr(3, std::string::npos), '-');
+
+    for (auto& token : extensions)
+    {
+      if (token.length() == 1)
+      {
+        // found a new extension name: save the segments accumulated since the last extension name
+        if (!extSegments.empty())
+        {
+          Bcp47Extension e{.name = key, .segments = std::move(extSegments)};
+          tag.m_extensions.push_back(e);
+          extSegments.clear();
+        }
+        key = token[0];
+        continue;
+      }
+      extSegments.push_back(std::move(token));
+    }
+    // Save the text accumulated for the last found extension name
+    if (!extSegments.empty())
+    {
+      Bcp47Extension e{.name = key, .segments = std::move(extSegments)};
+      tag.m_extensions.push_back(e);
+    }
+  }
+
+  std::string puRaw = regLangCode.GetMatch("privateuse");
+  if (puRaw.empty())
+  {
+    puRaw = regLangCode.GetMatch("globalprivateuse");
+    if (!puRaw.empty())
+      tag.m_type = Bcp47TagType::PRIVATE_USE;
+  }
+
+  if (!puRaw.empty())
+    // Skip the initial - of the match
+    tag.m_privateUse = StringUtils::Split(puRaw.substr(1, std::string::npos), '-');
+
+  return tag;
+}
+
+std::optional<ParsedBcp47Tag> CBcp47Parser::TryParseRegularGrandfathered(const std::string& str)
+{
+  assert(std::ranges::none_of(str, [](char c) { return StringUtils::isasciiuppercaseletter(c); }));
+
+  // List safe to hardcode because RFC 5646 2.1 states
+  // ... grandfathered tags listed in the productions 'regular' and 'irregular' ...  were registered
+  // under [RFC3066] and are a fixed list that can never change.
+  constexpr auto RegularGrandfatheredTags =
+      std::array{"art-lojban"sv, "cel-gaulish"sv, "no-bok"sv,     "no-nyn"sv,  "zh-guoyu"sv,
+                 "zh-hakka"sv,   "zh-min"sv,      "zh-min-nan"sv, "zh-xiang"sv};
+
+  static_assert(std::ranges::is_sorted(RegularGrandfatheredTags, {}, {}));
+
+  constexpr auto minSize =
+      std::ranges::min(RegularGrandfatheredTags, {}, &std::string_view::size).size();
+  constexpr auto maxSize =
+      std::ranges::max(RegularGrandfatheredTags, {}, &std::string_view::size).size();
+
+  if (str.size() < minSize || str.size() > maxSize)
+    return {};
+
+  auto it = std::ranges::lower_bound(RegularGrandfatheredTags, str, {}, {});
+  if (it != RegularGrandfatheredTags.end() && *it == str)
+  {
+    ParsedBcp47Tag tag{};
+    tag.m_grandfathered = *it;
+    tag.m_type = Bcp47TagType::GRANDFATHERED;
+    return tag;
+  }
+
+  return std::nullopt;
+}
+
+std::optional<ParsedBcp47Tag> CBcp47Parser::TryParseIrregularGrandfathered(const std::string& str)
+{
+  assert(std::ranges::none_of(str, [](char c) { return StringUtils::isasciiuppercaseletter(c); }));
+
+  // List safe to hardcode because RFC 5646 2.1 states
+  // ... grandfathered tags listed in the productions 'regular' and 'irregular' ...  were registered
+  // under [RFC3066] and are a fixed list that can never change.
+
+  constexpr auto IrregularGrandfatheredTags =
+      std::array{"en-GB-oed"sv, "i-ami"sv, "i-bnn"sv,     "i-default"sv, "i-enochian"sv, "i-hak"sv,
+                 "i-klingon"sv, "i-lux"sv, "i-mingo"sv,   "i-navajo"sv,  "i-pwn"sv,      "i-tao"sv,
+                 "i-tay"sv,     "i-tsu"sv, "sgn-BE-FR"sv, "sgn-BE-NL"sv, "sgn-CH-DE"sv};
+
+  static_assert(std::ranges::is_sorted(IrregularGrandfatheredTags, {}, {}));
+
+  constexpr auto minSize =
+      std::ranges::min(IrregularGrandfatheredTags, {}, &std::string_view::size).size();
+  constexpr auto maxSize =
+      std::ranges::max(IrregularGrandfatheredTags, {}, &std::string_view::size).size();
+
+  if (str.size() < minSize || str.size() > maxSize)
+    return {};
+
+  auto it = std::ranges::lower_bound(IrregularGrandfatheredTags, str, {}, {});
+  if (it != IrregularGrandfatheredTags.end() && *it == str)
+  {
+    ParsedBcp47Tag tag{};
+    tag.m_grandfathered = *it;
+    tag.m_type = Bcp47TagType::GRANDFATHERED;
+    return tag;
+  }
+
+  return std::nullopt;
+}

--- a/xbmc/utils/i18n/Bcp47Parser.h
+++ b/xbmc/utils/i18n/Bcp47Parser.h
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/i18n/Bcp47Common.h"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace KODI::UTILS::I18N
+{
+enum class Bcp47TagType
+{
+  WELL_FORMED, ///< The tag conforms to the syntax specified by RFC5646 and is not a special case.
+  GRANDFATHERED, ///< The tag is a regular or irregular grandfathered tag.
+  PRIVATE_USE, ///< The tag consists solely of private-use subtags.
+};
+
+struct ParsedBcp47Tag
+{
+  Bcp47TagType m_type = Bcp47TagType::WELL_FORMED;
+  std::string m_language;
+  std::vector<std::string> m_extLangs;
+  std::string m_script;
+  std::string m_region;
+  std::vector<std::string> m_variants;
+  std::vector<Bcp47Extension> m_extensions;
+  std::vector<std::string> m_privateUse;
+  std::string m_grandfathered;
+
+  bool operator==(const ParsedBcp47Tag&) const = default;
+};
+
+class CBcp47Parser
+{
+public:
+  /*!
+   * \brief Parse a string as a BCP47 language tag
+   * \param[in] str String to parse
+   * \return parsed tag if it complies with RFC5646, std::nullopt otherwise.
+   */
+  static std::optional<ParsedBcp47Tag> Parse(std::string str);
+
+private:
+  CBcp47Parser() = delete;
+
+  static std::optional<ParsedBcp47Tag> TryParseIso639(const std::string& str);
+  static std::optional<ParsedBcp47Tag> TryGenericParse(const std::string& str);
+  static std::optional<ParsedBcp47Tag> TryParseRegularGrandfathered(const std::string& str);
+  static std::optional<ParsedBcp47Tag> TryParseIrregularGrandfathered(const std::string& str);
+};
+} // namespace KODI::UTILS::I18N

--- a/xbmc/utils/i18n/Bcp47Parser.h
+++ b/xbmc/utils/i18n/Bcp47Parser.h
@@ -16,13 +16,6 @@
 
 namespace KODI::UTILS::I18N
 {
-enum class Bcp47TagType
-{
-  WELL_FORMED, ///< The tag conforms to the syntax specified by RFC5646 and is not a special case.
-  GRANDFATHERED, ///< The tag is a regular or irregular grandfathered tag.
-  PRIVATE_USE, ///< The tag consists solely of private-use subtags.
-};
-
 struct ParsedBcp47Tag
 {
   Bcp47TagType m_type = Bcp47TagType::WELL_FORMED;

--- a/xbmc/utils/i18n/CMakeLists.txt
+++ b/xbmc/utils/i18n/CMakeLists.txt
@@ -1,9 +1,14 @@
-set(SOURCES Iso3166_1.cpp
+set(SOURCES Bcp47.cpp
+            Bcp47Parser.cpp
+            Iso3166_1.cpp
             Iso639.cpp
             Iso639_1.cpp
             Iso639_2.cpp)
 
-set(HEADERS Iso3166_1.h
+set(HEADERS Bcp47.h
+            Bcp47Common.h
+            Bcp47Parser.h
+            Iso3166_1.h
             Iso3166_1_Table.h
             Iso639.h
             Iso639_1.h

--- a/xbmc/utils/i18n/CMakeLists.txt
+++ b/xbmc/utils/i18n/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES Bcp47.cpp
+            Bcp47Formatter.cpp
             Bcp47Parser.cpp
             Iso3166_1.cpp
             Iso639.cpp
@@ -7,6 +8,7 @@ set(SOURCES Bcp47.cpp
 
 set(HEADERS Bcp47.h
             Bcp47Common.h
+            Bcp47Formatter.h
             Bcp47Parser.h
             Iso3166_1.h
             Iso3166_1_Table.h

--- a/xbmc/utils/i18n/Iso3166_1.cpp
+++ b/xbmc/utils/i18n/Iso3166_1.cpp
@@ -14,20 +14,41 @@
 
 using namespace KODI::UTILS::I18N;
 
+namespace
+{
+std::optional<ISO3166_1> FindAlpha2(std::string_view code)
+{
+  const auto it = std::ranges::lower_bound(TableISO3166_1, code, {}, &ISO3166_1::alpha2);
+  if (it != TableISO3166_1.end() && it->alpha2 == code)
+    return *it;
+
+  return std::nullopt;
+}
+
+std::optional<ISO3166_1> FindAlpha3(std::string_view code)
+{
+  const auto it = std::ranges::lower_bound(TableISO3166_1ByAlpha3, code, {}, &ISO3166_1::alpha3);
+  if (it != TableISO3166_1ByAlpha3.end() && it->alpha3 == code)
+    return *it;
+
+  return std::nullopt;
+}
+} // namespace
+
 std::optional<std::string> CIso3166_1::Alpha2ToAlpha3(std::string_view code)
 {
-  auto it = std::ranges::lower_bound(TableISO3166_1, code, {}, &ISO3166_1::alpha2);
-  if (it != TableISO3166_1.end() && it->alpha2 == code)
-    return std::string{it->alpha3};
+  const auto entry = FindAlpha2(code);
+  if (entry.has_value())
+    return std::string{entry->alpha3};
 
   return std::nullopt;
 }
 
 std::optional<std::string> CIso3166_1::Alpha3ToAlpha2(std::string_view code)
 {
-  auto it = std::ranges::lower_bound(TableISO3166_1ByAlpha3, code, {}, &ISO3166_1::alpha3);
-  if (it != TableISO3166_1ByAlpha3.end() && it->alpha3 == code)
-    return std::string{it->alpha2};
+  const auto entry = FindAlpha3(code);
+  if (entry.has_value())
+    return std::string{entry->alpha2};
 
   return std::nullopt;
 }
@@ -40,4 +61,19 @@ bool CIso3166_1::ContainsAlpha3(std::string_view code)
 bool CIso3166_1::ContainsAlpha2(std::string_view code)
 {
   return std::ranges::binary_search(TableISO3166_1, code, {}, &ISO3166_1::alpha2);
+}
+
+std::optional<std::string> CIso3166_1::LookupByCode(std::string_view code)
+{
+  std::optional<ISO3166_1> entry;
+
+  if (code.size() == 2)
+    entry = FindAlpha2(code);
+  else if (code.size() == 3)
+    entry = FindAlpha3(code);
+
+  if (entry.has_value())
+    return std::string{entry->name};
+
+  return std::nullopt;
 }

--- a/xbmc/utils/i18n/Iso3166_1.cpp
+++ b/xbmc/utils/i18n/Iso3166_1.cpp
@@ -36,3 +36,8 @@ bool CIso3166_1::ContainsAlpha3(std::string_view code)
 {
   return std::ranges::binary_search(TableISO3166_1ByAlpha3, code, {}, &ISO3166_1::alpha3);
 }
+
+bool CIso3166_1::ContainsAlpha2(std::string_view code)
+{
+  return std::ranges::binary_search(TableISO3166_1, code, {}, &ISO3166_1::alpha2);
+}

--- a/xbmc/utils/i18n/Iso3166_1.h
+++ b/xbmc/utils/i18n/Iso3166_1.h
@@ -46,5 +46,12 @@ public:
    * \return true for an existing alpha-2 code, false otherwise.
    */
   static bool ContainsAlpha2(std::string_view code);
+
+  /*!
+   * \brief Retrieve the name of the provided ISO 3166-1 regionl code.
+   * \param[in] code alpha-2 or alpha-3 ISO 3166-1 code
+   * \return English name of the region, nullopt if no region by that code exists.
+   */
+  static std::optional<std::string> LookupByCode(std::string_view code);
 };
 } // namespace KODI::UTILS::I18N

--- a/xbmc/utils/i18n/Iso3166_1.h
+++ b/xbmc/utils/i18n/Iso3166_1.h
@@ -39,5 +39,12 @@ public:
    * \return true for an existing alpha-3 code, false otherwise.
    */
   static bool ContainsAlpha3(std::string_view code);
+
+  /*!
+   * \brief Existence of the provided alpha-2 code in the collection of ISO 3166-1 regions.
+   * \param[in] code lowercase alpha-2 code
+   * \return true for an existing alpha-2 code, false otherwise.
+   */
+  static bool ContainsAlpha2(std::string_view code);
 };
 } // namespace KODI::UTILS::I18N

--- a/xbmc/utils/i18n/test/CMakeLists.txt
+++ b/xbmc/utils/i18n/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES TestBcp47.cpp
+            TestBcp47Formatter.cpp
             TestBcp47Parser.cpp
             TestIso3166_1.cpp
             TestIso639_1.cpp

--- a/xbmc/utils/i18n/test/CMakeLists.txt
+++ b/xbmc/utils/i18n/test/CMakeLists.txt
@@ -1,5 +1,10 @@
-set(SOURCES TestIso3166_1.cpp
+set(SOURCES TestBcp47.cpp
+            TestBcp47Parser.cpp
+            TestIso3166_1.cpp
             TestIso639_1.cpp
-            TestIso639_2.cpp)
+            TestIso639_2.cpp
+            TestI18nUtils.cpp)
+
+set(HEADERS TestI18nUtils.h)
 
 core_add_test_library(utils_i18n_test)

--- a/xbmc/utils/i18n/test/TestBcp47.cpp
+++ b/xbmc/utils/i18n/test/TestBcp47.cpp
@@ -176,52 +176,6 @@ TEST(TestI18nBcp47, ValidateExtensions)
   EXPECT_FALSE(tag->IsValid());
 }
 
-struct TestRecommendedCasing
-{
-  std::string input;
-  std::string expected;
-};
-
-std::ostream& operator<<(std::ostream& os, const TestRecommendedCasing& rhs)
-{
-  return os << rhs.input;
-}
-
-const TestRecommendedCasing RecommendedCasingTests[] = {
-    {"Ab", "ab"},
-    {"aB", "ab"},
-    {"ab-ExT-eXt", "ab-ext-ext"},
-    {"En-Ca-X-cA", "en-CA-x-ca"},
-    {"eN-cA-x-cA", "en-CA-x-ca"},
-    {"az-lAtN-x-Latn", "az-Latn-x-latn"},
-    {"ab-AbCdE-bCdEfGhI", "ab-abcde-bcdefghi"},
-    {"Zh-GuOyU", "zh-guoyu"},
-};
-
-class RecommendedCasingTester : public testing::Test,
-                                public testing::WithParamInterface<TestRecommendedCasing>
-{
-};
-
-TEST_P(RecommendedCasingTester, ParseTag)
-{
-  auto& param = GetParam();
-
-  auto actual = CBcp47::ParseTag(param.input);
-
-  EXPECT_TRUE(actual.has_value());
-
-  if (actual.has_value())
-  {
-    // { required to quiet clang warning about dangling else
-    EXPECT_EQ(param.expected, actual->Format());
-  }
-}
-
-INSTANTIATE_TEST_SUITE_P(TestI18nBcp47,
-                         RecommendedCasingTester,
-                         testing::ValuesIn(RecommendedCasingTests));
-
 TEST(TestI18nBcp47, ValidateExtLang)
 {
   auto tag = CBcp47::ParseTag("ar-aao");

--- a/xbmc/utils/i18n/test/TestBcp47.cpp
+++ b/xbmc/utils/i18n/test/TestBcp47.cpp
@@ -1,0 +1,235 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "utils/StringUtils.h"
+#include "utils/i18n/Bcp47.h"
+#include "utils/i18n/Bcp47Parser.h"
+#include "utils/i18n/test/TestI18nUtils.h"
+
+#include <gtest/gtest.h>
+
+using namespace KODI::UTILS::I18N;
+
+namespace KODI::UTILS::I18N
+{
+std::ostream& operator<<(std::ostream& os, const CBcp47& obj)
+{
+  if (obj.IsGrandfathered()) [[unlikely]]
+  {
+    os << "BCP47 (grandfathered: " << obj.GetGrandfathered() << ")";
+    return os;
+  }
+
+  os << "BCP47 (language: " << obj.GetLanguage() << ", extended languages: {"
+     << StringUtils::Join(obj.GetExtLangs(), ",") << "}, script: " << obj.GetScript()
+     << ", region: " << obj.GetRegion() << ", variants: {"
+     << StringUtils::Join(obj.GetVariants(), ",") << "}, extensions: {";
+
+  for (const auto& ext : obj.GetExtensions())
+    os << ext << " ";
+
+  os << "}, private use: {" << StringUtils::Join(obj.GetPrivateUse(), ", ") << "}, ";
+  os << "grandfathered: " << obj.GetGrandfathered() << ")";
+
+  return os;
+}
+} // namespace KODI::UTILS::I18N
+
+struct TestBcp47ParseTag
+{
+  std::string input;
+  ParsedBcp47Tag expected;
+  bool status{true};
+};
+
+std::ostream& operator<<(std::ostream& os, const TestBcp47ParseTag& rhs)
+{
+  return os << rhs.input;
+}
+
+// clang-format off
+const TestBcp47ParseTag ParseBcp47Tests[] = {
+    {"ab", {Bcp47TagType::WELL_FORMED, "ab", {}, "", "", {}, {}, {}, ""}},
+    // invalid, more than 8 letters
+    {"montenegro", {}, false},
+    {"", {}, false},
+    // Combine all subtags
+    {"ab-ext-bcde-fg-abcde-0abc-1def-e-abcd-ef-f-ef-x-a-bcd",
+      {Bcp47TagType::WELL_FORMED, "ab", {"ext"}, "bcde", "fg", {{"abcde"}, {"0abc"}, {"1def"}}, {{'e', {{"abcd"}, {"ef"}}},{'f', {{"ef"}}}}, {"a", "bcd"}, ""}},
+    // Just a private use subtag
+    {"x-a-bcd", {Bcp47TagType::PRIVATE_USE, "", {}, "", "", {}, {}, {"a", "bcd"}, ""}},
+    // Irregular grandfathered
+    {"i-ami", {Bcp47TagType::GRANDFATHERED, "", {}, "", "", {}, {}, {}, "i-ami"}},
+    // Regular grandfathered
+    {"cel-gaulish", {Bcp47TagType::GRANDFATHERED, "", {}, "", "", {}, {}, {}, "cel-gaulish"}},
+};
+// clang-format on
+
+class Bcp47ParseTagTester : public testing::Test,
+                            public testing::WithParamInterface<TestBcp47ParseTag>
+{
+};
+
+TEST_P(Bcp47ParseTagTester, ParseTag)
+{
+  auto& param = GetParam();
+  auto actual = CBcp47::ParseTag(param.input);
+
+  EXPECT_EQ(param.status, actual.has_value());
+  if (param.status && actual.has_value())
+  {
+    // { required to quiet clang warning about dangling else
+    EXPECT_EQ(param.expected, actual.value());
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(TestI18nBcp47, Bcp47ParseTagTester, testing::ValuesIn(ParseBcp47Tests));
+
+TEST(TestI18nBcp47, Canonicalize)
+{
+  // ISO 639-1 code
+  auto tag = CBcp47::ParseTag("en");
+  tag->Canonicalize();
+  EXPECT_EQ(tag->Format(), "en");
+
+  // unsorted extensions
+  tag = CBcp47::ParseTag("ab-d-ef-g-hi-a-bc");
+  tag->Canonicalize();
+  EXPECT_EQ(tag->Format(), "ab-a-bc-d-ef-g-hi");
+}
+
+TEST(TestI18nBcp47, ValidateLanguage)
+{
+  // ISO 639-1
+  auto tag = CBcp47::ParseTag("en");
+  EXPECT_TRUE(tag->IsValid());
+
+  // ISO 639-2 that has an equivalent ISO 639-1
+  tag = CBcp47::ParseTag("eng");
+  EXPECT_FALSE(tag->IsValid());
+
+  // ISO 639-2/B that has an equivalent ISO 639-1
+  tag = CBcp47::ParseTag("tib");
+  EXPECT_FALSE(tag->IsValid());
+
+  // ISO 639-2/T that has an equivalent ISO 639-1
+  tag = CBcp47::ParseTag("bod");
+  EXPECT_FALSE(tag->IsValid());
+
+  // ISO 639-2 without ISO 639-1 equivalent
+  tag = CBcp47::ParseTag("ady");
+  EXPECT_TRUE(tag->IsValid());
+
+  // Private use ISO 639-2
+  tag = CBcp47::ParseTag("qaa");
+  EXPECT_TRUE(tag->IsValid());
+}
+
+TEST(TestI18nBcp47, ValidateRegion)
+{
+  // ISO 3166-1
+  auto tag = CBcp47::ParseTag("en-GB");
+  EXPECT_TRUE(tag->IsValid());
+
+  // Private use
+  tag = CBcp47::ParseTag("en-AA");
+  EXPECT_TRUE(tag->IsValid());
+
+  // UN M.49 - support to be added with IANA language subtags registry
+  tag = CBcp47::ParseTag("es-419");
+  EXPECT_FALSE(tag->IsValid());
+}
+
+TEST(TestI18nBcp47, ValidateVariants)
+{
+  auto tag = CBcp47::ParseTag("en-variant");
+  EXPECT_TRUE(tag->IsValid());
+
+  tag = CBcp47::ParseTag("en");
+  EXPECT_TRUE(tag->IsValid());
+
+  tag = CBcp47::ParseTag("en-variant-variant");
+  EXPECT_FALSE(tag->IsValid());
+}
+
+TEST(TestI18nBcp47, ValidateExtensions)
+{
+  // extension with multiple segments
+  auto tag = CBcp47::ParseTag("ab-a-bcdefghi-jk");
+  EXPECT_TRUE(tag->IsValid());
+
+  // multiple extensions in non-alphabetical order are OK
+  tag = CBcp47::ParseTag("ab-b-ab-a-cd");
+  EXPECT_TRUE(tag->IsValid());
+
+  // no extension
+  tag = CBcp47::ParseTag("ab");
+  EXPECT_TRUE(tag->IsValid());
+
+  // duplicate extensions not allowed
+  tag = CBcp47::ParseTag("ab-a-bc-a-de");
+  EXPECT_FALSE(tag->IsValid());
+}
+
+struct TestRecommendedCasing
+{
+  std::string input;
+  std::string expected;
+};
+
+std::ostream& operator<<(std::ostream& os, const TestRecommendedCasing& rhs)
+{
+  return os << rhs.input;
+}
+
+const TestRecommendedCasing RecommendedCasingTests[] = {
+    {"Ab", "ab"},
+    {"aB", "ab"},
+    {"ab-ExT-eXt", "ab-ext-ext"},
+    {"En-Ca-X-cA", "en-CA-x-ca"},
+    {"eN-cA-x-cA", "en-CA-x-ca"},
+    {"az-lAtN-x-Latn", "az-Latn-x-latn"},
+    {"ab-AbCdE-bCdEfGhI", "ab-abcde-bcdefghi"},
+    {"Zh-GuOyU", "zh-guoyu"},
+};
+
+class RecommendedCasingTester : public testing::Test,
+                                public testing::WithParamInterface<TestRecommendedCasing>
+{
+};
+
+TEST_P(RecommendedCasingTester, ParseTag)
+{
+  auto& param = GetParam();
+
+  auto actual = CBcp47::ParseTag(param.input);
+
+  EXPECT_TRUE(actual.has_value());
+
+  if (actual.has_value())
+  {
+    // { required to quiet clang warning about dangling else
+    EXPECT_EQ(param.expected, actual->Format());
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(TestI18nBcp47,
+                         RecommendedCasingTester,
+                         testing::ValuesIn(RecommendedCasingTests));
+
+TEST(TestI18nBcp47, ValidateExtLang)
+{
+  auto tag = CBcp47::ParseTag("ar-aao");
+  EXPECT_TRUE(tag->IsValid());
+
+  // Multiple extlangs are rejected whether they exist in registry or not
+  tag = CBcp47::ParseTag("en-abc-def");
+  EXPECT_FALSE(tag->IsValid());
+
+  //! @todo add test for inexistent extlang after implementation of the registry
+}

--- a/xbmc/utils/i18n/test/TestBcp47.cpp
+++ b/xbmc/utils/i18n/test/TestBcp47.cpp
@@ -19,7 +19,7 @@ namespace KODI::UTILS::I18N
 {
 std::ostream& operator<<(std::ostream& os, const CBcp47& obj)
 {
-  if (obj.IsGrandfathered()) [[unlikely]]
+  if (obj.GetType() == Bcp47TagType::GRANDFATHERED) [[unlikely]]
   {
     os << "BCP47 (grandfathered: " << obj.GetGrandfathered() << ")";
     return os;

--- a/xbmc/utils/i18n/test/TestBcp47Formatter.cpp
+++ b/xbmc/utils/i18n/test/TestBcp47Formatter.cpp
@@ -1,0 +1,119 @@
+/*
+ *  Copyright (C) 2005-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "utils/StringUtils.h"
+#include "utils/i18n/Bcp47.h"
+#include "utils/i18n/Bcp47Formatter.h"
+
+#include <gtest/gtest.h>
+
+using namespace KODI::UTILS::I18N;
+
+struct TestFormatting
+{
+  std::string input;
+  std::string english;
+};
+
+std::ostream& operator<<(std::ostream& os, const TestFormatting& rhs)
+{
+  return os << rhs.input;
+}
+
+// clang-format off
+const TestFormatting FormattingTests[] = {
+    {"en", "English"},
+    {"eng", "English"},
+    {"en-AU", "English (Australia)"},
+    {"es-419", "Spanish (419)"}, // M.49 region - result will change with registry support
+    {"zh-yue-Hant-HK", "Chinese (yue, Hant, Hong Kong)"}, // result will change with registry support
+    {"yue-Hant", "yue (Hant)"}, // result will change with registry support
+    // All subtags
+    {"zz-ext-exz-bcde-fg-abcde-0abc-e-abcd-ef-f-ef-x-a-bcd",
+     "zz (ext-exz, Bcde, FG, abcde-0abc, e-abcd-ef-f-ef, x-a-bcd)"},
+    // Private use only
+    {"x-a-bcd", "x-a-bcd"},
+    // Irregular grandfathered - result will change with registry support
+    {"i-ami", "i-ami"},
+};
+// clang-format on
+
+class FormatTester : public testing::Test, public testing::WithParamInterface<TestFormatting>
+{
+};
+
+TEST_P(FormatTester, FormatRaw)
+{
+  // Well-formed tags (as well as grandfathered tags) should round-trip except for the casing
+  const auto& param = GetParam();
+  const auto tag = CBcp47::ParseTag(param.input);
+  EXPECT_TRUE(tag.has_value());
+  if (tag.has_value())
+  {
+    // { required to quiet clang warning about dangling else
+    EXPECT_EQ(StringUtils::ToLower(param.input), StringUtils::ToLower(tag.value().Format()));
+  }
+}
+
+TEST_P(FormatTester, FormatEnglish)
+{
+  const auto& param = GetParam();
+  const auto tag = CBcp47::ParseTag(param.input);
+  EXPECT_TRUE(tag.has_value());
+  if (tag.has_value())
+  {
+    // { required to quiet clang warning about dangling else
+    EXPECT_EQ(param.english, tag.value().Format(Bcp47FormattingStyle::FORMAT_ENGLISH));
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(TestI18nBcp47Formatter, FormatTester, testing::ValuesIn(FormattingTests));
+
+struct TestRecommendedCasing
+{
+  std::string input;
+  std::string expected;
+};
+
+std::ostream& operator<<(std::ostream& os, const TestRecommendedCasing& rhs)
+{
+  return os << rhs.input;
+}
+
+const TestRecommendedCasing RecommendedCasingTests[] = {
+    {"Ab", "ab"},
+    {"aB", "ab"},
+    {"ab-ExT-eXt", "ab-ext-ext"},
+    {"En-Ca-X-cA", "en-CA-x-ca"},
+    {"eN-cA-x-cA", "en-CA-x-ca"},
+    {"az-lAtN-x-Latn", "az-Latn-x-latn"},
+    {"ab-AbCdE-bCdEfGhI", "ab-abcde-bcdefghi"},
+    {"Zh-GuOyU", "zh-guoyu"},
+};
+
+class RecommendedCasingTester : public testing::Test,
+                                public testing::WithParamInterface<TestRecommendedCasing>
+{
+};
+
+TEST_P(RecommendedCasingTester, ParseTag)
+{
+  const auto& param = GetParam();
+  auto actual = CBcp47::ParseTag(param.input);
+
+  EXPECT_TRUE(actual.has_value());
+  if (actual.has_value())
+  {
+    // { required to quiet clang warning about dangling else
+    EXPECT_EQ(param.expected, actual->Format());
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(TestI18nBcp47Formatter,
+                         RecommendedCasingTester,
+                         testing::ValuesIn(RecommendedCasingTests));

--- a/xbmc/utils/i18n/test/TestBcp47Parser.cpp
+++ b/xbmc/utils/i18n/test/TestBcp47Parser.cpp
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "utils/i18n/Bcp47Parser.h"
+#include "utils/i18n/test/TestI18nUtils.h"
+
+#include <gtest/gtest.h>
+
+using namespace KODI::UTILS::I18N;
+
+struct TestBcp47Parser
+{
+  std::string input;
+  ParsedBcp47Tag expected;
+  bool status{true};
+};
+
+std::ostream& operator<<(std::ostream& os, const TestBcp47Parser& rhs)
+{
+  return os << rhs.input;
+}
+
+// clang-format off
+const TestBcp47Parser ParseBcp47Tests[] = {
+    // ISO 639-1 code
+    {"ab", {Bcp47TagType::WELL_FORMED, "ab", {}, "", "", {}, {}, {}, ""}},
+    // ISO 639-2 code
+    {"abc", {Bcp47TagType::WELL_FORMED, "abc", {}, "", "", {}, {}, {}, ""}},
+    // ISO 639-2 code with extended language subtags
+    {"abc-def-ghi", {Bcp47TagType::WELL_FORMED, "abc", {"def", "ghi"}, "", "", {}, {}, {}, ""}},
+    // registered 5-8 letters code
+    {"abcde", {Bcp47TagType::WELL_FORMED, "abcde", {}, "", "", {}, {}, {}, ""}},
+    // invalid, more than 8 letters
+    {"montenegro", {}, false},
+    {"not a valid tag", {}, false},
+    // script
+    {"ab-abcd", {Bcp47TagType::WELL_FORMED, "ab", {}, "abcd", "", {}, {}, {}, ""}},
+    {"ab-abc0", {}, false},
+    // Region ISO 3166-1
+    {"ab-ab", {Bcp47TagType::WELL_FORMED, "ab", {}, "", "ab", {}, {}, {}, ""}},
+    // Region UN M.49
+    {"ab-012", {Bcp47TagType::WELL_FORMED, "ab", {}, "", "012", {}, {}, {}, ""}},
+    {"ab-a01", {}, false},
+    // Variants
+    {"ab-abcde-bcdefghi", {Bcp47TagType::WELL_FORMED, "ab", {}, "", "", {{"abcde"}, {"bcdefghi"}}, {}, {}, ""}},
+    {"ab-abcde-0abc-1def", {Bcp47TagType::WELL_FORMED, "ab", {}, "", "", {{"abcde"}, {"0abc"}, {"1def"}}, {}, {}, ""}},
+    {"ab-0abcd", {}, false},
+    // Extensions
+    {"ab-a-bcdefghi-jk", {Bcp47TagType::WELL_FORMED, "ab", {}, "", "", {}, {{'a', {{"bcdefghi"}, {"jk"}}}}, {}, ""}},
+    {"ab-a-bc-de-a-fg-hi", {Bcp47TagType::WELL_FORMED, "ab", {}, "", "", {}, {{'a', {{"bc"}, {"de"}}}, {'a', {{"fg"}, {"hi"}}}}, {}, ""}},
+    {"ab-a-bc-d-ef", {Bcp47TagType::WELL_FORMED, "ab", {}, "", "", {}, {{'a', {{"bc"}}},{'d', {{"ef"}}}}, {}, ""}},
+    {"ab-a-bc-d-ef-a-gh", {Bcp47TagType::WELL_FORMED, "ab", {}, "", "", {}, {{'a', {{"bc"}}},{'d', {{"ef"}}}, {'a', {{"gh"}}}}, {}, ""}},
+    {"ab-a-b", {}, false},
+    {"ab-a-bcdefghij", {}, false},
+    // Private use
+    {"ab-x-b-cdefghij", {Bcp47TagType::WELL_FORMED, "ab", {}, "", "", {}, {}, {"b", "cdefghij"}, ""}},
+    {"ab-x-bcdefghij", {}, false},
+    // Combine all subtags
+    {"ab-ext-bcde-fg-abcde-0abc-1def-e-abcd-ef-f-ef-x-a-bcd",
+      {Bcp47TagType::WELL_FORMED, "ab", {"ext"}, "bcde", "fg", {{"abcde"}, {"0abc"}, {"1def"}}, {{'e', {{"abcd"}, {"ef"}}},{'f', {{"ef"}}}}, {"a", "bcd"}, ""}},
+    // Just a private use subtag
+    {"x-a-bcd", {Bcp47TagType::PRIVATE_USE, "", {}, "", "", {}, {}, {"a", "bcd"}, ""}},
+    // Irregular grandfathered
+    {"i-ami", {Bcp47TagType::GRANDFATHERED, "", {}, "", "", {}, {}, {}, "i-ami"}},
+    // Regular grandfathered
+    {"cel-gaulish", {Bcp47TagType::GRANDFATHERED, "", {}, "", "", {}, {}, {}, "cel-gaulish"}},
+    // empty or whitespace
+    {"", {}, false},
+    {" ", {}, false},
+    {"  ", {}, false},
+    // surrounding whitespace
+    {" en ", {Bcp47TagType::WELL_FORMED, "en", {}, "", "", {}, {}, {}, ""}},
+    // various case
+    {"EN", {Bcp47TagType::WELL_FORMED, "en", {}, "", "", {}, {}, {}, ""}},
+    {"En", {Bcp47TagType::WELL_FORMED, "en", {}, "", "", {}, {}, {}, ""}},
+};
+// clang-format on
+
+class Bcp47ParserTester : public testing::Test, public testing::WithParamInterface<TestBcp47Parser>
+{
+};
+
+TEST_P(Bcp47ParserTester, Parse)
+{
+  auto& param = GetParam();
+  auto actual = CBcp47Parser::Parse(param.input);
+
+  EXPECT_EQ(param.status, actual.has_value());
+  if (param.status && actual.has_value())
+  {
+    // { required to quiet clang warning about dangling else
+    EXPECT_EQ(param.expected, actual.value());
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(TestI18nBcp47Parser,
+                         Bcp47ParserTester,
+                         testing::ValuesIn(ParseBcp47Tests));

--- a/xbmc/utils/i18n/test/TestI18nUtils.cpp
+++ b/xbmc/utils/i18n/test/TestI18nUtils.cpp
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "utils/i18n/test/TestI18nUtils.h"
+
+#include "utils/StringUtils.h"
+#include "utils/i18n/Bcp47Common.h"
+#include "utils/i18n/Bcp47Parser.h"
+
+namespace KODI::UTILS::I18N
+{
+std::ostream& operator<<(std::ostream& os, const Bcp47Extension& obj)
+{
+  os << obj.name << ": {" << StringUtils::Join(obj.segments, ",") << "}";
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const ParsedBcp47Tag& obj)
+{
+  os << "BCP47 (language: " << obj.m_language << ", extended languages: {"
+     << StringUtils::Join(obj.m_extLangs, ",") << "}, script: " << obj.m_script
+     << ", region: " << obj.m_region << ", variants: {" << StringUtils::Join(obj.m_variants, ",")
+     << "}, extensions: {";
+
+  for (const auto& ext : obj.m_extensions)
+    os << ext << " ";
+
+  os << "}, private use: {" << StringUtils::Join(obj.m_privateUse, ", ") << "}, ";
+  os << "grandfathered: " << obj.m_grandfathered << ")";
+
+  return os;
+}
+} // namespace KODI::UTILS::I18N

--- a/xbmc/utils/i18n/test/TestI18nUtils.h
+++ b/xbmc/utils/i18n/test/TestI18nUtils.h
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <ostream>
+
+namespace KODI::UTILS::I18N
+{
+struct Bcp47Extension;
+struct ParsedBcp47Tag;
+
+std::ostream& operator<<(std::ostream& os, const Bcp47Extension& obj);
+std::ostream& operator<<(std::ostream& os, const ParsedBcp47Tag& obj);
+} // namespace KODI::UTILS::I18N

--- a/xbmc/utils/i18n/test/TestIso3166_1.cpp
+++ b/xbmc/utils/i18n/test/TestIso3166_1.cpp
@@ -47,3 +47,20 @@ TEST(TestI18nIso3166_1, ContainsAlpha3)
   EXPECT_TRUE(CIso3166_1::ContainsAlpha3("aia"));
   EXPECT_FALSE(CIso3166_1::ContainsAlpha3("zzz"));
 }
+
+TEST(TestI18nIso3166_1, LookupByCode)
+{
+  std::optional<std::string> result;
+
+  result = CIso3166_1::LookupByCode("ai");
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(*result, "Anguilla");
+
+  result = CIso3166_1::LookupByCode("aia");
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(*result, "Anguilla");
+
+  // zzz is reserved for private use and won't ever be allocated
+  result = CIso3166_1::LookupByCode("zzz");
+  EXPECT_FALSE(result.has_value());
+}

--- a/xbmc/utils/test/TestLangCodeExpander.cpp
+++ b/xbmc/utils/test/TestLangCodeExpander.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "utils/LangCodeExpander.h"
+#include "utils/StringUtils.h"
 
 #include <gtest/gtest.h>
 
@@ -198,3 +199,41 @@ TEST(TestLangCodeExpander, LookupInISO639Tables)
   EXPECT_FALSE(CLangCodeExpanderTest::CallLookupInISO639Tables("a", varstr));
   EXPECT_FALSE(CLangCodeExpanderTest::CallLookupInISO639Tables("fr-CA", varstr));
 }
+
+struct TestISO6392ToISO6391
+{
+  std::string input;
+  bool status;
+  std::string expected;
+};
+
+// clang-format off
+const TestISO6392ToISO6391 ISO6392ToISO6391Tests[] = {
+    {"", false, ""},
+    {"en", false, ""}, // ISO 639-1
+    {"eng", true, "en"},
+    {"tib", true, "bo"},
+    {"bod", true, "bo"},
+    {"zzz", false, ""},  // not assigned
+    {" eng ", true, "en"},
+    {"ENG", true, "en"}, // case-insensitive conversion
+};
+// clang-format on
+
+class ISO6392ToISO6391Tester : public testing::Test,
+                               public testing::WithParamInterface<TestISO6392ToISO6391>
+{
+};
+
+TEST_P(ISO6392ToISO6391Tester, Lookup)
+{
+  std::string output;
+
+  EXPECT_EQ(GetParam().status,
+            g_LangCodeExpander.ConvertISO6392ToISO6391(GetParam().input, output));
+  EXPECT_EQ(GetParam().expected, output);
+}
+
+INSTANTIATE_TEST_SUITE_P(TestLangCodeExpander,
+                         ISO6392ToISO6391Tester,
+                         testing::ValuesIn(ISO6392ToISO6391Tests));

--- a/xbmc/utils/test/TestLangCodeExpander.cpp
+++ b/xbmc/utils/test/TestLangCodeExpander.cpp
@@ -282,3 +282,36 @@ TEST_P(LookupTester, Lookup)
 }
 
 INSTANTIATE_TEST_SUITE_P(TestLangCodeExpander, LookupTester, testing::ValuesIn(LookupTests));
+
+struct TestFindTag
+{
+  std::string input;
+  std::string expected;
+};
+
+// clang-format off
+const TestFindTag FindTagTests[] = {
+    {"track name", ""},
+    {"track name {en}", "en"},
+    {"track name {en-US}", "en-US"},
+    {"track name {es-419}", "es-419"},
+    {"track name {en} more text", "en"},
+    {"{en} track name", "en"},
+    {"track name {", ""},
+    {"track name {}", ""},
+    {"}{en}{fr}", "en"},
+    {"track name {EN}", "en"},
+    {"track name { en }", "en"},
+};
+// clang-format on
+
+class FindTagTester : public testing::Test, public testing::WithParamInterface<TestFindTag>
+{
+};
+
+TEST_P(FindTagTester, Find)
+{
+  EXPECT_EQ(GetParam().expected, g_LangCodeExpander.FindLanguageCodeWithSubtag(GetParam().input));
+}
+
+INSTANTIATE_TEST_SUITE_P(TestLangCodeExpander, FindTagTester, testing::ValuesIn(FindTagTests));

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5059,7 +5059,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMovie(const dbiplus::sql_record* cons
   else
     details.SetPremieredFromDBDate(premieredString);
   details.SetOriginalLanguage(record->at(VIDEODB_DETAILS_MOVIE_ORIGINAL_LANGUAGE).get_asString(),
-                              CVideoInfoTag::LanguageProcessing::PROCESSING_NONE);
+                              CVideoInfoTag::LanguageTagSource::SOURCE_INTERNAL);
 
   if (getDetails)
   {
@@ -5159,7 +5159,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForTvShow(const dbiplus::sql_record* con
   details.SetUniqueID(record->at(VIDEODB_DETAILS_TVSHOW_UNIQUEID_VALUE).get_asString(), record->at(VIDEODB_DETAILS_TVSHOW_UNIQUEID_TYPE).get_asString(), true);
   details.SetDuration(record->at(VIDEODB_DETAILS_TVSHOW_DURATION).get_asInt());
   details.SetOriginalLanguage(record->at(VIDEODB_DETAILS_TVSHOW_ORIGINAL_LANGUAGE).get_asString(),
-                              CVideoInfoTag::LanguageProcessing::PROCESSING_NONE);
+                              CVideoInfoTag::LanguageTagSource::SOURCE_INTERNAL);
   details.SetTagLine(record->at(VIDEODB_DETAILS_TVSHOW_TAGLINE).get_asString());
 
   //! @todo videotag member + guiinfo int needed?
@@ -5257,7 +5257,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForEpisode(const dbiplus::sql_record* co
   details.SetPremieredFromDBDate(record->at(VIDEODB_DETAILS_EPISODE_TVSHOW_AIRED).get_asString());
   details.SetOriginalLanguage(
       record->at(VIDEODB_DETAILS_EPISODE_TVSHOW_ORIGINAL_LANGUAGE).get_asString(),
-      CVideoInfoTag::LanguageProcessing::PROCESSING_NONE);
+      CVideoInfoTag::LanguageTagSource::SOURCE_INTERNAL);
 
   details.SetResumePoint(record->at(VIDEODB_DETAILS_EPISODE_RESUME_TIME).get_asInt(),
                          record->at(VIDEODB_DETAILS_EPISODE_TOTAL_TIME).get_asInt(),

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -54,6 +54,7 @@
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/XMLUtils.h"
+#include "utils/i18n/TableLanguageCodes.h"
 #include "utils/log.h"
 #include "video/VideoDatabaseColumns.h"
 #include "video/VideoDbUrl.h"

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1502,7 +1502,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
   XMLUtils::GetDateTime(movie, "dateadded", m_dateAdded);
 
   if (XMLUtils::GetString(movie, "originallanguage", value) &&
-      !SetOriginalLanguage(value, LanguageProcessing::PROCESSING_NORMALIZE))
+      !SetOriginalLanguage(value, LanguageTagSource::SOURCE_EXTERNAL))
     CLog::LogF(LOGWARNING, "<originallanguage> tag value {} is not recognized", value);
 }
 
@@ -1759,21 +1759,18 @@ void CVideoInfoTag::SetOriginalTitle(std::string originalTitle)
   m_strOriginalTitle = Trim(std::move(originalTitle));
 }
 
-bool CVideoInfoTag::SetOriginalLanguage(std::string language, LanguageProcessing proc)
+bool CVideoInfoTag::SetOriginalLanguage(std::string language, LanguageTagSource source)
 {
-  StringUtils::Trim(language);
-
-  if (proc == LanguageProcessing::PROCESSING_NONE)
+  if (source == LanguageTagSource::SOURCE_INTERNAL)
   {
-    m_originalLanguage = language;
+    m_originalLanguage = std::move(language);
     return true;
   }
 
-  std::string normalized;
-  if (proc == LanguageProcessing::PROCESSING_NORMALIZE &&
-      g_LangCodeExpander.ConvertToISO6392B(language, normalized))
+  StringUtils::Trim(language);
+  if (g_LangCodeExpander.ConvertToAudioBcp47(language, language))
   {
-    m_originalLanguage = normalized;
+    m_originalLanguage = std::move(language);
     return true;
   }
 

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -40,6 +40,7 @@ void CVideoInfoTag::Reset()
   m_strTitle.clear();
   m_strShowTitle.clear();
   m_strOriginalTitle.clear();
+  m_originalLanguage.clear();
   m_strSortTitle.clear();
   m_cast.clear();
   m_set.Reset();
@@ -387,6 +388,8 @@ void CVideoInfoTag::Merge(CVideoInfoTag& other)
     m_strShowTitle = other.m_strShowTitle;
   if (!other.m_strOriginalTitle.empty())
     m_strOriginalTitle = other.m_strOriginalTitle;
+  if (!other.m_originalLanguage.empty())
+    m_originalLanguage = other.m_originalLanguage;
   if (!other.m_strSortTitle.empty())
     m_strSortTitle = other.m_strSortTitle;
   if (!other.m_cast.empty())
@@ -554,6 +557,7 @@ void CVideoInfoTag::Archive(CArchive& ar)
     ar << m_strMPAARating;
     ar << m_strFileNameAndPath;
     ar << m_strOriginalTitle;
+    ar << m_originalLanguage;
     ar << m_strEpisodeGuide;
     ar << m_premiered;
     ar << m_bHasPremiered;
@@ -660,6 +664,7 @@ void CVideoInfoTag::Archive(CArchive& ar)
     ar >> m_strMPAARating;
     ar >> m_strFileNameAndPath;
     ar >> m_strOriginalTitle;
+    ar >> m_originalLanguage;
     ar >> m_strEpisodeGuide;
     ar >> m_premiered;
     ar >> m_bHasPremiered;
@@ -783,6 +788,7 @@ void CVideoInfoTag::Serialize(CVariant& value) const
   value["mpaa"] = m_strMPAARating;
   value["filenameandpath"] = m_strFileNameAndPath;
   value["originaltitle"] = m_strOriginalTitle;
+  value["originallanguage"] = m_originalLanguage;
   value["sorttitle"] = m_strSortTitle;
   value["episodeguide"] = m_strEpisodeGuide;
   value["premiered"] = m_premiered.IsValid() ? m_premiered.GetAsDBDate() : StringUtils::Empty;
@@ -1771,6 +1777,7 @@ bool CVideoInfoTag::SetOriginalLanguage(std::string language, LanguageProcessing
     return true;
   }
 
+  CLog::LogF(LOGERROR, "{} is not recognized as a valid language tag or English name", language);
   return false;
 }
 

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1768,7 +1768,7 @@ bool CVideoInfoTag::SetOriginalLanguage(std::string language, LanguageTagSource 
   }
 
   StringUtils::Trim(language);
-  if (g_LangCodeExpander.ConvertToAudioBcp47(language, language))
+  if (g_LangCodeExpander.ConvertToBcp47(language, language))
   {
     m_originalLanguage = std::move(language);
     return true;

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -158,20 +158,22 @@ public:
   void SetMPAARating(std::string mpaaRating);
   void SetFileNameAndPath(std::string fileNameAndPath);
   void SetOriginalTitle(std::string originalTitle);
-  enum class LanguageProcessing
+
+  enum class LanguageTagSource
   {
-    PROCESSING_NONE,
-    PROCESSING_NORMALIZE
+    SOURCE_INTERNAL,
+    SOURCE_EXTERNAL,
   };
+
   /*!
-   * \brief Set the original language, with optional preprocessing.
-   * \param[in] language ISO 639-2/B language code or text to be preprocessed.
-   * The preprocessing can convert from ISO 639-1, ISO 639-2/B and ISO 639-2/T codes or a full
-   * english name string to ISO-639-2/B.
-   * \param[in] proc processing type
-   * \return success of the preprocessing
+   * \brief Set the original audio language, with optional conversion.
+   * \param[in] language The original language.
+   * \param[in] type The language tag type.
+   *            For 'type' TYPE_ANY, the function will attempt to guess the encoding of 'language'
+   *            and recognizes ISO 639-1, ISO 639-2, BCP47 tags, and English names
+   * \return success of the conversion
    */
-  bool SetOriginalLanguage(std::string language, LanguageProcessing proc);
+  bool SetOriginalLanguage(std::string language, LanguageTagSource source);
   void SetEpisodeGuide(std::string episodeGuide);
   void SetStatus(std::string status);
   void SetProductionCode(std::string productionCode);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Implement a BCP 47 language tags parser with full support of RFC5646, a fast path for tags made up of the language subtag only (ex: en, ara), and convert a few code paths to use the new functionality.

### Language descriptions

The English language description displayed for subtitles and audio tracks now supports bcp47 language tags and mimicks locale names. It is however limited by the lack of support of the IANA language subtags registry and for now only the recently updated existing ISO639-1/-2 and ISO 3166-1 support is used to convert languages and regions to their English names.

For example:
- en-AU => English (Australia) (en is ISO 639-1 and AU is ISO 3166-1)
- es-419 => Spanish (419) (es is ISO 639-1, 419 is M.49 and requires the registry)
- zh-yue-Hant-HK => Chinese (yue Hant Hong Kong) (extlang yue and script Hant require the registry)
- yue-HK => yue (Hong Kong) (yue is ISO 639-3 and requires the registry)

As was already happening before the PR, user languages defined in as.xml or language addons take precedence and provide "friendlier" names.

### External subtitles / audio tracks

Modified the parsing of external subtitles /audio tracks to accept bcp47 language tags in the filename. The - separators have to be replaced with _ since - is already a segment separator for filenames. For example:
Big.Buck.Bunny.forced.**en_AU**.srt

### Movies and TV Shows original language

The original language scraped or imported from nfo is now stored as BCP47 in the video db. Existing entries were converted from ISO 639-2/B to BCP47 by a DB bump.

The original language field was missed in a couple places of the VideoInfoTag when it was added and this is now corrected.


### Other support of BCP47 in media

There is nothing to change for InputStream as far as I can tell, it already forwards bcp47 language tags to core and benefits from the improved conversion to English language names of the PR.

Internal tracks of file-based media are problematic due to missing support of BCP47 in ffmpeg, at least for mkv (mp4 seems problematic as well).
The workaround of entering the language tag in the track name, surrounded by curly braces, was upgraded to the new BCP 47 parser.

### Future PR
- a fast path could be added for language+region or language+script if it is felt necessary, in order to avoid the full blown regexp parsing for common/easy tags
- implement the match algorithms of BCP47 to improve the selection of the best audio or subtitle track to
- implement the IANA language subtags registry for better conversion of BCP47 to English and for validation of the tags
- internally store track languages as BCP47 objects instead of string to reduce the amount of parsing
- alternatively implement caching of parsed tags
- what to do about the translation of language names themselves - the registry or ISO norms only contain English names for all subtags

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Many code paths were limited to 3 letter ISO 639-2 codes, not sufficient to express the variety of languages.
BCP 47 is the standard.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added unit tests for everything. All pass.
Confirmed that external subs, mkv, ia have the additional subtags, and that those are translated to English on screen (within limits imposed by lack of support of the IANA language subtags registry.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

more languages recognized without having to define entries in advancedsettings.xml/language codes or requiring language addons to be installed.

## Screenshots (if appropriate):
external subs
<img width="1114" height="516" alt="image" src="https://github.com/user-attachments/assets/ac1e22f2-78d0-4df4-8f4d-70b6d09b4a66" />

inputstream adaptative
<img width="1107" height="800" alt="image" src="https://github.com/user-attachments/assets/e0a97fb5-61f4-48d1-b23d-cb941493a3fa" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
