### PR TITLE
[gles] Set unpack alignment for texture handling

### DIFF
--- a/xbmc/guilib/GUIFontTTFGLES.cpp
+++ b/xbmc/guilib/GUIFontTTFGLES.cpp
@@ -83,6 +83,8 @@ bool CGUIFontTTFGLES::FirstBegin()
 
   if (m_textureStatus == TEXTURE_VOID)
   {
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+
     // Have OpenGL generate a texture object handle for us
     glGenTextures(1, static_cast<GLuint*>(&m_nTexture));
 
@@ -115,6 +117,8 @@ bool CGUIFontTTFGLES::FirstBegin()
   {
     // Copies one more line in case we have to sample from there
     m_updateY2 = std::min(m_updateY2 + 1, m_texture->GetHeight());
+
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
 
     glBindTexture(GL_TEXTURE_2D, m_nTexture);
     glTexSubImage2D(GL_TEXTURE_2D, 0, 0, m_updateY1, m_texture->GetWidth(), m_updateY2 - m_updateY1,

--- a/xbmc/guilib/TextureGLES.cpp
+++ b/xbmc/guilib/TextureGLES.cpp
@@ -284,8 +284,10 @@ void CGLESTexture::LoadToGPU()
   // read one/two bytes at the time.
   if (m_textureFormat == KD_TEX_FMT_SDR_R8)
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-  if (m_textureFormat == KD_TEX_FMT_SDR_RG8)
+  else if (m_textureFormat == KD_TEX_FMT_SDR_RG8)
     glPixelStorei(GL_UNPACK_ALIGNMENT, 2);
+  else
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
 
   TextureFormat glesFormat;
   if (m_isGLESVersion30orNewer)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Make sure `GL_UNPACK_ALIGNMENT` is set before calling `glTexImage2D` or `glTexSubImage2D`.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Trying to fix the reported issues on webOS related to subtitle rendering. 

Specifically, `GL_UNPACK_ALIGNMENT` is set to 1 here during subtitle rendering:
https://github.com/xbmc/xbmc/blob/a473070053223e54341eeee9a8a088a2dd0db068/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp#L118

Since `GL_UNPACK_ALIGNMENT` is changed globally make sure before calling the functions the value is reset to the default value of 4.

Maybe fixes #27630 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS, but it was fine on my device before and after this change

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
