### PR TITLE
[PipeWire] Fix deadlock in format enumeration

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -300,7 +300,6 @@ void CAESinkPipewire::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
   list.emplace_back(defaultDevice);
 
   auto& registry = pipewire->GetRegistry();
-  std::lock_guard lg(registry);
 
   for (const auto& [id, node] : registry.GetNodes())
   {

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -303,6 +303,12 @@ void CAESinkPipewire::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
 
   for (const auto& [id, node] : registry.GetNodes())
   {
+    // Immediately after a node has been added to the registry it doesn't have information yet.
+    // Once PipeWire populated the info the audio engine is informed about the update and the
+    // enumeration is performed again.
+    if (!node->HasInfo())
+      continue;
+
     CAEDeviceInfo device;
     device.m_deviceType = AE_DEVTYPE_PCM;
     device.m_deviceName = node->Get(PW_KEY_NODE_NAME);

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -323,17 +323,6 @@ void CAESinkPipewire::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
     std::for_each(defaultSampleRates.cbegin(), defaultSampleRates.cend(),
                   [&device](const auto& rate) { device.m_sampleRates.emplace_back(rate); });
 
-    node->EnumerateFormats();
-
-    int ret = loop.Wait(5s);
-    if (ret == -ETIMEDOUT)
-    {
-      CLog::Log(LOGDEBUG,
-                "CAESinkPipewire::{} - timed out out waiting for formats to be enumerated",
-                __FUNCTION__);
-      continue;
-    }
-
     auto& channels = node->GetChannels();
     if (channels.empty())
       continue;

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
@@ -12,6 +12,8 @@
 #include "PipewireCore.h"
 #include "PipewireRegistry.h"
 #include "PipewireThreadLoop.h"
+#include "ServiceBroker.h"
+#include "cores/AudioEngine/Interfaces/AE.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
@@ -207,11 +209,12 @@ void CPipewireNode::Param(void* userdata,
                           const struct spa_pod* param)
 {
   auto& node = *reinterpret_cast<CPipewireNode*>(userdata);
-  auto& loop = node.GetRegistry().GetCore().GetContext().GetThreadLoop();
 
-  node.Parse(SPA_POD_TYPE(param), SPA_POD_BODY(param), SPA_POD_BODY_SIZE(param));
-
-  loop.Signal(false);
+  if (node.Parse(SPA_POD_TYPE(param), SPA_POD_BODY(param), SPA_POD_BODY_SIZE(param)))
+  {
+    if (IAE* ae = CServiceBroker::GetActiveAE(); ae)
+      ae->DeviceChange();
+  }
 }
 
 pw_node_events CPipewireNode::CreateNodeEvents()

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
@@ -58,6 +58,17 @@ void CPipewireNode::Info(void* userdata, const struct pw_node_info* info)
   {
     node.m_info.reset(pw_node_info_update(nullptr, info));
   }
+
+  // Check if the node parameters changed, if yes enumerate the available formats
+  if ((info->change_mask & PW_NODE_CHANGE_MASK_PARAMS) != 0)
+  {
+    for (auto param : std::span(info->params, info->n_params))
+    {
+      if (param.id == SPA_PARAM_EnumFormat && param.flags & SPA_PARAM_INFO_READ)
+        pw_node_enum_params(reinterpret_cast<pw_node*>(node.m_proxy.get()), 0, param.id, 0, 0,
+                            nullptr);
+    }
+  }
 }
 
 std::string CPipewireNode::Get(const std::string& key) const

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
@@ -52,12 +52,11 @@ void CPipewireNode::Info(void* userdata, const struct pw_node_info* info)
   if (node.m_info)
   {
     CLog::Log(LOGDEBUG, "CPipewireNode::{} - node {} changed", __FUNCTION__, info->id);
-    pw_node_info* m_info = node.m_info.get();
-    m_info = pw_node_info_update(m_info, info);
+    pw_node_info_update(node.m_info.get(), info);
   }
   else
   {
-    node.m_info.reset(pw_node_info_update(node.m_info.get(), info));
+    node.m_info.reset(pw_node_info_update(nullptr, info));
   }
 }
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
@@ -34,19 +34,6 @@ CPipewireNode::~CPipewireNode()
   spa_hook_remove(&m_objectListener);
 }
 
-void CPipewireNode::EnumerateFormats()
-{
-  if (!m_info)
-    return;
-
-  for (uint32_t param = 0; param < m_info->n_params; param++)
-  {
-    if (m_info->params[param].id == SPA_PARAM_EnumFormat)
-      pw_node_enum_params(reinterpret_cast<struct pw_node*>(m_proxy.get()), 0,
-                          m_info->params[param].id, 0, 0, NULL);
-  }
-}
-
 void CPipewireNode::Info(void* userdata, const struct pw_node_info* info)
 {
   auto& node = *reinterpret_cast<CPipewireNode*>(userdata);

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
@@ -32,8 +32,6 @@ public:
   CPipewireNode() = delete;
   ~CPipewireNode() override;
 
-  void EnumerateFormats();
-
   bool HasInfo() const { return m_info != nullptr; }
 
   std::string Get(const std::string& key) const;

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
@@ -34,6 +34,8 @@ public:
 
   void EnumerateFormats();
 
+  bool HasInfo() const { return m_info != nullptr; }
+
   std::string Get(const std::string& key) const;
 
   std::set<spa_audio_format>& GetFormats() { return m_formats; }

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
@@ -42,7 +42,7 @@ public:
   std::set<spa_audio_iec958_codec>& GetIEC958Codecs() { return m_iec958Codecs; }
 
 private:
-  void Parse(uint32_t type, void* body, uint32_t size);
+  bool Parse(uint32_t type, void* body, uint32_t size);
 
   static void Info(void* userdata, const struct pw_node_info* info);
   static void Param(void* userdata,

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
@@ -43,6 +43,8 @@ void CPipewireRegistry::OnGlobalAdded(void* userdata,
                                       uint32_t version,
                                       const struct spa_dict* props)
 {
+  auto& registry = *reinterpret_cast<CPipewireRegistry*>(userdata);
+
   if (strcmp(type, PW_TYPE_INTERFACE_Node) != 0)
     return;
 
@@ -53,8 +55,6 @@ void CPipewireRegistry::OnGlobalAdded(void* userdata,
   if (strcmp(mediaClass, "Audio/Sink") != 0)
     return;
 
-  auto& registry = *reinterpret_cast<CPipewireRegistry*>(userdata);
-  std::lock_guard lg(registry);
   auto& nodes = registry.GetNodes();
 
   nodes[id] = std::make_unique<CPipewireNode>(registry, id, type);
@@ -65,7 +65,6 @@ void CPipewireRegistry::OnGlobalAdded(void* userdata,
 void CPipewireRegistry::OnGlobalRemoved(void* userdata, uint32_t id)
 {
   auto& registry = *reinterpret_cast<CPipewireRegistry*>(userdata);
-  std::lock_guard lg(registry);
   auto& nodes = registry.GetNodes();
 
   auto it = nodes.find(id);

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include "threads/CriticalSection.h"
-
 #include <map>
 #include <memory>
 #include <string>
@@ -37,10 +35,6 @@ public:
 
   std::map<uint32_t, std::unique_ptr<CPipewireNode>>& GetNodes() { return m_nodes; }
 
-  // C++ BasicLockable requirements
-  void lock() { m_lock.lock(); }
-  void unlock() { m_lock.unlock(); }
-
 private:
   static void OnGlobalAdded(void* userdata,
                             uint32_t id,
@@ -65,8 +59,6 @@ private:
   std::unique_ptr<pw_registry, PipewireRegistryDeleter> m_registry;
 
   std::map<uint32_t, std::unique_ptr<CPipewireNode>> m_nodes;
-
-  CCriticalSection m_lock;
 };
 
 } // namespace PIPEWIRE


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

In #26454 I attempted to fix a crash related to PipeWire, but while the crash was gone I instead introduced a deadlock (see https://github.com/xbmc/xbmc/issues/27420#issuecomment-3644359503 for the details).

In the end the problem comes down to PipeWire being event based while we try to simulate polling in `CAESinkPipewire::EnumerateDevicesEx`. @argo242 proposed a patch in https://github.com/xbmc/xbmc/issues/27420#issuecomment-3679213141 that would make the current approach work properly, but I think the better strategy is to make use of the PipeWire events.

With this PR we trigger an enumeration of the audio formats immediately when PipeWire informs us of a node's property change. We also inform the audio engine that a device has changed and `CAESinkPipewire::EnumerateDevicesEx` gets called.

The only minor downside is that after a new device appears, `CAESinkPipewire::EnumerateDevicesEx` gets called before PipeWire has gathered all the devices information so we ignore the device. Moments later PipeWire gathers the information and there are one or more change events that trigger `CAESinkPipewire::EnumerateDevicesEx`.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Resolve the deadlock in #26454 without introducing a crash again.

Fixes #27420.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Attaching and removing an AV receiver. Performing PipeWire configuration changes that trigger changes to the node parameters.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

No deadlocks when audio devices change.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
