### PR TITLE
[Video] Fix #27121 broke Bluray menus.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlay.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlay.h
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <assert.h>
-#include <atomic>
 #include <memory>
 #include <stdexcept>
 #include <vector>
@@ -55,6 +53,14 @@ public:
   }
 
   virtual ~CDVDOverlay() = default;
+
+  bool operator==(const CDVDOverlay& other) const
+  {
+    constexpr double epsilon{0.1};
+    return std::abs(iPTSStartTime - other.iPTSStartTime) < epsilon &&
+           std::abs(iPTSStopTime - other.iPTSStopTime) < epsilon && bForced == other.bForced &&
+           replace == other.replace;
+  }
 
   bool IsOverlayType(DVDOverlayType type) const { return (m_type == type); }
 

--- a/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
@@ -87,8 +87,7 @@ void CDVDOverlayContainer::CleanUp(double pts)
         const std::shared_ptr<CDVDOverlay>& pOverlay2 = *it2;
         // There can be multiple overlays queued at same start point.
         // Skip them to find a new start point.
-        if (pOverlay2->bForced && pOverlay2->iPTSStartTime <= pts &&
-            pOverlay->iPTSStartTime != pOverlay2->iPTSStartTime)
+        if (pOverlay2->bForced && pOverlay2->iPTSStartTime <= pts)
           bNewer = true;
       }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Group subtitles that share the same start/stop/forced/replace attributes prior to passing for processing.
(Thanks to @CrystalP for the tip)

Also, as part of understanding subtitle processing, refactored CDVDOverlayContainer.
Most is just moderninsing for C++20 but also cost of CleanUp() is now O(n log n) rather than O(n^2).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #27582.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.
Against sample from #27095.
Against sample provided by @KarellenX.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
