### PR TITLE
ActiveAE: Fix missing initial ~200 ms of audio at playback start

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1415,7 +1415,9 @@ msgctxt "#294"
 msgid "Create bookmark"
 msgstr ""
 
-#empty string with id 295
+msgctxt "#295"
+msgid "Low latency mode"
+msgstr ""
 
 msgctxt "#296"
 msgid "Clear bookmarks"
@@ -21364,7 +21366,13 @@ msgctxt "#36415"
 msgid "No info available yet."
 msgstr ""
 
-#empty strings from id 36416 to 36418
+#empty strings from id 36416 to 36417
+
+#. Description of setting with label #295 "Low latency mode"
+#: system/settings/settings.xml
+msgctxt "#36418"
+msgid "Reduces audio processing latency. Improves playback start, unpause and seek (the audio returns sooner).\nYou can disable this setting if you experience audio issues."
+msgstr ""
 
 #. Description of setting with label #21417 "Settings"
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3254,6 +3254,11 @@
           </dependencies>
           <control type="toggle" />
         </setting>
+        <setting id="audiooutput.lowlatency" type="boolean" label="295" help="36418">
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
         <setting id="audiooutput.processquality" type="integer" label="13505" help="36169">
           <requirement>HAS_AE_QUALITY_LEVELS</requirement>
           <level>2</level>

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1962,10 +1962,17 @@ bool CActiveAE::RunStages()
   const bool isTrueHDPassthrough =
       (m_mode == MODE_RAW && m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD);
 
-  // m_targetBufferLevel grows progressively from ~0ms (virtual zero buffer and zero latency)
-  // to ~200 ms (nominal buffer and nominal latency), same as before.
-  if (m_targetBufferLevel < MAX_WATER_LEVEL)
-    m_targetBufferLevel += 0.0001f; // 2000 iterations -> ramp-up of ~10 seconds
+  if (m_settings.lowLatencyMode)
+  {
+    // m_targetBufferLevel grows progressively from ~0ms (virtual zero buffer and zero latency)
+    // to ~200 ms (nominal buffer and nominal latency), same as before.
+    if (m_targetBufferLevel < MAX_WATER_LEVEL)
+      m_targetBufferLevel += 0.0001f; // 2000 iterations -> ramp-up of ~10 seconds
+  }
+  else
+  {
+    m_targetBufferLevel = MAX_WATER_LEVEL + 0.0001f;
+  }
 
   // The buffer level "GetWaterLevel()" always tries to follow m_targetBufferLevel because when it
   // is lower, audio samples are added, and when it is higher, audio samples stop being added
@@ -1977,7 +1984,7 @@ bool CActiveAE::RunStages()
     for (it = m_streams.begin(); it != m_streams.end(); ++it)
     {
       // reset target buffer level at pause (but not initial start pause)
-      if ((*it)->m_paused && (*it)->m_started)
+      if ((*it)->m_paused && (*it)->m_started && m_settings.lowLatencyMode)
         m_targetBufferLevel = 0;
 
       if ((*it)->m_paused || !(*it)->m_started || !(*it)->m_processingBuffers || !(*it)->m_pClock)
@@ -2683,6 +2690,7 @@ void CActiveAE::LoadSettings()
   m_settings.streamNoise = settings->GetBool(CSettings::SETTING_AUDIOOUTPUT_STREAMNOISE);
   m_settings.silenceTimeoutMinutes = settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE);
   m_settings.mixSubLevel = settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_MIXSUBLEVEL) / 100.0;
+  m_settings.lowLatencyMode = settings->GetBool(CSettings::SETTING_AUDIOOUTPUT_LOWLATENCY);
 }
 
 void CActiveAE::ValidateOutputDevices(bool saveChanges)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -64,6 +64,7 @@ struct AudioSettings
   bool streamNoise;
   int silenceTimeoutMinutes;
   float mixSubLevel;
+  bool lowLatencyMode;
 };
 
 class CActiveAEControlProtocol : public Protocol

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -408,5 +408,7 @@ protected:
   float m_aeVolume;
   bool m_aeMuted;
   bool m_aeGUISoundForce;
+
+  float m_targetBufferLevel{0.0f};
 };
 };

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -414,6 +414,7 @@ public:
   static constexpr auto SETTING_AUDIOOUTPUT_DTSHDPASSTHROUGH = "audiooutput.dtshdpassthrough";
   static constexpr auto SETTING_AUDIOOUTPUT_DTSHDCOREFALLBACK = "audiooutput.dtshdcorefallback";
   static constexpr auto SETTING_AUDIOOUTPUT_VOLUMESTEPS = "audiooutput.volumesteps";
+  static constexpr auto SETTING_AUDIOOUTPUT_LOWLATENCY = "audiooutput.lowlatency";
   static constexpr auto SETTING_INPUT_PERIPHERALS = "input.peripherals";
   static constexpr auto SETTING_INPUT_PERIPHERALLIBRARIES = "input.peripherallibraries";
   static constexpr auto SETTING_INPUT_ENABLEMOUSE = "input.enablemouse";


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The constant `MAX_WATER_LEVEL` determines buffered audio time after AE stages. We want 200 ms of buffer during playback (for stability) but low latency at playback start.

The two things a same time is impossible except if constant is not constant but variable...

The transition takes 10 seconds: it's slow enough that AE won't notice anything strange.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes: https://github.com/xbmc/xbmc/issues/27645
Fixes: https://github.com/xbmc/xbmc/issues/23535

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested in Windows in debug mode and observed buffer level variable it behaves as expected in several scenario's (pause, rewind, seek, etc). 
- Tested also playback one video without stop previous (keep playback in background). 
- Tested GUI sounds.
- Tested in Shield: tested passthrough, tested TrueHD passthrough, tested audio transcoding to AC3. No issues found.  

After testing, it exceeded even my expectations: besides fixing the initial audio issue, it greatly improves the pause (the audio returns much faster). The audio also returns sooner after the seek, etc. All this also with passthrough. 🙂

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Fix missing initial ~200 ms of audio at playback start. 

The changes should be very safe because after a transitory at the beginning of playback, everything remains the same as before. No timings or buffered length changed at all.

## Screenshots (if appropriate):

<img width="1920" height="1129" alt="screenshot00002" src="https://github.com/user-attachments/assets/a06a041d-3618-42b7-93ff-b740a5318f45" />




## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
