### PR TITLE
[GUI] Fix culling issues with smart redraw 

### DIFF
--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -125,14 +125,18 @@ void CGUIControl::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyreg
   bool changed = (m_controlDirtyState & DIRTY_STATE_CONTROL) != 0 || (m_bInvalidated && IsVisible());
   m_controlDirtyState = 0;
 
-  if (Animate(currentTime))
-    MarkDirtyRegion();
+  // If the control has an active animation, mark it as dirty even if culled because the
+  // animation might change the alpha at a later time so processing needs to continue
+  const bool animated = Animate(currentTime);
 
-  // if the control changed culling state from true to false, mark it
   const bool culled = m_transform.alpha <= 0.01f;
-  if (m_isCulled != culled)
+
+  // if the control changed culling state from true to false, mark it.
+  const bool cullingChanged = m_isCulled != culled;
+
+  if (cullingChanged || animated)
   {
-    m_isCulled = false;
+    m_isCulled = false; // set to false so MarkDirtyRegion() isn't a no-op
     MarkDirtyRegion();
   }
   m_isCulled = culled;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

4cf2befed9b7d55a06127dc148b91db6c3142fc0 added the optimization to cull controls if they are not visible due to their opacity.

Once a control is culled, calling `MarkDirtyRegion()` becomes a no-op and a `CGUIWindow` doesn't execute its `DoProcess()` anymore with smart redraw enabled:
https://github.com/xbmc/xbmc/blob/3963d5406614c7594a7b7112eb4316eef3b5b84b/xbmc/guilib/GUIWindow.cpp#L328-L331
This is a problem if the control is culled but has an animation that would later change the alpha such that culling is removed. Therefore we have to make sure the control stays dirty as long as an animation is active even if the control is culled during rendering.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix smart redraw issues reported in various places:

- #25727
- #22295
- https://github.com/xbmc/xbmc/issues/24539#issuecomment-2028828422

Fix #25727.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Runtime tested.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

See linked issues.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
