### PR TITLE
GUIDialogFileBrowser: Show busy dialog while fetching directory listing

### DIFF
--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -19,6 +19,7 @@
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "Util.h"
+#include "dialogs/GUIDialogBusy.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "filesystem/MultiPathDirectory.h"
@@ -359,7 +360,13 @@ void CGUIDialogFileBrowser::Update(const std::string &strDirectory)
     CFileItemList items;
     std::string strParentPath;
 
-    if (!m_rootDir.GetDirectory(pathToUrl, items, m_useFileDirectories, false))
+    CGetDirectoryItems runnable(m_rootDir, pathToUrl, items, m_useFileDirectories, false);
+    if (!CGUIDialogBusy::Wait(&runnable, 100, true))
+    {
+      // cancelled
+      return;
+    }
+    else if (!runnable.GetResult())
     {
       CLog::Log(LOGERROR, "CGUIDialogFileBrowser::GetDirectory({}) failed",
                 pathToUrl.GetRedacted());

--- a/xbmc/filesystem/VirtualDirectory.h
+++ b/xbmc/filesystem/VirtualDirectory.h
@@ -10,6 +10,7 @@
 
 #include "IDirectory.h"
 #include "MediaSource.h"
+#include "threads/IRunnable.h"
 
 #include <memory>
 #include <string>
@@ -54,5 +55,32 @@ namespace XFILE
     std::vector<CMediaSource> m_sources;
     bool m_allowNonLocalSources;
     std::shared_ptr<IDirectory> m_pDir;
+  };
+
+  class CGetDirectoryItems final : public IRunnable
+  {
+  public:
+    CGetDirectoryItems(
+        CVirtualDirectory& dir, const CURL& url, CFileItemList& items, bool useDir, bool keepImpl)
+      : m_dir(dir),
+        m_url(url),
+        m_items(items),
+        m_useDir(useDir),
+        m_keepImpl(keepImpl)
+    {
+    }
+
+    void Run() override { m_result = m_dir.GetDirectory(m_url, m_items, m_useDir, m_keepImpl); }
+    void Cancel() override { m_dir.CancelDirectory(); }
+
+    bool GetResult() const { return m_result; }
+
+  private:
+    CVirtualDirectory& m_dir;
+    const CURL& m_url;
+    CFileItemList& m_items;
+    bool m_useDir{false};
+    bool m_result{false};
+    bool m_keepImpl{false};
   };
 }

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -21,10 +21,6 @@ class CFileItemList;
 class CGUIViewState;
 enum class SourceType;
 
-namespace
-{
-class CGetDirectoryItems;
-}
 class TiXmlElement;
 
 // base class for all media windows


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Cleaned up version of #27493, originally authored by @heros-os.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #27399.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Add a non existing NFS server in the "browse for new share". Try to browse into that NFS share. On master the GUI blocks until the timeout is reached, with this PR the busy dialog is shown.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

GUI isn't blocked while Kodi tries to access a NFS share.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
