### PR TITLE
[Claude] Add instruction to wrap comments around 80 chars

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -61,6 +61,9 @@ jobs:
 
             Rules:
             - NO positive feedback, NO "looks good", NO summary sections
+            - Wrap comment text at ~80 characters per line for readability
+              on small screens and with large fonts (code blocks and file
+              paths can exceed this limit)
             - Keep each issue brief but clear
             - Use inline comments for code-specific issues
             - Skip severity sections if empty


### PR DESCRIPTION
## Description

As title says, tweaks our claude instructions to improve its style output.

## Motivation and context

Wrapping around 80 chars keeps lines shorter to improve readability on small screens or for large fonts.

## How has this been tested?

Claude suggested:

```cpp
// Only break early when spacing is non-negative. Negative spacing (compressed text)
// makes width prediction unreliable, so we must process all glyphs to maintain
// queue consistency with the second rendering pass.
if (maxPixelWidth > 0 && spacePerSpaceCharacter >= 0)
```

Used Claude to simulate this rule:

```cpp
// Only break early when spacing is non-negative. Negative spacing
// (compressed text) makes width prediction unreliable, so we must process
// all glyphs to maintain queue consistency with the second rendering pass.
if (maxPixelWidth > 0 && spacePerSpaceCharacter >= 0)
```
## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
