### PR TITLE
[Addons] Implement equals for CAddonInstallJob

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -89,6 +89,8 @@ public:
                        ADDON::RepositoryPtr& repo,
                        ADDON::AddonPtr& addon);
 
+  bool Equals(const CJob* job) const override;
+
   void SetDependsInstall(DependencyJob dependsInstall) { m_dependsInstall = dependsInstall; }
   void SetAllowCheckForUpdates(AllowCheckForUpdates allowCheckForUpdates)
   {
@@ -663,6 +665,21 @@ bool CAddonInstallJob::GetAddon(const std::string& addonID,
   repo = std::static_pointer_cast<CRepository>(tmp);
 
   return true;
+}
+
+bool CAddonInstallJob::Equals(const CJob* job) const
+{
+  if (strcmp(job->GetType(), GetType()) != 0)
+    return false;
+
+  const CAddonInstallJob* installJob = dynamic_cast<const CAddonInstallJob*>(job);
+  if (installJob == nullptr)
+    return false;
+
+  if (!m_addon || !installJob->m_addon)
+    return false;
+
+  return m_addon->ID() == installJob->m_addon->ID();
 }
 
 bool CAddonInstallJob::DoWork()


### PR DESCRIPTION
## Description
https://github.com/xbmc/xbmc/pull/27624 introduced a regression for multiple concurrent addon installations. The root cause of the issue is that `CAddonInstallJob` inherits from `CFileOperations` jobs and the parent implementation would return true for different addons. This was not really a problem before `10e6892920da` because as long as the job started processing it would be moved out of `m_jobQueue` and placed in `m_processing`. However, now, we also check if the job is a running duplicate to append callbacks to existing running jobs, so we also check the jobs that are actually processing (in `m_processing`. 
The proper solution is to correctly implement `CAddonInstallJob::Equals` so that it doesn't consider two jobs for different addons as equal. The bug itself was in Kodi already, it wasn't simply visible before.

## Motivation and context
Reported a regression reported by @ksooo on slack

## How has this been tested?
Run time tested on macOS. Deleted the addon folder, start Kodi, check that there are multiple updates and that "Update all addons" work.

## What is the effect on users?
Should restore functionality that used to work before.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

