### PR TITLE
GUIFontTTF: Fix crash in a edge case

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -622,6 +622,9 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
       }
 
       cursorX += ch->m_advance;
+
+      if ((alignment & XBFONT_JUSTIFIED) && (text[itGlyph->m_glyphInfo.cluster] & 0xffff) == L' ')
+        cursorX += spacePerSpaceCharacter;
     }
 
     // Reserve vector space: 4 vertex for each glyph


### PR DESCRIPTION
## Description
GUIFontTTF: Fix crash in a edge case

Fixes https://github.com/xbmc/xbmc/issues/27586

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is minimal fix based on the root cause identified here: https://github.com/xbmc/xbmc/issues/27586#issuecomment-3689297533

This fix does not modify the rendering behavior. The only change is that when the text is justified and the spacing of spaces is negative (which is very infrequent), it adds all characters to the queue, even if they won't be rendered. This is done because it's not easy to estimate the number of characters in the first pass (`XBFONT_JUSTIFIED` only) and prevent more characters from being rendered in the second pass than were accounted for in the first pass.

Note that this type of crash is very unlikely because justified text is achieved 99% of the time by increasing the spacing between words (not decreasing it) and therefore the failure does not occur even for justified text.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested resizing TV Guide window to very small size: crash before and no crash after.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Fix crash/hang in very rare cases as described in https://github.com/xbmc/xbmc/issues/27586. It's also possible that other random/rare crashes in other parts of the GUI and not identified yet, are also due to this.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
