### PR TITLE
webOS: transcode to DD+ instead of DD if eARC supported and enabled

### DIFF
--- a/xbmc/platform/linux/PlatformWebOS.cpp
+++ b/xbmc/platform/linux/PlatformWebOS.cpp
@@ -73,6 +73,7 @@ bool CPlatformWebOS::InitStageTwo()
     CLog::Log(LOGERROR, "Failed to disable core dumps");
 
   WebOSTVPlatformConfig::Load();
+  WebOSTVPlatformConfig::LoadARCStatus();
   return CPlatformLinux::InitStageTwo();
 }
 

--- a/xbmc/platform/linux/WebOSTVPlatformConfig.h
+++ b/xbmc/platform/linux/WebOSTVPlatformConfig.h
@@ -8,13 +8,29 @@
 
 #pragma once
 
+#include <atomic>
+#include <memory>
+
+#include <webos-helpers/libhelpers.h>
+
 class CVariant;
+
+struct HContextDeleter
+{
+  void operator()(HContext* ctx) const noexcept { HUnregisterServiceCallback(ctx); }
+};
 
 class WebOSTVPlatformConfig
 {
+private:
+  static inline std::unique_ptr<HContext, HContextDeleter> m_requestContextARC{new HContext{}};
+  static inline std::atomic<bool> m_eAC3Supported{false};
+
 public:
   static void Load();
+  static void LoadARCStatus();
   static int GetWebOSVersion();
   static bool SupportsDTS();
   static bool SupportsHDR();
+  static bool SupportsEAC3();
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
LG webOS does not allow  internal apps to passthrough Dolby TrueHD audio to an A/V amp. At the moment we transcode to AC3.

Instead lets have the option to transcode to E-AC3 and use Dolby Digital Plus for higher quality and (maybe more) channels.

## How has this been tested?
LG G4 OLED - webOS 10
Denon X2700H 5.1 surround connected via HDMI 2 (eARC).

Playback of kodi samples:
DD+ - Birds of Prey -> DD 5.1+ activated on A/V amp
DD - Big buck bunny -> DD activated on A/V amp

## What is the effect on users?
Users might experience higher quality audio output when playback of Dolby TrueHD files.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
