### PR TITLE
[JobManager] Add support for multiple callbacks per job

### DIFF
--- a/xbmc/jobs/Job.h
+++ b/xbmc/jobs/Job.h
@@ -119,6 +119,16 @@ public:
    */
   virtual bool ShouldCancel(unsigned int progress, unsigned int total) const;
 
+  /*!
+   \brief Get the number of callbacks pending for this job during completion.
+
+   When count > 1, callbacks should make copies of any data they extract from the job
+   to avoid sharing state with other callbacks that will also receive this job's results.
+
+   \return number of callbacks still waiting to be notified, 0 if not in completion phase.
+   */
+  size_t GetPendingCallbackCount() const;
+
 private:
   CJobManager* m_progressCallback{nullptr};
 };


### PR DESCRIPTION
## Description
When multiple callers request the same job (determined by CJob::Equals), the job manager now registers all callbacks instead of discarding duplicates. When the job completes, all registered callbacks are notified.

This fixes an issue where multiple GUI containers loading the same content path would not all get populated, as only the first requester received the completion callback.

To avoid shared state issues, callbacks can check CJob::IsShared() to determine if they need to make copies of the job's data. The last callback to be notified will see IsShared() return false, avoiding an unnecessary copy.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/27622

## How has this been tested?
Runtime tested in macOS. Also simulated the same path that caused the original issue report.

## What is the effect on users?
Complex skins can reuse multiple containers pointing to the same path.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
