### PR TITLE
CShoutcastFile::Process: Send Player.OnPropertyChanged for radio stream metadata updates

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -12189,9 +12189,15 @@ void CGUIInfoManager::OnApplicationMessage(KODI::MESSAGING::ThreadMessage* pMsg)
       return;
 
     if (pMsg->param1 == 1 && item->HasMusicInfoTag()) // only grab music tag
+    {
       SetCurrentSongTag(*item->GetMusicInfoTag());
+      CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Info, "OnChanged");
+    }
     else if (pMsg->param1 == 2 && item->HasVideoInfoTag()) // only grab video tag
+    {
       SetCurrentVideoTag(*item->GetVideoInfoTag());
+      CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Info, "OnChanged");
+    }
     else
       SetCurrentItem(*item);
 

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -361,14 +361,14 @@ void CShoutcastFile::Process()
           const TagInfo& tagInfo = front;
           CFileItem* item = new CFileItem(*tagInfo.second); // will be deleted by msg receiver
           CFileItemPtr itemPtr = std::make_shared<CFileItem>(*tagInfo.second);
-          const auto& musicTag = tagInfo.second; // Read while holding lock and before pop()
+          const auto& musicTag = tagInfo.second;
+          // Discard first placeholder/master tag with only station info
           bool shouldAnnounce = !musicTag->GetTitle().empty() || !musicTag->GetArtist().empty();
           m_tags.pop();
           CSingleExit ex(m_tagSection);
           CServiceBroker::GetAppMessenger()->PostMsg(TMSG_UPDATE_CURRENT_ITEM, 1, -1,
                                                      static_cast<void*>(item));
 
-          // Announce property change for radio stream metadata updates
           if (shouldAnnounce)
           {
             const auto& components = CServiceBroker::GetAppComponents();
@@ -378,8 +378,8 @@ void CShoutcastFile::Process()
             {
               CVariant data;
               data["player"]["playerid"] = static_cast<int>(PLAYLIST::Id::TYPE_MUSIC);
-              CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPropertyChanged",
-                                                                 itemPtr, data);
+              CServiceBroker::GetAnnouncementManager()->Announce(
+                  ANNOUNCEMENT::Player, "OnPropertyChanged", itemPtr, data);
             }
           }
         }

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -372,7 +372,6 @@ void CShoutcastFile::Process()
               CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST::Id::TYPE_MUSIC)
           {
             const auto& musicTag = tagInfo.second;
-            // also discards first placeholder/master tag with only station info
             if (!musicTag->GetTitle().empty() || !musicTag->GetArtist().empty())
             {
               CVariant data;

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -374,7 +374,8 @@ void CShoutcastFile::Process()
             const auto& components = CServiceBroker::GetAppComponents();
             const auto appPlayer = components.GetComponent<CApplicationPlayer>();
             if (appPlayer->IsPlayingAudio() &&
-                CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST::Id::TYPE_MUSIC)
+                CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() ==
+                    PLAYLIST::Id::TYPE_MUSIC)
             {
               CVariant data;
               data["player"]["playerid"] = static_cast<int>(PLAYLIST::Id::TYPE_MUSIC);

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -372,6 +372,7 @@ void CShoutcastFile::Process()
               CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST::Id::TYPE_MUSIC)
           {
             const auto& musicTag = tagInfo.second;
+            // also discards first placeholder/master tag with only station info
             if (!musicTag->GetTitle().empty() || !musicTag->GetArtist().empty())
             {
               CVariant data;

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -361,14 +361,14 @@ void CShoutcastFile::Process()
           const TagInfo& tagInfo = front;
           CFileItem* item = new CFileItem(*tagInfo.second); // will be deleted by msg receiver
           CFileItemPtr itemPtr = std::make_shared<CFileItem>(*tagInfo.second);
-          const auto& musicTag = tagInfo.second;
-          // Discard first placeholder/master tag with only station info
+          const auto& musicTag = tagInfo.second; // Read while holding lock and before pop()
           bool shouldAnnounce = !musicTag->GetTitle().empty() || !musicTag->GetArtist().empty();
           m_tags.pop();
           CSingleExit ex(m_tagSection);
           CServiceBroker::GetAppMessenger()->PostMsg(TMSG_UPDATE_CURRENT_ITEM, 1, -1,
                                                      static_cast<void*>(item));
 
+          // Announce property change for radio stream metadata updates
           if (shouldAnnounce)
           {
             const auto& components = CServiceBroker::GetAppComponents();
@@ -378,8 +378,8 @@ void CShoutcastFile::Process()
             {
               CVariant data;
               data["player"]["playerid"] = static_cast<int>(PLAYLIST::Id::TYPE_MUSIC);
-              CServiceBroker::GetAnnouncementManager()->Announce(
-                  ANNOUNCEMENT::Player, "OnPropertyChanged", itemPtr, data);
+              CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPropertyChanged",
+                                                                 itemPtr, data);
             }
           }
         }

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -361,19 +361,20 @@ void CShoutcastFile::Process()
           const TagInfo& tagInfo = front;
           CFileItem* item = new CFileItem(*tagInfo.second); // will be deleted by msg receiver
           CFileItemPtr itemPtr = std::make_shared<CFileItem>(*tagInfo.second);
+          const auto& musicTag = tagInfo.second; // Read while holding lock and before pop()
+          bool shouldAnnounce = !musicTag->GetTitle().empty() || !musicTag->GetArtist().empty();
           m_tags.pop();
+          CSingleExit ex(m_tagSection);
           CServiceBroker::GetAppMessenger()->PostMsg(TMSG_UPDATE_CURRENT_ITEM, 1, -1,
                                                      static_cast<void*>(item));
 
           // Announce property change for radio stream metadata updates
-          const auto& components = CServiceBroker::GetAppComponents();
-          const auto appPlayer = components.GetComponent<CApplicationPlayer>();
-          if (appPlayer->IsPlayingAudio() &&
-              CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST::Id::TYPE_MUSIC)
+          if (shouldAnnounce)
           {
-            const auto& musicTag = tagInfo.second;
-            // also discards first placeholder/master tag with only station info
-            if (!musicTag->GetTitle().empty() || !musicTag->GetArtist().empty())
+            const auto& components = CServiceBroker::GetAppComponents();
+            const auto appPlayer = components.GetComponent<CApplicationPlayer>();
+            if (appPlayer->IsPlayingAudio() &&
+                CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST::Id::TYPE_MUSIC)
             {
               CVariant data;
               data["player"]["playerid"] = static_cast<int>(PLAYLIST::Id::TYPE_MUSIC);

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -15,7 +15,6 @@
 
 #include "FileCache.h"
 #include "FileItem.h"
-#include "PlayListPlayer.h"
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "application/ApplicationComponents.h"
@@ -24,6 +23,7 @@
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "music/tags/MusicInfoTag.h"
+#include "PlayListPlayer.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "threads/SingleLock.h"

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -371,14 +371,10 @@ void CShoutcastFile::Process()
           if (appPlayer->IsPlayingAudio() &&
               CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST::Id::TYPE_MUSIC)
           {
-            const auto& musicTag = tagInfo.second;
-            if (!musicTag->GetTitle().empty() || !musicTag->GetArtist().empty())
-            {
-              CVariant data;
-              data["player"]["playerid"] = static_cast<int>(PLAYLIST::Id::TYPE_MUSIC);
-              CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPropertyChanged",
-                                                                 itemPtr, data);
-            }
+            CVariant data;
+            data["player"]["playerid"] = static_cast<int>(PLAYLIST::Id::TYPE_MUSIC);
+            CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPropertyChanged",
+                                                               itemPtr, data);
           }
         }
       }

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -371,10 +371,14 @@ void CShoutcastFile::Process()
           if (appPlayer->IsPlayingAudio() &&
               CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST::Id::TYPE_MUSIC)
           {
-            CVariant data;
-            data["player"]["playerid"] = static_cast<int>(PLAYLIST::Id::TYPE_MUSIC);
-            CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPropertyChanged",
-                                                               itemPtr, data);
+            const auto& musicTag = tagInfo.second;
+            if (!musicTag->GetTitle().empty() || !musicTag->GetArtist().empty())
+            {
+              CVariant data;
+              data["player"]["playerid"] = static_cast<int>(PLAYLIST::Id::TYPE_MUSIC);
+              CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPropertyChanged",
+                                                                 itemPtr, data);
+            }
           }
         }
       }

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -15,6 +15,7 @@
 
 #include "FileCache.h"
 #include "FileItem.h"
+#include "PlayListPlayer.h"
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "application/ApplicationComponents.h"
@@ -23,7 +24,6 @@
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "music/tags/MusicInfoTag.h"
-#include "PlayListPlayer.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "threads/SingleLock.h"

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -17,13 +17,9 @@
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "URL.h"
-#include "application/ApplicationComponents.h"
-#include "application/ApplicationPlayer.h"
 #include "filesystem/CurlFile.h"
-#include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "music/tags/MusicInfoTag.h"
-#include "PlayListPlayer.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "threads/SingleLock.h"
@@ -33,13 +29,11 @@
 #include "utils/RegExp.h"
 #include "utils/StringUtils.h"
 #include "utils/UrlOptions.h"
-#include "utils/Variant.h"
 
 #include <climits>
 #include <memory>
 #include <mutex>
 
-using namespace KODI;
 using namespace XFILE;
 using namespace MUSIC_INFO;
 using namespace std::chrono_literals;
@@ -358,24 +352,10 @@ void CShoutcastFile::Process()
         }
         else
         {
-          const TagInfo& tagInfo = front;
-          CFileItem* item = new CFileItem(*tagInfo.second); // will be deleted by msg receiver
-          CFileItemPtr itemPtr = std::make_shared<CFileItem>(*tagInfo.second);
+          CFileItem* item = new CFileItem(*front.second); // will be deleted by msg receiver
           m_tags.pop();
           CServiceBroker::GetAppMessenger()->PostMsg(TMSG_UPDATE_CURRENT_ITEM, 1, -1,
                                                      static_cast<void*>(item));
-
-          // Announce property change for radio stream metadata updates
-          const auto& components = CServiceBroker::GetAppComponents();
-          const auto appPlayer = components.GetComponent<CApplicationPlayer>();
-          if (appPlayer->IsPlayingAudio() &&
-              CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST::Id::TYPE_MUSIC)
-          {
-            CVariant data;
-            data["player"]["playerid"] = static_cast<int>(PLAYLIST::Id::TYPE_MUSIC);
-            CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPropertyChanged",
-                                                               itemPtr, data);
-          }
         }
       }
     }

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -374,8 +374,7 @@ void CShoutcastFile::Process()
             const auto& components = CServiceBroker::GetAppComponents();
             const auto appPlayer = components.GetComponent<CApplicationPlayer>();
             if (appPlayer->IsPlayingAudio() &&
-                CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() ==
-                    PLAYLIST::Id::TYPE_MUSIC)
+                CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST::Id::TYPE_MUSIC)
             {
               CVariant data;
               data["player"]["playerid"] = static_cast<int>(PLAYLIST::Id::TYPE_MUSIC);

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -17,9 +17,13 @@
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "URL.h"
+#include "application/ApplicationComponents.h"
+#include "application/ApplicationPlayer.h"
 #include "filesystem/CurlFile.h"
+#include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "music/tags/MusicInfoTag.h"
+#include "PlayListPlayer.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "threads/SingleLock.h"
@@ -29,11 +33,13 @@
 #include "utils/RegExp.h"
 #include "utils/StringUtils.h"
 #include "utils/UrlOptions.h"
+#include "utils/Variant.h"
 
 #include <climits>
 #include <memory>
 #include <mutex>
 
+using namespace KODI;
 using namespace XFILE;
 using namespace MUSIC_INFO;
 using namespace std::chrono_literals;
@@ -352,10 +358,24 @@ void CShoutcastFile::Process()
         }
         else
         {
-          CFileItem* item = new CFileItem(*front.second); // will be deleted by msg receiver
+          const TagInfo& tagInfo = front;
+          CFileItem* item = new CFileItem(*tagInfo.second); // will be deleted by msg receiver
+          CFileItemPtr itemPtr = std::make_shared<CFileItem>(*tagInfo.second);
           m_tags.pop();
           CServiceBroker::GetAppMessenger()->PostMsg(TMSG_UPDATE_CURRENT_ITEM, 1, -1,
                                                      static_cast<void*>(item));
+
+          // Announce property change for radio stream metadata updates
+          const auto& components = CServiceBroker::GetAppComponents();
+          const auto appPlayer = components.GetComponent<CApplicationPlayer>();
+          if (appPlayer->IsPlayingAudio() &&
+              CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST::Id::TYPE_MUSIC)
+          {
+            CVariant data;
+            data["player"]["playerid"] = static_cast<int>(PLAYLIST::Id::TYPE_MUSIC);
+            CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPropertyChanged",
+                                                               itemPtr, data);
+          }
         }
       }
     }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Send `Player.OnPropertyChanged` on metadata changes during SHOUTcast (radio) streams. Example:

```
{"jsonrpc":"2.0","method":"Player.OnPropertyChanged","params":{"data":{"item":{"artist":["Paris Paloma"],"title":"Good Boy","type":"song"},"player":{"playerid":0}},"sender":"xbmc"}}
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Radio streams can send metadata updates for each song during playback. While Kodi PAPlayer correctly updates the UI, no WS event is ever sent, so player state on integrations becomes stale. This PR sends a `Player.OnPropertyChanged` on metadata changes so integrations are aware artist/title changed. 

## How has this been tested?
build and tested locally with several streams.

Findings: First I wanted to skip sending the first announcement, because technically its not a "change" but more of an "initialization". But then, i've noticed some radios (KEXP) do long interludes and the metadata is first applied long after starting. So better to be a bit "noisy" than keeping integrations stale.

https://stream.radioparadise.com/aac-320
notice `Player.OnAVStart` after `Player.OnPropertyChanged` (noisy)
```
{"jsonrpc":"2.0","method":"Info.OnChanged","params":{"data":null,"sender":"xbmc"}}
{"jsonrpc":"2.0","method":"Player.OnPlay","params":{"data":{"item":{"type":"unknown"},"player":{"playerid":0,"speed":1}},"sender":"xbmc"}}
{"jsonrpc":"2.0","method":"Player.OnPropertyChanged","params":{"data":{"item":{"artist":["Kaleo"],"title":"Run No More","type":"song"},"player":{"playerid":0}},"sender":"xbmc"}}
{"jsonrpc":"2.0","method":"Player.OnAVStart","params":{"data":{"item":{"type":"unknown"},"player":{"playerid":0,"speed":1}},"sender":"xbmc"}}
{"jsonrpc":"2.0","method":"Player.OnPropertyChanged","params":{"data":{"item":{"artist":["The Shins"],"title":"Black Wave","type":"song"},"player":{"playerid":0}},"sender":"xbmc"}}
{"jsonrpc":"2.0","method":"Player.OnPropertyChanged","params":{"data":{"item":{"artist":["Namaste"],"title":"Jam","type":"song"},"player":{"playerid":0}},"sender":"xbmc"}}
{"jsonrpc":"2.0","method":"Player.OnPropertyChanged","params":{"data":{"item":{"artist":["The Smashing Pumpkins"],"title":"Set the Ray To Jerry","type":"song"},"player":{"playerid":0}},"sender":"xbmc"}}
```

https://kexp.streamguys1.com/kexp160.aac
notice `Player.OnAVStart` before `Player.OnPropertyChanged` (aka not noisy)
```
{"jsonrpc":"2.0","method":"Info.OnChanged","params":{"data":null,"sender":"xbmc"}}
{"jsonrpc":"2.0","method":"Player.OnPlay","params":{"data":{"item":{"type":"unknown"},"player":{"playerid":0,"speed":1}},"sender":"xbmc"}}
{"jsonrpc":"2.0","method":"Player.OnAVStart","params":{"data":{"item":{"type":"unknown"},"player":{"playerid":0,"speed":1}},"sender":"xbmc"}}
{"jsonrpc":"2.0","method":"Player.OnPropertyChanged","params":{"data":{"item":{"artist":["Cheryl Waters"],"title":"The Midday Show","type":"song"},"player":{"playerid":0}},"sender":"xbmc"}}
{"jsonrpc":"2.0","method":"Player.OnPropertyChanged","params":{"data":{"item":{"artist":["Cat Power"],"title":"The Moon","type":"song"},"player":{"playerid":0}},"sender":"xbmc"}}
``` 

## What is the effect on users?
Integrations relying on WS events can now keep metadata in sync during shoutcast playbacks.


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
