### PR TITLE
DVDVideoCodecDRMPRIME: Fix AV1 playback using v4l2request hwaccel

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -343,7 +343,6 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
     }
   }
 
-  m_pCodecContext->pix_fmt = AV_PIX_FMT_DRM_PRIME;
   m_pCodecContext->opaque = static_cast<void*>(this);
   m_pCodecContext->get_format = GetFormat;
   m_pCodecContext->get_buffer2 = GetBuffer;


### PR DESCRIPTION
## Description

The FFmpeg AV1 decoder, in contrast to decoders for other codecs, only call `ff_get_format()` to initialize a hwaccel when `AVCodecContext.pix_fmt` is set to a `pix_fmt` not supported by the decoder.

Remove the optional initialization of `AVCodecContext.pix_fmt` to fix AV1 playback using v4l2request hwaccel.

## Motivation and context

AV1 videos cannot be decoded using a hwaccel that use `AV_PIX_FMT_DRM_PRIME`.

## How has this been tested?

Using Kodi on LibreELEC and latest [FFmpeg v4l2request PR](https://code.ffmpeg.org/FFmpeg/FFmpeg/pulls/20847) on a Rockchip RK3588 device.

## What is the effect on users?

AV1 videos can be decoded, should not have any significant affect for other codecs.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
