### PR TITLE
[tools/depends] bootstrap check minimum version of m4 pre-depends

### DIFF
--- a/tools/depends/bootstrap
+++ b/tools/depends/bootstrap
@@ -4,7 +4,16 @@
 # order to bootstrap.
 DEPENDS=`dirname $0`
 export PATH="$DEPENDS/pre-build-deps/bin:$PATH"
-which m4 >/dev/null 2>/dev/null || make -C $DEPENDS/pre-depends/m4-pre-depends
+
+# Source - https://apple.stackexchange.com/a/123408
+# Posted by TJ Luoma, modified by community. See post 'Timeline' for change history
+# Retrieved 2025-11-29, License - CC BY-SA 4.0
+version() { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+
+M4_VERSION=$($(which m4) --version 2>/dev/null | awk 'NR==1{for(i=1;i<=NF;i++){ if($i ~ "[0-9].[0-9].[0-9]"){print $i} } }')
+if [ $(version $M4_VERSION) -lt $(version "1.4.8") ]; then
+  make -C $DEPENDS/pre-depends/m4-pre-depends
+fi
 which autoconf >/dev/null 2>/dev/null || make -C $DEPENDS/pre-depends/autoconf-pre-depends
 which autoconf >/dev/null 2>/dev/null || \
   (echo "autoconf was not found and could not be built. Aborting." && exit 1)


### PR DESCRIPTION
## Description
autoconf 2.7.2 has a minimum version of m4 of 1.4.8. m4 that comes with macos (/usr/bin/m4) currently on macos 26 is

```
% /usr/bin/m4 --version
GNU M4 1.4.6
```
## Motivation and context
Fix apple CI failures after #27528 merge.

## How has this been tested?
Locally testing cases with/without existing m4, and checking the build path correctly runs, or not, when expected.

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
