### PR TITLE
ModuleHelpers.cmake: handle empty options as [] not ['']

### DIFF
--- a/cmake/scripts/common/ModuleHelpers.cmake
+++ b/cmake/scripts/common/ModuleHelpers.cmake
@@ -895,12 +895,15 @@ function(create_mesonbuiltin)
 
     set(input "${CMAKE_${cmake_flag_name}} ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_${cmake_flag_name}}")
     string(STRIP "${input}" input)
-
-    # builtinpairs cmake source variables are specifically single strings, and not lists
-    string(REGEX REPLACE "[ ]+" "', '" tmp_string "${input}")
-    string(PREPEND tmp_string "${meson_label_name} = ['")
-    string(APPEND tmp_string "']")
-    string(APPEND output_string "${tmp_string}\n")
+    if(input STREQUAL "")
+      string(APPEND output_string "${meson_label_name} = []\n")
+    else()
+      # builtinpairs cmake source variables are specifically single strings, and not lists
+      string(REGEX REPLACE "[ ]+" "', '" tmp_string "${input}")
+      string(PREPEND tmp_string "${meson_label_name} = ['")
+      string(APPEND tmp_string "']")
+      string(APPEND output_string "${tmp_string}\n")
+    endif()
   endforeach()
 
   # allow a module to override the default_library type.


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

cmake script doesn't handle well empty options, generating

```
c_link_args = ['']
cpp_link_args = ['']
```
instead of 
```
c_link_args = []
cpp_link_args = []
```

This patch adds a check for a special case when options are empty

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Building from source on linux is broken with
```
/usr/bin/ld: cannot find : No such file or directory
```

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Building successfully after the patch

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Build kodi on linux

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
