### PR TITLE
Fix Missing Sound on Return from FF/RW to Tempo Play / Remove Tempo Play to Normal Play Unneeded Flush

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3152,7 +3152,8 @@ void CVideoPlayer::HandleMessages()
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_SETSPEED))
     {
-      int speed = std::static_pointer_cast<CDVDMsgPlayerSetSpeed>(pMsg)->GetSpeed();
+      const auto msg = std::static_pointer_cast<CDVDMsgPlayerSetSpeed>(pMsg);
+      const int speed = msg->GetSpeed();
 
       // correct our current clock, as it would start going wrong otherwise
       if (m_State.timestamp > 0)
@@ -3181,10 +3182,17 @@ void CVideoPlayer::HandleMessages()
         pvrinputstream->Pause(speed == 0);
       }
 
-      // do a seek after rewind, clock is not in sync with current pts
-      if ((speed == DVD_PLAYSPEED_NORMAL) &&
-          (m_playSpeed != DVD_PLAYSPEED_NORMAL) &&
-          (m_playSpeed != DVD_PLAYSPEED_PAUSE))
+      const bool isTempoSpeed = msg->IsTempo();
+      const bool wasNotTempoSpeed =
+          !(m_playSpeed != DVD_PLAYSPEED_NORMAL &&
+            m_processInfo->IsTempoAllowed(static_cast<float>(m_playSpeed) / DVD_PLAYSPEED_NORMAL));
+
+      // Seek when:
+      // 1. Returning to normal 1.0x or tempo play from FF
+      // 3. Returning to normal 1.0x or tempo play from RW (clock is not in sync with current pts)
+      // 2. Returning to normal 1.0x from tempo play
+      if ((speed == DVD_PLAYSPEED_NORMAL || (isTempoSpeed && wasNotTempoSpeed)) &&
+          (m_playSpeed != DVD_PLAYSPEED_NORMAL) && (m_playSpeed != DVD_PLAYSPEED_PAUSE))
       {
         double iTime = m_VideoPlayerVideo->GetCurrentPts();
         if (iTime == DVD_NOPTS_VALUE)
@@ -3201,7 +3209,7 @@ void CVideoPlayer::HandleMessages()
         m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
       }
 
-      if (std::static_pointer_cast<CDVDMsgPlayerSetSpeed>(pMsg)->IsTempo())
+      if (isTempoSpeed)
         m_processInfo->SetTempo(static_cast<float>(speed) / DVD_PLAYSPEED_NORMAL);
       else
         m_processInfo->SetSpeed(static_cast<float>(speed) / DVD_PLAYSPEED_NORMAL);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Videoplayer stops feeding the audio packets queue during fast forward and rewind causing no audio when resuming play/tempo play.
The code already addressed the normal play case with a seek/flush on return, the PR adds the same for the return to tempo play case.

Conversely, returning from tempo play to normal play caused a flush (misdetection of a fast forward to normal play return) but it's not necessary as the audio queue is in a good state in tempo play. Removing that seek helped unify the conditions a bit.


The better fix would be to avoid the seek as a way to flush things as it's heavy-handed and the position after seeks is usually off by a few seconds. However that requires deeper changes to videoplayer to keep feeding the audio queue during FF (but still discard packets too old for the current ts to have room in the queue for new packets)

@fritsch would appreciate your take.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #27063.

Used Claude's analysis and suggestions as inspiration. It provided the hints needed to start getting a handle on the issue but diagnosed the root cause incorrectly.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Positive testing with normal play > tempo play > normal play (no flush)
Positive testing with tempo play, fast forward or rewind, back to play (flush)
Negative testing with normal play, fast forward or rewind, back to play (flush)
Negative testing with fast forward or rewind speed changes (no flush)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Fixes lack of audio when returning from fast forward or rewind back to tempo play.
Avoid unnecessary seek when returning from tempo play to normal play.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
