### PR TITLE
[GUI] GUIWindowManager: Fix crash when ReloadSkin is called with modal dialog active

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1223,9 +1223,16 @@ void CGUIWindowManager::Process(unsigned int currentTime)
     pWindow->DoProcess(currentTime, m_dirtyregions);
 
   // process all dialogs - visibility may change etc.
-  for (const auto& entry : m_mapWindows)
+  // make copy of map as skin reload can modify m_mapWindows during iteration
+  auto mapWindows = m_mapWindows;
+  for (const auto& entry : mapWindows)
   {
-    CGUIWindow *pWindow = entry.second;
+    // verify window still exists (could be deleted during skin reload)
+    auto it = m_mapWindows.find(entry.first);
+    if (it == m_mapWindows.end() || it->second != entry.second)
+      continue;
+
+    CGUIWindow* pWindow = entry.second;
     if (pWindow && pWindow->IsDialog())
       pWindow->DoProcess(currentTime, m_dirtyregions);
   }


### PR DESCRIPTION

## Description
When a modal dialog is active and ReloadSkin builtin is executed, a crash occurs in Process() due to iterator invalidation. The issue happens because DoProcess() on a dialog can trigger a nested call chain that eventually calls DeInitialize(), which modifies m_mapWindows while Process() is still iterating over it.

The fix makes a copy of the map before iteration (preventing iterator invalidation) and verifies each window still exists before processing it (preventing use-after-free if windows are deleted during skin reload).

## Motivation and context
Close #21382

## How has this been tested?
Runtime tested with the instructions provided by the user

## What is the effect on users?
Avoid crashes triggered by skin reload

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
