### PR TITLE
[macOS] improve storage info display

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -16,3 +16,6 @@ d1e6fff19c1cf2a266f0429c8d0ddea3195ddcce
 
 # formatting JSON-RPC schemas
 537d5e552f68e5cb851ad97b15ec785f73adae60
+
+# formatting xbmc/platform/darwin/osx/storage/OSXStorageProvider.cpp (now .mm)
+b86f51b52a671effa00317a3a75fd8912b58bdf6

--- a/xbmc/platform/darwin/osx/storage/CMakeLists.txt
+++ b/xbmc/platform/darwin/osx/storage/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(SOURCES OSXStorageProvider.cpp)
+set(SOURCES OSXStorageProvider.mm)
 
 set(HEADERS OSXStorageProvider.h)
 

--- a/xbmc/platform/darwin/osx/storage/OSXStorageProvider.mm
+++ b/xbmc/platform/darwin/osx/storage/OSXStorageProvider.mm
@@ -269,18 +269,16 @@ private:
   static void RunloopPerformCallback(void* info) {}
   CFRunLoopSourceContext m_runLoopSourceContext = {.perform = RunloopPerformCallback};
 
-  bool m_success;
-  bool m_completed;
+  bool m_success{true};
+  bool m_completed{false};
   const DASessionRef m_session;
   const CFRunLoopRef m_runloop;
   const CFRunLoopSourceRef m_runloopSource;
-  DADiskRef m_disk;
+  DADiskRef m_disk{nullptr};
 };
 
 DAOperationContext::DAOperationContext(const std::string& mountpath)
-  : m_success(true),
-    m_completed(false),
-    m_session(DASessionCreate(kCFAllocatorDefault)),
+  : m_session(DASessionCreate(kCFAllocatorDefault)),
     m_runloop(CFRunLoopGetCurrent()), // not owner!
     m_runloopSource(CFRunLoopSourceCreate(kCFAllocatorDefault, 0, &m_runLoopSourceContext))
 {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
- fetches volumes info using macOS SDK instead of showing raw `df` output
- clang-formats the touched file

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Human-readable volumes info. Compare the screenshot below to what we have now:
```
Filesystem        Size    Used   Avail Capacity iused ifree %iused  Mounted on
/dev/disk1s1s1    329G     11G     10G    53%    427k  101M    0%   /
/dev/disk1s3      329G   2708M     10G    21%    6.3k  101M    0%   /System/Volumes/Preboot
/dev/disk1s5      329G   1074M     10G    10%       1  101M    0%   /System/Volumes/VM
/dev/disk1s6      329G   1618k     10G     1%      25  101M    0%   /System/Volumes/Update
/dev/disk1s2      329G    302G     10G    97%    3.2M  101M    3%   /System/Volumes/Data
```

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ran debug build on my Mac

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
- only useful volumes info for end user
- now also shows all possible filesystems as well as network-attached volumes

## Screenshots (if appropriate):
<img width="2513" height="830" alt="Screenshot 2025-12-21 at 11 07 57" src="https://github.com/user-attachments/assets/a463919a-33cf-45ae-aafa-c53536f69b40" />


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
