### PR TITLE
fixed: restore build with libmysqlclient

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -183,8 +183,15 @@ int MysqlDatabase::connect(bool create_new)
                     cert.empty() ? nullptr : cert.c_str(), ca.empty() ? nullptr : ca.c_str(),
                     capath.empty() ? nullptr : capath.c_str(),
                     ciphers.empty() ? nullptr : ciphers.c_str());
+#ifdef HAS_MARIADB
       my_bool enforce_tls = enforceSsl;
       mysql_options(conn, MYSQL_OPT_SSL_ENFORCE, (void*)&enforce_tls);
+#elif MYSQL_VERSION_ID >= 80014
+      mysql_ssl_mode enforce_tls = enforceSsl ? SSL_MODE_REQUIRED : SSL_MODE_PREFERRED;
+      mysql_options(conn, MYSQL_OPT_SSL_MODE, (void*)&enforce_tls);
+#else
+      CLog::Log(LOGWARNING, "MySQL: Not enforcing SSL mode, unsupported client version");
+#endif
       mysql_options(conn, MYSQL_OPT_CONNECT_TIMEOUT, &connect_timeout);
     }
 


### PR DESCRIPTION
## Description
Recent ssl addition to mysql (http://github.com/xbmc/xbmc/commit/402168ae) uses
an API that has been removed in mysqlclient 8. Deal with this.

## Motivation and context
Make stuff build on my box

## How has this been tested?
It builds

## What is the effect on users?
Hopefully none other than it builds and has ssl..

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
