### PR TITLE
[cmake] Fix internal brotli with ninja, remove FHPSA from nghttp

### DIFF
--- a/cmake/modules/FindBrotli.cmake
+++ b/cmake/modules/FindBrotli.cmake
@@ -22,8 +22,6 @@ if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
                    -DBROTLI_DISABLE_TESTS=ON
                    -DBROTLI_DISABLE_EXE=ON)
 
-    BUILD_DEP_TARGET()
-
     # Retrieve suffix of platform byproduct to apply to second brotli library
     string(REGEX REPLACE "^.*\\." "" _LIBEXT ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BYPRODUCT})
     if(NOT (WIN32 OR WINDOWS_STORE))
@@ -31,6 +29,14 @@ if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
     endif()
 
     set(BROTLICOMMON_LIBRARY_RELEASE "${DEP_LOCATION}/lib/${_PREFIX}brotlicommon.${_LIBEXT}")
+
+    # Brotli creates two byproducts of relevance. set BUILD_BYPRODUCTS to be both
+    # brotlicommon and brotlidec. This has to occur before BUILD_DEP_TARGET
+    set(BUILD_BYPRODUCTS ${BROTLICOMMON_LIBRARY_RELEASE}
+                         ${DEP_LOCATION}/lib/${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BYPRODUCT})
+
+    BUILD_DEP_TARGET()
+
     set(BROTLIDEC_LIBRARY_RELEASE "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY}")
 
     # Todo: debug postfix libs for windows

--- a/cmake/modules/FindNGHttp2.cmake
+++ b/cmake/modules/FindNGHttp2.cmake
@@ -58,65 +58,9 @@ if(NOT TARGET LIBRARY::NGHttp2)
     cmake_language(EVAL CODE "
       buildmacro${CMAKE_FIND_PACKAGE_NAME}()
     ")
-  else()
-    if(TARGET nghttp2::nghttp2 OR TARGET nghttp2::nghttp2_static)
-
-      # We have a preference for the static lib when needed, however provide support for the shared
-      # lib as well
-      if(TARGET nghttp2::nghttp2_static)
-        set(_target nghttp2::nghttp2_static)
-      else()
-        set(_target nghttp2::nghttp2)
-      endif()
-
-      # This is for the case where a distro provides a non standard (Debug/Release) config type
-      # convert this back to either DEBUG/RELEASE or just RELEASE
-      # we only do this because we use find_package_handle_standard_args for config time output
-      # and it isnt capable of handling TARGETS, so we have to extract the info
-      get_target_property(_NGHTTP2_CONFIGURATIONS ${_target} IMPORTED_CONFIGURATIONS)
-      if(_NGHTTP2_CONFIGURATIONS)
-        foreach(_nghttp2_config IN LISTS _NGHTTP2_CONFIGURATIONS)
-          # Some non standard config (eg None on Debian)
-          # Just set to RELEASE var so select_library_configurations can continue to work its magic
-          string(TOUPPER ${_nghttp2_config} _nghttp2_config_UPPER)
-          if((NOT ${_nghttp2_config_UPPER} STREQUAL "RELEASE") AND
-             (NOT ${_nghttp2_config_UPPER} STREQUAL "DEBUG"))
-            get_target_property(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_RELEASE ${_target} IMPORTED_LOCATION_${_nghttp2_config_UPPER})
-          else()
-            get_target_property(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_${_nghttp2_config_UPPER} ${_target} IMPORTED_LOCATION_${_nghttp2_config_UPPER})
-          endif()
-        endforeach()
-      else()
-        get_target_property(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_RELEASE ${_target} IMPORTED_LOCATION)
-      endif()
-
-      get_target_property(NGHTTP2_INCLUDE_DIR ${_target} INTERFACE_INCLUDE_DIRECTORIES)
-    elseif(TARGET PkgConfig::${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME})
-      # First item is the full path of the library file found
-      # pkg_check_modules does not populate a variable of the found library explicitly
-      list(GET ${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME}_LINK_LIBRARIES 0 ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_RELEASE)
-
-      get_target_property(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR PkgConfig::${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME} INTERFACE_INCLUDE_DIRECTORIES)
-
-      set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VERSION ${${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME}_VERSION})
-    endif()
   endif()
 
-  include(SelectLibraryConfigurations)
-  select_library_configurations(${${CMAKE_FIND_PACKAGE_NAME}_MODULE})
-  unset(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARIES)
-
-  if(NOT VERBOSE_FIND)
-     set(${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY TRUE)
-   endif()
-
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(NGHttp2
-                                    REQUIRED_VARS ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR
-                                    VERSION_VAR ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VERSION)
-
-  if(NGHttp2_FOUND)
-
+  if(${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME}_FOUND)
     if((TARGET nghttp2::nghttp2 OR TARGET nghttp2::nghttp2_static) AND NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
       # We have a preference for the static lib when needed, however provide support 
       # for the shared lib as well


### PR DESCRIPTION
## Description
Fix building internal brotli with ninja
Remove FHPSA usage from FindNGHttp2

## Motivation and context
@kambala-decapitator mentioned an issue with clion, and it looks to be ninja byproduct related. His error pointed at nghttp2, but ive only encountered an issue with brotli so far.

## How has this been tested?
Build macos aarch64 using ninja generator

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
