### PR TITLE
MySQL/MariaDB Settings Refactor and new setting for MYSQL_OPT_SSL_ENFORCE option

### DIFF
--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -627,7 +627,7 @@ CDatabase::ConnectionState CDatabase::Connect(const std::string& dbName,
   // set configuration regardless if any are empty
   m_pDB->setConfig(dbSettings.key.c_str(), dbSettings.cert.c_str(), dbSettings.ca.c_str(),
                    dbSettings.capath.c_str(), dbSettings.ciphers.c_str(), dbSettings.connecttimeout,
-                   dbSettings.compression);
+                   dbSettings.enforceSsl, dbSettings.compression);
 
   // create the datasets
   m_pDS.reset(m_pDB->CreateDataset());

--- a/xbmc/dbwrappers/dataset.cpp
+++ b/xbmc/dbwrappers/dataset.cpp
@@ -46,6 +46,7 @@ int Database::connectFull(const char* newHost,
                           const char* newCA,
                           const char* newCApath,
                           const char* newCiphers,
+                          bool newEnforceSsl,
                           bool newCompression)
 {
   host = newHost;
@@ -58,6 +59,7 @@ int Database::connectFull(const char* newHost,
   ca = newCA;
   capath = newCApath;
   ciphers = newCiphers;
+  enforceSsl = newEnforceSsl;
   compression = newCompression;
 
   return connect(true);

--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -64,6 +64,7 @@ protected:
   std::string ca;
   std::string capath;
   std::string ciphers; // SSL - Encryption info
+  bool enforceSsl{false};
   unsigned int connect_timeout; // seconds
 
 public:
@@ -107,6 +108,7 @@ public:
                          const char* newCApath,
                          const char* newCiphers,
                          unsigned int newConnectTimeout,
+                         bool newEnforceSsl,
                          bool newCompression)
   {
     key = newKey;
@@ -115,6 +117,7 @@ public:
     capath = newCApath;
     ciphers = newCiphers;
     connect_timeout = newConnectTimeout;
+    enforceSsl = newEnforceSsl;
     compression = newCompression;
   }
 
@@ -136,6 +139,7 @@ public:
                           const char* newCA = nullptr,
                           const char* newCApath = nullptr,
                           const char* newCiphers = nullptr,
+                          bool newEnforceSsl = false,
                           bool newCompression = false);
   virtual void disconnect() { active = false; }
   virtual int postconnect() { return DB_COMMAND_OK; }

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -183,6 +183,8 @@ int MysqlDatabase::connect(bool create_new)
                     cert.empty() ? nullptr : cert.c_str(), ca.empty() ? nullptr : ca.c_str(),
                     capath.empty() ? nullptr : capath.c_str(),
                     ciphers.empty() ? nullptr : ciphers.c_str());
+      my_bool enforce_tls = enforceSsl;
+      mysql_options(conn, MYSQL_OPT_SSL_ENFORCE, (void*)&enforce_tls);
       mysql_options(conn, MYSQL_OPT_CONNECT_TIMEOUT, &connect_timeout);
     }
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -58,6 +58,22 @@ std::vector<CRegExp> CompileRegexesFromXML(TiXmlElement* folderStacking)
   return CompileRegexes(patterns);
 }
 
+void ParseDatabaseSettings(const TiXmlElement* element, DatabaseSettings& settings)
+{
+  XMLUtils::GetString(element, "type", settings.type);
+  XMLUtils::GetString(element, "host", settings.host);
+  XMLUtils::GetString(element, "port", settings.port);
+  XMLUtils::GetString(element, "user", settings.user);
+  XMLUtils::GetString(element, "pass", settings.pass);
+  XMLUtils::GetString(element, "name", settings.name);
+  XMLUtils::GetString(element, "key", settings.key);
+  XMLUtils::GetString(element, "cert", settings.cert);
+  XMLUtils::GetString(element, "ca", settings.ca);
+  XMLUtils::GetString(element, "capath", settings.capath);
+  XMLUtils::GetString(element, "ciphers", settings.ciphers);
+  XMLUtils::GetUInt(element, "connecttimeout", settings.connecttimeout, 1, 300);
+  XMLUtils::GetBoolean(element, "compression", settings.compression);
+}
 } // unnamed namespace
 
 void CAdvancedSettings::OnSettingsLoaded()
@@ -1223,78 +1239,24 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     }
   }
 
-  const TiXmlElement* pDatabase = pRootElement->FirstChildElement("videodatabase");
-  if (pDatabase)
+  if (const TiXmlElement* dbElement = pRootElement->FirstChildElement("videodatabase");
+      dbElement != nullptr)
   {
     CLog::Log(LOGWARNING, "VIDEO database configuration is experimental.");
-    XMLUtils::GetString(pDatabase, "type", m_databaseVideo.type);
-    XMLUtils::GetString(pDatabase, "host", m_databaseVideo.host);
-    XMLUtils::GetString(pDatabase, "port", m_databaseVideo.port);
-    XMLUtils::GetString(pDatabase, "user", m_databaseVideo.user);
-    XMLUtils::GetString(pDatabase, "pass", m_databaseVideo.pass);
-    XMLUtils::GetString(pDatabase, "name", m_databaseVideo.name);
-    XMLUtils::GetString(pDatabase, "key", m_databaseVideo.key);
-    XMLUtils::GetString(pDatabase, "cert", m_databaseVideo.cert);
-    XMLUtils::GetString(pDatabase, "ca", m_databaseVideo.ca);
-    XMLUtils::GetString(pDatabase, "capath", m_databaseVideo.capath);
-    XMLUtils::GetString(pDatabase, "ciphers", m_databaseVideo.ciphers);
-    XMLUtils::GetUInt(pDatabase, "connecttimeout", m_databaseVideo.connecttimeout, 1, 300);
-    XMLUtils::GetBoolean(pDatabase, "compression", m_databaseVideo.compression);
+    ParseDatabaseSettings(dbElement, m_databaseVideo);
   }
 
-  pDatabase = pRootElement->FirstChildElement("musicdatabase");
-  if (pDatabase)
-  {
-    XMLUtils::GetString(pDatabase, "type", m_databaseMusic.type);
-    XMLUtils::GetString(pDatabase, "host", m_databaseMusic.host);
-    XMLUtils::GetString(pDatabase, "port", m_databaseMusic.port);
-    XMLUtils::GetString(pDatabase, "user", m_databaseMusic.user);
-    XMLUtils::GetString(pDatabase, "pass", m_databaseMusic.pass);
-    XMLUtils::GetString(pDatabase, "name", m_databaseMusic.name);
-    XMLUtils::GetString(pDatabase, "key", m_databaseMusic.key);
-    XMLUtils::GetString(pDatabase, "cert", m_databaseMusic.cert);
-    XMLUtils::GetString(pDatabase, "ca", m_databaseMusic.ca);
-    XMLUtils::GetString(pDatabase, "capath", m_databaseMusic.capath);
-    XMLUtils::GetString(pDatabase, "ciphers", m_databaseMusic.ciphers);
-    XMLUtils::GetUInt(pDatabase, "connecttimeout", m_databaseMusic.connecttimeout, 1, 300);
-    XMLUtils::GetBoolean(pDatabase, "compression", m_databaseMusic.compression);
-  }
+  if (const TiXmlElement* dbElement = pRootElement->FirstChildElement("musicdatabase");
+      dbElement != nullptr)
+    ParseDatabaseSettings(dbElement, m_databaseMusic);
 
-  pDatabase = pRootElement->FirstChildElement("tvdatabase");
-  if (pDatabase)
-  {
-    XMLUtils::GetString(pDatabase, "type", m_databaseTV.type);
-    XMLUtils::GetString(pDatabase, "host", m_databaseTV.host);
-    XMLUtils::GetString(pDatabase, "port", m_databaseTV.port);
-    XMLUtils::GetString(pDatabase, "user", m_databaseTV.user);
-    XMLUtils::GetString(pDatabase, "pass", m_databaseTV.pass);
-    XMLUtils::GetString(pDatabase, "name", m_databaseTV.name);
-    XMLUtils::GetString(pDatabase, "key", m_databaseTV.key);
-    XMLUtils::GetString(pDatabase, "cert", m_databaseTV.cert);
-    XMLUtils::GetString(pDatabase, "ca", m_databaseTV.ca);
-    XMLUtils::GetString(pDatabase, "capath", m_databaseTV.capath);
-    XMLUtils::GetString(pDatabase, "ciphers", m_databaseTV.ciphers);
-    XMLUtils::GetUInt(pDatabase, "connecttimeout", m_databaseTV.connecttimeout, 1, 300);
-    XMLUtils::GetBoolean(pDatabase, "compression", m_databaseTV.compression);
-  }
+  if (const TiXmlElement* dbElement = pRootElement->FirstChildElement("tvdatabase");
+      dbElement != nullptr)
+    ParseDatabaseSettings(dbElement, m_databaseTV);
 
-  pDatabase = pRootElement->FirstChildElement("epgdatabase");
-  if (pDatabase)
-  {
-    XMLUtils::GetString(pDatabase, "type", m_databaseEpg.type);
-    XMLUtils::GetString(pDatabase, "host", m_databaseEpg.host);
-    XMLUtils::GetString(pDatabase, "port", m_databaseEpg.port);
-    XMLUtils::GetString(pDatabase, "user", m_databaseEpg.user);
-    XMLUtils::GetString(pDatabase, "pass", m_databaseEpg.pass);
-    XMLUtils::GetString(pDatabase, "name", m_databaseEpg.name);
-    XMLUtils::GetString(pDatabase, "key", m_databaseEpg.key);
-    XMLUtils::GetString(pDatabase, "cert", m_databaseEpg.cert);
-    XMLUtils::GetString(pDatabase, "ca", m_databaseEpg.ca);
-    XMLUtils::GetString(pDatabase, "capath", m_databaseEpg.capath);
-    XMLUtils::GetString(pDatabase, "ciphers", m_databaseEpg.ciphers);
-    XMLUtils::GetUInt(pDatabase, "connecttimeout", m_databaseEpg.connecttimeout, 1, 300);
-    XMLUtils::GetBoolean(pDatabase, "compression", m_databaseEpg.compression);
-  }
+  if (const TiXmlElement* dbElement = pRootElement->FirstChildElement("epgdatabase");
+      dbElement != nullptr)
+    ParseDatabaseSettings(dbElement, m_databaseEpg);
 
   pElement = pRootElement->FirstChildElement("enablemultimediakeys");
   if (pElement)

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -72,6 +72,7 @@ void ParseDatabaseSettings(const TiXmlElement* element, DatabaseSettings& settin
   XMLUtils::GetString(element, "capath", settings.capath);
   XMLUtils::GetString(element, "ciphers", settings.ciphers);
   XMLUtils::GetUInt(element, "connecttimeout", settings.connecttimeout, 1, 300);
+  XMLUtils::GetBoolean(element, "enforcessl", settings.enforceSsl);
   XMLUtils::GetBoolean(element, "compression", settings.compression);
 }
 } // unnamed namespace

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -51,6 +51,7 @@ public:
     capath.clear();
     ciphers.clear();
     connecttimeout = DEFAULT_CONNECT_TIMEOUT;
+    enforceSsl = false;
     compression = false;
   };
   std::string type;
@@ -65,6 +66,7 @@ public:
   std::string capath;
   std::string ciphers;
   unsigned int connecttimeout{DEFAULT_CONNECT_TIMEOUT};
+  bool enforceSsl{false};
   bool compression;
 };
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Address the code duplication of the advanced settings parsing of database connection parameters.

Add advanced settings `enforcessl` to the databases settings to control the MYSQL_OPT_SSL_ENFORCE option. Ex:
```
<advancedsettings>
  <videodatabase>
    <type>mysql</type>
    <host>server ip</host>
    <user>username</user>
    <pass>pwd</pass>
    <enforcessl>false</enforcessl>
  </videodatabase> 
</advancedsettings>
```

When the option is true (default of the connector since library bump to 3.3.15) an SSL/TLS connection will be attempted first for new connections, which creates a delay when contacting a server without SSL configured, and very significantly degrades the time to establish a connection.

To avoid a performance regression for now, the option will default to false in Kodi (don't attempt SSL/TLS first)
After the implementation of a database connection pool to reduce the number of connection creations it will be possible to change the default to true for improved security by default without a performance impact.

For upcoming connector 3.4.8 the setting must be combined with MYSQL_OPT_SSL_VERIFY_SERVER_CERT, see PR 27611.

@fuzzard  FYI

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #27646.

New security options default values in 3.3 of the maria db c connector cause the connection time to a server without SSL to explode (from ~30ms to 200-300ms). Some navigation creates multiple connections consecutively, resulting in a noticeable degradation for the user.
 
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Testd with the setting true and false.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Restore v21 performance.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
