### PR TITLE
[guilib] Reduce idle CPU with control state caching

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -1027,15 +1027,17 @@ void CGUIBaseContainer::SetPageControlRange()
   {
     CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), m_pageControl, m_itemsPerPage, GetRows());
     SendWindowMessage(msg);
+    m_lastPageControlOffset = -1;
   }
 }
 
 void CGUIBaseContainer::UpdatePageControl(int offset)
 {
-  if (m_pageControl)
+  if (m_pageControl && m_lastPageControlOffset != offset)
   { // tell our pagecontrol (scrollbar or whatever) to update (offset it by our cursor position)
     CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), m_pageControl, offset);
     SendWindowMessage(msg);
+    m_lastPageControlOffset = offset;
   }
 }
 
@@ -1311,6 +1313,7 @@ void CGUIBaseContainer::Reset()
   m_wasReset = true;
   m_items.clear();
   m_lastItem.reset();
+  m_lastPageControlOffset = -1;
   ResetAutoScrolling();
 }
 

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -151,6 +151,7 @@ protected:
   std::shared_ptr<CGUIListItem> m_lastItem;
 
   int m_pageControl;
+  int m_lastPageControlOffset = -1;
 
   std::list<CGUIListItemLayout> m_layouts;
   std::list<CGUIListItemLayout> m_focusedLayouts;

--- a/xbmc/guilib/GUIBorderedImage.cpp
+++ b/xbmc/guilib/GUIBorderedImage.cpp
@@ -45,9 +45,16 @@ void CGUIBorderedImage::Process(unsigned int currentTime, CDirtyRegionList &dirt
                        m_textureCurrent->GetXPosition() + m_textureCurrent->GetWidth(),
                        m_textureCurrent->GetYPosition() + m_textureCurrent->GetHeight());
     rect.Intersect(m_textureCurrent->GetRenderRect());
-    m_borderImage->SetPosition(rect.x1 - m_borderSize.x1, rect.y1 - m_borderSize.y1);
-    m_borderImage->SetWidth(rect.Width() + m_borderSize.x1 + m_borderSize.x2);
-    m_borderImage->SetHeight(rect.Height() + m_borderSize.y1 + m_borderSize.y2);
+
+    // Only update border position/size when the rect actually changes
+    if (m_lastBorderRect != rect)
+    {
+      m_borderImage->SetPosition(rect.x1 - m_borderSize.x1, rect.y1 - m_borderSize.y1);
+      m_borderImage->SetWidth(rect.Width() + m_borderSize.x1 + m_borderSize.x2);
+      m_borderImage->SetHeight(rect.Height() + m_borderSize.y1 + m_borderSize.y2);
+      m_lastBorderRect = rect;
+    }
+
     m_borderImage->SetDiffuseColor(m_diffuseColor);
     if (m_borderImage->Process(currentTime))
       MarkDirtyRegion();

--- a/xbmc/guilib/GUIBorderedImage.h
+++ b/xbmc/guilib/GUIBorderedImage.h
@@ -30,6 +30,7 @@ public:
 protected:
   std::unique_ptr<CGUITexture> m_borderImage;
   CRect m_borderSize;
+  CRect m_lastBorderRect;
 
 private:
   CGUIBorderedImage(const CGUIBorderedImage& right);

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -89,8 +89,15 @@ void CGUIButtonControl::Process(unsigned int currentTime, CDirtyRegionList &dirt
       alphaChannel += 192;
       alphaChannel = (unsigned int)((float)m_alpha * (float)alphaChannel / 255.0f);
     }
-    if (m_imgFocus->SetAlpha((unsigned char)alphaChannel))
-      MarkDirtyRegion();
+
+    // Only update alpha and mark dirty if the calculated alpha actually changed
+    unsigned char newAlpha = static_cast<unsigned char>(alphaChannel);
+    if (m_lastFocusAlpha != newAlpha)
+    {
+      if (m_imgFocus->SetAlpha(newAlpha))
+        MarkDirtyRegion();
+      m_lastFocusAlpha = newAlpha;
+    }
 
     m_imgFocus->SetVisible(true);
     m_imgNoFocus->SetVisible(false);
@@ -413,6 +420,7 @@ void CGUIButtonControl::OnFocus()
 void CGUIButtonControl::OnUnFocus()
 {
   m_unfocusActions.ExecuteActions(GetID(), GetParentID());
+  m_lastFocusAlpha = 255; // Reset alpha cache when losing focus
 }
 
 void CGUIButtonControl::SetSelected(bool bSelected)

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -420,7 +420,7 @@ void CGUIButtonControl::OnFocus()
 void CGUIButtonControl::OnUnFocus()
 {
   m_unfocusActions.ExecuteActions(GetID(), GetParentID());
-  m_lastFocusAlpha = 255; // Reset alpha cache when losing focus
+  m_lastFocusAlpha = 0; // Invalidate alpha cache when losing focus
 }
 
 void CGUIButtonControl::SetSelected(bool bSelected)

--- a/xbmc/guilib/GUIButtonControl.h
+++ b/xbmc/guilib/GUIButtonControl.h
@@ -93,7 +93,7 @@ protected:
   std::unique_ptr<CGUITexture> m_imgNoFocus;
   unsigned int  m_focusCounter;
   unsigned char m_alpha;
-  unsigned char m_lastFocusAlpha = 255;
+  unsigned char m_lastFocusAlpha{0};
 
   float m_minWidth;
   float m_maxWidth;

--- a/xbmc/guilib/GUIButtonControl.h
+++ b/xbmc/guilib/GUIButtonControl.h
@@ -93,6 +93,7 @@ protected:
   std::unique_ptr<CGUITexture> m_imgNoFocus;
   unsigned int  m_focusCounter;
   unsigned char m_alpha;
+  unsigned char m_lastFocusAlpha = 255;
 
   float m_minWidth;
   float m_maxWidth;

--- a/xbmc/guilib/GUIControlGroupList.h
+++ b/xbmc/guilib/GUIControlGroupList.h
@@ -117,6 +117,8 @@ protected:
 
   CScroller m_scroller;
   int m_lastScrollerValue;
+  int m_lastPageControlSize = -1;
+  int m_lastPageControlTotalSize = -1;
 
   bool m_useControlPositions;
   ORIENTATION m_orientation;

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1643,6 +1643,7 @@ void CGUIWindowManager::DispatchThreadMessages()
     {
       CGUIMessage* msg = it->first;
       int win = it->second;
+      bool foundDuplicate = false;
 
       // Only deduplicate safe "set" messages where order doesn't matter
       if (msg->GetMessage() == GUI_MSG_ITEM_SELECT ||
@@ -1661,13 +1662,15 @@ void CGUIWindowManager::DispatchThreadMessages()
             // Found a duplicate - delete this older message
             delete msg;
             it = m_vecThreadMessages.erase(it);
-            goto next_message;  // Skip to next message
+            foundDuplicate = true;
+            break;
           }
           ++next;
         }
       }
-      ++it;
-      next_message:;
+
+      if (!foundDuplicate)
+        ++it;
     }
   }
 


### PR DESCRIPTION
## Description

  Found and fixed several spots where the GUI was doing redundant work every frame. Added caching so we only update when something actually changes instead of blindly updating 60 times a second.

  Changes:
  - GUIBaseContainer & GUIControlGroupList - cache scrollbar offset, only message when it changes
  - GUITexture - don't return "changed" every frame while async loading textures
  - GUIButtonControl - cache the alpha value instead of recalculating every frame
  - GUIBorderedImage - cache rect and skip recalculating position/size
  - GUIWindowManager - remove duplicate messages from queue before processing

  10 files touched across these controls.

  ## Motivation and context

  Was getting high CPU usage just sitting idle in PM4K (and probably other plugin UIs). Turns out we were doing a lot of unnecessary work:

  - Sending messages to scrollbars constantly even when nothing changed
  - Textures marking themselves dirty every frame during loading
  - Recalculating button alpha that was already the right value
  - Processing duplicate setLabel messages from Python addons

  Just added caching - check if the value changed before doing the work.

  ## How has this been tested?

  Windows 10, MSVC 2022. Tested with PM4K and Estuary.

  - Left PM4K open idle with scrollbars - CPU definitely lower
  - Scrolled through big movie libraries - works fine
  - Checked window transitions, button focus, texture loading - all good
  - No visual glitches or broken behavior

  ## What is the effect on users?

  Lower CPU when sitting idle in plugin UIs, especially ones with scrollbars. Better scrolling performance. Less wasted work in Python addons.

  Biggest difference for complex addons like PM4K/YouTube and on slower hardware.

  Nothing looks different, just uses less CPU.

  ## Screenshots (if appropriate):

  N/A

  ## Types of change

  - [X] **Improvement** (non-breaking change which improves existing functionality)

  ## Checklist:

  - [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
  - [ ] My change requires a change to the documentation, either Doxygen or wiki
  - [ ] I have updated the documentation accordingly
  - [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
  - [ ] I have added tests to cover my change
  - [X] All new and existing tests passed