### PR TITLE
[macOS] Only disable GUI rendering if the window is not visible

### DIFF
--- a/xbmc/windowing/osx/OpenGL/WindowControllerMacOS.mm
+++ b/xbmc/windowing/osx/OpenGL/WindowControllerMacOS.mm
@@ -116,7 +116,7 @@ void EnableRenderGUI(bool enable)
   g_application.m_AppFocused = true;
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::GUI, "WindowFocused");
 
-  EnableRenderGUI(true);
+  EnableRenderGUI([self isWindowVisible]);
 
   auto winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
   if (winSystem)
@@ -129,8 +129,6 @@ void EnableRenderGUI(bool enable)
 {
   g_application.m_AppFocused = false;
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::GUI, "WindowUnfocused");
-
-  EnableRenderGUI(false);
 
   auto winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
   if (winSystem)
@@ -151,7 +149,12 @@ void EnableRenderGUI(bool enable)
 {
   g_application.m_AppFocused = true;
 
-  EnableRenderGUI(true);
+  EnableRenderGUI([self isWindowVisible]);
+}
+
+- (void)windowDidChangeOcclusionState:(NSNotification*)aNotification
+{
+  EnableRenderGUI([self isWindowVisible]);
 }
 
 - (void)windowDidMove:(NSNotification*)aNotification
@@ -270,4 +273,10 @@ void EnableRenderGUI(bool enable)
     return;
   winSystem->SignalFullScreenStateChanged(true);
 }
+
+- (BOOL)isWindowVisible
+{
+  return (self.window.occlusionState & NSWindowOcclusionStateVisible) != 0;
+}
+
 @end


### PR DESCRIPTION
## Description
https://github.com/xbmc/xbmc/pull/27273 disabled GUI rendering whenever the window resigns its key window state (gets unfocused). However, it doesn't make sense since the application/window may still be visible and actually playing video content - it's just not the key window. Instead, disable GUI rendering when the window actually gets completely occluded and enable GUI rendering when it's partially visible.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/27435 

## How has this been tested?
Runtime tested by checking the CPU load in xcode while playing a video (window occluded, window partially visible, etc).

## What is the effect on users?
They should now be able to have Kodi rendering if the window is visible. CPU load reduced if the window is not visible.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

