### PR TITLE
[cmake] FindFFMPEG

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -314,7 +314,7 @@ else()
 
       # ToDo: We cant use IMPORTED_TARGET yet.
       # Linux CI fails with gmp related link issues when using the imported target
-      pkg_check_modules(FFMPEG_${libname_UPPER} ${libname}${libversion} REQUIRED ${SEARCH_QUIET})
+      pkg_check_modules(FFMPEG_${libname_UPPER} ${libname}${libversion} ${SEARCH_QUIET})
 
       # As windows does a simple find_library call, the output is a filename to the library
       # for the pkgconfig search, we can get the full file path from _LINK_LIBRARIES first element

--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -30,8 +30,15 @@ macro(buildFFMPEG)
   include(cmake/scripts/common/ModuleHelpers.cmake)
 
   # Check for dependencies - Must be done before SETUP_BUILD_VARS
-  get_libversion_data("dav1d" "target")
-  find_package(Dav1d ${LIB_DAV1D_VER} MODULE ${SEARCH_QUIET})
+  if(KODI_DEPENDSBUILD OR (WIN32 OR WINDOWS_STORE))
+    get_libversion_data("dav1d" "target")
+    set(DAV1D_REQUIRED REQUIRED)
+  else()
+    # FFMPEG 7+ currently only has a version requirement of Dav1d 1.0.0
+    set(LIB_DAV1D_VER 1.0.0)
+  endif()
+
+  find_package(Dav1d ${LIB_DAV1D_VER} ${DAV1D_REQUIRED} ${SEARCH_QUIET})
   if(NOT TARGET LIBRARY::Dav1d)
     message(STATUS "dav1d not found, internal ffmpeg build will be missing AV1 support!")
   else()


### PR DESCRIPTION
## Description
Remove search requirement on dav1d when building internal ffmpeg
Remove REQUIRE when searching for ffmpeg libs

## Motivation and context
Enable a user to build internal ffmpeg, but use a system dav1d without using internal dav1d

## How has this been tested?
@howie-f 

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
