### PR TITLE
MusicGUIInfo: use streamUrlData as coverURL when its an image (e.g. radio paradise)

### DIFF
--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -214,10 +214,15 @@ bool CShoutcastFile::ExtractTagInfo(const char* buf)
         if (StringUtils::StartsWithNoCase(streamUrlData, "http://") ||
             StringUtils::StartsWithNoCase(streamUrlData, "https://"))
         {
-          // Bauer Media Radio listenapi null event to erase current data
-          if (!StringUtils::EndsWithNoCase(streamUrlData, "eventdata/-1"))
+          const CURL dataURL(streamUrlData);
+          // Check if StreamUrl is a direct image URL (e.g., Radio Paradise)
+          if (dataURL.IsPicture())
           {
-            const CURL dataURL(streamUrlData);
+            coverURL = streamUrlData;
+          }
+          // Bauer Media Radio listenapi null event to erase current data
+          else if (!StringUtils::EndsWithNoCase(streamUrlData, "eventdata/-1"))
+          {
             XFILE::CCurlFile http;
             std::string extData;
 


### PR DESCRIPTION
## Description
Some radio streams (e.g. radio paradise) advertise song cover on the streamUrl metadata. e.g. 
```
ffmpeg -i https://stream.radioparadise.com/aac-320 -f null -

  Metadata:
    icy-br          : 320
    icy-description : DJ-mixed blend of modern and classic rock, electronica, world music, and more. Always 100% commercial-free
    icy-genre       : Eclectic
    icy-name        : Radio Paradise (320k aac)
    icy-pub         : 1
    icy-url         : https://radioparadise.com
    StreamTitle     : PJ Harvey - This Mess We're In (w/ Thom Yorke)
    StreamUrl       : http://img.radioparadise.com/covers/l/7427.jpg
    encoder         : Lavf61.7.100
```

This PR introduces a small change to check if StreamUrl is an image and if so set is as StationArt tag for kodi to display on the UI player and expose through jsonrpc endpoint. 

## Motivation and context
Show artwork when playing internet radio

## How has this been tested?
Build kodi locally and played radio paradise and other streams to make sure it's working as intended. Also confirm artwork shows on home assistant integration.

## What is the effect on users?
Available artwork should now appear on kodi UI audio player and integrations like Home assistant.

## Screenshots (if appropriate):
<img width="725" height="502" alt="Screenshot 2026-01-06 at 08 06 33" src="https://github.com/user-attachments/assets/1908631e-6200-436f-a08d-b6a8babfdfac" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
