### PR TITLE
[Wayland] InputProcessorKeyboard: Support long-press

### DIFF
--- a/xbmc/windowing/wayland/InputProcessorKeyboard.cpp
+++ b/xbmc/windowing/wayland/InputProcessorKeyboard.cpp
@@ -168,7 +168,10 @@ void CInputProcessorKeyboard::ConvertAndSendKey(std::uint32_t scancode, bool pre
 
   XBMC_Event event{SendKey(scancode, xbmcKey, static_cast<std::uint16_t> (utf32), pressed)};
 
-  if (pressed && m_keymap->ShouldKeycodeRepeat(xkbCode) && m_keyRepeatInterval > 0)
+  // In the past this checked `CXkbcommonKeymap::ShouldKeycodeRepeat()`, but this prevents
+  // handling of long-presses, see #23273. So instead we repeat always and Kodi handles
+  // it internally further up in `CKeyboardStat::TranslateKey()`.
+  if (pressed && m_keyRepeatInterval > 0)
   {
     // Can't modify keyToRepeat until we're sure the thread isn't accessing it
     m_keyRepeatTimer.Stop(true);
@@ -208,10 +211,9 @@ void CInputProcessorKeyboard::KeyRepeatTimeout()
 {
   // Reset ourselves
   m_keyRepeatTimer.RestartAsync(std::chrono::milliseconds(m_keyRepeatInterval));
-  // Simulate repeat: Key up and down
+  // Send `XBMC_KEYDOWN` again without `XBMC_KEYUP` in between, we'll figure out
+  // further up the chain if we want to handle this as a repeat or long-press.
   XBMC_Event event = m_keyToRepeat;
-  event.type = XBMC_KEYUP;
-  m_handler.OnKeyboardEvent(event);
   event.type = XBMC_KEYDOWN;
   m_handler.OnKeyboardEvent(event);
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Let the logic further up handle key repeat vs. long-press.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #23273.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Browsing the GUI. Long-press "enter" opens the context menu if one exists. Long press of buttons in lists or input fields correctly repeats the key for scrolling or entering multiple characters.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Same behavior as on other platforms.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
