### PR TITLE
[Addons] Avoid delete since window ownership belongs to CGUIWindowMan…

### DIFF
--- a/xbmc/addons/interfaces/gui/Window.cpp
+++ b/xbmc/addons/interfaces/gui/Window.cpp
@@ -229,12 +229,9 @@ void Interface_GUIWindow::destroy(KODI_HANDLE kodiBase, KODI_GUI_WINDOW_HANDLE h
     }
     // Free any window properties
     pAddonWindow->ClearProperties();
-    // free the window's resources and unload it (free all guicontrols)
-    pAddonWindow->FreeResources(true);
-
-    CServiceBroker::GetGUI()->GetWindowManager().Remove(pAddonWindow->GetID());
+    // Unload window, freeing all of its resources
+    CServiceBroker::GetGUI()->GetWindowManager().Delete(pAddonWindow->GetID());
   }
-  delete pAddonWindow;
   Interface_GUIGeneral::unlock();
 }
 

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -700,8 +700,9 @@ void CGUIWindowManager::Remove(int id)
   }
 }
 
-// removes and deletes the window.  Should only be called
-// from the class that created the window using new.
+// Removes and deletes the window. Should only be called
+// from the class that created the window and transferred
+// ownership to CGUIWindowManager via Add.
 void CGUIWindowManager::Delete(int id)
 {
   std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());


### PR DESCRIPTION
…ager

## Description
Fixes another regression caused by https://github.com/xbmc/xbmc/pull/27620. Since now ownership belongs to CGUIWindowManager (vector of `shared_ptr`) clients should avoid deleting the pointer manually. In this case, `Delete` is the way to go since it makes sure the window is not only deleted from the map but also moved into the vector containing windows marked for deletion (which will be empty in the next FrameMove() iteration along with any resources (controlgroups) bound to it).

## Motivation and context
Fixes another issue reported by @ksooo 

## How has this been tested?
Compiled only I don't know how to reproduce. Code logic seems to be correct though.

## What is the effect on users?
No crashes

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

