### PR TITLE
[Games] Refactor handling of video shader textures

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
@@ -13,13 +13,10 @@
 #include "cores/RetroPlayer/rendering/RenderContext.h"
 #include "cores/RetroPlayer/rendering/RenderVideoSettings.h"
 #include "cores/RetroPlayer/shaders/gles/ShaderPresetGLES.h"
-#include "cores/RetroPlayer/shaders/gles/ShaderTextureGLES.h"
-#include "guilib/TextureFormats.h"
-#include "guilib/TextureGLES.h"
+#include "cores/RetroPlayer/shaders/gles/ShaderTextureGLESRef.h"
 #include "utils/BufferObjectFactory.h"
 #include "utils/GLUtils.h"
 
-#include <cassert>
 #include <cstddef>
 
 using namespace KODI;
@@ -58,7 +55,8 @@ void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
   const ViewportCoordinates dest{m_rotatedDestCoords};
 
   auto renderBuffer = static_cast<CRenderBufferDMA*>(m_renderBuffer);
-  assert(renderBuffer != nullptr);
+  if (renderBuffer == nullptr)
+    return;
 
   RenderBufferTextures* rbTextures;
   const auto it = m_RBTexturesMap.find(renderBuffer);
@@ -68,21 +66,21 @@ void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
   }
   else
   {
-    // We can't copy or move CGLTexture, so construct source/target in-place
     rbTextures = new RenderBufferTextures{
         // Source texture
-        std::make_shared<CGLESTexture>(static_cast<unsigned int>(renderBuffer->GetWidth()),
-                                       static_cast<unsigned int>(renderBuffer->GetHeight()),
-                                       XB_FMT_RGB8, renderBuffer->TextureID()),
-        // Target texture
-        std::make_shared<CGLESTexture>(static_cast<unsigned int>(m_context.GetScreenWidth()),
-                                       static_cast<unsigned int>(m_context.GetScreenHeight())),
+        std::make_shared<SHADER::CShaderTextureGLESRef>(
+            static_cast<unsigned int>(renderBuffer->GetWidth()),
+            static_cast<unsigned int>(renderBuffer->GetHeight()), renderBuffer->TextureID()),
+        // Target texture is empty wrapper used to pass target width and height
+        std::make_shared<SHADER::CShaderTextureGLESRef>(
+            static_cast<unsigned int>(m_context.GetScreenWidth()),
+            static_cast<unsigned int>(m_context.GetScreenHeight())),
     };
     m_RBTexturesMap.emplace(renderBuffer, rbTextures);
   }
 
-  std::shared_ptr<CGLESTexture> sourceTexture = rbTextures->source;
-  std::shared_ptr<CGLESTexture> targetTexture = rbTextures->target;
+  std::shared_ptr<SHADER::CShaderTextureGLESRef> source = rbTextures->source;
+  std::shared_ptr<SHADER::CShaderTextureGLESRef> target = rbTextures->target;
 
   Updateshaders();
 
@@ -93,15 +91,13 @@ void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
     if (m_shaderPreset->GetPasses()[0].filterType == SHADER::FilterType::LINEAR)
       filter = GL_LINEAR;
 
-    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
+    glBindTexture(m_textureTarget, source->GetTextureID());
     glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    SHADER::CShaderTextureGLES source(sourceTexture, false);
-    SHADER::CShaderTextureGLES target(targetTexture, false);
-    if (!m_shaderPreset->RenderUpdate(dest, {m_fullDestWidth, m_fullDestHeight}, source, target))
+    if (!m_shaderPreset->RenderUpdate(dest, {m_fullDestWidth, m_fullDestHeight}, *source, *target))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;
@@ -123,7 +119,7 @@ void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
     if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
       filter = GL_LINEAR;
 
-    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
+    glBindTexture(m_textureTarget, source->GetTextureID());
     glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -12,9 +12,7 @@
 #include "cores/RetroPlayer/buffers/RenderBufferPoolOpenGL.h"
 #include "cores/RetroPlayer/rendering/RenderContext.h"
 #include "cores/RetroPlayer/shaders/gl/ShaderPresetGL.h"
-#include "cores/RetroPlayer/shaders/gl/ShaderTextureGL.h"
-#include "guilib/TextureFormats.h"
-#include "guilib/TextureGL.h"
+#include "cores/RetroPlayer/shaders/gl/ShaderTextureGLRef.h"
 #include "utils/GLUtils.h"
 #include "utils/log.h"
 
@@ -288,21 +286,21 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
   }
   else
   {
-    // We can't copy or move CGLTexture, so construct source/target in-place
     rbTextures = new RenderBufferTextures{
         // Source texture
-        std::make_shared<CGLTexture>(static_cast<unsigned int>(renderBuffer->GetWidth()),
-                                     static_cast<unsigned int>(renderBuffer->GetHeight()),
-                                     XB_FMT_RGB8, renderBuffer->TextureID()),
-        // Target texture
-        std::make_shared<CGLTexture>(static_cast<unsigned int>(m_context.GetScreenWidth()),
-                                     static_cast<unsigned int>(m_context.GetScreenHeight())),
+        std::make_shared<SHADER::CShaderTextureGLRef>(
+            static_cast<unsigned int>(renderBuffer->GetWidth()),
+            static_cast<unsigned int>(renderBuffer->GetHeight()), renderBuffer->TextureID()),
+        // Target texture is empty wrapper used to pass target width and height
+        std::make_shared<SHADER::CShaderTextureGLRef>(
+            static_cast<unsigned int>(m_context.GetScreenWidth()),
+            static_cast<unsigned int>(m_context.GetScreenHeight())),
     };
     m_RBTexturesMap.emplace(renderBuffer, rbTextures);
   }
 
-  std::shared_ptr<CGLTexture> sourceTexture = rbTextures->source;
-  std::shared_ptr<CGLTexture> targetTexture = rbTextures->target;
+  std::shared_ptr<SHADER::CShaderTextureGLRef> source = rbTextures->source;
+  std::shared_ptr<SHADER::CShaderTextureGLRef> target = rbTextures->target;
 
   Updateshaders();
 
@@ -313,15 +311,13 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
     if (m_shaderPreset->GetPasses()[0].filterType == SHADER::FilterType::LINEAR)
       filter = GL_LINEAR;
 
-    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
+    glBindTexture(m_textureTarget, source->GetTextureID());
     glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    SHADER::CShaderTextureGL source(sourceTexture, false);
-    SHADER::CShaderTextureGL target(targetTexture, false);
-    if (!m_shaderPreset->RenderUpdate(dest, {m_fullDestWidth, m_fullDestHeight}, source, target))
+    if (!m_shaderPreset->RenderUpdate(dest, {m_fullDestWidth, m_fullDestHeight}, *source, *target))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;
@@ -343,7 +339,7 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
     if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
       filter = GL_LINEAR;
 
-    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
+    glBindTexture(m_textureTarget, source->GetTextureID());
     glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
@@ -16,10 +16,13 @@
 
 #include "system_gl.h"
 
-class CGLTexture;
-
 namespace KODI
 {
+namespace SHADER
+{
+class CShaderTextureGLRef;
+} // namespace SHADER
+
 namespace RETRO
 {
 class CRenderContext;
@@ -58,16 +61,18 @@ protected:
     float x, y, z;
     float u1, v1;
   };
+
   struct Svertex
   {
     float x;
     float y;
     float z;
   };
+
   struct RenderBufferTextures
   {
-    std::shared_ptr<CGLTexture> source;
-    std::shared_ptr<CGLTexture> target;
+    std::shared_ptr<SHADER::CShaderTextureGLRef> source;
+    std::shared_ptr<SHADER::CShaderTextureGLRef> target;
   };
 
   // implementation of CRPBaseRenderer

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -13,14 +13,11 @@
 #include "cores/RetroPlayer/rendering/RenderContext.h"
 #include "cores/RetroPlayer/rendering/RenderVideoSettings.h"
 #include "cores/RetroPlayer/shaders/gles/ShaderPresetGLES.h"
-#include "cores/RetroPlayer/shaders/gles/ShaderTextureGLES.h"
-#include "guilib/TextureFormats.h"
-#include "guilib/TextureGLES.h"
+#include "cores/RetroPlayer/shaders/gles/ShaderTextureGLESRef.h"
 #include "utils/GLUtils.h"
 #include "utils/log.h"
 
 #include <cstring>
-#include <stddef.h>
 
 using namespace KODI;
 using namespace RETRO;
@@ -128,12 +125,6 @@ void CRPRendererOpenGLES::DrawBlackBars()
 {
   glDisable(GL_BLEND);
 
-  struct Svertex
-  {
-    float x;
-    float y;
-    float z;
-  };
   Svertex vertices[24];
   GLubyte count = 0;
 
@@ -260,21 +251,21 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
   }
   else
   {
-    // We can't copy or move CGLESTexture, so construct source/target in-place
     rbTextures = new RenderBufferTextures{
         // Source texture
-        std::make_shared<CGLESTexture>(static_cast<unsigned int>(renderBuffer->GetWidth()),
-                                       static_cast<unsigned int>(renderBuffer->GetHeight()),
-                                       XB_FMT_RGB8, renderBuffer->TextureID()),
-        // Target texture
-        std::make_shared<CGLESTexture>(static_cast<unsigned int>(m_context.GetScreenWidth()),
-                                       static_cast<unsigned int>(m_context.GetScreenHeight())),
+        std::make_shared<SHADER::CShaderTextureGLESRef>(
+            static_cast<unsigned int>(renderBuffer->GetWidth()),
+            static_cast<unsigned int>(renderBuffer->GetHeight()), renderBuffer->TextureID()),
+        // Target texture is empty wrapper used to pass target width and height
+        std::make_shared<SHADER::CShaderTextureGLESRef>(
+            static_cast<unsigned int>(m_context.GetScreenWidth()),
+            static_cast<unsigned int>(m_context.GetScreenHeight())),
     };
     m_RBTexturesMap.emplace(renderBuffer, rbTextures);
   }
 
-  std::shared_ptr<CGLESTexture> sourceTexture = rbTextures->source;
-  std::shared_ptr<CGLESTexture> targetTexture = rbTextures->target;
+  std::shared_ptr<SHADER::CShaderTextureGLESRef> source = rbTextures->source;
+  std::shared_ptr<SHADER::CShaderTextureGLESRef> target = rbTextures->target;
 
   Updateshaders();
 
@@ -285,15 +276,13 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
     if (m_shaderPreset->GetPasses()[0].filterType == SHADER::FilterType::LINEAR)
       filter = GL_LINEAR;
 
-    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
+    glBindTexture(m_textureTarget, source->GetTextureID());
     glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    SHADER::CShaderTextureGLES source(sourceTexture, false);
-    SHADER::CShaderTextureGLES target(targetTexture, false);
-    if (!m_shaderPreset->RenderUpdate(dest, {m_fullDestWidth, m_fullDestHeight}, source, target))
+    if (!m_shaderPreset->RenderUpdate(dest, {m_fullDestWidth, m_fullDestHeight}, *source, *target))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;
@@ -315,7 +304,7 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
     if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
       filter = GL_LINEAR;
 
-    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
+    glBindTexture(m_textureTarget, source->GetTextureID());
     glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
@@ -22,10 +22,13 @@
 
 #include "system_gl.h"
 
-class CGLESTexture;
-
 namespace KODI
 {
+namespace SHADER
+{
+class CShaderTextureGLESRef;
+} // namespace SHADER
+
 namespace RETRO
 {
 class CRenderBufferOpenGLES;
@@ -64,6 +67,19 @@ protected:
     float u1, v1;
   };
 
+  struct Svertex
+  {
+    float x;
+    float y;
+    float z;
+  };
+
+  struct RenderBufferTextures
+  {
+    std::shared_ptr<SHADER::CShaderTextureGLESRef> source;
+    std::shared_ptr<SHADER::CShaderTextureGLESRef> target;
+  };
+
   // implementation of CRPBaseRenderer
   void RenderInternal(bool clear, uint8_t alpha) override;
   void FlushInternal() override;
@@ -83,19 +99,13 @@ protected:
 
   virtual void Render(uint8_t alpha);
 
+  std::map<CRenderBufferOpenGLES*, std::unique_ptr<RenderBufferTextures>> m_RBTexturesMap;
+
   GLuint m_mainIndexVBO;
   GLuint m_mainVertexVBO;
   GLuint m_blackbarsVertexVBO;
   GLenum m_textureTarget = GL_TEXTURE_2D;
   float m_clearColour = 0.0f;
-
-  struct RenderBufferTextures
-  {
-    std::shared_ptr<CGLESTexture> source;
-    std::shared_ptr<CGLESTexture> target;
-  };
-
-  std::map<CRenderBufferOpenGLES*, std::unique_ptr<RenderBufferTextures>> m_RBTexturesMap;
 };
 } // namespace RETRO
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
@@ -147,14 +147,12 @@ bool CShaderPreset::Update()
   {
     m_failedPaths.insert(m_presetPath);
     CLog::Log(LOGWARNING, "CShaderPreset::Update: {}", msg);
-    DisposeShaderTextures();
+    DisposeShaders();
     return false;
   };
 
   if (m_bPresetNeedsUpdate && !HasPathFailed(m_presetPath))
   {
-    DisposeShaderTextures();
-
     if (!CreateShaderTextures())
       return updateFailed("A shader texture failed to init");
   }
@@ -236,6 +234,8 @@ void CShaderPreset::CalculateScaledSize(const KODI::SHADER::ShaderPass& pass,
 
 void CShaderPreset::DisposeShaders()
 {
+  DisposeShaderTextures();
+
   m_pShaders.clear();
   m_passes.clear();
 }
@@ -243,7 +243,6 @@ void CShaderPreset::DisposeShaders()
 void CShaderPreset::DisposeShaderTextures()
 {
   m_pShaderTextures.clear();
-  m_bPresetNeedsUpdate = true;
 }
 
 bool CShaderPreset::HasPathFailed(const std::string& path) const

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.h
@@ -111,6 +111,5 @@ protected:
   // Playback speed
   double m_speed{1.0};
 };
-
 } // namespace SHADER
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/shaders/gl/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/shaders/gl/CMakeLists.txt
@@ -3,12 +3,14 @@ if(TARGET ${APP_NAME_LC}::OpenGl)
                       ShaderLutGL.cpp
                       ShaderPresetGL.cpp
                       ShaderTextureGL.cpp
+                      ShaderTextureGLRef.cpp
                       ShaderUtilsGL.cpp
   )
   list(APPEND HEADERS ShaderGL.h
                       ShaderLutGL.h
                       ShaderPresetGL.h
                       ShaderTextureGL.h
+                      ShaderTextureGLRef.h
                       ShaderUtilsGL.h
   )
 

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
@@ -24,6 +24,12 @@ public:
   CShaderGL();
   ~CShaderGL() override;
 
+  // Disallow copy and move (this object owns raw GL IDs)
+  CShaderGL(const CShaderGL&) = delete;
+  CShaderGL& operator=(const CShaderGL&) = delete;
+  CShaderGL(CShaderGL&&) = delete;
+  CShaderGL& operator=(CShaderGL&&) = delete;
+
   // Implementation of IShader
   bool Create(std::string shaderSource,
               std::string shaderPath,
@@ -42,6 +48,9 @@ public:
                          const std::vector<std::unique_ptr<IShader>>& pShaders,
                          uint64_t frameCount) override;
   void UpdateMVP() override;
+
+  // OpenGL interface
+  void Destroy();
 
 private:
   struct UniformInputs
@@ -68,7 +77,7 @@ private:
   UniformFrameInputs GetFrameInputData(GLuint texture) const;
   UniformFrameInputs GetFrameUniformInputs() const { return m_uniformFrameInputs; }
   void GetUniformLocs();
-  void SetShaderParameters(CGLTexture& sourceTexture);
+  void SetShaderParameters(CShaderTextureGL& sourceTexture);
 
   // Currently loaded shader's source code
   std::string m_shaderSource;
@@ -100,8 +109,7 @@ private:
   // Index of the video shader pass
   unsigned int m_passIdx{0};
 
-  // Value to modulo (%) frame count with
-  // Unused if 0
+  // Value to modulo (%) frame count with (unused if 0)
   unsigned int m_frameCountMod{0};
 
   GLuint m_shaderProgram{0};

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderLutGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderLutGL.cpp
@@ -63,6 +63,7 @@ std::unique_ptr<CTexture> CShaderLutGL::CreateLUTTexture(const ShaderLut& lut)
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrapType);
 
   const GLfloat blackBorder[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+
   glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, blackBorder);
 
   return texture;

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderLutGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderLutGL.h
@@ -36,5 +36,4 @@ private:
 
   std::unique_ptr<CTexture> m_texture;
 };
-
 } // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.h
@@ -38,6 +38,5 @@ protected:
   bool CreateSamplers() override { return true; }
   void RenderShader(IShader& shader, IShaderTexture& source, IShaderTexture& target) override;
 };
-
 } // namespace SHADER
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGL.cpp
@@ -8,56 +8,78 @@
 
 #include "ShaderTextureGL.h"
 
-#include "guilib/TextureGL.h"
 #include "utils/log.h"
 
 #include <cassert>
 
 using namespace KODI::SHADER;
 
-CShaderTextureGL::CShaderTextureGL(std::shared_ptr<CGLTexture> texture, bool sRgbFramebuffer)
-  : m_texture(std::move(texture)),
-    m_sRgbFramebuffer(sRgbFramebuffer)
+CShaderTextureGL::CShaderTextureGL(uint32_t textureWidth, uint32_t textureHeight)
+  : m_textureWidth(textureWidth),
+    m_textureHeight(textureHeight)
 {
-  assert(m_texture.get() != nullptr);
 }
 
 CShaderTextureGL::~CShaderTextureGL()
 {
-  if (FBO != 0)
-    glDeleteFramebuffers(1, &FBO);
+  DestroyFBO();
+  DestroyTextureObject();
 }
 
 float CShaderTextureGL::GetWidth() const
 {
-  return static_cast<float>(m_texture->GetWidth());
+  return static_cast<float>(m_textureWidth);
 }
 
 float CShaderTextureGL::GetHeight() const
 {
-  return static_cast<float>(m_texture->GetHeight());
+  return static_cast<float>(m_textureHeight);
 }
 
-bool CShaderTextureGL::CreateFBO()
+void CShaderTextureGL::CreateTextureObject()
 {
-  if (FBO == 0)
-    glGenFramebuffers(1, &FBO);
+  glGenTextures(1, &m_texture);
+}
 
-  return true;
+void CShaderTextureGL::DestroyTextureObject()
+{
+  if (m_texture != 0)
+    glDeleteTextures(1, &m_texture);
+
+  m_texture = 0;
+}
+
+void CShaderTextureGL::BindToUnit(unsigned int unit)
+{
+  glActiveTexture(GL_TEXTURE0 + unit);
+  glBindTexture(GL_TEXTURE_2D, m_texture);
+}
+
+void CShaderTextureGL::CreateFBO()
+{
+  if (m_FBO == 0)
+    glGenFramebuffers(1, &m_FBO);
+}
+
+void CShaderTextureGL::DestroyFBO()
+{
+  if (m_FBO != 0)
+    glDeleteFramebuffers(1, &m_FBO);
+
+  m_FBO = 0;
 }
 
 bool CShaderTextureGL::BindFBO()
 {
-  const GLuint renderTargetID = m_texture->GetTextureID();
-  if (renderTargetID == 0)
+  if (m_texture == 0)
     return false;
 
-  if (FBO == 0 && !CreateFBO())
-    return false;
+  if (m_FBO == 0)
+    CreateFBO();
 
-  glBindFramebuffer(GL_FRAMEBUFFER, FBO);
-  glBindTexture(GL_TEXTURE_2D, renderTargetID);
-  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, renderTargetID, 0);
+  glBindFramebuffer(GL_FRAMEBUFFER, m_FBO);
+  glBindTexture(GL_TEXTURE_2D, m_texture);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture, 0);
 
   if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
   {

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGL.h
@@ -14,34 +14,49 @@
 
 #include "system_gl.h"
 
-class CGLTexture;
-
 namespace KODI::SHADER
 {
 
 class CShaderTextureGL : public IShaderTexture
 {
 public:
-  CShaderTextureGL(std::shared_ptr<CGLTexture> texture, bool sRgbFramebuffer);
+  CShaderTextureGL(uint32_t textureWidth, uint32_t textureHeight);
   ~CShaderTextureGL() override;
+
+  // Disallow copy and move (this object owns raw GL IDs)
+  CShaderTextureGL(const CShaderTextureGL&) = delete;
+  CShaderTextureGL& operator=(const CShaderTextureGL&) = delete;
+  CShaderTextureGL(CShaderTextureGL&&) = delete;
+  CShaderTextureGL& operator=(CShaderTextureGL&&) = delete;
 
   // Implementation of IShaderTexture
   float GetWidth() const override;
   float GetHeight() const override;
 
   // OpenGL interface
-  CGLTexture& GetTexture() { return *m_texture; }
-  const CGLTexture& GetTexture() const { return *m_texture; }
+  void CreateTextureObject();
+  void DestroyTextureObject();
+  void BindToUnit(unsigned int unit);
+  GLuint GetTextureID() const { return m_texture; }
+
+  void SetSRGBFramebuffer() { m_sRgbFramebuffer = true; }
   bool IsSRGBFramebuffer() const { return m_sRgbFramebuffer; }
 
+  void SetMipmapping() { m_mipmapping = true; }
+  bool IsMipmapped() const { return m_mipmapping; }
+
   // Frame buffer interface
-  bool CreateFBO();
+  void CreateFBO();
+  void DestroyFBO();
   bool BindFBO();
   void UnbindFBO() const;
 
 private:
-  std::shared_ptr<CGLTexture> m_texture;
+  uint32_t m_textureWidth{0};
+  uint32_t m_textureHeight{0};
+  GLuint m_texture{0};
+  GLuint m_FBO{0};
   bool m_sRgbFramebuffer{false};
-  GLuint FBO{0};
+  bool m_mipmapping{false};
 };
 } // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGLRef.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGLRef.cpp
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (C) 2019-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ShaderTextureGLRef.h"
+
+using namespace KODI::SHADER;
+
+CShaderTextureGLRef::CShaderTextureGLRef(uint32_t textureWidth,
+                                         uint32_t textureHeight,
+                                         GLuint texture)
+  : m_textureWidth(textureWidth),
+    m_textureHeight(textureHeight),
+    m_texture(texture)
+{
+}
+
+float CShaderTextureGLRef::GetWidth() const
+{
+  return static_cast<float>(m_textureWidth);
+}
+
+float CShaderTextureGLRef::GetHeight() const
+{
+  return static_cast<float>(m_textureHeight);
+}
+
+void CShaderTextureGLRef::BindToUnit(unsigned int unit)
+{
+  glActiveTexture(GL_TEXTURE0 + unit);
+  glBindTexture(GL_TEXTURE_2D, m_texture);
+}

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGLRef.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGLRef.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017-2025 Team Kodi
+ *  Copyright (C) 2019-2025 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -10,11 +10,7 @@
 
 #include "cores/RetroPlayer/shaders/IShaderTexture.h"
 
-#include <memory>
-
-#include <d3d11.h>
-
-class CD3DTexture;
+#include "system_gl.h"
 
 namespace KODI::SHADER
 {
@@ -24,23 +20,23 @@ namespace KODI::SHADER
  *
  * NOTE: The lifetime of the external texture object must outlast this class.
  */
-class CShaderTextureDXRef : public IShaderTexture
+class CShaderTextureGLRef : public IShaderTexture
 {
 public:
-  explicit CShaderTextureDXRef(CD3DTexture& texture);
-  ~CShaderTextureDXRef() override = default;
+  CShaderTextureGLRef(uint32_t textureWidth, uint32_t textureHeight, GLuint texture = 0);
+  ~CShaderTextureGLRef() override = default;
 
   // Implementation of IShaderTexture
   float GetWidth() const override;
   float GetHeight() const override;
 
-  // DirectX interface
-  CD3DTexture& GetTexture() { return m_texture; }
-  const CD3DTexture& GetTexture() const { return m_texture; }
-  ID3D11ShaderResourceView* GetShaderResource() const;
+  // OpenGL interface
+  void BindToUnit(unsigned int unit);
+  GLuint GetTextureID() const { return m_texture; }
 
 private:
-  // Construction parameter
-  CD3DTexture& m_texture;
+  uint32_t m_textureWidth{0};
+  uint32_t m_textureHeight{0};
+  GLuint m_texture{0};
 };
 } // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderUtilsGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderUtilsGL.h
@@ -21,5 +21,4 @@ public:
   static GLint TranslateWrapType(WrapType wrapType);
   static std::string GetGLSLVersion(std::string& source);
 };
-
 } // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/gles/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/shaders/gles/CMakeLists.txt
@@ -3,12 +3,14 @@ if(TARGET ${APP_NAME_LC}::OpenGLES)
                       ShaderLutGLES.cpp
                       ShaderPresetGLES.cpp
                       ShaderTextureGLES.cpp
+                      ShaderTextureGLESRef.cpp
                       ShaderUtilsGLES.cpp
   )
   list(APPEND HEADERS ShaderGLES.h
                       ShaderLutGLES.h
                       ShaderPresetGLES.h
                       ShaderTextureGLES.h
+                      ShaderTextureGLESRef.h
                       ShaderUtilsGLES.cpp
   )
 

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
@@ -24,6 +24,12 @@ public:
   CShaderGLES();
   ~CShaderGLES() override;
 
+  // Disallow copy and move (this object owns raw GL IDs)
+  CShaderGLES(const CShaderGLES&) = delete;
+  CShaderGLES& operator=(const CShaderGLES&) = delete;
+  CShaderGLES(CShaderGLES&&) = delete;
+  CShaderGLES& operator=(CShaderGLES&&) = delete;
+
   // Implementation of IShader
   bool Create(std::string shaderSource,
               std::string shaderPath,
@@ -42,6 +48,9 @@ public:
                          const std::vector<std::unique_ptr<IShader>>& pShaders,
                          uint64_t frameCount) override;
   void UpdateMVP() override;
+
+  // OpenGL interface
+  void Destroy();
 
 private:
   struct UniformInputs
@@ -68,7 +77,7 @@ private:
   UniformFrameInputs GetFrameInputData(GLuint texture);
   UniformFrameInputs GetFrameUniformInputs() const { return m_uniformFrameInputs; }
   void GetUniformLocs();
-  void SetShaderParameters(CGLESTexture& sourceTexture);
+  void SetShaderParameters(CShaderTextureGLES& sourceTexture);
 
   // Currently loaded shader's source code
   std::string m_shaderSource;
@@ -100,8 +109,7 @@ private:
   // Index of the video shader pass
   unsigned int m_passIdx{0};
 
-  // Value to modulo (%) frame count with
-  // Unused if 0
+  // Value to modulo (%) frame count with (unused if 0)
   unsigned int m_frameCountMod{0};
 
   GLuint m_shaderProgram{0};

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderLutGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderLutGLES.h
@@ -36,5 +36,4 @@ private:
 
   std::unique_ptr<CTexture> m_texture;
 };
-
 } // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.cpp
@@ -70,7 +70,7 @@ bool CShaderPresetGLES::CreateShaders()
 
 bool CShaderPresetGLES::CreateShaderTextures()
 {
-  m_pShaderTextures.clear();
+  DisposeShaderTextures();
 
   unsigned int major{0};
   unsigned int minor{0};
@@ -90,6 +90,24 @@ bool CShaderPresetGLES::CreateShaderTextures()
     float2 textureSize;
     CalculateScaledSize(pass, prevSize, scaledSize);
 
+    //! @todo Enable usage of optimal texture sizes once multi-pass preset
+    // geometry and LUT rendering are fixed.
+    //
+    // Current issues:
+    //   - Enabling optimal texture sizes breaks geometry for many multi-pass
+    //     presets
+    //   - LUTs render incorrectly due to missing per-pass and per-LUT
+    //     TexCoord attributes.
+    //
+    // Planned solution:
+    //   - Implement additional TexCoord attributes for each pass and LUT,
+    //     setting coordinates to `xamt` and `yamt` instead of 1
+    //
+    // Reference implementation in RetroArch:
+    //   https://github.com/libretro/RetroArch/blob/09a59edd6b415b7bd124b03bda68ccc4d60b0ea8/gfx/drivers/gl2.c#L3018
+    //
+    textureSize = scaledSize; // CShaderUtils::GetOptimalTextureSize(scaledSize)
+
     if (shaderIdx + 1 == numPasses)
     {
       // We're supposed to output at full (viewport) resolution
@@ -98,6 +116,35 @@ bool CShaderPresetGLES::CreateShaderTextures()
     }
     else
     {
+      auto shaderTextureGLES = std::make_unique<CShaderTextureGLES>(
+          static_cast<unsigned int>(textureSize.x), static_cast<unsigned int>(textureSize.y));
+
+      shaderTextureGLES->CreateTextureObject(); // Create new internal texture
+
+      const ShaderPass& nextPass = m_passes[shaderIdx + 1];
+
+      if (pass.fbo.sRgbFramebuffer)
+        shaderTextureGLES->SetSRGBFramebuffer();
+
+      if (nextPass.mipmap)
+        shaderTextureGLES->SetMipmapping();
+
+      const GLint wrapType = CShaderUtilsGLES::TranslateWrapType(nextPass.wrapType);
+
+      const GLuint magFilterType =
+          (nextPass.filterType == FilterType::LINEAR ? GL_LINEAR : GL_NEAREST);
+
+      const GLuint minFilterType =
+          (nextPass.mipmap ? (nextPass.filterType == FilterType::LINEAR ? GL_LINEAR_MIPMAP_LINEAR
+                                                                        : GL_NEAREST_MIPMAP_NEAREST)
+                           : magFilterType);
+
+      glBindTexture(GL_TEXTURE_2D, shaderTextureGLES->GetTextureID());
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, magFilterType);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, minFilterType);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrapType);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrapType);
+
       // Determine the framebuffer data format
       GLint internalFormat;
       GLenum pixelFormat;
@@ -121,66 +168,10 @@ bool CShaderPresetGLES::CreateShaderTextures()
         }
       }
 
-      //! @todo Enable usage of optimal texture sizes once multi-pass preset
-      // geometry and LUT rendering are fixed.
-      //
-      // Current issues:
-      //   - Enabling optimal texture sizes breaks geometry for many multi-pass
-      //     presets
-      //   - LUTs render incorrectly due to missing per-pass and per-LUT
-      //     TexCoord attributes.
-      //
-      // Planned solution:
-      //   - Implement additional TexCoord attributes for each pass and LUT,
-      //     setting coordinates to `xamt` and `yamt` instead of 1
-      //
-      // Reference implementation in RetroArch:
-      //   https://github.com/libretro/RetroArch/blob/09a59edd6b415b7bd124b03bda68ccc4d60b0ea8/gfx/drivers/gl2.c#L3018
-      //
-      textureSize = scaledSize; // CShaderUtils::GetOptimalTextureSize(scaledSize)
-
-      auto textureGL = std::make_shared<CGLESTexture>(static_cast<unsigned int>(textureSize.x),
-                                                      static_cast<unsigned int>(textureSize.y),
-                                                      XB_FMT_A8R8G8B8); // Format is not used
-
-      textureGL->CreateTextureObject();
-
-      if (textureGL->GetTextureID() <= 0)
-      {
-        CLog::Log(
-            LOGERROR,
-            "CShaderPresetGLES::CreateShaderTextures: Couldn't create texture for video shader: {}",
-            pass.sourcePath);
-        return false;
-      }
-
-      const ShaderPass& nextPass = m_passes[shaderIdx + 1];
-
-      if (nextPass.mipmap)
-        textureGL->SetMipmapping();
-
-      textureGL->SetScalingMethod(nextPass.filterType == FilterType::LINEAR
-                                      ? TEXTURE_SCALING::LINEAR
-                                      : TEXTURE_SCALING::NEAREST);
-
-      const GLint wrapType = CShaderUtilsGLES::TranslateWrapType(nextPass.wrapType);
-      const GLuint magFilterType =
-          (nextPass.filterType == FilterType::LINEAR ? GL_LINEAR : GL_NEAREST);
-      const GLuint minFilterType =
-          (nextPass.mipmap ? (nextPass.filterType == FilterType::LINEAR ? GL_LINEAR_MIPMAP_LINEAR
-                                                                        : GL_NEAREST_MIPMAP_NEAREST)
-                           : magFilterType);
-
-      glBindTexture(GL_TEXTURE_2D, textureGL->GetTextureID());
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, magFilterType);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, minFilterType);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrapType);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrapType);
       glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, textureSize.x, textureSize.y, 0, pixelFormat,
                    internalFormat == GL_RGBA32F ? GL_FLOAT : GL_UNSIGNED_BYTE, nullptr);
 
-      m_pShaderTextures.emplace_back(
-          std::make_unique<CShaderTextureGLES>(std::move(textureGL), pass.fbo.sRgbFramebuffer));
+      m_pShaderTextures.emplace_back(std::move(shaderTextureGLES));
     }
 
     // Notify shader of its source and dest size

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.h
@@ -38,6 +38,5 @@ protected:
   bool CreateSamplers() override { return true; }
   void RenderShader(IShader& shader, IShaderTexture& source, IShaderTexture& target) override;
 };
-
 } // namespace SHADER
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderTextureGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderTextureGLES.h
@@ -14,34 +14,49 @@
 
 #include "system_gl.h"
 
-class CGLESTexture;
-
 namespace KODI::SHADER
 {
 
 class CShaderTextureGLES : public IShaderTexture
 {
 public:
-  CShaderTextureGLES(std::shared_ptr<CGLESTexture> texture, bool sRgbFramebuffer);
+  CShaderTextureGLES(uint32_t textureWidth, uint32_t textureHeight);
   ~CShaderTextureGLES() override;
+
+  // Disallow copy and move (this object owns raw GL IDs)
+  CShaderTextureGLES(const CShaderTextureGLES&) = delete;
+  CShaderTextureGLES& operator=(const CShaderTextureGLES&) = delete;
+  CShaderTextureGLES(CShaderTextureGLES&&) = delete;
+  CShaderTextureGLES& operator=(CShaderTextureGLES&&) = delete;
 
   // Implementation of IShaderTexture
   float GetWidth() const override;
   float GetHeight() const override;
 
   // OpenGLES interface
-  CGLESTexture& GetTexture() { return *m_texture; }
-  const CGLESTexture& GetTexture() const { return *m_texture; }
+  void CreateTextureObject();
+  void DestroyTextureObject();
+  void BindToUnit(unsigned int unit);
+  GLuint GetTextureID() const { return m_texture; }
+
+  void SetSRGBFramebuffer() { m_sRgbFramebuffer = true; }
   bool IsSRGBFramebuffer() const { return m_sRgbFramebuffer; }
 
+  void SetMipmapping() { m_mipmapping = true; }
+  bool IsMipmapped() const { return m_mipmapping; }
+
   // Frame buffer interface
-  bool CreateFBO();
+  void CreateFBO();
+  void DestroyFBO();
   bool BindFBO();
   void UnbindFBO() const;
 
 private:
-  std::shared_ptr<CGLESTexture> m_texture;
+  uint32_t m_textureWidth{0};
+  uint32_t m_textureHeight{0};
+  GLuint m_texture{0};
+  GLuint m_FBO{0};
   bool m_sRgbFramebuffer{false};
-  GLuint FBO{0};
+  bool m_mipmapping{false};
 };
 } // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderTextureGLESRef.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderTextureGLESRef.cpp
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (C) 2019-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ShaderTextureGLESRef.h"
+
+using namespace KODI::SHADER;
+
+CShaderTextureGLESRef::CShaderTextureGLESRef(uint32_t textureWidth,
+                                             uint32_t textureHeight,
+                                             GLuint texture)
+  : m_textureWidth(textureWidth),
+    m_textureHeight(textureHeight),
+    m_texture(texture)
+{
+}
+
+float CShaderTextureGLESRef::GetWidth() const
+{
+  return static_cast<float>(m_textureWidth);
+}
+
+float CShaderTextureGLESRef::GetHeight() const
+{
+  return static_cast<float>(m_textureHeight);
+}
+
+void CShaderTextureGLESRef::BindToUnit(unsigned int unit)
+{
+  glActiveTexture(GL_TEXTURE0 + unit);
+  glBindTexture(GL_TEXTURE_2D, m_texture);
+}

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderTextureGLESRef.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderTextureGLESRef.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017-2025 Team Kodi
+ *  Copyright (C) 2019-2025 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -10,11 +10,7 @@
 
 #include "cores/RetroPlayer/shaders/IShaderTexture.h"
 
-#include <memory>
-
-#include <d3d11.h>
-
-class CD3DTexture;
+#include "system_gl.h"
 
 namespace KODI::SHADER
 {
@@ -24,23 +20,23 @@ namespace KODI::SHADER
  *
  * NOTE: The lifetime of the external texture object must outlast this class.
  */
-class CShaderTextureDXRef : public IShaderTexture
+class CShaderTextureGLESRef : public IShaderTexture
 {
 public:
-  explicit CShaderTextureDXRef(CD3DTexture& texture);
-  ~CShaderTextureDXRef() override = default;
+  CShaderTextureGLESRef(uint32_t textureWidth, uint32_t textureHeight, GLuint texture = 0);
+  ~CShaderTextureGLESRef() override = default;
 
   // Implementation of IShaderTexture
   float GetWidth() const override;
   float GetHeight() const override;
 
-  // DirectX interface
-  CD3DTexture& GetTexture() { return m_texture; }
-  const CD3DTexture& GetTexture() const { return m_texture; }
-  ID3D11ShaderResourceView* GetShaderResource() const;
+  // OpenGLES interface
+  void BindToUnit(unsigned int unit);
+  GLuint GetTextureID() const { return m_texture; }
 
 private:
-  // Construction parameter
-  CD3DTexture& m_texture;
+  uint32_t m_textureWidth{0};
+  uint32_t m_textureHeight{0};
+  GLuint m_texture{0};
 };
 } // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderUtilsGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderUtilsGLES.h
@@ -21,5 +21,4 @@ public:
   static GLint TranslateWrapType(WrapType wrapType);
   static std::string GetGLSLVersion(std::string& source);
 };
-
 } // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.h
@@ -74,5 +74,4 @@ private:
   CRect m_sourceRect{};
   KODI::RETRO::ViewportCoordinates m_destPoints{};
 };
-
 } // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.h
@@ -130,5 +130,4 @@ private:
   // Sampler state
   //ID3D11SamplerState* m_pSampler{nullptr};
 };
-
 } // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderLutDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderLutDX.h
@@ -39,5 +39,4 @@ private:
 
   std::unique_ptr<CTexture> m_texture;
 };
-
 } // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.cpp
@@ -117,7 +117,7 @@ bool CShaderPresetDX::CreateBuffers()
 
 bool CShaderPresetDX::CreateShaderTextures()
 {
-  m_pShaderTextures.clear();
+  DisposeShaderTextures();
 
   float2 prevSize = m_videoSize;
   float2 prevTextureSize = m_videoSize;

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.h
@@ -49,6 +49,5 @@ private:
   // Linear sampler
   ID3D11SamplerState* m_pSampLinear = nullptr;
 };
-
 } // namespace SHADER
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderSamplerDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderSamplerDX.h
@@ -24,5 +24,4 @@ public:
 private:
   ID3D11SamplerState* const m_sampler;
 };
-
 } // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderTextureDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderTextureDX.h
@@ -41,5 +41,4 @@ private:
   // Construction parameter
   const std::shared_ptr<CD3DTexture> m_texture;
 };
-
 } // namespace KODI::SHADER

--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -141,8 +141,8 @@ std::unique_ptr<CTexture> CTexture::CreateTexture(unsigned int width,
   return std::make_unique<CGLTexture>(width, height, format);
 }
 
-CGLTexture::CGLTexture(unsigned int width, unsigned int height, XB_FMT format, GLuint texture)
-  : CTexture(width, height, format), m_texture(texture)
+CGLTexture::CGLTexture(unsigned int width, unsigned int height, XB_FMT format)
+  : CTexture(width, height, format)
 {
   unsigned int major, minor;
   CServiceBroker::GetRenderSystem()->GetRenderVersion(major, minor);

--- a/xbmc/guilib/TextureGL.h
+++ b/xbmc/guilib/TextureGL.h
@@ -34,10 +34,7 @@ struct Textureswizzle
 class CGLTexture : public CTexture
 {
 public:
-  CGLTexture(unsigned int width = 0,
-             unsigned int height = 0,
-             XB_FMT format = XB_FMT_A8R8G8B8,
-             GLuint texture = 0);
+  CGLTexture(unsigned int width = 0, unsigned int height = 0, XB_FMT format = XB_FMT_A8R8G8B8);
   ~CGLTexture() override;
 
   // Implementation of CTexture

--- a/xbmc/guilib/TextureGLES.cpp
+++ b/xbmc/guilib/TextureGLES.cpp
@@ -179,8 +179,8 @@ std::unique_ptr<CTexture> CTexture::CreateTexture(unsigned int width,
   return std::make_unique<CGLESTexture>(width, height, format);
 }
 
-CGLESTexture::CGLESTexture(unsigned int width, unsigned int height, XB_FMT format, GLuint texture)
-  : CTexture(width, height, format), m_texture(texture)
+CGLESTexture::CGLESTexture(unsigned int width, unsigned int height, XB_FMT format)
+  : CTexture(width, height, format)
 {
   unsigned int major, minor;
   CServiceBroker::GetRenderSystem()->GetRenderVersion(major, minor);

--- a/xbmc/guilib/TextureGLES.h
+++ b/xbmc/guilib/TextureGLES.h
@@ -31,10 +31,7 @@ struct TextureSwizzle
 class CGLESTexture : public CTexture
 {
 public:
-  CGLESTexture(unsigned int width = 0,
-               unsigned int height = 0,
-               XB_FMT format = XB_FMT_A8R8G8B8,
-               GLuint texture = 0);
+  CGLESTexture(unsigned int width = 0, unsigned int height = 0, XB_FMT format = XB_FMT_A8R8G8B8);
   ~CGLESTexture() override;
 
   // Implementation of CTexture


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
- Removes the dependency on _guilib_ from _ShaderTextureGL_ class
- Adds the missing functionality to _ShaderTextureGL_ class
- Handle the external texture ownership in _ShaderTextureGL_ class
- Improves _DisposeShaders()_ and _DisposeShadeTextures()_ logic (common for all platforms)
- Fixes missing `glDeleteProgram()` in _ShaderGL_ class (possible GPU memory leak)
- Moves all `gl*()` calls from object destructors to dedicated `Destroy()` methods
- Sync the code between all renderers (removed _assert()_, changed order etc.)
- Minor improvements (move _struct_ definition to header file, align white spaces etc.)
- Adds _ShaderTextureGLRef_ class to handle the external textures without the internal flag (the _ShaderTextureGL_ now always owns its texture and FBO and the _ShaderTextureGLRef_ is used for passing external textures, in line with the _ShaderTextureDXRef_ for DirectX)
- Reverts the changes to _guilib_ introduced in the video shader GSoC PR (https://github.com/xbmc/xbmc/commit/f88b39e81b20e40f7076dfaa39b005d648d7b101)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/xbmc/xbmc/issues/27636, the GUI texture cache corruption after exiting RetroPlayer.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Linux / Wayland / both OpenGL and OpenGL ES builds

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Fixed GUI textures after playing games.

## Screenshots (if appropriate):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b89d77e2-28f9-41c4-b7c2-7118857794e2" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f2926ac4-1034-40bd-8afe-6aa5b61c07c0" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
