### PR TITLE
Fix `ValidateField` to correctly detect invalid characters as per issue #26044.

### DIFF
--- a/lib/libUPnP/Platinum/Source/Core/PltProtocolInfo.cpp
+++ b/lib/libUPnP/Platinum/Source/Core/PltProtocolInfo.cpp
@@ -227,16 +227,27 @@ PLT_ProtocolInfo::ValidateField(const char*  val,
     if (num_chars && NPT_StringLength(val) != num_chars)
         return NPT_ERROR_INVALID_SYNTAX;
 
-    while (val) {
-        char c = *val++;
-        if (c == '\0') return NPT_SUCCESS;
+    while (val)
+    {
+        const char c = *val;
+        if (c == '\0')
+        {
+            return NPT_SUCCESS;
+        }
+        ++val;
 
         // look for character in valid chars
         const char* p = valid_chars;
-        while (*p != c && ++p) {};
+        while ((*p != c) && (*p != '\0'))
+        {
+            ++p;
+        }
 
         // reached end of valid chars means we didn't find it
-        if (!p) break;
+        if (*p == '\0')
+        {
+            break;
+        }
     }
 
     return NPT_ERROR_INVALID_SYNTAX;

--- a/lib/libUPnP/patches/0057-neptune-Fix-PLT_ProtocolInfo-ValidateField.patch
+++ b/lib/libUPnP/patches/0057-neptune-Fix-PLT_ProtocolInfo-ValidateField.patch
@@ -1,0 +1,37 @@
+diff --git a/lib/libUPnP/Platinum/Source/Core/PltProtocolInfo.cpp b/lib/libUPnP/Platinum/Source/Core/PltProtocolInfo.cpp
+index d22dc02bcf..d49bcec4e7 100644
+--- a/lib/libUPnP/Platinum/Source/Core/PltProtocolInfo.cpp
++++ b/lib/libUPnP/Platinum/Source/Core/PltProtocolInfo.cpp
+@@ -227,16 +227,27 @@ PLT_ProtocolInfo::ValidateField(const char*  val,
+     if (num_chars && NPT_StringLength(val) != num_chars)
+         return NPT_ERROR_INVALID_SYNTAX;
+ 
+-    while (val) {
+-        char c = *val++;
+-        if (c == '\0') return NPT_SUCCESS;
++    while (val)
++    {
++        const char c = *val;
++        if (c == '\0')
++        {
++            return NPT_SUCCESS;
++        }
++        ++val;
+ 
+         // look for character in valid chars
+         const char* p = valid_chars;
+-        while (*p != c && ++p) {};
++        while ((*p != c) && (*p != '\0'))
++        {
++            ++p;
++        }
+ 
+         // reached end of valid chars means we didn't find it
+-        if (!p) break;
++        if (*p == '\0')
++        {
++            break;
++        }
+     }
+ 
+     return NPT_ERROR_INVALID_SYNTAX;


### PR DESCRIPTION

## Description
As the code was, if there were no matching character, the inner while loop runs past the end of valid_chars until by chance it encounters a matching character elsewhere.

## Motivation and context
Issue #26044 

## How has this been tested?
N/A

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
