### PR TITLE
[cmake] Fix double installation of TexturePacker

### DIFF
--- a/cmake/modules/buildtools/FindTexturePacker.cmake
+++ b/cmake/modules/buildtools/FindTexturePacker.cmake
@@ -82,8 +82,7 @@ if(NOT TARGET TexturePacker::TexturePacker::Executable)
                      "-DCMAKE_OBJDUMP=${CMAKE_OBJDUMP}"
                      "-DCMAKE_RANLIB=${CMAKE_RANLIB}"
                      "-DDEPENDS_PATH=${DEPENDS_PATH}"
-                     -DKODI_SOURCE_DIR=${CMAKE_SOURCE_DIR}
-                     -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/build)
+                     -DKODI_SOURCE_DIR=${CMAKE_SOURCE_DIR})
 
       # Create a list with an alternate separator e.g. pipe symbol
       string(REPLACE ";" "|" string_ARCH_DEFINES "${ARCH_DEFINES}")
@@ -110,15 +109,14 @@ if(NOT TARGET TexturePacker::TexturePacker::Executable)
                           SOURCE_DIR ${CMAKE_SOURCE_DIR}/tools/depends/native/TexturePacker/src
                           PREFIX ${CORE_BUILD_DIR}/build-texturepacker
                           LIST_SEPARATOR |
-                          INSTALL_DIR ${CMAKE_BINARY_DIR}/build
+                          INSTALL_COMMAND ""
                           CMAKE_ARGS ${CMAKE_ARGS}
                           BUILD_ALWAYS ON
-                          BUILD_BYPRODUCTS ${CMAKE_BINARY_DIR}/build/bin/TexturePacker)
+                          BUILD_BYPRODUCTS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/build-texturepacker/src/buildtexturepacker-build/TexturePacker)
 
-      ExternalProject_Get_Property(buildtexturepacker INSTALL_DIR)
       add_executable(TexturePacker IMPORTED)
       set_target_properties(TexturePacker PROPERTIES
-                                          IMPORTED_LOCATION "${INSTALL_DIR}/bin/TexturePacker")
+                                          IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/build-texturepacker/src/buildtexturepacker-build/TexturePacker")
 
       add_dependencies(TexturePacker buildtexturepacker)
 


### PR DESCRIPTION
## Description

There is no need for FindTexturePacker.cmake to install TexturePacker. This change stubs the install command, runs TexturePacker from its build location, and the wider Kodi installation sources it from there.

## Motivation and context

TexturePacker is being installed twice, but this is only noticeable when installing Kodi with DESTDIR, which is common in distributions. The copy installed by FindTexturePacker.cmake normally gets reinstalled in place, but with DESTDIR applied, it lands under /path/to/destdir/path/to/build.

## How has this been tested?

This has been tested by myself and others on Gentoo Linux using its (live master) Kodi package. I have tested both a native build and a cross build. See gentoo/gentoo#44433.

## What is the effect on users?

Probably only noticeable to distributions. If they were working around this by deleting the extra copy, they will no longer need to.

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed