### PR TITLE
[GUIDialogFileBrowser] Use Delete instead of Remove for proper window…

### DIFF
--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -656,7 +656,7 @@ bool CGUIDialogFileBrowser::ShowAndGetImage(const CFileItemList& items,
     result = browser->m_selectedPath;
     if (result == "image://Browse")
     { // "Browse for thumb"
-      CServiceBroker::GetGUI()->GetWindowManager().Remove(browser->GetID());
+      CServiceBroker::GetGUI()->GetWindowManager().Delete(browser->GetID());
       return ShowAndGetImage(shares, g_localizeStrings.Get(label), result);
     }
   }
@@ -664,7 +664,7 @@ bool CGUIDialogFileBrowser::ShowAndGetImage(const CFileItemList& items,
   if (flip)
     *flip = browser->m_bFlip != 0;
 
-  CServiceBroker::GetGUI()->GetWindowManager().Remove(browser->GetID());
+  CServiceBroker::GetGUI()->GetWindowManager().Delete(browser->GetID());
   return confirmed;
 }
 
@@ -738,7 +738,7 @@ bool CGUIDialogFileBrowser::ShowAndGetFile(const std::vector<CMediaSource>& shar
   bool confirmed(browser->IsConfirmed());
   if (confirmed)
     path = browser->m_selectedPath;
-  CServiceBroker::GetGUI()->GetWindowManager().Remove(browser->GetID());
+  CServiceBroker::GetGUI()->GetWindowManager().Delete(browser->GetID());
   return confirmed;
 }
 
@@ -794,13 +794,13 @@ bool CGUIDialogFileBrowser::ShowAndGetFile(const std::string &directory, const s
     path = browser->m_selectedPath;
   if (path == "file://Browse")
   { // "Browse for thumb"
-    CServiceBroker::GetGUI()->GetWindowManager().Remove(browser->GetID());
+    CServiceBroker::GetGUI()->GetWindowManager().Delete(browser->GetID());
     std::vector<CMediaSource> shares;
     CServiceBroker::GetMediaManager().GetLocalDrives(shares);
 
     return ShowAndGetFile(shares, mask, heading, path, useThumbs,useFileDirectories);
   }
-  CServiceBroker::GetGUI()->GetWindowManager().Remove(browser->GetID());
+  CServiceBroker::GetGUI()->GetWindowManager().Delete(browser->GetID());
   return confirmed;
 }
 
@@ -832,7 +832,7 @@ bool CGUIDialogFileBrowser::ShowAndGetFileList(const std::vector<CMediaSource>& 
     else
       path.push_back(browser->m_selectedPath);
   }
-  CServiceBroker::GetGUI()->GetWindowManager().Remove(browser->GetID());
+  CServiceBroker::GetGUI()->GetWindowManager().Delete(browser->GetID());
   return confirmed;
 }
 
@@ -903,7 +903,7 @@ bool CGUIDialogFileBrowser::ShowAndGetSource(
   if (confirmed)
     path = browser->m_selectedPath;
 
-  CServiceBroker::GetGUI()->GetWindowManager().Remove(browser->GetID());
+  CServiceBroker::GetGUI()->GetWindowManager().Delete(browser->GetID());
   return confirmed;
 }
 


### PR DESCRIPTION
… prunning

## Description
Follow up to https://github.com/xbmc/xbmc/pull/27654 and for consistency with https://github.com/xbmc/xbmc/pull/27656. When dialogs/windows are created by external components and added to window manager they should actually use `Delete` instead of just `Remove` to ensure proper cleanup of the window resources. `Delete` removes the window from the map but also moves the window into the list of windows marked for deletion. On the next `FrameMove` any windows marked for deletion have their resources pruned (e.g. control groups) before getting unused/freed avoiding leaks.

## Motivation and context
Makes sense and is a safer way to ensure all resources belonging to the window are actually deleted.

## How has this been tested?
Compiled, installed an addon.

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

