### PR TITLE
[dialogs] Fix crash on install add-on from zip file.

### DIFF
--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -611,6 +611,20 @@ void CGUIDialogFileBrowser::OnWindowUnload()
   m_viewControl.Reset();
 }
 
+namespace
+{
+CGUIDialogFileBrowser* GetUniqueBrowserInstance()
+{
+  auto browser = new CGUIDialogFileBrowser();
+
+  // Register new window with window manager. This hands ownership of browser pointer over
+  // to the window manager! So, no delete of the instance created here is needed.
+  CServiceBroker::GetGUI()->GetWindowManager().AddUniqueInstance(browser);
+
+  return browser;
+}
+} // unnamed namespace
+
 bool CGUIDialogFileBrowser::ShowAndGetImage(const CFileItemList& items,
                                             const std::vector<CMediaSource>& shares,
                                             const std::string& heading,
@@ -618,10 +632,9 @@ bool CGUIDialogFileBrowser::ShowAndGetImage(const CFileItemList& items,
                                             bool* flip,
                                             int label)
 {
-  CGUIDialogFileBrowser *browser = new CGUIDialogFileBrowser();
+  CGUIDialogFileBrowser* const browser{GetUniqueBrowserInstance()};
   if (!browser)
     return false;
-  CServiceBroker::GetGUI()->GetWindowManager().AddUniqueInstance(browser);
 
   browser->m_browsingForImages = true;
   browser->m_singleList = true;
@@ -644,7 +657,6 @@ bool CGUIDialogFileBrowser::ShowAndGetImage(const CFileItemList& items,
     if (result == "image://Browse")
     { // "Browse for thumb"
       CServiceBroker::GetGUI()->GetWindowManager().Remove(browser->GetID());
-      delete browser;
       return ShowAndGetImage(shares, g_localizeStrings.Get(label), result);
     }
   }
@@ -653,8 +665,6 @@ bool CGUIDialogFileBrowser::ShowAndGetImage(const CFileItemList& items,
     *flip = browser->m_bFlip != 0;
 
   CServiceBroker::GetGUI()->GetWindowManager().Remove(browser->GetID());
-  delete browser;
-
   return confirmed;
 }
 
@@ -700,10 +710,9 @@ bool CGUIDialogFileBrowser::ShowAndGetFile(const std::vector<CMediaSource>& shar
                                            bool useThumbs /* = false */,
                                            bool useFileDirectories /* = false */)
 {
-  CGUIDialogFileBrowser *browser = new CGUIDialogFileBrowser();
+  CGUIDialogFileBrowser* const browser{GetUniqueBrowserInstance()};
   if (!browser)
     return false;
-  CServiceBroker::GetGUI()->GetWindowManager().AddUniqueInstance(browser);
 
   browser->m_useFileDirectories = useFileDirectories;
 
@@ -730,17 +739,15 @@ bool CGUIDialogFileBrowser::ShowAndGetFile(const std::vector<CMediaSource>& shar
   if (confirmed)
     path = browser->m_selectedPath;
   CServiceBroker::GetGUI()->GetWindowManager().Remove(browser->GetID());
-  delete browser;
   return confirmed;
 }
 
 // same as above, starting in a single directory
 bool CGUIDialogFileBrowser::ShowAndGetFile(const std::string &directory, const std::string &mask, const std::string &heading, std::string &path, bool useThumbs /* = false */, bool useFileDirectories /* = false */, bool singleList /* = false */)
 {
-  CGUIDialogFileBrowser *browser = new CGUIDialogFileBrowser();
+  CGUIDialogFileBrowser* const browser{GetUniqueBrowserInstance()};
   if (!browser)
     return false;
-  CServiceBroker::GetGUI()->GetWindowManager().AddUniqueInstance(browser);
 
   browser->m_useFileDirectories = useFileDirectories;
   browser->m_browsingForImages = useThumbs;
@@ -788,14 +795,12 @@ bool CGUIDialogFileBrowser::ShowAndGetFile(const std::string &directory, const s
   if (path == "file://Browse")
   { // "Browse for thumb"
     CServiceBroker::GetGUI()->GetWindowManager().Remove(browser->GetID());
-    delete browser;
     std::vector<CMediaSource> shares;
     CServiceBroker::GetMediaManager().GetLocalDrives(shares);
 
     return ShowAndGetFile(shares, mask, heading, path, useThumbs,useFileDirectories);
   }
   CServiceBroker::GetGUI()->GetWindowManager().Remove(browser->GetID());
-  delete browser;
   return confirmed;
 }
 
@@ -806,10 +811,9 @@ bool CGUIDialogFileBrowser::ShowAndGetFileList(const std::vector<CMediaSource>& 
                                                bool useThumbs /* = false */,
                                                bool useFileDirectories /* = false */)
 {
-  CGUIDialogFileBrowser *browser = new CGUIDialogFileBrowser();
+  CGUIDialogFileBrowser* const browser{GetUniqueBrowserInstance()};
   if (!browser)
     return false;
-  CServiceBroker::GetGUI()->GetWindowManager().AddUniqueInstance(browser);
 
   browser->m_useFileDirectories = useFileDirectories;
   browser->m_multipleSelection = true;
@@ -829,7 +833,6 @@ bool CGUIDialogFileBrowser::ShowAndGetFileList(const std::vector<CMediaSource>& 
       path.push_back(browser->m_selectedPath);
   }
   CServiceBroker::GetGUI()->GetWindowManager().Remove(browser->GetID());
-  delete browser;
   return confirmed;
 }
 
@@ -859,12 +862,9 @@ bool CGUIDialogFileBrowser::ShowAndGetSource(
   // 4.  Optionally allow user to browse the local and network locations for their share.
   // 5.  On OK, return.
 
-  // Create a new filebrowser window
-  CGUIDialogFileBrowser *browser = new CGUIDialogFileBrowser();
-  if (!browser) return false;
-
-  // Add it to our window manager
-  CServiceBroker::GetGUI()->GetWindowManager().AddUniqueInstance(browser);
+  CGUIDialogFileBrowser* const browser{GetUniqueBrowserInstance()};
+  if (!browser)
+    return false;
 
   std::vector<CMediaSource> shares;
   if (!strType.empty())
@@ -904,7 +904,6 @@ bool CGUIDialogFileBrowser::ShowAndGetSource(
     path = browser->m_selectedPath;
 
   CServiceBroker::GetGUI()->GetWindowManager().Remove(browser->GetID());
-  delete browser;
   return confirmed;
 }
 


### PR DESCRIPTION
## Description
Fixes #27653 
Regression introduced with #27620, and actually not only install add-ons from zip files is affected.

@enen92 please review.

## Motivation and context
Fix #27653 

## How has this been tested?
Manually, by installing an add-on from a zip file.

## What is the effect on users?
Add-ons can be installed from zip files again.

## Screenshots (if appropriate):
n/a

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
