### PR TITLE
[webOS] Implement audio volume settings in non-passthrough mode

### DIFF
--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
@@ -19,6 +19,7 @@
 #include "Interface/TimingConstants.h"
 #include "Process/ProcessInfo.h"
 #include "VideoRenderers/RenderManager.h"
+#include "application/ApplicationVolumeHandling.h"
 #include "cores/AudioEngine/Encoders/AEEncoderFFmpeg.h"
 #include "cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
@@ -31,6 +32,7 @@
 #include "settings/lib/Setting.h"
 #include "utils/Base64.h"
 #include "utils/BitstreamConverter.h"
+#include "utils/ComponentContainer.h"
 #include "utils/JSONVariantParser.h"
 #include "utils/JSONVariantWriter.h"
 #include "utils/SystemInfo.h"
@@ -1281,6 +1283,11 @@ unsigned int CMediaPipelineWebOS::GetQueueLevel(const StreamType type) const
   return std::min(99L, std::lround(100.0 * bytes / capacity));
 }
 
+void CMediaPipelineWebOS::SetDynamicRangeCompression(const long drc)
+{
+  m_audioLimiter.SetAmplification(std::pow(10.0f, static_cast<float>(drc) / 2000.0f));
+}
+
 void CMediaPipelineWebOS::Process()
 {
   while (!m_bStop)
@@ -1356,6 +1363,7 @@ void CMediaPipelineWebOS::ProcessAudio()
                   settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_PROCESSQUALITY));
               m_audioResample = std::make_unique<ActiveAE::CActiveAEBufferPoolResample>(
                   m_audioCodec->GetFormat(), dstFormat, quality);
+              m_audioLimiter.SetSamplerate(dstFormat.m_sampleRate);
               const double sublevel =
                   settings->GetNumber(CSettings::SETTING_AUDIOOUTPUT_MIXSUBLEVEL) / 100.0;
               m_audioResample->Create(
@@ -1418,6 +1426,29 @@ void CMediaPipelineWebOS::ProcessAudio()
                                                  : AC3_MAX_SYNC_FRAME_SIZE;
                 auto p = std::make_shared<CDVDMsgDemuxerPacket>(
                     CDVDDemuxUtils::AllocateDemuxPacket(maxSize));
+
+                const bool passthrough =
+                    CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                        CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGH);
+                if (!passthrough && buf->pkt->config.fmt == AV_SAMPLE_FMT_FLTP)
+                {
+                  float volume = CServiceBroker::GetAppComponents()
+                                     .GetComponent<CApplicationVolumeHandling>()
+                                     ->GetVolumePercent() /
+                                 100.0f;
+                  volume *= m_audioLimiter.Run(reinterpret_cast<float**>(buf->pkt->data),
+                                               buf->pkt->config.channels, 0, buf->pkt->planes > 1);
+
+                  for (std::size_t j = 0; j < static_cast<std::size_t>(buf->pkt->planes); ++j)
+                  {
+                    const std::size_t numSamples = static_cast<std::size_t>(buf->pkt->nb_samples) *
+                                                   buf->pkt->config.channels /
+                                                   static_cast<std::size_t>(buf->pkt->planes);
+                    std::span samples{reinterpret_cast<float*>(buf->pkt->data[j]), numSamples};
+                    std::ranges::for_each(samples, [volume](float& s) { s *= volume; });
+                  }
+                }
+
                 p->m_packet->pts = static_cast<double>(buf->timestamp);
                 p->m_packet->iSize = maxSize;
                 p->m_packet->iStreamId = RESAMPLED_STREAM_ID;

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
@@ -1391,6 +1391,13 @@ void CMediaPipelineWebOS::ProcessAudio()
             }
 
             ActiveAE::CSampleBuffer* buffer = m_encoderBuffers->GetFreeBuffer();
+
+            const double centerMixLevel = frame.hasDownmix ? frame.centerMixLevel : M_SQRT1_2;
+            const double curDB = 20.0 * std::log10(centerMixLevel);
+            frame.centerMixLevel =
+                std::pow(10.0, (curDB + m_processInfo.GetVideoSettings().m_CenterMixLevel) / 20.0);
+            frame.hasDownmix = true;
+            buffer->centerMixLevel = frame.centerMixLevel;
             buffer->timestamp = static_cast<int64_t>(frame.pts);
             buffer->pkt->nb_samples = static_cast<int>(frame.nb_frames);
 

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.h
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.h
@@ -12,6 +12,7 @@
 #include "DVDMessageQueue.h"
 #include "DVDStreamInfo.h"
 #include "IVideoPlayer.h"
+#include "cores/AudioEngine/Utils/AELimiter.h"
 #include "threads/Thread.h"
 #include "utils/BitstreamStats.h"
 
@@ -200,6 +201,12 @@ public:
    * @return Channel count.
    */
   int GetAudioChannels() const { return m_audioHint.channels; }
+
+  /**
+   * @brief Set dynamic range compression for audio playback.
+   * @param drc Dynamic range compression level.
+   */
+  void SetDynamicRangeCompression(long drc);
 
   /**
    * @brief Enable or disable subtitle rendering.
@@ -403,6 +410,7 @@ private:
   std::unique_ptr<ActiveAE::CActiveAEBufferPool> m_encoderBuffers{nullptr};
   std::unique_ptr<ActiveAE::CActiveAEBufferPoolResample> m_audioResample{nullptr};
   std::unique_ptr<CAEEncoderFFmpeg> m_audioEncoder{nullptr};
+  CAELimiter m_audioLimiter;
   std::atomic<unsigned long> m_droppedFrames{0};
   std::chrono::duration<double, std::ratio<1, DVD_TIME_BASE>> m_audioClock{0.0};
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudioWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudioWebOS.cpp
@@ -64,8 +64,9 @@ void CVideoPlayerAudioWebOS::SendMessage(const std::shared_ptr<CDVDMsg> msg, con
   m_mediaPipeline.SendAudioMessage(msg, priority);
 }
 
-void CVideoPlayerAudioWebOS::SetDynamicRangeCompression(long drc)
+void CVideoPlayerAudioWebOS::SetDynamicRangeCompression(const long drc)
 {
+  m_mediaPipeline.SetDynamicRangeCompression(drc);
 }
 
 std::string CVideoPlayerAudioWebOS::GetPlayerInfo()


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The PR adds the volume and dynamic range compression which were previously not respected in non-passthrough mode.

It also adds setting center level downmixing information for each audio frame.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
More complete audio settings

Fixes #27444

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
