### PR TITLE
[Subtitles][CC] Add support for H264 AVCC to bitstream parser

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/CMakeLists.txt
@@ -2,6 +2,11 @@ set(SOURCES DemuxMultiSource.cpp
             DVDDemux.cpp
             DVDDemuxBXA.cpp
             DVDDemuxCC.cpp
+            DVDDemuxCC/CCBitstreamParserFactory.cpp
+            DVDDemuxCC/H264AnnexBBitstreamParser.cpp
+            DVDDemuxCC/H264AVCCBitstreamParser.cpp
+            DVDDemuxCC/H264CCBitstreamParser.cpp
+            DVDDemuxCC/MPEG2CCBitstreamParser.cpp
             DVDDemuxCDDA.cpp
             DVDDemuxClient.cpp
             DVDDemuxFFmpeg.cpp
@@ -13,6 +18,14 @@ set(HEADERS DemuxMultiSource.h
             DVDDemux.h
             DVDDemuxBXA.h
             DVDDemuxCC.h
+            DVDDemuxCC/Bitstream.h
+            DVDDemuxCC/CaptionBlock.h
+            DVDDemuxCC/CCBitstreamParserFactory.h
+            DVDDemuxCC/H264AnnexBBitstreamParser.h
+            DVDDemuxCC/H264AVCCBitstreamParser.h
+            DVDDemuxCC/H264CCBitstreamParser.h
+            DVDDemuxCC/ICCBitstreamParser.h
+            DVDDemuxCC/MPEG2CCBitstreamParser.h
             DVDDemuxCDDA.h
             DVDDemuxClient.h
             DVDDemuxFFmpeg.h

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
@@ -22,6 +22,8 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <iterator>
+#include <ranges>
 #include <utility>
 
 namespace COLOR = KODI::UTILS::COLOR;
@@ -172,11 +174,7 @@ DemuxPacket* CDVDDemuxCC::Read(DemuxPacket *pSrcPacket)
   }
 
   // Move temp buffer to reorder buffer
-  while (!m_ccTempBuffer.empty())
-  {
-    m_ccReorderBuffer.push_back(std::move(m_ccTempBuffer.back()));
-    m_ccTempBuffer.pop_back();
-  }
+  std::ranges::move(std::views::reverse(m_ccTempBuffer), std::back_inserter(m_ccReorderBuffer));
 
   if (!m_parser)
   {

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -8,6 +8,8 @@
 
 #include "DVDDemuxCC.h"
 
+#include "DVDDemuxCC/CCBitstreamParserFactory.h"
+#include "DVDDemuxCC/CaptionBlock.h"
 #include "DVDDemuxUtils.h"
 #include "ServiceBroker.h"
 #include "cores/VideoPlayer/DVDCodecs/Overlay/contrib/cc_decoder708.h"
@@ -107,108 +109,16 @@ void ApplyStyleModifiers(std::string& ccText, const cc_attribute_t& ccAttributes
 }
 } // namespace
 
-class CBitstream
-{
-public:
-  CBitstream(uint8_t *data, int bits)
-  {
-    m_data = data;
-    m_offset = 0;
-    m_len = bits;
-    m_error = false;
-  }
-  unsigned int readBits(int num)
-  {
-    int r = 0;
-    while (num > 0)
-    {
-      if (m_offset >= m_len)
-      {
-        m_error = true;
-        return 0;
-      }
-      num--;
-      if (m_data[m_offset / 8] & (1 << (7 - (m_offset & 7))))
-        r |= 1 << num;
-      m_offset++;
-    }
-    return r;
-  }
-  unsigned int readGolombUE(int maxbits = 32)
-  {
-    int lzb = -1;
-    int bits = 0;
-    for (int b = 0; !b; lzb++, bits++)
-    {
-      if (bits > maxbits)
-        return 0;
-      b = readBits(1);
-    }
-    return (1 << lzb) - 1 + readBits(lzb);
-  }
-
-private:
-  uint8_t *m_data;
-  int m_offset;
-  int m_len;
-  bool m_error;
-};
-
-class CCaptionBlock
-{
-  CCaptionBlock(const CCaptionBlock&) = delete;
-  CCaptionBlock& operator=(const CCaptionBlock&) = delete;
-public:
-  explicit CCaptionBlock(int size)
-  {
-    m_data = (uint8_t*)malloc(size);
-    m_size = size;
-    m_pts = 0.0; //silence coverity uninitialized warning, is set elsewhere
-  }
-  virtual ~CCaptionBlock()
-  {
-    free(m_data);
-  }
-  double m_pts;
-  uint8_t *m_data;
-  int m_size;
-};
-
 bool reorder_sort (CCaptionBlock *lhs, CCaptionBlock *rhs)
 {
   return (lhs->m_pts > rhs->m_pts);
 }
 
-CCBitstreamFormat CDVDDemuxCC::DetectBitstreamFormat(const uint8_t* extradata, int extrasize)
-{
-  // Detect AVCC vs Annex B format for H.264
-  if (m_codec == AV_CODEC_ID_H264 && extradata && extrasize >= 7)
-  {
-    // AVCC format: first byte is 0x01 (avcC version)
-    if (extradata[0] == 1)
-    {
-      CLog::Log(LOGDEBUG, "CDVDDemuxCC: Detected AVCC format from extradata");
-      return CCBitstreamFormat::AVCC;
-    }
-    // Annex B format: starts with NAL start codes
-    else if ((extradata[0] == 0 && extradata[1] == 0 && extradata[2] == 0 && extradata[3] == 1) ||
-             (extradata[0] == 0 && extradata[1] == 0 && extradata[2] == 1))
-    {
-      CLog::Log(LOGDEBUG, "CDVDDemuxCC: Detected Annex B format from extradata");
-      return CCBitstreamFormat::ANNEXB;
-    }
-  }
-
-  // No extradata or MPEG2, default to Annex B
-  return CCBitstreamFormat::ANNEXB;
-}
-
 CDVDDemuxCC::CDVDDemuxCC(AVCodecID codec, const uint8_t* extradata, int extrasize)
-  : m_codec(codec),
-    m_format(DetectBitstreamFormat(extradata, extrasize))
 {
   m_hasData = false;
   m_curPts = 0.0;
+  m_parser = CCBitstreamParserFactory::CreateParser(codec, extradata, extrasize);
 }
 
 CDVDDemuxCC::~CDVDDemuxCC()
@@ -247,275 +157,49 @@ int CDVDDemuxCC::GetNrOfStreams() const
 
 DemuxPacket* CDVDDemuxCC::Read(DemuxPacket *pSrcPacket)
 {
-  DemuxPacket *pPacket = NULL;
-  uint32_t startcode = 0xffffffff;
-  int picType = 0;
-  int p = 0;
-  int len;
+  DemuxPacket* pPacket = nullptr;
 
   if (!pSrcPacket)
   {
     pPacket = Decode();
     return pPacket;
   }
+
   if (pSrcPacket->pts == DVD_NOPTS_VALUE)
   {
     return pPacket;
   }
 
+  // Move temp buffer to reorder buffer
   while (!m_ccTempBuffer.empty())
   {
     m_ccReorderBuffer.push_back(m_ccTempBuffer.back());
     m_ccTempBuffer.pop_back();
   }
 
-  // AVCC format: length-prefixed NAL units
-  if (m_format == CCBitstreamFormat::AVCC && m_codec == AV_CODEC_ID_H264)
+  if (!m_parser)
   {
-    while (p + 4 < pSrcPacket->iSize)
-    {
-      // Read 4-byte big-endian length prefix
-      uint32_t nalSize = (pSrcPacket->pData[p] << 24) | (pSrcPacket->pData[p + 1] << 16) |
-                         (pSrcPacket->pData[p + 2] << 8) | pSrcPacket->pData[p + 3];
-      p += 4;
-
-      // Check if we have enough data for this NAL unit
-      if (p > pSrcPacket->iSize || nalSize > static_cast<uint32_t>(pSrcPacket->iSize - p))
-        break;
-
-      // Get NAL unit type
-      uint8_t nalType = pSrcPacket->pData[p] & 0x1F;
-
-      // Process slice NAL units to determine picture type
-      if (nalType >= 1 && nalType <= 5)
-      {
-        uint8_t* buf = pSrcPacket->pData + p;
-        len = nalSize;
-        if (len > 1) // Need at least NAL header + RBSP data
-        {
-          // Skip NAL header byte
-          CBitstream bs(buf + 1, (len - 1) * 8);
-          bs.readGolombUE(); // first_mb_in_slice
-          int sliceType = bs.readGolombUE(); // slice_type
-          if (sliceType == 2 || sliceType == 7) // I slice
-            picType = 1;
-          else if (sliceType == 0 || sliceType == 5) // P slice
-            picType = 2;
-          if (picType == 0)
-          {
-            while (!m_ccTempBuffer.empty())
-            {
-              m_ccReorderBuffer.push_back(m_ccTempBuffer.back());
-              m_ccTempBuffer.pop_back();
-            }
-          }
-        }
-      }
-      else if (nalType == 6) // SEI NAL unit
-      {
-        uint8_t* buf = pSrcPacket->pData + p;
-        len = nalSize;
-
-        // Look for CEA-608/708 user data in SEI
-        // SEI payload structure: [payload_type] [payload_size] [payload_data]
-        int seiPos = 1; // Skip NAL header byte
-        while (seiPos + 2 < len)
-        {
-          // Read payload type
-          int payloadType = 0;
-          while (seiPos < len && buf[seiPos] == 0xFF)
-          {
-            payloadType += 255;
-            seiPos++;
-          }
-          if (seiPos < len)
-            payloadType += buf[seiPos++];
-
-          // Read payload size
-          int payloadSize = 0;
-          while (seiPos < len && buf[seiPos] == 0xFF)
-          {
-            payloadSize += 255;
-            seiPos++;
-          }
-          if (seiPos < len)
-            payloadSize += buf[seiPos++];
-
-          // Check if this is user data registered (type 4) with GA94 identifier
-          if (payloadType == 4 && seiPos + payloadSize <= len)
-          {
-            uint8_t* userdata = buf + seiPos;
-
-            // Check for ITU-T T.35 format: country_code (1 byte) + provider_code (2 bytes) + "GA94"
-            // or direct "GA94" format (Annex B style)
-            int gaOffset = -1;
-            if (payloadSize >= 11 && userdata[3] == 'G' && userdata[4] == 'A' &&
-                userdata[5] == '9' && userdata[6] == '4' && userdata[7] == 3)
-            {
-              // ITU-T T.35 format with country/provider codes (B5 00 31 GA94...)
-              gaOffset = 3;
-            }
-            else if (payloadSize >= 8 && userdata[0] == 'G' && userdata[1] == 'A' &&
-                     userdata[2] == '9' && userdata[3] == '4' && userdata[4] == 3)
-            {
-              // Direct GA94 format
-              gaOffset = 0;
-            }
-
-            if (gaOffset >= 0)
-            {
-              uint8_t* ga94data = userdata + gaOffset;
-              int cc_count = ga94data[5] & 0x1f;
-              if (cc_count > 0 && payloadSize >= gaOffset + 6 + cc_count * 3)
-              {
-                CCaptionBlock* cc = new CCaptionBlock(cc_count * 3);
-                memcpy(cc->m_data, ga94data + 7, cc_count * 3);
-                cc->m_pts = pSrcPacket->pts;
-                m_ccTempBuffer.push_back(cc);
-              }
-            }
-          }
-
-          seiPos += payloadSize;
-        }
-      }
-
-      p += nalSize;
-    }
-  }
-  else
-  {
-    // Annex B format: start code based
-    while ((len = pSrcPacket->iSize - p) > 3)
-    {
-      if ((startcode & 0xffffff00) == 0x00000100)
-      {
-        if (m_codec == AV_CODEC_ID_MPEG2VIDEO)
-        {
-          int scode = startcode & 0xFF;
-          if (scode == 0x00)
-          {
-            if (len > 4)
-            {
-              uint8_t* buf = pSrcPacket->pData + p;
-              picType = (buf[1] & 0x38) >> 3;
-            }
-          }
-          else if (scode == 0xb2) // user data
-          {
-            uint8_t* buf = pSrcPacket->pData + p;
-            if (len >= 6 && buf[0] == 'G' && buf[1] == 'A' && buf[2] == '9' && buf[3] == '4' &&
-                buf[4] == 3 && (buf[5] & 0x40))
-            {
-              int cc_count = buf[5] & 0x1f;
-              if (cc_count > 0 && len >= 7 + cc_count * 3)
-              {
-                CCaptionBlock* cc = new CCaptionBlock(cc_count * 3);
-                memcpy(cc->m_data, buf + 7, cc_count * 3);
-                cc->m_pts = pSrcPacket->pts;
-                if (picType == 1 || picType == 2)
-                  m_ccTempBuffer.push_back(cc);
-                else
-                  m_ccReorderBuffer.push_back(cc);
-              }
-            }
-            else if (len >= 6 && buf[0] == 'C' && buf[1] == 'C' && buf[2] == 1)
-            {
-              int oddidx = (buf[4] & 0x80) ? 0 : 1;
-              int cc_count = (buf[4] & 0x3e) >> 1;
-              int extrafield = buf[4] & 0x01;
-              if (extrafield)
-                cc_count++;
-
-              if (cc_count > 0 && len >= 5 + cc_count * 3 * 2)
-              {
-                CCaptionBlock* cc = new CCaptionBlock(cc_count * 3);
-                uint8_t* src = buf + 5;
-                uint8_t* dst = cc->m_data;
-
-                for (int i = 0; i < cc_count; i++)
-                {
-                  for (int j = 0; j < 2; j++)
-                  {
-                    if (i == cc_count - 1 && extrafield && j == 1)
-                      break;
-
-                    if ((oddidx == j) && (src[0] == 0xFF))
-                    {
-                      dst[0] = 0x04;
-                      dst[1] = src[1];
-                      dst[2] = src[2];
-                      dst += 3;
-                    }
-                    src += 3;
-                  }
-                }
-                cc->m_pts = pSrcPacket->pts;
-                m_ccReorderBuffer.push_back(cc);
-                picType = 1;
-              }
-            }
-          }
-        }
-        else if (m_codec == AV_CODEC_ID_H264)
-        {
-          int scode = startcode & 0x9F;
-          // slice data comes after SEI
-          if (scode >= 1 && scode <= 5)
-          {
-            uint8_t* buf = pSrcPacket->pData + p;
-            CBitstream bs(buf, len * 8);
-            bs.readGolombUE();
-            int sliceType = bs.readGolombUE();
-            if (sliceType == 2 || sliceType == 7) // I slice
-              picType = 1;
-            else if (sliceType == 0 || sliceType == 5) // P slice
-              picType = 2;
-            if (picType == 0)
-            {
-              while (!m_ccTempBuffer.empty())
-              {
-                m_ccReorderBuffer.push_back(m_ccTempBuffer.back());
-                m_ccTempBuffer.pop_back();
-              }
-            }
-          }
-          if (scode == 0x06) // SEI
-          {
-            uint8_t* buf = pSrcPacket->pData + p;
-            if (len >= 12 && buf[3] == 0 && buf[4] == 49 && buf[5] == 'G' && buf[6] == 'A' &&
-                buf[7] == '9' && buf[8] == '4' && buf[9] == 3)
-            {
-              uint8_t* userdata = buf + 10;
-              int cc_count = userdata[0] & 0x1f;
-              if (len >= cc_count * 3 + 10)
-              {
-                CCaptionBlock* cc = new CCaptionBlock(cc_count * 3);
-                memcpy(cc->m_data, userdata + 2, cc_count * 3);
-                cc->m_pts = pSrcPacket->pts;
-                m_ccTempBuffer.push_back(cc);
-              }
-            }
-          }
-        }
-      }
-      startcode = startcode << 8 | pSrcPacket->pData[p++];
-    }
+    CLog::Log(LOGERROR, "CDVDDemuxCC::Read - No parser available");
+    return pPacket;
   }
 
-  // Decode CC data when we encounter an I-frame (picType==1) or P-frame (picType==2).
-  // These are reference frames that ensure correct temporal ordering of CC data,
-  // as B-frames may be reordered during decoding.
-  if ((picType == 1 || picType == 2) && !m_ccReorderBuffer.empty())
+  CCPictureType picType = m_parser->ParsePacket(pSrcPacket, m_ccTempBuffer, m_ccReorderBuffer);
+
+  // Decode CC data when we encounter an I-frame or P-frame (reference frames).
+  // Reference frames ensure correct temporal ordering of CC data,
+  // as B-frames (CCPictureType::OTHER) may be reordered during decoding.
+  if ((picType == CCPictureType::I_FRAME || picType == CCPictureType::P_FRAME) &&
+      !m_ccReorderBuffer.empty())
   {
     if (!m_ccDecoder)
     {
       if (!OpenDecoder())
-        return NULL;
+        return nullptr;
     }
     std::sort(m_ccReorderBuffer.begin(), m_ccReorderBuffer.end(), reorder_sort);
     pPacket = Decode();
   }
+
   return pPacket;
 }
 
@@ -605,14 +289,14 @@ void CDVDDemuxCC::Dispose()
 
 DemuxPacket* CDVDDemuxCC::Decode()
 {
-  DemuxPacket *pPacket = NULL;
+  DemuxPacket* pPacket = nullptr;
 
   while(!m_hasData && !m_ccReorderBuffer.empty())
   {
     CCaptionBlock *cc = m_ccReorderBuffer.back();
     m_ccReorderBuffer.pop_back();
     m_curPts = cc->m_pts;
-    m_ccDecoder->Decode(cc->m_data, cc->m_size);
+    m_ccDecoder->Decode(cc->m_data.data(), static_cast<int>(cc->m_data.size()));
     delete cc;
   }
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
@@ -121,7 +121,7 @@ CDVDDemuxCC::CDVDDemuxCC(AVCodecID codec, const uint8_t* extradata, int extrasiz
 {
   m_hasData = false;
   m_curPts = 0.0;
-  m_parser = CCBitstreamParserFactory::CreateParser(codec, extradata, extrasize);
+  m_parser = CCBitstreamParserFactory::CreateParser(codec, std::span(extradata, extrasize));
 }
 
 CDVDDemuxCC::~CDVDDemuxCC()

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
@@ -9,12 +9,12 @@
 #pragma once
 
 #include "DVDDemux.h"
+#include "DVDDemuxCC/CaptionBlock.h"
 #include "DVDDemuxCC/ICCBitstreamParser.h"
 
 #include <memory>
 #include <vector>
 
-class CCaptionBlock;
 class CDecoderCC708;
 class ICCBitstreamParser;
 
@@ -54,8 +54,8 @@ protected:
   std::vector<CDemuxStreamSubtitle> m_streams;
   bool m_hasData;
   double m_curPts;
-  std::vector<CCaptionBlock*> m_ccReorderBuffer;
-  std::vector<CCaptionBlock*> m_ccTempBuffer;
+  std::vector<CCaptionBlock> m_ccReorderBuffer;
+  std::vector<CCaptionBlock> m_ccTempBuffer;
   std::unique_ptr<CDecoderCC708> m_ccDecoder;
   std::unique_ptr<ICCBitstreamParser> m_parser;
 };

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -9,18 +9,14 @@
 #pragma once
 
 #include "DVDDemux.h"
+#include "DVDDemuxCC/ICCBitstreamParser.h"
 
 #include <memory>
 #include <vector>
 
 class CCaptionBlock;
 class CDecoderCC708;
-
-enum class CCBitstreamFormat
-{
-  ANNEXB, // Annex B format with start codes (0x000001)
-  AVCC // AVCC format with length-prefixed NAL units
-};
+class ICCBitstreamParser;
 
 class CDVDDemuxCC : public CDVDDemux
 {
@@ -46,7 +42,6 @@ protected:
   bool OpenDecoder();
   void Dispose();
   DemuxPacket* Decode();
-  CCBitstreamFormat DetectBitstreamFormat(const uint8_t* extradata, int extrasize);
 
   struct streamdata
   {
@@ -62,6 +57,5 @@ protected:
   std::vector<CCaptionBlock*> m_ccReorderBuffer;
   std::vector<CCaptionBlock*> m_ccTempBuffer;
   std::unique_ptr<CDecoderCC708> m_ccDecoder;
-  AVCodecID m_codec;
-  CCBitstreamFormat m_format = CCBitstreamFormat::ANNEXB;
+  std::unique_ptr<ICCBitstreamParser> m_parser;
 };

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
@@ -16,10 +16,16 @@
 class CCaptionBlock;
 class CDecoderCC708;
 
+enum class CCBitstreamFormat
+{
+  ANNEXB, // Annex B format with start codes (0x000001)
+  AVCC // AVCC format with length-prefixed NAL units
+};
+
 class CDVDDemuxCC : public CDVDDemux
 {
 public:
-  explicit CDVDDemuxCC(AVCodecID codec);
+  explicit CDVDDemuxCC(AVCodecID codec, const uint8_t* extradata, int extrasize);
   ~CDVDDemuxCC() override;
 
   bool Reset() override { return true; }
@@ -40,6 +46,7 @@ protected:
   bool OpenDecoder();
   void Dispose();
   DemuxPacket* Decode();
+  CCBitstreamFormat DetectBitstreamFormat(const uint8_t* extradata, int extrasize);
 
   struct streamdata
   {
@@ -56,4 +63,5 @@ protected:
   std::vector<CCaptionBlock*> m_ccTempBuffer;
   std::unique_ptr<CDecoderCC708> m_ccDecoder;
   AVCodecID m_codec;
+  CCBitstreamFormat m_format = CCBitstreamFormat::ANNEXB;
 };

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/Bitstream.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/Bitstream.h
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+class CBitstream
+{
+public:
+  CBitstream(const uint8_t* data, int bits)
+  {
+    m_data = data;
+    m_offset = 0;
+    m_len = bits;
+    m_error = false;
+  }
+  unsigned int readBits(int num)
+  {
+    int r = 0;
+    while (num > 0)
+    {
+      if (m_offset >= m_len)
+      {
+        m_error = true;
+        return 0;
+      }
+      num--;
+      if (m_data[m_offset / 8] & (1 << (7 - (m_offset & 7))))
+        r |= 1 << num;
+      m_offset++;
+    }
+    return r;
+  }
+  unsigned int readGolombUE(int maxbits = 32)
+  {
+    int lzb = -1;
+    int bits = 0;
+    for (int b = 0; !b; lzb++, bits++)
+    {
+      if (bits > maxbits)
+      {
+        m_error = true;
+        return 0;
+      }
+      b = readBits(1);
+    }
+    // Prevent undefined behavior from shifting >= 32 bits
+    // Valid Golomb codes should have lzb < 32
+    if (lzb > 31)
+    {
+      m_error = true;
+      return 0;
+    }
+    return (1U << lzb) - 1 + readBits(lzb);
+  }
+
+  bool hasError() const { return m_error; }
+
+private:
+  const uint8_t* m_data;
+  int m_offset;
+  int m_len;
+  bool m_error;
+};

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/CCBitstreamParserFactory.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/CCBitstreamParserFactory.cpp
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "CCBitstreamParserFactory.h"
+
+#include "H264AVCCBitstreamParser.h"
+#include "H264AnnexBBitstreamParser.h"
+#include "MPEG2CCBitstreamParser.h"
+#include "utils/log.h"
+
+std::unique_ptr<ICCBitstreamParser> CCBitstreamParserFactory::CreateParser(AVCodecID codec,
+                                                                           const uint8_t* extradata,
+                                                                           int extrasize)
+{
+  if (codec == AV_CODEC_ID_MPEG2VIDEO)
+  {
+    CLog::Log(LOGDEBUG, "CCBitstreamParserFactory: Creating MPEG2CCBitstreamParser");
+    return std::make_unique<CMPEG2CCBitstreamParser>();
+  }
+  else if (codec == AV_CODEC_ID_H264)
+  {
+    // Detect AVCC vs Annex B format from extradata
+    if (extradata && extrasize >= 7)
+    {
+      // AVCC format: first byte is 0x01 (AVCC version)
+      if (extradata[0] == 1)
+      {
+        CLog::Log(
+            LOGDEBUG,
+            "CCBitstreamParserFactory: Creating H264AVCCBitstreamParser (detected AVCC format)");
+        return std::make_unique<CH264AVCCBitstreamParser>();
+      }
+    }
+    CLog::Log(
+        LOGDEBUG,
+        "CCBitstreamParserFactory: Creating H264AnnexBBitstreamParser (detected Annex B format)");
+    return std::make_unique<CH264AnnexBBitstreamParser>();
+  }
+
+  CLog::Log(LOGWARNING, "CCBitstreamParserFactory: Unsupported codec for CC parsing: {}", codec);
+  return nullptr;
+}

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/CCBitstreamParserFactory.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/CCBitstreamParserFactory.cpp
@@ -13,9 +13,8 @@
 #include "MPEG2CCBitstreamParser.h"
 #include "utils/log.h"
 
-std::unique_ptr<ICCBitstreamParser> CCBitstreamParserFactory::CreateParser(AVCodecID codec,
-                                                                           const uint8_t* extradata,
-                                                                           int extrasize)
+std::unique_ptr<ICCBitstreamParser> CCBitstreamParserFactory::CreateParser(
+    AVCodecID codec, std::span<const uint8_t> extradata)
 {
   if (codec == AV_CODEC_ID_MPEG2VIDEO)
   {
@@ -25,7 +24,7 @@ std::unique_ptr<ICCBitstreamParser> CCBitstreamParserFactory::CreateParser(AVCod
   else if (codec == AV_CODEC_ID_H264)
   {
     // Detect AVCC vs Annex B format from extradata
-    if (extradata && extrasize >= 7)
+    if (extradata.size() >= 7)
     {
       // AVCC format: first byte is 0x01 (AVCC version)
       if (extradata[0] == 1)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/CCBitstreamParserFactory.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/CCBitstreamParserFactory.h
@@ -28,6 +28,5 @@ public:
    * \return Parser instance or nullptr if codec is unsupported
    */
   static std::unique_ptr<ICCBitstreamParser> CreateParser(AVCodecID codec,
-                                                          const uint8_t* extradata,
-                                                          int extrasize);
+                                                          std::span<const uint8_t> extradata);
 };

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/CCBitstreamParserFactory.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/CCBitstreamParserFactory.h
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "ICCBitstreamParser.h"
+#include "cores/FFmpeg.h"
+
+#include <memory>
+
+/*!
+ * \brief Factory for creating codec-specific closed caption bitstream parsers
+ */
+class CCBitstreamParserFactory
+{
+public:
+  /*!
+   * \brief Create appropriate parser based on codec and extradata
+   *
+   * \param codec AVCodecID identifying the video codec
+   * \param extradata Pointer to codec extradata
+   * \param extrasize Size of extradata in bytes
+   * \return Parser instance or nullptr if codec is unsupported
+   */
+  static std::unique_ptr<ICCBitstreamParser> CreateParser(AVCodecID codec,
+                                                          const uint8_t* extradata,
+                                                          int extrasize);
+};

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/CaptionBlock.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/CaptionBlock.h
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+class CCaptionBlock
+{
+  CCaptionBlock(const CCaptionBlock&) = delete;
+  CCaptionBlock& operator=(const CCaptionBlock&) = delete;
+
+public:
+  explicit CCaptionBlock(int size) : m_pts(0.0), m_data(size) {}
+  virtual ~CCaptionBlock() = default;
+  double m_pts;
+  std::vector<uint8_t> m_data;
+};

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/CaptionBlock.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/CaptionBlock.h
@@ -13,12 +13,8 @@
 
 class CCaptionBlock
 {
-  CCaptionBlock(const CCaptionBlock&) = delete;
-  CCaptionBlock& operator=(const CCaptionBlock&) = delete;
-
 public:
   explicit CCaptionBlock(int size) : m_pts(0.0), m_data(size) {}
-  virtual ~CCaptionBlock() = default;
   double m_pts;
   std::vector<uint8_t> m_data;
 };

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AVCCBitstreamParser.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AVCCBitstreamParser.cpp
@@ -13,6 +13,8 @@
 #include "utils/log.h"
 
 #include <climits>
+#include <iterator>
+#include <ranges>
 
 CCPictureType CH264AVCCBitstreamParser::ParsePacket(DemuxPacket* pPacket,
                                                     std::vector<CCaptionBlock>& tempBuffer,
@@ -57,11 +59,7 @@ CCPictureType CH264AVCCBitstreamParser::ParsePacket(DemuxPacket* pPacket,
         {
           CLog::LogF(LOGDEBUG, "Corrupted slice header detected, marking packet as invalid");
           // Flush any CC data from tempBuffer to reorderBuffer before returning
-          while (!tempBuffer.empty())
-          {
-            reorderBuffer.push_back(std::move(tempBuffer.back()));
-            tempBuffer.pop_back();
-          }
+          std::ranges::move(std::views::reverse(tempBuffer), std::back_inserter(reorderBuffer));
           return CCPictureType::INVALID;
         }
 
@@ -74,11 +72,7 @@ CCPictureType CH264AVCCBitstreamParser::ParsePacket(DemuxPacket* pPacket,
         // If this is a B-frame, move CC data from temp to reorder buffer
         if (picType == CCPictureType::OTHER)
         {
-          while (!tempBuffer.empty())
-          {
-            reorderBuffer.push_back(std::move(tempBuffer.back()));
-            tempBuffer.pop_back();
-          }
+          std::ranges::move(std::views::reverse(tempBuffer), std::back_inserter(reorderBuffer));
         }
       }
     }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AVCCBitstreamParser.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AVCCBitstreamParser.cpp
@@ -8,14 +8,15 @@
 
 #include "H264AVCCBitstreamParser.h"
 
+#include "CaptionBlock.h"
 #include "cores/VideoPlayer/Interface/DemuxPacket.h"
 #include "utils/log.h"
 
 #include <climits>
 
 CCPictureType CH264AVCCBitstreamParser::ParsePacket(DemuxPacket* pPacket,
-                                                    std::vector<CCaptionBlock*>& tempBuffer,
-                                                    std::vector<CCaptionBlock*>& reorderBuffer)
+                                                    std::vector<CCaptionBlock>& tempBuffer,
+                                                    std::vector<CCaptionBlock>& reorderBuffer)
 {
   CCPictureType picType = CCPictureType::OTHER;
   int p = 0;
@@ -58,7 +59,7 @@ CCPictureType CH264AVCCBitstreamParser::ParsePacket(DemuxPacket* pPacket,
           // Flush any CC data from tempBuffer to reorderBuffer before returning
           while (!tempBuffer.empty())
           {
-            reorderBuffer.push_back(tempBuffer.back());
+            reorderBuffer.push_back(std::move(tempBuffer.back()));
             tempBuffer.pop_back();
           }
           return CCPictureType::INVALID;
@@ -75,7 +76,7 @@ CCPictureType CH264AVCCBitstreamParser::ParsePacket(DemuxPacket* pPacket,
         {
           while (!tempBuffer.empty())
           {
-            reorderBuffer.push_back(tempBuffer.back());
+            reorderBuffer.push_back(std::move(tempBuffer.back()));
             tempBuffer.pop_back();
           }
         }
@@ -98,7 +99,7 @@ CCPictureType CH264AVCCBitstreamParser::ParsePacket(DemuxPacket* pPacket,
 void CH264AVCCBitstreamParser::ParseSEINALUnit(uint8_t* buf,
                                                int len,
                                                double pts,
-                                               std::vector<CCaptionBlock*>& tempBuffer)
+                                               std::vector<CCaptionBlock>& tempBuffer)
 {
   // SEI payload structure: [payload_type] [payload_size] [payload_data] [repeat...]
   // payload_type and payload_size use 0xFF for values >= 255

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AVCCBitstreamParser.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AVCCBitstreamParser.cpp
@@ -1,0 +1,143 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "H264AVCCBitstreamParser.h"
+
+#include "cores/VideoPlayer/Interface/DemuxPacket.h"
+#include "utils/log.h"
+
+#include <climits>
+
+CCPictureType CH264AVCCBitstreamParser::ParsePacket(DemuxPacket* pPacket,
+                                                    std::vector<CCaptionBlock*>& tempBuffer,
+                                                    std::vector<CCaptionBlock*>& reorderBuffer)
+{
+  CCPictureType picType = CCPictureType::OTHER;
+  int p = 0;
+
+  // Iterate through length-prefixed NAL units
+  while (pPacket->iSize >= 4 && p <= pPacket->iSize - 4)
+  {
+    // Read 4-byte big-endian length prefix
+    uint32_t nalSize = (static_cast<uint32_t>(pPacket->pData[p]) << 24) |
+                       (static_cast<uint32_t>(pPacket->pData[p + 1]) << 16) |
+                       (static_cast<uint32_t>(pPacket->pData[p + 2]) << 8) |
+                       static_cast<uint32_t>(pPacket->pData[p + 3]);
+    p += 4;
+
+    // Check if we have enough data for this NAL unit
+    if (nalSize == 0 || nalSize > INT_MAX || nalSize > static_cast<uint32_t>(pPacket->iSize - p))
+    {
+      CLog::LogF(LOGDEBUG, "Invalid NAL size {} at position {}, packet size {}", nalSize, p - 4,
+                 pPacket->iSize);
+      break;
+    }
+
+    // Get NAL unit type from lower 5 bits of NAL header
+    uint8_t nalType = pPacket->pData[p] & 0x1F;
+
+    // Process slice NAL units (types 1-5) to determine picture type
+    if (nalType >= 1 && nalType <= 5)
+    {
+      uint8_t* buf = pPacket->pData + p;
+      int len = nalSize;
+
+      if (len > 1) // Need at least NAL header + RBSP data
+      {
+        CCPictureType slicePicType = DetectSliceType(buf, len);
+
+        // If parsing failed due to corrupted Golomb codes, mark entire packet as invalid
+        if (slicePicType == CCPictureType::INVALID)
+        {
+          CLog::LogF(LOGDEBUG, "Corrupted slice header detected, marking packet as invalid");
+          // Flush any CC data from tempBuffer to reorderBuffer before returning
+          while (!tempBuffer.empty())
+          {
+            reorderBuffer.push_back(tempBuffer.back());
+            tempBuffer.pop_back();
+          }
+          return CCPictureType::INVALID;
+        }
+
+        // Update picture type (prefer I-frame > P-frame > OTHER)
+        if (slicePicType == CCPictureType::I_FRAME)
+          picType = CCPictureType::I_FRAME;
+        else if (slicePicType == CCPictureType::P_FRAME && picType == CCPictureType::OTHER)
+          picType = CCPictureType::P_FRAME;
+
+        // If this is a B-frame, move CC data from temp to reorder buffer
+        if (picType == CCPictureType::OTHER)
+        {
+          while (!tempBuffer.empty())
+          {
+            reorderBuffer.push_back(tempBuffer.back());
+            tempBuffer.pop_back();
+          }
+        }
+      }
+    }
+    // Process SEI NAL unit (type 6) for closed caption data
+    else if (nalType == 6)
+    {
+      uint8_t* buf = pPacket->pData + p;
+      int len = nalSize;
+      ParseSEINALUnit(buf, len, pPacket->pts, tempBuffer);
+    }
+
+    p += nalSize;
+  }
+
+  return picType;
+}
+
+void CH264AVCCBitstreamParser::ParseSEINALUnit(uint8_t* buf,
+                                               int len,
+                                               double pts,
+                                               std::vector<CCaptionBlock*>& tempBuffer)
+{
+  // SEI payload structure: [payload_type] [payload_size] [payload_data] [repeat...]
+  // payload_type and payload_size use 0xFF for values >= 255
+
+  int seiPos = 1; // Skip NAL header byte
+
+  while (seiPos < len)
+  {
+    // Read payload type (supports extended values with 0xFF bytes)
+    int payloadType = 0;
+    while (seiPos < len && buf[seiPos] == 0xFF)
+    {
+      payloadType += 255;
+      seiPos++;
+    }
+    if (seiPos < len)
+      payloadType += buf[seiPos++];
+    else
+      break;
+
+    // Read payload size (supports extended values with 0xFF bytes)
+    int payloadSize = 0;
+    while (seiPos < len && buf[seiPos] == 0xFF)
+    {
+      payloadSize += 255;
+      seiPos++;
+    }
+    if (seiPos < len)
+      payloadSize += buf[seiPos++];
+    else
+      break;
+
+    // Check if this is user_data_registered_itu_t_t35 (type 4) with GA94 CC data
+    if (payloadType == 4 && seiPos + payloadSize <= len)
+    {
+      uint8_t* userdata = buf + seiPos;
+      ProcessSEIPayload(userdata, payloadSize, pts, tempBuffer);
+    }
+
+    seiPos += payloadSize;
+  }
+}

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AVCCBitstreamParser.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AVCCBitstreamParser.h
@@ -10,6 +10,8 @@
 
 #include "H264CCBitstreamParser.h"
 
+#include <span>
+
 /*!
  * \brief H.264 AVCC format closed caption parser
  *
@@ -56,5 +58,7 @@ private:
    * \param pts Presentation timestamp
    * \param tempBuffer Temporary buffer for CC data
    */
-  void ParseSEINALUnit(uint8_t* buf, int len, double pts, std::vector<CCaptionBlock>& tempBuffer);
+  void ParseSEINALUnit(std::span<const uint8_t> buf,
+                       double pts,
+                       std::vector<CCaptionBlock>& tempBuffer);
 };

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AVCCBitstreamParser.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AVCCBitstreamParser.h
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "H264CCBitstreamParser.h"
+
+/*!
+ * \brief H.264 AVCC format closed caption parser
+ *
+ * Parses H.264 streams in AVCC (AVC1) format used by MP4/MKV containers.
+ * AVCC uses length-prefixed NAL units:
+ * - 4-byte big-endian length prefix
+ * - NAL unit data (length bytes)
+ * - Repeat for each NAL unit
+ *
+ * Extracts CC data from SEI NAL units (type 6) with payload type 4.
+ */
+class CH264AVCCBitstreamParser : public CH264CCBitstreamParser
+{
+public:
+  CH264AVCCBitstreamParser() = default;
+  ~CH264AVCCBitstreamParser() override = default;
+
+  /*!
+   * \brief Parse AVCC packet for closed caption data
+   *
+   * Iterates through length-prefixed NAL units, extracting CC data from
+   * SEI payloads and detecting picture type from slice headers.
+   *
+   * \param pPacket H.264 video packet in AVCC format
+   * \param tempBuffer Temporary buffer for CC data from reference frames
+   * \param reorderBuffer Reorder buffer for CC data
+   * \return Picture type (I_FRAME, P_FRAME, or OTHER)
+   */
+  CCPictureType ParsePacket(DemuxPacket* pPacket,
+                            std::vector<CCaptionBlock*>& tempBuffer,
+                            std::vector<CCaptionBlock*>& reorderBuffer) override;
+
+  const char* GetName() const override { return "H264AVCCBitstreamParser"; }
+
+private:
+  /*!
+   * \brief Parse SEI NAL unit for closed caption data
+   *
+   * SEI structure: [payload_type] [payload_size] [payload_data] [repeat...]
+   * Looks for payload type 4 (user_data_registered_itu_t_t35) containing GA94 CC data.
+   *
+   * \param buf Pointer to SEI NAL unit data
+   * \param len Length of SEI NAL unit
+   * \param pts Presentation timestamp
+   * \param tempBuffer Temporary buffer for CC data
+   */
+  void ParseSEINALUnit(uint8_t* buf, int len, double pts, std::vector<CCaptionBlock*>& tempBuffer);
+};

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AVCCBitstreamParser.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AVCCBitstreamParser.h
@@ -39,8 +39,8 @@ public:
    * \return Picture type (I_FRAME, P_FRAME, or OTHER)
    */
   CCPictureType ParsePacket(DemuxPacket* pPacket,
-                            std::vector<CCaptionBlock*>& tempBuffer,
-                            std::vector<CCaptionBlock*>& reorderBuffer) override;
+                            std::vector<CCaptionBlock>& tempBuffer,
+                            std::vector<CCaptionBlock>& reorderBuffer) override;
 
   const char* GetName() const override { return "H264AVCCBitstreamParser"; }
 
@@ -56,5 +56,5 @@ private:
    * \param pts Presentation timestamp
    * \param tempBuffer Temporary buffer for CC data
    */
-  void ParseSEINALUnit(uint8_t* buf, int len, double pts, std::vector<CCaptionBlock*>& tempBuffer);
+  void ParseSEINALUnit(uint8_t* buf, int len, double pts, std::vector<CCaptionBlock>& tempBuffer);
 };

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AnnexBBitstreamParser.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AnnexBBitstreamParser.cpp
@@ -8,12 +8,13 @@
 
 #include "H264AnnexBBitstreamParser.h"
 
+#include "CaptionBlock.h"
 #include "cores/VideoPlayer/Interface/DemuxPacket.h"
 #include "utils/log.h"
 
 CCPictureType CH264AnnexBBitstreamParser::ParsePacket(DemuxPacket* pPacket,
-                                                      std::vector<CCaptionBlock*>& tempBuffer,
-                                                      std::vector<CCaptionBlock*>& reorderBuffer)
+                                                      std::vector<CCaptionBlock>& tempBuffer,
+                                                      std::vector<CCaptionBlock>& reorderBuffer)
 {
   CCPictureType picType = CCPictureType::OTHER;
   uint32_t startcode = 0xffffffff;
@@ -46,7 +47,7 @@ CCPictureType CH264AnnexBBitstreamParser::ParsePacket(DemuxPacket* pPacket,
             // Flush any CC data from tempBuffer to reorderBuffer before returning
             while (!tempBuffer.empty())
             {
-              reorderBuffer.push_back(tempBuffer.back());
+              reorderBuffer.push_back(std::move(tempBuffer.back()));
               tempBuffer.pop_back();
             }
             return CCPictureType::INVALID;
@@ -63,7 +64,7 @@ CCPictureType CH264AnnexBBitstreamParser::ParsePacket(DemuxPacket* pPacket,
           {
             while (!tempBuffer.empty())
             {
-              reorderBuffer.push_back(tempBuffer.back());
+              reorderBuffer.push_back(std::move(tempBuffer.back()));
               tempBuffer.pop_back();
             }
           }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AnnexBBitstreamParser.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AnnexBBitstreamParser.cpp
@@ -12,6 +12,9 @@
 #include "cores/VideoPlayer/Interface/DemuxPacket.h"
 #include "utils/log.h"
 
+#include <iterator>
+#include <ranges>
+
 CCPictureType CH264AnnexBBitstreamParser::ParsePacket(DemuxPacket* pPacket,
                                                       std::vector<CCaptionBlock>& tempBuffer,
                                                       std::vector<CCaptionBlock>& reorderBuffer)
@@ -45,11 +48,7 @@ CCPictureType CH264AnnexBBitstreamParser::ParsePacket(DemuxPacket* pPacket,
           {
             CLog::LogF(LOGDEBUG, "Corrupted slice header detected, marking packet as invalid");
             // Flush any CC data from tempBuffer to reorderBuffer before returning
-            while (!tempBuffer.empty())
-            {
-              reorderBuffer.push_back(std::move(tempBuffer.back()));
-              tempBuffer.pop_back();
-            }
+            std::ranges::move(std::views::reverse(tempBuffer), std::back_inserter(reorderBuffer));
             return CCPictureType::INVALID;
           }
 
@@ -62,11 +61,7 @@ CCPictureType CH264AnnexBBitstreamParser::ParsePacket(DemuxPacket* pPacket,
           // If this is a B-frame, move CC data from temp to reorder buffer
           if (picType == CCPictureType::OTHER)
           {
-            while (!tempBuffer.empty())
-            {
-              reorderBuffer.push_back(std::move(tempBuffer.back()));
-              tempBuffer.pop_back();
-            }
+            std::ranges::move(std::views::reverse(tempBuffer), std::back_inserter(reorderBuffer));
           }
         }
       }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AnnexBBitstreamParser.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AnnexBBitstreamParser.cpp
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "H264AnnexBBitstreamParser.h"
+
+#include "cores/VideoPlayer/Interface/DemuxPacket.h"
+#include "utils/log.h"
+
+CCPictureType CH264AnnexBBitstreamParser::ParsePacket(DemuxPacket* pPacket,
+                                                      std::vector<CCaptionBlock*>& tempBuffer,
+                                                      std::vector<CCaptionBlock*>& reorderBuffer)
+{
+  CCPictureType picType = CCPictureType::OTHER;
+  uint32_t startcode = 0xffffffff;
+  int p = 0;
+  int len;
+
+  // Scan packet for Annex B start codes (0x000001 or 0x00000001)
+  while ((len = pPacket->iSize - p) > 3)
+  {
+    // Check for start code in the form 0x000001xx
+    if ((startcode & 0xffffff00) == 0x00000100)
+    {
+      // Extract NAL unit type (lower 5 bits) while masking out nal_ref_idc (bits 6-5)
+      // Mask 0x9F = 0b10011111 keeps forbidden_zero_bit (bit 7) and nal_unit_type (bits 4-0)
+      int scode = startcode & 0x9F;
+
+      // Slice NAL units (types 1-5) - determine picture type
+      if (scode >= 1 && scode <= 5)
+      {
+        uint8_t* buf = pPacket->pData + p;
+
+        if (len > 1)
+        {
+          CCPictureType slicePicType = DetectSliceType(buf, len);
+
+          // If parsing failed due to corrupted Golomb codes, mark entire packet as invalid
+          if (slicePicType == CCPictureType::INVALID)
+          {
+            CLog::LogF(LOGDEBUG, "Corrupted slice header detected, marking packet as invalid");
+            // Flush any CC data from tempBuffer to reorderBuffer before returning
+            while (!tempBuffer.empty())
+            {
+              reorderBuffer.push_back(tempBuffer.back());
+              tempBuffer.pop_back();
+            }
+            return CCPictureType::INVALID;
+          }
+
+          // Update picture type (prefer I-frame > P-frame > OTHER)
+          if (slicePicType == CCPictureType::I_FRAME)
+            picType = CCPictureType::I_FRAME;
+          else if (slicePicType == CCPictureType::P_FRAME && picType == CCPictureType::OTHER)
+            picType = CCPictureType::P_FRAME;
+
+          // If this is a B-frame, move CC data from temp to reorder buffer
+          if (picType == CCPictureType::OTHER)
+          {
+            while (!tempBuffer.empty())
+            {
+              reorderBuffer.push_back(tempBuffer.back());
+              tempBuffer.pop_back();
+            }
+          }
+        }
+      }
+      // SEI NAL unit (type 6) - extract closed caption data
+      else if (scode == 0x06)
+      {
+        uint8_t* buf = pPacket->pData + p;
+
+        // Simplified check for GA94 closed caption data in SEI
+        // Search for GA94 marker and pass to ProcessSEIPayload for full validation
+        // ProcessSEIPayload handles both ITU-T T.35 format and direct GA94 format
+        for (int i = 0; i <= len - 8; i++)
+        {
+          if (buf[i] == 'G' && buf[i + 1] == 'A' && buf[i + 2] == '9' && buf[i + 3] == '4' &&
+              buf[i + 4] == 3)
+          {
+            // Pass from start of potential ITU-T T.35 prefix (3 bytes before GA94)
+            // or from GA94 itself if no prefix exists
+            int startOffset = (i >= 3) ? i - 3 : i;
+            ProcessSEIPayload(buf + startOffset, len - startOffset, pPacket->pts, tempBuffer);
+            break;
+          }
+        }
+      }
+    }
+
+    startcode = startcode << 8 | pPacket->pData[p++];
+  }
+
+  return picType;
+}

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AnnexBBitstreamParser.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AnnexBBitstreamParser.h
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "H264CCBitstreamParser.h"
+
+/*!
+ * \brief H.264 Annex B format closed caption parser
+ *
+ * Parses H.264 streams in Annex B format used by MPEG-TS and broadcast streams.
+ * Annex B uses start codes to delimit NAL units:
+ * - 0x000001 (3-byte start code) or 0x00000001 (4-byte start code)
+ * - NAL unit data until next start code
+ *
+ * Extracts CC data from SEI NAL units (type 6) with payload type 4.
+ */
+class CH264AnnexBBitstreamParser : public CH264CCBitstreamParser
+{
+public:
+  CH264AnnexBBitstreamParser() = default;
+  ~CH264AnnexBBitstreamParser() override = default;
+
+  /*!
+   * \brief Parse Annex B packet for closed caption data
+   *
+   * Scans for start codes, extracts CC data from SEI NAL units, and
+   * detects picture type from slice headers.
+   *
+   * \param pPacket H.264 video packet in Annex B format
+   * \param tempBuffer Temporary buffer for CC data from reference frames
+   * \param reorderBuffer Reorder buffer for CC data
+   * \return Picture type (I_FRAME, P_FRAME, or OTHER)
+   */
+  CCPictureType ParsePacket(DemuxPacket* pPacket,
+                            std::vector<CCaptionBlock*>& tempBuffer,
+                            std::vector<CCaptionBlock*>& reorderBuffer) override;
+
+  const char* GetName() const override { return "H264AnnexBBitstreamParser"; }
+};

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AnnexBBitstreamParser.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264AnnexBBitstreamParser.h
@@ -38,8 +38,8 @@ public:
    * \return Picture type (I_FRAME, P_FRAME, or OTHER)
    */
   CCPictureType ParsePacket(DemuxPacket* pPacket,
-                            std::vector<CCaptionBlock*>& tempBuffer,
-                            std::vector<CCaptionBlock*>& reorderBuffer) override;
+                            std::vector<CCaptionBlock>& tempBuffer,
+                            std::vector<CCaptionBlock>& reorderBuffer) override;
 
   const char* GetName() const override { return "H264AnnexBBitstreamParser"; }
 };

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264CCBitstreamParser.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264CCBitstreamParser.cpp
@@ -15,14 +15,13 @@
 
 #include <algorithm>
 
-void CH264CCBitstreamParser::ProcessSEIPayload(uint8_t* buf,
-                                               int len,
+void CH264CCBitstreamParser::ProcessSEIPayload(std::span<const uint8_t> buf,
                                                double pts,
                                                std::vector<CCaptionBlock>& tempBuffer)
 {
-  if (len < 8)
+  if (buf.size() < 8)
   {
-    CLog::LogF(LOGDEBUG, "SEI payload too small ({})", len);
+    CLog::LogF(LOGDEBUG, "SEI payload too small ({})", buf.size());
     return;
   }
 
@@ -35,12 +34,13 @@ void CH264CCBitstreamParser::ProcessSEIPayload(uint8_t* buf,
   int gaOffset = -1;
 
   // Check for ITU-T T.35 format with GA94 at offset 3
-  if (len >= 11 && buf[3] == 'G' && buf[4] == 'A' && buf[5] == '9' && buf[6] == '4' && buf[7] == 3)
+  if (buf.size() >= 11 && buf[3] == 'G' && buf[4] == 'A' && buf[5] == '9' && buf[6] == '4' &&
+      buf[7] == 3)
   {
     gaOffset = 3;
   }
   // Check for direct GA94 format at offset 0
-  else if (len >= 8 && buf[0] == 'G' && buf[1] == 'A' && buf[2] == '9' && buf[3] == '4' &&
+  else if (buf.size() >= 8 && buf[0] == 'G' && buf[1] == 'A' && buf[2] == '9' && buf[3] == '4' &&
            buf[4] == 3)
   {
     gaOffset = 0;
@@ -53,38 +53,37 @@ void CH264CCBitstreamParser::ProcessSEIPayload(uint8_t* buf,
   }
 
   // GA94 format: 'G' 'A' '9' '4' 0x03 flags cc_data...
-  uint8_t* userdata = buf + gaOffset;
-  int payloadSize = len - gaOffset;
+  std::span<const uint8_t> userdata = buf.subspan(gaOffset);
 
   // Check process_cc_data_flag (bit 6 of flags byte)
-  if (payloadSize < 5 || !(userdata[5] & 0x40))
+  if (userdata.size() < 5 || !(userdata[5] & 0x40))
   {
     CLog::LogF(LOGDEBUG, "Invalid GA94 flags or payload too small");
     return;
   }
 
-  int cc_count = userdata[5] & 0x1f;
-  if (cc_count == 0 || payloadSize < 7 + cc_count * 3)
+  unsigned cc_count = userdata[5] & 0x1f;
+  if (cc_count == 0 || userdata.size() < 7 + cc_count * 3)
   {
     CLog::LogF(LOGDEBUG, "Invalid cc_count ({}) or insufficient data", cc_count);
     return;
   }
 
-  tempBuffer.emplace_back(cc_count * 3);
-  std::copy(userdata + 7, userdata + 7 + cc_count * 3, tempBuffer.back().m_data.data());
-  tempBuffer.back().m_pts = pts;
+  CCaptionBlock& cb = tempBuffer.emplace_back(cc_count * 3);
+  std::copy_n(userdata.begin() + 7, cc_count * 3, cb.m_data.begin());
+  cb.m_pts = pts;
 }
 
-CCPictureType CH264CCBitstreamParser::DetectSliceType(uint8_t* buf, int len)
+CCPictureType CH264CCBitstreamParser::DetectSliceType(std::span<const uint8_t> buf)
 {
-  if (len < 2)
+  if (buf.size() < 2)
   {
-    CLog::LogF(LOGDEBUG, "Slice too small ({})", len);
+    CLog::LogF(LOGDEBUG, "Slice too small ({})", buf.size());
     return CCPictureType::INVALID;
   }
 
   // Skip NAL header byte - RBSP data starts at buf+1
-  CBitstream bs(buf + 1, (len - 1) * 8);
+  CBitstream bs(buf.data() + 1, (buf.size() - 1) * 8);
 
   bs.readGolombUE(); // first_mb_in_slice
   if (bs.hasError())

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264CCBitstreamParser.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264CCBitstreamParser.cpp
@@ -1,0 +1,117 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "H264CCBitstreamParser.h"
+
+#include "Bitstream.h"
+#include "CaptionBlock.h"
+#include "cores/VideoPlayer/Interface/DemuxPacket.h"
+#include "utils/log.h"
+
+#include <cstring>
+
+void CH264CCBitstreamParser::ProcessSEIPayload(uint8_t* buf,
+                                               int len,
+                                               double pts,
+                                               std::vector<CCaptionBlock*>& tempBuffer)
+{
+  if (len < 8)
+  {
+    CLog::LogF(LOGDEBUG, "SEI payload too small ({})", len);
+    return;
+  }
+
+  // SEI user data may have ITU-T T.35 prefix or direct GA94 format
+  // ITU-T T.35 format: country_code(1 byte) + provider_code(2 bytes) + user_data
+  // Example: B5 00 31 47 41 39 34 03 ... (0xB5=USA, 0x0031=ATSC, "GA94"...)
+  //
+  // Direct GA94 format: 47 41 39 34 03 ... ("GA94"...)
+
+  int gaOffset = -1;
+
+  // Check for ITU-T T.35 format with GA94 at offset 3
+  if (len >= 11 && buf[3] == 'G' && buf[4] == 'A' && buf[5] == '9' && buf[6] == '4' && buf[7] == 3)
+  {
+    gaOffset = 3;
+  }
+  // Check for direct GA94 format at offset 0
+  else if (len >= 8 && buf[0] == 'G' && buf[1] == 'A' && buf[2] == '9' && buf[3] == '4' &&
+           buf[4] == 3)
+  {
+    gaOffset = 0;
+  }
+
+  if (gaOffset == -1)
+  {
+    CLog::LogF(LOGDEBUG, "GA94 marker not found in SEI payload");
+    return;
+  }
+
+  // GA94 format: 'G' 'A' '9' '4' 0x03 flags cc_data...
+  uint8_t* userdata = buf + gaOffset;
+  int payloadSize = len - gaOffset;
+
+  // Check process_cc_data_flag (bit 6 of flags byte)
+  if (payloadSize < 5 || !(userdata[5] & 0x40))
+  {
+    CLog::LogF(LOGDEBUG, "Invalid GA94 flags or payload too small");
+    return;
+  }
+
+  int cc_count = userdata[5] & 0x1f;
+  if (cc_count == 0 || payloadSize < 7 + cc_count * 3)
+  {
+    CLog::LogF(LOGDEBUG, "Invalid cc_count ({}) or insufficient data", cc_count);
+    return;
+  }
+
+  CCaptionBlock* cc = new CCaptionBlock(cc_count * 3);
+  memcpy(cc->m_data.data(), userdata + 7, cc_count * 3);
+  cc->m_pts = pts;
+  tempBuffer.push_back(cc);
+}
+
+CCPictureType CH264CCBitstreamParser::DetectSliceType(uint8_t* buf, int len)
+{
+  if (len < 2)
+  {
+    CLog::LogF(LOGDEBUG, "Slice too small ({})", len);
+    return CCPictureType::INVALID;
+  }
+
+  // Skip NAL header byte - RBSP data starts at buf+1
+  CBitstream bs(buf + 1, (len - 1) * 8);
+
+  bs.readGolombUE(); // first_mb_in_slice
+  if (bs.hasError())
+  {
+    CLog::LogF(LOGDEBUG, "Failed to read first_mb_in_slice");
+    return CCPictureType::INVALID;
+  }
+
+  int sliceType = bs.readGolombUE(); // slice_type
+  if (bs.hasError())
+  {
+    CLog::LogF(LOGDEBUG, "Failed to read slice_type");
+    return CCPictureType::INVALID;
+  }
+
+  // H.264 slice types:
+  // 0,5 = P (predicted)
+  // 1,6 = B (bi-directional)
+  // 2,7 = I (intra)
+  // 3,8 = SP
+  // 4,9 = SI
+
+  if (sliceType == 2 || sliceType == 7) // I slice
+    return CCPictureType::I_FRAME;
+  else if (sliceType == 0 || sliceType == 5) // P slice
+    return CCPictureType::P_FRAME;
+
+  return CCPictureType::OTHER;
+}

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264CCBitstreamParser.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264CCBitstreamParser.cpp
@@ -13,12 +13,12 @@
 #include "cores/VideoPlayer/Interface/DemuxPacket.h"
 #include "utils/log.h"
 
-#include <cstring>
+#include <algorithm>
 
 void CH264CCBitstreamParser::ProcessSEIPayload(uint8_t* buf,
                                                int len,
                                                double pts,
-                                               std::vector<CCaptionBlock*>& tempBuffer)
+                                               std::vector<CCaptionBlock>& tempBuffer)
 {
   if (len < 8)
   {
@@ -70,10 +70,9 @@ void CH264CCBitstreamParser::ProcessSEIPayload(uint8_t* buf,
     return;
   }
 
-  CCaptionBlock* cc = new CCaptionBlock(cc_count * 3);
-  memcpy(cc->m_data.data(), userdata + 7, cc_count * 3);
-  cc->m_pts = pts;
-  tempBuffer.push_back(cc);
+  tempBuffer.emplace_back(cc_count * 3);
+  std::copy(userdata + 7, userdata + 7 + cc_count * 3, tempBuffer.back().m_data.data());
+  tempBuffer.back().m_pts = pts;
 }
 
 CCPictureType CH264CCBitstreamParser::DetectSliceType(uint8_t* buf, int len)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264CCBitstreamParser.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264CCBitstreamParser.cpp
@@ -52,25 +52,25 @@ void CH264CCBitstreamParser::ProcessSEIPayload(std::span<const uint8_t> buf,
     return;
   }
 
-  // GA94 format: 'G' 'A' '9' '4' 0x03 flags cc_data...
+  // GA94 format: 'G' 'A' '9' '4' 0x03 flags ccData...
   std::span<const uint8_t> userdata = buf.subspan(gaOffset);
 
-  // Check process_cc_data_flag (bit 6 of flags byte)
+  // Check process_ccData_flag (bit 6 of flags byte)
   if (userdata.size() < 5 || !(userdata[5] & 0x40))
   {
     CLog::LogF(LOGDEBUG, "Invalid GA94 flags or payload too small");
     return;
   }
 
-  unsigned cc_count = userdata[5] & 0x1f;
-  if (cc_count == 0 || userdata.size() < 7 + cc_count * 3)
+  unsigned ccCount = userdata[5] & 0x1f;
+  if (ccCount == 0 || userdata.size() < 7 + ccCount * 3)
   {
-    CLog::LogF(LOGDEBUG, "Invalid cc_count ({}) or insufficient data", cc_count);
+    CLog::LogF(LOGDEBUG, "Invalid ccCount ({}) or insufficient data", ccCount);
     return;
   }
 
-  CCaptionBlock& cb = tempBuffer.emplace_back(cc_count * 3);
-  std::copy_n(userdata.begin() + 7, cc_count * 3, cb.m_data.begin());
+  CCaptionBlock& cb = tempBuffer.emplace_back(ccCount * 3);
+  std::copy_n(userdata.begin() + 7, ccCount * 3, cb.m_data.begin());
   cb.m_pts = pts;
 }
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264CCBitstreamParser.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264CCBitstreamParser.h
@@ -36,10 +36,7 @@ protected:
    * \param pts Presentation timestamp for CC data
    * \param tempBuffer Temporary buffer for CC data (for reordering)
    */
-  void ProcessSEIPayload(uint8_t* buf,
-                         int len,
-                         double pts,
-                         std::vector<CCaptionBlock*>& tempBuffer);
+  void ProcessSEIPayload(uint8_t* buf, int len, double pts, std::vector<CCaptionBlock>& tempBuffer);
 
   /*!
    * \brief Detect slice type from H.264 slice header

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264CCBitstreamParser.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264CCBitstreamParser.h
@@ -10,6 +10,8 @@
 
 #include "ICCBitstreamParser.h"
 
+#include <span>
+
 /*!
  * \brief Base class for H.264 closed caption bitstream parsers
  *
@@ -36,7 +38,9 @@ protected:
    * \param pts Presentation timestamp for CC data
    * \param tempBuffer Temporary buffer for CC data (for reordering)
    */
-  void ProcessSEIPayload(uint8_t* buf, int len, double pts, std::vector<CCaptionBlock>& tempBuffer);
+  void ProcessSEIPayload(std::span<const uint8_t> buf,
+                         double pts,
+                         std::vector<CCaptionBlock>& tempBuffer);
 
   /*!
    * \brief Detect slice type from H.264 slice header
@@ -48,5 +52,5 @@ protected:
    * \param len Length of slice data
    * \return Picture type (I_FRAME, P_FRAME, OTHER, or INVALID if parsing fails)
    */
-  CCPictureType DetectSliceType(uint8_t* buf, int len);
+  CCPictureType DetectSliceType(std::span<const uint8_t> buf);
 };

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264CCBitstreamParser.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/H264CCBitstreamParser.h
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "ICCBitstreamParser.h"
+
+/*!
+ * \brief Base class for H.264 closed caption bitstream parsers
+ *
+ * Provides shared functionality for parsing H.264 SEI (Supplemental Enhancement
+ * Information) payloads containing CEA-608/708 closed caption data.
+ *
+ * H.264 CC data is embedded in SEI NAL units (type 6) with payload type 4
+ * (user_data_registered_itu_t_t35). The data may be prefixed with ITU-T T.35
+ * country/provider codes or contain GA94 data directly.
+ */
+class CH264CCBitstreamParser : public ICCBitstreamParser
+{
+protected:
+  /*!
+   * \brief Process SEI payload containing closed caption data
+   *
+   * Searches for GA94 closed caption payload within SEI user data.
+   * Handles both:
+   * - ITU-T T.35 format: country_code(1) + provider_code(2) + 'GA94'...
+   * - Direct GA94 format: 'GA94'...
+   *
+   * \param buf Pointer to SEI payload data
+   * \param len Length of SEI payload
+   * \param pts Presentation timestamp for CC data
+   * \param tempBuffer Temporary buffer for CC data (for reordering)
+   */
+  void ProcessSEIPayload(uint8_t* buf,
+                         int len,
+                         double pts,
+                         std::vector<CCaptionBlock*>& tempBuffer);
+
+  /*!
+   * \brief Detect slice type from H.264 slice header
+   *
+   * Parses the slice header to determine if this is an I-slice, P-slice, or B-slice.
+   * Used to determine when to decode CC data (I/P frames only).
+   *
+   * \param buf Pointer to slice NAL unit data (after NAL header)
+   * \param len Length of slice data
+   * \return Picture type (I_FRAME, P_FRAME, OTHER, or INVALID if parsing fails)
+   */
+  CCPictureType DetectSliceType(uint8_t* buf, int len);
+};

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/ICCBitstreamParser.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/ICCBitstreamParser.h
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+class CCaptionBlock;
+struct DemuxPacket;
+
+/*!
+ * \brief H.264/MPEG2 bitstream format for NAL unit framing
+ */
+enum class CCBitstreamFormat
+{
+  ANNEXB, //!< Annex B format with start codes (0x000001 or 0x00000001)
+  AVCC //!< AVCC format with length-prefixed NAL units (MP4/MKV)
+};
+
+/*!
+ * \brief Picture type for determining when to decode closed caption data
+ *
+ * CC data is decoded on reference frames (I/P) to ensure correct temporal
+ * ordering, as B-frames may be reordered during video decoding.
+ */
+enum class CCPictureType
+{
+  INVALID = -1, //!< Corrupted/malformed frame - parsing error detected
+  OTHER = 0, //!< B-frame or frame type that doesn't require CC processing
+  I_FRAME = 1, //!< I-frame (Intra-coded picture) - keyframe
+  P_FRAME = 2 //!< P-frame (Predicted picture) - forward prediction
+};
+
+/*!
+ * \brief Base interface for codec-specific closed caption bitstream parsers
+ *
+ * Implementations extract CEA-608/708 closed caption data from video packets.
+ * Each codec (MPEG2, H.264 AVCC, H.264 Annex B) has its own parsing logic.
+ */
+class ICCBitstreamParser
+{
+public:
+  virtual ~ICCBitstreamParser() = default;
+
+  /*!
+   * \brief Parse a video packet and extract closed caption data
+   *
+   * \param pPacket Video packet to parse (contains raw bitstream data)
+   * \param tempBuffer Temporary buffer for CC data (used for reordering)
+   * \param reorderBuffer Reorder buffer for CC data (sorted by PTS)
+   * \return Picture type of the frame, used to determine when to decode CC
+   *
+   * Implementations search for SEI (H.264) or user data (MPEG2) NAL units
+   * containing GA94 closed caption payloads.
+   */
+  virtual CCPictureType ParsePacket(DemuxPacket* pPacket,
+                                    std::vector<CCaptionBlock*>& tempBuffer,
+                                    std::vector<CCaptionBlock*>& reorderBuffer) = 0;
+
+  /*!
+   * \brief Get parser name for debugging/logging
+   * \return Human-readable parser name
+   */
+  virtual const char* GetName() const = 0;
+};

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/ICCBitstreamParser.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/ICCBitstreamParser.h
@@ -60,8 +60,8 @@ public:
    * containing GA94 closed caption payloads.
    */
   virtual CCPictureType ParsePacket(DemuxPacket* pPacket,
-                                    std::vector<CCaptionBlock*>& tempBuffer,
-                                    std::vector<CCaptionBlock*>& reorderBuffer) = 0;
+                                    std::vector<CCaptionBlock>& tempBuffer,
+                                    std::vector<CCaptionBlock>& reorderBuffer) = 0;
 
   /*!
    * \brief Get parser name for debugging/logging

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/MPEG2CCBitstreamParser.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/MPEG2CCBitstreamParser.cpp
@@ -1,0 +1,171 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "MPEG2CCBitstreamParser.h"
+
+#include "CaptionBlock.h"
+#include "cores/VideoPlayer/Interface/DemuxPacket.h"
+#include "utils/log.h"
+
+#include <cstring>
+
+CCPictureType CMPEG2CCBitstreamParser::ParsePacket(DemuxPacket* pPacket,
+                                                   std::vector<CCaptionBlock*>& tempBuffer,
+                                                   std::vector<CCaptionBlock*>& reorderBuffer)
+{
+  CCPictureType picType = CCPictureType::OTHER;
+  uint32_t startcode = 0xffffffff;
+  int p = 0;
+  int len;
+
+  // Scan packet for MPEG2 start codes
+  while ((len = pPacket->iSize - p) > 3)
+  {
+    if ((startcode & 0xffffff00) == 0x00000100)
+    {
+      int scode = startcode & 0xFF;
+
+      // Picture header (0x00) - determine picture type
+      if (scode == 0x00)
+      {
+        if (len > 4)
+        {
+          uint8_t* buf = pPacket->pData + p;
+          int mpegPicType = (buf[1] & 0x38) >> 3;
+
+          // Convert MPEG2 picture type to CCPictureType
+          // MPEG2: 1=I-frame, 2=P-frame, 3=B-frame
+          if (mpegPicType == 1)
+            picType = CCPictureType::I_FRAME;
+          else if (mpegPicType == 2)
+            picType = CCPictureType::P_FRAME;
+          else
+            picType = CCPictureType::OTHER;
+        }
+      }
+      // User data (0xb2) - extract closed caption data
+      else if (scode == 0xb2)
+      {
+        uint8_t* buf = pPacket->pData + p;
+
+        // Check for GA94 format
+        if (len >= 6 && buf[0] == 'G' && buf[1] == 'A' && buf[2] == '9' && buf[3] == '4')
+        {
+          ProcessGA94UserData(buf, len, pPacket->pts, picType, tempBuffer, reorderBuffer);
+        }
+        // Check for CC format (SCTE-20)
+        else if (len >= 6 && buf[0] == 'C' && buf[1] == 'C' && buf[2] == 1)
+        {
+          ProcessCCUserData(buf, len, pPacket->pts, reorderBuffer);
+          // CC format always uses I-frame timing
+          picType = CCPictureType::I_FRAME;
+        }
+      }
+    }
+
+    startcode = startcode << 8 | pPacket->pData[p++];
+  }
+
+  return picType;
+}
+
+void CMPEG2CCBitstreamParser::ProcessGA94UserData(uint8_t* buf,
+                                                  int len,
+                                                  double pts,
+                                                  CCPictureType picType,
+                                                  std::vector<CCaptionBlock*>& tempBuffer,
+                                                  std::vector<CCaptionBlock*>& reorderBuffer)
+{
+  // GA94 format: 'G' 'A' '9' '4' 0x03 flags cc_data...
+  // buf[4] should be 0x03 (user_data_type_code)
+  // buf[5] contains flags and cc_count
+  if (buf[4] != 3 || !(buf[5] & 0x40)) // Check user_data_type_code and process_cc_data_flag
+  {
+    CLog::LogF(LOGDEBUG, "Invalid GA94 user_data_type_code or process_cc_data_flag not set");
+    return;
+  }
+
+  int cc_count = buf[5] & 0x1f;
+  if (cc_count == 0 || len < 7 + cc_count * 3)
+  {
+    CLog::LogF(LOGDEBUG, "Invalid cc_count ({}) or insufficient data (len={})", cc_count, len);
+    return;
+  }
+
+  CCaptionBlock* cc = new CCaptionBlock(cc_count * 3);
+  memcpy(cc->m_data.data(), buf + 7, cc_count * 3);
+  cc->m_pts = pts;
+
+  // Reference frames (I/P) go to temp buffer for proper ordering
+  // Non-reference frames (B) go directly to reorder buffer
+  if (picType == CCPictureType::I_FRAME || picType == CCPictureType::P_FRAME)
+    tempBuffer.push_back(cc);
+  else
+    reorderBuffer.push_back(cc);
+}
+
+void CMPEG2CCBitstreamParser::ProcessCCUserData(uint8_t* buf,
+                                                int len,
+                                                double pts,
+                                                std::vector<CCaptionBlock*>& reorderBuffer)
+{
+  // CC format (SCTE-20): 'C' 'C' 0x01 ...
+  // buf[3] is reserved
+  // buf[4] contains field information and cc_count
+
+  int oddidx = (buf[4] & 0x80) ? 0 : 1;
+  int cc_count = (buf[4] & 0x3e) >> 1;
+  int extrafield = buf[4] & 0x01;
+
+  if (extrafield)
+    cc_count++;
+
+  if (cc_count == 0 || len < 5 + cc_count * 3 * 2)
+  {
+    CLog::LogF(LOGDEBUG, "Invalid CC user data: cc_count={}, len={}", cc_count, len);
+    return;
+  }
+
+  CCaptionBlock* cc = new CCaptionBlock(cc_count * 3);
+  uint8_t* src = buf + 5;
+  uint8_t* dst = cc->m_data.data();
+  int bytesWritten = 0;
+
+  for (int i = 0; i < cc_count; i++)
+  {
+    for (int j = 0; j < 2; j++)
+    {
+      if (i == cc_count - 1 && extrafield && j == 1)
+        break;
+
+      // Check if this is valid CC data for the current field
+      if ((oddidx == j) && (src[0] == 0xFF))
+      {
+        dst[0] = 0x04; // CEA-608 field indicator
+        dst[1] = src[1];
+        dst[2] = src[2];
+        dst += 3;
+        bytesWritten += 3;
+      }
+      src += 3;
+    }
+  }
+
+  cc->m_data.resize(bytesWritten);
+
+  // Only add to buffer if we actually extracted valid CC data
+  if (bytesWritten > 0)
+  {
+    cc->m_pts = pts;
+    reorderBuffer.push_back(cc);
+  }
+  else
+  {
+    delete cc;
+  }
+}

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/MPEG2CCBitstreamParser.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/MPEG2CCBitstreamParser.h
@@ -47,8 +47,8 @@ private:
   /*!
    * \brief Process GA94 format user data
    *
-   * GA94 format: 'G''A''9''4' 0x03 flags cc_data...
-   * Extracts cc_count and cc_data triplets.
+   * GA94 format: 'G''A''9''4' 0x03 flags ccData...
+   * Extracts ccCount and ccData triplets.
    */
   void ProcessGA94UserData(std::span<const uint8_t> buf,
                            double pts,

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/MPEG2CCBitstreamParser.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/MPEG2CCBitstreamParser.h
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "ICCBitstreamParser.h"
+
+/*!
+ * \brief MPEG2 closed caption parser
+ *
+ * Extracts CEA-608/708 closed caption data from MPEG2 video streams.
+ * Searches for:
+ * - Picture headers (start code 0x00) to determine picture type (I/P/B)
+ * - User data (start code 0xb2) containing GA94 or CC closed caption payloads
+ */
+class CMPEG2CCBitstreamParser : public ICCBitstreamParser
+{
+public:
+  CMPEG2CCBitstreamParser() = default;
+  ~CMPEG2CCBitstreamParser() override = default;
+
+  /*!
+   * \brief Parse MPEG2 packet for closed caption data
+   *
+   * Scans the packet for MPEG2 start codes and extracts CC data from user data sections.
+   * Supports both GA94 and CC data formats.
+   *
+   * \param pPacket MPEG2 video packet with Annex B start codes
+   * \param tempBuffer Temporary buffer for CC data from reference frames
+   * \param reorderBuffer Reorder buffer for CC data
+   * \return Picture type (I_FRAME, P_FRAME, or OTHER)
+   */
+  CCPictureType ParsePacket(DemuxPacket* pPacket,
+                            std::vector<CCaptionBlock*>& tempBuffer,
+                            std::vector<CCaptionBlock*>& reorderBuffer) override;
+
+  const char* GetName() const override { return "MPEG2CCBitstreamParser"; }
+
+private:
+  /*!
+   * \brief Process GA94 format user data
+   *
+   * GA94 format: 'G''A''9''4' 0x03 flags cc_data...
+   * Extracts cc_count and cc_data triplets.
+   */
+  void ProcessGA94UserData(uint8_t* buf,
+                           int len,
+                           double pts,
+                           CCPictureType picType,
+                           std::vector<CCaptionBlock*>& tempBuffer,
+                           std::vector<CCaptionBlock*>& reorderBuffer);
+
+  /*!
+   * \brief Process CC format user data
+   *
+   * CC format: 'C''C' 0x01 ... (SCTE-20 format)
+   * Used by some broadcast systems, extracts field-based CC data.
+   */
+  void ProcessCCUserData(uint8_t* buf,
+                         int len,
+                         double pts,
+                         std::vector<CCaptionBlock*>& reorderBuffer);
+};

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/MPEG2CCBitstreamParser.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/MPEG2CCBitstreamParser.h
@@ -10,6 +10,8 @@
 
 #include "ICCBitstreamParser.h"
 
+#include <span>
+
 /*!
  * \brief MPEG2 closed caption parser
  *
@@ -48,8 +50,7 @@ private:
    * GA94 format: 'G''A''9''4' 0x03 flags cc_data...
    * Extracts cc_count and cc_data triplets.
    */
-  void ProcessGA94UserData(uint8_t* buf,
-                           int len,
+  void ProcessGA94UserData(std::span<const uint8_t> buf,
                            double pts,
                            CCPictureType picType,
                            std::vector<CCaptionBlock>& tempBuffer,
@@ -61,8 +62,7 @@ private:
    * CC format: 'C''C' 0x01 ... (SCTE-20 format)
    * Used by some broadcast systems, extracts field-based CC data.
    */
-  void ProcessCCUserData(uint8_t* buf,
-                         int len,
+  void ProcessCCUserData(std::span<const uint8_t> buf,
                          double pts,
                          std::vector<CCaptionBlock>& reorderBuffer);
 };

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/MPEG2CCBitstreamParser.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC/MPEG2CCBitstreamParser.h
@@ -36,8 +36,8 @@ public:
    * \return Picture type (I_FRAME, P_FRAME, or OTHER)
    */
   CCPictureType ParsePacket(DemuxPacket* pPacket,
-                            std::vector<CCaptionBlock*>& tempBuffer,
-                            std::vector<CCaptionBlock*>& reorderBuffer) override;
+                            std::vector<CCaptionBlock>& tempBuffer,
+                            std::vector<CCaptionBlock>& reorderBuffer) override;
 
   const char* GetName() const override { return "MPEG2CCBitstreamParser"; }
 
@@ -52,8 +52,8 @@ private:
                            int len,
                            double pts,
                            CCPictureType picType,
-                           std::vector<CCaptionBlock*>& tempBuffer,
-                           std::vector<CCaptionBlock*>& reorderBuffer);
+                           std::vector<CCaptionBlock>& tempBuffer,
+                           std::vector<CCaptionBlock>& reorderBuffer);
 
   /*!
    * \brief Process CC format user data
@@ -64,5 +64,5 @@ private:
   void ProcessCCUserData(uint8_t* buf,
                          int len,
                          double pts,
-                         std::vector<CCaptionBlock*>& reorderBuffer);
+                         std::vector<CCaptionBlock>& reorderBuffer);
 };

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4055,7 +4055,8 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
   // open CC demuxer if video is mpeg2
   if ((hint.codec == AV_CODEC_ID_MPEG2VIDEO || hint.codec == AV_CODEC_ID_H264) && !m_pCCDemuxer)
   {
-    m_pCCDemuxer = std::make_unique<CDVDDemuxCC>(hint.codec);
+    m_pCCDemuxer = std::make_unique<CDVDDemuxCC>(hint.codec, hint.extradata.GetData(),
+                                                 static_cast<int>(hint.extradata.GetSize()));
     m_SelectionStreams.Clear(StreamType::NONE, STREAM_SOURCE_VIDEOMUX);
   }
 


### PR DESCRIPTION
## Description
This pull request adds H264 AVCC (AVC Configuration) format support to the closed caption demuxer and bitstream parser. Previously, our demuxer only handled H264 streams in Annex B format, but many container formats (particularly MP4/MOV) use the AVCC format which stores parameter sets separately and uses length-prefixed NAL units instead of start codes. This enables proper extraction and parsing of CEA-608/CEA-708 closed caption data from H264 AVCC encoded video streams, extending compatibility with a broader range of media files. With a little bit of help from AI :)

A couple of samples to test the implementation (https://github.com/xbmc/xbmc/pull/21410).

https://github.com/user-attachments/assets/46c8c734-6a09-43b9-b7af-3ac43f8aa0aa
https://limewire.com/?referrer=pq7i8xx7p2

The PR keeps the previous AnnexB implementation for H264 and MPEG2, so regressions are not to be expected.
[[Subtitles] Add support for H264 AVCC to bitstream parser](https://github.com/xbmc/xbmc/commit/3c6a7f15cbcd16992f625ab2c2c010fe7e602778) is the actual implementation
 [[Subtitles][CC] Re-architecture DVDDemuxCC](https://github.com/xbmc/xbmc/commit/825a0cda2589aeb4bbe405bcced2a4707e291cdf) reorganizes the code a bit reducing the complexity and moving parsing logic for each codec to independent files.

cc @CastagnaIT @matthuisman 

## Motivation and context
I hoped that with a bitstream filter in ffmpeg we could drop the parsing logic from Kodi (https://github.com/ffstaging/FFmpeg/pull/50) but even if that was a reality we would still need to detect the picture types to reorder captions and decode them (so an ffmpeg bsf is of no use).
Using ffmpeg decoders is also not an option due to the overhead when using hardware video decoders.

## How has this been tested?
Runtime tested against all my CC samples (mpeg2, h264... all work)

## What is the effect on users?
Closed caption support should be better

## Screenshots (if appropriate):
<img width="783" height="445" alt="image" src="https://github.com/user-attachments/assets/8e5a5125-5900-4699-ac9e-3cd4d1c5d375" />
<img width="774" height="438" alt="image" src="https://github.com/user-attachments/assets/34f096aa-300e-4776-ae06-26d795546701" />


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
