### PR TITLE
Fix interference between unit tests and portable mode

### DIFF
--- a/xbmc/application/AppParamParser.cpp
+++ b/xbmc/application/AppParamParser.cpp
@@ -102,8 +102,8 @@ void CAppParamParser::ParseArg(const std::string &arg)
     DisplayVersion();
   else if (arg == "--standalone")
     m_params->SetStandAlone(true);
-  else if (arg == "-p" || arg  == "--portable")
-    m_params->SetPlatformDirectories(false);
+  else if (arg == "-p" || arg == "--portable")
+    m_params->SetUserDirectoriesLocation(UserDirectoriesLocation::PORTABLE);
   else if (arg == "--debug")
     m_params->SetLogLevel(LOG_LEVEL_DEBUG);
   else if (arg == "--test")

--- a/xbmc/application/AppParams.h
+++ b/xbmc/application/AppParams.h
@@ -17,6 +17,13 @@
 
 class CFileItemList;
 
+enum class UserDirectoriesLocation
+{
+  PLATFORM, //!< Standard platform location for application preferences
+  PORTABLE, //!< portable_data directory, next to the application executable
+  TEST, //!< test_data directory, next to the application executable
+};
+
 class CAppParams
 {
 public:
@@ -32,11 +39,8 @@ public:
   bool IsStandAlone() const { return m_standAlone; }
   void SetStandAlone(bool standAlone) { m_standAlone = standAlone; }
 
-  bool HasPlatformDirectories() const { return m_platformDirectories; }
-  void SetPlatformDirectories(bool platformDirectories)
-  {
-    m_platformDirectories = platformDirectories;
-  }
+  UserDirectoriesLocation GetUserDirectoriesLocation() const { return m_userDirectoriesLocation; }
+  void SetUserDirectoriesLocation(UserDirectoriesLocation loc) { m_userDirectoriesLocation = loc; }
 
   bool IsTestMode() const { return m_testmode; }
   void SetTestMode(bool testMode) { m_testmode = testMode; }
@@ -82,7 +86,6 @@ private:
 
   bool m_startFullScreen{false};
   bool m_standAlone{false};
-  bool m_platformDirectories{true};
   bool m_testmode{false};
 
   std::string m_settingsFile;
@@ -92,6 +95,7 @@ private:
   std::string m_glInterface;
 
   std::unique_ptr<CFileItemList> m_playlist;
+  UserDirectoriesLocation m_userDirectoriesLocation{UserDirectoriesLocation::PLATFORM};
 
   // The raw command-line arguments
   std::vector<std::string> m_rawArgs;

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -302,7 +302,8 @@ bool CApplication::Create()
 #ifdef TARGET_POSIX //! @todo Win32 has no special://home/ mapping by default, so we
   //!       must create these here. Ideally this should be using special://home/ and
   //!      be platform agnostic (i.e. unify the InitDirectories*() functions)
-  if (!CServiceBroker::GetAppParams()->HasPlatformDirectories())
+  if (CServiceBroker::GetAppParams()->GetUserDirectoriesLocation() !=
+      UserDirectoriesLocation::PLATFORM)
 #endif
   {
     CDirectory::Create("special://xbmc/addons");

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -12,6 +12,7 @@
 #include "ServiceBroker.h"
 #include "Util.h"
 #include "WindowHelper.h"
+#include "application/AppParams.h"
 #include "guilib/LocalizeStrings.h"
 #include "my_ntddscsi.h"
 #include "rendering/dx/DirectXHelper.h"
@@ -339,7 +340,7 @@ size_t CWIN32Util::GetSystemMemorySize()
 #endif
 }
 
-std::string CWIN32Util::GetProfilePath(const bool platformDirectories)
+std::string CWIN32Util::GetProfilePath(UserDirectoriesLocation loc)
 {
   std::string strProfilePath;
 #ifdef TARGET_WINDOWS_STORE
@@ -348,10 +349,18 @@ std::string CWIN32Util::GetProfilePath(const bool platformDirectories)
 #else
   std::string strHomePath = CUtil::GetHomePath();
 
-  if (platformDirectories)
-    strProfilePath = URIUtils::AddFileToFolder(GetAppDataFolder(), CCompileInfo::GetAppName());
-  else
-    strProfilePath = URIUtils::AddFileToFolder(strHomePath , "portable_data");
+  switch (loc)
+  {
+    case UserDirectoriesLocation::PLATFORM:
+      strProfilePath = URIUtils::AddFileToFolder(GetAppDataFolder(), CCompileInfo::GetAppName());
+      break;
+    case UserDirectoriesLocation::PORTABLE:
+      strProfilePath = URIUtils::AddFileToFolder(strHomePath, "portable_data");
+      break;
+    case UserDirectoriesLocation::TEST:
+      strProfilePath = URIUtils::AddFileToFolder(strHomePath, "test_data");
+      break;
+  }
 
   if (strProfilePath.length() == 0)
     strProfilePath = strHomePath;

--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -29,7 +29,9 @@ struct VideoDriverInfo
   void Log();
 };
 
-class CURL; // forward declaration
+// forward declarations
+class CURL;
+enum class UserDirectoriesLocation;
 
 class CWIN32Util
 {
@@ -43,7 +45,7 @@ public:
   static std::string GetResInfoString();
   static size_t GetSystemMemorySize();
 
-  static std::string GetProfilePath(const bool platformDirectories);
+  static std::string GetProfilePath(UserDirectoriesLocation loc);
   static std::string UncToSmb(const std::string &strPath);
   static std::string SmbToUnc(const std::string &strPath);
   static bool AddExtraLongPathPrefix(std::wstring& path);

--- a/xbmc/platform/win32/threads/Win32Exception.cpp
+++ b/xbmc/platform/win32/threads/Win32Exception.cpp
@@ -57,8 +57,9 @@ typedef DWORD (__stdcall *tSSO)( IN DWORD SymOptions );
 // GetCurrentPackageFullName
 typedef LONG (__stdcall *GCPFN)(UINT32*, PWSTR);
 
+// Definition of class static members
 std::string win32_exception::mVersion;
-bool win32_exception::m_platformDir;
+std::string win32_exception::m_platformDir;
 
 bool win32_exception::write_minidump(EXCEPTION_POINTERS* pEp)
 {
@@ -74,8 +75,7 @@ bool win32_exception::write_minidump(EXCEPTION_POINTERS* pEp)
                                      stLocalTime.hour, stLocalTime.minute, stLocalTime.second);
 
   dumpFileName = CWIN32Util::SmbToUnc(
-      URIUtils::AddFileToFolder(CWIN32Util::GetProfilePath(m_platformDir),
-                                CUtil::MakeLegalFileName(std::move(dumpFileName))));
+      URIUtils::AddFileToFolder(m_platformDir, CUtil::MakeLegalFileName(std::move(dumpFileName))));
 
   dumpFileNameW = KODI::PLATFORM::WINDOWS::ToW(dumpFileName);
   HANDLE hDumpFile = CreateFileW(dumpFileNameW.c_str(), GENERIC_WRITE, 0, 0, CREATE_ALWAYS, 0, 0);
@@ -191,8 +191,7 @@ bool win32_exception::write_stacktrace(EXCEPTION_POINTERS* pEp)
                                      stLocalTime.hour, stLocalTime.minute, stLocalTime.second);
 
   dumpFileName = CWIN32Util::SmbToUnc(
-      URIUtils::AddFileToFolder(CWIN32Util::GetProfilePath(m_platformDir),
-                                CUtil::MakeLegalFileName(std::move(dumpFileName))));
+      URIUtils::AddFileToFolder(m_platformDir, CUtil::MakeLegalFileName(std::move(dumpFileName))));
 
   dumpFileNameW = KODI::PLATFORM::WINDOWS::ToW(dumpFileName);
   hDumpFile = CreateFileW(dumpFileNameW.c_str(), GENERIC_WRITE, 0, 0, CREATE_ALWAYS, 0, 0);

--- a/xbmc/platform/win32/threads/Win32Exception.h
+++ b/xbmc/platform/win32/threads/Win32Exception.h
@@ -19,11 +19,14 @@ public:
     typedef const void* Address; // OK on Win32 platform
 
     static void set_version(std::string version) { mVersion = std::move(version); }
-    static void set_platformDirectories(const bool platformDir) { m_platformDir = platformDir; }
+    static void set_platformDirectories(const std::string& platformDir)
+    {
+      m_platformDir = platformDir;
+    }
     static bool write_minidump(EXCEPTION_POINTERS* pEp);
     static bool write_stacktrace(EXCEPTION_POINTERS* pEp);
     static bool ShouldHook();
 private:
     static std::string mVersion;
-    static bool m_platformDir;
+    static std::string m_platformDir;
 };

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -41,7 +41,7 @@ TestBasicEnvironment::TestBasicEnvironment() = default;
 void TestBasicEnvironment::SetUp()
 {
   const auto params = std::make_shared<CAppParams>();
-  params->SetPlatformDirectories(false);
+  params->SetUserDirectoriesLocation(UserDirectoriesLocation::TEST);
 
   CAppEnvironment::SetUp(params);
 

--- a/xbmc/test/TestUtils.cpp
+++ b/xbmc/test/TestUtils.cpp
@@ -86,7 +86,6 @@ bool CXBMCTestUtils::SetReferenceFileBasePath()
   /* Set xbmc, xbmcbin and home path */
   CSpecialProtocol::SetXBMCPath(xbmcPath);
   CSpecialProtocol::SetXBMCBinPath(xbmcPath);
-  CSpecialProtocol::SetHomePath(URIUtils::AddFileToFolder(xbmcPath, "portable_data"));
 
   return true;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Run unit tests with a new storage location "test_data" for user directories (ex. special://home, ...) instead of portable_data in order to preserve the contents of portable_data.

TestBasicEnvironment::SetUp() needs to initialize the profile manager but it was overwriting the contents of portable_data\userdata\profiles.xml with data unsuitable for normal Kodi execution after unit tests execution (see Motivation paragraph)

The boolean member m_platformDirectories member was turned into an enumeration UserDirectoriesLocation that enables a third location for user directories. Values:
* PLATFORM and PORTABLE are equivalent to m_platformDirectories true and false respectively.
* TEST is set only when running the unit tests and defines a new location in a test_data directory next to the executable, leveraging other existing code that computes the user directories path and creates them.

An alternative could have been an override the masterprofile special path later in the process (CXBMCTestUtils::SetReferenceFileBasePath()) similar to what was done for special://home (now unnecessary), followed by creation of the directory but it felt more ad-hoc and not well integrated.

The profile manager was added in #14538
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Running unit tests overwrites profiles.xml in portable_data/userdata of the build directory with invalid profile information.
- the content of profiles.xml is lost.
- movies and tv shows library appear empty when running the app in portable mode under debugger afterwards.

This is annoying and wastes time when developing as profiles.xml must be restored from a backup or deleted after running unit tests in order to run the app in the debugger.

Windows devs who don't use portable mode with Visual Studio are not affected.
I'm not sure of the impact of the issue on platforms other than Windows.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows: ran unit tests and ran Kodi normally in portable and platform modes.
Linux / OSX / Android: don't have environments to test.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
none

## Screenshots (if appropriate):
test_data subdirectory in the main debug build directory, next to portable_data and at the same level as the executable:

<img width="494" height="220" alt="image" src="https://github.com/user-attachments/assets/bb1ac42d-3c27-4afa-8fe5-619606b98f87" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
