### PR TITLE
AEStreamInfo: fix AC3 duration when sample rate is different from 48 KHz

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
@@ -51,7 +51,7 @@ double CAEStreamInfo::GetDuration() const
   switch (m_type)
   {
     case STREAM_TYPE_AC3:
-      duration = 0.032;
+      duration = 1536.0 / m_sampleRate;
       break;
     case STREAM_TYPE_EAC3:
       duration = 6144.0 / m_sampleRate / 4;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
AEStreamInfo: fix AC3 duration when sample rate is different from 48 KHz

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
AC3 frame duration (time) is not constant and depends on sample rate like others codecs. For AC3 what is constant is that all frames has 1536 samples. Then duration is only 0.032 s for 48000 Hz:

1536 / 48000 = 0.032 s

AC3 supports 32, 44.1 and 48 KHz sample rates. 

Found when looking at forum issue: https://forum.kodi.tv/showthread.php?tid=383488&pid=3250972#pid3250972

This bug has remained hidden for a long time because its repercussions are limited for several reasons: 48000 Hz is almost exclusively used in videos and movies. It doesn't affect Windows passthrough because there are no calls to `GetDuration()`. It's most affected Android in RAW PT only (and only if AC3 is not 48 Khz).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with video file reencoded the audio and with eac3to changed with option `-resampleTo44100`. 
Tested on Android with RAW PT. This file plays with audio broken before (a/v sync every few seconds) and plays fine after.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Fix playback issues when audio is AC3 at 32 or 44.1 Khz.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
