### PR TITLE
[linux] Implement custom PowerSyscall class.

### DIFF
--- a/xbmc/platform/linux/powermanagement/CMakeLists.txt
+++ b/xbmc/platform/linux/powermanagement/CMakeLists.txt
@@ -1,6 +1,8 @@
-set(SOURCES LinuxPowerSyscall.cpp)
+set(SOURCES CustomPowerSyscall.cpp
+            LinuxPowerSyscall.cpp)
 
-set(HEADERS FallbackPowerSyscall.h
+set(HEADERS CustomPowerSyscall.h
+            FallbackPowerSyscall.h
             LinuxPowerSyscall.h)
 
 if(TARGET ${APP_NAME_LC}::DBus)

--- a/xbmc/platform/linux/powermanagement/CustomPowerSyscall.cpp
+++ b/xbmc/platform/linux/powermanagement/CustomPowerSyscall.cpp
@@ -1,0 +1,142 @@
+/*
+ *  Copyright (C) 2005-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "CustomPowerSyscall.h"
+
+#include "ServiceBroker.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
+#include "utils/log.h"
+
+#include <cstdlib>
+
+#include <sys/wait.h>
+
+CCustomPowerSyscall::CCustomPowerSyscall()
+{
+  CLog::Log(LOGINFO, "Selected Custom as PowerSyscall");
+
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+  if (settings)
+  {
+    m_powerdownCommand = settings->m_powerdownCommand;
+    m_rebootCommand = settings->m_rebootCommand;
+    m_suspendCommand = settings->m_suspendCommand;
+    m_hibernateCommand = settings->m_hibernateCommand;
+  }
+  else
+  {
+    CLog::Log(LOGWARNING, "CCustomPowerSyscall: Could not get settings component");
+  }
+
+  if (!m_powerdownCommand.empty())
+  {
+    CLog::Log(LOGINFO, "CCustomPowerSyscall: Powerdown command: {}", m_powerdownCommand);
+  }
+
+  if (!m_rebootCommand.empty())
+  {
+    CLog::Log(LOGINFO, "CCustomPowerSyscall: Reboot command: {}", m_rebootCommand);
+  }
+
+  if (!m_suspendCommand.empty())
+  {
+    CLog::Log(LOGINFO, "CCustomPowerSyscall: Suspend command: {}", m_suspendCommand);
+  }
+
+  if (!m_hibernateCommand.empty())
+  {
+    CLog::Log(LOGINFO, "CCustomPowerSyscall: Hibernate command: {}", m_hibernateCommand);
+  }
+}
+
+bool CCustomPowerSyscall::Powerdown()
+{
+  if (m_powerdownCommand.empty())
+    return false;
+
+  CLog::Log(LOGINFO, "CCustomPowerSyscall: Executing powerdown: {}", m_powerdownCommand);
+  return ExecuteCommand(m_powerdownCommand);
+}
+
+bool CCustomPowerSyscall::Reboot()
+{
+  if (m_rebootCommand.empty())
+    return false;
+
+  CLog::Log(LOGINFO, "CCustomPowerSyscall: Executing reboot: {}", m_rebootCommand);
+  return ExecuteCommand(m_rebootCommand);
+}
+
+bool CCustomPowerSyscall::Suspend()
+{
+  if (m_suspendCommand.empty())
+    return false;
+
+  CLog::Log(LOGINFO, "CCustomPowerSyscall: Executing suspend: {}", m_suspendCommand);
+  return ExecuteCommand(m_suspendCommand);
+}
+
+bool CCustomPowerSyscall::Hibernate()
+{
+  if (m_hibernateCommand.empty())
+    return false;
+
+  CLog::Log(LOGINFO, "CCustomPowerSyscall: Executing hibernate: {}", m_hibernateCommand);
+  return ExecuteCommand(m_hibernateCommand);
+}
+
+bool CCustomPowerSyscall::CanPowerdown()
+{
+  return !m_powerdownCommand.empty();
+}
+
+bool CCustomPowerSyscall::CanReboot()
+{
+  return !m_rebootCommand.empty();
+}
+
+bool CCustomPowerSyscall::CanSuspend()
+{
+  return !m_suspendCommand.empty();
+}
+
+bool CCustomPowerSyscall::CanHibernate()
+{
+  return !m_hibernateCommand.empty();
+}
+
+bool CCustomPowerSyscall::HasCustomCommands()
+{
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+  if (settings)
+  {
+    return !settings->m_powerdownCommand.empty() || !settings->m_rebootCommand.empty() ||
+           !settings->m_suspendCommand.empty() || !settings->m_hibernateCommand.empty();
+  }
+
+  return false;
+}
+
+bool CCustomPowerSyscall::ExecuteCommand(const std::string& command)
+{
+  if (command.empty())
+    return false;
+
+  int status = system(command.c_str());
+  if (status == -1)
+    return false;
+
+  if (WEXITSTATUS(status) != 0)
+  {
+    CLog::Log(LOGERROR, "CCustomPowerSyscall: Failed to execute command: {}", command);
+    return false;
+  }
+
+  return true;
+}

--- a/xbmc/platform/linux/powermanagement/CustomPowerSyscall.h
+++ b/xbmc/platform/linux/powermanagement/CustomPowerSyscall.h
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2005-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "powermanagement/IPowerSyscall.h"
+
+#include <string>
+
+class CCustomPowerSyscall : public CPowerSyscallWithoutEvents
+{
+public:
+  CCustomPowerSyscall();
+  ~CCustomPowerSyscall() override = default;
+
+  bool Powerdown() override;
+  bool Suspend() override;
+  bool Hibernate() override;
+  bool Reboot() override;
+
+  bool CanPowerdown() override;
+  bool CanSuspend() override;
+  bool CanHibernate() override;
+  bool CanReboot() override;
+
+  int BatteryLevel() override { return 0; }
+
+  static bool HasCustomCommands();
+
+private:
+  std::string m_powerdownCommand;
+  std::string m_rebootCommand;
+  std::string m_suspendCommand;
+  std::string m_hibernateCommand;
+
+  static bool ExecuteCommand(const std::string& command);
+};

--- a/xbmc/platform/linux/powermanagement/LinuxPowerSyscall.cpp
+++ b/xbmc/platform/linux/powermanagement/LinuxPowerSyscall.cpp
@@ -7,6 +7,8 @@
  */
 
 #include "LinuxPowerSyscall.h"
+
+#include "CustomPowerSyscall.h"
 #include "FallbackPowerSyscall.h"
 #if defined(HAS_DBUS)
 #include "ConsoleUPowerSyscall.h"
@@ -27,16 +29,13 @@ IPowerSyscall* CLinuxPowerSyscall::CreateInstance()
   int bestCount = -1;
   int currCount = -1;
 
-  std::list< std::pair< std::function<bool()>,
-                        std::function<IPowerSyscall*()> > > powerManagers =
-  {
-    std::make_pair(CConsoleUPowerSyscall::HasConsoleKitAndUPower,
-                   [] { return new CConsoleUPowerSyscall(); }),
-    std::make_pair(CLogindUPowerSyscall::HasLogind,
-                   [] { return new CLogindUPowerSyscall(); }),
-    std::make_pair(CUPowerSyscall::HasUPower,
-                   [] { return new CUPowerSyscall(); })
-  };
+  std::list<std::pair<std::function<bool()>, std::function<IPowerSyscall*()>>> powerManagers = {
+      std::make_pair(CConsoleUPowerSyscall::HasConsoleKitAndUPower,
+                     [] { return new CConsoleUPowerSyscall(); }),
+      std::make_pair(CLogindUPowerSyscall::HasLogind, [] { return new CLogindUPowerSyscall(); }),
+      std::make_pair(CUPowerSyscall::HasUPower, [] { return new CUPowerSyscall(); }),
+      std::make_pair(CCustomPowerSyscall::HasCustomCommands,
+                     [] { return new CCustomPowerSyscall(); })};
   for(const auto& powerManager : powerManagers)
   {
     if (powerManager.first())
@@ -54,9 +53,13 @@ IPowerSyscall* CLinuxPowerSyscall::CreateInstance()
   }
   if (bestPowerManager)
     return bestPowerManager.release();
-  else
 #endif // HAS_DBUS
-    return new CFallbackPowerSyscall();
+
+  // Try CustomPowerSyscall as a fallback before the do-nothing FallbackPowerSyscall
+  if (CCustomPowerSyscall::HasCustomCommands())
+    return new CCustomPowerSyscall();
+
+  return new CFallbackPowerSyscall();
 }
 
 void CLinuxPowerSyscall::Register()

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -434,6 +434,11 @@ void CAdvancedSettings::Initialize()
 
   m_cpuTempCmd = "";
   m_gpuTempCmd = "";
+
+  m_powerdownCommand = "";
+  m_rebootCommand = "";
+  m_suspendCommand = "";
+  m_hibernateCommand = "";
 #if defined(TARGET_DARWIN)
   // default for osx is fullscreen always on top
   m_alwaysOnTop = true;
@@ -1172,6 +1177,15 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 
   XMLUtils::GetString(pRootElement, "cputempcommand", m_cpuTempCmd);
   XMLUtils::GetString(pRootElement, "gputempcommand", m_gpuTempCmd);
+
+  const TiXmlElement* pPowerManagement = pRootElement->FirstChildElement("powermanagement");
+  if (pPowerManagement)
+  {
+    XMLUtils::GetString(pPowerManagement, "powerdown", m_powerdownCommand);
+    XMLUtils::GetString(pPowerManagement, "reboot", m_rebootCommand);
+    XMLUtils::GetString(pPowerManagement, "suspend", m_suspendCommand);
+    XMLUtils::GetString(pPowerManagement, "hibernate", m_hibernateCommand);
+  }
 
   XMLUtils::GetBoolean(pRootElement, "alwaysontop", m_alwaysOnTop);
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -327,6 +327,12 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::string m_cpuTempCmd;
     std::string m_gpuTempCmd;
 
+    /* Power management command overrides */
+    std::string m_powerdownCommand;
+    std::string m_rebootCommand;
+    std::string m_suspendCommand;
+    std::string m_hibernateCommand;
+
     /* PVR/TV related advanced settings */
     int m_iPVRTimeCorrection;     /*!< @brief correct all times (epg tags, timer tags, recording tags) by this amount of minutes. defaults to 0. */
     int m_iPVRInfoToggleInterval; /*!< @brief if there are more than 1 pvr gui info item available (e.g. multiple recordings active at the same time), use this toggle delay in milliseconds. defaults to 3000. */


### PR DESCRIPTION
Fix for systems without (e)logind, which have no way to run power management operations via Kodi.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

a new `PowerSyscall` class implementation for linux systems which run without `(e)logind` allowing such systems to reboot, powerdown, suspend, and hibernate from `kodi` by adding custom commands to `advancedsettings.xml`, like so:

```xml
<advancedsettings version="1.0">
  <powermanagement>
    <powerdown>sudo poweroff</powerdown>
    <reboot>sudo reboot</reboot>
    <suspend>sudo zzz</suspend>
    <hibernate>sudo ZZZ</hibernate>
  </powermanagement>
</advancedsettings>
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

in 2025 it is entirely possible to run a linux system without `(e)logind` thanks to the great `seatd` project - it would be great if those systems could issue power commands (like reboot) from `kodi`

resolves #26825

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

i built and tested this code against `kodi` version `21.3`, as well as version `22.0a2`

testing involved running `kodi` with and without configuration in `advancedsettings.xml` and ensuring functionality worked as expected + no regressions in other power syscall classes being selected + carefully reviewing the logs provided by `kodi`

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

this change only impacts users who opt-in by adding configuration to their `advancedsettings.xml` - it will allow users to specify commands that `kodi` should run when power operations are selected from the menu

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
