### PR TITLE
AESinkPulse: Use also 48 khz for testing

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -736,7 +736,7 @@ bool CAESinkPULSE::Register(bool allowPipeWireCompatServer)
   pa_sample_spec ss;
   ss.format = PA_SAMPLE_S16NE;
   ss.channels = 2;
-  ss.rate = 44100;
+  ss.rate = 48000;
   s = pa_simple_new(NULL, "Kodi-Tester", PA_STREAM_PLAYBACK, NULL, "Test", &ss, NULL, NULL, NULL);
   if (!s)
   {


### PR DESCRIPTION
After 94cbdefddfa40f1edfac1b3375df6fb6e62d5967 our default samplerate also for menu sounds is 48 khz.

This has no user impact, it's only used for test checking pulseaudio server connection and avoids that the backend eventually has to setup some short time resampler as we switch to 48 khz from AE directly.