### PR TITLE
[Video] Streamdetails are not saved for blurays played through the menu selected via the simple menu.

### DIFF
--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -59,6 +59,7 @@ bool ShouldUpdateStreamDetails(const CFileItem& file)
 {
   // If a title/playlist hasn't been selected for a bluray/dvds then the stream details may not be known
   const bool isDiscOrStream{VIDEO::IsBDFile(file) || VIDEO::IsDVDFile(file) || file.IsDiscImage() ||
+                            URIUtils::IsBlurayMenuPath(file.GetDynPath()) ||
                             NETWORK::IsInternetStream(file)};
 
   // Stream details may be already set from a previous playback or nfo

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -9,7 +9,6 @@
 #include "URIUtils.h"
 
 #include "FileItem.h"
-#include "FileItemList.h"
 #include "PasswordManager.h"
 #include "ServiceBroker.h"
 #include "StringUtils.h"
@@ -35,7 +34,6 @@
 #include <array>
 #include <cassert>
 #include <charconv>
-#include <ranges>
 #include <vector>
 
 #include <arpa/inet.h>
@@ -1438,6 +1436,11 @@ bool URIUtils::IsVideoDb(const std::string& strFile)
 bool URIUtils::IsBlurayPath(const std::string& strFile)
 {
   return IsProtocol(strFile, "bluray");
+}
+
+bool URIUtils::IsBlurayMenuPath(const std::string& file)
+{
+  return IsBlurayPath(file) && GetFileName(file) == "menu";
 }
 
 bool URIUtils::IsOpticalMediaFile(const std::string& file)

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -270,6 +270,7 @@ public:
   static bool IsDiscImage(const std::string& file);
   static bool IsDiscImageStack(const std::string& file);
   static bool IsBlurayPath(const std::string& strFile);
+  static bool IsBlurayMenuPath(const std::string& file);
 
   /*! \brief Determines if a file is from optical media (ie. index.bdmv, video_ts.ifo etc..)
    \param file file path for determination.


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Playing Blurays through the disc menu when Settings -> Player -> Use bluray menu -> correctly saved the streamdetails of the main title.
Playing Blurays through the disc menu when selected via the simple menu failed.

This is due to the former passing the 'real' path (which was detected by IsBDFile()) but the latter passing bluray://xxxx/menu.

Added a function to detect the latter.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Identified by @CrystalP in #27543 (comments).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
