### PR TITLE
[cmake] FindFFMPEG.cmake: deprecate use of WITH_FFMPEG

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -267,6 +267,7 @@ else()
 endif()
 
 if(WITH_FFMPEG)
+  message(DEPRECATION "WITH_FFMPEG is deprecated. Please use FFMPEG_PATH instead.")
   set(FFMPEG_PATH ${WITH_FFMPEG})
 endif()
 

--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -12,10 +12,7 @@
 # FFMPEG_PATH - use external ffmpeg not found in system paths
 #               usage: -DFFMPEG_PATH=/path/to/ffmpeg_install_prefix
 #
-# WITH_FFMPEG - use external ffmpeg not found in system paths
-#               WARNING: this option is for developers as it will _disable ffmpeg version checks_!
-#               Consider using FFMPEG_PATH instead, which _does_ check library versions
-#               usage: -DWITH_FFMPEG=/path/to/ffmpeg_install_prefix
+# WITH_FFMPEG - use external ffmpeg not found in system paths (deprecated)
 #
 # --------
 # This will define the following target:
@@ -245,36 +242,32 @@ macro(buildFFMPEG)
 endmacro()
 
 
-# Allows building with external ffmpeg not found in system paths,
-# without library version checks
+# We track multiple versions due to API changes. For dependsbuild or windows, we always
+# have latest version to properly track rebuiling.
+if(KODI_DEPENDSBUILD OR (WIN32 OR WINDOWS_STORE))
+  # required ffmpeg library versions - tools/depends/target/ffmpeg versions
+  set(REQUIRED_FFMPEG_VERSION 8.0.1)
+  set(_avutil_ver "=60.8.100")
+  set(_avcodec_ver "=62.11.100")
+  set(_avformat_ver "=62.3.100")
+  set(_avfilter_ver "=11.4.100")
+  set(_swscale_ver "=9.1.100")
+  set(_swresample_ver "=6.1.100")
+  set(_postproc_ver "=59.1.100")
+else()
+  # required ffmpeg library versions - minimum supported API compat versions
+  set(REQUIRED_FFMPEG_VERSION 7.0.0)
+  set(_avutil_ver ">=59.8.100")
+  set(_avcodec_ver ">=61.3.100")
+  set(_avformat_ver ">=61.1.100")
+  set(_avfilter_ver ">=10.1.100")
+  set(_swscale_ver ">=8.1.100")
+  set(_swresample_ver ">=5.1.100")
+  set(_postproc_ver ">=58.1.100")
+endif()
+
 if(WITH_FFMPEG)
   set(FFMPEG_PATH ${WITH_FFMPEG})
-  message(STATUS "Warning: FFmpeg version checking disabled")
-  set(REQUIRED_FFMPEG_VERSION undef)
-else()
-  # We track multiple versions due to API changes. For dependsbuild or windows, we always
-  # have latest version to properly track rebuiling.
-  if(KODI_DEPENDSBUILD OR (WIN32 OR WINDOWS_STORE))
-    # required ffmpeg library versions - tools/depends/target/ffmpeg versions
-    set(REQUIRED_FFMPEG_VERSION 8.0.1)
-    set(_avutil_ver "=60.8.100")
-    set(_avcodec_ver "=62.11.100")
-    set(_avformat_ver "=62.3.100")
-    set(_avfilter_ver "=11.4.100")
-    set(_swscale_ver "=9.1.100")
-    set(_swresample_ver "=6.1.100")
-    set(_postproc_ver "=59.1.100")
-  else()
-    # required ffmpeg library versions - minimum supported API compat versions
-    set(REQUIRED_FFMPEG_VERSION 7.0.0)
-    set(_avutil_ver ">=59.8.100")
-    set(_avcodec_ver ">=61.3.100")
-    set(_avformat_ver ">=61.1.100")
-    set(_avfilter_ver ">=10.1.100")
-    set(_swscale_ver ">=8.1.100")
-    set(_swresample_ver ">=5.1.100")
-    set(_postproc_ver ">=58.1.100")
-  endif()
 endif()
 
 # Allows building with external ffmpeg not found in system paths,


### PR DESCRIPTION
This fixes building using WITH_FFMPEG version and deprecates the old behaviour.

Please use FFMPEG_PATH instead as we now only restrict a minimum ffmpeg version (not an exact version)

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Using `WITH_FFMPEG` doesn't  allow cmake to finish configuration
```
cmake -DENABLE_INTERNAL_FFMPEG=OFF -DWITH_FFMPEG=/home/lukas/ffmpeg-8.0 ..

<snip>

-- Warning: FFmpeg version checking disabled
-- Found PkgConfig: /usr/bin/pkg-config (found version "2.3.0")
CMake Error at cmake/modules/FindFFMPEG.cmake:435 (message):
  Suitable FFmpeg version not found, consider using
  -DENABLE_INTERNAL_FFMPEG=ON
Call Stack (most recent call first):
  cmake/scripts/common/Macros.cmake:378 (find_package)
  cmake/scripts/common/Macros.cmake:390 (find_package_with_ver)
  CMakeLists.txt:290 (core_require_dep)


-- Configuring incomplete, errors occurred!
```

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
