### PR TITLE
[System] Fixes for path manipulation with tests.

### DIFF
--- a/cmake/installdata/test-reference-data.txt
+++ b/cmake/installdata/test-reference-data.txt
@@ -49,6 +49,8 @@ xbmc/video/test/testdata/moviestack_subfolder_parts/Movie_(2001)/part_2/Movie_(2
 xbmc/video/test/testdata/moviestack_subfolder_parts/Movie_(2001)/part_3/Movie_(2001)_part3.mkv
 xbmc/video/test/testdata/moviestack_subfolder_disc_parts/Movie_(2001)/part_1/VIDEO_TS/VIDEO_TS.IFO
 xbmc/video/test/testdata/moviestack_subfolder_disc_parts/Movie_(2001)/part_2/BDMV/index.bdmv
+xbmc/video/test/testdata/moviestack_subfolder_movie/Movie(2001)part1/Movie_(2001)_part1.mkv
+xbmc/video/test/testdata/moviestack_subfolder_movie/Movie(2001)part2/Movie_(2001)_part2.mkv
 xbmc/utils/test/CXBMCTinyXML-test.xml
 xbmc/utils/test/rss.xml
 xbmc/utils/test/data/bluray/BDMV/STREAM/00001.m2ts

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -25,7 +25,6 @@
 #include "games/GameUtils.h"
 #include "games/tags/GameInfoTag.h"
 #include "guilib/LocalizeStrings.h"
-#include "media/MediaLockState.h"
 #include "music/Album.h"
 #include "music/Artist.h"
 #include "music/MusicDatabase.h"
@@ -1958,6 +1957,7 @@ std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
   return strMovieName;
 }
 
+// Used to determine the location of nfo files and artwork
 std::string CFileItem::GetLocalMetadataPath() const
 {
   if (IsFolder() && !IsFileFolder())

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -897,7 +897,8 @@ bool CFileItem::IsFileFolder(FileFolderType types) const
     if (PLAYLIST::IsSmartPlayList(*this) ||
         (PLAYLIST::IsPlayList(*this) &&
          CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_playlistAsFolders) ||
-        IsAPK() || IsZIP() || IsRAR() || IsRSS() || MUSIC::IsAudioBook(*this) ||
+        IsAPK() || IsZIP() || IsRAR() || IsRSS() || URIUtils::IsArchive(GetURL()) ||
+        MUSIC::IsAudioBook(*this) ||
 #if defined(TARGET_ANDROID)
         IsType(".apk") ||
 #endif

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1844,32 +1844,23 @@ std::string CFileItem::FindLocalArt(const std::string &artFile, bool useFolder) 
   return "";
 }
 
-std::string CFileItem::GetMovieName(bool bUseFolderNames /* = false */) const
+std::string CFileItem::GetMovieName(bool bUseFolderNames /* = false */, int depth /* = 0 */) const
 {
   if (IsPlugin() && HasVideoInfoTag() && !GetVideoInfoTag()->m_strTitle.empty())
     return GetVideoInfoTag()->m_strTitle;
-
-  // Deal with special case of files in a 'Disc n' folder etc..
-  if (bUseFolderNames)
-  {
-    const std::string r{URIUtils::GetTrailingPartNumberRegex()};
-    CRegExp regex{true, CRegExp::autoUtf8, r.c_str()};
-    std::string path{URIUtils::GetDirectory(
-        URIUtils::IsBDFile(GetPath()) ? URIUtils::GetDiscBase(GetPath()) : GetPath())};
-    URIUtils::RemoveSlashAtEnd(path);
-    if (regex.RegFind(path) != -1)
-    {
-      std::string moviePath{URIUtils::GetParentPath(path)};
-      URIUtils::RemoveSlashAtEnd(moviePath);
-      return URIUtils::GetFileName(moviePath);
-    }
-  }
 
   if (IsLabelPreformatted())
     return GetLabel();
 
   if (m_pvrRecordingInfoTag)
     return m_pvrRecordingInfoTag->m_strTitle;
+
+  if (depth > 3)
+  {
+    CLog::LogF(LOGERROR, "Depth limit exceeded");
+    return {};
+  }
+
   if (URIUtils::IsPVRRecording(m_strPath))
   {
     const std::string title = CPVRRecording::GetTitleFromURL(m_strPath);
@@ -1879,7 +1870,28 @@ std::string CFileItem::GetMovieName(bool bUseFolderNames /* = false */) const
 
   std::string strMovieName;
   if (URIUtils::IsStack(m_strPath))
-    strMovieName = CStackDirectory::GetStackTitlePath(m_strPath);
+  {
+    strMovieName = CStackDirectory::GetStackTitlePath(m_strPath); // Can be a file or folder
+    if (URIUtils::IsStack(strMovieName))
+    {
+      // Stacks in stacks not supported, avoid infinite loop
+      strMovieName = "";
+      return strMovieName;
+    }
+
+    if (bUseFolderNames || URIUtils::GetFileName(strMovieName).empty())
+    {
+      CFileItem item(URIUtils::GetDirectory(strMovieName), true);
+      strMovieName = item.GetMovieName(true, depth + 1);
+      return strMovieName;
+    }
+    else
+    {
+      CFileItem item(strMovieName, false);
+      strMovieName = item.GetMovieName(false, depth + 1);
+      return strMovieName;
+    }
+  }
   else
     strMovieName = GetBaseMoviePath(bUseFolderNames);
 
@@ -1896,30 +1908,51 @@ std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
 
   if (IsMultiPath())
     strMovieName = CMultiPathDirectory::GetFirstPath(m_strPath);
+  if (strMovieName.empty())
+    return strMovieName;
 
   if (URIUtils::IsBlurayPath(strMovieName))
-    strMovieName = URIUtils::GetDiscBasePath(strMovieName);
+  {
+    strMovieName = bUseFolderNames ? URIUtils::GetDiscBasePath(strMovieName)
+                                   : URIUtils::GetDiscBase(strMovieName);
+  }
+  else if (bUseFolderNames && URIUtils::IsStack(strMovieName))
+  {
+    strMovieName = CStackDirectory::GetBasePath(m_strPath);
+  }
   else if (bUseFolderNames && (!IsFolder() || URIUtils::IsInArchive(m_strPath) ||
                                (HasVideoInfoTag() && GetVideoInfoTag()->m_iDbId > 0 &&
                                 !CMediaTypes::IsContainer(GetVideoInfoTag()->m_type))))
   {
-    std::string name2{strMovieName};
-    URIUtils::GetParentPath(name2, strMovieName);
-    if (URIUtils::IsInArchive(m_strPath))
-    {
-      // Try to get archive itself, if empty take path before
-      name2 = GetURL().GetHostName();
-      if (name2.empty())
-        name2 = strMovieName;
+    const std::string name{strMovieName};
+    URIUtils::GetParentPath(name, strMovieName);
+  }
+  if (strMovieName.empty())
+    return strMovieName;
 
-      URIUtils::GetParentPath(name2, strMovieName);
+  const CURL url{strMovieName};
+  if (URIUtils::IsInArchive(strMovieName) || URIUtils::IsArchive(url))
+  {
+    // Try to get archive itself, if empty take path before
+    std::string name{url.GetHostName()};
+    if (name.empty())
+      name = strMovieName;
+    if (bUseFolderNames)
+    {
+      if (!URIUtils::GetParentPath(name, strMovieName))
+        strMovieName = name;
     }
+    else
+      strMovieName = name;
   }
 
   // Remove any trailing 'Disc n' and disc path (VIDEO_TS or BDMV) to get actual movie title
-  strMovieName = CUtil::RemoveTrailingPartNumberSegmentFromPath(
-      strMovieName,
-      bUseFolderNames ? CUtil::PreserveFileName::REMOVE : CUtil::PreserveFileName::KEEP);
+  if (!URIUtils::IsStack(strMovieName))
+  {
+    strMovieName = CUtil::RemoveTrailingPartNumberSegmentFromPath(
+        strMovieName,
+        bUseFolderNames ? CUtil::PreserveFileName::REMOVE : CUtil::PreserveFileName::KEEP);
+  }
 
   return strMovieName;
 }

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -401,7 +401,7 @@ public:
   std::string GetThumbHideIfUnwatched(const CFileItem* item) const;
 
   // Gets the correct movie title
-  std::string GetMovieName(bool bUseFolderNames = false) const;
+  std::string GetMovieName(bool bUseFolderNames = false, int depth = 0) const;
 
   /*! \brief Find the base movie path (i.e. the item the user expects us to use to lookup the movie)
    For folder items, with "use foldernames for lookups" it returns the folder.

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -415,15 +415,18 @@ void protectIPv6(std::string &hn)
 
 char CURL::GetDirectorySeparator() const
 {
+  if (URIUtils::IsDOSPath(m_strFileName))
+    return '\\';
+  if (URIUtils::IsAbsolutePOSIXPath(m_strFileName))
+    return '/';
 #ifndef TARGET_POSIX
   //We don't want to use IsLocal here, it can return true
   //for network protocols that matches localhost or hostname
   //we only ever want to use \ for win32 local filesystem
-  if ( m_strProtocol.empty() )
+  if (m_strProtocol.empty())
     return '\\';
-  else
 #endif
-    return '/';
+  return '/';
 }
 
 std::string CURL::Get() const

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -25,6 +25,7 @@
 
 #include <array>
 #include <iterator>
+#include <ranges>
 #include <string>
 #include <system_error>
 #include <vector>
@@ -747,27 +748,12 @@ void CURL::RemoveProtocolOption(const std::string &key)
 
 bool CURL::HasExtension(std::string_view extensions) const
 {
-  const size_t pos = m_strFileName.find_last_of("./\\");
-  if (pos == std::string::npos || m_strFileName[pos] != '.')
-    return false;
-
-  const std::string extensionLower{
-      StringUtils::ToLower(std::string_view(m_strFileName).substr(pos))};
-
-  const std::vector<std::string> extensionsLower =
-      StringUtils::Split(StringUtils::ToLower(extensions), '|');
-
-  return std::ranges::any_of(extensionsLower, [&extensionLower](const std::string& ext)
-                             { return StringUtils::EndsWith(ext, extensionLower); });
+  return URIUtils::HasExtension(m_strFileName, extensions);
 }
 
 std::string CURL::GetExtension() const
 {
-  size_t period = m_strFileName.find_last_of("./\\");
-  if (period == std::string::npos || m_strFileName[period] != '.')
-    return std::string();
-
-  return m_strFileName.substr(period);
+  return URIUtils::GetExtension(m_strFileName);
 }
 
 bool CURL::IsStack() const
@@ -884,7 +870,7 @@ bool CURL::IsPicture() const
 bool CURL::HasParentInHostname() const
 {
   return IsProtocol("zip") || IsProtocol("apk") || IsProtocol("bluray") || IsProtocol("udf") ||
-         IsProtocol("iso9660") || IsProtocol("xbt") || IsProtocol("rar") ||
+         IsProtocol("iso9660") || IsProtocol("xbt") || IsProtocol("rar") || IsProtocol("archive") ||
          (CServiceBroker::IsAddonInterfaceUp() &&
           CServiceBroker::GetFileExtensionProvider().EncodedHostName(GetProtocol()));
 }

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1902,6 +1902,7 @@ std::string CUtil::GetFrameworksPath(bool forPython)
   return strFrameworksPath;
 }
 
+// Used to determine external audio and subtitles location and filename
 void CUtil::GetVideoBasePathAndFileName(const std::string& videoPath,
                                         std::string& basePath,
                                         std::string& videoFileName)
@@ -1913,6 +1914,18 @@ void CUtil::GetVideoBasePathAndFileName(const std::string& videoPath,
     CFileItem item(path, false);
     videoFileName = item.GetMovieName();
     basePath = item.GetLocalMetadataPath();
+  }
+  else if (const CURL url{videoPath}; URIUtils::IsArchive(url))
+  {
+    CFileItem item(videoPath, false);
+    videoFileName = item.GetMovieName();
+    basePath = item.GetLocalMetadataPath();
+  }
+  else if (URIUtils::IsStack(videoPath))
+  {
+    CFileItem item(videoPath, false);
+    videoFileName = item.GetMovieName();
+    basePath = URIUtils::GetBasePath(videoPath);
   }
   else
   {

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -403,7 +403,9 @@ std::string GetPartAndRemoveDiscFromPath(std::string& path,
     return {};
 
   path = URIUtils::GetDirectory(path);
-  path = URIUtils::IsDiscPath(path) ? URIUtils::GetDiscBase(path) : path;
+  path = URIUtils::IsDiscPath(path) || URIUtils::IsBlurayPath(path)
+             ? URIUtils::GetDiscBasePath(path)
+             : path;
   std::string basePath{path};
   URIUtils::RemoveSlashAtEnd(basePath);
 

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2460,3 +2460,17 @@ std::string CUtil::GetHexString(const std::span<const uint8_t>& buf, int count)
   std::ranges::for_each(buf, [&](auto x) { ss << static_cast<int>(x); });
   return std::move(ss).str();
 }
+
+bool CUtil::UseDynPathForAddOrUpdate(const CFileItem& item)
+{
+  if (item.IsStack() ||
+      (URIUtils::IsBlurayPath(item.GetDynPath()) &&
+       (item.GetVideoContentType() == VideoDbContentType::MOVIES ||
+        item.GetVideoContentType() == VideoDbContentType::EPISODES ||
+        item.GetVideoContentType() == VideoDbContentType::UNKNOWN /* Removable bluray */)))
+  {
+    return true;
+  }
+
+  return URIUtils::IsArchive(CURL(item.GetDynPath()));
+}

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1086,7 +1086,8 @@ std::string CUtil::ValidatePath(std::string path, bool bFixDoubleSlashes /* = fa
   else if (path.find("://") != std::string::npos || path.find(":\\\\") != std::string::npos)
 #endif
   {
-    StringUtils::Replace(path, '\\', '/');
+    if (!URIUtils::IsDOSPath(path))
+      StringUtils::Replace(path, '\\', '/');
     /* The double slash correction should only be used when *absolutely*
        necessary! This applies to certain DLLs or use from Python DLLs/scripts
        that incorrectly generate double (back) slashes.

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1230,13 +1230,16 @@ int CUtil::GetMatchingSource(const std::string& strPath1,
 
   // stack://
   if (checkURL.IsProtocol("stack"))
-    strPath.erase(0, 8); // remove the stack protocol
+    strPath = CStackDirectory::GetBasePath(checkURL.Get());
 
   // bluray://
   if (checkURL.IsProtocol("bluray"))
     strPath = URIUtils::GetDiscBase(checkURL.Get()); // get the actual path on disc
 
   if (checkURL.IsProtocol("shout"))
+    strPath = checkURL.GetHostName();
+
+  if (URIUtils::IsArchive(checkURL))
     strPath = checkURL.GetHostName();
 
   if (checkURL.IsProtocol("multipath"))

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -6,88 +6,101 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include "network/Network.h"
-#include "network/NetworkFileItemClassify.h"
-#include "playlists/PlayListFileItemClassify.h"
-#include "video/VideoFileItemClassify.h"
-#if defined(TARGET_DARWIN)
-#include <sys/param.h>
+// System headers
+#ifdef TARGET_DARWIN
 #include <mach-o/dyld.h>
+#include <sys/param.h>
 #endif
 
-#if defined(TARGET_FREEBSD)
+#ifdef TARGET_FREEBSD
 #include <sys/param.h>
 #include <sys/sysctl.h>
 #endif
 
 #ifdef TARGET_POSIX
-#include <sys/types.h>
 #include <dirent.h>
-#include <unistd.h>
+#include <sys/types.h>
 #include <sys/wait.h>
+#include <unistd.h>
 #endif
-#if defined(TARGET_ANDROID)
-#include <androidjni/ApplicationInfo.h>
-#include "platform/android/activity/XBMCApp.h"
-#include "CompileInfo.h"
-#endif
-#include "ServiceBroker.h"
-#include "Util.h"
-#include "addons/VFSEntry.h"
-#include "filesystem/Directory.h"
-#include "filesystem/MultiPathDirectory.h"
-#include "filesystem/PVRDirectory.h"
-#include "filesystem/RSSDirectory.h"
-#include "filesystem/SpecialProtocol.h"
-#include "filesystem/StackDirectory.h"
 
-#include <stdlib.h>
-#ifdef HAS_UPNP
-#include "filesystem/UPnPDirectory.h"
+#ifdef TARGET_ANDROID
+#include <androidjni/ApplicationInfo.h>
 #endif
-#include "profiles/ProfileManager.h"
-#include "utils/RegExp.h"
-#include "windowing/GraphicContext.h"
-#include "guilib/TextureManager.h"
-#include "storage/MediaManager.h"
+
+// Kodi headers that include system headers
+// (come before Util.h to stabilize __stat64 typedefs)
+#include "FileItem.h"
+#include "ServiceBroker.h"
+#include "URL.h"
+#include "filesystem/Directory.h"
+#include "filesystem/File.h"
+#include "filesystem/SpecialProtocol.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+#include "utils/log.h"
+
+// Class header
+#include "Util.h"
+
+// Other platform specific headers
 #ifdef TARGET_WINDOWS
-#include "utils/CharsetConverter.h"
 #include "WIN32Util.h"
+#include "utils/CharsetConverter.h"
 #endif
-#if defined(TARGET_DARWIN)
+
+#ifdef TARGET_DARWIN
 #include "CompileInfo.h"
 #include "platform/darwin/DarwinUtils.h"
 #endif
-#include "URL.h"
+
+#ifdef TARGET_ANDROID
+#include "CompileInfo.h"
+
+#include "platform/android/activity/XBMCApp.h"
+#endif
+
+// Remaining headers
+#include "addons/VFSEntry.h"
 #include "cores/VideoPlayer/DVDSubtitles/DVDSubtitleStream.h"
 #include "cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.h"
-#include "filesystem/File.h"
+#include "filesystem/MultiPathDirectory.h"
+#include "filesystem/PVRDirectory.h"
+#include "filesystem/RSSDirectory.h"
+#include "filesystem/StackDirectory.h"
+#ifdef HAS_UPNP
+#include "filesystem/UPnPDirectory.h"
+#endif
 #include "guilib/LocalizeStrings.h"
+#include "guilib/TextureManager.h"
+#include "network/Network.h"
+#include "network/NetworkFileItemClassify.h"
 #include "platform/Environment.h"
+#include "playlists/PlayListFileItemClassify.h"
+#include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "storage/MediaManager.h"
 #include "utils/Digest.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/LangCodeExpander.h"
-#include "utils/StringUtils.h"
-#include "utils/URIUtils.h"
-#include "utils/log.h"
+#include "utils/RegExp.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoFileItemClassify.h"
+#include "windowing/GraphicContext.h"
 #include "windowing/WinSystem.h"
 
 #ifdef HAVE_LIBCAP
-  #include <sys/capability.h>
+#include <sys/capability.h>
 #endif
-
-#include "cores/VideoPlayer/DVDDemuxers/DVDDemux.h"
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cstdint>
 #include <cstdlib>
-#include <ctime>
 #include <iomanip>
 #include <memory>
 #include <random>

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -259,6 +259,13 @@ public:
                                           std::string& basePath,
                                           std::string& videoFileName);
 
+  /*! \brief If a file has a stack://, bluray:// or archive (zip://, rar://, archive://) path,
+   *         use the dynamic path for updates (settings, SaveFileStateJob) instead of the real path.
+   *  \param item The file item to check.
+   *  \return true if dynamic path should be used, false otherwise.
+   */
+  static bool UseDynPathForAddOrUpdate(const CFileItem& item);
+
 #if !defined(TARGET_WINDOWS)
 private:
   static unsigned int s_randomSeed;

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -290,18 +290,34 @@ protected:
     *   \param[out] associatedFiles A vector containing the full paths of all found associated files.
     */
   static void ScanPathsForAssociatedItems(const std::string& videoName,
-                                          const CFileItemList& items,
+                                          CFileItemList& items,
                                           const std::vector<std::string>& item_exts,
                                           std::vector<std::string>& associatedFiles);
+
+  /** \brief Determines if the given path is an archive and scans it for associated files of a given video.
+    *   \param path The path of the file.
+    *   \param videoName The name of the video file.
+    *   \param item_exts A vector of extensions specifying the associated files.
+    *   \param associatedFiles A vector containing the full paths of all found associated files.
+    *   \param[in]  depth The current recursion depth. Callers do not need to set this.
+    *   \return An integer indicating the number of associated files found or -1 if not an archive.
+    */
+  static int DetermineArchiveAndScanForAssociatedItems(const std::string& path,
+                                                       const std::string& videoName,
+                                                       const std::vector<std::string>& item_exts,
+                                                       std::vector<std::string>& associatedFiles,
+                                                       int depth = 0);
 
   /** \brief Searches in an archive for associated files of a given video.
     *   \param[in]  strArchivePath The full path of the archive.
     *   \param[in]  videoNameNoExt The filename of the video without extension for which associated files should be retrieved.
     *   \param[in]  item_exts A vector of extensions specifying the associated files.
+    *   \param[in]  depth The current recursion depth.
     *   \param[out] associatedFiles A vector containing the full paths of all found associated files.
     */
   static int ScanArchiveForAssociatedItems(const std::string& strArchivePath,
                                            const std::string& videoNameNoExt,
                                            const std::vector<std::string>& item_exts,
-                                           std::vector<std::string>& associatedFiles);
+                                           std::vector<std::string>& associatedFiles,
+                                           int depth);
 };

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -11,11 +11,9 @@
 #include "MediaSource.h" // Definition of std::vector<CMediaSource>
 #include "utils/Digest.h"
 
-#include <climits>
-#include <cmath>
+#include <cstdint>
 #include <span>
-#include <stdint.h>
-#include <string.h>
+#include <string>
 #include <vector>
 
 //! \brief Enumeration of filesystem types for LegalPath/FileName
@@ -143,13 +141,6 @@ public:
       std::string path,
       bool bFixDoubleSlashes =
           false); ///< return a validated path, with correct directory separators.
-
-  /*!
-   * \brief Check if a filename contains a supported font extension.
-   * \param filename The filename to check
-   * \return True if it is supported, otherwise false
-   */
-  static bool IsSupportedFontExtension(const std::string& fileName);
 
   /*! \brief Split a comma separated parameter list into separate parameters.
    Takes care of the case where we may have a quoted string containing commas, or we may

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -165,7 +165,7 @@ CScraper::CScraper(const AddonInfoPtr& addonInfo, AddonType addonType)
       break;
   }
 
-  m_isPython = URIUtils::GetExtension(addonInfo->Type(addonType)->LibPath()) == ".py";
+  m_isPython = addonInfo->Type(addonType)->LibPath().ends_with(".py");
 }
 
 bool CScraper::Supports(ContentType content) const

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -110,6 +110,16 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
           CVFSEntryIFileDirectoryWrapper* wrap = new CVFSEntryIFileDirectoryWrapper(vfsAddon);
           if (wrap->ContainsFiles(url))
           {
+            // Paths returned may contain encoded urls but with capitals (eg. %2A rather than %2a)
+            // CURL will always use lower case for encoded chars, so we need to normalize here
+            // Otherwise there may be file/path mismatches later on
+            for (auto& item : wrap->GetItems())
+            {
+              CURL itemUrl{item->GetPath()};
+              if (URIUtils::HasParentInHostname(itemUrl))
+                item->SetPath(itemUrl.Get());
+            }
+
             if (wrap->GetItems().Size() == 1)
             {
               // one STORED file - collapse it down

--- a/xbmc/filesystem/StackDirectory.cpp
+++ b/xbmc/filesystem/StackDirectory.cpp
@@ -123,7 +123,8 @@ std::string CStackDirectory::GetStackTitlePath(const std::string& strPath)
   {
     // Create stacked title
     stackTitle = stackParts[0].title + stackParts[0].volume +
-                 (isFolderStack ? "/" : URIUtils::GetExtension(parts[0]->GetPath()));
+                 (isFolderStack ? (URIUtils::IsDOSPath(commonPath) ? "\\" : "/")
+                                : URIUtils::GetExtension(parts[0]->GetPath()));
 
     // Check if source path uses URL encoding
     if (!isFolderStack && URIUtils::HasEncodedFilename(CURL(commonPath)))
@@ -228,6 +229,11 @@ bool CStackDirectory::ConstructStackPath(const std::vector<std::string>& paths,
 }
 
 std::string CStackDirectory::GetParentPath(const std::string& stackPath)
+{
+  return GetBasePath(stackPath);
+}
+
+std::string CStackDirectory::GetBasePath(const std::string& stackPath)
 {
   static constexpr int MAX_ITERATIONS{5};
   std::vector<std::string> paths;

--- a/xbmc/filesystem/StackDirectory.h
+++ b/xbmc/filesystem/StackDirectory.h
@@ -73,10 +73,11 @@ namespace XFILE
                                    const std::string& newPath = {});
 
     /*!
-    \brief Get the parent path in common from all the parts of a stack:// path
+    \brief Get the base/parent path in common from all the parts of a stack:// path
     \param stackPath The stack:// path
-    \return The parent path
+    \return The base/parent path
     */
+    static std::string GetBasePath(const std::string& stackPath);
     static std::string GetParentPath(const std::string& stackPath);
   };
 }

--- a/xbmc/music/test/TestMusicFileItemClassify.cpp
+++ b/xbmc/music/test/TestMusicFileItemClassify.cpp
@@ -85,7 +85,7 @@ TEST(TestMusicFileItemClassify, MusicExtensions)
   {
     if (!ext.empty())
     {
-      EXPECT_TRUE(MUSIC::IsAudio(CFileItem(ext, false)));
+      EXPECT_TRUE(MUSIC::IsAudio(CFileItem("test" + ext, false)));
     }
   }
 }

--- a/xbmc/network/test/TestNetworkFileItemClassify.cpp
+++ b/xbmc/network/test/TestNetworkFileItemClassify.cpp
@@ -23,11 +23,15 @@ namespace
 
 struct SimpleDefinition
 {
-  SimpleDefinition(const std::string& path, bool folder, bool res) : item(path, folder), result(res)
+  SimpleDefinition(std::string path, bool folder, bool res)
+    : path(std::move(path)),
+      folder(folder),
+      result(res)
   {
   }
 
-  CFileItem item;
+  std::string path;
+  bool folder;
   bool result;
 };
 
@@ -40,7 +44,10 @@ class InternetStreamTest : public testing::WithParamInterface<SimpleDefinition>,
 
 TEST_P(InternetStreamTest, IsInternetStream)
 {
-  EXPECT_EQ(NETWORK::IsInternetStream(GetParam().item), GetParam().result);
+  const SimpleDefinition& param = GetParam();
+
+  CFileItem item(param.path, param.folder);
+  EXPECT_EQ(NETWORK::IsInternetStream(item), param.result);
 }
 
 const auto inetstream_tests = std::array{
@@ -125,7 +132,9 @@ class RemoteTest : public testing::WithParamInterface<SimpleDefinition>, public 
 
 TEST_P(RemoteTest, IsRemote)
 {
-  EXPECT_EQ(NETWORK::IsRemote(GetParam().item), GetParam().result);
+  const SimpleDefinition& param = GetParam();
+  CFileItem item(param.path, param.folder);
+  EXPECT_EQ(NETWORK::IsRemote(item), param.result);
 }
 
 const auto remote_tests = std::array{
@@ -158,7 +167,9 @@ class StreamedFilesystemTest : public testing::WithParamInterface<SimpleDefiniti
 
 TEST_P(StreamedFilesystemTest, IsStreamedFilesystem)
 {
-  EXPECT_EQ(NETWORK::IsStreamedFilesystem(GetParam().item), GetParam().result);
+  const SimpleDefinition& param = GetParam();
+  CFileItem item(param.path, param.folder);
+  EXPECT_EQ(NETWORK::IsStreamedFilesystem(item), param.result);
 }
 
 const auto streamedfs_tests = std::array{

--- a/xbmc/playlists/test/TestPlayListFileItemClassify.cpp
+++ b/xbmc/playlists/test/TestPlayListFileItemClassify.cpp
@@ -18,15 +18,16 @@ using namespace KODI;
 
 struct PlayListClassifyTest
 {
-  PlayListClassifyTest(const std::string& path, bool res, const std::string& mime = "")
-    : item(path, false), result(res)
+  PlayListClassifyTest(std::string path, bool res, std::string mime = "")
+    : path(std::move(path)),
+      result(res),
+      mime(std::move(mime))
   {
-    if (!mime.empty())
-      item.SetMimeType(mime);
   }
 
-  CFileItem item;
+  std::string path;
   bool result;
+  std::string mime;
 };
 
 class PlayListTest : public testing::WithParamInterface<PlayListClassifyTest>, public testing::Test
@@ -35,7 +36,13 @@ class PlayListTest : public testing::WithParamInterface<PlayListClassifyTest>, p
 
 TEST_P(PlayListTest, IsPlayList)
 {
-  EXPECT_EQ(PLAYLIST::IsPlayList(GetParam().item), GetParam().result);
+  const PlayListClassifyTest& param = GetParam();
+
+  CFileItem item(param.path, false);
+  if (!param.mime.empty())
+    item.SetMimeType(param.mime);
+
+  EXPECT_EQ(PLAYLIST::IsPlayList(item), param.result);
 }
 
 const auto playlist_tests = std::array{

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -286,7 +286,7 @@ void CAdvancedSettings::Initialize()
                                         m_allExcludeFromScanRegExps.end());
 
   m_folderStackRegExps = CompileRegexes({
-      "(.*?)(?:[^\\/])((?:cd|dvd|p(?:(?:ar)?t)|dis[ck])[ _.-]*[0-9])$",
+      "^(.*?)[ _.-]*((?:cd|dvd|p(?:(?:ar)?t)|dis[ck])[ _.-]*[0-9])$",
       "()((?:p(?:(?:ar)?t)[ _.-]*[0-9]))$",
   });
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -496,8 +496,10 @@ void CAdvancedSettings::Initialize()
       ".png|.jpg|.jpeg|.bmp|.gif|.ico|.tif|.tiff|.tga|.pcx|.cbz|.zip|.rss|.webp|.jp2|.apng|.avif|.heif|.heic";
   m_musicExtensions = ".b4s|.nsv|.m4a|.flac|.aac|.strm|.pls|.rm|.rma|.mpa|.wav|.wma|.ogg|.mp3|.mp2|.m3u|.gdm|.imf|.m15|.sfx|.uni|.ac3|.dts|.cue|.aif|.aiff|.wpl|.xspf|.ape|.mac|.mpc|.mp+|.mpp|.shn|.zip|.wv|.dsp|.xsp|.xwav|.waa|.wvs|.wam|.gcm|.idsp|.mpdsp|.mss|.spt|.rsd|.sap|.cmc|.cmr|.dmc|.mpt|.mpd|.rmt|.tmc|.tm8|.tm2|.oga|.url|.pxml|.tta|.rss|.wtv|.mka|.tak|.opus|.dff|.dsf|.m4b|.dtshd";
   m_videoExtensions = ".m4v|.3g2|.3gp|.nsv|.tp|.ts|.ty|.strm|.pls|.rm|.rmvb|.mpd|.m3u|.m3u8|.ifo|.mov|.qt|.divx|.xvid|.bivx|.vob|.nrg|.img|.iso|.udf|.pva|.wmv|.asf|.asx|.ogm|.m2v|.avi|.bin|.dat|.mpg|.mpeg|.mp4|.mkv|.mk3d|.avc|.vp3|.svq3|.nuv|.viv|.dv|.fli|.flv|.001|.wpl|.xspf|.zip|.vdr|.dvr-ms|.xsp|.mts|.m2t|.m2ts|.evo|.ogv|.sdp|.avs|.rec|.url|.pxml|.vc1|.h264|.rcv|.rss|.mpls|.mpl|.webm|.bdmv|.bdm|.wtv|.trp|.f4v";
-  m_subtitlesExtensions = ".utf|.utf8|.utf-8|.sub|.srt|.smi|.rt|.txt|.ssa|.text|.ssa|.aqt|.jss|"
-                          ".ass|.vtt|.idx|.ifo|.zip|.sup";
+  m_subtitlesExtensions = ".utf|.utf8|.utf-8|.sub|.srt|.smi|.rt|.txt|.ssa|.text|.ssa|.aqt|.jss|."
+                          "ass|.vtt|.idx|.ifo|.zip|.sup";
+  m_archiveExtensions = ".tgz|.tbz2|.xz|.7z|.bz2|.gz|.tar|.rar|.zip";
+  m_compoundArchiveExtensions = ".tar.bz2|.tar.gz|.tar.xz";
   m_discStubExtensions = ".disc";
   // internal music extensions
   m_musicExtensions += "|.cdda";

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -382,6 +382,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     // runtime settings which cannot be set from advancedsettings.xml
     std::string m_videoExtensions;
+    std::string m_archiveExtensions;
+    std::string m_compoundArchiveExtensions;
     std::string m_discStubExtensions;
     std::string m_subtitlesExtensions;
     std::string m_musicExtensions;

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -17,14 +17,14 @@
 #include <gtest/gtest.h>
 
 using ::testing::Test;
-using ::testing::WithParamInterface;
 using ::testing::ValuesIn;
+using ::testing::WithParamInterface;
 
 struct TestFileData
 {
-  const char *file;
+  const char* file;
   bool use_folder;
-  const char *base;
+  const char* base;
 };
 
 struct TestNameData
@@ -65,23 +65,7 @@ class TestFileItemLocalMetadataPath : public AdvancedSettingsResetBase,
 };
 
 const TestFileData BaseMovies[] = {
-    {"c:\\dir\\filename.avi", false, "c:\\dir\\filename.avi"},
-    {"c:\\dir\\filename.avi", true, "c:\\dir\\"},
-    {"/dir/filename.avi", false, "/dir/filename.avi"},
-    {"/dir/filename.avi", true, "/dir/"},
-    {"smb://somepath/file.avi", false, "smb://somepath/file.avi"},
-    {"smb://somepath/file.avi", true, "smb://somepath/"},
-    {"smb://somepath/disc 1/file.avi", false, "smb://somepath/disc 1/file.avi"},
-    {"smb://somepath/disc 1/file.avi", true, "smb://somepath/"},
-    {"stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi",
-     false,
-     "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi"},
-    {"stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi",
-     true, "/path/to/movie_name/"},
-    {"/home/user/TV Shows/Dexter/S1/1x01.avi", false, "/home/user/TV Shows/Dexter/S1/1x01.avi"},
-    {"/home/user/TV Shows/Dexter/S1/1x01.avi", true, "/home/user/TV Shows/Dexter/S1/"},
-    {"zip://g%3a%5cmultimedia%5cmovies%5cSphere%2ezip/Sphere.avi", true,
-     "g:\\multimedia\\movies\\"},
+    // Linux path tests
     {"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie/"},
     {"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", true, "/home/user/movies/movie/"},
     {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie/"},
@@ -94,15 +78,188 @@ const TestFileData BaseMovies[] = {
     {"/home/user/movies/movie/file.iso", true, "/home/user/movies/movie/"},
     {"/home/user/movies/movie/disc 1/movie.iso", false, "/home/user/movies/movie/disc 1/movie.iso"},
     {"/home/user/movies/movie/disc 1/file.iso", true, "/home/user/movies/movie/"},
-    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/00800.mpls",
-     true, "smb://somepath/"},
-    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fDisc%201%252fmovie.iso%2f/BDMV/PLAYLIST/"
+    {"stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi",
+     false,
+     "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi"},
+    {"stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi",
+     true, "/path/to/movie_name/"},
+    // DOS path tests
+    {"D:\\Movies\\Movie\\video_ts\\VIDEO_TS.IFO", false, "D:\\Movies\\Movie\\"},
+    {"D:\\Movies\\Movie\\video_ts\\VIDEO_TS.IFO", true, "D:\\Movies\\Movie\\"},
+    {"D:\\Movies\\Movie\\disc 1\\video_ts\\VIDEO_TS.IFO", false, "D:\\Movies\\Movie\\"},
+    {"D:\\Movies\\Movie\\disc 1\\video_ts\\VIDEO_TS.IFO", true, "D:\\Movies\\Movie\\"},
+    {"D:\\Movies\\Movie\\BDMV\\index.bdmv", false, "D:\\Movies\\Movie\\"},
+    {"D:\\Movies\\Movie\\BDMV\\index.bdmv", true, "D:\\Movies\\Movie\\"},
+    {"D:\\Movies\\Movie\\disc 1\\BDMV\\index.bdmv", false, "D:\\Movies\\Movie\\"},
+    {"D:\\Movies\\Movie\\disc 1\\BDMV\\index.bdmv", true, "D:\\Movies\\Movie\\"},
+    {"D:\\Movies\\Movie\\movie.iso", false, "D:\\Movies\\Movie\\movie.iso"},
+    {"D:\\Movies\\Movie\\file.iso", true, "D:\\Movies\\Movie\\"},
+    {"D:\\Movies\\Movie\\disc 1\\movie.iso", false, "D:\\Movies\\Movie\\disc 1\\movie.iso"},
+    {"D:\\Movies\\Movie\\disc 1\\file.iso", true, "D:\\Movies\\Movie\\"},
+    {"stack://D:\\Movies\\Movie\\Movie - part 1\\some_file1.avi , D:\\Movies\\Movie\\Movie - part "
+     "2\\some_file2.avi",
+     false,
+     "stack://D:\\Movies\\Movie\\Movie - part 1\\some_file1.avi , D:\\Movies\\Movie\\Movie - part "
+     "2\\some_file2.avi"},
+    {"stack://D:\\Movies\\Movie\\Movie - part 1\\some_file1.avi , D:\\Movies\\Movie\\Movie - part "
+     "2\\some_file2.avi",
+     true, "D:\\Movies\\Movie\\"},
+    // Windows server path tests
+    {"\\\\Server\\Movies\\Movie\\video_ts\\VIDEO_TS.IFO", false, "\\\\Server\\Movies\\Movie\\"},
+    {"\\\\Server\\Movies\\Movie\\video_ts\\VIDEO_TS.IFO", true, "\\\\Server\\Movies\\Movie\\"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\video_ts\\VIDEO_TS.IFO", false,
+     "\\\\Server\\Movies\\Movie\\"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\video_ts\\VIDEO_TS.IFO", true,
+     "\\\\Server\\Movies\\Movie\\"},
+    {"\\\\Server\\Movies\\Movie\\BDMV\\index.bdmv", false, "\\\\Server\\Movies\\Movie\\"},
+    {"\\\\Server\\Movies\\Movie\\BDMV\\index.bdmv", true, "\\\\Server\\Movies\\Movie\\"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\BDMV\\index.bdmv", false, "\\\\Server\\Movies\\Movie\\"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\BDMV\\index.bdmv", true, "\\\\Server\\Movies\\Movie\\"},
+    {"\\\\Server\\Movies\\Movie\\movie.iso", false, "\\\\Server\\Movies\\Movie\\movie.iso"},
+    {"\\\\Server\\Movies\\Movie\\file.iso", true, "\\\\Server\\Movies\\Movie\\"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\movie.iso", false,
+     "\\\\Server\\Movies\\Movie\\disc 1\\movie.iso"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\file.iso", true, "\\\\Server\\Movies\\Movie\\"},
+    {"stack://\\\\Server\\Movies\\Movie\\Movie - part 1\\some_file1.avi , "
+     "\\\\Server\\Movies\\Movie\\Movie - part "
+     "2\\some_file2.avi",
+     false,
+     "stack://\\\\Server\\Movies\\Movie\\Movie - part 1\\some_file1.avi , "
+     "\\\\Server\\Movies\\Movie\\Movie - part "
+     "2\\some_file2.avi"},
+    {"stack://\\\\Server\\Movies\\Movie\\Movie - part 1\\some_file1.avi , "
+     "\\\\Server\\Movies\\Movie\\Movie - part "
+     "2\\some_file2.avi",
+     true, "\\\\Server\\Movies\\Movie\\"},
+    // URL path tests with smb://
+    {"smb://home/user/movies/movie/video_ts/VIDEO_TS.IFO", false, "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/video_ts/VIDEO_TS.IFO", true, "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", false,
+     "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", true,
+     "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/BDMV/index.bdmv", false, "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/BDMV/index.bdmv", true, "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/disc 1/BDMV/index.bdmv", false, "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/disc 1/BDMV/index.bdmv", true, "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/movie.iso", false, "smb://home/user/movies/movie/movie.iso"},
+    {"smb://home/user/movies/movie/file.iso", true, "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/disc 1/movie.iso", false,
+     "smb://home/user/movies/movie/disc 1/movie.iso"},
+    {"smb://home/user/movies/movie/disc 1/file.iso", true, "smb://home/user/movies/movie/"},
+    {"stack://smb://path/to/movie_name/cd1/some_file1.avi , "
+     "smb://path/to/movie_name/cd2/some_file2.avi",
+     false,
+     "stack://smb://path/to/movie_name/cd1/some_file1.avi , "
+     "smb://path/to/movie_name/cd2/some_file2.avi"},
+    {"stack://smb://path/to/movie_name/cd1/some_file1.avi , "
+     "smb://path/to/movie_name/cd2/some_file2.avi",
+     true, "smb://path/to/movie_name/"},
+    // Embedded smb:// path tests
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     false, "smb://somepath/movie.iso"},
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/"
      "00800.mpls",
      true, "smb://somepath/"},
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fDisc%25201%252fmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     true, "smb://somepath/"},
+    {"bluray://smb%3a%2f%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", false, "smb://somepath/"},
     {"bluray://smb%3a%2f%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", true, "smb://somepath/"},
     {"bluray://smb%3a%2f%2fsomepath%2fDisc%201%2f/BDMV/PLAYLIST/00800.mpls", true,
      "smb://somepath/"},
-    {"zip://smb%3a%2f%2fsomepath%2fmovie.zip/BDMV/index.bdmv", true, "smb://somepath/"}};
+    {"zip://smb%3a%2f%2fsomepath%2fmovie.zip/BDMV/index.bdmv", false, "smb://somepath/movie.zip"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie.zip/BDMV/index.bdmv", true, "smb://somepath/"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.zip/BDMV/index.bdmv", true,
+     "smb://somepath/movie/"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie.rar/BDMV/index.bdmv", false, "smb://somepath/movie.rar"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie.rar/BDMV/index.bdmv", true, "smb://somepath/"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.rar/BDMV/index.bdmv", true,
+     "smb://somepath/movie/"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie.tar.gz/BDMV/index.bdmv", false,
+     "smb://somepath/movie.tar.gz"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie.tar.gz/BDMV/index.bdmv", true, "smb://somepath/"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.tar.gz/BDMV/index.bdmv", true,
+     "smb://somepath/movie/"},
+    // Embedded linux path tests
+    {"bluray://udf%3a%2f%2f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/00800.mpls", false,
+     "/somepath/movie.iso"},
+    {"bluray://udf%3a%2f%2f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/00800.mpls", true,
+     "/somepath/"},
+    {"bluray://udf%3a%2f%2f%252fsomepath%252fDisc%25201%252fmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     true, "/somepath/"},
+    {"bluray://%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", false, "/somepath/"},
+    {"bluray://%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", true, "/somepath/"},
+    {"bluray://%2fsomepath%2fDisc%201%2f/BDMV/PLAYLIST/00800.mpls", true, "/somepath/"},
+    {"zip://%2fsomepath%2fmovie.zip/BDMV/index.bdmv", false, "/somepath/movie.zip"},
+    {"zip://%2fsomepath%2fmovie.zip/BDMV/index.bdmv", true, "/somepath/"},
+    {"zip://%2fsomepath%2fdisc%201%2fmovie.zip/BDMV/index.bdmv", true, "/somepath/"},
+    {"rar://%2fsomepath%2fmovie.rar/BDMV/index.bdmv", false, "/somepath/movie.rar"},
+    {"rar://%2fsomepath%2fmovie.rar/BDMV/index.bdmv", true, "/somepath/"},
+    {"rar://%2fsomepath%2fdisc%201%2fmovie_disc.rar/BDMV/index.bdmv", true, "/somepath/"},
+    {"archive://%2fsomepath%2fmovie.tar.gz/BDMV/index.bdmv", false, "/somepath/movie.tar.gz"},
+    {"archive://%2fsomepath%2fmovie.tar.gz/BDMV/index.bdmv", true, "/somepath/"},
+    {"archive://%2fsomepath%2fdisc%201%2fmovie.tar.gz/BDMV/index.bdmv", true, "/somepath/"},
+    // Embedded DOS path tests
+    {"bluray://udf%3a%2f%2fD%253a%255cmovies%255cmovie.iso%2f/BDMV/PLAYLIST/00800.mpls", false,
+     "D:\\movies\\movie.iso"},
+    {"bluray://udf%3a%2f%2fD%253a%255cmovies%255cmovie.iso%2f/BDMV/PLAYLIST/00800.mpls", true,
+     "D:\\movies\\"},
+    {"bluray://udf%3a%2f%2fD%253a%255cmovies%255cDisc%25201%255cmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     true, "D:\\movies\\"},
+    {"bluray://D%3a%5cmovie%5c/BDMV/PLAYLIST/00800.mpls", false, "D:\\movie\\"},
+    {"bluray://D%3a%5cmovie%5c/BDMV/PLAYLIST/00800.mpls", true, "D:\\movie\\"},
+    {"bluray://D%3a%5cmovie%5cDisc%201%5c/BDMV/PLAYLIST/00800.mpls", true, "D:\\movie\\"},
+    {"zip://D%3a%5cmovies%5cmovie.zip/BDMV/index.bdmv", false, "D:\\movies\\movie.zip"},
+    {"zip://D%3a%5cmovies%5cmovie.zip/BDMV/index.bdmv", true, "D:\\movies\\"},
+    {"zip://D%3a%5cmovies%5cmovie%5cdisc%201%5cmovie.zip/BDMV/index.bdmv", true,
+     "D:\\movies\\movie\\"},
+    {"rar://D%3a%5cmovies%5cmovie.rar/BDMV/index.bdmv", false, "D:\\movies\\movie.rar"},
+    {"rar://D%3a%5cmovies%5cmovie.rar/BDMV/index.bdmv", true, "D:\\movies\\"},
+    {"rar://D%3a%5cmovies%5cmovie%5cdisc%201%5cmovie.rar/BDMV/index.bdmv", true,
+     "D:\\movies\\movie\\"},
+    {"archive://D%3a%5cmovies%5cmovie.tar.gz/BDMV/index.bdmv", false, "D:\\movies\\movie.tar.gz"},
+    {"archive://D%3a%5cmovies%5cmovie.tar.gz/BDMV/index.bdmv", true, "D:\\movies\\"},
+    {"archive://D%3a%5cmovies%5cmovie%5cdisc%201%5cmovie.tar.gz/BDMV/index.bdmv", true,
+     "D:\\movies\\movie\\"},
+    // Embedded Windows server path tests
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/00800.mpls",
+     false, "\\\\Server\\Movies\\movie.iso"},
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/00800.mpls",
+     true, "\\\\Server\\Movies\\"},
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cMovie%255cDisc%25201%255cmovie.iso%2f/"
+     "BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     true, "\\\\Server\\Movies\\Movie\\"},
+    {"bluray://%5c%5cServer%5cMovies%5cMovie%5c/BDMV/PLAYLIST/00800.mpls", false,
+     "\\\\Server\\Movies\\Movie\\"},
+    {"bluray://%5c%5cServer%5cMovies%5cMovie%5c/BDMV/PLAYLIST/00800.mpls", true,
+     "\\\\Server\\Movies\\Movie\\"},
+    {"bluray://%5c%5cServer%5cMovies%5cMovie%5cDisc%201%5c/BDMV/PLAYLIST/00800.mpls", true,
+     "\\\\Server\\Movies\\Movie\\"},
+    {"zip://%5c%5cServer%5cMovies%5cmovie.zip/BDMV/index.bdmv", false,
+     "\\\\Server\\Movies\\movie.zip"},
+    {"zip://%5c%5cServer%5cMovies%5cmovie.zip/BDMV/index.bdmv", true, "\\\\Server\\Movies\\"},
+    {"zip://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5cmovie.zip/BDMV/index.bdmv", true,
+     "\\\\Server\\Movies\\Movie\\"},
+    {"rar://%5c%5cServer%5cMovies%5cmovie.rar/BDMV/index.bdmv", false,
+     "\\\\Server\\Movies\\movie.rar"},
+    {"rar://%5c%5cServer%5cMovies%5cmovie.rar/BDMV/index.bdmv", true, "\\\\Server\\Movies\\"},
+    {"rar://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5cmovie.rar/BDMV/index.bdmv", true,
+     "\\\\Server\\Movies\\Movie\\"},
+    {"archive://%5c%5cServer%5cMovies%5cmovie.tar.gz/BDMV/index.bdmv", false,
+     "\\\\Server\\Movies\\movie.tar.gz"},
+    {"archive://%5c%5cServer%5cMovies%5cmovie.tar.gz/BDMV/index.bdmv", true,
+     "\\\\Server\\Movies\\"},
+    {"archive://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5cmovie.tar.gz/BDMV/index.bdmv", true,
+     "\\\\Server\\Movies\\Movie\\"}};
 
 TEST_P(TestFileItemBasePath, GetBaseMoviePath)
 {
@@ -116,14 +273,7 @@ TEST_P(TestFileItemBasePath, GetBaseMoviePath)
 INSTANTIATE_TEST_SUITE_P(BaseNameMovies, TestFileItemBasePath, ValuesIn(BaseMovies));
 
 const TestNameData BaseNames[] = {
-    {"c:\\dir\\movie.avi", false, "movie"},
-    {"c:\\movie\\filename.avi", true, "movie"},
-    {"/dir/movie.avi", false, "movie"},
-    {"/movie/filename.avi", true, "movie"},
-    {"smb://somepath/movie.avi", false, "movie"},
-    {"smb://somepath/movie/file.avi", true, "movie"},
-    {"smb://somepath/disc 1/movie.avi", false, "movie"},
-    {"smb://somepath/movie/disc 1/file.avi", true, "movie"},
+    // Linux path tests
     {"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", false, "movie"},
     {"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", true, "movie"},
     {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", false, "movie"},
@@ -132,10 +282,164 @@ const TestNameData BaseNames[] = {
     {"/home/user/movies/movie/BDMV/index.bdmv", true, "movie"},
     {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", false, "movie"},
     {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", true, "movie"},
-    {"/home/user/movies/movie.iso", false, "movie"},
+    {"/home/user/movies/movie/movie.iso", false, "movie"},
     {"/home/user/movies/movie/file.iso", true, "movie"},
-    {"/home/user/movies/disc 1/movie.iso", false, "movie"},
-    {"/home/user/movies/movie/disc 1/file.iso", true, "movie"}};
+    {"/home/user/movies/movie/disc 1/movie.iso", false, "movie"},
+    {"/home/user/movies/movie/disc 1/file.iso", true, "movie"},
+    {"stack:///path/to/movie_folder/cd1/movie_file1.avi , "
+     "/path/to/movie_folder/cd2/movie_file2.avi",
+     false, "movie"},
+    {"stack:///path/to/movie/cd1/some_file1.avi , /path/to/movie/cd2/some_file2.avi", true,
+     "movie"},
+    // DOS path tests
+    {"D:\\Movies\\Movie\\video_ts\\VIDEO_TS.IFO", false, "Movie"},
+    {"D:\\Movies\\Movie\\video_ts\\VIDEO_TS.IFO", true, "Movie"},
+    {"D:\\Movies\\Movie\\disc 1\\video_ts\\VIDEO_TS.IFO", false, "Movie"},
+    {"D:\\Movies\\Movie\\disc 1\\video_ts\\VIDEO_TS.IFO", true, "Movie"},
+    {"D:\\Movies\\Movie\\BDMV\\index.bdmv", false, "Movie"},
+    {"D:\\Movies\\Movie\\BDMV\\index.bdmv", true, "Movie"},
+    {"D:\\Movies\\Movie\\disc 1\\BDMV\\index.bdmv", false, "Movie"},
+    {"D:\\Movies\\Movie\\disc 1\\BDMV\\index.bdmv", true, "Movie"},
+    {"D:\\Movies\\Movie\\movie.iso", false, "movie"},
+    {"D:\\Movies\\Movie\\file.iso", true, "Movie"},
+    {"D:\\Movies\\Movie\\disc 1\\movie.iso", false, "movie"},
+    {"D:\\Movies\\Movie\\disc 1\\file.iso", true, "Movie"},
+    {"stack://D:\\Movies\\Movie\\movie_file1.avi , D:\\Movies\\Movie\\Movie - part "
+     "2\\movie_file2.avi",
+     false, "movie"},
+    {"stack://D:\\Movies\\Movie\\Movie - part 1\\some_file1.avi , D:\\Movies\\Movie\\Movie - part "
+     "2\\some_file2.avi",
+     true, "Movie"},
+    // Windows server path tests
+    {"\\\\Server\\Movies\\Movie\\video_ts\\VIDEO_TS.IFO", false, "Movie"},
+    {"\\\\Server\\Movies\\Movie\\video_ts\\VIDEO_TS.IFO", true, "Movie"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\video_ts\\VIDEO_TS.IFO", false, "Movie"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\video_ts\\VIDEO_TS.IFO", true, "Movie"},
+    {"\\\\Server\\Movies\\Movie\\BDMV\\index.bdmv", false, "Movie"},
+    {"\\\\Server\\Movies\\Movie\\BDMV\\index.bdmv", true, "Movie"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\BDMV\\index.bdmv", false, "Movie"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\BDMV\\index.bdmv", true, "Movie"},
+    {"\\\\Server\\Movies\\Movie\\movie.iso", false, "movie"},
+    {"\\\\Server\\Movies\\Movie\\file.iso", true, "Movie"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\movie.iso", false, "movie"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\file.iso", true, "Movie"},
+    {"stack://\\\\Server\\Movies\\Movie\\movie_file1.avi , "
+     "\\\\Server\\Movies\\Movie\\movie_file2.avi",
+     false, "movie"},
+    {"stack://\\\\Server\\Movies\\Movie\\Movie - part 1\\some_file1.avi , "
+     "\\\\Server\\Movies\\Movie\\Movie - part "
+     "2\\some_file2.avi",
+     true, "Movie"},
+    // URL path tests with smb://
+    {"smb://home/user/movies/movie/video_ts/VIDEO_TS.IFO", false, "movie"},
+    {"smb://home/user/movies/movie/video_ts/VIDEO_TS.IFO", true, "movie"},
+    {"smb://home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", false, "movie"},
+    {"smb://home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", true, "movie"},
+    {"smb://home/user/movies/movie/BDMV/index.bdmv", false, "movie"},
+    {"smb://home/user/movies/movie/BDMV/index.bdmv", true, "movie"},
+    {"smb://home/user/movies/movie/disc 1/BDMV/index.bdmv", false, "movie"},
+    {"smb://home/user/movies/movie/disc 1/BDMV/index.bdmv", true, "movie"},
+    {"smb://home/user/movies/movie/movie.iso", false, "movie"},
+    {"smb://home/user/movies/movie/file.iso", true, "movie"},
+    {"smb://home/user/movies/movie/disc 1/movie.iso", false, "movie"},
+    {"smb://home/user/movies/movie/disc 1/file.iso", true, "movie"},
+    {"stack://smb://path/to/movie_name/cd1/movie_file1.avi , "
+     "smb://path/to/movie_name/cd2/movie_file2.avi",
+     false, "movie"},
+    {"stack://smb://path/to/movie/cd1/some_file1.avi , "
+     "smb://path/to/movie/cd2/some_file2.avi",
+     true, "movie"},
+    // Embedded smb:// path tests
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     false, "movie"},
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie%252ffilm.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     true, "movie"},
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie%252fDisc%25201%252ffilm.iso%2f/"
+     "BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     true, "movie"},
+    {"bluray://smb%3a%2f%2fsomepath%2fmovie%2f/BDMV/PLAYLIST/00800.mpls", false, "movie"},
+    {"bluray://smb%3a%2f%2fsomepath%2fmovie%2f/BDMV/PLAYLIST/00800.mpls", true, "movie"},
+    {"bluray://smb%3a%2f%2fsomepath%2fmovie%2fDisc%201%2f/BDMV/PLAYLIST/00800.mpls", true, "movie"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie.zip/film.avi", false, "movie"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie%2ffilm.zip/film.avi", true, "movie"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2ffilm.zip/BDMV/index.bdmv", true, "movie"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie.rar/film.avi", false, "movie"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie%2ffilm.rar/film.avi", true, "movie"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2ffilm.rar/BDMV/index.bdmv", true, "movie"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie.tar.gz/film.avi", false, "movie"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie%2ffilm.tar.gz/film.avi", true, "movie"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2ffilm.tar.gz/BDMV/index.bdmv", true,
+     "movie"},
+    // Embedded linux path tests
+    {"bluray://udf%3a%2f%2f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/00800.mpls", false,
+     "movie"},
+    {"bluray://udf%3a%2f%2f%252fsomepath%252fmovie%252ffile.iso%2f/BDMV/PLAYLIST/00800.mpls", true,
+     "movie"},
+    {"bluray://udf%3a%2f%2f%252fsomepath%252fmovie%252fDisc%25201%252ffilm.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     true, "movie"},
+    {"bluray://%2fsomepath%2fmovie%2f/BDMV/PLAYLIST/00800.mpls", false, "movie"},
+    {"bluray://%2fsomepath%2fmovie%2f/BDMV/PLAYLIST/00800.mpls", true, "movie"},
+    {"bluray://%2fsomepath%2fmovie%2fDisc%201%2f/BDMV/PLAYLIST/00800.mpls", true, "movie"},
+    {"zip://%2fsomepath%2fmovie.zip/film.avi", false, "movie"},
+    {"zip://%2fsomepath%2fmovie%2ffilm.zip/film.avi", true, "movie"},
+    {"zip://%2fsomepath%2fmovie%2fmovie%2fdisc%201%2ffilm.zip/BDMV/index.bdmv", true, "movie"},
+    {"rar://%2fsomepath%2fmovie.rar/film.avi", false, "movie"},
+    {"rar://%2fsomepath%2fmovie%2ffilm.rar/BDMV/index.bdmv", true, "movie"},
+    {"rar://%2fsomepath%2fmovie%2fdisc%201%2ffilm.rar/BDMV/index.bdmv", true, "movie"},
+    {"archive://%2fsomepath%2fmovie.tar.gz/film.avi", false, "movie"},
+    {"archive://%2fsomepath%2fmovie%2ffilm.tar.gz/film.avi", true, "movie"},
+    {"archive://%2fsomepath%2fmovie%2fdisc%201%2ffilm.tar.gz/BDMV/index.bdmv", true, "movie"},
+    // Embedded DOS path tests
+    {"bluray://udf%3a%2f%2fD%253a%255cmovies%255cmovie.iso%2f/BDMV/PLAYLIST/00800.mpls", false,
+     "movie"},
+    {"bluray://udf%3a%2f%2fD%253a%255cmovies%255cmovie%255cfilm.iso%2f/BDMV/PLAYLIST/00800.mpls",
+     true, "movie"},
+    {"bluray://udf%3a%2f%2fD%253a%255cmovies%255cmovie%255cDisc%25201%255cfilm.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     true, "movie"},
+    {"bluray://D%3a%5csomepath%5cmovie%5c/BDMV/PLAYLIST/00800.mpls", false, "movie"},
+    {"bluray://D%3a%5csomepath%5cmovie%5c/BDMV/PLAYLIST/00800.mpls", true, "movie"},
+    {"bluray://D%3a%5csomepath%5cmovie%5cDisc%201%5c/BDMV/PLAYLIST/00800.mpls", true, "movie"},
+    {"zip://C%3a%5cmovies%5cmovie.zip/film.avi", false, "movie"},
+    {"zip://C%3a%5cmovies%5cmovie%5cfilm.zip/film.avi", true, "movie"},
+    {"zip://C%3a%5cmovies%5cmovie%5cdisc%201%5cfilm.zip/BDMV/index.bdmv", true, "movie"},
+    {"rar://C%3a%5cmovies%5cmovie.rar/film.avi", false, "movie"},
+    {"rar://C%3a%5cmovies%5cmovie%5cfilm.rar/film.avi", true, "movie"},
+    {"rar://C%3a%5cmovies%5cmovie%5cdisc%201%5cfilm.rar/BDMV/index.bdmv", true, "movie"},
+    {"archive://C%3a%5cmovies%5cmovie.tar.gz/film.avi", false, "movie"},
+    {"archive://C%3a%5cmovies%5cmovie%5cfilm.tar.gz/film.avi", true, "movie"},
+    {"archive://C%3a%5cmovies%5cmovie%5cdisc%201%5cfilm.tar.gz/BDMV/index.bdmv", true, "movie"},
+    // Embedded Windows server path tests
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/00800.mpls",
+     false, "movie"},
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie%255cfilm.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     true, "movie"},
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie%255cDisc%25201%255cmovie.iso%2f/"
+     "BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     true, "movie"},
+    {"bluray://%5c%5csomepath%5cmovie%5c/BDMV/PLAYLIST/00800.mpls", false, "movie"},
+    {"bluray://%5c%5csomepath%5cmovie%5c/BDMV/PLAYLIST/00800.mpls", true, "movie"},
+    {"bluray://%5c%5csomepath%5cmovie%5cDisc%201%5c/BDMV/PLAYLIST/00800.mpls", true, "movie"},
+    {"zip://%5c%5cServer%5cMovies%5cmovie.zip/film.avi", false, "movie"},
+    {"zip://%5c%5cServer%5cMovies%5cmovie%5cfilm.zip/film.avi", true, "movie"},
+    {"zip://%5c%5cServer%5cMovies%5cmovie%5cdisc%201%5cfilm.zip/BDMV/index.bdmv", true, "movie"},
+    {"rar://%5c%5cServer%5cMovies%5cmovie.rar/film.avi", false, "movie"},
+    {"rar://%5c%5cServer%5cMovies%5cmovie%5cfilm.rar/film.avi", true, "movie"},
+    {"rar://%5c%5cServer%5cMovies%5cmovie%5cdisc%201%5cfilm.rar/BDMV/index.bdmv", true, "movie"},
+    {"archive://%5c%5cServer%5cMovies%5cmovie.tar.gz/film.avi", false, "movie"},
+    {"archive://%5c%5cServer%5cMovies%5cmovie%5cfilm.tar.gz/film.avi", true, "movie"},
+    {"archive://%5c%5cServer%5cMovies%5cmovie%5cdisc%201%5cfilm.tar.gz/BDMV/index.bdmv", true,
+     "movie"}};
 
 TEST_P(TestFileItemMovieName, GetMovieName)
 {
@@ -149,15 +453,8 @@ TEST_P(TestFileItemMovieName, GetMovieName)
 INSTANTIATE_TEST_SUITE_P(NameMovies, TestFileItemMovieName, ValuesIn(BaseNames));
 
 const TestFileData BasePaths[] = {
-    {"c:\\dir\\", true, "c:\\dir\\"},
-    {"/dir/filename.avi", false, "/dir/"},
-    {"/dir/", true, "/dir/"},
-    {"smb://somepath/file.avi", false, "smb://somepath/"},
-    {"smb://somepath/", true, "smb://somepath/"},
-    {"smb://somepath/disc 1/file.avi", false, "smb://somepath/disc 1/"},
-    {"smb://somepath/disc 1/", true, "smb://somepath/disc 1/"},
-    {"/home/user/TV Shows/Dexter/S1/1x01.avi", false, "/home/user/TV Shows/Dexter/S1/"},
-    {"/home/user/TV Shows/Dexter/S1/", true, "/home/user/TV Shows/Dexter/S1/"},
+    // Linux path tests
+    {"/home/user/movies/movie/", true, "/home/user/movies/movie/"},
     {"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie/"},
     {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", false,
      "/home/user/movies/movie/disc 1/"},
@@ -165,17 +462,122 @@ const TestFileData BasePaths[] = {
     {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", false, "/home/user/movies/movie/disc 1/"},
     {"/home/user/movies/movie/movie.iso", false, "/home/user/movies/movie/"},
     {"/home/user/movies/movie/disc 1/movie.iso", false, "/home/user/movies/movie/disc 1/"},
-    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/00800.mpls",
+    {"stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi",
+     false, "/path/to/movie_name/"},
+    // DOS path tests
+    {"D:\\Movies\\Movie\\", true, "D:\\Movies\\Movie\\"},
+    {"D:\\Movies\\Movie\\video_ts\\VIDEO_TS.IFO", false, "D:\\Movies\\Movie\\"},
+    {"D:\\Movies\\Movie\\disc 1\\video_ts\\VIDEO_TS.IFO", false, "D:\\Movies\\Movie\\disc 1\\"},
+    {"D:\\Movies\\Movie\\BDMV\\index.bdmv", false, "D:\\Movies\\Movie\\"},
+    {"D:\\Movies\\Movie\\disc 1\\BDMV\\index.bdmv", false, "D:\\Movies\\Movie\\disc 1\\"},
+    {"D:\\Movies\\Movie\\movie.iso", false, "D:\\Movies\\Movie\\"},
+    {"D:\\Movies\\Movie\\disc 1\\movie.iso", false, "D:\\Movies\\Movie\\disc 1\\"},
+    {"stack://D:\\Movies\\Movie\\Movie - part 1\\some_file1.avi , D:\\Movies\\Movie\\Movie - part "
+     "2\\some_file2.avi",
+     false, "D:\\Movies\\Movie\\"},
+    // Windows server path tests
+    {"\\\\Server\\Movies\\Movie\\", true, "\\\\Server\\Movies\\Movie\\"},
+    {"\\\\Server\\Movies\\Movie\\video_ts\\VIDEO_TS.IFO", false, "\\\\Server\\Movies\\Movie\\"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\video_ts\\VIDEO_TS.IFO", false,
+     "\\\\Server\\Movies\\Movie\\disc 1\\"},
+    {"\\\\Server\\Movies\\Movie\\BDMV\\index.bdmv", false, "\\\\Server\\Movies\\Movie\\"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\BDMV\\index.bdmv", false,
+     "\\\\Server\\Movies\\Movie\\disc 1\\"},
+    {"\\\\Server\\Movies\\Movie\\movie.iso", false, "\\\\Server\\Movies\\Movie\\"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\movie.iso", false, "\\\\Server\\Movies\\Movie\\disc 1\\"},
+    {"stack://\\\\Server\\Movies\\Movie\\Movie - part 1\\some_file1.avi , "
+     "\\\\Server\\Movies\\Movie\\Movie - part "
+     "2\\some_file2.avi",
+     false, "\\\\Server\\Movies\\Movie\\"},
+    // URL path tests with smb://
+    {"smb://home/user/movies/movie/", true, "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/video_ts/VIDEO_TS.IFO", false, "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", false,
+     "smb://home/user/movies/movie/disc 1/"},
+    {"smb://home/user/movies/movie/BDMV/index.bdmv", false, "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/disc 1/BDMV/index.bdmv", false,
+     "smb://home/user/movies/movie/disc 1/"},
+    {"smb://home/user/movies/movie/movie.iso", false, "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/disc 1/movie.iso", false,
+     "smb://home/user/movies/movie/disc 1/"},
+    {"stack://smb://path/to/movie_name/cd1/some_file1.avi , "
+     "smb://path/to/movie_name/cd2/some_file2.avi",
+     false, "smb://path/to/movie_name/"},
+    // Embedded smb:// path tests
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
      false, "smb://somepath/"},
-    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fdisc%201%252fmovie.iso%2f/BDMV/PLAYLIST/"
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fdisc%25201%252fmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
      "00800.mpls",
      false, "smb://somepath/disc 1/"},
     {"bluray://smb%3a%2f%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", false, "smb://somepath/"},
     {"bluray://smb%3a%2f%2fsomepath%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls", false,
      "smb://somepath/disc 1/"},
-    {"/dir/filename.m3u8", true, "/dir/"},
-    {"/dir/filename.zip", true, "/dir/"},
-    {"smb://somepath/filename.rar", true, "smb://somepath/"}};
+    {"zip://smb%3a%2f%2fsomepath%2fmovie.zip/BDMV/index.bdmv", false, "smb://somepath/"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2ffilm.zip/BDMV/index.bdmv", false,
+     "smb://somepath/movie/disc 1/"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie.rar/BDMV/index.bdmv", false, "smb://somepath/"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2ffilm.rar/BDMV/index.bdmv", false,
+     "smb://somepath/movie/disc 1/"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie.tar.gz/BDMV/index.bdmv", false, "smb://somepath/"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2ffilm.tar.gz/BDMV/index.bdmv", false,
+     "smb://somepath/movie/disc 1/"},
+    // Embedded linux path tests
+    {"bluray://udf%3a%2f%2f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/00800.mpls", false,
+     "/somepath/"},
+    {"bluray://udf%3a%2f%2f%252fsomepath%252fdisc%25201%252fmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     false, "/somepath/disc 1/"},
+    {"bluray://%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", false, "/somepath/"},
+    {"bluray://%2fsomepath%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls", false, "/somepath/disc 1/"},
+    {"zip://%2fsomepath%2fmovie.zip/BDMV/index.bdmv", false, "/somepath/"},
+    {"zip://%2fsomepath%2fdisc%201%2fmovie.zip/BDMV/index.bdmv", false, "/somepath/disc 1/"},
+    {"rar://%2fsomepath%2fmovie.rar/BDMV/index.bdmv", false, "/somepath/"},
+    {"rar://%2fsomepath%2fdisc%201%2fmovie_disc.rar/BDMV/index.bdmv", false, "/somepath/disc 1/"},
+    {"archive://%2fsomepath%2fmovie.tar.gz/BDMV/index.bdmv", false, "/somepath/"},
+    {"archive://%2fsomepath%2fdisc%201%2fmovie.tar.gz/BDMV/index.bdmv", true, "/somepath/disc 1/"},
+    // Embedded DOS path tests
+    {"bluray://udf%3a%2f%2fD%253a%255cmovies%255cmovie.iso%2f/BDMV/PLAYLIST/00800.mpls", false,
+     "D:\\movies\\"},
+    {"bluray://udf%3a%2f%2fD%253a%255cmovies%255cdisc%25201%255cmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     false, "D:\\movies\\disc 1\\"},
+    {"bluray://D%3a%5cmovie%5c/BDMV/PLAYLIST/00800.mpls", false, "D:\\movie\\"},
+    {"bluray://D%3a%5cmovie%5cdisc%201%5c/BDMV/PLAYLIST/00800.mpls", false, "D:\\movie\\disc 1\\"},
+    {"zip://D%3a%5cmovies%5cmovie.zip/BDMV/index.bdmv", false, "D:\\movies\\"},
+    {"zip://D%3a%5cmovies%5cmovie%5cdisc%201%5cmovie.zip/BDMV/index.bdmv", false,
+     "D:\\movies\\movie\\disc 1\\"},
+    {"rar://D%3a%5cmovies%5cmovie.rar/BDMV/index.bdmv", false, "D:\\movies\\"},
+    {"rar://D%3a%5cmovies%5cmovie%5cdisc%201%5cmovie.rar/BDMV/index.bdmv", false,
+     "D:\\movies\\movie\\disc 1\\"},
+    {"archive://D%3a%5cmovies%5cmovie.tar.gz/BDMV/index.bdmv", false, "D:\\movies\\"},
+    {"archive://D%3a%5cmovies%5cmovie%5cdisc%201%5cmovie.tar.gz/BDMV/index.bdmv", false,
+     "D:\\movies\\movie\\disc 1\\"},
+    // Embedded Windows server path tests
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/00800.mpls",
+     false, "\\\\Server\\Movies\\"},
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cMovie%255cdisc%25201%255cmovie.iso%2f/"
+     "BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     false, "\\\\Server\\Movies\\Movie\\disc 1\\"},
+    {"bluray://%5c%5cServer%5cMovies%5cMovie%5c/BDMV/PLAYLIST/00800.mpls", false,
+     "\\\\Server\\Movies\\Movie\\"},
+    {"bluray://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5c/BDMV/PLAYLIST/00800.mpls", false,
+     "\\\\Server\\Movies\\Movie\\disc 1\\"},
+    {"zip://%5c%5cServer%5cMovies%5cmovie.zip/BDMV/index.bdmv", false, "\\\\Server\\Movies\\"},
+    {"zip://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5cmovie.zip/BDMV/index.bdmv", false,
+     "\\\\Server\\Movies\\Movie\\disc 1\\"},
+    {"rar://%5c%5cServer%5cMovies%5cmovie.rar/BDMV/index.bdmv", false, "\\\\Server\\Movies\\"},
+    {"rar://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5cmovie.rar/BDMV/index.bdmv", false,
+     "\\\\Server\\Movies\\Movie\\disc 1\\"},
+    {"archive://%5c%5cServer%5cMovies%5cmovie.tar.gz/BDMV/index.bdmv", false,
+     "\\\\Server\\Movies\\"},
+    {"archive://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5cmovie.tar.gz/BDMV/index.bdmv", false,
+     "\\\\Server\\Movies\\Movie\\disc 1\\"}};
 
 TEST_P(TestFileItemLocalMetadataPath, GetLocalMetadataPath)
 {

--- a/xbmc/test/TestURL.cpp
+++ b/xbmc/test/TestURL.cpp
@@ -124,3 +124,166 @@ TEST(TestURL, TestWithoutFilenameEncodingDecoding)
   EXPECT_EQ("u$ername", decoded.GetUserName());
   EXPECT_EQ("pa$$word", decoded.GetPassWord());
 }
+
+TEST_F(TestCURL, TestPaths)
+{
+  // Linux path
+  std::string path{"/somepath/path/movie.avi"};
+  CURL url(path);
+  EXPECT_EQ(url.GetFileName(), path);
+  EXPECT_EQ(url.GetShareName(), "");
+  EXPECT_EQ(url.GetHostName(), "");
+  EXPECT_EQ(url.GetProtocol(), "");
+  EXPECT_EQ(url.GetFileType(), "avi");
+  EXPECT_EQ(url.Get(), path);
+
+  path = "/somepath/path/";
+  url.SetFileName(path);
+  EXPECT_EQ(url.Get(), path);
+
+  // DOS path
+  path = "D:\\Movies\\movie.avi";
+  url = CURL(path);
+  EXPECT_EQ(url.GetFileName(), path);
+  EXPECT_EQ(url.GetShareName(), "D:");
+  EXPECT_EQ(url.GetHostName(), "");
+  EXPECT_EQ(url.GetProtocol(), "");
+  EXPECT_EQ(url.GetFileType(), "avi");
+  EXPECT_EQ(url.Get(), path);
+
+  path = "D:\\Movies\\";
+  url.SetFileName(path);
+  EXPECT_EQ(url.Get(), path);
+
+  // Windows server path
+  path = "\\\\Server\\Movies\\movie.avi";
+  url = CURL(path);
+  EXPECT_EQ(url.GetFileName(), path);
+  EXPECT_EQ(url.GetShareName(), "");
+  EXPECT_EQ(url.GetHostName(), "");
+  EXPECT_EQ(url.GetProtocol(), "");
+  EXPECT_EQ(url.GetFileType(), "avi");
+  EXPECT_EQ(url.Get(), path);
+
+  path = "\\\\Server\\Movies\\";
+  url.SetFileName(path);
+  EXPECT_EQ(url.Get(), path);
+
+  // URL path with smb://
+  path = "smb://somepath/Movies/movie.mkv";
+  url = CURL(path);
+  EXPECT_EQ(url.GetFileName(), "Movies/movie.mkv");
+  EXPECT_EQ(url.GetShareName(), "Movies");
+  EXPECT_EQ(url.GetHostName(), "somepath");
+  EXPECT_EQ(url.GetProtocol(), "smb");
+  EXPECT_EQ(url.GetFileType(), "mkv");
+  EXPECT_EQ(url.Get(), path);
+
+  url.SetFileName("Films/film.mp4");
+  path = "smb://somepath/Films/film.mp4";
+  EXPECT_EQ(url.GetFileName(), "Films/film.mp4");
+  EXPECT_EQ(url.GetShareName(), "Films");
+  EXPECT_EQ(url.GetHostName(), "somepath");
+  EXPECT_EQ(url.GetProtocol(), "smb");
+  EXPECT_EQ(url.GetFileType(), "mp4");
+  EXPECT_EQ(url.Get(), path);
+
+  // bluray:// path
+  path =
+      "bluray://"
+      "udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fMovies%252fAlien%2520(1979)%252fDisc%25201%252f"
+      "ALIEN.ISO%2f/BDMV/PLAYLIST/"
+      "00800.mpls";
+  url = CURL(path);
+  EXPECT_EQ(url.GetFileName(), "BDMV/PLAYLIST/00800.mpls");
+  EXPECT_EQ(url.GetShareName(), "BDMV");
+  EXPECT_EQ(url.GetHostName(),
+            "udf://smb%3a%2f%2fsomepath%2fMovies%2fAlien%20(1979)%2fDisc%201%2fALIEN.ISO/");
+  EXPECT_EQ(url.GetProtocol(), "bluray");
+  EXPECT_EQ(url.GetFileType(), "mpls");
+  EXPECT_EQ(url.Get(), path);
+
+  // Contains an embedded udf:// path
+  std::string path2{url.GetHostName()};
+  CURL url2(path2);
+  EXPECT_EQ(url2.GetFileName(), "");
+  EXPECT_EQ(url2.GetShareName(), "");
+  EXPECT_EQ(url2.GetHostName(), "smb://somepath/Movies/Alien (1979)/Disc 1/ALIEN.ISO");
+  EXPECT_EQ(url2.GetProtocol(), "udf");
+  EXPECT_EQ(url2.GetFileType(), "");
+  EXPECT_EQ(url2.Get(), path2);
+
+  // Contains an embedded smb:// path
+  std::string path3{url2.GetHostName()};
+  CURL url3(path3);
+  EXPECT_EQ(url3.GetFileName(), "Movies/Alien (1979)/Disc 1/ALIEN.ISO");
+  EXPECT_EQ(url3.GetShareName(), "Movies");
+  EXPECT_EQ(url3.GetHostName(), "somepath");
+  EXPECT_EQ(url3.GetProtocol(), "smb");
+  EXPECT_EQ(url3.GetFileType(), "iso");
+  EXPECT_EQ(url3.Get(), path3);
+
+  // Alter the smb path to point to Disc 2
+  url3.SetFileName("Movies/Alien (1979)/Disc 2/ALIEN_DISC2.NRG");
+  path3 = "smb://somepath/Movies/Alien (1979)/Disc 2/ALIEN_DISC2.NRG";
+  EXPECT_EQ(url3.GetFileName(), "Movies/Alien (1979)/Disc 2/ALIEN_DISC2.NRG");
+  EXPECT_EQ(url3.GetShareName(), "Movies");
+  EXPECT_EQ(url3.GetHostName(), "somepath");
+  EXPECT_EQ(url3.GetProtocol(), "smb");
+  EXPECT_EQ(url3.GetFileType(), "nrg");
+  EXPECT_EQ(url3.Get(), path3);
+
+  // Update the udf:// path to use the new smb path
+  url2.SetHostName(url3.Get());
+  path2 = "udf://smb%3a%2f%2fsomepath%2fMovies%2fAlien%20(1979)%2fDisc%202%2fALIEN_DISC2.NRG/";
+  EXPECT_EQ(url2.GetFileName(), "");
+  EXPECT_EQ(url2.GetShareName(), "");
+  EXPECT_EQ(url2.GetHostName(), "smb://somepath/Movies/Alien (1979)/Disc 2/ALIEN_DISC2.NRG");
+  EXPECT_EQ(url2.GetProtocol(), "udf");
+  EXPECT_EQ(url2.GetFileType(), "");
+  EXPECT_EQ(url2.Get(), path2);
+
+  // Update the bluray:// path to use the new udf path
+  url.SetHostName(url2.Get());
+  path = "bluray://"
+         "udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fMovies%252fAlien%20(1979)%252fDisc%202%252f"
+         "ALIEN_DISC2.NRG%2f/BDMV/PLAYLIST/"
+         "00800.mpls";
+  url = CURL(path);
+  EXPECT_EQ(url.GetFileName(), "BDMV/PLAYLIST/00800.mpls");
+  EXPECT_EQ(url.GetShareName(), "BDMV");
+  EXPECT_EQ(url.GetHostName(),
+            "udf://smb%3a%2f%2fsomepath%2fMovies%2fAlien (1979)%2fDisc 2%2fALIEN_DISC2.NRG/");
+  EXPECT_EQ(url.GetProtocol(), "bluray");
+  EXPECT_EQ(url.GetFileType(), "mpls");
+  EXPECT_EQ(url.Get(), path);
+}
+
+TEST_F(TestCURL, TestExtensions)
+{
+  CURL url("/somepath/path/movie.zip");
+  EXPECT_EQ(".zip", url.GetExtension());
+  std::string extensions{".zip|.rar|.tar.gz"};
+  EXPECT_TRUE(url.HasExtension(extensions));
+
+  url = CURL("/somepath/path/movie.tar.gz");
+  EXPECT_EQ(".tar.gz", url.GetExtension());
+  EXPECT_TRUE(url.HasExtension(extensions));
+
+  url = CURL("/somepath/path/movie.gz");
+  EXPECT_EQ(".gz", url.GetExtension());
+  EXPECT_FALSE(url.HasExtension(extensions));
+
+  url = CURL("/somepath/path/movie.name.zip");
+  EXPECT_EQ(".zip", url.GetExtension());
+  extensions = ".zip|.rar|.tar.gz";
+  EXPECT_TRUE(url.HasExtension(extensions));
+
+  url = CURL("/somepath/path/movie.name.tar.gz");
+  EXPECT_EQ(".tar.gz", url.GetExtension());
+  EXPECT_TRUE(url.HasExtension(extensions));
+
+  url = CURL("/somepath/path/movie.name.gz");
+  EXPECT_EQ(".gz", url.GetExtension());
+  EXPECT_FALSE(url.HasExtension(extensions));
+}

--- a/xbmc/test/TestUtil.cpp
+++ b/xbmc/test/TestUtil.cpp
@@ -8,6 +8,7 @@
 
 #include "Util.h"
 
+#include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>
 
 using ::testing::Test;
@@ -70,8 +71,6 @@ TEST(TestUtil, ValidatePath)
 {
   std::string path;
 #ifdef TARGET_WINDOWS
-  path = "C:/foo/bar/";
-  EXPECT_EQ(CUtil::ValidatePath(path), "C:\\foo\\bar\\");
   path = "C:\\\\foo\\\\bar\\";
   EXPECT_EQ(CUtil::ValidatePath(path, true), "C:\\foo\\bar\\");
   path = "\\\\foo\\\\bar\\";
@@ -82,6 +81,8 @@ TEST(TestUtil, ValidatePath)
   path = "/foo//bar/";
   EXPECT_EQ(CUtil::ValidatePath(path, true), "/foo/bar/");
 #endif
+  path = "C:\\foo\\bar\\";
+  EXPECT_EQ(CUtil::ValidatePath(path), "C:\\foo\\bar\\");
   path = "smb://foo/bar/";
   EXPECT_EQ(CUtil::ValidatePath(path), "smb://foo/bar/");
   path = "smb://foo//bar/";
@@ -288,21 +289,95 @@ class TestDiscNumbers : public Test, public WithParamInterface<TestDiscData>
 {
 };
 
-const TestDiscData BaseFiles[] = {{"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", ""},
-                                  {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", "1"},
-                                  {"/home/user/movies/movie/BDMV/index.bdmv", ""},
-                                  {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", "1"},
-                                  {"/home/user/movies/movie.iso", ""},
-                                  {"/home/user/movies/movie/file.iso", ""},
-                                  {"/home/user/movies/disc 1/movie.iso", "1"},
-                                  {"/home/user/movies/movie/disc 1/file.iso", "1"},
-                                  {"/home/user/movies/movie.avi", ""},
-                                  {"/home/user/movies/movie/file.avi", ""},
-                                  {"/home/user/movies/movie/disc 1/file.avi", "1"},
-                                  {"/home/user/movies/movie/disk 1/file.avi", "1"},
-                                  {"/home/user/movies/movie/cd 1/file.avi", "1"},
-                                  {"/home/user/movies/movie/dvd 1/file.avi", "1"},
-                                  {"smb://home/user/movies/movie/disc 1/file.avi", "1"}};
+const TestDiscData BaseFiles[] = {
+    // Linux path tests
+    {"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", ""},
+    {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", "1"},
+    {"/home/user/movies/movie/BDMV/index.bdmv", ""},
+    {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", "1"},
+    {"/home/user/movies/movie.iso", ""},
+    {"/home/user/movies/movie/file.iso", ""},
+    {"/home/user/movies/disc 1/movie.iso", "1"},
+    {"/home/user/movies/movie/disc 1/file.iso", "1"},
+    {"/home/user/movies/movie.avi", ""},
+    {"/home/user/movies/movie/file.avi", ""},
+    {"/home/user/movies/movie/disc 1/file.avi", "1"},
+    {"/home/user/movies/movie/disk 1/file.avi", "1"},
+    {"/home/user/movies/movie/cd 1/file.avi", "1"},
+    {"/home/user/movies/movie/dvd 1/file.avi", "1"},
+    // DOS path tests
+    {"D:\\Movies\\Movie\\video_ts\\VIDEO_TS.IFO", ""},
+    {"D:\\Movies\\Movie\\disc 1\\video_ts\\VIDEO_TS.IFO", "1"},
+    {"D:\\Movies\\Movie\\BDMV\\index.bdmv", ""},
+    {"D:\\Movies\\Movie\\disc 1\\BDMV\\index.bdmv", "1"},
+    {"D:\\Movies\\Movie\\movie.iso", ""},
+    {"D:\\Movies\\Movie\\file.iso", ""},
+    {"D:\\Movies\\Movie\\disc 1\\movie.iso", "1"},
+    {"D:\\Movies\\Movie\\disc 1\\file.iso", "1"},
+    {"D:\\Movies\\Movie\\movie.avi", ""},
+    {"D:\\Movies\\Movie\\file.avi", ""},
+    {"D:\\Movies\\Movie\\disc 1\\file.avi", "1"},
+    {"D:\\Movies\\Movie\\disk 1\\file.avi", "1"},
+    {"D:\\Movies\\Movie\\cd 1\\file.avi", "1"},
+    {"D:\\Movies\\Movie\\dvd 1\\file.avi", "1"},
+    // Server path tests
+    {"\\\\Server\\Movies\\Movie\\video_ts\\VIDEO_TS.IFO", ""},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\video_ts\\VIDEO_TS.IFO", "1"},
+    {"\\\\Server\\Movies\\Movie\\BDMV\\index.bdmv", ""},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\BDMV\\index.bdmv", "1"},
+    {"\\\\Server\\Movies\\Movie\\movie.iso", ""},
+    {"\\\\Server\\Movies\\Movie\\file.iso", ""},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\movie.iso", "1"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\file.iso", "1"},
+    {"\\\\Server\\Movies\\Movie\\movie.avi", ""},
+    {"\\\\Server\\Movies\\Movie\\file.avi", ""},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\file.avi", "1"},
+    {"\\\\Server\\Movies\\Movie\\disk 1\\file.avi", "1"},
+    {"\\\\Server\\Movies\\Movie\\cd 1\\file.avi", "1"},
+    {"\\\\Server\\Movies\\Movie\\dvd 1\\file.avi", "1"},
+    // URL path tests with smb://
+    {"smb://home/user/movies/movie/video_ts/VIDEO_TS.IFO", ""},
+    {"smb://home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", "1"},
+    {"smb://home/user/movies/movie/BDMV/index.bdmv", ""},
+    {"smb://home/user/movies/movie/disc 1/BDMV/index.bdmv", "1"},
+    {"smb://home/user/movies/movie.iso", ""},
+    {"smb://home/user/movies/movie/file.iso", ""},
+    {"smb://home/user/movies/disc 1/movie.iso", "1"},
+    {"smb://home/user/movies/movie/disc 1/file.iso", "1"},
+    {"smb://home/user/movies/movie.avi", ""},
+    {"smb://home/user/movies/movie/file.avi", ""},
+    {"smb://home/user/movies/movie/disc 1/file.avi", "1"},
+    {"smb://home/user/movies/movie/disk 1/file.avi", "1"},
+    {"smb://home/user/movies/movie/cd 1/file.avi", "1"},
+    {"smb://home/user/movies/movie/dvd 1/file.avi", "1"},
+    // Embedded linux path tests
+    {"bluray://udf%3a%2f%2f%252fsomepath%252fpath%252fdisc%25201%252fmovie.iso%2f/"
+     "BDMV/PLAYLIST/00800.mpls",
+     "1"},
+    {"zip://%2fsomepath%2fpath%2fdisc%202%2fmovie.zip/BDMV/index.bdmv", "2"},
+    {"rar://%2fsomepath%2fpath%2fdisc%203%2fmovie.rar/BDMV/index.bdmv", "3"},
+    {"archive://%2fsomepath%2fpath%2fdisc%204%2fmovie.tar.gz/VIDEO_TS/VIDEO_TS.IFO", "4"},
+    // Embedded DOS path tests
+    {"bluray://udf%3a%2f%2fD%253a%255csomepath%255cdisc%25201%255cmovie.iso%2f/"
+     "BDMV/PLAYLIST/00800.mpls",
+     "1"},
+    {"zip://D%3a%5csomepath%5cdisc%202%5cmovie.zip/BDMV/index.bdmv", "2"},
+    {"rar://D%3a%5csomepath%5cdisc%203%5cmovie.rar/BDMV/index.bdmv", "3"},
+    {"archive://D%3a%5csomepath%5cdisc%204%5cmovie.tar.gz/VIDEO_TS/VIDEO_TS.IFO", "4"},
+    // Embedded windows server path tests
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovie%255cdisc%25201%255cmovie.iso%2f/"
+     "BDMV/PLAYLIST/00800.mpls",
+     "1"},
+    {"zip://%5c%5cServer%5cMovie%5cdisc%202%5cmovie.zip/BDMV/index.bdmv", "2"},
+    {"rar://%5c%5cServer%5cMovie%5cdisc%203%5cmovie.rar/BDMV/index.bdmv", "3"},
+    {"archive://%5c%5cServer%5cMovie%5cdisc%204%5cmovie.tar.gz/VIDEO_TS/VIDEO_TS.IFO", "4"},
+    // Embedded URL tests with smb://
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fdisc%25201%252fmovie.iso%2f/"
+     "BDMV/PLAYLIST/00800.mpls",
+     "1"},
+    {"zip://smb%3a%2f%2fsomepath%2fpath%2fdisc%202%2fmovie.zip/BDMV/index.bdmv", "2"},
+    {"rar://smb%3a%2f%2fsomepath%2fpath%2fdisc%203%2fmovie.rar/BDMV/index.bdmv", "3"},
+    {"archive://smb%3a%2f%2fsomepath%2fpath%2fdisc%204%2fmovie.tar.gz/VIDEO_TS/VIDEO_TS.IFO", "4"}};
 
 TEST_P(TestDiscNumbers, GetDiscNumbers)
 {
@@ -323,6 +398,7 @@ class TestRemoveDiscNumbers : public Test, public WithParamInterface<TestRemoveD
 };
 
 const TestRemoveData BasePaths[] = {
+    // Linux path tests
     {"/home/user/movies/movie/video_ts/", "/home/user/movies/movie/"},
     {"/home/user/movies/movie/disc 1/video_ts/", "/home/user/movies/movie/"},
     {"/home/user/movies/movie/BDMV/", "/home/user/movies/movie/"},
@@ -334,7 +410,75 @@ const TestRemoveData BasePaths[] = {
     {"/home/user/movies/movie/disk 1/file.avi", "/home/user/movies/movie/"},
     {"/home/user/movies/movie/cd 1/file.avi", "/home/user/movies/movie/"},
     {"/home/user/movies/movie/dvd 1/file.avi", "/home/user/movies/movie/"},
-    {"smb://home/user/movies/movie/disc 1/file.avi", "smb://home/user/movies/movie/"}};
+    // DOS path tests
+    {"D:\\movies\\movie\\video_ts\\", "D:\\movies\\movie\\"},
+    {"D:\\movies\\movie\\disc 1\\video_ts\\", "D:\\movies\\movie\\"},
+    {"D:\\movies\\movie\\BDMV\\", "D:\\movies\\movie\\"},
+    {"D:\\movies\\movie\\disc 1\\BDMV\\index.bdmv", "D:\\movies\\movie\\"},
+    {"D:\\movies\\movie\\file.iso", "D:\\movies\\movie\\"},
+    {"D:\\movies\\movie\\disc 1\\file.iso", "D:\\movies\\movie\\"},
+    {"D:\\movies\\movie\\file.avi", "D:\\movies\\movie\\"},
+    {"D:\\movies\\movie\\disc 1\\file.avi", "D:\\movies\\movie\\"},
+    {"D:\\movies\\movie\\disk 1\\file.avi", "D:\\movies\\movie\\"},
+    {"D:\\movies\\movie\\cd 1\\file.avi", "D:\\movies\\movie\\"},
+    {"D:\\movies\\movie\\dvd 1\\file.avi", "D:\\movies\\movie\\"},
+    // Server path tests
+    {"\\\\Server\\Movies\\movie\\video_ts\\", "\\\\Server\\Movies\\movie\\"},
+    {"\\\\Server\\Movies\\movie\\disc 1\\video_ts\\", "\\\\Server\\Movies\\movie\\"},
+    {"\\\\Server\\Movies\\movie\\BDMV\\", "\\\\Server\\Movies\\movie\\"},
+    {"\\\\Server\\Movies\\movie\\disc 1\\BDMV\\index.bdmv", "\\\\Server\\Movies\\movie\\"},
+    {"\\\\Server\\Movies\\movie\\file.iso", "\\\\Server\\Movies\\movie\\"},
+    {"\\\\Server\\Movies\\movie\\disc 1\\file.iso", "\\\\Server\\Movies\\movie\\"},
+    {"\\\\Server\\Movies\\movie\\file.avi", "\\\\Server\\Movies\\movie\\"},
+    {"\\\\Server\\Movies\\movie\\disc 1\\file.avi", "\\\\Server\\Movies\\movie\\"},
+    {"\\\\Server\\Movies\\movie\\disk 1\\file.avi", "\\\\Server\\Movies\\movie\\"},
+    {"\\\\Server\\Movies\\movie\\cd 1\\file.avi", "\\\\Server\\Movies\\movie\\"},
+    {"\\\\Server\\Movies\\movie\\dvd 1\\file.avi", "\\\\Server\\Movies\\movie\\"},
+    // URL path tests with smb://
+    {"smb://home/user/movies/movie/video_ts/", "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/disc 1/video_ts/", "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/BDMV/", "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/disc 1/BDMV/index.bdmv", "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/file.iso", "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/disc 1/file.iso", "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/file.avi", "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/disc 1/file.avi", "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/disk 1/file.avi", "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/cd 1/file.avi", "smb://home/user/movies/movie/"},
+    {"smb://home/user/movies/movie/dvd 1/file.avi", "smb://home/user/movies/movie/"},
+    // Embedded linux path tests
+    {"bluray://udf%3a%2f%2f%252fsomepath%252fpath%252fdisc%25201%252fmovie.iso%2f/"
+     "BDMV/PLAYLIST/00800.mpls",
+     "/somepath/path/"},
+    {"zip://%2fsomepath%2fpath%2fdisc%202%2fmovie.zip/BDMV/index.bdmv", "/somepath/path/"},
+    {"rar://%2fsomepath%2fpath%2fdisc%203%2fmovie.rar/BDMV/index.bdmv", "/somepath/path/"},
+    {"archive://%2fsomepath%2fpath%2fdisc%204%2fmovie.tar.gz/VIDEO_TS/VIDEO_TS.IFO",
+     "/somepath/path/"},
+    // Embedded DOS path tests
+    {"bluray://udf%3a%2f%2fD%253a%255csomepath%255cdisc%25201%255cmovie.iso%2f/"
+     "BDMV/PLAYLIST/00800.mpls",
+     "D:\\somepath\\"},
+    {"zip://D%3a%5csomepath%5cdisc%202%5cmovie.zip/BDMV/index.bdmv", "D:\\somepath\\"},
+    {"rar://D%3a%5csomepath%5cdisc%203%5cmovie.rar/BDMV/index.bdmv", "D:\\somepath\\"},
+    {"archive://D%3a%5csomepath%5cdisc%204%5cmovie.tar.gz/VIDEO_TS/VIDEO_TS.IFO", "D:\\somepath\\"},
+    // Embedded Windows server path tests
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovie%255cdisc%25201%255cmovie.iso%2f/"
+     "BDMV/PLAYLIST/00800.mpls",
+     "\\\\Server\\Movie\\"},
+    {"zip://%5c%5cServer%5cMovie%5cdisc%202%5cmovie.zip/BDMV/index.bdmv", "\\\\Server\\Movie\\"},
+    {"rar://%5c%5cServer%5cMovie%5cdisc%203%5cmovie.rar/BDMV/index.bdmv", "\\\\Server\\Movie\\"},
+    {"archive://%5c%5cServer%5cMovie%5cdisc%204%5cmovie.tar.gz/VIDEO_TS/VIDEO_TS.IFO",
+     "\\\\Server\\Movie\\"},
+    // Embedded URL tests with smb://
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fdisc%25201%252fmovie.iso%2f/"
+     "BDMV/PLAYLIST/00800.mpls",
+     "smb://somepath/path/"},
+    {"zip://smb%3a%2f%2fsomepath%2fpath%2fdisc%202%2fmovie.zip/BDMV/index.bdmv",
+     "smb://somepath/path/"},
+    {"rar://smb%3a%2f%2fsomepath%2fpath%2fdisc%203%2fmovie.rar/BDMV/index.bdmv",
+     "smb://somepath/path/"},
+    {"archive://smb%3a%2f%2fsomepath%2fpath%2fdisc%204%2fmovie.tar.gz/VIDEO_TS/VIDEO_TS.IFO",
+     "smb://somepath/path/"}};
 
 TEST_P(TestRemoveDiscNumbers, RemoveDiscNumbers)
 {
@@ -357,12 +501,7 @@ class TestVideoBasePathAndFileName : public Test, public WithParamInterface<Test
 };
 
 const TestBaseData Paths[] = {
-    {"bluray://smb%3a%2f%2fsomepath%2fmovie%2f/BDMV/PLAYLIST/00800.mpls", "smb://somepath/movie/",
-     "movie"},
-    {"c:\\dir\\movie.avi", "c:\\dir\\", "movie"},
-    {"/dir/movie.avi", "/dir/", "movie"},
-    {"smb://somepath/movie.avi", "smb://somepath/", "movie"},
-    {"smb://somepath/disc 1/movie.avi", "smb://somepath/disc 1/", "movie"},
+    // Linux path tests
     {"/home/user/movies/movie/video_ts/video_ts.ifo", "/home/user/movies/movie/", "movie"},
     {"/home/user/movies/movie/disc 1/video_ts/video_ts.ifo", "/home/user/movies/movie/disc 1/",
      "movie"},
@@ -370,15 +509,115 @@ const TestBaseData Paths[] = {
     {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", "/home/user/movies/movie/disc 1/", "movie"},
     {"/home/user/movies/movie/file.iso", "/home/user/movies/movie/", "file"},
     {"/home/user/movies/movie/disc 1/file.iso", "/home/user/movies/movie/disc 1/", "file"},
+    // DOS path tests
+    {"D:\\movies\\movie\\video_ts\\video_ts.ifo", "D:\\movies\\movie\\", "movie"},
+    {"D:\\movies\\movie\\disc 1\\video_ts\\video_ts.ifo", "D:\\movies\\movie\\disc 1\\", "movie"},
+    {"D:\\movies\\movie\\BDMV\\index.bdmv", "D:\\movies\\movie\\", "movie"},
+    {"D:\\movies\\movie\\disc 1\\BDMV\\index.bdmv", "D:\\movies\\movie\\disc 1\\", "movie"},
+    {"D:\\movies\\movie\\file.iso", "D:\\movies\\movie\\", "file"},
+    {"D:\\movies\\movie\\disc 1\\file.iso", "D:\\movies\\movie\\disc 1\\", "file"},
+    // Windows server path tests
+    {"\\\\Server\\Movies\\movie\\video_ts\\video_ts.ifo", "\\\\Server\\Movies\\movie\\", "movie"},
+    {"\\\\Server\\Movies\\movie\\disc 1\\video_ts\\video_ts.ifo",
+     "\\\\Server\\Movies\\movie\\disc 1\\", "movie"},
+    {"\\\\Server\\Movies\\movie\\BDMV\\index.bdmv", "\\\\Server\\Movies\\movie\\", "movie"},
+    {"\\\\Server\\Movies\\movie\\disc 1\\BDMV\\index.bdmv", "\\\\Server\\Movies\\movie\\disc 1\\",
+     "movie"},
+    {"\\\\Server\\Movies\\movie\\file.iso", "\\\\Server\\Movies\\movie\\", "file"},
+    {"\\\\Server\\Movies\\movie\\disc 1\\file.iso", "\\\\Server\\Movies\\movie\\disc 1\\", "file"},
+    // URL path tests with smb://
+    {"smb://home/user/movies/movie/video_ts/video_ts.ifo", "smb://home/user/movies/movie/",
+     "movie"},
+    {"smb://home/user/movies/movie/disc 1/video_ts/video_ts.ifo",
+     "smb://home/user/movies/movie/disc 1/", "movie"},
+    {"smb://home/user/movies/movie/BDMV/index.bdmv", "smb://home/user/movies/movie/", "movie"},
+    {"smb://home/user/movies/movie/disc 1/BDMV/index.bdmv", "smb://home/user/movies/movie/disc 1/",
+     "movie"},
+    {"smb://home/user/movies/movie/file.iso", "smb://home/user/movies/movie/", "file"},
+    {"smb://home/user/movies/movie/disc 1/file.iso", "smb://home/user/movies/movie/disc 1/",
+     "file"},
+    // Embedded URL tests with smb://
     {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/00800.mpls",
      "smb://somepath/", "movie"},
-    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fdisc%201%252fmovie.iso%2f/BDMV/PLAYLIST/"
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fdisc%25201%252fmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
      "00800.mpls",
      "smb://somepath/disc 1/", "movie"},
     {"bluray://smb%3a%2f%2fsomepath%2fmovie%2f/BDMV/PLAYLIST/00800.mpls", "smb://somepath/movie/",
      "movie"},
     {"bluray://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls",
-     "smb://somepath/movie/disc 1/", "movie"}};
+     "smb://somepath/movie/disc 1/", "movie"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie%2fmovie.zip/BDMV/PLAYLIST/00800.mpls",
+     "smb://somepath/movie/", "movie"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie.zip/file.mkv",
+     "smb://somepath/movie/disc 1/", "movie"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie%2fmovie.rar/BDMV/PLAYLIST/00800.mpls",
+     "smb://somepath/movie/", "movie"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie.rar/file.mkv",
+     "smb://somepath/movie/disc 1/", "movie"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie%2fmovie.tar.gz/BDMV/PLAYLIST/00800.mpls",
+     "smb://somepath/movie/", "movie"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie.tar.gz/file.mkv",
+     "smb://somepath/movie/disc 1/", "movie"},
+    // Embedded linux path tests
+    {"bluray://udf%3a%2f%2f%252fsomepath%252fdisc%25201%252fmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     "/somepath/disc 1/", "movie"},
+    {"bluray://%2fsomepath%2fmovie%2f/BDMV/PLAYLIST/00800.mpls", "/somepath/movie/", "movie"},
+    {"bluray://%2fsomepath%2fmovie%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls",
+     "/somepath/movie/disc 1/", "movie"},
+    {"zip://%2fsomepath%2fmovie%2fmovie.zip/BDMV/PLAYLIST/00800.mpls", "/somepath/movie/", "movie"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie.zip/file.mkv",
+     "smb://somepath/movie/disc 1/", "movie"},
+    {"rar://%2fsomepath%2fmovie%2fmovie.rar/BDMV/PLAYLIST/00800.mpls", "/somepath/movie/", "movie"},
+    {"rar://%2fsomepath%2fmovie%2fdisc%201%2fmovie.rar/file.mkv", "/somepath/movie/disc 1/",
+     "movie"},
+    {"archive://%2fsomepath%2fmovie%2fmovie.tar.gz/BDMV/PLAYLIST/00800.mpls", "/somepath/movie/",
+     "movie"},
+    {"archive://%2fsomepath%2fmovie%2fdisc%201%2fmovie.tar.gz/file.mkv", "/somepath/movie/disc 1/",
+     "movie"},
+    // Embedded DOS path tests
+    {"bluray://udf%3a%2f%2fD%253a%255csomepath%255cmovie%255cdisc%25201%255cmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     "D:\\somepath\\movie\\disc 1\\", "movie"},
+    {"bluray://D%3a%5csomepath%5cmovie%5c/BDMV/PLAYLIST/00800.mpls", "D:\\somepath\\movie\\",
+     "movie"},
+    {"bluray://D%3a%5csomepath%5cmovie%5cdisc%201%5c/BDMV/PLAYLIST/00800.mpls",
+     "D:\\somepath\\movie\\disc 1\\", "movie"},
+    {"zip://D%3a%5csomepath%5cmovie%5cmovie.zip/BDMV/PLAYLIST/00800.mpls", "D:\\somepath\\movie\\",
+     "movie"},
+    {"zip://D%3a%5csomepath%5cmovie%5cdisc%201%5cmovie.zip/file.mkv",
+     "D:\\somepath\\movie\\disc 1\\", "movie"},
+    {"rar://D%3a%5csomepath%5cmovie%5cmovie.rar/BDMV/PLAYLIST/00800.mpls", "D:\\somepath\\movie\\",
+     "movie"},
+    {"rar://D%3a%5csomepath%5cmovie%5cdisc%201%5cmovie.rar/file.mkv",
+     "D:\\somepath\\movie\\disc 1\\", "movie"},
+    {"archive://D%3a%5csomepath%5cmovie%5cmovie.tar.gz/BDMV/PLAYLIST/00800.mpls",
+     "D:\\somepath\\movie\\", "movie"},
+    {"archive://D%3a%5csomepath%5cmovie%5cdisc%201%5cmovie.tar.gz/file.mkv",
+     "D:\\somepath\\movie\\disc 1\\", "movie"},
+    // Embedded windows server path tests
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie%255cdisc%25201%255cmovie.iso%2f/"
+     "BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     "\\\\Server\\Movies\\movie\\disc 1\\", "movie"},
+    {"bluray://%5c%5cServer%5cMovies%5cmovie%5cdisc%201%5c/BDMV/PLAYLIST/00800.mpls",
+     "\\\\Server\\Movies\\movie\\disc 1\\", "movie"},
+    {"zip://%5c%5cServer%5cMovies%5cmovie%5cmovie.zip/BDMV/PLAYLIST/00800.mpls",
+     "\\\\Server\\Movies\\movie\\", "movie"},
+    {"zip://%5c%5cServer%5cMovies%5cmovie%5cdisc%201%5cmovie.zip/file.mkv",
+     "\\\\Server\\Movies\\movie\\disc 1\\", "movie"},
+    {"rar://%5c%5cServer%5cMovies%5cmovie%5cmovie.rar/BDMV/PLAYLIST/00800.mpls",
+     "\\\\Server\\Movies\\movie\\", "movie"},
+    {"rar://%5c%5cServer%5cMovies%5cmovie%5cdisc%201%5cmovie.rar/file.mkv",
+     "\\\\Server\\Movies\\movie\\disc 1\\", "movie"},
+    {"archive://%5c%5cServer%5cMovies%5cmovie%5cmovie.tar.gz/BDMV/PLAYLIST/00800.mpls",
+     "\\\\Server\\Movies\\movie\\", "movie"},
+    {"archive://%5c%5cServer%5cMovies%5cmovie%5cdisc%201%5cmovie.tar.gz/file.mkv",
+     "\\\\Server\\Movies\\movie\\disc 1\\", "movie"}};
 
 TEST_P(TestVideoBasePathAndFileName, GetVideoBasePathAndFileName)
 {
@@ -411,29 +650,158 @@ class TestMatchingSource : public Test, public WithParamInterface<TestMatchingSo
 
 constexpr SourceData Sources[] = {{"Movies", "smb://somepath/Movies/"},
                                   {"TV Shows", "smb://somepath/TV Shows/"},
-                                  {"Documentaries", "/somepath/Documentaries/"}};
+                                  {"Documentaries", "smb://somepath/Documentaries/"},
+                                  {"Movies", "/somepath/Movies/"},
+                                  {"TV Shows", "/somepath/TV Shows/"},
+                                  {"Documentaries", "/somepath/Documentaries/"},
+                                  {"Movies", "D:\\somepath\\Movies\\"},
+                                  {"TV Shows", "D:\\somepath\\TV Shows\\"},
+                                  {"Documentaries", "D:\\somepath\\Documentaries\\"},
+                                  {"Movies", "\\\\Server\\Movies\\"},
+                                  {"TV Shows", "\\\\Server\\TV Shows\\"},
+                                  {"Documentaries", "\\\\Server\\Documentaries\\"}};
 
 constexpr TestMatchingSourceData SourcesToMatch[] = {
+    // URL path tests with smb://
     {"smb://somepath/Movies/Alien (1979)/ALIEN.ISO", 0},
     {"smb://somepath/Movies/Alien (1979)/Disc 1/ALIEN.ISO", 0},
     {"smb://somepath/Movies/Alien (1979)/Disc 1/BDMV/index.bdmv", 0},
     {"bluray://"
-     "udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fMovies%252fAlien%20(1979)%252fALIEN.ISO%2f/BDMV/"
+     "udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fMovies%252fAlien%2520(1979)%252fALIEN.ISO%2f/"
+     "BDMV/"
      "PLAYLIST/"
      "00800.mpls",
      0},
     {"bluray://"
-     "udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fMovies%252fAlien%20(1979)%252fDisc%201%252f"
+     "udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fMovies%252fAlien%2520(1979)%252fDisc%25201%252f"
      "ALIEN.ISO%2f/BDMV/PLAYLIST/"
      "00800.mpls",
      0},
-    {"bluray://smb%3a%2f%2fsomepath%2fMovies%2fAlien%20(1979)/BDMV/PLAYLIST/00800.mpls", 0},
-    {"bluray://smb%3a%2f%2fsomepath%2fMovies%2fAlien%20(1979)%2fDisc%201/BDMV/PLAYLIST/00800.mpls",
+    {"bluray://smb%3a%2f%2fsomepath%2fMovies%2fAlien%2520(1979)/BDMV/PLAYLIST/00800.mpls", 0},
+    {"bluray://smb%3a%2f%2fsomepath%2fMovies%2fAlien%2520(1979)%2fDisc%201/BDMV/PLAYLIST/"
+     "00800.mpls",
      0},
-    {"stack:///somepath/Documentaries/other/part 1.mkv,/somepath/Documentaries/other/part 2.mkv",
-     2},
     {"smb://somepath/TV Shows/A Perfect Planet (2021)/", 1},
-    {"smb://somepath/Other/Something Else/", -1}};
+    {"smb://somepath/Other/Something Else/", -1},
+    {"zip://smb%3a%2f%2fsomepath%2fMovies%2fmovie.zip/BDMV/PLAYLIST/00800.mpls", 0},
+    {"zip://smb%3a%2f%2fsomepath%2fTV%20Shows%2fShowf%2fdisc%201%2fshow.rar/file.mkv", 1},
+    {"rar://smb%3a%2f%2fsomepath%2fMovies%2fmovie.rar/BDMV/PLAYLIST/00800.mpls", 0},
+    {"rar://smb%3a%2f%2fsomepath%2fTV%20Shows%2fShowf%2fdisc%201%2fshow.rar/file.mkv", 1},
+    {"archive://smb%3a%2f%2fsomepath%2fMovies%2fmovie.tar.gz/BDMV/PLAYLIST/00800.mpls", 0},
+    {"archive://smb%3a%2f%2fsomepath%2fTV%20Shows%2fShowf%2fdisc%201%2fshow.tar.gz/file.mkv", 1},
+    {"stack://smb://somepath/Documentaries/other/part 1.mkv , "
+     "smb://somepath/Documentaries/other/part 2.mkv",
+     2},
+    {"stack://smb://somepath/Documentaries/other/other part 1/file.mkv , "
+     "smb://somepath/Documentaries/other/other part 2/file.mkv",
+     2},
+    // Linux path tests
+    {"/somepath/Movies/Alien (1979)/ALIEN.ISO", 3},
+    {"/somepath/Movies/Alien (1979)/Disc 1/ALIEN.ISO", 3},
+    {"/somepath/Movies/Alien (1979)/Disc 1/BDMV/index.bdmv", 3},
+    {"bluray://"
+     "udf%3a%2f%2f%252fsomepath%252fMovies%252fAlien%2520(1979)%252fALIEN.ISO%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     3},
+    {"bluray://"
+     "udf%3a%2f%2f%252fsomepath%252fMovies%252fAlien%2520(1979)%252fDisc%25201%252f"
+     "ALIEN.ISO%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     3},
+    {"bluray://%2fsomepath%2fMovies%2fAlien%2520(1979)/BDMV/PLAYLIST/00800.mpls", 3},
+    {"bluray://%2fsomepath%2fMovies%2fAlien%2520(1979)%2fDisc%201/BDMV/PLAYLIST/"
+     "00800.mpls",
+     3},
+    {"/somepath/TV Shows/A Perfect Planet (2021)/", 4},
+    {"/somepath/Other/Something Else/", -1},
+    {"zip://%2fsomepath%2fMovies%2fmovie.zip/BDMV/PLAYLIST/00800.mpls", 3},
+    {"zip://%2fsomepath%2fTV%20Shows%2fShowf%2fdisc%201%2fshow.rar/file.mkv", 4},
+    {"rar://%2fsomepath%2fMovies%2fmovie.rar/BDMV/PLAYLIST/00800.mpls", 3},
+    {"rar://%2fsomepath%2fTV%20Shows%2fShowf%2fdisc%201%2fshow.rar/file.mkv", 4},
+    {"archive://%2fsomepath%2fMovies%2fmovie.tar.gz/BDMV/PLAYLIST/00800.mpls", 3},
+    {"archive://%2fsomepath%2fTV%20Shows%2fShowf%2fdisc%201%2fshow.tar.gz/file.mkv", 4},
+    {"stack:///somepath/Documentaries/other/part 1.mkv , "
+     "/somepath/Documentaries/other/part 2.mkv",
+     5},
+    {"stack:///somepath/Documentaries/other/other part 1/file.mkv , "
+     "/somepath/Documentaries/other/other part 2/file.mkv",
+     5},
+    // DOS path tests
+    {"D:\\somepath\\Movies\\Alien (1979)\\ALIEN.ISO", 6},
+    {"D:\\somepath\\Movies\\Alien (1979)\\Disc 1\\ALIEN.ISO", 6},
+    {"D:\\somepath\\Movies\\Alien (1979)\\Disc 1\\BDMV\\index.bdmv", 6},
+    {"bluray://udf%3a%2f%2fD%253a%255csomepath%255cMovies%255cAlien%2520(1979)%255cmovie.iso%2f/"
+     "BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     6},
+    {"bluray://"
+     "udf%3a%2f%2fD%253a%255csomepath%255cMovies%255cAlien%2520(1979)%255cdisc%25201%255cmovie.iso%"
+     "2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     6},
+    {"bluray://"
+     "D%3a%5csomepath%5cMovies%5cAlien%20(1979)%5c/BDMV/PLAYLIST/"
+     "00800.mpls",
+     6},
+    {"bluray://"
+     "D%3a%5csomepath%5cMovies%5cAlien%20(1979)%5cdisc%201%5c/BDMV/PLAYLIST/"
+     "00800.mpls",
+     6},
+    {"D:\\somepath\\TV Shows\\A Perfect Planet (2021)\\", 7},
+    {"D:\\somepath\\Other/Something Else\\", -1},
+    {"zip://D%3a%5csomepath%5cMovies%5cmovie.zip/BDMV/PLAYLIST/00800.mpls", 6},
+    {"zip://D%3a%5csomepath%5cTV%20Shows%5cdisc%201%5cshow.rar/file.mkv", 7},
+    {"rar://D%3a%5csomepath%5cMovies%5cmovie.rar/BDMV/PLAYLIST/00800.mpls", 6},
+    {"rar://D%3a%5csomepath%5cTV%20Shows%5cdisc%201%5cshow.rar/file.mkv", 7},
+    {"archive://D%3a%5csomepath%5cMovies%5cmovie.tar.gz/BDMV/PLAYLIST/00800.mpls", 6},
+    {"archive://D%3a%5csomepath%5cTV%20Shows%5cdisc%201%2fshow.tar.gz/file.mkv", 7},
+    {"stack://D:\\somepath\\Documentaries\\other\\part 1.mkv , "
+     "D:\\somepath\\Documentaries\\other\\part 2.mkv",
+     8},
+    {"stack://D:\\somepath\\Documentaries\\other\\other part 1\\file.mkv , "
+     "D:\\somepath\\Documentaries\\other\\other part 2\\file.mkv",
+     8},
+    // Windows server path tests
+    {"\\\\Server\\Movies\\Alien (1979)\\ALIEN.ISO", 9},
+    {"\\\\Server\\Movies\\Alien (1979)\\Disc 1\\ALIEN.ISO", 9},
+    {"\\\\Server\\Movies\\Alien (1979)\\Disc 1\\BDMV\\index.bdmv", 9},
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cAlien%2520(1979)%255cmovie.iso%2f/"
+     "BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     9},
+    {"bluray://"
+     "udf%3a%2f%2f%255c%255cServer%255cMovies%255cAlien%2520(1979)%255cdisc%25201%255cmovie.iso%"
+     "2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     9},
+    {"bluray://"
+     "%5c%5cServer%5cMovies%5cAlien%20(1979)%5c/BDMV/PLAYLIST/"
+     "00800.mpls",
+     9},
+    {"bluray://"
+     "%5c%5cServer%5cMovies%5cAlien%20(1979)%5cdisc%201%5c/BDMV/PLAYLIST/"
+     "00800.mpls",
+     9},
+    {"\\\\Server\\TV Shows\\A Perfect Planet (2021)\\", 10},
+    {"\\\\Server\\Other\\Something Else\\", -1},
+    {"zip://%5c%5cServer%5cMovies%5cmovie.zip/BDMV/PLAYLIST/00800.mpls", 9},
+    {"zip://%5c%5cServer%5cTV%20Shows%5cdisc%201%5cshow.rar/file.mkv", 10},
+    {"rar://%5c%5cServer%5cMovies%5cmovie.rar/BDMV/PLAYLIST/00800.mpls", 9},
+    {"rar://%5c%5cServer%5cTV%20Shows%5cdisc%201%5cshow.rar/file.mkv", 10},
+    {"archive://%5c%5cServer%5cMovies%5cmovie.tar.gz/BDMV/PLAYLIST/00800.mpls", 9},
+    {"archive://%5c%5cServer%5cTV%20Shows%5cdisc%201%2fshow.tar.gz/file.mkv", 10},
+    {"stack://\\\\Server\\Documentaries\\other\\part 1.mkv , "
+     "\\\\Server\\Documentaries\\other\\part 2.mkv",
+     11},
+    {"stack://\\\\Server\\Documentaries\\other\\other part 1\\file.mkv , "
+     "\\\\Server\\Documentaries\\other\\other part 2\\file.mkv",
+     11},
+};
 
 TEST_P(TestMatchingSource, GetMatchingSource)
 {

--- a/xbmc/utils/FileExtensionProvider.cpp
+++ b/xbmc/utils/FileExtensionProvider.cpp
@@ -21,7 +21,9 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
+#include <ranges>
 #include <string>
+#include <string_view>
 #include <vector>
 
 using namespace ADDON;
@@ -104,6 +106,57 @@ std::string CFileExtensionProvider::GetVideoExtensions() const
   if (!extensions.empty())
     extensions += '|';
   extensions += GetAddonExtensions(AddonType::VFS);
+
+  return extensions;
+}
+
+namespace
+{
+std::string GetSingleExtensions(const std::string& extensions)
+{
+  std::string out;
+  for (const auto& ext : StringUtils::Split(extensions, "|"))
+  {
+    if (ext.empty())
+      continue;
+
+    if (std::ranges::count(ext, '.') == 1)
+      out.append(ext + "|");
+  }
+  if (!out.empty())
+    out.pop_back();
+  return out;
+}
+
+std::string GetCompoundExtensions(std::string_view extensions)
+{
+  std::string out;
+  for (const auto& ext : StringUtils::Split(extensions, "|"))
+  {
+    if (ext.empty())
+      continue;
+
+    if (std::ranges::count(ext, '.') > 1)
+      out.append(ext + "|");
+  }
+  if (!out.empty())
+    out.pop_back();
+  return out;
+}
+} // namespace
+
+std::string CFileExtensionProvider::GetArchiveExtensions() const
+{
+  std::string extensions(m_advancedSettings->m_archiveExtensions);
+  extensions += '|' + GetSingleExtensions(GetAddonExtensions(AddonType::VFS));
+
+  return extensions;
+}
+
+std::string CFileExtensionProvider::GetCompoundArchiveExtensions() const
+{
+  std::string extensions(m_advancedSettings->m_compoundArchiveExtensions);
+  extensions += '|' + GetCompoundExtensions(GetAddonExtensions(AddonType::VFS));
 
   return extensions;
 }

--- a/xbmc/utils/FileExtensionProvider.h
+++ b/xbmc/utils/FileExtensionProvider.h
@@ -53,6 +53,16 @@ public:
   const std::string& GetDiscStubExtensions() const;
 
   /*!
+   * @brief Returns a list of archive extensions with a single dot (eg. .zip)
+   */
+  std::string GetArchiveExtensions() const;
+
+  /*!
+   * @brief Returns a list of archive extensions with a multiple dots (eg. .tar.gz)
+   */
+  std::string GetCompoundArchiveExtensions() const;
+
+  /*!
    * @brief Returns a file folder extensions
    */
   std::string GetFileFolderExtensions() const;

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -41,11 +41,7 @@ void CSaveFileState::DoWork(CFileItem& item,
                             bool updatePlayCount)
 {
   std::string progressTrackingFile = item.GetPath();
-  if (item.IsStack() ||
-      (URIUtils::IsBlurayPath(item.GetDynPath()) &&
-       (item.GetVideoContentType() == VideoDbContentType::MOVIES ||
-        item.GetVideoContentType() == VideoDbContentType::EPISODES ||
-        item.GetVideoContentType() == VideoDbContentType::UNKNOWN /* Removable bluray */)))
+  if (CUtil::UseDynPathForAddOrUpdate(item))
   {
     progressTrackingFile = item.GetDynPath();
   }

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -436,7 +436,24 @@ bool URIUtils::GetParentPath(const std::string& strPath, std::string& strParent)
       return GetParentPath(strFile, strParent);
     }
     strParent = url2.Get();
-    return true;
+    return !strParent.empty();
+  }
+  else if (IsBDFile(strPath) || IsDVDFile(strPath))
+  {
+    std::string folder{GetDirectory(strPath)};
+    RemoveSlashAtEnd(folder);
+    const std::string lastFolder{GetFileName(folder)};
+    if (StringUtils::EqualsNoCase(lastFolder, "VIDEO_TS") ||
+        StringUtils::EqualsNoCase(lastFolder, "BDMV"))
+      strParent = GetParentPath(folder); // go back up another one
+    else
+      strParent = folder;
+    return !strParent.empty();
+  }
+  else if (IsArchive(url))
+  {
+    strParent = GetDirectory(url.GetHostName());
+    return !strParent.empty();
   }
   else if (url.IsProtocol("stack"))
   {
@@ -562,14 +579,7 @@ std::string URIUtils::GetDiscBase(const std::string& file)
   if (IsDiscImage(discFile))
     return discFile; // return .ISO
 
-  std::string parent{GetParentPath(discFile)};
-  std::string parentFolder{parent};
-  RemoveSlashAtEnd(parentFolder);
-  parentFolder = GetFileName(parentFolder);
-  if (StringUtils::EqualsNoCase(parentFolder, "VIDEO_TS") ||
-      StringUtils::EqualsNoCase(parentFolder, "BDMV"))
-    return GetParentPath(parent); // go back up another one
-  return parent;
+  return GetParentPath(discFile);
 }
 
 std::string URIUtils::GetDiscBasePath(const std::string& file)

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -30,10 +30,17 @@
 #include "platform/win32/CharsetConverter.h"
 #endif
 
+#include "application/Application.h"
+
 #include <algorithm>
 #include <array>
 #include <cassert>
 #include <charconv>
+#include <cstdint>
+#include <optional>
+#include <ranges>
+#include <string>
+#include <string_view>
 #include <vector>
 
 #include <arpa/inet.h>
@@ -148,128 +155,186 @@ std::string URIUtils::GetExtension(const CURL& url)
   return url.GetExtension();
 }
 
-std::string URIUtils::GetExtension(const std::string& strFileName)
+static constexpr int NO_EXTENSION{-1};
+enum class FindExtensions : uint8_t
 {
-  if (IsURL(strFileName))
+  ONLY_IN_LIST,
+  ALL_EXTENSIONS
+};
+enum class FinalDot : uint8_t
+{
+  IGNORE_FINAL_DOT,
+  CONSIDER_FINAL_DOT
+};
+
+namespace
+{
+/*! \brief Finds the extension (if any) in a given file path.
+   \param path The file path.
+   \param extensions List of '.' prefixed lowercase extensions separated with '|'. 
+                     If there is no list then all extensions are found,
+                     along with selected compound archive extensions.
+   \param extensionsToFind Whether to find only extensions in the given list or all extensions.
+   \param finalDotAction Action to take if there is a final dot in the filename.
+   \return The position of the extension in the path, or NO_EXTENSION if none found.
+ */
+int FindExtension(const std::string& path,
+                  std::string_view extensions = "",
+                  FindExtensions extensionsToFind = FindExtensions::ALL_EXTENSIONS,
+                  FinalDot finalDotAction = FinalDot::IGNORE_FINAL_DOT)
+{
+  if (path.empty())
+    return NO_EXTENSION;
+
+  // Special directories
+  const size_t separator{path.find_last_of("/\\")};
+  const std::string last{path.substr(separator == std::string::npos ? 0 : separator + 1)};
+  if (last == "." || last == "..")
+    return NO_EXTENSION;
+
+  // Single trailing dot - no extension
+  if (path.back() == '.')
+    return finalDotAction == FinalDot::IGNORE_FINAL_DOT ? NO_EXTENSION
+                                                        : static_cast<int>(path.size() - 1);
+
+  const size_t period{path.find_last_of('.')};
+  if (period == std::string::npos || (separator != std::string::npos && period < separator))
+    return NO_EXTENSION; // Separator after last period means no extension
+  if (period == 0 || (separator != std::string::npos && period == separator + 1))
+    return NO_EXTENSION; // No extension (a leading dot only)
+
+  // If no extensions are passed then the routine generically removes all extensions
+  // However it is almost impossible to determine what is a double dot/compound extension and
+  //  what is part of the filename (with dots) so we use a list of known important (to Kodi - ie. archives)
+  //  compound extensions to check against.
+  auto exts{StringUtils::Split(
+      !extensions.empty()
+          ? extensions
+          : CServiceBroker::GetFileExtensionProvider().GetCompoundArchiveExtensions(),
+      '|')};
+
+  // Compound extensions first (otherwise .tar.gz could be detected as .gz only)
+  std::ranges::sort(exts, std::greater{},
+                    [](std::string_view s) { return std::ranges::count(s, '.'); });
+
+  const std::string file{StringUtils::ToLower(last)};
+  for (auto& ext : exts)
   {
-    CURL url(strFileName);
+    if (!ext.empty())
+    {
+      if (const size_t start{ext.find('.')}; start != std::string::npos && start > 0)
+        ext.erase(0, start);
+      if (file.ends_with(ext))
+        return static_cast<int>(path.size() - ext.size());
+    }
+  }
+
+  if (extensionsToFind == FindExtensions::ONLY_IN_LIST)
+    return NO_EXTENSION;
+
+  // Single dot extension
+  return static_cast<int>(period);
+}
+} // namespace
+
+std::string URIUtils::GetExtension(const std::string& path)
+{
+  if (IsURL(path))
+  {
+    CURL url(path);
     return url.GetExtension();
   }
 
-  size_t period = strFileName.find_last_of("./\\");
-  if (period == std::string::npos || strFileName[period] != '.')
-    return std::string();
+  if (const int extension{FindExtension(path)}; extension != NO_EXTENSION)
+    return path.substr(extension);
+  return {};
+}
 
-  return strFileName.substr(period);
+bool URIUtils::HasExtension(const std::string& path)
+{
+  if (IsURL(path))
+  {
+    CURL url(path);
+    return HasExtension(url.GetFileName());
+  }
+
+  return FindExtension(path) != NO_EXTENSION;
+}
+
+bool URIUtils::HasExtension(const CURL& url, std::string_view strExtensions)
+{
+  return url.HasExtension(strExtensions);
+}
+
+bool URIUtils::HasExtension(const std::string& path, std::string_view extensions)
+{
+  if (IsURL(path))
+  {
+    const CURL url(path);
+    return HasExtension(url.GetFileName(), extensions);
+  }
+
+  return FindExtension(path, extensions, FindExtensions::ONLY_IN_LIST) != NO_EXTENSION;
+}
+
+void URIUtils::RemoveExtension(std::string& path)
+{
+  if (IsURL(path))
+  {
+    CURL url(path);
+    path = url.GetFileName();
+    RemoveExtension(path);
+    url.SetFileName(path);
+    path = url.Get();
+    return;
+  }
+
+  // Extensions to remove
+  const std::string extensions{
+      CServiceBroker::GetFileExtensionProvider().GetPictureExtensions() +
+      CServiceBroker::GetFileExtensionProvider().GetMusicExtensions() +
+      CServiceBroker::GetFileExtensionProvider().GetVideoExtensions() +
+      CServiceBroker::GetFileExtensionProvider().GetSubtitleExtensions() +
+      CServiceBroker::GetFileExtensionProvider().GetCompoundArchiveExtensions() +
+      CServiceBroker::GetFileExtensionProvider().GetArchiveExtensions() +
+      "|.py|.xml|.milk|.xbt|.cdg"
+#ifdef TARGET_DARWIN
+      + "|.app|.applescript|.workflow"
+#endif
+  };
+
+  if (const int extension{FindExtension(path, extensions, FindExtensions::ONLY_IN_LIST,
+                                        FinalDot::CONSIDER_FINAL_DOT)};
+      extension != NO_EXTENSION)
+  {
+    path.resize(extension);
+  }
+}
+
+std::string URIUtils::ReplaceExtension(const std::string& path, const std::string& newExtension)
+{
+  if (IsURL(path))
+  {
+    CURL url(path);
+    url.SetFileName(ReplaceExtension(url.GetFileName(), newExtension));
+    return url.Get();
+  }
+
+  const int extension{
+      FindExtension(path, "", FindExtensions::ALL_EXTENSIONS, FinalDot::CONSIDER_FINAL_DOT)};
+  std::string_view base{path};
+  if (extension != NO_EXTENSION)
+    base = base.substr(0, extension);
+  std::string result;
+  result.reserve(base.size() + newExtension.size());
+  result.append(base);
+  result.append(newExtension);
+  return result;
 }
 
 bool URIUtils::HasPluginPath(const CFileItem& item)
 {
   return IsPlugin(item.GetPath()) || IsPlugin(item.GetDynPath());
-}
-
-bool URIUtils::HasExtension(const std::string& strFileName)
-{
-  if (IsURL(strFileName))
-  {
-    CURL url(strFileName);
-    return HasExtension(url.GetFileName());
-  }
-
-  size_t iPeriod = strFileName.find_last_of("./\\");
-  return iPeriod != std::string::npos && strFileName[iPeriod] == '.';
-}
-
-bool URIUtils::HasExtension(const CURL& url, const std::string& strExtensions)
-{
-  return url.HasExtension(strExtensions);
-}
-
-bool URIUtils::HasExtension(const std::string& strFileName, const std::string& strExtensions)
-{
-  if (IsURL(strFileName))
-  {
-    const CURL url(strFileName);
-    return HasExtension(url.GetFileName(), strExtensions);
-  }
-
-  const size_t pos = strFileName.find_last_of("./\\");
-  if (pos == std::string::npos || strFileName[pos] != '.')
-    return false;
-
-  const std::string extensionLower = StringUtils::ToLower(strFileName.substr(pos));
-
-  const std::vector<std::string> extensionsLower =
-      StringUtils::Split(StringUtils::ToLower(strExtensions), '|');
-
-  for (const auto& ext : extensionsLower)
-  {
-    if (StringUtils::EndsWith(ext, extensionLower))
-      return true;
-  }
-
-  return false;
-}
-
-void URIUtils::RemoveExtension(std::string& strFileName)
-{
-  if(IsURL(strFileName))
-  {
-    CURL url(strFileName);
-    strFileName = url.GetFileName();
-    RemoveExtension(strFileName);
-    url.SetFileName(strFileName);
-    strFileName = url.Get();
-    return;
-  }
-
-  size_t period = strFileName.find_last_of("./\\");
-  if (period != std::string::npos && strFileName[period] == '.')
-  {
-    std::string strExtension = strFileName.substr(period);
-    StringUtils::ToLower(strExtension);
-    strExtension += "|";
-
-    std::string strFileMask;
-    strFileMask = CServiceBroker::GetFileExtensionProvider().GetPictureExtensions();
-    strFileMask += "|" + CServiceBroker::GetFileExtensionProvider().GetMusicExtensions();
-    strFileMask += "|" + CServiceBroker::GetFileExtensionProvider().GetVideoExtensions();
-    strFileMask += "|" + CServiceBroker::GetFileExtensionProvider().GetSubtitleExtensions();
-#if defined(TARGET_DARWIN)
-    strFileMask += "|.py|.xml|.milk|.xbt|.cdg|.app|.applescript|.workflow";
-#else
-    strFileMask += "|.py|.xml|.milk|.xbt|.cdg";
-#endif
-    strFileMask += "|";
-
-    if (strFileMask.find(strExtension) != std::string::npos)
-      strFileName.erase(period);
-  }
-}
-
-std::string URIUtils::ReplaceExtension(const std::string& strFile,
-                                      const std::string& strNewExtension)
-{
-  if(IsURL(strFile))
-  {
-    CURL url(strFile);
-    url.SetFileName(ReplaceExtension(url.GetFileName(), strNewExtension));
-    return url.Get();
-  }
-
-  std::string strChangedFile;
-  std::string strExtension = GetExtension(strFile);
-  if (!strExtension.empty())
-  {
-    strChangedFile = strFile.substr(0, strFile.size() - strExtension.size()) ;
-    strChangedFile += strNewExtension;
-  }
-  else
-  {
-    strChangedFile = strFile;
-    strChangedFile += strNewExtension;
-  }
-  return strChangedFile;
 }
 
 std::string URIUtils::GetFileName(const CURL& url)

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -527,31 +527,23 @@ std::string URIUtils::GetBasePath(const std::string& strPath)
 {
   std::string strCheck{strPath};
   if (IsStack(strPath))
-    strCheck = CStackDirectory::GetFirstStackedFile(strPath);
-
-  std::string strDirectory = GetDirectory(strCheck);
-
-  if (IsInRAR(strCheck))
-  {
-    std::string path{strDirectory};
-    GetParentPath(path, strDirectory);
-  }
+    return CStackDirectory::GetBasePath(strPath);
 
   if (IsBDFile(strCheck) || IsDVDFile(strCheck))
-    strDirectory = GetDiscBasePath(strCheck);
+    return GetDiscBasePath(strCheck);
 
 #ifdef HAVE_LIBBLURAY
   if (IsBlurayPath(strCheck))
-    strDirectory = CBlurayDirectory::GetBasePath(CURL(strCheck));
+    return CBlurayDirectory::GetBasePath(CURL(strCheck));
 #endif
 
-  if (IsStack(strPath))
+  if (const CURL url(strPath); IsArchive(url))
   {
-    strCheck = strDirectory;
-    RemoveSlashAtEnd(strCheck);
-    if (GetFileName(strCheck).size() == 3 && StringUtils::StartsWithNoCase(GetFileName(strCheck), "cd"))
-      strDirectory = GetDirectory(strCheck);
+    if (const std::string & hostname{url.GetHostName()}; !hostname.empty())
+      strCheck = hostname;
   }
+
+  std::string strDirectory = GetDirectory(strCheck);
 
   return strDirectory;
 }

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -583,12 +583,10 @@ bool URIUtils::GetParentPath(const std::string& strPath, std::string& strParent)
   }
 
   size_t iPos = strFile.rfind('/');
-#ifndef TARGET_POSIX
   if (iPos == std::string::npos)
   {
     iPos = strFile.rfind('\\');
   }
-#endif
   if (iPos == std::string::npos)
   {
     url.SetFileName("");
@@ -1556,13 +1554,21 @@ bool URIUtils::IsLibraryContent(const std::string &strFile)
           StringUtils::EndsWith(strFile, ".xsp"));
 }
 
-bool URIUtils::IsDOSPath(const std::string &path)
+bool URIUtils::IsDOSPath(const std::string& path)
 {
   if (path.size() > 1 && path[1] == ':' && isalpha(path[0]))
     return true;
 
   // windows network drives
   if (path.size() > 1 && path[0] == '\\' && path[1] == '\\')
+    return true;
+
+  return false;
+}
+
+bool URIUtils::IsAbsolutePOSIXPath(const std::string& path)
+{
+  if (path.size() > 1 && path[0] == '/')
     return true;
 
   return false;

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1107,6 +1107,11 @@ bool URIUtils::IsArchive(const std::string& strFile)
   return HasExtension(strFile, ".zip|.rar|.apk|.cbz|.cbr");
 }
 
+bool URIUtils::IsArchive(const CURL& url)
+{
+  return url.IsProtocol("archive") || url.IsProtocol("zip") || url.IsProtocol("rar");
+}
+
 bool URIUtils::IsDiscImage(const std::string& file)
 {
   return HasExtension(file, ".img|.iso|.nrg|.udf");

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -47,8 +47,7 @@ public:
   static std::string GetFileOrFolderName(std::string_view path);
 
   static std::string GetExtension(const CURL& url);
-  static std::string GetExtension(const std::string& strFileName);
-
+  static std::string GetExtension(const std::string& path);
 
   /*! \brief Check if the CFileItem has a plugin path.
    \param item The CFileItem.
@@ -58,29 +57,28 @@ public:
 
   /*!
    \brief Check if there is a file extension
-   \param strFileName Path or URL to check
+   \param path Path or URL to check
    \return \e true if strFileName have an extension.
    \note Returns false when strFileName is empty.
    \sa GetExtension
    */
-  static bool HasExtension(const std::string& strFileName);
+  static bool HasExtension(const std::string& path);
 
   /*!
    \brief Check if filename have any of the listed extensions
-   \param strFileName Path or URL to check
-   \param strExtensions List of '.' prefixed lowercase extensions separated with '|'
+   \param path Path or URL to check
+   \param extensions List of '.' prefixed lowercase extensions separated with '|'
    \return \e true if strFileName have any one of the extensions.
    \note The check is case insensitive for strFileName, but requires
          strExtensions to be lowercase. Returns false when strFileName or
          strExtensions is empty.
    \sa GetExtension
    */
-  static bool HasExtension(const std::string& strFileName, const std::string& strExtensions);
-  static bool HasExtension(const CURL& url, const std::string& strExtensions);
+  static bool HasExtension(const std::string& path, std::string_view extensions);
+  static bool HasExtension(const CURL& url, std::string_view strExtensions);
 
-  static void RemoveExtension(std::string& strFileName);
-  static std::string ReplaceExtension(const std::string& strFile,
-                                     const std::string& strNewExtension);
+  static void RemoveExtension(std::string& path);
+  static std::string ReplaceExtension(const std::string& path, const std::string& newExtension);
   static void Split(const std::string& strFileNameAndPath,
                     std::string& strPath, std::string& strFileName);
   static std::vector<std::string> SplitPath(const std::string& strPath);

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -83,7 +83,7 @@ public:
                     std::string& strPath, std::string& strFileName);
   static std::vector<std::string> SplitPath(const std::string& strPath);
 
-  static void GetCommonPath(std::string& strParent, const std::string& strPath);
+  static void GetCommonPath(std::string& parent, std::string_view path);
   static std::string GetParentPath(const std::string& strPath);
   static bool GetParentPath(const std::string& strPath, std::string& strParent);
 

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -222,7 +222,8 @@ public:
   static bool IsSourcesPath(const std::string& strFile);
   static bool IsCDDA(const std::string& strFile);
   static bool IsDAV(const std::string& strFile);
-  static bool IsDOSPath(const std::string &path);
+  static bool IsDOSPath(const std::string& path);
+  static bool IsAbsolutePOSIXPath(const std::string& path);
   static bool IsDVD(const std::string& strFile);
   static bool IsFTP(const std::string& strFile);
   static bool IsHTTP(const std::string& strFile, bool bTranslate = false);

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -267,6 +267,7 @@ public:
   static bool IsAPK(const std::string& strFile);
   static bool IsZIP(const std::string& strFile);
   static bool IsArchive(const std::string& strFile);
+  static bool IsArchive(const CURL& url);
   static bool IsDiscImage(const std::string& file);
   static bool IsDiscImageStack(const std::string& file);
   static bool IsBlurayPath(const std::string& strFile);

--- a/xbmc/utils/test/TestArtUtils.cpp
+++ b/xbmc/utils/test/TestArtUtils.cpp
@@ -14,7 +14,6 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "settings/lib/SettingsManager.h"
 #include "utils/ArtUtils.h"
 #include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
@@ -45,9 +44,9 @@ std::string unique_path(const std::string& input)
   };
 
   std::string ret;
-  ret.reserve(input.size());
-  std::ranges::transform(input, std::back_inserter(ret),
-                         [&randchar](const char c) { return (c == '%') ? randchar() : c; });
+  ret.resize(input.size());
+  std::ranges::transform(input, ret.begin(),
+                         [&](const char c) { return c == '%' ? randchar() : c; });
 
   return ret;
 }
@@ -66,15 +65,17 @@ AdvancedSettingsResetBase::AdvancedSettingsResetBase()
   settings->GetAdvancedSettings()->Uninitialize(*settingsMgr);
   settings->GetAdvancedSettings()->Initialize(*settingsMgr);
 }
+} // namespace
+
+// ART::GetLocalArtBaseFilename() tests
 
 struct ArtFilenameTest
 {
   std::string path;
-  std::string dynPath;
   std::string result;
-  bool isFolder = false;
-  bool result_folder = false;
-  bool force_use_folder = false;
+  bool isFolder{false};
+  bool result_folder{false};
+  bool force_use_folder{false};
   ART::AdditionalIdentifiers additionalIdentifiers{ART::AdditionalIdentifiers::NONE};
   int playlist{-1};
   int season{-1};
@@ -86,257 +87,199 @@ class GetLocalArtBaseFilenameTest : public testing::WithParamInterface<ArtFilena
 {
 };
 
-const auto local_art_filename_tests = std::array{
-    ArtFilenameTest{"/home/user/foo.avi", "", "/home/user/foo.avi"},
-    ArtFilenameTest{"stack:///home/user/foo-cd1.avi , /home/user/foo-cd2.avi", "",
-                    "/home/user/foo.avi"},
-    ArtFilenameTest{"zip://%2fhome%2fuser%2fbar.zip/foo.avi", "", "/home/user/foo.avi"},
-    ArtFilenameTest{"multipath://%2fhome%2fuser%2fbar%2f/%2fhome%2fuser%2ffoo%2f", "",
-                    "/home/user/bar/", true, true},
-    ArtFilenameTest{"/home/user/foo/foo.iso", "", "/home/user/foo/foo.iso"},
-    ArtFilenameTest{"/home/user/VIDEO_TS/VIDEO_TS.IFO", "", "/home/user/", false, true},
-    ArtFilenameTest{"/home/user/BDMV/index.bdmv", "", "/home/user/", false, true},
-    ArtFilenameTest{"/home/user/foo.avi", "", "/home/user/", false, true, true},
-    ArtFilenameTest{
-        "smb://somepath/movie.iso",
-        "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/00800.mpls",
-        "smb://somepath/movie.iso"},
-    ArtFilenameTest{
-        "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/00800.mpls",
-        "", "smb://somepath/movie.iso"},
-    ArtFilenameTest{"bluray://smb%3a%2f%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", "",
-                    "smb://somepath/", false, true},
-    ArtFilenameTest{"bluray://smb%3a%2f%2fsomepath%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls", "",
-                    "smb://somepath/disc 1/", false, true},
-    ArtFilenameTest{"/home/user/foo.avi", "", "/home/user/foo-S03E04.avi", false, false, false,
-                    ART::AdditionalIdentifiers::SEASON_AND_EPISODE, -1, 3, 4},
-    ArtFilenameTest{"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252ftvshow.iso%2f/BDMV/"
-                    "PLAYLIST/00800.mpls",
-                    "", "smb://somepath/tvshow-S03E04.iso", false, false, false,
-                    ART::AdditionalIdentifiers::SEASON_AND_EPISODE, -1, 3, 4},
-    ArtFilenameTest{"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/"
-                    "PLAYLIST/00800.mpls",
-                    "", "smb://somepath/movie-00800.iso", false, false, false,
-                    ART::AdditionalIdentifiers::PLAYLIST, 800},
-};
-
-struct FanartTest
-{
-  std::string path;
-  std::string result;
-};
-
-class GetLocalFanartTest : public testing::WithParamInterface<FanartTest>, public testing::Test
-{
-};
-
-const auto local_fanart_tests = std::array{
-    FanartTest{"stack://#DIRECTORY#foo-cd1.avi , #DIRECTORY#foo-cd2.avi", "foo-fanart.jpg"},
-    FanartTest{"stack://#DIRECTORY#foo-cd1.avi , #DIRECTORY#foo-cd2.avi", "foo-cd1-fanart.jpg"},
-    FanartTest{"zip://#URLENCODED_DIRECTORY#bar.zip/foo.avi", "foo-fanart.jpg"},
-    FanartTest{"ftp://some.where/foo.avi", ""},
-    FanartTest{"https://some.where/foo.avi", ""},
-    FanartTest{"upnp://some.where/123", ""},
-    FanartTest{"bluray://1", ""},
-    FanartTest{"/home/user/1.pvr", ""},
-    FanartTest{"plugin://random.video/1", ""},
-    FanartTest{"addons://plugins/video/1", ""},
-    FanartTest{"dvd://1", ""},
-    FanartTest{"", ""},
-    FanartTest{"foo.avi", ""},
-    FanartTest{"foo.avi", "foo-fanart.jpg"},
-    FanartTest{"videodb://movies/1", ""},
-    FanartTest{"videodb://movies/1", "foo-fanart.jpg"},
-};
-
-struct IconTest
-{
-  std::string path;
-  std::string icon;
-  std::string overlay{};
-  bool isFolder = false;
-  bool valid = true;
-  bool no_overlay = false;
-};
-
-class FillInDefaultIconTest : public testing::WithParamInterface<IconTest>, public testing::Test
-{
-};
-
-const auto icon_tests = std::array{
-    IconTest{"pvr://guide", "", "", false, false},
-    IconTest{"/home/user/test.pvr", "DefaultTVShows.png"},
-    IconTest{"/home/user/test.zip", "DefaultFile.png"},
-    IconTest{"/home/user/test.mp3", "DefaultAudio.png"},
-    IconTest{"/home/user/test.avi", "DefaultVideo.png"},
-    IconTest{"/home/user/test.jpg", "DefaultPicture.png"},
-    IconTest{"/home/user/test.m3u", "DefaultPlaylist.png"},
-    IconTest{"/home/user/test.xsp", "DefaultPlaylist.png"},
-    IconTest{"/home/user/test.py", "DefaultScript.png"},
-    IconTest{"favourites://1", "DefaultFavourites.png"},
-    IconTest{"/home/user/test.fil", "DefaultFile.png"},
-    IconTest{"/home/user/test.m3u", "DefaultPlaylist.png", "", true},
-    IconTest{"/home/user/test.xsp", "DefaultPlaylist.png", "", true},
-    IconTest{"..", "DefaultFolderBack.png", "", true},
-    IconTest{"/home/user/test/", "DefaultFolder.png", "", true},
-    IconTest{"zip://%2fhome%2fuser%2fbar.zip/foo.avi", "DefaultVideo.png", "OverlayZIP.png"},
-    IconTest{"zip://%2fhome%2fuser%2fbar.zip/foo.avi", "DefaultVideo.png", "", false, true, true},
-    IconTest{"rar://%2fhome%2fuser%2fbar.rar/foo.avi", "DefaultVideo.png", "OverlayRAR.png"},
-    IconTest{"rar://%2fhome%2fuser%2fbar.rar/foo.avi", "DefaultVideo.png", "", false, true, true},
-};
-
-struct TbnTest
-{
-  std::string path;
-  std::string result;
-  bool isFolder = false;
-  int season{-1};
-  int episode{-1};
-};
-
-class GetTbnTest : public testing::WithParamInterface<TbnTest>, public testing::Test
-{
-};
-
-struct FolderTest
-{
-  std::string path;
-  std::string thumb;
-  std::string result;
-};
-
-const auto folder_thumb_tests = std::array{
-    FolderTest{"c:\\dir\\", "art.jpg", "c:\\dir\\art.jpg"},
-    FolderTest{"/home/user/", "folder.jpg", "/home/user/folder.jpg"},
-    FolderTest{"plugin://plugin.video.foo/", "folder.jpg", ""},
-    FolderTest{"stack:///home/user/bar/foo-cd1.avi , /home/user/bar/foo-cd2.avi", "folder.jpg",
-               "/home/user/bar/folder.jpg"},
-    FolderTest{"stack:///home/user/cd1/foo-cd1.avi , /home/user/cd2/foo-cd2.avi", "artist.jpg",
-               "/home/user/artist.jpg"},
-    FolderTest{"zip://%2fhome%2fuser%2fbar.zip/foo.avi", "cover.png", "/home/user/cover.png"},
-    FolderTest{"multipath://%2fhome%2fuser%2fbar%2f/%2fhome%2fuser%2ffoo%2f", "folder.jpg",
-               "/home/user/bar/folder.jpg"},
-};
-
-class FolderThumbTest : public testing::WithParamInterface<FolderTest>, public testing::Test
-{
-};
-
-struct LocalArtTest
-{
-  std::string file;
-  std::string art;
-  bool use_folder{false};
-  std::string base;
-  int season{-1};
-  int episode{-1};
-  int playlist{-1};
-  ART::AdditionalIdentifiers additionalIdentifiers{ART::AdditionalIdentifiers::NONE};
-};
-
-const auto local_art_tests = std::array{
-    LocalArtTest{"c:\\dir\\filename.avi", "art.jpg", false, "c:\\dir\\filename-art.jpg"},
-    LocalArtTest{"c:\\dir\\filename.avi", "art.jpg", true, "c:\\dir\\art.jpg"},
-    LocalArtTest{"/dir/filename.avi", "art.jpg", false, "/dir/filename-art.jpg"},
-    LocalArtTest{"/dir/filename.avi", "art.jpg", true, "/dir/art.jpg"},
-    LocalArtTest{"smb://somepath/file.avi", "art.jpg", false, "smb://somepath/file-art.jpg"},
-    LocalArtTest{"smb://somepath/file.avi", "art.jpg", true, "smb://somepath/art.jpg"},
-    LocalArtTest{"stack:///path/to/movie-cd1.avi , /path/to/movie-cd2.avi", "art.jpg", false,
-                 "/path/to/movie-art.jpg"},
-    LocalArtTest{"stack:///path/to/movie-cd1.avi , /path/to/movie-cd2.avi", "art.jpg", true,
-                 "/path/to/art.jpg"},
-    LocalArtTest{
-        "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi",
-        "art.jpg", true, "/path/to/movie_name/art.jpg"},
-    LocalArtTest{"/home/user/TV Shows/Dexter/S1/1x01.avi", "art.jpg", false,
-                 "/home/user/TV Shows/Dexter/S1/1x01-art.jpg"},
-    LocalArtTest{"/home/user/TV Shows/Dexter/S1/1x01.avi", "art.jpg", true,
-                 "/home/user/TV Shows/Dexter/S1/art.jpg"},
-    LocalArtTest{"zip://g%3a%5cmultimedia%5cmovies%5cSphere%2ezip/Sphere.avi", "art.jpg", false,
-                 "g:\\multimedia\\movies\\Sphere-art.jpg"},
-    LocalArtTest{"zip://g%3a%5cmultimedia%5cmovies%5cSphere%2ezip/Sphere.avi", "art.jpg", true,
-                 "g:\\multimedia\\movies\\art.jpg"},
-    LocalArtTest{"/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", "art.jpg", false,
-                 "/home/user/movies/movie_name/art.jpg"},
-    LocalArtTest{"/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", "art.jpg", true,
-                 "/home/user/movies/movie_name/art.jpg"},
-    LocalArtTest{"/home/user/movies/movie_name/BDMV/index.bdmv", "art.jpg", false,
-                 "/home/user/movies/movie_name/art.jpg"},
-    LocalArtTest{"/home/user/movies/movie_name/BDMV/index.bdmv", "art.jpg", true,
-                 "/home/user/movies/movie_name/art.jpg"},
-    LocalArtTest{"c:\\dir\\filename.avi", "", false, "c:\\dir\\filename.tbn"},
-    LocalArtTest{"/dir/filename.avi", "", false, "/dir/filename.tbn"},
-    LocalArtTest{"smb://somepath/file.avi", "", false, "smb://somepath/file.tbn"},
-    LocalArtTest{"/home/user/TV Shows/Dexter/S1/1x01.avi", "", false,
-                 "/home/user/TV Shows/Dexter/S1/1x01.tbn"},
-    LocalArtTest{"zip://g%3a%5cmultimedia%5cmovies%5cSphere%2ezip/Sphere.avi", "", false,
-                 "g:\\multimedia\\movies\\Sphere.tbn"},
-    LocalArtTest{"/home/user/movies/movie_name/BDMV/index.bdmv", "thumb.jpg", false,
-                 "/home/user/movies/movie_name/BDMV/index-S03E04-thumb.jpg", 3, 4, -1,
-                 ART::AdditionalIdentifiers::SEASON_AND_EPISODE},
-    LocalArtTest{"/home/user/tv_show/tv_show.iso", "thumb.jpg", false,
-                 "/home/user/tv_show/tv_show-S03E04-thumb.jpg", 3, 4, -1,
-                 ART::AdditionalIdentifiers::SEASON_AND_EPISODE},
-    LocalArtTest{"/home/user/movies/movie_name/BDMV/index.bdmv", "thumb.jpg", false,
-                 "/home/user/movies/movie_name/BDMV/index-00800-thumb.jpg", -1, -1, 800,
-                 ART::AdditionalIdentifiers::PLAYLIST},
-    LocalArtTest{"/home/user/movie/movie.iso", "thumb.jpg", false,
-                 "/home/user/movie/movie-00800-thumb.jpg", -1, -1, 800,
-                 ART::AdditionalIdentifiers::PLAYLIST},
-};
-
-class TestLocalArt : public AdvancedSettingsResetBase,
-                     public testing::WithParamInterface<LocalArtTest>
-{
-};
-
-} // namespace
-
-TEST_P(FillInDefaultIconTest, FillInDefaultIcon)
-{
-  CFileItem item(GetParam().path, GetParam().isFolder);
-  if (!GetParam().valid)
-    item.SetArt("icon", "InvalidImage.png");
-  item.SetLabel(GetParam().path);
-  if (GetParam().no_overlay)
-    item.SetProperty("icon_never_overlay", true);
-  ART::FillInDefaultIcon(item);
-  EXPECT_EQ(item.GetArt("icon"), GetParam().valid ? GetParam().icon : "InvalidImage.png");
-  EXPECT_EQ(item.GetOverlayImage(), GetParam().overlay);
-}
-
-INSTANTIATE_TEST_SUITE_P(TestArtUtils, FillInDefaultIconTest, testing::ValuesIn(icon_tests));
-
-TEST_P(FolderThumbTest, GetFolderThumb)
-{
-  CFileItem item(GetParam().path, true);
-  const std::string thumb = ART::GetFolderThumb(item, GetParam().thumb);
-  EXPECT_EQ(thumb, GetParam().result);
-}
-
-INSTANTIATE_TEST_SUITE_P(TestArtUtils, FolderThumbTest, testing::ValuesIn(folder_thumb_tests));
-
-TEST_P(TestLocalArt, GetLocalArt)
-{
-  CFileItem item;
-  item.SetPath(GetParam().file);
-  CVideoInfoTag* tag{item.GetVideoInfoTag()};
-  tag->m_iSeason = GetParam().season;
-  tag->m_iEpisode = GetParam().episode;
-  tag->m_iTrack = GetParam().playlist;
-  std::string path = CURL(ART::GetLocalArt(item, GetParam().art, GetParam().use_folder,
-                                           GetParam().additionalIdentifiers))
-                         .Get();
-  std::string compare = CURL(GetParam().base).Get();
-  EXPECT_EQ(compare, path);
-}
-
-INSTANTIATE_TEST_SUITE_P(TestArtUtils, TestLocalArt, testing::ValuesIn(local_art_tests));
+const ArtFilenameTest local_art_filename_tests[] = {
+    // Linux path tests
+    {"/home/user/movies/movie/movie.avi", "/home/user/movies/movie/movie.avi"},
+    {"/home/user/movies/movie/disc 1/movie.avi", "/home/user/movies/movie/disc 1/movie.avi"},
+    {"/home/user/movies/movie/video_ts/video_ts.ifo", "/home/user/movies/movie/", false, true},
+    {"/home/user/movies/movie/disc 1/video_ts/video_ts.ifo", "/home/user/movies/movie/disc 1/",
+     false, true},
+    {"/home/user/movies/movie/BDMV/index.bdmv", "/home/user/movies/movie/", false, true},
+    {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", "/home/user/movies/movie/disc 1/", false,
+     true},
+    {"stack:///path/to/movie_name/movie-part-1.avi , /path/to/movie_name/movie-part-2.avi",
+     "/path/to/movie_name/movie.avi"},
+    {"stack:///path/to/movie/movie part 1/file.avi , /path/to/movie/movie part 2/file.avi",
+     "/path/to/movie/movie.avi"},
+    // URL path tests with smb://
+    {"smb://home/user/movies/movie/movie.avi", "smb://home/user/movies/movie/movie.avi"},
+    {"smb://home/user/movies/movie/disc 1/movie.avi",
+     "smb://home/user/movies/movie/disc 1/movie.avi"},
+    {"smb://home/user/movies/movie/video_ts/video_ts.ifo", "smb://home/user/movies/movie/", false,
+     true},
+    {"smb://home/user/movies/movie/disc 1/video_ts/video_ts.ifo",
+     "smb://home/user/movies/movie/disc 1/", false, true},
+    {"smb://home/user/movies/movie/BDMV/index.bdmv", "smb://home/user/movies/movie/", false, true},
+    {"smb://home/user/movies/movie/disc 1/BDMV/index.bdmv", "smb://home/user/movies/movie/disc 1/",
+     false, true},
+    {"stack://smb://path/to/movie_name/movie-part-1.avi , "
+     "smb://path/to/movie_name/movie-part-2.avi",
+     "smb://path/to/movie_name/movie.avi"},
+    {"stack://smb://path/to/movie/movie part 1/file.avi , smb://path/to/movie/movie part "
+     "2/file.avi",
+     "smb://path/to/movie/movie.avi"},
+    // DOS path tests
+    {"D:\\Movies\\Movie\\movie.avi", "D:\\Movies\\Movie\\movie.avi"},
+    {"D:\\Movies\\Movie\\disc 1\\movie.avi", "D:\\Movies\\Movie\\disc 1\\movie.avi"},
+    {"D:\\Movies\\Movie\\video_ts\\video_ts.ifo", "D:\\Movies\\Movie\\", false, true},
+    {"D:\\Movies\\Movie\\disc 1\\video_ts\\video_ts.ifo", "D:\\Movies\\Movie\\disc 1\\", false,
+     true},
+    {"D:\\Movies\\Movie\\BDMV\\index.bdmv", "D:\\Movies\\Movie\\", false, true},
+    {"D:\\Movies\\Movie\\disc 1\\BDMV\\index.bdmv", "D:\\Movies\\Movie\\disc 1\\", false, true},
+    {"stack://D:\\movie_name\\movie-part-1.avi , "
+     "D:\\movie_name\\movie-part-2.avi",
+     "D:\\movie_name\\movie.avi"},
+    {"stack://D:\\movie\\movie part 1\\file.avi , D:\\movie\\movie part 2\\file.avi",
+     "D:\\movie\\movie.avi"},
+    // Windows server path tests
+    {"\\\\Server\\Movies\\Movie\\movie.avi", "\\\\Server\\Movies\\Movie\\movie.avi"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\movie.avi",
+     "\\\\Server\\Movies\\Movie\\disc 1\\movie.avi"},
+    {"\\\\Server\\Movies\\Movie\\video_ts\\video_ts.ifo", "\\\\Server\\Movies\\Movie\\", false,
+     true},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\video_ts\\video_ts.ifo",
+     "\\\\Server\\Movies\\Movie\\disc 1\\", false, true},
+    {"\\\\Server\\Movies\\Movie\\BDMV\\index.bdmv", "\\\\Server\\Movies\\Movie\\", false, true},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\BDMV\\index.bdmv", "\\\\Server\\Movies\\Movie\\disc 1\\",
+     false, true},
+    {"stack://\\\\Server\\Movies\\Movie\\movie-part-1.avi , "
+     "\\\\Server\\Movies\\Movie\\movie-part-2.avi",
+     "\\\\Server\\Movies\\Movie\\movie.avi"},
+    {"stack://\\\\Server\\Movies\\Movie\\movie part 1\\file.avi , \\\\Server\\Movies\\Movie\\movie "
+     "part 2\\file.avi",
+     "\\\\Server\\Movies\\Movie\\movie.avi"},
+    // Embedded URL path tests with smb://
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     "smb://somepath/movie.iso"},
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fdisc%25201%252fmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     "smb://somepath/disc 1/movie.iso"},
+    {"bluray://smb%3a%2f%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", "smb://somepath/", false, true},
+    {"bluray://smb%3a%2f%2fsomepath%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls",
+     "smb://somepath/disc 1/", false, true},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie.zip/film.mkv", "smb://somepath/movie.avi"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie.zip/BDMV/index.bdmv", "smb://somepath/movie.avi"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie.zip/BDMV/index.bdmv",
+     "smb://somepath/movie/disc 1/movie.avi"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie.rar/film.mkv", "smb://somepath/movie.avi"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie.rar/BDMV/index.bdmv", "smb://somepath/movie.avi"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie.rar/BDMV/index.bdmv",
+     "smb://somepath/movie/disc 1/movie.avi"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie.tar.gz/film.mkv", "smb://somepath/movie.avi"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie.tar.gz/BDMV/index.bdmv", "smb://somepath/movie.avi"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie.tar.gz/BDMV/index.bdmv",
+     "smb://somepath/movie/disc 1/movie.avi"},
+    {"multipath://smb%3a%2f%2fhome%2fuser%2fbar%2f/smb%3a%2f%2fhome%2fuser%2ffoo%2f",
+     "smb://home/user/bar/"},
+    // Embedded linux path tests
+    {"bluray://udf%3a%2f%2f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     "/somepath/movie.iso"},
+    {"bluray://udf%3a%2f%2f%252fsomepath%252fdisc%25201%252fmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     "/somepath/disc 1/movie.iso"},
+    {"bluray://%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", "/somepath/", false, true},
+    {"bluray://%2fsomepath%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls", "/somepath/disc 1/", false,
+     true},
+    {"zip://%2fsomepath%2fmovie.zip/film.mkv", "/somepath/movie.avi"},
+    {"zip://%2fsomepath%2fmovie.zip/BDMV/index.bdmv", "/somepath/movie.avi"},
+    {"zip://%2fsomepath%2fmovie%2fdisc%201%2fmovie.zip/BDMV/index.bdmv",
+     "/somepath/movie/disc 1/movie.avi"},
+    {"rar://%2fsomepath%2fmovie.rar/film.mkv", "/somepath/movie.avi"},
+    {"rar://%2fsomepath%2fmovie.rar/BDMV/index.bdmv", "/somepath/movie.avi"},
+    {"rar://%2fsomepath%2fmovie%2fdisc%201%2fmovie.rar/BDMV/index.bdmv",
+     "/somepath/movie/disc 1/movie.avi"},
+    {"archive://%2fsomepath%2fmovie.tar.gz/film.mkv", "/somepath/movie.avi"},
+    {"archive://%2fsomepath%2fmovie.tar.gz/BDMV/index.bdmv", "/somepath/movie.avi"},
+    {"archive://%2fsomepath%2fmovie%2fdisc%201%2fmovie.tar.gz/BDMV/index.bdmv",
+     "/somepath/movie/disc 1/movie.avi"},
+    {"multipath://%2fhome%2fuser%2fbar%2f/%2fhome%2fuser%2ffoo%2f", "/home/user/bar/"},
+    // Embedded DOS path tests
+    {"bluray://udf%3a%2f%2fD%253a%255csomepath%255cmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     "D:\\somepath\\movie.iso"},
+    {"bluray://udf%3a%2f%2fD%253a%255csomepath%255cdisc%25201%255cmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     "D:\\somepath\\disc 1\\movie.iso"},
+    {"bluray://D%3a%5csomepath%5c/BDMV/PLAYLIST/00800.mpls", "D:\\somepath\\", false, true},
+    {"bluray://D%3a%5csomepath%5cdisc%201%5c/BDMV/PLAYLIST/00800.mpls", "D:\\somepath\\disc 1\\",
+     false, true},
+    {"zip://D%3a%5csomepath%5cmovie.zip/film.mkv", "D:\\somepath\\movie.avi"},
+    {"zip://D%3a%5csomepath%5cmovie.zip/BDMV/index.bdmv", "D:\\somepath\\movie.avi"},
+    {"zip://D%3a%5csomepath%5cmovie%5cdisc%201%5cmovie.zip/BDMV/index.bdmv",
+     "D:\\somepath\\movie\\disc 1\\movie.avi"},
+    {"rar://D%3a%5csomepath%5cmovie.rar/film.mkv", "D:\\somepath\\movie.avi"},
+    {"rar://D%3a%5csomepath%5cmovie.rar/BDMV/index.bdmv", "D:\\somepath\\movie.avi"},
+    {"rar://D%3a%5csomepath%5cmovie%5cdisc%201%5cmovie.rar/BDMV/index.bdmv",
+     "D:\\somepath\\movie\\disc 1\\movie.avi"},
+    {"archive://D%3a%5csomepath%5cmovie.tar.gz/film.mkv", "D:\\somepath\\movie.avi"},
+    {"archive://D%3a%5csomepath%5cmovie.tar.gz/BDMV/index.bdmv", "D:\\somepath\\movie.avi"},
+    {"archive://D%3a%5csomepath%5cmovie%5cdisc%201%5cmovie.tar.gz/BDMV/index.bdmv",
+     "D:\\somepath\\movie\\disc 1\\movie.avi"},
+    {"multipath://D%3a%5chome%5cuser%5cbar%5c/D%3a%5chome%5cuser%5cfoo%5c",
+     "D:\\home\\user\\bar\\"},
+    // Embedded windows server path tests
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     "\\\\Server\\Movies\\movie.iso"},
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cMovie%255cdisc%25201%255cmovie.iso%2f/"
+     "BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     "\\\\Server\\Movies\\Movie\\disc 1\\movie.iso"},
+    {"bluray://%5c%5cServer%5cMovies%5c/BDMV/PLAYLIST/00800.mpls", "\\\\Server\\Movies\\", false,
+     true},
+    {"bluray://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5c/BDMV/PLAYLIST/00800.mpls",
+     "\\\\Server\\Movies\\Movie\\disc 1\\", false, true},
+    {"zip://%5c%5cServer%5cMovies%5cmovie.zip/film.mkv", "\\\\Server\\Movies\\movie.avi"},
+    {"zip://%5c%5cServer%5cMovies%5cmovie.zip/BDMV/index.bdmv", "\\\\Server\\Movies\\movie.avi"},
+    {"zip://%5c%5cServer%5cMovies%5cmovie%5cdisc%201%5cmovie.zip/BDMV/index.bdmv",
+     "\\\\Server\\Movies\\movie\\disc 1\\movie.avi"},
+    {"rar://%5c%5cServer%5cMovies%5cmovie.rar/film.mkv", "\\\\Server\\Movies\\movie.avi"},
+    {"rar://%5c%5cServer%5cMovies%5cmovie.rar/BDMV/index.bdmv", "\\\\Server\\Movies\\movie.avi"},
+    {"rar://%5c%5cServer%5cMovies%5cmovie%5cdisc%201%5cmovie.rar/BDMV/index.bdmv",
+     "\\\\Server\\Movies\\movie\\disc 1\\movie.avi"},
+    {"archive://%5c%5cServer%5cMovies%5cmovie.tar.gz/film.mkv", "\\\\Server\\Movies\\movie.avi"},
+    {"archive://%5c%5cServer%5cMovies%5cmovie.tar.gz/BDMV/index.bdmv",
+     "\\\\Server\\Movies\\movie.avi"},
+    {"archive://%5c%5cServer%5cMovies%5cmovie%5cdisc%201%5cmovie.tar.gz/BDMV/index.bdmv",
+     "\\\\Server\\Movies\\movie\\disc 1\\movie.avi"},
+    {"multipath://%5c%5chome%5cuser%5cbar%5c/%5c%5chome%5cuser%5cfoo%5c", "\\\\home\\user\\bar\\"},
+    // Special tests
+    // Episodes
+    {"/home/user/foo.avi", "/home/user/foo-S03E04.avi", false, false, false,
+     ART::AdditionalIdentifiers::SEASON_AND_EPISODE, -1, 3, 4},
+    {"/home/user/BDMV/index.bdmv", "/home/user/BDMV/index-S03E04.bdmv", false, false, false,
+     ART::AdditionalIdentifiers::SEASON_AND_EPISODE, -1, 3, 4},
+    {"smb://home/user/foo.avi", "smb://home/user/foo-S03E04.avi", false, false, false,
+     ART::AdditionalIdentifiers::SEASON_AND_EPISODE, -1, 3, 4},
+    {"D:\\home\\user\\foo.avi", "D:\\home\\user\\foo-S03E04.avi", false, false, false,
+     ART::AdditionalIdentifiers::SEASON_AND_EPISODE, -1, 3, 4},
+    {"\\\\Server\\user\\foo.avi", "\\\\Server\\user\\foo-S03E04.avi", false, false, false,
+     ART::AdditionalIdentifiers::SEASON_AND_EPISODE, -1, 3, 4},
+    {"bluray://smb%3a%2f%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls",
+     "smb://somepath/BDMV/index-S03E04.bdmv", false, false, false,
+     ART::AdditionalIdentifiers::SEASON_AND_EPISODE, -1, 3, 4},
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252ftvshow.iso%2f/BDMV/"
+     "PLAYLIST/00800.mpls",
+     "smb://somepath/tvshow-S03E04.iso", false, false, false,
+     ART::AdditionalIdentifiers::SEASON_AND_EPISODE, -1, 3, 4},
+    // Playlists
+    {"bluray://smb%3a%2f%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls",
+     "smb://somepath/BDMV/index-00800.bdmv", false, false, false,
+     ART::AdditionalIdentifiers::PLAYLIST, 800},
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/"
+     "PLAYLIST/00800.mpls",
+     "smb://somepath/movie-00800.iso", false, false, false, ART::AdditionalIdentifiers::PLAYLIST,
+     800}};
 
 TEST_P(GetLocalArtBaseFilenameTest, GetLocalArtBaseFilename)
 {
   CFileItem item(GetParam().path, GetParam().isFolder);
-  item.SetDynPath(GetParam().dynPath);
   CVideoInfoTag* tag{item.GetVideoInfoTag()};
   tag->m_iSeason = GetParam().season;
   tag->m_iEpisode = GetParam().episode;
@@ -353,6 +296,42 @@ INSTANTIATE_TEST_SUITE_P(TestArtUtils,
                          GetLocalArtBaseFilenameTest,
                          testing::ValuesIn(local_art_filename_tests));
 
+// ART::GetLocalFanart() tests
+
+struct FanartTest
+{
+  std::string path;
+  std::string result;
+};
+
+class GetLocalFanartTest : public testing::WithParamInterface<FanartTest>, public testing::Test
+{
+};
+
+const FanartTest local_fanart_tests[] = {
+    {"stack://#DIRECTORY#foo-cd1.avi , #DIRECTORY#foo-cd2.avi", "foo-fanart.jpg"},
+    {"stack://#DIRECTORY#foo-cd1.avi , #DIRECTORY#foo-cd2.avi", "foo-cd1-fanart.jpg"},
+    {"stack://#DIRECTORY#movie/movie part 1/foo.avi , #DIRECTORY#movie/movie part 2/foo.avi",
+     "movie/movie-fanart.jpg"},
+    {"stack://#DIRECTORY#movie/movie part 1/foo.avi , #DIRECTORY#movie/movie part 2/foo.avi",
+     "movie/movie part 1/foo-fanart.jpg"},
+    {"zip://#URLENCODED_DIRECTORY#bar.zip/foo.avi", "bar-fanart.jpg"},
+    {"rar://#URLENCODED_DIRECTORY#bar.rar/foo.avi", "bar-fanart.jpg"},
+    {"archive://#URLENCODED_DIRECTORY#bar.tar.gz/foo.avi", "bar-fanart.jpg"},
+    {"ftp://some.where/foo.avi", ""},
+    {"https://some.where/foo.avi", ""},
+    {"upnp://some.where/123", ""},
+    {"bluray://1", ""},
+    {"/home/user/1.pvr", ""},
+    {"plugin://random.video/1", ""},
+    {"addons://plugins/video/1", ""},
+    {"dvd://1", ""},
+    {"", ""},
+    {"foo.avi", ""},
+    {"foo.avi", "foo-fanart.jpg"},
+    {"videodb://movies/1", ""},
+    {"videodb://movies/1", "foo-fanart.jpg"}};
+
 TEST_P(GetLocalFanartTest, GetLocalFanart)
 {
   std::string path, file_path, uniq;
@@ -367,6 +346,8 @@ TEST_P(GetLocalFanartTest, GetLocalFanart)
     path = URIUtils::AddFileToFolder(tmpdir, uniq);
     URIUtils::AddSlashAtEnd(path);
     XFILE::CDirectory::Create(path);
+    if (const std::string dir{URIUtils::GetDirectory(GetParam().result)}; !dir.empty())
+      XFILE::CDirectory::Create(URIUtils::AddFileToFolder(path, dir, ""));
     std::ofstream of(URIUtils::AddFileToFolder(path, GetParam().result), std::ios::out);
     if (GetParam().path.find("#DIRECTORY#") != std::string::npos)
     {
@@ -394,13 +375,736 @@ TEST_P(GetLocalFanartTest, GetLocalFanart)
   }
   const std::string res = ART::GetLocalFanart(item);
 
-  EXPECT_EQ(URIUtils::GetFileName(res), GetParam().result);
+  EXPECT_EQ(URIUtils::GetFileName(res), URIUtils::GetFileName(GetParam().result));
 
   if (!GetParam().result.empty())
     XFILE::CDirectory::RemoveRecursive(path);
 }
 
 INSTANTIATE_TEST_SUITE_P(TestArtUtils, GetLocalFanartTest, testing::ValuesIn(local_fanart_tests));
+
+// ART::FillInDefaultIcon() tests
+
+struct IconTest
+{
+  std::string path;
+  std::string icon;
+  std::string overlay{};
+  bool isFolder = false;
+  bool valid = true;
+  bool no_overlay = false;
+};
+
+class FillInDefaultIconTest : public testing::WithParamInterface<IconTest>, public testing::Test
+{
+};
+
+const IconTest icon_tests[] = {
+    {"pvr://guide", "", "", false, false},
+    {"/home/user/test.pvr", "DefaultTVShows.png"},
+    {"/home/user/test.zip", "DefaultFile.png"},
+    {"/home/user/test.mp3", "DefaultAudio.png"},
+    {"/home/user/test.avi", "DefaultVideo.png"},
+    {"/home/user/test.jpg", "DefaultPicture.png"},
+    {"/home/user/test.m3u", "DefaultPlaylist.png"},
+    {"/home/user/test.xsp", "DefaultPlaylist.png"},
+    {"/home/user/test.py", "DefaultScript.png"},
+    {"favourites://1", "DefaultFavourites.png"},
+    {"/home/user/test.fil", "DefaultFile.png"},
+    {"/home/user/test.m3u", "DefaultPlaylist.png", "", true},
+    {"/home/user/test.xsp", "DefaultPlaylist.png", "", true},
+    {"..", "DefaultFolderBack.png", "", true},
+    {"/home/user/test/", "DefaultFolder.png", "", true},
+    {"zip://%2fhome%2fuser%2fbar.zip/foo.avi", "DefaultVideo.png", "OverlayZIP.png"},
+    {"zip://%2fhome%2fuser%2fbar.zip/foo.avi", "DefaultVideo.png", "", false, true, true},
+    {"rar://%2fhome%2fuser%2fbar.rar/foo.avi", "DefaultVideo.png", "OverlayRAR.png"},
+    {"rar://%2fhome%2fuser%2fbar.rar/foo.avi", "DefaultVideo.png", "", false, true, true},
+    {"archive://%2fhome%2fuser%2fbar.tar.gz/foo.avi", "DefaultVideo.png", "OverlayRAR.png"},
+    {"archive://%2fhome%2fuser%2fbar.tar.gz/foo.avi", "DefaultVideo.png", "", false, true, true}};
+
+TEST_P(FillInDefaultIconTest, FillInDefaultIcon)
+{
+  CFileItem item(GetParam().path, GetParam().isFolder);
+  if (!GetParam().valid)
+    item.SetArt("icon", "InvalidImage.png");
+  item.SetLabel(GetParam().path);
+  if (GetParam().no_overlay)
+    item.SetProperty("icon_never_overlay", true);
+  ART::FillInDefaultIcon(item);
+  EXPECT_EQ(item.GetArt("icon"), GetParam().valid ? GetParam().icon : "InvalidImage.png");
+  EXPECT_EQ(item.GetOverlayImage(), GetParam().overlay);
+}
+
+INSTANTIATE_TEST_SUITE_P(TestArtUtils, FillInDefaultIconTest, testing::ValuesIn(icon_tests));
+
+// ART::GetFolderThumb() tests
+
+struct FolderTest
+{
+  std::string path;
+  std::string thumb;
+  std::string result;
+};
+
+class FolderThumbTest : public testing::WithParamInterface<FolderTest>, public testing::Test
+{
+};
+
+const FolderTest folder_thumb_tests[] = {
+    // Linux path tests
+    {"/home/user/movies/movie/", "folder.jpg", "/home/user/movies/movie/folder.jpg"},
+    {"/home/user/movies/movie/disc 1/", "folder.jpg", "/home/user/movies/movie/disc 1/folder.jpg"},
+    {"/home/user/movies/movie/video_ts/", "folder.jpg", "/home/user/movies/movie/folder.jpg"},
+    {"/home/user/movies/movie/disc 1/video_ts/", "folder.jpg",
+     "/home/user/movies/movie/disc 1/folder.jpg"},
+    {"/home/user/movies/movie/BDMV/", "folder.jpg", "/home/user/movies/movie/folder.jpg"},
+    {"/home/user/movies/movie/disc 1/BDMV/", "folder.jpg",
+     "/home/user/movies/movie/disc 1/folder.jpg"},
+    {"stack:///path/to/movie_name/part-1.avi , /path/to/movie_name/part-2.avi", "folder.jpg",
+     "/path/to/movie_name/folder.jpg"},
+    // URL path tests using smb://
+    {"smb://home/user/movies/movie/", "folder.jpg", "smb://home/user/movies/movie/folder.jpg"},
+    {"smb://home/user/movies/movie/disc 1/", "folder.jpg",
+     "smb://home/user/movies/movie/disc 1/folder.jpg"},
+    {"smb://home/user/movies/movie/video_ts/", "folder.jpg",
+     "smb://home/user/movies/movie/folder.jpg"},
+    {"smb://home/user/movies/movie/disc 1/video_ts/", "folder.jpg",
+     "smb://home/user/movies/movie/disc 1/folder.jpg"},
+    {"smb://home/user/movies/movie/BDMV/", "folder.jpg", "smb://home/user/movies/movie/folder.jpg"},
+    {"smb://home/user/movies/movie/disc 1/BDMV/", "folder.jpg",
+     "smb://home/user/movies/movie/disc 1/folder.jpg"},
+    {"stack://smb://path/to/movie_name/part-1.avi , "
+     "smb://path/to/movie_name/part-2.avi",
+     "folder.jpg", "smb://path/to/movie_name/folder.jpg"},
+    // DOS path tests
+    {"D:\\movies\\movie\\", "folder.jpg", "D:\\movies\\movie\\folder.jpg"},
+    {"D:\\movies\\movie\\disc 1\\", "folder.jpg", "D:\\movies\\movie\\disc 1\\folder.jpg"},
+    {"D:\\movies\\movie\\video_ts\\", "folder.jpg", "D:\\movies\\movie\\folder.jpg"},
+    {"D:\\movies\\movie\\disc 1\\video_ts\\", "folder.jpg",
+     "D:\\movies\\movie\\disc 1\\folder.jpg"},
+    {"D:\\movies\\movie\\BDMV\\", "folder.jpg", "D:\\movies\\movie\\folder.jpg"},
+    {"D:\\movies\\movie\\disc 1\\BDMV\\", "folder.jpg", "D:\\movies\\movie\\disc 1\\folder.jpg"},
+    {"stack://D:\\movies\\movie_name\\part-1.avi , D:\\movies\\movie_name\\part-2.avi",
+     "folder.jpg", "D:\\movies\\movie_name\\folder.jpg"},
+    // Windows server path tests
+    {"\\\\Server\\Movies\\Movie\\", "folder.jpg", "\\\\Server\\Movies\\Movie\\folder.jpg"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\", "folder.jpg",
+     "\\\\Server\\Movies\\Movie\\disc 1\\folder.jpg"},
+    {"\\\\Server\\Movies\\Movie\\video_ts\\", "folder.jpg",
+     "\\\\Server\\Movies\\Movie\\folder.jpg"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\video_ts\\", "folder.jpg",
+     "\\\\Server\\Movies\\Movie\\disc 1\\folder.jpg"},
+    {"\\\\Server\\Movies\\Movie\\BDMV\\", "folder.jpg", "\\\\Server\\Movies\\Movie\\folder.jpg"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\BDMV\\", "folder.jpg",
+     "\\\\Server\\Movies\\Movie\\disc 1\\folder.jpg"},
+    {"stack://\\\\Server\\Movies\\Movie_name\\part-1.avi , "
+     "\\\\Server\\Movies\\Movie_name\\part-2.avi",
+     "folder.jpg", "\\\\Server\\Movies\\Movie_name\\folder.jpg"},
+    // Embedded URL path tests with smb://
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     "folder.jpg", "smb://somepath/folder.jpg"},
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fdisc%25201%252fmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     "folder.jpg", "smb://somepath/disc 1/folder.jpg"},
+    {"bluray://smb%3a%2f%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", "folder.jpg",
+     "smb://somepath/folder.jpg"},
+    {"bluray://smb%3a%2f%2fsomepath%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls", "folder.jpg",
+     "smb://somepath/disc 1/folder.jpg"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie.zip/film.mkv", "folder.jpg", "smb://somepath/folder.jpg"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie.zip/BDMV/index.bdmv", "folder.jpg",
+     "smb://somepath/folder.jpg"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.zip/BDMV/index.bdmv", "folder.jpg",
+     "smb://somepath/movie/disc 1/folder.jpg"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie.rar/film.mkv", "folder.jpg", "smb://somepath/folder.jpg"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie.rar/BDMV/index.bdmv", "folder.jpg",
+     "smb://somepath/folder.jpg"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.rar/BDMV/index.bdmv", "folder.jpg",
+     "smb://somepath/movie/disc 1/folder.jpg"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie.tar.gz/film.mkv", "folder.jpg",
+     "smb://somepath/folder.jpg"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie.tar.gz/BDMV/index.bdmv", "folder.jpg",
+     "smb://somepath/folder.jpg"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.tar.gz/BDMV/index.bdmv",
+     "folder.jpg", "smb://somepath/movie/disc 1/folder.jpg"},
+    {"multipath://smb%3a%2f%2fhome%2fuser%2fbar%2f/smb%3a%2f%2fhome%2fuser%2ffoo%2f", "folder.jpg",
+     "smb://home/user/bar/folder.jpg"},
+    // Embedded linux path tests
+    {"bluray://udf%3a%2f%2f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     "folder.jpg", "/somepath/folder.jpg"},
+    {"bluray://udf%3a%2f%2f%252fsomepath%252fdisc%25201%252fmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     "folder.jpg", "/somepath/disc 1/folder.jpg"},
+    {"bluray://%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", "folder.jpg", "/somepath/folder.jpg"},
+    {"bluray://%2fsomepath%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls", "folder.jpg",
+     "/somepath/disc 1/folder.jpg"},
+    {"zip://%2fsomepath%2fmovie.zip/BDMV/index.bdmv", "folder.jpg", "/somepath/folder.jpg"},
+    {"zip://%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.zip/BDMV/index.bdmv", "folder.jpg",
+     "/somepath/movie/disc 1/folder.jpg"},
+    {"rar://%2fsomepath%2fmovie.rar/BDMV/index.bdmv", "folder.jpg", "/somepath/folder.jpg"},
+    {"rar://%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.rar/BDMV/index.bdmv", "folder.jpg",
+     "/somepath/movie/disc 1/folder.jpg"},
+    {"archive://%2fsomepath%2fmovie.tar.gz/BDMV/index.bdmv", "folder.jpg", "/somepath/folder.jpg"},
+    {"archive://%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.tar.gz/BDMV/index.bdmv", "folder.jpg",
+     "/somepath/movie/disc 1/folder.jpg"},
+    {"multipath://%2fhome%2fuser%2fbar%2f/%2fhome%2fuser%2ffoo%2f", "folder.jpg",
+     "/home/user/bar/folder.jpg"},
+    // Embedded DOS path tests
+    {"bluray://udf%3a%2f%2fD%253a%255csomepath%255cmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     "folder.jpg", "D:\\somepath\\folder.jpg"},
+    {"bluray://udf%3a%2f%2fD%253a%255csomepath%255cdisc%25201%255cmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     "folder.jpg", "D:\\somepath\\disc 1\\folder.jpg"},
+    {"bluray://D%3a%5csomepath%5c/BDMV/PLAYLIST/00800.mpls", "folder.jpg",
+     "D:\\somepath\\folder.jpg"},
+    {"bluray://D%3a%5csomepath%5cdisc%201%5c/BDMV/PLAYLIST/00800.mpls", "folder.jpg",
+     "D:\\somepath\\disc 1\\folder.jpg"},
+    {"zip://D%3a%5csomepath%5cmovie.zip/BDMV/index.bdmv", "folder.jpg", "D:\\somepath\\folder.jpg"},
+    {"zip://D%3a%5csomepath%5cmovie%5cdisc%201%5cmovie_disc.zip/BDMV/index.bdmv", "folder.jpg",
+     "D:\\somepath\\movie\\disc 1\\folder.jpg"},
+    {"rar://D%3a%5csomepath%5cmovie.rar/BDMV/index.bdmv", "folder.jpg", "D:\\somepath\\folder.jpg"},
+    {"rar://D%3a%5csomepath%5cmovie%5cdisc%201%5cmovie_disc.rar/BDMV/index.bdmv", "folder.jpg",
+     "D:\\somepath\\movie\\disc 1\\folder.jpg"},
+    {"archive://D%3a%5csomepath%5cmovie.tar.gz/BDMV/index.bdmv", "folder.jpg",
+     "D:\\somepath\\folder.jpg"},
+    {"archive://D%3a%5csomepath%5cmovie%5cdisc%201%5cmovie_disc.tar.gz/BDMV/index.bdmv",
+     "folder.jpg", "D:\\somepath\\movie\\disc 1\\folder.jpg"},
+    {"multipath://D%3a%5chome%5cuser%5cbar%5c/D%3a%5chome%5cuser%5cfoo%5c", "folder.jpg",
+     "D:\\home\\user\\bar\\folder.jpg"},
+    // Embedded Windows server path tests
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cMovie%255cmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     "folder.jpg", "\\\\Server\\Movies\\Movie\\folder.jpg"},
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cMovie%255cdisc%25201%255cmovie.iso%2f/"
+     "BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     "folder.jpg", "\\\\Server\\Movies\\Movie\\disc 1\\folder.jpg"},
+    {"bluray://%5c%5cServer%5cMovies%5cMovie%5c/BDMV/PLAYLIST/00800.mpls", "folder.jpg",
+     "\\\\Server\\Movies\\Movie\\folder.jpg"},
+    {"bluray://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5c/BDMV/PLAYLIST/00800.mpls", "folder.jpg",
+     "\\\\Server\\Movies\\Movie\\disc 1\\folder.jpg"},
+    {"zip://%5c%5cServer%5cMovies%5cMovie%5cmovie.zip/BDMV/index.bdmv", "folder.jpg",
+     "\\\\Server\\Movies\\Movie\\folder.jpg"},
+    {"zip://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5cmovie_disc.zip/BDMV/index.bdmv",
+     "folder.jpg", "\\\\Server\\Movies\\Movie\\disc 1\\folder.jpg"},
+    {"rar://%5c%5cServer%5cMovies%5cMovie%5cmovie.rar/BDMV/index.bdmv", "folder.jpg",
+     "\\\\Server\\Movies\\Movie\\folder.jpg"},
+    {"rar://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5cmovie_disc.rar/BDMV/index.bdmv",
+     "folder.jpg", "\\\\Server\\Movies\\Movie\\disc 1\\folder.jpg"},
+    {"archive://%5c%5cServer%5cMovies%5cMovie%5cmovie.tar.gz/BDMV/index.bdmv", "folder.jpg",
+     "\\\\Server\\Movies\\Movie\\folder.jpg"},
+    {"archive://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5cmovie_disc.tar.gz/BDMV/index.bdmv",
+     "folder.jpg", "\\\\Server\\Movies\\Movie\\disc 1\\folder.jpg"},
+    {"multipath://%5c%5chome%5cuser%5cbar%5c/5c%5chome%5cuser%5cfoo%5c", "folder.jpg",
+     "\\\\home\\user\\bar\\folder.jpg"}};
+
+TEST_P(FolderThumbTest, GetFolderThumb)
+{
+  CFileItem item(GetParam().path, true);
+  const std::string thumb = ART::GetFolderThumb(item, GetParam().thumb);
+  EXPECT_EQ(thumb, GetParam().result);
+}
+
+INSTANTIATE_TEST_SUITE_P(TestArtUtils, FolderThumbTest, testing::ValuesIn(folder_thumb_tests));
+
+// ART::GetLocalArt() tests
+
+struct LocalArtTest
+{
+  std::string file;
+  std::string art;
+  bool use_folder;
+  std::string base;
+  int season{-1};
+  int episode{-1};
+  int playlist{-1};
+  ART::AdditionalIdentifiers additionalIdentifiers{ART::AdditionalIdentifiers::NONE};
+};
+
+class TestLocalArt : public AdvancedSettingsResetBase,
+                     public testing::WithParamInterface<LocalArtTest>
+{
+};
+
+const LocalArtTest local_art_tests[] = {
+    // Linux path tests
+    {"/home/user/movies/movie/movie.iso", "art.jpg", false,
+     "/home/user/movies/movie/movie-art.jpg"},
+    {"/home/user/movies/movie/file.iso", "art.jpg", true, "/home/user/movies/movie/art.jpg"},
+    {"/home/user/movies/movie/disc 1/movie.iso", "art.jpg", false,
+     "/home/user/movies/movie/disc 1/movie-art.jpg"},
+    {"/home/user/movies/movie/disc 1/file.iso", "art.jpg", true,
+     "/home/user/movies/movie/disc 1/art.jpg"},
+    {"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", "art.jpg", false,
+     "/home/user/movies/movie/art.jpg"},
+    {"/home/user/movies/movie/video_ts/VIDEO_TS.IFO", "art.jpg", true,
+     "/home/user/movies/movie/art.jpg"},
+    {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", "art.jpg", false,
+     "/home/user/movies/movie/disc 1/art.jpg"},
+    {"/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", "art.jpg", true,
+     "/home/user/movies/movie/disc 1/art.jpg"},
+    {"/home/user/movies/movie/BDMV/index.bdmv", "art.jpg", false,
+     "/home/user/movies/movie/art.jpg"},
+    {"/home/user/movies/movie/BDMV/index.bdmv", "art.jpg", true, "/home/user/movies/movie/art.jpg"},
+    {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", "art.jpg", false,
+     "/home/user/movies/movie/disc 1/art.jpg"},
+    {"/home/user/movies/movie/disc 1/BDMV/index.bdmv", "art.jpg", true,
+     "/home/user/movies/movie/disc 1/art.jpg"},
+    {"stack:///path/to/movie_name/movie-part-1.avi , /path/to/movie_name/movie-part-2.avi",
+     "art.jpg", false, "/path/to/movie_name/movie-art.jpg"},
+    {"stack:///path/to/movie/cd1/some_file1.avi , /path/to/movie/cd2/some_file2.avi", "art.jpg",
+     true, "/path/to/movie/art.jpg"},
+    // URL path tests using smb://
+    {"smb://home/user/movies/movie/movie.iso", "art.jpg", false,
+     "smb://home/user/movies/movie/movie-art.jpg"},
+    {"smb://home/user/movies/movie/file.iso", "art.jpg", true,
+     "smb://home/user/movies/movie/art.jpg"},
+    {"smb://home/user/movies/movie/disc 1/movie.iso", "art.jpg", false,
+     "smb://home/user/movies/movie/disc 1/movie-art.jpg"},
+    {"smb://home/user/movies/movie/disc 1/file.iso", "art.jpg", true,
+     "smb://home/user/movies/movie/disc 1/art.jpg"},
+    {"smb://home/user/movies/movie/video_ts/VIDEO_TS.IFO", "art.jpg", false,
+     "smb://home/user/movies/movie/art.jpg"},
+    {"smb://home/user/movies/movie/video_ts/VIDEO_TS.IFO", "art.jpg", true,
+     "smb://home/user/movies/movie/art.jpg"},
+    {"smb://home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", "art.jpg", false,
+     "smb://home/user/movies/movie/disc 1/art.jpg"},
+    {"smb://home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO", "art.jpg", true,
+     "smb://home/user/movies/movie/disc 1/art.jpg"},
+    {"smb://home/user/movies/movie/BDMV/index.bdmv", "art.jpg", false,
+     "smb://home/user/movies/movie/art.jpg"},
+    {"smb://home/user/movies/movie/BDMV/index.bdmv", "art.jpg", true,
+     "smb://home/user/movies/movie/art.jpg"},
+    {"smb://home/user/movies/movie/disc 1/BDMV/index.bdmv", "art.jpg", false,
+     "smb://home/user/movies/movie/disc 1/art.jpg"},
+    {"smb://home/user/movies/movie/disc 1/BDMV/index.bdmv", "art.jpg", true,
+     "smb://home/user/movies/movie/disc 1/art.jpg"},
+    {"stack://smb://path/to/movie_name/movie-part-1.avi , "
+     "smb://path/to/movie_name/movie-part-2.avi",
+     "art.jpg", false, "smb://path/to/movie_name/movie-art.jpg"},
+    {"stack://smb://path/to/movie/cd1/some_file1.avi , smb://path/to/movie/cd2/some_file2.avi",
+     "art.jpg", true, "smb://path/to/movie/art.jpg"},
+    // DOS path tests
+    {"D:\\movies\\movie\\movie.iso", "art.jpg", false, "D:\\movies\\movie\\movie-art.jpg"},
+    {"D:\\movies\\movie\\file.iso", "art.jpg", true, "D:\\movies\\movie\\art.jpg"},
+    {"D:\\movies\\movie\\disc 1\\movie.iso", "art.jpg", false,
+     "D:\\movies\\movie\\disc 1\\movie-art.jpg"},
+    {"D:\\movies\\movie\\disc 1\\file.iso", "art.jpg", true, "D:\\movies\\movie\\disc 1\\art.jpg"},
+    {"D:\\movies\\movie\\video_ts\\VIDEO_TS.IFO", "art.jpg", false, "D:\\movies\\movie\\art.jpg"},
+    {"D:\\movies\\movie\\video_ts\\VIDEO_TS.IFO", "art.jpg", true, "D:\\movies\\movie\\art.jpg"},
+    {"D:\\movies\\movie\\disc 1\\video_ts\\VIDEO_TS.IFO", "art.jpg", false,
+     "D:\\movies\\movie\\disc 1\\art.jpg"},
+    {"D:\\movies\\movie\\disc 1\\video_ts\\VIDEO_TS.IFO", "art.jpg", true,
+     "D:\\movies\\movie\\disc 1\\art.jpg"},
+    {"D:\\movies\\movie\\BDMV\\index.bdmv", "art.jpg", false, "D:\\movies\\movie\\art.jpg"},
+    {"D:\\movies\\movie\\BDMV/index.bdmv", "art.jpg", true, "D:\\movies\\movie\\art.jpg"},
+    {"D:\\movies\\movie\\disc 1\\BDMV\\index.bdmv", "art.jpg", false,
+     "D:\\movies\\movie\\disc 1\\art.jpg"},
+    {"D:\\movies\\movie\\disc 1\\BDMV\\index.bdmv", "art.jpg", true,
+     "D:\\movies\\movie\\disc 1\\art.jpg"},
+    {"stack://D:\\movies\\movie_name\\movie-part-1.avi , D:\\movies\\movie_name\\movie-part-2.avi",
+     "art.jpg", false, "D:\\movies\\movie_name\\movie-art.jpg"},
+    {"stack://D:\\movies\\movie\\cd1\\some_file1.avi , D:\\movies\\movie\\cd2\\some_file2.avi",
+     "art.jpg", true, "D:\\movies\\movie\\art.jpg"},
+    // Windows server path tests
+    {"\\\\Server\\Movies\\Movie\\movie.iso", "art.jpg", false,
+     "\\\\Server\\Movies\\Movie\\movie-art.jpg"},
+    {"\\\\Server\\Movies\\Movie\\file.iso", "art.jpg", true, "\\\\Server\\Movies\\Movie\\art.jpg"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\movie.iso", "art.jpg", false,
+     "\\\\Server\\Movies\\Movie\\disc 1\\movie-art.jpg"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\file.iso", "art.jpg", true,
+     "\\\\Server\\Movies\\Movie\\disc 1\\art.jpg"},
+    {"\\\\Server\\Movies\\Movie\\video_ts\\VIDEO_TS.IFO", "art.jpg", false,
+     "\\\\Server\\Movies\\Movie\\art.jpg"},
+    {"\\\\Server\\Movies\\Movie\\video_ts\\VIDEO_TS.IFO", "art.jpg", true,
+     "\\\\Server\\Movies\\Movie\\art.jpg"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\video_ts\\VIDEO_TS.IFO", "art.jpg", false,
+     "\\\\Server\\Movies\\Movie\\disc 1\\art.jpg"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\video_ts\\VIDEO_TS.IFO", "art.jpg", true,
+     "\\\\Server\\Movies\\Movie\\disc 1\\art.jpg"},
+    {"\\\\Server\\Movies\\Movie\\BDMV\\index.bdmv", "art.jpg", false,
+     "\\\\Server\\Movies\\Movie\\art.jpg"},
+    {"\\\\Server\\Movies\\Movie\\BDMV/index.bdmv", "art.jpg", true,
+     "\\\\Server\\Movies\\Movie\\art.jpg"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\BDMV\\index.bdmv", "art.jpg", false,
+     "\\\\Server\\Movies\\Movie\\disc 1\\art.jpg"},
+    {"\\\\Server\\Movies\\Movie\\disc 1\\BDMV\\index.bdmv", "art.jpg", true,
+     "\\\\Server\\Movies\\Movie\\disc 1\\art.jpg"},
+    {"stack://\\\\Server\\Movies\\Movie_name\\movie-part-1.avi , "
+     "\\\\Server\\Movies\\Movie_name\\movie-part-2.avi",
+     "art.jpg", false, "\\\\Server\\Movies\\Movie_name\\movie-art.jpg"},
+    {"stack://\\\\Server\\Movies\\Movie\\cd1\\some_file1.avi , "
+     "\\\\Server\\Movies\\Movie\\cd2\\some_file2.avi",
+     "art.jpg", true, "\\\\Server\\Movies\\Movie\\art.jpg"},
+    // Embedded URL path tests with smb://
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     "art.jpg", false, "smb://somepath/movie-art.jpg"},
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     "art.jpg", true, "smb://somepath/art.jpg"},
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fdisc%25201%252fmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     "art.jpg", true, "smb://somepath/disc 1/art.jpg"},
+    {"bluray://smb%3a%2f%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", "art.jpg", false,
+     "smb://somepath/art.jpg"},
+    {"bluray://smb%3a%2f%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", "art.jpg", true,
+     "smb://somepath/art.jpg"},
+    {"bluray://smb%3a%2f%2fsomepath%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls", "art.jpg", true,
+     "smb://somepath/disc 1/art.jpg"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie.zip/BDMV/index.bdmv", "art.jpg", false,
+     "smb://somepath/movie-art.jpg"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie.zip/BDMV/index.bdmv", "art.jpg", true,
+     "smb://somepath/art.jpg"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.zip/BDMV/index.bdmv", "art.jpg",
+     true, "smb://somepath/movie/disc 1/art.jpg"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie.rar/BDMV/index.bdmv", "art.jpg", false,
+     "smb://somepath/movie-art.jpg"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie.rar/BDMV/index.bdmv", "art.jpg", true,
+     "smb://somepath/art.jpg"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.rar/BDMV/index.bdmv", "art.jpg",
+     true, "smb://somepath/movie/disc 1/art.jpg"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie.tar.gz/BDMV/index.bdmv", "art.jpg", false,
+     "smb://somepath/movie-art.jpg"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie.tar.gz/BDMV/index.bdmv", "art.jpg", true,
+     "smb://somepath/art.jpg"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.tar.gz/BDMV/index.bdmv",
+     "art.jpg", true, "smb://somepath/movie/disc 1/art.jpg"},
+    // Embedded linux path tests
+    {"bluray://udf%3a%2f%2f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     "art.jpg", false, "/somepath/movie-art.jpg"},
+    {"bluray://udf%3a%2f%2f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     "art.jpg", true, "/somepath/art.jpg"},
+    {"bluray://udf%3a%2f%2f%252fsomepath%252fdisc%25201%252fmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     "art.jpg", true, "/somepath/disc 1/art.jpg"},
+    {"bluray://%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", "art.jpg", false, "/somepath/art.jpg"},
+    {"bluray://%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls", "art.jpg", true, "/somepath/art.jpg"},
+    {"bluray://%2fsomepath%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls", "art.jpg", true,
+     "/somepath/disc 1/art.jpg"},
+    {"zip://%2fsomepath%2fmovie.zip/BDMV/index.bdmv", "art.jpg", false, "/somepath/movie-art.jpg"},
+    {"zip://%2fsomepath%2fmovie.zip/BDMV/index.bdmv", "art.jpg", true, "/somepath/art.jpg"},
+    {"zip://%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.zip/BDMV/index.bdmv", "art.jpg", true,
+     "/somepath/movie/disc 1/art.jpg"},
+    {"rar://%2fsomepath%2fmovie.rar/BDMV/index.bdmv", "art.jpg", false, "/somepath/movie-art.jpg"},
+    {"rar://%2fsomepath%2fmovie.rar/BDMV/index.bdmv", "art.jpg", true, "/somepath/art.jpg"},
+    {"rar://%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.rar/BDMV/index.bdmv", "art.jpg", true,
+     "/somepath/movie/disc 1/art.jpg"},
+    {"archive://%2fsomepath%2fmovie.tar.gz/BDMV/index.bdmv", "art.jpg", false,
+     "/somepath/movie-art.jpg"},
+    {"archive://%2fsomepath%2fmovie.tar.gz/BDMV/index.bdmv", "art.jpg", true, "/somepath/art.jpg"},
+    {"archive://%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.tar.gz/BDMV/index.bdmv", "art.jpg",
+     true, "/somepath/movie/disc 1/art.jpg"},
+    // Embedded DOS path tests
+    {"bluray://udf%3a%2f%2fD%253a%255csomepath%255cmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     "art.jpg", false, "D:\\somepath\\movie-art.jpg"},
+    {"bluray://udf%3a%2f%2fD%253a%255csomepath%255cmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     "art.jpg", true, "D:\\somepath\\art.jpg"},
+    {"bluray://udf%3a%2f%2fD%253a%255csomepath%255cdisc%25201%255cmovie.iso%5c/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     "art.jpg", true, "D:\\somepath\\disc 1\\art.jpg"},
+    {"bluray://D%3a%5csomepath%5c/BDMV/PLAYLIST/00800.mpls", "art.jpg", false,
+     "D:\\somepath\\art.jpg"},
+    {"bluray://D%3a%5csomepath%5c/BDMV/PLAYLIST/00800.mpls", "art.jpg", true,
+     "D:\\somepath\\art.jpg"},
+    {"bluray://D%3a%5csomepath%5cdisc%201%5c/BDMV/PLAYLIST/00800.mpls", "art.jpg", true,
+     "D:\\somepath\\disc 1\\art.jpg"},
+    {"zip://D%3a%5csomepath%5cmovie.zip/BDMV/index.bdmv", "art.jpg", false,
+     "D:\\somepath\\movie-art.jpg"},
+    {"zip://D%3a%5csomepath%5cmovie.zip/BDMV/index.bdmv", "art.jpg", true, "D:\\somepath\\art.jpg"},
+    {"zip://D%3a%5csomepath%5cmovie%5cdisc%201%5cmovie_disc.zip/BDMV/index.bdmv", "art.jpg", true,
+     "D:\\somepath\\movie\\disc 1\\art.jpg"},
+    {"rar://D%3a%5csomepath%5cmovie.rar/BDMV/index.bdmv", "art.jpg", false,
+     "D:\\somepath\\movie-art.jpg"},
+    {"rar://D%3a%5csomepath%5cmovie.rar/BDMV/index.bdmv", "art.jpg", true, "D:\\somepath\\art.jpg"},
+    {"rar://D%3a%5csomepath%5cmovie%5cdisc%201%5cmovie_disc.rar/BDMV/index.bdmv", "art.jpg", true,
+     "D:\\somepath\\movie\\disc 1\\art.jpg"},
+    {"archive://D%3a%5csomepath%5cmovie.tar.gz/BDMV/index.bdmv", "art.jpg", false,
+     "D:\\somepath\\movie-art.jpg"},
+    {"archive://D%3a%5csomepath%5cmovie.tar.gz/BDMV/index.bdmv", "art.jpg", true,
+     "D:\\somepath\\art.jpg"},
+    {"archive://D%3a%5csomepath%5cmovie%5cdisc%201%5cmovie_disc.tar.gz/BDMV/index.bdmv", "art.jpg",
+     true, "D:\\somepath\\movie\\disc 1\\art.jpg"},
+    // Embedded Windows server path tests
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     "art.jpg", false, "\\\\Server\\Movies\\movie-art.jpg"},
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cMovie%255cmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     "art.jpg", true, "\\\\Server\\Movies\\Movie\\art.jpg"},
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cMovie%255cdisc%25201%255cmovie.iso%2f/"
+     "BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     "art.jpg", true, "\\\\Server\\Movies\\Movie\\disc 1\\art.jpg"},
+    {"bluray://%5c%5cServer%5cMovies%5cMovie%5c/BDMV/PLAYLIST/00800.mpls", "art.jpg", false,
+     "\\\\Server\\Movies\\Movie\\art.jpg"},
+    {"bluray://%5c%5cServer%5cMovies%5cMovie%5c/BDMV/PLAYLIST/00800.mpls", "art.jpg", true,
+     "\\\\Server\\Movies\\Movie\\art.jpg"},
+    {"bluray://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5c/BDMV/PLAYLIST/00800.mpls", "art.jpg",
+     true, "\\\\Server\\Movies\\Movie\\disc 1\\art.jpg"},
+    {"zip://%5c%5cServer%5cMovies%5cMovie%5cmovie.zip/BDMV/index.bdmv", "art.jpg", false,
+     "\\\\Server\\Movies\\Movie\\movie-art.jpg"},
+    {"zip://%5c%5cServer%5cMovies%5cMovie%5cmovie.zip/BDMV/index.bdmv", "art.jpg", true,
+     "\\\\Server\\Movies\\Movie\\art.jpg"},
+    {"zip://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5cmovie_disc.zip/BDMV/index.bdmv", "art.jpg",
+     true, "\\\\Server\\Movies\\Movie\\disc 1\\art.jpg"},
+    {"rar://%5c%5cServer%5cMovies%5cMovie%5cmovie.rar/BDMV/index.bdmv", "art.jpg", false,
+     "\\\\Server\\Movies\\Movie\\movie-art.jpg"},
+    {"rar://%5c%5cServer%5cMovies%5cMovie%5cmovie.rar/BDMV/index.bdmv", "art.jpg", true,
+     "\\\\Server\\Movies\\Movie\\art.jpg"},
+    {"rar://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5cmovie_disc.rar/BDMV/index.bdmv", "art.jpg",
+     true, "\\\\Server\\Movies\\Movie\\disc 1\\art.jpg"},
+    {"archive://%5c%5cServer%5cMovies%5cMovie%5cmovie.tar.gz/BDMV/index.bdmv", "art.jpg", false,
+     "\\\\Server\\Movies\\Movie\\movie-art.jpg"},
+    {"archive://%5c%5cServer%5cMovies%5cMovie%5cmovie.tar.gz/BDMV/index.bdmv", "art.jpg", true,
+     "\\\\Server\\Movies\\Movie\\art.jpg"},
+    {"archive://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5cmovie_disc.tar.gz/BDMV/index.bdmv",
+     "art.jpg", true, "\\\\Server\\Movies\\Movie\\disc 1\\art.jpg"},
+    // Special tests
+    // Blank art file
+    {"/home/user/movies/movie/movie.iso", "", false, "/home/user/movies/movie/movie.tbn"},
+    {"D:\\movies\\movie\\movie.iso", "", false, "D:\\movies\\movie\\movie.tbn"},
+    // Episodes
+    {"/home/user/movies/movie_name/BDMV/index.bdmv", "thumb.jpg", false,
+     "/home/user/movies/movie_name/BDMV/index-S03E04-thumb.jpg", 3, 4, -1,
+     ART::AdditionalIdentifiers::SEASON_AND_EPISODE},
+    {"/home/user/tv_show/tv_show.iso", "thumb.jpg", false,
+     "/home/user/tv_show/tv_show-S03E04-thumb.jpg", 3, 4, -1,
+     ART::AdditionalIdentifiers::SEASON_AND_EPISODE},
+    // Playlists
+    {"/home/user/movies/movie_name/BDMV/index.bdmv", "thumb.jpg", false,
+     "/home/user/movies/movie_name/BDMV/index-00800-thumb.jpg", -1, -1, 800,
+     ART::AdditionalIdentifiers::PLAYLIST},
+    {"/home/user/movie/movie.iso", "thumb.jpg", false, "/home/user/movie/movie-00800-thumb.jpg", -1,
+     -1, 800, ART::AdditionalIdentifiers::PLAYLIST}};
+
+TEST_P(TestLocalArt, GetLocalArt)
+{
+  CFileItem item;
+  item.SetPath(GetParam().file);
+  CVideoInfoTag* tag{item.GetVideoInfoTag()};
+  tag->m_iSeason = GetParam().season;
+  tag->m_iEpisode = GetParam().episode;
+  tag->m_iTrack = GetParam().playlist;
+  std::string path = ART::GetLocalArt(item, GetParam().art, GetParam().use_folder,
+                                      GetParam().additionalIdentifiers);
+  EXPECT_EQ(path, GetParam().base);
+}
+
+INSTANTIATE_TEST_SUITE_P(TestArtUtils, TestLocalArt, testing::ValuesIn(local_art_tests));
+
+// ART::GetTBNFile() tests
+
+struct TbnTest
+{
+  std::string path;
+  std::string result;
+  bool isFolder{false};
+  int season{-1};
+  int episode{-1};
+};
+
+class GetTbnTest : public testing::WithParamInterface<TbnTest>, public testing::Test
+{
+};
+
+const TbnTest tbn_tests[] = {
+    // Linux path tests
+    {"/home/user/movies/movie/movie.avi", "/home/user/movies/movie/movie.tbn"},
+    {"/home/user/movies/movie/movie.xbt", "/home/user/movies/movie/movie.tbn", true}, // File folder
+    {"/home/user/movies/movie/", "/home/user/movies/movie.tbn", true},
+    {"/home/user/movies/movie/disc 1/movie.avi", "/home/user/movies/movie/disc 1/movie.tbn"},
+    {"/home/user/movies/movie/video_ts/video_ts.ifo",
+     "/home/user/movies/movie/video_ts/video_ts.tbn"},
+    {"/home/user/movies/movie/disc 1/video_ts/video_ts.ifo",
+     "/home/user/movies/movie/disc 1/video_ts/video_ts.tbn"},
+    {"/home/user/movies/movie/BDMV/index.bdmv", "/home/user/movies/movie/BDMV/index.tbn"},
+    {"/home/user/movies/movie/disc 1/BDMV/index.bdmv",
+     "/home/user/movies/movie/disc 1/BDMV/index.tbn"},
+    {"stack:///home/user/movies/movie_name/movie-part-1.avi , "
+     "/home/user/movies/movie_name/movie-part-2.avi",
+     "/home/user/movies/movie_name/movie.tbn"},
+    {"stack:///home/user/movies/movie/movie part 1/file.avi , /home/user/movies/movie/movie part "
+     "2/file.avi",
+     "/home/user/movies/movie/movie.tbn"},
+    // URL path tests using smb://
+    {"smb://home/user/movies/movie/movie.avi", "smb://home/user/movies/movie/movie.tbn"},
+    {"smb://home/user/movies/movie/movie.xbt", "smb://home/user/movies/movie/movie.tbn",
+     true}, // File folder
+    {"smb://home/user/movies/movie/", "smb://home/user/movies/movie.tbn", true},
+    {"smb://home/user/movies/movie/disc 1/movie.avi",
+     "smb://home/user/movies/movie/disc 1/movie.tbn"},
+    {"smb://home/user/movies/movie/video_ts/video_ts.ifo",
+     "smb://home/user/movies/movie/video_ts/video_ts.tbn"},
+    {"smb://home/user/movies/movie/disc 1/video_ts/video_ts.ifo",
+     "smb://home/user/movies/movie/disc 1/video_ts/video_ts.tbn"},
+    {"smb://home/user/movies/movie/BDMV/index.bdmv", "smb://home/user/movies/movie/BDMV/index.tbn"},
+    {"smb://home/user/movies/movie/disc 1/BDMV/index.bdmv",
+     "smb://home/user/movies/movie/disc 1/BDMV/index.tbn"},
+    // DOS path tests
+    {"D:\\Movies\\movies\\movie\\movie.avi", "D:\\Movies\\movies\\movie\\movie.tbn"},
+    {"D:\\Movies\\movies\\movie\\movie.xbt", "D:\\Movies\\movies\\movie\\movie.tbn",
+     true}, // File folder
+    {"D:\\Movies\\movies\\movie\\", "D:\\Movies\\movies\\movie.tbn", true},
+    {"D:\\Movies\\movies\\movie\\disc 1\\movie.avi",
+     "D:\\Movies\\movies\\movie\\disc 1\\movie.tbn"},
+    {"D:\\Movies\\movies\\movie\\video_ts\\video_ts.ifo",
+     "D:\\Movies\\movies\\movie\\video_ts\\video_ts.tbn"},
+    {"D:\\Movies\\movies\\movie\\disc 1\\video_ts\\video_ts.ifo",
+     "D:\\Movies\\movies\\movie\\disc 1\\video_ts\\video_ts.tbn"},
+    {"D:\\Movies\\movies\\movie\\BDMV\\index.bdmv", "D:\\Movies\\movies\\movie\\BDMV\\index.tbn"},
+    {"D:\\Movies\\movies\\movie\\disc 1\\BDMV\\index.bdmv",
+     "D:\\Movies\\movies\\movie\\disc 1\\BDMV\\index.tbn"},
+    {"stack://D:\\Movies\\movies\\movie_name\\movie-part-1.avi , "
+     "D:\\Movies\\movies\\movie_name\\movie-part-2.avi",
+     "D:\\Movies\\movies\\movie_name\\movie.tbn"},
+    {"stack://D:\\Movies\\movies\\movie\\movie part 1\\file.avi , "
+     "D:\\Movies\\movies\\movie\\movie part 2\\file.avi",
+     "D:\\Movies\\movies\\movie\\movie.tbn"},
+    // Windows server path tests
+    {"\\\\Server\\Movies\\movies\\movie\\movie.avi",
+     "\\\\Server\\Movies\\movies\\movie\\movie.tbn"},
+    {"\\\\Server\\Movies\\movies\\movie\\movie.xbt", "\\\\Server\\Movies\\movies\\movie\\movie.tbn",
+     true}, // File folder
+    {"\\\\Server\\Movies\\movies\\movie\\", "\\\\Server\\Movies\\movies\\movie.tbn", true},
+    {"\\\\Server\\Movies\\movies\\movie\\disc 1\\movie.avi",
+     "\\\\Server\\Movies\\movies\\movie\\disc 1\\movie.tbn"},
+    {"\\\\Server\\Movies\\movies\\movie\\video_ts\\video_ts.ifo",
+     "\\\\Server\\Movies\\movies\\movie\\video_ts\\video_ts.tbn"},
+    {"\\\\Server\\Movies\\movies\\movie\\disc 1\\video_ts\\video_ts.ifo",
+     "\\\\Server\\Movies\\movies\\movie\\disc 1\\video_ts\\video_ts.tbn"},
+    {"\\\\Server\\Movies\\movies\\movie\\BDMV\\index.bdmv",
+     "\\\\Server\\Movies\\movies\\movie\\BDMV\\index.tbn"},
+    {"\\\\Server\\Movies\\movies\\movie\\disc 1\\BDMV\\index.bdmv",
+     "\\\\Server\\Movies\\movies\\movie\\disc 1\\BDMV\\index.tbn"},
+    {"stack://\\\\Server\\Movies\\movies\\movie_name\\movie-part-1.avi , "
+     "\\\\Server\\Movies\\movies\\movie_name\\movie-part-2.avi",
+     "\\\\Server\\Movies\\movies\\movie_name\\movie.tbn"},
+    {"stack://\\\\Server\\Movies\\movies\\movie\\movie part 1\\file.avi , "
+     "\\\\Server\\Movies\\movies\\movie\\movie part 2\\file.avi",
+     "\\\\Server\\Movies\\movies\\movie\\movie.tbn"},
+    // Embedded linux path tests
+    {"bluray://udf%3a%2f%2f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     "/somepath/movie.tbn"},
+    {"bluray://udf%3a%2f%2f%252fsomepath%252fdisc%25201%252fmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     "/somepath/disc 1/movie.tbn"},
+    {"bluray://%2fsomepath%2fmovie%2f/BDMV/PLAYLIST/00800.mpls", "/somepath/movie/BDMV/index.tbn"},
+    {"bluray://%2fsomepath%2fmovie%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls",
+     "/somepath/movie/disc 1/BDMV/index.tbn"},
+    {"zip://%2fsomepath%2fmovie.zip/film.mkv", "/somepath/movie.tbn"},
+    {"zip://%2fsomepath%2fmovie.zip/BDMV/index.bdmv", "/somepath/movie.tbn"},
+    {"zip://%2fsomepath%2fmovie%2fdisc%201%2fmovie.zip/BDMV/index.bdmv",
+     "/somepath/movie/disc 1/movie.tbn"},
+    {"rar://%2fsomepath%2fmovie.rar/film.mkv", "/somepath/movie.tbn"},
+    {"rar://%2fsomepath%2fmovie.rar/BDMV/index.bdmv", "/somepath/movie.tbn"},
+    {"rar://%2fsomepath%2fmovie%2fdisc%201%2fmovie.rar/BDMV/index.bdmv",
+     "/somepath/movie/disc 1/movie.tbn"},
+    {"archive://%2fsomepath%2fmovie.tar.gz/film.mkv", "/somepath/movie.tbn"},
+    {"archive://%2fsomepath%2fmovie.tar.gz/BDMV/index.bdmv", "/somepath/movie.tbn"},
+    {"archive://%2fsomepath%2fmovie%2fdisc%201%2fmovie.tar.gz/BDMV/index.bdmv",
+     "/somepath/movie/disc 1/movie.tbn"},
+    // Embedded linux path tests
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     "smb://somepath/movie.tbn"},
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fdisc%25201%252fmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     "smb://somepath/disc 1/movie.tbn"},
+    {"bluray://smb%3a%2f%2fsomepath%2fmovie%2f/BDMV/PLAYLIST/00800.mpls",
+     "smb://somepath/movie/BDMV/index.tbn"},
+    {"bluray://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls",
+     "smb://somepath/movie/disc 1/BDMV/index.tbn"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie.zip/film.mkv", "smb://somepath/movie.tbn"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie.zip/BDMV/index.bdmv", "smb://somepath/movie.tbn"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie.zip/BDMV/index.bdmv",
+     "smb://somepath/movie/disc 1/movie.tbn"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie.rar/film.mkv", "smb://somepath/movie.tbn"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie.rar/BDMV/index.bdmv", "smb://somepath/movie.tbn"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie.rar/BDMV/index.bdmv",
+     "smb://somepath/movie/disc 1/movie.tbn"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie.tar.gz/film.mkv", "smb://somepath/movie.tbn"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie.tar.gz/BDMV/index.bdmv", "smb://somepath/movie.tbn"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie.tar.gz/BDMV/index.bdmv",
+     "smb://somepath/movie/disc 1/movie.tbn"},
+    // Embedded DOS path tests
+    {"bluray://udf%3a%2f%2fD%253a%255csomepath%255cmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     "D:\\somepath\\movie.tbn"},
+    {"bluray://udf%3a%2f%2fD%253a%255csomepath%255cdisc%25201%255cmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     "D:\\somepath\\disc 1\\movie.tbn"},
+    {"bluray://D%3a%5csomepath%5cmovie%5c/BDMV/PLAYLIST/00800.mpls",
+     "D:\\somepath\\movie\\BDMV\\index.tbn"},
+    {"bluray://D%3a%5csomepath%5cmovie%5cdisc%201%5c/BDMV/PLAYLIST/00800.mpls",
+     "D:\\somepath\\movie\\disc 1\\BDMV\\index.tbn"},
+    {"zip://D%3a%5csomepath%5cmovie.zip/film.mkv", "D:\\somepath\\movie.tbn"},
+    {"zip://D%3a%5csomepath%5cmovie.zip/BDMV/index.bdmv", "D:\\somepath\\movie.tbn"},
+    {"zip://D%3a%5csomepath%5cmovie%5cdisc%201%5cmovie.zip/BDMV/index.bdmv",
+     "D:\\somepath\\movie\\disc 1\\movie.tbn"},
+    {"rar://D%3a%5csomepath%5cmovie.rar/film.mkv", "D:\\somepath\\movie.tbn"},
+    {"rar://D%3a%5csomepath%5cmovie.rar/BDMV/index.bdmv", "D:\\somepath\\movie.tbn"},
+    {"rar://D%3a%5csomepath%5cmovie%5cdisc%201%5cmovie.rar/BDMV/index.bdmv",
+     "D:\\somepath\\movie\\disc 1\\movie.tbn"},
+    {"archive://D%3a%5csomepath%5cmovie.tar.gz/film.mkv", "D:\\somepath\\movie.tbn"},
+    {"archive://D%3a%5csomepath%5cmovie.tar.gz/BDMV/index.bdmv", "D:\\somepath\\movie.tbn"},
+    {"archive://D%3a%5csomepath%5cmovie%5cdisc%201%5cmovie.tar.gz/BDMV/index.bdmv",
+     "D:\\somepath\\movie\\disc 1\\movie.tbn"},
+    // Embedded Windows server path tests
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/"
+     "00800.mpls",
+     "\\\\Server\\Movies\\movie.tbn"},
+    {"bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cdisc%25201%255cmovie.iso%2f/BDMV/"
+     "PLAYLIST/"
+     "00800.mpls",
+     "\\\\Server\\Movies\\disc 1\\movie.tbn"},
+    {"bluray://%5c%5cServer%5cMovies%5cmovie%5c/BDMV/PLAYLIST/00800.mpls",
+     "\\\\Server\\Movies\\movie\\BDMV\\index.tbn"},
+    {"bluray://%5c%5cServer%5cMovies%5cmovie%5cdisc%201%5c/BDMV/PLAYLIST/00800.mpls",
+     "\\\\Server\\Movies\\movie\\disc 1\\BDMV\\index.tbn"},
+    {"zip://%5c%5cServer%5cMovies%5cmovie.zip/film.mkv", "\\\\Server\\Movies\\movie.tbn"},
+    {"zip://%5c%5cServer%5cMovies%5cmovie.zip/BDMV/index.bdmv", "\\\\Server\\Movies\\movie.tbn"},
+    {"zip://%5c%5cServer%5cMovies%5cmovie%5cdisc%201%5cmovie.zip/BDMV/index.bdmv",
+     "\\\\Server\\Movies\\movie\\disc 1\\movie.tbn"},
+    {"rar://%5c%5cServer%5cMovies%5cmovie.rar/film.mkv", "\\\\Server\\Movies\\movie.tbn"},
+    {"rar://%5c%5cServer%5cMovies%5cmovie.rar/BDMV/index.bdmv", "\\\\Server\\Movies\\movie.tbn"},
+    {"rar://%5c%5cServer%5cMovies%5cmovie%5cdisc%201%5cmovie.rar/BDMV/index.bdmv",
+     "\\\\Server\\Movies\\movie\\disc 1\\movie.tbn"},
+    {"archive://%5c%5cServer%5cMovies%5cmovie.tar.gz/film.mkv", "\\\\Server\\Movies\\movie.tbn"},
+    {"archive://%5c%5cServer%5cMovies%5cmovie.tar.gz/BDMV/index.bdmv",
+     "\\\\Server\\Movies\\movie.tbn"},
+    {"archive://%5c%5cServer%5cMovies%5cmovie%5cdisc%201%5cmovie.tar.gz/BDMV/index.bdmv",
+     "\\\\Server\\Movies\\movie\\disc 1\\movie.tbn"},
+    // Special tests
+    // Episodes
+    {"/home/user/foo.avi", "/home/user/foo-S03E04.tbn", false, 3, 4},
+    {"/home/user/BDMV/index.bdmv", "/home/user/BDMV/index-S03E04.tbn", false, 3, 4},
+    {"smb://home/user/foo.avi", "smb://home/user/foo-S03E04.tbn", false, 3, 4},
+    {"D:\\home\\user\\foo.avi", "D:\\home\\user\\foo-S03E04.tbn", false, 3, 4},
+    {"\\\\Server\\user\\foo.avi", "\\\\Server\\user\\foo-S03E04.tbn", false, 3, 4},
+    {"bluray://smb%3a%2f%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls",
+     "smb://somepath/BDMV/index-S03E04.tbn", false, 3, 4},
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252ftvshow.iso%2f/BDMV/"
+     "PLAYLIST/00800.mpls",
+     "smb://somepath/tvshow-S03E04.tbn", false, 3, 4}};
 
 TEST_P(GetTbnTest, TbnTest)
 {
@@ -409,30 +1113,9 @@ TEST_P(GetTbnTest, TbnTest)
             GetParam().result);
 }
 
-const auto tbn_tests = std::array{
-    TbnTest{"/home/user/video.avi", "/home/user/video.tbn"},
-    TbnTest{"/home/user/video/", "/home/user/video.tbn", true},
-    TbnTest{"/home/user/bar.xbt", "/home/user/bar.tbn", true},
-    TbnTest{"zip://%2fhome%2fuser%2fbar.zip/foo.avi", "/home/user/foo.tbn"},
-    TbnTest{"stack:///home/user/foo-cd1.avi , /home/user/foo-cd2.avi", "/home/user/foo.tbn"},
-    TbnTest{"/home/user/BDMV/index.bdmv", "/home/user/BDMV/index.tbn"},
-    TbnTest{"/home/user/movie.iso", "/home/user/movie.tbn"},
-    TbnTest{"bluray://smb%3a%2f%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls",
-            "smb://somepath/BDMV/index.tbn"},
-    TbnTest{
-        "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/00800.mpls",
-        "smb://somepath/movie.tbn"},
-    TbnTest{"/home/user/video.avi", "/home/user/video-S03E04.tbn", false, 3, 4},
-    TbnTest{"/home/user/BDMV/index.bdmv", "/home/user/BDMV/index-S03E04.tbn", false, 3, 4},
-    TbnTest{"/home/user/movie.iso", "/home/user/movie-S03E04.tbn", false, 3, 4},
-    TbnTest{"bluray://smb%3a%2f%2fsomepath%2f/BDMV/PLAYLIST/00800.mpls",
-            "smb://somepath/BDMV/index-S03E04.tbn", false, 3, 4},
-    TbnTest{
-        "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fmovie.iso%2f/BDMV/PLAYLIST/00800.mpls",
-        "smb://somepath/movie-S03E04.tbn", false, 3, 4},
-};
-
 INSTANTIATE_TEST_SUITE_P(TestArtUtils, GetTbnTest, testing::ValuesIn(tbn_tests));
+
+// ART::GetTBNFile() stack tests
 
 TEST(TestArtUtils, GetTbnStack)
 {

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -10,6 +10,7 @@
 #include "URL.h"
 #include "filesystem/File.h"
 #include "filesystem/MultiPathDirectory.h"
+#include "interfaces/legacy/WindowInterceptor.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "test/TestUtils.h"
@@ -19,6 +20,10 @@
 #include <utility>
 
 #include <gtest/gtest.h>
+
+using ::testing::Test;
+using ::testing::ValuesIn;
+using ::testing::WithParamInterface;
 
 using namespace XFILE;
 
@@ -40,49 +45,177 @@ TEST_F(TestURIUtils, PathHasParent)
 
 TEST_F(TestURIUtils, GetDirectory)
 {
-  EXPECT_STREQ("/path/to/", URIUtils::GetDirectory("/path/to/movie.avi").c_str());
-  EXPECT_STREQ("/path/to/", URIUtils::GetDirectory("/path/to/").c_str());
-  EXPECT_STREQ("/path/to/|option=foo", URIUtils::GetDirectory("/path/to/movie.avi|option=foo").c_str());
-  EXPECT_STREQ("/path/to/|option=foo", URIUtils::GetDirectory("/path/to/|option=foo").c_str());
-  EXPECT_STREQ("", URIUtils::GetDirectory("movie.avi").c_str());
-  EXPECT_STREQ("", URIUtils::GetDirectory("movie.avi|option=foo").c_str());
-  EXPECT_STREQ("", URIUtils::GetDirectory("").c_str());
+  EXPECT_EQ("/path/to/", URIUtils::GetDirectory("/path/to/movie.avi"));
+  EXPECT_EQ("/path/to/", URIUtils::GetDirectory("/path/to/"));
+  EXPECT_EQ("/path/to/|option=foo", URIUtils::GetDirectory("/path/to/movie.avi|option=foo"));
+  EXPECT_EQ("/path/to/|option=foo", URIUtils::GetDirectory("/path/to/|option=foo"));
+  EXPECT_EQ("", URIUtils::GetDirectory("movie.avi"));
+  EXPECT_EQ("", URIUtils::GetDirectory("movie.avi|option=foo"));
+  EXPECT_EQ("", URIUtils::GetDirectory(""));
 
   // Make sure it works when assigning to the same str as the reference parameter
   std::string var = "/path/to/movie.avi|option=foo";
   var = URIUtils::GetDirectory(var);
-  EXPECT_STREQ("/path/to/|option=foo", var.c_str());
+  EXPECT_EQ("/path/to/|option=foo", var);
 }
 
 TEST_F(TestURIUtils, GetExtension)
 {
-  EXPECT_STREQ(".avi",
-               URIUtils::GetExtension("/path/to/movie.avi").c_str());
+  // When testing file names with dots there is no way of telling what is an extension and what isn't
+  //  without a list of extensions. This is why movie.name and .movie.name fail and are commented out
+
+  EXPECT_EQ(".avi", URIUtils::GetExtension("/path/to/movie.avi"));
+  EXPECT_EQ("", URIUtils::GetExtension("/path/to/movie."));
+  EXPECT_EQ("", URIUtils::GetExtension("/path/to/.movie"));
+  EXPECT_EQ("", URIUtils::GetExtension("/path/to/movie"));
+  EXPECT_EQ(".ext", URIUtils::GetExtension("/path/to/.movie.ext"));
+  EXPECT_EQ(".tar.gz", URIUtils::GetExtension("/path/to/movie.tar.gz"));
+
+  EXPECT_EQ(".avi", URIUtils::GetExtension("/path/to/movie.name.avi"));
+  EXPECT_EQ("", URIUtils::GetExtension("/path/to/movie.name."));
+  //EXPECT_EQ("", URIUtils::GetExtension("/path/to/.movie.name"));
+  //EXPECT_EQ("", URIUtils::GetExtension("/path/to/movie.name"));
+  EXPECT_EQ(".ext", URIUtils::GetExtension("/path/to/.movie.name.ext"));
+  EXPECT_EQ(".tar.gz", URIUtils::GetExtension("/path/to/movie.name.tar.gz"));
+
+  EXPECT_EQ(".avi", URIUtils::GetExtension("D:\\path\\movie.avi"));
+  EXPECT_EQ("", URIUtils::GetExtension("D:\\path\\movie."));
+  EXPECT_EQ("", URIUtils::GetExtension("D:\\path\\.movie"));
+  EXPECT_EQ("", URIUtils::GetExtension("D:\\path\\movie"));
+  EXPECT_EQ(".ext", URIUtils::GetExtension("D:\\path\\.movie.ext"));
+  EXPECT_EQ(".tar.gz", URIUtils::GetExtension("D:\\path\\movie.tar.gz"));
+
+  EXPECT_EQ(".avi", URIUtils::GetExtension("D:\\path\\movie.name.avi"));
+  EXPECT_EQ("", URIUtils::GetExtension("D:\\path\\movie.name."));
+  //EXPECT_EQ("", URIUtils::GetExtension("D:\\path\\.movie.name"));
+  //EXPECT_EQ("", URIUtils::GetExtension("D:\\path\\movie.name"));
+  EXPECT_EQ(".ext", URIUtils::GetExtension("D:\\path\\.movie.name.ext"));
+  EXPECT_EQ(".tar.gz", URIUtils::GetExtension("D:\\path\\movie.name.tar.gz"));
+
+  EXPECT_EQ(".avi", URIUtils::GetExtension("\\\\Server\\path\\movie.avi"));
+  EXPECT_EQ("", URIUtils::GetExtension("\\\\Server\\path\\movie."));
+  EXPECT_EQ("", URIUtils::GetExtension("\\\\Server\\path\\.movie"));
+  EXPECT_EQ("", URIUtils::GetExtension("\\\\Server\\path\\movie"));
+  EXPECT_EQ(".ext", URIUtils::GetExtension("\\\\Server\\path\\.movie.ext"));
+  EXPECT_EQ(".tar.gz", URIUtils::GetExtension("\\\\Server\\path\\movie.tar.gz"));
+
+  EXPECT_EQ(".avi", URIUtils::GetExtension("\\\\Server\\path\\movie.name.avi"));
+  EXPECT_EQ("", URIUtils::GetExtension("\\\\Server\\path\\movie.name."));
+  //EXPECT_EQ("", URIUtils::GetExtension("\\\\Server\\path\\.movie.name"));
+  //EXPECT_EQ("", URIUtils::GetExtension("\\\\Server\\path\\movie.name"));
+  EXPECT_EQ(".ext", URIUtils::GetExtension("\\\\Server\\path\\.movie.name.ext"));
+  EXPECT_EQ(".tar.gz", URIUtils::GetExtension("\\\\Server\\path\\movie.name.tar.gz"));
+
+  EXPECT_EQ(".avi", URIUtils::GetExtension("smb://path/to/movie.avi"));
+  EXPECT_EQ("", URIUtils::GetExtension("smb://path/to/movie."));
+  EXPECT_EQ("", URIUtils::GetExtension("smb://path/to/.movie"));
+  EXPECT_EQ("", URIUtils::GetExtension("smb://path/to/movie"));
+  EXPECT_EQ(".ext", URIUtils::GetExtension("smb://path/to/.movie.ext"));
+  EXPECT_EQ(".tar.gz", URIUtils::GetExtension("smb://path/to/movie.tar.gz"));
+
+  EXPECT_EQ(".avi", URIUtils::GetExtension("smb://path/to/movie.name.avi"));
+  EXPECT_EQ("", URIUtils::GetExtension("smb://path/to/movie.name."));
+  //EXPECT_EQ("", URIUtils::GetExtension("smb://path/to/.movie.name"));
+  //EXPECT_EQ("", URIUtils::GetExtension("smb://path/to/movie.name"));
+  EXPECT_EQ(".ext", URIUtils::GetExtension("smb://path/to/.movie.name.ext"));
+  EXPECT_EQ(".tar.gz", URIUtils::GetExtension("smb://path/to/movie.name.tar.gz"));
+
+  EXPECT_EQ("", URIUtils::GetExtension("."));
+  EXPECT_EQ("", URIUtils::GetExtension(".."));
+  EXPECT_EQ("", URIUtils::GetExtension("/path/to/."));
+  EXPECT_EQ("", URIUtils::GetExtension("/path/to/.."));
+  EXPECT_EQ("", URIUtils::GetExtension("D:\\path\\."));
+  EXPECT_EQ("", URIUtils::GetExtension("D:\\path\\.."));
+  EXPECT_EQ("", URIUtils::GetExtension("\\\\server\\path\\."));
+  EXPECT_EQ("", URIUtils::GetExtension("\\\\server\\path\\.."));
+
+  EXPECT_EQ(".avi", URIUtils::GetExtension("movie.avi"));
+  EXPECT_EQ("", URIUtils::GetExtension("movie."));
+  EXPECT_EQ("", URIUtils::GetExtension(".movie"));
+  EXPECT_EQ("", URIUtils::GetExtension("movie"));
+  EXPECT_EQ(".ext", URIUtils::GetExtension(".movie.ext"));
+  EXPECT_EQ(".tar.gz", URIUtils::GetExtension("movie.tar.gz"));
+
+  EXPECT_EQ(".avi", URIUtils::GetExtension("movie.name.avi"));
+  EXPECT_EQ("", URIUtils::GetExtension("movie.name."));
+  //EXPECT_EQ("", URIUtils::GetExtension(".movie.name"));
+  //EXPECT_EQ("", URIUtils::GetExtension("movie.name"));
+  EXPECT_EQ(".ext", URIUtils::GetExtension(".movie.name.ext"));
+  EXPECT_EQ(".tar.gz", URIUtils::GetExtension("movie.name.tar.gz"));
 }
 
 TEST_F(TestURIUtils, HasExtension)
 {
-  EXPECT_TRUE (URIUtils::HasExtension("/path/to/movie.AvI"));
+  EXPECT_TRUE(URIUtils::HasExtension("/path/to/movie.AvI"));
   EXPECT_FALSE(URIUtils::HasExtension("/path/to/movie"));
   EXPECT_FALSE(URIUtils::HasExtension("/path/.to/movie"));
   EXPECT_FALSE(URIUtils::HasExtension(""));
 
-  EXPECT_TRUE (URIUtils::HasExtension("/path/to/movie.AvI", ".avi"));
+  EXPECT_TRUE(URIUtils::HasExtension("/path/to/movie.AvI", ".avi"));
   EXPECT_FALSE(URIUtils::HasExtension("/path/to/movie.AvI", ".mkv"));
   EXPECT_FALSE(URIUtils::HasExtension("/path/.avi/movie", ".avi"));
   EXPECT_FALSE(URIUtils::HasExtension("", ".avi"));
 
-  EXPECT_TRUE (URIUtils::HasExtension("/path/movie.AvI", ".avi|.mkv|.mp4"));
-  EXPECT_TRUE (URIUtils::HasExtension("/path/movie.AvI", ".mkv|.avi|.mp4"));
+  EXPECT_TRUE(URIUtils::HasExtension("/path/movie.AvI", ".avi|.mkv|.mp4"));
+  EXPECT_TRUE(URIUtils::HasExtension("/path/movie.AvI", ".mkv|.avi|.mp4"));
   EXPECT_FALSE(URIUtils::HasExtension("/path/movie.AvI", ".mpg|.mkv|.mp4"));
   EXPECT_FALSE(URIUtils::HasExtension("/path.mkv/movie.AvI", ".mpg|.mkv|.mp4"));
+  EXPECT_FALSE(URIUtils::HasExtension("", ".avi|.mkv|.mp4"));
+
+  EXPECT_TRUE(URIUtils::HasExtension("D:\\Path\\movie.AvI"));
+  EXPECT_FALSE(URIUtils::HasExtension("D:\\Path\\movie"));
+  EXPECT_FALSE(URIUtils::HasExtension("D:\\Path\\.to\\movie"));
+  EXPECT_FALSE(URIUtils::HasExtension(""));
+
+  EXPECT_TRUE(URIUtils::HasExtension("D:\\Path\\movie.AvI", ".avi"));
+  EXPECT_FALSE(URIUtils::HasExtension("D:\\Path\\movie.AvI", ".mkv"));
+  EXPECT_FALSE(URIUtils::HasExtension("D:\\Path\\.avi\\movie", ".avi"));
+  EXPECT_FALSE(URIUtils::HasExtension("", ".avi"));
+
+  EXPECT_TRUE(URIUtils::HasExtension("D:\\Path\\movie.AvI", ".avi|.mkv|.mp4"));
+  EXPECT_TRUE(URIUtils::HasExtension("D:\\Path\\movie.AvI", ".mkv|.avi|.mp4"));
+  EXPECT_FALSE(URIUtils::HasExtension("D:\\Path\\movie.AvI", ".mpg|.mkv|.mp4"));
+  EXPECT_FALSE(URIUtils::HasExtension("D:\\Path.mkv\\movie.AvI", ".mpg|.mkv|.mp4"));
+  EXPECT_FALSE(URIUtils::HasExtension("", ".avi|.mkv|.mp4"));
+
+  EXPECT_TRUE(URIUtils::HasExtension("smb://path/to/movie.AvI"));
+  EXPECT_FALSE(URIUtils::HasExtension("smb://path/to/movie"));
+  EXPECT_FALSE(URIUtils::HasExtension("smb://path/.to/movie"));
+  EXPECT_FALSE(URIUtils::HasExtension(""));
+
+  EXPECT_TRUE(URIUtils::HasExtension("smb://path/to/movie.AvI", ".avi"));
+  EXPECT_FALSE(URIUtils::HasExtension("smb://path/to/movie.AvI", ".mkv"));
+  EXPECT_FALSE(URIUtils::HasExtension("smb://path/.avi/movie", ".avi"));
+  EXPECT_FALSE(URIUtils::HasExtension("", ".avi"));
+
+  EXPECT_TRUE(URIUtils::HasExtension("smb://path/movie.AvI", ".avi|.mkv|.mp4"));
+  EXPECT_TRUE(URIUtils::HasExtension("smb://path/movie.AvI", ".mkv|.avi|.mp4"));
+  EXPECT_FALSE(URIUtils::HasExtension("smb://path/movie.AvI", ".mpg|.mkv|.mp4"));
+  EXPECT_FALSE(URIUtils::HasExtension("smb://path.mkv/movie.AvI", ".mpg|.mkv|.mp4"));
+  EXPECT_FALSE(URIUtils::HasExtension("", ".avi|.mkv|.mp4"));
+
+  EXPECT_TRUE(URIUtils::HasExtension("movie.AvI"));
+  EXPECT_FALSE(URIUtils::HasExtension("movie"));
+  EXPECT_FALSE(URIUtils::HasExtension("movie."));
+  EXPECT_FALSE(URIUtils::HasExtension(".movie"));
+  EXPECT_FALSE(URIUtils::HasExtension(""));
+
+  EXPECT_TRUE(URIUtils::HasExtension("movie.AvI", ".avi"));
+  EXPECT_FALSE(URIUtils::HasExtension("movie.AvI", ".mkv"));
+  EXPECT_FALSE(URIUtils::HasExtension("movie", ".avi"));
+  EXPECT_FALSE(URIUtils::HasExtension("movie.", ".avi"));
+  EXPECT_FALSE(URIUtils::HasExtension(".movie", ".avi"));
+  EXPECT_FALSE(URIUtils::HasExtension("", ".avi"));
+
+  EXPECT_TRUE(URIUtils::HasExtension("movie.AvI", ".avi|.mkv|.mp4"));
+  EXPECT_TRUE(URIUtils::HasExtension("movie.AvI", ".mkv|.avi|.mp4"));
+  EXPECT_FALSE(URIUtils::HasExtension("movie.AvI", ".mpg|.mkv|.mp4"));
   EXPECT_FALSE(URIUtils::HasExtension("", ".avi|.mkv|.mp4"));
 }
 
 TEST_F(TestURIUtils, GetFileName)
 {
-  EXPECT_STREQ("movie.avi",
-               URIUtils::GetFileName("/path/to/movie.avi").c_str());
+  EXPECT_EQ("movie.avi", URIUtils::GetFileName("/path/to/movie.avi"));
 }
 
 TEST_F(TestURIUtils, RemoveExtension)
@@ -94,7 +227,111 @@ TEST_F(TestURIUtils, RemoveExtension)
   ref = "/path/to/file";
   var = "/path/to/file.xml";
   URIUtils::RemoveExtension(var);
-  EXPECT_STREQ(ref.c_str(), var.c_str());
+  EXPECT_EQ(ref, var);
+
+  var = "/path/to/file.zip";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  var = "/path/to/file.rar";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  var = "/path/to/file.gz";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  var = "/path/to/file.tar";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  var = "/path/to/file.tar.gz";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  var = "/path/to/file.";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  var = "/path/to/file";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  ref = "/path/to/.file";
+  var = "/path/to/.file";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  ref = "/path/to/file.name";
+  var = "/path/to/file.name.mp4";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  var = "/path/to/file.name.tar.gz";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  ref = ".";
+  var = ".";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  ref = "..";
+  var = "..";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  ref = "";
+  var = "";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  ref = "file";
+  var = "file.xml";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  var = "file.zip";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  var = "file.rar";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  var = "file.gz";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  var = "file.tar";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  var = "file.tar.gz";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  var = "file.";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  var = "file";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  ref = ".file";
+  var = ".file";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  ref = "file.name";
+  var = "file.name.mp4";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
+
+  var = "file.name.tar.gz";
+  URIUtils::RemoveExtension(var);
+  EXPECT_EQ(ref, var);
 }
 
 TEST_F(TestURIUtils, ReplaceExtension)
@@ -104,7 +341,23 @@ TEST_F(TestURIUtils, ReplaceExtension)
 
   ref = "/path/to/file.xsd";
   var = URIUtils::ReplaceExtension("/path/to/file.xml", ".xsd");
-  EXPECT_STREQ(ref.c_str(), var.c_str());
+  EXPECT_EQ(ref, var);
+
+  var = URIUtils::ReplaceExtension("/path/to/file.tar.gz", ".xsd");
+  EXPECT_EQ(ref, var);
+
+  var = URIUtils::ReplaceExtension("/path/to/file.", ".xsd");
+  EXPECT_EQ(ref, var);
+
+  var = URIUtils::ReplaceExtension("/path/to/file", ".xsd");
+  EXPECT_EQ(ref, var);
+
+  ref = "/path/to/.file.xsd";
+  var = URIUtils::ReplaceExtension("/path/to/.file", ".xsd");
+  EXPECT_EQ(ref, var);
+
+  var = URIUtils::ReplaceExtension("/path/to/.file.xml", ".xsd");
+  EXPECT_EQ(ref, var);
 }
 
 TEST_F(TestURIUtils, Split)
@@ -117,34 +370,33 @@ TEST_F(TestURIUtils, Split)
   refpath = "/path/to/";
   reffile = "movie.avi";
   URIUtils::Split("/path/to/movie.avi", varpath, varfile);
-  EXPECT_STREQ(refpath.c_str(), varpath.c_str());
-  EXPECT_STREQ(reffile.c_str(), varfile.c_str());
+  EXPECT_EQ(refpath, varpath);
+  EXPECT_EQ(reffile, varfile);
 
   std::string varpathOptional, varfileOptional;
 
   refpath = "/path/to/";
   reffile = "movie?movie.avi";
   URIUtils::Split("/path/to/movie?movie.avi", varpathOptional, varfileOptional);
-  EXPECT_STREQ(refpath.c_str(), varpathOptional.c_str());
-  EXPECT_STREQ(reffile.c_str(), varfileOptional.c_str());
+  EXPECT_EQ(refpath, varpathOptional);
+  EXPECT_EQ(reffile, varfileOptional);
 
   refpath = "file:///path/to/";
   reffile = "movie.avi";
   URIUtils::Split("file:///path/to/movie.avi?showinfo=true", varpathOptional, varfileOptional);
-  EXPECT_STREQ(refpath.c_str(), varpathOptional.c_str());
-  EXPECT_STREQ(reffile.c_str(), varfileOptional.c_str());
+  EXPECT_EQ(refpath, varpathOptional);
+  EXPECT_EQ(reffile, varfileOptional);
 }
 
 TEST_F(TestURIUtils, SplitPath)
 {
-  std::vector<std::string> strarray;
+  const std::vector<std::string> array{
+      URIUtils::SplitPath("http://www.test.com/path/to/movie.avi")};
 
-  strarray = URIUtils::SplitPath("http://www.test.com/path/to/movie.avi");
-
-  EXPECT_STREQ("http://www.test.com/", strarray.at(0).c_str());
-  EXPECT_STREQ("path", strarray.at(1).c_str());
-  EXPECT_STREQ("to", strarray.at(2).c_str());
-  EXPECT_STREQ("movie.avi", strarray.at(3).c_str());
+  EXPECT_EQ("http://www.test.com/", array.at(0));
+  EXPECT_EQ("path", array.at(1));
+  EXPECT_EQ("to", array.at(2));
+  EXPECT_EQ("movie.avi", array.at(3));
 }
 
 TEST_F(TestURIUtils, SplitPathLocal)
@@ -154,18 +406,16 @@ TEST_F(TestURIUtils, SplitPathLocal)
 #else
   const char *path = "/path/to/movie.avi";
 #endif
-  std::vector<std::string> strarray;
-
-  strarray = URIUtils::SplitPath(path);
+  const std::vector<std::string> array{URIUtils::SplitPath(path)};
 
 #ifndef TARGET_LINUX
-  EXPECT_STREQ("C:", strarray.at(0).c_str());
+  EXPECT_EQ("C:", array.at(0));
 #else
-  EXPECT_STREQ("", strarray.at(0).c_str());
+  EXPECT_EQ("", array.at(0));
 #endif
-  EXPECT_STREQ("path", strarray.at(1).c_str());
-  EXPECT_STREQ("to", strarray.at(2).c_str());
-  EXPECT_STREQ("movie.avi", strarray.at(3).c_str());
+  EXPECT_EQ("path", array.at(1));
+  EXPECT_EQ("to", array.at(2));
+  EXPECT_EQ("movie.avi", array.at(3));
 }
 
 TEST_F(TestURIUtils, GetCommonPath)
@@ -173,56 +423,395 @@ TEST_F(TestURIUtils, GetCommonPath)
   std::string ref;
   std::string var;
 
-  ref = "/path/";
-  var = "/path/2/movie.avi";
-  URIUtils::GetCommonPath(var, "/path/to/movie.avi");
-  EXPECT_STREQ(ref.c_str(), var.c_str());
+  ref = "/a/b/";
+  var = "/a/b/";
+  URIUtils::GetCommonPath(var, "/a/b/");
+  EXPECT_EQ(ref, var);
+
+  ref = "/a/b/";
+  var = "/a/b/cd1/";
+  URIUtils::GetCommonPath(var, "/a/b/cd2");
+  EXPECT_EQ(ref, var);
+
+  ref = "/a/b/";
+  var = "/a/b/";
+  URIUtils::GetCommonPath(var, "/a/b/c/");
+  EXPECT_EQ(ref, var);
+
+  ref = "/";
+  var = "/a/";
+  URIUtils::GetCommonPath(var, "/b/");
+  EXPECT_EQ(ref, var);
+
+  ref = "/a/b/";
+  var = "/a/b/movie.avi";
+  URIUtils::GetCommonPath(var, "/a/b/");
+  EXPECT_EQ(ref, var);
+
+  ref = "/a/b/";
+  var = "/a/b/cd1/movie.avi";
+  URIUtils::GetCommonPath(var, "/a/b/cd2");
+  EXPECT_EQ(ref, var);
+
+  ref = "/a/b/";
+  var = "/a/b/movie.avi";
+  URIUtils::GetCommonPath(var, "/a/b/c/");
+  EXPECT_EQ(ref, var);
+
+  ref = "/";
+  var = "/a/movie.avi";
+  URIUtils::GetCommonPath(var, "/b/");
+  EXPECT_EQ(ref, var);
 }
 
-TEST_F(TestURIUtils, GetParentPath)
+struct TestPathData
 {
-  std::string ref;
-  std::string var;
+  const char* path;
+  const char* parent;
+  const char* base;
+};
 
-  ref = "/path/to/";
-  var = URIUtils::GetParentPath("/path/to/movie.avi");
-  EXPECT_STREQ(ref.c_str(), var.c_str());
-
-  var.clear();
-  EXPECT_TRUE(URIUtils::GetParentPath("/path/to/movie.avi", var));
-  EXPECT_STREQ(ref.c_str(), var.c_str());
-}
-
-TEST_F(TestURIUtils, GetBasePath)
+class TestParentPath : public testing::Test, public testing::WithParamInterface<TestPathData>
 {
-  std::string ref;
-  std::string var;
+};
 
-  ref = "smb://somepath/path/";
+class TestBasePath : public testing::Test, public testing::WithParamInterface<TestPathData>
+{
+};
 
-  var = URIUtils::GetBasePath("smb://somepath/path/movie.avi");
-  EXPECT_STREQ(ref.c_str(), var.c_str());
+const TestPathData Paths[] = {
+    // Linux path tests
+    {.path = "/home/user/movies/movie/file.iso",
+     .parent = "/home/user/movies/movie/",
+     .base = "/home/user/movies/movie/"},
+    {.path = "/home/user/movies/movie/disc 1/file.iso",
+     .parent = "/home/user/movies/movie/disc 1/",
+     .base = "/home/user/movies/movie/"},
+    {.path = "/home/user/movies/movie/video_ts/VIDEO_TS.IFO",
+     .parent = "/home/user/movies/movie/",
+     .base = "/home/user/movies/movie/"},
+    {.path = "/home/user/movies/movie/disc 1/video_ts/VIDEO_TS.IFO",
+     .parent = "/home/user/movies/movie/disc 1/",
+     .base = "/home/user/movies/movie/"},
+    {.path = "/home/user/movies/movie/BDMV/index.bdmv",
+     .parent = "/home/user/movies/movie/",
+     .base = "/home/user/movies/movie/"},
+    {.path = "/home/user/movies/movie/disc 1/BDMV/index.bdmv",
+     .parent = "/home/user/movies/movie/disc 1/",
+     .base = "/home/user/movies/movie/"},
+    {.path = "stack:///home/user/movies/movie.avi , "
+             "/home/user/movies/movie.avi",
+     .parent = "/home/user/movies/",
+     .base = "/home/user/movies/"},
+    {.path = "stack:///home/user/movies/movie/cd1/some_file1.avi , "
+             "/home/user/movies/movie/cd2/some_file2.avi",
+     .parent = "/home/user/movies/movie/",
+     .base = "/home/user/movies/movie/"},
+    // DOS path tests
+    {.path = "D:\\movies\\movie\\file.iso",
+     .parent = "D:\\movies\\movie\\",
+     .base = "D:\\movies\\movie\\"},
+    {.path = "D:\\movies\\movie\\disc 1\\file.iso",
+     .parent = "D:\\movies\\movie\\disc 1\\",
+     .base = "D:\\movies\\movie\\"},
+    {.path = "D:\\movies\\movie\\video_ts\\VIDEO_TS.IFO",
+     .parent = "D:\\movies\\movie\\",
+     .base = "D:\\movies\\movie\\"},
+    {.path = "D:\\movies\\movie\\disc 1\\video_ts\\VIDEO_TS.IFO",
+     .parent = "D:\\movies\\movie\\disc 1\\",
+     .base = "D:\\movies\\movie\\"},
+    {.path = "D:\\movies\\movie\\BDMV\\index.bdmv",
+     .parent = "D:\\movies\\movie\\",
+     .base = "D:\\movies\\movie\\"},
+    {.path = "D:\\movies\\movie\\disc 1\\BDMV\\index.bdmv",
+     .parent = "D:\\movies\\movie\\disc 1\\",
+     .base = "D:\\movies\\movie\\"},
+    {.path = "stack://D:\\movies\\movie_part_1.avi , "
+             "D:\\movies\\movie_part_2.avi",
+     .parent = "D:\\movies\\",
+     .base = "D:\\movies\\"},
+    {.path = "stack://D:\\movies\\movie\\movie_part_1\\file.avi , "
+             "D:\\movies\\movie\\movie_part_2\\file.avi",
+     .parent = "D:\\movies\\movie\\",
+     .base = "D:\\movies\\movie\\"},
+    // Windows server path tests
+    {.path = "\\\\Server\\Movies\\movie\\file.iso",
+     .parent = "\\\\Server\\Movies\\movie\\",
+     .base = "\\\\Server\\Movies\\movie\\"},
+    {.path = "\\\\Server\\Movies\\movie\\disc 1\\file.iso",
+     .parent = "\\\\Server\\Movies\\movie\\disc 1\\",
+     .base = "\\\\Server\\Movies\\movie\\"},
+    {.path = "\\\\Server\\Movies\\movie\\video_ts\\VIDEO_TS.IFO",
+     .parent = "\\\\Server\\Movies\\movie\\",
+     .base = "\\\\Server\\Movies\\movie\\"},
+    {.path = "\\\\Server\\Movies\\movie\\disc 1\\video_ts\\VIDEO_TS.IFO",
+     .parent = "\\\\Server\\Movies\\movie\\disc 1\\",
+     .base = "\\\\Server\\Movies\\movie\\"},
+    {.path = "\\\\Server\\Movies\\movie\\BDMV\\index.bdmv",
+     .parent = "\\\\Server\\Movies\\movie\\",
+     .base = "\\\\Server\\Movies\\movie\\"},
+    {.path = "\\\\Server\\Movies\\movie\\disc 1\\BDMV\\index.bdmv",
+     .parent = "\\\\Server\\Movies\\movie\\disc 1\\",
+     .base = "\\\\Server\\Movies\\movie\\"},
+    {.path = "stack://\\\\Server\\Movies\\movie_part_1.avi , "
+             "\\\\Server\\Movies\\movie_part_2.avi",
+     .parent = "\\\\Server\\Movies\\",
+     .base = "\\\\Server\\Movies\\"},
+    {.path = "stack://\\\\Server\\Movies\\movie\\movie_part_1\\file.avi , "
+             "\\\\Server\\Movies\\movie\\movie_part_2\\file.avi",
+     .parent = "\\\\Server\\Movies\\movie\\",
+     .base = "\\\\Server\\Movies\\movie\\"},
+    // URL path tests using smb://
+    {.path = "smb://server/movies/movie/file.iso",
+     .parent = "smb://server/movies/movie/",
+     .base = "smb://server/movies/movie/"},
+    {.path = "smb://server/movies/movie/disc 1/file.iso",
+     .parent = "smb://server/movies/movie/disc 1/",
+     .base = "smb://server/movies/movie/"},
+    {.path = "smb://server/movies/movie/video_ts/VIDEO_TS.IFO",
+     .parent = "smb://server/movies/movie/",
+     .base = "smb://server/movies/movie/"},
+    {.path = "smb://server/movies/movie/disc 1/video_ts/VIDEO_TS.IFO",
+     .parent = "smb://server/movies/movie/disc 1/",
+     .base = "smb://server/movies/movie/"},
+    {.path = "smb://server/movies/movie/BDMV/index.bdmv",
+     .parent = "smb://server/movies/movie/",
+     .base = "smb://server/movies/movie/"},
+    {.path = "smb://server/movies/movie/disc 1/BDMV/index.bdmv",
+     .parent = "smb://server/movies/movie/disc 1/",
+     .base = "smb://server/movies/movie/"},
+    {.path = "stack://smb://home/user/movies/movie.avi , "
+             "smb://home/user/movies/movie.avi",
+     .parent = "smb://home/user/movies/",
+     .base = "smb://home/user/movies/"},
+    {.path = "stack://smb://home/user/movies/movie/cd1/some_file1.avi , "
+             "smb://home/user/movies/movie/cd2/some_file2.avi",
+     .parent = "smb://home/user/movies/movie/",
+     .base = "smb://home/user/movies/movie/"},
+    // Embedded URL path tests using smb://
+    {.path = "bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls",
+     .parent = "smb://somepath/path/",
+     .base = "smb://somepath/path/"},
+    {.path = "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/"
+             "PLAYLIST/00800.mpls",
+     .parent = "smb://somepath/path/",
+     .base = "smb://somepath/path/"},
+    {.path = "zip://smb%3a%2f%2fsomepath%2fpath%2fmovie.zip/movie.mkv",
+     .parent = "smb://somepath/path/",
+     .base = "smb://somepath/path/"},
+    {.path = "zip://smb%3a%2f%2fsomepath%2fpath%2fmovie.zip/BDMV/index.bdmv",
+     .parent = "smb://somepath/path/",
+     .base = "smb://somepath/path/"},
+    {.path = "rar://smb%3a%2f%2fsomepath%2fpath%2fmovie.rar/movie.mkv",
+     .parent = "smb://somepath/path/",
+     .base = "smb://somepath/path/"},
+    {.path = "rar://smb%3a%2f%2fsomepath%2fpath%2fmovie.rar/BDMV/index.bdmv",
+     .parent = "smb://somepath/path/",
+     .base = "smb://somepath/path/"},
+    {.path = "archive://smb%3a%2f%2fsomepath%2fpath%2fmovie.tar.gz/movie.mkv",
+     .parent = "smb://somepath/path/",
+     .base = "smb://somepath/path/"},
+    {.path = "archive://smb%3a%2f%2fsomepath%2fpath%2fmovie.tar.gz/BDMV/index.bdmv",
+     .parent = "smb://somepath/path/",
+     .base = "smb://somepath/path/"},
+    {.path = "bluray://smb%3a%2f%2fsomepath%2fpath%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls",
+     .parent = "smb://somepath/path/disc 1/",
+     .base = "smb://somepath/path/"},
+    {.path = "bluray://"
+             "udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fdisc%25201%252fmovie.iso%2f/BDMV/"
+             "PLAYLIST/00800.mpls",
+     .parent = "smb://somepath/path/disc 1/",
+     .base = "smb://somepath/path/"},
+    {.path = "zip://smb%3a%2f%2fsomepath%2fpath%2fdisc%201%2fmovie.zip/movie.mkv",
+     .parent = "smb://somepath/path/disc 1/",
+     .base = "smb://somepath/path/"},
+    {.path = "zip://smb%3a%2f%2fsomepath%2fpath%2fdisc%201%2fmovie.zip/BDMV/index.bdmv",
+     .parent = "smb://somepath/path/disc 1/",
+     .base = "smb://somepath/path/"},
+    {.path = "rar://smb%3a%2f%2fsomepath%2fpath%2fdisc%201%2fmovie.rar/movie.mkv",
+     .parent = "smb://somepath/path/disc 1/",
+     .base = "smb://somepath/path/"},
+    {.path = "rar://smb%3a%2f%2fsomepath%2fpath%2fdisc%201%2fmovie.rar/BDMV/index.bdmv",
+     .parent = "smb://somepath/path/disc 1/",
+     .base = "smb://somepath/path/"},
+    {.path = "archive://smb%3a%2f%2fsomepath%2fpath%2fdisc%201%2fmovie.tar.gz/movie.mkv",
+     .parent = "smb://somepath/path/disc 1/",
+     .base = "smb://somepath/path/"},
+    {.path = "archive://smb%3a%2f%2fsomepath%2fpath%2fdisc%201%2fmovie.tar.gz/BDMV/index.bdmv",
+     .parent = "smb://somepath/path/disc 1/",
+     .base = "smb://somepath/path/"},
+    // Embedded linux path tests
+    {.path = "bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls",
+     .parent = "/somepath/path/",
+     .base = "/somepath/path/"},
+    {.path = "bluray://udf%3a%2f%2f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/"
+             "PLAYLIST/00800.mpls",
+     .parent = "/somepath/path/",
+     .base = "/somepath/path/"},
+    {.path = "zip://%2fsomepath%2fpath%2fmovie.zip/movie.mkv",
+     .parent = "/somepath/path/",
+     .base = "/somepath/path/"},
+    {.path = "zip://%2fsomepath%2fpath%2fmovie.zip/BDMV/index.bdmv",
+     .parent = "/somepath/path/",
+     .base = "/somepath/path/"},
+    {.path = "rar://%2fsomepath%2fpath%2fmovie.rar/movie.mkv",
+     .parent = "/somepath/path/",
+     .base = "/somepath/path/"},
+    {.path = "rar://%2fsomepath%2fpath%2fmovie.rar/BDMV/index.bdmv",
+     .parent = "/somepath/path/",
+     .base = "/somepath/path/"},
+    {.path = "archive://%2fsomepath%2fpath%2fmovie.tar.gz/movie.mkv",
+     .parent = "/somepath/path/",
+     .base = "/somepath/path/"},
+    {.path = "archive://%2fsomepath%2fpath%2fmovie.tar.gz/BDMV/index.bdmv",
+     .parent = "/somepath/path/",
+     .base = "/somepath/path/"},
+    {.path = "bluray://%2fsomepath%2fpath%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls",
+     .parent = "/somepath/path/disc 1/",
+     .base = "/somepath/path/"},
+    {.path = "bluray://"
+             "udf%3a%2f%2f%252fsomepath%252fpath%252fdisc%25201%252fmovie.iso%2f/BDMV/"
+             "PLAYLIST/00800.mpls",
+     .parent = "/somepath/path/disc 1/",
+     .base = "/somepath/path/"},
+    {.path = "zip://%2fsomepath%2fpath%2fdisc%201%2fmovie.zip/movie.mkv",
+     .parent = "/somepath/path/disc 1/",
+     .base = "/somepath/path/"},
+    {.path = "zip://%2fsomepath%2fpath%2fdisc%201%2fmovie.zip/BDMV/index.bdmv",
+     .parent = "/somepath/path/disc 1/",
+     .base = "/somepath/path/"},
+    {.path = "rar://%2fsomepath%2fpath%2fdisc%201%2fmovie.rar/movie.mkv",
+     .parent = "/somepath/path/disc 1/",
+     .base = "/somepath/path/"},
+    {.path = "rar://%2fsomepath%2fpath%2fdisc%201%2fmovie.rar/BDMV/index.bdmv",
+     .parent = "/somepath/path/disc 1/",
+     .base = "/somepath/path/"},
+    {.path = "archive://%2fsomepath%2fpath%2fdisc%201%2fmovie.tar.gz/movie.mkv",
+     .parent = "/somepath/path/disc 1/",
+     .base = "/somepath/path/"},
+    {.path = "archive://%2fsomepath%2fpath%2fdisc%201%2fmovie.tar.gz/BDMV/index.bdmv",
+     .parent = "/somepath/path/disc 1/",
+     .base = "/somepath/path/"},
+    // Embedded DOS path tests
+    {.path = "bluray://udf%3a%2f%2fD%253a%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/00800.mpls",
+     .parent = "D:\\Movies\\",
+     .base = "D:\\Movies\\"},
+    {.path = "bluray://D%3a%5cMovies%5c/BDMV/PLAYLIST/00800.mpls",
+     .parent = "D:\\Movies\\",
+     .base = "D:\\Movies\\"},
+    {.path = "zip://D%3a%5cMovies%5cmovie.zip/movie.mkv",
+     .parent = "D:\\Movies\\",
+     .base = "D:\\Movies\\"},
+    {.path = "zip://D%3a%5cMovies%5cmovie.zip/BDMV/index.bdmv",
+     .parent = "D:\\Movies\\",
+     .base = "D:\\Movies\\"},
+    {.path = "rar://D%3a%5cMovies%5cmovie.rar/movie.mkv",
+     .parent = "D:\\Movies\\",
+     .base = "D:\\Movies\\"},
+    {.path = "rar://D%3a%5cMovies%5cmovie.rar/BDMV/index.bdmv",
+     .parent = "D:\\Movies\\",
+     .base = "D:\\Movies\\"},
+    {.path = "archive://D%3a%5cMovies%5cmovie.tar.gz/movie.mkv",
+     .parent = "D:\\Movies\\",
+     .base = "D:\\Movies\\"},
+    {.path = "archive://D%3a%5cMovies%5cmovie.tar.gz/BDMV/index.bdmv",
+     .parent = "D:\\Movies\\",
+     .base = "D:\\Movies\\"},
+    {.path = "bluray://D%3a%5cMovies%5cDisc%201%5c/BDMV/PLAYLIST/00800.mpls",
+     .parent = "D:\\Movies\\Disc 1\\",
+     .base = "D:\\Movies\\"},
+    {.path = "bluray://udf%3a%2f%2fD%253a%255cMovies%255cDisc%25201%255cmovie.iso%2f/BDMV/"
+             "PLAYLIST/00800.mpls",
+     .parent = "D:\\Movies\\Disc 1\\",
+     .base = "D:\\Movies\\"},
+    {.path = "zip://D%3a%5cMovies%5cDisc%201%5cmovie.zip/movie.mkv",
+     .parent = "D:\\Movies\\Disc 1\\",
+     .base = "D:\\Movies\\"},
+    {.path = "zip://D%3a%5cMovies%5cDisc%201%5cmovie.zip/BDMV/index.bdmv",
+     .parent = "D:\\Movies\\Disc 1\\",
+     .base = "D:\\Movies\\"},
+    {.path = "rar://D%3a%5cMovies%5cDisc%201%5cmovie.rar/movie.mkv",
+     .parent = "D:\\Movies\\Disc 1\\",
+     .base = "D:\\Movies\\"},
+    {.path = "rar://D%3a%5cMovies%5cDisc%201%5cmovie.rar/BDMV/index.bdmv",
+     .parent = "D:\\Movies\\Disc 1\\",
+     .base = "D:\\Movies\\"},
+    {.path = "archive://D%3a%5cMovies%5cDisc%201%5cmovie.tar.gz/movie.mkv",
+     .parent = "D:\\Movies\\Disc 1\\",
+     .base = "D:\\Movies\\"},
+    {.path = "archive://D%3a%5cMovies%5cDisc%201%5cmovie.tar.gz/BDMV/index.bdmv",
+     .parent = "D:\\Movies\\Disc 1\\",
+     .base = "D:\\Movies\\"},
+    // Embedded windows server path tests
+    {.path = "bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/"
+             "00800.mpls",
+     .parent = "\\\\Server\\Movies\\",
+     .base = "\\\\Server\\Movies\\"},
+    {.path = "bluray://%5c%5cServer%5cMovies%5c/BDMV/PLAYLIST/00800.mpls",
+     .parent = "\\\\Server\\Movies\\",
+     .base = "\\\\Server\\Movies\\"},
+    {.path = "zip://%5c%5cServer%5cMovies%5cmovie.zip/movie.mkv",
+     .parent = "\\\\Server\\Movies\\",
+     .base = "\\\\Server\\Movies\\"},
+    {.path = "zip://%5c%5cServer%5cMovies%5cmovie.zip/BDMV/index.bdmv",
+     .parent = "\\\\Server\\Movies\\",
+     .base = "\\\\Server\\Movies\\"},
+    {.path = "rar://%5c%5cServer%5cMovies%5cmovie.rar/movie.mkv",
+     .parent = "\\\\Server\\Movies\\",
+     .base = "\\\\Server\\Movies\\"},
+    {.path = "rar://%5c%5cServer%5cMovies%5cmovie.rar/BDMV/index.bdmv",
+     .parent = "\\\\Server\\Movies\\",
+     .base = "\\\\Server\\Movies\\"},
+    {.path = "archive://%5c%5cServer%5cMovies%5cmovie.tar.gz/movie.mkv",
+     .parent = "\\\\Server\\Movies\\",
+     .base = "\\\\Server\\Movies\\"},
+    {.path = "archive://%5c%5cServer%5cMovies%5cmovie.tar.gz/BDMV/index.bdmv",
+     .parent = "\\\\Server\\Movies\\",
+     .base = "\\\\Server\\Movies\\"},
+    {.path = "bluray://%5c%5cServer%5cMovies%5cDisc%201%5c/BDMV/PLAYLIST/00800.mpls",
+     .parent = "\\\\Server\\Movies\\Disc 1\\",
+     .base = "\\\\Server\\Movies\\"},
+    {.path =
+         "bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cDisc%25201%255cmovie.iso%2f/BDMV/"
+         "PLAYLIST/00800.mpls",
+     .parent = "\\\\Server\\Movies\\Disc 1\\",
+     .base = "\\\\Server\\Movies\\"},
+    {.path = "zip://%5c%5cServer%5cMovies%5cDisc%201%5cmovie.zip/movie.mkv",
+     .parent = "\\\\Server\\Movies\\Disc 1\\",
+     .base = "\\\\Server\\Movies\\"},
+    {.path = "zip://%5c%5cServer%5cMovies%5cDisc%201%5cmovie.zip/BDMV/index.bdmv",
+     .parent = "\\\\Server\\Movies\\Disc 1\\",
+     .base = "\\\\Server\\Movies\\"},
+    {.path = "rar://%5c%5cServer%5cMovies%5cDisc%201%5cmovie.rar/movie.mkv",
+     .parent = "\\\\Server\\Movies\\Disc 1\\",
+     .base = "\\\\Server\\Movies\\"},
+    {.path = "rar://%5c%5cServer%5cMovies%5cDisc%201%5cmovie.rar/BDMV/index.bdmv",
+     .parent = "\\\\Server\\Movies\\Disc 1\\",
+     .base = "\\\\Server\\Movies\\"},
+    {.path = "archive://%5c%5cServer%5cMovies%5cDisc%201%5cmovie.tar.gz/movie.mkv",
+     .parent = "\\\\Server\\Movies\\Disc 1\\",
+     .base = "\\\\Server\\Movies\\"},
+    {.path = "archive://%5c%5cServer%5cMovies%5cDisc%201%5cmovie.tar.gz/BDMV/index.bdmv",
+     .parent = "\\\\Server\\Movies\\Disc 1\\",
+     .base = "\\\\Server\\Movies\\"}};
 
-  var = URIUtils::GetBasePath("smb://somepath/path/BDMV/index.bdmv");
-  EXPECT_STREQ(ref.c_str(), var.c_str());
-
-  var = URIUtils::GetBasePath("bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls");
-  EXPECT_STREQ(ref.c_str(), var.c_str());
-
-  var = URIUtils::GetBasePath(
-      "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/"
-      "00800.mpls");
-  EXPECT_STREQ(ref.c_str(), var.c_str());
-
-  ref = "smb://somepath/path/disc 1/";
-
-  var = URIUtils::GetBasePath("smb://somepath/path/disc 1/movie.avi");
-  EXPECT_STREQ(ref.c_str(), var.c_str());
-
-  var = URIUtils::GetBasePath(
-      "bluray://smb%3a%2f%2fsomepath%2fpath%2fdisc%201%2f/BDMV/PLAYLIST/00800.mpls");
-  EXPECT_STREQ(ref.c_str(), var.c_str());
+TEST_P(TestParentPath, GetParentPath)
+{
+  const std::string& path{GetParam().path};
+  const std::string& parent{URIUtils::GetParentPath(path)};
+  EXPECT_EQ(parent, GetParam().parent);
 }
+
+INSTANTIATE_TEST_SUITE_P(ParentPath, TestParentPath, ValuesIn(Paths));
+
+TEST_P(TestBasePath, GetBasePath)
+{
+  const std::string& path{GetParam().path};
+  const std::string& base{URIUtils::GetBasePath(path)};
+  EXPECT_EQ(base, GetParam().parent);
+}
+
+INSTANTIATE_TEST_SUITE_P(BasePath, TestBasePath, ValuesIn(Paths));
 
 TEST_F(TestURIUtils, SubstitutePath)
 {
@@ -248,43 +837,43 @@ TEST_F(TestURIUtils, SubstitutePath)
 
   ref = "https://myserver/some%20other%20path/sub%20dir/movie%20name.avi";
   var = URIUtils::SubstitutePath("C:\\My Videos\\sub dir\\movie name.avi");
-  EXPECT_STREQ(ref.c_str(), var.c_str());
+  EXPECT_EQ(ref, var);
 
   ref = "C:\\My Videos\\sub dir\\movie name.avi";
   var = URIUtils::SubstitutePath("https://myserver/some%20other%20path/sub%20dir/movie%20name.avi", true);
-  EXPECT_STREQ(ref.c_str(), var.c_str());
+  EXPECT_EQ(ref, var);
 
   ref = "D:\\Local Music\\MP3 Collection\\Phil Collins\\Some CD\\01 - Two Hearts.mp3";
   var = URIUtils::SubstitutePath("davs://otherserver/my%20music%20path/Phil%20Collins/Some%20CD/01%20-%20Two%20Hearts.mp3");
-  EXPECT_STREQ(ref.c_str(), var.c_str());
+  EXPECT_EQ(ref, var);
 
   ref = "davs://otherserver/my%20music%20path/Phil%20Collins/Some%20CD/01%20-%20Two%20Hearts.mp3";
   var = URIUtils::SubstitutePath("D:\\Local Music\\MP3 Collection\\Phil Collins\\Some CD\\01 - Two Hearts.mp3", true);
-  EXPECT_STREQ(ref.c_str(), var.c_str());
+  EXPECT_EQ(ref, var);
 
   ref = "/some/other/path2/to/movie.avi";
   var = URIUtils::SubstitutePath("/this/path1/to/movie.avi");
-  EXPECT_STREQ(ref.c_str(), var.c_str());
+  EXPECT_EQ(ref, var);
 
   ref = "/this/path1/to/movie.avi";
   var = URIUtils::SubstitutePath("/some/other/path2/to/movie.avi", true);
-  EXPECT_STREQ(ref.c_str(), var.c_str());
+  EXPECT_EQ(ref, var);
 
   ref = "/no/translation path/";
   var = URIUtils::SubstitutePath(ref);
-  EXPECT_STREQ(ref.c_str(), var.c_str());
+  EXPECT_EQ(ref, var);
 
   ref = "/no/translation path/";
   var = URIUtils::SubstitutePath(ref, true);
-  EXPECT_STREQ(ref.c_str(), var.c_str());
+  EXPECT_EQ(ref, var);
 
   ref = "c:\\no\\translation path";
   var = URIUtils::SubstitutePath(ref);
-  EXPECT_STREQ(ref.c_str(), var.c_str());
+  EXPECT_EQ(ref, var);
 
   ref = "c:\\no\\translation path";
   var = URIUtils::SubstitutePath(ref, true);
-  EXPECT_STREQ(ref.c_str(), var.c_str());
+  EXPECT_EQ(ref, var);
 }
 
 TEST_F(TestURIUtils, IsAddonsPath)
@@ -500,7 +1089,7 @@ TEST_F(TestURIUtils, AddSlashAtEnd)
   ref = "bluray://path/to/file/";
   var = "bluray://path/to/file/";
   URIUtils::AddSlashAtEnd(var);
-  EXPECT_STREQ(ref.c_str(), var.c_str());
+  EXPECT_EQ(ref, var);
 }
 
 TEST_F(TestURIUtils, HasSlashAtEnd)
@@ -517,7 +1106,7 @@ TEST_F(TestURIUtils, RemoveSlashAtEnd)
   ref = "bluray://path/to/file";
   var = "bluray://path/to/file/";
   URIUtils::RemoveSlashAtEnd(var);
-  EXPECT_STREQ(ref.c_str(), var.c_str());
+  EXPECT_EQ(ref, var);
 }
 
 TEST_F(TestURIUtils, CreateArchivePath)
@@ -527,18 +1116,18 @@ TEST_F(TestURIUtils, CreateArchivePath)
 
   ref = "zip://%2fpath%2fto%2f/file";
   var = URIUtils::CreateArchivePath("zip", CURL("/path/to/"), "file").Get();
-  EXPECT_STREQ(ref.c_str(), var.c_str());
+  EXPECT_EQ(ref, var);
 }
 
 TEST_F(TestURIUtils, AddFileToFolder)
 {
   std::string ref = "/path/to/file";
   std::string var = URIUtils::AddFileToFolder("/path/to", "file");
-  EXPECT_STREQ(ref.c_str(), var.c_str());
+  EXPECT_EQ(ref, var);
 
   ref = "/path/to/file/and/more";
   var = URIUtils::AddFileToFolder("/path", "to", "file", "and", "more");
-  EXPECT_STREQ(ref.c_str(), var.c_str());
+  EXPECT_EQ(ref, var);
 }
 
 TEST_F(TestURIUtils, HasParentInHostname)
@@ -567,39 +1156,39 @@ TEST_F(TestURIUtils, GetRealPath)
   std::string ref;
 
   ref = "/path/to/file/";
-  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath(ref).c_str());
+  EXPECT_EQ(ref, URIUtils::GetRealPath(ref));
 
   ref = "path/to/file";
-  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("../path/to/file").c_str());
-  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("./path/to/file").c_str());
+  EXPECT_EQ(ref, URIUtils::GetRealPath("../path/to/file"));
+  EXPECT_EQ(ref, URIUtils::GetRealPath("./path/to/file"));
 
   ref = "/path/to/file";
-  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath(ref).c_str());
-  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("/path/to/./file").c_str());
-  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("/./path/to/./file").c_str());
-  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("/path/to/some/../file").c_str());
-  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("/../path/to/some/../file").c_str());
+  EXPECT_EQ(ref, URIUtils::GetRealPath(ref));
+  EXPECT_EQ(ref, URIUtils::GetRealPath("/path/to/./file"));
+  EXPECT_EQ(ref, URIUtils::GetRealPath("/./path/to/./file"));
+  EXPECT_EQ(ref, URIUtils::GetRealPath("/path/to/some/../file"));
+  EXPECT_EQ(ref, URIUtils::GetRealPath("/../path/to/some/../file"));
 
   ref = "/path/to";
-  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("/path/to/some/../file/..").c_str());
+  EXPECT_EQ(ref, URIUtils::GetRealPath("/path/to/some/../file/.."));
 
 #ifdef TARGET_WINDOWS
   ref = "\\\\path\\to\\file\\";
-  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath(ref).c_str());
+  EXPECT_EQ(ref, URIUtils::GetRealPath(ref));
 
   ref = "path\\to\\file";
-  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("..\\path\\to\\file").c_str());
-  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath(".\\path\\to\\file").c_str());
+  EXPECT_EQ(ref, URIUtils::GetRealPath("..\\path\\to\\file"));
+  EXPECT_EQ(ref, URIUtils::GetRealPath(".\\path\\to\\file"));
 
   ref = "\\\\path\\to\\file";
-  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath(ref).c_str());
-  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("\\\\path\\to\\.\\file").c_str());
-  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("\\\\.\\path/to\\.\\file").c_str());
-  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("\\\\path\\to\\some\\..\\file").c_str());
-  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("\\\\..\\path\\to\\some\\..\\file").c_str());
+  EXPECT_EQ(ref, URIUtils::GetRealPath(ref));
+  EXPECT_EQ(ref, URIUtils::GetRealPath("\\\\path\\to\\.\\file"));
+  EXPECT_EQ(ref, URIUtils::GetRealPath("\\\\.\\path/to\\.\\file"));
+  EXPECT_EQ(ref, URIUtils::GetRealPath("\\\\path\\to\\some\\..\\file"));
+  EXPECT_EQ(ref, URIUtils::GetRealPath("\\\\..\\path\\to\\some\\..\\file"));
 
   ref = "\\\\path\\to";
-  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("\\\\path\\to\\some\\..\\file\\..").c_str());
+  EXPECT_EQ(ref, URIUtils::GetRealPath("\\\\path\\to\\some\\..\\file\\.."));
 #endif
 
   // test rar/zip paths
@@ -819,15 +1408,49 @@ TEST_F(TestURIUtils, ContainersEncodeHostnamePaths)
 
 TEST_F(TestURIUtils, GetDiscBase)
 {
-  constexpr std::string_view refDir{"smb://somepath/path/"};
+  std::string refDir{"/somepath/path/"};
+  EXPECT_EQ(refDir, URIUtils::GetDiscBase("/somepath/path/BDMV/index.bdmv"));
+  EXPECT_EQ(refDir,
+            URIUtils::GetDiscBase("bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls"));
+
+  refDir = "/somepath/path/movie.iso";
+  EXPECT_EQ(refDir, URIUtils::GetDiscBase("/somepath/path/movie.iso"));
+  EXPECT_EQ(refDir,
+            URIUtils::GetDiscBase(
+                "bluray://udf%3a%2f%2f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+                "00800.mpls"));
+
+  refDir = "D:\\Movies\\";
+  EXPECT_EQ(refDir, URIUtils::GetDiscBase("D:\\Movies\\BDMV\\index.bdmv"));
+  EXPECT_EQ(refDir, URIUtils::GetDiscBase("bluray://D%3a%5cMovies%5c/BDMV/PLAYLIST/00800.mpls"));
+
+  refDir = "D:\\Movies\\movie.iso";
+  EXPECT_EQ(refDir, URIUtils::GetDiscBase("D:\\Movies\\movie.iso"));
+  EXPECT_EQ(refDir, URIUtils::GetDiscBase(
+                        "bluray://udf%3a%2f%2fD%253a%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/"
+                        "00800.mpls"));
+
+  refDir = "\\\\Server\\Movies\\";
+  EXPECT_EQ(refDir, URIUtils::GetDiscBase("\\\\Server\\Movies\\BDMV\\index.bdmv"));
+  EXPECT_EQ(refDir,
+            URIUtils::GetDiscBase("bluray://%5c%5cServer%5cMovies%5c/BDMV/PLAYLIST/00800.mpls"));
+
+  refDir = "\\\\Server\\Movies\\movie.iso";
+  EXPECT_EQ(refDir, URIUtils::GetDiscBase("\\\\Server\\Movies\\movie.iso"));
+  EXPECT_EQ(refDir,
+            URIUtils::GetDiscBase(
+                "bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/"
+                "00800.mpls"));
+
+  refDir = "smb://somepath/path/";
   EXPECT_EQ(refDir, URIUtils::GetDiscBase("smb://somepath/path/BDMV/index.bdmv"));
   EXPECT_EQ(refDir, URIUtils::GetDiscBase(
                         "bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls"));
 
-  constexpr std::string_view refIso{"smb://somepath/path/movie.iso"};
-  EXPECT_EQ(refIso, URIUtils::GetDiscBase("smb://somepath/path/movie.iso"));
+  refDir = "smb://somepath/path/movie.iso";
+  EXPECT_EQ(refDir, URIUtils::GetDiscBase("smb://somepath/path/movie.iso"));
   EXPECT_EQ(
-      refIso,
+      refDir,
       URIUtils::GetDiscBase(
           "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/"
           "00800.mpls"));
@@ -835,7 +1458,36 @@ TEST_F(TestURIUtils, GetDiscBase)
 
 TEST_F(TestURIUtils, GetDiscBasePath)
 {
-  constexpr std::string_view refDir{"smb://somepath/path/"};
+  std::string refDir{"/somepath/path/"};
+  EXPECT_EQ(refDir, URIUtils::GetDiscBasePath("/somepath/path/BDMV/index.bdmv"));
+  EXPECT_EQ(refDir,
+            URIUtils::GetDiscBasePath("bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls"));
+  EXPECT_EQ(refDir, URIUtils::GetDiscBasePath("/somepath/path/movie.iso"));
+  EXPECT_EQ(refDir,
+            URIUtils::GetDiscBasePath(
+                "bluray://udf%3a%2f%2f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+                "00800.mpls"));
+
+  refDir = "D:\\Movies\\";
+  EXPECT_EQ(refDir, URIUtils::GetDiscBasePath("D:\\Movies\\BDMV\\index.bdmv"));
+  EXPECT_EQ(refDir,
+            URIUtils::GetDiscBasePath("bluray://D%3a%5cMovies%5c/BDMV/PLAYLIST/00800.mpls"));
+  EXPECT_EQ(refDir, URIUtils::GetDiscBasePath("D:\\Movies\\movie.iso"));
+  EXPECT_EQ(refDir, URIUtils::GetDiscBasePath(
+                        "bluray://udf%3a%2f%2fD%253a%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/"
+                        "00800.mpls"));
+
+  refDir = "\\\\Server\\Movies\\";
+  EXPECT_EQ(refDir, URIUtils::GetDiscBasePath("\\\\Server\\Movies\\BDMV\\index.bdmv"));
+  EXPECT_EQ(refDir, URIUtils::GetDiscBasePath(
+                        "bluray://%5c%5cServer%5cMovies%5c/BDMV/PLAYLIST/00800.mpls"));
+  EXPECT_EQ(refDir, URIUtils::GetDiscBasePath("\\\\Server\\Movies\\movie.iso"));
+  EXPECT_EQ(refDir,
+            URIUtils::GetDiscBasePath(
+                "bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/"
+                "00800.mpls"));
+
+  refDir = "smb://somepath/path/";
   EXPECT_EQ(refDir, URIUtils::GetDiscBasePath("smb://somepath/path/BDMV/index.bdmv"));
   EXPECT_EQ(refDir, URIUtils::GetDiscBasePath(
                         "bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls"));
@@ -849,6 +1501,27 @@ TEST_F(TestURIUtils, GetDiscBasePath)
 
 TEST_F(TestURIUtils, GetDiscFile)
 {
+  EXPECT_EQ("/somepath/path/BDMV/index.bdmv",
+            URIUtils::GetDiscFile("bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls"));
+  EXPECT_EQ("/somepath/path/movie.iso",
+            URIUtils::GetDiscFile(
+                "bluray://udf%3a%2f%2f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+                "00800.mpls"));
+
+  EXPECT_EQ("D:\\Movies\\BDMV\\index.bdmv",
+            URIUtils::GetDiscFile("bluray://D%3a%5cMovies%5c/BDMV/PLAYLIST/00800.mpls"));
+  EXPECT_EQ(
+      "D:\\Movies\\movie.iso",
+      URIUtils::GetDiscFile("bluray://udf%3a%2f%2fD%253a%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/"
+                            "00800.mpls"));
+
+  EXPECT_EQ("\\\\Server\\Movies\\BDMV\\index.bdmv",
+            URIUtils::GetDiscFile("bluray://%5c%5cServer%5cMovies%5c/BDMV/PLAYLIST/00800.mpls"));
+  EXPECT_EQ("\\\\Server\\Movies\\movie.iso",
+            URIUtils::GetDiscFile(
+                "bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/"
+                "00800.mpls"));
+
   EXPECT_EQ(
       "smb://somepath/path/BDMV/index.bdmv",
       URIUtils::GetDiscFile("bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls"));
@@ -861,7 +1534,26 @@ TEST_F(TestURIUtils, GetDiscFile)
 
 TEST_F(TestURIUtils, GetDiscUnderlyingFile)
 {
-  CURL url{"bluray://smb%3a%2f%2fsomepath%2fpath%2f/file.ext"};
+  CURL url{"bluray://%2fsomepath%2fpath%2f/file.ext"};
+  EXPECT_EQ("/somepath/path/file.ext", URIUtils::GetDiscUnderlyingFile(url));
+
+  url = CURL("bluray://udf%3a%2f%2f%252fsomepath%252fpath%252fmovie.iso%2f/file.ext");
+  EXPECT_EQ("udf://%2fsomepath%2fpath%2fmovie.iso/file.ext", URIUtils::GetDiscUnderlyingFile(url));
+
+  url = CURL("bluray://D%3a%5cMovies%5c/file.ext");
+  EXPECT_EQ("D:\\Movies\\file.ext", URIUtils::GetDiscUnderlyingFile(url));
+
+  url = CURL("bluray://udf%3a%2f%2fD%253a%255cMovies%255cmovie.iso%2f/file.ext");
+  EXPECT_EQ("udf://D%3a%5cMovies%5cmovie.iso/file.ext", URIUtils::GetDiscUnderlyingFile(url));
+
+  url = CURL("bluray://%5c%5cServer%5cMovies%5c/file.ext");
+  EXPECT_EQ("\\\\Server\\Movies\\file.ext", URIUtils::GetDiscUnderlyingFile(url));
+
+  url = CURL("bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie.iso%2f/file.ext");
+  EXPECT_EQ("udf://%5c%5cServer%5cMovies%5cmovie.iso/file.ext",
+            URIUtils::GetDiscUnderlyingFile(url));
+
+  url = CURL("bluray://smb%3a%2f%2fsomepath%2fpath%2f/file.ext");
   EXPECT_EQ("smb://somepath/path/file.ext", URIUtils::GetDiscUnderlyingFile(url));
 
   url = CURL("bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/file.ext");
@@ -871,16 +1563,50 @@ TEST_F(TestURIUtils, GetDiscUnderlyingFile)
 
 TEST_F(TestURIUtils, GetBlurayRootPath)
 {
-  constexpr std::string_view refRoot{"bluray://smb%3a%2f%2fsomepath%2fpath%2f/root"};
-  EXPECT_EQ(refRoot, URIUtils::GetBlurayRootPath("smb://somepath/path/BDMV/index.bdmv"));
-  EXPECT_EQ(refRoot, URIUtils::GetBlurayRootPath(
-                         "bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls"));
+  std::string refDir{"bluray://%2fsomepath%2fpath%2f/root"};
+  EXPECT_EQ(refDir, URIUtils::GetBlurayRootPath("/somepath/path/BDMV/index.bdmv"));
+  EXPECT_EQ(refDir,
+            URIUtils::GetBlurayRootPath("bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls"));
 
-  constexpr std::string_view refIsoRoot{
-      "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/root"};
-  EXPECT_EQ(refIsoRoot, URIUtils::GetBlurayRootPath("smb://somepath/path/movie.iso"));
+  refDir = "bluray://udf%3a%2f%2f%252fsomepath%252fpath%252fmovie.iso%2f/root";
+  EXPECT_EQ(refDir, URIUtils::GetBlurayRootPath("/somepath/path/movie.iso"));
+  EXPECT_EQ(refDir,
+            URIUtils::GetBlurayRootPath(
+                "bluray://udf%3a%2f%2f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+                "00800.mpls"));
+
+  refDir = "bluray://D%3a%5cMovies%5c/root";
+  EXPECT_EQ(refDir, URIUtils::GetBlurayRootPath("D:\\Movies\\BDMV\\index.bdmv"));
+  EXPECT_EQ(refDir,
+            URIUtils::GetBlurayRootPath("bluray://D%3a%5cMovies%5c/BDMV/PLAYLIST/00800.mpls"));
+
+  refDir = "bluray://udf%3a%2f%2fD%253a%255cMovies%255cmovie.iso%2f/root";
+  EXPECT_EQ(refDir, URIUtils::GetBlurayRootPath("D:\\Movies\\movie.iso"));
+  EXPECT_EQ(refDir, URIUtils::GetBlurayRootPath(
+                        "bluray://udf%3a%2f%2fD%253a%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/"
+                        "00800.mpls"));
+
+  refDir = "bluray://%5c%5cServer%5cMovies%5c/root";
+  EXPECT_EQ(refDir, URIUtils::GetBlurayRootPath("\\\\Server\\Movies\\BDMV\\index.bdmv"));
+  EXPECT_EQ(refDir, URIUtils::GetBlurayRootPath(
+                        "bluray://%5c%5cServer%5cMovies%5c/BDMV/PLAYLIST/00800.mpls"));
+
+  refDir = "bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie.iso%2f/root";
+  EXPECT_EQ(refDir, URIUtils::GetBlurayRootPath("\\\\Server\\Movies\\movie.iso"));
+  EXPECT_EQ(refDir,
+            URIUtils::GetBlurayRootPath(
+                "bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/"
+                "00800.mpls"));
+
+  refDir = "bluray://smb%3a%2f%2fsomepath%2fpath%2f/root";
+  EXPECT_EQ(refDir, URIUtils::GetBlurayRootPath("smb://somepath/path/BDMV/index.bdmv"));
+  EXPECT_EQ(refDir, URIUtils::GetBlurayRootPath(
+                        "bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls"));
+
+  refDir = "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/root";
+  EXPECT_EQ(refDir, URIUtils::GetBlurayRootPath("smb://somepath/path/movie.iso"));
   EXPECT_EQ(
-      refIsoRoot,
+      refDir,
       URIUtils::GetBlurayRootPath(
           "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/"
           "00800.mpls"));
@@ -888,16 +1614,54 @@ TEST_F(TestURIUtils, GetBlurayRootPath)
 
 TEST_F(TestURIUtils, GetBlurayEpisodePath)
 {
-  constexpr std::string_view ref{"bluray://smb%3a%2f%2fsomepath%2fpath%2f/root/episode/3/4"};
-  EXPECT_EQ(ref, URIUtils::GetBlurayEpisodePath("smb://somepath/path/BDMV/index.bdmv", 3, 4));
-  EXPECT_EQ(ref, URIUtils::GetBlurayEpisodePath(
-                     "bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls", 3, 4));
+  std::string refDir{"bluray://%2fsomepath%2fpath%2f/root/episode/3/4"};
+  EXPECT_EQ(refDir, URIUtils::GetBlurayEpisodePath("/somepath/path/BDMV/index.bdmv", 3, 4));
+  EXPECT_EQ(refDir, URIUtils::GetBlurayEpisodePath(
+                        "bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls", 3, 4));
 
-  constexpr std::string_view refIso{
-      "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/root/episode/3/4"};
-  EXPECT_EQ(refIso, URIUtils::GetBlurayEpisodePath("smb://somepath/path/movie.iso", 3, 4));
+  refDir = "bluray://udf%3a%2f%2f%252fsomepath%252fpath%252fmovie.iso%2f/root/episode/3/4";
+  EXPECT_EQ(refDir, URIUtils::GetBlurayEpisodePath("/somepath/path/movie.iso", 3, 4));
+  EXPECT_EQ(refDir,
+            URIUtils::GetBlurayEpisodePath(
+                "bluray://udf%3a%2f%2f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+                "00800.mpls",
+                3, 4));
+
+  refDir = "bluray://D%3a%5cMovies%5c/root/episode/3/4";
+  EXPECT_EQ(refDir, URIUtils::GetBlurayEpisodePath("D:\\Movies\\BDMV\\index.bdmv", 3, 4));
+  EXPECT_EQ(refDir, URIUtils::GetBlurayEpisodePath(
+                        "bluray://D%3a%5cMovies%5c/BDMV/PLAYLIST/00800.mpls", 3, 4));
+
+  refDir = "bluray://udf%3a%2f%2fD%253a%255cMovies%255cmovie.iso%2f/root/episode/3/4";
+  EXPECT_EQ(refDir, URIUtils::GetBlurayEpisodePath("D:\\Movies\\movie.iso", 3, 4));
+  EXPECT_EQ(refDir, URIUtils::GetBlurayEpisodePath(
+                        "bluray://udf%3a%2f%2fD%253a%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/"
+                        "00800.mpls",
+                        3, 4));
+
+  refDir = "bluray://%5c%5cServer%5cMovies%5c/root/episode/3/4";
+  EXPECT_EQ(refDir, URIUtils::GetBlurayEpisodePath("\\\\Server\\Movies\\BDMV\\index.bdmv", 3, 4));
+  EXPECT_EQ(refDir, URIUtils::GetBlurayEpisodePath(
+                        "bluray://%5c%5cServer%5cMovies%5c/BDMV/PLAYLIST/00800.mpls", 3, 4));
+
+  refDir = "bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie.iso%2f/root/episode/3/4";
+  EXPECT_EQ(refDir, URIUtils::GetBlurayEpisodePath("\\\\Server\\Movies\\movie.iso", 3, 4));
+  EXPECT_EQ(refDir,
+            URIUtils::GetBlurayEpisodePath(
+                "bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/"
+                "00800.mpls",
+                3, 4));
+
+  refDir = "bluray://smb%3a%2f%2fsomepath%2fpath%2f/root/episode/3/4";
+  EXPECT_EQ(refDir, URIUtils::GetBlurayEpisodePath("smb://somepath/path/BDMV/index.bdmv", 3, 4));
+  EXPECT_EQ(refDir, URIUtils::GetBlurayEpisodePath(
+                        "bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls", 3, 4));
+
+  refDir =
+      "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/root/episode/3/4";
+  EXPECT_EQ(refDir, URIUtils::GetBlurayEpisodePath("smb://somepath/path/movie.iso", 3, 4));
   EXPECT_EQ(
-      refIso,
+      refDir,
       URIUtils::GetBlurayEpisodePath(
           "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/"
           "00800.mpls",
@@ -906,6 +1670,36 @@ TEST_F(TestURIUtils, GetBlurayEpisodePath)
 
 TEST_F(TestURIUtils, GetBlurayPlaylistPath)
 {
+  EXPECT_EQ("bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/",
+            URIUtils::GetBlurayPlaylistPath("/somepath/path/BDMV/index.bdmv"));
+  EXPECT_EQ("bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls",
+            URIUtils::GetBlurayPlaylistPath("/somepath/path/BDMV/index.bdmv", 800));
+  EXPECT_EQ("bluray://udf%3a%2f%2f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/",
+            URIUtils::GetBlurayPlaylistPath("/somepath/path/movie.iso"));
+  EXPECT_EQ("bluray://udf%3a%2f%2f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+            "00800.mpls",
+            URIUtils::GetBlurayPlaylistPath("/somepath/path/movie.iso", 800));
+
+  EXPECT_EQ("bluray://D%3a%5cMovies%5c/BDMV/PLAYLIST/",
+            URIUtils::GetBlurayPlaylistPath("D:\\Movies\\BDMV\\index.bdmv"));
+  EXPECT_EQ("bluray://D%3a%5cMovies%5c/BDMV/PLAYLIST/00800.mpls",
+            URIUtils::GetBlurayPlaylistPath("D:\\Movies\\BDMV\\index.bdmv", 800));
+  EXPECT_EQ("bluray://udf%3a%2f%2fD%253a%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/",
+            URIUtils::GetBlurayPlaylistPath("D:\\Movies\\movie.iso"));
+  EXPECT_EQ("bluray://udf%3a%2f%2fD%253a%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/"
+            "00800.mpls",
+            URIUtils::GetBlurayPlaylistPath("D:\\Movies\\movie.iso", 800));
+
+  EXPECT_EQ("bluray://%5c%5cServer%5cMovies%5c/BDMV/PLAYLIST/",
+            URIUtils::GetBlurayPlaylistPath("\\\\Server\\Movies\\BDMV\\index.bdmv"));
+  EXPECT_EQ("bluray://%5c%5cServer%5cMovies%5c/BDMV/PLAYLIST/00800.mpls",
+            URIUtils::GetBlurayPlaylistPath("\\\\Server\\Movies\\BDMV\\index.bdmv", 800));
+  EXPECT_EQ("bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/",
+            URIUtils::GetBlurayPlaylistPath("\\\\Server\\Movies\\movie.iso"));
+  EXPECT_EQ("bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/"
+            "00800.mpls",
+            URIUtils::GetBlurayPlaylistPath("\\\\Server\\Movies\\movie.iso", 800));
+
   EXPECT_EQ("bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/",
             URIUtils::GetBlurayPlaylistPath("smb://somepath/path/BDMV/index.bdmv"));
   EXPECT_EQ("bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls",
@@ -921,6 +1715,30 @@ TEST_F(TestURIUtils, GetBlurayPlaylistPath)
 
 TEST_F(TestURIUtils, GetBlurayPlaylistFromPath)
 {
+  EXPECT_EQ(URIUtils::GetBlurayPlaylistFromPath(
+                "bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls"),
+            800);
+  EXPECT_EQ(URIUtils::GetBlurayPlaylistFromPath(
+                "bluray://udf%3a%2f%2f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+                "00800.mpls"),
+            800);
+
+  EXPECT_EQ(
+      URIUtils::GetBlurayPlaylistFromPath("bluray://D%3a%5cMovies%5c/BDMV/PLAYLIST/00800.mpls"),
+      800);
+  EXPECT_EQ(URIUtils::GetBlurayPlaylistFromPath(
+                "bluray://udf%3a%2f%2fD%253a%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/"
+                "00800.mpls"),
+            800);
+
+  EXPECT_EQ(URIUtils::GetBlurayPlaylistFromPath(
+                "bluray://%5c%5cServer%5cMovies%5c/BDMV/PLAYLIST/00800.mpls"),
+            800);
+  EXPECT_EQ(URIUtils::GetBlurayPlaylistFromPath(
+                "bluray://udf%3a%2f%2f%255c%255cServer%255cMovies%255cmovie.iso%2f/BDMV/PLAYLIST/"
+                "00800.mpls"),
+            800);
+
   EXPECT_EQ(URIUtils::GetBlurayPlaylistFromPath(
                 "bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls"),
             800);
@@ -1084,6 +1902,44 @@ TEST_F(TestURIUtils, CheckConsistencyBetweenFileNameUtilities)
     EXPECT_EQ("a:b", URIUtils::GetFileName("/hello/there/a:b"));
     EXPECT_EQ("a:b", CURL_FileName_URIUtils_Split("/hello/there/a:b"));
     EXPECT_EQ("a:b", URIUtils_Split("/hello/there/a:b"));
+  }
+  {
+    const std::string path{
+        "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/"
+        "00800.mpls"};
+
+    EXPECT_EQ("BDMV/PLAYLIST/00800.mpls", CURL(path).GetFileName());
+
+    EXPECT_EQ("00800.mpls", URIUtils::GetFileName(path));
+    EXPECT_EQ("00800.mpls", CURL_FileName_URIUtils_Split(path));
+    EXPECT_EQ("00800.mpls", URIUtils_Split(path));
+  }
+  {
+    const std::string path{"zip://smb%3a%2f%2fsomepath%2fpath%2fmovie.zip/movie.mkv"};
+
+    EXPECT_EQ("movie.mkv", CURL(path).GetFileName());
+
+    EXPECT_EQ("movie.mkv", URIUtils::GetFileName(path));
+    EXPECT_EQ("movie.mkv", CURL_FileName_URIUtils_Split(path));
+    EXPECT_EQ("movie.mkv", URIUtils_Split(path));
+  }
+  {
+    const std::string path{"rar://smb%3a%2f%2fsomepath%2fpath%2fmovie.zip/BDMV/index.bdmv"};
+
+    EXPECT_EQ("BDMV/index.bdmv", CURL(path).GetFileName());
+
+    EXPECT_EQ("index.bdmv", URIUtils::GetFileName(path));
+    EXPECT_EQ("index.bdmv", CURL_FileName_URIUtils_Split(path));
+    EXPECT_EQ("index.bdmv", URIUtils_Split(path));
+  }
+  {
+    const std::string path{"archive://smb%3a%2f%2fsomepath%2fpath%2fmovie.tar.gz/BDMV/index.bdmv"};
+
+    EXPECT_EQ("BDMV/index.bdmv", CURL(path).GetFileName());
+
+    EXPECT_EQ("index.bdmv", URIUtils::GetFileName(path));
+    EXPECT_EQ("index.bdmv", CURL_FileName_URIUtils_Split(path));
+    EXPECT_EQ("index.bdmv", URIUtils_Split(path));
   }
 }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -120,7 +120,7 @@ int CVideoDatabase::GetPathId(const std::string& strPath)
       return -1;
 
     std::string strPath1(strPath);
-    if (URIUtils::IsStack(strPath) || StringUtils::StartsWithNoCase(strPath, "rar://") || StringUtils::StartsWithNoCase(strPath, "zip://"))
+    if (URIUtils::IsStack(strPath))
       URIUtils::GetParentPath(strPath,strPath1);
 
     URIUtils::AddSlashAtEnd(strPath1);
@@ -334,7 +334,7 @@ int CVideoDatabase::AddPath(const std::string& strPath, const std::string &paren
       return -1;
 
     std::string strPath1(strPath);
-    if (URIUtils::IsStack(strPath) || StringUtils::StartsWithNoCase(strPath, "rar://") || StringUtils::StartsWithNoCase(strPath, "zip://"))
+    if (URIUtils::IsStack(strPath))
       URIUtils::GetParentPath(strPath,strPath1);
 
     URIUtils::AddSlashAtEnd(strPath1);
@@ -565,7 +565,7 @@ int CVideoDatabase::AddOrUpdateFile(const std::string& fileAndPath,
 
 int CVideoDatabase::AddFile(const CFileItem& item)
 {
-  if (URIUtils::IsBlurayPath(item.GetDynPath()) || item.IsStack())
+  if (CUtil::UseDynPathForAddOrUpdate(item))
     return AddFile(item.GetDynPath());
   if (IsVideoDb(item) && item.HasVideoInfoTag())
   {
@@ -11197,8 +11197,7 @@ void CVideoDatabase::ConstructPath(std::string& strDest,
                                    const std::string& strPath,
                                    const std::string& strFileName) const
 {
-  if (URIUtils::IsStack(strFileName) ||
-      URIUtils::IsInArchive(strFileName) || URIUtils::IsPlugin(strPath))
+  if (URIUtils::IsStack(strFileName) || URIUtils::IsPlugin(strPath))
     strDest = strFileName;
   else
     strDest = URIUtils::AddFileToFolder(strPath, strFileName);
@@ -11208,7 +11207,7 @@ void CVideoDatabase::SplitPath(const std::string& strFileNameAndPath,
                                std::string& strPath,
                                std::string& strFileName) const
 {
-  if (URIUtils::IsStack(strFileNameAndPath) || StringUtils::StartsWithNoCase(strFileNameAndPath, "rar://") || StringUtils::StartsWithNoCase(strFileNameAndPath, "zip://"))
+  if (URIUtils::IsStack(strFileNameAndPath))
   {
     URIUtils::GetParentPath(strFileNameAndPath,strPath);
     strFileName = strFileNameAndPath;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8328,6 +8328,8 @@ ScraperPtr CVideoDatabase::GetScraperForPath(const std::string& strPath,
 
     if (URIUtils::IsMultiPath(strPath))
       strPath2 = CMultiPathDirectory::GetFirstPath(strPath);
+    else if (URIUtils::IsStack(strPath))
+      strPath2 = CStackDirectory::GetFirstStackedFile(strPath);
     else
       strPath2 = strPath;
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2131,6 +2131,7 @@ bool CVideoDatabase::GetFileInfo(const std::string& strFilenameAndPath, CVideoIn
     details.m_strPath = m_pDS->fv("path.strPath").get_asString();
     std::string strFileName = m_pDS->fv("files.strFilename").get_asString();
     ConstructPath(details.m_strFileNameAndPath, details.m_strPath, strFileName);
+    details.m_basePath = URIUtils::GetBasePath(details.m_strPath);
     details.SetPlayCount(std::max(details.GetPlayCount(), m_pDS->fv("files.playCount").get_asInt()));
     if (!details.m_lastPlayed.IsValid())
       details.m_lastPlayed.SetFromDBDateTime(m_pDS->fv("files.lastPlayed").get_asString());

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1924,7 +1924,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
       // Deal with 'Disc n' subdirectories
       // Unless dealing with a full nfo in which case details are taken from there already
-      if (!pItem->GetProperty("from_nfo").asBoolean(false))
+      if (!pItem->GetProperty("from_nfo").asBoolean(false) && !pItem->IsStack())
       {
         const std::string discNum{CUtil::GetPartNumberFromPath(movieDetails.m_strFileNameAndPath)};
         if (!discNum.empty())

--- a/xbmc/video/test/TestVideoFileItemClassify.cpp
+++ b/xbmc/video/test/TestVideoFileItemClassify.cpp
@@ -135,7 +135,7 @@ TEST(TestVideoFileItemClassify, VideoExtensions)
   {
     if (!ext.empty())
     {
-      EXPECT_TRUE(VIDEO::IsVideo(CFileItem(ext, false)));
+      EXPECT_TRUE(VIDEO::IsVideo(CFileItem("test" + ext, false)));
     }
   }
 }

--- a/xbmc/video/test/TestVideoFileItemClassify.cpp
+++ b/xbmc/video/test/TestVideoFileItemClassify.cpp
@@ -29,23 +29,18 @@ using namespace KODI;
 
 struct StubDefinition
 {
-  StubDefinition(const std::string& path,
-                 bool res = true,
-                 const std::string& tagPath = "",
-                 bool isFolder = false)
-    : item(path, isFolder), result(res)
+  StubDefinition(std::string path, bool res = true, std::string tagPath = "", bool isFolder = false)
+    : path(std::move(path)),
+      result(res),
+      tagPath(std::move(tagPath)),
+      isFolder(isFolder)
   {
-    if (!tagPath.empty())
-    {
-      if (isFolder)
-        item.GetVideoInfoTag()->m_strPath = tagPath;
-      else
-        item.GetVideoInfoTag()->m_strFileNameAndPath = tagPath;
-    }
   }
 
-  CFileItem item;
+  std::string path;
   bool result;
+  std::string tagPath;
+  bool isFolder;
 };
 
 class DiscStubTest : public testing::WithParamInterface<StubDefinition>, public testing::Test
@@ -54,7 +49,18 @@ class DiscStubTest : public testing::WithParamInterface<StubDefinition>, public 
 
 TEST_P(DiscStubTest, IsDiscStub)
 {
-  EXPECT_EQ(VIDEO::IsDiscStub(GetParam().item), GetParam().result);
+  const StubDefinition& param = GetParam();
+
+  CFileItem item(param.path, param.isFolder);
+  if (!param.tagPath.empty())
+  {
+    if (param.isFolder)
+      item.GetVideoInfoTag()->m_strPath = param.tagPath;
+    else
+      item.GetVideoInfoTag()->m_strFileNameAndPath = param.tagPath;
+  }
+
+  EXPECT_EQ(VIDEO::IsDiscStub(item), param.result);
 }
 
 const auto discstub_tests = std::array{
@@ -70,36 +76,18 @@ INSTANTIATE_TEST_SUITE_P(TestVideoFileItemClassify,
 
 struct VideoClassifyTest
 {
-  VideoClassifyTest(const std::string& path,
-                    bool res = true,
-                    const std::string& mime = "",
-                    int tag_type = 0)
-    : item(path, false), result(res)
+  VideoClassifyTest(std::string path, bool res = true, std::string mime = "", int tag_type = 0)
+    : path(std::move(path)),
+      result(res),
+      mime(std::move(mime)),
+      tag_type(tag_type)
   {
-    if (!mime.empty())
-      item.SetMimeType(mime);
-    switch (tag_type)
-    {
-      case 1:
-        item.GetVideoInfoTag()->m_strFileNameAndPath = path;
-        break;
-      case 2:
-        item.GetGameInfoTag()->SetGameClient("some_client");
-        break;
-      case 3:
-        item.GetMusicInfoTag()->SetPlayCount(1);
-        break;
-      case 4:
-        item.GetPictureInfoTag()->SetInfo("foo", "bar");
-        ;
-        break;
-      default:
-        break;
-    }
   }
 
-  CFileItem item;
+  std::string path;
   bool result;
+  std::string mime;
+  int tag_type;
 };
 
 class VideoTest : public testing::WithParamInterface<VideoClassifyTest>, public testing::Test
@@ -108,7 +96,31 @@ class VideoTest : public testing::WithParamInterface<VideoClassifyTest>, public 
 
 TEST_P(VideoTest, IsVideo)
 {
-  EXPECT_EQ(VIDEO::IsVideo(GetParam().item), GetParam().result);
+  const VideoClassifyTest& param = GetParam();
+
+  CFileItem item(param.path, false);
+  if (!param.mime.empty())
+    item.SetMimeType(param.mime);
+
+  switch (param.tag_type)
+  {
+    case 1:
+      item.GetVideoInfoTag()->m_strFileNameAndPath = param.path;
+      break;
+    case 2:
+      item.GetGameInfoTag()->SetGameClient("some_client");
+      break;
+    case 3:
+      item.GetMusicInfoTag()->SetPlayCount(1);
+      break;
+    case 4:
+      item.GetPictureInfoTag()->SetInfo("foo", "bar");
+      break;
+    default:
+      break;
+  }
+
+  EXPECT_EQ(VIDEO::IsVideo(item), param.result);
 }
 
 const auto video_tests = std::array{


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Following on from @CrystalP's #27488 I remembered I had started this a while ago but pulled out the bluray:// parts.

I've gone through almost all of the path manipulation routines and tried to make sure there are tests that cover DOS paths, linux paths, smb:// paths, bluray:// paths, zip:// paths, rar:// paths and archive:// paths.

Look at the tests and work backwards is probably easiest.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

1) zip:// and rar:// paths were not being properly stored in the database.
2) Metadata and external subs/audio were not being properly located for zip://, archive:// and stack:// paths.
3) archive:// paths were being wrongly cleaned from the database.
4) DOS paths were being inconsistently handled.
5) During stack:// path construction not all separators between movie name and part number were removed.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1) Adding tests.
2) Functional tests using this directory structure:
```
├───28 Weeks Later (2007)
│       28.Weeks.Later.2007.1080p.BluRay.x264.DTS-FGT.rar
│       28.Weeks.Later.2007.1080p.BluRay.x264.DTS-FGT.zul.srt
│
├───The Hobbit An Unexpected Journey (2012)
│       The Hobbit An Unexpected Journey (2012) Part 1.mp4
│       The Hobbit An Unexpected Journey (2012) Part 2.mp4
│       The Hobbit An Unexpected Journey (2012) Part 3.mp4
│       The Hobbit An Unexpected Journey (2012) Part 4.mp4
│       The Hobbit An Unexpected Journey (2012).zul.srt
│
├───The Lord of the Rings The Two Towers (2002)
│   │   The Lord of the Rings The Two Towers (2002).zul.srt
│   │
│   ├───The Lord of the Rings The Two Towers (2002) part 1
│   │       The Lord of the RIngs The Two Towers Part 1.mp4
│   │
│   ├───The Lord of the Rings The Two Towers (2002) part 2
│   │       The Lord of the RIngs The Two Towers Part 2.mp4
│   │
│   ├───The Lord of the Rings The Two Towers (2002) part 3
│   │       The Lord of the RIngs The Two Towers Part 3.mp4
│   │
│   └───The Lord of the Rings The Two Towers (2002) part 4
│           The Lord of the RIngs The Two Towers Part 4.mp4
│
├───Van Wilder (2002)
│       Van.Wilder.2002.PROPER.1080p.BluRay.x265-RARBG.zip
│       Van.Wilder.2002.PROPER.1080p.BluRay.x265-RARBG.zul.srt
│
└───Van Wilder Freshman Year (2009)
        Van.Wilder.Freshman.Year.2009.UNRATED.1080p.AMZN.WEBRip.DDP5.1.x264-pawel2006.tar.gz
        Van.Wilder.Freshman.Year.2009.UNRATED.1080p.AMZN.WEBRip.DDP5.1.x264-pawel2006.zul.srt
```

Library scanned then archive and rar add-ons are enabled and library scanned again.

_**Before**_

**Path table**
 
<img width="940" height="174" alt="image" src="https://github.com/user-attachments/assets/0c2f76de-2f3e-4a2b-8a5d-242e775b0f8f" />

**File table**
 
<img width="940" height="121" alt="image" src="https://github.com/user-attachments/assets/900f6c86-97ee-44d4-8a82-1f72a47e0dc7" />

**External subtitles**
 
<img width="940" height="380" alt="image" src="https://github.com/user-attachments/assets/29fa4d6d-c82f-4848-abb7-ae6c3e1714f4" />

Only found for .rar files

**All play**

**Refresh**

Zip:// - works
Archive:// - works
Rar:// - works
Stack:// - crashes

**Export to NFO**

rar:// correct
stack:// (files) correct
stack:// (folders) nfo has no filename, art placed in folder of movie name. Art within has no filename.
zip:// correct
archive:// fails

_**After**_

**Path table**
 
<img width="2403" height="533" alt="image" src="https://github.com/user-attachments/assets/7107194d-70b8-48cf-8ff6-d7b8bb4d82c6" />

Note lower case encoding in rar:// path,.

**File table**

<img width="940" height="123" alt="image" src="https://github.com/user-attachments/assets/f7c07979-bad0-4101-ac82-0927b5256468" />
 
**External subtitles**
 
<img width="940" height="459" alt="image" src="https://github.com/user-attachments/assets/0135d4e0-b2d5-4f17-b6dd-a5595bf9b373" />

Found for all

**All play**

**Refresh**

Zip:// - works
Archive:// - works
Rar:// - works
Stack:// - works

**Export to NFO and subsequent import (scan with local scraper)**

rar:// correct
stack:// (files) correct
stack:// (folders) correct
zip:// correct
archive:// correct

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
