### PR TITLE
[Video] Fix repetitive calls to UpdateFileItemStreamDetails().

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
@@ -152,7 +152,7 @@ void ProcessMenuPlaylists(std::vector<CDVDInputStream::PlaylistInformation>& pla
 }
 } // namespace
 
-CDVDInputStream::UpdateState CDVDInputStream::UpdatePlaylistDetails(
+CDVDInputStream::UpdateState CDVDInputStream::UpdateItemFromPlaylistDetails(
     DVDStreamType type,
     std::vector<PlaylistInformation>& playedPlaylists,
     CFileItem& item,

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
@@ -75,8 +75,10 @@ void CDVDInputStream::SavePlaylistDetails(std::vector<PlaylistInformation>& play
   {
     // Update last playlist entry
     auto& lastPlaylist = playedPlaylists.back();
+
+    assert(lastPlaylist.duration == currentPlaylistInformation.duration); // Should be the same
+
     lastPlaylist.watchedTime += watchedTime;
-    lastPlaylist.duration = currentPlaylistInformation.duration;
     lastPlaylist.details = currentPlaylistInformation.details;
     CLog::LogFC(LOGDEBUG, LOGBLURAY, "Updated playlist/title {} - watched time {} seconds",
                 currentPlaylistInformation.playlist, lastPlaylist.watchedTime.count() / 1000);

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -217,12 +217,24 @@ public:
     NOT_PLAYED
   };
 
+  /*!
+  \brief Saves the current state of the current stream (including stream details)
+  \param details streamdetails of the current playing stream
+  */
   virtual void SaveCurrentState(const CStreamDetails& details) {}
-  virtual UpdateState UpdateCurrentState(CFileItem& item, double time, bool& closed)
+
+  /*!
+  \brief Updates the given fileitem with the state and streamdetails of what is decided to be the main (ie. main movie) title
+  \param item fileitem to update
+  \param time current playback time
+  \param closed sets closed to indicate if the stream was closed (=true) (ie. playback stopped before end) or finished (=false)
+  \returns an UpdateState flag indicating if no main title was played (=NOT_PLAYED), the main title was played completely (=FINISHED) 
+  \        or no update needs to be made to the VideoPlayer state (=NONE)
+  */
+  virtual UpdateState UpdateItemFromSavedStates(CFileItem& item, double time, bool& closed)
   {
     return UpdateState::NONE;
   }
-  virtual void UpdateStack(CFileItem& item) {}
 
   struct PlaylistInformation
   {
@@ -234,15 +246,35 @@ public:
     CStreamDetails details;
   };
 
+  /*!
+  \brief Function shared with DVDInputStreamBluray (for Blurays) and DVDInputStreamNavigator (for DVDs) to save playlist/title details
+  \param playedPlaylists vector of played playlists/titles to update
+  \param startTime a time point indicating when playback started (used to calculate the actual time a playlist/title was played for)
+  \param currentPlaylistInformation information about the current playlist/title being played
+  */
   static void SavePlaylistDetails(std::vector<PlaylistInformation>& playedPlaylists,
                                   std::chrono::steady_clock::time_point startTime,
                                   const PlaylistInformation& currentPlaylistInformation);
 
-  static UpdateState UpdatePlaylistDetails(DVDStreamType type,
-                                           std::vector<PlaylistInformation>& playedPlaylists,
-                                           CFileItem& item,
-                                           double time,
-                                           bool& closed);
+  /*!
+  \brief Function shared with DVDInputStreamBluray (for Blurays) and DVDInputStreamNavigator (for DVDs) to updates the given fileitem with 
+  \      the state and streamdetails of what is decided to be the main (ie. main movie) title
+  \param type playback type (DVD or Bluray)
+  \param playedPlaylists vector of played playlists/titles
+  \param item fileitem to update
+  \param time current playback time
+  \param closed sets closed to indicate if the stream was closed (=true) (ie. playback stopped before end) or finished (=false)
+  \returns an UpdateState flag indicating if no main title was played (=NOT_PLAYED), the main title was played completely (=FINISHED) 
+  \        or no update needs to be made (=NONE)
+  */
+  static UpdateState UpdateItemFromPlaylistDetails(
+      DVDStreamType type,
+      std::vector<PlaylistInformation>& playedPlaylists,
+      CFileItem& item,
+      double time,
+      bool& closed);
+
+  virtual void UpdateStack(CFileItem& item) {}
 
   static void UpdateStackItem(CFileItem& item, std::chrono::milliseconds length);
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -1347,9 +1347,9 @@ void CDVDInputStreamBluray::SaveCurrentState(const CStreamDetails& details)
   m_startWatchTime = std::chrono::steady_clock::now();
 }
 
-CDVDInputStream::UpdateState CDVDInputStreamBluray::UpdateCurrentState(CFileItem& item,
-                                                                       double time,
-                                                                       bool& closed)
+CDVDInputStream::UpdateState CDVDInputStreamBluray::UpdateItemFromSavedStates(CFileItem& item,
+                                                                              double time,
+                                                                              bool& closed)
 {
   std::unique_lock lock(m_statesLock);
 
@@ -1357,7 +1357,8 @@ CDVDInputStream::UpdateState CDVDInputStreamBluray::UpdateCurrentState(CFileItem
   if (item.HasVideoInfoTag())
     SaveCurrentState(item.GetVideoInfoTag()->m_streamDetails);
 
-  return UpdatePlaylistDetails(DVDSTREAM_TYPE_BLURAY, m_playedPlaylists, item, time, closed);
+  return UpdateItemFromPlaylistDetails(DVDSTREAM_TYPE_BLURAY, m_playedPlaylists, item, time,
+                                       closed);
 }
 
 void CDVDInputStreamBluray::UpdateStack(CFileItem& item)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -141,7 +141,7 @@ public:
   void ProcessEvent();
 
   void SaveCurrentState(const CStreamDetails& details) override;
-  UpdateState UpdateCurrentState(CFileItem& item, double time, bool& closed) override;
+  UpdateState UpdateItemFromSavedStates(CFileItem& item, double time, bool& closed) override;
   void UpdateStack(CFileItem& item) override;
 
 protected:

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -1593,9 +1593,9 @@ void CDVDInputStreamNavigator::SaveCurrentState(const CStreamDetails& details)
   m_startWatchTime = std::chrono::steady_clock::now();
 }
 
-CDVDInputStream::UpdateState CDVDInputStreamNavigator::UpdateCurrentState(CFileItem& item,
-                                                                          double time,
-                                                                          bool& closed)
+CDVDInputStream::UpdateState CDVDInputStreamNavigator::UpdateItemFromSavedStates(CFileItem& item,
+                                                                                 double time,
+                                                                                 bool& closed)
 {
   std::unique_lock lock(m_statesLock);
 
@@ -1603,7 +1603,7 @@ CDVDInputStream::UpdateState CDVDInputStreamNavigator::UpdateCurrentState(CFileI
   if (item.HasVideoInfoTag())
     SaveCurrentState(item.GetVideoInfoTag()->m_streamDetails);
 
-  return UpdatePlaylistDetails(DVDSTREAM_TYPE_DVD, m_playedPlaylists, item, time, closed);
+  return UpdateItemFromPlaylistDetails(DVDSTREAM_TYPE_DVD, m_playedPlaylists, item, time, closed);
 }
 
 void CDVDInputStreamNavigator::UpdateStack(CFileItem& item)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -146,7 +146,7 @@ public:
   VideoStreamInfo GetVideoStreamInfo();
 
   void SaveCurrentState(const CStreamDetails& details) override;
-  UpdateState UpdateCurrentState(CFileItem& item, double time, bool& closed) override;
+  UpdateState UpdateItemFromSavedStates(CFileItem& item, double time, bool& closed) override;
   void UpdateStack(CFileItem& item) override;
 
 protected:

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -980,6 +980,14 @@ bool CVideoPlayer::OpenDemuxStream()
 
   m_offset_pts = 0;
 
+  if (m_updateStreamDetails)
+  {
+    CFileItem item;
+    UpdateFileItemStreamDetails(item, UpdateStreamDetails::ALWAYS_UPDATE);
+    if (item.HasVideoInfoTag())
+      m_pInputStream->SaveCurrentState(item.GetVideoInfoTag()->m_streamDetails);
+  }
+
   return true;
 }
 
@@ -5221,12 +5229,6 @@ void CVideoPlayer::UpdatePlayState(double timeout)
   }
 
   m_processInfo->SetPlayTimes(state.startTime, state.time, state.timeMin, state.timeMax);
-
-  // Save state of the current stream (for blurays/DVDs)
-  CFileItem item;
-  UpdateFileItemStreamDetails(item, UpdateStreamDetails::ALWAYS_UPDATE);
-  if (item.HasVideoInfoTag())
-    m_pInputStream->SaveCurrentState(item.GetVideoInfoTag()->m_streamDetails);
 
   std::unique_lock lock(m_StateSection);
   m_State = state;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -33,7 +33,6 @@
 #include "VideoPlayerRadioRDS.h"
 #include "VideoPlayerVideo.h"
 #include "application/Application.h"
-#include "application/ApplicationStackHelper.h"
 #include "cores/DataCacheCore.h"
 #include "cores/EdlEdit.h"
 #include "cores/FFmpeg.h"
@@ -748,7 +747,6 @@ CVideoPlayer::CVideoPlayer(IPlayerCallback& callback)
   m_caching = CACHESTATE_DONE;
   m_HasVideo = false;
   m_HasAudio = false;
-  m_UpdateStreamDetails = false;
 
   const int tenthsSeconds = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
       CSettings::SETTING_VIDEOPLAYER_QUEUETIMESIZE);
@@ -2697,7 +2695,6 @@ void CVideoPlayer::OnExit()
       m_State.Clear();
       break;
     case NONE:
-    default:
       break;
   }
 
@@ -3291,7 +3288,7 @@ void CVideoPlayer::HandleMessages()
       m_bAbortRequest = true;
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_SET_UPDATE_STREAM_DETAILS))
-      m_UpdateStreamDetails = true;
+      m_updateStreamDetails = true;
   }
 }
 
@@ -5433,13 +5430,13 @@ void CVideoPlayer::UpdateFileItemStreamDetails(CFileItem& item, UpdateStreamDeta
 {
   if (update == UpdateStreamDetails::UPDATE_IF_FLAGGED)
   {
-    if (!m_UpdateStreamDetails)
+    if (!m_updateStreamDetails)
       return;
 
     // For blurays
     item.SetProperty("update_stream_details", true);
 
-    m_UpdateStreamDetails = false;
+    m_updateStreamDetails = false;
   }
 
   CLog::Log(LOGDEBUG, "CVideoPlayer: updating file item stream details with available streams");

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2686,7 +2686,7 @@ void CVideoPlayer::OnExit()
   // For other input streams no action is taken (as NONE is returned by the default virtual function)
   constexpr double STREAM_FINISHED{std::numeric_limits<double>::max()};
   const CDVDInputStream::UpdateState updateState{
-      m_pInputStream->UpdateCurrentState(fileItem, m_State.time, m_bCloseRequest)};
+      m_pInputStream->UpdateItemFromSavedStates(fileItem, m_State.time, m_bCloseRequest)};
   switch (updateState)
   {
     using enum CDVDInputStream::UpdateState;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -600,7 +600,7 @@ protected:
   bool m_HasVideo;
   bool m_HasAudio;
 
-  bool m_UpdateStreamDetails;
+  bool m_updateStreamDetails{false};
 
   std::atomic<bool> m_displayLost;
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Inform VideoPlayer whenever a title/playlist is changed so that the streamdetails can be saved (for discs played through disc menu - eg. all DVDs currently and by choice for blurays). 

Once streamdetails are saved then stop calling UpdateFileItemStreamDetails().

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #27533.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally playing a bluray and DVD through the disc menu and confirming correct main title playlist and associated streamdetails are saved.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
