### PR TITLE
[Windows] Fix the ability to detect dav1d version changes to rebuild FFmpeg

### DIFF
--- a/tools/buildsteps/windows/buildhelpers.sh
+++ b/tools/buildsteps/windows/buildhelpers.sh
@@ -184,11 +184,11 @@ PATH_CHANGE_REV_FILENAME=".last_success_revision"
 #params paths to be hashed
 function getBuildHash ()
 {
-  local package="$(extractPackage $3)"
-  local version="$(extractVersion $4)"
+  local ver_dav1d="$(extractVersion $3)"
+  local ver_ffmpeg="$(extractVersion $4)"
   local hashStr
   hashStr="$(git rev-list HEAD --max-count=1  -- $@)"
-  hashStr="$hashStr $@ $version $package"
+  hashStr="$hashStr $@ $ver_ffmpeg $ver_dav1d"
   echo $hashStr
 }
 
@@ -237,15 +237,6 @@ function extractVersion()
   local ver=$(grep "VERSION=" $file | sed 's/VERSION=//g;s/#.*$//g;/^$/d')
 
   echo $ver
-}
-
-function extractPackage()
-{
-  local path="$1"
-  local file="$path/0_package.target-$TRIPLET.list"
-  local package=$(grep '^dav1d-' $file)
-
-  echo $package
 }
 
 function cleanLastSuccess()

--- a/tools/buildsteps/windows/make-mingwlibs.sh
+++ b/tools/buildsteps/windows/make-mingwlibs.sh
@@ -77,7 +77,7 @@ checkfiles() {
 
 buildProcess() {
 export PREFIX=/xbmc/project/BuildDependencies/mingwlibs/$TRIPLET
-if [ "$(pathChanged $PREFIX /xbmc/tools/buildsteps/windows /xbmc/project/BuildDependencies/scripts /xbmc/tools/depends/target/ffmpeg/FFMPEG-VERSION)" == "0" ]; then
+if [ "$(pathChanged $PREFIX /xbmc/tools/buildsteps/windows /xbmc/tools/depends/target/dav1d/DAV1D-VERSION /xbmc/tools/depends/target/ffmpeg/FFMPEG-VERSION)" == "0" ]; then
   return
 fi
 
@@ -110,7 +110,7 @@ echo "--------------------------------------------------------------------------
 echo " compile mingw libs $TRIPLET done..."
 echo "-------------------------------------------------------------------------------"
 
-tagSuccessFulBuild $PREFIX /xbmc/tools/buildsteps/windows /xbmc/project/BuildDependencies/scripts /xbmc/tools/depends/target/ffmpeg/FFMPEG-VERSION
+tagSuccessFulBuild $PREFIX /xbmc/tools/buildsteps/windows /xbmc/tools/depends/target/dav1d/DAV1D-VERSION /xbmc/tools/depends/target/ffmpeg/FFMPEG-VERSION
 }
 
 run_builds() {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
[Windows] Fix the ability to detect dav1d version changes to rebuild FFmpeg (when necessary).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some time ago implemented the detection of dav1d version changes to force rebuild FFmpeg in https://github.com/xbmc/xbmc/pull/26158. Now since the build of dav1d has changed (from pre-built to cmake time) are necessary some changes here.

The change is very simple: 

The version info is read from `/xbmc/tools/depends/target/dav1d/DAV1D-VERSION ` 
instead of `/xbmc/project/BuildDependencies/scripts/0_package.target-ARCH.list`

`extractPackage()` function is not necessary now because is used the same `extractVersion()` used for FFmpeg.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested build Windows x64

The signature of FFmpeg build now is like:

`fb0b15c4dadd57b0cd42b981e6a75c696d4d7f4c /xbmc/project/BuildDependencies/mingwlibs/x64 /xbmc/tools/buildsteps/windows /xbmc/tools/depends/target/dav1d/DAV1D-VERSION /xbmc/tools/depends/target/ffmpeg/FFMPEG-VERSION 8.0.1 1.5.2`

In `.last_success_revision` file

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Detects changes in FFmpeg or dav1d version to trigger rebuild when necessary, even testing unmerged changes locally or if versions not changes but modifications on build scripts.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
